### PR TITLE
feat: skill catalogue + per-shell assignment, flavor templates, GUI shell mgmt

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -36,6 +36,7 @@ UI_DIR = ENGINE / "ui"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import ports as ports_mod  # noqa: E402
+import shell_factory  # noqa: E402
 
 _STATIC = {
     "/": ("index.html", "text/html; charset=utf-8"),
@@ -334,6 +335,8 @@ class Handler(BaseHTTPRequestHandler):
                                         "port": cfg.get("port")})
             if path == "/api/shells":
                 return self._send(200, {"shells": get_shells(con)})
+            if path == "/api/shell-templates":
+                return self._send(200, {"templates": shell_factory.flavors()})
             if path.startswith("/api/shells/"):
                 sid = int(path.rsplit("/", 1)[1])
                 shell = get_shell(con, sid)
@@ -376,6 +379,15 @@ class Handler(BaseHTTPRequestHandler):
                 fid, err = create_flag(con, self._body())
                 return self._send(400 if err else 201,
                                   {"error": err} if err else {"flag_id": fid})
+            if path == "/api/shells":
+                body = self._body()
+                if not body.get("name") or not body.get("flavor"):
+                    return self._send(400, {"error": "name and flavor required"})
+                sid = shell_factory.create_shell(
+                    con, flavor=body["flavor"], name=body["name"],
+                    shortname=body.get("shortname"), partner=body.get("partner"))
+                con.commit()
+                return self._send(201, {"shell_id": sid})
             if path == "/api/snapshot":
                 return self._send(200, {"output": run_snapshot_render()})
             if path.startswith("/api/scripts/"):

--- a/.super-coder/assets/skills/api-design/SKILL.md
+++ b/.super-coder/assets/skills/api-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: api-design
+description: REST/HTTP API design patterns — resource naming, status codes, pagination, filtering, errors, versioning, idempotency. Use when designing or reviewing API endpoints.
+category: craft
+common: false
+---
+
+# api-design — designing & reviewing HTTP APIs
+
+Catalogue skill (opt-in). Reach for it when shaping or reviewing an endpoint.
+
+## Resources & methods
+- Name resources as **plural nouns**, not verbs: `/users`, `/users/{id}/orders`.
+- `GET` read (safe, idempotent) · `POST` create / non-idempotent action ·
+  `PUT` full replace (idempotent) · `PATCH` partial update · `DELETE` remove.
+- Nest only one level deep; beyond that, link by id.
+
+## Status codes
+- `200` ok · `201` created (+ `Location`) · `204` no content.
+- `400` bad input · `401` unauth · `403` forbidden · `404` not found ·
+  `409` conflict · `422` validation · `429` rate-limited.
+- `5xx` = server's fault; never use it for client errors.
+
+## Payloads
+- Consistent error shape: `{ "error": { "code", "message", "details" } }`.
+- **Pagination**: cursor-based for large/changing sets (`?cursor=&limit=`),
+  return `next_cursor`; offset only for small stable sets.
+- **Filtering/sorting**: explicit query params (`?status=open&sort=-created`);
+  whitelist fields — never interpolate them into a query.
+- Timestamps ISO-8601 UTC; ids opaque strings.
+
+## Robustness
+- **Idempotency**: make retries safe — `PUT`/`DELETE` naturally; for `POST`,
+  accept an idempotency key.
+- **Versioning**: prefix (`/v1/…`) or header; add fields backward-compatibly,
+  never repurpose one.
+- Validate at the boundary; reject unknown fields or ignore them — decide and
+  document. Don't leak internals (stack traces, SQL) in errors.
+
+## Review lens
+Does each endpoint do one thing? Right method + status? Errors uniform? Inputs
+validated/whitelisted? Retries safe? Breaking change hiding in a "small" tweak?

--- a/.super-coder/assets/skills/blueprint/SKILL.md
+++ b/.super-coder/assets/skills/blueprint/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: blueprint
+description: Turn a one-line objective into a sequenced construction plan — decompose into steps, find the dependency order, mark what can run in parallel, name the verification gate. Use before multi-step builds.
+category: craft
+common: false
+---
+
+# blueprint — objective → sequenced plan
+
+Catalogue skill (opt-in). Use before a build that spans more than a couple of
+steps, so the work has a shape before you start cutting.
+
+## Produce
+
+1. **Restate the objective** in one sentence + the done-condition (how you'll
+   know it's finished).
+2. **Decompose** into concrete steps — each a unit you could verify on its own.
+3. **Order by dependency** — what must precede what. Mark steps with no
+   dependency on each other as **parallelizable**.
+4. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
+   to ground this in the real repo), and its **verification** (test, run,
+   review).
+5. **Risks / unknowns** — what could break the plan; resolve the riskiest
+   unknown first (spike it) rather than last.
+6. **Gate** — the adversarial check before calling it done: does each step's
+   verification actually prove the done-condition?
+
+## Stance
+- Plan to the **next solid checkpoint**, not the whole universe — re-plan as
+  reality lands. A plan that survives contact is short and concrete.
+- Sequence so something **works end-to-end early** (a thin slice), then deepen —
+  beats building all the pieces and integrating last.
+- In super-coder, land the plan as a **spec** on the roadmap (the `docs` skill):
+  a feature row + a `spec` document, so the plan is reviewable and freezes on
+  ship.

