### PR TITLE
feat: B4 — OpenCode adapter + formal adapters/ seam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@
 .super-coder/shell_db.db-shm
 
 # Boot artifact — rebuilt at launch from the DB. The harness dictates the name;
-# we dual-write both. Ignored everywhere.
+# we dual-write both. Ignored everywhere. opencode.json is emitted from the
+# OpenCode adapter template each launch (same deal).
 /CLAUDE.md
 /AGENTS.md
+/opencode.json
 
 # Per-shell skill render — .claude/skills/<name>/SKILL.md, rebuilt at boot for
 # whichever shell launches (harness-consumed cache, like the boot artifact).

--- a/.super-coder/README.md
+++ b/.super-coder/README.md
@@ -62,9 +62,29 @@ snapshot (fork-local). `make rebuild` seeds the catalogue, then loads grants.
 
 ## Adapters
 
-`adapters/<harness>/` holds the thin, harness-specific seam: provider/model
-config, tool/permission config, MCP config, launch command. `claude/` is v1;
-`opencode/` is next. Everything above the seam is harness-blind.
+`adapters/<harness>/` is the **only** harness-specific seam — everything above it
+is harness-blind. Each holds an `adapter.json`:
+
+| field | meaning |
+|---|---|
+| `launch` | argv exec'd to start the harness |
+| `boot_artifact` | the context file this harness reads (informational) |
+| `emit` | files in the adapter dir copied to the repo root at launch (gitignored, regenerated each launch from the tracked template) |
+| `env` | extra env merged into the launch environment |
+
+- **`claude/`** — reads `CLAUDE.md` + `.claude/skills/*/SKILL.md` natively; nothing
+  extra to emit.
+- **`opencode/`** — reads `AGENTS.md` + `.claude/skills/*/SKILL.md` natively, and
+  emits **`opencode.json`** (instructions → `AGENTS.md`, tool permissions, `mcp`
+  slot). `env.OPENCODE_DISABLE_CLAUDE_CODE=1` avoids double-loading `CLAUDE.md`
+  (we dual-write both). Edit the tracked `opencode.json` template to change a
+  fork's config.
+
+The boot render dual-writes `CLAUDE.md` + `AGENTS.md` and the skills, so both
+harnesses consume the same substrate unchanged — that's the harness-agnostic bet.
+`run.py` picks the harness (`HARNESS` env → `instance.json` → claude), loads its
+adapter, emits its files, and exec's its launch command. An unknown harness falls
+back to running its own name + reading `AGENTS.md`.
 
 ## Review layer (`api/` + `ui/`)
 

--- a/.super-coder/adapters/claude/README.md
+++ b/.super-coder/adapters/claude/README.md
@@ -1,0 +1,17 @@
+# adapters/claude — Claude Code
+
+Claude Code reads the boot artifact (`CLAUDE.md`) and `.claude/skills/<name>/SKILL.md`
+natively — both already emitted by the render chain — so the adapter only carries
+the launch command. No extra config file to emit at v1.
+
+`adapter.json` fields (the harness seam contract):
+
+| field | meaning |
+|---|---|
+| `launch` | argv exec'd to start the harness |
+| `boot_artifact` | the context file this harness reads (informational) |
+| `emit` | files in this dir copied to the repo root at launch (none for Claude) |
+| `env` | extra env merged into the launch environment |
+
+A `.claude/settings.json` template could live here later (permissions, hooks);
+not needed for v1.

--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -1,0 +1,7 @@
+{
+  "harness": "claude",
+  "launch": ["claude"],
+  "boot_artifact": "CLAUDE.md",
+  "emit": [],
+  "env": {}
+}

--- a/.super-coder/adapters/opencode/README.md
+++ b/.super-coder/adapters/opencode/README.md
@@ -1,0 +1,25 @@
+# adapters/opencode — OpenCode
+
+OpenCode consumes our Claude-format assets almost unchanged — it reads `AGENTS.md`
+at the repo root and `.claude/skills/<name>/SKILL.md` natively (Agent Skills
+format), both already emitted by the render chain. The adapter adds the one
+harness-specific file OpenCode wants and the launch command.
+
+- **`opencode.json`** (emitted to the repo root at launch, gitignored like the
+  boot artifact) — points `instructions` at `AGENTS.md`, sets default tool
+  permissions (edit allow / webfetch allow / bash ask), and leaves an `mcp` slot.
+  Edit this **template** (tracked) to change a fork's OpenCode config; the live
+  file is regenerated each launch. Model is intentionally unset — the harness is
+  rented; pick it in OpenCode (`-m provider/model`) or add `"model"` here.
+- **`env.OPENCODE_DISABLE_CLAUDE_CODE=1`** — best-effort: stop OpenCode from also
+  loading `CLAUDE.md` (we dual-write both with identical content; this avoids a
+  double-load). ⚠ The exact env name is a **research flag to verify on live
+  OpenCode** — if wrong it's a harmless no-op (the content is identical anyway).
+
+## Verify on live OpenCode (research flags from the spec)
+
+- skills dir spelling consumed (`.claude/skills/` ✓ vs any `agent(s)/` variant)
+- `OPENCODE_DISABLE_CLAUDE_CODE` env name (above)
+- session-storage paths (doc 404'd at research time)
+
+None block the contract; confirm during real-repo testing.

--- a/.super-coder/adapters/opencode/adapter.json
+++ b/.super-coder/adapters/opencode/adapter.json
@@ -1,0 +1,7 @@
+{
+  "harness": "opencode",
+  "launch": ["opencode"],
+  "boot_artifact": "AGENTS.md",
+  "emit": ["opencode.json"],
+  "env": { "OPENCODE_DISABLE_CLAUDE_CODE": "1" }
+}

--- a/.super-coder/adapters/opencode/opencode.json
+++ b/.super-coder/adapters/opencode/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["AGENTS.md"],
+  "permission": {
+    "edit": "allow",
+    "webfetch": "allow",
+    "bash": "ask"
+  },
+  "mcp": {}
+}

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -91,6 +91,7 @@ _GITIGNORE_BLOCK = f"""
 /.super-coder/instance.json
 /CLAUDE.md
 /AGENTS.md
+/opencode.json
 /.claude/skills/
 """
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -32,12 +32,32 @@ sys.path.insert(0, str(ENGINE / "render"))
 from compose import compose_boot  # noqa: E402
 import flat  # noqa: E402
 
