### PR TITLE
feat(sandbox): dev kit — ./sc deps + ./sc test, per-fork deps not baked, baked browser

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -1,12 +1,14 @@
 # super-coder sandbox image — the *environment*, not the code.
 #
 # The repo is bind-mounted at runtime (see `./sc launch`); this image carries
-# what the harness needs to run: python3 + sqlite3, git/curl, gh, and the
-# harness CLIs (claude / opencode / codex) baked in via their official native
-# installers (the same ones install.py uses — keep the URLs in sync with
+# what the harness needs to run: python3 + sqlite3, git/curl/ripgrep, gh, and the
+# harness CLIs (claude / opencode / codex / vibe) baked in via their official
+# native installers (the same ones install.py uses — keep the URLs in sync with
 # scripts/install.py HARNESS_INSTALL).
-# It also carries the common *project* runtimes a forked repo's dev surface needs
-# (node LTS), so `npm`/dev servers work without an ephemeral in-container install.
+# It also carries the dev-kit TOOLCHAIN super-coder develops against — node LTS for
+# Svelte/Vite, plus a baked Playwright+Chromium browser for E2E tests — but NOT the
+# fork's app deps: those install per-fork into the bind-mounted repo's own .venv /
+# node_modules via `./sc deps`, so versions track the fork's pins, not the image.
 #
 # Why bake the binaries but mount the creds: claude installs as a symlink into
 # ~/.local/share/claude/versions/<v> (awkward to bind-mount); opencode + codex
@@ -24,9 +26,11 @@ ARG SC_UID=1000
 ARG SC_GID=1000
 
 # sqlite3 CLI + git + curl + bash + ca-certs (installers pipe-to-bash over https).
+# ripgrep (rg) — the fast code search shells reach for when working a repo; the
+# mapping flow and a shell grepping its tree both expect `rg` on PATH.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      sqlite3 git curl bash ca-certificates \
+      sqlite3 git curl bash ca-certificates ripgrep \
  && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI (gh) — the in-container push/PR path: the GUI "publish" flow
