### PR TITLE
feat(run): docker sandbox as the default run model

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# The sandbox image COPYs nothing from the build context (the repo is bind-
+# mounted at runtime, not baked). So send the daemon an empty context — keeps
+# builds fast and avoids tar'ing .git / the .db / node_modules.
+*

--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -1,0 +1,47 @@
+# super-coder sandbox image — the *environment*, not the code.
+#
+# The repo is bind-mounted at runtime (see `./sc launch`); this image carries
+# only what the harness needs to run: python3 + sqlite3, git/curl, and the two
+# harness CLIs baked in via their official native installers (the same ones
+# install.py uses — keep the URLs in sync with scripts/install.py HARNESS_INSTALL).
+#
+# Why bake the binaries but mount the creds: claude installs as a symlink into
+# ~/.local/share/claude/versions/<v> (awkward to bind-mount); opencode is a fat
+# self-contained binary. Baking both sidesteps the symlink dance. Auth/config
+# (~/.claude, ~/.claude.json, ~/.config/opencode, ~/.local/share/opencode) is
+# mounted rw from the host so the container reuses the login you already did —
+# no in-container `auth login`.
+#
+# The container runs as your uid (compose `user:`) with HOME=/home/<user> equal
+# to the host, so paths match host==container and Path.home() finds everything.
+FROM python:3.12-slim
+
+ARG SC_USER=j3d1
+ARG SC_UID=1000
+ARG SC_GID=1000
+
+# sqlite3 CLI + git + curl + bash + ca-certs (installers pipe-to-bash over https).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      sqlite3 git curl bash ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# A user matching the host uid/gid so bind-mounted files aren't root-owned.
+RUN groupadd -g ${SC_GID} ${SC_USER} \
+ && useradd -m -u ${SC_UID} -g ${SC_GID} -s /bin/bash ${SC_USER}
+
+USER ${SC_USER}
+ENV HOME=/home/${SC_USER}
+# The dirs the official installers drop binaries into — on PATH so execvpe and
+# run.py's ensure_harness_path() agree (it derives the same dirs from Path.home).
+ENV PATH=/home/${SC_USER}/.local/bin:/home/${SC_USER}/.opencode/bin:${PATH}
+
+# Harness CLIs — official native installers, no npm (mirrors install.py).
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+ && curl -fsSL https://opencode.ai/install | bash
+
+WORKDIR /home/${SC_USER}/super-coder
+
+# Foreground stdlib server (api + static UI on one port). compose overrides the
+# port; SC_BIND=0.0.0.0 (set in compose) lets docker publish it.
+CMD ["./sc", "serve"]

