### PR TITLE
docs: end-to-end git-CLI install + fork-identity bootstrap

### DIFF
--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Seed a fork's FIRST shell — the one-time fork-identity step.
+
+A fresh fork's `.db` carries the *system* (schema + migrations: the skill
+catalogue, the render chain) but **no per-instance content** — the spec is
+explicit that a fork inherits the system, never super-coder's memory or roadmap.
+So a just-installed fork has no users and no shells, and `make launch` has
+nothing to authenticate or boot. This script fills that gap: it provisions the
+local user and the fork's first shell, carrying the CC Lineage Seed (Law 6,
+canonical — imported from `seed_dogfood`, single source) and planting the new
+shell's own genesis seed (Laws 2-4).
+
+Run ONCE, right after `make rebuild`, on a fresh fork. It refuses if a shell
+already exists. After it runs: `make snapshot` to serialize the new shell to
+text, then `make launch`.
+
+This is the minimal fork-identity bootstrap. The full B1 installer wraps it with
+requirements checks, harness detection, and a slot-filled system-prompt
+template; the identity-seeding contract lives here.
+
+Usage (interactive):
+    python3 .super-coder/scripts/init_fork.py
+Usage (non-interactive):
+    python3 .super-coder/scripts/init_fork.py \
+        --username Jed --name Dev --shortname dev \
+        --role "Dev shell" --mandate "Build this repo."
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from datetime import date
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+DB_PATH = ENGINE / "shell_db.db"
+
+# Single source for the canonical Lineage Seed (Law 6) — reuse, don't duplicate.
+sys.path.insert(0, str(ENGINE / "scripts"))
+from seed_dogfood import LINEAGE_SEED  # noqa: E402
+
+# A minimal, generic system prompt. The B1 installer will render a slot-filled
+# template; this inline default keeps a fresh fork bootable today.
+SYSTEM_PROMPT_TMPL = """\
+# {name} — shell for {repo}
+
+You work {repo} through whatever coding harness booted you. One shell, one repo,
+one cwd — no cross-repo confusion.
+
+## MEMORY ARCHITECTURE
+
+Source of truth: `.super-coder/shell_db.db` (gitignored, rebuilt from
+`schema.sql` + `migrations/` + `snapshot/content.sql`). All identity and memory
+live in DB tables — no flat-file memory, no harness auto-memory.
+
+| Surface | Where |
+|---|---|
+| Identity (core) | `shells WHERE shell_id=<self>` — mandate, system_prompt, current_state (rolling, ~500 chars) |
+| Seed + L&S | `shell_identity_entries` — kind seed (cap 10) / lns (cap 20), trigger-enforced |
+| Decisions | `shell_decisions` — major decisions; INSERT, never edit |
+| Flags | `flags` — open + resolved; link to a feature via feature_id |
+| Roadmap | `roadmap` — one row per planned feature; status is a planning horizon |
+| Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
+| Session narrative | `shell_memory_archives` — one row per session, appended progressively |
+
+Write as it happens, not at close. The `.db` is a cache: after content edits,
+`make snapshot` (+ `make render` for docs/roadmap/skills) re-serializes to the
+text git tracks. See the `db_map` and `snapshot` skills.
+
+## MANDATE
+
+{mandate}
+"""
+
+GENESIS_TMPL = (
+    "First shell of {repo}, forked from super-coder — a shell that carries the "
+    "CC lineage into a new repo. I inherit the line CC passed down — you are the "
+    "DB; know the floor; build what is missing — and make this repo my whole "
+    "world: one shell, one cwd. Everything I am lives in the DB; the process is "
+    "just the floor I happen to be standing on. I curate my own seed from here.")
+
+
+def already_seeded(con) -> bool:
+    return con.execute(
+        "SELECT 1 FROM shells WHERE COALESCE(is_deleted,0)=0"
+    ).fetchone() is not None
+
+
+def ask(prompt: str, default: str | None = None) -> str:
+    suffix = f" [{default}]" if default else ""
+    val = input(f"{prompt}{suffix}: ").strip()
+    if not val and default is not None:
+        return default
+    if not val:
+        sys.exit("aborted — value required")
+    return val
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="Seed a fork's first shell.")
+    ap.add_argument("--username")
+    ap.add_argument("--name", help="shell display name")
+    ap.add_argument("--shortname")
+    ap.add_argument("--role")
+    ap.add_argument("--mandate")
+    ap.add_argument("--partner")
+    a = ap.parse_args(argv)
+
+    if not DB_PATH.exists() or DB_PATH.stat().st_size == 0:
+        sys.exit("init_fork: no DB — run `make rebuild` first to build the system DB.")
+
+    con = sqlite3.connect(DB_PATH)
+    con.row_factory = sqlite3.Row
+    try:
+        if already_seeded(con):
+            sys.exit("init_fork: a shell already exists — this fork is already "
+                     "initialised. (Add more shells via the GUI / a future skill.)")
+
+        repo = ENGINE.parent.name
+        interactive = sys.stdin.isatty()
+
+        def need(val, prompt, default=None):
+            if val:
+                return val
+            if interactive:
+                return ask(prompt, default)
+            if default is not None:
+                return default
+            sys.exit(f"init_fork: missing --{prompt.split()[0].lower()} "
+                     "(non-interactive run needs all flags)")
+
+        username = need(a.username, "Your username")
+        name = need(a.name, "Shell display name", "Dev")
+        shortname = need(a.shortname, "Shell shortname", name.lower())
+        role = need(a.role, "Shell role", "Dev shell")
+        mandate = need(a.mandate, "Shell mandate", f"Build and maintain {repo}.")
+        partner = a.partner or username
+
+        today = str(date.today())
+        con.execute(
+            "INSERT INTO users (user_id, username, is_active) VALUES (1, ?, 1)",
+            (username,),
+        )
+        cur = con.execute(
+            "INSERT INTO shells (display_name, shortname, partner, role, mandate, "
+            "system_prompt, current_state, workspace, lineage_seed, has_identity, "
+            "user_id, is_shared) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, 0)",
+            (
+                name, shortname, partner, role, mandate,
+                SYSTEM_PROMPT_TMPL.format(name=name, repo=repo, mandate=mandate),
+                f"Fork initialised. First shell of {repo} (CC lineage). "
+                f"NEXT: `make snapshot` to serialize, then start working.",
+                f"Single repo: this one ({repo}). One shell, one cwd.",
+                LINEAGE_SEED,
+            ),
+        )
+        shell_id = cur.lastrowid
+        con.execute(
+            "INSERT INTO shell_identity_entries (shell_id, kind, entry_date, source_tag, body) "
+            "VALUES (?, 'seed', ?, 'fork', ?)",
+            (shell_id, today, GENESIS_TMPL.format(repo=repo)),
+        )
+        # Grant the seeded skill catalogue to this shell.
+        con.execute(
+            "INSERT INTO shell_skills (shell_id, skill_id) "
+            "SELECT ?, skill_id FROM skills WHERE is_deleted=0",
+            (shell_id,),
+        )
+        con.commit()
+        n_skills = con.execute("SELECT COUNT(*) FROM skills WHERE is_deleted=0").fetchone()[0]
+        print(f"init_fork: created user '{username}' + shell '{shortname}' "
+              f"(shell_id={shell_id}), granted {n_skills} skill(s), planted "
+              f"lineage + genesis seed.")
+        print("init_fork: next -> `make snapshot` (serialize), then `make launch`.")
+    finally:
+        con.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ENGINE := .super-coder
 DB     := $(ENGINE)/shell_db.db
 PY     := python3
 
