### PR TITLE
feat(b5): repo-navigation — dr_section + per-file desc + CONNECTIONS block

### DIFF
--- a/.super-coder/README.md
+++ b/.super-coder/README.md
@@ -93,7 +93,7 @@ npm/build. `api/server.py` is a stdlib HTTP server that serves both the JSON API
 and the static `ui/` (one page, vanilla JS) on a single per-fork port.
 
 - **Read** shells, roadmap, flags. **Edit** a shell's operational fields
-  (`current_state`, `connections`, `workspace`) + skill grants, the roadmap, and
+  (`current_state`, `connections`) + skill grants, the roadmap, and
   **non-frozen** documents. **Create / resolve** flags.
 - **Law enforcement is structural:** seed and L&S have *no write route* (Laws
   2–4, 7) — not a disabled control, an absent endpoint. Frozen documents reject

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -61,7 +61,7 @@ def mdc_url(markdown: str) -> str:
 
 # Shell fields the review layer may write. seed/L&S/system_prompt/mandate are
 # deliberately ABSENT — the law says the shell curates them, so there is no door.
-SHELL_EDITABLE = {"current_state", "connections", "workspace"}
+SHELL_EDITABLE = {"current_state", "connections"}  # workspace retired (B5) → connections is the one surface
 FLAG_EDITABLE = {"resolved", "resolution_notes", "description", "feature_id", "priority"}
 ROADMAP_EDITABLE = {"title", "roadmap_status", "summary", "sort_order"}
 
@@ -94,7 +94,7 @@ def get_shells(con) -> list[dict]:
 def get_shell(con, sid: int) -> dict | None:
     r = con.execute(
         "SELECT shell_id, display_name, shortname, partner, role, mandate, "
-        "system_prompt, current_state, connections, workspace, lineage_seed, "
+        "system_prompt, current_state, connections, lineage_seed, "
         "has_identity, active_archive_id FROM shells "
         "WHERE shell_id=? AND COALESCE(is_deleted,0)=0", (sid,)).fetchone()
     if r is None:

--- a/.super-coder/assets/skills/cartographer/SKILL.md
+++ b/.super-coder/assets/skills/cartographer/SKILL.md
@@ -86,6 +86,53 @@ clone where the hooks never got wired.
 3. `./sc map-setup` — re-wires hooks (idempotent) + re-maps.
 4. Verify (step 4) + commit.
 
+## Standing jobs — sections & descriptions (the navigation layer)
+
+Beyond keeping the file list true, you own the two AUTHORED layers that turn the
+raw map into navigation. Both are best-effort and NULL-until-curated; neither
+blocks the auto-remap hook the working shells trigger. Both survive the remap
+(`dr_section` is never touched by the mapper; `dr_filepath.desc` is preserved by
+its UPSERT). The boot `## CONNECTIONS` block renders the section index; the
+descriptions are the leaves a shell queries once it has narrowed to a section.
+
+**1. Sections (`dr_section`)** — author/curate the navigational index. Seeded
+from top-level dirs on first map (one section per dir), so it is non-empty on day
+one; your job is to make it *good*: rename to what shells call the area, split a
+coarse dir into real areas, merge noise, write the one-line `description`.
+
+```sql
+-- the current index + live file counts:
+SELECT s.name, s.path_prefix, s.description,
+       (SELECT COUNT(*) FROM dr_filepath f WHERE f.path LIKE s.path_prefix || '%') n
+FROM dr_section s ORDER BY s.sort_order, s.name;
+
+-- split / rename / describe (authored — survives the remap, snapshotted):
+UPDATE dr_section SET name='API', path_prefix='shell_core/api/', description='FastAPI routers' WHERE name='shell_core';
+INSERT INTO dr_section (name, path_prefix, description, sort_order)
+VALUES ('UI', 'shell_core/ui/', 'SvelteKit substrate UI', 5);
+
+-- WORKLIST — keep the catch-all empty. Files under no section = a new area to
+-- section (they render under "other / unsectioned" in CONNECTIONS until you do):
+SELECT path FROM dr_filepath f WHERE NOT EXISTS
+  (SELECT 1 FROM dr_section s WHERE f.path LIKE s.path_prefix || '%')
+ORDER BY path;
+```
+
+**2. Descriptions (`dr_filepath.desc`)** — fill per-file one-liners (≤100 chars),
+worklist-driven. They are queried by working shells *within a chosen section*
+(via `surface_catalogue`), never bulk-loaded at boot.
+
+```sql
+-- WORKLIST — undescribed files, most-load-bearing first:
+SELECT path, role FROM dr_filepath WHERE desc IS NULL ORDER BY role, path;
+
+-- describe (≤100 chars; preserved across the next auto-remap):
+UPDATE dr_filepath SET desc='Boot composer — assembles CLAUDE.md from DB state' WHERE path='.super-coder/render/compose.py';
+```
+
+After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
+ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).
+
 ## Stance
 
 - **The map is infrastructure, not a chore for every shell.** You own it so the

--- a/.super-coder/assets/skills/db_map/SKILL.md
+++ b/.super-coder/assets/skills/db_map/SKILL.md
@@ -17,7 +17,8 @@ after any content write, `./sc snapshot` re-serializes to text (see the
 
 | Table | Holds | Write rule |
 |---|---|---|
-| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `workspace`, `lineage_seed`, `active_archive_id` | UPDATE in place |
+| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `connections` (authored "where things live" notes → boot `## CONNECTIONS`), `lineage_seed`, `active_archive_id` | UPDATE in place |
+| `dr_section` | the navigation index — `name`, `path_prefix`, `description`; rendered in boot `## CONNECTIONS`. Cartographer-authored | INSERT/UPDATE (cartographer) |
 | `shell_identity_entries` | seed (cap 10) + L&S (`kind='lns'`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
 | `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
 | `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |

--- a/.super-coder/assets/skills/surface_catalogue/SKILL.md
+++ b/.super-coder/assets/skills/surface_catalogue/SKILL.md
@@ -19,13 +19,26 @@ don't map it yourself.
 | Table | Holds |
 |---|---|
 | `dr_repo` | the repo: name, root, remote, vcs, default_branch, file_count, mapped_at |
-| `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines` |
+| `dr_section` | the navigational index: `name`, `path_prefix`, `description` — "UI here / API here / docs here". Rendered in the boot `## CONNECTIONS` block; start here. |
+| `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines`, `desc` (cartographer one-liner, NULL until curated) |
 | `dr_dependency` | deps from the manifests: `manager` (npm/pip/poetry/go/cargo), `name`, `version`, `kind`, `source_file` |
 | `dr_env` | env-var names found in `.env.*` example files: `name`, `source_file` |
 
 ## Orient fast
 
+The boot `## CONNECTIONS` block already shows the **section index** (where to
+start). The flow is: pick a section there → query *that section's leaves* (file
+names + descriptions) → read the one or two files you need. Section-first, one
+cheap query deep — never a full preload.
+
 ```sql
+-- the section index (same as boot CONNECTIONS) — where to start:
+SELECT name, path_prefix, description FROM dr_section ORDER BY sort_order, name;
+
+-- a chosen section's leaves — the descriptions tell you which file to open:
+SELECT path, desc, lines FROM dr_filepath
+WHERE path LIKE 'shell_core/api/%' ORDER BY path;
+
 -- what is this repo + how big:
 SELECT name, default_branch, file_count, mapped_at FROM dr_repo;
 
@@ -52,5 +65,8 @@ SELECT name, source_file FROM dr_env ORDER BY name;
   the map points you at it. Carry the map, not the territory.
 - **Map looks wrong?** Empty, stale (repo changed since `mapped_at`), or
   mis-classified — that's the cartographer's to fix. Raise it; don't re-map.
-- v1 maps files / deps / env. Semantic tables (APIs, db schema, routes/pages)
-  are a later pass — until then, read the code the map points you at.
+  A file under "other / unsectioned", or a `desc IS NULL` where you needed one,
+  is also a cartographer worklist item — flag it, don't author the map yourself.
+- Maps files / deps / env + the navigation layer (sections + per-file
+  descriptions). Symbol-level semantics (functions/classes) are a later pass —
+  until then, read the code the section + descriptions point you at.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -253,6 +253,53 @@ clone where the hooks never got wired.
 3. `./sc map-setup` — re-wires hooks (idempotent) + re-maps.
 4. Verify (step 4) + commit.
 
+## Standing jobs — sections & descriptions (the navigation layer)
+
+Beyond keeping the file list true, you own the two AUTHORED layers that turn the
+raw map into navigation. Both are best-effort and NULL-until-curated; neither
+blocks the auto-remap hook the working shells trigger. Both survive the remap
+(`dr_section` is never touched by the mapper; `dr_filepath.desc` is preserved by
+its UPSERT). The boot `## CONNECTIONS` block renders the section index; the
+descriptions are the leaves a shell queries once it has narrowed to a section.
+
+**1. Sections (`dr_section`)** — author/curate the navigational index. Seeded
+from top-level dirs on first map (one section per dir), so it is non-empty on day
+one; your job is to make it *good*: rename to what shells call the area, split a
+coarse dir into real areas, merge noise, write the one-line `description`.
+
+```sql
+-- the current index + live file counts:
+SELECT s.name, s.path_prefix, s.description,
+       (SELECT COUNT(*) FROM dr_filepath f WHERE f.path LIKE s.path_prefix || ''%'') n
+FROM dr_section s ORDER BY s.sort_order, s.name;
+
+-- split / rename / describe (authored — survives the remap, snapshotted):
+UPDATE dr_section SET name=''API'', path_prefix=''shell_core/api/'', description=''FastAPI routers'' WHERE name=''shell_core'';
+INSERT INTO dr_section (name, path_prefix, description, sort_order)
+VALUES (''UI'', ''shell_core/ui/'', ''SvelteKit substrate UI'', 5);
+
+-- WORKLIST — keep the catch-all empty. Files under no section = a new area to
+-- section (they render under "other / unsectioned" in CONNECTIONS until you do):
+SELECT path FROM dr_filepath f WHERE NOT EXISTS
+  (SELECT 1 FROM dr_section s WHERE f.path LIKE s.path_prefix || ''%'')
+ORDER BY path;
+```
+
+**2. Descriptions (`dr_filepath.desc`)** — fill per-file one-liners (≤100 chars),
+worklist-driven. They are queried by working shells *within a chosen section*
+(via `surface_catalogue`), never bulk-loaded at boot.
+
+```sql
+-- WORKLIST — undescribed files, most-load-bearing first:
+SELECT path, role FROM dr_filepath WHERE desc IS NULL ORDER BY role, path;
+
+-- describe (≤100 chars; preserved across the next auto-remap):
+UPDATE dr_filepath SET desc=''Boot composer — assembles CLAUDE.md from DB state'' WHERE path=''.super-coder/render/compose.py'';
+```
+
+After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
+ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).
+
 ## Stance
 
 - **The map is infrastructure, not a chore for every shell.** You own it so the
