### PR TITLE
feat: B3 review layer — dependency-free localhost GUI + per-fork ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 # Only the render output is ignored; a fork's own .claude/settings stays tracked.
 /.claude/skills/
 
+# Per-instance local config — derived ports etc. Local to this fork, never
+# propagates (re-derived from the repo path if absent). Hand-overridable.
+/.super-coder/instance.json
+
 # Python / tooling
 __pycache__/
 *.pyc

--- a/.super-coder/README.md
+++ b/.super-coder/README.md
@@ -65,3 +65,24 @@ snapshot (fork-local). `make rebuild` seeds the catalogue, then loads grants.
 `adapters/<harness>/` holds the thin, harness-specific seam: provider/model
 config, tool/permission config, MCP config, launch command. `claude/` is v1;
 `opencode/` is next. Everything above the seam is harness-blind.
+
+## Review layer (`api/` + `ui/`)
+
+A **zero-dependency** localhost GUI over the live DB — no FastAPI, no venv, no
+npm/build. `api/server.py` is a stdlib HTTP server that serves both the JSON API
+and the static `ui/` (one page, vanilla JS) on a single per-fork port.
+
+- **Read** shells, roadmap, flags. **Edit** a shell's operational fields
+  (`current_state`, `connections`, `workspace`) + skill grants, the roadmap, and
+  **non-frozen** documents. **Create / resolve** flags.
+- **Law enforcement is structural:** seed and L&S have *no write route* (Laws
+  2–4, 7) — not a disabled control, an absent endpoint. Frozen documents reject
+  edits server-side.
+- `POST /api/snapshot` runs `snapshot.py` + `render.py flat` — the manual
+  precursor to the B6 commit→PR automation.
+
+`scripts/ports.py` derives this fork's port from its repo path (`8800 + sha1 %
+100`), bumping past anything occupied, and persists it to the gitignored
+`instance.json`. `ecosystem.config.cjs` names the pm2 process `sc-<repo>` so
+forks (and the host repo's own pm2 apps) never clash. `make up` / `down` /
+`health` / `serve` drive it.

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""super-coder review layer — a zero-dependency localhost server.
+
+One stdlib HTTP server serves both the JSON API and the static review UI on a
+single per-fork port (see scripts/ports.py). No FastAPI, no venv, no build step:
+a fork needs only python3 + sqlite3, which the install already requires. Single-
+user, localhost — network controls are the operator's, exactly like superCC's
+API surface.
+
+It is a REVIEW layer over the live `shell_db.db`. The law-curated fields (seed,
+L&S) are returned for reading but have **no write endpoint at all** — not a
+disabled control, an absent route (Laws 2-4, 7; spec §GUI). Editable: a shell's
+operational fields (current_state, connections, workspace) + skill grants;
+roadmap rows; non-frozen documents; flags (create / resolve).
+
+Run:
+    python3 .super-coder/api/server.py [--port N]
+    (defaults to the derived port from scripts/ports.py)
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+ENGINE = Path(__file__).resolve().parents[1]
+DB_PATH = ENGINE / "shell_db.db"
+UI_DIR = ENGINE / "ui"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import ports as ports_mod  # noqa: E402
+
+_STATIC = {
+    "/": ("index.html", "text/html; charset=utf-8"),
+    "/index.html": ("index.html", "text/html; charset=utf-8"),
+    "/app.js": ("app.js", "application/javascript; charset=utf-8"),
+    "/style.css": ("style.css", "text/css; charset=utf-8"),
+}
+
+# Shell fields the review layer may write. seed/L&S/system_prompt/mandate are
+# deliberately ABSENT — the law says the shell curates them, so there is no door.
+SHELL_EDITABLE = {"current_state", "connections", "workspace"}
+FLAG_EDITABLE = {"resolved", "resolution_notes", "description", "feature_id", "priority"}
+ROADMAP_EDITABLE = {"title", "roadmap_status", "summary", "sort_order"}
+
+
+def db() -> sqlite3.Connection:
+    con = sqlite3.connect(DB_PATH)
+    con.row_factory = sqlite3.Row
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+def rows(cur) -> list[dict]:
+    return [dict(r) for r in cur.fetchall()]
+
+
+# ── Data assembly ─────────────────────────────────────────────────────────────
+
+def get_shells(con) -> list[dict]:
+    return rows(con.execute(
+        "SELECT shell_id, display_name, shortname, role, mandate, is_shared "
+        "FROM shells WHERE COALESCE(is_deleted,0)=0 ORDER BY shell_id"))
+
+
+def get_shell(con, sid: int) -> dict | None:
+    r = con.execute(
+        "SELECT shell_id, display_name, shortname, partner, role, mandate, "
+        "system_prompt, current_state, connections, workspace, lineage_seed, "
+        "has_identity, active_archive_id FROM shells "
+        "WHERE shell_id=? AND COALESCE(is_deleted,0)=0", (sid,)).fetchone()
+    if r is None:
+        return None
+    shell = dict(r)
+    shell["seed"] = rows(con.execute(
+        "SELECT entry_id, entry_date, body FROM shell_identity_entries "
+        "WHERE shell_id=? AND kind='seed' AND is_deleted=0 AND retired_at IS NULL "
+        "ORDER BY entry_date, entry_id", (sid,)))
+    shell["lns"] = rows(con.execute(
+        "SELECT entry_id, entry_date, body FROM shell_identity_entries "
+        "WHERE shell_id=? AND kind='lns' AND is_deleted=0 AND retired_at IS NULL "
+        "ORDER BY entry_date, entry_id", (sid,)))
+    shell["skills"] = rows(con.execute(
+        "SELECT s.skill_id, s.name, s.description, "
+        "(SELECT 1 FROM shell_skills ss WHERE ss.shell_id=? AND ss.skill_id=s.skill_id) "
+        "AS granted FROM skills s WHERE s.is_deleted=0 ORDER BY s.name", (sid,)))
+    shell["decisions"] = rows(con.execute(
+        "SELECT decision_id, decision_date, priority, decision FROM shell_decisions "
+        "WHERE shell_id=? AND COALESCE(is_deleted,0)=0 ORDER BY decision_id DESC "
+        "LIMIT 25", (sid,)))
+    return shell
+
+
+_ORDER = ["next", "near_term", "long_term", "brainstorm", "shipped"]
+_LABEL = {"next": "Next", "near_term": "Near term", "long_term": "Long term",
+          "brainstorm": "Brainstorm", "shipped": "Shipped"}
+
+
+def get_roadmap(con) -> dict:
+    feats = rows(con.execute(
+        "SELECT r.feature_id, r.title, r.roadmap_status, r.sort_order, r.summary, "
+        "s.shortname AS owner FROM roadmap r LEFT JOIN shells s "
+        "ON s.shell_id=r.owning_shell ORDER BY r.sort_order, r.feature_id"))
+    docs_by: dict[int, list] = {}
+    for d in rows(con.execute(
+            "SELECT document_id, feature_id, kind, seq, title, frozen, frozen_date, "
+            "render_path FROM documents ORDER BY feature_id, kind, seq")):
+        docs_by.setdefault(d["feature_id"], []).append(d)
+    flags_by: dict[int, list] = {}
+    for f in rows(con.execute(
+            "SELECT flag_id, display_name, description FROM flags "
+            "WHERE resolved=0 AND COALESCE(is_deleted,0)=0 AND feature_id IS NOT NULL")):
+        flags_by.setdefault(f["feature_id"], []).append(f)
+    for f in feats:
+        f["documents"] = docs_by.get(f["feature_id"], [])
+        f["open_flags"] = flags_by.get(f["feature_id"], [])
+    buckets = [{"status": s, "label": _LABEL[s],
+                "features": [f for f in feats if f["roadmap_status"] == s]}
+               for s in _ORDER]
+    return {"buckets": [b for b in buckets if b["features"]]}
+
+
+def get_flags(con) -> dict:
+    flags = rows(con.execute(
+        "SELECT f.flag_id, f.display_name, f.priority, f.description, f.created_date, "
+        "f.resolved, f.resolved_date, f.resolution_notes, f.feature_id, "
+        "r.title AS feature_title FROM flags f LEFT JOIN roadmap r "
+        "ON r.feature_id=f.feature_id WHERE COALESCE(f.is_deleted,0)=0 "
+        "ORDER BY f.resolved, f.flag_id DESC"))
+    features = rows(con.execute(
+        "SELECT feature_id, title FROM roadmap ORDER BY sort_order, feature_id"))
+    return {"flags": flags, "features": features}
+
+
+# ── Mutations ─────────────────────────────────────────────────────────────────
+
+def patch_columns(con, table, pk_col, pk, body, allowed):
+    fields = {k: v for k, v in body.items() if k in allowed}
+    if not fields:
+        return False, "no editable fields in payload"
+    sets = ", ".join(f"{k}=?" for k in fields)
+    con.execute(f"UPDATE {table} SET {sets} WHERE {pk_col}=?",
+                (*fields.values(), pk))
+    con.commit()
+    return True, None
+
+
+def patch_document(con, doc_id, body):
+    r = con.execute("SELECT frozen FROM documents WHERE document_id=?",
+                    (doc_id,)).fetchone()
+    if r is None:
+        return False, "no such document"
+    if r["frozen"]:
+        return False, "document is frozen — open the next spec, don't edit this one"
+    return patch_columns(con, "documents", "document_id", doc_id, body,
+                          {"body", "title"})
+
+
+def create_flag(con, body):
+    if not body.get("description"):
+        return None, "description required"
+    cur = con.execute(
+        "INSERT INTO flags (display_name, description, priority, feature_id, shell_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (body.get("display_name"), body["description"],
+         body.get("priority", "Medium"), body.get("feature_id"),
+         body.get("shell_id")))
+    con.commit()
+    return cur.lastrowid, None
+
+
+def set_grant(con, sid, skill_id, granted):
+    if granted:
+        con.execute("INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
+                    "VALUES (?, ?)", (sid, skill_id))
+    else:
+        con.execute("DELETE FROM shell_skills WHERE shell_id=? AND skill_id=?",
+                    (sid, skill_id))
+    con.commit()
+
+
+def run_snapshot_render():
+    """Serialize + render after edits (manual precursor to the B6 automation)."""
+    import subprocess
+    out = []
+    for script in ("snapshot.py", "render.py"):
+        arg = ["flat"] if script == "render.py" else []
+        p = subprocess.run([sys.executable, str(ENGINE / "scripts" / script), *arg],
+                           capture_output=True, text=True)
+        out.append((p.stdout + p.stderr).strip())
+    return "\n".join(out)
+
+
+# ── HTTP ──────────────────────────────────────────────────────────────────────
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "super-coder/1.0"
+
+    def _send(self, code, payload, ctype="application/json"):
+        body = (json.dumps(payload) if ctype.startswith("application/json")
+                else payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self) -> dict:
+        n = int(self.headers.get("Content-Length") or 0)
+        if not n:
+            return {}
+        try:
+            return json.loads(self.rfile.read(n) or b"{}")
+        except json.JSONDecodeError:
+            return {}
+
+    def log_message(self, *a):  # quiet
+        pass
+
+    # -- static + GET --
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path in _STATIC:
+            fname, ctype = _STATIC[path]
+            f = UI_DIR / fname
+            if not f.exists():
+                return self._send(404, "not built", "text/plain")
+            return self._send(200, f.read_text(), ctype)
+        if not path.startswith("/api/"):
+            return self._send(404, {"error": "not found"})
+        con = db()
+        try:
+            if path == "/api/health":
+                cfg = ports_mod.resolve()
+                return self._send(200, {"ok": True, "repo": cfg.get("repo"),
+                                        "port": cfg.get("port")})
+            if path == "/api/shells":
+                return self._send(200, {"shells": get_shells(con)})
+            if path.startswith("/api/shells/"):
+                sid = int(path.rsplit("/", 1)[1])
+                shell = get_shell(con, sid)
+                return self._send(200 if shell else 404,
+                                  shell or {"error": "no such shell"})
+            if path == "/api/roadmap":
+                return self._send(200, get_roadmap(con))
+            if path.startswith("/api/documents/"):
+                did = int(path.rsplit("/", 1)[1])
+                r = con.execute("SELECT * FROM documents WHERE document_id=?",
+                                (did,)).fetchone()
+                return self._send(200 if r else 404,
+                                  dict(r) if r else {"error": "no such document"})
+            if path == "/api/flags":
+                return self._send(200, get_flags(con))
+            return self._send(404, {"error": "not found"})
+        except (ValueError, sqlite3.Error) as e:
+            return self._send(400, {"error": str(e)})
+        finally:
+            con.close()
+
+    def do_POST(self):
+        path = urlparse(self.path).path
+        con = db()
+        try:
+            if path == "/api/flags":
+                fid, err = create_flag(con, self._body())
+                return self._send(400 if err else 201,
+                                  {"error": err} if err else {"flag_id": fid})
+            if path == "/api/snapshot":
+                return self._send(200, {"output": run_snapshot_render()})
+            return self._send(404, {"error": "not found"})
+        except (ValueError, sqlite3.Error) as e:
+            return self._send(400, {"error": str(e)})
+        finally:
+            con.close()
+
+    def do_PATCH(self):
+        path = urlparse(self.path).path
+        body = self._body()
+        con = db()
+        try:
+            if path.startswith("/api/shells/") and path.count("/") == 3:
+                sid = int(path.rsplit("/", 1)[1])
+                ok, err = patch_columns(con, "shells", "shell_id", sid, body,
+                                        SHELL_EDITABLE)
+                return self._send(200 if ok else 400, {"ok": ok, "error": err})
+            if path.startswith("/api/flags/"):
+                fid = int(path.rsplit("/", 1)[1])
+                if body.get("resolved"):
+                    from datetime import date
+                    body.setdefault("resolved_date", date.today().isoformat())
+                ok, err = patch_columns(con, "flags", "flag_id", fid, body,
+                                        FLAG_EDITABLE | {"resolved_date"})
+                return self._send(200 if ok else 400, {"ok": ok, "error": err})
+            if path.startswith("/api/roadmap/"):
+                rid = int(path.rsplit("/", 1)[1])
+                ok, err = patch_columns(con, "roadmap", "feature_id", rid, body,
+                                        ROADMAP_EDITABLE)
+                return self._send(200 if ok else 400, {"ok": ok, "error": err})
+            if path.startswith("/api/documents/"):
+                did = int(path.rsplit("/", 1)[1])
+                ok, err = patch_document(con, did, body)
+                return self._send(200 if ok else 400, {"ok": ok, "error": err})
+            return self._send(404, {"error": "not found"})
+        except (ValueError, sqlite3.Error) as e:
+            return self._send(400, {"error": str(e)})
+        finally:
+            con.close()
+
+    def do_PUT(self):
+        # grant toggle: PUT /api/shells/{id}/skills/{skill_id}  {granted: bool}
+        path = urlparse(self.path).path
+        parts = path.strip("/").split("/")
+        con = db()
+        try:
+            if len(parts) == 5 and parts[1] == "shells" and parts[3] == "skills":
+                set_grant(con, int(parts[2]), int(parts[4]),
+                          bool(self._body().get("granted")))
+                return self._send(200, {"ok": True})
+            return self._send(404, {"error": "not found"})
+        except (ValueError, sqlite3.Error) as e:
+            return self._send(400, {"error": str(e)})
+        finally:
+            con.close()
+
+
+def main(argv):
+    port = None
+    if "--port" in argv:
+        port = int(argv[argv.index("--port") + 1])
+    if port is None:
+        port = ports_mod.resolve().get("port", 8800)
+    if not DB_PATH.exists():
+        sys.exit(f"server: no DB at {DB_PATH} — run `make rebuild` first.")
+    httpd = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    print(f"super-coder review layer → http://127.0.0.1:{port}  (DB: {DB_PATH.name})")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        httpd.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/ecosystem.config.cjs
+++ b/.super-coder/ecosystem.config.cjs
@@ -1,0 +1,40 @@
+// pm2 process definition for super-coder's review layer.
+//
+// One stdlib server (api/server.py) serves the JSON API + the static UI on this
+// fork's derived port (scripts/ports.py → .super-coder/instance.json). The pm2
+// process name is unique PER FORK ("sc-<repo>") so several forks — and the host
+// repo's own pm2 apps — coexist in the one shared pm2 daemon without clashing.
+//
+// `make up` runs `ports.py ensure` first, so instance.json exists before this
+// file is read.
+
+const path = require("path");
+const { execSync } = require("child_process");
+
+const ENGINE = __dirname;                       // .super-coder/
+const REPO_ROOT = path.join(ENGINE, "..");
+const py = process.env.SC_PYTHON || "python3";
+
+function ports() {
+  try {
+    return JSON.parse(execSync(`${py} ${path.join(ENGINE, "scripts/ports.py")} show`).toString());
+  } catch {
+    return { repo: path.basename(REPO_ROOT), port: 8800 };
+  }
+}
+const cfg = ports();
+
+module.exports = {
+  apps: [
+    {
+      name: `sc-${cfg.repo}`,
+      script: path.join(ENGINE, "api/server.py"),
+      interpreter: py,
+      args: `--port ${cfg.port}`,
+      cwd: REPO_ROOT,
+      autorestart: true,
+      max_restarts: 5,
+      env: { PYTHONUNBUFFERED: "1" },
+    },
+  ],
+};

--- a/.super-coder/scripts/ports.py
+++ b/.super-coder/scripts/ports.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Resolve this fork's localhost ports — deterministic per repo, never fixed.
+
+A super-coder fork runs *inside* a host repo that often has its own dev server,
+and several forks may run at once. So the port can't be hardcoded. Each fork
+derives a stable per-repo offset from its absolute path (sha1 % 100) and lands
+in a distinctive band well clear of the neighbors:
+
+    port = 8800 + offset     (away from superCC 8000 / dos-arch 8001, and the
+                              common host-app ports 3000 / 5173 / 8080)
+
+v1 runs a single server that serves both the JSON API and the static review UI
+on this one port — one port per fork, not two. The resolved port is persisted to
+`.super-coder/instance.json` (gitignored — per-instance, local, like the `.db`)
+so it stays stable across restarts and can be hand-overridden. At resolve time an
+occupied port is bumped to the next free offset and persisted, so a hash clash or
+busy port self-heals once.
+
+Usage:
+    python3 .super-coder/scripts/ports.py show     # print resolved ports (JSON)
+    python3 .super-coder/scripts/ports.py ensure    # resolve + persist instance.json
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+import sys
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+CONFIG = ENGINE / "instance.json"
+
+PORT_BASE = 8800
+SPAN = 100  # offsets 0..99 → port 8800-8899
+
+
+def _offset(seed: str) -> int:
+    return int(hashlib.sha1(seed.encode()).hexdigest(), 16) % SPAN
+
+
+def _free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            s.bind(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+
+
+def _derive() -> dict:
+    """Derive a fresh port from the repo path, bumping the offset past any
+    occupied port so it lands free."""
+    base = _offset(str(REPO_ROOT))
+    for i in range(SPAN):
+        port = PORT_BASE + (base + i) % SPAN
+        if _free(port):
+            break
+    else:  # pragma: no cover — all 100 offsets busy is implausible
+        port = PORT_BASE + base
+    return {"repo": REPO_ROOT.name, "port": port, "harness": "claude"}
+
+
+def resolve(persist: bool = False) -> dict:
+    """Return this fork's config. An existing instance.json wins (respects hand
+    edits) and is returned verbatim; otherwise derive a free port from the repo
+    path. `persist=True` writes it to instance.json so it stays stable. To force
+    a re-derive (e.g. after a port clash), delete the file."""
+    if CONFIG.exists():
+        try:
+            cfg = json.loads(CONFIG.read_text())
+            if "port" in cfg:
+                return cfg
+        except json.JSONDecodeError:
+            pass
+    cfg = _derive()
+    if persist:
+        CONFIG.write_text(json.dumps(cfg, indent=2) + "\n")
+    return cfg
+
+
+def main(argv: list[str]) -> int:
+    mode = argv[0] if argv else "show"
+    if mode == "ensure":
+        print(json.dumps(resolve(persist=True)))
+    elif mode == "show":
+        print(json.dumps(resolve(persist=False)))
+    elif mode == "port":          # bare integer, for shell/Makefile use
+        print(resolve(persist=False)["port"])
+    elif mode == "name":          # pm2 process name — unique per fork
+        print("sc-" + resolve(persist=False).get("repo", "fork"))
+    else:
+        sys.exit("usage: ports.py [show|ensure|port|name]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -1,0 +1,261 @@
+// super-coder review UI — vanilla JS, no build step. Talks to the same-origin
+// stdlib API. Read everything; edit only what the laws and freeze rules allow.
+
+const $ = (s, r = document) => r.querySelector(s);
+const el = (t, props = {}, ...kids) => {
+  const n = Object.assign(document.createElement(t), props);
+  for (const k of kids) n.append(k?.nodeType ? k : document.createTextNode(k ?? ""));
+  return n;
+};
+const esc = (s) => (s ?? "").replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+
+async function api(path, method = "GET", body) {
+  const r = await fetch("/api" + path, {
+    method, headers: body ? { "Content-Type": "application/json" } : {},
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await r.json().catch(() => ({}));
+  if (!r.ok) throw new Error(data.error || r.statusText);
+  return data;
+}
+
+function toast(msg) {
+  const t = el("div", { className: "toast" }, msg);
+  document.body.append(t);
+  setTimeout(() => t.remove(), 4000);
+}
+function setStatus(s) { $("#status").textContent = s; }
+
+// md-converter deep-link: the spec reuses ?c= (gzip+base64url). We don't have the
+// encoder client-side, so v1 links to the app with the doc title as a hint;
+// full ?c= encoding lands when the GUI shares superCC's Python encoder.
+const MDC = "https://md-converter.designs-os.com";
+
+// ── Shells ──────────────────────────────────────────────────────────────────
+async function renderShells(root) {
+  const { shells } = await api("/shells");
+  root.replaceChildren();
+  for (const s of shells) {
+    const full = await api("/shells/" + s.shell_id);
+    root.append(shellCard(full));
+  }
+}
+
+function field(label, value, key, sid) {
+  const ta = el("textarea", { value: value || "", rows: key === "current_state" ? 4 : 2 });
+  const save = el("button", { className: "act", textContent: "save" });
+  save.onclick = async () => {
+    try { await api("/shells/" + sid, "PATCH", { [key]: ta.value }); setStatus("saved " + key); }
+    catch (e) { toast("error: " + e.message); }
+  };
+  return el("div", {}, el("label", { className: "k", textContent: label }), ta, save);
+}
+
+function shellCard(s) {
+  const c = el("div", { className: "card" });
+  c.append(el("h2", {}, `${s.display_name} `, el("span", { className: "muted", textContent: "/" + (s.shortname || "") })));
+  c.append(el("div", { className: "muted" }, `${s.role || ""} — ${s.mandate || ""}`));
+
+  // editable operational fields
+  c.append(field("current_state", s.current_state, "current_state", s.shell_id));
+  c.append(field("connections", s.connections, "connections", s.shell_id));
+  c.append(field("workspace", s.workspace, "workspace", s.shell_id));
+
+  // skills + grants (editable)
+  const sk = el("div", {});
+  sk.append(el("label", { className: "k", textContent: "skills + grants" }));
+  for (const k of s.skills) {
+    const cb = el("input", { type: "checkbox", checked: !!k.granted });
+    cb.onchange = async () => {
+      try { await api(`/shells/${s.shell_id}/skills/${k.skill_id}`, "PUT", { granted: cb.checked }); setStatus("grant updated"); }
+      catch (e) { toast("error: " + e.message); cb.checked = !cb.checked; }
+    };
+    sk.append(el("div", { className: "list-skill" }, cb, el("b", {}, k.name),
+      el("span", { className: "muted", textContent: " — " + (k.description || "").split("\n")[0] })));
+  }
+  c.append(sk);
+
+  // seed + L&S — READ ONLY (no edit endpoint exists; law-curated)
+  if (s.seed?.length) {
+    const box = el("div", { className: "locked" });
+    box.append(el("label", { className: "k", textContent: "seed (read-only — shell-curated, Laws 2–4)" }));
+    for (const e of s.seed) box.append(el("div", { className: "seed-entry" },
+      el("div", { className: "d", textContent: e.entry_date }), el("div", {}, e.body)));
+    c.append(box);
+  }
+  if (s.lns?.length) {
+    const box = el("div", { className: "locked" });
+    box.append(el("label", { className: "k", textContent: "lessons & stances (read-only — Law 7)" }));
+    for (const e of s.lns) box.append(el("div", { className: "lns-entry" }, e.body));
+    c.append(box);
+  }
+  if (s.lineage_seed) {
+    const d = el("details", {}, el("summary", {}, "lineage seed (read-only)"));
+    d.append(el("div", { className: "locked seed-entry" }, s.lineage_seed));
+    c.append(d);
+  }
+  return c;
+}
+
+// ── Roadmap ───────────────────────────────────────────────────────────────────
+const STATUSES = ["brainstorm", "long_term", "near_term", "next", "shipped"];
+
+async function renderRoadmap(root) {
+  const { buckets } = await api("/roadmap");
+  root.replaceChildren();
+  for (const b of buckets) {
+    const sec = el("div", { className: "bucket" }, el("h2", {}, b.label));
+    for (const f of b.features) sec.append(featureCard(f));
+    root.append(sec);
+  }
+}
+
+function featureCard(f) {
+  const c = el("div", { className: "card" });
+  const head = el("h2", {}, f.title || "(untitled)");
+  if (f.owner) head.append(el("span", { className: "pill " + f.roadmap_status, textContent: " " + f.owner }));
+  c.append(head);
+
+  // editable: title / status / summary / sort
+  const title = el("input", { type: "text", value: f.title || "" });
+  const status = el("select", {});
+  for (const s of STATUSES) status.append(el("option", { value: s, selected: s === f.roadmap_status, textContent: s }));
+  const summary = el("textarea", { value: f.summary || "", rows: 2 });
+  const save = el("button", { className: "act", textContent: "save feature" });
+  save.onclick = async () => {
+    try { await api("/roadmap/" + f.feature_id, "PATCH", { title: title.value, roadmap_status: status.value, summary: summary.value }); setStatus("feature saved"); load("roadmap"); }
+    catch (e) { toast("error: " + e.message); }
+  };
+  c.append(el("div", { className: "grid2" },
+    el("span", { className: "k" }, "title"), title,
+    el("span", { className: "k" }, "status"), status,
+    el("span", { className: "k" }, "summary"), summary), save);
+
+  // documents — tabbed; non-frozen editable, frozen read-only
+  for (const d of f.documents || []) c.append(docBlock(d));
+
+  // open flags = blockers
+  if (f.open_flags?.length) {
+    const fl = el("div", {});
+    fl.append(el("label", { className: "k", textContent: "blockers (open flags)" }));
+    for (const x of f.open_flags) fl.append(el("div", { className: "tag" }, `${x.display_name || ""} ${x.description || ""}`));
+    c.append(fl);
+  }
+  return c;
+}
+
+function docBlock(d) {
+  const wrap = el("div", {});
+  const label = `${d.kind} v${d.seq}${d.frozen ? " · frozen " + (d.frozen_date || "") : ""}: ${d.title || ""}`;
+  const det = el("details", {}, el("summary", {}, label));
+  const ta = el("textarea", { rows: 12 });
+  const open = el("button", { className: "act", textContent: "open in md-converter ↗" });
+  open.onclick = () => window.open(MDC, "_blank");
+  det.ontoggle = async () => {
+    if (!det.open || ta.dataset.loaded) return;
+    const full = await api("/documents/" + d.document_id);
+    ta.value = full.body || ""; ta.dataset.loaded = "1";
+  };
+  det.append(ta);
+  if (d.frozen) {
+    ta.readOnly = true;
+    det.append(el("div", { className: "lock-note", textContent: "frozen — read-only. Open the next spec, don't edit this one." }), open);
+  } else {
+    const save = el("button", { className: "act primary", textContent: "save doc" });
+    save.onclick = async () => {
+      try { await api("/documents/" + d.document_id, "PATCH", { body: ta.value }); setStatus("doc saved"); }
+      catch (e) { toast("error: " + e.message); }
+    };
+    det.append(el("div", { className: "row" }, save, open));
+  }
+  wrap.append(det);
+  return wrap;
+}
+
+// ── Flags ──────────────────────────────────────────────────────────────────────
+async function renderFlags(root) {
+  const { flags, features } = await api("/flags");
+  root.replaceChildren();
+
+  // create
+  const card = el("div", { className: "card" });
+  card.append(el("h2", {}, "New flag"));
+  const name = el("input", { type: "text", placeholder: "display name (e.g. SC-001)" });
+  const desc = el("input", { type: "text", placeholder: "[Area] description | Blocker for: …" });
+  const feat = el("select", {});
+  feat.append(el("option", { value: "", textContent: "— no feature —" }));
+  for (const f of features) feat.append(el("option", { value: f.feature_id, textContent: f.title }));
+  const prio = el("select", {});
+  for (const p of ["High", "Medium", "Low"]) prio.append(el("option", { value: p, selected: p === "Medium", textContent: p }));
+  const create = el("button", { className: "act primary", textContent: "create flag" });
+  create.onclick = async () => {
+    if (!desc.value) return toast("description required");
+    try {
+      await api("/flags", "POST", { display_name: name.value || null, description: desc.value, feature_id: feat.value || null, priority: prio.value });
+      setStatus("flag created"); load("flags");
+    } catch (e) { toast("error: " + e.message); }
+  };
+  card.append(el("div", { className: "grid2" },
+    el("span", { className: "k" }, "name"), name,
+    el("span", { className: "k" }, "description"), desc,
+    el("span", { className: "k" }, "feature"), feat,
+    el("span", { className: "k" }, "priority"), prio), create);
+  root.append(card);
+
+  // grouped by feature
+  const byFeat = {};
+  for (const f of flags) (byFeat[f.feature_title || "— unlinked —"] ||= []).push(f);
+  for (const [title, list] of Object.entries(byFeat)) {
+    const c = el("div", { className: "card" });
+    c.append(el("h2", {}, title));
+    for (const f of list) c.append(flagRow(f));
+    root.append(c);
+  }
+}
+
+function flagRow(f) {
+  const row = el("div", { className: "flag" + (f.resolved ? " resolved" : "") });
+  row.append(el("span", { className: "pill " + (f.priority || "").toLowerCase() }, f.priority || ""));
+  const d = el("div", { className: "desc" });
+  d.append(el("b", {}, (f.display_name ? f.display_name + " " : "")), esc(f.description || ""));
+  if (f.resolved) d.append(el("div", { className: "tag" }, `resolved ${f.resolved_date || ""} — ${f.resolution_notes || ""}`));
+  row.append(d);
+  if (!f.resolved) {
+    const btn = el("button", { className: "act", textContent: "resolve" });
+    btn.onclick = async () => {
+      const notes = prompt("Resolution notes:");
+      if (notes === null) return;
+      try { await api("/flags/" + f.flag_id, "PATCH", { resolved: 1, resolution_notes: notes }); setStatus("flag resolved"); load("flags"); }
+      catch (e) { toast("error: " + e.message); }
+    };
+    row.append(btn);
+  }
+  return row;
+}
+
+// ── Tabs + boot ────────────────────────────────────────────────────────────────
+const VIEWS = {
+  shells: ["#view-shells", renderShells],
+  roadmap: ["#view-roadmap", renderRoadmap],
+  flags: ["#view-flags", renderFlags],
+};
+async function load(tab) {
+  const [sel, fn] = VIEWS[tab];
+  try { await fn($(sel)); } catch (e) { $(sel).replaceChildren(el("div", { className: "card" }, "error: " + e.message)); }
+}
+function show(tab) {
+  for (const b of document.querySelectorAll("nav button")) b.classList.toggle("active", b.dataset.tab === tab);
+  for (const k of Object.keys(VIEWS)) $(VIEWS[k][0]).hidden = k !== tab;
+  load(tab);
+}
+document.querySelectorAll("nav button").forEach((b) => (b.onclick = () => show(b.dataset.tab)));
+$("#snapshot").onclick = async () => {
+  setStatus("snapshotting…");
+  try { const r = await api("/snapshot", "POST"); toast(r.output || "done"); setStatus("snapshot done"); }
+  catch (e) { toast("error: " + e.message); }
+};
+(async () => {
+  try { const h = await api("/health"); $("#repo").textContent = h.repo; setStatus("port " + h.port); }
+  catch { setStatus("offline"); }
+  show("shells");
+})();

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>super-coder — review</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header>
+    <h1>super-coder<span id="repo"></span></h1>
+    <nav>
+      <button data-tab="shells" class="active">Shells</button>
+      <button data-tab="roadmap">Roadmap</button>
+      <button data-tab="flags">Flags</button>
+    </nav>
+    <div class="tools">
+      <span id="status" class="status"></span>
+      <button id="snapshot" title="make snapshot + render (precursor to B6 auto-commit)">snapshot ⤓</button>
+    </div>
+  </header>
+  <main>
+    <section id="view-shells" class="view"></section>
+    <section id="view-roadmap" class="view" hidden></section>
+    <section id="view-flags" class="view" hidden></section>
+  </main>
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -1,0 +1,78 @@
+:root {
+  --bg: #0f1115; --panel: #171a21; --panel2: #1e222b; --line: #2a2f3a;
+  --ink: #e6e9ef; --dim: #9aa3b2; --accent: #6ea8fe; --accent2: #2a3340;
+  --ok: #57c98a; --warn: #e0b252; --lock: #5a6373;
+  --r: 8px; font-synthesis: none;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--bg); color: var(--ink);
+  font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+header {
+  display: flex; align-items: center; gap: 1.5rem; padding: .7rem 1.2rem;
+  border-bottom: 1px solid var(--line); position: sticky; top: 0;
+  background: var(--bg); z-index: 5;
+}
+h1 { font-size: 1.05rem; margin: 0; font-weight: 650; letter-spacing: .2px; }
+h1 span { color: var(--dim); font-weight: 400; }
+h1 span::before { content: " / "; color: var(--line); }
+nav { display: flex; gap: .25rem; }
+nav button {
+  background: none; border: 1px solid transparent; color: var(--dim);
+  padding: .35rem .8rem; border-radius: var(--r); cursor: pointer; font: inherit;
+}
+nav button:hover { color: var(--ink); }
+nav button.active { background: var(--accent2); color: var(--ink); border-color: var(--line); }
+.tools { margin-left: auto; display: flex; align-items: center; gap: .8rem; }
+.status { color: var(--dim); font-size: .8rem; }
+#snapshot {
+  background: var(--panel2); color: var(--ink); border: 1px solid var(--line);
+  padding: .35rem .7rem; border-radius: var(--r); cursor: pointer; font: inherit;
+}
+#snapshot:hover { border-color: var(--accent); }
+main { padding: 1.2rem; max-width: 1100px; margin: 0 auto; }
+.view { display: grid; gap: 1rem; }
+
+.card {
+  background: var(--panel); border: 1px solid var(--line); border-radius: var(--r);
+  padding: 1rem 1.1rem;
+}
+.card h2 { margin: 0 0 .2rem; font-size: 1rem; }
+.muted { color: var(--dim); }
+.row { display: flex; gap: 1rem; flex-wrap: wrap; }
+.pill {
+  display: inline-block; font-size: .72rem; padding: .1rem .5rem; border-radius: 99px;
+  background: var(--accent2); color: var(--dim); border: 1px solid var(--line);
+}
+.pill.next { color: var(--accent); } .pill.shipped { color: var(--ok); }
+.grid2 { display: grid; grid-template-columns: 180px 1fr; gap: .4rem 1rem; align-items: start; }
+.grid2 > .k { color: var(--dim); }
+label.k { color: var(--dim); display: block; margin: .6rem 0 .2rem; font-size: .85rem; }
+textarea, input[type=text], select {
+  width: 100%; background: var(--panel2); color: var(--ink); border: 1px solid var(--line);
+  border-radius: 6px; padding: .5rem .6rem; font: inherit; resize: vertical;
+}
+textarea:focus, input:focus, select:focus { outline: 1px solid var(--accent); }
+button.act {
+  background: var(--accent2); color: var(--ink); border: 1px solid var(--line);
+  padding: .4rem .8rem; border-radius: 6px; cursor: pointer; font: inherit; margin-top: .5rem;
+}
+button.act:hover { border-color: var(--accent); }
+button.act.primary { background: var(--accent); color: #0b0e13; border-color: var(--accent); }
+.locked {
+  border-left: 2px solid var(--lock); padding-left: .8rem; color: var(--dim);
+}
+.lock-note { font-size: .72rem; color: var(--lock); }
+.seed-entry, .lns-entry { margin: .5rem 0; padding-left: .6rem; border-left: 1px solid var(--line); }
+.seed-entry .d { color: var(--dim); font-size: .78rem; }
+details summary { cursor: pointer; color: var(--accent); }
+.bucket > h2 { font-size: .8rem; text-transform: uppercase; letter-spacing: .08em; color: var(--dim); margin: 1.4rem 0 .5rem; }
+.doc-body { white-space: pre-wrap; background: var(--panel2); border: 1px solid var(--line); border-radius: 6px; padding: .8rem; max-height: 420px; overflow: auto; font: 12.5px/1.55 ui-monospace, monospace; }
+.flag { display: flex; gap: .8rem; align-items: flex-start; padding: .6rem 0; border-bottom: 1px solid var(--line); }
+.flag.resolved { opacity: .5; }
+.flag .desc { flex: 1; }
+.tag { font-size: .72rem; color: var(--dim); }
+a { color: var(--accent); }
+.list-skill { display: flex; align-items: center; gap: .5rem; padding: .2rem 0; }
+.toast { position: fixed; bottom: 1rem; right: 1rem; background: var(--panel2); border: 1px solid var(--accent); border-radius: var(--r); padding: .6rem 1rem; max-width: 420px; white-space: pre-wrap; font: 12px/1.5 ui-monospace, monospace; }

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ ENGINE := .super-coder
 DB     := $(ENGINE)/shell_db.db
 PY     := python3
 
-.PHONY: help rebuild migrate snapshot render seed-skills init launch launch-% verify clean-db
+ECO    := $(ENGINE)/ecosystem.config.cjs
+
+.PHONY: help rebuild migrate snapshot render seed-skills init launch launch-% verify clean-db up down restart health serve ports
 
 help:
 	@echo "super-coder — forkable shell substrate"
@@ -16,6 +18,10 @@ help:
 	@echo "  make launch              username auth + pick shell + render boot + exec harness"
 	@echo "  make launch-<shortname>  boot that shell directly (skip picker)"
 	@echo "  make verify              rebuild + flat render + render-only boot (headless proof)"
+	@echo "  make up / down / restart start/stop the localhost review layer (pm2, per-fork port)"
+	@echo "  make serve               run the review layer in the foreground (no pm2)"
+	@echo "  make health              curl the review layer's /api/health"
+	@echo "  make ports               show this fork's derived port"
 	@echo "  make clean-db            remove the rebuilt $(DB) (text serializations untouched)"
 
 rebuild:
@@ -46,6 +52,25 @@ verify:
 	@$(PY) $(ENGINE)/scripts/rebuild.py
 	@$(PY) $(ENGINE)/scripts/render.py flat
 	@RENDER_ONLY=1 $(PY) $(ENGINE)/scripts/run.py --first
+
+ports:
+	@$(PY) $(ENGINE)/scripts/ports.py show
+
+up:
+	@$(PY) $(ENGINE)/scripts/ports.py ensure >/dev/null
+	@pm2 start $(ECO) && echo "→ review layer up at http://127.0.0.1:$$($(PY) $(ENGINE)/scripts/ports.py port)"
+
+down:
+	@pm2 delete $(ECO) 2>/dev/null && echo "→ review layer stopped" || echo "→ not running"
+
+restart:
+	@pm2 restart $(ECO)
+
+serve:
+	@$(PY) $(ENGINE)/api/server.py
+
+health:
+	@curl -s http://127.0.0.1:$$($(PY) $(ENGINE)/scripts/ports.py port)/api/health && echo ""
 
 clean-db:
 	@rm -f $(DB) $(DB)-wal $(DB)-shm && echo "removed $(DB) (rebuild with: make rebuild)"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,33 @@ make verify              # rebuild + flat render + headless boot (no exec) — t
 make help                # all targets
 ```
 
