### PR TITLE
feat(admin): admin shell flavor + local skill and migration management

### DIFF
--- a/.super-coder/assets/skills/local_skill_management/SKILL.md
+++ b/.super-coder/assets/skills/local_skill_management/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: local_skill_management
+description: Create, persist, assign, and remove fork-specific skills — the correct authoring path so skills survive snapshot/rebuild cycles.
+category: substrate
+---
+
+# local_skill_management — fork-specific skills that survive
+
+Fork-specific skills live in the DB and are persisted via `.sc-state/content.sql`
+(the snapshot). The asset file under `.super-coder/assets/skills/` is used to
+**seed the skill initially** — but that directory is gitignored engine territory:
+`./sc update` materializes upstream engine files there, which removes any local
+additions. After the first seed + snapshot, **content.sql is the durable form**.
+
+The correct path: **file → seed → grant → snapshot → commit**.
+
+## Creating a fork-specific skill
+
+1. **Write the skill file.**
+   Path: `.super-coder/assets/skills/<name>/SKILL.md`
+
+   Required frontmatter:
+   ```yaml
+   ---
+   name: skill_name
+   description: One-line summary — shown in boot and catalogue
+   category: substrate   # or craft; omit for default
+   ---
+   ```
+   Body: Markdown. Write the procedure the shell will follow. Imperative,
+   precise — this is what boots into context, so compress ruthlessly.
+
+2. **Seed the skill into the DB.**
+   ```bash
+   cd <repo> && ./sc seed-skills
+   ```
+   UPSERTs the skill row into the live DB by name (id-stable). Does not touch
+   skills already in the DB that are absent from assets — those are other local
+   skills, left intact.
+
+3. **Grant the skill to the target shell(s).**
+   Find shell IDs:
+   ```sql
+   SELECT shell_id, display_name, flavor FROM shells WHERE is_deleted = 0;
+   ```
+   Grant:
+   ```sql
+   INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
+   SELECT <shell_id>, skill_id FROM skills
+   WHERE name = '<skill_name>' AND is_deleted = 0;
+   ```
+
+4. **Snapshot — this is the persistence step.**
+   ```bash
+   ./sc snapshot && ./sc render
+   ```
+   `snapshot.py` serializes local skills (any skill whose name is not in the
+   upstream engine assets) into `.sc-state/content.sql`. This is what survives
+   `./sc update` — when the engine materialize overwrites `.super-coder/assets/
+   skills/`, the skill row and its full content are reconstructed from
+   content.sql on rebuild. Without this step the skill is lost on next update.
+
+5. **Commit.**
+   Stage `.sc-state/content.sql` and `skills_sc/`. The asset file and
+   `0001_seed_skills.sql` are transient for local skills — don't rely on them
+   across updates.
+
+## Assigning an existing skill to additional shells
+
+```sql
+INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
+SELECT <shell_id>, skill_id FROM skills
+WHERE name = '<skill_name>' AND is_deleted = 0;
+```
+Then `./sc snapshot && ./sc render` and commit.
+
+## Removing a skill
+
+1. **Soft-delete the DB row and revoke grants.**
+   ```sql
+   UPDATE skills SET is_deleted = 1 WHERE name = '<name>';
+   DELETE FROM shell_skills
+   WHERE skill_id = (SELECT skill_id FROM skills WHERE name = '<name>');
+   ```
+
+2. **Snapshot, render, commit.**
+   ```bash
+   ./sc snapshot && ./sc render
+   ```
+   The deletion serializes to content.sql. If the asset file still exists under
+   `.super-coder/assets/skills/`, remove it too so `./sc seed-skills` doesn't
+   re-insert it.
+
+## What NOT to do
+
+- **Never skip the snapshot after creating a skill.** The asset file under
+  `.super-coder/assets/skills/` is overwritten by `./sc update`. If you seed
+  without snapshotting, the skill vanishes on the next engine update.
+- **Never edit `0001_seed_skills.sql` by hand.** It is generated; hand edits
+  are overwritten on the next `./sc seed-skills`.
+- **Never use the GUI to create skills.** The GUI writes only to the DB — it
+  cannot write the asset file or trigger a snapshot. Use this procedure instead.