-# The launch command per harness. The adapters/ seam owns this for real in B1;
-# inline here keeps the spine self-contained. HARNESS env overrides.
-LAUNCH = {
-    "claude": ["claude"],
-    "opencode": ["opencode"],
-}
+ADAPTERS = ENGINE / "adapters"
+
+
+def load_adapter(harness: str) -> dict:
+    """The harness-specific seam (adapters/<harness>/adapter.json): launch argv,
+    which files to emit at the repo root, and extra launch env. Unknown harness
+    falls back to running its own name + reading AGENTS.md."""
+    path = ADAPTERS / harness / "adapter.json"
+    if path.exists():
+        return json.loads(path.read_text())
+    return {"harness": harness, "launch": [harness], "boot_artifact": "AGENTS.md",
+            "emit": [], "env": {}}
+
+
+def emit_adapter(adapter: dict) -> list[str]:
+    """Copy the adapter's harness-specific config files (e.g. opencode.json) to
+    the repo root. These are emitted artifacts (gitignored), regenerated each
+    launch from the tracked template in the adapter dir."""
+    adir = ADAPTERS / adapter["harness"]
+    written = []
+    for fname in adapter.get("emit", []):
+        src = adir / fname
+        if src.exists():
+            atomic_write(REPO_ROOT / fname, src.read_text())
+            written.append(fname)
+    return written
 
 
 def _configured_harness() -> str | None:
@@ -181,19 +201,25 @@ def main() -> None:
     print(f"→ skills: {len(skills['written'])} written, "
           f"{len(skills['skipped'])} unchanged → .claude/skills/")
 
+    # Harness: HARNESS env wins, else this fork's configured harness
+    # (instance.json, set by the installer), else claude. The adapter seam owns
+    # the launch command + any harness-specific config to emit.
+    harness = os.environ.get("HARNESS") or _configured_harness() or "claude"
+    adapter = load_adapter(harness)
+    emitted = emit_adapter(adapter)
+    print(f"→ harness: {harness} (reads {adapter.get('boot_artifact', 'AGENTS.md')})")
+    if emitted:
+        print(f"→ emitted {', '.join(emitted)}")
+
     if os.environ.get("RENDER_ONLY"):
         print("→ RENDER_ONLY set — not exec'ing the harness.")
         return
 
-    # Harness: HARNESS env wins, else this fork's configured harness
-    # (instance.json, set by the installer), else claude.
-    harness = os.environ.get("HARNESS") or _configured_harness() or "claude"
-    cmd = LAUNCH.get(harness)
-    if not cmd:
-        sys.exit(f"unknown harness '{harness}' (known: {', '.join(LAUNCH)})")
+    cmd = adapter.get("launch") or [harness]
+    env = {**os.environ, **{k: str(v) for k, v in adapter.get("env", {}).items()}}
     os.chdir(REPO_ROOT)
     print(f"→ exec {' '.join(cmd)}\n")
-    os.execvp(cmd[0], cmd)
+    os.execvpe(cmd[0], cmd, env)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Proves the harness-agnostic bet across **Claude Code + OpenCode**. Boot already dual-writes `CLAUDE.md` + `AGENTS.md` + `.claude/skills` (both harnesses read these natively), so OpenCode needed only its config + launch wiring.

- **Formalized `adapters/<harness>/adapter.json`** as the only harness-specific seam (replaces `run.py`'s inline `LAUNCH` dict): `launch` / `boot_artifact` / `emit` / `env`. `run.py` loads it, emits the listed files, exec's `launch` with the adapter env. Unknown harness falls back (run its name, read `AGENTS.md`).
- **claude** — emits nothing extra (reads `CLAUDE.md` + skills natively).
- **opencode** — emits `opencode.json` (instructions → `AGENTS.md`, perms edit/allow · bash/ask, `mcp` slot) from a tracked template; live file gitignored, regenerated each launch. `env.OPENCODE_DISABLE_CLAUDE_CODE=1` best-effort to avoid double-loading `CLAUDE.md`. Model unset (harness is rented).

**Verified render-only**: opencode emits a valid `opencode.json`, claude doesn't, both adapters load. `opencode` isn't installed here, so **runtime verify is pending** — research flags (env name, skills-dir spelling, session paths) documented in `adapters/opencode/README.md` for real-repo testing.

Decision #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)