+## Review layer (localhost GUI)
+
+A zero-dependency localhost GUI to review the substrate — shells, roadmap,
+flags. One stdlib Python server serves both the JSON API and a static UI; no
+venv, no npm, no build step.
+
+```bash
+make up        # start it (pm2) on this fork's derived port
+make health    # curl /api/health
+make down      # stop it
+make serve     # run it in the foreground (no pm2)
+make ports     # show this fork's derived port
+```
+
+**Ports are derived per repo**, never fixed — because a fork runs *inside* a
+host repo that may have its own dev server, and several forks can run at once.
+Each fork hashes its path to a stable port in the `88xx` band (clear of superCC
+8000 / dos-arch 8001 and common host ports), persisted to a gitignored
+`.super-coder/instance.json` you can hand-edit. Two forks won't collide.
+
+What you can do in the GUI: read everything; edit a shell's operational fields
+(`current_state`, `connections`, `workspace`) and skill grants; edit the roadmap
+and **non-frozen** documents; create and resolve flags. **seed and L&S are
+read-only** — the laws say the shell curates them, so the API ships no endpoint
+to write them at all. A `snapshot ⤓` button re-serializes + renders after edits
+(the manual precursor to the B6 commit→PR automation).
+
 The live `.super-coder/shell_db.db` is **gitignored and rebuilt** from
 git-tracked text. See `.super-coder/README.md` for the full model.
 


