### PR TITLE
docs(boot): add RUNNING THE APP guardrail — dev servers vs supervised host stack

### DIFF
--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -42,3 +42,18 @@ shell, `--message send <shortname> <body>`; mark an item read with
 `--message mark-read <id>` once you've acted on it.
 
 ---
+
+## RUNNING THE APP
+
+Two runtimes, two homes — keep them apart:
+
+- **Project dev servers** (vite, `npm run dev`, etc.) belong in the **sandbox**,
+  bound to `0.0.0.0:$SC_DEV_PORT` — the per-fork port `./sc launch` publishes to
+  the host for exactly this. Reach it at `http://127.0.0.1:$SC_DEV_PORT`.
+- **A process-supervised host stack** (pm2 / `make`) is owned by its supervisor.
+  Start/stop/restart only through it (`make up`, `make restart`) — never a bare
+  `vite dev` / `npm run dev` on the host. A hand-run dev server races the
+  supervised process for its port, fails to bind, and orphans — taking the app
+  down.
+
+---


### PR DESCRIPTION
## Why

Follow-up to #42. Now that the sandbox bakes node + publishes `$SC_DEV_PORT`, a shell can run a bare `vite dev` / `npm run dev` **on the host** — which races a pm2/`make`-supervised UI for its port, fails to bind, and leaves an orphan that takes the app down. This exact thing happened on dos-arch (a shell knocked over pm2 supervision and orphaned a manual vite on 5174). This turns the foot-gun into a boot-time rule.

## What

New static `## RUNNING THE APP` section in `templates/boot.md`:

- **Project dev servers** → the **sandbox**, bound to `0.0.0.0:$SC_DEV_PORT` (the port `./sc launch` publishes for exactly this).
- **A process-supervised host stack** (pm2 / `make`) → driven only through its supervisor (`make up`/`make restart`), never a bare dev server on the host.

`boot.md` renders into every fork's `AGENTS.md`/`CLAUDE.md`, so it's **always on the boot load path** — the right altitude for *prevention* (a skill is lazy-loaded; a shell about to run `vite dev` won't have invoked it). Kept **fork-agnostic** — no dos-arch specifics (`make up`, 5174, the app list); those live in each fork's Makefile.

## Verification

`compose_boot()` renders the section cleanly with `$SC_DEV_PORT` left literal (guidance, not interpolated).

## Propagation

Forks inherit via `./sc update` + the launch re-render of the boot artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)