### PR TITLE
docs: note the optional ./sc → make alias (host opts in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ skill *name*, so they're immune to catalogue-id shifts.
 ./sc help                # all targets
 ```
 
+**Prefer `make`?** super-coder never touches your repo's `Makefile`, but you can
+alias the common case in your own — a one-liner you control:
+
+```make
+super:           ## boot super-coder
+	@./sc launch
+```
+
+Then `make super` runs it. (For other commands call `./sc <cmd>` directly —
+forwarding arbitrary args through `make` is the quoting mess `./sc` exists to
+avoid.)
+
 ## Review layer (localhost GUI)
 
 A zero-dependency localhost GUI to review the substrate — shells, roadmap,


### PR DESCRIPTION
super-coder ships `./sc` and never touches the host `Makefile`. Documents the one-liner a fork can add to its **own** Makefile (`super: ; @./sc launch`) for `make` ergonomics — with the caveat that forwarding arbitrary args through `make` is the quoting mess `./sc` exists to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)