### PR TITLE
fix(admin): local_skill_management + migration_management non-common

### DIFF
--- a/.super-coder/assets/skills/local_skill_management/SKILL.md
+++ b/.super-coder/assets/skills/local_skill_management/SKILL.md
@@ -2,6 +2,7 @@
 name: local_skill_management
 description: Create, persist, assign, and remove fork-specific skills — the correct authoring path so skills survive snapshot/rebuild cycles.
 category: substrate
+common: false
 ---
 
 # local_skill_management — fork-specific skills that survive

--- a/.super-coder/assets/skills/migration_management/SKILL.md
+++ b/.super-coder/assets/skills/migration_management/SKILL.md
@@ -2,6 +2,7 @@
 name: migration_management
 description: Author and apply fork-specific DB schema migrations — naming, format, how to apply locally and verify.
 category: substrate
+common: false
 ---
 
 # migration_management — fork-specific schema changes

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -896,7 +896,7 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
   'Create, persist, assign, and remove fork-specific skills — the correct authoring path so skills survive snapshot/rebuild cycles.',
   'substrate',
   NULL,
-  1,
+  0,
   '# local_skill_management — fork-specific skills that survive
 
 Fork-specific skills live in the DB and are persisted via `.sc-state/content.sql`
@@ -1173,7 +1173,7 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
   'Author and apply fork-specific DB schema migrations — naming, format, how to apply locally and verify.',
   'substrate',
   NULL,
-  1,
+  0,
   '# migration_management — fork-specific schema changes
 
 Migrations live in `.super-coder/migrations/` and apply in numeric order,

--- a/.super-coder/migrations/0011_admin_skills_noncommon.sql
+++ b/.super-coder/migrations/0011_admin_skills_noncommon.sql
@@ -1,0 +1,20 @@
+-- 0011 — local_skill_management + migration_management to admin-only
+--
+-- Both skills shipped in 0010 without common: false in their frontmatter,
+-- defaulting to common=1. They should be admin-only (same as self_update).
+-- Revoke from non-admin shells; the UPSERT in the skills seed corrects the
+-- common flag in the live DB on ./sc update.
+
+BEGIN;
+
+DELETE FROM shell_skills
+WHERE skill_id IN (
+    SELECT skill_id FROM skills
+    WHERE name IN ('local_skill_management', 'migration_management')
+      AND is_deleted = 0
+  )
+  AND shell_id IN (
+    SELECT shell_id FROM shells WHERE flavor != 'admin' AND is_deleted = 0
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

- `local_skill_management` and `migration_management` shipped in #60 without `common: false`, defaulting to `common=1` — granted to every shell. Both are admin-only skills (same as `self_update`).
- Added `common: false` to both SKILL.md frontmatter files.
- Migration 0011 revokes existing grants from non-admin shells on `./sc update`.

## After merging

Run `./sc update` in dos-arch (and any other forks) — migration 0011 will strip `local_skill_management` and `migration_management` from PLN/DEV/REV/CART shells, leaving them only on ADM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)