### PR TITLE
feat(sandbox): shared sc-net network + bake pytest

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -52,6 +52,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/*
 
+# pytest — a *project* test runtime, not a harness/engine dep. The engine's own
+# tests are stdlib-unittest by design (no-dependency style), but forked repos'
+# dev surfaces commonly use pytest; baking it system-wide (same rationale as node
+# above) means shells run `pytest` without an ephemeral pip install that
+# evaporates on the next rebuild. Installed as root into /usr/local so it's on
+# PATH for the unprivileged ${SC_USER} the container actually runs as.
+RUN pip install --no-cache-dir pytest
+
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
 RUN groupadd -g ${SC_GID} ${SC_USER} \
  && useradd -m -u ${SC_UID} -g ${SC_GID} -s /bin/bash ${SC_USER}

--- a/sc
+++ b/sc
@@ -23,6 +23,10 @@ devport() { "$PY" "$S/ports.py" devport; }
 # docker and so run the same whether on the host or inside the container.
 IMG=super-coder-sandbox
 CNAME="sc-$(basename "$here")"   # unique per fork, like the pm2 name
+# Shared inter-fork network. Sandbox containers join it so a shell in one fork
+# can reach another fork's API by container name (http://sc-<repo>:<port>) — see
+# dnet(). Override with SC_NET to isolate a fork onto its own network.
+SC_NET="${SC_NET:-sc-net}"
 
 # Fail fast with the fix if the docker daemon isn't reachable, instead of a
 # cryptic build/run error. Host setup is one-time and lives in `./sc doctor` /
@@ -52,6 +56,18 @@ dcreds() {
 duser() {
   if docker info 2>/dev/null | grep -qi rootless; then echo "0:0"
   else echo "$(id -u):$(id -g)"; fi
+}
+
+# Ensure the shared inter-fork network exists (idempotent — created once, reused
+# by every fork). Sandbox containers join it so a shell in one fork can reach
+# another fork's API by container name (http://sc-<repo>:<port>, e.g.
+# sc-dos-arch:8804) — Docker's embedded DNS resolves container names on a
+# user-defined network, which the default bridge does NOT do. This is
+# container<->container only: host port publishing stays 127.0.0.1-bound, so no
+# new host exposure. A fork that wants isolation sets SC_NET to its own name.
+dnet() {
+  docker network inspect "$SC_NET" >/dev/null 2>&1 \
+    || docker network create "$SC_NET" >/dev/null
 }
 
 # Build the env image (the repo is bind-mounted at run time, never baked — see
@@ -93,6 +109,7 @@ case "$cmd" in
     p="$(port)"
     dp="$(devport)"
     dbuild
+    dnet
     # Forward GitHub auth for the in-container push/PR path (GUI publish + shells
     # opening their own PRs). Prefer a repo-scoped SC_GH_TOKEN; else reuse the
     # host's gh login. NOTE: this widens the sandbox — anything in the container
@@ -103,6 +120,7 @@ case "$cmd" in
     git_email="$(git -C "$here" config user.email 2>/dev/null || true)"
     docker rm -f "$CNAME" >/dev/null 2>&1 || true
     docker run -d --name "$CNAME" --restart unless-stopped \
+      --network "$SC_NET" \
       --user "$(duser)" \
       -e HOME="$HOME" -e SC_BIND=0.0.0.0 -e SC_PYTHON=python3 -e PYTHONUNBUFFERED=1 \
       -e SC_SANDBOX=1 -e SC_DEV_PORT="$dp" \


### PR DESCRIPTION
## Why

Two sandbox-environment issues hitting shells in the docker sandbox:

1. **Can't reach a sibling fork's API.** Each fork's sandbox runs as its own container (`sc-super-coder`, `sc-dos-arch`, …) on Docker's **default bridge**, with ports published to `127.0.0.1` only. The default bridge has no name-based DNS, and loopback-bound published ports aren't reachable from a sibling container — so a shell in one fork has no route to another fork's API (e.g. dos-arch at `:8804`). This blocked shells from troubleshooting across forks.
2. **No pytest.** The image bakes python/node/gh but not pytest; shells were asking for it.

## What

- **Shared `sc-net` network.** `./sc launch` ensures a user-defined `sc-net` (idempotent `dnet()`) and attaches each sandbox container to it. Forks now reach each other by container name — `http://sc-<repo>:<port>`, e.g. `http://sc-dos-arch:8804` — via Docker's embedded DNS. **Container↔container only**: host port publishing stays `127.0.0.1`-bound, so no new host exposure. `SC_NET=<name>` overrides to isolate a fork.
- **Bake pytest.** System-wide `pip install pytest` in the Dockerfile (same rationale as the baked node runtime). The engine's *own* tests remain stdlib-unittest by design — this is for forked repos' dev surfaces.

## Verification

- Fresh image ships `pytest 9.0.3`.
- A container on `sc-net` resolves and reaches `sc-dos-arch:8804/api/health` → **HTTP 200** by name.

## Propagation note

This changes the engine launch path, so it reaches a fork on its next **engine update + relaunch**. Already-running containers won't be on `sc-net` until they relaunch — to unblock immediately, `docker network connect sc-net sc-<repo>` (done for the live `sc-dos-arch` already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)