### PR TITLE
feat(launch): harness picker after shell selection

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sqlite3
 import sys
 from datetime import date, datetime
@@ -58,6 +59,55 @@ def emit_adapter(adapter: dict) -> list[str]:
             atomic_write(REPO_ROOT / fname, src.read_text())
             written.append(fname)
     return written
+
+
+def detect_harnesses() -> list[str]:
+    """Harnesses installable RIGHT NOW: an adapter dir with adapter.json whose
+    launch command is also on PATH. Adapter-dir order. Drives the launch-time
+    picker — we only offer a harness the host can actually exec."""
+    if not ADAPTERS.exists():
+        return []
+    found = []
+    for d in sorted(ADAPTERS.iterdir()):
+        cfg = d / "adapter.json"
+        if not (d.is_dir() and cfg.exists()):
+            continue
+        try:
+            adapter = json.loads(cfg.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        cmd = (adapter.get("launch") or [d.name])[0]
+        if shutil.which(cmd):
+            found.append(adapter.get("harness", d.name))
+    return found
+
+
+def pick_harness(detected: list[str], default: str, first: bool) -> str | None:
+    """Resolve the harness when no explicit override (--harness / HARNESS) was
+    given. Returns None when nothing is detected so the caller can fall back to
+    instance.json/'claude' — preserving the old silent behavior on a host with
+    no harness CLI on PATH (headless verify, CI). The pick is per-launch only:
+    nothing is written back, so two terminals can boot the same fork on
+    different harnesses in parallel."""
+    if not detected:
+        return None
+    if len(detected) == 1:
+        return detected[0]
+    dflt = default if default in detected else detected[0]
+    # --first and non-TTY (verify/CI) never prompt — take the default silently.
+    if first or not sys.stdin.isatty():
+        return dflt
+    print("\nHarness:")
+    for i, h in enumerate(detected, 1):
+        mark = "  (default)" if h == dflt else ""
+        print(f"  {i}. {h}{mark}")
+    while True:
+        choice = input(f"\nPick (1-{len(detected)}, Enter for {dflt}): ").strip()
+        if not choice:
+            return dflt
+        if choice.isdigit() and 1 <= int(choice) <= len(detected):
+            return detected[int(choice) - 1]
+        print("  invalid choice")
 
 
 def _configured_harness() -> str | None:
@@ -198,12 +248,36 @@ def atomic_write(path: Path, content: str) -> None:
 def main() -> None:
     args = sys.argv[1:]
     first = "--first" in args
-    positional = [a for a in args if not a.startswith("-")]
+    # --harness <name> / --harness=<name> forces the harness and skips the
+    # picker; its value must not be mistaken for the shell shortname positional.
+    flag_harness = None
+    positional = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--harness":
+            flag_harness = args[i + 1] if i + 1 < len(args) else None
+            i += 2
+            continue
+        if a.startswith("--harness="):
+            flag_harness = a.split("=", 1)[1]
+        elif not a.startswith("-"):
+            positional.append(a)
+        i += 1
     requested = positional[0] if positional else None
 
     con = open_db()
     user = authenticate(con)
     chosen = pick_shell(list_shells(con, user["user_id"]), requested, first)
+
+    # Harness pick, right after the shell pick: an explicit --harness / HARNESS
+    # override wins silently; otherwise offer the harnesses on PATH when more
+    # than one is present (per-launch, never persisted), falling back to this
+    # fork's instance.json value / 'claude' when nothing is detected.
+    default_harness = _configured_harness() or "claude"
+    harness = (flag_harness or os.environ.get("HARNESS")
+               or pick_harness(detect_harnesses(), default_harness, first)
+               or default_harness)
 
     session_id, archive_id = open_session(con, chosen["shell_id"])
 
@@ -231,10 +305,8 @@ def main() -> None:
     print(f"→ skills: {len(skills['written'])} written, "
           f"{len(skills['skipped'])} unchanged → .claude/skills/")
 
-    # Harness: HARNESS env wins, else this fork's configured harness
-    # (instance.json, set by the installer), else claude. The adapter seam owns
-    # the launch command + any harness-specific config to emit.
-    harness = os.environ.get("HARNESS") or _configured_harness() or "claude"
+    # Harness was resolved up front (override / picker / default); the adapter
+    # seam owns the launch command + any harness-specific config to emit.
     adapter = load_adapter(harness)
     emitted = emit_adapter(adapter)
     print(f"→ harness: {harness} (reads {adapter.get('boot_artifact', 'AGENTS.md')})")

--- a/README.md
+++ b/README.md
@@ -98,14 +98,23 @@ skill *name*, so they're immune to catalogue-id shifts.
 ## Run (everyday)
 
 ```bash
-./sc launch              # auth + pick a shell + render boot + exec the harness
-./sc launch-<shortname>  # boot one shell directly, skip the picker
+./sc launch              # auth + pick a shell + pick a harness + render boot + exec
+./sc launch-<shortname>  # boot one shell directly, skip the shell picker
 ./sc rebuild             # rebuild .super-coder/shell_db.db from schema + migrations + snapshot
 ./sc render              # regenerate the tracked flat _sc files from the DB
 ./sc snapshot            # serialize per-instance tables → snapshot/content.sql
 ./sc verify              # rebuild + flat render + headless boot (no exec) — the proof
 ./sc help                # all targets
 ```
+
+**Choosing a harness.** The boot artifact is dual-written every launch
+(`CLAUDE.md` for Claude Code, `AGENTS.md` for the rest), so any installed harness
+can boot the same shell. At launch, after you pick a shell: `--harness <name>` or
+`HARNESS=<name>` forces one; otherwise, when more than one harness is on `PATH`,
+you're prompted (default = your fork's `instance.json` harness). The pick is
+per-launch and never written back — so two terminals can run the **same** shell on
+different harnesses at once (one Claude Code, one OpenCode). A fork with a single
+harness on `PATH` skips the prompt.
 
 **Prefer `make`?** super-coder never touches your repo's `Makefile`, but you can
 alias the common case in your own — a one-liner you control:

