### PR TITLE
feat(launch): per-flavor harness + model launch defaults

### DIFF
--- a/.super-coder/migrations/0006_flavor_defaults.sql
+++ b/.super-coder/migrations/0006_flavor_defaults.sql
@@ -1,0 +1,29 @@
+-- 0006 — per-flavor launch defaults (harness + model)
+--
+-- Adds flavor_defaults and seeds the alpha team's roles. Idempotent and
+-- converges with schema.sql on rebuild (CREATE … IF NOT EXISTS; INSERT OR
+-- IGNORE), matching the 0002–0005 precedent. ADVISORY ONLY: run.py uses these
+-- to set the launch default and annotate the picker, but --harness / -m / the
+-- picker override them. model is harness-specific (opencode "provider/model");
+-- NULL lets the harness pick its own (the claude harness manages its model).
+--
+-- Doctrine (see shell_decisions, CC home DB): middle roles (dev, cartographer)
+-- = a cheap, caching, coding-tuned model; bookends (planner, reviewer) =
+-- premium, with the reviewer on a different lineage (claude) for adversarial
+-- diversity against GPT-authored code. Retune with UPDATE as trial data lands.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS flavor_defaults (
+    flavor   TEXT PRIMARY KEY,
+    harness  TEXT NOT NULL,
+    model    TEXT
+);
+
+INSERT OR IGNORE INTO flavor_defaults (flavor, harness, model) VALUES
+    ('dev',          'opencode', 'openai/gpt-5.1-codex-mini'),
+    ('cartographer', 'opencode', 'openai/gpt-5.1-codex-mini'),
+    ('planner',      'opencode', 'openai/gpt-5.5'),
+    ('reviewer',     'claude',   NULL);
+
+COMMIT;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -48,7 +48,7 @@ CREATE TABLE shells (
     workspace         TEXT,                          -- RETIRED (B5): superseded by connections; unrendered, unauthored, kept to avoid a table rebuild
 
     lineage_seed      TEXT,
-    flavor            TEXT,                          -- planning / dev / review (NULL = bespoke, e.g. maintainer)
+    flavor            TEXT,                          -- dev / planner / reviewer / cartographer (NULL = bespoke, e.g. maintainer); launch defaults in flavor_defaults
     has_identity      INTEGER NOT NULL DEFAULT 0,
     bootstrapped      INTEGER NOT NULL DEFAULT 0,   -- 1 once the shell has run first-run orientation
 
@@ -72,6 +72,17 @@ WHEN NEW.flavor = 'cartographer' AND (
 BEGIN
   SELECT RAISE(ABORT, 'cartographer is a singleton — this fork already has one');
 END;
+
+-- Per-flavor launch defaults: the harness + model a shell of this flavor boots
+-- with. ADVISORY ONLY — overridable per launch (--harness / -m / the picker);
+-- run.py reads these to set the default and annotate the picker. model is
+-- harness-specific (opencode "provider/model"); NULL = let the harness pick its
+-- own (e.g. the claude harness). Seeded in migrations/0006.
+CREATE TABLE flavor_defaults (
+    flavor   TEXT PRIMARY KEY,
+    harness  TEXT NOT NULL,
+    model    TEXT
+);
 
 CREATE TABLE shell_memory_archives (
     archive_id     INTEGER PRIMARY KEY,

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -232,15 +232,38 @@ def authenticate(con: sqlite3.Connection) -> sqlite3.Row:
 
 def list_shells(con: sqlite3.Connection, user_id: int) -> list[sqlite3.Row]:
     return con.execute(
-        "SELECT shell_id, display_name, shortname, mandate, is_shared FROM shells "
+        "SELECT shell_id, display_name, shortname, mandate, is_shared, flavor FROM shells "
         "WHERE (user_id=? OR is_shared=1) AND COALESCE(is_deleted,0)=0 "
         "ORDER BY is_shared, shell_id",
         (user_id,),
     ).fetchall()
 
 
+def flavor_defaults(con: sqlite3.Connection) -> dict:
+    """flavor -> {'harness', 'model'} launch defaults. Empty if the table is
+    absent (older fork mid-migration) so the launcher degrades to its prior
+    behavior rather than failing."""
+    try:
+        return {r["flavor"]: r for r in
+                con.execute("SELECT flavor, harness, model FROM flavor_defaults")}
+    except sqlite3.OperationalError:
+        return {}
+
+
+def _default_label(defaults: dict, flavor: str | None) -> str:
+    """Picker annotation: the harness (+ short model id) a shell of this flavor
+    boots with by default, so the operator knows which harness to launch if they
+    forget. Blank for bespoke shells with no flavor default."""
+    fd = defaults.get(flavor)
+    if not fd or not fd["harness"]:
+        return ""
+    model = fd["model"]
+    return fd["harness"] + (f" · {model.split('/')[-1]}" if model else "")
+
+
 def pick_shell(shells: list[sqlite3.Row], requested: str | None,
-               first: bool) -> sqlite3.Row:
+               first: bool, defaults: dict | None = None) -> sqlite3.Row:
+    defaults = defaults or {}
     if not shells:
         sys.exit("FATAL: no shells available to this user.")
     if requested:
@@ -253,11 +276,12 @@ def pick_shell(shells: list[sqlite3.Row], requested: str | None,
         return chosen
     if first or not sys.stdin.isatty():
         return shells[0]
-    # Interactive picker
-    print(f"\n{'ID':>3}  {'Name':<16}{'Shortname':<14}")
+    # Interactive picker — the Default column tells the operator the intended
+    # harness/model (advisory; overridable at launch).
+    print(f"\n{'ID':>3}  {'Name':<16}{'Shortname':<14}{'Default (harness · model)'}")
     for s in shells:
         print(f"{s['shell_id']:>3}  {(s['display_name'] or ''):<16}"
-              f"{(s['shortname'] or ''):<14}")
+              f"{(s['shortname'] or ''):<14}{_default_label(defaults, s['flavor'])}")
     valid = {s["shell_id"] for s in shells}
     while True:
         choice = input("\nPick (ID): ").strip()
@@ -340,16 +364,24 @@ def main() -> None:
 
     con = open_db()
     user = authenticate(con)
-    chosen = pick_shell(list_shells(con, user["user_id"]), requested, first)
+    fdefaults = flavor_defaults(con)
+    chosen = pick_shell(list_shells(con, user["user_id"]), requested, first, fdefaults)
+
+    # This shell's flavor default (advisory): the harness it boots with and, for
+    # opencode, the model to pre-select. Both are overridable below — the flavor
+    # default only sets the fallback, never a lock.
+    fdef = fdefaults.get(chosen["flavor"])
+    flavor_harness = fdef["harness"] if fdef else None
+    flavor_model = fdef["model"] if fdef else None
 
     # Harness pick, right after the shell pick: an explicit --harness / HARNESS
     # override wins silently; otherwise offer the harnesses on PATH when more
     # than one is present (per-launch, never persisted), falling back to this
-    # fork's instance.json value / 'claude' when nothing is detected. Fold the
-    # installer bin dirs onto PATH first so detection sees an installed-but-not-
-    # yet-on-PATH harness (e.g. opencode in ~/.opencode/bin).
+    # shell's flavor default, then the fork's instance.json value / 'claude'.
+    # Fold the installer bin dirs onto PATH first so detection sees an installed-
+    # but-not-yet-on-PATH harness (e.g. opencode in ~/.opencode/bin).
     ensure_harness_path()
-    default_harness = _configured_harness() or "claude"
+    default_harness = flavor_harness or _configured_harness() or "claude"
     harness = (flag_harness or os.environ.get("HARNESS")
                or pick_harness(detect_harnesses(), default_harness, first)
                or default_harness)
@@ -387,6 +419,22 @@ def main() -> None:
     print(f"→ harness: {harness} (reads {adapter.get('boot_artifact', 'AGENTS.md')})")
     if emitted:
         print(f"→ emitted {', '.join(emitted)}")
+
+    # Flavor model default: pre-select the model in the emitted opencode.json so
+    # the operator boots straight into the intended model. opencode-specific (the
+    # only emitted config with a model field); a NULL flavor model, or a harness
+    # that doesn't emit opencode.json (e.g. claude), skips this. Still overridable
+    # in-session / via `-m`.
+    if flavor_model and "opencode.json" in (adapter.get("emit") or []):
+        ocfg = REPO_ROOT / "opencode.json"
+        if ocfg.exists():
+            try:
+                cfg = json.loads(ocfg.read_text())
+            except (json.JSONDecodeError, OSError):
+                cfg = {}
+            cfg["model"] = flavor_model
+            atomic_write(ocfg, json.dumps(cfg, indent=2) + "\n")
+            print(f"→ model: {flavor_model} (flavor default for {chosen['flavor']})")
     sandboxed = apply_sandbox(adapter)
     if sandboxed:
         print(f"→ sandbox: allow-all permissions → {', '.join(sandboxed)}")


### PR DESCRIPTION
## Why

Coding shells split into two cost/quality regimes (from the opencode token analysis): high-volume mechanical roles (dev, cartographer) want a cheap, caching, coding-tuned model; low-volume judgment roles (planner, reviewer) want premium — and the reviewer wants a *different lineage* than the GPT dev so it doesn't share blind spots when reviewing GPT-authored code. This encodes that as per-flavor launch defaults instead of leaving model/harness choice to chance at every launch.

## What

- **`schema.sql`** — new `flavor_defaults(flavor, harness, model)` table; `shells.flavor` comment canonicalized to `dev / planner / reviewer / cartographer`.
- **`migrations/0006`** — seeds the alpha team's defaults; idempotent and converges with `schema.sql` on rebuild (the 0005 precedent):

  | flavor | harness | model |
  |---|---|---|
  | dev | opencode | `openai/gpt-5.1-codex-mini` |
  | cartographer | opencode | `openai/gpt-5.1-codex-mini` |
  | planner | opencode | `openai/gpt-5.5` |
  | reviewer | claude | *(harness picks)* |

- **`run.py`** — the booting shell's flavor sets the **default harness** (overridable by `--harness` / `HARNESS` / the picker) and, for opencode, **pre-selects the model** in the emitted `opencode.json` (overridable by `-m` / in-session). The picker gains a `Default (harness · model)` column so the operator knows the intended harness if they forget.

## Design notes

- **Advisory, never a lock.** Every default is overridable per launch. Boot a coder into opencode → codex-mini pre-selected but changeable; boot it into Claude Code instead → the model default simply doesn't apply.
- **A table, not a dict** — models will get retuned as the Kimi/codex-mini trial data lands; that's an `UPDATE`, not a code edit.
- Degrades gracefully: a fork mid-migration without `flavor_defaults`, or a bespoke/NULL-flavor shell (e.g. maintainer), behaves exactly as before.

## Test plan

- [x] `schema.sql` + `0006` parse and converge in a throwaway DB; seed rows correct.
- [x] `0006` applies via `migrate.py` on the existing DB.
- [x] Helpers unit-tested: `flavor_defaults()` + `_default_label()` (labels correct; NULL/bespoke → blank).
- [x] Full `RENDER_ONLY` launch of a cartographer: flavor drove harness=`opencode` and injected `model: openai/gpt-5.1-codex-mini` into `opencode.json`.
- [ ] Live `./sc launch` per role once merged + propagated.

## Notes

Separate from #45 (boot-render). Seeding an actual 4-shell team into new forks is follow-up packaging — this PR only makes flavor drive the launch.