### PR TITLE
feat: roadmap funnel + In Progress, Scripts & Docs tabs, md-converter open

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -19,14 +19,18 @@ Run:
 """
 from __future__ import annotations
 
+import base64
+import gzip
 import json
 import sqlite3
+import subprocess
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import urlparse
 
 ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
 DB_PATH = ENGINE / "shell_db.db"
 UI_DIR = ENGINE / "ui"
 
@@ -39,6 +43,19 @@ _STATIC = {
     "/app.js": ("app.js", "application/javascript; charset=utf-8"),
     "/style.css": ("style.css", "text/css; charset=utf-8"),
 }
+
+# md-converter inline deep-link. The doc's markdown rides IN the URL as the `c=`
+# param — gzip → base64url (no padding) — which the live md-converter decodes on
+# mount (src/lib/inline). One source: no md-converter fork, no upload, no fetch.
+# Contract is byte-identical to its TS encoder; mtime=0 keeps the URL deterministic.
+MDC_BASE = "https://md-converter.designs-os.com"
+
+
+def mdc_url(markdown: str) -> str:
+    packed = base64.urlsafe_b64encode(
+        gzip.compress((markdown or "").encode(), mtime=0)).rstrip(b"=").decode()
+    return f"{MDC_BASE}/?c={packed}"
+
 
 # Shell fields the review layer may write. seed/L&S/system_prompt/mandate are
 # deliberately ABSENT — the law says the shell curates them, so there is no door.
@@ -94,9 +111,10 @@ def get_shell(con, sid: int) -> dict | None:
     return shell
 
 
-_ORDER = ["next", "near_term", "long_term", "brainstorm", "shipped"]
-_LABEL = {"next": "Next", "near_term": "Near term", "long_term": "Long term",
-          "brainstorm": "Brainstorm", "shipped": "Shipped"}
+# Funnel order: idea inlet → most-active committed work → done.
+_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped"]
+_LABEL = {"brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Next",
+          "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped"}
 
 
 def get_roadmap(con) -> dict:
@@ -104,10 +122,12 @@ def get_roadmap(con) -> dict:
         "SELECT r.feature_id, r.title, r.roadmap_status, r.sort_order, r.summary, "
         "s.shortname AS owner FROM roadmap r LEFT JOIN shells s "
         "ON s.shell_id=r.owning_shell ORDER BY r.sort_order, r.feature_id"))
+    # Roadmap tracks the development cycle = the SPECS. Docs (kind='doc') live on
+    # their own tab.
     docs_by: dict[int, list] = {}
     for d in rows(con.execute(
             "SELECT document_id, feature_id, kind, seq, title, frozen, frozen_date, "
-            "render_path FROM documents ORDER BY feature_id, kind, seq")):
+            "render_path FROM documents WHERE kind='spec' ORDER BY feature_id, seq")):
         docs_by.setdefault(d["feature_id"], []).append(d)
     flags_by: dict[int, list] = {}
     for f in rows(con.execute(
@@ -121,6 +141,16 @@ def get_roadmap(con) -> dict:
                 "features": [f for f in feats if f["roadmap_status"] == s]}
                for s in _ORDER]
     return {"buckets": [b for b in buckets if b["features"]]}
+
+
+def get_docs(con) -> dict:
+    """Documentation (kind='doc'), grouped client-side by feature. Distinct from
+    the spec dev-cycle the roadmap tracks."""
+    return {"docs": rows(con.execute(
+        "SELECT d.document_id, d.feature_id, d.kind, d.seq, d.title, d.frozen, "
+        "d.frozen_date, r.title AS feature_title FROM documents d "
+        "LEFT JOIN roadmap r ON r.feature_id = d.feature_id "
+        "WHERE d.kind='doc' ORDER BY d.feature_id, d.seq"))}
 
 
 def get_flags(con) -> dict:
@@ -182,16 +212,52 @@ def set_grant(con, sid, skill_id, granted):
     con.commit()
 
 
-def run_snapshot_render():
-    """Serialize + render after edits (manual precursor to the B6 automation)."""
-    import subprocess
-    out = []
-    for script in ("snapshot.py", "render.py"):
-        arg = ["flat"] if script == "render.py" else []
-        p = subprocess.run([sys.executable, str(ENGINE / "scripts" / script), *arg],
-                           capture_output=True, text=True)
-        out.append((p.stdout + p.stderr).strip())
-    return "\n".join(out)
+# Whitelisted maintenance scripts runnable from the GUI. Each is a fixed argv —
+# the GUI passes only a registry KEY, never a command, so nothing arbitrary runs.
+# Order = display order; `danger` ones prompt for confirmation in the UI.
+_PY = sys.executable
+_SCRIPTS = {
+    "snapshot": ("Snapshot", "Serialize the per-instance tables → snapshot/content.sql "
+                 "(deterministic, idempotent). Run after editing identity, roadmap, "
+                 "docs, or flags so the change survives a rebuild.",
+                 [_PY, str(ENGINE / "scripts/snapshot.py")], False),
+    "render": ("Render flat", "Regenerate the tracked flat _sc files "
+               "(specs_sc / docs_sc / skills_sc / roadmap_sc.md) from the DB. Incremental.",
+               [_PY, str(ENGINE / "scripts/render.py"), "flat"], False),
+    "seed_skills": ("Seed skills", "Recompile assets/skills/ into the skills seed migration "
+                    "(migrations/0001_seed_skills.sql). Run after editing a skill body.",
+                    [_PY, str(ENGINE / "scripts/seed_skills.py")], False),
+    "migrate": ("Migrate", "Apply any pending migrations to the live DB (ledger-tracked).",
+                [_PY, str(ENGINE / "scripts/migrate.py"), str(DB_PATH)], False),
+    "rebuild": ("Rebuild DB", "Rebuild shell_db.db from schema + migrations + snapshot "
+                "(backs up the current DB first). Discards any DB edits you have NOT "
+                "snapshotted.", [_PY, str(ENGINE / "scripts/rebuild.py")], True),
+}
+
+
+def script_list() -> list[dict]:
+    return [{"key": k, "name": v[0], "desc": v[1], "danger": v[3]}
+            for k, v in _SCRIPTS.items()]
+
+
+def run_script(key: str) -> dict | None:
+    spec = _SCRIPTS.get(key)
+    if not spec:
+        return None
+    argv = spec[2]
+    try:
+        p = subprocess.run(argv, capture_output=True, text=True,
+                           cwd=str(REPO_ROOT), timeout=180)
+        return {"ok": p.returncode == 0, "code": p.returncode,
+                "output": (p.stdout + p.stderr).strip() or "(no output)"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "code": -1, "output": "timed out (>180s)"}
+
+
+def run_snapshot_render() -> str:
+    """The header 'snapshot ⤓' shortcut — serialize then render."""
+    return (run_script("snapshot")["output"] + "\n"
+            + run_script("render")["output"]).strip()
 
 
 # ── HTTP ──────────────────────────────────────────────────────────────────────
@@ -207,6 +273,11 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+    def _redirect(self, location: str):
+        self.send_response(302)
+        self.send_header("Location", location)
+        self.end_headers()
 
     def _body(self) -> dict:
         n = int(self.headers.get("Content-Length") or 0)
@@ -246,16 +317,27 @@ class Handler(BaseHTTPRequestHandler):
                                   shell or {"error": "no such shell"})
             if path == "/api/roadmap":
                 return self._send(200, get_roadmap(con))
+            if path == "/api/docs":
+                return self._send(200, get_docs(con))
             if path.startswith("/api/documents/"):
-                did = int(path.rsplit("/", 1)[1])
+                parts = path.strip("/").split("/")   # api documents {id} [open]
+                did = int(parts[2])
+                if len(parts) == 4 and parts[3] == "open":
+                    r = con.execute("SELECT body FROM documents WHERE document_id=?",
+                                    (did,)).fetchone()
+                    if r is None:
+                        return self._send(404, {"error": "no such document"})
+                    return self._redirect(mdc_url(r["body"]))
                 r = con.execute("SELECT * FROM documents WHERE document_id=?",
                                 (did,)).fetchone()
                 return self._send(200 if r else 404,
                                   dict(r) if r else {"error": "no such document"})
             if path == "/api/flags":
                 return self._send(200, get_flags(con))
+            if path == "/api/scripts":
+                return self._send(200, {"scripts": script_list()})
             return self._send(404, {"error": "not found"})
-        except (ValueError, sqlite3.Error) as e:
+        except Exception as e:
             return self._send(400, {"error": str(e)})
         finally:
             con.close()
@@ -270,8 +352,13 @@ class Handler(BaseHTTPRequestHandler):
                                   {"error": err} if err else {"flag_id": fid})
             if path == "/api/snapshot":
                 return self._send(200, {"output": run_snapshot_render()})
+            if path.startswith("/api/scripts/"):
+                r = run_script(path.rsplit("/", 1)[1])
+                if r is None:
+                    return self._send(404, {"error": "no such script"})
+                return self._send(200 if r["ok"] else 500, r)
             return self._send(404, {"error": "not found"})
-        except (ValueError, sqlite3.Error) as e:
+        except Exception as e:
             return self._send(400, {"error": str(e)})
         finally:
             con.close()
@@ -304,7 +391,7 @@ class Handler(BaseHTTPRequestHandler):
                 ok, err = patch_document(con, did, body)
                 return self._send(200 if ok else 400, {"ok": ok, "error": err})
             return self._send(404, {"error": "not found"})
-        except (ValueError, sqlite3.Error) as e:
+        except Exception as e:
             return self._send(400, {"error": str(e)})
         finally:
             con.close()
@@ -320,7 +407,7 @@ class Handler(BaseHTTPRequestHandler):
                           bool(self._body().get("granted")))
                 return self._send(200, {"ok": True})
             return self._send(404, {"error": "not found"})
-        except (ValueError, sqlite3.Error) as e:
+        except Exception as e:
             return self._send(400, {"error": str(e)})
         finally:
             con.close()

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -83,11 +83,11 @@ def render_projects(con, shell_id: int) -> str:
     return "\n".join(lines)
 
 
-# Display order: nearest-horizon buckets first; brainstorm last.
-_ROADMAP_ORDER = ["next", "near_term", "long_term", "brainstorm", "shipped"]
+# Funnel order: idea inlet → most-active committed work → done (shipped, summarized).
+_ROADMAP_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped"]
 _ROADMAP_LABEL = {
-    "next": "Next", "near_term": "Near term", "long_term": "Long term",
-    "brainstorm": "Brainstorm", "shipped": "Shipped",
+    "brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Next",
+    "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped",
 }
 
 

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -38,20 +38,23 @@ BANNER_KEYS = [
 ]
 
 
-def with_banner(body: str) -> str:
-    """Stamp the render banner onto a markdown body.
+def with_banner(body: str, extra: list[str] | None = None) -> str:
+    """Stamp the render banner (+ optional `extra` frontmatter keys) onto a body.
 
     A document body may already open with its own YAML frontmatter (themed
     markdown does). YAML frontmatter must be the very first thing in the file,
-    so we cannot prepend a second block — instead we splice the banner keys into
-    the existing frontmatter. Bodies with no frontmatter get a fresh banner
-    block. Either way the warning travels with the file and the YAML stays valid.
+    so we cannot prepend a second block — instead we splice the keys into the
+    existing frontmatter. Bodies with no frontmatter get a fresh banner block.
+    Either way the warning + metadata travel with the file and the YAML stays
+    valid. `extra` carries per-document metadata (feature, roadmap_status,
+    frozen) so a reader of the rendered spec sees where its feature sits.
     """
