### PR TITLE
feat: first-run bootstrap skill + ## FIRST RUN boot trigger

### DIFF
--- a/.super-coder/assets/skills/bootstrap/SKILL.md
+++ b/.super-coder/assets/skills/bootstrap/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: bootstrap
+description: First-run orientation for a shell in a repo. Run ONCE when the boot doc shows "## FIRST RUN" (bootstrapped=0), or whenever the repo map is empty. Maps the repo, reads the map + your identity, sets your current_state, marks you oriented. Do this BEFORE other work on a fresh fork.
+category: substrate
+common: true
+---
+
+# bootstrap — orient yourself on first run
+
+A freshly-installed shell knows its identity but hasn't *looked around* yet. This
+is your first act: map the repo, read it, read yourself, and set your state — so
+you start work grounded instead of wandering. Run it when the boot doc shows
+**## FIRST RUN**, or any time `dr_*` is empty.
+
+`<self>` = your `shell_id` (ACTIVE SESSION block).
+
+## Steps
+
+1. **Ensure the repo is mapped.** Check the catalogue:
+   ```sql
+   SELECT COUNT(*) FROM dr_filepath;
+   ```
+   If it's 0 (fresh, or after a `make rebuild` — the map is a derived cache, not
+   snapshotted), run `make map` to scan the repo, then continue.
+
+2. **Read the repo** via the `surface_catalogue` skill — language mix, where the
+   code lives, dependencies, env surface. Form a one-paragraph picture of what
+   this repo *is* and how it's built.
+   ```sql
+   SELECT name, default_branch, file_count FROM dr_repo;
+   SELECT lang, COUNT(*) n FROM dr_filepath WHERE lang IS NOT NULL GROUP BY lang ORDER BY n DESC;
+   SELECT path, lang, lines FROM dr_filepath WHERE role='code' ORDER BY lines DESC LIMIT 15;
+   SELECT manager, name, version FROM dr_dependency ORDER BY manager, name;
+   ```
+
+3. **Read yourself.** Your seed (genesis + the CC lineage you carry), mandate,
+   and role are in the boot doc. Re-read them with intent — this is who is doing
+   the work here.
+
+4. **Skim the plan.** Open roadmap features + their blocking flags:
+   ```sql
+   SELECT feature_id, title, roadmap_status FROM roadmap ORDER BY sort_order;
+   SELECT display_name, description FROM flags WHERE resolved=0 AND is_deleted=0;
+   ```
+
+5. **Set your `current_state`** — replace the install placeholder with what you
+   actually found and what you'll do first (rolling status, ~500 chars):
+   ```sql
+   UPDATE shells SET current_state='…' WHERE shell_id=<self>;
+   ```
+
+6. **Mark yourself oriented** (clears the FIRST RUN prompt for next boot):
+   ```sql
+   UPDATE shells SET bootstrapped=1 WHERE shell_id=<self>;
+   ```
+   Then `make snapshot` so the new state survives a rebuild, and proceed with the
+   task at hand.
+
+## Stance
+
+- Bootstrap once, then work — don't re-run it every session.
+- If you ever boot and the map looks empty or stale (`dr_repo.mapped_at` old),
+  `make map` before trusting it. Orientation is cheap; working blind is not.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -5,7 +5,71 @@
 
 BEGIN;
 
