### PR TITLE
feat(harness): add Codex harness + per-(flavor×harness) model defaults

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -1,18 +1,19 @@
 # super-coder sandbox image — the *environment*, not the code.
 #
 # The repo is bind-mounted at runtime (see `./sc launch`); this image carries
-# what the harness needs to run: python3 + sqlite3, git/curl, gh, and the two
-# harness CLIs baked in via their official native installers (the same ones
-# install.py uses — keep the URLs in sync with scripts/install.py HARNESS_INSTALL).
+# what the harness needs to run: python3 + sqlite3, git/curl, gh, and the
+# harness CLIs (claude / opencode / codex) baked in via their official native
+# installers (the same ones install.py uses — keep the URLs in sync with
+# scripts/install.py HARNESS_INSTALL).
 # It also carries the common *project* runtimes a forked repo's dev surface needs
 # (node LTS), so `npm`/dev servers work without an ephemeral in-container install.
 #
 # Why bake the binaries but mount the creds: claude installs as a symlink into
-# ~/.local/share/claude/versions/<v> (awkward to bind-mount); opencode is a fat
-# self-contained binary. Baking both sidesteps the symlink dance. Auth/config
-# (~/.claude, ~/.claude.json, ~/.config/opencode, ~/.local/share/opencode) is
-# mounted rw from the host so the container reuses the login you already did —
-# no in-container `auth login`.
+# ~/.local/share/claude/versions/<v> (awkward to bind-mount); opencode + codex
+# are fat self-contained binaries. Baking them sidesteps the symlink dance.
+# Auth/config (~/.claude, ~/.claude.json, ~/.config/opencode,
+# ~/.local/share/opencode, ~/.codex) is mounted rw from the host so the container
+# reuses the login you already did — no in-container `auth login`.
 #
 # The container runs as your uid (compose `user:`) with HOME=/home/<user> equal
 # to the host, so paths match host==container and Path.home() finds everything.
@@ -62,8 +63,10 @@ ENV HOME=/home/${SC_USER}
 ENV PATH=/home/${SC_USER}/.local/bin:/home/${SC_USER}/.opencode/bin:${PATH}
 
 # Harness CLIs — official native installers, no npm (mirrors install.py).
+# codex drops into ~/.local/bin (already on PATH above), same as claude.
 RUN curl -fsSL https://claude.ai/install.sh | bash \
- && curl -fsSL https://opencode.ai/install | bash
+ && curl -fsSL https://opencode.ai/install | bash \
+ && curl -fsSL https://chatgpt.com/codex/install.sh | sh
 
 # Safe in-container git auth — structurally prevents a token in a URL. The
 # sandbox has no ssh, so `git@github.com:` remotes (e.g. a fork's default

--- a/.super-coder/adapters/claude/README.md
+++ b/.super-coder/adapters/claude/README.md
@@ -12,6 +12,8 @@ the launch command. No extra config file to emit at v1.
 | `boot_artifact` | the context file this harness reads (informational) |
 | `emit` | files in this dir copied to the repo root at launch (none for Claude) |
 | `env` | extra env merged into the launch environment |
+| `model` | `{ "flag": "--model" }` — run.py appends `--model <id>` for the flavor's claude model (alias: `sonnet`/`haiku`/`opus`) |
+| `sandbox` | `merge_json`: project-scoped config patched in-sandbox (allow-all permissions) |
 
 A `.claude/settings.json` template could live here later (permissions, hooks);
 not needed for v1.

--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -4,6 +4,7 @@
   "boot_artifact": "CLAUDE.md",
   "emit": [],
   "env": {},
