### PR TITLE
feat(ui): flags open/resolved toggle, docs search, Flags next to Docs

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -241,6 +241,8 @@ function docBlock(d, { readOnly = false } = {}) {
 }
 
 // ── Docs ──────────────────────────────────────────────────────────────────────
+let docsQuery = "";   // persists across re-renders so the search box keeps its value
+
 async function renderDocs(root) {
   const { docs } = await api("/docs");
   root.replaceChildren();
@@ -251,17 +253,34 @@ async function renderDocs(root) {
       "No docs yet. A doc is a kind='doc' document against a feature — authored by the shell, viewable here."));
     return;
   }
-  const byFeat = {};
-  for (const d of docs) (byFeat[d.feature_title || "— unlinked —"] ||= []).push(d);
-  for (const [title, list] of Object.entries(byFeat)) {
-    const c = el("div", { className: "card" });
-    c.append(el("h2", {}, title));
-    for (const d of list) c.append(docBlock(d));
-    root.append(c);
-  }
+
+  // search bar — filters by doc title or feature on every keystroke
+  const search = el("input", { type: "text", className: "search", placeholder: "search docs…", value: docsQuery });
+  const results = el("div", {});
+  const draw = () => {
+    const q = docsQuery.trim().toLowerCase();
+    const matched = q
+      ? docs.filter((d) => `${d.title || ""} ${d.feature_title || ""}`.toLowerCase().includes(q))
+      : docs;
+    results.replaceChildren();
+    if (!matched.length) { results.append(el("div", { className: "muted" }, "No docs match.")); return; }
+    const byFeat = {};
+    for (const d of matched) (byFeat[d.feature_title || "— unlinked —"] ||= []).push(d);
+    for (const [title, list] of Object.entries(byFeat)) {
+      const c = el("div", { className: "card" });
+      c.append(el("h2", {}, title));
+      for (const d of list) c.append(docBlock(d));
+      results.append(c);
+    }
+  };
+  search.oninput = () => { docsQuery = search.value; draw(); };
+  root.append(search, results);
+  draw();
 }
 
 // ── Flags ──────────────────────────────────────────────────────────────────────
+let flagFilter = "open";   // open | resolved | all — persists across re-renders
+
 async function renderFlags(root) {
   const { flags, features } = await api("/flags");
   root.replaceChildren();
@@ -291,9 +310,21 @@ async function renderFlags(root) {
     el("span", { className: "k" }, "priority"), prio), create);
   root.append(card);
 
-  // grouped by feature
+  // open | resolved | all toggle (segmented, single-select)
+  const bar = el("div", { className: "filters seg" });
+  for (const [key, label] of [["open", "Open"], ["resolved", "Resolved"], ["all", "All"]]) {
+    const chip = el("button", { className: "chip" + (flagFilter === key ? " on" : ""), textContent: label });
+    chip.onclick = () => { flagFilter = key; renderFlags(root); };
+    bar.append(chip);
+  }
+  root.append(bar);
+
+  // grouped by feature, filtered by the toggle
+  const shown = flags.filter((f) =>
+    flagFilter === "all" ? true : flagFilter === "resolved" ? f.resolved : !f.resolved);
+  if (!shown.length) { root.append(el("div", { className: "muted" }, "No flags in this view.")); return; }
   const byFeat = {};
-  for (const f of flags) (byFeat[f.feature_title || "— unlinked —"] ||= []).push(f);
+  for (const f of shown) (byFeat[f.feature_title || "— unlinked —"] ||= []).push(f);
   for (const [title, list] of Object.entries(byFeat)) {
     const c = el("div", { className: "card" });
     c.append(el("h2", {}, title));
@@ -425,8 +456,8 @@ const VIEWS = {
   shells: ["#view-shells", renderShells],
   roadmap: ["#view-roadmap", renderRoadmap],
   docs: ["#view-docs", renderDocs],
-  map: ["#view-map", renderMap],
   flags: ["#view-flags", renderFlags],
+  map: ["#view-map", renderMap],
   scripts: ["#view-scripts", renderScripts],
 };
 async function load(tab) {

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -13,8 +13,8 @@
       <button data-tab="shells" class="active">Shells</button>
       <button data-tab="roadmap">Roadmap</button>
       <button data-tab="docs">Docs</button>
-      <button data-tab="map">Map</button>
       <button data-tab="flags">Flags</button>
+      <button data-tab="map">Map</button>
       <button data-tab="scripts">Scripts</button>
     </nav>
     <div class="tools">
@@ -27,8 +27,8 @@
     <section id="view-shells" class="view"></section>
     <section id="view-roadmap" class="view" hidden></section>
     <section id="view-docs" class="view" hidden></section>
-    <section id="view-map" class="view" hidden></section>
     <section id="view-flags" class="view" hidden></section>
+    <section id="view-map" class="view" hidden></section>
     <section id="view-scripts" class="view" hidden></section>
   </main>
   <script src="/app.js"></script>

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -75,6 +75,7 @@ a.act { text-decoration: none; display: inline-block; }
 .seed-entry, .lns-entry { margin: .5rem 0; padding-left: .6rem; border-left: 1px solid var(--line); }
 .seed-entry .d { color: var(--dim); font-size: .78rem; }
 details summary { cursor: pointer; color: var(--accent); }
+.search { margin: 0 0 1rem; }
 .filters { display: flex; gap: .4rem; flex-wrap: wrap; margin: 0 0 1rem; }
 .chip {
   background: var(--panel2); color: var(--dim); border: 1px solid var(--line);


### PR DESCRIPTION
Small review-UI changes (vanilla JS, no build step — served directly from `.super-coder/ui/`).

## Changes
- **Flags page** — segmented `Open | Resolved | All` toggle (default **Open**), reusing the existing `.filters.seg`/`.chip` styles from Roadmap. Filters the list before grouping; selection persists across re-renders (e.g. after resolving a flag).
- **Docs page** — full-width search bar filtering by doc title or feature on each keystroke, re-grouping live. Query persists across re-renders.
- **Nav** — swapped Map and Flags so **Flags sits next to Docs**. Updated nav buttons, `<section>` order, and the `VIEWS` map together.

## Files
- `.super-coder/ui/app.js`
- `.super-coder/ui/index.html`
- `.super-coder/ui/style.css` (one rule: `.search` margin)

Picked up on a page refresh — no build/restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)