### PR TITLE
Retire the authored shells.connections layer (B5 vestige)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -63,7 +63,7 @@ def mdc_url(markdown: str) -> str:
 
 # Shell fields the review layer may write. seed/L&S/system_prompt/mandate are
 # deliberately ABSENT — the law says the shell curates them, so there is no door.
-SHELL_EDITABLE = {"current_state", "connections"}  # workspace retired (B5) → connections is the one surface
+SHELL_EDITABLE = {"current_state"}  # workspace + connections both retired (B5) → current_state is the one writable surface; "where things live" is the derived dr_* map
 FLAG_EDITABLE = {"resolved", "resolution_notes", "description", "feature_id", "priority"}
 ROADMAP_EDITABLE = {"title", "roadmap_status", "summary", "sort_order"}
 
@@ -96,7 +96,7 @@ def get_shells(con) -> list[dict]:
 def get_shell(con, sid: int) -> dict | None:
     r = con.execute(
         "SELECT shell_id, display_name, shortname, partner, role, mandate, "
-        "system_prompt, current_state, connections, lineage_seed, "
+        "system_prompt, current_state, lineage_seed, "
         "has_identity, active_archive_id FROM shells "
         "WHERE shell_id=? AND COALESCE(is_deleted,0)=0", (sid,)).fetchone()
     if r is None:

--- a/.super-coder/assets/skills/db_map/SKILL.md
+++ b/.super-coder/assets/skills/db_map/SKILL.md
@@ -17,7 +17,7 @@ after any content write, `./sc snapshot` re-serializes to text (see the
 
 | Table | Holds | Write rule |
 |---|---|---|
-| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `connections` (authored "where things live" notes → boot `## CONNECTIONS`), `lineage_seed`, `active_archive_id` | UPDATE in place |
+| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `lineage_seed`, `active_archive_id`. (`connections`/`workspace` retired — boot `## CONNECTIONS` is derived from the `dr_*` map, not authored here) | UPDATE in place |
 | `dr_section` | the navigation index — `name`, `path_prefix`, `description`; rendered in boot `## CONNECTIONS`. Cartographer-authored | INSERT/UPDATE (cartographer) |
 | `shell_identity_entries` | seed (cap 10) + L&S (`kind='lns'`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
 | `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -422,7 +422,7 @@ after any content write, `./sc snapshot` re-serializes to text (see the
 
 | Table | Holds | Write rule |
 |---|---|---|
-| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `connections` (authored "where things live" notes → boot `## CONNECTIONS`), `lineage_seed`, `active_archive_id` | UPDATE in place |
+| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `lineage_seed`, `active_archive_id`. (`connections`/`workspace` retired — boot `## CONNECTIONS` is derived from the `dr_*` map, not authored here) | UPDATE in place |
 | `dr_section` | the navigation index — `name`, `path_prefix`, `description`; rendered in boot `## CONNECTIONS`. Cartographer-authored | INSERT/UPDATE (cartographer) |
 | `shell_identity_entries` | seed (cap 10) + L&S (`kind=''lns''`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
 | `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -83,12 +83,13 @@ def render_projects(con, shell_id: int) -> str:
     return "\n".join(lines)
 
 
-def render_connections(con, shell) -> str:
-    """## CONNECTIONS — the single "where things live" surface (B5). Three layers,
-    top to bottom: a derived header (facts, never authored), the section index
-    (`dr_section`, prefix-joined to live file counts), and the authored notes
-    (`shells.connections` free text — wiring the map can't derive). The shell sees
-    *where to start* here, then queries one section's leaves on demand."""
+def render_connections(con) -> str:
+    """## CONNECTIONS — the single "where things live" surface (B5). Two layers,
+    top to bottom: a derived header (facts, never authored) and the section index
+    (`dr_section`, prefix-joined to live file counts). The shell sees *where to
+    start* here, then queries one section's leaves on demand. (The old authored
+    `shells.connections` free-text layer was retired — nothing prompted shells to
+    fill it, so it sat empty; the map is the surface now.)"""
     repo = con.execute(
         "SELECT root, default_branch, mapped_at FROM dr_repo WHERE repo_id=1").fetchone()
     lines = ["**Need to find something? Look here first** — read the `dr_*` map via "
@@ -116,9 +117,6 @@ def render_connections(con, shell) -> str:
         if unsectioned:
             lines.append(f"- _other / unsectioned_ · {unsectioned} files — cartographer worklist")
 
-    notes = ((shell["connections"] if "connections" in shell.keys() else None) or "").strip()
-    if notes:
-        lines += ["", notes]
     return "\n".join(lines)
 
 
@@ -224,7 +222,7 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
         "", "---", "",
         "## SYSTEM PROMPT", "", system_prompt,
         "", "---", "",
-        "## CONNECTIONS", "", render_connections(con, shell),
+        "## CONNECTIONS", "", render_connections(con),
         "", "---", "",
         "## CURRENT STATE", "", current_state,
         "", "---", "",

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -44,8 +44,8 @@ CREATE TABLE shells (
     mandate           TEXT,
     system_prompt     TEXT    NOT NULL,
     current_state     TEXT,
-    connections       TEXT,                          -- authored "where things live" notes; rendered in ## CONNECTIONS (B5)
-    workspace         TEXT,                          -- RETIRED (B5): superseded by connections; unrendered, unauthored, kept to avoid a table rebuild
+    connections       TEXT,                          -- RETIRED (B5): authored "where things live" layer; nothing prompted shells to fill it so it sat empty — ## CONNECTIONS is now wholly derived from the dr_* map. Unrendered, unauthored, kept to avoid a table rebuild
+    workspace         TEXT,                          -- RETIRED (B5): superseded by connections (itself since retired); unrendered, unauthored, kept to avoid a table rebuild
 
     lineage_seed      TEXT,
     flavor            TEXT,                          -- dev / planner / reviewer / cartographer (NULL = bespoke, e.g. maintainer); launch defaults in flavor_defaults

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -86,7 +86,6 @@ function shellCard(s) {
 
   // editable operational fields
   c.append(field("current_state", s.current_state, "current_state", s.shell_id));
-  c.append(field("connections", s.connections, "connections", s.shell_id));
 
   // skills + grants (editable)
   const sk = el("div", {});


### PR DESCRIPTION
## What

The boot `## CONNECTIONS` block had **three layers**: a derived repo header, the cartographer-maintained `dr_section` index, and an **authored free-text layer** (`shells.connections`). This PR retires the authored layer — the block is now wholly derived from the `dr_*` map.

## Why

The redline (`shared/redlines/connections.png`) flagged an empty box in the shell editor that reads as "removed / broken." Investigation: **nothing instructs a shell to write `connections`.**

- `boot.md` (the only always-loaded surface) tells shells to *read* the `dr_*` map — never to author free-text.
- No flavor system prompt (`planner/dev/reviewer/cartographer.json`) mentions it.
- The sole write-mention was a passive description in the lazy-loaded `db_map` skill.

So it sat empty on every newly-created shell (PLN1/DEV1/REV1). The B5 redesign had already moved "where things live" onto the derived map + cartographer; the authored free-text was a leftover. This finishes that retirement — same pattern `workspace` got.

## Changes

- `render/compose.py` — `render_connections` drops the notes layer (two derived layers remain)
- `ui/app.js` + `api/server.py` — remove the editable field + `SHELL_EDITABLE` entry + dead SELECT column
- `schema.sql` — mark the `connections` column **RETIRED** (column kept, like `workspace`, to avoid a table rebuild)
- `assets/skills/db_map/SKILL.md` — drop `connections` from the write table; `0001_seed_skills.sql` regenerated

## Migration / forks

No schema migration needed — the column stays. Installed forks pick up the db_map wording via `./sc update` (re-applies the regenerated skills seed). Existing authored `connections` values (e.g. CART1) simply stop rendering.

## Verified

- `render_connections` smoke-tested against the live DB: renders header + section index, no crash, prior authored note does **not** leak.
- `py_compile` + `node --check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)