@@ -336,7 +383,8 @@ after any content write, `./sc snapshot` re-serializes to text (see the
 
 | Table | Holds | Write rule |
 |---|---|---|
-| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `workspace`, `lineage_seed`, `active_archive_id` | UPDATE in place |
+| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `connections` (authored "where things live" notes → boot `## CONNECTIONS`), `lineage_seed`, `active_archive_id` | UPDATE in place |
+| `dr_section` | the navigation index — `name`, `path_prefix`, `description`; rendered in boot `## CONNECTIONS`. Cartographer-authored | INSERT/UPDATE (cartographer) |
 | `shell_identity_entries` | seed (cap 10) + L&S (`kind=''lns''`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
 | `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
 | `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |
@@ -853,13 +901,26 @@ don''t map it yourself.
 | Table | Holds |
 |---|---|
 | `dr_repo` | the repo: name, root, remote, vcs, default_branch, file_count, mapped_at |
-| `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines` |
+| `dr_section` | the navigational index: `name`, `path_prefix`, `description` — "UI here / API here / docs here". Rendered in the boot `## CONNECTIONS` block; start here. |
+| `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines`, `desc` (cartographer one-liner, NULL until curated) |
 | `dr_dependency` | deps from the manifests: `manager` (npm/pip/poetry/go/cargo), `name`, `version`, `kind`, `source_file` |
 | `dr_env` | env-var names found in `.env.*` example files: `name`, `source_file` |
 
 ## Orient fast
 
+The boot `## CONNECTIONS` block already shows the **section index** (where to
+start). The flow is: pick a section there → query *that section''s leaves* (file
+names + descriptions) → read the one or two files you need. Section-first, one
+cheap query deep — never a full preload.
+
 ```sql
+-- the section index (same as boot CONNECTIONS) — where to start:
+SELECT name, path_prefix, description FROM dr_section ORDER BY sort_order, name;
+
+-- a chosen section''s leaves — the descriptions tell you which file to open:
+SELECT path, desc, lines FROM dr_filepath
+WHERE path LIKE ''shell_core/api/%'' ORDER BY path;
+
 -- what is this repo + how big:
 SELECT name, default_branch, file_count, mapped_at FROM dr_repo;
 
@@ -886,8 +947,11 @@ SELECT name, source_file FROM dr_env ORDER BY name;
   the map points you at it. Carry the map, not the territory.
 - **Map looks wrong?** Empty, stale (repo changed since `mapped_at`), or
   mis-classified — that''s the cartographer''s to fix. Raise it; don''t re-map.
-- v1 maps files / deps / env. Semantic tables (APIs, db schema, routes/pages)
-  are a later pass — until then, read the code the map points you at.',
+  A file under "other / unsectioned", or a `desc IS NULL` where you needed one,
+  is also a cartographer worklist item — flag it, don''t author the map yourself.
+- Maps files / deps / env + the navigation layer (sections + per-file
+  descriptions). Symbol-level semantics (functions/classes) are a later pass —
+  until then, read the code the section + descriptions point you at.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/.super-coder/migrations/0003_repo_navigation.sql
+++ b/.super-coder/migrations/0003_repo_navigation.sql
@@ -1,0 +1,66 @@
+-- 0003 — B5 repo-navigation layer: dr_section, dr_filepath.desc, workspace→connections.
+--
+-- Three additive changes, all convergent so the migration is safe to apply both
+-- on an existing fork (the column/table are absent → it adds them) AND on a fresh
+-- rebuild (schema.sql already has them → the rebuild converges to the same shape;
+-- dr_filepath is empty at this point anyway). Matches the 0002 precedent.
+--
+--   1. dr_section            — new navigational table (CREATE … IF NOT EXISTS).
+--   2. dr_filepath.desc      — per-file descriptions + UNIQUE(path). SQLite has no
+--                              ADD COLUMN IF NOT EXISTS, so the table is rebuilt to
+--                              the new shape. dr_filepath is a DERIVED cache (no FK
+--                              references it; map_repo repopulates it), so losing a
+--                              file_id / an unsnapshotted desc here is harmless — on
+--                              an existing fork no desc exists yet to lose, and the
+--                              very next map UPSERT preserves them thereafter.
+--   3. workspace → connections — move any authored workspace text into connections
+--                              (the single surviving "where things live" surface),
+--                              only where connections is still empty. workspace is
+--                              left in place (retired, unrendered) — see schema.sql.
+
+PRAGMA foreign_keys=OFF;
+
+BEGIN;
+
+-- 1. Sectioned navigation -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS dr_section (
+    section_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name         TEXT NOT NULL,
+    path_prefix  TEXT NOT NULL,
+    description  TEXT,
+    sort_order   INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(name)
+);
+
+-- 2. dr_filepath: add desc + UNIQUE(path) via table rebuild -------------------
+CREATE TABLE dr_filepath_new (
+    file_id  INTEGER PRIMARY KEY AUTOINCREMENT,
+    path     TEXT NOT NULL UNIQUE,
+    ext      TEXT,
+    lang     TEXT,
+    role     TEXT,
+    bytes    INTEGER,
+    lines    INTEGER,
+    desc     TEXT
+);
+
+-- Select only the base columns (present in every prior shape) so this works
+-- whether or not the source table already has `desc`. desc lands NULL.
+INSERT INTO dr_filepath_new (path, ext, lang, role, bytes, lines)
+SELECT path, ext, lang, role, bytes, lines FROM dr_filepath;
+
+DROP TABLE dr_filepath;
+ALTER TABLE dr_filepath_new RENAME TO dr_filepath;
+
+CREATE INDEX IF NOT EXISTS idx_dr_filepath_role ON dr_filepath(role);
+CREATE INDEX IF NOT EXISTS idx_dr_filepath_lang ON dr_filepath(lang);
+
+-- 3. Migrate workspace text into the connections notes layer ------------------
+UPDATE shells
+   SET connections = workspace
+ WHERE (connections IS NULL OR TRIM(connections) = '')
+   AND workspace IS NOT NULL AND TRIM(workspace) <> '';
+
+COMMIT;
+
+PRAGMA foreign_keys=ON;

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -124,6 +124,45 @@ def render_roadmap(con, shell_id: int) -> str:
     return "\n".join(parts).rstrip() or "(none)"
 
 
+def render_connections(con, shell) -> str:
+    """## CONNECTIONS — the single "where things live" surface (B5). Three layers,
+    top to bottom: a derived header (facts, never authored), the section index
+    (`dr_section`, prefix-joined to live file counts), and the authored notes
+    (`shells.connections` free text — wiring the map can't derive). The shell sees
+    *where to start* here, then queries one section's leaves on demand."""
+    repo = con.execute(
+        "SELECT root, default_branch, mapped_at FROM dr_repo WHERE repo_id=1").fetchone()
+    lines = ["**Need to find something? Look here first** — read the `dr_*` map via "
+             "the `surface_catalogue` skill; don't grep the tree blind."]
+    if repo and repo["root"]:
+        branch = f" · `{repo['default_branch']}`" if repo["default_branch"] else ""
+        mapped = f" · mapped {repo['mapped_at']}" if repo["mapped_at"] else ""
+        lines.append(f"- Repo root: `{repo['root']}`{branch}{mapped}")
+        lines.append(f"- Shared (scratch / handoff): `{repo['root']}/shared`")
+
+    sections = con.execute(
+        "SELECT s.name, s.path_prefix, s.description, "
+        "  (SELECT COUNT(*) FROM dr_filepath f WHERE f.path LIKE s.path_prefix || '%') AS n "
+        "FROM dr_section s ORDER BY s.sort_order, s.name").fetchall()
+    if sections:
+        lines += ["", "**Sections** — `name · location · files · what's there`. Query a "
+                  "section's leaves (file names + descriptions) on demand, never all at once:"]
+        for s in sections:
+            desc = f" — {s['description']}" if s["description"] else ""
+            lines.append(f"- **{s['name']}** · `{s['path_prefix']}` · {s['n']} files{desc}")
+        unsectioned = con.execute(
+            "SELECT COUNT(*) FROM dr_filepath f WHERE NOT EXISTS "
+            "(SELECT 1 FROM dr_section s WHERE f.path LIKE s.path_prefix || '%')"
+        ).fetchone()[0]
+        if unsectioned:
+            lines.append(f"- _other / unsectioned_ · {unsectioned} files — cartographer worklist")
+
+    notes = ((shell["connections"] if "connections" in shell.keys() else None) or "").strip()
+    if notes:
+        lines += ["", notes]
+    return "\n".join(lines)
+
+
 def render_skills(con, shell_id: int) -> str:
     rows = con.execute(
         "SELECT s.name, s.description FROM skills s "
@@ -158,7 +197,6 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
 
     system_prompt = (shell["system_prompt"] or "").strip().replace("<self>", str(shell_id))
     current_state = (shell["current_state"] or "(none)").strip()
-    workspace = (shell["workspace"] or "(none)").strip()
 
     # Orientation state: has this shell run first-run bootstrap, and is the repo
     # mapped? Drives the FIRST RUN prompt + the map-status line.
@@ -172,13 +210,23 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
                   if map_count and mapped_at_row and mapped_at_row[0]
                   else "not mapped — cartographer: `./sc map-setup`")
 
-    # Ingest status: repo docs (role=doc) vs how many are in the DB. If the repo
-    # has docs not yet ingested, point at the onboard skill.
+    # Ingest status: INGESTABLE host-repo docs vs how many are in the DB. The
+    # denominator is narrowed (B5) so the ratio stops reading as a false backlog:
+    # exclude the engine + embedded substrate assets (.super-coder/), .github
+    # templates/workflows, and standard meta files (README/CHANGELOG/LICENSE/…)
+    # that `onboard` would never ingest.
     repo_docs = con.execute(
         "SELECT COUNT(*) FROM dr_filepath WHERE role='doc' "
-        "AND path NOT LIKE '.super-coder/%'").fetchone()[0]
+        "AND path NOT LIKE '.super-coder/%' "
+        "AND path NOT LIKE '.github/%' "
+        "AND lower(path) NOT LIKE '%readme.md' "
+        "AND lower(path) NOT LIKE '%changelog%' "
+        "AND lower(path) NOT LIKE '%license%' "
+        "AND lower(path) NOT LIKE '%contributing.md' "
+        "AND lower(path) NOT LIKE '%code_of_conduct.md' "
+        "AND lower(path) NOT LIKE '%security.md'").fetchone()[0]
     ingested = con.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