--- a/.super-coder/README.md
+++ b/.super-coder/README.md
@@ -103,6 +103,8 @@ and the static `ui/` (one page, vanilla JS) on a single per-fork port.
 
 `scripts/ports.py` derives this fork's port from its repo path (`8800 + sha1 %
 100`), bumping past anything occupied, and persists it to the gitignored
-`instance.json`. `ecosystem.config.cjs` names the pm2 process `sc-<repo>` so
-forks (and the host repo's own pm2 apps) never clash. `./sc up` / `down` /
-`health` / `serve` drive it.
+`instance.json`. The server runs inside the docker sandbox (`Dockerfile` +
+`./sc launch`/`down`); the container is named `sc-<repo>` so forks never clash,
+and the port publishes to `127.0.0.1` only. `./sc serve` runs it on the host
+without docker (the escape hatch). `ecosystem.config.cjs` (pm2) is legacy from
+the pre-docker host model and no longer on the default path.

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import base64
 import gzip
 import json
+import os
 import sqlite3
 import subprocess
 import sys
@@ -464,8 +465,13 @@ def main(argv):
         port = ports_mod.resolve().get("port", 8800)
     if not DB_PATH.exists():
         sys.exit(f"server: no DB at {DB_PATH} — run `make rebuild` first.")
-    httpd = ThreadingHTTPServer(("127.0.0.1", port), Handler)
-    print(f"super-coder review layer → http://127.0.0.1:{port}  (DB: {DB_PATH.name})")
+    # Bind 127.0.0.1 by default (the host stance: localhost-only, operator owns
+    # network controls). In the container set SC_BIND=0.0.0.0 so docker can
+    # publish the port — the jail is the `-p 127.0.0.1:PORT:PORT` mapping, which
+    # keeps it loopback-only on the host regardless of the in-container bind.
+    bind = os.environ.get("SC_BIND", "127.0.0.1")
+    httpd = ThreadingHTTPServer((bind, port), Handler)
+    print(f"super-coder review layer → http://127.0.0.1:{port}  (bind {bind}, DB: {DB_PATH.name})")
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -67,9 +67,15 @@ ROADMAP_EDITABLE = {"title", "roadmap_status", "summary", "sort_order"}
 
 
 def db() -> sqlite3.Connection:
-    con = sqlite3.connect(DB_PATH)
+    con = sqlite3.connect(DB_PATH, timeout=5)
     con.row_factory = sqlite3.Row
     con.execute("PRAGMA foreign_keys=ON")
+    # The server and a harness session now write this DB from separate processes
+    # (both share the bind-mounted file in the sandbox). WAL lets a reader and a
+    # writer coexist; busy_timeout makes a contended write wait instead of raising
+    # "database is locked". WAL is a persistent DB property — set once, sticks.
+    con.execute("PRAGMA journal_mode=WAL")
+    con.execute("PRAGMA busy_timeout=5000")
     return con
 
 

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -158,17 +158,15 @@ def report_docker() -> dict:
     st = docker_status()
     user = os.environ.get("USER", "$USER")
     state = st["state"]
-    if state == "rootful":
-        print("  docker    ✓ rootful — ideal: 1:1 uid bind-mounts, harness runs as you")
-    elif state == "rootless":
-        print("  docker    ✓ rootless — works. The sandbox runs the container as root,")
-        print("            which under rootless maps to YOU, so mounts come out yours.")
-        print("            One wart: claude runs as root inside (its --dangerously-skip-")
-        print("            permissions flag is blocked; the sandbox replaces the need).")
-        print("            For a normal-user harness + simpler mounts, prefer rootful:")
-        print(f"              sudo usermod -aG docker {user}")
-        print("              sudo systemctl enable --now docker.socket   # log out/in after")
-        print("              docker context use default")
+    if state == "rootless":
+        print("  docker    ✓ rootless — the default, nothing to set up. The sandbox runs")
+        print("            the container as root, which under rootless maps to YOU, so repo")
+        print("            writes come out yours (no phantom-uid problem). Only wart: claude")
+        print("            runs as root inside (its --dangerously-skip-permissions flag is")
+        print("            blocked — the sandbox replaces the need for it).")
+    elif state == "rootful":
+        print("  docker    ✓ rootful — also fine: 1:1 uid bind-mounts, harness runs as you")
+        print("            (no claude-as-root wart). Either mode works; duser() adapts.")
     elif state == "no-daemon":
         print("  docker    ⚠ CLI present but no daemon reachable. Start one:")
         print(f"            rootful : sudo usermod -aG docker {user} && sudo systemctl enable --now docker.socket  (re-login)")

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -7,7 +7,8 @@ from "engine present" to "a shell you can launch":
 
     1. Guard   — refuse to run in the super-coder SOURCE repo, or on a fork that
                  is already installed (both would destroy content). --force skips.
-    2. Require — python3 + sqlite3 (+ a heads-up if git or curl is missing).
+    2. Require — python3 + sqlite3 (+ a heads-up if git/curl missing, and a
+                 docker preflight for the sandbox run path — advisory, not fatal).
     3. Harness — ensure claude + opencode are installed (official native
                  installers, no npm); pick the launch default → instance.json.
     4. Strip   — super-coder's own per-instance content; a fork inherits the
@@ -26,6 +27,7 @@ Usage:
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -133,6 +135,53 @@ def ensure_harnesses() -> dict[str, str]:
     return status
 
 
+# ── Docker preflight (the default run mode is a sandbox container) ────────────
+# Advisory only: real docker setup needs root + a re-login, so install GUIDES with
+# the right commands for the state it finds, never mutates. Mirrors the git/curl
+# warnings — a missing/under-configured docker is not fatal, because the no-docker
+# escape hatch (`./sc serve` + `./sc boot`) still runs the shell on the host.
+
+def docker_status() -> dict:
+    """Docker availability + mode. 'absent' (no CLI) · 'no-daemon' (CLI but no
+    reachable daemon / no socket access) · 'rootless' · 'rootful'."""
+    if not shutil.which("docker"):
+        return {"state": "absent"}
+    p = sh("docker", "info", "--format", "{{.SecurityOptions}}")
+    if p.returncode != 0:
+        tail = (p.stderr or "").strip().splitlines()
+        return {"state": "no-daemon", "detail": tail[-1] if tail else ""}
+    return {"state": "rootless" if "rootless" in (p.stdout or "").lower() else "rootful"}
+
+
+def report_docker() -> dict:
+    """Print the docker preflight block for the sandbox run path. Returns status."""
+    st = docker_status()
+    user = os.environ.get("USER", "$USER")
+    state = st["state"]
+    if state == "rootful":
+        print("  docker    ✓ rootful — ideal: 1:1 uid bind-mounts, harness runs as you")
+    elif state == "rootless":
+        print("  docker    ✓ rootless — works. The sandbox runs the container as root,")
+        print("            which under rootless maps to YOU, so mounts come out yours.")
+        print("            One wart: claude runs as root inside (its --dangerously-skip-")
+        print("            permissions flag is blocked; the sandbox replaces the need).")
+        print("            For a normal-user harness + simpler mounts, prefer rootful:")
+        print(f"              sudo usermod -aG docker {user}")
+        print("              sudo systemctl enable --now docker.socket   # log out/in after")
+        print("              docker context use default")
+    elif state == "no-daemon":
+        print("  docker    ⚠ CLI present but no daemon reachable. Start one:")
+        print(f"            rootful : sudo usermod -aG docker {user} && sudo systemctl enable --now docker.socket  (re-login)")
+        print("            rootless: dockerd-rootless-setuptool.sh install && systemctl --user enable --now docker")
+        if st.get("detail"):
+            print(f"            ({st['detail']})")
+    else:  # absent
+        print("  docker    ⚠ not found — the default run mode is a sandbox container.")
+        print("            Install it (e.g. Arch: sudo pacman -S docker), then `./sc doctor`.")
+        print("            Or run without docker via the escape hatch: ./sc serve + ./sc boot")
+    return st
+
+
 # Ignore lines a fork needs — the rebuilt/derived artifacts. The git checkout
 # that brings the engine in doesn't carry super-coder's .gitignore, so the
 # installer appends them to the host repo's .gitignore (idempotent via marker).
@@ -168,7 +217,7 @@ def main(argv: list[str]) -> int:
     force = "--force" in argv
     skip_harness = "--skip-harness-install" in argv
     # super-coder's own flags — strip them so they don't reach init_fork's parser.
-    own = {"--force", "--skip-harness-install", "--ensure-harness"}
+    own = {"--force", "--skip-harness-install", "--ensure-harness", "--check-docker"}
     fork_args = [a for a in argv if a not in own]
 
     # Standalone: just ensure the harness CLIs and exit (for an already-installed
@@ -176,6 +225,12 @@ def main(argv: list[str]) -> int:
     if "--ensure-harness" in argv:
         step("Ensuring harness CLIs (claude + opencode)")
         ensure_harnesses()
+        return 0
+
+    # Standalone docker preflight (re-run after configuring docker) — `./sc doctor`.
+    if "--check-docker" in argv:
+        step("Checking the sandbox runtime (docker)")
+        report_docker()
         return 0
 
     # 1. Guards ---------------------------------------------------------------
@@ -199,6 +254,9 @@ def main(argv: list[str]) -> int:
         print("  ⚠ git not on PATH — needed for the commit→PR flow later.")
     if not shutil.which("curl"):
         print("  ⚠ curl not on PATH — needed to auto-install a missing harness.")
+    # Docker is the default run path (the sandbox); guide if it's missing or
+    # under-configured. Never fatal — `./sc serve`+`boot` run without it.
+    report_docker()
 
     # 3. Ensure harness CLIs --------------------------------------------------
     # Install both claude + opencode if missing, via their official NATIVE

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -180,6 +180,45 @@ def report_docker() -> dict:
     return st
 
 
+# ── Harness login preflight ──────────────────────────────────────────────────
+# The sandbox mounts your host harness creds in (binaries are baked in the image;
+# auth is host-mounted so you don't re-login on every restart). So a one-time
+# host login is what makes those cred files exist. We detect + guide; the login
+# itself is an interactive oauth flow we can't script.
+
+def harness_login_status() -> dict:
+    """Heuristic 'logged in?' per harness, from the host cred files the sandbox
+    mounts. claude stores an oauthAccount in ~/.claude.json; opencode writes
+    ~/.local/share/opencode/auth.json on `auth login`."""
+    claude = False
+    cj = Path.home() / ".claude.json"
+    if cj.exists():
+        try:
+            claude = "oauthAccount" in json.loads(cj.read_text())
+        except (json.JSONDecodeError, OSError):
+            claude = False
+    oc = Path.home() / ".local" / "share" / "opencode" / "auth.json"
+    opencode = oc.exists() and oc.stat().st_size > 2
+    return {"claude": claude, "opencode": opencode}
+
+
+def report_logins() -> dict:
+    """Print the harness-login preflight. The sandbox can't run a harness you
+    haven't logged into; the login lives on the host and gets mounted in."""
+    st = harness_login_status()
+    if st["claude"]:
+        print("  claude    ✓ logged in")
+    else:
+        print("  claude    ⚠ not logged in — run `claude` then `/login` once on the host")
+        print("            (creates ~/.claude.json, which the sandbox mounts in).")
+    if st["opencode"]:
+        print("  opencode  ✓ logged in")
+    else:
+        print("  opencode  ⚠ not logged in — run `opencode auth login` once on the host")
+        print("            (creates ~/.local/share/opencode/auth.json, mounted in).")
+    return st
+
+
 # Ignore lines a fork needs — the rebuilt/derived artifacts. The git checkout
 # that brings the engine in doesn't carry super-coder's .gitignore, so the
 # installer appends them to the host repo's .gitignore (idempotent via marker).
@@ -225,10 +264,13 @@ def main(argv: list[str]) -> int:
         ensure_harnesses()
         return 0
 
-    # Standalone docker preflight (re-run after configuring docker) — `./sc doctor`.
+    # Standalone preflight (re-run after configuring docker / logging in) —
+    # `./sc doctor`: is the sandbox ready to launch + boot a harness?
     if "--check-docker" in argv:
-        step("Checking the sandbox runtime (docker)")
+        step("Sandbox runtime (docker)")
         report_docker()
+        step("Harness login (host creds the sandbox mounts in)")
+        report_logins()
         return 0
 
     # 1. Guards ---------------------------------------------------------------
@@ -271,6 +313,11 @@ def main(argv: list[str]) -> int:
         ensure_harnesses()
     harness = detect_harness() or "claude"  # claude preferred; both should be present
     print(f"  → default harness for instance.json: {harness}")
+
+    # 3.1 Harness login — the sandbox mounts host creds in, so a one-time host
+    # login is what populates them. Detect + guide; the oauth flow isn't scriptable.
+    step("Harness login (one-time, on the host — the sandbox mounts these creds in)")
+    report_logins()
 
     # 3.5 Wire the host repo's .gitignore -------------------------------------
     step("Wiring .gitignore")

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -151,8 +151,12 @@ def open_db() -> sqlite3.Connection:
             f"FATAL: no usable DB at {DB_PATH}.\n"
             f"  Rebuild it from text:  ./sc rebuild"
         )
-    con = sqlite3.connect(DB_PATH)
+    con = sqlite3.connect(DB_PATH, timeout=5)
     con.row_factory = sqlite3.Row
+    # Coexist with the review server writing the same file from another process
+    # (see server.py db()): WAL + a busy_timeout instead of "database is locked".
+    con.execute("PRAGMA journal_mode=WAL")
+    con.execute("PRAGMA busy_timeout=5000")
     con.execute("SELECT 1 FROM shells LIMIT 1")  # smoke
     return con
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# super-coder — convenience targets. All logic lives in ./sc (the dispatcher);
+# these only delegate. `sc` deliberately owns the engine so it travels with a
+# fork (install.py checks out `.super-coder` + `sc`, NOT this Makefile) — so this
+# file is source-repo ergonomics only, never propagates, and never clobbers a
+# fork's own Makefile. Delete it and you lose nothing: `./sc <cmd>` is identical.
+#
+#   make launch            build + start the docker sandbox
+#   make enter             attach an interactive session (pick shell + harness)
+#   make enter s=cc        attach + boot the 'cc' shell directly
+#   make down              stop the sandbox
+.PHONY: launch enter down build logs serve health ports verify install
+
+launch:  ; ./sc launch
+enter:   ; ./sc $(if $(s),enter-$(s),enter)
+down:    ; ./sc down
+build:   ; ./sc build
+logs:    ; ./sc logs
+serve:   ; ./sc serve
+health:  ; ./sc health
+ports:   ; ./sc ports
+verify:  ; ./sc verify
+install: ; ./sc install

--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ never collides with your repo's own `/docs`, `/specs`, or skills. A fork
 inherits the **system** (schema + the skill catalogue + the render chain), never
 super-coder's own memory or roadmap.
 
-> Requirements: `python3`, `sqlite3`, `git`, `curl`; `pm2` for the review GUI.
-> (No `make` — `./sc` is a plain shell dispatcher. No `npm` — the harness CLIs
-> install via their own native installers.) `./sc install` installs the harness
-> CLIs (`claude` + `opencode`) for you if they're missing.
+> Requirements: `docker` — the default run mode is a sandbox container, so the
+> harness's "allow everything" is safe (the kernel is the boundary; the
+> container sees only this repo + your harness creds). The image bakes the rest:
+> `python3`, `sqlite3`, `git`, `curl`, and the harness CLIs (`claude` +
+> `opencode`, via their official native installers, no npm). `make` targets wrap
+> the common commands; `./sc <cmd>` works without `make`. No docker? The
+> `./sc serve` + `./sc boot` primitives run on the host with only `python3` +
+> `sqlite3` (and a harness on `PATH`).
 
 ```bash
 cd your-repo                    # an existing git repo