--- a/.super-coder/assets/skills/migration_management/SKILL.md
+++ b/.super-coder/assets/skills/migration_management/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: migration_management
+description: Author and apply fork-specific DB schema migrations — naming, format, how to apply locally and verify.
+category: substrate
+---
+
+# migration_management — fork-specific schema changes
+
+Migrations live in `.super-coder/migrations/` and apply in numeric order,
+tracked by the `schema_migrations` ledger table. Engine updates apply pending
+migrations automatically; you can apply them locally without a fetch using
+`./sc update --no-fetch`.
+
+**Scope:** fork-specific schema changes — tables, columns, constraints, or
+system-content seeds (skills, flavor defaults) that this fork needs and that
+will not ship upstream. Upstream engine migrations arrive via `./sc update`
+and require no action from you.
+
+## Authoring a migration
+
+1. **Find the next migration number.**
+   ```bash
+   ls .super-coder/migrations/ | sort | tail -5
+   ```
+   Name the file `NNNN_<slug>.sql` where NNNN is the next integer, zero-padded
+   to 4 digits (e.g. `0012`).
+
+2. **Write the file.**
+   Path: `.super-coder/migrations/NNNN_<slug>.sql`
+
+   Requirements:
+   - Wrap in `BEGIN; ... COMMIT;`
+   - Idempotent: `CREATE TABLE IF NOT EXISTS`, `INSERT OR IGNORE`,
+     `CREATE INDEX IF NOT EXISTS`, `DROP TABLE IF EXISTS` before recreate
+   - Comment header: migration number, intent, and doctrine notes if relevant
+   - Structure and system content only — per-instance data (shell memory,
+     grants, roadmap, flags) lives in `.sc-state/content.sql` via snapshot,
+     not in migrations
+
+3. **Apply locally.**
+   ```bash
+   ./sc update --no-fetch
+   ```
+   Skips the upstream fetch; applies all pending local migrations in order.
+   Confirm the migration landed:
+   ```sql
+   SELECT * FROM schema_migrations ORDER BY applied_at DESC LIMIT 5;
+   ```
+
+4. **Verify.**
+   ```bash
+   ./sc verify
+   ```
+   Headless boot proof — confirms shells, memory, and schema are intact.
+
+5. **Snapshot and commit.**
+   ```bash
+   ./sc snapshot
+   ```
+   Commit `.sc-state/content.sql` + `migrations/NNNN_<slug>.sql`.
+
+## What makes a good migration
+
+- **Additive by default.** Add columns, tables, indexes. Avoid DROP or RENAME
+  unless correcting a prior mistake; prefer a new column over renaming one that
+  code may already reference.
+- **No per-instance content.** Shell memory, skill grants, roadmap items, and
+  flags go in the snapshot, not here. Migrations carry structure and system
+  content that propagates to all forks.
+- **Comment the why.** Future-you reading a migration needs the intent, not
+  just the SQL.
+
+## Rollback
+
+There is no per-migration rollback. `./sc rollback` restores the full DB +
+engine to the prior update point (`engine.ref.prev`). Use it only when a
+migration is so broken the DB is corrupt or the app won't start. For logical
+errors, write a corrective migration instead.

--- a/.super-coder/assets/skills/self_update/SKILL.md
+++ b/.super-coder/assets/skills/self_update/SKILL.md
@@ -3,7 +3,7 @@ name: self_update
 description: Update this fork's super-coder engine in place — fetch + materialize new code + migrations, keep all your memory; roll back a bad update soundly. The shell hands off to its own next boot. Use when a super-coder update is available.
 category: substrate
 command: ./sc update
