### PR TITLE
feat(harness): add Mistral Vibe as a fourth harness option

### DIFF
--- a/.super-coder/adapters/vibe/README.md
+++ b/.super-coder/adapters/vibe/README.md
@@ -1,0 +1,48 @@
+# adapters/vibe — Mistral Vibe CLI
+
+Vibe reads the boot artifact (`AGENTS.md`) and project `AGENTS.md` conventions
+natively — already emitted by the render chain — so the adapter only carries the
+launch command plus a trust flag and a sandbox approval flag.
+
+**Why it exists:** the Mistral-models sibling of the claude/codex harnesses —
+a first-party, open-source (Apache-2.0) CLI billed against a Mistral plan
+(Free / Pro $14.99 / Team) or a self-managed API key. Devstral / Mistral-Medium
+coding models. opencode stays the universal metered catch-all; vibe is the
+native Mistral path.
+
+`adapter.json` fields (the harness seam contract):
+
+| field | meaning |
+|---|---|
+| `launch` | argv exec'd to start the harness (`vibe --trust`) |
+| `boot_artifact` | the context file this harness reads (`AGENTS.md`, informational) |
+| `emit` | files copied to the repo root at launch (none — vibe reads `~/.vibe` + `AGENTS.md`) |
+| `env` | extra env merged into the launch environment (none) |
+| `sandbox.launch_flags` | flags appended ONLY inside the docker sandbox (`SC_SANDBOX`) |
+
+**`--trust` (base launch):** the launcher writes the `AGENTS.md` it wants Vibe to
+load, then asks Vibe to trust the dir it just authored — so the trust prompt
+("trust this folder?") never blocks a launch. `--trust` is per-invocation only
+(not persisted to `~/.vibe/trusted_folders.toml`), so it leaves no global state
+and re-trusts cleanly each launch. This is the trust gate, distinct from tool
+*approval* below.
+
+**`--agent auto-approve` (sandbox only):** appended only in the container
+(`SC_SANDBOX`), where the container itself is the safety boundary — tools run
+without per-action approval (matches how claude/opencode/codex get allow-all
+permissions in-sandbox). On the no-docker host path (`./sc boot`), Vibe keeps its
+normal `default_agent` approval behavior.
+
+**No `model` field:** Vibe takes no model from the launch seam. It selects a model
+via `active_model` in `~/.vibe/config.toml` (set at `vibe --setup`), overridable
+by the `VIBE_ACTIVE_MODEL` env var — neither of which is the `--flag`/JSON-file
+mechanism run.py's model seam drives. Vibe's model ids are Mistral-specific and
+don't map to the claude/codex/opencode flavor models, so routing a flavor model
+here would be meaningless; Vibe uses its configured default.
+
+**Host setup (one-time):** install + authenticate once on the host —
+`curl -LsSf https://mistral.ai/vibe/install.sh | bash` (installs via `uv tool
+install mistral-vibe`; the `vibe` binary lands in `~/.local/bin`), then
+`vibe --setup` to store the API key, or export `MISTRAL_API_KEY` in your shell.
+`./sc install` / `./sc update` / `./sc ensure-harness` install the binary
+automatically; auth stays manual.

--- a/.super-coder/adapters/vibe/adapter.json
+++ b/.super-coder/adapters/vibe/adapter.json
@@ -1,0 +1,8 @@
+{
+  "harness": "vibe",
+  "launch": ["vibe", "--trust"],
+  "boot_artifact": "AGENTS.md",
+  "emit": [],
+  "env": {},
+  "sandbox": { "launch_flags": ["--agent", "auto-approve"] }
+}

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -9,7 +9,7 @@ from "engine present" to "a shell you can launch":
                  is already installed (both would destroy content). --force skips.
     2. Require — python3 + sqlite3 (+ a heads-up if git/curl missing, and a
                  docker preflight for the sandbox run path — advisory, not fatal).