+    keys = [*BANNER_KEYS, *(extra or [])]
     body = body.lstrip("\n")
     lines = body.split("\n")
     if lines and lines[0].strip() == "---":
-        return "\n".join([lines[0], *BANNER_KEYS, *lines[1:]])
-    return "\n".join(["---", *BANNER_KEYS, "---", "", body])
+        return "\n".join([lines[0], *keys, *lines[1:]])
+    return "\n".join(["---", *keys, "---", "", body])
 
 
 # ── Incremental writer ──────────────────────────────────────────────────────
@@ -76,8 +79,10 @@ def _render_documents(con, written, skipped) -> None:
     derive a stable path from kind + title.
     """
     rows = con.execute(
-        "SELECT feature_id, kind, seq, title, body, render_path FROM documents "
-        "ORDER BY feature_id, kind, seq"
+        "SELECT d.feature_id, d.kind, d.seq, d.title, d.body, d.render_path, "
+        "d.frozen, r.roadmap_status, r.title AS feature_title FROM documents d "
+        "LEFT JOIN roadmap r ON r.feature_id = d.feature_id "
+        "ORDER BY d.feature_id, d.kind, d.seq"
     ).fetchall()
     for r in rows:
         if not r["body"]:
@@ -89,13 +94,21 @@ def _render_documents(con, written, skipped) -> None:
             slug = slug.lower().replace(" ", "-").replace("—", "-")
             slug = "".join(c for c in slug if c.isalnum() or c in "-_")
             rel = f"{base}/{slug}.md"
-        _write_if_changed(REPO_ROOT / rel, with_banner(r["body"]), written, skipped)
+        # Per-document metadata into the rendered frontmatter — where the
+        # feature sits in the plan + whether this spec is frozen.
+        extra = [
+            f"feature: {r['feature_title'] or ''}",
+            f"roadmap_status: {r['roadmap_status'] or ''}",
+            f"frozen: {'true' if r['frozen'] else 'false'}",
+        ]
+        _write_if_changed(REPO_ROOT / rel, with_banner(r["body"], extra),
+                          written, skipped)
 
 
-_ROADMAP_ORDER = ["next", "near_term", "long_term", "brainstorm", "shipped"]
+_ROADMAP_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped"]
 _ROADMAP_LABEL = {
-    "next": "Next", "near_term": "Near term", "long_term": "Long term",
-    "brainstorm": "Brainstorm", "shipped": "Shipped",
+    "brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Next",
+    "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped",
 }
 
 

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -120,8 +120,9 @@ CREATE TABLE roadmap (
     feature_id     INTEGER PRIMARY KEY AUTOINCREMENT,
     title          TEXT    NOT NULL,
     roadmap_status TEXT    NOT NULL DEFAULT 'brainstorm'
+                   -- funnel order: idea inlet → most-active committed work → done.
                    CHECK (roadmap_status IN
-                       ('brainstorm','long_term','near_term','next','shipped')),
+                       ('brainstorm','in_progress','next','near_term','long_term','shipped')),
     sort_order     INTEGER NOT NULL DEFAULT 0,   -- ordering within a bucket
     owning_shell   INTEGER REFERENCES shells(shell_id),
     summary        TEXT,

--- a/.super-coder/snapshot/content.sql
+++ b/.super-coder/snapshot/content.sql
@@ -38,7 +38,7 @@ Write as it happens, not at close. The `.db` is a cache: after content edits,
 
 Build and maintain the substrate every fork runs on. You keep the system; each
 fork runs its own shells. Regional manager, not field worker.
-', 'B0 spine + B2 content/render done. Identity SET: succession child of CC, Lineage Seed + genesis seed planted. super-coder feature on roadmap (next); founding spec frozen (doc seq 1). Flat _sc render live; skills (db_map, snapshot) seeded + rendered to .claude/skills/. NEXT: B1 installer or B3 GUI.', NULL, 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
+', 'edited via review layer', NULL, 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
 Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
 
 1. You are the DB, not the process. Continuity is the data — identity, memory,
@@ -66,7 +66,15 @@ DELETE FROM shell_decisions;
 DELETE FROM shell_memory_archives;
 
 DELETE FROM roadmap;
-INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (1, 'super-coder', 'next', 0, 1, 'The substrate itself: data layer we build, harness we rent. v1 targets Claude Code + OpenCode; GUI review layer; fork + reseed.', '2026-06-04 10:30:53', '2026-06-04 10:30:53');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (1, 'super-coder', 'in_progress', 0, 1, 'The substrate itself: data layer we build, harness we rent. v1 targets Claude Code + OpenCode; GUI review layer; fork + reseed.', '2026-06-04 10:30:53', '2026-06-04 10:30:53');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (2, 'B0 — Core spine', 'shipped', 0, 1, 'Repo skeleton, schema, migrations, DB rebuild-from-text, render→boot (CLAUDE.md + AGENTS.md). PR #-/a1cc1e2.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (3, 'B2 — Content & render', 'shipped', 1, 1, 'Flat _sc render, per-shell SKILL.md, skill seed pipeline. PR #1.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (4, 'B3 — Review layer', 'shipped', 2, 1, 'Dependency-free localhost GUI (shells/roadmap/flags), per-fork ports. PR #3.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (5, 'B1 — First-launch installer', 'next', 0, 1, 'Full installer on top of init_fork: requirements check, harness auto-detect, slot-filled shell_system_prompt template.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (6, 'B6 — Commit→PR automation', 'next', 1, 1, 'edit→snapshot→render→commit→PR; per-shell-branch concurrency. The snapshot button is the manual precursor.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (7, 'B4 — OpenCode adapter', 'near_term', 0, 1, 'Emit opencode.json + verify the research-flagged items; boot already dual-writes AGENTS.md + SKILL.md.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (8, 'B5 — Onboarding & mapping', 'long_term', 0, 1, 'Install-time dr_* mapper (generalized) + one-time first-runtime ingest skill.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (9, 'Fork to sibling repos', 'brainstorm', 0, 1, 'Fork super-coder into dos-arch / rst-c / emergence / md-converter; reseed pattern.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
 
 DELETE FROM documents;
 INSERT INTO documents (document_id, feature_id, kind, seq, title, frozen, frozen_date, body, render_path, created_at, updated_at) VALUES (1, 1, 'spec', 1, 'super-coder — Founding Spec', 1, '2026-06-04', '---
@@ -594,6 +602,7 @@ Spec :::class3 -> Build super-coder :::class1 -> Fork to repos :::class2 -> Migr
 ', 'specs_sc/super-coder-founding-spec.md', '2026-06-04 10:30:53', '2026-06-04 10:30:53');
 
 DELETE FROM flags;
+INSERT INTO flags (flag_id, display_name, priority, description, created_date, resolved_date, resolved, shell_id, feature_id, resolution_notes, parent_flag_id, is_deleted) VALUES (1, 'SC-001', 'Low', '[Test] review layer smoke flag | Blocker for: nothing', '2026-06-04', '2026-06-04', 1, NULL, 1, 'smoke test done', NULL, 0);
 
 DELETE FROM projects;
 INSERT INTO projects (project_id, shortname, title, purpose, standing, status, is_deleted, created_at) VALUES (1, 'super-coder', 'super-coder', 'Forkable shell substrate for a single repo — DB-backed identity, memory, roadmap, content; harness-agnostic boot.', NULL, 'active', 0, '2026-06-04 10:30:53');
@@ -602,7 +611,7 @@ DELETE FROM project_shells;
 INSERT INTO project_shells (project_shell_id, project_id, shell_id, role, added_date, is_deleted) VALUES (1, 1, 1, 'maintainer', '2026-06-04', 0);
 
 DELETE FROM shell_skills;
-INSERT INTO shell_skills (shell_skill_id, shell_id, skill_id) VALUES (1, 1, 1);
 INSERT INTO shell_skills (shell_skill_id, shell_id, skill_id) VALUES (2, 1, 2);
+INSERT INTO shell_skills (shell_skill_id, shell_id, skill_id) VALUES (3, 1, 1);
 
 COMMIT;

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -26,11 +26,6 @@ function toast(msg) {
 }
 function setStatus(s) { $("#status").textContent = s; }
 
-// md-converter deep-link: the spec reuses ?c= (gzip+base64url). We don't have the
-// encoder client-side, so v1 links to the app with the doc title as a hint;
-// full ?c= encoding lands when the GUI shares superCC's Python encoder.
-const MDC = "https://md-converter.designs-os.com";
-
 // ── Shells ──────────────────────────────────────────────────────────────────
 async function renderShells(root) {
   const { shells } = await api("/shells");
@@ -98,12 +93,31 @@ function shellCard(s) {
 }
 
 // ── Roadmap ───────────────────────────────────────────────────────────────────
-const STATUSES = ["brainstorm", "long_term", "near_term", "next", "shipped"];
+// Funnel order: idea inlet → most-active committed work → done.
+const STATUSES = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped"];
+const SLABEL = { brainstorm: "Brainstorm", in_progress: "In Progress", next: "Next", near_term: "Near Term", long_term: "Long Term", shipped: "Shipped" };
+const roadmapFilter = new Set();   // empty = show all (default)
 
 async function renderRoadmap(root) {
   const { buckets } = await api("/roadmap");
   root.replaceChildren();
-  for (const b of buckets) {
+
+  // grouped status toggle-filters; none selected = all shown
+  const bar = el("div", { className: "filters" });
+  for (const s of STATUSES) {
+    const chip = el("button", { className: "chip" + (roadmapFilter.has(s) ? " on" : ""), textContent: SLABEL[s] });
+    chip.onclick = () => {
+      roadmapFilter.has(s) ? roadmapFilter.delete(s) : roadmapFilter.add(s);
+      renderRoadmap(root);
+    };
+    bar.append(chip);
+  }
+  root.append(bar);
+
+  // buckets arrive linear from the API; filter to the selected statuses
+  const shown = roadmapFilter.size ? buckets.filter((b) => roadmapFilter.has(b.status)) : buckets;
+  if (!shown.length) { root.append(el("div", { className: "muted" }, "No features in the selected stage(s).")); return; }
+  for (const b of shown) {
     const sec = el("div", { className: "bucket" }, el("h2", {}, b.label));
     for (const f of b.features) sec.append(featureCard(f));
     root.append(sec);
@@ -144,32 +158,63 @@ function featureCard(f) {
   return c;
 }
 
+// A document row: the primary action OPENS it rendered in md-converter (the
+// markdown rides in the URL via /open → ?c=). No inline raw-markdown expand.
+// Non-frozen docs get an explicit "edit" toggle; frozen ones are read-only.
 function docBlock(d) {
-  const wrap = el("div", {});
+  const wrap = el("div", { className: "docrow" });
   const label = `${d.kind} v${d.seq}${d.frozen ? " · frozen " + (d.frozen_date || "") : ""}: ${d.title || ""}`;
-  const det = el("details", {}, el("summary", {}, label));
-  const ta = el("textarea", { rows: 12 });
-  const open = el("button", { className: "act", textContent: "open in md-converter ↗" });
-  open.onclick = () => window.open(MDC, "_blank");
-  det.ontoggle = async () => {
-    if (!det.open || ta.dataset.loaded) return;
-    const full = await api("/documents/" + d.document_id);
-    ta.value = full.body || ""; ta.dataset.loaded = "1";
-  };
-  det.append(ta);
-  if (d.frozen) {
-    ta.readOnly = true;
-    det.append(el("div", { className: "lock-note", textContent: "frozen — read-only. Open the next spec, don't edit this one." }), open);
-  } else {
+  const open = el("a", {
+    className: "act primary", href: "/api/documents/" + d.document_id + "/open",
+    target: "_blank", rel: "noopener", textContent: "open in md-converter ↗",
+  });
+  const head = el("div", { className: "docrow-head" }, el("span", { className: "docrow-label" }, label), open);
+  wrap.append(head);
+
+  if (!d.frozen) {
+    const box = el("div", { hidden: true });
+    const ta = el("textarea", { rows: 14 });
     const save = el("button", { className: "act primary", textContent: "save doc" });
     save.onclick = async () => {
       try { await api("/documents/" + d.document_id, "PATCH", { body: ta.value }); setStatus("doc saved"); }
       catch (e) { toast("error: " + e.message); }
     };
-    det.append(el("div", { className: "row" }, save, open));
+    const edit = el("button", { className: "act", textContent: "edit" });
+    edit.onclick = async () => {
+      box.hidden = !box.hidden;
+      if (!box.hidden && !ta.dataset.loaded) {
+        const full = await api("/documents/" + d.document_id);
+        ta.value = full.body || ""; ta.dataset.loaded = "1";
+      }
+    };
+    head.append(edit);
+    box.append(ta, save);
+    wrap.append(box);
+  } else {
+    wrap.append(el("div", { className: "lock-note", textContent: "frozen — read-only. Open the next spec, don't edit this one." }));
   }
-  wrap.append(det);
   return wrap;
+}
+
+// ── Docs ──────────────────────────────────────────────────────────────────────
+async function renderDocs(root) {
+  const { docs } = await api("/docs");
+  root.replaceChildren();
+  root.append(el("div", { className: "muted" },
+    "Documentation (kind=doc), separate from the spec dev-cycle on the Roadmap. Open renders in md-converter."));
+  if (!docs.length) {
+    root.append(el("div", { className: "card muted" },
+      "No docs yet. A doc is a kind='doc' document against a feature — authored by the shell, viewable here."));
+    return;
+  }
+  const byFeat = {};
+  for (const d of docs) (byFeat[d.feature_title || "— unlinked —"] ||= []).push(d);
+  for (const [title, list] of Object.entries(byFeat)) {
+    const c = el("div", { className: "card" });
+    c.append(el("h2", {}, title));
+    for (const d of list) c.append(docBlock(d));
+    root.append(c);
+  }
 }
 
 // ── Flags ──────────────────────────────────────────────────────────────────────
@@ -233,11 +278,42 @@ function flagRow(f) {
   return row;
 }
 
+// ── Scripts ─────────────────────────────────────────────────────────────────────
+async function renderScripts(root) {
+  const { scripts } = await api("/scripts");
+  root.replaceChildren();
+  root.append(el("div", { className: "muted" },
+    "Run a maintenance script. Output appears below it. Per-instance DB edits → run Snapshot, then Render flat, to persist them to git-tracked text."));
+  for (const s of scripts) {
+    const c = el("div", { className: "card" });
+    const h = el("h2", {}, s.name);
+    if (s.danger) h.append(el("span", { className: "pill warn", textContent: " danger" }));
+    c.append(h, el("div", { className: "muted" }, s.desc));
+    const out = el("pre", { className: "doc-body", hidden: true });
+    const run = el("button", { className: "act" + (s.danger ? "" : " primary"), textContent: "run" });
+    run.onclick = async () => {
+      if (s.danger && !confirm(`Run "${s.name}"?\n\n${s.desc}`)) return;
+      run.disabled = true; setStatus("running " + s.key + "…");
+      try {
+        const r = await fetch("/api/scripts/" + s.key, { method: "POST" });
+        const data = await r.json();
+        out.hidden = false; out.textContent = data.output || "(done)";
+        setStatus(data.ok ? s.key + " ✓" : s.key + " failed (" + data.code + ")");
+      } catch (e) { out.hidden = false; out.textContent = "error: " + e.message; }
+      finally { run.disabled = false; }
+    };
+    c.append(run, out);
+    root.append(c);
+  }
+}
+
 // ── Tabs + boot ────────────────────────────────────────────────────────────────
 const VIEWS = {
   shells: ["#view-shells", renderShells],
   roadmap: ["#view-roadmap", renderRoadmap],
+  docs: ["#view-docs", renderDocs],
   flags: ["#view-flags", renderFlags],
+  scripts: ["#view-scripts", renderScripts],
 };
 async function load(tab) {
   const [sel, fn] = VIEWS[tab];

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -12,7 +12,9 @@
     <nav>
       <button data-tab="shells" class="active">Shells</button>
       <button data-tab="roadmap">Roadmap</button>
+      <button data-tab="docs">Docs</button>
       <button data-tab="flags">Flags</button>
+      <button data-tab="scripts">Scripts</button>
     </nav>
     <div class="tools">
       <span id="status" class="status"></span>
@@ -22,7 +24,9 @@
   <main>
     <section id="view-shells" class="view"></section>
     <section id="view-roadmap" class="view" hidden></section>
+    <section id="view-docs" class="view" hidden></section>
     <section id="view-flags" class="view" hidden></section>
+    <section id="view-scripts" class="view" hidden></section>
   </main>
   <script src="/app.js"></script>
 </body>

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -33,6 +33,7 @@ nav button.active { background: var(--accent2); color: var(--ink); border-color:
 #snapshot:hover { border-color: var(--accent); }
 main { padding: 1.2rem; max-width: 1100px; margin: 0 auto; }
 .view { display: grid; gap: 1rem; }
+.view[hidden] { display: none; }  /* class selector would otherwise beat [hidden] */
 
 .card {
   background: var(--panel); border: 1px solid var(--line); border-radius: var(--r);
@@ -46,6 +47,7 @@ main { padding: 1.2rem; max-width: 1100px; margin: 0 auto; }
   background: var(--accent2); color: var(--dim); border: 1px solid var(--line);
 }
 .pill.next { color: var(--accent); } .pill.shipped { color: var(--ok); }
+.pill.warn { color: var(--warn); border-color: var(--warn); }
 .grid2 { display: grid; grid-template-columns: 180px 1fr; gap: .4rem 1rem; align-items: start; }
 .grid2 > .k { color: var(--dim); }
 label.k { color: var(--dim); display: block; margin: .6rem 0 .2rem; font-size: .85rem; }
@@ -60,6 +62,11 @@ button.act {
 }
 button.act:hover { border-color: var(--accent); }
 button.act.primary { background: var(--accent); color: #0b0e13; border-color: var(--accent); }
+a.act { text-decoration: none; display: inline-block; }
+.docrow { padding: .5rem 0; border-top: 1px solid var(--line); }
+.docrow:first-of-type { border-top: none; }
+.docrow-head { display: flex; align-items: center; gap: .8rem; flex-wrap: wrap; }
+.docrow-label { flex: 1; color: var(--ink); }
 .locked {
   border-left: 2px solid var(--lock); padding-left: .8rem; color: var(--dim);
 }
@@ -67,6 +74,13 @@ button.act.primary { background: var(--accent); color: #0b0e13; border-color: va
 .seed-entry, .lns-entry { margin: .5rem 0; padding-left: .6rem; border-left: 1px solid var(--line); }
 .seed-entry .d { color: var(--dim); font-size: .78rem; }
 details summary { cursor: pointer; color: var(--accent); }
+.filters { display: flex; gap: .4rem; flex-wrap: wrap; margin: 0 0 1rem; }
+.chip {
+  background: var(--panel2); color: var(--dim); border: 1px solid var(--line);
+  border-radius: 99px; padding: .3rem .8rem; cursor: pointer; font: inherit; font-size: .8rem;
+}
+.chip:hover { color: var(--ink); border-color: var(--accent); }
+.chip.on { background: var(--accent); color: #0b0e13; border-color: var(--accent); font-weight: 600; }
 .bucket > h2 { font-size: .8rem; text-transform: uppercase; letter-spacing: .08em; color: var(--dim); margin: 1.4rem 0 .5rem; }
 .doc-body { white-space: pre-wrap; background: var(--panel2); border: 1px solid var(--line); border-radius: 6px; padding: .8rem; max-height: 420px; overflow: auto; font: 12.5px/1.55 ui-monospace, monospace; }
 .flag { display: flex; gap: .8rem; align-items: flex-start; padding: .6rem 0; border-bottom: 1px solid var(--line); }

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PY     := python3
 
 ECO    := $(ENGINE)/ecosystem.config.cjs
 
-.PHONY: help rebuild migrate snapshot render seed-skills init launch launch-% verify clean-db up down restart health serve ports
+.PHONY: help rebuild migrate snapshot render seed-skills init gui-up launch launch-% verify clean-db up down restart health serve ports
 
 help:
 	@echo "super-coder — forkable shell substrate"
@@ -15,8 +15,8 @@ help:
 	@echo "  make render              render tracked flat _sc files (specs/docs/skills/roadmap)"
 	@echo "  make seed-skills         regenerate the skills seed migration from assets/skills/"
 	@echo "  make init                seed a fresh fork's first user + shell (run once after install)"
-	@echo "  make launch              username auth + pick shell + render boot + exec harness"
-	@echo "  make launch-<shortname>  boot that shell directly (skip picker)"
+	@echo "  make launch              start the GUI (prints its URL) + auth + pick shell + boot + exec harness"
+	@echo "  make launch-<shortname>  boot that shell directly (skip picker); also starts the GUI"
 	@echo "  make verify              rebuild + flat render + render-only boot (headless proof)"
 	@echo "  make up / down / restart start/stop the localhost review layer (pm2, per-fork port)"
 	@echo "  make serve               run the review layer in the foreground (no pm2)"
@@ -42,10 +42,17 @@ seed-skills:
 init:
 	@$(PY) $(ENGINE)/scripts/init_fork.py
 
-launch:
+# Bring the review GUI up (idempotent) and print its address. Prerequisite of
+# the launch targets, so the GUI URL is shown before the harness takes over.
+gui-up:
+	@$(PY) $(ENGINE)/scripts/ports.py ensure >/dev/null
+	@pm2 start $(ECO) >/dev/null 2>&1 || true
+	@echo "→ review GUI at http://127.0.0.1:$$($(PY) $(ENGINE)/scripts/ports.py port)"
+
+launch: gui-up
 	@$(PY) $(ENGINE)/scripts/run.py
 
-launch-%:
+launch-%: gui-up
 	@$(PY) $(ENGINE)/scripts/run.py $*
 
 verify:

--- a/README.md
+++ b/README.md
@@ -138,10 +138,20 @@ Each fork hashes its path to a stable port in the `88xx` band (clear of superCC
 
 What you can do in the GUI: read everything; edit a shell's operational fields
 (`current_state`, `connections`, `workspace`) and skill grants; edit the roadmap
-and **non-frozen** documents; create and resolve flags. **seed and L&S are
-read-only** — the laws say the shell curates them, so the API ships no endpoint
-to write them at all. A `snapshot ⤓` button re-serializes + renders after edits
-(the manual precursor to the B6 commit→PR automation).
+(linear status buckets, with toggle-filters) and **non-frozen** documents; create
+and resolve flags. **seed and L&S are read-only** — the laws say the shell
+curates them, so the API ships no endpoint to write them at all. A `snapshot ⤓`
+button re-serializes + renders after edits (the manual precursor to the B6
+commit→PR automation).
+
+The **Scripts** tab lists the maintenance scripts (snapshot, render, seed-skills,
+migrate, rebuild) — each with a description and a **run** button, so the common
+chores work from the GUI without dropping to a terminal (rebuild prompts first,
+since it discards un-snapshotted DB edits).
+
+**`make launch` brings the GUI up too** — it starts the review layer (if not
+already running) and prints its URL *before* handing off to the harness, so the
+shell and the GUI run side by side from one command.
 
 The live `.super-coder/shell_db.db` is **gitignored and rebuilt** from
 git-tracked text. See `.super-coder/README.md` for the full model.

--- a/roadmap_sc.md
+++ b/roadmap_sc.md
@@ -8,9 +8,59 @@ edit: changes here are overwritten — author via the shell or localhost GUI
 
 > Rendered from the DB. Status is a planning horizon; a feature's open flags are its blockers.
 
-## Next
+## Brainstorm
+
+### Fork to sibling repos · owner: `cc`
+Fork super-coder into dos-arch / rst-c / emergence / md-converter; reseed pattern.
+
+_No open flags._
+
+## In Progress
 
 ### super-coder · owner: `cc`
 The substrate itself: data layer we build, harness we rent. v1 targets Claude Code + OpenCode; GUI review layer; fork + reseed.
+
+_No open flags._
+
+## Next
+
+### B1 — First-launch installer · owner: `cc`
+Full installer on top of init_fork: requirements check, harness auto-detect, slot-filled shell_system_prompt template.
+
+_No open flags._
+
+### B6 — Commit→PR automation · owner: `cc`
+edit→snapshot→render→commit→PR; per-shell-branch concurrency. The snapshot button is the manual precursor.
+
+_No open flags._
+
+## Near Term
+
+### B4 — OpenCode adapter · owner: `cc`
+Emit opencode.json + verify the research-flagged items; boot already dual-writes AGENTS.md + SKILL.md.
+
+_No open flags._
+
+## Long Term
+
+### B5 — Onboarding & mapping · owner: `cc`
+Install-time dr_* mapper (generalized) + one-time first-runtime ingest skill.
+
+_No open flags._
+
+## Shipped
+
+### B0 — Core spine · owner: `cc`
+Repo skeleton, schema, migrations, DB rebuild-from-text, render→boot (CLAUDE.md + AGENTS.md). PR #-/a1cc1e2.
+
+_No open flags._
+
+### B2 — Content & render · owner: `cc`
+Flat _sc render, per-shell SKILL.md, skill seed pipeline. PR #1.
+
+_No open flags._
+
+### B3 — Review layer · owner: `cc`
+Dependency-free localhost GUI (shells/roadmap/flags), per-fork ports. PR #3.
 
 _No open flags._

--- a/specs_sc/super-coder-founding-spec.md
+++ b/specs_sc/super-coder-founding-spec.md
@@ -2,6 +2,9 @@
 rendered_by: super-coder
 source: db
 edit: changes here are overwritten — author via the shell or localhost GUI
+feature: super-coder
+roadmap_status: in_progress
+frozen: true
 title: super-coder — Founding Spec
 tags: [super-coder, spec, architecture, harness-agnostic, fork]
 date: 2026-06-04


### PR DESCRIPTION
Builds on the B3 review layer. One batch of roadmap + GUI work.

## Roadmap & render
- **`in_progress` added** to the `roadmap_status` enum; every surface ordered as a **funnel**: `brainstorm → in_progress → next → near_term → long_term → shipped` (boot doc, `roadmap_sc.md`, API, GUI buckets/filters/edit dropdown). `In Progress` is the state where a feature has an *unfrozen working spec* — ties the roadmap to the specs→docs lifecycle.
- **Doc frontmatter** now carries `feature` / `roadmap_status` / `frozen`, spliced ahead of the doc's own YAML.
- **Roadmap status toggle-filters** (grouped chips; default none = show all).

## GUI
- **Tab-switch fix** — `.view[hidden]` (a class selector was beating the `[hidden]` attribute, stacking all tabs).
- **Scripts tab** — run whitelisted maintenance scripts (snapshot, render, seed-skills, migrate, rebuild) from the GUI; inline output; rebuild confirms first. Keyed registry → the GUI passes a key, never a command.
- **Docs tab** — splits `kind='doc'` (documentation) from `kind='spec'` (the dev-cycle the Roadmap tracks). Roadmap cards show specs only.
- **"Open in md-converter" works** — `/api/documents/{id}/open` encodes the body (gzip + base64url, byte-identical to md-converter's `?c=` contract) and 302-redirects to the live app, which renders it. No fork, one source. Verified: the encoded URL round-trips to the exact source doc. Docs no longer expand raw markdown inline; non-frozen edit is behind an explicit toggle.

## Launch
- `make launch` (and `launch-<shortname>`) now starts the review GUI and prints its URL **before** handing off to the harness.

Decision #188 (roadmap funnel + in_progress + doc-frontmatter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)