@@ -52,13 +56,22 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/*
 
-# pytest — a *project* test runtime, not a harness/engine dep. The engine's own
-# tests are stdlib-unittest by design (no-dependency style), but forked repos'
-# dev surfaces commonly use pytest; baking it system-wide (same rationale as node
-# above) means shells run `pytest` without an ephemeral pip install that
-# evaporates on the next rebuild. Installed as root into /usr/local so it's on
-# PATH for the unprivileged ${SC_USER} the container actually runs as.
-RUN pip install --no-cache-dir pytest
+# Playwright E2E browser — baked at the IMAGE level on purpose, unlike the per-fork
+# app deps (those land in the fork's .venv / node_modules via `./sc deps`). It stays
+# baked because: (1) Chromium needs a pile of OS libraries (`--with-deps` shells out
+# to apt), which only root can install and which don't belong in a venv; (2) the E2E
+# runner drives the *running app over HTTP*, not via the app's venv, so it must be
+# present whichever fork is mounted. Install browsers to a world-readable shared path
+# so the unprivileged ${SC_USER} (the container's real uid) finds them — the default
+# /root/.cache/ms-playwright is unreadable to that user. PLAYWRIGHT_BROWSERS_PATH is
+# inherited by the running container, so a fork's own playwright / @playwright/test
+# runner (in its .venv / node_modules) resolves the SAME baked browser. Pin the
+# version: a runner only drives the browser build it shipped with, so an unpinned
+# client + an older cached browser silently mismatch — keep this >= any fork's pin.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+RUN pip install --no-cache-dir "playwright==1.60.0" \
+ && playwright install --with-deps chromium \
+ && chmod -R a+rX /opt/ms-playwright
 
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
 RUN groupadd -g ${SC_GID} ${SC_USER} \
@@ -71,10 +84,12 @@ ENV HOME=/home/${SC_USER}
 ENV PATH=/home/${SC_USER}/.local/bin:/home/${SC_USER}/.opencode/bin:${PATH}
 
 # Harness CLIs — official native installers, no npm (mirrors install.py).
-# codex drops into ~/.local/bin (already on PATH above), same as claude.
+# codex drops into ~/.local/bin (already on PATH above), same as claude. vibe's
+# installer self-bootstraps uv (astral.sh) then `uv tool install`s into ~/.local/bin.
 RUN curl -fsSL https://claude.ai/install.sh | bash \
  && curl -fsSL https://opencode.ai/install | bash \
- && curl -fsSL https://chatgpt.com/codex/install.sh | sh
+ && curl -fsSL https://chatgpt.com/codex/install.sh | sh \
+ && curl -LsSf https://mistral.ai/vibe/install.sh | bash
 
 # Safe in-container git auth — structurally prevents a token in a URL. The
 # sandbox has no ssh, so `git@github.com:` remotes (e.g. a fork's default

--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -14,10 +14,12 @@
 #   make down           stop the sandbox
 #   make update         fetch + materialize the engine, reconcile in place
 #   make rollback       sound undo of a bad update (restore DB + engine)
+#   make deps           install this fork's deps into the bind-mounted .venv + node_modules
+#   make test           run backend (.venv pytest / unittest) + UI (vitest) suites
 #   make sc ARGS=health run any ./sc subcommand (passthrough)
 #
 SC := ./sc
-.PHONY: launch enter down build logs serve health ports verify update rollback snapshot render map install sc
+.PHONY: launch enter down build logs serve health ports verify update rollback snapshot render map install sc deps test
 
 launch:   ; $(SC) launch
 enter:    ; $(SC) $(if $(s),enter-$(s),enter)
@@ -34,4 +36,6 @@ snapshot: ; $(SC) snapshot
 render:   ; $(SC) render $(ARGS)
 map:      ; $(SC) map
 install:  ; $(SC) install
+deps:     ; $(SC) deps
+test:     ; $(SC) test
 sc:       ; $(SC) $(ARGS)

--- a/sc
+++ b/sc
@@ -80,6 +80,107 @@ dbuild() {
     "$here"
 }
 
+# ── dev kit (deps + test) — in-container primitives, like serve/boot ──────────
+# A shell runs these from INSIDE the sandbox, where pip/npm act directly on the
+# bind-mounted repo: the .venv / node_modules they create live in the mount and so
+# persist across image rebuilds (the point of installing per-fork instead of baking
+# into the image). They run in the CURRENT environment — no docker re-exec — so on
+# the no-docker host path they use host python3/node, exactly like serve/boot.
+
+# List a fork's manifests, pruning the install-artifact + engine + vcs trees that
+# map_repo.py's SKIP_DIRS also excludes (never descend an installed/engine tree).
+# Also prunes `vendor/` — installing has a stronger reason to skip it than mapping
+# does: a vendored/submodule package.json (e.g. ui/vendor/md-converter) is built by
+# its parent, and a stray `npm ci`/`pip install` there runs third-party lifecycle
+# scripts we don't own. We install only the manifests the fork itself authors.
+_sc_find_manifests() {  # $1 = filename glob, e.g. 'requirements*.txt'
+  find "$here" \
+    \( -name node_modules -o -name .venv -o -name venv -o -name .super-coder \
+       -o -name .sc-state -o -name .git -o -name __pycache__ \
+       -o -name dist -o -name build -o -name vendor \) -prune -o \
+    -name "$1" -type f -print
+}
+
+# Install the fork's deps into the bind-mounted repo: one repo-root .venv from every
+# requirements*.txt (fork pins win), then an engine baseline test kit layered on with
+# only-if-needed so `./sc test` works even if the fork's reqs omit pytest; plus
+# `npm ci` for each package.json. Discovery is a glob walk (map-independent — runs on
+# a fresh fork before `./sc map`). A map-backed fast path would read dr_filepath.path
+# (dr_dependency.source_file is basename-only, so it can't locate a manifest's dir).
+sc_deps() {
+  rc=0
+  venv="$here/.venv"
+  reqs="$(_sc_find_manifests 'requirements*.txt')"
+  base_reqs="$(printf '%s\n' "$reqs" | grep -v 'requirements-dev\.txt' || true)"
+  if [ -n "$base_reqs" ]; then
+    if [ ! -x "$venv/bin/python" ]; then
+      echo "→ deps: creating $venv"
+      "$PY" -m venv "$venv" || { echo "✗ deps: venv create failed" >&2; return 1; }
+    fi
+    # Fork pins first (authoritative), with a sibling requirements-dev.txt if present.
+    printf '%s\n' "$base_reqs" | while IFS= read -r req; do
+      [ -n "$req" ] || continue
+      echo "→ deps: pip install -r $req"
+      "$venv/bin/pip" install -q -r "$req" || exit 1
+      dev="$(dirname "$req")/requirements-dev.txt"
+      if [ -f "$dev" ]; then
+        echo "→ deps: pip install -r $dev"
+        "$venv/bin/pip" install -q -r "$dev" || exit 1
+      fi
+    done || rc=1
+    # Engine baseline test kit — only-if-needed never overrides a fork's pin.
+    echo "→ deps: engine test kit (pytest httpx coverage, only-if-needed)"
+    "$venv/bin/pip" install -q --upgrade-strategy only-if-needed pytest httpx coverage || rc=1
+  fi
+  pkgs="$(_sc_find_manifests 'package.json')"
+  if [ -n "$pkgs" ]; then
+    printf '%s\n' "$pkgs" | while IFS= read -r pkg; do
+      [ -n "$pkg" ] || continue
+      d="$(dirname "$pkg")"
+      if [ -f "$d/package-lock.json" ]; then
+        echo "→ deps: npm ci in $d"; ( cd "$d" && npm ci ) || exit 1
+      else
+        echo "→ deps: npm install in $d"; ( cd "$d" && npm install ) || exit 1
+      fi
+    done || rc=1
+  fi
+  if [ -z "$base_reqs" ] && [ -z "$pkgs" ]; then
+    echo "→ deps: no requirements*.txt or package.json found — nothing to install"
+  fi
+  [ "$rc" -eq 0 ] || { echo "✗ deps: one or more installs failed" >&2; return 1; }
+  echo "✓ deps: done"
+}
+
+# Run the fork's test suites: backend (the .venv's pytest, honoring the fork's
+# pytest.ini; else the engine's own stdlib-unittest suite) + UI (npm run test /
+# vitest in any package.json dir that declares a test script). Non-zero if any fail.
+sc_test() {
+  rc=0
+  venv="$here/.venv"
+  if [ -x "$venv/bin/pytest" ]; then
+    echo "→ test: $venv/bin/pytest"
+    ( cd "$here" && "$venv/bin/pytest" "$@" ) || rc=1
+  elif ls "$here"/tests/test_*.py >/dev/null 2>&1; then
+    echo "→ test: python3 -m unittest discover (stdlib)"
+    ( cd "$here" && "$PY" -m unittest discover -s tests -p 'test_*.py' ) || rc=1
+  else
+    echo "→ test: no python tests found"
+  fi
+  pkgs="$(_sc_find_manifests 'package.json')"
+  if [ -n "$pkgs" ]; then
+    printf '%s\n' "$pkgs" | while IFS= read -r pkg; do
+      [ -n "$pkg" ] || continue
+      d="$(dirname "$pkg")"
+      # Only run where a "test" script is declared (else npm errors "missing script").
+      if "$PY" -c "import json,sys; sys.exit(0 if json.load(open(sys.argv[1])).get('scripts',{}).get('test') else 1)" "$pkg" 2>/dev/null; then
+        echo "→ test: npm run test in $d"; ( cd "$d" && npm run test ) || exit 1
+      fi
+    done || rc=1
+  fi
+  [ "$rc" -eq 0 ] || { echo "✗ test: one or more suites failed" >&2; return 1; }
+  echo "✓ test: all suites passed"
+}
+
 cmd="${1:-help}"; [ $# -gt 0 ] && shift
 
 case "$cmd" in
@@ -101,6 +202,8 @@ case "$cmd" in
   serve)        exec "$PY" "$ENGINE/api/server.py" "$@" ;;
   boot)         exec "$PY" "$S/run.py" "$@" ;;
   boot-*)       exec "$PY" "$S/run.py" "${cmd#boot-}" "$@" ;;
+  deps)         sc_deps "$@" ;;
+  test)         sc_test "$@" ;;
   # ── docker sandbox (host-side; the default way to run) ──
   launch)
     dcheck
@@ -183,6 +286,8 @@ super-coder — forkable shell substrate
   Primitives (run inside the container; also the no-docker host escape hatch):
   ./sc serve               run the review layer (api + static UI) in the foreground
   ./sc boot [shortname]    auth + pick shell + pick harness + boot (no container, no GUI)
+  ./sc deps                install this fork's python (.venv) + node (node_modules) deps into the bind-mount
+  ./sc test                run backend (.venv pytest or stdlib unittest) + UI (vitest) suites; non-zero on any failure
 
   ./sc verify              rebuild + flat render + render-only boot (headless proof)
   ./sc health              curl the review layer's /api/health


### PR DESCRIPTION
Turns the sandbox into a **dev kit**: instead of baking project runtimes into the image, each fork installs its *own* pinned deps into the bind-mounted repo from inside the container, and gets `./sc deps` / `./sc test` plus a ready E2E browser.

> Supersedes this PR's original "bake FastAPI" approach. The repo is already bind-mounted live (`sc:131 -v "$here:$here"`), so deps don't need baking — installed *inside* the container they run there and persist in the mount across image rebuilds. The image carries only the **toolchain + an engine test kit**; app libs track the fork's pins, not the image.

## Dockerfile
- **+ ripgrep** (`rg`) in the base apt layer.
- **− system `pytest` bake** — app/test libs now live in the fork's `.venv`.
- **+ Playwright + Chromium baked at image level** (root, before the `USER` switch; `--with-deps` for OS libs) into a world-readable `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright`, so the unprivileged user *and* a fork's own runner both resolve it. Pinned `playwright==1.60.0`. Baked (not per-fork) because it needs root-only OS libs and drives the app over HTTP, not via the app venv.
- **+ vibe** in the harness install layer — parity with `install.py HARNESS_INSTALL`, missing since #53.
- Header reframed: toolchain + baked browser; app deps come per-fork.

## `sc` (propagates to forks)
- **`./sc deps`** — glob-discovers the fork's `requirements*.txt` + `package.json` (pruning install-artifact / engine / `vendor` trees), builds one **repo-root `.venv`** (fork pins win), layers an engine baseline (`pytest httpx coverage`, `--upgrade-strategy only-if-needed` so it never clobbers a pin), and `npm ci`s each `package.json`. An in-container primitive like `serve`/`boot` — runs in the current env, no docker re-exec.
- **`./sc test`** — `.venv` pytest (honors the fork's `pytest.ini`) else stdlib unittest; plus `npm run test` (vitest) in each UI dir that declares a test script. Non-zero on any suite failure.
- Help text for both; `aliases.mk` gets propagating `deps`/`test` targets.

## Why this shape (recap of the design call)
- **In-container install, not baked:** exact pinned versions, no image bloat, no "which FastAPI is my app using" ambiguity. dos-arch's pm2 already runs `.venv/bin/uvicorn`.
- **Engine baseline test kit:** testing tools the host repo may not pin (pytest etc.) are layered in, so `./sc test` works even on a fork that didn't declare them.
- **Browser baked, on purpose:** OS libs can't live in a venv; the E2E runner drives the app over HTTP. Cost (~1.6GB) accepted for always-on visual testing.
- **Cartographer stays the declarer:** `./sc map` records deps into `dr_dependency`; `./sc deps` materializes. (Discovery uses a glob walk so it runs before `./sc map` ever has.)

## Verification (rebuilt image, 3.6GB)
- Toolchain present (rg 14.1.1, node 22, npm, gh, sqlite3); `fastapi` + `pytest` **no longer importable** system-wide (pivot confirmed); **Chromium launches as the unprivileged user** from `/opt/ms-playwright`; all four harnesses (claude/opencode/codex/**vibe 2.14.0**) on PATH.
- `./sc test` on the engine source repo runs the **12-test stdlib unittest suite**, exit 0.
- End-to-end fixture in-container: `./sc deps` builds `.venv` (fork `httpx` + baseline pytest) + `npm install`; `./sc test` runs `.venv/bin/pytest` (**2 passed**, sees the fork dep) + `npm test`; `.venv` persists in the bind-mount and is container-only by design.

_Branch name is stale (`feat/sandbox-fastapi-stack`) from this PR's first revision; squash-merge uses the title above._

🤖 Generated with [Claude Code](https://claude.com/claude-code)