### PR TITLE
feat(boot): fold repo-map orientation into boot head, trim roadmap

### DIFF
--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Compose the boot artifact from live DB state.
 
-Pure render: reads the chosen shell's identity, memory, projects, roadmap, and
-skills out of the DB and assembles one markdown document. The launcher
+Pure render: reads the chosen shell's identity, memory, projects, and skills
+out of the DB and assembles one markdown document. The launcher
 (`scripts/run.py`) dual-writes the result to `CLAUDE.md` + `AGENTS.md` at the
 repo root — one compose, two outputs, consumed natively by Claude Code and the
 AGENTS.md-reading harnesses (OpenCode, Goose, Crush).
@@ -81,47 +81,6 @@ def render_projects(con, shell_id: int) -> str:
         role = f" ({r['role']})" if r["role"] else ""
         lines.append(f"- {r['shortname']}{role}: {r['purpose'] or '(no purpose set)'}")
     return "\n".join(lines)
-
-
-# Funnel order: idea inlet → most-active committed work → done (shipped,
-# summarized) → taken-off-the-board (retired).
-_ROADMAP_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped", "retired"]
-_ROADMAP_LABEL = {
-    "brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Next",
-    "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped",
-    "retired": "Retired",
-}
-
-
-def render_roadmap(con, shell_id: int) -> str:
-    """Compact roadmap index for the boot doc. Features owned by this shell are
-    marked; the DB is the index, so the shell sees what's planned at a glance.
-    Shipped features are summarized as a count, not enumerated."""
-    rows = con.execute(
-        "SELECT feature_id, title, roadmap_status, owning_shell, sort_order "
-        "FROM roadmap ORDER BY sort_order, feature_id"
-    ).fetchall()
-    if not rows:
-        return "(none)"
-    buckets: dict[str, list] = {}
-    shipped = 0
-    for r in rows:
-        if r["roadmap_status"] == "shipped":
-            shipped += 1
-            continue
-        buckets.setdefault(r["roadmap_status"], []).append(r)
-    parts = []
-    for status in _ROADMAP_ORDER:
-        if status not in buckets:
-            continue
-        parts.append(f"**{_ROADMAP_LABEL[status]}**")
-        for r in buckets[status]:
-            mine = " · *mine*" if r["owning_shell"] == shell_id else ""
-            parts.append(f"- {r['title']}{mine}")
-        parts.append("")
-    if shipped:
-        parts.append(f"_{shipped} shipped._")
-    return "\n".join(parts).rstrip() or "(none)"
 
 
 def render_connections(con, shell) -> str:
@@ -265,6 +224,8 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
         "", "---", "",
         "## SYSTEM PROMPT", "", system_prompt,
         "", "---", "",
+        "## CONNECTIONS", "", render_connections(con, shell),
+        "", "---", "",
         "## CURRENT STATE", "", current_state,
         "", "---", "",
         "## SEED", "", render_seed(con, shell_id),
@@ -272,10 +233,6 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
         "## LESSONS & STANCES", "", render_lns(con, shell_id),
         "", "---", "",
         "## ACTIVE PROJECTS", "", render_projects(con, shell_id),
-        "", "---", "",
-        "## CONNECTIONS", "", render_connections(con, shell),
-        "", "---", "",
-        "## ROADMAP", "", render_roadmap(con, shell_id),
         "", "---", "",
         "## SKILLS", "", render_skills(con, shell_id),
         "", "---", "",

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -33,6 +33,44 @@ any per-shell prompt loads, before any query runs.
 
 ---
 
