### PR TITLE
fix(codex): ChatGPT-account model ids (gpt-5.4→gpt-5.4-mini) + host harness sign-in docs

### DIFF
--- a/.super-coder/migrations/0007_flavor_defaults_per_harness.sql
+++ b/.super-coder/migrations/0007_flavor_defaults_per_harness.sql
@@ -18,7 +18,9 @@
 -- a fast coding-tuned model; bookends (planner, reviewer) = premium. Each flavor
 -- offers THREE provider lineages, one per harness:
 --   codex    — OpenAI via ChatGPT subscription (flat billing, no per-token API
---              metering — the reason this exists). Bare model ids (gpt-5.4).
+--              metering — the reason this exists). Bare model ids (gpt-5.5,
+--              gpt-5.4-mini — the two codex+ChatGPT exposes; gpt-5.4 was an
+--              API-only id ChatGPT-account codex rejects, see 0009).
 --   claude   — Anthropic via subscription. Aliases (sonnet/haiku/opus).
 --   opencode — open-weights via Ollama Cloud, a deliberately DIFFERENT lineage
 --              (not a second OpenAI path). provider/model ids (ollama/…-cloud);
@@ -42,10 +44,10 @@ CREATE TABLE flavor_defaults (
 );
 
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES
-    ('dev',          'codex',    'gpt-5.4',                       1),
+    ('dev',          'codex',    'gpt-5.4-mini',                  1),
     ('dev',          'claude',   'sonnet',                        0),
     ('dev',          'opencode', 'ollama/qwen3-coder:480b-cloud', 0),
-    ('cartographer', 'codex',    'gpt-5.4',                       1),
+    ('cartographer', 'codex',    'gpt-5.4-mini',                  1),
     ('cartographer', 'claude',   'haiku',                         0),
     ('cartographer', 'opencode', 'ollama/gpt-oss:20b-cloud',      0),
     ('planner',      'codex',    'gpt-5.5',                       1),

--- a/.super-coder/migrations/0009_codex_chatgpt_model_ids.sql
+++ b/.super-coder/migrations/0009_codex_chatgpt_model_ids.sql
@@ -1,0 +1,15 @@
+-- 0009 — fix codex model ids for ChatGPT-account use.
+--
+-- 0007 seeded the codex workhorse rows (dev, cartographer) with model 'gpt-5.4'.
+-- That id is API-only — Codex driven by a ChatGPT subscription (which is the
+-- whole reason the codex harness exists: flat billing, no per-token metering)
+-- rejects it: HTTP 400 "The 'gpt-5.4' model is not supported when using Codex
+-- with a ChatGPT account." The two ids codex+ChatGPT actually exposes are
+-- 'gpt-5.5' (premium — already on planner/reviewer) and 'gpt-5.4-mini' (the
+-- fast/cheap step below it). Repoint the workhorse rows to the mini, which
+-- preserves the intended tiering (bookends premium, middle roles cheaper).
+--
+-- Idempotent: targets the dead id, so a no-op once corrected (or on a fresh
+-- install whose 0007 already seeds 'gpt-5.4-mini').
+UPDATE flavor_defaults SET model = 'gpt-5.4-mini'
+ WHERE harness = 'codex' AND model = 'gpt-5.4';

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ super-coder's own memory or roadmap.
 > harness's "allow everything" is safe (the kernel is the boundary; the
 > container sees only this repo + your harness creds). The image bakes the rest:
 > `python3`, `sqlite3`, `git`, `curl`, and the harness CLIs (`claude` +
-> `opencode`, via their official native installers, no npm). `make` targets wrap
+> `opencode` + `codex`, via their official native installers, no npm). `make` targets wrap
 > the common commands; `./sc <cmd>` works without `make`. No docker? The
 > `./sc serve` + `./sc boot` primitives run on the host with only `python3` +
 > `sqlite3` (and a harness on `PATH`).