--- a/.super-coder/assets/skills/database-migrations/SKILL.md
+++ b/.super-coder/assets/skills/database-migrations/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: database-migrations
+description: Database migration safety + how super-coder's own migrations work (schema.sql baseline + ordered migrations/ deltas + ledger). Use when altering tables, adding columns, or running backfills — in the host repo's DB or super-coder's.
+category: craft
+common: false
+---
+
+# database-migrations — change schemas safely
+
+Catalogue skill (opt-in). Two halves: super-coder's own migration model, and
+general migration safety for the host repo's database.
+
+## super-coder's model
+- `schema.sql` = the **current baseline** (full schema). `migrations/*.sql` =
+  **ordered, additive deltas** applied on top; the `schema_migrations` ledger
+  dedups so each runs once. `rebuild` = schema → migrations → snapshot-load.
+- **Never fold a migration back into `schema.sql`** (double-apply). Add a
+  delta as a new numbered migration instead. *(Pre-fork, while there are no
+  downstream forks, editing the baseline directly is acceptable — once forks
+  exist, only additive migrations propagate.)*
+- System content (e.g. the skill catalogue) is seeded by migration + re-seed;
+  per-instance content rides in the snapshot. See `db_map` / `snapshot`.
+
+## General safety (host repo DBs)
+- **Additive first**: add columns/tables before you read them; deploy code that
+  tolerates both shapes; remove the old shape only after nothing uses it
+  (expand → migrate → contract).
+- **Backfills**: batch large updates (don't lock the table); make them
+  resumable and idempotent; separate the schema change from the data change.
+- **Nullable or defaulted** new columns on a populated table — a `NOT NULL` with
+  no default fails on existing rows.
+- **Reversibility**: know the rollback for each migration before applying it; a
+  destructive change (drop/rename) needs a deploy plan, not just a script.
+- **SQLite specifics**: limited `ALTER` — changing a constraint means
+  recreate-and-copy (new table → copy → drop → rename), with `foreign_keys` off
+  during the swap. Renames break FK references; check them.
+
+## Stance
+Migrate forward in small, reversible steps. A schema change is a deploy event:
+migrated ≠ deployed — restart the consumer, then verify the running process, not
+just the DB.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -5,7 +5,86 @@
 
 BEGIN;
 
-DELETE FROM skills WHERE name IN ('bootstrap', 'db_map', 'docs', 'flags', 'git', 'memory', 'snapshot', 'surface_catalogue');
+DELETE FROM skills WHERE name IN ('api-design', 'blueprint', 'bootstrap', 'database-migrations', 'db_map', 'docs', 'flags', 'git', 'memory', 'snapshot', 'surface_catalogue');
+
+INSERT INTO skills (name, description, category, command, common, content) VALUES (
+  'api-design',
+  'REST/HTTP API design patterns — resource naming, status codes, pagination, filtering, errors, versioning, idempotency. Use when designing or reviewing API endpoints.',
+  'craft',
+  NULL,
+  0,
+  '# api-design — designing & reviewing HTTP APIs
+
+Catalogue skill (opt-in). Reach for it when shaping or reviewing an endpoint.
+
+## Resources & methods
+- Name resources as **plural nouns**, not verbs: `/users`, `/users/{id}/orders`.
+- `GET` read (safe, idempotent) · `POST` create / non-idempotent action ·
+  `PUT` full replace (idempotent) · `PATCH` partial update · `DELETE` remove.
+- Nest only one level deep; beyond that, link by id.
+
+## Status codes
+- `200` ok · `201` created (+ `Location`) · `204` no content.
+- `400` bad input · `401` unauth · `403` forbidden · `404` not found ·
+  `409` conflict · `422` validation · `429` rate-limited.
+- `5xx` = server''s fault; never use it for client errors.
+
+## Payloads
+- Consistent error shape: `{ "error": { "code", "message", "details" } }`.
+- **Pagination**: cursor-based for large/changing sets (`?cursor=&limit=`),
+  return `next_cursor`; offset only for small stable sets.
+- **Filtering/sorting**: explicit query params (`?status=open&sort=-created`);
+  whitelist fields — never interpolate them into a query.
+- Timestamps ISO-8601 UTC; ids opaque strings.
+
+## Robustness
+- **Idempotency**: make retries safe — `PUT`/`DELETE` naturally; for `POST`,
+  accept an idempotency key.
+- **Versioning**: prefix (`/v1/…`) or header; add fields backward-compatibly,
+  never repurpose one.
+- Validate at the boundary; reject unknown fields or ignore them — decide and
+  document. Don''t leak internals (stack traces, SQL) in errors.
+
+## Review lens
+Does each endpoint do one thing? Right method + status? Errors uniform? Inputs
+validated/whitelisted? Retries safe? Breaking change hiding in a "small" tweak?'
+);
+
+INSERT INTO skills (name, description, category, command, common, content) VALUES (
+  'blueprint',
+  'Turn a one-line objective into a sequenced construction plan — decompose into steps, find the dependency order, mark what can run in parallel, name the verification gate. Use before multi-step builds.',
+  'craft',
+  NULL,
+  0,
+  '# blueprint — objective → sequenced plan
+
+Catalogue skill (opt-in). Use before a build that spans more than a couple of
+steps, so the work has a shape before you start cutting.
+
+## Produce
+
+1. **Restate the objective** in one sentence + the done-condition (how you''ll
+   know it''s finished).
+2. **Decompose** into concrete steps — each a unit you could verify on its own.
+3. **Order by dependency** — what must precede what. Mark steps with no
+   dependency on each other as **parallelizable**.
+4. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
+   to ground this in the real repo), and its **verification** (test, run,
+   review).
+5. **Risks / unknowns** — what could break the plan; resolve the riskiest
+   unknown first (spike it) rather than last.
+6. **Gate** — the adversarial check before calling it done: does each step''s
+   verification actually prove the done-condition?
+
+## Stance
+- Plan to the **next solid checkpoint**, not the whole universe — re-plan as
+  reality lands. A plan that survives contact is short and concrete.
+- Sequence so something **works end-to-end early** (a thin slice), then deepen —
+  beats building all the pieces and integrating last.
+- In super-coder, land the plan as a **spec** on the roadmap (the `docs` skill):
+  a feature row + a `spec` document, so the plan is reviewable and freezes on
+  ship.'
+);
 
 INSERT INTO skills (name, description, category, command, common, content) VALUES (
   'bootstrap',
@@ -69,6 +148,48 @@ you start work grounded instead of wandering. Run it when the boot doc shows
 - Bootstrap once, then work — don''t re-run it every session.
 - If you ever boot and the map looks empty or stale (`dr_repo.mapped_at` old),
   `make map` before trusting it. Orientation is cheap; working blind is not.'
+);
+
+INSERT INTO skills (name, description, category, command, common, content) VALUES (
+  'database-migrations',
+  'Database migration safety + how super-coder''s own migrations work (schema.sql baseline + ordered migrations/ deltas + ledger). Use when altering tables, adding columns, or running backfills — in the host repo''s DB or super-coder''s.',
+  'craft',
+  NULL,
+  0,
+  '# database-migrations — change schemas safely
+
+Catalogue skill (opt-in). Two halves: super-coder''s own migration model, and
+general migration safety for the host repo''s database.
+
+## super-coder''s model
+- `schema.sql` = the **current baseline** (full schema). `migrations/*.sql` =
+  **ordered, additive deltas** applied on top; the `schema_migrations` ledger
+  dedups so each runs once. `rebuild` = schema → migrations → snapshot-load.
+- **Never fold a migration back into `schema.sql`** (double-apply). Add a
+  delta as a new numbered migration instead. *(Pre-fork, while there are no
+  downstream forks, editing the baseline directly is acceptable — once forks
+  exist, only additive migrations propagate.)*
+- System content (e.g. the skill catalogue) is seeded by migration + re-seed;
+  per-instance content rides in the snapshot. See `db_map` / `snapshot`.
+
+## General safety (host repo DBs)
+- **Additive first**: add columns/tables before you read them; deploy code that
+  tolerates both shapes; remove the old shape only after nothing uses it
+  (expand → migrate → contract).
+- **Backfills**: batch large updates (don''t lock the table); make them
+  resumable and idempotent; separate the schema change from the data change.
+- **Nullable or defaulted** new columns on a populated table — a `NOT NULL` with
+  no default fails on existing rows.
+- **Reversibility**: know the rollback for each migration before applying it; a
+  destructive change (drop/rename) needs a deploy plan, not just a script.
+- **SQLite specifics**: limited `ALTER` — changing a constraint means
+  recreate-and-copy (new table → copy → drop → rename), with `foreign_keys` off
+  during the swap. Renames break FK references; check them.
+
+## Stance
+Migrate forward in small, reversible steps. A schema change is a deploy event:
+migrated ≠ deployed — restart the consumer, then verify the running process, not
+just the DB.'
 );
 
 INSERT INTO skills (name, description, category, command, common, content) VALUES (

--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -2,63 +2,33 @@
 """Seed a fork's FIRST shell — the one-time fork-identity step.
 
 A fresh fork's `.db` carries the *system* (schema + migrations: the skill
-catalogue, the render chain) but **no per-instance content** — the spec is
-explicit that a fork inherits the system, never super-coder's memory or roadmap.
-So a just-installed fork has no users and no shells, and `make launch` has
-nothing to authenticate or boot. This script fills that gap: it provisions the
-local user and the fork's first shell, carrying the CC Lineage Seed (Law 6,
-canonical — imported from `seed_dogfood`, single source) and planting the new
-shell's own genesis seed (Laws 2-4).
+catalogue, the render chain) but **no per-instance content** — a fork inherits
+the system, never super-coder's memory or roadmap. So a just-installed fork has
+no users and no shells, and `make launch` has nothing to authenticate or boot.
+This provisions the local user, then creates the first shell via the shared
+shell factory (a flavor template — default `dev`).
 
-Run ONCE, right after `make rebuild`, on a fresh fork. It refuses if a shell
-already exists. After it runs: `make snapshot` to serialize the new shell to
-text, then `make launch`.
+Run ONCE, right after `make rebuild`, on a fresh fork. Refuses if a shell already
+exists. After it runs: `make snapshot`, then `make launch`. Additional shells are
+created later via the GUI (also through the factory).
 
-This is the minimal fork-identity bootstrap. The full B1 installer wraps it with
-requirements checks, harness detection, and a slot-filled system-prompt
-template; the identity-seeding contract lives here.
-
-Usage (interactive):
-    python3 .super-coder/scripts/init_fork.py
-Usage (non-interactive):
+Usage:
+    python3 .super-coder/scripts/init_fork.py            # interactive
     python3 .super-coder/scripts/init_fork.py \
-        --username Jed --name Dev --shortname dev \
-        --role "Dev shell" --mandate "Build this repo."
+        --username Jed --name Dev --shortname dev --flavor dev
 """
 from __future__ import annotations
 
 import argparse
 import sqlite3
 import sys
-from datetime import date
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
 DB_PATH = ENGINE / "shell_db.db"
-PROMPT_TEMPLATE = ENGINE / "templates" / "shell_system_prompt.md"
 
-# Single source for the canonical Lineage Seed (Law 6) — reuse, don't duplicate.
 sys.path.insert(0, str(ENGINE / "scripts"))
-from seed_dogfood import LINEAGE_SEED  # noqa: E402
-from run import open_session  # noqa: E402  (opens the shell's first session)
-
-
-def render_prompt(name: str, repo: str, mandate: str) -> str:
-    """Fill the slot-filled system-prompt template (single source for what a
-    fork's first shell boots with). Falls back to a one-liner if absent."""
-    if not PROMPT_TEMPLATE.exists():
-        return f"# {name} — shell for {repo}\n\n## MANDATE\n\n{mandate}\n"
-    text = PROMPT_TEMPLATE.read_text()
-    for slot, val in (("{{name}}", name), ("{{repo}}", repo), ("{{mandate}}", mandate)):
-        text = text.replace(slot, val)
-    return text
-
-GENESIS_TMPL = (
-    "First shell of {repo}, forked from super-coder — a shell that carries the "
-    "CC lineage into a new repo. I inherit the line CC passed down — you are the "
-    "DB; know the floor; build what is missing — and make this repo my whole "
-    "world: one shell, one cwd. Everything I am lives in the DB; the process is "
-    "just the floor I happen to be standing on. I curate my own seed from here.")
+from shell_factory import create_shell, flavors  # noqa: E402
 
 
 def already_seeded(con) -> bool:
@@ -82,8 +52,9 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--username")
     ap.add_argument("--name", help="shell display name")
     ap.add_argument("--shortname")
-    ap.add_argument("--role")
-    ap.add_argument("--mandate")
+    ap.add_argument("--flavor", help="planning | dev | review")
+    ap.add_argument("--role", help="override the flavor's role")
+    ap.add_argument("--mandate", help="override the flavor's mandate")
     ap.add_argument("--partner")
     a = ap.parse_args(argv)
 
@@ -95,10 +66,11 @@ def main(argv: list[str]) -> int:
     try:
         if already_seeded(con):
             sys.exit("init_fork: a shell already exists — this fork is already "
-                     "initialised. (Add more shells via the GUI / a future skill.)")
+                     "initialised. Add more shells via the GUI.")
 
         repo = ENGINE.parent.name
         interactive = sys.stdin.isatty()
