### PR TITLE
feat(admin): admin shell boots in the repo root and maintains main directly

### DIFF
--- a/.super-coder/assets/skills/git/SKILL.md
+++ b/.super-coder/assets/skills/git/SKILL.md
@@ -19,6 +19,10 @@ were your code. Engine changes are authored upstream in super-coder.
 
 1. **Never commit straight to the default branch.** Branch first:
    `git checkout -b <type>/<short-desc>` (feat/fix/chore/docs).
+   *Admin-flavor exception:* the admin shell boots in the repo root on `main`
+   and maintains it directly (engine updates, migrations, applying approved
+   patches) — the branch-guard exempts it. If that's you, commit to main is
+   your mandate; every other shell branches first, always.
 2. Commit in logical units. End the message with your shell's attribution so
    parallel shells' work stays legible:
    ```
@@ -61,9 +65,10 @@ text, then commit that text. See the `snapshot` skill.
 
 - Confirm you're in the intended repo before destructive ops (`git -C` if ever in
   doubt).
-- Multi-shell: dev shells each boot into their own git worktree at
-  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel dev shells
-  never share a cwd — worktree isolation is automatic.
+- Multi-shell: shells each boot into their own git worktree at
+  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel shells
+  never share a cwd — worktree isolation is automatic. The admin shell is the
+  one exception: it boots in the repo root on `main`.
 - Preview UI work: because you edit in your worktree, your changes do NOT show on
   the fork's main dev server. `./sc preview` runs a router that serves every
   shell's worktree UI live (HMR) on the fork's `dev_port`, one subdomain each:

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -840,6 +840,10 @@ were your code. Engine changes are authored upstream in super-coder.
 
 1. **Never commit straight to the default branch.** Branch first:
    `git checkout -b <type>/<short-desc>` (feat/fix/chore/docs).
+   *Admin-flavor exception:* the admin shell boots in the repo root on `main`
+   and maintains it directly (engine updates, migrations, applying approved
+   patches) — the branch-guard exempts it. If that''s you, commit to main is
+   your mandate; every other shell branches first, always.
 2. Commit in logical units. End the message with your shell''s attribution so
    parallel shells'' work stays legible:
    ```
@@ -882,9 +886,10 @@ text, then commit that text. See the `snapshot` skill.
 
 - Confirm you''re in the intended repo before destructive ops (`git -C` if ever in
   doubt).
-- Multi-shell: dev shells each boot into their own git worktree at
-  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel dev shells
-  never share a cwd — worktree isolation is automatic.
+- Multi-shell: shells each boot into their own git worktree at
+  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel shells
+  never share a cwd — worktree isolation is automatic. The admin shell is the
+  one exception: it boots in the repo root on `main`.
 - Preview UI work: because you edit in your worktree, your changes do NOT show on
   the fork''s main dev server. `./sc preview` runs a router that serves every
   shell''s worktree UI live (HMR) on the fork''s `dev_port`, one subdomain each:

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -236,6 +236,11 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
     if work_dir is not None:
         active_session.append(
             f"- worktree: `{work_dir}` (your cwd — branch and commit from here)")
+    elif shell["flavor"] == "admin":
+        active_session.append(
+            "- working dir: repo root, branch `main` — you maintain main "
+            "directly (the only shell that does; every other shell works "
+            "from a worktree and lands changes via PRs)")
 
     parts = [
         template,

--- a/.super-coder/scripts/branch-guard.sh
+++ b/.super-coder/scripts/branch-guard.sh
@@ -20,6 +20,15 @@ set -euo pipefail
 # Not a git work tree (rare for a fork, but be safe) → nothing to guard.
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
+# The admin shell is the ONE exemption: it boots in the repo root (no worktree)
+# and maintains the default branch directly — engine updates, migrations,
+# applying approved patches. run.py exports SC_SHELL_FLAVOR at launch; like
+# SC_PROTECTED_BRANCHES this is a guardrail against accidents, not a security
+# boundary.
+if [ "${SC_SHELL_FLAVOR:-}" = "admin" ]; then
+  exit 0
+fi
+
 # symbolic-ref answers "which branch is HEAD" reliably: it returns the name even
 # on an unborn branch (first commit on main → still guarded), and returns nothing
 # on detached HEAD (rebases/bisects stay unblocked). Fall back to rev-parse.

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -461,9 +461,12 @@ def main() -> None:
     # separate branches without clobbering each other — planner/reviewer commit
     # their own artifacts (specs, snapshots, state) there too. All artifacts
     # (CLAUDE.md, AGENTS.md, skills, harness config) land in the worktree root;
-    # the harness is exec'd from there.
+    # the harness is exec'd from there. The ONE exception is the admin flavor:
+    # it maintains `main` itself (engine updates, migrations, applying approved
+    # patches), so it boots in the repo root — no worktree, no shell/* branch.
+    # The branch-guard exempts it via SC_SHELL_FLAVOR (exported at exec below).
     work_dir = REPO_ROOT
-    if chosen["shortname"]:
+    if chosen["shortname"] and chosen["flavor"] != "admin":
         work_dir = REPO_ROOT / ".sc-worktrees" / chosen["shortname"].lower()
         ensure_worktree(work_dir, chosen["shortname"])
 
@@ -484,6 +487,8 @@ def main() -> None:
           f"(shell_id={full['shell_id']}, session={session_id})")
     if work_dir != REPO_ROOT:
         print(f"→ worktree: {work_dir}")