-common: true
+common: false
 ---
 
 # self_update — laying a new floor under your own feet

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -892,6 +892,115 @@ ON CONFLICT(name) DO UPDATE SET
   content=excluded.content, is_deleted=0;
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'local_skill_management',
+  'Create, persist, assign, and remove fork-specific skills — the correct authoring path so skills survive snapshot/rebuild cycles.',
+  'substrate',
+  NULL,
+  1,
+  '# local_skill_management — fork-specific skills that survive
+
+Fork-specific skills live in the DB and are persisted via `.sc-state/content.sql`
+(the snapshot). The asset file under `.super-coder/assets/skills/` is used to
+**seed the skill initially** — but that directory is gitignored engine territory:
+`./sc update` materializes upstream engine files there, which removes any local
+additions. After the first seed + snapshot, **content.sql is the durable form**.
+
+The correct path: **file → seed → grant → snapshot → commit**.
+
+## Creating a fork-specific skill
+
+1. **Write the skill file.**
+   Path: `.super-coder/assets/skills/<name>/SKILL.md`
+
+   Required frontmatter:
+   ```yaml
+   ---
+   name: skill_name
+   description: One-line summary — shown in boot and catalogue
+   category: substrate   # or craft; omit for default
+   ---
+   ```
+   Body: Markdown. Write the procedure the shell will follow. Imperative,
+   precise — this is what boots into context, so compress ruthlessly.
+
+2. **Seed the skill into the DB.**
+   ```bash
+   cd <repo> && ./sc seed-skills
+   ```
+   UPSERTs the skill row into the live DB by name (id-stable). Does not touch
+   skills already in the DB that are absent from assets — those are other local
+   skills, left intact.
+
+3. **Grant the skill to the target shell(s).**
+   Find shell IDs:
+   ```sql
+   SELECT shell_id, display_name, flavor FROM shells WHERE is_deleted = 0;
+   ```
+   Grant:
+   ```sql
+   INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
+   SELECT <shell_id>, skill_id FROM skills
+   WHERE name = ''<skill_name>'' AND is_deleted = 0;
+   ```
+
+4. **Snapshot — this is the persistence step.**
+   ```bash
+   ./sc snapshot && ./sc render
+   ```
+   `snapshot.py` serializes local skills (any skill whose name is not in the
+   upstream engine assets) into `.sc-state/content.sql`. This is what survives
+   `./sc update` — when the engine materialize overwrites `.super-coder/assets/
+   skills/`, the skill row and its full content are reconstructed from
+   content.sql on rebuild. Without this step the skill is lost on next update.
+
+5. **Commit.**
+   Stage `.sc-state/content.sql` and `skills_sc/`. The asset file and
+   `0001_seed_skills.sql` are transient for local skills — don''t rely on them
+   across updates.
+
+## Assigning an existing skill to additional shells
+
+```sql
+INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
+SELECT <shell_id>, skill_id FROM skills
+WHERE name = ''<skill_name>'' AND is_deleted = 0;
+```
+Then `./sc snapshot && ./sc render` and commit.
+
+## Removing a skill
+
+1. **Soft-delete the DB row and revoke grants.**
+   ```sql
+   UPDATE skills SET is_deleted = 1 WHERE name = ''<name>'';
+   DELETE FROM shell_skills
+   WHERE skill_id = (SELECT skill_id FROM skills WHERE name = ''<name>'');
+   ```
+
+2. **Snapshot, render, commit.**
+   ```bash
+   ./sc snapshot && ./sc render
+   ```
+   The deletion serializes to content.sql. If the asset file still exists under
+   `.super-coder/assets/skills/`, remove it too so `./sc seed-skills` doesn''t
+   re-insert it.
+
+## What NOT to do
+
+- **Never skip the snapshot after creating a skill.** The asset file under
+  `.super-coder/assets/skills/` is overwritten by `./sc update`. If you seed
+  without snapshotting, the skill vanishes on the next engine update.
+- **Never edit `0001_seed_skills.sql` by hand.** It is generated; hand edits
+  are overwritten on the next `./sc seed-skills`.
+- **Never use the GUI to create skills.** The GUI writes only to the DB — it
+  cannot write the asset file or trigger a snapshot. Use this procedure instead.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'memory',
   'How this shell writes its memory — current_state, session narrative, seed, L&S, decisions. Write as it happens, not at close. Use to know WHEN and HOW to persist identity/work memory, and the caps.',
   'substrate',