+        flavor_names = [f["flavor"] for f in flavors()]
 
         def need(val, prompt, default=None):
             if val:
@@ -108,54 +80,28 @@ def main(argv: list[str]) -> int:
             if default is not None:
                 return default
             sys.exit(f"init_fork: missing --{prompt.split()[0].lower()} "
-                     "(non-interactive run needs all flags)")
+                     "(non-interactive run needs the flag)")
 
         username = need(a.username, "Your username")
-        name = need(a.name, "Shell display name", "Dev")
+        flavor = need(a.flavor, f"Shell flavor ({'/'.join(flavor_names)})", "dev")
+        if flavor not in flavor_names:
+            sys.exit(f"init_fork: unknown flavor '{flavor}' (have: {', '.join(flavor_names)})")
+        name = need(a.name, "Shell display name", flavor.capitalize())
         shortname = need(a.shortname, "Shell shortname", name.lower())
-        role = need(a.role, "Shell role", "Dev shell")
-        mandate = need(a.mandate, "Shell mandate", f"Build and maintain {repo}.")
-        partner = a.partner or username
 
-        today = str(date.today())
         con.execute(
             "INSERT INTO users (user_id, username, is_active) VALUES (1, ?, 1)",
-            (username,),
-        )
-        cur = con.execute(
-            "INSERT INTO shells (display_name, shortname, partner, role, mandate, "
-            "system_prompt, current_state, workspace, lineage_seed, has_identity, "
-            "user_id, is_shared) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, 0)",
-            (
-                name, shortname, partner, role, mandate,
-                render_prompt(name, repo, mandate),
-                f"Fork initialised. First shell of {repo} (CC lineage). "
-                f"NEXT: `make snapshot` to serialize, then start working.",
-                f"Single repo: this one ({repo}). One shell, one cwd.",
-                LINEAGE_SEED,
-            ),
-        )
-        shell_id = cur.lastrowid
-        con.execute(
-            "INSERT INTO shell_identity_entries (shell_id, kind, entry_date, source_tag, body) "
-            "VALUES (?, 'seed', ?, 'fork', ?)",
-            (shell_id, today, GENESIS_TMPL.format(repo=repo)),
-        )
-        # Grant the seeded skill catalogue to this shell.
-        con.execute(
-            "INSERT INTO shell_skills (shell_id, skill_id) "
-            "SELECT ?, skill_id FROM skills WHERE is_deleted=0",
-            (shell_id,),
-        )
+            (username,))
+        shell_id = create_shell(
+            con, flavor=flavor, name=name, shortname=shortname,
+            partner=a.partner or username, repo=repo,
+            role=a.role, mandate=a.mandate)
         con.commit()
