### PR TITLE
feat(preview): live worktree UI preview via subdomain router (./sc preview)

### DIFF
--- a/.sc-state/content.sql
+++ b/.sc-state/content.sql
@@ -201,6 +201,7 @@ INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (9, 'Fork to sibling repos', 'brainstorm', 0, 1, 'Fork super-coder into dos-arch / rst-c / emergence / md-converter; reseed pattern.', '2026-06-04 11:12:03', '2026-06-04 11:12:03');
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (10, 'B7 — Engine/Fork Separation & Update Lifecycle', 'next', 70, 1, 'Engine becomes a gitignored downstream dependency (materialized from upstream, pinned by engine.ref); fork''s DB is the one preserved artifact; update = snapshot→migrate, rollback = sound (DB+engine) pair-restore. Stops shells confusing the substrate for the project. See specs_sc/b7-engine-fork-separation.md.', '2026-06-07 13:25:16', '2026-06-07 13:25:16');
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (11, 'Dev shell git worktrees', 'shipped', 0, 1, 'Give each dev shell its own git worktree so multiple dev shells can run in parallel without sharing a tree. Reviewer/planner stay on the main tree (read-only on git).', '2026-06-11 00:15:53', '2026-06-11 00:29:51');
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at) VALUES (12, 'Dev shell live UI preview', 'shipped', 73, 1, 'One router on the fork''s dev_port fans out to each dev shell''s worktree vite, routed by subdomain (http://<shortname>.localhost:<dev_port>/) — live HMR per worktree, no base-path config, no concurrent-edit conflict. post-commit hook prints the URL. See specs_sc/dev-preview.md.', '2026-06-11 05:14:10', '2026-06-11 05:14:10');
 
 DELETE FROM documents;
 INSERT INTO documents (document_id, feature_id, kind, seq, title, frozen, frozen_date, body, render_path, created_at, updated_at) VALUES (1, 1, 'spec', 1, 'super-coder — Founding Spec', 1, '2026-06-04', '---
@@ -1317,6 +1318,100 @@ A new dev shell created via `./sc init` or the GUI has a worktree at the
 expected path. Launching that shell opens claude with cwd = worktree path.
 Two dev shells can be launched simultaneously on different branches without
 touching each other''s uncommitted work.', 'specs_sc/dev-worktrees.md', '2026-06-11 00:15:53', '2026-06-11 00:15:53');
+INSERT INTO documents (document_id, feature_id, kind, seq, title, frozen, frozen_date, body, render_path, created_at, updated_at) VALUES (5, 12, 'spec', 1, 'Dev shell live UI preview — implementation spec', 0, NULL, '# Dev shell live UI preview
+
+## Problem
+
+Dev shells each own a git worktree (`.sc-worktrees/<shortname>/`) — see
+[dev-worktrees](dev-worktrees.md). That isolates *edits*, but it breaks
+*viewing*: the fork''s dev server runs from the main checkout, so a shell''s UI
+changes — made in its worktree — never show on the live dev server. Pointing the
+one dev server at a single worktree would just clobber the isolation the
+worktrees exist to provide, and two shells previewing at once would fight over
+one port.
+
+## Solution
+
+One router on the fork''s `dev_port` that fans out to a per-worktree vite, routed
+by **subdomain**:
+
+    http://dev1.localhost:<dev_port>/      dev1''s worktree UI, live (HMR)
+    http://dev2.localhost:<dev_port>/      dev2''s worktree UI, live (HMR)
+    http://localhost:<dev_port>/           index of available shells
+
+`*.localhost` resolves to 127.0.0.1 on modern systems — no hosts-file or DNS
+setup. Each worktree''s vite runs at root on a private internal port; the router
+reads the `Host` header and proxies to the matching backend.
+
+### Why subdomain, not path-prefix (`:port/dev1/...`)
+
+The fork UIs are SvelteKit with SSR server routes (the same-origin `/api/*`
+trust seam is a real server route). Serving several apps under one port by
+**path prefix** would force every app to emit `/dev1/`-prefixed URLs — i.e.
+`kit.paths.base`, an app-wide build-time setting baked into every internal link
+*and* the `/api` seam — injected per-shell into each fork''s committed config,
+plus an HMR-behind-prefix dance. **Subdomain** sidesteps all of it: each
+subdomain is a distinct origin, so the app serves from root unchanged — no base
+config, `/api` seam intact, native HMR.
+
+### Why per-connection routing works
+
+A browser keeps one TCP connection per origin, so the first `Host` seen on a
+connection is its route for life. The router reads the request header block,
+picks the backend, then splices raw bytes both directions — HTTP keep-alive and
+websocket upgrades (HMR) flow through untouched, no per-request reparsing.
+
+## Surfaces
+
+### 1. `preview.py` (`./sc preview`)
+Discovers `.sc-worktrees/*` with a UI dir; for each: symlinks the main
+checkout''s `node_modules` into the worktree UI (same repo + lockfile → valid),
+best-effort `git submodule update --init`, writes a generated sidecar vite
+config (`.sc-preview.vite.config.js`, gitignored under `.sc-worktrees/`) that
+extends the worktree''s own config with `allowedHosts: [''.localhost'']` and
+`hmr.clientPort = dev_port` (so the HMR client dials the front port, not the
+private one), then launches `vite dev` on a free internal port. An asyncio
+proxy on `dev_port` routes by `Host` subdomain label. A 5s reconcile loop picks
+up new worktrees and reaps removed ones — dynamic, no restart.
+
+Binds `$SC_BIND` (0.0.0.0 in the sandbox so the published port is reachable;
+127.0.0.1 on the host). Front port is `$SC_DEV_PORT` if set (the sandbox
+publishes it) else the repo-derived `dev_port`. Binds the front port first, so a
+clash (e.g. the sandbox already publishes `dev_port`) fails fast with guidance
+instead of spawning vites it would have to reap.
+
+### 2. `sc` — `preview)` dispatch + help line.
+
+### 3. `post-commit` hook
+Fires via `core.hooksPath`. On a commit from a worktree
+(`*/.sc-worktrees/*`), prints `→ preview: http://<shortname>.localhost:<dev_port>/`.
+Silent on the main checkout. Best-effort — never blocks the commit.
+
+### 4. `git` skill
+A note so the shell surfaces the printed preview URL to the FnB after committing
+UI work, and starts `./sc preview` if it isn''t already up.
+
+## Runtime model
+
+`./sc preview` is meant to run where the shells run: inside the sandbox
+container `dev_port` is free (the publish maps it out to the host), so the router
+binds it there and `http://<shortname>.localhost:<dev_port>/` is reachable from
+the host browser. On a pm2/host fork, run it on the host where `dev_port` is
+free. It is long-lived (one per fork) and reaps its vites on Ctrl-C.
+
+## Out of scope (this spec)
+
+- A pm2/supervised long-run wrapper — run it in the foreground or background it.
+- HTTPS / non-`.localhost` hostnames — dev-only, plain HTTP.
+- Reviewer/planner shells — git read-only, no UI to preview.
+
+## Done condition
+
+With two dev-shell worktrees that carry a UI, `./sc preview` serves each at
+`http://<shortname>.localhost:<dev_port>/` — independent content per branch,
+assets and the `/api` seam intact, and HMR live (a `101 Switching Protocols`
+through the router). Committing in a worktree prints that worktree''s preview URL.
+', 'specs_sc/dev-preview.md', '2026-06-11 05:14:10', '2026-06-11 05:14:10');
 
 DELETE FROM flags;
 INSERT INTO flags (flag_id, display_name, priority, description, created_date, resolved_date, resolved, shell_id, feature_id, resolution_notes, parent_flag_id, is_deleted) VALUES (1, 'SC-001', 'Low', '[Test] review layer smoke flag | Blocker for: nothing', '2026-06-04', '2026-06-04', 1, NULL, 1, 'smoke test done', NULL, 0);

--- a/.super-coder/assets/skills/git/SKILL.md
+++ b/.super-coder/assets/skills/git/SKILL.md
@@ -61,6 +61,13 @@ text, then commit that text. See the `snapshot` skill.
 
 - Confirm you're in the intended repo before destructive ops (`git -C` if ever in
   doubt).
-- Multi-shell: every shell boots into its own worktree at
-  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>` — per-shell
-  branches keep parallel work from colliding.
+- Multi-shell: dev shells each boot into their own git worktree at
+  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel dev shells
+  never share a cwd — worktree isolation is automatic.
+- Preview UI work: because you edit in your worktree, your changes do NOT show on
+  the fork's main dev server. `./sc preview` runs a router that serves every
+  shell's worktree UI live (HMR) on the fork's `dev_port`, one subdomain each:
+  `http://<shortname>.localhost:<dev_port>/`. The `post-commit` hook prints your
+  URL after each commit — surface that line to the FnB so they can eyeball the
+  change. If preview isn't running, start it once from the main checkout:
+  `./sc preview`.

--- a/.super-coder/hooks/post-commit
+++ b/.super-coder/hooks/post-commit
@@ -1,0 +1,23 @@
+#!/bin/sh
+# super-coder post-commit — surface this dev shell's live preview URL.
+# Tracked hook, fired via core.hooksPath (wired by `./sc map-setup`). Best-effort,
+# never blocks: a commit always succeeds regardless of what this prints.
+#
+# A dev shell commits from its worktree (.sc-worktrees/<shortname>/), so its UI
+# edits are live at http://<shortname>.localhost:<dev_port>/ once `./sc preview`
+# is running. Print that line after every commit so the shell (and the FnB) can
+# eyeball the change immediately. On the main checkout (not a worktree) there is
+# nothing to preview — stay silent.
+root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+case "$root" in
+  */.sc-worktrees/*) ;;   # in a shell worktree → continue
+  *) exit 0 ;;            # main checkout or elsewhere → nothing to preview
+esac
+short="$(basename "$root")"
+# Engine + dev_port resolution: walk up to the main repo root that owns ./sc.
+main="${root%/.sc-worktrees/*}"
+[ -x "$main/.super-coder/scripts/ports.py" ] || exit 0
+dp="$("${SC_PYTHON:-python3}" "$main/.super-coder/scripts/ports.py" devport 2>/dev/null)" || exit 0
+[ -n "$dp" ] || exit 0
+echo "→ preview: http://$short.localhost:$dp/   (run './sc preview' from $main if not up)"
+exit 0

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -882,9 +882,16 @@ text, then commit that text. See the `snapshot` skill.
 
 - Confirm you''re in the intended repo before destructive ops (`git -C` if ever in
   doubt).
-- Multi-shell: every shell boots into its own worktree at
-  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>` — per-shell
-  branches keep parallel work from colliding.',
+- Multi-shell: dev shells each boot into their own git worktree at
+  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel dev shells
+  never share a cwd — worktree isolation is automatic.
+- Preview UI work: because you edit in your worktree, your changes do NOT show on
+  the fork''s main dev server. `./sc preview` runs a router that serves every
+  shell''s worktree UI live (HMR) on the fork''s `dev_port`, one subdomain each:
+  `http://<shortname>.localhost:<dev_port>/`. The `post-commit` hook prints your
+  URL after each commit — surface that line to the FnB so they can eyeball the
+  change. If preview isn''t running, start it once from the main checkout:
+  `./sc preview`.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/.super-coder/scripts/preview.py
+++ b/.super-coder/scripts/preview.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Live-preview every dev shell's worktree UI through one front port.
+
+The problem: dev shells each own a git worktree (`.sc-worktrees/<shortname>/`),
+but the fork's dev server runs from the *main* checkout — so a shell's UI edits,
+made in its worktree, never reach the live dev server. Pointing the one dev
+server at a single worktree would just clobber the isolation the worktrees exist
+to provide.
+
+The fix: one router on the fork's `dev_port` that fans out to a per-worktree
+vite, routed by **subdomain**. Each worktree's vite runs at root on a private
+internal port; the router reads the `Host` header and proxies
+`http://<shortname>.localhost:<dev_port>/...` to that worktree's vite —
+HTTP and the HMR websocket alike. `*.localhost` resolves to 127.0.0.1 on modern
+systems, so no hosts-file or DNS setup is needed.
+
+Subdomain (not path-prefix) routing is deliberate: each subdomain is a distinct
+origin, so the SvelteKit app serves from root unchanged — no `kit.paths.base`,
+no rewrite of the same-origin `/api/*` server-route seam, native HMR. A
+path-prefix scheme would force all three.
+
+    http://dev1.localhost:8842/        dev1's worktree UI, live
+    http://dev2.localhost:8842/        dev2's worktree UI, live
+    http://localhost:8842/             index of available shells
+
+Routing is per-connection: a browser keeps one TCP connection per origin, so the
+first `Host` seen on a connection is the route for its whole life. That lets the
+proxy splice raw bytes after the header block — HTTP keep-alive and websocket
+upgrades flow through untouched, no per-request reparsing.
+
+Usage:
+    python3 .super-coder/scripts/preview.py        # run in foreground (Ctrl-C to stop)
+
+Bind host honours $SC_BIND (0.0.0.0 in the sandbox so the published port is
+reachable; 127.0.0.1 on the host). Front port is $SC_DEV_PORT if set (the
+sandbox publishes it) else the repo-derived dev_port from ports.py.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import socket
+import sys
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+SCRIPTS = ENGINE / "scripts"
+WORKTREES = REPO_ROOT / ".sc-worktrees"
+SIDECAR = ".sc-preview.vite.config.js"  # generated per worktree-ui (under .sc-worktrees/, gitignored)
+
+sys.path.insert(0, str(SCRIPTS))
+import ports  # noqa: E402  — reuse the one port-derivation source
+
+
+# ── worktree / ui discovery ──────────────────────────────────────────────────
+
+def _find_ui_dir(root: Path) -> Path | None:
+    """Shallowest dir under `root` holding a vite config (skip node_modules)."""
+    best: Path | None = None
+    best_depth = 99
+    for pat in ("vite.config.js", "vite.config.ts", "vite.config.mjs"):
+        for cfg in root.glob(f"**/{pat}"):
+            if "node_modules" in cfg.parts or ".svelte-kit" in cfg.parts:
+                continue
+            depth = len(cfg.relative_to(root).parts)
+            if depth < best_depth:
+                best, best_depth = cfg.parent, depth
+    return best
+
+
+def discover() -> dict[str, Path]:
+    """Map each worktree's shortname (dir name) -> its UI dir, where one exists."""
+    out: dict[str, Path] = {}
+    if not WORKTREES.is_dir():
+        return out
+    for wt in sorted(WORKTREES.iterdir()):
+        if not wt.is_dir():
+            continue
+        ui = _find_ui_dir(wt)
+        if ui is not None:
+            out[wt.name] = ui
+    return out
+
+
+# ── per-worktree vite preparation ────────────────────────────────────────────
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _ensure_node_modules(ui: Path) -> bool:
+    """Symlink the main checkout's node_modules into the worktree UI if missing.
+    Same repo + lockfile, so main's install is valid. Returns False if neither
+    the worktree nor main has node_modules (caller should skip/warn)."""
+    if (ui / "node_modules").exists():
+        return True
+    # worktree UI lives at .sc-worktrees/<name>/<rel>; main UI is REPO_ROOT/<rel>
+    try:
+        sub = ui.relative_to(WORKTREES)          # <name>/<rel...>
+        main_ui = REPO_ROOT.joinpath(*sub.parts[1:])
+    except ValueError:
+        main_ui = None
+    if main_ui and (main_ui / "node_modules").is_dir():
+        (ui / "node_modules").symlink_to(main_ui / "node_modules")
+        return True
+    return False
+
+
+def _ensure_submodules(wt_root: Path) -> None:
+    """Best-effort submodule init (e.g. vendor/md-converter) — never blocks."""
+    if (wt_root / ".gitmodules").exists():
+        try:
+            import subprocess
+            subprocess.run(["git", "-C", str(wt_root), "submodule", "update",
+                            "--init", "--recursive"],
+                           capture_output=True, timeout=120)
+        except Exception:
+            pass
+
+
+def _write_sidecar(ui: Path, dev_port: int) -> Path:
+    """Generate a vite config that extends the worktree's own, overriding only
+    what subdomain-behind-a-shared-port needs: allow *.localhost hosts, and point
+    the HMR client back at the front port (else it dials the private port)."""
+    sidecar = ui / SIDECAR
+    sidecar.write_text(
+        "// GENERATED by ./sc preview — do not edit, do not commit.\n"
+        "// Extends this worktree's vite.config with the overrides the preview\n"
+        "// router needs: accept *.localhost, route HMR through the front port.\n"
+        "import { mergeConfig } from 'vite';\n"
+        "import base from './vite.config.js';\n"
+        "const cfg = typeof base === 'function'\n"
+        "  ? await base({ command: 'serve', mode: 'development' })\n"
+        "  : base;\n"
+        "export default mergeConfig(cfg, {\n"
+        "  server: {\n"
+        "    host: '127.0.0.1',\n"
+        "    strictPort: true,\n"
+        "    allowedHosts: ['.localhost'],\n"
+        f"    hmr: {{ clientPort: {dev_port}, protocol: 'ws' }},\n"
+        "  },\n"
+        "});\n"
+    )
+    return sidecar
+
+
+async def _log_pump(name: str, stream: asyncio.StreamReader) -> None:
+    while True:
+        line = await stream.readline()
+        if not line:
+            break
+        sys.stdout.write(f"  [{name}] {line.decode(errors='replace').rstrip()}\n")
+        sys.stdout.flush()
+
+
+async def start_vite(name: str, ui: Path, dev_port: int) -> tuple[int, asyncio.subprocess.Process] | None:
+    """Prepare and launch one worktree's vite; return (internal_port, proc)."""
+    if not _ensure_node_modules(ui):
+        print(f"  · {name}: no node_modules in worktree or main — run an install "
+              f"in {ui}; skipping")
+        return None
+    _ensure_submodules(WORKTREES / name)  # worktree root = .sc-worktrees/<name>
+    _write_sidecar(ui, dev_port)
+    port = _free_port()
+    vite = ui / "node_modules" / ".bin" / "vite"
+    if not vite.exists():
+        print(f"  · {name}: vite not found at {vite}; skipping")
+        return None
+    proc = await asyncio.create_subprocess_exec(
+        str(vite), "dev", "--config", SIDECAR,
+        "--port", str(port), "--host", "127.0.0.1", "--strictPort",
+        cwd=str(ui),
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+    )
+    asyncio.ensure_future(_log_pump(name, proc.stdout))
+    return port, proc
+
+
+# ── the router ───────────────────────────────────────────────────────────────
+
+class Router:
+    def __init__(self, dev_port: int, bind: str):
+        self.dev_port = dev_port
+        self.bind = bind
+        self.routes: dict[str, int] = {}             # shortname -> internal port
+        self.procs: dict[str, asyncio.subprocess.Process] = {}
+        self.uis: dict[str, Path] = {}
+
+    def _label(self, host: str) -> str | None:
+        host = host.split(":")[0].strip().lower()
+        if host.endswith(".localhost"):
+            return host[: -len(".localhost")].split(".")[-1]
+        return None  # bare localhost / 127.0.0.1 / unknown → the index
+
+    async def reconcile(self) -> None:
+        """Bring running vites in line with the worktrees on disk (dynamic:
+        new shells appear, deleted ones are reaped) — no restart needed."""
+        found = discover()
+        for name, ui in found.items():
+            if name in self.routes:
+                continue
+            started = await start_vite(name, ui, self.dev_port)
+            if started:
+                port, proc = started
+                self.routes[name] = port
+                self.procs[name] = proc
+                self.uis[name] = ui
+                print(f"  → {name}: http://{name}.localhost:{self.dev_port}/  (vite :{port})")
+        for name in [n for n in self.routes if n not in found]:
+            self._kill(name)
+            print(f"  ← {name}: worktree gone — preview stopped")
+
+    def _kill(self, name: str) -> None:
+        proc = self.procs.pop(name, None)
+        self.routes.pop(name, None)
+        self.uis.pop(name, None)
+        if proc and proc.returncode is None:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+
+    def shutdown(self) -> None:
+        for name in list(self.procs):
+            self._kill(name)
+
+    async def reconcile_loop(self) -> None:
+        while True:
+            await asyncio.sleep(5)
+            try:
+                await self.reconcile()
+            except Exception as e:  # never let a scan kill the router
+                print(f"  ! reconcile error: {e}")
+
+    async def handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            buf = b""
+            while b"\r\n\r\n" not in buf:
+                chunk = await reader.read(65536)
+                if not chunk:
+                    writer.close()
+                    return
+                buf += chunk
+                if len(buf) > 1 << 18:  # 256 KiB of headers → bail
+                    break
+            host = _header(buf, b"host") or ""
+            label = self._label(host)
+            target = self.routes.get(label) if label else None
+            if target is None:
+                await self._serve_index(writer, label, host)
+                return
+            try:
+                br, bw = await asyncio.open_connection("127.0.0.1", target)
+            except OSError:
+                await _respond(writer, 502, f"{label}: backend not ready")
+                return
+            bw.write(buf)
+            await bw.drain()
+            await asyncio.gather(_pipe(reader, bw), _pipe(br, writer),
+                                 return_exceptions=True)
+        except Exception:
+            try:
+                writer.close()
+            except Exception:
+                pass
+
+    async def _serve_index(self, writer: asyncio.StreamWriter, label, host) -> None:
+        if label and label not in self.routes:
+            await _respond(writer, 404,
+                           f"no preview for '{label}'. Open shells: "
+                           f"{', '.join(self.routes) or '(none)'}")
+            return
+        rows = "".join(
+            f'<li><a href="http://{n}.localhost:{self.dev_port}/">'
+            f'{n}.localhost:{self.dev_port}</a></li>'
+            for n in sorted(self.routes)
+        ) or "<li><em>no dev-shell worktree UIs found</em></li>"
+        body = (f"<!doctype html><meta charset=utf-8>"
+                f"<title>sc preview</title>"
+                f"<h1>super-coder · live worktree previews</h1><ul>{rows}</ul>"
+                f"<p>Each link is a dev shell's worktree, live with HMR.</p>")
+        await _respond(writer, 200, body, content_type="text/html; charset=utf-8")
+
+    async def serve(self) -> None:
+        # Bind first, before spawning any vite — a port clash should fail fast
+        # and cleanly, not after starting N dev servers we'd have to reap.
+        try:
+            server = await asyncio.start_server(self.handle, self.bind, self.dev_port)
+        except OSError as e:
+            print(f"sc preview: cannot bind {self.bind}:{self.dev_port} "
+                  f"({e.strerror}).")
+            print(f"  dev_port {self.dev_port} is already in use — most often the "
+                  f"sandbox already publishes it, or a preview is already running.")
+            print(f"  Run preview inside the sandbox (dev_port is free in there), "
+                  f"stop the other listener, or set SC_DEV_PORT to a free port.")
+            return
+        print(f"sc preview · front http://{self.bind}:{self.dev_port}  "
+              f"(index at http://localhost:{self.dev_port}/)")
+        await self.reconcile()
+        if not self.routes:
+            print("  (no worktree UIs yet — will pick them up as shells appear)")
+        asyncio.ensure_future(self.reconcile_loop())
+        async with server:
+            await server.serve_forever()
+
+
+# ── tiny HTTP/byte helpers ───────────────────────────────────────────────────
+
+def _header(buf: bytes, name: bytes) -> str | None:
+    head = buf.split(b"\r\n\r\n", 1)[0]
+    for line in head.split(b"\r\n")[1:]:
+        k, _, v = line.partition(b":")
+        if k.strip().lower() == name:
+            return v.strip().decode(errors="replace")
+    return None
+
+
+async def _pipe(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+    try:
+        while True:
+            data = await r.read(65536)
+            if not data:
+                break
+            w.write(data)
+            await w.drain()
+    except Exception:
+        pass
+    finally:
+        try:
+            w.close()
+        except Exception:
+            pass
+
+
+async def _respond(writer: asyncio.StreamWriter, status: int, body: str,
+                   content_type: str = "text/plain; charset=utf-8") -> None:
+    reason = {200: "OK", 404: "Not Found", 502: "Bad Gateway"}.get(status, "OK")
+    payload = body.encode()
+    head = (f"HTTP/1.1 {status} {reason}\r\n"
+            f"Content-Type: {content_type}\r\n"
+            f"Content-Length: {len(payload)}\r\n"
+            f"Connection: close\r\n\r\n").encode()
+    try:
+        writer.write(head + payload)
+        await writer.drain()
+    except Exception:
+        pass
+    finally:
+        try:
+            writer.close()
+        except Exception:
+            pass
+
+
+def main() -> int:
+    bind = os.environ.get("SC_BIND", "127.0.0.1")
+    dev_port = int(os.environ.get("SC_DEV_PORT") or ports.resolve()["dev_port"])
+    router = Router(dev_port, bind)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, lambda: (router.shutdown(), loop.stop()))
+        except NotImplementedError:  # pragma: no cover — non-unix
+            pass
+    try:
+        loop.run_until_complete(router.serve())
+    except (KeyboardInterrupt, RuntimeError):
+        pass
+    finally:
+        router.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/roadmap_sc.md
+++ b/roadmap_sc.md
@@ -72,3 +72,8 @@ _No open flags._
 Dependency-free localhost GUI (shells/roadmap/flags), per-fork ports. PR #3.
 
 _No open flags._
+
+### Dev shell live UI preview · owner: `cc`
+One router on the fork's dev_port fans out to each dev shell's worktree vite, routed by subdomain (http://<shortname>.localhost:<dev_port>/) — live HMR per worktree, no base-path config, no concurrent-edit conflict. post-commit hook prints the URL. See specs_sc/dev-preview.md.
+
+_No open flags._

--- a/sc
+++ b/sc
@@ -221,6 +221,7 @@ case "$cmd" in
   map-setup)    exec "$PY" "$S/map_setup.py" ;;
   seed-skills)  exec "$PY" "$S/seed_skills.py" ;;
   ports)        exec "$PY" "$S/ports.py" show ;;