### PR DESCRIPTION
## B3 — GUI review layer

A localhost review layer over the live `shell_db.db` — **Shells / Roadmap / Flags**.

### Built dependency-free (deliberate deviation)
Spec said FastAPI + SvelteKit (mirror superCC); this ships a **stdlib HTTP server** (`api/server.py`) serving the JSON API **+ a static vanilla-JS UI** (`ui/`) on one port. Why: super-coder forks into arbitrary repos — a per-fork venv (FastAPI) + `npm install`/build (SvelteKit) makes every install heavy and competes with the host app's toolchain. This needs only `python3` (already required), keeps forks light, and meets the spec's intent. Upgradeable later.

### Law enforcement is structural
seed + L&S have **no write route at all** (Laws 2–4, 7) — an absent endpoint, not a disabled control. Frozen documents reject edits server-side. Editable: a shell's operational fields (`current_state`/`connections`/`workspace`) + skill grants, the roadmap, and non-frozen docs; flags create/resolve. `POST /api/snapshot` runs snapshot + render (manual precursor to B6).

### Per-fork ports — derive from repo
`port = 8800 + sha1(repo path) % 100`, bumped past anything occupied, persisted to the gitignored `instance.json` (hand-overridable). One server = one port per fork; deterministic so forks auto-separate and stay stable across restarts — clear of superCC (8000/5173), dos-arch (8001/5174), and the host app. pm2 process named `sc-<repo>` so forks + the host's own pm2 apps never clash. `make up/down/restart/serve/health/ports`.

### Verification
Running via pm2: `/api/health`, shells, roadmap, flags serve; flag create+resolve, `current_state` edit, grant toggle work; **law guard** (seed/system_prompt PATCH rejected, no seed route) + **freeze guard** confirmed; no port collision; `make down` removes only this fork's process.

Decision #187. Resolves the spec's open "GUI edit policy" question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)