### PR TITLE
feat(install): forks get make launch/enter aliases (opt-in, no clobber)

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -1,0 +1,34 @@
+# super-coder make aliases — convenience wrappers around ./sc.
+#
+# The dispatcher ./sc is the canonical interface; these targets only delegate.
+# This file travels with the engine, so `make launch` / `make enter` work in a
+# fork exactly as in the source repo — WITHOUT super-coder ever owning or
+# clobbering the fork's Makefile (#13): install wires a fork to *include* this
+# file (or auto-creates a one-line Makefile when the fork has none); it never
+# overwrites a Makefile you already have. Delete the include and you lose
+# nothing — `./sc <cmd>` is identical.
+#
+#   make launch         build + start the docker sandbox (+ review GUI)
+#   make enter          attach an interactive session (pick shell + harness)
+#   make enter s=ap01   attach + boot the 'ap01' shell directly
+#   make down           stop the sandbox
+#   make sc ARGS=health run any ./sc subcommand (passthrough)
+#
+SC := ./sc
+.PHONY: launch enter down build logs serve health ports verify update snapshot render map install sc
+
+launch:   ; $(SC) launch
+enter:    ; $(SC) $(if $(s),enter-$(s),enter)
+down:     ; $(SC) down
+build:    ; $(SC) build
+logs:     ; $(SC) logs
+serve:    ; $(SC) serve
+health:   ; $(SC) health
+ports:    ; $(SC) ports
+verify:   ; $(SC) verify
+update:   ; $(SC) update
+snapshot: ; $(SC) snapshot
+render:   ; $(SC) render $(ARGS)
+map:      ; $(SC) map
+install:  ; $(SC) install
+sc:       ; $(SC) $(ARGS)

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -354,6 +354,22 @@ def main(argv: list[str]) -> int:
     subprocess.run([PY, str(ENGINE / "scripts/snapshot.py")])
     subprocess.run([PY, str(ENGINE / "scripts/render.py"), "flat"])
 
+    # 8.5 Wire `make` aliases — opt-in, never clobber a host Makefile (#13).
+    # No Makefile → drop a one-line include so `make launch`/`enter` work out of
+    # the box. Already have one → leave it; just print the line to opt in.
+    step("Wiring make aliases")
+    mk = REPO_ROOT / "Makefile"
+    if mk.exists():
+        print("  Makefile present — left untouched. For `make launch`/`enter`, add:")
+        print("    include .super-coder/aliases.mk")
+    else:
+        mk.write_text(
+            "# Fork Makefile — super-coder convenience aliases (make launch / enter).\n"
+            "# Edit freely; add your own targets below the include.\n"
+            "include .super-coder/aliases.mk\n"
+        )
+        print("  wrote Makefile (include .super-coder/aliases.mk) → `make launch` works")
+
     # Record harness + installed marker in instance.json ---------------------
     cfg = ports_mod.resolve(persist=False)
     cfg["harness"] = harness
@@ -366,7 +382,8 @@ def main(argv: list[str]) -> int:
     print(f"  GUI port: {cfg['port']}  (http://127.0.0.1:{cfg['port']})")
     print("\nNext:")
     print("  git add -A && git commit -m 'install super-coder'")
-    print("  ./sc launch        # starts the review GUI + boots your shell")
+    print("  ./sc launch        # or: make launch — starts the sandbox + GUI")
+    print("  ./sc enter         # or: make enter  — attach + boot your shell")
     return 0
 
 

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -53,6 +53,7 @@ import seed_skills  # noqa: E402
 # super-coder-only (stripped on install); assets/shells/ is empty/vestigial.
 ENGINE_PATHS = [
     "sc",
+    ".super-coder/aliases.mk",
     ".super-coder/schema.sql",
     ".super-coder/ecosystem.config.cjs",
     ".super-coder/README.md",

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,12 @@
 # file is source-repo ergonomics only, never propagates, and never clobbers a
 # fork's own Makefile. Delete it and you lose nothing: `./sc <cmd>` is identical.
 #
+# The targets live in .super-coder/aliases.mk — the single source of truth
+# shared with forks (install wires a fork to include the same file). Edit the
+# aliases there, not here.
+#
 #   make launch            build + start the docker sandbox
 #   make enter             attach an interactive session (pick shell + harness)
 #   make enter s=cc        attach + boot the 'cc' shell directly
 #   make down              stop the sandbox
-.PHONY: launch enter down build logs serve health ports verify install
-
-launch:  ; ./sc launch
-enter:   ; ./sc $(if $(s),enter-$(s),enter)
-down:    ; ./sc down
-build:   ; ./sc build
-logs:    ; ./sc logs
-serve:   ; ./sc serve
-health:  ; ./sc health
-ports:   ; ./sc ports
-verify:  ; ./sc verify
-install: ; ./sc install
+include .super-coder/aliases.mk


### PR DESCRIPTION
## What

`./sc` is the canonical interface, but `make launch` / `make enter` are muscle memory. `#13` deliberately stopped shipping a Makefile to forks (to avoid clobbering a host's own) — the side effect was that **forks had no working `make` aliases**, and the source repo's inline aliases drifted from the `./sc` surface (the docker model `#23` changed `launch`/`enter` semantics).

This makes `make` aliases a real, single-source feature — without ever clobbering a host Makefile.

## Changes

- **`.super-coder/aliases.mk`** (new) — the canonical alias set wrapping `./sc`: `launch`, `enter` (`s=<shortname>` → `enter-<shortname>`), `down`, `build`, `logs`, `serve`, `health`, `ports`, `verify`, `update`, `snapshot`, `render` (`ARGS=`), `map`, `install`, and an `sc` passthrough. Travels with the engine.
- **`Makefile`** (source repo) — now just `include .super-coder/aliases.mk`. One definition shared by the source repo and forks → no more drift.
- **`install.py`** — new step wires the aliases for the fork:
  - **No Makefile** → auto-create a one-line `include .super-coder/aliases.mk` so `make launch`/`enter` work out of the box.
  - **Makefile present** → left untouched; print the include line to opt in. Honors `#13`.
- **`update.py`** — `aliases.mk` added to `ENGINE_PATHS` so the alias set stays current on `./sc update`.

## Verification

- `py_compile` clean for `install.py` + `update.py`.
- Source Makefile (post-refactor) resolves every target.
- A **simulated fork** with only the one-line `include` Makefile resolves all targets, including:
  - `make enter s=ap01` → `./sc enter-ap01`
  - `make render ARGS=flat` → `./sc render flat`

## Note on the live dos-arch fork

The currently-running dos-arch fork was installed before this change and already has a hand-fixed Makefile (its own targets), so it's unaffected. After this merges it can adopt the shared `aliases.mk` via `./sc update` + swapping its targets for the one-line include — optional, not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)