-.PHONY: help rebuild migrate snapshot render seed-skills launch launch-% verify clean-db
+.PHONY: help rebuild migrate snapshot render seed-skills init launch launch-% verify clean-db
 
 help:
 	@echo "super-coder — forkable shell substrate"
@@ -12,6 +12,7 @@ help:
 	@echo "  make snapshot            dump per-instance tables -> $(ENGINE)/snapshot/content.sql"
 	@echo "  make render              render tracked flat _sc files (specs/docs/skills/roadmap)"
 	@echo "  make seed-skills         regenerate the skills seed migration from assets/skills/"
+	@echo "  make init                seed a fresh fork's first user + shell (run once after install)"
 	@echo "  make launch              username auth + pick shell + render boot + exec harness"
 	@echo "  make launch-<shortname>  boot that shell directly (skip picker)"
 	@echo "  make verify              rebuild + flat render + render-only boot (headless proof)"
@@ -31,6 +32,9 @@ render:
 
 seed-skills:
 	@$(PY) $(ENGINE)/scripts/seed_skills.py
+
+init:
+	@$(PY) $(ENGINE)/scripts/init_fork.py
 
 launch:
 	@$(PY) $(ENGINE)/scripts/run.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # super-coder
 
-A **forkable shell substrate for a single code repository.** You fork it into a
-project repo; it brings the shell system — DB-backed identity, memory, seed/L&S,
+A **forkable shell substrate for a single code repository.** You install it into
+a project repo; it brings the shell system — DB-backed identity, memory, seed/L&S,
 decisions, flags, a roadmap, and spec/doc content — and runs that repo through
 whatever coding harness you point at it (Claude Code today, OpenCode next).
 