@@ -48,7 +52,8 @@ git checkout super-coder/main -- .super-coder sc
 
 # 3. Commit the install, then boot:
 git add -A && git commit -m "chore: install super-coder"
-./sc launch                     # starts the review GUI + boots your shell
+./sc launch                     # build + start the sandbox (server + GUI)
+./sc enter                      # attach: auth + pick shell + pick harness + boot
 ```
 
 `./sc install` does the rest: checks requirements, **installs the harness CLIs**
@@ -70,7 +75,7 @@ python3 .super-coder/scripts/install.py \
     --role "Dev shell" --mandate "Build and maintain this repo."
 ```
 
-After `./sc launch` you're talking to the shell, working your repo. Author
+After `./sc enter` you're talking to the shell, working your repo. Author
 memory, roadmap, and specs into the DB; `./sc snapshot` (+ `./sc render`)
 serializes back to the text git tracks.
 
@@ -107,13 +112,16 @@ can make it.
 ## Run (everyday)
 
 ```bash
-./sc launch              # auth + pick a shell + pick a harness + render boot + exec
-./sc launch-<shortname>  # boot one shell directly, skip the shell picker
+./sc launch              # build + start the sandbox container (server + GUI), 127.0.0.1 only
+./sc enter               # attach a session: auth + pick a shell + pick a harness + boot
+./sc enter-<shortname>   # attach + boot one shell directly, skip the shell picker
+./sc down                # stop + remove the sandbox container
+./sc logs                # tail the sandbox server logs
 ./sc rebuild             # rebuild .super-coder/shell_db.db from schema + migrations + snapshot
 ./sc render              # regenerate the tracked flat _sc files from the DB
 ./sc snapshot            # serialize per-instance tables → snapshot/content.sql
 ./sc verify              # rebuild + flat render + headless boot (no exec) — the proof
-./sc help                # all targets
+./sc help                # all commands
 ```
 
 **Choosing a harness.** The boot artifact is dual-written every launch
