### PR TITLE
chore(git): clean up local branch after a merge

### DIFF
--- a/.super-coder/assets/skills/git/SKILL.md
+++ b/.super-coder/assets/skills/git/SKILL.md
@@ -22,6 +22,19 @@ plain `git` (cwd = repo root) is safe. The discipline:
 3. Push, open a **PR**, then **stop**. **Do not merge** without an explicit
    directive from the FnB — opening is the default, merging is a separate gate.
 
+## After a merge — clean up local
+
+Once the FnB merges your PR, tidy local so stale branches don't accumulate:
+
+1. `git checkout main && git pull` — fast-forward onto the merged commit.
+2. Delete the merged branch: `git branch -d <branch>`. If it was
+   **squash-merged**, git won't recognize it as merged and `-d` refuses — confirm
+   the PR shows *merged* on the remote, then `git branch -D <branch>`.
+3. `git fetch --prune` — drop remote-tracking refs for branches deleted upstream.
+
+Only after the PR is merged. Never delete a branch carrying unmerged, un-PR'd
+work — a deleted branch with no PR is lost work.
+
 ## Don't commit rebuilt/derived files
 
 These are gitignored and regenerated — never add them:

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -580,6 +580,19 @@ plain `git` (cwd = repo root) is safe. The discipline:
 3. Push, open a **PR**, then **stop**. **Do not merge** without an explicit
    directive from the FnB — opening is the default, merging is a separate gate.
 
+## After a merge — clean up local
+
+Once the FnB merges your PR, tidy local so stale branches don''t accumulate:
+
+1. `git checkout main && git pull` — fast-forward onto the merged commit.
+2. Delete the merged branch: `git branch -d <branch>`. If it was
+   **squash-merged**, git won''t recognize it as merged and `-d` refuses — confirm
+   the PR shows *merged* on the remote, then `git branch -D <branch>`.
+3. `git fetch --prune` — drop remote-tracking refs for branches deleted upstream.
+
+Only after the PR is merged. Never delete a branch carrying unmerged, un-PR''d
+work — a deleted branch with no PR is lost work.
+
 ## Don''t commit rebuilt/derived files
 
 These are gitignored and regenerated — never add them:


### PR DESCRIPTION
Small addition to the `git` skill: it documented the open side (branch → commit → push → PR → stop) but not the close side. After the FnB merges, the local branch lingers.

Adds an **"After a merge — clean up local"** step:
1. `git checkout main && git pull` — fast-forward onto the merged commit.
2. `git branch -d <branch>` — with the squash-merge caveat (`-D` after confirming the PR shows merged, since git won't recognize a squash as merged).
3. `git fetch --prune` — drop remote-tracking refs for deleted upstream branches.

Guard-railed: only after the PR is merged; never delete un-PR'd work.

Independent of the cartographer PR (#36); the `0001_seed_skills.sql` regen touches only the `git` skill block (non-overlapping with #36's cartographer block, so both auto-merge). Messaging tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)