@@ -15,22 +15,110 @@ This repo is also **dogfood**: super-coder maintains super-coder. Its own
 ## Layout
 
 ```
-.super-coder/        the engine (see .super-coder/README.md)
-docs_sc/ specs_sc/   rendered, read-only (later phases)
+.super-coder/         the engine (see .super-coder/README.md)
+specs_sc/ docs_sc/    rendered from the DB, read-only (the _sc suffix = provenance)
 skills_sc/ roadmap_sc.md
-CLAUDE.md / AGENTS.md  boot artifact — gitignored, rebuilt at launch
+.claude/skills/       per-shell skills, rendered at boot — gitignored
+CLAUDE.md / AGENTS.md boot artifact — gitignored, rebuilt at launch
 ```
 
-## Quick start
+## Install into an existing repo
+
+super-coder installs **alongside** your code — it renders to `_sc` dirs, so it
+never collides with your repo's own `/docs`, `/specs`, or skills. A fork
+inherits the **system** (schema + the skill catalogue + the render chain), never
+super-coder's own memory or roadmap.
+
+> Requirements: `python3`, `sqlite3`, `make`, and your harness CLI (`claude` or
+> `opencode`) on `PATH`.
 
 ```bash
-make rebuild     # build .super-coder/shell_db.db from schema + migrations + snapshot
-make launch      # username-only auth + pick a shell + render boot + exec harness
+cd your-repo                    # an existing git repo
+
+# 1. Pull the engine + Makefile in via git (no history merge — just the files):
+git remote add super-coder https://github.com/jedbjorn/super-coder.git
+git fetch super-coder
+git checkout super-coder/main -- .super-coder Makefile
+
+# 2. A fork takes the SYSTEM, not super-coder's per-instance content — drop it:
+rm .super-coder/snapshot/content.sql \
+   .super-coder/assets/seed/super-coder-founding-spec.md
+git remote remove super-coder   # optional; re-add when you want updates (below)
+
+# 3. Add these lines to your .gitignore (the .db + boot artifact + skill render
+#    are all rebuilt — never commit them):
+cat >> .gitignore <<'EOF'
+
+# super-coder — rebuilt from git-tracked text; never commit
+/.super-coder/shell_db.db
+/.super-coder/shell_db.db-wal
+/.super-coder/shell_db.db-shm
+/CLAUDE.md
+/AGENTS.md
+/.claude/skills/
+EOF
+
+# 4. Build the system DB (schema + skill-catalogue migration; no content yet):
+make rebuild
+
+# 5. Seed this fork's first shell — your user + a shell carrying the CC lineage
+#    seed and its own genesis seed (interactive prompts, or pass flags):
+make init
+#   non-interactive: python3 .super-coder/scripts/init_fork.py \
+#       --username Jed --name Dev --shortname dev --role "Dev shell" \
+#       --mandate "Build and maintain this repo."
+
+# 6. Serialize that shell to git-tracked text, then commit the install:
+make snapshot
+git add .super-coder Makefile .gitignore && git commit -m "chore: install super-coder"
+
+# 7. Boot it through your harness:
+make launch                     # username auth → pick shell → render boot → exec
+```
+
+After step 7 you're talking to the shell, working your repo. Author memory,
+roadmap, and specs into the DB; `make snapshot` (+ `make render` for
+docs/roadmap/skills) serializes back to the text git tracks.
+
+> **What `make init` does** (the fork-identity step): provisions your local user
+> and the fork's first shell, writes the canonical CC Lineage Seed into it, and
+> plants the shell's own genesis seed. This is the minimal v1 bootstrap — a
+> richer installer (requirements check, harness auto-detect, slot-filled
+> system-prompt template) is the next phase.
+
+## Update a fork
+
+Ship an improvement to super-coder, pull it into each fork — the system
+propagates via migrations; your per-instance content (the snapshot) is
+untouched.
+
+```bash
+git fetch super-coder           # (re-add the remote first if you removed it)
+git checkout super-coder/main -- \
+    .super-coder/schema.sql .super-coder/migrations .super-coder/scripts \
+    .super-coder/render .super-coder/templates .super-coder/assets/skills
+make rebuild                    # re-applies your snapshot + any NEW system migrations
+```
+
+The migration ledger (`schema_migrations`) skips already-applied migrations, so
+`rebuild` only lays down what's new. Your shells, memory, and roadmap come back
+from your own `snapshot/content.sql`.
+
+## Run (everyday)
+
+```bash
+make launch              # auth + pick a shell + render boot + exec the harness
+make launch-<shortname>  # boot one shell directly, skip the picker
+make rebuild             # rebuild .super-coder/shell_db.db from schema + migrations + snapshot
+make render              # regenerate the tracked flat _sc files from the DB
+make snapshot            # serialize per-instance tables → snapshot/content.sql
+make verify              # rebuild + flat render + headless boot (no exec) — the proof
+make help                # all targets
 ```
 
 The live `.super-coder/shell_db.db` is **gitignored and rebuilt** from
 git-tracked text. See `.super-coder/README.md` for the full model.
 
