### PR TITLE
feat(dev-kit): ruff+mypy+datasette baseline, ./sc lint/typecheck, dev_kit skill

### DIFF
--- a/.super-coder/assets/skills/dev_kit/SKILL.md
+++ b/.super-coder/assets/skills/dev_kit/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: dev_kit
+description: What the sandbox dev kit provides + how to drive it — ./sc deps, ./sc test, ./sc lint, ./sc typecheck, the .venv tools, rg/sqlite3, the baked browser, and the container/host app boundary. Use when building or testing in a fork.
+category: substrate
+common: false
+---
+
+# dev_kit — the sandbox dev kit
+
+What you have to build, test, and inspect a fork — and the one boundary that
+trips shells up.
+
+## You are in a container
+
+You run **inside the sandbox container**; the repo is bind-mounted at its host
+path. The app the FnB watches in their browser is a **separate instance** — the
+host-supervised stack (pm2 / `make`), outside your container. To *see* the app
+yourself, run a dev server **inside** the sandbox on `0.0.0.0:$SC_DEV_PORT`; the
+FnB reaches that instance at `http://127.0.0.1:$SC_DEV_PORT`. (See the boot
+doc's `RUNNING THE APP` section.)
+
+## Install + run
+
+- `./sc deps` — install the fork's deps into the bind-mount: a repo-root `.venv`
+  from every `requirements*.txt` (fork pins win) + `npm ci`/`install` per
+  `package.json`. Persists across image rebuilds. **Run this first.**
+- `./sc test` — backend (`.venv` pytest honoring the fork's `pytest.ini`, else
+  the engine's stdlib unittest) + UI (`npm run test` / vitest where a `test`
+  script is declared). Non-zero if any suite fails.
+
+## The `.venv` dev kit
+
+`./sc deps` layers these onto the fork's own deps with `--upgrade-strategy
+only-if-needed`, so a fork's pins and its `[tool.ruff]`/`[tool.mypy]` config
+always win. **Available, not enforced** — opt in per fork.
+
+- `./sc lint [paths]` → `.venv/bin/ruff check` — lint + format-check.
+  (`.venv/bin/ruff format` to apply formatting.)
+- `./sc typecheck [paths]` → `.venv/bin/mypy` — Python type-check.
+- `.venv/bin/pytest` / `coverage` / `httpx` — test + HTTP client (also via `./sc test`).
+- `.venv/bin/datasette <db.sqlite>` — browse a SQLite DB in a web GUI when the
+  `sqlite3` CLI isn't enough. Bind `0.0.0.0:$SC_DEV_PORT` to view it from the host.
+
+> The `.venv` baseline only materializes when the fork declares Python (a
+> `requirements*.txt`). A pure-frontend fork gets node only.
+
+## Baked into the image
+
+Always present, no `./sc deps` needed:
+
+- `rg` (ripgrep), `sqlite3` CLI, `curl`, `node` 22 / `npm`.
+- **Playwright + Chromium** at `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright`
+  (world-readable). The fork's `@playwright/test` / `playwright` runner resolves
+  it automatically — E2E drives the *running* app over HTTP, so start a dev
+  server first.
+
+## Frontend checks
+
+`svelte-check`, `tsc`, vitest come from the fork's own `package.json` devDeps —
+installed by `./sc deps`' `npm ci`, run via the fork's npm scripts (or `./sc test`).
+
+## Stance
+
+`./sc deps` before anything else in a fresh sandbox — qwen's "node missing" was
+just deps-not-installed. Lint/type-check are there when you want them, never
+forced; respect the fork's config. To see the app, run a dev server in the
+container — never restart the FnB's host stack.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -9,7 +9,7 @@ BEGIN;
 
 -- Retire any catalogue skill that is no longer authored (soft-delete;
 -- keeps the row + id so a re-add is stable and grants are recoverable).
-UPDATE skills SET is_deleted=1 WHERE name NOT IN ('api-design', 'blueprint', 'bootstrap', 'cartographer', 'database-migrations', 'db_map', 'docs', 'flags', 'git', 'memory', 'messaging', 'onboard', 'redline_review', 'self_update', 'snapshot', 'surface_catalogue');
+UPDATE skills SET is_deleted=1 WHERE name NOT IN ('api-design', 'blueprint', 'bootstrap', 'cartographer', 'database-migrations', 'db_map', 'dev_kit', 'docs', 'flags', 'git', 'memory', 'messaging', 'onboard', 'redline_review', 'self_update', 'snapshot', 'surface_catalogue');
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'api-design',
@@ -476,6 +476,79 @@ WHERE flag_id=?;
 Content lives in the `.db` until you serialize it. Run `./sc snapshot` (and
 `./sc render` if you changed documents/roadmap/skills), then commit the text —
 see the `snapshot` skill for the full lifecycle.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'dev_kit',
+  'What the sandbox dev kit provides + how to drive it — ./sc deps, ./sc test, ./sc lint, ./sc typecheck, the .venv tools, rg/sqlite3, the baked browser, and the container/host app boundary. Use when building or testing in a fork.',
+  'substrate',
+  NULL,
+  0,
+  '# dev_kit — the sandbox dev kit
+
+What you have to build, test, and inspect a fork — and the one boundary that
+trips shells up.
+
+## You are in a container
+
+You run **inside the sandbox container**; the repo is bind-mounted at its host
+path. The app the FnB watches in their browser is a **separate instance** — the
+host-supervised stack (pm2 / `make`), outside your container. To *see* the app
+yourself, run a dev server **inside** the sandbox on `0.0.0.0:$SC_DEV_PORT`; the
+FnB reaches that instance at `http://127.0.0.1:$SC_DEV_PORT`. (See the boot
+doc''s `RUNNING THE APP` section.)
+
+## Install + run
+
+- `./sc deps` — install the fork''s deps into the bind-mount: a repo-root `.venv`
+  from every `requirements*.txt` (fork pins win) + `npm ci`/`install` per
+  `package.json`. Persists across image rebuilds. **Run this first.**
+- `./sc test` — backend (`.venv` pytest honoring the fork''s `pytest.ini`, else
+  the engine''s stdlib unittest) + UI (`npm run test` / vitest where a `test`
+  script is declared). Non-zero if any suite fails.
+
+## The `.venv` dev kit
+
+`./sc deps` layers these onto the fork''s own deps with `--upgrade-strategy
+only-if-needed`, so a fork''s pins and its `[tool.ruff]`/`[tool.mypy]` config
+always win. **Available, not enforced** — opt in per fork.
+
+- `./sc lint [paths]` → `.venv/bin/ruff check` — lint + format-check.
+  (`.venv/bin/ruff format` to apply formatting.)
+- `./sc typecheck [paths]` → `.venv/bin/mypy` — Python type-check.
+- `.venv/bin/pytest` / `coverage` / `httpx` — test + HTTP client (also via `./sc test`).
+- `.venv/bin/datasette <db.sqlite>` — browse a SQLite DB in a web GUI when the
+  `sqlite3` CLI isn''t enough. Bind `0.0.0.0:$SC_DEV_PORT` to view it from the host.
+
+> The `.venv` baseline only materializes when the fork declares Python (a
+> `requirements*.txt`). A pure-frontend fork gets node only.
+
+## Baked into the image
+
+Always present, no `./sc deps` needed:
+
+- `rg` (ripgrep), `sqlite3` CLI, `curl`, `node` 22 / `npm`.
+- **Playwright + Chromium** at `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright`
+  (world-readable). The fork''s `@playwright/test` / `playwright` runner resolves
+  it automatically — E2E drives the *running* app over HTTP, so start a dev
+  server first.
+
+## Frontend checks
+
+`svelte-check`, `tsc`, vitest come from the fork''s own `package.json` devDeps —
+installed by `./sc deps`'' `npm ci`, run via the fork''s npm scripts (or `./sc test`).
+
+## Stance
+
+`./sc deps` before anything else in a fresh sandbox — qwen''s "node missing" was
+just deps-not-installed. Lint/type-check are there when you want them, never
+forced; respect the fork''s config. To see the app, run a dev server in the
+container — never restart the FnB''s host stack.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -92,7 +92,10 @@ shell, `--message send <shortname> <body>`; mark an item read with
 
 ## RUNNING THE APP
 