@@ -1060,6 +1169,91 @@ ON CONFLICT(name) DO UPDATE SET
   content=excluded.content, is_deleted=0;
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'migration_management',
+  'Author and apply fork-specific DB schema migrations — naming, format, how to apply locally and verify.',
+  'substrate',
+  NULL,
+  1,
+  '# migration_management — fork-specific schema changes
+
+Migrations live in `.super-coder/migrations/` and apply in numeric order,
+tracked by the `schema_migrations` ledger table. Engine updates apply pending
+migrations automatically; you can apply them locally without a fetch using
+`./sc update --no-fetch`.
+
+**Scope:** fork-specific schema changes — tables, columns, constraints, or
+system-content seeds (skills, flavor defaults) that this fork needs and that
+will not ship upstream. Upstream engine migrations arrive via `./sc update`
+and require no action from you.
+
+## Authoring a migration
+
+1. **Find the next migration number.**
+   ```bash
+   ls .super-coder/migrations/ | sort | tail -5
+   ```
+   Name the file `NNNN_<slug>.sql` where NNNN is the next integer, zero-padded
+   to 4 digits (e.g. `0012`).
+
+2. **Write the file.**
+   Path: `.super-coder/migrations/NNNN_<slug>.sql`
+
+   Requirements:
+   - Wrap in `BEGIN; ... COMMIT;`
+   - Idempotent: `CREATE TABLE IF NOT EXISTS`, `INSERT OR IGNORE`,
+     `CREATE INDEX IF NOT EXISTS`, `DROP TABLE IF EXISTS` before recreate
+   - Comment header: migration number, intent, and doctrine notes if relevant
+   - Structure and system content only — per-instance data (shell memory,
+     grants, roadmap, flags) lives in `.sc-state/content.sql` via snapshot,
+     not in migrations
+
+3. **Apply locally.**
+   ```bash
+   ./sc update --no-fetch
+   ```
+   Skips the upstream fetch; applies all pending local migrations in order.
+   Confirm the migration landed:
+   ```sql
+   SELECT * FROM schema_migrations ORDER BY applied_at DESC LIMIT 5;
+   ```
+
+4. **Verify.**
+   ```bash
+   ./sc verify
+   ```
+   Headless boot proof — confirms shells, memory, and schema are intact.
+
+5. **Snapshot and commit.**
+   ```bash
+   ./sc snapshot
+   ```
+   Commit `.sc-state/content.sql` + `migrations/NNNN_<slug>.sql`.
+
+## What makes a good migration
+
+- **Additive by default.** Add columns, tables, indexes. Avoid DROP or RENAME
+  unless correcting a prior mistake; prefer a new column over renaming one that
+  code may already reference.
+- **No per-instance content.** Shell memory, skill grants, roadmap items, and
+  flags go in the snapshot, not here. Migrations carry structure and system
+  content that propagates to all forks.
+- **Comment the why.** Future-you reading a migration needs the intent, not
+  just the SQL.
+
+## Rollback
+
+There is no per-migration rollback. `./sc rollback` restores the full DB +
+engine to the prior update point (`engine.ref.prev`). Use it only when a
+migration is so broken the DB is corrupt or the app won''t start. For logical
+errors, write a corrective migration instead.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'onboard',
   'One-time, FnB-supervised ingest of a repo''s EXISTING docs/specs into the DB + roadmap backfill. The only time content flows file→DB. Run once after bootstrap on a fork that has existing documentation. Planning shell''s job.',
   'substrate',
@@ -1179,7 +1373,7 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
   'Update this fork''s super-coder engine in place — fetch + materialize new code + migrations, keep all your memory; roll back a bad update soundly. The shell hands off to its own next boot. Use when a super-coder update is available.',
   'substrate',
   './sc update',