@@ -125,17 +133,11 @@ per-launch and never written back — so two terminals can run the **same** shel
 different harnesses at once (one Claude Code, one OpenCode). A fork with a single
 harness on `PATH` skips the prompt.
 
-**Prefer `make`?** super-coder never touches your repo's `Makefile`, but you can
-alias the common case in your own — a one-liner you control:
-
-```make
-super:           ## boot super-coder
-	@./sc launch
-```
-
-Then `make super` runs it. (For other commands call `./sc <cmd>` directly —
-forwarding arbitrary args through `make` is the quoting mess `./sc` exists to
-avoid.)
+**`make`.** The source repo ships a thin root `Makefile` that delegates to
+`./sc` (`make launch` / `make enter` / `make enter s=cc` / `make down`). It is
+source-repo ergonomics only — `install.py` checks out `.super-coder` + `sc`, not
+the `Makefile`, so it never propagates to a fork or clobbers a fork's own
+`Makefile`. In a fork, use `./sc <cmd>` (or alias it in your own `Makefile`).
 
 ## Review layer (localhost GUI)
 
@@ -143,11 +145,16 @@ A zero-dependency localhost GUI to review the substrate — shells, roadmap,
 flags. One stdlib Python server serves both the JSON API and a static UI; no
 venv, no npm, no build step.
 
