### PR TITLE
feat(docs skill): embed themed-markdown authoring contract

### DIFF
--- a/.super-coder/assets/skills/docs/SKILL.md
+++ b/.super-coder/assets/skills/docs/SKILL.md
@@ -54,3 +54,158 @@ The GUI and the render layer both refuse edits to frozen docs.
 Open any doc rendered: the GUI's "open in md-converter ↗" (Roadmap card or Docs
 tab) — the body rides in the URL, no upload. For long-form authoring, write the
 markdown to the `body` and let the render + md-converter handle presentation.
+
+---
+
+# Authoring format (themed-markdown)
+
+The `body` you write **is** themed-markdown — the format md-converter renders.
+**Your job is structure; styling is the renderer's job.** Never write visual
+instructions (colors, fonts, sizes, themes). Apply the four semantic classes;
+the theme picks the actual colors.
+
+Use **only** the constructs below. Anything else either drops silently or breaks
+the render.
+
+`req` = required · `opt` = optional · `≤N` = soft character cap (over-cap wraps
+awkwardly or overflows a fixed UI slot).
+
+## Frontmatter
+
+Author these in the body's frontmatter:
+
+```
+---
+title: Document Title
+tags: [tag1, tag2]
+date: YYYY-MM-DD
+project: Project Name
+purpose: Brief description
+---
+```
+
+| Field | Status | Cap |
+|---|---|---|
+| `title` | req | ≤40 |
+| `tags` | req (YAML list; `[]` ok) | — |
+| `date` | opt | `YYYY-MM-DD` |
+| `project` | opt | ≤40 |
+| `purpose` | opt | ≤40 |
+
+`date`/`project`/`purpose` → footer meta cards. **`./sc render` injects
+`feature`, `roadmap_status`, `frozen`, `rendered_by`, `source` on top of these
+— don't write those yourself.** Never use comma-separated tags (`tags: a, b`);
+always a YAML list.
+
+## Structure
+
+| Syntax | Role | Cap |
+|---|---|---|
+| `# Title` | doc title (opt; falls back to `frontmatter.title`) | — |
+| `## Section` | sidebar tab | ≤28 |
+| `### Heading` | subsection → `<h3>` | ≤80 |
+
+H4–H6 ⛔.
+
+**Tab rule:** every H2 = one tab. Content between two H2s belongs to the first.
+Content between H1 and the first H2 is **silently dropped** — put intro under an
+H2 (e.g. "Overview"). Single-section docs may omit H2s (whole doc = one tab).
+
+**Doc scale:** the app renders every section up-front and re-renders every
+Mermaid on each tab switch. Aim for ≤25 sections and ≤15 Mermaid diagrams; split
+larger material.
+
+## Inline · lists · tables · images · code
+
+- Inline: `**bold**` · `*italic*` · `~~strike~~` · `` `code` `` · `[text](url)`
+- Lists: `-` unordered · `1.` ordered · `- [ ]` / `- [x]` tasks
+- Tables: standard GFM pipe tables
+- Images: `![alt](https://url/img.png)` — absolute URLs only, descriptive alt
+- Code: fenced with a language hint (```` ```python ````)
+
+## Color classes
+
+`class1`–`class4`, available on callouts, stat cards, mermaid nodes, and linear
+steps. **You choose which class fits each piece by meaning** — the theme decides
+the color. Keep one class per semantic role across the doc (e.g. `class1` =
+primary, `class2` = supporting, `class3` = positive/done, `class4` =
+caution/warning). Consistency > specific choice.
+
+## Callouts
+
+```
+> [!class1]
+> Callout content.
+```
+Cap ≤280 (one short paragraph). class1–class4.
+
+## Stat cards
+
+````
+```stats
+:::class1
+value: 87%
+label: User satisfaction
+description: Up 12% from last quarter
+:::class2
+value: 1.2M
+label: Active users
+```
+````
+
+| Field | Status | Cap | Notes |
+|---|---|---|---|
+| `value` | req | ≤12 | Short token: `87%`, `1.2M`. Not sentences. |
+| `label` | req | ≤28 | One short noun phrase. |
+| `description` | opt | one short line | Omit if no signal. |
+
+Layout: 2 per row; trailing odd card spans the row.
+
+## Mermaid
+
+````
+```mermaid
+graph LR
+  A[Start]:::class1 --> B[Middle]:::class2 --> C[End]:::class3
+```
+````
+
+Class via `:::classN` on nodes. The app injects `classDef` — **don't** write
+`classDef`, `fill:`, or any style directive. Node label cap ≤24 (Mermaid
+auto-sizes nodes; long labels balloon them).
+
+**Quote labels with special characters.** Unquoted node text is parsed as
+Mermaid grammar, not literal text. Any label containing `/`, `(`, `)`, `*`, `[`,
+`]`, `{`, `}`, `<`, `>`, `#`, `:`, `;`, or a quote **must** be wrapped in double
+quotes inside the brackets — otherwise the diagram throws *"Syntax error in
+text"* and renders nothing. Notably `A[/text/]` is the parallelogram shape, so a
+literal path like `/lease/mail/*` breaks unless quoted.
+
+```
+GOOD:  AD["/admin/user-credentials/"]:::class3
+       N["count > 0"]:::class2
+BAD:   AD[/admin/user-credentials/]      (parsed as a parallelogram shape → error)
+       N[count > 0]                      (> is a grammar token → error)
+```
+
+Cylinder/stadium shapes are fine as-is — `DB[(secrets.db)]`, `X([ready])` —
+quote only the inner *text*, not the shape brackets.
+
+## Linear
+
+````
+```linear
+Step 1 :::class1 -> Step 2 :::class2 -> Step 3 :::class3
+```
+````
+Steps separated by `->`, optional class via `:::classN`. Step text cap ≤24
+(fixed-size cards).
+
+## Never
+
+- H4–H6 · blockquotes (except callouts) · footnotes · raw HTML
+- Color / font / size / theme / visual mentions (the theme owns styling)
+- Content between H1 and the first H2 (silently dropped — use an H2)
+- Comma-separated `tags` (must be a YAML list)
+- `classDef` / `fill:` / style directives inside Mermaid
+- Unquoted Mermaid labels containing special characters

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -536,7 +536,162 @@ The GUI and the render layer both refuse edits to frozen docs.
 
 Open any doc rendered: the GUI''s "open in md-converter ↗" (Roadmap card or Docs
 tab) — the body rides in the URL, no upload. For long-form authoring, write the
-markdown to the `body` and let the render + md-converter handle presentation.',
+markdown to the `body` and let the render + md-converter handle presentation.
+
+---
+
+# Authoring format (themed-markdown)
+
+The `body` you write **is** themed-markdown — the format md-converter renders.
+**Your job is structure; styling is the renderer''s job.** Never write visual
+instructions (colors, fonts, sizes, themes). Apply the four semantic classes;
+the theme picks the actual colors.
+
+Use **only** the constructs below. Anything else either drops silently or breaks
+the render.
+
+`req` = required · `opt` = optional · `≤N` = soft character cap (over-cap wraps
+awkwardly or overflows a fixed UI slot).
+
+## Frontmatter
+
+Author these in the body''s frontmatter:
+
+```
+---
+title: Document Title
+tags: [tag1, tag2]
+date: YYYY-MM-DD
+project: Project Name
+purpose: Brief description
+---
+```
+
+| Field | Status | Cap |
+|---|---|---|
+| `title` | req | ≤40 |
+| `tags` | req (YAML list; `[]` ok) | — |
+| `date` | opt | `YYYY-MM-DD` |
+| `project` | opt | ≤40 |
+| `purpose` | opt | ≤40 |
+
+`date`/`project`/`purpose` → footer meta cards. **`./sc render` injects
+`feature`, `roadmap_status`, `frozen`, `rendered_by`, `source` on top of these
+— don''t write those yourself.** Never use comma-separated tags (`tags: a, b`);
+always a YAML list.
+
+## Structure
+
+| Syntax | Role | Cap |
+|---|---|---|
+| `# Title` | doc title (opt; falls back to `frontmatter.title`) | — |
+| `## Section` | sidebar tab | ≤28 |
+| `### Heading` | subsection → `<h3>` | ≤80 |
+
+H4–H6 ⛔.
+
+**Tab rule:** every H2 = one tab. Content between two H2s belongs to the first.
+Content between H1 and the first H2 is **silently dropped** — put intro under an
+H2 (e.g. "Overview"). Single-section docs may omit H2s (whole doc = one tab).
+
+**Doc scale:** the app renders every section up-front and re-renders every
+Mermaid on each tab switch. Aim for ≤25 sections and ≤15 Mermaid diagrams; split
+larger material.
+
+## Inline · lists · tables · images · code
+
+- Inline: `**bold**` · `*italic*` · `~~strike~~` · `` `code` `` · `[text](url)`
+- Lists: `-` unordered · `1.` ordered · `- [ ]` / `- [x]` tasks
+- Tables: standard GFM pipe tables
+- Images: `![alt](https://url/img.png)` — absolute URLs only, descriptive alt
+- Code: fenced with a language hint (```` ```python ````)
+
+## Color classes
+
+`class1`–`class4`, available on callouts, stat cards, mermaid nodes, and linear
+steps. **You choose which class fits each piece by meaning** — the theme decides
+the color. Keep one class per semantic role across the doc (e.g. `class1` =
+primary, `class2` = supporting, `class3` = positive/done, `class4` =
+caution/warning). Consistency > specific choice.
+
+## Callouts
+
+```
+> [!class1]
+> Callout content.
+```
+Cap ≤280 (one short paragraph). class1–class4.
+
+## Stat cards
+
+````
+```stats
+:::class1
+value: 87%
+label: User satisfaction
+description: Up 12% from last quarter
+:::class2
+value: 1.2M
+label: Active users
+```
+````
+
+| Field | Status | Cap | Notes |
+|---|---|---|---|
+| `value` | req | ≤12 | Short token: `87%`, `1.2M`. Not sentences. |
+| `label` | req | ≤28 | One short noun phrase. |
+| `description` | opt | one short line | Omit if no signal. |
+
+Layout: 2 per row; trailing odd card spans the row.
+
+## Mermaid
+
+````
+```mermaid
+graph LR
+  A[Start]:::class1 --> B[Middle]:::class2 --> C[End]:::class3
+```
+````
+
+Class via `:::classN` on nodes. The app injects `classDef` — **don''t** write
+`classDef`, `fill:`, or any style directive. Node label cap ≤24 (Mermaid
+auto-sizes nodes; long labels balloon them).
+
+**Quote labels with special characters.** Unquoted node text is parsed as
+Mermaid grammar, not literal text. Any label containing `/`, `(`, `)`, `*`, `[`,
+`]`, `{`, `}`, `<`, `>`, `#`, `:`, `;`, or a quote **must** be wrapped in double
+quotes inside the brackets — otherwise the diagram throws *"Syntax error in
+text"* and renders nothing. Notably `A[/text/]` is the parallelogram shape, so a
+literal path like `/lease/mail/*` breaks unless quoted.
+
+```
+GOOD:  AD["/admin/user-credentials/"]:::class3
+       N["count > 0"]:::class2
+BAD:   AD[/admin/user-credentials/]      (parsed as a parallelogram shape → error)
+       N[count > 0]                      (> is a grammar token → error)
+```
+
+Cylinder/stadium shapes are fine as-is — `DB[(secrets.db)]`, `X([ready])` —
+quote only the inner *text*, not the shape brackets.
+
+## Linear
+
+````
+```linear
+Step 1 :::class1 -> Step 2 :::class2 -> Step 3 :::class3
+```
+````
+Steps separated by `->`, optional class via `:::classN`. Step text cap ≤24
+(fixed-size cards).
+
+## Never
+
+- H4–H6 · blockquotes (except callouts) · footnotes · raw HTML
+- Color / font / size / theme / visual mentions (the theme owns styling)
+- Content between H1 and the first H2 (silently dropped — use an H2)
+- Comma-separated `tags` (must be a YAML list)
+- `classDef` / `fill:` / style directives inside Mermaid
+- Unquoted Mermaid labels containing special characters',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/skills_sc/docs.md
+++ b/skills_sc/docs.md
@@ -61,3 +61,158 @@ The GUI and the render layer both refuse edits to frozen docs.
 Open any doc rendered: the GUI's "open in md-converter ↗" (Roadmap card or Docs
 tab) — the body rides in the URL, no upload. For long-form authoring, write the
 markdown to the `body` and let the render + md-converter handle presentation.
+
+---
+
+# Authoring format (themed-markdown)
+
+The `body` you write **is** themed-markdown — the format md-converter renders.
+**Your job is structure; styling is the renderer's job.** Never write visual
+instructions (colors, fonts, sizes, themes). Apply the four semantic classes;
+the theme picks the actual colors.
+
+Use **only** the constructs below. Anything else either drops silently or breaks
+the render.
+
+`req` = required · `opt` = optional · `≤N` = soft character cap (over-cap wraps
+awkwardly or overflows a fixed UI slot).
+
+## Frontmatter
+
+Author these in the body's frontmatter:
+
+```
+---
+title: Document Title
+tags: [tag1, tag2]
+date: YYYY-MM-DD
+project: Project Name
+purpose: Brief description
+---
+```
+
+| Field | Status | Cap |
+|---|---|---|
+| `title` | req | ≤40 |
+| `tags` | req (YAML list; `[]` ok) | — |
+| `date` | opt | `YYYY-MM-DD` |
+| `project` | opt | ≤40 |
+| `purpose` | opt | ≤40 |
+
+`date`/`project`/`purpose` → footer meta cards. **`./sc render` injects
+`feature`, `roadmap_status`, `frozen`, `rendered_by`, `source` on top of these
+— don't write those yourself.** Never use comma-separated tags (`tags: a, b`);
+always a YAML list.
+
+## Structure
+
+| Syntax | Role | Cap |
+|---|---|---|
+| `# Title` | doc title (opt; falls back to `frontmatter.title`) | — |
+| `## Section` | sidebar tab | ≤28 |
+| `### Heading` | subsection → `<h3>` | ≤80 |
+
+H4–H6 ⛔.
+
+**Tab rule:** every H2 = one tab. Content between two H2s belongs to the first.
+Content between H1 and the first H2 is **silently dropped** — put intro under an
+H2 (e.g. "Overview"). Single-section docs may omit H2s (whole doc = one tab).
+
+**Doc scale:** the app renders every section up-front and re-renders every
+Mermaid on each tab switch. Aim for ≤25 sections and ≤15 Mermaid diagrams; split
+larger material.
+
+## Inline · lists · tables · images · code
+
+- Inline: `**bold**` · `*italic*` · `~~strike~~` · `` `code` `` · `[text](url)`
+- Lists: `-` unordered · `1.` ordered · `- [ ]` / `- [x]` tasks
+- Tables: standard GFM pipe tables
+- Images: `![alt](https://url/img.png)` — absolute URLs only, descriptive alt
+- Code: fenced with a language hint (```` ```python ````)
+
+## Color classes
+
+`class1`–`class4`, available on callouts, stat cards, mermaid nodes, and linear
+steps. **You choose which class fits each piece by meaning** — the theme decides
+the color. Keep one class per semantic role across the doc (e.g. `class1` =
+primary, `class2` = supporting, `class3` = positive/done, `class4` =
+caution/warning). Consistency > specific choice.
+
+## Callouts
+
+```
+> [!class1]
+> Callout content.
+```
+Cap ≤280 (one short paragraph). class1–class4.
+
+## Stat cards
+
+````
+```stats
+:::class1
+value: 87%
+label: User satisfaction
+description: Up 12% from last quarter
+:::class2
+value: 1.2M
+label: Active users
+```
+````
+
+| Field | Status | Cap | Notes |
+|---|---|---|---|
+| `value` | req | ≤12 | Short token: `87%`, `1.2M`. Not sentences. |
+| `label` | req | ≤28 | One short noun phrase. |
+| `description` | opt | one short line | Omit if no signal. |
+
+Layout: 2 per row; trailing odd card spans the row.
+
+## Mermaid
+
+````
+```mermaid
+graph LR
+  A[Start]:::class1 --> B[Middle]:::class2 --> C[End]:::class3
+```
+````
+
+Class via `:::classN` on nodes. The app injects `classDef` — **don't** write
+`classDef`, `fill:`, or any style directive. Node label cap ≤24 (Mermaid
+auto-sizes nodes; long labels balloon them).
+
+**Quote labels with special characters.** Unquoted node text is parsed as
+Mermaid grammar, not literal text. Any label containing `/`, `(`, `)`, `*`, `[`,
+`]`, `{`, `}`, `<`, `>`, `#`, `:`, `;`, or a quote **must** be wrapped in double
+quotes inside the brackets — otherwise the diagram throws *"Syntax error in
+text"* and renders nothing. Notably `A[/text/]` is the parallelogram shape, so a
+literal path like `/lease/mail/*` breaks unless quoted.
+
+```
+GOOD:  AD["/admin/user-credentials/"]:::class3
+       N["count > 0"]:::class2
+BAD:   AD[/admin/user-credentials/]      (parsed as a parallelogram shape → error)
+       N[count > 0]                      (> is a grammar token → error)
+```
+
+Cylinder/stadium shapes are fine as-is — `DB[(secrets.db)]`, `X([ready])` —
+quote only the inner *text*, not the shape brackets.
+
+## Linear
+
+````
+```linear
+Step 1 :::class1 -> Step 2 :::class2 -> Step 3 :::class3
+```
+````
+Steps separated by `->`, optional class via `:::classN`. Step text cap ≤24
+(fixed-size cards).
+
+## Never
+
+- H4–H6 · blockquotes (except callouts) · footnotes · raw HTML
+- Color / font / size / theme / visual mentions (the theme owns styling)
+- Content between H1 and the first H2 (silently dropped — use an H2)
+- Comma-separated `tags` (must be a YAML list)
+- `classDef` / `fill:` / style directives inside Mermaid
+- Unquoted Mermaid labels containing special characters


### PR DESCRIPTION
## Why

The `docs` skill covered the document **lifecycle** (DB-owned bodies, `./sc render`, freeze-on-ship) but said nothing about the **format** of the body it produces — even though every body renders through md-converter. Authoring shells were writing themed-markdown constructs (frontmatter, callouts, stat cards, mermaid with `:::class` nodes) with no guidance, so format traps surfaced only at render time.

The trigger: Mermaid node labels containing special characters — literal URL paths like `/lease/mail/*` — parse as **shape syntax** (`A[/text/]` is a parallelogram), throw *"Syntax error in text"*, and render nothing. Several dos-arch specs (mail-sync, calendar-sync, credential-custody-lease, mail-calendar-sync) hit exactly this.

## What

Port the full **themed-markdown** contract into the `docs` skill as an "Authoring format" section:

- Frontmatter — reconciled with the engine's render-injected `feature`/`roadmap_status`/`frozen`/`rendered_by`/`source` fields (author writes `title`/`tags`/`date`/`project`/`purpose`; engine injects the rest)
- H2-as-tabs structure, `###` subsections, no H4–H6, tab/drop rules, doc-scale caps
- `class1`–`class4` semantic color classes
- Callouts, stat cards, **mermaid** (with an explicit label-quoting rule + good/bad examples), linear diagrams
- The "Never" list

Regenerated the seed migration (`0001_seed_skills.sql`, id-stable UPSERT) and the flat `skills_sc/docs.md`.

## Propagation

Forks pick this up via `./sc update` (step 4 re-runs the seed against the live DB — no rebuild). dos-arch will pull it off this branch in a paired change.

## Files
- `.super-coder/assets/skills/docs/SKILL.md` — source
- `.super-coder/migrations/0001_seed_skills.sql` — regenerated seed
- `skills_sc/docs.md` — flat render

🤖 Generated with [Claude Code](https://claude.com/claude-code)