### PR TITLE
fix(skills): DB as canonical harness-agnostic skill load path

### DIFF
--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -129,10 +129,26 @@ def render_skills(con, shell_id: int) -> str:
     ).fetchall()
     if not rows:
         return "(none)"
-    return "\n".join(
-        f"- **{r['name']}** — {(r['description'] or '').strip().splitlines()[0] if r['description'] else ''}"
-        for r in rows
-    )
+    # Substrate skills load from the DB, not a harness skill dir — so they work
+    # on every harness (claude/codex/opencode/vibe), present and future, with no
+    # per-harness bridging. These are SEPARATE from and ADDITIONAL to whatever
+    # native skills your harness ships (codex's `.system` set, claude plugins,
+    # …; vibe ships none). Below: name, one-line description, and the exact query
+    # to load each skill's full procedure on demand.
+    lines = [
+        "Substrate skills granted to you — loaded from your memory DB, **in "
+        "addition to** any native skills your harness provides. Load a skill's "
+        "full procedure on demand with the query under it:",
+        "",
+    ]
+    for r in rows:
+        desc = (r["description"] or "").strip().splitlines()[0] if r["description"] else ""
+        lines.append(f"- **{r['name']}** — {desc}")
+        lines.append(
+            "  - load: `sqlite3 .super-coder/shell_db.db \"SELECT content FROM "
+            f"skills WHERE name='{r['name']}' AND is_deleted=0;\"`"
+        )
+    return "\n".join(lines)
 
 
 def fetch_counts(con, shell_id: int) -> dict:

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -11,9 +11,14 @@ reverse):
     DB → flat is one-way; the files are never read back.
 
   • Harness skills — `.claude/skills/<name>/SKILL.md` for the booting shell's
-    granted skills. Consumed natively by Claude Code / OpenCode / Crush.
-    Like the boot artifact (CLAUDE.md/AGENTS.md) this is GITIGNORED and rebuilt
-    at launch — a per-shell cache, not tracked content.
+    granted skills. A NON-load-bearing convenience cache for harnesses that
+    auto-discover this path natively (Claude Code / OpenCode / Crush). It is NOT
+    the source of truth and NOT the cross-harness load path: codex reads its own
+    `$CODEX_HOME/skills` and vibe (Mistral) has no skill dir at all. The
+    canonical, harness-agnostic load path is the DB — the boot doc's `## SKILLS`
+    block renders each grant's exact `SELECT content FROM skills …` query
+    (see compose.render_skills). Like the boot artifact (CLAUDE.md/AGENTS.md)
+    this dir is GITIGNORED and rebuilt at launch — a per-shell cache.
 
 Render is incremental: an artifact whose composed content already matches what
 is on disk is skipped (no write, no mtime churn), so re-rendering an unchanged


### PR DESCRIPTION
## Problem

Granted skills are listed in the boot `## SKILLS` block, but were only *loadable* on harnesses that auto-discover `.claude/skills/` (claude, opencode). **codex** reads its own `$CODEX_HOME/skills` and **vibe (Mistral)** has no skill dir at all — so on those harnesses a shell's substrate skills were unreachable. A codex dev shell hit this live and had to reverse-engineer the messaging skill from raw `shell_messages` SQL.

## Fix

Make the **DB the canonical, harness-agnostic skill load path**:

- `compose.render_skills` now renders, per granted skill, the exact load query — `sqlite3 .super-coder/shell_db.db "SELECT content FROM skills WHERE name='<skill>' AND is_deleted=0;"` — framed as substrate skills **in addition to** native harness skills.
- `flat.py` docstring: the `.claude/skills/` render is demoted from "the skill mechanism" to a **non-load-bearing convenience cache** for harnesses that auto-discover it. Removes the two-sources-of-truth implication.

No per-harness bridging — every harness (present and future) reaches skills the same way, since every shell already runs SQL against its memory DB.

## Verified

- Both files compile; a real render emits the per-skill query block correctly.
- `render/` is in `ENGINE_PATHS` → propagates to forks via `./sc update`.
- codex `.system` skills already bind-mounted in-sandbox (`sc:268`); vibe confirmed to have no native skill layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)