### PR TITLE
feat: B5 (map) — dr_* repo catalogue, so the shell can read its repo

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -153,6 +153,27 @@ def get_docs(con) -> dict:
         "WHERE d.kind='doc' ORDER BY d.feature_id, d.seq"))}
 
 
+def get_map(con) -> dict:
+    """The dr_* repo catalogue, summarized — how the shell (and the FnB) sees
+    what's in the host repo."""
+    repo = con.execute("SELECT * FROM dr_repo WHERE repo_id=1").fetchone()
+    total = con.execute("SELECT COUNT(*) FROM dr_filepath").fetchone()[0]
+    return {
+        "repo": dict(repo) if repo else None,
+        "total_files": total,
+        "by_lang": rows(con.execute(
+            "SELECT lang, COUNT(*) AS n, COALESCE(SUM(lines),0) AS lines "
+            "FROM dr_filepath WHERE lang IS NOT NULL GROUP BY lang ORDER BY n DESC")),
+        "by_role": rows(con.execute(
+            "SELECT role, COUNT(*) AS n FROM dr_filepath GROUP BY role ORDER BY n DESC")),
+        "deps": rows(con.execute(
+            "SELECT manager, name, version, kind, source_file FROM dr_dependency "
+            "ORDER BY manager, name")),
+        "env": rows(con.execute(
+            "SELECT name, source_file FROM dr_env ORDER BY name")),
+    }
+
+
 def get_flags(con) -> dict:
     flags = rows(con.execute(
         "SELECT f.flag_id, f.display_name, f.priority, f.description, f.created_date, "
@@ -229,6 +250,9 @@ _SCRIPTS = {
                     [_PY, str(ENGINE / "scripts/seed_skills.py")], False),
     "migrate": ("Migrate", "Apply any pending migrations to the live DB (ledger-tracked).",
                 [_PY, str(ENGINE / "scripts/migrate.py"), str(DB_PATH)], False),
+    "map": ("Map repo", "Scan the host repo into the dr_* catalogue "
+            "(files / deps / env) — how the shell reads its repo. Re-run when the "
+            "repo changes.", [_PY, str(ENGINE / "scripts/map_repo.py")], False),
     "rebuild": ("Rebuild DB", "Rebuild shell_db.db from schema + migrations + snapshot "
                 "(backs up the current DB first). Discards any DB edits you have NOT "
                 "snapshotted.", [_PY, str(ENGINE / "scripts/rebuild.py")], True),
@@ -319,6 +343,8 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, get_roadmap(con))
             if path == "/api/docs":
                 return self._send(200, get_docs(con))
+            if path == "/api/map":
+                return self._send(200, get_map(con))
             if path.startswith("/api/documents/"):
                 parts = path.strip("/").split("/")   # api documents {id} [open]
                 did = int(parts[2])

--- a/.super-coder/assets/skills/surface_catalogue/SKILL.md
+++ b/.super-coder/assets/skills/surface_catalogue/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: surface_catalogue
+description: Read the host repo via the dr_* catalogue (files, languages, deps, env) BEFORE grepping or walking the tree. Run `make map` to refresh it. Use to orient in an unfamiliar repo fast.
+category: substrate
+command: make map
+common: true
+---
+
+# surface_catalogue — read the repo from the map, not by grepping
+
+super-coder lives inside a host repo. The **dr_\*** tables are a scan of that
+repo — query them first to orient, instead of walking the tree blind. The map is
+a derived cache (not snapshotted); refresh it with `make map` after the repo
+changes.
+
+| Table | Holds |
+|---|---|
+| `dr_repo` | the repo: name, root, remote, vcs, default_branch, file_count, mapped_at |
+| `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines` |
+| `dr_dependency` | deps from the manifests: `manager` (npm/pip/poetry/go/cargo), `name`, `version`, `kind`, `source_file` |
+| `dr_env` | env-var names found in `.env.*` example files: `name`, `source_file` |
+
+## Orient fast
+
+```sql
+-- what is this repo + how big:
+SELECT name, default_branch, file_count, mapped_at FROM dr_repo;
+
+-- language mix:
+SELECT lang, COUNT(*) n, SUM(lines) lines FROM dr_filepath
+WHERE lang IS NOT NULL GROUP BY lang ORDER BY n DESC;
+
+-- where the code lives (skip docs/config/assets):
+SELECT path, lang, lines FROM dr_filepath WHERE role='code' ORDER BY lines DESC;
+
+-- find files by area (the map is the index; grep only what it points at):
+SELECT path FROM dr_filepath WHERE path LIKE '%auth%';
+
+-- stack + config surface:
+SELECT manager, name, version FROM dr_dependency ORDER BY manager, name;
+SELECT name, source_file FROM dr_env ORDER BY name;
+```
+
+## Stance
+
+- **Map first, grep second.** Query `dr_filepath` to find the handful of files
+  that matter, then read those — don't `grep -r` the whole tree.
+- **Stale map?** If the repo changed since `mapped_at`, run `make map` (or the
+  Map tab's re-map) before trusting it.
+- v1 maps files / deps / env. Semantic tables (APIs, db schema, routes/pages)
+  are a later pass — until then, read the code the map points you at.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -5,7 +5,7 @@
 
 BEGIN;
 
-DELETE FROM skills WHERE name IN ('db_map', 'snapshot');
+DELETE FROM skills WHERE name IN ('db_map', 'snapshot', 'surface_catalogue');
 
 INSERT INTO skills (name, description, category, command, common, content) VALUES (
   'db_map',
@@ -132,6 +132,57 @@ shell is *granted* a skill is per-instance (snapshot).
 
 > The commit→PR automation (B6) will run snapshot → render → commit → PR
 > automatically per shell. Until then it is this manual ritual.'
+);
+
+INSERT INTO skills (name, description, category, command, common, content) VALUES (
+  'surface_catalogue',
+  'Read the host repo via the dr_* catalogue (files, languages, deps, env) BEFORE grepping or walking the tree. Run `make map` to refresh it. Use to orient in an unfamiliar repo fast.',
+  'substrate',
+  'make map',
+  1,
+  '# surface_catalogue — read the repo from the map, not by grepping
+
+super-coder lives inside a host repo. The **dr_\*** tables are a scan of that
+repo — query them first to orient, instead of walking the tree blind. The map is
+a derived cache (not snapshotted); refresh it with `make map` after the repo
+changes.
+
+| Table | Holds |
+|---|---|
+| `dr_repo` | the repo: name, root, remote, vcs, default_branch, file_count, mapped_at |
+| `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines` |
+| `dr_dependency` | deps from the manifests: `manager` (npm/pip/poetry/go/cargo), `name`, `version`, `kind`, `source_file` |
+| `dr_env` | env-var names found in `.env.*` example files: `name`, `source_file` |
+
+## Orient fast
+
+```sql
+-- what is this repo + how big:
+SELECT name, default_branch, file_count, mapped_at FROM dr_repo;
+
+-- language mix:
+SELECT lang, COUNT(*) n, SUM(lines) lines FROM dr_filepath
+WHERE lang IS NOT NULL GROUP BY lang ORDER BY n DESC;
+
+-- where the code lives (skip docs/config/assets):
+SELECT path, lang, lines FROM dr_filepath WHERE role=''code'' ORDER BY lines DESC;
+
+-- find files by area (the map is the index; grep only what it points at):
+SELECT path FROM dr_filepath WHERE path LIKE ''%auth%'';
+
+-- stack + config surface:
+SELECT manager, name, version FROM dr_dependency ORDER BY manager, name;
+SELECT name, source_file FROM dr_env ORDER BY name;
+```
+
+## Stance
+
+- **Map first, grep second.** Query `dr_filepath` to find the handful of files
+  that matter, then read those — don''t `grep -r` the whole tree.
+- **Stale map?** If the repo changed since `mapped_at`, run `make map` (or the
+  Map tab''s re-map) before trusting it.
+- v1 maps files / deps / env. Semantic tables (APIs, db schema, routes/pages)
+  are a later pass — until then, read the code the map points you at.'
 );
 
 COMMIT;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -212,6 +212,49 @@ CREATE TABLE project_shells (
     UNIQUE (project_id, shell_id)
 );
 
+-- ── Repo catalogue (dr_*) — the host repo, mapped ───────────────────────────
+-- super-coder is dropped INTO a host repo; these tables are how the shell reads
+-- that repo without grepping blind. Structure is system (ships in the baseline);
+-- the ROWS are a derived cache of the host repo, populated by scripts/map_repo.py
+-- (`make map`, run at install) — NOT snapshotted, re-mappable when the repo
+-- changes. v1 maps files / deps / env; semantic tables (api/db/page) come later.
+
+CREATE TABLE dr_repo (
+    repo_id        INTEGER PRIMARY KEY,
+    name           TEXT,
+    root           TEXT,
+    remote         TEXT,
+    vcs            TEXT,
+    default_branch TEXT,
+    file_count     INTEGER,
+    mapped_at      TEXT
+);
+
+CREATE TABLE dr_filepath (
+    file_id  INTEGER PRIMARY KEY AUTOINCREMENT,
+    path     TEXT NOT NULL,           -- repo-relative
+    ext      TEXT,
+    lang     TEXT,                    -- inferred from extension
+    role     TEXT,                    -- code / doc / config / test / asset / env
+    bytes    INTEGER,
+    lines    INTEGER
+);
+
+CREATE TABLE dr_dependency (
+    dep_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    manager     TEXT,                 -- npm / pip / poetry / go / cargo
+    name        TEXT NOT NULL,
+    version     TEXT,
+    kind        TEXT,                 -- runtime / dev
+    source_file TEXT
+);
+
+CREATE TABLE dr_env (
+    env_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT NOT NULL,
+    source_file TEXT
+);
+
 -- ── Indexes ─────────────────────────────────────────────────────────────────
 
 CREATE INDEX idx_flags_parent   ON flags(parent_flag_id);
@@ -222,3 +265,6 @@ CREATE INDEX idx_documents_feature ON documents(feature_id, kind, seq);
 CREATE INDEX idx_sie_shell_kind_active
     ON shell_identity_entries(shell_id, kind)
     WHERE is_deleted = 0 AND retired_at IS NULL;
+CREATE INDEX idx_dr_filepath_role ON dr_filepath(role);
+CREATE INDEX idx_dr_filepath_lang ON dr_filepath(lang);
+CREATE INDEX idx_dr_dependency_mgr ON dr_dependency(manager);

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -174,7 +174,11 @@ def main(argv: list[str]) -> int:
     if r.returncode != 0:
         sys.exit("install: first-shell seeding failed (or was aborted).")
 
-    # 7. Persist: snapshot + render ------------------------------------------
+    # 7. Map the host repo into the dr_* catalogue (so the shell can read it) --
+    step("Mapping the repo (dr_* catalogue)")
+    subprocess.run([PY, str(ENGINE / "scripts/map_repo.py")])
+
+    # 8. Persist: snapshot + render ------------------------------------------
     step("Serializing + rendering")
     subprocess.run([PY, str(ENGINE / "scripts/snapshot.py")])
     subprocess.run([PY, str(ENGINE / "scripts/render.py"), "flat"])
@@ -185,7 +189,7 @@ def main(argv: list[str]) -> int:
     cfg["installed_at"] = date.today().isoformat()
     ports_mod.CONFIG.write_text(json.dumps(cfg, indent=2) + "\n")
 
-    # 8. Done -----------------------------------------------------------------
+    # 9. Done -----------------------------------------------------------------
     step("Installed ✓")
     print(f"  harness : {harness}")
     print(f"  GUI port: {cfg['port']}  (http://127.0.0.1:{cfg['port']})")

--- a/.super-coder/scripts/map_repo.py
+++ b/.super-coder/scripts/map_repo.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Map the host repo into the dr_* catalogue — how the shell reads its repo.
+
+super-coder lives INSIDE a host repo. This walks that repo and records what's
+there — files (with language + role), dependencies (from the common manifests),
+and env-var names — into the dr_* tables, so the shell queries the catalogue
+instead of grepping blind (see the `surface_catalogue` skill).
+
+The catalogue is a DERIVED CACHE of the repo, not authored content: it is NOT
+snapshotted. Re-run any time the repo changes:
+
+    make map          # or: python3 .super-coder/scripts/map_repo.py
+
+Idempotent — clears and repopulates dr_*. v1 maps files / deps / env; the
+semantic tables (APIs, db, pages) are a later pass.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+DB_PATH = ENGINE / "shell_db.db"
+
+SKIP_DIRS = {".git", "node_modules", ".super-coder", ".venv", "venv",
+             "__pycache__", ".svelte-kit", "dist", "build", ".next", "target",
+             "vendor", ".claude", ".idea", ".vscode", "coverage", ".pytest_cache"}
+MAX_FILES = 20000  # backstop for huge trees; logs if hit
+
+LANG = {
+    ".py": "Python", ".js": "JavaScript", ".mjs": "JavaScript", ".cjs": "JavaScript",
+    ".ts": "TypeScript", ".tsx": "TypeScript", ".jsx": "JavaScript",
+    ".svelte": "Svelte", ".vue": "Vue", ".go": "Go", ".rs": "Rust", ".rb": "Ruby",
+    ".java": "Java", ".kt": "Kotlin", ".c": "C", ".h": "C", ".cpp": "C++",
+    ".cs": "C#", ".php": "PHP", ".swift": "Swift", ".sh": "Shell", ".bash": "Shell",
+    ".sql": "SQL", ".md": "Markdown", ".mdx": "Markdown", ".json": "JSON",
+    ".yaml": "YAML", ".yml": "YAML", ".toml": "TOML", ".ini": "INI",
+    ".css": "CSS", ".scss": "SCSS", ".html": "HTML", ".xml": "XML",
+    ".txt": "Text", ".cfg": "Config", ".env": "Env",
+}
+CODE_LANGS = {"Python", "JavaScript", "TypeScript", "Svelte", "Vue", "Go", "Rust",
+              "Ruby", "Java", "Kotlin", "C", "C++", "C#", "PHP", "Swift", "Shell", "SQL"}
+CONFIG_EXTS = {".json", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".conf"}
+
+
+def infer_role(path: str, ext: str, lang: str | None) -> str:
+    p = path.lower()
+    name = path.rsplit("/", 1)[-1].lower()
+    if name.startswith(".env"):
+        return "env"
+    if "test" in p or "spec" in p and lang in CODE_LANGS:
+        return "test"
+    if ext in (".md", ".mdx", ".rst", ".txt"):
+        return "doc"
+    if ext in CONFIG_EXTS or name in ("dockerfile", "makefile"):
+        return "config"
+    if lang in CODE_LANGS:
+        return "code"
+    return "asset"
+
+
+def count_lines(p: Path) -> int | None:
+    try:
+        with p.open("rb") as f:
+            return sum(1 for _ in f)
+    except OSError:
+        return None
+
+
+def git(*args: str) -> str | None:
+    r = subprocess.run(["git", "-C", str(REPO_ROOT), *args],
+                       capture_output=True, text=True)
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def is_source_repo() -> bool:
+    """In a fork, .super-coder is infrastructure (skip it). In the super-coder
+    SOURCE repo the engine IS the project, so map it too."""
+    url = git("remote", "get-url", "origin")
+    return bool(url) and url.rstrip("/").split("/")[-1].removesuffix(".git") == "super-coder"
+
+
+# ── Dependency parsers (best-effort; each guarded) ───────────────────────────
+
+def deps_package_json(p: Path) -> list[tuple]:
+    out = []
+    try:
+        data = json.loads(p.read_text())
+    except (json.JSONDecodeError, OSError):
+        return out
+    for key, kind in (("dependencies", "runtime"), ("devDependencies", "dev")):
+        for name, ver in (data.get(key) or {}).items():
+            out.append(("npm", name, str(ver), kind, "package.json"))
+    return out
+
+
+def deps_requirements(p: Path) -> list[tuple]:
+    out = []
+    try:
+        for line in p.read_text().splitlines():
+            line = line.split("#", 1)[0].strip()
+            if not line or line.startswith("-"):
+                continue
+            m = re.match(r"^([A-Za-z0-9_.\-\[\]]+)\s*([=<>!~]=?.*)?$", line)
+            if m:
+                out.append(("pip", m.group(1), (m.group(2) or "").strip(), "runtime", p.name))
+    except OSError:
+        pass
+    return out
+
+
+def deps_pyproject(p: Path) -> list[tuple]:
+    out = []
+    try:
+        import tomllib
+        data = tomllib.loads(p.read_text())
+    except Exception:
+        return out
+    for dep in (data.get("project", {}).get("dependencies") or []):
+        name = re.split(r"[=<>!~ \[]", dep, 1)[0]
+        out.append(("pip", name, dep[len(name):].strip(), "runtime", "pyproject.toml"))
+    poetry = data.get("tool", {}).get("poetry", {})
+    for name, ver in (poetry.get("dependencies") or {}).items():
+        if name.lower() != "python":
+            out.append(("poetry", name, str(ver), "runtime", "pyproject.toml"))
+    return out
+
+
+def deps_go_mod(p: Path) -> list[tuple]:
+    out = []
+    try:
+        for m in re.finditer(r"^\s*([\w./\-]+)\s+(v[\w.\-]+)", p.read_text(), re.M):
+            out.append(("go", m.group(1), m.group(2), "runtime", "go.mod"))
+    except OSError:
+        pass
+    return out
+
+
+def deps_cargo(p: Path) -> list[tuple]:
+    out = []
+    try:
+        import tomllib
+        data = tomllib.loads(p.read_text())
+    except Exception:
+        return out
+    for name, ver in (data.get("dependencies") or {}).items():
+        out.append(("cargo", name, ver if isinstance(ver, str) else str(ver), "runtime", "Cargo.toml"))
+    return out
+
+
+MANIFESTS = {
+    "package.json": deps_package_json, "requirements.txt": deps_requirements,
+    "pyproject.toml": deps_pyproject, "go.mod": deps_go_mod, "Cargo.toml": deps_cargo,
+}
+ENV_FILES = (".env.example", ".env.sample", ".env.template", ".env.dist")
+ENV_RE = re.compile(r"^\s*(?:export\s+)?([A-Z][A-Z0-9_]*)\s*=")
+
+
+def main() -> int:
+    if not DB_PATH.exists():
+        sys.exit("map_repo: no DB — run `make rebuild` (or `make install`) first.")
+    con = sqlite3.connect(DB_PATH)
+    skip = SKIP_DIRS - ({".super-coder"} if is_source_repo() else set())
+    try:
+        for t in ("dr_repo", "dr_filepath", "dr_dependency", "dr_env"):
+            con.execute(f"DELETE FROM {t}")
+
+        files = deps = envs = 0
+        truncated = False
+        for p in sorted(REPO_ROOT.rglob("*")):
+            rel_parts = p.relative_to(REPO_ROOT).parts
+            if any(part in skip for part in rel_parts):
+                continue
+            if not p.is_file():
+                continue
+            if files >= MAX_FILES:
+                truncated = True
+                break
+            rel = "/".join(rel_parts)
+            ext = p.suffix.lower()
+            lang = LANG.get(ext)
+            role = infer_role(rel, ext, lang)
+            try:
+                size = p.stat().st_size
+            except OSError:
+                size = None
+            con.execute(
+                "INSERT INTO dr_filepath (path, ext, lang, role, bytes, lines) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (rel, ext or None, lang, role, size,
+                 count_lines(p) if (lang or role in ("doc", "config")) else None))
+            files += 1
+
+            name = p.name
+            if name in MANIFESTS:
+                for row in MANIFESTS[name](p):
+                    con.execute(
+                        "INSERT INTO dr_dependency (manager, name, version, kind, source_file) "
+                        "VALUES (?, ?, ?, ?, ?)", row)
+                    deps += 1
+            if name in ENV_FILES:
+                for line in p.read_text(errors="ignore").splitlines():
+                    m = ENV_RE.match(line)
+                    if m:
+                        con.execute("INSERT INTO dr_env (name, source_file) VALUES (?, ?)",
+                                    (m.group(1), rel))
+                        envs += 1
+
+        con.execute(
+            "INSERT INTO dr_repo (repo_id, name, root, remote, vcs, default_branch, "
+            "file_count, mapped_at) VALUES (1, ?, ?, ?, ?, ?, ?, ?)",
+            (REPO_ROOT.name, str(REPO_ROOT), git("remote", "get-url", "origin"),
+             "git" if (REPO_ROOT / ".git").exists() else None,
+             git("rev-parse", "--abbrev-ref", "HEAD"), files,
+             datetime.now().isoformat(timespec="seconds")))
+        con.commit()
+        msg = f"map_repo: {files} files, {deps} deps, {envs} env vars → dr_* ({REPO_ROOT.name})"
+        if truncated:
+            msg += f"  ⚠ stopped at MAX_FILES={MAX_FILES}"
+        print(msg)
+    finally:
+        con.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.super-coder/snapshot/content.sql
+++ b/.super-coder/snapshot/content.sql
@@ -73,7 +73,7 @@ INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (5, 'B1 — First-launch installer', 'next', 0, 1, 'Full installer on top of init_fork: requirements check, harness auto-detect, slot-filled shell_system_prompt template.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (6, 'B6 — Commit→PR automation', 'next', 1, 1, 'edit→snapshot→render→commit→PR; per-shell-branch concurrency. The snapshot button is the manual precursor.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (7, 'B4 — OpenCode adapter', 'near_term', 0, 1, 'Emit opencode.json + verify the research-flagged items; boot already dual-writes AGENTS.md + SKILL.md.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
-INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (8, 'B5 — Onboarding & mapping', 'long_term', 0, 1, 'Install-time dr_* mapper (generalized) + one-time first-runtime ingest skill.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (8, 'B5 — Onboarding & mapping', 'near_term', 0, 1, 'dr_* code map DONE (files/deps/env, make map, GUI Map tab, surface_catalogue skill). Next: content ingest (README/docs/specs → DB + roadmap backfill) + semantic tables (api/db/page).', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (9, 'Fork to sibling repos', 'brainstorm', 0, 1, 'Fork super-coder into dos-arch / rst-c / emergence / md-converter; reseed pattern.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
 
 DELETE FROM documents;
@@ -613,5 +613,6 @@ INSERT INTO project_shells (project_shell_id, project_id, shell_id, role, added_
 DELETE FROM shell_skills;
 INSERT INTO shell_skills (shell_skill_id, shell_id, skill_id) VALUES (2, 1, 2);
 INSERT INTO shell_skills (shell_skill_id, shell_id, skill_id) VALUES (3, 1, 1);
+INSERT INTO shell_skills (shell_skill_id, shell_id, skill_id) VALUES (4, 1, 3);
 
 COMMIT;

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -307,11 +307,81 @@ async function renderScripts(root) {
   }
 }
 
+// ── Map (dr_* repo catalogue) ───────────────────────────────────────────────────
+function bars(items, label, val) {
+  const max = Math.max(1, ...items.map(val));
+  const wrap = el("div", { className: "bars" });
+  for (const it of items) {
+    const row = el("div", { className: "bar-row" });
+    row.append(el("span", { className: "bar-label" }, label(it)));
+    const track = el("div", { className: "bar-track" });
+    const fill = el("div", { className: "bar-fill" });
+    fill.style.width = Math.round((val(it) / max) * 100) + "%";
+    track.append(fill);
+    row.append(track, el("span", { className: "bar-n" }, String(val(it))));
+    wrap.append(row);
+  }
+  return wrap;
+}
+
+async function renderMap(root) {
+  const m = await api("/map");
+  root.replaceChildren();
+  if (!m.repo) {
+    root.append(el("div", { className: "card muted" },
+      "Repo not mapped yet. Run Map (Scripts tab) or `make map` to scan the repo into the dr_* catalogue."));
+    return;
+  }
+  const r = m.repo;
+  const head = el("div", { className: "card" });
+  head.append(el("h2", {}, r.name || "(repo)"));
+  head.append(el("div", { className: "grid2" },
+    el("span", { className: "k" }, "branch"), el("span", {}, r.default_branch || "—"),
+    el("span", { className: "k" }, "remote"), el("span", { className: "muted" }, r.remote || "—"),
+    el("span", { className: "k" }, "files"), el("span", {}, String(m.total_files)),
+    el("span", { className: "k" }, "mapped"), el("span", { className: "muted" }, r.mapped_at || "—")));
+  const remap = el("button", { className: "act", textContent: "re-map ↻" });
+  remap.onclick = async () => {
+    remap.disabled = true; setStatus("mapping…");
+    try { await fetch("/api/scripts/map", { method: "POST" }); setStatus("mapped"); renderMap(root); }
+    finally { remap.disabled = false; }
+  };
+  head.append(remap);
+  root.append(head);
+
+  if (m.by_lang.length) {
+    const c = el("div", { className: "card" });
+    c.append(el("h2", {}, "Languages"));
+    c.append(bars(m.by_lang, (x) => x.lang, (x) => x.n));
+    root.append(c);
+  }
+  if (m.by_role.length) {
+    const c = el("div", { className: "card" });
+    c.append(el("h2", {}, "File roles"));
+    c.append(bars(m.by_role, (x) => x.role, (x) => x.n));
+    root.append(c);
+  }
+  if (m.deps.length) {
+    const c = el("div", { className: "card" });
+    c.append(el("h2", {}, `Dependencies (${m.deps.length})`));
+    for (const d of m.deps) c.append(el("div", { className: "tag" },
+      `${d.manager} · ${d.name} ${d.version || ""}${d.kind === "dev" ? " (dev)" : ""}`));
+    root.append(c);
+  }
+  if (m.env.length) {
+    const c = el("div", { className: "card" });
+    c.append(el("h2", {}, `Env vars (${m.env.length})`));
+    for (const e of m.env) c.append(el("div", { className: "tag" }, `${e.name}  — ${e.source_file}`));
+    root.append(c);
+  }
+}
+
 // ── Tabs + boot ────────────────────────────────────────────────────────────────
 const VIEWS = {
   shells: ["#view-shells", renderShells],
   roadmap: ["#view-roadmap", renderRoadmap],
   docs: ["#view-docs", renderDocs],
+  map: ["#view-map", renderMap],
   flags: ["#view-flags", renderFlags],
   scripts: ["#view-scripts", renderScripts],
 };

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -13,6 +13,7 @@
       <button data-tab="shells" class="active">Shells</button>
       <button data-tab="roadmap">Roadmap</button>
       <button data-tab="docs">Docs</button>
+      <button data-tab="map">Map</button>
       <button data-tab="flags">Flags</button>
       <button data-tab="scripts">Scripts</button>
     </nav>
@@ -25,6 +26,7 @@
     <section id="view-shells" class="view"></section>
     <section id="view-roadmap" class="view" hidden></section>
     <section id="view-docs" class="view" hidden></section>
+    <section id="view-map" class="view" hidden></section>
     <section id="view-flags" class="view" hidden></section>
     <section id="view-scripts" class="view" hidden></section>
   </main>

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -90,3 +90,9 @@ details summary { cursor: pointer; color: var(--accent); }
 a { color: var(--accent); }
 .list-skill { display: flex; align-items: center; gap: .5rem; padding: .2rem 0; }
 .toast { position: fixed; bottom: 1rem; right: 1rem; background: var(--panel2); border: 1px solid var(--accent); border-radius: var(--r); padding: .6rem 1rem; max-width: 420px; white-space: pre-wrap; font: 12px/1.5 ui-monospace, monospace; }
+.bars { display: grid; gap: .3rem; }
+.bar-row { display: grid; grid-template-columns: 110px 1fr 40px; align-items: center; gap: .6rem; }
+.bar-label { color: var(--dim); font-size: .85rem; }
+.bar-track { background: var(--panel2); border-radius: 99px; height: 10px; overflow: hidden; }
+.bar-fill { background: var(--accent); height: 100%; }
+.bar-n { text-align: right; color: var(--dim); font-size: .8rem; }

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PY     := python3
 
 ECO    := $(ENGINE)/ecosystem.config.cjs
 
-.PHONY: help install rebuild migrate snapshot render seed-skills init gui-up launch launch-% verify clean-db up down restart health serve ports
+.PHONY: help install rebuild migrate snapshot render seed-skills init map gui-up launch launch-% verify clean-db up down restart health serve ports
 
 help:
 	@echo "super-coder — forkable shell substrate"
@@ -14,6 +14,7 @@ help:
 	@echo "  make migrate             apply pending migrations to an existing $(DB)"
 	@echo "  make snapshot            dump per-instance tables -> $(ENGINE)/snapshot/content.sql"
 	@echo "  make render              render tracked flat _sc files (specs/docs/skills/roadmap)"
+	@echo "  make map                 scan the host repo into the dr_* catalogue (re-runnable)"
 	@echo "  make seed-skills         regenerate the skills seed migration from assets/skills/"
 	@echo "  make init                seed a fresh fork's first user + shell (run once after install)"
 	@echo "  make launch              start the GUI (prints its URL) + auth + pick shell + boot + exec harness"
@@ -39,6 +40,9 @@ snapshot:
 
 render:
 	@$(PY) $(ENGINE)/scripts/render.py flat
+
+map:
+	@$(PY) $(ENGINE)/scripts/map_repo.py
 
 seed-skills:
 	@$(PY) $(ENGINE)/scripts/seed_skills.py

--- a/roadmap_sc.md
+++ b/roadmap_sc.md
@@ -41,10 +41,8 @@ Emit opencode.json + verify the research-flagged items; boot already dual-writes
 
 _No open flags._
 
-## Long Term
-
 ### B5 — Onboarding & mapping · owner: `cc`
-Install-time dr_* mapper (generalized) + one-time first-runtime ingest skill.
+dr_* code map DONE (files/deps/env, make map, GUI Map tab, surface_catalogue skill). Next: content ingest (README/docs/specs → DB + roadmap backfill) + semantic tables (api/db/page).
 
 _No open flags._
 

--- a/skills_sc/README.md
+++ b/skills_sc/README.md
@@ -10,3 +10,4 @@ edit: changes here are overwritten — author via the shell or localhost GUI
 
 - [`db_map`](skills_sc/db_map.md) — Schema map + reusable SQL for super-coder's shell_db.db. Check before composing any DB query — identity, memory, roadmap, documents, flags, skills.
 - [`snapshot`](skills_sc/snapshot.md) — Persist DB work to git-tracked text — when and how to run make snapshot / make render before committing. The .db is a cache; text is the source of truth.
+- [`surface_catalogue`](skills_sc/surface_catalogue.md) — Read the host repo via the dr_* catalogue (files, languages, deps, env) BEFORE grepping or walking the tree. Run `make map` to refresh it. Use to orient in an unfamiliar repo fast.

--- a/skills_sc/surface_catalogue.md
+++ b/skills_sc/surface_catalogue.md
@@ -1,0 +1,57 @@
+---
+rendered_by: super-coder
+source: db
+edit: changes here are overwritten — author via the shell or localhost GUI
+---
+
+# surface_catalogue
+
+Read the host repo via the dr_* catalogue (files, languages, deps, env) BEFORE grepping or walking the tree. Run `make map` to refresh it. Use to orient in an unfamiliar repo fast.
+
+**Category:** substrate  ·  **Command:** `make map`
+
+---
+
+# surface_catalogue — read the repo from the map, not by grepping
+
+super-coder lives inside a host repo. The **dr_\*** tables are a scan of that
+repo — query them first to orient, instead of walking the tree blind. The map is
+a derived cache (not snapshotted); refresh it with `make map` after the repo
+changes.
+
+| Table | Holds |
+|---|---|
+| `dr_repo` | the repo: name, root, remote, vcs, default_branch, file_count, mapped_at |
+| `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines` |
+| `dr_dependency` | deps from the manifests: `manager` (npm/pip/poetry/go/cargo), `name`, `version`, `kind`, `source_file` |
+| `dr_env` | env-var names found in `.env.*` example files: `name`, `source_file` |
+
+## Orient fast
+
+```sql
+-- what is this repo + how big:
+SELECT name, default_branch, file_count, mapped_at FROM dr_repo;
+
+-- language mix:
+SELECT lang, COUNT(*) n, SUM(lines) lines FROM dr_filepath
+WHERE lang IS NOT NULL GROUP BY lang ORDER BY n DESC;
+
+-- where the code lives (skip docs/config/assets):
+SELECT path, lang, lines FROM dr_filepath WHERE role='code' ORDER BY lines DESC;
+
+-- find files by area (the map is the index; grep only what it points at):
+SELECT path FROM dr_filepath WHERE path LIKE '%auth%';
+
+-- stack + config surface:
+SELECT manager, name, version FROM dr_dependency ORDER BY manager, name;
+SELECT name, source_file FROM dr_env ORDER BY name;
+```
+
+## Stance
+
+- **Map first, grep second.** Query `dr_filepath` to find the handful of files
+  that matter, then read those — don't `grep -r` the whole tree.
+- **Stale map?** If the repo changed since `mapped_at`, run `make map` (or the
+  Map tab's re-map) before trusting it.
+- v1 maps files / deps / env. Semantic tables (APIs, db schema, routes/pages)
+  are a later pass — until then, read the code the map points you at.


### PR DESCRIPTION
The harness-agnostic gap for testing in a real fork was **repo-awareness** (install + GUI already shipped). This adds the **dr_\* catalogue** — how the shell reads its host repo without grepping blind.

- **Schema**: `dr_repo` · `dr_filepath` (lang + role per file) · `dr_dependency` (npm/pip/poetry/go/cargo manifests) · `dr_env` (`.env.*` examples).
- **`scripts/map_repo.py` + `make map`** — scans the host repo, idempotent. Skips `.super-coder` in **forks** (infra); maps it in the **source repo** (the engine is super-coder's own project). Run at install.
- **The map is a DERIVED CACHE — not snapshotted**; re-derive with `make map` (like the `.db` is rebuilt). Keeps the snapshot small and never stale-in-git.
- **GUI Map tab** (`/api/map`): repo header, language/role bars, deps, env, re-map button. `map` added to the runnable script registry.
- **`surface_catalogue` skill** ("map first, grep second"), seeded + granted.
- **`install.py`** maps the repo after seeding → a fresh fork is immediately repo-aware.

**Verified** in a real-shaped throwaway fork: host files mapped with correct lang/role, deps+env parsed from manifests, `.super-coder` skipped (0 leaked), skill rendered, boots.

**Deferred (B5 second half):** content ingest (README/docs/specs → `documents` + roadmap backfill) and semantic tables (`dr_api`/`dr_db`/`dr_page`).

Decision #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)