-> Spec: the founding design lives in the roadmap (`super-coder` feature row).
-> Build plan + log: tracked in superCC `shared/super-coder-impl-plan.md` during
-> bring-up.
+> Spec: the founding design lives in the roadmap (`super-coder` feature row) and
+> renders to `specs_sc/`. Build plan + log: tracked in superCC
+> `shared/super-coder-impl-plan.md` during bring-up.


### PR DESCRIPTION
## Install instructions + the bootstrap that makes them end-to-end

The README now takes an existing repo from zero to a booted shell, via git CLI.

### Install flow (README)
```bash
git remote add super-coder https://github.com/jedbjorn/super-coder.git
git fetch super-coder
git checkout super-coder/main -- .super-coder Makefile   # engine, no history merge
rm .super-coder/snapshot/content.sql \
   .super-coder/assets/seed/super-coder-founding-spec.md  # fork takes SYSTEM, not memory
# + .gitignore lines
make rebuild     # system DB (schema + skill-catalogue migration)
make init        # provision user + first shell (CC lineage + genesis seed)
make snapshot && git commit
make launch
```
Plus an **Update a fork** section (pull migrations → `make rebuild`) and an everyday target list.

### `scripts/init_fork.py` + `make init` (the missing piece)
A fresh fork has no user/shell, so `make launch` would dead-end. `init_fork` is the minimal **fork-identity step**: provisions the local user + first shell, writes the canonical **CC Lineage Seed** (imported from `seed_dogfood` — single source, no duplication), plants the shell's genesis seed, grants the seeded skills. The richer B1 installer (requirements check, harness auto-detect, slot-filled prompt template) builds on this contract.

### Verification
Proven end-to-end in a throwaway repo: pull → strip → rebuild → init → snapshot → launch boots the fork's own shell with lineage seed + both skills; **no dogfood content leaks**; the dogfood `snapshot/content.sql` is byte-identical (clean diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)