### PR TITLE
fix(sandbox): acceptEdits not bypassPermissions for harness elevation (root-safe)

### DIFF
--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -7,7 +7,7 @@
   "sandbox": {
     "merge_json": {
       ".claude/settings.json": {
-        "permissions": { "defaultMode": "bypassPermissions" }
+        "permissions": { "defaultMode": "acceptEdits" }
       }
     }
   }


### PR DESCRIPTION
## Problem

`make enter` on a fork crashes when the sandbox execs `claude` as root/sudo:

```
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
```

The crash isn't a literal CLI flag — it's the sandbox elevation merging `"defaultMode": "bypassPermissions"` into the project `.claude/settings.json`. `bypassPermissions` is the settings-equivalent of `--dangerously-skip-permissions`, so it hits the same root guard and aborts the launch.

## Fix

Swap the adapter's `sandbox.merge_json` patch from `bypassPermissions` to **`acceptEdits`** — the broadest permission mode that does **not** trip the root guard. Combined with the fork's bare-tool-name `allow` list (each bare name = all uses of that tool), this preserves the near-zero-prompt sandbox UX, root-agnostically: whether the root context comes from the host shell or the container exec, `acceptEdits` sidesteps the guard entirely.

Every future fork inherits this via the engine template; verified end-to-end booting the dos-arch fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)