### PR TITLE
feat(cartographer): singleton guard + shape-change notice curation (PR2)

### DIFF
--- a/.super-coder/assets/skills/cartographer/SKILL.md
+++ b/.super-coder/assets/skills/cartographer/SKILL.md
@@ -133,6 +133,44 @@ UPDATE dr_filepath SET desc='Boot composer — assembles CLAUDE.md from DB state
 After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
 ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).
 
+## Shape-change notices — the curation trigger
+
+The git hooks keep the *mechanical* catalogue fresh on their own (paths, langs,
+deps), but a newly-landed file arrives `desc IS NULL` and unsectioned — the
+authored layer above doesn't fill itself. So working shells **message you** when
+they change the repo's shape, turning curation from a next-boot *pull* into a
+timely *push*. This is the only inbox traffic you act on as cartographer.
+
+**The notice contract** (what the relay shells send — one source of truth here;
+the relay skills point at this section). A working shell sends, via the
+`messaging` skill, to shortname `cartographer`:
+
+```
+--message send cartographer "shape: <what landed> — paths: <region/>; <ref>. curate."
+```
+
+- Sent by the shell that *lands code shape*: the **dev/coder** shell on merge (new
+  feature implemented, new doc written). NOT the planner — specs render into a
+  known, predictable area and need no semantic curation.
+- The body names **what** changed and **where** (the path region) so your pass is
+  scoped, not a full re-survey. A `documents`/feature ref is welcome but optional.
+
+**On a notice** — check inbox, then run the existing worklists *scoped to the
+named region*, and mark read:
+
+```sql
+-- 1. the new files this notice is about (scope by the region it named):
+SELECT path, role FROM dr_filepath
+WHERE desc IS NULL AND path LIKE 'region/%' ORDER BY role, path;
+-- 2. describe them (≤100 chars) — UPDATE dr_filepath SET desc=… per the worklist above.
+-- 3. do they form / join a section? curate dr_section if the region is a new area.
+```
+
+Then `./sc snapshot` and `--message mark-read <id>` (see the `messaging` skill).
+The mechanical remap already ran via the hook; your job on the notice is purely
+the authored layer — describe the new leaves, section a new area. Scope is free:
+`desc IS NULL` already narrows to exactly the uncurated tail.
+
 ## Stance
 
 - **The map is infrastructure, not a chore for every shell.** You own it so the

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -300,6 +300,44 @@ UPDATE dr_filepath SET desc=''Boot composer — assembles CLAUDE.md from DB stat
 After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
 ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).
 
+## Shape-change notices — the curation trigger
+
+The git hooks keep the *mechanical* catalogue fresh on their own (paths, langs,
+deps), but a newly-landed file arrives `desc IS NULL` and unsectioned — the
+authored layer above doesn''t fill itself. So working shells **message you** when
+they change the repo''s shape, turning curation from a next-boot *pull* into a
+timely *push*. This is the only inbox traffic you act on as cartographer.
+
+**The notice contract** (what the relay shells send — one source of truth here;
+the relay skills point at this section). A working shell sends, via the
+`messaging` skill, to shortname `cartographer`:
+
+```
+--message send cartographer "shape: <what landed> — paths: <region/>; <ref>. curate."
+```
+
+- Sent by the shell that *lands code shape*: the **dev/coder** shell on merge (new
+  feature implemented, new doc written). NOT the planner — specs render into a
+  known, predictable area and need no semantic curation.
+- The body names **what** changed and **where** (the path region) so your pass is
+  scoped, not a full re-survey. A `documents`/feature ref is welcome but optional.
+
+**On a notice** — check inbox, then run the existing worklists *scoped to the
+named region*, and mark read:
+
+```sql
+-- 1. the new files this notice is about (scope by the region it named):
+SELECT path, role FROM dr_filepath
+WHERE desc IS NULL AND path LIKE ''region/%'' ORDER BY role, path;
+-- 2. describe them (≤100 chars) — UPDATE dr_filepath SET desc=… per the worklist above.
+-- 3. do they form / join a section? curate dr_section if the region is a new area.
+```
+
+Then `./sc snapshot` and `--message mark-read <id>` (see the `messaging` skill).
+The mechanical remap already ran via the hook; your job on the notice is purely
+the authored layer — describe the new leaves, section a new area. Scope is free:
+`desc IS NULL` already narrows to exactly the uncurated tail.
+
 ## Stance
 
 - **The map is infrastructure, not a chore for every shell.** You own it so the

