### PR TITLE
feat(opencode): enable LSP by default in the adapter template

### DIFF
--- a/.super-coder/adapters/opencode/README.md
+++ b/.super-coder/adapters/opencode/README.md
@@ -11,6 +11,16 @@ harness-specific file OpenCode wants and the launch command.
   Edit this **template** (tracked) to change a fork's OpenCode config; the live
   file is regenerated each launch. Model is intentionally unset — the harness is
   rented; pick it in OpenCode (`-m provider/model`) or add `"model"` here.
+- **`"lsp": true`** — enabled by default. OpenCode's own default is LSP *off*; we
+  turn it on so the model gets language-server diagnostics as a feedback loop
+  (it sees the type error / unresolved import it just introduced and fixes it
+  before handing back). Servers start lazily, per detected file extension, so
+  languages absent from a fork cost nothing. Built-in servers cover the common
+  languages (Pyright, tsserver, gopls, rust-analyzer, …); switch `true` → `{}`
+  to keep built-ins while adding custom servers. **Offline/airgapped forks:** set
+  `OPENCODE_DISABLE_LSP_DOWNLOAD=true` in the environment — OpenCode auto-fetches
+  server binaries on first use, and this is the only knob for it (env-only, no
+  JSON key), so we leave it to the env rather than forcing it off here.
 - **`env.OPENCODE_DISABLE_CLAUDE_CODE=1`** — best-effort: stop OpenCode from also
   loading `CLAUDE.md` (we dual-write both with identical content; this avoids a
   double-load). ⚠ The exact env name is a **research flag to verify on live

--- a/.super-coder/adapters/opencode/opencode.json
+++ b/.super-coder/adapters/opencode/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "lsp": true,
   "instructions": ["AGENTS.md"],
   "permission": {
     "edit": "allow",


### PR DESCRIPTION
## What

Turn on OpenCode's language-server integration by default in the opencode adapter template (`.super-coder/adapters/opencode/opencode.json`):

```json
"lsp": true
```

OpenCode ships LSP **off** by default. Enabling it gives the model language-server **diagnostics as a correctness feedback loop** — it sees the type error / unresolved import it just introduced and fixes it before handing back. Servers start lazily per detected file extension, so languages absent from a fork cost nothing.

The emitted live `opencode.json` is regenerated from this template each launch, so every fork now gets LSP on by default (still per-fork overridable by editing the template).

## README

Documents the new default plus:
- `true → {}` to keep built-ins while adding custom servers.
- `OPENCODE_DISABLE_LSP_DOWNLOAD=true` env escape hatch for offline/airgapped forks. Download control is **env-only** (no JSON key), and forcing it off would break the normal one-time fetch — so it stays in the env layer rather than the sandbox JSON merge.

## Not yet verified live

Config-only change; not yet smoke-tested against live OpenCode. The clean check (open a file, introduce a type error, confirm the diagnostic reaches the model) folds naturally into the roadmap **B4** opencode-adapter verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)