### PR TITLE
fix(launch): harness picker misses opencode installed off-PATH (~/.opencode/bin)

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -33,6 +33,9 @@ sys.path.insert(0, str(ENGINE / "render"))
 from compose import compose_boot  # noqa: E402
 import flat  # noqa: E402
 
+sys.path.insert(0, str(ENGINE / "scripts"))
+import install  # noqa: E402  — reuse its canonical HARNESS_BIN (one source of truth)
+
 ADAPTERS = ENGINE / "adapters"
 
 
@@ -61,10 +64,32 @@ def emit_adapter(adapter: dict) -> list[str]:
     return written
 
 
+def ensure_harness_path() -> None:
+    """Prepend the dirs where the official installers drop harness binaries onto
+    this process's PATH, so detection (shutil.which) and exec (execvpe) agree
+    with what `./sc install` / `./sc ensure-harness` installed.
+
+    The opencode installer drops its binary in ~/.opencode/bin and only edits a
+    shell rc — a dir a fresh launch shell does NOT carry on PATH. Without this,
+    detect_harnesses() silently never offers opencode even though ensure-harness
+    reported it installed: install.py trusts HARNESS_BIN, the launcher trusted
+    PATH only, and they disagreed. Reuse install.HARNESS_BIN so there is one
+    source for where a harness lives."""
+    try:
+        bin_dirs = [p.parent for p in install.HARNESS_BIN.values()]
+    except Exception:
+        return
+    parts = os.environ.get("PATH", "").split(os.pathsep)
+    add = [str(d) for d in bin_dirs if d.is_dir() and str(d) not in parts]
+    if add:
+        os.environ["PATH"] = os.pathsep.join(add + parts)
+
+
 def detect_harnesses() -> list[str]:
     """Harnesses installable RIGHT NOW: an adapter dir with adapter.json whose
-    launch command is also on PATH. Adapter-dir order. Drives the launch-time
-    picker — we only offer a harness the host can actually exec."""
+    launch command is also on PATH (after ensure_harness_path() has folded in
+    the installer bin dirs). Adapter-dir order. Drives the launch-time picker —
+    we only offer a harness the host can actually exec."""
     if not ADAPTERS.exists():
         return []
     found = []
@@ -275,7 +300,10 @@ def main() -> None:
     # Harness pick, right after the shell pick: an explicit --harness / HARNESS
     # override wins silently; otherwise offer the harnesses on PATH when more
     # than one is present (per-launch, never persisted), falling back to this
-    # fork's instance.json value / 'claude' when nothing is detected.
+    # fork's instance.json value / 'claude' when nothing is detected. Fold the
+    # installer bin dirs onto PATH first so detection sees an installed-but-not-
+    # yet-on-PATH harness (e.g. opencode in ~/.opencode/bin).
+    ensure_harness_path()
     default_harness = _configured_harness() or "claude"
     harness = (flag_harness or os.environ.get("HARNESS")
                or pick_harness(detect_harnesses(), default_harness, first)


### PR DESCRIPTION
## Symptom
On a host with **both** harnesses installed, `make launch` / `./sc launch` boots straight into claude with **no picker** — even though `./sc ensure-harness` reports `opencode  ✓ already installed`.

## Root cause — installer and launcher disagreed
| | check | sees opencode in `~/.opencode/bin`? |
|---|---|---|
| `install.py` `_harness_installed()` | `shutil.which() **or** HARNESS_BIN[name].exists()` | ✅ "already installed" |
| `run.py` `detect_harnesses()` | `shutil.which()` only (PATH) | ❌ never offered |

opencode's installer drops its binary in `~/.opencode/bin` and only edits a shell rc — a dir a **fresh launch shell does not carry on PATH**. So `install.py` (which knows `HARNESS_BIN`) says installed, while the launcher (PATH-only) silently drops it. With `len(detected) == 1`, `pick_harness` returns that one silently → no menu.

## Fix
`run.py` now calls `ensure_harness_path()` before harness resolution: it prepends the `install.HARNESS_BIN` parent dirs onto `os.environ['PATH']`. Both detection (`shutil.which`) and the eventual `os.execvpe` then agree with what the installer installed — no dependence on a refreshed shell rc. Reuses `install.HARNESS_BIN` (one source of truth for where a harness lives); idempotent; degrades safely if the import is unavailable.

## Verification
- With a sanitized PATH, `detect_harnesses()` went `[]` → `['claude','opencode']` after `ensure_harness_path()`; idempotent on re-run.
- `./sc verify` boots clean through `main()` (import + new call path exercised).

Surfaced by dos-arch (a fork); fix lands in the engine so every fork inherits it on the next `./sc update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)