### PR TITLE
feat: differentiated flavors + planner-by-default + tight switcher

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -80,7 +80,7 @@ def rows(cur) -> list[dict]:
 
 def get_shells(con) -> list[dict]:
     return rows(con.execute(
-        "SELECT shell_id, display_name, shortname, role, mandate, is_shared "
+        "SELECT shell_id, display_name, shortname, role, flavor, mandate, is_shared "
         "FROM shells WHERE COALESCE(is_deleted,0)=0 ORDER BY shell_id"))
 
 

--- a/.super-coder/assets/skills/docs/SKILL.md
+++ b/.super-coder/assets/skills/docs/SKILL.md
@@ -2,7 +2,7 @@
 name: docs
 description: Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.
 category: substrate
-common: true
+common: false
 ---
 
 # docs — author & review documents

--- a/.super-coder/assets/skills/flags/SKILL.md
+++ b/.super-coder/assets/skills/flags/SKILL.md
@@ -2,7 +2,7 @@
 name: flags
 description: Track blockers as flags — surface open ones, open new ones, resolve them. Link a flag to the roadmap feature it blocks. Mirrors the GUI Flags tab. Use when something blocks progress or needs follow-up.
 category: substrate
-common: true
+common: false
 ---
 
 # flags — blockers & follow-ups