+  "model": { "flag": "--model" },
   "sandbox": {
     "merge_json": {
       ".claude/settings.json": {

--- a/.super-coder/adapters/codex/README.md
+++ b/.super-coder/adapters/codex/README.md
@@ -1,0 +1,33 @@
+# adapters/codex — OpenAI Codex CLI
+
+Codex reads the boot artifact (`AGENTS.md`) and project `AGENTS.md` conventions
+natively — already emitted by the render chain — so the adapter only carries the
+launch command plus how it takes a model and a sandbox flag.
+
+**Why it exists:** the *subscription* path for OpenAI models. Signing into Codex
+with a ChatGPT plan bills against that plan (flat, capped) instead of per-token
+OpenAI API metering — which is the only way to run OpenAI models without an API
+bill. (opencode can run OpenAI too, but only via a metered API key.) This makes
+codex the OpenAI sibling of the claude harness: first-party CLI, subscription
+billing. opencode stays as the universal metered catch-all.
+
+`adapter.json` fields (the harness seam contract):
+
+| field | meaning |
+|---|---|
+| `launch` | argv exec'd to start the harness (`codex`) |
+| `boot_artifact` | the context file this harness reads (`AGENTS.md`, informational) |
+| `emit` | files copied to the repo root at launch (none — codex reads `~/.codex` + `AGENTS.md`) |
+| `env` | extra env merged into the launch environment |
+| `model` | `{ "flag": "--model" }` — run.py appends `--model <id>` for the flavor's codex model |
+| `sandbox.launch_flags` | flags appended ONLY inside the docker sandbox (`SC_SANDBOX`) |
+
+`--dangerously-bypass-approvals-and-sandbox` is appended only in the container,
+where the container itself is the safety boundary (matches how claude/opencode
+get allow-all permissions in-sandbox). On the no-docker host path (`./sc boot`),
+codex keeps its normal approval prompts.
+
+**Host setup (one-time):** the binary is baked into the sandbox image, but auth is
+mounted from the host — so `codex` must be installed + logged in on the host once:
+`curl -fsSL https://chatgpt.com/codex/install.sh | sh` then `codex` and sign in
+with ChatGPT. That writes `~/.codex/auth.json`, which `./sc launch` mounts in.

--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -1,0 +1,9 @@
+{
+  "harness": "codex",
+  "launch": ["codex"],
+  "boot_artifact": "AGENTS.md",
+  "emit": [],
+  "env": {},
+  "model": { "flag": "--model" },
+  "sandbox": { "launch_flags": ["--dangerously-bypass-approvals-and-sandbox"] }
+}

--- a/.super-coder/adapters/opencode/adapter.json
+++ b/.super-coder/adapters/opencode/adapter.json
@@ -4,6 +4,7 @@
   "boot_artifact": "AGENTS.md",
   "emit": ["opencode.json"],
   "env": { "OPENCODE_DISABLE_CLAUDE_CODE": "1" },
+  "model": { "file": "opencode.json", "key": "model" },
   "sandbox": {
     "merge_json": {
       "opencode.json": {

--- a/.super-coder/migrations/0007_flavor_defaults_per_harness.sql
+++ b/.super-coder/migrations/0007_flavor_defaults_per_harness.sql
@@ -1,0 +1,48 @@
+-- 0007 — per-(flavor × harness) launch model defaults
+--
+-- Reshapes flavor_defaults from one-row-per-flavor (flavor PRIMARY KEY) to a
+-- (flavor, harness) matrix, so a flavor can carry a DIFFERENT model per harness
+-- — the operator picks the harness at launch and gets that harness's model. The
+-- old shape could only name one harness+model per flavor.
+--
+-- is_default marks which harness the picker pre-selects for a flavor (advisory;
+-- --harness / the picker / -m still override).
+--
+-- flavor_defaults is pure launch config — no FKs reference it, no per-instance
+-- memory in it — so DROP + recreate + reseed is safe, idempotent, and converges
+-- with schema.sql on rebuild (schema makes the new shape; 0006 inserts the 4 old
+-- rows; this drops & reseeds the 8 new ones — both fresh-rebuild and existing
+-- forks land identical). Matches the 0002–0006 convergence precedent.
+--
+-- Doctrine (see shell_decisions, CC home DB): middle roles (dev, cartographer) =
+-- a fast coding-tuned model; bookends (planner, reviewer) = premium. Each flavor
+-- offers an OpenAI option on the CODEX harness (ChatGPT-subscription billing, no
+-- per-token API metering — the reason this exists) and an Anthropic option on the
+-- CLAUDE harness. The reviewer DEFAULTS to claude (is_default) — a different model
+-- lineage from the GPT-authored code it reviews, for adversarial diversity.
+-- Codex model ids are bare (gpt-5.4); claude uses aliases (sonnet/haiku/opus).
+-- Retune with UPDATE / a later migration as trial data lands.
+
+BEGIN;
+
+DROP TABLE IF EXISTS flavor_defaults;
+
+CREATE TABLE flavor_defaults (
+    flavor     TEXT    NOT NULL,
+    harness    TEXT    NOT NULL,
+    model      TEXT,
+    is_default INTEGER NOT NULL DEFAULT 0,   -- 1 = picker default harness for this flavor
+    PRIMARY KEY (flavor, harness)
+);
+
+INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES
+    ('dev',          'codex',  'gpt-5.4', 1),
+    ('dev',          'claude', 'sonnet',  0),
+    ('cartographer', 'codex',  'gpt-5.4', 1),
+    ('cartographer', 'claude', 'haiku',   0),
+    ('planner',      'codex',  'gpt-5.5', 1),
+    ('planner',      'claude', 'opus',    0),
+    ('reviewer',     'codex',  'gpt-5.5', 0),
+    ('reviewer',     'claude', 'opus',    1);
+
+COMMIT;

--- a/.super-coder/migrations/0007_flavor_defaults_per_harness.sql
+++ b/.super-coder/migrations/0007_flavor_defaults_per_harness.sql
@@ -16,11 +16,17 @@
 --
 -- Doctrine (see shell_decisions, CC home DB): middle roles (dev, cartographer) =
 -- a fast coding-tuned model; bookends (planner, reviewer) = premium. Each flavor
--- offers an OpenAI option on the CODEX harness (ChatGPT-subscription billing, no
--- per-token API metering — the reason this exists) and an Anthropic option on the
--- CLAUDE harness. The reviewer DEFAULTS to claude (is_default) — a different model
--- lineage from the GPT-authored code it reviews, for adversarial diversity.
--- Codex model ids are bare (gpt-5.4); claude uses aliases (sonnet/haiku/opus).
+-- offers THREE provider lineages, one per harness:
+--   codex    — OpenAI via ChatGPT subscription (flat billing, no per-token API
+--              metering — the reason this exists). Bare model ids (gpt-5.4).
+--   claude   — Anthropic via subscription. Aliases (sonnet/haiku/opus).
+--   opencode — open-weights via Ollama Cloud, a deliberately DIFFERENT lineage
+--              (not a second OpenAI path). provider/model ids (ollama/…-cloud);
+--              opencode's ollama-cloud provider config + signin is handled
+--              per-fork, not here — these rows only set the runtime model.
+-- The reviewer DEFAULTS to claude (is_default) — a different model lineage from
+-- the GPT-authored code it reviews, for adversarial diversity. Codex/claude are
+-- the picker defaults; opencode is always the third option (is_default 0).
 -- Retune with UPDATE / a later migration as trial data lands.
 
 BEGIN;
@@ -36,13 +42,17 @@ CREATE TABLE flavor_defaults (
 );
 
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES
-    ('dev',          'codex',  'gpt-5.4', 1),
-    ('dev',          'claude', 'sonnet',  0),
-    ('cartographer', 'codex',  'gpt-5.4', 1),
-    ('cartographer', 'claude', 'haiku',   0),
-    ('planner',      'codex',  'gpt-5.5', 1),
-    ('planner',      'claude', 'opus',    0),
-    ('reviewer',     'codex',  'gpt-5.5', 0),
-    ('reviewer',     'claude', 'opus',    1);
+    ('dev',          'codex',    'gpt-5.4',                       1),
+    ('dev',          'claude',   'sonnet',                        0),
+    ('dev',          'opencode', 'ollama/qwen3-coder:480b-cloud', 0),
+    ('cartographer', 'codex',    'gpt-5.4',                       1),
+    ('cartographer', 'claude',   'haiku',                         0),
+    ('cartographer', 'opencode', 'ollama/gpt-oss:20b-cloud',      0),
+    ('planner',      'codex',    'gpt-5.5',                       1),
+    ('planner',      'claude',   'opus',                          0),
+    ('planner',      'opencode', 'ollama/deepseek-v4-pro:cloud',  0),
+    ('reviewer',     'codex',    'gpt-5.5',                       0),
+    ('reviewer',     'claude',   'opus',                          1),
+    ('reviewer',     'opencode', 'ollama/kimi-k2.6:cloud',        0);
 
 COMMIT;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -75,13 +75,18 @@ END;
 
 -- Per-flavor launch defaults: the harness + model a shell of this flavor boots
 -- with. ADVISORY ONLY — overridable per launch (--harness / -m / the picker);
--- run.py reads these to set the default and annotate the picker. model is
--- harness-specific (opencode "provider/model"); NULL = let the harness pick its
--- own (e.g. the claude harness). Seeded in migrations/0006.
+-- A (flavor, harness) matrix: each flavor offers a model per harness, so the
+-- operator picks the harness at launch and gets that harness's model. run.py
+-- reads these to resolve the launch model + annotate the picker; is_default marks
+-- the picker's pre-selected harness for a flavor. model is harness-specific (codex
+-- bare id "gpt-5.4" / claude alias "sonnet" / opencode "provider/model"); NULL =
+-- let the harness pick its own. Reshaped + reseeded in migrations/0007.
 CREATE TABLE flavor_defaults (
-    flavor   TEXT PRIMARY KEY,
-    harness  TEXT NOT NULL,
-    model    TEXT
+    flavor     TEXT    NOT NULL,
+    harness    TEXT    NOT NULL,
+    model      TEXT,
+    is_default INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (flavor, harness)
 );
 
 CREATE TABLE shell_memory_archives (

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -9,7 +9,7 @@ from "engine present" to "a shell you can launch":
                  is already installed (both would destroy content). --force skips.
     2. Require — python3 + sqlite3 (+ a heads-up if git/curl missing, and a
                  docker preflight for the sandbox run path — advisory, not fatal).
-    3. Harness — ensure claude + opencode are installed (official native
+    3. Harness — ensure claude + opencode + codex are installed (official native
                  installers, no npm); pick the launch default → instance.json.
     4. Strip   — super-coder's own per-instance content; a fork inherits the
                  SYSTEM (schema + skill catalogue + render chain), never the memory.
@@ -76,26 +76,29 @@ def already_installed() -> bool:
 
 
 def detect_harness() -> str | None:
-    for h in ("claude", "opencode"):
+    for h in ("claude", "opencode", "codex"):
         if _harness_installed(h):
             return h
     return None
 
 
 # Official NATIVE installers — no npm. Claude Code dropped npm as the primary
-# path (https://code.claude.com/docs/en/setup); opencode ships its own script
-# too. Pipe-to-bash, latest version.
+# path (https://code.claude.com/docs/en/setup); opencode + codex ship their own
+# scripts too. Pipe-to-shell, latest version.
 HARNESS_INSTALL = {
     "claude":   "curl -fsSL https://claude.ai/install.sh | bash",
     "opencode": "curl -fsSL https://opencode.ai/install | bash",
+    "codex":    "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
 }
 # Where each installer drops its binary. Checked post-install because the new
 # bin dir is NOT on this process's PATH — the installer edits shell rc files,
 # which only a fresh shell picks up. shutil.which alone would miss a just-
-# installed CLI.
+# installed CLI. (codex's native installer drops into ~/.local/bin, same as
+# claude; ~/.codex is its config/auth home, not the binary.)
 HARNESS_BIN = {
     "claude":   Path.home() / ".local" / "bin" / "claude",
     "opencode": Path.home() / ".opencode" / "bin" / "opencode",
+    "codex":    Path.home() / ".local" / "bin" / "codex",
 }
 
 
@@ -105,7 +108,7 @@ def _harness_installed(name: str) -> bool:
 
 def ensure_harnesses() -> dict[str, str]:
     """Install any missing harness CLI via its official native installer (no
-    npm) — both claude + opencode, so a fork can launch and run either. Best
+    npm) — claude + opencode + codex, so a fork can launch and run any. Best
     effort: a failed install warns and continues (the harness is only needed at
     launch and can be installed by hand later). Returns {name: status}."""
     status: dict[str, str] = {}
@@ -199,7 +202,12 @@ def harness_login_status() -> dict:
             claude = False
     oc = Path.home() / ".local" / "share" / "opencode" / "auth.json"
     opencode = oc.exists() and oc.stat().st_size > 2
-    return {"claude": claude, "opencode": opencode}
+    # codex writes ~/.codex/auth.json on ChatGPT/API login (unless using the
+    # system keyring, which we can't probe — false negative is safe: it only
+    # downgrades the ✓ to a ⚠ reminder).
+    cx = Path.home() / ".codex" / "auth.json"
+    codex = cx.exists() and cx.stat().st_size > 2
+    return {"claude": claude, "opencode": opencode, "codex": codex}
 
 
 def report_logins() -> dict:
@@ -216,6 +224,11 @@ def report_logins() -> dict:
     else:
         print("  opencode  ⚠ not logged in — run `opencode auth login` once on the host")
         print("            (creates ~/.local/share/opencode/auth.json, mounted in).")
+    if st["codex"]:
+        print("  codex     ✓ logged in")
+    else:
+        print("  codex     ⚠ not logged in — run `codex` then sign in with ChatGPT once on the host")
+        print("            (creates ~/.codex/auth.json, which the sandbox mounts in).")
     return st
 
 
@@ -260,7 +273,7 @@ def main(argv: list[str]) -> int:
     # Standalone: just ensure the harness CLIs and exit (for an already-installed
     # fork). Runs before the guards so it works anywhere.
     if "--ensure-harness" in argv:
-        step("Ensuring harness CLIs (claude + opencode)")
+        step("Ensuring harness CLIs (claude + opencode + codex)")
         ensure_harnesses()
         return 0
 
@@ -299,12 +312,12 @@ def main(argv: list[str]) -> int:
     report_docker()
 
     # 3. Ensure harness CLIs --------------------------------------------------
-    # Install both claude + opencode if missing, via their official NATIVE
-    # installers (no npm). The new harness picker lets a fork launch + run
-    # either, so we want both present. --skip-harness-install detects only
-    # (CI / air-gapped). instance.json's harness is the launch default; the
-    # picker overrides it per-launch.
-    step("Ensuring harness CLIs (claude + opencode)")
+    # Install claude + opencode + codex if missing, via their official NATIVE
+    # installers (no npm). The harness picker lets a fork launch + run any, so we
+    # want all present. --skip-harness-install detects only (CI / air-gapped).
+    # instance.json's harness is the launch default; the picker overrides it
+    # per-launch.
+    step("Ensuring harness CLIs (claude + opencode + codex)")
     if skip_harness:
         print("  --skip-harness-install set — detecting only, not installing")
         for n in HARNESS_INSTALL:

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -240,14 +240,23 @@ def list_shells(con: sqlite3.Connection, user_id: int) -> list[sqlite3.Row]:
 
 
 def flavor_defaults(con: sqlite3.Connection) -> dict:
-    """flavor -> {'harness', 'model'} launch defaults. Empty if the table is
-    absent (older fork mid-migration) so the launcher degrades to its prior
-    behavior rather than failing."""
+    """flavor -> {'default_harness', 'models': {harness: model}} launch defaults.
+    The (flavor, harness) matrix: each flavor names a model per harness, and one
+    harness is the picker default (is_default). Empty if the table is absent
+    (older fork mid-migration) so the launcher degrades to its prior behavior
+    rather than failing."""
     try:
-        return {r["flavor"]: r for r in
-                con.execute("SELECT flavor, harness, model FROM flavor_defaults")}
+        rows = con.execute(
+            "SELECT flavor, harness, model, is_default FROM flavor_defaults")
     except sqlite3.OperationalError:
         return {}
+    out: dict = {}
+    for r in rows:
+        fd = out.setdefault(r["flavor"], {"default_harness": None, "models": {}})
+        fd["models"][r["harness"]] = r["model"]
+        if r["is_default"]:
+            fd["default_harness"] = r["harness"]
+    return out
 
 
 def _default_label(defaults: dict, flavor: str | None) -> str:
@@ -255,10 +264,11 @@ def _default_label(defaults: dict, flavor: str | None) -> str:
     boots with by default, so the operator knows which harness to launch if they
     forget. Blank for bespoke shells with no flavor default."""
     fd = defaults.get(flavor)
-    if not fd or not fd["harness"]:
+    if not fd or not fd["default_harness"]:
         return ""
-    model = fd["model"]
-    return fd["harness"] + (f" · {model.split('/')[-1]}" if model else "")
+    harness = fd["default_harness"]
+    model = fd["models"].get(harness)
+    return harness + (f" · {model.split('/')[-1]}" if model else "")
 
 
 def pick_shell(shells: list[sqlite3.Row], requested: str | None,
@@ -367,12 +377,12 @@ def main() -> None:
     fdefaults = flavor_defaults(con)
     chosen = pick_shell(list_shells(con, user["user_id"]), requested, first, fdefaults)
 
-    # This shell's flavor default (advisory): the harness it boots with and, for
-    # opencode, the model to pre-select. Both are overridable below — the flavor
-    # default only sets the fallback, never a lock.
+    # This shell's flavor default (advisory): the harness it boots with. The
+    # model is resolved AFTER the harness pick — a flavor names a model PER
+    # harness, so the model tracks whichever harness the operator lands on. Both
+    # are overridable — the flavor default only sets the fallback, never a lock.
     fdef = fdefaults.get(chosen["flavor"])
-    flavor_harness = fdef["harness"] if fdef else None
-    flavor_model = fdef["model"] if fdef else None
+    flavor_harness = fdef["default_harness"] if fdef else None
 
     # Harness pick, right after the shell pick: an explicit --harness / HARNESS
     # override wins silently; otherwise offer the harnesses on PATH when more
@@ -385,6 +395,11 @@ def main() -> None:
     harness = (flag_harness or os.environ.get("HARNESS")
                or pick_harness(detect_harnesses(), default_harness, first)
                or default_harness)
+
+    # Now that the harness is known, resolve THIS flavor's model for it (the
+    # (flavor, harness) cell). None when the flavor has no entry for the chosen
+    # harness (e.g. opencode as a manual fallback) — then the harness picks its own.
+    flavor_model = fdef["models"].get(harness) if fdef else None
 
     session_id, archive_id = open_session(con, chosen["shell_id"])
 
@@ -420,30 +435,44 @@ def main() -> None:
     if emitted:
         print(f"→ emitted {', '.join(emitted)}")
 
-    # Flavor model default: pre-select the model in the emitted opencode.json so
-    # the operator boots straight into the intended model. opencode-specific (the
-    # only emitted config with a model field); a NULL flavor model, or a harness
-    # that doesn't emit opencode.json (e.g. claude), skips this. Still overridable
-    # in-session / via `-m`.
-    if flavor_model and "opencode.json" in (adapter.get("emit") or []):
-        ocfg = REPO_ROOT / "opencode.json"
-        if ocfg.exists():
+    # Flavor model default: route the model to the harness the operator picked.
+    # The adapter declares HOW it takes a model — a launch flag (claude/codex:
+    # `--model <id>`) or a config-file key (opencode: opencode.json "model"). A
+    # NULL flavor model, or a harness declaring neither, skips this. Still
+    # overridable in-session / via the harness's own `-m`.
+    model_args: list[str] = []
+    mcfg = adapter.get("model") or {}
+    if flavor_model and mcfg.get("flag"):
+        model_args = [mcfg["flag"], flavor_model]
+        print(f"→ model: {flavor_model} (flavor default for {chosen['flavor']})")
+    elif flavor_model and mcfg.get("file"):
+        mfile = REPO_ROOT / mcfg["file"]
+        if mfile.exists():
             try:
-                cfg = json.loads(ocfg.read_text())
+                cfg = json.loads(mfile.read_text())
             except (json.JSONDecodeError, OSError):
                 cfg = {}
-            cfg["model"] = flavor_model
-            atomic_write(ocfg, json.dumps(cfg, indent=2) + "\n")
+            cfg[mcfg.get("key", "model")] = flavor_model
+            atomic_write(mfile, json.dumps(cfg, indent=2) + "\n")
             print(f"→ model: {flavor_model} (flavor default for {chosen['flavor']})")
     sandboxed = apply_sandbox(adapter)
     if sandboxed:
         print(f"→ sandbox: allow-all permissions → {', '.join(sandboxed)}")
 
+    # Sandbox-only launch flags — e.g. codex's approval/sandbox bypass, safe
+    # because the container is the safety boundary. The no-docker host path keeps
+    # the harness's normal prompts (SC_SANDBOX unset).
+    sandbox_flags: list[str] = []
+    if os.environ.get("SC_SANDBOX"):
+        sandbox_flags = (adapter.get("sandbox") or {}).get("launch_flags") or []
+        if sandbox_flags:
+            print(f"→ sandbox: launch flags → {' '.join(sandbox_flags)}")
+
     if os.environ.get("RENDER_ONLY"):
         print("→ RENDER_ONLY set — not exec'ing the harness.")
         return
 
-    cmd = adapter.get("launch") or [harness]
+    cmd = (adapter.get("launch") or [harness]) + model_args + sandbox_flags
     env = {**os.environ, **{k: str(v) for k, v in adapter.get("env", {}).items()}}
     os.chdir(REPO_ROOT)
     print(f"→ exec {' '.join(cmd)}\n")

--- a/sc
+++ b/sc
@@ -41,7 +41,7 @@ dcheck() {
 # breaks claude — so seed it with empty json. Real creds come from a one-time
 # host login (`./sc doctor` guides it); this just keeps the mounts valid.
 dcreds() {
-  mkdir -p "$HOME/.claude" "$HOME/.config/opencode" "$HOME/.local/share/opencode" 2>/dev/null || true
+  mkdir -p "$HOME/.claude" "$HOME/.config/opencode" "$HOME/.local/share/opencode" "$HOME/.codex" 2>/dev/null || true
   [ -e "$HOME/.claude.json" ] || echo '{}' > "$HOME/.claude.json"
 }
 
@@ -114,6 +114,7 @@ case "$cmd" in
       -v "$HOME/.claude.json:$HOME/.claude.json" \
       -v "$HOME/.config/opencode:$HOME/.config/opencode" \
       -v "$HOME/.local/share/opencode:$HOME/.local/share/opencode" \
+      -v "$HOME/.codex:$HOME/.codex" \
       -p "127.0.0.1:$p:$p" \
       -p "127.0.0.1:$dp:$dp" \
       "$IMG" ./sc serve --port "$p" >/dev/null
@@ -136,7 +137,7 @@ case "$cmd" in
 super-coder — forkable shell substrate
 
   ./sc install             first-launch bootstrap for a fork (requirements, harness, first shell)
-  ./sc ensure-harness      install claude + opencode if missing (official native installers, no npm)
+  ./sc ensure-harness      install claude + opencode + codex if missing (official native installers, no npm)
   ./sc doctor              sandbox readiness: docker (rootless/rootful) + harness login
   ./sc update              self-fetch the engine + reconcile IN PLACE (migrate, sync skills, map); --no-fetch to skip fetch
   ./sc rebuild             build the .db from schema + migrations + snapshot


### PR DESCRIPTION
## Why

OpenAI flavors routed through **opencode → OpenAI API key → metered, per-token billing**, and opencode can't ride a ChatGPT subscription — **Codex CLI is the only way to run OpenAI models on a flat ChatGPT plan**. This adds Codex as a third harness and gives every flavor three **distinct provider lineages**: OpenAI (codex) / Anthropic (claude) / open-weights via Ollama Cloud (opencode).

## What

**Codex = picker option 2** (free — `detect_harnesses()` scans adapters alphabetically: `claude · codex · opencode`).

**`flavor_defaults` reshaped** from one-row-per-flavor (`flavor` PK) to a `(flavor, harness)` matrix + `is_default`, so a flavor names a *different model per harness* and the model tracks whichever harness the operator picks at launch:

| flavor | codex (OpenAI, subscription) | claude (Anthropic, subscription) | opencode (Ollama Cloud, open-weights) | default |
|---|---|---|---|---|
| dev | `gpt-5.4` | `sonnet` | `ollama/qwen3-coder:480b-cloud` | codex |
| cartographer | `gpt-5.4` | `haiku` | `ollama/gpt-oss:20b-cloud` | codex |
| planner | `gpt-5.5` | `opus` | `ollama/deepseek-v4-pro:cloud` | codex |
| reviewer | `gpt-5.5` | `opus` | `ollama/kimi-k2.6:cloud` | **claude** (adversarial-diversity doctrine) |

opencode is a **deliberately different lineage** (open-weights), not a second OpenAI path. Its rows only set the runtime model; opencode's ollama-cloud provider config + signin is handled per-fork.

### Changes
- **`migrations/0007`** — DROP+recreate+reseed (pure launch config, no FKs/user data); converges with `schema.sql` on rebuild. `schema.sql` DDL updated to match.
- **`run.py`** — `flavor_defaults()` → `{flavor:{default_harness,models}}`; model resolved **after** the harness pick. Model application generalized off a new adapter `model` field: `flag` (claude/codex append `--model <id>`) or `file` (opencode writes `opencode.json`). Adapter `sandbox.launch_flags` appended only under `SC_SANDBOX` (codex's `--dangerously-bypass-approvals-and-sandbox`).
- **`adapters/codex/`** — new `adapter.json` + README; `claude`/`opencode` gain a `model` field.
- **`install.py` / `sc` / `Dockerfile`** — register codex (native installer → `~/.local/bin`, same as claude), `~/.codex` cred mount, login-status check, baked image binary.

## One-time host setup (after merge)
Codex isn't installed/logged-in on the host yet. Before the codex option boots:
```
curl -fsSL https://chatgpt.com/codex/install.sh | sh   # then: codex → sign in with ChatGPT
```
This writes `~/.codex/auth.json`, which `./sc launch` mounts into the sandbox (binary baked in image, auth mounted from host — same model as claude/opencode). Ollama Cloud signin for opencode is handled per-fork.

## Verification
- `./sc rebuild` → 12 `flavor_defaults` rows, correct `is_default`; fresh-schema + migration paths converge.
- `./sc verify` parses the new shape cleanly.
- `HARNESS=<h> RENDER_ONLY=1 ./sc boot CART1` → resolves `haiku` (claude) / `gpt-5.4` (codex) / `ollama/gpt-oss:20b-cloud` written into opencode.json (opencode) — the "OR" works across all three lineages.
- `SC_SANDBOX=1 HARNESS=codex` → appends the codex bypass flag (absent on the host path).

Forks (e.g. dos-arch) pick this up via `./sc update` applying 0007. Model tags are trivially retunable via UPDATE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)