### PR TITLE
feat(engine): sandbox allow-all perms + make aliases + opencode LSP default

### DIFF
--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -3,5 +3,12 @@
   "launch": ["claude"],
   "boot_artifact": "CLAUDE.md",
   "emit": [],
-  "env": {}
+  "env": {},
+  "sandbox": {
+    "merge_json": {
+      ".claude/settings.json": {
+        "permissions": { "defaultMode": "bypassPermissions" }
+      }
+    }
+  }
 }

--- a/.super-coder/adapters/opencode/README.md
+++ b/.super-coder/adapters/opencode/README.md
@@ -11,6 +11,16 @@ harness-specific file OpenCode wants and the launch command.
   Edit this **template** (tracked) to change a fork's OpenCode config; the live
   file is regenerated each launch. Model is intentionally unset — the harness is
   rented; pick it in OpenCode (`-m provider/model`) or add `"model"` here.
+- **`"lsp": true`** — enabled by default. OpenCode's own default is LSP *off*; we
+  turn it on so the model gets language-server diagnostics as a feedback loop
+  (it sees the type error / unresolved import it just introduced and fixes it
+  before handing back). Servers start lazily, per detected file extension, so
+  languages absent from a fork cost nothing. Built-in servers cover the common
+  languages (Pyright, tsserver, gopls, rust-analyzer, …); switch `true` → `{}`
+  to keep built-ins while adding custom servers. **Offline/airgapped forks:** set
+  `OPENCODE_DISABLE_LSP_DOWNLOAD=true` in the environment — OpenCode auto-fetches
+  server binaries on first use, and this is the only knob for it (env-only, no
+  JSON key), so we leave it to the env rather than forcing it off here.
 - **`env.OPENCODE_DISABLE_CLAUDE_CODE=1`** — best-effort: stop OpenCode from also
   loading `CLAUDE.md` (we dual-write both with identical content; this avoids a
   double-load). ⚠ The exact env name is a **research flag to verify on live

--- a/.super-coder/adapters/opencode/adapter.json
+++ b/.super-coder/adapters/opencode/adapter.json
@@ -3,5 +3,12 @@
   "launch": ["opencode"],
   "boot_artifact": "AGENTS.md",
   "emit": ["opencode.json"],
-  "env": { "OPENCODE_DISABLE_CLAUDE_CODE": "1" }
+  "env": { "OPENCODE_DISABLE_CLAUDE_CODE": "1" },
+  "sandbox": {
+    "merge_json": {
+      "opencode.json": {
+        "permission": { "bash": "allow" }
+      }
+    }
+  }
 }

