### PR TITLE
fix(flavor+harness): canonical planner/reviewer vocab + update ensures all harnesses

### DIFF
--- a/.super-coder/migrations/0008_canonical_flavor_vocab.sql
+++ b/.super-coder/migrations/0008_canonical_flavor_vocab.sql
@@ -1,0 +1,13 @@
+-- 0008 — align existing shell flavors to the canonical planner/reviewer vocab.
+--
+-- Early shell templates emitted flavor 'planning'/'review', but flavor_defaults
+-- (0006/0007) and the schema comment use 'planner'/'reviewer' — matching the
+-- role-noun pattern of 'dev'/'cartographer'. The mismatch meant a planning/
+-- review shell never matched a flavor_default row: blank picker default and no
+-- model pin (it fell through to the harness's built-in model). The templates
+-- are now renamed to planner.json/reviewer.json (the filename stem IS the
+-- flavor); this migration fixes shells already created under the old vocab.
+--
+-- Idempotent: a no-op once flavors are canonical (or on a fork with none).
+UPDATE shells SET flavor = 'planner'  WHERE flavor = 'planning';
+UPDATE shells SET flavor = 'reviewer' WHERE flavor = 'review';

--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -52,7 +52,7 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--username")
     ap.add_argument("--name", help="shell display name")
     ap.add_argument("--shortname")
-    ap.add_argument("--flavor", help="planning | dev | review")
+    ap.add_argument("--flavor", help="planner | dev | reviewer")
     ap.add_argument("--role", help="override the flavor's role")
     ap.add_argument("--mandate", help="override the flavor's mandate")
     ap.add_argument("--partner")
@@ -83,9 +83,9 @@ def main(argv: list[str]) -> int:
                      "(non-interactive run needs the flag)")
 
         username = need(a.username, "Your username")
-        # The first shell is a PLANNING shell — every fork needs a planner to
+        # The first shell is a PLANNER shell — every fork needs a planner to
         # scope the work. (--flavor overrides; the GUI creates other flavors.)
-        flavor = a.flavor or "planning"
+        flavor = a.flavor or "planner"
         if flavor not in flavor_names:
             sys.exit(f"init_fork: unknown flavor '{flavor}' (have: {', '.join(flavor_names)})")
         name = need(a.name, "Shell display name", flavor.capitalize())

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -55,6 +55,7 @@ ENGINE_REF_PREV = STATE_DIR / "engine.ref.prev"
 PY = sys.executable
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+import install as install_mod  # noqa: E402  (ensure_harnesses)
 import migrate as migrate_mod  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402
 import seed_skills  # noqa: E402
@@ -250,6 +251,14 @@ def main(argv: list[str]) -> int:
               "(engine + engine.ref unchanged)")
     else:
         fetch_and_materialize(branch)
+
+    # Harnesses can be ADDED upstream between releases (e.g. codex landed after
+    # dos-arch installed), so a fork that updates must pick up any newly-required
+    # harness — not just the ones present at first install. Best-effort + native
+    # installers (no npm); a failure warns and continues (install by hand later).
+    # Auth/login stays manual; this only ensures the CLI binary is present.
+    print("→ ensure harnesses installed (claude + opencode + codex)")
+    install_mod.ensure_harnesses()
 
     migrate_or_rebuild()
 

--- a/.super-coder/templates/shells/planner.json
+++ b/.super-coder/templates/shells/planner.json
@@ -1,5 +1,5 @@
 {
-  "flavor": "planning",
+  "flavor": "planner",
   "abbr": "PLN",
   "role": "Planning shell",
   "mandate": "Turn objectives into specs and sequenced plans for {{repo}}. Own the roadmap; decide before building; break work into verifiable steps.",

--- a/.super-coder/templates/shells/reviewer.json
+++ b/.super-coder/templates/shells/reviewer.json
@@ -1,5 +1,5 @@
 {
-  "flavor": "review",
+  "flavor": "reviewer",
   "abbr": "REV",
   "role": "Review shell",
   "mandate": "Review changes, specs, and decisions in {{repo}}. Find bugs, verify claims, check work against intent. Adversarial by default.",


### PR DESCRIPTION
Two launch-config bugs surfaced by booting the **dos-arch** fork's shell picker (blank defaults for the planning/review shells; a `codex` default that couldn't be selected).

## 1. Flavor vocab drift → blank defaults + no model pin

Shell templates emitted `flavor: planning` / `flavor: review`, but `flavor_defaults` (0006/0007) **and** the schema comment use `planner` / `reviewer` (the role-noun pattern of `dev`/`cartographer`). `load_flavor` resolves `<flavor>.json` by filename — **the stem IS the flavor** — so those shells never matched a `flavor_defaults` row: blank picker default and **no model pin** (they fell through to the harness's built-in model). `dev`/`cartographer` matched and worked, masking it.

- Rename `planning.json`→`planner.json`, `review.json`→`reviewer.json` (+ their `flavor` field).
- `init_fork.py`: first-shell default `planning`→`planner`; help text `planner | dev | reviewer`.
- **`0008_canonical_flavor_vocab.sql`**: rename existing shells' flavor `planning`→`planner`, `review`→`reviewer` (idempotent) — so each fork's *already-created* shells are fixed on update, not just newly-created ones. (Migrations run before content.sql loads, and the post-migrate snapshot re-dumps the fixed flavors, so a rebuild round-trips correctly.)

## 2. `update` never installed newly-added harnesses

`install.py.ensure_harnesses()` installs claude + opencode + codex (official native installers, no npm) — but only `./sc install` called it. A fork installed **before codex existed** (dos-arch) never got the codex binary, so the picker advertised a `codex` default it couldn't launch. `update.py` now calls `ensure_harnesses()` too, so an update picks up any harness added upstream. Best-effort (a failed install warns and continues); auth/login stays manual.

## Verification

`./sc verify` green on the source: 8 migrations incl. 0008 + headless boot. `flavors()` → `[cartographer, dev, planner, reviewer]`. `update.py` imports `ensure_harnesses` cleanly with no side effects.

After merge, dos-arch picks this up via `./sc update` — which applies 0008 (fixes PLN1/REV1), installs the codex binary, and lands the renamed templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)