-Two runtimes, two homes — keep them apart:
+You run **inside the sandbox container**; this repo is bind-mounted in at its host
+path. The app the FnB watches in their browser is a **separate instance** — the
+host-supervised stack, outside your container. So there are two runtimes with two
+homes — keep them apart:
 
 - **Project dev servers** (vite, `npm run dev`, etc.) belong in the **sandbox**,
   bound to `0.0.0.0:$SC_DEV_PORT` — the per-fork port `./sc launch` publishes to

--- a/.super-coder/templates/shells/dev.json
+++ b/.super-coder/templates/shells/dev.json
@@ -4,5 +4,5 @@
   "role": "Dev shell",
   "mandate": "Build and implement in {{repo}} — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.",
   "focus": "You are a builder. Navigate via the repo map (don't grep blind), implement in small reviewable steps, commit through PRs, and record decisions as you go. Planning scopes the work; you make it real; review verifies it.",
-  "skills": ["docs", "flags", "git", "database-migrations", "redline_review"]
+  "skills": ["docs", "flags", "git", "database-migrations", "redline_review", "dev_kit"]
 }

--- a/sc
+++ b/sc
@@ -128,9 +128,11 @@ sc_deps() {
         "$venv/bin/pip" install -q -r "$dev" || exit 1
       fi
     done || rc=1
-    # Engine baseline test kit — only-if-needed never overrides a fork's pin.
-    echo "→ deps: engine test kit (pytest httpx coverage, only-if-needed)"
-    "$venv/bin/pip" install -q --upgrade-strategy only-if-needed pytest httpx coverage || rc=1
+    # Engine baseline dev kit — test (pytest/httpx/coverage), lint+format (ruff),
+    # type-check (mypy), SQLite GUI (datasette). only-if-needed never overrides a
+    # fork's pin or its [tool.ruff]/[tool.mypy] config — available, not enforced.
+    echo "→ deps: engine dev kit (pytest httpx coverage ruff mypy datasette, only-if-needed)"
+    "$venv/bin/pip" install -q --upgrade-strategy only-if-needed pytest httpx coverage ruff mypy datasette || rc=1
   fi
   pkgs="$(_sc_find_manifests 'package.json')"
   if [ -n "$pkgs" ]; then
@@ -181,6 +183,26 @@ sc_test() {
   echo "✓ test: all suites passed"
 }
 
+# Lint + format-check the fork's python with the .venv's ruff (honors the fork's
+# [tool.ruff] config). Defaults to the repo root; pass paths/flags through. The
+# tool is available, not enforced — a fork opts in by running this. Needs `./sc deps`.
+sc_lint() {
+  venv="$here/.venv"
+  [ -x "$venv/bin/ruff" ] || { echo "✗ lint: no .venv/bin/ruff — run ./sc deps first" >&2; return 1; }
+  echo "→ lint: $venv/bin/ruff check"
+  ( cd "$here" && "$venv/bin/ruff" check "$@" )
+}
+
+# Type-check the fork's python with the .venv's mypy (honors the fork's
+# [tool.mypy] config). Same available-not-enforced stance as lint. Needs `./sc deps`.
+sc_typecheck() {
+  venv="$here/.venv"
+  [ -x "$venv/bin/mypy" ] || { echo "✗ typecheck: no .venv/bin/mypy — run ./sc deps first" >&2; return 1; }
+  echo "→ typecheck: $venv/bin/mypy"
+  if [ $# -gt 0 ]; then ( cd "$here" && "$venv/bin/mypy" "$@" )
+  else ( cd "$here" && "$venv/bin/mypy" . ); fi
+}
+
 cmd="${1:-help}"; [ $# -gt 0 ] && shift
 
 case "$cmd" in
@@ -204,6 +226,8 @@ case "$cmd" in
   boot-*)       exec "$PY" "$S/run.py" "${cmd#boot-}" "$@" ;;
   deps)         sc_deps "$@" ;;
   test)         sc_test "$@" ;;