--- a/.super-coder/adapters/opencode/opencode.json
+++ b/.super-coder/adapters/opencode/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "lsp": true,
   "instructions": ["AGENTS.md"],
   "permission": {
     "edit": "allow",

--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -1,0 +1,34 @@
+# super-coder make aliases — convenience wrappers around ./sc.
+#
+# The dispatcher ./sc is the canonical interface; these targets only delegate.
+# This file travels with the engine, so `make launch` / `make enter` work in a
+# fork exactly as in the source repo — WITHOUT super-coder ever owning or
+# clobbering the fork's Makefile (#13): install wires a fork to *include* this
+# file (or auto-creates a one-line Makefile when the fork has none); it never
+# overwrites a Makefile you already have. Delete the include and you lose
+# nothing — `./sc <cmd>` is identical.
+#
+#   make launch         build + start the docker sandbox (+ review GUI)
+#   make enter          attach an interactive session (pick shell + harness)
+#   make enter s=ap01   attach + boot the 'ap01' shell directly
+#   make down           stop the sandbox
+#   make sc ARGS=health run any ./sc subcommand (passthrough)
+#
+SC := ./sc
+.PHONY: launch enter down build logs serve health ports verify update snapshot render map install sc
+
+launch:   ; $(SC) launch
+enter:    ; $(SC) $(if $(s),enter-$(s),enter)
+down:     ; $(SC) down
+build:    ; $(SC) build
+logs:     ; $(SC) logs
+serve:    ; $(SC) serve
+health:   ; $(SC) health
+ports:    ; $(SC) ports
+verify:   ; $(SC) verify
+update:   ; $(SC) update
+snapshot: ; $(SC) snapshot
+render:   ; $(SC) render $(ARGS)
+map:      ; $(SC) map
+install:  ; $(SC) install
+sc:       ; $(SC) $(ARGS)

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -354,6 +354,22 @@ def main(argv: list[str]) -> int:
     subprocess.run([PY, str(ENGINE / "scripts/snapshot.py")])
     subprocess.run([PY, str(ENGINE / "scripts/render.py"), "flat"])
 
+    # 8.5 Wire `make` aliases — opt-in, never clobber a host Makefile (#13).
+    # No Makefile → drop a one-line include so `make launch`/`enter` work out of
+    # the box. Already have one → leave it; just print the line to opt in.
+    step("Wiring make aliases")
+    mk = REPO_ROOT / "Makefile"
+    if mk.exists():
+        print("  Makefile present — left untouched. For `make launch`/`enter`, add:")
+        print("    include .super-coder/aliases.mk")
+    else:
+        mk.write_text(
+            "# Fork Makefile — super-coder convenience aliases (make launch / enter).\n"
+            "# Edit freely; add your own targets below the include.\n"
+            "include .super-coder/aliases.mk\n"
+        )
+        print("  wrote Makefile (include .super-coder/aliases.mk) → `make launch` works")
+
     # Record harness + installed marker in instance.json ---------------------
     cfg = ports_mod.resolve(persist=False)
     cfg["harness"] = harness
@@ -366,7 +382,8 @@ def main(argv: list[str]) -> int:
     print(f"  GUI port: {cfg['port']}  (http://127.0.0.1:{cfg['port']})")
     print("\nNext:")
     print("  git add -A && git commit -m 'install super-coder'")
-    print("  ./sc launch        # starts the review GUI + boots your shell")
+    print("  ./sc launch        # or: make launch — starts the sandbox + GUI")
+    print("  ./sc enter         # or: make enter  — attach + boot your shell")
     return 0
 
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -64,6 +64,47 @@ def emit_adapter(adapter: dict) -> list[str]:
     return written
 
 
+def _deep_merge(base: dict, patch: dict) -> dict:
+    """Recursively merge patch into base (patch wins on scalar conflicts);
+    mutates and returns base. Nested dicts merge key-wise so a fork's other
+    settings survive."""
+    for k, v in patch.items():
+        if isinstance(v, dict) and isinstance(base.get(k), dict):
+            _deep_merge(base[k], v)
+        else:
+            base[k] = v
+    return base
+
+
+def apply_sandbox(adapter: dict) -> list[str]:
+    """Sandbox-only: elevate harness permissions to allow-all when booting
+    INSIDE the docker sandbox (SC_SANDBOX, set by `sc launch`'s docker run). The
+    container is the safety boundary, so permission prompts inside it are pure
+    friction; the no-docker host escape hatch (`./sc boot` with SC_SANDBOX
+    unset) keeps normal prompts. Each adapter declares sandbox.merge_json:
+    {repo-relative-path: patch}; we deep-merge the patch into that
+    project-scoped file (preserving any keys the fork set). Paths are
+    repo-relative, so this never touches host-global config (~/.claude etc.)."""
+    if not os.environ.get("SC_SANDBOX"):
+        return []
+    spec = (adapter.get("sandbox") or {}).get("merge_json") or {}
+    touched = []
+    for rel, patch in spec.items():
+        dst = REPO_ROOT / rel
+        cur: dict = {}
+        if dst.exists():
+            try:
+                cur = json.loads(dst.read_text())
+            except (json.JSONDecodeError, OSError):
+                print(f"  ! {rel} is not valid JSON — leaving it untouched")
+                continue
+        _deep_merge(cur, patch)
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(dst, json.dumps(cur, indent=2) + "\n")
+        touched.append(rel)
+    return touched
+
+
 def ensure_harness_path() -> None:
     """Prepend the dirs where the official installers drop harness binaries onto
     this process's PATH, so detection (shutil.which) and exec (execvpe) agree
@@ -346,6 +387,9 @@ def main() -> None:
     print(f"→ harness: {harness} (reads {adapter.get('boot_artifact', 'AGENTS.md')})")
     if emitted:
         print(f"→ emitted {', '.join(emitted)}")
+    sandboxed = apply_sandbox(adapter)
+    if sandboxed:
+        print(f"→ sandbox: allow-all permissions → {', '.join(sandboxed)}")
 
     if os.environ.get("RENDER_ONLY"):
         print("→ RENDER_ONLY set — not exec'ing the harness.")

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -53,6 +53,7 @@ import seed_skills  # noqa: E402
 # super-coder-only (stripped on install); assets/shells/ is empty/vestigial.
 ENGINE_PATHS = [
     "sc",
+    ".super-coder/aliases.mk",
     ".super-coder/schema.sql",
     ".super-coder/ecosystem.config.cjs",
     ".super-coder/README.md",

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,12 @@
 # file is source-repo ergonomics only, never propagates, and never clobbers a
 # fork's own Makefile. Delete it and you lose nothing: `./sc <cmd>` is identical.
 #
+# The targets live in .super-coder/aliases.mk — the single source of truth
+# shared with forks (install wires a fork to include the same file). Edit the
+# aliases there, not here.
+#
 #   make launch            build + start the docker sandbox
 #   make enter             attach an interactive session (pick shell + harness)
 #   make enter s=cc        attach + boot the 'cc' shell directly
 #   make down              stop the sandbox
-.PHONY: launch enter down build logs serve health ports verify install
-
-launch:  ; ./sc launch
-enter:   ; ./sc $(if $(s),enter-$(s),enter)
-down:    ; ./sc down
-build:   ; ./sc build
-logs:    ; ./sc logs
-serve:   ; ./sc serve
-health:  ; ./sc health
-ports:   ; ./sc ports
-verify:  ; ./sc verify
-install: ; ./sc install
+include .super-coder/aliases.mk

--- a/sc
+++ b/sc
@@ -93,6 +93,7 @@ case "$cmd" in
     docker run -d --name "$CNAME" --restart unless-stopped \
       --user "$(duser)" \
       -e HOME="$HOME" -e SC_BIND=0.0.0.0 -e SC_PYTHON=python3 -e PYTHONUNBUFFERED=1 \
+      -e SC_SANDBOX=1 \
       -w "$here" \
       -v "$here:$here" \
       -v "$HOME/.claude:$HOME/.claude" \


### PR DESCRIPTION
Wrap-up PR bundling the engine work on this branch (individual commits preserved):

- **`feat(install)`** — forks get `make launch`/`enter` aliases, opt-in, never clobbers a host Makefile.
- **`feat(sandbox)`** — allow-all harness permissions inside the SC_SANDBOX docker boundary (`apply_sandbox`/`_deep_merge` in run.py; `sandbox.merge_json` on the claude + opencode adapters).
- **`feat(opencode)`** — enable LSP by default in the opencode adapter template (supersedes the standalone PR #27, which is closed as redundant — the LSP commit lands here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)