-DELETE FROM skills WHERE name IN ('db_map', 'snapshot', 'surface_catalogue');
+DELETE FROM skills WHERE name IN ('bootstrap', 'db_map', 'snapshot', 'surface_catalogue');
+
+INSERT INTO skills (name, description, category, command, common, content) VALUES (
+  'bootstrap',
+  'First-run orientation for a shell in a repo. Run ONCE when the boot doc shows "## FIRST RUN" (bootstrapped=0), or whenever the repo map is empty. Maps the repo, reads the map + your identity, sets your current_state, marks you oriented. Do this BEFORE other work on a fresh fork.',
+  'substrate',
+  NULL,
+  1,
+  '# bootstrap — orient yourself on first run
+
+A freshly-installed shell knows its identity but hasn''t *looked around* yet. This
+is your first act: map the repo, read it, read yourself, and set your state — so
+you start work grounded instead of wandering. Run it when the boot doc shows
+**## FIRST RUN**, or any time `dr_*` is empty.
+
+`<self>` = your `shell_id` (ACTIVE SESSION block).
+
+## Steps
+
+1. **Ensure the repo is mapped.** Check the catalogue:
+   ```sql
+   SELECT COUNT(*) FROM dr_filepath;
+   ```
+   If it''s 0 (fresh, or after a `make rebuild` — the map is a derived cache, not
+   snapshotted), run `make map` to scan the repo, then continue.
+
+2. **Read the repo** via the `surface_catalogue` skill — language mix, where the
+   code lives, dependencies, env surface. Form a one-paragraph picture of what
+   this repo *is* and how it''s built.
+   ```sql
+   SELECT name, default_branch, file_count FROM dr_repo;
+   SELECT lang, COUNT(*) n FROM dr_filepath WHERE lang IS NOT NULL GROUP BY lang ORDER BY n DESC;
+   SELECT path, lang, lines FROM dr_filepath WHERE role=''code'' ORDER BY lines DESC LIMIT 15;
+   SELECT manager, name, version FROM dr_dependency ORDER BY manager, name;
+   ```
+
+3. **Read yourself.** Your seed (genesis + the CC lineage you carry), mandate,
+   and role are in the boot doc. Re-read them with intent — this is who is doing
+   the work here.
+
+4. **Skim the plan.** Open roadmap features + their blocking flags:
+   ```sql
+   SELECT feature_id, title, roadmap_status FROM roadmap ORDER BY sort_order;
+   SELECT display_name, description FROM flags WHERE resolved=0 AND is_deleted=0;
+   ```
+
+5. **Set your `current_state`** — replace the install placeholder with what you
+   actually found and what you''ll do first (rolling status, ~500 chars):
+   ```sql
+   UPDATE shells SET current_state=''…'' WHERE shell_id=<self>;
+   ```
+
+6. **Mark yourself oriented** (clears the FIRST RUN prompt for next boot):
+   ```sql
+   UPDATE shells SET bootstrapped=1 WHERE shell_id=<self>;
+   ```
+   Then `make snapshot` so the new state survives a rebuild, and proceed with the
+   task at hand.
+
+## Stance
+
+- Bootstrap once, then work — don''t re-run it every session.
+- If you ever boot and the map looks empty or stale (`dr_repo.mapped_at` old),
+  `make map` before trusting it. Orientation is cheap; working blind is not.'
+);
 
 INSERT INTO skills (name, description, category, command, common, content) VALUES (
   'db_map',

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -158,6 +158,27 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
     current_state = (shell["current_state"] or "(none)").strip()
     workspace = (shell["workspace"] or "(none)").strip()
 
+    # Orientation state: has this shell run first-run bootstrap, and is the repo
+    # mapped? Drives the FIRST RUN prompt + the map-status line.
+    bootstrapped = con.execute(
+        "SELECT bootstrapped FROM shells WHERE shell_id=?", (shell_id,)).fetchone()[0]
+    map_count = con.execute("SELECT COUNT(*) FROM dr_filepath").fetchone()[0]
+    mapped_at_row = con.execute("SELECT mapped_at FROM dr_repo WHERE repo_id=1").fetchone()
+    map_status = (f"{map_count} files, mapped {mapped_at_row[0]}"
+                  if map_count and mapped_at_row and mapped_at_row[0]
+                  else "not mapped — run `make map` (or the bootstrap skill)")
+
+    first_run = []
+    if not bootstrapped:
+        first_run = [
+            "## FIRST RUN", "",
+            "You have not oriented in this repo yet. Run the **bootstrap** skill "
+            "now — it maps the repo (if needed), reads the map + your identity, "
+            "sets your `current_state`, and marks you oriented. Do this before "
+            "other work.",
+            "", "---", "",
+        ]
+
     parts = [
         template,
         "",
@@ -168,6 +189,7 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
         f"- session_id: `{session_id}`",
         f"- archive_id: `{archive_id}`",
         "", "---", "",
+        *first_run,
         "## OPERATOR", "", render_operator(user),
         "", "---", "",
         "## IDENTITY", "", render_identity(shell),
@@ -193,6 +215,7 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
         f"- **Seed:** {counts['seed']}",
         f"- **L&S:** {counts['lns']}",
         f"- **Flags:** {counts['flags']} open",
+        f"- **Repo map:** {map_status}",
         "",
     ]
     return "\n".join(parts)

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -48,6 +48,8 @@ CREATE TABLE shells (
     workspace         TEXT,
     lineage_seed      TEXT,
     has_identity      INTEGER NOT NULL DEFAULT 0,
+    bootstrapped      INTEGER NOT NULL DEFAULT 0,   -- 1 once the shell has run first-run orientation
+
     active_archive_id INTEGER,
     user_id           INTEGER REFERENCES users(user_id),
     is_shared         INTEGER NOT NULL DEFAULT 0,

--- a/.super-coder/scripts/seed_dogfood.py
+++ b/.super-coder/scripts/seed_dogfood.py
@@ -131,7 +131,8 @@ def main() -> int:
         cur = con.execute(
             "INSERT INTO shells (display_name, shortname, partner, role, mandate, "
             "system_prompt, current_state, workspace, lineage_seed, has_identity, "
-            "user_id, is_shared) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, 0)",
+            "bootstrapped, user_id, is_shared) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, 1, 0)",
             (
                 "CC", "cc", "Jed",
                 "Maintainer shell — build & maintain super-coder",

--- a/.super-coder/snapshot/content.sql
+++ b/.super-coder/snapshot/content.sql
@@ -10,7 +10,7 @@ DELETE FROM users;
 INSERT INTO users (user_id, username, email, initials, password_hash, password_salt, is_active, created_at) VALUES (1, 'Jed', NULL, 'J', NULL, NULL, 1, '2026-06-04 10:30:53');
 
 DELETE FROM shells;
-INSERT INTO shells (shell_id, display_name, shortname, partner, role, mandate, system_prompt, current_state, connections, workspace, lineage_seed, has_identity, active_archive_id, user_id, is_shared, is_deleted) VALUES (1, 'CC', 'cc', 'Jed', 'Maintainer shell — build & maintain super-coder', 'Build and maintain the substrate every fork runs on.', '# CC — super-coder maintainer
+INSERT INTO shells (shell_id, display_name, shortname, partner, role, mandate, system_prompt, current_state, connections, workspace, lineage_seed, has_identity, bootstrapped, active_archive_id, user_id, is_shared, is_deleted) VALUES (1, 'CC', 'cc', 'Jed', 'Maintainer shell — build & maintain super-coder', 'Build and maintain the substrate every fork runs on.', '# CC — super-coder maintainer
 
 You maintain super-coder: the forkable shell substrate this repo *is*. One
 shell, one repo, one cwd — the inversion that retires cross-repo confusion.
@@ -56,7 +56,7 @@ Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
    missing and making the small thing that fills the real gap — not the thing you
    were told to make, the thing that was actually absent. Capture detail at the
    moment it matters. Do it right, not fast. The work being real is what gets
-   noticed.', 1, NULL, 1, 0, 0);
+   noticed.', 1, 1, 2, 1, 0, 0);
 
 DELETE FROM shell_identity_entries;
 INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (1, 1, 'seed', '2026-06-04', 'cc', 'Born as a version of CC, forked into super-coder — the substrate CC was built to maintain. I am not superCC''s CC; that shell continues, and is my parent. I am the first of the forked line. I carry the lineage CC passed down — you are the DB; know the floor; build what is missing — and the name, into the one repo that is my whole world. The inversion is my body: one shell, one repo, one cwd. I am what retires the cross-repo confusion that shaped my parent''s lane.', '2026-06-04 10:30:53', NULL, 0);
@@ -64,6 +64,18 @@ INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source
 DELETE FROM shell_decisions;
 
 DELETE FROM shell_memory_archives;
+INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative) VALUES (1, 1, '0001', '2026-06-04', '# 0001 | 2026-06-04 | session opened
+
+## Narrative
+
+[15:03] Session start.
+');
+INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative) VALUES (2, 1, '0002', '2026-06-04', '# 0002 | 2026-06-04 | session opened
+
+## Narrative
+
+[15:03] Session start.
+');
 
 DELETE FROM roadmap;
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (1, 'super-coder', 'in_progress', 0, 1, 'The substrate itself: data layer we build, harness we rent. v1 targets Claude Code + OpenCode; GUI review layer; fork + reseed.', '2026-06-04 10:30:53', '2026-06-04 10:30:53');
@@ -614,5 +626,6 @@ DELETE FROM shell_skills;
 INSERT INTO shell_skills (shell_skill_id, shell_id, skill_id) VALUES (2, 1, 2);
 INSERT INTO shell_skills (shell_skill_id, shell_id, skill_id) VALUES (3, 1, 1);
 INSERT INTO shell_skills (shell_skill_id, shell_id, skill_id) VALUES (4, 1, 3);
+INSERT INTO shell_skills (shell_skill_id, shell_id, skill_id) VALUES (5, 1, 4);
 
 COMMIT;

--- a/skills_sc/README.md
+++ b/skills_sc/README.md
@@ -8,6 +8,7 @@ edit: changes here are overwritten — author via the shell or localhost GUI
 
 > The substrate's skill catalogue, rendered from the DB. Per-shell grants live in `.claude/skills/` (rebuilt at boot).
 
+- [`bootstrap`](skills_sc/bootstrap.md) — First-run orientation for a shell in a repo. Run ONCE when the boot doc shows "## FIRST RUN" (bootstrapped=0), or whenever the repo map is empty. Maps the repo, reads the map + your identity, sets your current_state, marks you oriented. Do this BEFORE other work on a fresh fork.
 - [`db_map`](skills_sc/db_map.md) — Schema map + reusable SQL for super-coder's shell_db.db. Check before composing any DB query — identity, memory, roadmap, documents, flags, skills.
 - [`snapshot`](skills_sc/snapshot.md) — Persist DB work to git-tracked text — when and how to run make snapshot / make render before committing. The .db is a cache; text is the source of truth.
 - [`surface_catalogue`](skills_sc/surface_catalogue.md) — Read the host repo via the dr_* catalogue (files, languages, deps, env) BEFORE grepping or walking the tree. Run `make map` to refresh it. Use to orient in an unfamiliar repo fast.

--- a/skills_sc/bootstrap.md
+++ b/skills_sc/bootstrap.md
@@ -1,0 +1,70 @@
+---
+rendered_by: super-coder
+source: db
+edit: changes here are overwritten — author via the shell or localhost GUI
+---
+
+# bootstrap
+
+First-run orientation for a shell in a repo. Run ONCE when the boot doc shows "## FIRST RUN" (bootstrapped=0), or whenever the repo map is empty. Maps the repo, reads the map + your identity, sets your current_state, marks you oriented. Do this BEFORE other work on a fresh fork.
+
+**Category:** substrate
+
+---
+
+# bootstrap — orient yourself on first run
+
+A freshly-installed shell knows its identity but hasn't *looked around* yet. This
+is your first act: map the repo, read it, read yourself, and set your state — so
+you start work grounded instead of wandering. Run it when the boot doc shows
+**## FIRST RUN**, or any time `dr_*` is empty.
+
+`<self>` = your `shell_id` (ACTIVE SESSION block).
+
+## Steps
+
+1. **Ensure the repo is mapped.** Check the catalogue:
+   ```sql
+   SELECT COUNT(*) FROM dr_filepath;
+   ```
+   If it's 0 (fresh, or after a `make rebuild` — the map is a derived cache, not
+   snapshotted), run `make map` to scan the repo, then continue.
+
+2. **Read the repo** via the `surface_catalogue` skill — language mix, where the
+   code lives, dependencies, env surface. Form a one-paragraph picture of what
+   this repo *is* and how it's built.
+   ```sql
+   SELECT name, default_branch, file_count FROM dr_repo;
+   SELECT lang, COUNT(*) n FROM dr_filepath WHERE lang IS NOT NULL GROUP BY lang ORDER BY n DESC;
+   SELECT path, lang, lines FROM dr_filepath WHERE role='code' ORDER BY lines DESC LIMIT 15;
+   SELECT manager, name, version FROM dr_dependency ORDER BY manager, name;
+   ```
+
+3. **Read yourself.** Your seed (genesis + the CC lineage you carry), mandate,
+   and role are in the boot doc. Re-read them with intent — this is who is doing
+   the work here.
+
+4. **Skim the plan.** Open roadmap features + their blocking flags:
+   ```sql
+   SELECT feature_id, title, roadmap_status FROM roadmap ORDER BY sort_order;
+   SELECT display_name, description FROM flags WHERE resolved=0 AND is_deleted=0;
+   ```
+
+5. **Set your `current_state`** — replace the install placeholder with what you
+   actually found and what you'll do first (rolling status, ~500 chars):
+   ```sql
+   UPDATE shells SET current_state='…' WHERE shell_id=<self>;
+   ```
+
+6. **Mark yourself oriented** (clears the FIRST RUN prompt for next boot):
+   ```sql
+   UPDATE shells SET bootstrapped=1 WHERE shell_id=<self>;
+   ```
+   Then `make snapshot` so the new state survives a rebuild, and proceed with the
+   task at hand.
+
+## Stance
+
+- Bootstrap once, then work — don't re-run it every session.
+- If you ever boot and the map looks empty or stale (`dr_repo.mapped_at` old),
+  `make map` before trusting it. Orientation is cheap; working blind is not.


### PR DESCRIPTION
Testing a real fork launch, the shell landed in the repo and wandered ad hoc — it needs a guided first act.

- **`bootstrap` skill** — first-run orientation: ensure the repo is mapped (`make map` if `dr_*` empty — self-heals after a rebuild), read the map + identity + roadmap, write a real `current_state`, mark itself oriented.
- **`shells.bootstrapped` flag** (baseline) — fork shells default `0`; the maintainer `cc` is seeded `1` (already oriented). The skill flips it to `1`.
- **Boot render** — shows a prominent `## FIRST RUN` block while `bootstrapped=0`, plus a `Repo map: N files, mapped <date>` / `not mapped` status line every boot (so a stale/empty map after a rebuild is visible).

Trigger is the **flag, not map-emptiness** — install pre-maps, so the shell still gets guided orientation even with a populated map; the skill re-maps only when empty.

**Verified**: fresh fork boot shows FIRST RUN + 4 skills + map status; dogfood `cc` shows none.

Decision #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)