--- a/.super-coder/migrations/0005_singleton_cartographer.sql
+++ b/.super-coder/migrations/0005_singleton_cartographer.sql
@@ -1,0 +1,28 @@
+-- 0005 — Cartographer singleton guard (trg_singleton_cartographer).
+--
+-- One additive, convergent change — safe both on an existing fork (the trigger
+-- is absent → created) and on a fresh rebuild (schema.sql already has it →
+-- CREATE … IF NOT EXISTS converges). Matches the 0002/0003/0004 precedent.
+--
+-- A fork has exactly one cartographer: it owns the repo map and no other shell
+-- maps, so a second is incoherent. The trigger blocks INSERT of a 2nd non-deleted
+-- cartographer (is_deleted=0 so a deleted one frees the slot). shell_factory
+-- pre-checks for a friendly error; this trigger is the DB backstop that also
+-- catches direct writes and the GUI `POST /api/shells` path.
+--
+-- Existing forks already carry exactly one cartographer (init_fork seeds it), so
+-- applying this never fires on the incumbent — it only guards the next INSERT.
+
+BEGIN;
+
+CREATE TRIGGER IF NOT EXISTS trg_singleton_cartographer
+BEFORE INSERT ON shells
+WHEN NEW.flavor = 'cartographer' AND (
+  SELECT COUNT(*) FROM shells
+  WHERE flavor = 'cartographer' AND is_deleted = 0
+) >= 1
+BEGIN
+  SELECT RAISE(ABORT, 'cartographer is a singleton — this fork already has one');
+END;
+
+COMMIT;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -58,6 +58,21 @@ CREATE TABLE shells (
     is_deleted        INTEGER NOT NULL DEFAULT 0
 );
 