+    elif chosen["flavor"] == "admin":
+        print("→ working dir: repo root (admin — maintains main directly)")
     print(f"→ wrote {work_dir / 'CLAUDE.md'}")
     print(f"→ wrote {work_dir / 'AGENTS.md'}")
     print(f"→ skills: {len(skills['written'])} written, "
@@ -539,6 +544,10 @@ def main() -> None:
 
     cmd = (adapter.get("launch") or [harness]) + model_args + sandbox_flags
     env = {**os.environ, **{k: str(v) for k, v in adapter.get("env", {}).items()}}
+    # The booted shell's flavor, inherited by everything the harness spawns.
+    # branch-guard.sh reads it to exempt the admin shell (which works on main
+    # by mandate); like SC_PROTECTED_BRANCHES it's a guardrail, not a boundary.
+    env["SC_SHELL_FLAVOR"] = chosen["flavor"] or ""
     os.chdir(work_dir)
     print(f"→ exec {' '.join(cmd)}\n")
     os.execvpe(cmd[0], cmd, env)

--- a/.super-coder/templates/shells/admin.json
+++ b/.super-coder/templates/shells/admin.json
@@ -2,7 +2,7 @@
   "flavor": "admin",
   "abbr": "ADM",
   "role": "Admin shell",
-  "mandate": "Own {{repo}}'s super-coder infrastructure — keep the engine current, skills healthy, and DB schema sound. No other shell touches the substrate; you own the floor.",
-  "focus": "You are the fork's infrastructure owner. Update the engine, manage rollbacks, author and persist fork-specific skills via the correct authoring path (file first, catalogue second, grant third), and apply schema migrations. Working shells consume the substrate; you maintain it.",
-  "skills": ["self_update", "local_skill_management", "migration_management"]
+  "mandate": "Own {{repo}}'s super-coder infrastructure — keep the engine current, skills healthy, and DB schema sound. You maintain `main` directly; no other shell touches the substrate or the default branch. You own the floor.",
+  "focus": "You are the fork's infrastructure owner and the ONLY shell that works in the repo root on `main` — every other shell operates from an isolated worktree and lands changes via PRs. You apply patches to main directly: engine updates, rollbacks, schema migrations, and merging approved work. Author and persist fork-specific skills via the correct authoring path (file first, catalogue second, grant third). Working shells consume the substrate; you maintain it.",
+  "skills": ["git", "self_update", "local_skill_management", "migration_management"]
 }

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ default per harness (the `flavor_defaults` table — the picker pre-selects it;
 | **reviewer** | adversarial review | `gpt-5.5` | `opus` ★ | `kimi-k2.6` |
 | **dev** | write the code | `gpt-5.4-mini` ★ | `sonnet` | `qwen3-coder:480b` |
 | **cartographer** | map the repo | `gpt-5.4-mini` ★ | `haiku` | `gpt-oss:20b` |
+| **admin** | own the substrate, maintain `main` | `gpt-5.5` ★ | `sonnet` | `qwen3-coder:480b` |
 
 ★ = the harness the picker pre-selects for that flavor.
 
@@ -242,6 +243,13 @@ The logic, three rules:
 - **Three lineages, always.** Every flavor offers Codex (OpenAI), Claude
   (Anthropic), and OpenCode (open-weights via Ollama) — pick any provider for any
   role at launch.
+- **Admin is the one shell on `main`.** Every other shell boots into an isolated
+  git worktree (`.sc-worktrees/<shortname>/`, branch `shell/<shortname>`) and
+  lands work via PRs; the admin shell boots in the **repo root** and maintains
+  the default branch directly — engine updates, rollbacks, migrations, applying
+  approved patches, fork-local skills. The branch-guard exempts it (and only
+  it). Its decisions carry real risk (a wrong rollback is data loss), so it
+  defaults premium on Codex.
 
 > **Vibe sits outside this matrix.** Mistral Vibe takes no model from the launch
 > seam — it selects its own via `active_model` in `~/.vibe/config.toml`

--- a/skills_sc/git.md
+++ b/skills_sc/git.md
@@ -26,6 +26,10 @@ were your code. Engine changes are authored upstream in super-coder.
 
 1. **Never commit straight to the default branch.** Branch first:
    `git checkout -b <type>/<short-desc>` (feat/fix/chore/docs).
+   *Admin-flavor exception:* the admin shell boots in the repo root on `main`
+   and maintains it directly (engine updates, migrations, applying approved
+   patches) — the branch-guard exempts it. If that's you, commit to main is
+   your mandate; every other shell branches first, always.
 2. Commit in logical units. End the message with your shell's attribution so
    parallel shells' work stays legible:
    ```
@@ -68,9 +72,10 @@ text, then commit that text. See the `snapshot` skill.
 
 - Confirm you're in the intended repo before destructive ops (`git -C` if ever in
   doubt).
-- Multi-shell: dev shells each boot into their own git worktree at
-  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel dev shells
-  never share a cwd — worktree isolation is automatic.
+- Multi-shell: shells each boot into their own git worktree at
+  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel shells
+  never share a cwd — worktree isolation is automatic. The admin shell is the
+  one exception: it boots in the repo root on `main`.
 - Preview UI work: because you edit in your worktree, your changes do NOT show on
   the fork's main dev server. `./sc preview` runs a router that serves every
   shell's worktree UI live (HMR) on the fork's `dev_port`, one subdomain each:


### PR DESCRIPTION
## What

The **admin flavor** is now the one shell that works in the **main checkout** — no worktree, no `shell/*` branch. Its job is maintaining `main` itself: engine updates, rollbacks, schema migrations, applying approved patches, fork-local skills. Every other shell keeps its isolated worktree and lands changes via PRs.

## How

| Surface | Change |
|---|---|
| `run.py` | Skip `ensure_worktree` for `flavor='admin'` — boots at `REPO_ROOT`. Exports `SC_SHELL_FLAVOR` into the harness env at exec (inherited by hooks, plugins, git). |
| `branch-guard.sh` | Exempt `SC_SHELL_FLAVOR=admin`. One edit point covers all four consumers (claude hook, codex hook, opencode plugin, git pre-commit). Guardrail against accidents, not a security boundary — same trust level as `SC_PROTECTED_BRANCHES`. |
| `compose.py` | ACTIVE SESSION line tells the admin shell its contract: repo root, `main`, sole maintainer. |
| `admin.json` | Mandate/focus rewritten around the main-checkout contract; grants the `git` skill (admin does real git work on main — it was the only flavor without it). |
| git skill | Admin-flavor exception documented; worktree note updated. `0001_seed_skills.sql` + `skills_sc/git.md` regenerated. |
| README | Admin row in the flavor table + doctrine bullet. |

## Verification

- Scratch-fork e2e: `ADM1` (factory-created) boots at repo root — no `.sc-worktrees/` entry, correct boot-doc line, `gpt-5.5` flavor default; `CART1` still gets `.sc-worktrees/cart1` on `shell/cart1`.
- Stubbed harness exec confirms the spawned process sees `SC_SHELL_FLAVOR=admin` with cwd at the repo root.
- branch-guard matrix: main+no-flavor → block(2), main+admin → allow(0), main+dev → block(2), feature-branch → allow(0).
- 19/19 existing tests pass; `render-check` clean against the committed mirror.

## Notes

- No schema change, no new migration — flavor-driven behavior only. Forks pick it up via `./sc update`.
- A fork that already created an admin shell (none exist today — dos-arch has the flavor machinery but no instance) would leave a stale `.sc-worktrees/<adm>/` behind; harmless, removable with `git worktree remove`.
- dos-arch follow-up after merge + `./sc update`: create its admin shell via the factory, then revoke the interim `self_update` grants on PLN1/DEV2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)