### PR TITLE
feat(sc): add update-harnesses command

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -13,25 +13,27 @@
 #   make enter s=ap01   attach + boot the 'ap01' shell directly
 #   make down           stop the sandbox
 #   make update         fetch + materialize the engine, reconcile in place
+#   make update-harnesses  update claude + opencode + codex + vibe to latest
 #   make rollback       sound undo of a bad update (restore DB + engine)
 #   make deps           install this fork's deps into the bind-mounted .venv + node_modules
 #   make test           run backend (.venv pytest / unittest) + UI (vitest) suites
 #   make sc ARGS=health run any ./sc subcommand (passthrough)
 #
 SC := ./sc
-.PHONY: launch enter down build logs serve health ports verify update rollback snapshot render map install sc deps test
+.PHONY: launch enter down build logs serve health ports verify update update-harnesses rollback snapshot render map install sc deps test
 
-launch:   ; $(SC) launch
-enter:    ; $(SC) $(if $(s),enter-$(s),enter)
-down:     ; $(SC) down
-build:    ; $(SC) build
-logs:     ; $(SC) logs
-serve:    ; $(SC) serve
-health:   ; $(SC) health
-ports:    ; $(SC) ports
-verify:   ; $(SC) verify
-update:   ; $(SC) update
-rollback: ; $(SC) rollback
+launch:            ; $(SC) launch
+enter:             ; $(SC) $(if $(s),enter-$(s),enter)
+down:              ; $(SC) down
+build:             ; $(SC) build
+logs:              ; $(SC) logs
+serve:             ; $(SC) serve
+health:            ; $(SC) health
+ports:             ; $(SC) ports
+verify:            ; $(SC) verify
+update:            ; $(SC) update
+update-harnesses:  ; $(SC) update-harnesses
+rollback:          ; $(SC) rollback
 snapshot: ; $(SC) snapshot
 render:   ; $(SC) render $(ARGS)
 map:      ; $(SC) map

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -111,6 +111,31 @@ def _harness_installed(name: str) -> bool:
     return bool(shutil.which(name)) or HARNESS_BIN.get(name, Path("/nonexistent")).exists()
 
 
+def update_harnesses() -> dict[str, str]:
+    """Force-update all harness CLIs by re-running their official native
+    installers regardless of whether they're already present. Unlike
+    ensure_harnesses(), never skips an installed harness — the installers
+    are idempotent and self-update to latest."""
+    status: dict[str, str] = {}
+    have_curl = bool(shutil.which("curl"))
+    for name, cmd in HARNESS_INSTALL.items():
+        if not have_curl:
+            print(f"  {name:9} ⚠ curl unavailable — update by hand: {cmd}")
+            status[name] = "no-curl"
+            continue
+        present = _harness_installed(name)
+        label = "updating" if present else "installing"
+        print(f"  {name:9} … {label}  ($ {cmd})")
+        rc = subprocess.run(["bash", "-c", cmd]).returncode
+        if rc == 0:
+            print(f"  {name:9} ✓ {'updated' if present else 'installed'}")
+            status[name] = "updated" if present else "installed"
+        else:
+            print(f"  {name:9} ⚠ installer returned rc={rc} — retry by hand: {cmd}")
+            status[name] = "failed"
+    return status
+
+
 def ensure_harnesses() -> dict[str, str]:
     """Install any missing harness CLI via its official native installer (no
     npm) — claude + opencode + codex + vibe, so a fork can launch and run any. Best
@@ -329,8 +354,14 @@ def main(argv: list[str]) -> int:
     force = "--force" in argv
     skip_harness = "--skip-harness-install" in argv
     # super-coder's own flags — strip them so they don't reach init_fork's parser.
-    own = {"--force", "--skip-harness-install", "--ensure-harness", "--check-docker"}
+    own = {"--force", "--skip-harness-install", "--ensure-harness", "--update-harnesses", "--check-docker"}
     fork_args = [a for a in argv if a not in own]
+
+    # Standalone: force-update all harness CLIs to latest and exit.
+    if "--update-harnesses" in argv:
+        step("Updating harness CLIs to latest (claude + opencode + codex + vibe)")
+        update_harnesses()
+        return 0
 
     # Standalone: just ensure the harness CLIs and exit (for an already-installed
     # fork). Runs before the guards so it works anywhere.

--- a/sc
+++ b/sc
@@ -209,7 +209,8 @@ case "$cmd" in
   install)         exec "$PY" "$S/install.py" "$@" ;;
   ensure-harness)  exec "$PY" "$S/install.py" --ensure-harness ;;
   doctor)          exec "$PY" "$S/install.py" --check-docker ;;
-  update)       exec "$PY" "$S/update.py" "$@" ;;
+  update)            exec "$PY" "$S/update.py" "$@" ;;
+  update-harnesses) exec "$PY" "$S/install.py" --update-harnesses ;;
   rollback)     exec "$PY" "$S/rollback.py" "$@" ;;
   init)         exec "$PY" "$S/init_fork.py" "$@" ;;
   rebuild)      exec "$PY" "$S/rebuild.py" "$@" ;;
@@ -292,6 +293,7 @@ super-coder — forkable shell substrate
   ./sc ensure-harness      install claude + opencode + codex if missing (official native installers, no npm)
   ./sc doctor              sandbox readiness: docker (rootless/rootful) + harness login
   ./sc update              fetch + materialize the engine (gitignored dep) + reconcile IN PLACE (migrate, sync skills, map); --no-fetch to skip fetch
+  ./sc update-harnesses    update claude + opencode + codex + vibe to latest (force-reruns official installers)
   ./sc rollback            sound undo of a bad update — restore the DB + engine (engine.ref.prev) together
   ./sc rebuild             build the .db from schema + migrations + snapshot
   ./sc migrate             apply pending migrations to an existing .db


### PR DESCRIPTION
## Summary

- Adds `./sc update-harnesses` / `make update-harnesses` that force-reruns the official native installers for claude, opencode, codex, and vibe
- Unlike `ensure-harness` (install-only), this updates already-present CLIs to latest
- Complements `make build` (which refreshes harnesses in the image) with an equivalent for the host path

## Test plan
- [ ] `./sc update-harnesses` runs all four installers and reports updated/failed per harness
- [ ] `make update-harnesses` delegates correctly via aliases.mk
- [ ] `./sc help` shows the new command
- [ ] No-curl path warns and continues rather than failing hard

🤖 Generated with [Claude Code](https://claude.com/claude-code)