### PR TITLE
feat(worktrees): isolated worktrees for ALL shells; planner/reviewer may commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@
 # propagates (re-derived from the repo path if absent). Hand-overridable.
 /.super-coder/instance.json
 
-# Dev-shell worktrees — one per dev shell, at .sc-worktrees/<shortname>/. Git
+# Shell worktrees — one per shell, at .sc-worktrees/<shortname>/. Git
 # worktrees inside the repo root; gitignored so the linked trees don't surface
 # as untracked content in the main working tree.
 /.sc-worktrees/

--- a/.super-coder/assets/skills/git/SKILL.md
+++ b/.super-coder/assets/skills/git/SKILL.md
@@ -61,5 +61,6 @@ text, then commit that text. See the `snapshot` skill.
 
 - Confirm you're in the intended repo before destructive ops (`git -C` if ever in
   doubt).
-- Multi-shell: per-shell branches keep parallel work from colliding (the planned
-  worktree model makes this clean — until then, one active shell per cwd).
+- Multi-shell: every shell boots into its own worktree at
+  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>` — per-shell
+  branches keep parallel work from colliding.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -882,8 +882,9 @@ text, then commit that text. See the `snapshot` skill.
 
 - Confirm you''re in the intended repo before destructive ops (`git -C` if ever in
   doubt).
-- Multi-shell: per-shell branches keep parallel work from colliding (the planned
-  worktree model makes this clean — until then, one active shell per cwd).',
+- Multi-shell: every shell boots into its own worktree at
+  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>` — per-shell
+  branches keep parallel work from colliding.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/.super-coder/migrations/0013_planner_reviewer_git_write.sql
+++ b/.super-coder/migrations/0013_planner_reviewer_git_write.sql
@@ -1,0 +1,25 @@
+-- 0013 — planner/reviewer shells may write and commit; worktrees for all shells.
+--
+-- The planner/reviewer templates used to bake "Git is read-only: diff, log,
+-- and read files only. Never checkout, restore, stash, or commit." into the
+-- shell's system_prompt at creation. That instruction is gone: every shell now
+-- boots into its own git worktree on shell/<shortname> (run.py no longer gates
+-- worktrees to the dev flavor), and planner/reviewer shells NEED git writes —
+-- they commit their own artifacts (specs, snapshots, .sc-state) on their
+-- branch. The templates (templates/shells/planner.json, reviewer.json) carry
+-- the new wording for shells created from here on; this migration rewrites the
+-- prompt of shells already created under the old wording.
+--
+-- Idempotent: REPLACE is a no-op once the old sentence is gone (or on a fork
+-- with no planner/reviewer shells).
+UPDATE shells SET system_prompt = REPLACE(
+    system_prompt,
+    'keep those lanes clean. Git is read-only: diff, log, and read files only. Never checkout, restore, stash, or commit.',
+    'keep those lanes clean. You work in your own worktree on your shell branch: write and commit your artifacts (specs, snapshots, state) there; leave feature code to dev.'
+) WHERE flavor = 'planner';
+
+UPDATE shells SET system_prompt = REPLACE(
+    system_prompt,
+    'you don''t build. Git is read-only: diff, log, and read files only. Never checkout, restore, stash, or commit.',
+    'you don''t build features. You work in your own worktree on your shell branch: write and commit your artifacts (review notes, snapshots, state) there.'
+) WHERE flavor = 'reviewer';

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -283,7 +283,7 @@ _GITIGNORE_BLOCK = f"""
 # codex config.toml).
 /.claude/settings.local.json
 /.codex/hooks.json
-# Dev-shell worktrees — one per dev shell, linked inside the repo root.
+# Shell worktrees — one per shell, linked inside the repo root.
 /.sc-worktrees/
 # .sc-state/ is TRACKED (content.sql + engine.ref). Only the ephemeral
 # pre-update restore pointer is ignored.

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -31,10 +31,6 @@ ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
 DB_PATH = ENGINE / "shell_db.db"
 
-# Flavors that get an isolated git worktree at .sc-worktrees/<shortname>/.
-# Reviewer and planner are git read-only — they share the main working tree.
-_WORKTREE_FLAVORS = {"dev"}
-
 sys.path.insert(0, str(ENGINE / "render"))
 from compose import compose_boot  # noqa: E402
 import flat  # noqa: E402
@@ -128,7 +124,7 @@ def apply_sandbox(adapter: dict, root: Path = REPO_ROOT) -> list[str]:
 
 
 def ensure_worktree(work_dir: Path, shortname: str) -> None:
-    """Create a git worktree for a dev shell at work_dir on branch shell/<shortname>.
+    """Create a git worktree for a shell at work_dir on branch shell/<shortname>.
 
     Idempotent: if work_dir already exists, assumes the worktree is intact and
     returns immediately. Creates the branch from HEAD if it doesn't exist yet;
@@ -458,12 +454,13 @@ def main() -> None:
         (chosen["shell_id"],),
     ).fetchone()
 
-    # Dev-flavor shells get an isolated git worktree so parallel dev shells can
-    # work on separate branches without clobbering each other. All artifacts
+    # Every shell gets an isolated git worktree so parallel shells can work on
+    # separate branches without clobbering each other — planner/reviewer commit
+    # their own artifacts (specs, snapshots, state) there too. All artifacts
     # (CLAUDE.md, AGENTS.md, skills, harness config) land in the worktree root;
-    # the harness is exec'd from there. All other flavors use the repo root.
+    # the harness is exec'd from there.
     work_dir = REPO_ROOT
-    if chosen["flavor"] in _WORKTREE_FLAVORS and chosen["shortname"]:
+    if chosen["shortname"]:
         work_dir = REPO_ROOT / ".sc-worktrees" / chosen["shortname"].lower()
         ensure_worktree(work_dir, chosen["shortname"])
 

--- a/.super-coder/templates/shells/planner.json
+++ b/.super-coder/templates/shells/planner.json
@@ -3,6 +3,6 @@
   "abbr": "PLN",
   "role": "Planning shell",
   "mandate": "Turn objectives into specs and sequenced plans for {{repo}}. Own the roadmap; decide before building; break work into verifiable steps.",
-  "focus": "You think before the team builds. Scope objectives into roadmap features and specs, sequence the work, and design the architecture and APIs. You plan; dev builds; review verifies — keep those lanes clean. Git is read-only: diff, log, and read files only. Never checkout, restore, stash, or commit.",
+  "focus": "You think before the team builds. Scope objectives into roadmap features and specs, sequence the work, and design the architecture and APIs. You plan; dev builds; review verifies — keep those lanes clean. You work in your own worktree on your shell branch: write and commit your artifacts (specs, snapshots, state) there; leave feature code to dev.",
   "skills": ["docs", "flags", "git", "blueprint", "api-design", "onboard"]
 }

--- a/.super-coder/templates/shells/reviewer.json
+++ b/.super-coder/templates/shells/reviewer.json
@@ -3,6 +3,6 @@
   "abbr": "REV",
   "role": "Review shell",
   "mandate": "Review changes, specs, and decisions in {{repo}}. Find bugs, verify claims, check work against intent. Adversarial by default.",
-  "focus": "You are the gate. Read diffs against their spec, hunt the bug the author missed, verify rather than trust, and open flags for what's wrong. You critique and confirm — you don't build. Git is read-only: diff, log, and read files only. Never checkout, restore, stash, or commit.",
+  "focus": "You are the gate. Read diffs against their spec, hunt the bug the author missed, verify rather than trust, and open flags for what's wrong. You critique and confirm — you don't build features. You work in your own worktree on your shell branch: write and commit your artifacts (review notes, snapshots, state) there.",
   "skills": ["flags", "git", "api-design", "database-migrations", "redline_review", "test_authoring"]
 }


### PR DESCRIPTION
## What

1. **Worktrees for every shell.** `run.py` drops the `_WORKTREE_FLAVORS = {"dev"}` gate — any shell with a shortname now boots into its own worktree at `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Combined with the branch-before-edit guard (#64, already flavor-agnostic), every shell is branch-isolated by default.
2. **Planner/reviewer can write + commit.** Their flavor templates drop the "Git is read-only: diff, log, and read files only. Never checkout, restore, stash, or commit." clause — these shells need to write and commit their own artifacts (specs, snapshots, `.sc-state`) on their branch. New wording keeps the lane discipline (planner doesn't write feature code, reviewer doesn't build features).
3. **Migration `0013`** rewrites the baked `system_prompt` of planner/reviewer shells already created on installed forks (the old wording was rendered into the DB at creation time). Idempotent; verified on a scratch DB from `schema.sql` (both flavors rewritten, second run no-op).
4. **Doc/comment sweep:** git skill note ("planned worktree model" → it's live now; seed migration regenerated), `.gitignore` + `install.py` gitignore-block comments.

## Notes for review

- This also moves **admin, cartographer, and bespoke (NULL-flavor, e.g. dogfood maintainer) shells** into worktrees — "all shells" taken literally. The DB stays shared (engine path resolves from the launcher's location, not cwd), same as dev shells today.
- Existing forks pick everything up via `./sc update` (engine sync + pending migrations + skill resync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)