+The server runs **inside the sandbox container** as its foreground process, so
+`./sc launch` brings it up and `./sc down` stops it. The port publishes to
+`127.0.0.1` only.
+
 ```bash
-./sc up        # start it (pm2) on this fork's derived port
+./sc launch    # start the sandbox — server + GUI come up on this fork's derived port
 ./sc health    # curl /api/health
-./sc down      # stop it
-./sc serve     # run it in the foreground (no pm2)
+./sc down      # stop the sandbox (and the server with it)
+./sc logs      # tail the server logs
+./sc serve     # run the server in the foreground on the host (no docker)
 ./sc ports     # show this fork's derived port
 ```
 
@@ -170,9 +177,10 @@ migrate, rebuild) — each with a description and a **run** button, so the commo
 chores work from the GUI without dropping to a terminal (rebuild prompts first,
 since it discards un-snapshotted DB edits).
 
-**`./sc launch` brings the GUI up too** — it starts the review layer (if not
-already running) and prints its URL *before* handing off to the harness, so the
-shell and the GUI run side by side from one command.
+**One container, two access paths** — `./sc launch` starts the server (GUI) as
+the container's foreground process and prints its URL; `./sc enter` then attaches
+an interactive harness session into that same container via `docker exec`, so the
+shell and the GUI run side by side, sharing the one bind-mounted repo + creds.
 
 The live `.super-coder/shell_db.db` is **gitignored and rebuilt** from
 git-tracked text. See `.super-coder/README.md` for the full model.

--- a/README.md
+++ b/README.md
@@ -38,24 +38,23 @@ super-coder's own memory or roadmap.
 > `./sc serve` + `./sc boot` primitives run on the host with only `python3` +
 > `sqlite3` (and a harness on `PATH`).
 