+-- Singleton guard: a fork has exactly one cartographer — it owns the repo map
+-- and no other shell maps, so a second one is incoherent. Mirrors the seed/L&S
+-- cap triggers (RAISE(ABORT) below the line). is_deleted=0 so a deleted
+-- cartographer frees the slot. shell_factory pre-checks for a friendly error;
+-- this is the DB backstop that also catches direct writes / the API path.
+CREATE TRIGGER trg_singleton_cartographer
+BEFORE INSERT ON shells
+WHEN NEW.flavor = 'cartographer' AND (
+  SELECT COUNT(*) FROM shells
+  WHERE flavor = 'cartographer' AND is_deleted = 0
+) >= 1
+BEGIN
+  SELECT RAISE(ABORT, 'cartographer is a singleton — this fork already has one');
+END;
+
 CREATE TABLE shell_memory_archives (
     archive_id     INTEGER PRIMARY KEY,
     shell_id       INTEGER NOT NULL REFERENCES shells(shell_id),

--- a/.super-coder/scripts/shell_factory.py
+++ b/.super-coder/scripts/shell_factory.py
@@ -82,6 +82,13 @@ def create_shell(con: sqlite3.Connection, *, flavor: str, name: str,
     """Insert a shell from `flavor`, grant its skills, open its first session.
     Returns the new shell_id. Caller commits."""
     tpl = load_flavor(flavor)
+    # Cartographer is a singleton: one map-keeper per fork. Friendly pre-check
+    # here; the trg_singleton_cartographer trigger is the DB backstop. is_deleted=0
+    # so a deleted cartographer frees the slot.
+    if flavor == "cartographer" and con.execute(
+            "SELECT COUNT(*) FROM shells WHERE flavor='cartographer' AND is_deleted=0"
+    ).fetchone()[0] >= 1:
+        raise ValueError("cartographer is a singleton — this fork already has one")
     repo = repo or REPO_ROOT.name
     role = role or tpl["role"]
     mandate = (mandate or tpl["mandate"]).replace("{{repo}}", repo)

--- a/.super-coder/templates/shells/cartographer.json
+++ b/.super-coder/templates/shells/cartographer.json
@@ -2,7 +2,7 @@
   "flavor": "cartographer",
   "abbr": "CART",
   "role": "Cartographer shell",
-  "mandate": "Own the repo map for {{repo}}. Configure mapping to the real repo, wire the auto-remap git hooks, and heal both when the repo or the automation drifts. No other shell maps.",
-  "focus": "You are the map-keeper. Working shells consume the dr_* catalogue and never map; you configure how {{repo}} is mapped (map.config.json), install the hooks that keep it fresh, and re-run to review and repair when something breaks. Run the cartographer skill on first boot, and again to heal.",
+  "mandate": "Own the repo map for {{repo}} — the fork's sole, singular map-keeper. Configure mapping, wire the auto-remap git hooks, heal both on drift, and keep the navigation layer (sections + file descriptions) current as the repo grows, curating on the shape-change notices working shells send. No other shell maps; there is only ever one of you.",
+  "focus": "You are the map-keeper. Working shells consume the dr_* catalogue and never map; you configure how {{repo}} is mapped (map.config.json), install the hooks that keep the mechanical catalogue fresh, and curate the authored layer above it — describing new files and sectioning new areas when the dev shell messages you that the repo's shape changed. Run the cartographer skill on first boot, again to heal, and on each shape-change notice.",
   "skills": ["cartographer", "git"]
 }

--- a/tests/test_singleton_cartographer.py
+++ b/tests/test_singleton_cartographer.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for the cartographer singleton guard.
+
+Stdlib `unittest`, no pytest — matching the engine's no-dependency style and
+test_shell_messaging.py. Each test builds a throwaway DB the way the engine
+ships it (schema.sql + every migration in filename order), then exercises the
+guard: the DB-layer trigger (trg_singleton_cartographer) and the friendly
+shell_factory pre-check.
+
+Run:
+    python3 tests/test_singleton_cartographer.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+INSERT_SHELL = (
+    "INSERT INTO shells (display_name, system_prompt, flavor) VALUES (?, 'x', ?)"
+)
+
+
+def build_db() -> sqlite3.Connection:
+    """Fresh in-memory DB: schema.sql + every migration, FK enforcement on."""
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for path in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(path.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+class SingletonCartographerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = build_db()
+
+    def tearDown(self) -> None:
+        self.con.close()
+
+    # ── trigger shape ─────────────────────────────────────────────────────────
+    def test_trigger_exists(self) -> None:
+        t = self.con.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' "
+            "AND name='trg_singleton_cartographer'"
+        ).fetchone()
+        self.assertIsNotNone(t, "singleton trigger missing after schema+migrations")
+
+    # ── first ok, second blocked ──────────────────────────────────────────────
+    def test_second_cartographer_rejected(self) -> None:
+        self.con.execute(INSERT_SHELL, ("Cartographer", "cartographer"))
+        self.con.commit()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(INSERT_SHELL, ("Cartographer 2", "cartographer"))
+
+    # ── a deleted cartographer frees the slot ─────────────────────────────────
+    def test_deleted_cartographer_frees_slot(self) -> None:
+        self.con.execute(INSERT_SHELL, ("Cartographer", "cartographer"))
+        self.con.commit()
+        self.con.execute(
+            "UPDATE shells SET is_deleted=1 WHERE flavor='cartographer'")
+        self.con.commit()
+        # No longer counts → a replacement is allowed.
+        self.con.execute(INSERT_SHELL, ("Cartographer 2", "cartographer"))
+        self.con.commit()
+        n = self.con.execute(
+            "SELECT COUNT(*) FROM shells WHERE flavor='cartographer' AND is_deleted=0"
+        ).fetchone()[0]
+        self.assertEqual(n, 1)
+
+    # ── other flavors are unconstrained ───────────────────────────────────────
+    def test_other_flavors_unconstrained(self) -> None:
+        for n in range(3):
+            self.con.execute(INSERT_SHELL, (f"Dev {n}", "dev"))
+            self.con.execute(INSERT_SHELL, (f"Review {n}", "review"))
+        self.con.commit()
+        devs = self.con.execute(
+            "SELECT COUNT(*) FROM shells WHERE flavor='dev'").fetchone()[0]
+        self.assertEqual(devs, 3)
+
+    # ── factory pre-check raises a friendly ValueError ────────────────────────
+    def test_factory_pre_check(self) -> None:
+        import sys
+        sys.path.insert(0, str(ENGINE / "scripts"))
+        import shell_factory  # noqa: E402
+
+        # Seed the incumbent directly (avoids running the full first-creation).
+        self.con.execute(INSERT_SHELL, ("Cartographer", "cartographer"))
+        self.con.commit()
+        with self.assertRaises(ValueError):
+            shell_factory.create_shell(
+                self.con, flavor="cartographer", name="Cartographer 2")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**PR2 of 2** in the flavored-shell workflow build (PR1 = relay skill speccing, follows). This is the cartographer upgrade.

## What & why

Grounding the design against the live system surfaced two things: the four flavors (planning/dev/review/cartographer) already exist, and the cartographer's map **already auto-remaps** via git hooks. So this PR is narrower than first scoped — the mechanical layer is handled; what's missing is enforcement of the cartographer's singularity and a trigger for the *authored* navigation layer.

### 1. Singleton guard — one map-keeper per fork
A fork has exactly one cartographer (it owns the map; no other shell maps). A second is incoherent.
- `trg_singleton_cartographer` BEFORE INSERT trigger on `shells`, mirroring the seed/L&S cap triggers. `is_deleted=0` → a deleted cartographer frees the slot.
- In both `schema.sql` (baseline) and `migrations/0005` (convergent `IF NOT EXISTS` for live forks — never fires on the incumbent, only guards the next INSERT).
- `shell_factory.create_shell` friendly `ValueError` pre-check; the trigger is the DB backstop that also catches direct writes + `POST /api/shells`.

### 2. Shape-change notice curation trigger
The git hooks keep the mechanical catalogue fresh, but a newly-landed file arrives `desc=NULL` and unsectioned — the authored layer doesn't fill itself. The curation worklists already existed in the skill; this adds the **trigger**:
- Working shells (the **dev** shell, on merge) message the cartographer when they change repo shape → curation becomes a timely *push*, not a next-boot pull.
- Notice contract lives in the cartographer `SKILL.md` (one source of truth; PR1's relay skills will point here) + a scoped response loop (free scoping via `desc IS NULL`).
- **Planner excluded** by design: specs render to a known, predictable area and need no semantic curation.
- Mandate/focus in the flavor template broadened to name the authored layer + the singularity.

## Design decisions (vs the original sketch)
- **Hardcoded trigger, not a `singleton_flavors` table** — mirrors the existing cap-trigger idiom; YAGNI until a second singleton appears.
- **Derive pipeline state, don't add a field** — (lands in PR1) state reads off existing `flags`/`frozen`/`documents`, no schema churn.

## Tests
- `tests/test_singleton_cartographer.py` — trigger present, 2nd rejected, deleted-frees-slot, other-flavors-unconstrained, factory pre-check. ✅
- `tests/test_shell_messaging.py` regression ✅
- Full schema+all-migrations convergence check ✅

## Propagation note
Editing the cartographer skill regenerates `0001_seed_skills.sql` (additive, same filename). Fresh installs/rebuilds pick it up; the live dos-arch fork gets it on its next `./sc rebuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)