### PR TITLE
feat(shells): auto-generate shortname from flavor (DEV1, PLN3…)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -387,7 +387,9 @@ class Handler(BaseHTTPRequestHandler):
                     con, flavor=body["flavor"], name=body["name"],
                     shortname=body.get("shortname"), partner=body.get("partner"))
                 con.commit()
-                return self._send(201, {"shell_id": sid})
+                sn = con.execute(
+                    "SELECT shortname FROM shells WHERE shell_id=?", (sid,)).fetchone()[0]
+                return self._send(201, {"shell_id": sid, "shortname": sn})
             if path == "/api/snapshot":
                 return self._send(200, {"output": run_snapshot_render()})
             if path.startswith("/api/scripts/"):

--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -89,7 +89,9 @@ def main(argv: list[str]) -> int:
         if flavor not in flavor_names:
             sys.exit(f"init_fork: unknown flavor '{flavor}' (have: {', '.join(flavor_names)})")
         name = need(a.name, "Shell display name", flavor.capitalize())
-        shortname = need(a.shortname, "Shell shortname", name.lower())
+        # shortname is optional — omit it and create_shell auto-names <ABBR><n>
+        # from the flavor (e.g. PLN1). --shortname still overrides.
+        shortname = a.shortname or None
 
         con.execute(
             "INSERT INTO users (user_id, username, is_active) VALUES (1, ?, 1)",
@@ -99,6 +101,8 @@ def main(argv: list[str]) -> int:
             partner=a.partner or username, repo=repo,
             role=a.role, mandate=a.mandate)
         con.commit()