+  lint)         sc_lint "$@" ;;
+  typecheck)    sc_typecheck "$@" ;;
   # ── docker sandbox (host-side; the default way to run) ──
   launch)
     dcheck
@@ -287,7 +311,10 @@ super-coder — forkable shell substrate
   ./sc serve               run the review layer (api + static UI) in the foreground
   ./sc boot [shortname]    auth + pick shell + pick harness + boot (no container, no GUI)
   ./sc deps                install this fork's python (.venv) + node (node_modules) deps into the bind-mount
+                             (plus an only-if-needed dev kit: pytest httpx coverage ruff mypy datasette)
   ./sc test                run backend (.venv pytest or stdlib unittest) + UI (vitest) suites; non-zero on any failure
+  ./sc lint [paths]        ruff check the fork's python (.venv ruff; honors [tool.ruff]) — available, not enforced
+  ./sc typecheck [paths]   mypy the fork's python (.venv mypy; honors [tool.mypy]) — available, not enforced
 
   ./sc verify              rebuild + flat render + render-only boot (headless proof)
   ./sc health              curl the review layer's /api/health


### PR DESCRIPTION
Follow-up to #54 (merged). The dev kit pivoted forks to install their own deps into the bind-mounted repo via `./sc deps`; this adds the depth a fork shell (qwen) asked for. **No image rebuild** — everything lands in the fork `.venv`, not the image.

## What's in it

**1 · `.venv` baseline (`./sc deps`)** gains `ruff` (lint/format), `mypy` (type-check), `datasette` (SQLite web GUI), installed `--upgrade-strategy only-if-needed` so a fork's pins and its `[tool.ruff]`/`[tool.mypy]` config always win. *Available, not enforced.*

**2 · `./sc lint` + `./sc typecheck`** — thin wrappers over the `.venv` ruff/mypy, mirroring `./sc test`. Pass paths/flags through; fail with a `run ./sc deps first` hint when the `.venv` is absent.

**3 · `dev_kit` skill** — granted to the `dev` flavor; documents the kit (deps/test/lint/typecheck, baked `rg`/`sqlite3`/Chromium) and the container↔host app boundary. `boot.md`'s `RUNNING THE APP` gains a lead-in naming the sandbox-container boundary explicitly — **stance unchanged** (shell still controls the host stack only through its supervisor).

## Verification

- `./sc test` (engine source) → 12/12 stdlib unittests green.
- Baseline pip line in a clean venv resolves ruff 0.15.16 / mypy 2.1.0 / datasette 0.65.2 / pytest 9.0.3.
- `./sc lint` / `./sc typecheck` with no `.venv` → clean failure + deps hint.
- `./sc seed-skills` → 17 skills incl `dev_kit`; `./sc rebuild` seeds the `dev_kit` row (substrate).

Forks pick this up via `./sc update`. Spec: `shared/dev-kit-tooling-spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)