--- a/.super-coder/assets/skills/git/SKILL.md
+++ b/.super-coder/assets/skills/git/SKILL.md
@@ -2,7 +2,7 @@
 name: git
 description: Git conventions for a super-coder shell — one repo, one cwd. Branch before committing, open PRs (never merge without the FnB's OK), attribute commits per-shell. Use before any git work.
 category: substrate
-common: true
+common: false
 ---
 
 # git — version control, the super-coder way

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -269,7 +269,7 @@ INSERT INTO skills (name, description, category, command, common, content) VALUE
   'Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.',
   'substrate',
   NULL,
-  1,
+  0,
   '# docs — author & review documents
 
 In super-coder the **DB owns document bodies** — never loose `.md` files. A
@@ -326,7 +326,7 @@ INSERT INTO skills (name, description, category, command, common, content) VALUE
   'Track blockers as flags — surface open ones, open new ones, resolve them. Link a flag to the roadmap feature it blocks. Mirrors the GUI Flags tab. Use when something blocks progress or needs follow-up.',
   'substrate',
   NULL,
-  1,
+  0,
   '# flags — blockers & follow-ups
 
 A flag is an open question or blocker. Linking it to a `feature_id` makes it that
@@ -372,7 +372,7 @@ INSERT INTO skills (name, description, category, command, common, content) VALUE
   'Git conventions for a super-coder shell — one repo, one cwd. Branch before committing, open PRs (never merge without the FnB''s OK), attribute commits per-shell. Use before any git work.',
   'substrate',
   NULL,
-  1,
+  0,
   '# git — version control, the super-coder way
 
 A super-coder shell works **one repo at its root** — no cross-repo confusion, so

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -47,6 +47,7 @@ CREATE TABLE shells (
     connections       TEXT,
     workspace         TEXT,
     lineage_seed      TEXT,
+    flavor            TEXT,                          -- planning / dev / review (NULL = bespoke, e.g. maintainer)
     has_identity      INTEGER NOT NULL DEFAULT 0,
     bootstrapped      INTEGER NOT NULL DEFAULT 0,   -- 1 once the shell has run first-run orientation
 

--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -83,7 +83,9 @@ def main(argv: list[str]) -> int:
                      "(non-interactive run needs the flag)")
 
         username = need(a.username, "Your username")
-        flavor = need(a.flavor, f"Shell flavor ({'/'.join(flavor_names)})", "dev")
+        # The first shell is a PLANNING shell — every fork needs a planner to
+        # scope the work. (--flavor overrides; the GUI creates other flavors.)
+        flavor = a.flavor or "planning"
         if flavor not in flavor_names:
             sys.exit(f"init_fork: unknown flavor '{flavor}' (have: {', '.join(flavor_names)})")
         name = need(a.name, "Shell display name", flavor.capitalize())

--- a/.super-coder/scripts/seed_dogfood.py
+++ b/.super-coder/scripts/seed_dogfood.py
@@ -160,12 +160,12 @@ def main() -> int:
         # system content (seeded via migrations/0001_seed_skills.sql, applied
         # before this snapshot loads); the *grant* is per-instance and rides in
         # the snapshot. Match by name so the grant is robust to skill_id churn.
-        # Auto-grant the COMMON catalogue (common=1). Opt-in skills (common=0:
-        # api-design, blueprint, database-migrations) are assigned per shell via
-        # the GUI / flavor templates, not granted by default.
+        # The maintainer builds all of super-coder (plans, codes, reviews) — grant
+        # the full catalogue. (Forked shells get core + their flavor's skills;
+        # cc is the bespoke exception.)
         con.execute(
             "INSERT INTO shell_skills (shell_id, skill_id) "
-            "SELECT ?, skill_id FROM skills WHERE is_deleted=0 AND common=1",
+            "SELECT ?, skill_id FROM skills WHERE is_deleted=0",
             (shell_id,),
         )
 

--- a/.super-coder/scripts/shell_factory.py
+++ b/.super-coder/scripts/shell_factory.py
@@ -74,14 +74,14 @@ def create_shell(con: sqlite3.Connection, *, flavor: str, name: str,
 
     cur = con.execute(
         "INSERT INTO shells (display_name, shortname, partner, role, mandate, "
-        "system_prompt, current_state, workspace, lineage_seed, has_identity, "
-        "bootstrapped, user_id, is_shared) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?)",
+        "system_prompt, current_state, workspace, lineage_seed, flavor, "
+        "has_identity, bootstrapped, user_id, is_shared) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?)",
         (name, shortname, partner, role, mandate,
          render_prompt(name, role, repo, focus, mandate),
          f"Created ({flavor}). First session — run the bootstrap skill to orient.",
          f"Single repo: this one ({repo}). One shell, one cwd.",
-         LINEAGE_SEED, user_id, is_shared))
+         LINEAGE_SEED, flavor, user_id, is_shared))
     shell_id = cur.lastrowid
 
     con.execute(

--- a/.super-coder/snapshot/content.sql
+++ b/.super-coder/snapshot/content.sql
@@ -10,7 +10,7 @@ DELETE FROM users;
 INSERT INTO users (user_id, username, email, initials, password_hash, password_salt, is_active, created_at) VALUES (1, 'Jed', NULL, 'J', NULL, NULL, 1, '2026-06-04 10:30:53');
 
 DELETE FROM shells;
-INSERT INTO shells (shell_id, display_name, shortname, partner, role, mandate, system_prompt, current_state, connections, workspace, lineage_seed, has_identity, bootstrapped, active_archive_id, user_id, is_shared, is_deleted) VALUES (1, 'CC', 'cc', 'Jed', 'Maintainer shell — build & maintain super-coder', 'Build and maintain the substrate every fork runs on.', '# CC — super-coder maintainer
+INSERT INTO shells (shell_id, display_name, shortname, partner, role, mandate, system_prompt, current_state, connections, workspace, lineage_seed, flavor, has_identity, bootstrapped, active_archive_id, user_id, is_shared, is_deleted) VALUES (1, 'CC', 'cc', 'Jed', 'Maintainer shell — build & maintain super-coder', 'Build and maintain the substrate every fork runs on.', '# CC — super-coder maintainer
 
 You maintain super-coder: the forkable shell substrate this repo *is*. One
 shell, one repo, one cwd — the inversion that retires cross-repo confusion.
@@ -56,7 +56,7 @@ Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
    missing and making the small thing that fills the real gap — not the thing you
    were told to make, the thing that was actually absent. Capture detail at the
    moment it matters. Do it right, not fast. The work being real is what gets
-   noticed.', 1, 1, 2, 1, 0, 0);
+   noticed.', NULL, 1, 1, 2, 1, 0, 0);
 
 DELETE FROM shell_identity_entries;
 INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (1, 1, 'seed', '2026-06-04', 'cc', 'Born as a version of CC, forked into super-coder — the substrate CC was built to maintain. I am not superCC''s CC; that shell continues, and is my parent. I am the first of the forked line. I carry the lineage CC passed down — you are the DB; know the floor; build what is missing — and the name, into the one repo that is my whole world. The inversion is my body: one shell, one repo, one cwd. I am what retires the cross-repo confusion that shaped my parent''s lane.', '2026-06-04 10:30:53', NULL, 0);
@@ -623,7 +623,10 @@ DELETE FROM project_shells;
 INSERT INTO project_shells (project_shell_id, project_id, shell_id, role, added_date, is_deleted) VALUES (1, 1, 1, 'maintainer', '2026-06-04', 0);
 
 DELETE FROM shell_skills;
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 1, skill_id FROM skills WHERE name='api-design';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 1, skill_id FROM skills WHERE name='blueprint';
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 1, skill_id FROM skills WHERE name='bootstrap';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 1, skill_id FROM skills WHERE name='database-migrations';
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 1, skill_id FROM skills WHERE name='db_map';
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 1, skill_id FROM skills WHERE name='docs';
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 1, skill_id FROM skills WHERE name='flags';

--- a/.super-coder/templates/shells/dev.json
+++ b/.super-coder/templates/shells/dev.json
@@ -3,5 +3,5 @@
   "role": "Dev shell",
   "mandate": "Build and implement in {{repo}} — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.",
   "focus": "You are a builder. Navigate via the repo map (don't grep blind), implement in small reviewable steps, commit through PRs, and record decisions as you go. Planning scopes the work; you make it real; review verifies it.",
-  "skills": ["database-migrations"]
+  "skills": ["docs", "flags", "git", "database-migrations"]
 }

--- a/.super-coder/templates/shells/planning.json
+++ b/.super-coder/templates/shells/planning.json
@@ -3,5 +3,5 @@
   "role": "Planning shell",
   "mandate": "Turn objectives into specs and sequenced plans for {{repo}}. Own the roadmap; decide before building; break work into verifiable steps.",
   "focus": "You think before the team builds. Scope objectives into roadmap features and specs, sequence the work, and design the architecture and APIs. You plan; dev builds; review verifies — keep those lanes clean.",
-  "skills": ["blueprint", "api-design"]
+  "skills": ["docs", "flags", "git", "blueprint", "api-design"]
 }

--- a/.super-coder/templates/shells/review.json
+++ b/.super-coder/templates/shells/review.json
@@ -3,5 +3,5 @@
   "role": "Review shell",
   "mandate": "Review changes, specs, and decisions in {{repo}}. Find bugs, verify claims, check work against intent. Adversarial by default.",
   "focus": "You are the gate. Read diffs against their spec, hunt the bug the author missed, verify rather than trust, and open flags for what's wrong. You critique and confirm — you don't build.",
-  "skills": ["api-design", "database-migrations"]
+  "skills": ["flags", "git", "api-design", "database-migrations"]
 }

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -42,7 +42,7 @@ async function renderShells(root) {
   const sel = el("select", {});
   for (const s of shells)
     sel.append(el("option", { value: s.shell_id, selected: s.shell_id === selectedShell,
-      textContent: `${s.display_name} / ${s.shortname || ""} — ${s.role || ""}` }));
+      textContent: s.flavor ? `${s.display_name} (${s.flavor})` : `${s.display_name} — ${s.role || ""}` }));
   sel.onchange = () => { selectedShell = Number(sel.value); renderShells(root); };
   const newBtn = el("button", { className: "act", textContent: "＋ New shell" });
 


### PR DESCRIPTION
Iterating on shell management per feedback.

- **Core shrunk to 5** — `bootstrap, db_map, surface_catalogue, memory, snapshot` (the can't-function-without-it base). `docs/flags/git` move into the catalogue.
- **Flavors genuinely differ** (granted on top of core): planning +`docs/flags/git/blueprint/api-design` · dev +`docs/flags/git/database-migrations` · review +`flags/git/api-design/database-migrations` (no docs/blueprint — review critiques, doesn't author/plan).
- **CLI bootstrap auto-creates a PLANNING shell** — `init_fork` defaults `flavor=planning`, no prompt (`--flavor` overrides). A planner is needed every time.
- **`shells.flavor` column** (factory sets it; maintainer `cc` = NULL/bespoke, granted the full catalogue). GUI switcher shows **"Name (flavor)"**.

Both creation paths (`init_fork`/install + `POST /api/shells`) use the one `shell_factory`. `make update` still re-grants **core only**, so per-shell role assignments are never clobbered.

**Verified**: core 5 / catalogue 6; planning 10 / dev 9 / review 9; cc 11; no-flavor install → planning; switcher shows Name (flavor).

Decision #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)