### PR TITLE
harden(sandbox): wire gh credential helper + ssh→https so the container never needs a token in a URL

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -52,6 +52,18 @@ ENV PATH=/home/${SC_USER}/.local/bin:/home/${SC_USER}/.opencode/bin:${PATH}
 RUN curl -fsSL https://claude.ai/install.sh | bash \
  && curl -fsSL https://opencode.ai/install | bash
 
+# Safe in-container git auth — structurally prevents a token in a URL. The
+# sandbox has no ssh, so `git@github.com:` remotes (e.g. a fork's default
+# origin) fail and tempt a `https://x-access-token:$TOK@github.com/...` fallback
+# that leaks the token to logs / `push -u` upstream output. Two configs close
+# that: (1) rewrite GitHub SSH remotes to HTTPS so plain `git push origin`
+# works; (2) hand credentials to git via `gh`, which serves them from the
+# runtime GH_TOKEN on demand — never on the command line, never in a URL. With
+# this, `git push origin <branch>` and `gh pr create` need zero manual token
+# handling; absent a token they fail closed (no prompt-loop, no leak).
+RUN git config --global url."https://github.com/".insteadOf "git@github.com:" \
+ && git config --global credential."https://github.com".helper "!gh auth git-credential"
+
 WORKDIR /home/${SC_USER}/super-coder
 
 # Foreground stdlib server (api + static UI on one port). compose overrides the


### PR DESCRIPTION
## Why

A super-coder sandbox forwards `GH_TOKEN` (`sc launch`) but had **no git credential wiring** and **no ssh client**. A fork's default `origin` is `git@github.com:` — unusable in the container — so a shell pushing a branch falls through SSH (fails), then HTTPS-extraheader, and finally reaches for `https://x-access-token:$TOK@github.com/...`. Git then echoes that URL (notably on `git push -u` upstream output), **leaking the token**. This happened live in the dos-arch fork with the account-wide `gh` token.

Adding `gh` to the image (#32) was necessary but **not sufficient**: gh present doesn't stop raw `git push` over an SSH remote from failing and tempting the URL fallback.

## What

Bake two configs into the image (after `USER`, so they land in the user's `~/.gitconfig`):

```dockerfile
git config --global url."https://github.com/".insteadOf "git@github.com:"
git config --global credential."https://github.com".helper "!gh auth git-credential"
```

1. **ssh→https rewrite** — `git push origin <branch>` works in the no-ssh container regardless of how the fork's remote is spelled.
2. **gh credential helper** — git gets credentials from gh, which serves them from the runtime `GH_TOKEN` on demand. Never on a command line, never in a URL.

Net: `git push origin <branch>` and `gh pr create` need zero manual token handling; with no token they **fail closed** (no prompt-loop, no leak).

## Scope / safety

- Image-layer only (`~/.gitconfig` isn't bind-mounted, so it's deterministic per build, fresh per container).
- Helper scoped to `https://github.com`; other hosts untouched.
- No behavior change to the token-forwarding path itself — that's a separate follow-up (drop the broad `$(gh auth token)` fallback in `sc:98` in favor of requiring `SC_GH_TOKEN`).

## Test plan

- `./sc launch` a fork with `SC_GH_TOKEN` set, then in-container: `git push origin <branch>` and `gh pr create` succeed with no token in any URL or log.
- Unset token → push fails closed (no prompt, no leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)