+        shortname = con.execute(
+            "SELECT shortname FROM shells WHERE shell_id=?", (shell_id,)).fetchone()[0]
 
         n = con.execute(
             "SELECT COUNT(*) FROM shell_skills WHERE shell_id=?", (shell_id,)).fetchone()[0]

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -124,7 +124,9 @@ def pick_shell(shells: list[sqlite3.Row], requested: str | None,
     if not shells:
         sys.exit("FATAL: no shells available to this user.")
     if requested:
-        chosen = next((s for s in shells if s["shortname"] == requested), None)
+        # Case-insensitive: auto-names are upper (DEV3) but `./sc launch-dev3` works.
+        chosen = next((s for s in shells if (s["shortname"] or "").lower()
+                       == requested.lower()), None)
         if chosen is None:
             avail = ", ".join(s["shortname"] or "?" for s in shells)
             sys.exit(f"no shell '{requested}'. Available: {avail}")

--- a/.super-coder/scripts/shell_factory.py
+++ b/.super-coder/scripts/shell_factory.py
@@ -48,6 +48,22 @@ def load_flavor(flavor: str) -> dict:
     return json.loads(p.read_text())
 
 
+def _auto_shortname(con: sqlite3.Connection, abbr: str) -> str:
+    """Default shortname when the caller gives none: <ABBR><n> — the flavor's
+    abbreviation + the next integer (e.g. DEV3, PLN1). Numbered max-suffix + 1
+    over ALL shells with that abbr, deleted included, so a number is never
+    reused after a delete. Lets a fork spin up shells without naming each one."""
+    abbr = abbr.upper()
+    hi = 0
+    for (sn,) in con.execute(
+            "SELECT shortname FROM shells WHERE shortname IS NOT NULL"):
+        if sn.upper().startswith(abbr):
+            suffix = sn[len(abbr):]
+            if suffix.isdigit():
+                hi = max(hi, int(suffix))
+    return f"{abbr}{hi + 1}"
+
+
 def render_prompt(name: str, role: str, repo: str, focus: str, mandate: str) -> str:
     if not PROMPT_TEMPLATE.exists():
         return f"# {name} — {role} for {repo}\n\n{focus}\n\n## MANDATE\n\n{mandate}\n"
@@ -70,7 +86,10 @@ def create_shell(con: sqlite3.Connection, *, flavor: str, name: str,
     role = role or tpl["role"]
     mandate = (mandate or tpl["mandate"]).replace("{{repo}}", repo)
     focus = tpl.get("focus", "").replace("{{repo}}", repo)
-    shortname = (shortname or name.lower().replace(" ", "-")).strip()
+    # Explicit shortname wins; otherwise auto-name <ABBR><n> from the flavor so
+    # the caller (GUI / init) need not supply one.
+    abbr = tpl.get("abbr") or flavor[:3]
+    shortname = shortname.strip() if shortname else _auto_shortname(con, abbr)
 
     cur = con.execute(
         "INSERT INTO shells (display_name, shortname, partner, role, mandate, "

--- a/.super-coder/templates/shells/dev.json
+++ b/.super-coder/templates/shells/dev.json
@@ -1,5 +1,6 @@
 {
   "flavor": "dev",
+  "abbr": "DEV",
   "role": "Dev shell",
   "mandate": "Build and implement in {{repo}} — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.",
   "focus": "You are a builder. Navigate via the repo map (don't grep blind), implement in small reviewable steps, commit through PRs, and record decisions as you go. Planning scopes the work; you make it real; review verifies it.",

--- a/.super-coder/templates/shells/planning.json
+++ b/.super-coder/templates/shells/planning.json
@@ -1,5 +1,6 @@
 {
   "flavor": "planning",
+  "abbr": "PLN",
   "role": "Planning shell",
   "mandate": "Turn objectives into specs and sequenced plans for {{repo}}. Own the roadmap; decide before building; break work into verifiable steps.",
   "focus": "You think before the team builds. Scope objectives into roadmap features and specs, sequence the work, and design the architecture and APIs. You plan; dev builds; review verifies — keep those lanes clean.",

--- a/.super-coder/templates/shells/review.json
+++ b/.super-coder/templates/shells/review.json
@@ -1,5 +1,6 @@
 {
   "flavor": "review",
+  "abbr": "REV",
   "role": "Review shell",
   "mandate": "Review changes, specs, and decisions in {{repo}}. Find bugs, verify claims, check work against intent. Adversarial by default.",
   "focus": "You are the gate. Read diffs against their spec, hunt the bug the author missed, verify rather than trust, and open flags for what's wrong. You critique and confirm — you don't build.",

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -56,7 +56,7 @@ async function renderShells(root) {
     if (!nm.value.trim()) return toast("name required");
     try {
       const r = await api("/shells", "POST", { flavor: fl.value, name: nm.value.trim() });
-      selectedShell = r.shell_id; setStatus("shell created"); renderShells(root);
+      selectedShell = r.shell_id; setStatus(`shell created — ${r.shortname}`); renderShells(root);
     } catch (e) { toast("error: " + e.message); }
   };
   newBtn.onclick = () => { form.hidden = !form.hidden; if (!form.hidden) nm.focus(); };


### PR DESCRIPTION
## What

New shells had no way to set a shortname — the GUI create form doesn't collect one, so the API fell back to `name.lower()`. This **auto-names** every shell `<ABBR><n>` from its flavor, so the operator never sets it.

`planning → PLN1`, `dev → DEV1`, `review → REV1` … the Nth dev shell is `DEV<N>`.

## How

- **Flavor templates** gain an `"abbr"` field (`DEV` / `PLN` / `REV`; fallback `flavor[:3].upper()` for future flavors).
- **`shell_factory._auto_shortname()`** — numbers as *max existing suffix for that abbr + 1*, scanning **all** shells incl. deleted, so a number is never reused after a delete. An explicit `shortname` still wins.
- **`init_fork`** — `--shortname` is now optional (auto when omitted); the success line reports the generated name.
- **API** `POST /api/shells` returns the generated `shortname`; the **GUI** toasts it (`shell created — DEV1`).
- **`pick_shell`** matches shortname **case-insensitively**, so the upper-case auto-names work as `./sc launch-dev3` too.

## Test (on a throwaway DB copy)

| step | result |
|---|---|
| 3× dev | `DEV1`, `DEV2`, `DEV3` |
| planning / review | `PLN1`, `REV1` |
| explicit `shortname="mydev"` | honored verbatim |
| delete `DEV2`, create dev | `DEV4` (max+1, no reuse) |
| pick `dev3` / `DEV3` / `Dev3` | all match `DEV3`; unknown errors cleanly |

`py_compile` clean on all changed scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)