### PR TITLE
fix(opencode): tame Qwen text-tool-call noise (steer + parallel_tool_calls off)

### DIFF
--- a/.super-coder/adapters/opencode/README.md
+++ b/.super-coder/adapters/opencode/README.md
@@ -25,6 +25,22 @@ harness-specific file OpenCode wants and the launch command.
   loading `CLAUDE.md` (we dual-write both with identical content; this avoids a
   double-load). ⚠ The exact env name is a **research flag to verify on live
   OpenCode** — if wrong it's a harmless no-op (the content is identical anyway).
+- **`tool-discipline.md`** + its entry in `instructions` — a static, harness-level
+  steer (not part of the render-chain-generated `AGENTS.md`, so it survives
+  regeneration). It tells the model never to emit tool calls as text/XML and never
+  to call the synthetic `invalid`/`unknown` tools. This breaks a **compounding
+  failure loop** seen with text-tool-call models (Qwen/Hermes): one malformed call
+  makes OpenCode inject its own `invalid`-tool error into context, which the model
+  then parrots back as more malformed calls. Referenced in place under
+  `.super-coder/adapters/opencode/` (path is relative to the repo root where
+  OpenCode runs); not emitted, just read.
+- **`provider.openrouter.options.extraBody.parallel_tool_calls: false`** — caps the
+  model to one tool call per turn over OpenRouter. Fewer batched calls means fewer
+  chances for a single malformed entry to poison the turn; a known stabilizer for
+  Qwen tool-calling. `extraBody` is merged straight into the request body by
+  OpenCode's bundled AI SDK (verified in the binary), so it reliably overrides the
+  default. Provider-scoped (all OpenRouter models); harmless for non-Qwen models.
+  `reasoning` is intentionally left untouched — the next dial if noise persists.
 
 ## Verify on live OpenCode (research flags from the spec)
 

--- a/.super-coder/adapters/opencode/opencode.json
+++ b/.super-coder/adapters/opencode/opencode.json
@@ -1,11 +1,18 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "lsp": true,
-  "instructions": ["AGENTS.md"],
+  "instructions": ["AGENTS.md", ".super-coder/adapters/opencode/tool-discipline.md"],
   "permission": {
     "edit": "allow",
     "webfetch": "allow",
     "bash": "ask"
+  },
+  "provider": {
+    "openrouter": {
+      "options": {
+        "extraBody": { "parallel_tool_calls": false }
+      }
+    }
   },
   "mcp": {}
 }

--- a/.super-coder/adapters/opencode/tool-discipline.md
+++ b/.super-coder/adapters/opencode/tool-discipline.md
@@ -1,0 +1,18 @@
+# Tool-Calling Discipline (opencode)
+
+Keep tool calls well-formed. These rules matter most for models that emit tool
+calls as text (Qwen, Hermes-style): one malformed call otherwise compounds into
+repeated failures as the model copies the harness's own error format back.
+
+- Call tools **only** through the harness's native tool mechanism. Never write a
+  tool call as prose or markup in message text — no `<function=...>`, no
+  `<parameter=...>`, no fenced tool blocks.
+- There is **no tool named `invalid`, `unknown`, or `function`**. They are not
+  real tools; never call them. The only callable tools are the ones the harness
+  advertises (bash, edit, glob, grep, read, write, task, todowrite, webfetch,
+  skill, question, …).
+- If a tool result reports an invalid call or an unavailable tool, do **not**
+  echo that error shape as a new call. Treat it as a signal to reissue the
+  *intended* action with a real tool name and correct arguments.
+- One logical action per tool call. Prefer a single well-formed call over
+  several speculative ones.


### PR DESCRIPTION
## Problem

Running `qwen/qwen3.7-max` (and other Hermes-style **text-tool-call** models) over OpenRouter in OpenCode produces a stream of:

> `Model tried to call unavailable tool 'unknown'. Available tools: …`

### Root cause (traced end-to-end)

1. `qwen/qwen3.7-max` has exactly **one** OpenRouter backend (Alibaba), which *does* support `tools` — so this is **not** a routing problem; `require_parameters`/backend-pinning would change nothing.
2. The model emits tool calls as Hermes/XML text. On a malformed block, the backend returns a `tool_call` whose `function.name` is literally `"unknown"` (verified: `"unknown"` is **not** an OpenCode fallback string).
3. OpenCode's `experimental_repairToolCall` only repairs **wrong casing**; everything else is rewritten to the synthetic **`invalid`** tool.
4. **Compounding loop:** OpenCode feeds its verbose `invalid`-tool error (`{tool:"unknown", error:"…"}`) back into context, and the model **parrots that error schema** as new malformed calls. One bad call breeds more.

The repair hook and stream parser are compiled into the OpenCode binary (not editable), so the fix is config + instructions at the adapter layer.

## Changes (adapter-level → every fork inherits)

- **`tool-discipline.md`** + an entry in `instructions[]` — a static, harness-level steer kept *separate* from the render-chain-generated `AGENTS.md` (so it survives regeneration). Tells the model never to emit tool calls as text/XML and never to call the synthetic `invalid`/`unknown` tools. **Breaks the compounding loop.**
- **`provider.openrouter.options.extraBody.parallel_tool_calls: false`** — one tool call per turn over OpenRouter; fewer batched calls, fewer chances for a malformed entry to poison the turn. `extraBody` is merged straight into the request body by the bundled AI SDK (verified in the binary). `reasoning` left untouched — the next dial if noise persists.

Both take effect at **next launch** (config is read at session start), so running sessions are unaffected.

## Verification status

- JSON validates; schema-confirmed keys (`instructions[]`, `provider.<id>.options` accepts arbitrary pass-through, model-entry shape).
- ⏳ **Live smoke test pending** — needs one tool-using Qwen turn over OpenRouter to confirm `parallel_tool_calls:false` reaches the wire and the noise drops. To run when a Qwen session is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)