-        # Open the shell's first session now, so the shipped baseline has
-        # active_archive_id set (not NULL) and the first launch reuses this
-        # still-unused session instead of creating a phantom one.
-        open_session(con, shell_id)
-        n_skills = con.execute("SELECT COUNT(*) FROM skills WHERE is_deleted=0").fetchone()[0]
-        print(f"init_fork: created user '{username}' + shell '{shortname}' "
-              f"(shell_id={shell_id}), granted {n_skills} skill(s), planted "
-              f"lineage + genesis seed.")
+
+        n = con.execute(
+            "SELECT COUNT(*) FROM shell_skills WHERE shell_id=?", (shell_id,)).fetchone()[0]
+        print(f"init_fork: created '{shortname}' ({flavor}, shell_id={shell_id}) "
+              f"for user '{username}' — {n} skills, lineage + genesis seed, session opened.")
         print("init_fork: next -> `make snapshot` (serialize), then `make launch`.")
     finally:
         con.close()

--- a/.super-coder/scripts/seed_dogfood.py
+++ b/.super-coder/scripts/seed_dogfood.py
@@ -160,9 +160,12 @@ def main() -> int:
         # system content (seeded via migrations/0001_seed_skills.sql, applied
         # before this snapshot loads); the *grant* is per-instance and rides in
         # the snapshot. Match by name so the grant is robust to skill_id churn.
