### PR TITLE
feat(ui): expandable roadmap/flag boxes, bigger current_state, polish

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -70,7 +70,7 @@ async function renderShells(root) {
 }
 
 function field(label, value, key, sid) {
-  const ta = el("textarea", { value: value || "", rows: key === "current_state" ? 4 : 2 });
+  const ta = el("textarea", { value: value || "", rows: key === "current_state" ? 12 : 2 });
   const save = el("button", { className: "act", textContent: "save" });
   save.onclick = async () => {
     try { await api("/shells/" + sid, "PATCH", { [key]: ta.value }); setStatus("saved " + key); }
@@ -164,37 +164,48 @@ async function renderRoadmap(root) {
 }
 
 function featureCard(f) {
-  const c = el("div", { className: "card" });
-  const head = el("h2", {}, f.title || "(untitled)");
-  if (f.owner) head.append(el("span", { className: "pill " + f.roadmap_status, textContent: " " + f.owner }));
-  c.append(head);
+  // Expandable box: collapsed shows title + status/owner pills + a one-line
+  // summary preview; expanded reveals the editable fields, docs, and blockers.
+  const c = el("details", { className: "card feature" });
+  const sum = el("summary", { className: "feature-head" });
+  sum.append(el("span", { className: "feature-title" }, f.title || "(untitled)"));
+  const meta = el("span", { className: "feature-meta" });
+  meta.append(el("span", { className: "pill " + f.roadmap_status, textContent: SLABEL[f.roadmap_status] || f.roadmap_status }));
+  if (f.owner) meta.append(el("span", { className: "pill " + f.roadmap_status, textContent: f.owner }));
+  if (f.open_flags?.length) meta.append(el("span", { className: "pill warn", textContent: f.open_flags.length + " ⚑" }));
+  sum.append(meta);
+  c.append(sum);
+  if (f.summary) c.append(el("div", { className: "feature-preview muted" }, f.summary));
+
+  const body = el("div", { className: "feature-body" });
 
   // editable: title / status / summary / sort
   const title = el("input", { type: "text", value: f.title || "" });
   const status = el("select", {});
   for (const s of STATUSES) status.append(el("option", { value: s, selected: s === f.roadmap_status, textContent: s }));
-  const summary = el("textarea", { value: f.summary || "", rows: 2 });
+  const summary = el("textarea", { value: f.summary || "", rows: 7 });
   const save = el("button", { className: "act", textContent: "save feature" });
   save.onclick = async () => {
     try { await api("/roadmap/" + f.feature_id, "PATCH", { title: title.value, roadmap_status: status.value, summary: summary.value }); setStatus("feature saved"); load("roadmap"); }
     catch (e) { toast("error: " + e.message); }
   };
-  c.append(el("div", { className: "grid2" },
+  body.append(el("div", { className: "grid2" },
     el("span", { className: "k" }, "title"), title,
     el("span", { className: "k" }, "status"), status,
     el("span", { className: "k" }, "summary"), summary), save);
 
   // documents — specs (editable/frozen per state) then docs (read-only here;
   // the Docs tab is where docs are edited)
-  for (const d of f.documents || []) c.append(docBlock(d, { readOnly: d.kind === "doc" }));
+  for (const d of f.documents || []) body.append(docBlock(d, { readOnly: d.kind === "doc" }));
 
   // open flags = blockers
   if (f.open_flags?.length) {
     const fl = el("div", {});
     fl.append(el("label", { className: "k", textContent: "blockers (open flags)" }));
     for (const x of f.open_flags) fl.append(el("div", { className: "tag" }, `${x.display_name || ""} ${x.description || ""}`));
-    c.append(fl);
+    body.append(fl);
   }
+  c.append(body);
   return c;
 }
 
@@ -334,13 +345,20 @@ async function renderFlags(root) {
 }
 
 function flagRow(f) {
-  const row = el("div", { className: "flag" + (f.resolved ? " resolved" : "") });
-  row.append(el("span", { className: "pill " + (f.priority || "").toLowerCase() }, f.priority || ""));
-  const d = el("div", { className: "desc" });
+  // Expandable: collapsed row shows priority + name + description on one line;
+  // expanding reveals the resolution note (resolved) or the resolve action (open).
+  const row = el("details", { className: "flag" + (f.resolved ? " resolved" : "") });
+  const head = el("summary", { className: "flag-head" });
+  head.append(el("span", { className: "pill " + (f.priority || "").toLowerCase() }, f.priority || ""));
+  const d = el("span", { className: "desc" });
   d.append(el("b", {}, (f.display_name ? f.display_name + " " : "")), esc(f.description || ""));
-  if (f.resolved) d.append(el("div", { className: "tag" }, `resolved ${f.resolved_date || ""} — ${f.resolution_notes || ""}`));
-  row.append(d);
-  if (!f.resolved) {
+  head.append(d);
+  row.append(head);
+
+  const body = el("div", { className: "flag-body" });
+  if (f.resolved) {
+    body.append(el("div", { className: "tag" }, `resolved ${f.resolved_date || ""} — ${f.resolution_notes || ""}`));
+  } else {
     const btn = el("button", { className: "act", textContent: "resolve" });
     btn.onclick = async () => {
       const notes = prompt("Resolution notes:");
@@ -348,8 +366,9 @@ function flagRow(f) {
       try { await api("/flags/" + f.flag_id, "PATCH", { resolved: 1, resolution_notes: notes }); setStatus("flag resolved"); load("flags"); }
       catch (e) { toast("error: " + e.message); }
     };
-    row.append(btn);
+    body.append(btn);
   }
+  row.append(body);
   return row;
 }
 

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -75,6 +75,30 @@ a.act { text-decoration: none; display: inline-block; }
 .seed-entry, .lns-entry { margin: .5rem 0; padding-left: .6rem; border-left: 1px solid var(--line); }
 .seed-entry .d { color: var(--dim); font-size: .78rem; }
 details summary { cursor: pointer; color: var(--accent); }
+
+/* ── Expandable feature boxes (Roadmap) ───────────────────────────────────── */
+details.feature { padding: 0; overflow: hidden; transition: border-color .12s; }
+details.feature[open] { border-color: var(--accent2); }
+details.feature > summary {
+  list-style: none; color: var(--ink); cursor: pointer; user-select: none;
+  display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
+  padding: .75rem 1.1rem; border-radius: var(--r);
+}
+details.feature > summary::-webkit-details-marker { display: none; }
+details.feature > summary::before {
+  content: "▸"; color: var(--dim); flex: none; transition: transform .12s; font-size: .8rem;
+}
+details.feature[open] > summary::before { transform: rotate(90deg); }
+details.feature > summary:hover { background: var(--accent2); }
+.feature-title { font-weight: 600; flex: 1 1 auto; min-width: 0; }
+.feature-meta { display: flex; gap: .35rem; flex-wrap: wrap; align-items: center; }
+.feature-preview {
+  padding: 0 1.1rem .75rem 2.2rem; font-size: .85rem;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+details.feature[open] > .feature-preview { display: none; }
+.feature-body { padding: 0 1.1rem 1.1rem; }
+.feature-body > .act:first-of-type { margin-top: .2rem; }
 .search { margin: 0 0 1rem; }
 .filters { display: flex; gap: .4rem; flex-wrap: wrap; margin: 0 0 1rem; }
 .chip {
@@ -93,9 +117,21 @@ details summary { cursor: pointer; color: var(--accent); }
 .bucket.collapsed > h2::before { transform: rotate(-90deg); }
 .bucket.collapsed > .card { display: none; }
 .doc-body { white-space: pre-wrap; background: var(--panel2); border: 1px solid var(--line); border-radius: 6px; padding: .8rem; max-height: 420px; overflow: auto; font: 12.5px/1.55 ui-monospace, monospace; }
-.flag { display: flex; gap: .8rem; align-items: flex-start; padding: .6rem 0; border-bottom: 1px solid var(--line); }
+.flag { border-bottom: 1px solid var(--line); }
 .flag.resolved { opacity: .5; }
+.flag > summary {
+  list-style: none; color: var(--ink); cursor: pointer; user-select: none;
+  display: flex; gap: .8rem; align-items: flex-start;
+  padding: .6rem .4rem; border-radius: 6px;
+}
+.flag > summary::-webkit-details-marker { display: none; }
+.flag > summary::before {
+  content: "▸"; color: var(--dim); flex: none; transition: transform .12s; font-size: .8rem; margin-top: .15rem;
+}
+.flag[open] > summary::before { transform: rotate(90deg); }
+.flag > summary:hover { background: var(--accent2); }
 .flag .desc { flex: 1; }
+.flag-body { padding: 0 .4rem .7rem 1.8rem; }
 .tag { font-size: .72rem; color: var(--dim); }
 a { color: var(--accent); }
 .list-skill { display: flex; align-items: center; gap: .5rem; padding: .2rem 0; }
@@ -111,3 +147,12 @@ a { color: var(--accent); }
 .bar-track { background: var(--panel2); border-radius: 99px; height: 10px; overflow: hidden; }
 .bar-fill { background: var(--accent); height: 100%; }
 .bar-n { text-align: right; color: var(--dim); font-size: .8rem; }
+
+/* ── Polish: motion + depth ──────────────────────────────────────────────── */
+nav button, button.act, .chip, #snapshot { transition: background .12s, border-color .12s, color .12s; }
+.card { transition: border-color .12s; }
+textarea, input[type=text], select { transition: border-color .12s, outline-color .12s; }
+.bar-fill { transition: width .3s ease; }
+.toast { animation: toast-in .18s ease-out; }
+@keyframes toast-in { from { opacity: 0; transform: translateY(.4rem); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) { * { transition: none !important; animation: none !important; } }


### PR DESCRIPTION
Tightens up the review UI (`.super-coder/ui/`).

## Changes
- **current_state** — textarea `4→12` rows so the full rolling status shows without scrolling.
- **Roadmap** — features are now expandable `<details>` boxes. Collapsed: title + status/owner pills + flag-count badge (`N ⚑`) + one-line summary preview (truncated). Expanded: caret rotates, editable fields/docs/blockers reveal. Summary editor `2→7` rows.
- **Flags** — now expandable `<details>` rows; resolve action / resolution note live behind the disclosure.
- **Polish** — custom disclosure carets, hover backgrounds on summaries, transitions on buttons/chips/nav/cards/inputs, animated toast entrance + bar fills, `prefers-reduced-motion` guard.

## Verification
- `node --check app.js` passes.
- `./sc serve` boots; `/`, `/app.js`, `/style.css` return 200; roadmap + flags APIs render. Bucket collapse-by-status still works (features keep the `.card` class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)