### PR TITLE
feat(gui): publish button — commit → push → rolling PR for GUI edits (B6)

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -26,6 +26,18 @@ RUN apt-get update \
       sqlite3 git curl bash ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
+# GitHub CLI (gh) — the in-container push/PR path: the GUI "publish" flow
+# (snapshot → render → commit → push → PR) and shells that open their own PRs.
+# Not in Debian's default repos, so add the official gh apt source. Auth is NOT
+# baked: the token arrives at runtime via GH_TOKEN (`./sc launch` forwards the
+# host's `gh auth token`, or a repo-scoped SC_GH_TOKEN) — never in the image.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update && apt-get install -y --no-install-recommends gh \
+ && rm -rf /var/lib/apt/lists/*
+
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
 RUN groupadd -g ${SC_GID} ${SC_USER} \
  && useradd -m -u ${SC_UID} -g ${SC_GID} -s /bin/bash ${SC_USER}

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -26,6 +26,8 @@ import os
 import sqlite3
 import subprocess
 import sys
+import threading
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import urlparse
@@ -297,6 +299,146 @@ def run_snapshot_render() -> str:
             + run_script("render")["output"]).strip()
 
 
+# ── Publish: serialize → commit → push → PR (the GUI "publish" button) ─────────
+# Single-rolling-branch model: every GUI edit lands on PUBLISH_BRANCH with ONE
+# open PR to main, so branches never proliferate and main stays clean until you
+# merge. Push + PR need a GitHub token in the env (GH_TOKEN); `./sc launch`
+# forwards it into the sandbox. Without a token the change is still COMMITTED
+# locally — the tree never goes dirty — only the push/PR is skipped, with a clear
+# message. A module lock serializes concurrent publishes (one git index).
+BASE_BRANCH = "main"
+PUBLISH_BRANCH = "gui-content"
+_PUBLISH_LOCK = threading.Lock()
+# The git-tracked text the DB rebuilds from + the flat renders. NOT the .db
+# (gitignored — see the install .gitignore block).
+PUBLISH_PATHS = [
+    ".super-coder/snapshot/content.sql",
+    ".super-coder/schema.sql",
+    ".super-coder/migrations",
+    "specs_sc", "docs_sc", "skills_sc", "roadmap_sc.md",
+]
+
+
+def _git(*args):
+    return subprocess.run(["git", *args], cwd=str(REPO_ROOT),
+                          capture_output=True, text=True)
+
+
+def _gh_token() -> str:
+    return (os.environ.get("SC_GH_TOKEN") or os.environ.get("GH_TOKEN") or "").strip()
+
+
+def _origin_https() -> str | None:
+    """origin URL as https (ssh `git@host:owner/repo` → https), so a token push
+    needs no ssh keys in the container."""
+    url = _git("remote", "get-url", "origin").stdout.strip()
+    if not url:
+        return None
+    if url.startswith("git@"):
+        url = "https://" + url.split("@", 1)[1].replace(":", "/", 1)
+    if url.startswith("https://") and not url.endswith(".git"):
+        url += ".git"
+    return url
+
+
+def _redact(s: str, token: str) -> str:
+    return s.replace(token, "***") if token else s
+
+
+def git_publish() -> dict:
+    out: list[str] = []
+
+    # 1. serialize the DB → git-tracked text + render the flat files.
+    out.append(run_snapshot_render())
+
+    # 2. land on the rolling branch (created from HEAD on first publish; the
+    #    operator stays on it — editing lives on gui-content, main stays clean).
+    cur = _git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    if cur != PUBLISH_BRANCH:
+        exists = _git("rev-parse", "--verify", "--quiet",
+                      f"refs/heads/{PUBLISH_BRANCH}").returncode == 0
+        sw = (_git("checkout", PUBLISH_BRANCH) if exists
+              else _git("checkout", "-b", PUBLISH_BRANCH))
+        if sw.returncode != 0:
+            return {"ok": False, "output": "\n".join(out) +
+                    f"\n\n✗ can't switch to '{PUBLISH_BRANCH}' from '{cur}':\n"
+                    f"{sw.stderr.strip()}\n\nCheck out '{PUBLISH_BRANCH}' (or commit/"
+                    "stash) before editing."}
+        out.append(f"on branch {PUBLISH_BRANCH} (from {cur})")
+
+    # 3. stage the publishable text + renders; commit if anything is new.
+    #    Filter to paths that exist — `git add` is fatal on a missing pathspec, and
+    #    a minimal fork may lack some (e.g. docs_sc/ before any doc is authored).
+    present = [p for p in PUBLISH_PATHS if (REPO_ROOT / p).exists()]
+    if present:
+        _git("add", "--", *present)
+    staged = _git("diff", "--cached", "--name-only").stdout.strip()
+    if staged:
+        n = len(staged.splitlines())
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+        msg = (f"gui: publish content edits ({n} file{'s' if n != 1 else ''})\n\n"
+               f"Serialized + rendered from the review GUI at {stamp}.\n\n"
+               + "\n".join(f"- {f}" for f in staged.splitlines()))
+        c = _git("commit", "-m", msg)
+        if c.returncode != 0:
+            return {"ok": False, "output": "\n".join(out) +
+                    "\n\n✗ commit failed:\n" + (c.stderr or c.stdout).strip()}
+        out.append(f"committed {n} file(s)")
+    else:
+        out.append("no new content to commit")
+
+    # 4. nothing ahead of main → nothing to publish.
+    ahead = _git("rev-list", "--count",
+                 f"{BASE_BRANCH}..{PUBLISH_BRANCH}").stdout.strip() or "0"
+    if ahead == "0":
+        return {"ok": True, "output": "\n".join(out) +
+                f"\n\n✓ {PUBLISH_BRANCH} matches {BASE_BRANCH} — nothing to publish."}
+
+    # 5. token gate: committed locally either way (tree clean), but push/PR needs it.
+    token = _gh_token()
+    if not token:
+        return {"ok": True, "output": "\n".join(out) +
+                f"\n\n⚠ committed on {PUBLISH_BRANCH} ({ahead} commit(s) ahead of "
+                f"{BASE_BRANCH}), but no GH_TOKEN — can't push or open a PR. Set "
+                "SC_GH_TOKEN, or `./sc launch` with a host gh login."}
+
+    # 6. push over token-https (no ssh keys needed).
+    url = _origin_https()
+    if not url:
+        return {"ok": False, "output": "\n".join(out) +
+                "\n\n✗ no 'origin' remote to push to."}
+    push_url = url.replace("https://", f"https://x-access-token:{token}@", 1)
+    p = _git("push", push_url, f"{PUBLISH_BRANCH}:{PUBLISH_BRANCH}")
+    if p.returncode != 0:
+        return {"ok": False, "output": "\n".join(out) +
+                "\n\n✗ push failed:\n" + _redact((p.stderr or p.stdout).strip(), token)}
+    out.append(f"pushed {PUBLISH_BRANCH} → origin ({ahead} commit(s) ahead)")
+
+    # 7. upsert ONE PR (gh reads the token from the env).
+    env = {**os.environ, "GH_TOKEN": token}
+
+    def gh(*args):
+        return subprocess.run(["gh", *args], cwd=str(REPO_ROOT),
+                              capture_output=True, text=True, env=env)
+
+    pr_url = gh("pr", "view", PUBLISH_BRANCH, "--json", "url", "-q", ".url").stdout.strip()
+    if not pr_url:
+        cr = gh("pr", "create", "--base", BASE_BRANCH, "--head", PUBLISH_BRANCH,
+                "--title", "GUI content edits",
+                "--body", "Rolling PR for content edited via the super-coder "
+                "review GUI (roadmap, docs, flags, identity). Auto-updated on each "
+                "publish; merge to land on main.")
+        if cr.returncode != 0:
+            return {"ok": False, "output": "\n".join(out) +
+                    "\n\n✗ PR create failed:\n" + _redact((cr.stderr or cr.stdout).strip(), token)}
+        pr_url = cr.stdout.strip()
+        out.append(f"opened PR: {pr_url}")
+    else:
+        out.append(f"updated PR: {pr_url}")
+
+    return {"ok": True, "output": "\n".join(out), "pr_url": pr_url}
+
+
 # ── HTTP ──────────────────────────────────────────────────────────────────────
 
 class Handler(BaseHTTPRequestHandler):
@@ -404,6 +546,10 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(201, {"shell_id": sid, "shortname": sn})
             if path == "/api/snapshot":
                 return self._send(200, {"output": run_snapshot_render()})
+            if path == "/api/publish":
+                with _PUBLISH_LOCK:
+                    r = git_publish()
+                return self._send(200 if r["ok"] else 500, r)
             if path.startswith("/api/scripts/"):
                 r = run_script(path.rsplit("/", 1)[1])
                 if r is None:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -55,6 +55,7 @@ import seed_skills  # noqa: E402
 ENGINE_PATHS = [
     "sc",
     ".super-coder/aliases.mk",
+    ".super-coder/Dockerfile",
     ".super-coder/schema.sql",
     ".super-coder/ecosystem.config.cjs",
     ".super-coder/README.md",

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -452,6 +452,18 @@ $("#snapshot").onclick = async () => {
   try { const r = await api("/snapshot", "POST"); toast(r.output || "done"); setStatus("snapshot done"); }
   catch (e) { toast("error: " + e.message); }
 };
+$("#publish").onclick = async (e) => {
+  const btn = e.currentTarget;
+  btn.disabled = true;
+  setStatus("publishing…");
+  try {
+    const r = await api("/publish", "POST");
+    toast(r.output || "published");
+    setStatus(r.pr_url ? "published → PR ready" : "published");
+    if (r.pr_url) window.open(r.pr_url, "_blank", "noopener");
+  } catch (e) { toast("publish error: " + e.message); setStatus("publish failed"); }
+  finally { btn.disabled = false; }
+};
 (async () => {
   try { const h = await api("/health"); $("#repo").textContent = h.repo; setStatus("port " + h.port); }
   catch { setStatus("offline"); }

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -19,7 +19,8 @@
     </nav>
     <div class="tools">
       <span id="status" class="status"></span>
-      <button id="snapshot" title="make snapshot + render (precursor to B6 auto-commit)">snapshot ⤓</button>
+      <button id="snapshot" title="serialize the DB → content.sql + render the flat _sc files (local only, no git)">snapshot ⤓</button>
+      <button id="publish" class="primary" title="snapshot + render, then commit → push → open/update one PR on the gui-content branch">publish ⤴</button>
     </div>
   </header>
   <main>

--- a/sc
+++ b/sc
@@ -90,11 +90,22 @@ case "$cmd" in
     "$PY" "$S/ports.py" ensure >/dev/null
     p="$(port)"
     dbuild
+    # Forward GitHub auth for the in-container push/PR path (GUI publish + shells
+    # opening their own PRs). Prefer a repo-scoped SC_GH_TOKEN; else reuse the
+    # host's gh login. NOTE: this widens the sandbox — anything in the container
+    # can act as you on GitHub within the token's scope. A fine-grained,
+    # single-repo PAT in SC_GH_TOKEN is the tighter option.
+    gh_token="${SC_GH_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+    git_name="$(git -C "$here" config user.name 2>/dev/null || true)"
+    git_email="$(git -C "$here" config user.email 2>/dev/null || true)"
     docker rm -f "$CNAME" >/dev/null 2>&1 || true
     docker run -d --name "$CNAME" --restart unless-stopped \
       --user "$(duser)" \
       -e HOME="$HOME" -e SC_BIND=0.0.0.0 -e SC_PYTHON=python3 -e PYTHONUNBUFFERED=1 \
       -e SC_SANDBOX=1 \
+      -e GH_TOKEN="$gh_token" \
+      -e GIT_AUTHOR_NAME="$git_name" -e GIT_AUTHOR_EMAIL="$git_email" \
+      -e GIT_COMMITTER_NAME="$git_name" -e GIT_COMMITTER_EMAIL="$git_email" \
       -w "$here" \
       -v "$here:$here" \
       -v "$HOME/.claude:$HOME/.claude" \


### PR DESCRIPTION
## Auto-commit + PR for GUI edits — kills the dirty-branch pile-up

Editing content in the review GUI used to write only the DB; turning that into git was manual (snapshot → commit → branch → PR), which left dirty trees and a pile of hand-made branches. This delivers the **B6 auto-commit** path the snapshot button's tooltip already promised.

### How it works
A new **`publish ⤴`** button → `POST /api/publish` → `git_publish()`:
1. **snapshot** (DB → `content.sql`) + **render** (flat `_sc` files)
2. stage the git-tracked text the DB rebuilds from (`content.sql`, `schema.sql`, `migrations/`, `specs_sc/`, `docs_sc/`, `skills_sc/`, `roadmap_sc.md`)
3. **commit** → **push** → **upsert ONE PR**

**Single rolling branch** `gui-content` with **one open PR** to `main`. All GUI edits stack onto it; the PR auto-updates each publish. Branches never proliferate; `main` stays clean until you merge.

### Decisions (per operator)
- **Branch model:** one rolling `gui-content` branch + a single auto-updated PR.
- **Trigger:** explicit `publish` button (batches edits into deliberate commits).
- **Auth:** the sandbox now carries push creds (shells need them too). `./sc launch` forwards a token — prefers a repo-scoped **`SC_GH_TOKEN`**, else the host's `gh auth token`. Push is **token-over-https** (ssh→https origin conversion) so no ssh keys enter the container; `gh` (installed in the image) reads the token for the PR.

### Graceful degradation
No token → the change is still **committed locally** (tree never goes dirty); only push/PR is skipped, with a clear message. Tokens are redacted from any surfaced output. A module lock serializes concurrent publishes.

### Files
| File | Change |
|---|---|
| `.super-coder/api/server.py` | `git_publish()` + `/api/publish` route + helpers (lock, redact, ssh→https) |
| `.super-coder/ui/index.html` + `app.js` | `publish ⤴` button + handler (opens the PR) |
| `.super-coder/Dockerfile` | install `gh` (official apt repo) |
| `sc` | `./sc launch` forwards `GH_TOKEN`/`SC_GH_TOKEN` + git identity into the sandbox |
| `.super-coder/scripts/update.py` | add `Dockerfile` to `ENGINE_PATHS` (was missing → forks never pulled image changes) |

No schema/DB change — pure engine code. Forks get it via `./sc update` + relaunch (rebuilds the image with `gh`).

### ⚠️ Security note
`GH_TOKEN` in the sandbox lets anything in the container act as you on GitHub within the token's scope (`repo`, `workflow`, `gist`). The sandbox's "allow-everything" stance was safe *because* it only saw this repo + harness creds; this widens it. **Recommended hardening:** a fine-grained PAT scoped to just the fork's repo, set as `SC_GH_TOKEN`.

### Verification
- **Host-tested:** branch creation / commit-on-`gui-content` / token-gate / nothing-to-publish paths, ssh→https conversion, token redaction — all green.
- **Sandbox gate (you run):** `./sc launch` (with host gh login) → edit something in the GUI → click **publish** → confirm `gui-content` pushed + a PR opens, and a second publish updates the same PR.

### Known follow-ups
- After merging the PR, re-cut `gui-content` from `main` (post-merge branch lifecycle isn't auto-reset in v1).
- Fine-grained PAT hardening (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)