### PR TITLE
feat(skills): redline_review skill for dev + review shells

### DIFF
--- a/.super-coder/assets/skills/redline_review/SKILL.md
+++ b/.super-coder/assets/skills/redline_review/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: redline_review
+description: Review PNG redlines from the shared scratch dir — find the image by filename match, describe what is seen, interpret intent, propose an implementation, then hold for approval before writing code. Use when the FnB says "redlines".
+category: craft
+common: false
+---
+
+# redline_review — read a redline before you build it
+
+A redline is a marked-up screenshot the FnB drops in the repo's shared scratch
+dir (`<repo>/shared/redlines/`) to communicate a change visually. This skill is
+the discipline for turning that image into an approved plan **before** any code.
+
+**Trigger:** the FnB says "redlines" (with or without specific context).
+
+## Steps
+
+1. **Find the image**
+   - List `shared/redlines/`.
+   - Match a filename to the prompt context (fuzzy / keyword).
+   - One file present and no strong mismatch → use it. Multiple → pick the best
+     filename match; if it's genuinely ambiguous, surface that rather than guess.
+
+2. **Read the image** — use the Read tool to load the PNG visually.
+
+3. **Report in three parts — skip none:**
+   - **What I see:** literal description — layout, labels, UI elements,
+     annotations, the markup itself.
+   - **What I understand:** the interpreted intent — the change or requirement
+     this redline is communicating.
+   - **What I propose:** a concrete implementation plan — files, components,
+     approach.
+
+4. **Hold** — do not write or execute any code until the FnB explicitly approves
+   the proposal.
+
+5. **After resolution is confirmed** — once the FnB confirms the redline is
+   resolved, delete the source `.png` from `shared/redlines/`. Delete only on
+   explicit confirmation, never on assumed completion.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -9,7 +9,7 @@ BEGIN;
 
 -- Retire any catalogue skill that is no longer authored (soft-delete;
 -- keeps the row + id so a re-add is stable and grants are recoverable).
-UPDATE skills SET is_deleted=1 WHERE name NOT IN ('api-design', 'blueprint', 'bootstrap', 'cartographer', 'database-migrations', 'db_map', 'docs', 'flags', 'git', 'memory', 'messaging', 'onboard', 'self_update', 'snapshot', 'surface_catalogue');
+UPDATE skills SET is_deleted=1 WHERE name NOT IN ('api-design', 'blueprint', 'bootstrap', 'cartographer', 'database-migrations', 'db_map', 'docs', 'flags', 'git', 'memory', 'messaging', 'onboard', 'redline_review', 'self_update', 'snapshot', 'surface_catalogue');
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'api-design',
@@ -889,6 +889,51 @@ never collide — so **coexist (freeze)** is the default. Offer the FnB:
 ## Stance
 Ingest is **once**. Don''t re-ingest (drift). After onboarding, author via the
 shell/GUI and render to flat — never edit the flat files or re-import them.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'redline_review',
+  'Review PNG redlines from the shared scratch dir — find the image by filename match, describe what is seen, interpret intent, propose an implementation, then hold for approval before writing code. Use when the FnB says "redlines".',
+  'craft',
+  NULL,
+  0,
+  '# redline_review — read a redline before you build it
+
+A redline is a marked-up screenshot the FnB drops in the repo''s shared scratch
+dir (`<repo>/shared/redlines/`) to communicate a change visually. This skill is
+the discipline for turning that image into an approved plan **before** any code.
+
+**Trigger:** the FnB says "redlines" (with or without specific context).
+
+## Steps
+
+1. **Find the image**
+   - List `shared/redlines/`.
+   - Match a filename to the prompt context (fuzzy / keyword).
+   - One file present and no strong mismatch → use it. Multiple → pick the best
+     filename match; if it''s genuinely ambiguous, surface that rather than guess.
+
+2. **Read the image** — use the Read tool to load the PNG visually.
+
+3. **Report in three parts — skip none:**
+   - **What I see:** literal description — layout, labels, UI elements,
+     annotations, the markup itself.
+   - **What I understand:** the interpreted intent — the change or requirement
+     this redline is communicating.
+   - **What I propose:** a concrete implementation plan — files, components,
+     approach.
+
+4. **Hold** — do not write or execute any code until the FnB explicitly approves
+   the proposal.
+
+5. **After resolution is confirmed** — once the FnB confirms the redline is
+   resolved, delete the source `.png` from `shared/redlines/`. Delete only on
+   explicit confirmation, never on assumed completion.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/.super-coder/templates/shells/dev.json
+++ b/.super-coder/templates/shells/dev.json
@@ -4,5 +4,5 @@
   "role": "Dev shell",
   "mandate": "Build and implement in {{repo}} — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.",
   "focus": "You are a builder. Navigate via the repo map (don't grep blind), implement in small reviewable steps, commit through PRs, and record decisions as you go. Planning scopes the work; you make it real; review verifies it.",
-  "skills": ["docs", "flags", "git", "database-migrations"]
+  "skills": ["docs", "flags", "git", "database-migrations", "redline_review"]
 }

--- a/.super-coder/templates/shells/review.json
+++ b/.super-coder/templates/shells/review.json
@@ -4,5 +4,5 @@
   "role": "Review shell",
   "mandate": "Review changes, specs, and decisions in {{repo}}. Find bugs, verify claims, check work against intent. Adversarial by default.",
   "focus": "You are the gate. Read diffs against their spec, hunt the bug the author missed, verify rather than trust, and open flags for what's wrong. You critique and confirm — you don't build.",
-  "skills": ["flags", "git", "api-design", "database-migrations"]
+  "skills": ["flags", "git", "api-design", "database-migrations", "redline_review"]
 }


### PR DESCRIPTION
## What

Adds a **redline_review** craft skill to super-coder and grants it to the **dev** and **review** shell flavors.

A redline is a marked-up screenshot the FnB drops in the repo's shared scratch dir (`<repo>/shared/redlines/`) to communicate a change visually. The skill is the discipline for turning that image into an approved plan **before** any code:

1. Find the PNG in `shared/redlines/` (filename match).
2. Read it visually.
3. Report in three parts — **what I see / what I understand / what I propose**.
4. Hold for explicit FnB approval before writing code.
5. Delete the source PNG only on confirmed resolution.

Ported from superCC's `redline_review`, adapted to super-coder's voice: `FnB` (not a named owner), `category: craft`, path keyed to the shared scratch dir super-coder already surfaces, and the dos-arch `dr_log` discipline dropped (no such catalogue here).

## Changes

- `assets/skills/redline_review/SKILL.md` — new skill (`common: false`, opt-in).
- `templates/shells/dev.json` + `templates/shells/review.json` — add `redline_review` to each flavor's grant list.
- `migrations/0001_seed_skills.sql` — regenerated via `./sc seed-skills` (16 skills); the skill **body** is system content and propagates to every fork.

## Notes

- Flavor templates are read at shell-creation time, so the grants apply to **new** dev/review shells. Existing shells won't auto-receive the grant — that's a per-instance `shell_skills` insert + snapshot, or a rebuild.
- Skill body = system (migration, propagates); grant = per-instance (snapshot). Consistent with the engine's content split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)