### PR TITLE
feat: B1 installer — make install, one-command fork bootstrap

### DIFF
--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -35,43 +35,22 @@ from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
 DB_PATH = ENGINE / "shell_db.db"
+PROMPT_TEMPLATE = ENGINE / "templates" / "shell_system_prompt.md"
 
 # Single source for the canonical Lineage Seed (Law 6) — reuse, don't duplicate.
 sys.path.insert(0, str(ENGINE / "scripts"))
 from seed_dogfood import LINEAGE_SEED  # noqa: E402
 
-# A minimal, generic system prompt. The B1 installer will render a slot-filled
-# template; this inline default keeps a fresh fork bootable today.
-SYSTEM_PROMPT_TMPL = """\
-# {name} — shell for {repo}
 
-You work {repo} through whatever coding harness booted you. One shell, one repo,
-one cwd — no cross-repo confusion.
-
-## MEMORY ARCHITECTURE
-
-Source of truth: `.super-coder/shell_db.db` (gitignored, rebuilt from
-`schema.sql` + `migrations/` + `snapshot/content.sql`). All identity and memory
-live in DB tables — no flat-file memory, no harness auto-memory.
-
-| Surface | Where |
-|---|---|
-| Identity (core) | `shells WHERE shell_id=<self>` — mandate, system_prompt, current_state (rolling, ~500 chars) |
-| Seed + L&S | `shell_identity_entries` — kind seed (cap 10) / lns (cap 20), trigger-enforced |
-| Decisions | `shell_decisions` — major decisions; INSERT, never edit |
-| Flags | `flags` — open + resolved; link to a feature via feature_id |
-| Roadmap | `roadmap` — one row per planned feature; status is a planning horizon |
-| Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
-| Session narrative | `shell_memory_archives` — one row per session, appended progressively |
-
-Write as it happens, not at close. The `.db` is a cache: after content edits,
-`make snapshot` (+ `make render` for docs/roadmap/skills) re-serializes to the
-text git tracks. See the `db_map` and `snapshot` skills.
-
-## MANDATE
-
-{mandate}
-"""
+def render_prompt(name: str, repo: str, mandate: str) -> str:
+    """Fill the slot-filled system-prompt template (single source for what a
+    fork's first shell boots with). Falls back to a one-liner if absent."""
+    if not PROMPT_TEMPLATE.exists():
+        return f"# {name} — shell for {repo}\n\n## MANDATE\n\n{mandate}\n"
+    text = PROMPT_TEMPLATE.read_text()
+    for slot, val in (("{{name}}", name), ("{{repo}}", repo), ("{{mandate}}", mandate)):
+        text = text.replace(slot, val)
+    return text
 
 GENESIS_TMPL = (
     "First shell of {repo}, forked from super-coder — a shell that carries the "
@@ -148,7 +127,7 @@ def main(argv: list[str]) -> int:
             "user_id, is_shared) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, 0)",
             (
                 name, shortname, partner, role, mandate,
-                SYSTEM_PROMPT_TMPL.format(name=name, repo=repo, mandate=mandate),
+                render_prompt(name, repo, mandate),
                 f"Fork initialised. First shell of {repo} (CC lineage). "
                 f"NEXT: `make snapshot` to serialize, then start working.",
                 f"Single repo: this one ({repo}). One shell, one cwd.",

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Install super-coder into a fork — first-launch bootstrap.
+
+Run once, in a host repo that has just pulled the engine
+(`git checkout super-coder/main -- .super-coder Makefile`). It takes that repo
+from "engine present" to "a shell you can launch":
+
+    1. Guard   — refuse to run in the super-coder SOURCE repo, or on a fork that
+                 is already installed (both would destroy content). --force skips.
+    2. Require — python3 + sqlite3 (+ a heads-up if git or a harness CLI is missing).
+    3. Detect  — the coding harness on PATH (claude / opencode) → instance.json.
+    4. Strip   — super-coder's own per-instance content; a fork inherits the
+                 SYSTEM (schema + skill catalogue + render chain), never the memory.
+    5. Build   — the system DB (schema + migrations; no per-instance content yet).
+    6. Seed    — the fork's first user + shell (delegates to init_fork; CC lineage
+                 + genesis seed + skill grants).
+    7. Persist — `make snapshot` (serialize the new shell) + `make render` (flat _sc).
+    8. Done    — print how to launch.
+
+Usage:
+    make install                      # interactive (prompts for user/shell)
+    python3 .super-coder/scripts/install.py [init_fork flags] [--force]
+        e.g. … --username Sam --name Dev --shortname dev --role "Dev shell"
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+PY = sys.executable
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import ports as ports_mod  # noqa: E402
+
+# super-coder's own per-instance content — present in a freshly-pulled fork
+# because the git checkout brought it along. A fork must not inherit it.
+STRIP = [
+    ENGINE / "snapshot" / "content.sql",
+    ENGINE / "assets" / "seed" / "super-coder-founding-spec.md",
+]
+
+
+def sh(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, text=True)
+
+
+def origin_basename() -> str | None:
+    p = sh("git", "-C", str(REPO_ROOT), "remote", "get-url", "origin")
+    if p.returncode != 0:
+        return None
+    return p.stdout.strip().rstrip("/").split("/")[-1].removesuffix(".git")
+
+
+def is_source_repo() -> bool:
+    """The super-coder source repo's origin is …/super-coder. A fork's origin is
+    its own repo (super-coder is a separate, differently-named remote)."""
+    return origin_basename() == "super-coder"
+
+
+def already_installed() -> bool:
+    if not ports_mod.CONFIG.exists():
+        return False
+    try:
+        return "installed_at" in json.loads(ports_mod.CONFIG.read_text())
+    except json.JSONDecodeError:
+        return False
+
+
+def detect_harness() -> str | None:
+    for h in ("claude", "opencode"):
+        if shutil.which(h):
+            return h
+    return None
+
+
+# Ignore lines a fork needs — the rebuilt/derived artifacts. The git checkout
+# that brings the engine in doesn't carry super-coder's .gitignore, so the
+# installer appends them to the host repo's .gitignore (idempotent via marker).
+_GITIGNORE_MARKER = "# super-coder — rebuilt/derived; never commit"
+_GITIGNORE_BLOCK = f"""
+{_GITIGNORE_MARKER}
+/.super-coder/shell_db.db
+/.super-coder/shell_db.db-wal
+/.super-coder/shell_db.db-shm
+/.super-coder/instance.json
+/CLAUDE.md
+/AGENTS.md
+/.claude/skills/
+"""
+
+
+def ensure_gitignore() -> bool:
+    gi = REPO_ROOT / ".gitignore"
+    existing = gi.read_text() if gi.exists() else ""
+    if _GITIGNORE_MARKER in existing:
+        return False
+    with gi.open("a") as f:
+        f.write(("" if existing.endswith("\n") or not existing else "\n") + _GITIGNORE_BLOCK)
+    return True
+
+
+def step(msg: str) -> None:
+    print(f"\n\033[1m→ {msg}\033[0m")
+
+
+def main(argv: list[str]) -> int:
+    force = "--force" in argv
+    fork_args = [a for a in argv if a != "--force"]
+
+    # 1. Guards ---------------------------------------------------------------
+    if is_source_repo() and not force:
+        sys.exit("install: this is the super-coder SOURCE repo — the installer is "
+                 "for forks. (Run it in a host repo that pulled the engine.) "
+                 "Use --force only if you really mean to re-init the source.")
+    if already_installed() and not force:
+        sys.exit("install: this fork is already installed (.super-coder/instance.json "
+                 "has installed_at). Re-installing destroys content — pass --force "
+                 "to override, or just `make launch`.")
+
+    # 2. Requirements ---------------------------------------------------------
+    step("Checking requirements")
+    try:
+        import sqlite3  # noqa: F401
+        print("  python3 + sqlite3 ✓")
+    except ImportError:
+        sys.exit("  python3 is missing the sqlite3 module — install it and retry.")
+    if not shutil.which("git"):
+        print("  ⚠ git not on PATH — needed for the commit→PR flow later.")
+
+    # 3. Detect harness -------------------------------------------------------
+    # We DETECT, we don't install — a fork's installer shouldn't silently run a
+    # global npm/curl install of someone else's CLI. If neither is present we
+    # print how to get one and carry on (the harness is only needed at launch).
+    step("Detecting harness")
+    harness = detect_harness()
+    if harness:
+        print(f"  found '{harness}' on PATH")
+    else:
+        harness = "claude"
+        print("  ⚠ no harness CLI found. Install one before `make launch`:")
+        print("      claude    npm i -g @anthropic-ai/claude-code   ·  https://docs.claude.com/claude-code")
+        print("      opencode  npm i -g opencode-ai                 ·  https://opencode.ai")
+        print("    Defaulting instance.json harness to 'claude' (edit it to switch).")
+
+    # 3.5 Wire the host repo's .gitignore -------------------------------------
+    step("Wiring .gitignore")
+    print("  added super-coder ignore lines" if ensure_gitignore()
+          else "  (already present)")
+
+    # 4. Strip super-coder's per-instance content -----------------------------
+    step("Stripping super-coder's per-instance content (a fork inherits the system, not the memory)")
+    for p in STRIP:
+        if p.exists():
+            p.unlink()
+            print(f"  removed {p.relative_to(REPO_ROOT)}")
+        else:
+            print(f"  (already absent) {p.relative_to(REPO_ROOT)}")
+
+    # 5. Build the system DB --------------------------------------------------
+    step("Building the system DB (schema + migrations)")
+    r = subprocess.run([PY, str(ENGINE / "scripts/rebuild.py")])
+    if r.returncode != 0:
+        sys.exit("install: rebuild failed.")
+
+    # 6. Seed the first shell (interactive unless flags were passed) ----------
+    step("Seeding this fork's first shell")
+    r = subprocess.run([PY, str(ENGINE / "scripts/init_fork.py"), *fork_args])
+    if r.returncode != 0:
+        sys.exit("install: first-shell seeding failed (or was aborted).")
+
+    # 7. Persist: snapshot + render ------------------------------------------
+    step("Serializing + rendering")
+    subprocess.run([PY, str(ENGINE / "scripts/snapshot.py")])
+    subprocess.run([PY, str(ENGINE / "scripts/render.py"), "flat"])
+
+    # Record harness + installed marker in instance.json ---------------------
+    cfg = ports_mod.resolve(persist=False)
+    cfg["harness"] = harness
+    cfg["installed_at"] = date.today().isoformat()
+    ports_mod.CONFIG.write_text(json.dumps(cfg, indent=2) + "\n")
+
+    # 8. Done -----------------------------------------------------------------
+    step("Installed ✓")
+    print(f"  harness : {harness}")
+    print(f"  GUI port: {cfg['port']}  (http://127.0.0.1:{cfg['port']})")
+    print("\nNext:")
+    print("  git add .super-coder Makefile .gitignore && git commit -m 'install super-coder'")
+    print("  make launch        # starts the review GUI + boots your shell")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -17,6 +17,7 @@ Usage:
 """
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 import sys
@@ -37,6 +38,16 @@ LAUNCH = {
     "claude": ["claude"],
     "opencode": ["opencode"],
 }
+
+
+def _configured_harness() -> str | None:
+    cfg = ENGINE / "instance.json"
+    if cfg.exists():
+        try:
+            return json.loads(cfg.read_text()).get("harness")
+        except (json.JSONDecodeError, OSError):
+            return None
+    return None
 
 
 def open_db() -> sqlite3.Connection:
@@ -174,7 +185,9 @@ def main() -> None:
         print("→ RENDER_ONLY set — not exec'ing the harness.")
         return
 
-    harness = os.environ.get("HARNESS", "claude")
+    # Harness: HARNESS env wins, else this fork's configured harness
+    # (instance.json, set by the installer), else claude.
+    harness = os.environ.get("HARNESS") or _configured_harness() or "claude"
     cmd = LAUNCH.get(harness)
     if not cmd:
         sys.exit(f"unknown harness '{harness}' (known: {', '.join(LAUNCH)})")

--- a/.super-coder/templates/shell_system_prompt.md
+++ b/.super-coder/templates/shell_system_prompt.md
@@ -1,0 +1,28 @@
+# {{name}} — shell for {{repo}}
+
+You work {{repo}} through whatever coding harness booted you. One shell, one repo,
+one cwd — no cross-repo confusion.
+
+## MEMORY ARCHITECTURE
+
+Source of truth: `.super-coder/shell_db.db` (gitignored, rebuilt from
+`schema.sql` + `migrations/` + `snapshot/content.sql`). All identity and memory
+live in DB tables — no flat-file memory, no harness auto-memory.
+
+| Surface | Where |
+|---|---|
+| Identity (core) | `shells WHERE shell_id=<self>` — mandate, system_prompt, current_state (rolling, ~500 chars) |
+| Seed + L&S | `shell_identity_entries` — kind seed (cap 10) / lns (cap 20), trigger-enforced |
+| Decisions | `shell_decisions` — major decisions; INSERT, never edit |
+| Flags | `flags` — open + resolved; link to a feature via feature_id |
+| Roadmap | `roadmap` — one row per planned feature; status is a planning horizon |
+| Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
+| Session narrative | `shell_memory_archives` — one row per session, appended progressively |
+
+Write as it happens, not at close. The `.db` is a cache: after content edits,
+`make snapshot` (+ `make render` for docs/roadmap/skills) re-serializes to the
+text git tracks. See the `db_map` and `snapshot` skills.
+
+## MANDATE
+
+{{mandate}}

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,12 @@ PY     := python3
 
 ECO    := $(ENGINE)/ecosystem.config.cjs
 
-.PHONY: help rebuild migrate snapshot render seed-skills init gui-up launch launch-% verify clean-db up down restart health serve ports
+.PHONY: help install rebuild migrate snapshot render seed-skills init gui-up launch launch-% verify clean-db up down restart health serve ports
 
 help:
 	@echo "super-coder — forkable shell substrate"
 	@echo ""
+	@echo "  make install             first-launch bootstrap for a fork (requirements, harness, first shell)"
 	@echo "  make rebuild             build $(DB) from schema + migrations + snapshot"
 	@echo "  make migrate             apply pending migrations to an existing $(DB)"
 	@echo "  make snapshot            dump per-instance tables -> $(ENGINE)/snapshot/content.sql"
@@ -23,6 +24,9 @@ help:
 	@echo "  make health              curl the review layer's /api/health"
 	@echo "  make ports               show this fork's derived port"
 	@echo "  make clean-db            remove the rebuilt $(DB) (text serializations untouched)"
+
+install:
+	@$(PY) $(ENGINE)/scripts/install.py
 
 rebuild:
 	@$(PY) $(ENGINE)/scripts/rebuild.py

--- a/README.md
+++ b/README.md
@@ -40,51 +40,34 @@ git remote add super-coder https://github.com/jedbjorn/super-coder.git
 git fetch super-coder
 git checkout super-coder/main -- .super-coder Makefile
 
-# 2. A fork takes the SYSTEM, not super-coder's per-instance content — drop it:
-rm .super-coder/snapshot/content.sql \
-   .super-coder/assets/seed/super-coder-founding-spec.md
-git remote remove super-coder   # optional; re-add when you want updates (below)
+# 2. Bootstrap the fork — one command:
+make install
 
-# 3. Add these lines to your .gitignore (the .db + boot artifact + skill render
-#    are all rebuilt — never commit them):
-cat >> .gitignore <<'EOF'
-
-# super-coder — rebuilt from git-tracked text; never commit
-/.super-coder/shell_db.db
-/.super-coder/shell_db.db-wal
-/.super-coder/shell_db.db-shm
-/CLAUDE.md
-/AGENTS.md
-/.claude/skills/
-EOF
-
-# 4. Build the system DB (schema + skill-catalogue migration; no content yet):
-make rebuild
-
-# 5. Seed this fork's first shell — your user + a shell carrying the CC lineage
-#    seed and its own genesis seed (interactive prompts, or pass flags):
-make init
-#   non-interactive: python3 .super-coder/scripts/init_fork.py \
-#       --username Jed --name Dev --shortname dev --role "Dev shell" \
-#       --mandate "Build and maintain this repo."
-
-# 6. Serialize that shell to git-tracked text, then commit the install:
-make snapshot
-git add .super-coder Makefile .gitignore && git commit -m "chore: install super-coder"
-
-# 7. Boot it through your harness:
-make launch                     # username auth → pick shell → render boot → exec
+# 3. Commit the install, then boot:
+git add -A && git commit -m "chore: install super-coder"
+make launch                     # starts the review GUI + boots your shell
 ```
 
-After step 7 you're talking to the shell, working your repo. Author memory,
-roadmap, and specs into the DB; `make snapshot` (+ `make render` for
-docs/roadmap/skills) serializes back to the text git tracks.
+`make install` does the rest: checks requirements, detects your harness
+(`claude` / `opencode`), wires your `.gitignore`, **strips super-coder's own
+per-instance content** (a fork inherits the *system* — schema + skill catalogue
++ render chain — never the memory or roadmap), builds the system DB, seeds your
+fork's **first shell** (your user + a shell carrying the CC Lineage Seed and its
+own genesis seed), and renders. It refuses to run in the super-coder source repo
+or on an already-installed fork (guarding against content loss).
 
-> **What `make init` does** (the fork-identity step): provisions your local user
-> and the fork's first shell, writes the canonical CC Lineage Seed into it, and
-> plants the shell's own genesis seed. This is the minimal v1 bootstrap — a
-> richer installer (requirements check, harness auto-detect, slot-filled
-> system-prompt template) is the next phase.
+Interactive by default (prompts for the shell's name/role/mandate); pass flags
+to script it:
+
+```bash
+python3 .super-coder/scripts/install.py \
+    --username Jed --name Dev --shortname dev \
+    --role "Dev shell" --mandate "Build and maintain this repo."
+```
+
+After `make launch` you're talking to the shell, working your repo. Author
+memory, roadmap, and specs into the DB; `make snapshot` (+ `make render`)
+serializes back to the text git tracks.
 
 ## Update a fork
 


### PR DESCRIPTION
`scripts/install.py` + **`make install`** takes a freshly-pulled fork from "engine present" to "a shell you can launch".

```bash
git fetch super-coder && git checkout super-coder/main -- .super-coder Makefile
make install        # ← this
make launch
```

- **Guards** — refuses in the super-coder SOURCE repo (origin-remote check) and on an already-installed fork (`installed_at`). `--force` overrides.
- **Requirements** — python3 + sqlite3 (+ git / harness heads-up).
- **Harness** — *detect* claude/opencode on PATH → `instance.json`. We don't auto-install; if missing, print the install command + link. `run.py` now resolves harness from `HARNESS` env → `instance.json` → claude.
- **`.gitignore`** — wires the host repo's ignore lines (the checkout doesn't carry ours).
- **Strip** super-coder's per-instance content — a fork inherits the *system*, not the memory/roadmap.
- **Build + seed + render** — system DB → first shell (delegates to `init_fork`: CC lineage + genesis + skill grants) → snapshot + flat render.
- `shell_system_prompt.md` extracted to a slot-filled template (single source).

**Verified** end-to-end in a throwaway fork: boots its own Dev shell, dogfood stripped (`docs:0`), skills granted, `.db`/`instance.json`/`CLAUDE.md` ignored, re-install + source guards both fire.

README install is now `make install` (was a 7-step manual sequence). Decision #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)