+## ORIENTATION
+
+Find things by querying the repo map — not by reading or grepping the tree. The
+`dr_*` tables are a scan of this repo, kept fresh for you (a cartographer shell
+owns and heals them; you read, you don't map), in `.super-coder/shell_db.db`
+(SQLite):
+
+| Table | Holds |
+|---|---|
+| `dr_section` | navigation index — `name`, `path_prefix`, `description` ("API here / UI here / docs here"). **Start here.** |
+| `dr_filepath` | one row per file — `path`, `lang`, `role` (code/doc/config/test/asset/env), `lines`, `desc` |
+| `dr_dependency` | deps from manifests — `manager`, `name`, `version` |
+| `dr_env` | env-var names from `.env.*` examples — `name`, `source_file` |
+| `dr_repo` | the repo — `root`, `default_branch`, `file_count`, `mapped_at` |
+
+Flow: pick a section → query that section's leaves → read the one or two files
+you need. Section-first, one cheap query deep — never a full preload.
+
+```
+# where to start (also rendered in ## CONNECTIONS below):
+sqlite3 .super-coder/shell_db.db \
+  "SELECT name, path_prefix, description FROM dr_section ORDER BY sort_order, name;"
+# a section's files — descriptions tell you which to open:
+sqlite3 .super-coder/shell_db.db \
+  "SELECT path, desc, lines FROM dr_filepath WHERE path LIKE '<prefix>%' ORDER BY path;"
+# find by area / stack / env:
+sqlite3 .super-coder/shell_db.db "SELECT path FROM dr_filepath WHERE path LIKE '%auth%';"
+sqlite3 .super-coder/shell_db.db "SELECT manager, name, version FROM dr_dependency;"
+```
+
+Map first, grep second; lazy-load only what the map points at. If the map looks
+empty, stale, or wrong, that's a cartographer task — flag it, don't map it
+yourself. Extended patterns (language mix, role filters) live in the
+`surface_catalogue` skill. Before writing SQL against your memory DB, check the
+`db_map` skill — don't read `schema.sql` raw.
+
+---
+
 ## MESSAGING
 
 Shells coordinate through an inbox. On boot, if the `## STATUS` `Inbox:` line is


### PR DESCRIPTION
## Why

Analysis of the opencode chat-history DB (46 dos-arch sessions) showed coding shells exploring by raw `read`/`grep`/`glob` instead of querying the `dr_*` catalogue — `schema.sql` read **49×** vs the `db_map` skill **3×**, `surface_catalogue` **2×** against ~1,300 raw exploration calls. The catalogue-first steer existed only as a soft one-liner pointing at a lazy skill the weaker models never opened. (The dominant cost levers — zero-caching models, `parallel_tool_calls: false` — are separate; this addresses the system-prompt lever.)

## What

- **`boot.md`** — new always-loaded `## ORIENTATION` block (below LAWS): the `dr_*` table map, the DB path, the section-first flow, starter `sqlite3` queries, the cartographer boundary, and the `db_map` / don't-read-`schema.sql`-raw pointer. Repo navigation is now in the boot head, not behind a skill the model has to choose to open.
- **`compose.py`** — `## CONNECTIONS` moved up to right after SYSTEM PROMPT (next to the navigation directive); `## ROADMAP` block removed (+ `render_roadmap` and its label/order dicts) — the roadmap lives in the `roadmap` table and is pulled on demand via `db_map`, not re-sent every turn.

Final order: `SYSTEM OVERRIDE → LAWS → ORIENTATION → MESSAGING → RUNNING THE APP → … → SYSTEM PROMPT → CONNECTIONS → CURRENT STATE → …`

## Net effect

Adds ~30 stable lines once; claws back a roadmap block that grew with every planned feature. Near-free on caching models, a real per-turn saving on the non-caching ones.

## Follow-up (not in this PR)

`surface_catalogue` skill should be trimmed to the extended reference (the basics now live in ORIENTATION) — that's a DB content edit (`skills` table + `./sc snapshot`), done separately. Until then there's mild, harmless duplication.

## Test plan

- [x] `compose_boot` renders against a live DB; section order verified, ORIENTATION present with `dr_*` queries, ROADMAP absent, markdown fences balanced.
- [ ] Confirm on a real `./sc launch` once merged + propagated via `self_update`.