--- a/sc
+++ b/sc
@@ -59,8 +59,10 @@ super-coder — forkable shell substrate
   ./sc map                 scan the host repo into the dr_* catalogue (re-runnable)
   ./sc seed-skills         regenerate the skills seed migration from assets/skills/
   ./sc init                seed a fresh fork's first user + shell (run once after install)
-  ./sc launch              start the GUI (prints its URL) + auth + pick shell + boot + exec harness
-  ./sc launch-<shortname>  boot that shell directly (skip picker); also starts the GUI
+  ./sc launch              start the GUI (prints its URL) + auth + pick shell + pick harness + boot
+  ./sc launch-<shortname>  boot that shell directly (skip shell picker); also starts the GUI
+                             harness: --harness <name> or HARNESS=<name> forces it; else when
+                             >1 harness is on PATH you're prompted (per-launch, not persisted)
   ./sc verify              rebuild + flat render + render-only boot (headless proof)
   ./sc up / down / restart start/stop the localhost review layer (pm2, per-fork port)
   ./sc serve               run the review layer in the foreground (no pm2)


### PR DESCRIPTION
## What

`./sc launch` resolved the harness silently (`HARNESS` env → `instance.json` → `claude`). This adds a **launch-time pick**, right after the shell picker, so a fork with both `claude` and `opencode` on `PATH` chooses per boot.

The pick is **per-launch and never persisted** — so the *same* shell can run on different harnesses in parallel terminals (one Claude Code, one OpenCode). The boot artifact is already dual-written (`CLAUDE.md` + `AGENTS.md`) every launch, so nothing else was needed for either harness to boot.

## Resolution order (after the shell pick)

| step | behavior |
|---|---|
| `--harness <name>` / `--harness=<name>` | forces it, no prompt |
| `HARNESS=<name>` env | forces it, no prompt |
| `detect_harnesses()` ∩ `PATH` = 0 | `instance.json` / `claude` — unchanged silent fallback |
| = 1 | use it silently |
| ≥2 + interactive TTY | **prompt** (default = `instance.json` harness) |
| ≥2 + `--first` / non-TTY (verify, CI) | default, no prompt |

`detect_harnesses()` discovers adapters dynamically (adapter dir + `adapter.json` launch cmd on `PATH`), so a new adapter is offered without editing `run.py`.

## Test

- `py_compile` clean
- `pick_harness` unit-tested across all branches (single/two/empty, bad default, Enter=default, numeric select, invalid-then-valid looping)
- End-to-end via `RENDER_ONLY=1`: default → claude; `--harness opencode` and `HARNESS=opencode` → opencode + emits `opencode.json`; `--harness=opencode` value not mistaken for the shell shortname
- Live `detect_harnesses()` on this host (only `claude` installed) → single-harness silent path, no prompt — correct

Docs updated: `sc help` + README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)