+  preview)      exec "$PY" "$S/preview.py" "$@" ;;
   # ── in-container primitives (no docker; also the host escape hatch) ──
   serve)        exec "$PY" "$ENGINE/api/server.py" "$@" ;;
   boot)         exec "$PY" "$S/run.py" "$@" ;;
@@ -327,6 +328,8 @@ super-coder — forkable shell substrate
   ./sc verify              rebuild + flat render + render-only boot (headless proof)
   ./sc health              curl the review layer's /api/health
   ./sc ports               show this fork's derived port
+  ./sc preview             live-preview every dev shell's worktree UI on one port,
+                             routed by subdomain (http://<shortname>.localhost:<dev_port>/)
   ./sc clean-db            remove the rebuilt .db (text serializations untouched)
 EOF
     ;;

--- a/skills_sc/git.md
+++ b/skills_sc/git.md
@@ -71,3 +71,10 @@ text, then commit that text. See the `snapshot` skill.
 - Multi-shell: dev shells each boot into their own git worktree at
   `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel dev shells
   never share a cwd — worktree isolation is automatic.
+- Preview UI work: because you edit in your worktree, your changes do NOT show on
+  the fork's main dev server. `./sc preview` runs a router that serves every
+  shell's worktree UI live (HMR) on the fork's `dev_port`, one subdomain each:
+  `http://<shortname>.localhost:<dev_port>/`. The `post-commit` hook prints your
+  URL after each commit — surface that line to the FnB so they can eyeball the
+  change. If preview isn't running, start it once from the main checkout:
+  `./sc preview`.

--- a/specs_sc/dev-preview.md
+++ b/specs_sc/dev-preview.md
@@ -1,0 +1,102 @@
+---
+rendered_by: super-coder
+source: db
+edit: changes here are overwritten — author via the shell or localhost GUI
+feature: Dev shell live UI preview
+roadmap_status: shipped
+frozen: false
+---
+
+# Dev shell live UI preview
+
+## Problem
+
+Dev shells each own a git worktree (`.sc-worktrees/<shortname>/`) — see
+[dev-worktrees](dev-worktrees.md). That isolates *edits*, but it breaks
+*viewing*: the fork's dev server runs from the main checkout, so a shell's UI
+changes — made in its worktree — never show on the live dev server. Pointing the
+one dev server at a single worktree would just clobber the isolation the
+worktrees exist to provide, and two shells previewing at once would fight over
+one port.
+
+## Solution
+
+One router on the fork's `dev_port` that fans out to a per-worktree vite, routed
+by **subdomain**:
+
+    http://dev1.localhost:<dev_port>/      dev1's worktree UI, live (HMR)
+    http://dev2.localhost:<dev_port>/      dev2's worktree UI, live (HMR)
+    http://localhost:<dev_port>/           index of available shells
+
+`*.localhost` resolves to 127.0.0.1 on modern systems — no hosts-file or DNS
+setup. Each worktree's vite runs at root on a private internal port; the router
+reads the `Host` header and proxies to the matching backend.
+
+### Why subdomain, not path-prefix (`:port/dev1/...`)
+
+The fork UIs are SvelteKit with SSR server routes (the same-origin `/api/*`
+trust seam is a real server route). Serving several apps under one port by
+**path prefix** would force every app to emit `/dev1/`-prefixed URLs — i.e.
+`kit.paths.base`, an app-wide build-time setting baked into every internal link
+*and* the `/api` seam — injected per-shell into each fork's committed config,
+plus an HMR-behind-prefix dance. **Subdomain** sidesteps all of it: each
+subdomain is a distinct origin, so the app serves from root unchanged — no base
+config, `/api` seam intact, native HMR.
+
+### Why per-connection routing works
+
+A browser keeps one TCP connection per origin, so the first `Host` seen on a
+connection is its route for life. The router reads the request header block,
+picks the backend, then splices raw bytes both directions — HTTP keep-alive and
+websocket upgrades (HMR) flow through untouched, no per-request reparsing.
+
+## Surfaces
+
+### 1. `preview.py` (`./sc preview`)
+Discovers `.sc-worktrees/*` with a UI dir; for each: symlinks the main
+checkout's `node_modules` into the worktree UI (same repo + lockfile → valid),
+best-effort `git submodule update --init`, writes a generated sidecar vite
+config (`.sc-preview.vite.config.js`, gitignored under `.sc-worktrees/`) that
+extends the worktree's own config with `allowedHosts: ['.localhost']` and
+`hmr.clientPort = dev_port` (so the HMR client dials the front port, not the
+private one), then launches `vite dev` on a free internal port. An asyncio
+proxy on `dev_port` routes by `Host` subdomain label. A 5s reconcile loop picks
+up new worktrees and reaps removed ones — dynamic, no restart.
+
+Binds `$SC_BIND` (0.0.0.0 in the sandbox so the published port is reachable;
+127.0.0.1 on the host). Front port is `$SC_DEV_PORT` if set (the sandbox
+publishes it) else the repo-derived `dev_port`. Binds the front port first, so a
+clash (e.g. the sandbox already publishes `dev_port`) fails fast with guidance
+instead of spawning vites it would have to reap.
+
+### 2. `sc` — `preview)` dispatch + help line.
+
+### 3. `post-commit` hook
+Fires via `core.hooksPath`. On a commit from a worktree
+(`*/.sc-worktrees/*`), prints `→ preview: http://<shortname>.localhost:<dev_port>/`.
+Silent on the main checkout. Best-effort — never blocks the commit.
+
+### 4. `git` skill
+A note so the shell surfaces the printed preview URL to the FnB after committing
+UI work, and starts `./sc preview` if it isn't already up.
+
+## Runtime model
+
+`./sc preview` is meant to run where the shells run: inside the sandbox
+container `dev_port` is free (the publish maps it out to the host), so the router
+binds it there and `http://<shortname>.localhost:<dev_port>/` is reachable from
+the host browser. On a pm2/host fork, run it on the host where `dev_port` is
+free. It is long-lived (one per fork) and reaps its vites on Ctrl-C.
+
+## Out of scope (this spec)
+
+- A pm2/supervised long-run wrapper — run it in the foreground or background it.
+- HTTPS / non-`.localhost` hostnames — dev-only, plain HTTP.
+- Reviewer/planner shells — git read-only, no UI to preview.
+
+## Done condition
+
+With two dev-shell worktrees that carry a UI, `./sc preview` serves each at
+`http://<shortname>.localhost:<dev_port>/` — independent content per branch,
+assets and the `/api` seam intact, and HMR live (a `101 Switching Protocols`
+through the router). Committing in a worktree prints that worktree's preview URL.


### PR DESCRIPTION
## Problem

Since worktrees rolled out to all shells (#70), each dev shell edits in
`.sc-worktrees/<shortname>/` — but the fork's dev server runs from the **main**
checkout, so a shell's UI changes never appear on the live server. Pointing the
one dev server at a single worktree would clobber the isolation worktrees exist
to provide, and concurrent shells would fight over one port.

## Solution

`./sc preview` — one router on the fork's `dev_port` that fans out to a
per-worktree vite, routed by **subdomain**:

```
http://dev1.localhost:<dev_port>/   dev1's worktree UI, live (HMR)
http://dev2.localhost:<dev_port>/   dev2's worktree UI, live (HMR)
http://localhost:<dev_port>/        index of available shells
```

`*.localhost` resolves to 127.0.0.1 with no setup.

### Why subdomain, not path-prefix (`:port/dev1/...`)

The UIs are SvelteKit with SSR server routes (the `/api/*` trust seam is a real
server route). Path-prefix routing would force every app to emit `/dev1/`-prefixed
URLs — `kit.paths.base`, baked into every link **and** the `/api` seam, injected
per-shell into each fork's committed config, plus HMR-behind-prefix. Subdomain
sidesteps all of it: each subdomain is a distinct origin, so the app serves from
root unchanged. (Decision recorded after weighing path-prefix vs port-per-shell
vs subdomain.)

## What's here

- **`preview.py`** — discover worktree UIs, symlink `node_modules` from main,
  init submodules, generate a sidecar vite config (`allowedHosts` + `hmr.clientPort`
  → front port), launch vite per worktree, asyncio Host-routed proxy on `dev_port`,
  5s reconcile loop (dynamic add/remove). Binds the front port first, so a clash
  (the sandbox already publishes `dev_port`) fails fast with guidance.
- **`sc`** — `preview` dispatch + help line.
- **`post-commit` hook** — prints the worktree's preview URL after each commit;
  silent on the main checkout.
- **`git` skill** — note to surface the URL and start preview if down (asset +
  regenerated seed migration).
- **spec** — `documents`/`roadmap` row (feature 12) → `specs_sc/dev-preview.md`.

## Verification (against dos-arch's two live worktrees)

- Per-branch isolation: dev1 `/contacts` (89228B) ≠ dev2 `/contacts` (89287B),
  separate vites.
- SvelteKit untouched: HTML, `/@vite/client` (205KB), `/_app` assets all 200;
  `/api` seam same-origin.
- **HMR websocket: `101 Switching Protocols` through the router** — live reload works.
- Clean 404 on unknown subdomain, index lists shells.

## Note (out of scope)

Rebuilding the engine DB surfaced **pre-existing** skill-catalogue drift
(`db_map.md` stale, and `local_skill_management`/`migration_management`/`spec`/
`test_authoring` never rendered to `skills_sc/`). I scoped that out of this PR —
flagging it for a separate catalogue-resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)