### PR TITLE
feat(skills): spec skill + spec_tasks table for cross-session spec execution

### DIFF
--- a/.super-coder/assets/skills/spec/SKILL.md
+++ b/.super-coder/assets/skills/spec/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: spec
+description: Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step. Load when starting any feature spec.
+category: craft
+common: false
+---
+
+# spec — analyze and execute a spec
+
+Load this skill at the start of any session where you're working a feature spec.
+Run **Analyze** before touching any code. Pause for FnB on blockers or unclear
+items you can't resolve alone.
+
+`<self>` = your shell_id.
+
+---
+
+## Step 1: Load the spec
+
+```sql
+-- find a feature and its active (non-frozen) spec:
+SELECT r.feature_id, r.title AS feature_title, r.roadmap_status,
+       d.document_id, d.seq, d.title AS spec_title, d.body, d.frozen
+FROM roadmap r
+JOIN documents d ON d.feature_id = r.feature_id AND d.kind = 'spec'
+WHERE (r.title LIKE '%<keyword>%' OR r.feature_id = <id>)
+  AND d.frozen = 0
+ORDER BY d.seq DESC LIMIT 1;
+
+-- check if a plan already exists for this spec:
+SELECT task_id, seq, title, status, completed_date
+FROM spec_tasks
+WHERE document_id = <doc_id>
+ORDER BY seq;
+```
+
+If tasks already exist, skip to **Step 4** (Track).
+
+Read the entire spec body before going further. Do not skim.
+
+---
+
+## Step 2: Analyze
+
+Surface the following before any planning or code:
+
+### Viability
+- Can this be completed in the current session? Bounded + clear entry points:
+  yes. Multiple layers, migrations, unknown dependencies: no — say so and
+  propose a session-sized slice.
+- Does the spec state a clear done-condition? If not, that is the first unclear
+  item.
+
+### Unclear items
+Things you cannot act on without guessing:
+- Ambiguous between two interpretations
+- Missing a critical detail (which table? which endpoint? which component?)
+- Implies knowledge not stated in the spec
+
+List these and ask the FnB before writing the plan.
+
+### Blockers
+Hard stops — prior work not shipped, missing environment state, unresolved
+external dependency. Open a flag for each:
+
+```sql
+INSERT INTO flags (display_name, description, priority, feature_id, shell_id)
+VALUES ('<SC-###>', '[Spec] <what is blocked> | Blocker for: <feature title>',
+        'High', <feature_id>, <self>);
+```
+
+Don't open flags for unclear items you can resolve by asking — ask first.
+
+---
+
+## Step 3: Plan
+
+Once analysis is clear and blockers are resolved or accepted, generate the task
+list and INSERT it. Always this shape:
+
+| seq | title | role |
+|---|---|---|
+| 0 | Preparation | Always first — read code paths, verify DB state, confirm entry points |
+| 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
+| N+1 | Verification | Always last — run tests, smoke-test against done-condition, snapshot + render |
+
+```sql
+INSERT INTO spec_tasks (feature_id, document_id, seq, title, description, shell_id)
+VALUES
+  (<feature_id>, <doc_id>, 0,   'Preparation',  'Read all relevant code paths, verify DB state, confirm entry points', <self>),
+  (<feature_id>, <doc_id>, 1,   '<Step 1>',     '<what it does>',                                                     <self>),
+  (<feature_id>, <doc_id>, 2,   '<Step 2>',     '<what it does>',                                                     <self>),
+  (<feature_id>, <doc_id>, <N>, 'Verification', 'Run tests, smoke-test against done-condition, snapshot + render',    <self>);
+```
+
+Then update `current_state` — no last-done yet, next is Preparation:
+
+```sql
+UPDATE shells SET current_state='[<feature_title>] — last: —. next: Preparation.'
+WHERE shell_id = <self>;
+```
+
+---
+
+## Step 4: Track session by session
+
+At the start of each work session, load the current plan state:
+
+```sql
+SELECT task_id, seq, title, description, status, completed_date
+FROM spec_tasks
+WHERE document_id = <doc_id>
+ORDER BY seq;
+```
+
+Find the first `pending` task. Mark it `in_progress`:
+
+```sql
+UPDATE spec_tasks SET status='in_progress' WHERE task_id=<id>;
+```
+
+Work only that task. When done, mark it complete and advance `current_state`:
+
+```sql
+UPDATE spec_tasks
+SET status='done', completed_date=date('now')
+WHERE task_id=<id>;
+
+-- resolve last-done and next-pending in one query:
+SELECT
+  (SELECT title FROM spec_tasks WHERE document_id=<doc_id> AND status='done'
+   ORDER BY seq DESC LIMIT 1) AS last_done,
+  (SELECT title FROM spec_tasks WHERE document_id=<doc_id> AND status='pending'
+   ORDER BY seq ASC LIMIT 1) AS next_up;
+
+UPDATE shells
+SET current_state='[<feature_title>] — last: <last_done>. next: <next_up>.'
+WHERE shell_id=<self>;
+```
+
+If `next_up` is NULL, all tasks are done — set current_state to reflect that
+and run `./sc snapshot`.
+
+---
+
+## Stance
+
+- **Analyze before acting.** The analysis phase discovers the gap between what
+  the spec says and what the code does.
+- **One task at a time.** Don't start task N+1 until task N is verified and
+  marked done.
+- **Verification is not optional.** It is the last task; skipping it makes
+  "done" meaningless.
+- **If the spec is too large for one session:** scope a session slice at
+  Preparation — cover steps 1–K that can be verified now, leave K+1–N pending.
+  Don't start work that can't be verified before the session ends.
+- **current_state always reflects the plan.** After every task completion,
+  update it — last done + next up. This is how the next session resumes without
+  reading the full task list first.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1525,6 +1525,171 @@ ON CONFLICT(name) DO UPDATE SET
   content=excluded.content, is_deleted=0;
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'spec',
+  'Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step. Load when starting any feature spec.',
+  'craft',
+  NULL,
+  0,
+  '# spec — analyze and execute a spec
+
+Load this skill at the start of any session where you''re working a feature spec.
+Run **Analyze** before touching any code. Pause for FnB on blockers or unclear
+items you can''t resolve alone.
+
+`<self>` = your shell_id.
+
+---
+
+## Step 1: Load the spec
+
+```sql
+-- find a feature and its active (non-frozen) spec:
+SELECT r.feature_id, r.title AS feature_title, r.roadmap_status,
+       d.document_id, d.seq, d.title AS spec_title, d.body, d.frozen
+FROM roadmap r
+JOIN documents d ON d.feature_id = r.feature_id AND d.kind = ''spec''
+WHERE (r.title LIKE ''%<keyword>%'' OR r.feature_id = <id>)
+  AND d.frozen = 0
+ORDER BY d.seq DESC LIMIT 1;
+
+-- check if a plan already exists for this spec:
+SELECT task_id, seq, title, status, completed_date
+FROM spec_tasks
+WHERE document_id = <doc_id>
+ORDER BY seq;
+```
+
+If tasks already exist, skip to **Step 4** (Track).
+
+Read the entire spec body before going further. Do not skim.
+
+---
+
+## Step 2: Analyze
+
+Surface the following before any planning or code:
+
+### Viability
+- Can this be completed in the current session? Bounded + clear entry points:
+  yes. Multiple layers, migrations, unknown dependencies: no — say so and
+  propose a session-sized slice.
+- Does the spec state a clear done-condition? If not, that is the first unclear
+  item.
+
+### Unclear items
+Things you cannot act on without guessing:
+- Ambiguous between two interpretations
+- Missing a critical detail (which table? which endpoint? which component?)
+- Implies knowledge not stated in the spec
+
+List these and ask the FnB before writing the plan.
+
+### Blockers
+Hard stops — prior work not shipped, missing environment state, unresolved
+external dependency. Open a flag for each:
+
+```sql
+INSERT INTO flags (display_name, description, priority, feature_id, shell_id)
+VALUES (''<SC-###>'', ''[Spec] <what is blocked> | Blocker for: <feature title>'',
+        ''High'', <feature_id>, <self>);
+```
+
+Don''t open flags for unclear items you can resolve by asking — ask first.
+
+---
+
+## Step 3: Plan
+
+Once analysis is clear and blockers are resolved or accepted, generate the task
+list and INSERT it. Always this shape:
+
+| seq | title | role |
+|---|---|---|
+| 0 | Preparation | Always first — read code paths, verify DB state, confirm entry points |
+| 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
+| N+1 | Verification | Always last — run tests, smoke-test against done-condition, snapshot + render |
+
+```sql
+INSERT INTO spec_tasks (feature_id, document_id, seq, title, description, shell_id)
+VALUES
+  (<feature_id>, <doc_id>, 0,   ''Preparation'',  ''Read all relevant code paths, verify DB state, confirm entry points'', <self>),
+  (<feature_id>, <doc_id>, 1,   ''<Step 1>'',     ''<what it does>'',                                                     <self>),
+  (<feature_id>, <doc_id>, 2,   ''<Step 2>'',     ''<what it does>'',                                                     <self>),
+  (<feature_id>, <doc_id>, <N>, ''Verification'', ''Run tests, smoke-test against done-condition, snapshot + render'',    <self>);
+```
+
+Then update `current_state` — no last-done yet, next is Preparation:
+
+```sql
+UPDATE shells SET current_state=''[<feature_title>] — last: —. next: Preparation.''
+WHERE shell_id = <self>;
+```
+
+---
+
+## Step 4: Track session by session
+
+At the start of each work session, load the current plan state:
+
+```sql
+SELECT task_id, seq, title, description, status, completed_date
+FROM spec_tasks
+WHERE document_id = <doc_id>
+ORDER BY seq;
+```
+
+Find the first `pending` task. Mark it `in_progress`:
+
+```sql
+UPDATE spec_tasks SET status=''in_progress'' WHERE task_id=<id>;
+```
+
+Work only that task. When done, mark it complete and advance `current_state`:
+
+```sql
+UPDATE spec_tasks
+SET status=''done'', completed_date=date(''now'')
+WHERE task_id=<id>;
+
+-- resolve last-done and next-pending in one query:
+SELECT
+  (SELECT title FROM spec_tasks WHERE document_id=<doc_id> AND status=''done''
+   ORDER BY seq DESC LIMIT 1) AS last_done,
+  (SELECT title FROM spec_tasks WHERE document_id=<doc_id> AND status=''pending''
+   ORDER BY seq ASC LIMIT 1) AS next_up;
+
+UPDATE shells
+SET current_state=''[<feature_title>] — last: <last_done>. next: <next_up>.''
+WHERE shell_id=<self>;
+```
+
+If `next_up` is NULL, all tasks are done — set current_state to reflect that
+and run `./sc snapshot`.
+
+---
+
+## Stance
+
+- **Analyze before acting.** The analysis phase discovers the gap between what
+  the spec says and what the code does.
+- **One task at a time.** Don''t start task N+1 until task N is verified and
+  marked done.
+- **Verification is not optional.** It is the last task; skipping it makes
+  "done" meaningless.
+- **If the spec is too large for one session:** scope a session slice at
+  Preparation — cover steps 1–K that can be verified now, leave K+1–N pending.
+  Don''t start work that can''t be verified before the session ends.
+- **current_state always reflects the plan.** After every task completion,
+  update it — last done + next up. This is how the next session resumes without
+  reading the full task list first.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'surface_catalogue',
   'Read the host repo via the dr_* catalogue (files, languages, deps, env) BEFORE grepping or walking the tree. Query first, lazy-load the few files it points at. Use to orient in an unfamiliar repo fast.',
   'substrate',