-    3. Harness — ensure claude + opencode + codex are installed (official native
+    3. Harness — ensure claude + opencode + codex + vibe are installed (official native
                  installers, no npm); pick the launch default → instance.json.
     4. Strip   — super-coder's own per-instance content; a fork inherits the
                  SYSTEM (schema + skill catalogue + render chain), never the memory.
@@ -77,19 +77,22 @@ def already_installed() -> bool:
 
 
 def detect_harness() -> str | None:
-    for h in ("claude", "opencode", "codex"):
+    for h in ("claude", "opencode", "codex", "vibe"):
         if _harness_installed(h):
             return h
     return None
 
 
 # Official NATIVE installers — no npm. Claude Code dropped npm as the primary
-# path (https://code.claude.com/docs/en/setup); opencode + codex ship their own
-# scripts too. Pipe-to-shell, latest version.
+# path (https://code.claude.com/docs/en/setup); opencode + codex + vibe ship their own
+# scripts too. Pipe-to-shell, latest version. vibe installs via uv (its script
+# checks for / uses `uv tool install mistral-vibe`); a missing uv makes its
+# install fail best-effort, same as any other harness.
 HARNESS_INSTALL = {
     "claude":   "curl -fsSL https://claude.ai/install.sh | bash",
     "opencode": "curl -fsSL https://opencode.ai/install | bash",
     "codex":    "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+    "vibe":     "curl -LsSf https://mistral.ai/vibe/install.sh | bash",
 }
 # Where each installer drops its binary. Checked post-install because the new
 # bin dir is NOT on this process's PATH — the installer edits shell rc files,
@@ -100,6 +103,7 @@ HARNESS_BIN = {
     "claude":   Path.home() / ".local" / "bin" / "claude",
     "opencode": Path.home() / ".opencode" / "bin" / "opencode",
     "codex":    Path.home() / ".local" / "bin" / "codex",
+    "vibe":     Path.home() / ".local" / "bin" / "vibe",
 }
 
 
@@ -109,7 +113,7 @@ def _harness_installed(name: str) -> bool:
 
 def ensure_harnesses() -> dict[str, str]:
     """Install any missing harness CLI via its official native installer (no
-    npm) — claude + opencode + codex, so a fork can launch and run any. Best
+    npm) — claude + opencode + codex + vibe, so a fork can launch and run any. Best
     effort: a failed install warns and continues (the harness is only needed at
     launch and can be installed by hand later). Returns {name: status}."""
     status: dict[str, str] = {}
@@ -326,7 +330,7 @@ def main(argv: list[str]) -> int:
     # Standalone: just ensure the harness CLIs and exit (for an already-installed
     # fork). Runs before the guards so it works anywhere.
     if "--ensure-harness" in argv:
-        step("Ensuring harness CLIs (claude + opencode + codex)")
+        step("Ensuring harness CLIs (claude + opencode + codex + vibe)")
         ensure_harnesses()
         return 0
 
@@ -365,12 +369,12 @@ def main(argv: list[str]) -> int:
     report_docker()
 
     # 3. Ensure harness CLIs --------------------------------------------------
-    # Install claude + opencode + codex if missing, via their official NATIVE
+    # Install claude + opencode + codex + vibe if missing, via their official NATIVE
     # installers (no npm). The harness picker lets a fork launch + run any, so we
     # want all present. --skip-harness-install detects only (CI / air-gapped).
     # instance.json's harness is the launch default; the picker overrides it
     # per-launch.
-    step("Ensuring harness CLIs (claude + opencode + codex)")
+    step("Ensuring harness CLIs (claude + opencode + codex + vibe)")
     if skip_harness:
         print("  --skip-harness-install set — detecting only, not installing")
         for n in HARNESS_INSTALL:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -257,7 +257,7 @@ def main(argv: list[str]) -> int:
     # harness — not just the ones present at first install. Best-effort + native
     # installers (no npm); a failure warns and continues (install by hand later).
     # Auth/login stays manual; this only ensures the CLI binary is present.
-    print("→ ensure harnesses installed (claude + opencode + codex)")
+    print("→ ensure harnesses installed (claude + opencode + codex + vibe)")
     install_mod.ensure_harnesses()
 
     migrate_or_rebuild()


### PR DESCRIPTION
Adds **Mistral Vibe** alongside claude / opencode / codex in the launch-time harness picker, and wires it into install + update so it's a first-class dependency.

## Why
Vibe is Mistral's first-party, open-source (Apache-2.0) agentic coding CLI — Devstral / Mistral-Medium models, billed against a Mistral plan (Free / Pro \$14.99 / Team) or a self-managed API key. It's the native Mistral sibling of the claude/codex harnesses; opencode stays the universal metered catch-all. Start free to evaluate output quality, promote to the \$14.99 plan as a dev option if it earns the daily rotation.

## What it took
Vibe reads `AGENTS.md` natively, so it slots into the existing adapter seam with **zero render-chain changes**.

- **`adapters/vibe/adapter.json`** — `launch: ["vibe", "--trust"]`, `boot_artifact: AGENTS.md`, sandbox-only `--agent auto-approve`.
- **`adapters/vibe/README.md`** — documents the seam contract.
- **`install.py`** — registers vibe in `HARNESS_INSTALL` (uv-based native installer) + `HARNESS_BIN` (`~/.local/bin/vibe`), and adds it to `detect_harness()` (last preference).
- **`update.py`** — already calls `ensure_harnesses()` over `HARNESS_INSTALL`, so `./sc update` picks vibe up automatically; only the status line needed the name.

`run.py` (picker / loader / exec) and the render chain are fully generic — untouched.

## Two Vibe-specific seam decisions
- **`--trust` in base launch (not sandbox-only):** the launcher writes the `AGENTS.md` it wants Vibe to load, then trusts the dir it just authored, so the "trust this folder?" prompt never blocks a launch. It's per-invocation (not persisted to `~/.vibe/trusted_folders.toml`), leaving no global state. This is the *trust* gate — distinct from tool *approval*.
- **`--agent auto-approve` sandbox-only:** the in-container allow-all analog to codex's `--dangerously-bypass…` / opencode's `permission: allow`. The host path keeps Vibe's normal approval behavior.
- **No `model` field:** Vibe selects via `active_model` in `~/.vibe/config.toml` (or `VIBE_ACTIVE_MODEL`), neither of which is run.py's flag/JSON-file seam; its model ids are Mistral-specific and don't map to flavor models anyway.

## Verification
Smoke-tested against **vibe 2.14.0** (installed via the registered installer):
- `detect_harnesses()` → `['claude', 'codex', 'opencode', 'vibe']`
- host argv → `vibe --trust`
- sandbox argv → `vibe --trust --agent auto-approve`
- `_harness_installed('vibe')` → `True`, bin at `~/.local/bin/vibe`

## Host setup (one-time, manual — auth is never automated)
`curl -LsSf https://mistral.ai/vibe/install.sh | bash` then `vibe --setup` (or export `MISTRAL_API_KEY`). `./sc install` / `update` / `ensure-harness` handle the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)