### PR TITLE
feat(roadmap): add 'retired' to roadmap_status enum

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -119,10 +119,12 @@ def get_shell(con, sid: int) -> dict | None:
     return shell
 
 
-# Funnel order: idea inlet → most-active committed work → done.
-_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped"]
+# Funnel order: idea inlet → most-active committed work → done (shipped) →
+# taken-off-the-board (retired). shipped = delivered; retired = chose not to.
+_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped", "retired"]
 _LABEL = {"brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Next",
-          "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped"}
+          "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped",
+          "retired": "Retired"}
 
 
 def get_roadmap(con) -> dict:

--- a/.super-coder/assets/skills/db_map/SKILL.md
+++ b/.super-coder/assets/skills/db_map/SKILL.md
@@ -21,7 +21,7 @@ after any content write, `./sc snapshot` re-serializes to text (see the
 | `shell_identity_entries` | seed (cap 10) + L&S (`kind='lns'`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
 | `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
 | `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |
-| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`long_term`→`near_term`→`next`→`shipped`), `sort_order` within a bucket | INSERT/UPDATE |
+| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row | INSERT/UPDATE |
 | `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
 | `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | catalogue via migration; grants via snapshot |
@@ -46,8 +46,9 @@ UPDATE shell_identity_entries SET retired_at=datetime('now') WHERE entry_id=?;
 INSERT INTO shell_decisions (shell_id, decision_date, title, body)
 VALUES (<self>, date('now'), '…', '…');
 
--- roadmap: move a feature's horizon / add one:
+-- roadmap: move a feature's horizon / add one / retire one off the board:
 UPDATE roadmap SET roadmap_status='next' WHERE feature_id=?;
+UPDATE roadmap SET roadmap_status='retired' WHERE feature_id=?;  -- decided-against / split / absorbed; keeps the row
 INSERT INTO roadmap (title, roadmap_status, sort_order, owning_shell, summary)
 VALUES ('…', 'brainstorm', 0, <self>, '…');
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -238,7 +238,7 @@ after any content write, `./sc snapshot` re-serializes to text (see the
 | `shell_identity_entries` | seed (cap 10) + L&S (`kind=''lns''`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
 | `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
 | `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |
-| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`long_term`→`near_term`→`next`→`shipped`), `sort_order` within a bucket | INSERT/UPDATE |
+| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row | INSERT/UPDATE |
 | `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
 | `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | catalogue via migration; grants via snapshot |
@@ -263,8 +263,9 @@ UPDATE shell_identity_entries SET retired_at=datetime(''now'') WHERE entry_id=?;
 INSERT INTO shell_decisions (shell_id, decision_date, title, body)
 VALUES (<self>, date(''now''), ''…'', ''…'');
 
--- roadmap: move a feature''s horizon / add one:
+-- roadmap: move a feature''s horizon / add one / retire one off the board:
 UPDATE roadmap SET roadmap_status=''next'' WHERE feature_id=?;
+UPDATE roadmap SET roadmap_status=''retired'' WHERE feature_id=?;  -- decided-against / split / absorbed; keeps the row
 INSERT INTO roadmap (title, roadmap_status, sort_order, owning_shell, summary)
 VALUES (''…'', ''brainstorm'', 0, <self>, ''…'');
 

--- a/.super-coder/migrations/0002_roadmap_add_retired_status.sql
+++ b/.super-coder/migrations/0002_roadmap_add_retired_status.sql
@@ -1,0 +1,57 @@
+-- 0002 — add 'retired' to the roadmap_status CHECK constraint.
+--
+-- Motivation (per the upstream proposal): a feature may be decided-against,
+-- split into successors, absorbed, or replaced — taken off the roadmap
+-- without being shipped. Today the only options are a status lie
+-- (in_progress / shipped) or deleting the row (loses history). 'retired' is
+-- the honest terminal status. Last in the funnel order because it sits
+-- beside shipped: shipped means we delivered; retired means we chose not to.
+--
+-- SQLite cannot ALTER a CHECK constraint, so the table is rebuilt. The roadmap
+-- is small (typically <100 rows); the copy is cheap. No data migration is
+-- needed — the new value is additive, so every existing row stays valid.
+--
+-- FK note: documents.feature_id and flags.feature_id BOTH declare
+-- `REFERENCES roadmap(feature_id)`. The drop/rename is safe because (a)
+-- migrate.py opens the connection with foreign_keys at its default (OFF), so
+-- the drop is not blocked, and (b) we restore a table of the *same* name, so
+-- those references resolve again afterward. PRAGMA foreign_keys=OFF is set
+-- defensively in case a future caller has it enabled; it must toggle outside
+-- a transaction, hence the placement around BEGIN/COMMIT.
+
+PRAGMA foreign_keys=OFF;
+
+BEGIN;
+
+CREATE TABLE roadmap_new (
+    feature_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+    title          TEXT    NOT NULL,
+    roadmap_status TEXT    NOT NULL DEFAULT 'brainstorm'
+                   -- funnel order: idea inlet → most-active committed work →
+                   -- done (shipped) → taken-off-the-board (retired).
+                   CHECK (roadmap_status IN
+                       ('brainstorm','in_progress','next','near_term',
+                        'long_term','shipped','retired')),
+    sort_order     INTEGER NOT NULL DEFAULT 0,
+    owning_shell   INTEGER REFERENCES shells(shell_id),
+    summary        TEXT,
+    created_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at     TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO roadmap_new
+  (feature_id, title, roadmap_status, sort_order, owning_shell, summary,
+   created_at, updated_at)
+SELECT
+  feature_id, title, roadmap_status, sort_order, owning_shell, summary,
+  created_at, updated_at
+FROM roadmap;
+
+DROP TABLE roadmap;
+ALTER TABLE roadmap_new RENAME TO roadmap;
+
+CREATE INDEX idx_roadmap_status ON roadmap(roadmap_status, sort_order);
+
+COMMIT;
+
+PRAGMA foreign_keys=ON;

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -83,11 +83,13 @@ def render_projects(con, shell_id: int) -> str:
     return "\n".join(lines)
 
 
-# Funnel order: idea inlet → most-active committed work → done (shipped, summarized).
-_ROADMAP_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped"]
+# Funnel order: idea inlet → most-active committed work → done (shipped,
+# summarized) → taken-off-the-board (retired).
+_ROADMAP_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped", "retired"]
 _ROADMAP_LABEL = {
     "brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Next",
     "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped",
+    "retired": "Retired",
 }
 
 

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -105,10 +105,11 @@ def _render_documents(con, written, skipped) -> None:
                           written, skipped)
 
 
-_ROADMAP_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped"]
+_ROADMAP_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped", "retired"]
 _ROADMAP_LABEL = {
     "brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Next",
     "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped",
+    "retired": "Retired",
 }
 
 

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -123,9 +123,12 @@ CREATE TABLE roadmap (
     feature_id     INTEGER PRIMARY KEY AUTOINCREMENT,
     title          TEXT    NOT NULL,
     roadmap_status TEXT    NOT NULL DEFAULT 'brainstorm'
-                   -- funnel order: idea inlet → most-active committed work → done.
+                   -- funnel order: idea inlet → most-active committed work →
+                   -- done (shipped) → taken-off-the-board (retired). shipped
+                   -- means we delivered; retired means we chose not to.
                    CHECK (roadmap_status IN
-                       ('brainstorm','in_progress','next','near_term','long_term','shipped')),
+                       ('brainstorm','in_progress','next','near_term',
+                        'long_term','shipped','retired')),
     sort_order     INTEGER NOT NULL DEFAULT 0,   -- ordering within a bucket
     owning_shell   INTEGER REFERENCES shells(shell_id),
     summary        TEXT,

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -127,8 +127,8 @@ function shellCard(s) {
 
 // ── Roadmap ───────────────────────────────────────────────────────────────────
 // Funnel order: idea inlet → most-active committed work → done.
-const STATUSES = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped"];
-const SLABEL = { brainstorm: "Brainstorm", in_progress: "In Progress", next: "Next", near_term: "Near Term", long_term: "Long Term", shipped: "Shipped" };
+const STATUSES = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped", "retired"];
+const SLABEL = { brainstorm: "Brainstorm", in_progress: "In Progress", next: "Next", near_term: "Near Term", long_term: "Long Term", shipped: "Shipped", retired: "Retired" };
 let roadmapFilter = null;            // null = show all (default); single-select
 const roadmapCollapsed = new Set();  // statuses whose section is collapsed
 

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -47,6 +47,7 @@ main { padding: 1.2rem; max-width: 1100px; margin: 0 auto; }
   background: var(--accent2); color: var(--dim); border: 1px solid var(--line);
 }
 .pill.next { color: var(--accent); } .pill.shipped { color: var(--ok); }
+.pill.retired { color: var(--dim); opacity: .6; text-decoration: line-through; }
 .pill.warn { color: var(--warn); border-color: var(--warn); }
 .grid2 { display: grid; grid-template-columns: 180px 1fr; gap: .4rem 1rem; align-items: start; }
 .grid2 > .k { color: var(--dim); }


### PR DESCRIPTION
## What

Adds `retired` to the `roadmap.roadmap_status` enum — last in the funnel, after `shipped`. Implements the upstream proposal verbatim (with one rationale correction, below).

A feature that is **decided-against**, **split** into successors, **absorbed**, or **replaced** has no honest status today: `in_progress` is a lie (work stopped), `shipped` is a lie (it didn't ship), deleting the row loses history. `retired` is the terminal "taken off the board" status — the row stays (audit trail, linkable). `shipped` = we delivered; `retired` = we chose not to.

## Changes

- **`schema.sql`** — `retired` added to the `roadmap_status` CHECK tuple + funnel comment
- **`migrations/0002_roadmap_add_retired_status.sql`** (new) — table-rebuild (SQLite can't `ALTER` a CHECK); recreates `idx_roadmap_status`; additive, no data migration
- **`api/server.py`**, **`render/compose.py`**, **`render/flat.py`**, **`ui/app.js`** — append `retired` to the status order arrays + labels (last)
- **`ui/style.css`** — muted + strikethrough `.pill.retired`
- **`assets/skills/db_map/SKILL.md`** + regenerated **`0001_seed_skills.sql`** — funnel shorthand + retire-via-`UPDATE` example

## Rationale correction vs. the proposal

The proposal claimed *"No FK-references roadmap, so the drop is safe."* That is **false** — `documents.feature_id` and `flags.feature_id` both `REFERENCES roadmap(feature_id)`. The drop/rename is safe for a different reason: `migrate.py` connects with `foreign_keys` at its default (OFF), and we restore a **same-named** table, so the references resolve again afterward. The migration sets `PRAGMA foreign_keys=OFF/ON` defensively around the rebuild (toggled outside the transaction).

## Verification

On a temp copy of the live DB: migration applies cleanly · 9→9 rows preserved · CHECK accepts `retired` / rejects garbage · `idx_roadmap_status` restored · `documents`/`flags` FK refs intact · `PRAGMA foreign_key_check` empty · re-run is a ledger no-op · engine Python byte-compiles.

This is the schema-migration engine update for the upcoming `./sc update` procedure test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)