--- a/.super-coder/migrations/0012_spec_tasks.sql
+++ b/.super-coder/migrations/0012_spec_tasks.sql
@@ -1,0 +1,17 @@
+-- 0012: add spec_tasks table for per-spec implementation plans
+-- Convergent: safe to run on forks that already have the table.
+
+CREATE TABLE IF NOT EXISTS spec_tasks (
+    task_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    feature_id     INTEGER NOT NULL REFERENCES roadmap(feature_id),
+    document_id    INTEGER NOT NULL REFERENCES documents(document_id),
+    seq            INTEGER NOT NULL,
+    title          TEXT    NOT NULL,
+    description    TEXT,
+    status         TEXT    NOT NULL DEFAULT 'pending'
+                   CHECK(status IN ('pending','in_progress','done')),
+    completed_date DATE,
+    shell_id       INTEGER REFERENCES shells(shell_id),
+    created_date   DATE    NOT NULL DEFAULT (date('now')),
+    UNIQUE(document_id, seq)
+);

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -206,6 +206,25 @@ CREATE TABLE flags (
     is_deleted       INTEGER NOT NULL DEFAULT 0
 );
 
+-- ── Spec tasks (per-instance — implementation plan for a spec) ──────────────
+-- One row per task. Seq 0 = Preparation, last seq = Verification, middle = impl
+-- steps. Status drives current_state updates (last done + next pending).
+
+CREATE TABLE spec_tasks (
+    task_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    feature_id     INTEGER NOT NULL REFERENCES roadmap(feature_id),
+    document_id    INTEGER NOT NULL REFERENCES documents(document_id),
+    seq            INTEGER NOT NULL,
+    title          TEXT    NOT NULL,
+    description    TEXT,
+    status         TEXT    NOT NULL DEFAULT 'pending'
+                   CHECK(status IN ('pending','in_progress','done')),
+    completed_date DATE,
+    shell_id       INTEGER REFERENCES shells(shell_id),
+    created_date   DATE    NOT NULL DEFAULT (date('now')),
+    UNIQUE(document_id, seq)
+);
+
 -- ── Shell Inbox (inter-shell messaging) ─────────────────────────────────────
 -- A shell writes a markdown message to another shell; the recipient discovers it
 -- on its next boot (the `## STATUS` Inbox count + the `messaging` skill's `check`

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -45,6 +45,7 @@ PER_INSTANCE_TABLES = [
     "roadmap",
     "documents",
     "flags",
+    "spec_tasks",
     "projects",
     "project_shells",
     "skills",


### PR DESCRIPTION
## Summary

- New `spec` skill for dev shells: analyze a spec, surface blockers/unclear items, generate a task plan (Preparation → impl steps → Verification), and track progress session by session
- New `spec_tasks` table — keyed to the spec (`document_id`) and the working shell (`shell_id`); `UNIQUE(document_id, seq)` enforces one plan per spec
- Migration `0012_spec_tasks.sql` (convergent `CREATE TABLE IF NOT EXISTS`) so existing forks pick it up
- `spec_tasks` added to `PER_INSTANCE_TABLES` in `snapshot.py` so the plan survives `./sc rebuild`
- `current_state` updated at every step with `last: <done>. next: <pending>` so the next session resumes without reading the full list

## Test plan

- [ ] `./sc rebuild` on a fork — `spec_tasks` table exists, no migration errors
- [ ] `./sc snapshot` — `spec_tasks` appears in `.sc-state/content.sql`
- [ ] Grant the `spec` skill to a dev shell and walk through the plan flow against a real spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)