@@ -92,8 +92,8 @@ git add -A && git commit -m "chore: install super-coder"   # engine is gitignore
 ```
 
 `./sc install` does the rest: checks requirements, **installs the harness CLIs**
-(`claude` + `opencode`, via their official native installers — no npm — if either
-is missing; `--skip-harness-install` to detect only), wires your `.gitignore`,
+(`claude` + `opencode` + `codex`, via their official native installers — no npm —
+if any are missing; `--skip-harness-install` to detect only), wires your `.gitignore`,
 **makes the engine a gitignored dependency** (`git rm -r --cached .super-coder` —
 files stay on disk; pins its upstream SHA in `.sc-state/engine.ref`), **strips
 super-coder's own per-instance content** (a fork inherits the *system* — schema +
@@ -116,6 +116,32 @@ python3 .super-coder/scripts/install.py \
 After `./sc enter` you're talking to the shell, working your repo. Author
 memory, roadmap, and specs into the DB; `./sc snapshot` (+ `./sc render`)
 serializes back to the text git tracks.
+
+## Sign in to your harness (on the host)
+
+The harnesses are just CLIs — `./sc install` (and `./sc update`, `./sc
+ensure-harness`) install the binaries, but you authenticate each **once, on the
+host**, with your own account/subscription:
+
+```bash
+claude                      # Claude Code — prompts to sign in on first run
+opencode auth login         # OpenCode
+codex login                 # Codex (OpenAI / ChatGPT account)
+```
+
+`./sc launch` bind-mounts each harness's credential dir into the sandbox
+(`~/.claude` + `~/.claude.json`, `~/.config/opencode` + `~/.local/share/opencode`,
+`~/.codex`), so host auth flows straight into the container — **you never sign in
+inside the sandbox.** Authenticate on the host, then `./sc enter`.
+
+> **⚠ Sign in on the host, not inside the sandbox.** OAuth logins spin up a
+> localhost callback server (Codex uses `:1455`). Run the login on the **host** so
+> your browser's callback reaches it. Logging in from *inside* the sandbox fails —
+> that port isn't published, so the browser gets `ERR_CONNECTION_REFUSED`.
+
+A note on Codex models: driven by a **ChatGPT account** (not an API key), Codex
+exposes `gpt-5.5` and `gpt-5.4-mini` — the flavor defaults are set to those.
+Plain API-only ids (e.g. `gpt-5.4`) return a 400 on a ChatGPT account.
 
 ## Update a fork
 


### PR DESCRIPTION
Surfaced when dos-arch booted a `dev` shell on codex and hit:

> `{"status":400,...,"message":"The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account."}`

## Root cause

Codex driven by a **ChatGPT subscription** (the whole reason the codex harness exists — flat billing, no per-token API metering) doesn't accept `gpt-5.4` — that's an API-only id. The two ids codex+ChatGPT exposes are **`gpt-5.5`** (premium) and **`gpt-5.4-mini`** (fast/cheap). The 0007 seed had the `dev`/`cartographer` workhorse rows on the dead `gpt-5.4`.

## Changes

- **0007 seed**: `dev`/`cartographer` codex model `gpt-5.4` → `gpt-5.4-mini` (fresh installs).
- **0009 migration**: same `UPDATE` for existing forks (idempotent, targets the dead id). Preserves the intended tiering — bookends (`planner`/`reviewer`) premium `gpt-5.5`, middle roles (`dev`/`cartographer`) the cheaper `gpt-5.4-mini`.
- **README — new "Sign in to your harness (on the host)" section**: authenticate claude/opencode/codex on the **host** (creds bind-mount into the sandbox; you never sign in inside the container), including the OAuth-callback gotcha — codex's `:1455` callback isn't published from the sandbox, so logging in *inside* it gives `ERR_CONNECTION_REFUSED`. Also a short note that codex+ChatGPT exposes `gpt-5.5`/`gpt-5.4-mini`. Fixes a drift (install installs claude+opencode+**codex**, was "claude + opencode").

## Verification

`./sc verify` green on the source: 9 migrations incl. 0009. `flavor_defaults` codex rows → `dev`/`cartographer` `gpt-5.4-mini`, `planner`/`reviewer` `gpt-5.5`.

After merge, dos-arch picks it up via `./sc update` (0009 repoints its codex rows). Model ids verified against codex's own state (`~/.codex/config.toml` availability flag + model picker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)