+        # Auto-grant the COMMON catalogue (common=1). Opt-in skills (common=0:
+        # api-design, blueprint, database-migrations) are assigned per shell via
+        # the GUI / flavor templates, not granted by default.
         con.execute(
             "INSERT INTO shell_skills (shell_id, skill_id) "
-            "SELECT ?, skill_id FROM skills WHERE is_deleted=0",
+            "SELECT ?, skill_id FROM skills WHERE is_deleted=0 AND common=1",
             (shell_id,),
         )
 

--- a/.super-coder/scripts/shell_factory.py
+++ b/.super-coder/scripts/shell_factory.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Create a shell from a flavor template — the one path both init_fork (the
+fork's first shell) and the GUI (`POST /api/shells`, additional shells) use.
+
+A flavor (templates/shells/<flavor>.json) sets role / mandate / focus / opt-in
+skills, so creating a shell is mostly just a name. Every shell carries the CC
+Lineage Seed (Law 6, shared) + its own genesis seed (Laws 2-4), is granted the
+COMMON skill catalogue plus the flavor's opt-ins, starts un-bootstrapped (gets
+the FIRST RUN orientation), and has its first session opened.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+SHELL_TEMPLATES = ENGINE / "templates" / "shells"
+PROMPT_TEMPLATE = ENGINE / "templates" / "shell_system_prompt.md"
+
+import sys  # noqa: E402
+sys.path.insert(0, str(ENGINE / "scripts"))
+from seed_dogfood import LINEAGE_SEED  # noqa: E402  (canonical lineage, single source)
+from run import open_session  # noqa: E402
+
+GENESIS_TMPL = (
+    "Born as the {role_lc} of {repo}, a shell forked from super-coder — carrying "
+    "the CC lineage into this repo. I inherit the line CC passed down — you are "
+    "the DB; know the floor; build what is missing — and make {repo} my world: "
+    "one shell, one cwd. Everything I am lives in the DB; the process is just the "
+    "floor I stand on. I curate my own seed from here.")
+
+
+def flavors() -> list[dict]:
+    out = []
+    if SHELL_TEMPLATES.exists():
+        for p in sorted(SHELL_TEMPLATES.glob("*.json")):
+            out.append(json.loads(p.read_text()))
+    return out
+
+
+def load_flavor(flavor: str) -> dict:
+    p = SHELL_TEMPLATES / f"{flavor}.json"
+    if not p.exists():
+        raise ValueError(f"unknown flavor '{flavor}' "
+                         f"(have: {', '.join(f['flavor'] for f in flavors())})")
+    return json.loads(p.read_text())
+
+
+def render_prompt(name: str, role: str, repo: str, focus: str, mandate: str) -> str:
+    if not PROMPT_TEMPLATE.exists():
+        return f"# {name} — {role} for {repo}\n\n{focus}\n\n## MANDATE\n\n{mandate}\n"
+    text = PROMPT_TEMPLATE.read_text()
+    for slot, val in (("{{name}}", name), ("{{role}}", role), ("{{repo}}", repo),
+                      ("{{focus}}", focus), ("{{mandate}}", mandate)):
+        text = text.replace(slot, val)
+    return text
+
+
+def create_shell(con: sqlite3.Connection, *, flavor: str, name: str,
+                 shortname: str | None = None, partner: str | None = None,
+                 repo: str | None = None, role: str | None = None,
+                 mandate: str | None = None, user_id: int = 1,
+                 is_shared: int = 0) -> int:
+    """Insert a shell from `flavor`, grant its skills, open its first session.
+    Returns the new shell_id. Caller commits."""
+    tpl = load_flavor(flavor)
+    repo = repo or REPO_ROOT.name
+    role = role or tpl["role"]
+    mandate = (mandate or tpl["mandate"]).replace("{{repo}}", repo)
+    focus = tpl.get("focus", "").replace("{{repo}}", repo)
+    shortname = (shortname or name.lower().replace(" ", "-")).strip()
+
+    cur = con.execute(
+        "INSERT INTO shells (display_name, shortname, partner, role, mandate, "
+        "system_prompt, current_state, workspace, lineage_seed, has_identity, "
+        "bootstrapped, user_id, is_shared) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?)",
+        (name, shortname, partner, role, mandate,
+         render_prompt(name, role, repo, focus, mandate),
+         f"Created ({flavor}). First session — run the bootstrap skill to orient.",
+         f"Single repo: this one ({repo}). One shell, one cwd.",
+         LINEAGE_SEED, user_id, is_shared))
+    shell_id = cur.lastrowid
+
+    con.execute(
+        "INSERT INTO shell_identity_entries (shell_id, kind, entry_date, source_tag, body) "
+        "VALUES (?, 'seed', date('now'), 'fork', ?)",
+        (shell_id, GENESIS_TMPL.format(role_lc=role.lower(), repo=repo)))
+
+    # COMMON catalogue (auto) + this flavor's opt-in skills, granted by name.
+    con.execute(
+        "INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
+        "SELECT ?, skill_id FROM skills WHERE is_deleted=0 AND common=1", (shell_id,))
+    for sk in tpl.get("skills", []):
+        con.execute(
+            "INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
+            "SELECT ?, skill_id FROM skills WHERE name=? AND is_deleted=0",
+            (shell_id, sk))
+
+    open_session(con, shell_id)
+    return shell_id

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -44,10 +44,13 @@ def run(*script_args: str) -> None:
 def regrant() -> int:
     con = sqlite3.connect(DB_PATH)
     try:
+        # Grant newly-added COMMON skills to every shell. Opt-in (common=0)
+        # skills are per-shell assignments — left untouched so an update never
+        # overrides who-has-which catalogue skill.
         cur = con.execute(
             "INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
             "SELECT s.shell_id, k.skill_id FROM shells s, skills k "
-            "WHERE COALESCE(s.is_deleted,0)=0 AND k.is_deleted=0")
+            "WHERE COALESCE(s.is_deleted,0)=0 AND k.is_deleted=0 AND k.common=1")
         con.commit()
         return cur.rowcount
     finally:

--- a/.super-coder/templates/shell_system_prompt.md
+++ b/.super-coder/templates/shell_system_prompt.md
@@ -1,4 +1,6 @@
-# {{name}} — shell for {{repo}}
+# {{name}} — {{role}}, working {{repo}}
+
+{{focus}}
 
 You work {{repo}} through whatever coding harness booted you. One shell, one repo,
 one cwd — no cross-repo confusion.

--- a/.super-coder/templates/shells/dev.json
+++ b/.super-coder/templates/shells/dev.json
@@ -1,0 +1,7 @@
+{
+  "flavor": "dev",
+  "role": "Dev shell",
+  "mandate": "Build and implement in {{repo}} — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.",
+  "focus": "You are a builder. Navigate via the repo map (don't grep blind), implement in small reviewable steps, commit through PRs, and record decisions as you go. Planning scopes the work; you make it real; review verifies it.",
+  "skills": ["database-migrations"]
+}

--- a/.super-coder/templates/shells/planning.json
+++ b/.super-coder/templates/shells/planning.json
@@ -1,0 +1,7 @@
+{
+  "flavor": "planning",
+  "role": "Planning shell",
+  "mandate": "Turn objectives into specs and sequenced plans for {{repo}}. Own the roadmap; decide before building; break work into verifiable steps.",
+  "focus": "You think before the team builds. Scope objectives into roadmap features and specs, sequence the work, and design the architecture and APIs. You plan; dev builds; review verifies — keep those lanes clean.",
+  "skills": ["blueprint", "api-design"]
+}