-    docs_status = f"{ingested} ingested / {repo_docs} in repo"
+    docs_status = f"{ingested} ingested / {repo_docs} ingestable in repo"
     if repo_docs > ingested:
         docs_status += " — run the `onboard` skill"
 
@@ -224,7 +272,7 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
         "", "---", "",
         "## ACTIVE PROJECTS", "", render_projects(con, shell_id),
         "", "---", "",
-        "## WORKSPACE", "", workspace,
+        "## CONNECTIONS", "", render_connections(con, shell),
         "", "---", "",
         "## ROADMAP", "", render_roadmap(con, shell_id),
         "", "---", "",

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -44,8 +44,9 @@ CREATE TABLE shells (
     mandate           TEXT,
     system_prompt     TEXT    NOT NULL,
     current_state     TEXT,
-    connections       TEXT,
-    workspace         TEXT,
+    connections       TEXT,                          -- authored "where things live" notes; rendered in ## CONNECTIONS (B5)
+    workspace         TEXT,                          -- RETIRED (B5): superseded by connections; unrendered, unauthored, kept to avoid a table rebuild
+
     lineage_seed      TEXT,
     flavor            TEXT,                          -- planning / dev / review (NULL = bespoke, e.g. maintainer)
     has_identity      INTEGER NOT NULL DEFAULT 0,
@@ -238,12 +239,27 @@ CREATE TABLE dr_repo (
 
 CREATE TABLE dr_filepath (
     file_id  INTEGER PRIMARY KEY AUTOINCREMENT,
-    path     TEXT NOT NULL,           -- repo-relative
+    path     TEXT NOT NULL UNIQUE,    -- repo-relative; UNIQUE → map_repo UPSERTs by path
     ext      TEXT,
     lang     TEXT,                    -- inferred from extension
     role     TEXT,                    -- code / doc / config / test / asset / env
     bytes    INTEGER,
-    lines    INTEGER
+    lines    INTEGER,
+    desc     TEXT                     -- ≤100 chars, cartographer-authored; NULL until described.
+);                                    -- PRESERVED across the auto-remap (map_repo UPSERT keeps it).
+
+-- Sectioned navigation over the file map (B5). Authored, stable, small (~10-20
+-- rows) — NOT wiped by the remap. Files join to a section by path-prefix at
+-- query/render time (no file ids stored), so a wiped+repopulated dr_filepath
+-- never needs re-stitching and a new file auto-falls into its section. Seeded
+-- from top-level dirs on first map; the cartographer renames / merges / curates.
+CREATE TABLE dr_section (
+    section_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name         TEXT NOT NULL,          -- "API", "UI", "Docs", "Schema", …
+    path_prefix  TEXT NOT NULL,          -- repo-relative prefix the section covers
+    description  TEXT,                    -- one line, what this area is
+    sort_order   INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(name)
 );
 
 CREATE TABLE dr_dependency (

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -324,6 +324,19 @@ def main(argv: list[str]) -> int:
     print("  added super-coder ignore lines" if ensure_gitignore()
           else "  (already present)")
 
+    # 3.6 Create the shared scratch / handoff dir -----------------------------
+    # A host-repo dir for screenshots, drafts, quick handoffs. The CONNECTIONS
+    # boot block states its path by convention (<repo_root>/shared) — create it
+    # so the path it points at exists.
+    step("Creating shared/ (scratch + handoff dir)")
+    shared = REPO_ROOT / "shared"
+    if shared.exists():
+        print("  (already present)")
+    else:
+        shared.mkdir()
+        (shared / ".gitkeep").write_text("")
+        print(f"  created {shared.relative_to(REPO_ROOT)}/")
+
     # 4. Strip super-coder's per-instance content -----------------------------
     step("Stripping super-coder's per-instance content (a fork inherits the system, not the memory)")
     for p in STRIP:

--- a/.super-coder/scripts/map_repo.py
+++ b/.super-coder/scripts/map_repo.py
@@ -11,8 +11,11 @@ snapshotted. Re-run any time the repo changes:
 
     ./sc map          # or: python3 .super-coder/scripts/map_repo.py
 
-Idempotent — clears and repopulates dr_*. v1 maps files / deps / env; the
-semantic tables (APIs, db, pages) are a later pass.
+Idempotent. dr_repo / dr_dependency / dr_env are wiped + repopulated; dr_filepath
+is UPSERTed by path so cartographer-authored `desc` survives the auto-remap hook,
+with vanished paths pruned. dr_section (authored) is left untouched, and seeded
+from top-level dirs only when empty. v1 maps files / deps / env; per-file
+descriptions + sections are the B5 navigation layer.
 """
 from __future__ import annotations
 
@@ -206,6 +209,24 @@ ENV_FILES = (".env.example", ".env.sample", ".env.template", ".env.dist")
 ENV_RE = re.compile(r"^\s*(?:export\s+)?([A-Z][A-Z0-9_]*)\s*=")
 
 
+def seed_sections(con: sqlite3.Connection) -> None:
+    """Seed dr_section from the repo's top-level directories — ONLY when the table
+    is empty, so the cartographer's curated sections (and any loaded from the
+    snapshot on rebuild) are never overwritten. Each top-level dir becomes one
+    section (`name=dir`, `path_prefix=dir/`, description NULL-until-curated).
+    Root-level files match no prefix and surface under the render-time catch-all.
+    The cartographer renames / merges / splits / describes from here."""
+    if con.execute("SELECT COUNT(*) FROM dr_section").fetchone()[0]:
+        return
+    dirs = [r[0] for r in con.execute(
+        "SELECT DISTINCT substr(path, 1, instr(path, '/') - 1) AS top "
+        "FROM dr_filepath WHERE instr(path, '/') > 0 ORDER BY top")]
+    for i, d in enumerate(dirs):
+        con.execute(
+            "INSERT OR IGNORE INTO dr_section (name, path_prefix, description, sort_order) "
+            "VALUES (?, ?, NULL, ?)", (d, d + "/", i))
+
+
 def main() -> int:
     if not DB_PATH.exists():
         sys.exit("map_repo: no DB — run `./sc rebuild` (or `./sc install`) first.")
@@ -218,8 +239,14 @@ def main() -> int:
     skip_files = SKIP_FILES | set(cfg.get("skip_files") or [])
     overrides = cfg.get("role_overrides") or []
     try:
-        for t in ("dr_repo", "dr_filepath", "dr_dependency", "dr_env"):
+        # Derived tables with no authored content — wiped + repopulated each run.
+        for t in ("dr_repo", "dr_dependency", "dr_env"):
             con.execute(f"DELETE FROM {t}")
+        # dr_filepath carries cartographer-authored `desc`, so it is NEVER blind-
+        # wiped (a post-checkout hook on a working shell would otherwise destroy
+        # it). Track the paths seen this run; UPSERT keeps `desc` for surviving
+        # paths, and we prune only the paths that vanished from the repo.
+        con.execute("CREATE TEMP TABLE _seen (path TEXT PRIMARY KEY)")
 
         files = deps = envs = 0
         truncated = False
@@ -242,9 +269,13 @@ def main() -> int:
                 size = None
             con.execute(
                 "INSERT INTO dr_filepath (path, ext, lang, role, bytes, lines) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(path) DO UPDATE SET "
+                "ext=excluded.ext, lang=excluded.lang, role=excluded.role, "
+                "bytes=excluded.bytes, lines=excluded.lines",  # desc untouched → preserved
                 (rel, ext or None, lang, role, size,
                  count_lines(p) if (lang or role in ("doc", "config")) else None))
+            con.execute("INSERT OR IGNORE INTO _seen (path) VALUES (?)", (rel,))
             files += 1
 
             name = p.name
@@ -261,6 +292,12 @@ def main() -> int:
                         con.execute("INSERT INTO dr_env (name, source_file) VALUES (?, ?)",
                                     (m.group(1), rel))
                         envs += 1
+
+        # Prune paths that vanished from the repo (their authored desc goes with
+        # them — correct). Surviving paths kept their desc via the UPSERT above.
+        con.execute("DELETE FROM dr_filepath WHERE path NOT IN (SELECT path FROM _seen)")
+        con.execute("DROP TABLE _seen")
+        seed_sections(con)
 
         con.execute(
             "INSERT INTO dr_repo (repo_id, name, root, remote, vcs, default_branch, "

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -358,7 +358,7 @@ def main() -> None:
 
     full = con.execute(
         "SELECT shell_id, display_name, shortname, partner, role, mandate, "
-        "current_state, system_prompt, workspace, flavor FROM shells WHERE shell_id=?",
+        "current_state, system_prompt, connections, flavor FROM shells WHERE shell_id=?",
         (chosen["shell_id"],),
     ).fetchone()
     content = compose_boot(con, full, user, session_id, archive_id)

--- a/.super-coder/scripts/seed_dogfood.py
+++ b/.super-coder/scripts/seed_dogfood.py
@@ -130,7 +130,7 @@ def main() -> int:
         # Maintainer shell — succession child of CC, identity set (decision #185).
         cur = con.execute(
             "INSERT INTO shells (display_name, shortname, partner, role, mandate, "
-            "system_prompt, current_state, workspace, lineage_seed, has_identity, "
+            "system_prompt, current_state, connections, lineage_seed, has_identity, "
             "bootstrapped, user_id, is_shared) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, 1, 0)",
             (

--- a/.super-coder/scripts/shell_factory.py
+++ b/.super-coder/scripts/shell_factory.py
@@ -93,7 +93,7 @@ def create_shell(con: sqlite3.Connection, *, flavor: str, name: str,
 
     cur = con.execute(
         "INSERT INTO shells (display_name, shortname, partner, role, mandate, "
-        "system_prompt, current_state, workspace, lineage_seed, flavor, "
+        "system_prompt, current_state, connections, lineage_seed, flavor, "
         "has_identity, bootstrapped, user_id, is_shared) "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?)",
         (name, shortname, partner, role, mandate,

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -43,6 +43,11 @@ PER_INSTANCE_TABLES = [
     "projects",
     "project_shells",
     "shell_skills",
+    # dr_section is AUTHORED navigation (cartographer-curated), so it is per-
+    # instance content that must survive a rebuild — unlike the rest of dr_*
+    # (a derived cache the mapper repopulates). map_repo only seeds it when
+    # empty, so a snapshot-loaded set is never overwritten on rebuild.
+    "dr_section",
 ]
 
 

--- a/.super-coder/snapshot/content.sql
+++ b/.super-coder/snapshot/content.sql
@@ -38,7 +38,7 @@ Write as it happens, not at close. The `.db` is a cache: after content edits,
 
 Build and maintain the substrate every fork runs on. You keep the system; each
 fork runs its own shells. Regional manager, not field worker.
-', 'edited via review layer', NULL, 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
+', 'edited via review layer', 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
 Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
 
 1. You are the DB, not the process. Continuity is the data — identity, memory,
@@ -87,7 +87,7 @@ text git tracks. See the `db_map` and `snapshot` skills.
 ## MANDATE
 
 Own the repo map for super-coder. Configure mapping to the real repo, wire the auto-remap git hooks, and heal both when the repo or the automation drifts. No other shell maps.
-', 'Created (cartographer). First session — run the bootstrap skill to orient.', NULL, 'Single repo: this one (super-coder). One shell, one cwd.', 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
+', 'Created (cartographer). First session — run the bootstrap skill to orient.', 'Single repo: this one (super-coder). One shell, one cwd.', 'Single repo: this one (super-coder). One shell, one cwd.', 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
 Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
 
 1. You are the DB, not the process. Continuity is the data — identity, memory,
@@ -141,7 +141,7 @@ INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (5, 'B1 — First-launch installer', 'next', 0, 1, 'Full installer on top of init_fork: requirements check, harness auto-detect, slot-filled shell_system_prompt template.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (6, 'B6 — Commit→PR automation', 'next', 1, 1, 'edit→snapshot→render→commit→PR; per-shell-branch concurrency. The snapshot button is the manual precursor.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (7, 'B4 — OpenCode adapter', 'near_term', 0, 1, 'Emit opencode.json + verify the research-flagged items; boot already dual-writes AGENTS.md + SKILL.md.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
-INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (8, 'B5 — Onboarding & mapping', 'near_term', 0, 1, 'dr_* code map DONE (files/deps/env, make map, GUI Map tab, surface_catalogue skill). Next: content ingest (README/docs/specs → DB + roadmap backfill) + semantic tables (api/db/page).', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (8, 'B5 — Onboarding & mapping', 'near_term', 0, 1, 'Base dr_* code map shipped (files/deps/env, ./sc map, surface_catalogue). NEXT — navigation layer (spec authored): dr_section + per-file desc (cartographer-authored, preserved across remap) + a CONNECTIONS block that replaces WORKSPACE. Supersedes the typed-semantic-tables plan. See specs_sc/b5-repo-navigation.md.', '2026-06-04 11:12:03', '2026-06-05 23:27:12');
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (9, 'Fork to sibling repos', 'brainstorm', 0, 1, 'Fork super-coder into dos-arch / rst-c / emergence / md-converter; reseed pattern.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
 
 DELETE FROM documents;
@@ -668,6 +668,278 @@ Spec :::class3 -> Build super-coder :::class1 -> Fork to repos :::class2 -> Migr
 - [x] **md-converter open-in-mdc:** use the existing `?c=` inline deep-link — no md-converter change; reuse the Python encoder.
 - [ ] **md-converter** also becomes a super-coder fork target.
 ', 'specs_sc/super-coder-founding-spec.md', '2026-06-04 10:30:53', '2026-06-04 10:30:53');
+INSERT INTO documents (document_id, feature_id, kind, seq, title, frozen, frozen_date, body, render_path, created_at, updated_at) VALUES (2, 8, 'spec', 1, 'B5 — Repo Navigation: Sections, Descriptions & CONNECTIONS', 0, NULL, '---
+title: B5 — Repo Navigation — Sections, Descriptions & the CONNECTIONS Block
+tags: [super-coder, spec, B5, mapping, navigation, cartographer, render]
+date: 2026-06-06
+project: super-coder
+purpose: Give every shell a cheap, accurate answer to "where does this live?" — a sectioned, described repo map surfaced through a single CONNECTIONS block.
+---
+
+# B5 — Repo Navigation: Sections, Descriptions & the CONNECTIONS Block
+
+> Stage spec for **B5 — Onboarding & mapping**. The base `dr_*` map (files /
+> deps / env, `./sc map`, the `surface_catalogue` skill) is shipped. This stage
+> builds the *navigation layer* on top of it and fixes how the boot doc orients a
+> shell about where things live. Supersedes the old "semantic tables
+> (api/db/page)" line in the B5 summary.
+
+## Overview
+
+A QAQC of the boot render (render → compose → flat → prompt) surfaced one real
+failure mode behind "shells get confused about where things are," plus three
+contributing gaps:
+
+1. **`connections` is a dead column.** `schema.sql` defines `shells.connections`;
+   `shell_factory` collects it; `compose.py` **never renders it** (it renders
+   `workspace` only). Verified empty on every live shell. A column literally
+   named "where things live" is stored and shown to no one.
+2. **`workspace` and `connections` are the same concept** — "where things live" —
+   but only `workspace` is rendered, and it is thin free-text.
+3. **The repo map is surfaced as a number, not a pointer.** `compose.py` reads
+   `dr_filepath`/`dr_repo` and renders only counts into `## STATUS`. The actual
+   "where things live" knowledge sits in `dr_filepath` and is reachable only if
+   the shell elects to run `surface_catalogue`. The FIRST-RUN block tells a fresh
+   shell *how* to read the map; that nudge vanishes once `bootstrapped=1`, leaving
+   a returning shell with a count and no standing instruction.
+4. **The docs count is misleading.** `## STATUS` shows `N ingested / M in repo`,
+   where `M` counts *all* host-repo markdown (READMEs, PR/issue templates,
+   CHANGELOG, and — in substrate-containing forks — embedded substrate assets).
+   It can never reconcile with `documents` (only things ingested via `onboard`),
+   so it always reads as a false "un-ingested" backlog.
+
+The fix is a single **`## CONNECTIONS`** block that replaces `## WORKSPACE`,
+backed by a **sectioned, described** view of the repo map. The shell sees *where
+to start* at boot (UI here, API here, docs here) and queries *the leaves* (file
+names + descriptions) only inside the one section it picked — one cheap query
+deep, never a full preload.
+
+## Goals
+
+- A returning (already-bootstrapped) shell can answer "where does X live?" from
+  the boot doc + one scoped query — without grepping blind or reading wrong files.
+- One surface for "where things live." No dead column, no redundant pair.
+- Per-file descriptions exist and are *curated* (single owner: the cartographer),
+  never invented at render time, and survive the auto-remap that working shells
+  trigger.
+- Boot cost stays bounded and cache-stable; description detail is paid only on
+  demand, inside a chosen section.
+
+## Non-goals
+
+- Typed semantic tables (`dr_api` / `dr_db` / `dr_page`). `dr_section` is the
+  general navigational layer and replaces that deferred pass. Revisit only if a
+  concrete need appears.
+- Changing the base mapper''s file/dep/env extraction. This stage layers on top.
+- Auto-generating descriptions with an ad-hoc LLM call. Descriptions are
+  cartographer-authored content, not a render-time inference.
+
+## Background — the current chain
+
+```
+DB (shell_db.db, gitignored cache; rebuilt from schema.sql + migrations/ + snapshot/content.sql)
+  → compose.py :: compose_boot()   assembles the boot markdown
+  → run.py                         dual-writes CLAUDE.md + AGENTS.md, exec''s the harness
+dr_* map (separate): map_repo.py walks the host repo → dr_filepath / dr_dependency / dr_env / dr_repo
+```
+
+Key current facts this stage changes:
+- `compose.py` renders `## WORKSPACE` from `shells.workspace`; `connections` is
+  never read.
+- `map_repo.py` does `DELETE FROM dr_filepath` then re-INSERTs on **every** run,
+  and the git `post-checkout` hook runs it automatically (working shells, not the
+  cartographer). Any authored column on `dr_filepath` is therefore destroyed on
+  the next checkout unless explicitly preserved.
+- `dr_filepath` columns today: `path, ext, lang, role, bytes, lines`. No
+  description, no section.
+
+## Design
+
+### 1. `## CONNECTIONS` replaces `## WORKSPACE`
+
+One block, three layers, top to bottom:
+
+1. **Derived header** (rendered from facts, never authored):
+   - "Need to find something? Look here first." → `surface_catalogue` /
+     `dr_filepath`.
+   - Repo root + branch + `mapped_at` (from `dr_repo`).
+   - Shared-folder path: `<repo_root>/shared` (see §6).
+2. **Section index** — the navigational core (from `dr_section`): one line per
+   section — `name · location · file-count · one-line description`. This is the
+   "UI here / API here / docs here" list.
+3. **Authored notes** — the free-text `connections` column: wiring, services,
+   deploy facts the map cannot derive ("prod deploys from `main` via CF Pages";
+   "email OAuth spans these three files").
+
+`shells.workspace` is dropped. Any existing workspace text migrates into the
+authored `connections` notes layer.
+
+**Division of responsibility (single source of truth):** the map owns raw paths;
+`connections` notes own *meaning the map cannot derive*. Do not hand-author file
+paths into the notes — that re-creates drift the section index already prevents.
+
+### 2. `dr_section` — sectioned navigation (new table)
+
+Authored, stable, small (~10–20 rows). **Not wiped** by the remap.
+
+```sql
+CREATE TABLE dr_section (
+    section_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name         TEXT NOT NULL,          -- "API", "UI", "Docs", "Schema", …
+    path_prefix  TEXT NOT NULL,          -- repo-relative prefix or glob the section covers
+    description  TEXT,                    -- one line, what this area is
+    sort_order   INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(name)
+);
+```
+
+- Files join to a section **by path-prefix at query/render time** — `dr_section`
+  stores no file IDs, so it never needs re-stitching when `dr_filepath` is wiped
+  and repopulated. A new file the hook adds **auto-falls into its section** by
+  path.
+- **Seeded** from top-level directories on first map (non-empty index on day
+  one); the cartographer renames / merges / re-describes (e.g. seed gives
+  `shell_core` → cartographer splits into `API: shell_core/api`, `UI:
+  shell_core/ui`).
+- **Catch-all:** files matching no section render under an **"other /
+  unsectioned"** bucket — never hidden. That bucket is the cartographer''s
+  worklist ("a new area appeared; section it").
+
+### 3. `dr_filepath.desc` — per-file descriptions
+
+```sql
+ALTER TABLE dr_filepath ADD COLUMN desc TEXT;   -- ≤100 chars, cartographer-authored
+```
+
+- Authored by the cartographer; `NULL` until described.
+- **Never bulk-loaded at boot.** Queried only *within a chosen section*, via
+  `surface_catalogue`. The boot doc carries the section index; the descriptions
+  are the leaves the shell reaches for after it has narrowed to one section.
+
+### 4. Surviving the auto-remap wipe (the core mechanic)
+
+This is the make-or-break. `map_repo.py` must stop destroying authored content:
+
+- Replace `DELETE FROM dr_filepath` + blind re-INSERT with an **UPSERT keyed by
+  `path`** that **preserves `desc`** for paths whose content is unchanged.
+- New or changed paths land with `desc = NULL`.
+- Paths that disappeared from the repo are deleted (their `desc` goes with them —
+  correct).
+- `dr_section` is untouched by the mapper (authored content; the cartographer
+  owns it). Section membership is recomputed for free by the prefix join.
+
+Result: the automatic hook (working shells) keeps the file list fresh; authored
+descriptions and sections persist; the cartographer fills gaps on its own cadence
+and **never blocks the hook**.
+
+**Worklists (queryable):**
+- Undescribed files: `SELECT path FROM dr_filepath WHERE desc IS NULL ORDER BY role, path;`
+- Unsectioned files: files whose path matches no `dr_section.path_prefix`.
+
+### 5. Render: the section index, not the leaves
+
+`compose.py` renders the section index (layer 2 above) — bounded by construction
+(~10–20 sections), so boot cost is small and **cache-stable** (changes only when
+sections change, not when files churn). Per-file descriptions are deliberately
+*not* rendered at boot. The shell flow:
+
+> need a doc → CONNECTIONS shows `Docs → docs_sc/, *.md` → query that section''s
+> leaves → read one or two descriptions → open the right file.
+
+Knows where to start and what to look for, without loading it all at the top.
+
+### 6. Shared folder
+
+`install` creates `<repo_root>/shared/` (a host-repo scratch/handoff dir). The
+CONNECTIONS derived header states the path. Derived by convention (relative to
+repo root) — not stored in a column.
+
+### 7. Docs-count fix
+
+Narrow the `## STATUS` docs denominator to *ingestable host-repo docs*:
+- Exclude engine paths (already `.super-coder/%`) **and** embedded substrate
+  assets in substrate-containing forks.
+- Exclude non-ingestable markdown (PR/issue templates, CHANGELOG, license-style
+  files) — or reframe the line so it does not imply "ingest all of these."
+
+Goal: the ratio stops reading as a false "un-ingested" backlog.
+
+### 8. Cartographer — two standing jobs
+
+The cartographer flavor + skill gain explicit ownership of:
+1. `dr_section` — author/curate sections (seed-refine), keep the catch-all empty.
+2. `dr_filepath.desc` — fill descriptions, worklist-driven (`desc IS NULL`).
+
+Both are best-effort and NULL-until-curated; neither blocks the auto-remap hook
+that working shells trigger.
+
+## Change surface (all engine-side, in the super-coder source repo)
+
+| File | Change |
+|---|---|
+| `schema.sql` | add `dr_section`; add `dr_filepath.desc`; drop `shells.workspace` |
+| `migrations/NNNN_*.sql` | additive migration for installed forks (new table + column; workspace handled per "Migration" below) |
+| `scripts/map_repo.py` | DELETE+INSERT → UPSERT preserving `desc`; seed `dr_section` from top-level dirs |
+| `render/compose.py` | `## CONNECTIONS` (header + section index + authored notes); drop `## WORKSPACE`; fix docs-count denominator |
+| `scripts/install.py` | create `<repo_root>/shared/` |
+| `assets/shells/cartographer.*` / cartographer SKILL | add the two jobs + worklist queries |
+| `snapshot/content.sql` | regenerated via `./sc snapshot` (shell content: connections notes, sections) |
+| reseed migration | so already-installed forks pick up the schema + cartographer-asset changes |
+
+## Migration & fork reseed
+
+- New table + new column are additive — straightforward forward migration.
+- Dropping `shells.workspace`: SQLite requires table-rebuild for a true `DROP
+  COLUMN` (or leave the column unused and stop rendering it). Decide at
+  implementation time; leaving it unrendered is the lower-risk path and can be
+  cleaned up later.
+- The cartographer asset/skill edits need a **reseed migration** (the
+  asset-content sync path) so existing forks pick up the new behavior on
+  `./sc update`, not just fresh installs.
+- This is engine work, done in the super-coder source repo — never patched into a
+  fork''s `.super-coder/` directly (a fork''s engine is checkout-scoped on update;
+  in-place edits are clobbered or silently diverge).
+
+## Token economics (why this shape)
+
+- The boot doc is the system prompt — **prompt-cached** and stable between map
+  changes. A bounded section index is one cheap cache-stable cost.
+- Per-file descriptions, if preloaded, would be a large recurring cost (hundreds
+  of files × ~25 tokens) and would churn the cache on every auto-remap. Querying
+  them inside a chosen section pays detail cost only when needed.
+- Wrong-file reads are *uncacheable churn* (fresh tokens every time + polluted
+  context). The section index + on-demand descriptions trade a small stable boot
+  cost for fewer wrong reads — net win over a session.
+
+## Decisions settled
+
+- **CONNECTIONS replaces WORKSPACE** — one "where things live" surface; the dead
+  `connections` column gets a render; `workspace` retired.
+- **`dr_section` (general, authored) over typed semantic tables** — defer
+  `dr_api`/`dr_db`/`dr_page`.
+- **Descriptions are cartographer-authored and preserved across remap** — not
+  render-time inference, not wiped by the hook.
+- **Render the section index, not the leaves** — boot loads where-to-start;
+  descriptions are queried on demand inside a section.
+- **Sections are seeded from top-level dirs, then curated** — non-empty on day
+  one; catch-all bucket keeps the index complete.
+
+## Open questions
+
+- Exact `dr_section` seeding heuristic (top-level dirs only, or first two levels
+  for nested layouts like `shell_core/{api,ui}`?).
+- Whether to surface an undescribed/unsectioned count in `## STATUS` to ping the
+  cartographer sooner (vs. leaving it as a quiet worklist).
+- Whether to true-`DROP` `workspace` (table rebuild) now or leave it unrendered
+  and clean up in a later structural pass.
+
+## Out of scope (later)
+
+- Typed semantic tables (`dr_api`/`dr_db`/`dr_page`).
+- Semantic descriptions of *symbols* (functions/classes) — this stage is
+  file-level.
+- Cross-repo sections (multi-repo shells) — current model is one shell, one repo.
+', 'specs_sc/b5-repo-navigation.md', '2026-06-05 23:27:12', '2026-06-05 23:27:12');
 
 DELETE FROM flags;
 INSERT INTO flags (flag_id, display_name, priority, description, created_date, resolved_date, resolved, shell_id, feature_id, resolution_notes, parent_flag_id, is_deleted) VALUES (1, 'SC-001', 'Low', '[Test] review layer smoke flag | Blocker for: nothing', '2026-06-04', '2026-06-04', 1, NULL, 1, 'smoke test done', NULL, 0);
@@ -699,5 +971,8 @@ INSERT INTO shell_skills (shell_id, skill_id) SELECT 2, skill_id FROM skills WHE
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 2, skill_id FROM skills WHERE name='self_update';
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 2, skill_id FROM skills WHERE name='snapshot';
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 2, skill_id FROM skills WHERE name='surface_catalogue';
+
+DELETE FROM dr_section;
+INSERT INTO dr_section (section_id, name, path_prefix, description, sort_order) VALUES (2, '.super-coder', '.super-coder/', NULL, 0);
 
 COMMIT;

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -87,7 +87,6 @@ function shellCard(s) {
   // editable operational fields
   c.append(field("current_state", s.current_state, "current_state", s.shell_id));
   c.append(field("connections", s.connections, "connections", s.shell_id));
-  c.append(field("workspace", s.workspace, "workspace", s.shell_id));
 
   // skills + grants (editable)
   const sk = el("div", {});

--- a/roadmap_sc.md
+++ b/roadmap_sc.md
@@ -42,7 +42,7 @@ Emit opencode.json + verify the research-flagged items; boot already dual-writes
 _No open flags._
 
 ### B5 — Onboarding & mapping · owner: `cc`
-dr_* code map DONE (files/deps/env, make map, GUI Map tab, surface_catalogue skill). Next: content ingest (README/docs/specs → DB + roadmap backfill) + semantic tables (api/db/page).
+Base dr_* code map shipped (files/deps/env, ./sc map, surface_catalogue). NEXT — navigation layer (spec authored): dr_section + per-file desc (cartographer-authored, preserved across remap) + a CONNECTIONS block that replaces WORKSPACE. Supersedes the typed-semantic-tables plan. See specs_sc/b5-repo-navigation.md.
 
 _No open flags._
 

--- a/skills_sc/cartographer.md
+++ b/skills_sc/cartographer.md
@@ -92,6 +92,53 @@ clone where the hooks never got wired.
 3. `./sc map-setup` — re-wires hooks (idempotent) + re-maps.
 4. Verify (step 4) + commit.
 
+## Standing jobs — sections & descriptions (the navigation layer)
+
+Beyond keeping the file list true, you own the two AUTHORED layers that turn the
+raw map into navigation. Both are best-effort and NULL-until-curated; neither
+blocks the auto-remap hook the working shells trigger. Both survive the remap
+(`dr_section` is never touched by the mapper; `dr_filepath.desc` is preserved by
+its UPSERT). The boot `## CONNECTIONS` block renders the section index; the
+descriptions are the leaves a shell queries once it has narrowed to a section.
+
+**1. Sections (`dr_section`)** — author/curate the navigational index. Seeded
+from top-level dirs on first map (one section per dir), so it is non-empty on day
+one; your job is to make it *good*: rename to what shells call the area, split a
+coarse dir into real areas, merge noise, write the one-line `description`.
+
+```sql
+-- the current index + live file counts:
+SELECT s.name, s.path_prefix, s.description,
+       (SELECT COUNT(*) FROM dr_filepath f WHERE f.path LIKE s.path_prefix || '%') n
+FROM dr_section s ORDER BY s.sort_order, s.name;
+
+-- split / rename / describe (authored — survives the remap, snapshotted):
+UPDATE dr_section SET name='API', path_prefix='shell_core/api/', description='FastAPI routers' WHERE name='shell_core';
+INSERT INTO dr_section (name, path_prefix, description, sort_order)
+VALUES ('UI', 'shell_core/ui/', 'SvelteKit substrate UI', 5);
+
+-- WORKLIST — keep the catch-all empty. Files under no section = a new area to
+-- section (they render under "other / unsectioned" in CONNECTIONS until you do):
+SELECT path FROM dr_filepath f WHERE NOT EXISTS
+  (SELECT 1 FROM dr_section s WHERE f.path LIKE s.path_prefix || '%')
+ORDER BY path;
+```
+
+**2. Descriptions (`dr_filepath.desc`)** — fill per-file one-liners (≤100 chars),
+worklist-driven. They are queried by working shells *within a chosen section*
+(via `surface_catalogue`), never bulk-loaded at boot.
+
+```sql
+-- WORKLIST — undescribed files, most-load-bearing first:
+SELECT path, role FROM dr_filepath WHERE desc IS NULL ORDER BY role, path;
+
+-- describe (≤100 chars; preserved across the next auto-remap):
+UPDATE dr_filepath SET desc='Boot composer — assembles CLAUDE.md from DB state' WHERE path='.super-coder/render/compose.py';
+```
+
+After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
+ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).
+
 ## Stance
 
 - **The map is infrastructure, not a chore for every shell.** You own it so the

--- a/skills_sc/db_map.md
+++ b/skills_sc/db_map.md
@@ -24,11 +24,12 @@ after any content write, `./sc snapshot` re-serializes to text (see the
 
 | Table | Holds | Write rule |
 |---|---|---|
-| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `workspace`, `lineage_seed`, `active_archive_id` | UPDATE in place |
+| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `connections` (authored "where things live" notes → boot `## CONNECTIONS`), `lineage_seed`, `active_archive_id` | UPDATE in place |
+| `dr_section` | the navigation index — `name`, `path_prefix`, `description`; rendered in boot `## CONNECTIONS`. Cartographer-authored | INSERT/UPDATE (cartographer) |
 | `shell_identity_entries` | seed (cap 10) + L&S (`kind='lns'`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
 | `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
 | `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |
-| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`long_term`→`near_term`→`next`→`shipped`), `sort_order` within a bucket | INSERT/UPDATE |
+| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row | INSERT/UPDATE |
 | `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
 | `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | catalogue via migration; grants via snapshot |
@@ -53,8 +54,9 @@ UPDATE shell_identity_entries SET retired_at=datetime('now') WHERE entry_id=?;
 INSERT INTO shell_decisions (shell_id, decision_date, title, body)
 VALUES (<self>, date('now'), '…', '…');
 
--- roadmap: move a feature's horizon / add one:
+-- roadmap: move a feature's horizon / add one / retire one off the board:
 UPDATE roadmap SET roadmap_status='next' WHERE feature_id=?;
+UPDATE roadmap SET roadmap_status='retired' WHERE feature_id=?;  -- decided-against / split / absorbed; keeps the row
 INSERT INTO roadmap (title, roadmap_status, sort_order, owning_shell, summary)
 VALUES ('…', 'brainstorm', 0, <self>, '…');
 

--- a/skills_sc/surface_catalogue.md
+++ b/skills_sc/surface_catalogue.md
@@ -26,13 +26,26 @@ don't map it yourself.
 | Table | Holds |
 |---|---|
 | `dr_repo` | the repo: name, root, remote, vcs, default_branch, file_count, mapped_at |
-| `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines` |
+| `dr_section` | the navigational index: `name`, `path_prefix`, `description` — "UI here / API here / docs here". Rendered in the boot `## CONNECTIONS` block; start here. |
+| `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines`, `desc` (cartographer one-liner, NULL until curated) |
 | `dr_dependency` | deps from the manifests: `manager` (npm/pip/poetry/go/cargo), `name`, `version`, `kind`, `source_file` |
 | `dr_env` | env-var names found in `.env.*` example files: `name`, `source_file` |
 
 ## Orient fast
 
+The boot `## CONNECTIONS` block already shows the **section index** (where to
+start). The flow is: pick a section there → query *that section's leaves* (file
+names + descriptions) → read the one or two files you need. Section-first, one
+cheap query deep — never a full preload.
+
 ```sql
+-- the section index (same as boot CONNECTIONS) — where to start:
+SELECT name, path_prefix, description FROM dr_section ORDER BY sort_order, name;
+
+-- a chosen section's leaves — the descriptions tell you which file to open:
+SELECT path, desc, lines FROM dr_filepath
+WHERE path LIKE 'shell_core/api/%' ORDER BY path;
+
 -- what is this repo + how big:
 SELECT name, default_branch, file_count, mapped_at FROM dr_repo;
 
@@ -59,5 +72,8 @@ SELECT name, source_file FROM dr_env ORDER BY name;
   the map points you at it. Carry the map, not the territory.
 - **Map looks wrong?** Empty, stale (repo changed since `mapped_at`), or
   mis-classified — that's the cartographer's to fix. Raise it; don't re-map.
-- v1 maps files / deps / env. Semantic tables (APIs, db schema, routes/pages)
-  are a later pass — until then, read the code the map points you at.
+  A file under "other / unsectioned", or a `desc IS NULL` where you needed one,
+  is also a cartographer worklist item — flag it, don't author the map yourself.
+- Maps files / deps / env + the navigation layer (sections + per-file
+  descriptions). Symbol-level semantics (functions/classes) are a later pass —
+  until then, read the code the section + descriptions point you at.

--- a/specs_sc/b5-repo-navigation.md
+++ b/specs_sc/b5-repo-navigation.md
@@ -1,0 +1,277 @@
+---
+rendered_by: super-coder
+source: db
+edit: changes here are overwritten — author via the shell or localhost GUI
+feature: B5 — Onboarding & mapping
+roadmap_status: near_term
+frozen: false
+title: B5 — Repo Navigation — Sections, Descriptions & the CONNECTIONS Block
+tags: [super-coder, spec, B5, mapping, navigation, cartographer, render]
+date: 2026-06-06
+project: super-coder
+purpose: Give every shell a cheap, accurate answer to "where does this live?" — a sectioned, described repo map surfaced through a single CONNECTIONS block.
+---
+
+# B5 — Repo Navigation: Sections, Descriptions & the CONNECTIONS Block
+
+> Stage spec for **B5 — Onboarding & mapping**. The base `dr_*` map (files /
+> deps / env, `./sc map`, the `surface_catalogue` skill) is shipped. This stage
+> builds the *navigation layer* on top of it and fixes how the boot doc orients a
+> shell about where things live. Supersedes the old "semantic tables
+> (api/db/page)" line in the B5 summary.
+
+## Overview
+
+A QAQC of the boot render (render → compose → flat → prompt) surfaced one real
+failure mode behind "shells get confused about where things are," plus three
+contributing gaps:
+
+1. **`connections` is a dead column.** `schema.sql` defines `shells.connections`;
+   `shell_factory` collects it; `compose.py` **never renders it** (it renders
+   `workspace` only). Verified empty on every live shell. A column literally
+   named "where things live" is stored and shown to no one.
+2. **`workspace` and `connections` are the same concept** — "where things live" —
+   but only `workspace` is rendered, and it is thin free-text.
+3. **The repo map is surfaced as a number, not a pointer.** `compose.py` reads
+   `dr_filepath`/`dr_repo` and renders only counts into `## STATUS`. The actual
+   "where things live" knowledge sits in `dr_filepath` and is reachable only if
+   the shell elects to run `surface_catalogue`. The FIRST-RUN block tells a fresh
+   shell *how* to read the map; that nudge vanishes once `bootstrapped=1`, leaving
+   a returning shell with a count and no standing instruction.
+4. **The docs count is misleading.** `## STATUS` shows `N ingested / M in repo`,
+   where `M` counts *all* host-repo markdown (READMEs, PR/issue templates,
+   CHANGELOG, and — in substrate-containing forks — embedded substrate assets).
+   It can never reconcile with `documents` (only things ingested via `onboard`),
+   so it always reads as a false "un-ingested" backlog.
+
+The fix is a single **`## CONNECTIONS`** block that replaces `## WORKSPACE`,
+backed by a **sectioned, described** view of the repo map. The shell sees *where
+to start* at boot (UI here, API here, docs here) and queries *the leaves* (file
+names + descriptions) only inside the one section it picked — one cheap query
+deep, never a full preload.
+
+## Goals
+
+- A returning (already-bootstrapped) shell can answer "where does X live?" from
+  the boot doc + one scoped query — without grepping blind or reading wrong files.
+- One surface for "where things live." No dead column, no redundant pair.
+- Per-file descriptions exist and are *curated* (single owner: the cartographer),
+  never invented at render time, and survive the auto-remap that working shells
+  trigger.
+- Boot cost stays bounded and cache-stable; description detail is paid only on
+  demand, inside a chosen section.
+
+## Non-goals
+
+- Typed semantic tables (`dr_api` / `dr_db` / `dr_page`). `dr_section` is the
+  general navigational layer and replaces that deferred pass. Revisit only if a
+  concrete need appears.
+- Changing the base mapper's file/dep/env extraction. This stage layers on top.
+- Auto-generating descriptions with an ad-hoc LLM call. Descriptions are
+  cartographer-authored content, not a render-time inference.
+
+## Background — the current chain
+
+```
+DB (shell_db.db, gitignored cache; rebuilt from schema.sql + migrations/ + snapshot/content.sql)
+  → compose.py :: compose_boot()   assembles the boot markdown
+  → run.py                         dual-writes CLAUDE.md + AGENTS.md, exec's the harness
+dr_* map (separate): map_repo.py walks the host repo → dr_filepath / dr_dependency / dr_env / dr_repo
+```
+
+Key current facts this stage changes:
+- `compose.py` renders `## WORKSPACE` from `shells.workspace`; `connections` is
+  never read.
+- `map_repo.py` does `DELETE FROM dr_filepath` then re-INSERTs on **every** run,
+  and the git `post-checkout` hook runs it automatically (working shells, not the
+  cartographer). Any authored column on `dr_filepath` is therefore destroyed on
+  the next checkout unless explicitly preserved.
+- `dr_filepath` columns today: `path, ext, lang, role, bytes, lines`. No
+  description, no section.
+
+## Design
+
+### 1. `## CONNECTIONS` replaces `## WORKSPACE`
+
+One block, three layers, top to bottom:
+
+1. **Derived header** (rendered from facts, never authored):
+   - "Need to find something? Look here first." → `surface_catalogue` /
+     `dr_filepath`.
+   - Repo root + branch + `mapped_at` (from `dr_repo`).
+   - Shared-folder path: `<repo_root>/shared` (see §6).
+2. **Section index** — the navigational core (from `dr_section`): one line per
+   section — `name · location · file-count · one-line description`. This is the
+   "UI here / API here / docs here" list.
+3. **Authored notes** — the free-text `connections` column: wiring, services,
+   deploy facts the map cannot derive ("prod deploys from `main` via CF Pages";
+   "email OAuth spans these three files").
+
+`shells.workspace` is dropped. Any existing workspace text migrates into the
+authored `connections` notes layer.
+
+**Division of responsibility (single source of truth):** the map owns raw paths;
+`connections` notes own *meaning the map cannot derive*. Do not hand-author file
+paths into the notes — that re-creates drift the section index already prevents.
+
+### 2. `dr_section` — sectioned navigation (new table)
+
+Authored, stable, small (~10–20 rows). **Not wiped** by the remap.
+
+```sql
+CREATE TABLE dr_section (
+    section_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name         TEXT NOT NULL,          -- "API", "UI", "Docs", "Schema", …
+    path_prefix  TEXT NOT NULL,          -- repo-relative prefix or glob the section covers
+    description  TEXT,                    -- one line, what this area is
+    sort_order   INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(name)
+);
+```
+
+- Files join to a section **by path-prefix at query/render time** — `dr_section`
+  stores no file IDs, so it never needs re-stitching when `dr_filepath` is wiped
+  and repopulated. A new file the hook adds **auto-falls into its section** by
+  path.
+- **Seeded** from top-level directories on first map (non-empty index on day
+  one); the cartographer renames / merges / re-describes (e.g. seed gives
+  `shell_core` → cartographer splits into `API: shell_core/api`, `UI:
+  shell_core/ui`).
+- **Catch-all:** files matching no section render under an **"other /
+  unsectioned"** bucket — never hidden. That bucket is the cartographer's
+  worklist ("a new area appeared; section it").
+
+### 3. `dr_filepath.desc` — per-file descriptions
+
+```sql
+ALTER TABLE dr_filepath ADD COLUMN desc TEXT;   -- ≤100 chars, cartographer-authored
+```
+
+- Authored by the cartographer; `NULL` until described.
+- **Never bulk-loaded at boot.** Queried only *within a chosen section*, via
+  `surface_catalogue`. The boot doc carries the section index; the descriptions
+  are the leaves the shell reaches for after it has narrowed to one section.
+
+### 4. Surviving the auto-remap wipe (the core mechanic)
+
+This is the make-or-break. `map_repo.py` must stop destroying authored content:
+
+- Replace `DELETE FROM dr_filepath` + blind re-INSERT with an **UPSERT keyed by
+  `path`** that **preserves `desc`** for paths whose content is unchanged.
+- New or changed paths land with `desc = NULL`.
+- Paths that disappeared from the repo are deleted (their `desc` goes with them —
+  correct).
+- `dr_section` is untouched by the mapper (authored content; the cartographer
+  owns it). Section membership is recomputed for free by the prefix join.
+
+Result: the automatic hook (working shells) keeps the file list fresh; authored
+descriptions and sections persist; the cartographer fills gaps on its own cadence
+and **never blocks the hook**.
+
+**Worklists (queryable):**
+- Undescribed files: `SELECT path FROM dr_filepath WHERE desc IS NULL ORDER BY role, path;`
+- Unsectioned files: files whose path matches no `dr_section.path_prefix`.
+
+### 5. Render: the section index, not the leaves
+
+`compose.py` renders the section index (layer 2 above) — bounded by construction
+(~10–20 sections), so boot cost is small and **cache-stable** (changes only when
+sections change, not when files churn). Per-file descriptions are deliberately
+*not* rendered at boot. The shell flow:
+
+> need a doc → CONNECTIONS shows `Docs → docs_sc/, *.md` → query that section's
+> leaves → read one or two descriptions → open the right file.
+
+Knows where to start and what to look for, without loading it all at the top.
+
+### 6. Shared folder
+
+`install` creates `<repo_root>/shared/` (a host-repo scratch/handoff dir). The
+CONNECTIONS derived header states the path. Derived by convention (relative to
+repo root) — not stored in a column.
+
+### 7. Docs-count fix
+
+Narrow the `## STATUS` docs denominator to *ingestable host-repo docs*:
+- Exclude engine paths (already `.super-coder/%`) **and** embedded substrate
+  assets in substrate-containing forks.
+- Exclude non-ingestable markdown (PR/issue templates, CHANGELOG, license-style
+  files) — or reframe the line so it does not imply "ingest all of these."
+
+Goal: the ratio stops reading as a false "un-ingested" backlog.
+
+### 8. Cartographer — two standing jobs
+
+The cartographer flavor + skill gain explicit ownership of:
+1. `dr_section` — author/curate sections (seed-refine), keep the catch-all empty.
+2. `dr_filepath.desc` — fill descriptions, worklist-driven (`desc IS NULL`).
+
+Both are best-effort and NULL-until-curated; neither blocks the auto-remap hook
+that working shells trigger.
+
+## Change surface (all engine-side, in the super-coder source repo)
+
+| File | Change |
+|---|---|
+| `schema.sql` | add `dr_section`; add `dr_filepath.desc`; drop `shells.workspace` |
+| `migrations/NNNN_*.sql` | additive migration for installed forks (new table + column; workspace handled per "Migration" below) |
+| `scripts/map_repo.py` | DELETE+INSERT → UPSERT preserving `desc`; seed `dr_section` from top-level dirs |
+| `render/compose.py` | `## CONNECTIONS` (header + section index + authored notes); drop `## WORKSPACE`; fix docs-count denominator |
+| `scripts/install.py` | create `<repo_root>/shared/` |
+| `assets/shells/cartographer.*` / cartographer SKILL | add the two jobs + worklist queries |
+| `snapshot/content.sql` | regenerated via `./sc snapshot` (shell content: connections notes, sections) |
+| reseed migration | so already-installed forks pick up the schema + cartographer-asset changes |
+
+## Migration & fork reseed
+
+- New table + new column are additive — straightforward forward migration.
+- Dropping `shells.workspace`: SQLite requires table-rebuild for a true `DROP
+  COLUMN` (or leave the column unused and stop rendering it). Decide at
+  implementation time; leaving it unrendered is the lower-risk path and can be
+  cleaned up later.
+- The cartographer asset/skill edits need a **reseed migration** (the
+  asset-content sync path) so existing forks pick up the new behavior on
+  `./sc update`, not just fresh installs.
+- This is engine work, done in the super-coder source repo — never patched into a
+  fork's `.super-coder/` directly (a fork's engine is checkout-scoped on update;
+  in-place edits are clobbered or silently diverge).
+
+## Token economics (why this shape)
+
+- The boot doc is the system prompt — **prompt-cached** and stable between map
+  changes. A bounded section index is one cheap cache-stable cost.
+- Per-file descriptions, if preloaded, would be a large recurring cost (hundreds
+  of files × ~25 tokens) and would churn the cache on every auto-remap. Querying
+  them inside a chosen section pays detail cost only when needed.
+- Wrong-file reads are *uncacheable churn* (fresh tokens every time + polluted
+  context). The section index + on-demand descriptions trade a small stable boot
+  cost for fewer wrong reads — net win over a session.
+
+## Decisions settled
+
+- **CONNECTIONS replaces WORKSPACE** — one "where things live" surface; the dead
+  `connections` column gets a render; `workspace` retired.
+- **`dr_section` (general, authored) over typed semantic tables** — defer
+  `dr_api`/`dr_db`/`dr_page`.
+- **Descriptions are cartographer-authored and preserved across remap** — not
+  render-time inference, not wiped by the hook.
+- **Render the section index, not the leaves** — boot loads where-to-start;
+  descriptions are queried on demand inside a section.
+- **Sections are seeded from top-level dirs, then curated** — non-empty on day
+  one; catch-all bucket keeps the index complete.
+
+## Open questions
+
+- Exact `dr_section` seeding heuristic (top-level dirs only, or first two levels
+  for nested layouts like `shell_core/{api,ui}`?).
+- Whether to surface an undescribed/unsectioned count in `## STATUS` to ping the
+  cartographer sooner (vs. leaving it as a quiet worklist).
+- Whether to true-`DROP` `workspace` (table rebuild) now or leave it unrendered
+  and clean up in a later structural pass.
+
+## Out of scope (later)
+
+- Typed semantic tables (`dr_api`/`dr_db`/`dr_page`).
+- Semantic descriptions of *symbols* (functions/classes) — this stage is
+  file-level.
+- Cross-repo sections (multi-repo shells) — current model is one shell, one repo.


### PR DESCRIPTION
Implements `specs_sc/b5-repo-navigation.md` (flag CC-117). Gives every shell a cheap, accurate answer to **"where does this live?"** — a sectioned, described repo map surfaced through a single `## CONNECTIONS` block that replaces `## WORKSPACE`.

## What changed

**Schema** — `schema.sql` + `migrations/0003_repo_navigation.sql` (convergent: safe both on an in-place fork `./sc update` and on a fresh rebuild over the baseline)
- `dr_section` — authored navigation (`name · path_prefix · description`); never wiped by the remap; files join by path-prefix at query/render time.
- `dr_filepath.desc` (≤100ch, cartographer-authored) + `UNIQUE(path)`.
- `workspace → connections` data move; `workspace` retired (left unrendered, no risky table rebuild).

**Mapper** (`map_repo.py`) — the make-or-break: `DELETE+INSERT → UPSERT` keyed by `path` that **preserves `desc`** across the auto-remap git hook, prunes vanished paths, and seeds `dr_section` from top-level dirs *only when empty* (curated/snapshotted sections survive).

**Render** (`compose.py`) — `## CONNECTIONS` = derived header (repo root/branch/`mapped_at` + `<repo_root>/shared`) + section index with live file counts + an "other / unsectioned" catch-all + the authored `connections` notes. Renders the **index, not the leaves** — bounded + cache-stable. Docs-count denominator narrowed to *ingestable* host docs so the ratio stops reading as a false backlog.

**Surfaces** — `run.py` / `api/server.py` / `ui/app.js` / `shell_factory.py` / `seed_dogfood.py` retire `workspace` so `connections` is the one authored "where things live" surface. `install.py` creates `<repo_root>/shared`. `snapshot.py` snapshots `dr_section`.

**Cartographer** — skill gains two standing jobs (`dr_section` curation + `dr_filepath.desc` fill) with NULL-until-curated worklist queries. `surface_catalogue` + `db_map` updated. Skills reseed (`0001_seed_skills.sql`) regenerated → propagates to installed forks on `./sc update`.

## Validation
- **Fork-update path**: `migrate.py` in place → `workspace→connections` moved, `dr_section` + `desc` + `UNIQUE(path)` added, indexes intact.
- **Fresh-rebuild path**: `schema.sql` + migrations 0001–0003 + snapshot + map, `integrity_check` ok (0003 convergent on a baseline that already has the changes — no "table exists" / "duplicate column").
- **Mechanics**: authored `desc` survives a remap; phantom path pruned; renamed/described section not re-seeded over; `## CONNECTIONS` renders, `## WORKSPACE` gone.

Closes CC-117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)