### PR TITLE
feat(sandbox): bake node LTS + publish a per-fork dev-server port

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -1,9 +1,11 @@
 # super-coder sandbox image — the *environment*, not the code.
 #
 # The repo is bind-mounted at runtime (see `./sc launch`); this image carries
-# only what the harness needs to run: python3 + sqlite3, git/curl, and the two
+# what the harness needs to run: python3 + sqlite3, git/curl, gh, and the two
 # harness CLIs baked in via their official native installers (the same ones
 # install.py uses — keep the URLs in sync with scripts/install.py HARNESS_INSTALL).
+# It also carries the common *project* runtimes a forked repo's dev surface needs
+# (node LTS), so `npm`/dev servers work without an ephemeral in-container install.
 #
 # Why bake the binaries but mount the creds: claude installs as a symlink into
 # ~/.local/share/claude/versions/<v> (awkward to bind-mount); opencode is a fat
@@ -36,6 +38,17 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
       > /etc/apt/sources.list.d/github-cli.list \
  && apt-get update && apt-get install -y --no-install-recommends gh \
+ && rm -rf /var/lib/apt/lists/*
+
+# Node.js LTS — a *project* runtime, not a harness dep. Forked repos increasingly
+# ship a JS/TS dev surface (vite/SvelteKit/etc); without node baked in, a shell
+# can run `npm` only by installing into the ephemeral container FS, which
+# evaporates on the next rebuild. Baked here it persists like python3. The
+# "no npm" note on the harness install below still holds — that's about how
+# claude/opencode get installed, not a ban on node for project work. NodeSource's
+# apt repo pins a clean LTS major (same pipe-to-bash idiom as the installers).
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/*
 
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.

--- a/.super-coder/scripts/ports.py
+++ b/.super-coder/scripts/ports.py
@@ -9,16 +9,21 @@ in a distinctive band well clear of the neighbors:
     port = 8800 + offset     (away from superCC 8000 / dos-arch 8001, and the
                               common host-app ports 3000 / 5173 / 8080)
 
-v1 runs a single server that serves both the JSON API and the static review UI
-on this one port — one port per fork, not two. The resolved port is persisted to
-`.super-coder/instance.json` (gitignored — per-instance, local, like the `.db`)
-so it stays stable across restarts and can be hand-overridden. At resolve time an
-occupied port is bumped to the next free offset and persisted, so a hash clash or
-busy port self-heals once.
+The substrate's own server (JSON API + static review UI) runs on `port`. A
+second `dev_port` is derived the same way for a *project* dev server (vite/etc)
+the shell starts inside the sandbox — `./sc launch` publishes both, and the
+shell binds its dev server to 0.0.0.0:dev_port so the host browser can reach it.
+Both are persisted to `.super-coder/instance.json` (gitignored — per-instance,
+local, like the `.db`) so they stay stable across restarts and can be
+hand-overridden. At resolve time an occupied port is bumped to the next free
+offset (and dev_port is kept distinct from port), so a hash clash or busy port
+self-heals once.
 
 Usage:
     python3 .super-coder/scripts/ports.py show     # print resolved ports (JSON)
     python3 .super-coder/scripts/ports.py ensure    # resolve + persist instance.json
+    python3 .super-coder/scripts/ports.py port      # bare serve port
+    python3 .super-coder/scripts/ports.py devport    # bare dev-server port
 """
 from __future__ import annotations
 
@@ -50,17 +55,26 @@ def _free(port: int) -> bool:
             return False
 
 
-def _derive() -> dict:
-    """Derive a fresh port from the repo path, bumping the offset past any
-    occupied port so it lands free."""
-    base = _offset(str(REPO_ROOT))
+def _resolve_offset(base: int, avoid: set[int]) -> int:
+    """Walk forward from a base offset to the first free port not in `avoid`."""
     for i in range(SPAN):
         port = PORT_BASE + (base + i) % SPAN
-        if _free(port):
-            break
-    else:  # pragma: no cover — all 100 offsets busy is implausible
-        port = PORT_BASE + base
-    return {"repo": REPO_ROOT.name, "port": port, "harness": "claude"}
+        if port not in avoid and _free(port):
+            return port
+    return PORT_BASE + base  # pragma: no cover — all 100 offsets busy is implausible
+
+
+def _dev_offset(port: int) -> int:
+    """Derive a dev port from a distinct seed, kept free and != the serve port."""
+    return _resolve_offset(_offset(str(REPO_ROOT) + ":dev"), avoid={port})
+
+
+def _derive() -> dict:
+    """Derive serve + dev ports from the repo path. Each is bumped past any
+    occupied port so it lands free, and dev_port is kept distinct from port."""
+    port = _resolve_offset(_offset(str(REPO_ROOT)), avoid=set())
+    return {"repo": REPO_ROOT.name, "port": port,
+            "dev_port": _dev_offset(port), "harness": "claude"}
 
 
 def resolve(persist: bool = False) -> dict:
@@ -68,14 +82,20 @@ def resolve(persist: bool = False) -> dict:
     edits) and is returned verbatim; otherwise derive a free port from the repo
     path. `persist=True` writes it to instance.json so it stays stable. To force
     a re-derive (e.g. after a port clash), delete the file."""
+    cfg = None
     if CONFIG.exists():
         try:
-            cfg = json.loads(CONFIG.read_text())
-            if "port" in cfg:
-                return cfg
+            loaded = json.loads(CONFIG.read_text())
+            if "port" in loaded:
+                cfg = loaded
         except json.JSONDecodeError:
             pass
-    cfg = _derive()
+    if cfg is None:
+        cfg = _derive()
+    elif "dev_port" not in cfg:
+        # Instance predates dev_port — backfill without disturbing the serve port
+        # (respects hand-edits to `port`); persisted below if requested.
+        cfg["dev_port"] = _dev_offset(cfg["port"])
     if persist:
         CONFIG.write_text(json.dumps(cfg, indent=2) + "\n")
     return cfg
@@ -89,10 +109,12 @@ def main(argv: list[str]) -> int:
         print(json.dumps(resolve(persist=False)))
     elif mode == "port":          # bare integer, for shell/sc use
         print(resolve(persist=False)["port"])
+    elif mode == "devport":       # bare dev-server port, for shell/sc use
+        print(resolve(persist=False)["dev_port"])
     elif mode == "name":          # pm2 process name — unique per fork
         print("sc-" + resolve(persist=False).get("repo", "fork"))
     else:
-        sys.exit("usage: ports.py [show|ensure|port|name]")
+        sys.exit("usage: ports.py [show|ensure|port|devport|name]")
     return 0
 
 

--- a/sc
+++ b/sc
@@ -14,6 +14,7 @@ DB="$ENGINE/shell_db.db"
 S="$ENGINE/scripts"
 
 port() { "$PY" "$S/ports.py" port; }
+devport() { "$PY" "$S/ports.py" devport; }
 
 # Host-side docker orchestration (raw docker — no compose plugin dependency).
 # The sandbox runs as you (uid/gid → no root-owned files), bind-mounts this repo
@@ -89,6 +90,7 @@ case "$cmd" in
     dcreds
     "$PY" "$S/ports.py" ensure >/dev/null
     p="$(port)"
+    dp="$(devport)"
     dbuild
     # Forward GitHub auth for the in-container push/PR path (GUI publish + shells
     # opening their own PRs). Prefer a repo-scoped SC_GH_TOKEN; else reuse the
@@ -102,7 +104,7 @@ case "$cmd" in
     docker run -d --name "$CNAME" --restart unless-stopped \
       --user "$(duser)" \
       -e HOME="$HOME" -e SC_BIND=0.0.0.0 -e SC_PYTHON=python3 -e PYTHONUNBUFFERED=1 \
-      -e SC_SANDBOX=1 \
+      -e SC_SANDBOX=1 -e SC_DEV_PORT="$dp" \
       -e GH_TOKEN="$gh_token" \
       -e GIT_AUTHOR_NAME="$git_name" -e GIT_AUTHOR_EMAIL="$git_email" \
       -e GIT_COMMITTER_NAME="$git_name" -e GIT_COMMITTER_EMAIL="$git_email" \
@@ -113,8 +115,10 @@ case "$cmd" in
       -v "$HOME/.config/opencode:$HOME/.config/opencode" \
       -v "$HOME/.local/share/opencode:$HOME/.local/share/opencode" \
       -p "127.0.0.1:$p:$p" \
+      -p "127.0.0.1:$dp:$dp" \
       "$IMG" ./sc serve --port "$p" >/dev/null
     echo "→ sandbox up · review GUI at http://127.0.0.1:$p"
+    echo "  dev server:    bind 0.0.0.0:$dp inside (\$SC_DEV_PORT) → http://127.0.0.1:$dp"
     echo "  boot a shell:  ./sc enter   (or ./sc enter-<shortname>)" ;;
   enter)        exec docker exec -it "$CNAME" ./sc boot "$@" ;;
   enter-*)      exec docker exec -it "$CNAME" ./sc boot "${cmd#enter-}" "$@" ;;


### PR DESCRIPTION
## Why

The sandbox image carried only what the **harness** needs (python3, sqlite3, git, gh, claude/opencode). But forked repos increasingly ship a JS/TS dev surface (vite/SvelteKit/etc), so shells hit `npm: not found` — and could only `npm install` into the **ephemeral container FS, which evaporates on the next rebuild**. This bakes node in so it persists, and publishes a reachable dev-server port so a shell's `npm run dev` is actually viewable from the host browser.

## Changes

- **Dockerfile** — Node 22 LTS via NodeSource in the root apt phase, as a *project* runtime (peer to python3, not a harness dep). The harness "no npm" note is untouched — that's about how claude/opencode install, not a ban on node for project work.
- **ports.py** — derive a second `dev_port` from a `:dev`-salted seed in the same 8800–8899 band, kept free and **distinct** from the serve port. Backfills pre-existing `instance.json` without disturbing the persisted serve port. New `devport` CLI verb.
- **sc** — `launch` publishes `-p 127.0.0.1:$dev_port:$dev_port` and passes `SC_DEV_PORT`, so a shell runs `vite --host 0.0.0.0 --port $SC_DEV_PORT` and the host reaches it at `http://127.0.0.1:<dev_port>`. One dev server per fork, collision-free (hashed per repo path like the serve port).

## Verification

- Image builds clean; inside it: `node v22.22.3`, `npm 10.9.8`, running as the host uid; `claude` + `python3` intact.
- `ports.py` emits distinct in-band serve/dev ports (`8800` / `8805` for this repo) and backfills on read.

## Propagation

Forks (e.g. dos-arch) inherit this via `./sc update` + an image rebuild (`./sc build` / next `launch`). Canonical-source change on purpose — patching a fork's `.super-coder/` copy alone would leave the next clone node-less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)