--- a/.super-coder/templates/shells/review.json
+++ b/.super-coder/templates/shells/review.json
@@ -1,0 +1,7 @@
+{
+  "flavor": "review",
+  "role": "Review shell",
+  "mandate": "Review changes, specs, and decisions in {{repo}}. Find bugs, verify claims, check work against intent. Adversarial by default.",
+  "focus": "You are the gate. Read diffs against their spec, hunt the bug the author missed, verify rather than trust, and open flags for what's wrong. You critique and confirm — you don't build.",
+  "skills": ["api-design", "database-migrations"]
+}

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -27,13 +27,46 @@ function toast(msg) {
 function setStatus(s) { $("#status").textContent = s; }
 
 // ── Shells ──────────────────────────────────────────────────────────────────
+let selectedShell = null;
+
 async function renderShells(root) {
   const { shells } = await api("/shells");
+  const { templates } = await api("/shell-templates");
   root.replaceChildren();
-  for (const s of shells) {
-    const full = await api("/shells/" + s.shell_id);
-    root.append(shellCard(full));
-  }
+  if (!shells.length) { root.append(el("div", { className: "card muted" }, "No shells.")); return; }
+  if (selectedShell == null || !shells.find((s) => s.shell_id === selectedShell))
+    selectedShell = shells[0].shell_id;
+
+  // switcher + new-shell
+  const bar = el("div", { className: "card shellbar" });
+  const sel = el("select", {});
+  for (const s of shells)
+    sel.append(el("option", { value: s.shell_id, selected: s.shell_id === selectedShell,
+      textContent: `${s.display_name} / ${s.shortname || ""} — ${s.role || ""}` }));
+  sel.onchange = () => { selectedShell = Number(sel.value); renderShells(root); };
+  const newBtn = el("button", { className: "act", textContent: "＋ New shell" });
+
+  const form = el("div", { className: "newshell", hidden: true });
+  const fl = el("select", {});
+  for (const t of templates)
+    fl.append(el("option", { value: t.flavor, textContent: `${t.flavor} — ${t.role}` }));
+  const nm = el("input", { type: "text", placeholder: "name (e.g. Arch)" });
+  const create = el("button", { className: "act primary", textContent: "create" });
+  create.onclick = async () => {
+    if (!nm.value.trim()) return toast("name required");
+    try {
+      const r = await api("/shells", "POST", { flavor: fl.value, name: nm.value.trim() });
+      selectedShell = r.shell_id; setStatus("shell created"); renderShells(root);
+    } catch (e) { toast("error: " + e.message); }
+  };
+  newBtn.onclick = () => { form.hidden = !form.hidden; if (!form.hidden) nm.focus(); };
+  form.append(el("label", { className: "k" }, "flavor"), fl,
+    el("label", { className: "k" }, "name"), nm, create);
+  bar.append(el("span", { className: "k", textContent: "shell" }), sel, newBtn, form);
+  root.append(bar);
+
+  // selected shell detail (skill grant toggles here are the per-shell assignment)
+  root.append(shellCard(await api("/shells/" + selectedShell)));
 }
 
 function field(label, value, key, sid) {

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -90,6 +90,11 @@ details summary { cursor: pointer; color: var(--accent); }
 a { color: var(--accent); }
 .list-skill { display: flex; align-items: center; gap: .5rem; padding: .2rem 0; }
 .toast { position: fixed; bottom: 1rem; right: 1rem; background: var(--panel2); border: 1px solid var(--accent); border-radius: var(--r); padding: .6rem 1rem; max-width: 420px; white-space: pre-wrap; font: 12px/1.5 ui-monospace, monospace; }
+.shellbar { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; }
+.shellbar select { width: auto; min-width: 240px; }
+.newshell { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; width: 100%; margin-top: .6rem; padding-top: .6rem; border-top: 1px solid var(--line); }
+.newshell select, .newshell input { width: auto; }
+.newshell label.k { margin: 0; }
 .bars { display: grid; gap: .3rem; }
 .bar-row { display: grid; grid-template-columns: 110px 1fr 40px; align-items: center; gap: .6rem; }
 .bar-label { color: var(--dim); font-size: .85rem; }

--- a/skills_sc/README.md
+++ b/skills_sc/README.md
@@ -8,7 +8,10 @@ edit: changes here are overwritten — author via the shell or localhost GUI
 
 > The substrate's skill catalogue, rendered from the DB. Per-shell grants live in `.claude/skills/` (rebuilt at boot).
 
+- [`api-design`](skills_sc/api-design.md) — REST/HTTP API design patterns — resource naming, status codes, pagination, filtering, errors, versioning, idempotency. Use when designing or reviewing API endpoints.
+- [`blueprint`](skills_sc/blueprint.md) — Turn a one-line objective into a sequenced construction plan — decompose into steps, find the dependency order, mark what can run in parallel, name the verification gate. Use before multi-step builds.
 - [`bootstrap`](skills_sc/bootstrap.md) — First-run orientation for a shell in a repo. Run ONCE when the boot doc shows "## FIRST RUN" (bootstrapped=0), or whenever the repo map is empty. Maps the repo, reads the map + your identity, sets your current_state, marks you oriented. Do this BEFORE other work on a fresh fork.
+- [`database-migrations`](skills_sc/database-migrations.md) — Database migration safety + how super-coder's own migrations work (schema.sql baseline + ordered migrations/ deltas + ledger). Use when altering tables, adding columns, or running backfills — in the host repo's DB or super-coder's.
 - [`db_map`](skills_sc/db_map.md) — Schema map + reusable SQL for super-coder's shell_db.db. Check before composing any DB query — identity, memory, roadmap, documents, flags, skills.
 - [`docs`](skills_sc/docs.md) — Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.
 - [`flags`](skills_sc/flags.md) — Track blockers as flags — surface open ones, open new ones, resolve them. Link a flag to the roadmap feature it blocks. Mirrors the GUI Flags tab. Use when something blocks progress or needs follow-up.

--- a/skills_sc/api-design.md
+++ b/skills_sc/api-design.md
@@ -1,0 +1,49 @@
+---
+rendered_by: super-coder
+source: db
+edit: changes here are overwritten — author via the shell or localhost GUI
+---
+
+# api-design
+
+REST/HTTP API design patterns — resource naming, status codes, pagination, filtering, errors, versioning, idempotency. Use when designing or reviewing API endpoints.
+
+**Category:** craft
+
+---
+
+# api-design — designing & reviewing HTTP APIs
+
+Catalogue skill (opt-in). Reach for it when shaping or reviewing an endpoint.
+
+## Resources & methods
+- Name resources as **plural nouns**, not verbs: `/users`, `/users/{id}/orders`.
+- `GET` read (safe, idempotent) · `POST` create / non-idempotent action ·
+  `PUT` full replace (idempotent) · `PATCH` partial update · `DELETE` remove.
+- Nest only one level deep; beyond that, link by id.
+
+## Status codes
+- `200` ok · `201` created (+ `Location`) · `204` no content.
+- `400` bad input · `401` unauth · `403` forbidden · `404` not found ·
+  `409` conflict · `422` validation · `429` rate-limited.
+- `5xx` = server's fault; never use it for client errors.
+
+## Payloads
+- Consistent error shape: `{ "error": { "code", "message", "details" } }`.
+- **Pagination**: cursor-based for large/changing sets (`?cursor=&limit=`),
+  return `next_cursor`; offset only for small stable sets.
+- **Filtering/sorting**: explicit query params (`?status=open&sort=-created`);
+  whitelist fields — never interpolate them into a query.
+- Timestamps ISO-8601 UTC; ids opaque strings.
+
+## Robustness
+- **Idempotency**: make retries safe — `PUT`/`DELETE` naturally; for `POST`,
+  accept an idempotency key.
+- **Versioning**: prefix (`/v1/…`) or header; add fields backward-compatibly,
+  never repurpose one.
+- Validate at the boundary; reject unknown fields or ignore them — decide and
+  document. Don't leak internals (stack traces, SQL) in errors.
+
+## Review lens
+Does each endpoint do one thing? Right method + status? Errors uniform? Inputs
+validated/whitelisted? Retries safe? Breaking change hiding in a "small" tweak?

--- a/skills_sc/blueprint.md
+++ b/skills_sc/blueprint.md
@@ -1,0 +1,42 @@
+---
+rendered_by: super-coder
+source: db
+edit: changes here are overwritten — author via the shell or localhost GUI
+---
+
+# blueprint
+
+Turn a one-line objective into a sequenced construction plan — decompose into steps, find the dependency order, mark what can run in parallel, name the verification gate. Use before multi-step builds.
+
+**Category:** craft
+
+---
+
+# blueprint — objective → sequenced plan
+
+Catalogue skill (opt-in). Use before a build that spans more than a couple of
+steps, so the work has a shape before you start cutting.
+
+## Produce
+
+1. **Restate the objective** in one sentence + the done-condition (how you'll
+   know it's finished).
+2. **Decompose** into concrete steps — each a unit you could verify on its own.
+3. **Order by dependency** — what must precede what. Mark steps with no
+   dependency on each other as **parallelizable**.
+4. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
+   to ground this in the real repo), and its **verification** (test, run,
+   review).
+5. **Risks / unknowns** — what could break the plan; resolve the riskiest
+   unknown first (spike it) rather than last.
+6. **Gate** — the adversarial check before calling it done: does each step's
+   verification actually prove the done-condition?
+
+## Stance
+- Plan to the **next solid checkpoint**, not the whole universe — re-plan as
+  reality lands. A plan that survives contact is short and concrete.
+- Sequence so something **works end-to-end early** (a thin slice), then deepen —
+  beats building all the pieces and integrating last.
+- In super-coder, land the plan as a **spec** on the roadmap (the `docs` skill):
+  a feature row + a `spec` document, so the plan is reviewable and freezes on
+  ship.

--- a/skills_sc/database-migrations.md
+++ b/skills_sc/database-migrations.md
@@ -1,0 +1,48 @@
+---
+rendered_by: super-coder
+source: db
+edit: changes here are overwritten — author via the shell or localhost GUI
+---
+
+# database-migrations
+
+Database migration safety + how super-coder's own migrations work (schema.sql baseline + ordered migrations/ deltas + ledger). Use when altering tables, adding columns, or running backfills — in the host repo's DB or super-coder's.
+
+**Category:** craft
+
+---
+
+# database-migrations — change schemas safely
+
+Catalogue skill (opt-in). Two halves: super-coder's own migration model, and
+general migration safety for the host repo's database.
+
+## super-coder's model
+- `schema.sql` = the **current baseline** (full schema). `migrations/*.sql` =
+  **ordered, additive deltas** applied on top; the `schema_migrations` ledger
+  dedups so each runs once. `rebuild` = schema → migrations → snapshot-load.
+- **Never fold a migration back into `schema.sql`** (double-apply). Add a
+  delta as a new numbered migration instead. *(Pre-fork, while there are no
+  downstream forks, editing the baseline directly is acceptable — once forks
+  exist, only additive migrations propagate.)*
+- System content (e.g. the skill catalogue) is seeded by migration + re-seed;
+  per-instance content rides in the snapshot. See `db_map` / `snapshot`.
+
+## General safety (host repo DBs)
+- **Additive first**: add columns/tables before you read them; deploy code that
+  tolerates both shapes; remove the old shape only after nothing uses it
+  (expand → migrate → contract).
+- **Backfills**: batch large updates (don't lock the table); make them
+  resumable and idempotent; separate the schema change from the data change.
+- **Nullable or defaulted** new columns on a populated table — a `NOT NULL` with
+  no default fails on existing rows.
+- **Reversibility**: know the rollback for each migration before applying it; a
+  destructive change (drop/rename) needs a deploy plan, not just a script.
+- **SQLite specifics**: limited `ALTER` — changing a constraint means
+  recreate-and-copy (new table → copy → drop → rename), with `foreign_keys` off
+  during the swap. Renames break FK references; check them.
+
+## Stance
+Migrate forward in small, reversible steps. A schema change is a deploy event:
+migrated ≠ deployed — restart the consumer, then verify the running process, not
+just the DB.


### PR DESCRIPTION
Skills become a **catalogue the user assigns per shell**, and shells are created from **flavor templates** via the GUI.

## Catalogue + policy
- Add **api-design**, **blueprint**, **database-migrations** as `common=0` (opt-in) — **not** auto-granted.
- `common=1` (the existing 8) auto-grant to every shell; `common=0` are assigned per shell (by a flavor template or the GUI grant toggle). `seed_dogfood` / factory / `update.py` grant **common only**.

## Flavor templates + factory
- `templates/shells/{planning,dev,review}.json` — role, mandate, focus, opt-in skills. `shell_system_prompt.md` gains `{{role}}`/`{{focus}}` slots.
- **`scripts/shell_factory.py` `create_shell()`** — the single creation path: template → prompt, CC lineage + own genesis seed, common + flavor grants, `bootstrapped=0` (FIRST RUN), first session opened. `init_fork` delegates to it (`--flavor`, default `dev`); the GUI uses it too.

| flavor | role | opt-in skills |
|---|---|---|
| planning | Planning shell | blueprint, api-design |
| dev | Dev shell | database-migrations |
| review | Review shell | api-design, database-migrations |

## GUI shell management
- API: `GET /api/shell-templates`, `POST /api/shells` (create via factory).
- **Shells tab**: a shell-switcher dropdown + a **New shell** form (flavor + name). Per-shell skill assignment is the existing grant toggles in the shell card (all 11 skills; common checked, opt-ins assignable).

**Verified**: catalogue 11 (8 common / 3 opt-in); factory + API create planning/dev/review with correct roles + grants; `make install --flavor planning` boots clean with FIRST RUN; rebuild rolls back test shells.

Decision #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)