### PR TITLE
Roadmap redline pass + slimmer launcher picker

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -123,12 +123,15 @@ def get_roadmap(con) -> dict:
         "SELECT r.feature_id, r.title, r.roadmap_status, r.sort_order, r.summary, "
         "s.shortname AS owner FROM roadmap r LEFT JOIN shells s "
         "ON s.shell_id=r.owning_shell ORDER BY r.sort_order, r.feature_id"))
-    # Roadmap tracks the development cycle = the SPECS. Docs (kind='doc') live on
-    # their own tab.
+    # Roadmap tracks the development cycle = the SPECS, with each feature's DOCS
+    # (kind='doc') listed underneath so specs and docs sit together. Docs are
+    # read-only here (open-link only); the Docs tab is where they're edited.
+    # kind DESC orders 'spec' before 'doc' within a feature.
     docs_by: dict[int, list] = {}
     for d in rows(con.execute(
             "SELECT document_id, feature_id, kind, seq, title, frozen, frozen_date, "
-            "render_path FROM documents WHERE kind='spec' ORDER BY feature_id, seq")):
+            "render_path FROM documents WHERE kind IN ('spec','doc') "
+            "ORDER BY feature_id, kind DESC, seq")):
         docs_by.setdefault(d["feature_id"], []).append(d)
     flags_by: dict[int, list] = {}
     for f in rows(con.execute(

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -209,10 +209,10 @@ def pick_shell(shells: list[sqlite3.Row], requested: str | None,
     if first or not sys.stdin.isatty():
         return shells[0]
     # Interactive picker
-    print(f"\n{'ID':>3}  {'Name':<16}{'Shortname':<14}Mandate")
+    print(f"\n{'ID':>3}  {'Name':<16}{'Shortname':<14}")
     for s in shells:
         print(f"{s['shell_id']:>3}  {(s['display_name'] or ''):<16}"
-              f"{(s['shortname'] or ''):<14}{s['mandate'] or ''}")
+              f"{(s['shortname'] or ''):<14}")
     valid = {s["shell_id"] for s in shells}
     while True:
         choice = input("\nPick (ID): ").strip()

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -129,29 +129,36 @@ function shellCard(s) {
 // Funnel order: idea inlet → most-active committed work → done.
 const STATUSES = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped"];
 const SLABEL = { brainstorm: "Brainstorm", in_progress: "In Progress", next: "Next", near_term: "Near Term", long_term: "Long Term", shipped: "Shipped" };
-const roadmapFilter = new Set();   // empty = show all (default)
+let roadmapFilter = null;            // null = show all (default); single-select
+const roadmapCollapsed = new Set();  // statuses whose section is collapsed
 
 async function renderRoadmap(root) {
   const { buckets } = await api("/roadmap");
   root.replaceChildren();
 
-  // grouped status toggle-filters; none selected = all shown
-  const bar = el("div", { className: "filters" });
+  // segmented single-select toggle; re-click the active one to clear → show all
+  const bar = el("div", { className: "filters seg" });
   for (const s of STATUSES) {
-    const chip = el("button", { className: "chip" + (roadmapFilter.has(s) ? " on" : ""), textContent: SLABEL[s] });
+    const chip = el("button", { className: "chip" + (roadmapFilter === s ? " on" : ""), textContent: SLABEL[s] });
     chip.onclick = () => {
-      roadmapFilter.has(s) ? roadmapFilter.delete(s) : roadmapFilter.add(s);
+      roadmapFilter = roadmapFilter === s ? null : s;
       renderRoadmap(root);
     };
     bar.append(chip);
   }
   root.append(bar);
 
-  // buckets arrive linear from the API; filter to the selected statuses
-  const shown = roadmapFilter.size ? buckets.filter((b) => roadmapFilter.has(b.status)) : buckets;
-  if (!shown.length) { root.append(el("div", { className: "muted" }, "No features in the selected stage(s).")); return; }
+  // buckets arrive linear from the API; filter to the single selected status
+  const shown = roadmapFilter ? buckets.filter((b) => b.status === roadmapFilter) : buckets;
+  if (!shown.length) { root.append(el("div", { className: "muted" }, "No features in the selected stage.")); return; }
   for (const b of shown) {
-    const sec = el("div", { className: "bucket" }, el("h2", {}, b.label));
+    const sec = el("div", { className: "bucket" + (roadmapCollapsed.has(b.status) ? " collapsed" : "") });
+    const h = el("h2", {}, b.label);
+    h.onclick = () => {
+      roadmapCollapsed.has(b.status) ? roadmapCollapsed.delete(b.status) : roadmapCollapsed.add(b.status);
+      renderRoadmap(root);
+    };
+    sec.append(h);
     for (const f of b.features) sec.append(featureCard(f));
     root.append(sec);
   }
@@ -178,8 +185,9 @@ function featureCard(f) {
     el("span", { className: "k" }, "status"), status,
     el("span", { className: "k" }, "summary"), summary), save);
 
-  // documents — tabbed; non-frozen editable, frozen read-only
-  for (const d of f.documents || []) c.append(docBlock(d));
+  // documents — specs (editable/frozen per state) then docs (read-only here;
+  // the Docs tab is where docs are edited)
+  for (const d of f.documents || []) c.append(docBlock(d, { readOnly: d.kind === "doc" }));
 
   // open flags = blockers
   if (f.open_flags?.length) {
@@ -194,15 +202,19 @@ function featureCard(f) {
 // A document row: the primary action OPENS it rendered in md-converter (the
 // markdown rides in the URL via /open → ?c=). No inline raw-markdown expand.
 // Non-frozen docs get an explicit "edit" toggle; frozen ones are read-only.
-function docBlock(d) {
+function docBlock(d, { readOnly = false } = {}) {
   const wrap = el("div", { className: "docrow" });
-  const label = `${d.kind} v${d.seq}${d.frozen ? " · frozen " + (d.frozen_date || "") : ""}: ${d.title || ""}`;
+  const label = d.kind === "doc"
+    ? `Doc - ${d.title || "(untitled)"}`
+    : `${d.kind} v${d.seq}${d.frozen ? " · frozen " + (d.frozen_date || "") : ""}: ${d.title || ""}`;
   const open = el("a", {
     className: "act primary", href: "/api/documents/" + d.document_id + "/open",
     target: "_blank", rel: "noopener", textContent: "open in md-converter ↗",
   });
   const head = el("div", { className: "docrow-head" }, el("span", { className: "docrow-label" }, label), open);
   wrap.append(head);
+
+  if (readOnly) return wrap;   // open-link only — no edit toggle, no lock-note
 
   if (!d.frozen) {
     const box = el("div", { hidden: true });

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -81,7 +81,15 @@ details summary { cursor: pointer; color: var(--accent); }
 }
 .chip:hover { color: var(--ink); border-color: var(--accent); }
 .chip.on { background: var(--accent); color: #0b0e13; border-color: var(--accent); font-weight: 600; }
-.bucket > h2 { font-size: .8rem; text-transform: uppercase; letter-spacing: .08em; color: var(--dim); margin: 1.4rem 0 .5rem; }
+/* segmented single-select group: connected, no gaps, shared border */
+.filters.seg { gap: 0; width: fit-content; }
+.filters.seg .chip { border-radius: 0; border-left-width: 0; }
+.filters.seg .chip:first-child { border-top-left-radius: 99px; border-bottom-left-radius: 99px; border-left-width: 1px; }
+.filters.seg .chip:last-child { border-top-right-radius: 99px; border-bottom-right-radius: 99px; }
+.bucket > h2 { font-size: .8rem; text-transform: uppercase; letter-spacing: .08em; color: var(--dim); margin: 1.4rem 0 .5rem; cursor: pointer; user-select: none; }
+.bucket > h2::before { content: "▾"; display: inline-block; width: 1em; color: var(--dim); transition: transform .12s; }
+.bucket.collapsed > h2::before { transform: rotate(-90deg); }
+.bucket.collapsed > .card { display: none; }
 .doc-body { white-space: pre-wrap; background: var(--panel2); border: 1px solid var(--line); border-radius: 6px; padding: .8rem; max-height: 420px; overflow: auto; font: 12.5px/1.55 ui-monospace, monospace; }
 .flag { display: flex; gap: .8rem; align-items: flex-start; padding: .6rem 0; border-bottom: 1px solid var(--line); }
 .flag.resolved { opacity: .5; }


### PR DESCRIPTION
Implements the three redlines dropped in `shared/redlines/`:

- **CLIlauncher** — the `make launch` shell picker drops the long, line-wrapping Mandate column; now just `ID · Name · Shortname`.
- **doclink** — each roadmap feature card now lists its docs (`kind='doc'`) beneath its specs, so specs and docs sit together. Doc rows are read-only here (`Doc - <title>` + open-in-md-converter); the Docs tab remains the edit surface.
- **filters** — the roadmap status filters become a single-select segmented toggle (re-click to clear → show all; no cross-filtering), and each status section is collapsible.