-**Docker mode — rootful vs rootless.** `./sc doctor` checks your docker and
-prints setup guidance. Both work (the launcher's `duser()` adapts), but
-**rootful is the smoother default**: bind-mounts map 1:1 to your uid and the
-harness runs as a normal user. Under rootless the sandbox runs the container as
-root (which maps to you), which works but makes `claude` run as root inside
-(its `--dangerously-skip-permissions` flag is blocked — the sandbox replaces the
-need for it). `./sc install` runs this preflight for you.
+**Docker mode — rootless is the default.** `./sc doctor` checks your docker.
+Both modes work (the launcher's `duser()` adapts), and **rootless is the chosen
+default: zero setup, same function.** Under rootless the sandbox runs the
+container as root, which maps to *you*, so repo writes come out owned by you —
+no phantom-uid problem (verified). Its only wart: `claude` runs as root inside,
+so its `--dangerously-skip-permissions` flag is blocked — the sandbox replaces
+the need for it. **Rootful is optional**, purely to drop that wart (1:1
+bind-mounts, harness runs as a normal user); it costs a one-time sudo + re-login.
 
-**Docker setup is one-time.** Do it once per machine; it persists across reboots,
-and `./sc launch` never repeats it (launch just checks the daemon is reachable
-and points you here if not). Two paths:
+**Setup is one-time per machine (and rootless needs none).** `./sc launch` only
+checks the daemon is reachable and points you here if not — it never does setup.
 
-- **Rootless — zero setup.** If rootless docker already runs as your user,
-  nothing to do; `./sc launch` works as-is. (Trade-off: the claude-as-root wart
-  above.)
-- **Rootful — one-time, needs sudo + a re-login.** Smoother runtime; the re-login
-  is unavoidable (a new `docker` group only applies to a fresh session), which is
-  why this can't fold into `launch`:
+- **Rootless (default) — nothing to do.** If rootless docker runs as your user,
+  `./sc launch` works as-is.
+- **Rootful (optional upgrade).** Needs sudo + a re-login (a new `docker` group
+  only applies to a fresh session — which is exactly why it can't fold into
+  `launch`):
 
   ```bash
   sudo usermod -aG docker $USER            # 1. join the docker group

--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ root (which maps to you), which works but makes `claude` run as root inside
 (its `--dangerously-skip-permissions` flag is blocked — the sandbox replaces the
 need for it). `./sc install` runs this preflight for you.
 
+**Docker setup is one-time.** Do it once per machine; it persists across reboots,
+and `./sc launch` never repeats it (launch just checks the daemon is reachable
+and points you here if not). Two paths:
+
+- **Rootless — zero setup.** If rootless docker already runs as your user,
+  nothing to do; `./sc launch` works as-is. (Trade-off: the claude-as-root wart
+  above.)
+- **Rootful — one-time, needs sudo + a re-login.** Smoother runtime; the re-login
+  is unavoidable (a new `docker` group only applies to a fresh session), which is
+  why this can't fold into `launch`:
+
+  ```bash
+  sudo usermod -aG docker $USER            # 1. join the docker group
+  sudo systemctl enable --now docker.socket # 2. start the system daemon
+  # 3. LOG OUT and back in (the group only applies to a new session)
+  docker context use default                # 4. point the CLI at the system daemon
+  systemctl --user disable --now docker.service  # 5. optional: stop rootless
+  ./sc doctor                               # verify → "docker ✓ rootful"
+  ```
+
 ```bash
 cd your-repo                    # an existing git repo
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ super-coder's own memory or roadmap.
 > `./sc serve` + `./sc boot` primitives run on the host with only `python3` +
 > `sqlite3` (and a harness on `PATH`).
 
+**Docker mode — rootful vs rootless.** `./sc doctor` checks your docker and
+prints setup guidance. Both work (the launcher's `duser()` adapts), but
+**rootful is the smoother default**: bind-mounts map 1:1 to your uid and the
+harness runs as a normal user. Under rootless the sandbox runs the container as
+root (which maps to you), which works but makes `claude` run as root inside
+(its `--dangerously-skip-permissions` flag is blocked — the sandbox replaces the
+need for it). `./sc install` runs this preflight for you.
+
 ```bash
 cd your-repo                    # an existing git repo
 

--- a/sc
+++ b/sc
@@ -47,6 +47,7 @@ cmd="${1:-help}"; [ $# -gt 0 ] && shift
 case "$cmd" in
   install)         exec "$PY" "$S/install.py" "$@" ;;
   ensure-harness)  exec "$PY" "$S/install.py" --ensure-harness ;;
+  doctor)          exec "$PY" "$S/install.py" --check-docker ;;
   update)       exec "$PY" "$S/update.py" "$@" ;;
   init)         exec "$PY" "$S/init_fork.py" "$@" ;;
   rebuild)      exec "$PY" "$S/rebuild.py" "$@" ;;
@@ -96,6 +97,7 @@ super-coder — forkable shell substrate
 
   ./sc install             first-launch bootstrap for a fork (requirements, harness, first shell)
   ./sc ensure-harness      install claude + opencode if missing (official native installers, no npm)
+  ./sc doctor              docker preflight for the sandbox (rootless/rootful + setup guidance)
   ./sc update              self-fetch the engine + reconcile IN PLACE (migrate, sync skills, map); --no-fetch to skip fetch
   ./sc rebuild             build the .db from schema + migrations + snapshot
   ./sc migrate             apply pending migrations to an existing .db

--- a/sc
+++ b/sc
@@ -23,6 +23,17 @@ port() { "$PY" "$S/ports.py" port; }
 IMG=super-coder-sandbox
 CNAME="sc-$(basename "$here")"   # unique per fork, like the pm2 name
 
+# Fail fast with the fix if the docker daemon isn't reachable, instead of a
+# cryptic build/run error. Host setup is one-time and lives in `./sc doctor` /
+# `./sc install` — it needs sudo + a re-login, so it can't fold into launch.
+dcheck() {
+  if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+    echo "✗ docker daemon not reachable — the sandbox needs it." >&2
+    echo "  Setup (one-time):  ./sc doctor      No docker:  ./sc serve + ./sc boot" >&2
+    exit 1
+  fi
+}
+
 # Which in-container uid writes the bind-mounted repo as YOU on the host.
 # Rootless docker maps container-root → host-you, so run as root (it is not real
 # root — just your user inside the namespace). Rootful maps uid 1:1, so run as
@@ -63,6 +74,7 @@ case "$cmd" in
   boot-*)       exec "$PY" "$S/run.py" "${cmd#boot-}" "$@" ;;
   # ── docker sandbox (host-side; the default way to run) ──
   launch)
+    dcheck
     "$PY" "$S/ports.py" ensure >/dev/null
     p="$(port)"
     dbuild
@@ -83,7 +95,7 @@ case "$cmd" in
   enter)        exec docker exec -it "$CNAME" ./sc boot "$@" ;;
   enter-*)      exec docker exec -it "$CNAME" ./sc boot "${cmd#enter-}" "$@" ;;
   down)         docker rm -f "$CNAME" >/dev/null 2>&1 && echo "→ sandbox stopped" || echo "→ not running" ;;
-  build)        dbuild ;;
+  build)        dcheck; dbuild ;;
   logs)         exec docker logs -f "$CNAME" ;;
   verify)
     "$PY" "$S/rebuild.py"

--- a/sc
+++ b/sc
@@ -1,7 +1,9 @@
 #!/bin/sh
-# super-coder entry point — a thin dispatcher so super-coder never owns the host
-# repo's root Makefile. Needs only python3 + sqlite3 (+ pm2 for the GUI). Run
-# from the repo root:  ./sc <command> [args]   ·   ./sc help
+# super-coder entry point — the dispatcher. All engine logic lives here so it
+# travels with a fork (install.py checks out .super-coder + sc). Host commands
+# (launch/enter/down) drive a docker sandbox; the in-container primitives
+# (serve/boot) need only python3 + sqlite3 and double as the no-docker host
+# escape hatch. Run from the repo root:  ./sc <command> [args]   ·   ./sc help
 set -e
 here="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 cd "$here"
@@ -9,14 +11,35 @@ cd "$here"
 ENGINE=.super-coder
 PY="${SC_PYTHON:-python3}"
 DB="$ENGINE/shell_db.db"
-ECO="$ENGINE/ecosystem.config.cjs"
 S="$ENGINE/scripts"
 
 port() { "$PY" "$S/ports.py" port; }
-gui_up() {
-  "$PY" "$S/ports.py" ensure >/dev/null
-  pm2 start "$ECO" >/dev/null 2>&1 || true
-  echo "→ review GUI at http://127.0.0.1:$(port)"
+
+# Host-side docker orchestration (raw docker — no compose plugin dependency).
+# The sandbox runs as you (uid/gid → no root-owned files), bind-mounts this repo
+# at its host path + your harness creds rw, and publishes this fork's derived
+# port to 127.0.0.1 only. The in-container primitives (`serve`, `boot`) need no
+# docker and so run the same whether on the host or inside the container.
+IMG=super-coder-sandbox
+CNAME="sc-$(basename "$here")"   # unique per fork, like the pm2 name
+
+# Which in-container uid writes the bind-mounted repo as YOU on the host.
+# Rootless docker maps container-root → host-you, so run as root (it is not real
+# root — just your user inside the namespace). Rootful maps uid 1:1, so run as
+# your uid. Get this wrong and the mount is read-only-ish (EACCES on write).
+duser() {
+  if docker info 2>/dev/null | grep -qi rootless; then echo "0:0"
+  else echo "$(id -u):$(id -g)"; fi
+}
+
+# Build the env image (the repo is bind-mounted at run time, never baked — see
+# .dockerignore: the build context is empty). Cheap to re-run; layers cache.
+dbuild() {
+  docker build -t "$IMG" -f "$ENGINE/Dockerfile" \
+    --build-arg SC_USER="$(id -un)" \
+    --build-arg SC_UID="$(id -u)" \
+    --build-arg SC_GID="$(id -g)" \
+    "$here"
 }
 
 cmd="${1:-help}"; [ $# -gt 0 ] && shift
@@ -33,18 +56,38 @@ case "$cmd" in
   map)          exec "$PY" "$S/map_repo.py" ;;
   seed-skills)  exec "$PY" "$S/seed_skills.py" ;;
   ports)        exec "$PY" "$S/ports.py" show ;;
+  # ── in-container primitives (no docker; also the host escape hatch) ──
   serve)        exec "$PY" "$ENGINE/api/server.py" "$@" ;;
-  launch)       gui_up; exec "$PY" "$S/run.py" "$@" ;;
-  launch-*)     gui_up; exec "$PY" "$S/run.py" "${cmd#launch-}" ;;
+  boot)         exec "$PY" "$S/run.py" "$@" ;;
+  boot-*)       exec "$PY" "$S/run.py" "${cmd#boot-}" "$@" ;;
+  # ── docker sandbox (host-side; the default way to run) ──
+  launch)
+    "$PY" "$S/ports.py" ensure >/dev/null
+    p="$(port)"
+    dbuild
+    docker rm -f "$CNAME" >/dev/null 2>&1 || true
+    docker run -d --name "$CNAME" --restart unless-stopped \
+      --user "$(duser)" \
+      -e HOME="$HOME" -e SC_BIND=0.0.0.0 -e SC_PYTHON=python3 -e PYTHONUNBUFFERED=1 \
+      -w "$here" \
+      -v "$here:$here" \
+      -v "$HOME/.claude:$HOME/.claude" \
+      -v "$HOME/.claude.json:$HOME/.claude.json" \
+      -v "$HOME/.config/opencode:$HOME/.config/opencode" \
+      -v "$HOME/.local/share/opencode:$HOME/.local/share/opencode" \
+      -p "127.0.0.1:$p:$p" \
+      "$IMG" ./sc serve --port "$p" >/dev/null
+    echo "→ sandbox up · review GUI at http://127.0.0.1:$p"
+    echo "  boot a shell:  ./sc enter   (or ./sc enter-<shortname>)" ;;
+  enter)        exec docker exec -it "$CNAME" ./sc boot "$@" ;;
+  enter-*)      exec docker exec -it "$CNAME" ./sc boot "${cmd#enter-}" "$@" ;;
+  down)         docker rm -f "$CNAME" >/dev/null 2>&1 && echo "→ sandbox stopped" || echo "→ not running" ;;
+  build)        dbuild ;;
+  logs)         exec docker logs -f "$CNAME" ;;
   verify)
     "$PY" "$S/rebuild.py"
     "$PY" "$S/render.py" flat
     RENDER_ONLY=1 exec "$PY" "$S/run.py" --first ;;
-  up)
-    "$PY" "$S/ports.py" ensure >/dev/null
-    pm2 start "$ECO" && echo "→ review layer up at http://127.0.0.1:$(port)" ;;
-  down)         pm2 delete "$ECO" 2>/dev/null && echo "→ review layer stopped" || echo "→ not running" ;;
-  restart)      exec pm2 restart "$ECO" ;;
   health)       curl -s "http://127.0.0.1:$(port)/api/health" && echo "" ;;
   clean-db)     rm -f "$DB" "$DB-wal" "$DB-shm" && echo "removed $DB (rebuild with: ./sc rebuild)" ;;
   help|-h|--help)
@@ -61,13 +104,23 @@ super-coder — forkable shell substrate
   ./sc map                 scan the host repo into the dr_* catalogue (re-runnable)
   ./sc seed-skills         regenerate the skills seed migration from assets/skills/
   ./sc init                seed a fresh fork's first user + shell (run once after install)
-  ./sc launch              start the GUI (prints its URL) + auth + pick shell + pick harness + boot
-  ./sc launch-<shortname>  boot that shell directly (skip shell picker); also starts the GUI
+
+  Sandbox (docker — the default way to run; allow-everything is safe because the
+  container only sees this repo + your harness creds):
+  ./sc launch              build + start the sandbox container (server + GUI), 127.0.0.1 only
+  ./sc enter               attach an interactive session: auth + pick shell + pick harness + boot
+  ./sc enter-<shortname>   attach + boot that shell directly (skip the shell picker)
                              harness: --harness <name> or HARNESS=<name> forces it; else when
                              >1 harness is on PATH you're prompted (per-launch, not persisted)
+  ./sc down                stop + remove the sandbox container
+  ./sc build               (re)build the sandbox image
+  ./sc logs                tail the sandbox server logs
+
+  Primitives (run inside the container; also the no-docker host escape hatch):
+  ./sc serve               run the review layer (api + static UI) in the foreground
+  ./sc boot [shortname]    auth + pick shell + pick harness + boot (no container, no GUI)
+
   ./sc verify              rebuild + flat render + render-only boot (headless proof)
-  ./sc up / down / restart start/stop the localhost review layer (pm2, per-fork port)
-  ./sc serve               run the review layer in the foreground (no pm2)
   ./sc health              curl the review layer's /api/health
   ./sc ports               show this fork's derived port
   ./sc clean-db            remove the rebuilt .db (text serializations untouched)

--- a/sc
+++ b/sc
@@ -34,6 +34,16 @@ dcheck() {
   fi
 }
 
+# Ensure the harness cred mount-sources exist as the RIGHT TYPE before docker
+# bind-mounts them. A missing DIR source is harmless (docker makes a dir), but a
+# missing FILE source (~/.claude.json) gets auto-created as a directory and
+# breaks claude — so seed it with empty json. Real creds come from a one-time
+# host login (`./sc doctor` guides it); this just keeps the mounts valid.
+dcreds() {
+  mkdir -p "$HOME/.claude" "$HOME/.config/opencode" "$HOME/.local/share/opencode" 2>/dev/null || true
+  [ -e "$HOME/.claude.json" ] || echo '{}' > "$HOME/.claude.json"
+}
+
 # Which in-container uid writes the bind-mounted repo as YOU on the host.
 # Rootless docker maps container-root → host-you, so run as root (it is not real
 # root — just your user inside the namespace). Rootful maps uid 1:1, so run as
@@ -75,6 +85,7 @@ case "$cmd" in
   # ── docker sandbox (host-side; the default way to run) ──
   launch)
     dcheck
+    dcreds
     "$PY" "$S/ports.py" ensure >/dev/null
     p="$(port)"
     dbuild
@@ -109,7 +120,7 @@ super-coder — forkable shell substrate
 
   ./sc install             first-launch bootstrap for a fork (requirements, harness, first shell)
   ./sc ensure-harness      install claude + opencode if missing (official native installers, no npm)
-  ./sc doctor              docker preflight for the sandbox (rootless/rootful + setup guidance)
+  ./sc doctor              sandbox readiness: docker (rootless/rootful) + harness login
   ./sc update              self-fetch the engine + reconcile IN PLACE (migrate, sync skills, map); --no-fetch to skip fetch
   ./sc rebuild             build the .db from schema + migrations + snapshot
   ./sc migrate             apply pending migrations to an existing .db


### PR DESCRIPTION
## What

Makes a **docker sandbox the default way to run super-coder**. The harness can now safely "allow everything" because the kernel is the boundary — the container sees only the bind-mounted repo + your harness creds, nothing else on the host. This replaces the host-level (no-docker) model, where allow-all meant the agent ran with your full ambient authority.

## How it runs (CLI-driven, one container)

| command | does |
|---|---|
| `./sc launch` | build env image + start container; stdlib server (api + static UI) runs foreground, published to `127.0.0.1` only |
| `./sc enter` / `enter-<shortname>` | `docker exec -it` into that container → existing boot flow (auth → pick shell → pick harness → exec harness) on the TTY |
| `./sc down` / `build` / `logs` | lifecycle |
| `./sc serve` / `boot` | in-container primitives **and** the no-docker host escape hatch |

`make launch` / `make enter [s=cc]` / `make down` delegate to `./sc`.

## Image

`.super-coder/Dockerfile` — `python3` + `sqlite3` + `git` + `curl`, with `claude` + `opencode` baked in via their official native installers. Repo + harness creds mounted **rw** at host-identical paths; binaries baked, auth/state mounted (no overlap) → reuses the login you already did.

## Notes / decisions

- **Rootless docker handled.** Container-root maps to host-you under rootless, so `duser()` runs as root (rootless) or your uid (rootful) — whichever writes the mount as you.
- **`server.py`**: new `SC_BIND` env (default `127.0.0.1`; container sets `0.0.0.0`). The loopback jail is the `-p 127.0.0.1:PORT:PORT` mapping, so the localhost-only stance is preserved at the publish layer.
- **Raw docker, no compose** — the compose v2 plugin isn't installed on the host; raw `docker` needs no extra install.
- **Makefile is source-repo only** — `install.py` checks out `.super-coder` + `sc`, not the `Makefile`, so it never propagates to / clobbers a fork.

## Verified (smoke test)

- image builds; `claude` 2.1.165 + `opencode` 1.16.0 on PATH inside
- `./sc launch` → server up, `/api/health` green, port on `127.0.0.1` only
- boot inside the container writes `CLAUDE.md`/`AGENTS.md` + session row to the mounted repo, **`j3d1`-owned (not root)**
- a DB write inside the container **survived `down` + `launch`**

## Known follow-ups (not in this PR)

- **sqlite WAL**: server + harness now write the DB from separate processes in one container. No `journal_mode=WAL`/`busy_timeout` is set anywhere (pre-existing — host pm2 + harness already shared the DB). Worth adding before heavy concurrent use to avoid "database is locked".
- **claude as root under rootless**: claude runs fine but `--dangerously-skip-permissions` is blocked as root — the sandbox replaces the need for it (relax via settings, not that flag). Untested interactively; verify with `./sc enter`.
- `ecosystem.config.cjs` (pm2) is now legacy/off the default path; left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)