-  1,
+  0,
   '# self_update — laying a new floor under your own feet
 
 This is you updating your own substrate. Not an external rebuild — **the local

--- a/.super-coder/migrations/0010_admin_flavor.sql
+++ b/.super-coder/migrations/0010_admin_flavor.sql
@@ -1,0 +1,26 @@
+-- 0010 — admin flavor defaults + self_update to admin-only
+--
+-- Introduces the admin flavor with its model defaults. Admin is the fork's
+-- infrastructure owner (engine updates, rollbacks, migrations, skill lifecycle).
+-- Decisions carry real risk (wrong rollback = data loss), so codex default
+-- is gpt-5.5 (premium). Claude: sonnet. Opencode: qwen3-coder.
+--
+-- self_update moves from common: true to common: false in this release.
+-- Revoke existing grants on non-admin shells so the live DB converges with
+-- the updated skill catalogue on ./sc update.
+
+BEGIN;
+
+INSERT OR IGNORE INTO flavor_defaults (flavor, harness, model, is_default) VALUES
+    ('admin', 'codex',    'gpt-5.5',                       1),
+    ('admin', 'claude',   'sonnet',                        0),
+    ('admin', 'opencode', 'ollama/qwen3-coder:480b-cloud', 0);
+
+-- Revoke self_update from non-admin shells.
+-- Safe if self_update doesn't exist yet (skill_id subquery returns NULL →
+-- DELETE matches nothing). Idempotent.
+DELETE FROM shell_skills
+WHERE skill_id = (SELECT skill_id FROM skills WHERE name = 'self_update' AND is_deleted = 0)
+  AND shell_id IN (SELECT shell_id FROM shells WHERE flavor != 'admin' AND is_deleted = 0);
+
+COMMIT;

--- a/.super-coder/templates/shells/admin.json
+++ b/.super-coder/templates/shells/admin.json
@@ -1,0 +1,8 @@
+{
+  "flavor": "admin",
+  "abbr": "ADM",
+  "role": "Admin shell",
+  "mandate": "Own {{repo}}'s super-coder infrastructure — keep the engine current, skills healthy, and DB schema sound. No other shell touches the substrate; you own the floor.",
+  "focus": "You are the fork's infrastructure owner. Update the engine, manage rollbacks, author and persist fork-specific skills via the correct authoring path (file first, catalogue second, grant third), and apply schema migrations. Working shells consume the substrate; you maintain it.",
+  "skills": ["self_update", "local_skill_management", "migration_management"]
+}


### PR DESCRIPTION
## Summary

- **Admin shell flavor** (`ADM`) — the fork's sole infrastructure owner. Mandate: keep the engine current, skills healthy, and DB schema sound. No other shell touches the substrate.
- **`local_skill_management` skill** — encodes the correct authoring path for fork-specific skills: write asset file → `./sc seed-skills` → grant → snapshot. Closes the GUI-only antipattern that lost `skill_authoring` in dos-arch.
- **`migration_management` skill** — author and apply fork-specific DB migrations; naming convention, idempotent SQL format, apply via `./sc update --no-fetch`, verify with `./sc verify`.
- **`self_update` → non-common** — engine updates are now admin-only. Migration 0010 revokes existing `self_update` grants from non-admin shells on `./sc update`.

## What to do after merging

1. `./sc update` in any fork to apply migration 0010 (revokes `self_update` from dev/planner/reviewer/cartographer shells).
2. Create an admin shell in each fork that needs local skill/migration management.
3. In dos-arch: use Admin + `local_skill_management` to properly author `skill_authoring` and any other fork-specific skills going forward.

## Test plan

- [ ] `./sc seed-skills` produces 19 skills with `self_update` at `common=0`
- [ ] `./sc update --no-fetch` applies migration 0010 cleanly (check `schema_migrations`)
- [ ] Creating an admin shell grants `self_update`, `local_skill_management`, `migration_management` + common skills
- [ ] Dev/planner/reviewer shells no longer have `self_update` after update
- [ ] `./sc verify` passes after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)