### PR TITLE
feat(launcher): group shells by flavor in picker

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -279,7 +279,7 @@ def list_shells(con: sqlite3.Connection, user_id: int) -> list[sqlite3.Row]:
     return con.execute(
         "SELECT shell_id, display_name, shortname, mandate, is_shared, flavor FROM shells "
         "WHERE (user_id=? OR is_shared=1) AND COALESCE(is_deleted,0)=0 "
-        "ORDER BY is_shared, shell_id",
+        "ORDER BY flavor IS NULL, flavor, shell_id",
         (user_id,),
     ).fetchall()
 
@@ -331,10 +331,14 @@ def pick_shell(shells: list[sqlite3.Row], requested: str | None,
         return chosen
     if first or not sys.stdin.isatty():
         return shells[0]
-    # Interactive picker — the Default column tells the operator the intended
-    # harness/model (advisory; overridable at launch).
+    # Interactive picker — shells grouped by flavor, each group labelled.
     print(f"\n{'ID':>3}  {'Name':<16}{'Shortname':<14}{'Default (harness · model)'}")
+    _sentinel = object()
+    cur_flavor: object = _sentinel
     for s in shells:
+        if s["flavor"] != cur_flavor:
+            cur_flavor = s["flavor"]
+            print(f"\n{cur_flavor or '(bespoke)'}")
         print(f"{s['shell_id']:>3}  {(s['display_name'] or ''):<16}"
               f"{(s['shortname'] or ''):<14}{_default_label(defaults, s['flavor'])}")
     valid = {s["shell_id"] for s in shells}


### PR DESCRIPTION
## Summary

- Shells in the interactive picker are now grouped by flavor with a heading per group
- Sorted alphabetically by flavor then `shell_id` within each group
- `(bespoke)` label for `flavor=NULL` shells, sorted last
- Two-line change: sort order in `list_shells()`, group header tracking in `pick_shell()`

## Before

```
 ID  Name            Shortname     Default (harness · model)
  1  Arch-Planner-01 PLN1          claude · sonnet
  2  Arch-dev-01     DEV1          claude · sonnet
  3  Arch-review-01  REV1          claude · sonnet
  4  Cartographer    CART1
  5  Arch-dev-02     DEV2          claude · sonnet
```

## After

```
 ID  Name            Shortname     Default (harness · model)

cartographer
  4  Cartographer    CART1

dev
  2  Arch-dev-01     DEV1          claude · sonnet
  5  Arch-dev-02     DEV2          claude · sonnet

planner
  1  Arch-Planner-01 PLN1          claude · sonnet

reviewer
  3  Arch-review-01  REV1          claude · sonnet
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)