### PR TITLE
feat(launcher): worktree drift check + safe auto-sync at boot

### DIFF
--- a/.super-coder/assets/skills/git/SKILL.md
+++ b/.super-coder/assets/skills/git/SKILL.md
@@ -15,6 +15,31 @@ everything except `.super-coder/`. The engine is a gitignored, materialized
 dependency (refreshed by `./sc update`); don't commit it or edit it as if it
 were your code. Engine changes are authored upstream in super-coder.
 
+## Sync before you start
+
+Your `shell/<shortname>` branch is a **moving base pinned to `origin/main`**,
+not a content branch — work happens on feature branches cut from it. A worktree
+is born at first-boot HEAD and drifts as other shells' PRs merge; a stale base
+means you read code that no longer exists and your PRs conflict on arrival.
+
+The launcher checks drift at every boot and **auto-syncs when provably nothing
+can be lost** (on the base branch, clean tree, no local-only commits). The
+result is the `sync:` line in ACTIVE SESSION above — read it. When it says
+**NOT auto-synced**, or mid-session before starting a new unit of work:
+
+1. `git fetch origin main && git rev-list --count HEAD..origin/main` — behind
+   count. Zero → carry on.
+2. Behind → take stock of local state BEFORE touching anything:
+   `git status` (uncommitted), `git rev-list origin/main..HEAD` (unmerged
+   commits), `git branch --no-merged origin/main` (unlanded branches).
+3. Anything local → **surface it to the FnB first**: list the commits/files and
+   ask — land it, stash it, or discard? No sync without their call (soft gate).
+4. Clean (or FnB said go) → `git checkout shell/<shortname> && git reset --hard
+   origin/main`. **Never `git pull`/merge on the base branch** — merge bubbles
+   accumulate forever, and your own squash-merged work replays as conflicts.
+5. Never reset a *feature* branch to `origin/main` — only the base. A stale
+   feature branch gets `git rebase origin/main` if it must catch up.
+
 ## Branch → commit → push → PR → stop
 
 1. **Never commit straight to the default branch.** Branch first:
@@ -22,7 +47,8 @@ were your code. Engine changes are authored upstream in super-coder.
    *Admin-flavor exception:* the admin shell boots in the repo root on `main`
    and maintains it directly (engine updates, migrations, applying approved
    patches) — the branch-guard exempts it. If that's you, commit to main is
-   your mandate; every other shell branches first, always.
+   your mandate; start each session with `git pull --ff-only` so you maintain
+   the real main. Every other shell branches first, always.
 2. Commit in logical units. End the message with your shell's attribution so
    parallel shells' work stays legible:
    ```
@@ -35,7 +61,11 @@ were your code. Engine changes are authored upstream in super-coder.
 
 Once the FnB merges your PR, tidy local so stale branches don't accumulate:
 
-1. `git checkout main && git pull` — fast-forward onto the merged commit.
+1. Re-pin your base onto the merged commit. In a worktree you **cannot**
+   `git checkout main` — main is checked out at the repo root, and git refuses
+   a branch already checked out in another worktree. Instead:
+   `git checkout shell/<shortname> && git fetch origin && git reset --hard
+   origin/main`. (Admin shell, repo root: `git pull --ff-only` on main.)
 2. Delete the merged branch: `git branch -d <branch>`. If it was
    **squash-merged**, git won't recognize it as merged and `-d` refuses — confirm
    the PR shows *merged* on the remote, then `git branch -D <branch>`.
@@ -66,9 +96,10 @@ text, then commit that text. See the `snapshot` skill.
 - Confirm you're in the intended repo before destructive ops (`git -C` if ever in
   doubt).
 - Multi-shell: shells each boot into their own git worktree at
-  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel shells
-  never share a cwd — worktree isolation is automatic. The admin shell is the
-  one exception: it boots in the repo root on `main`.
+  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>` — a moving base
+  the launcher keeps pinned to `origin/main` (see 'Sync before you start').
+  Parallel shells never share a cwd — worktree isolation is automatic. The
+  admin shell is the one exception: it boots in the repo root on `main`.
 - Preview UI work: because you edit in your worktree, your changes do NOT show on
   the fork's main dev server. `./sc preview` runs a router that serves every
   shell's worktree UI live (HMR) on the fork's `dev_port`, one subdomain each:

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -836,6 +836,31 @@ everything except `.super-coder/`. The engine is a gitignored, materialized
 dependency (refreshed by `./sc update`); don''t commit it or edit it as if it
 were your code. Engine changes are authored upstream in super-coder.
 
+## Sync before you start
+
+Your `shell/<shortname>` branch is a **moving base pinned to `origin/main`**,
+not a content branch — work happens on feature branches cut from it. A worktree
+is born at first-boot HEAD and drifts as other shells'' PRs merge; a stale base
+means you read code that no longer exists and your PRs conflict on arrival.
+
+The launcher checks drift at every boot and **auto-syncs when provably nothing
+can be lost** (on the base branch, clean tree, no local-only commits). The
+result is the `sync:` line in ACTIVE SESSION above — read it. When it says
+**NOT auto-synced**, or mid-session before starting a new unit of work:
+
+1. `git fetch origin main && git rev-list --count HEAD..origin/main` — behind
+   count. Zero → carry on.
+2. Behind → take stock of local state BEFORE touching anything:
+   `git status` (uncommitted), `git rev-list origin/main..HEAD` (unmerged
+   commits), `git branch --no-merged origin/main` (unlanded branches).
+3. Anything local → **surface it to the FnB first**: list the commits/files and
+   ask — land it, stash it, or discard? No sync without their call (soft gate).
+4. Clean (or FnB said go) → `git checkout shell/<shortname> && git reset --hard
+   origin/main`. **Never `git pull`/merge on the base branch** — merge bubbles
+   accumulate forever, and your own squash-merged work replays as conflicts.
+5. Never reset a *feature* branch to `origin/main` — only the base. A stale
+   feature branch gets `git rebase origin/main` if it must catch up.
+
 ## Branch → commit → push → PR → stop
 
 1. **Never commit straight to the default branch.** Branch first:
@@ -843,7 +868,8 @@ were your code. Engine changes are authored upstream in super-coder.
    *Admin-flavor exception:* the admin shell boots in the repo root on `main`
    and maintains it directly (engine updates, migrations, applying approved
    patches) — the branch-guard exempts it. If that''s you, commit to main is
-   your mandate; every other shell branches first, always.
+   your mandate; start each session with `git pull --ff-only` so you maintain
+   the real main. Every other shell branches first, always.
 2. Commit in logical units. End the message with your shell''s attribution so
    parallel shells'' work stays legible:
    ```
@@ -856,7 +882,11 @@ were your code. Engine changes are authored upstream in super-coder.
 
 Once the FnB merges your PR, tidy local so stale branches don''t accumulate:
 
-1. `git checkout main && git pull` — fast-forward onto the merged commit.
+1. Re-pin your base onto the merged commit. In a worktree you **cannot**
+   `git checkout main` — main is checked out at the repo root, and git refuses
+   a branch already checked out in another worktree. Instead:
+   `git checkout shell/<shortname> && git fetch origin && git reset --hard
+   origin/main`. (Admin shell, repo root: `git pull --ff-only` on main.)
 2. Delete the merged branch: `git branch -d <branch>`. If it was
    **squash-merged**, git won''t recognize it as merged and `-d` refuses — confirm
    the PR shows *merged* on the remote, then `git branch -D <branch>`.
@@ -887,9 +917,10 @@ text, then commit that text. See the `snapshot` skill.
 - Confirm you''re in the intended repo before destructive ops (`git -C` if ever in
   doubt).
 - Multi-shell: shells each boot into their own git worktree at
-  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel shells
-  never share a cwd — worktree isolation is automatic. The admin shell is the
-  one exception: it boots in the repo root on `main`.
+  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>` — a moving base
+  the launcher keeps pinned to `origin/main` (see ''Sync before you start'').
+  Parallel shells never share a cwd — worktree isolation is automatic. The
+  admin shell is the one exception: it boots in the repo root on `main`.
 - Preview UI work: because you edit in your worktree, your changes do NOT show on
   the fork''s main dev server. `./sc preview` runs a router that serves every
   shell''s worktree UI live (HMR) on the fork''s `dev_port`, one subdomain each:

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -163,12 +163,16 @@ def fetch_counts(con, shell_id: int) -> dict:
 
 
 def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
-                 archive_id: int, work_dir: "Path | None" = None) -> str:
+                 archive_id: int, work_dir: "Path | None" = None,
+                 sync_note: "str | None" = None) -> str:
     """Assemble the full boot markdown for `shell`, driven by `user`.
 
     work_dir, when set, is the shell's effective working directory (dev-shell
     worktree). Its path is surfaced in ACTIVE SESSION so the shell knows it
-    operates from a worktree rather than the repo root.
+    operates from a worktree rather than the repo root. sync_note is the
+    launcher's worktree-drift status (run.sync_worktree) — surfaced alongside
+    so a stale or divergent worktree is ambient knowledge, not something the
+    shell must remember to check.
     """
     template = TEMPLATE_PATH.read_text().rstrip()
     shell_id = shell["shell_id"]
@@ -236,6 +240,8 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
     if work_dir is not None:
         active_session.append(
             f"- worktree: `{work_dir}` (your cwd — branch and commit from here)")
+        if sync_note:
+            active_session.append(f"- sync: {sync_note}")
     elif shell["flavor"] == "admin":
         active_session.append(
             "- working dir: repo root, branch `main` — you maintain main "

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -146,6 +146,62 @@ def ensure_worktree(work_dir: Path, shortname: str) -> None:
         sys.exit(f"FATAL: could not create worktree at {work_dir}:\n{result.stderr.strip()}")
 
 
+def _git(work_dir: Path, *args: str, timeout: int = 15) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(["git", "-C", str(work_dir), *args],
+                          capture_output=True, text=True, timeout=timeout)
+
+
+def sync_worktree(work_dir: Path, shortname: str) -> str:
+    """Bring a shell's worktree base in line with the default branch — or say
+    why not. Returns a one-line status for the boot doc + launch print.
+
+    Doctrine: `shell/<shortname>` is a MOVING BASE pinned to origin/<default>,
+    not a content branch — work happens on feature branches cut from it, so a
+    worktree is born at first-boot HEAD and drifts as PRs merge unless someone
+    moves it. This does, when provably nothing can be lost: HEAD is the shell
+    base branch, the tree is clean, and there are no local-only commits → fetch
+    + `reset --hard origin/<default>` (NEVER pull/merge: merge bubbles on a
+    long-lived branch, and squash-merged work replays as conflicts). Anything
+    local → no touch; the status tells the shell to surface it to the FnB
+    (git skill, 'Sync before you start'). Soft-fails on network/timeout —
+    an offline boot must never block on a drift check.
+    """
+    default = (os.environ.get("SC_PROTECTED_BRANCHES") or "main").split()[0]
+    upstream = f"origin/{default}"
+    try:
+        if _git(work_dir, "fetch", "origin", default, "--quiet",
+                timeout=20).returncode != 0:
+            return f"drift check skipped (could not fetch {upstream} — offline?)"
+        if _git(work_dir, "rev-parse", "--verify", "--quiet",
+                upstream).returncode != 0:
+            return f"drift check skipped (no {upstream})"
+        behind = int(_git(work_dir, "rev-list", "--count",
+                          f"HEAD..{upstream}").stdout.strip() or 0)
+        ahead = int(_git(work_dir, "rev-list", "--count",
+                         f"{upstream}..HEAD").stdout.strip() or 0)
+        dirty = bool(_git(work_dir, "status", "--porcelain").stdout.strip())
+        branch = _git(work_dir, "symbolic-ref", "--short", "HEAD").stdout.strip()
+
+        local = [p for p, on in ((f"{ahead} unmerged local commit(s)", ahead),
+                                 ("uncommitted changes", dirty)) if on]
+        if behind == 0:
+            note = f" ({'; '.join(local)})" if local else ""
+            return f"in sync with {upstream}{note}"
+        if branch != f"shell/{shortname.lower()}":
+            return (f"{behind} behind {upstream}, mid-work on `{branch}` — not "
+                    "auto-synced; land or stash first (git skill: 'Sync before "
+                    "you start')")
+        if local:
+            return (f"⚠ {behind} behind {upstream} with {' + '.join(local)} — "
+                    "NOT auto-synced. Surface the local work to the FnB before "
+                    "doing anything else (git skill: 'Sync before you start')")
+        if _git(work_dir, "reset", "--hard", upstream).returncode != 0:
+            return f"⚠ {behind} behind {upstream} — auto-sync FAILED; see git skill"
+        return f"auto-synced to {upstream} (was {behind} behind; nothing local to lose)"
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return "drift check skipped (git timed out or errored)"
+
+
 def ensure_harness_path() -> None:
     """Prepend the dirs where the official installers drop harness binaries onto
     this process's PATH, so detection (shutil.which) and exec (execvpe) agree
@@ -466,12 +522,15 @@ def main() -> None:
     # patches), so it boots in the repo root — no worktree, no shell/* branch.
     # The branch-guard exempts it via SC_SHELL_FLAVOR (exported at exec below).
     work_dir = REPO_ROOT
+    sync_note = None
     if chosen["shortname"] and chosen["flavor"] != "admin":
         work_dir = REPO_ROOT / ".sc-worktrees" / chosen["shortname"].lower()
         ensure_worktree(work_dir, chosen["shortname"])
+        sync_note = sync_worktree(work_dir, chosen["shortname"])
 
     content = compose_boot(con, full, user, session_id, archive_id,
-                           work_dir=work_dir if work_dir != REPO_ROOT else None)
+                           work_dir=work_dir if work_dir != REPO_ROOT else None,
+                           sync_note=sync_note)
 
     # Render this shell's granted skills to .claude/skills/<name>/SKILL.md —
     # harness-consumed, gitignored, rebuilt per boot (like the boot artifact).
@@ -487,6 +546,7 @@ def main() -> None:
           f"(shell_id={full['shell_id']}, session={session_id})")
     if work_dir != REPO_ROOT:
         print(f"→ worktree: {work_dir}")
+        print(f"→ sync: {sync_note}")
     elif chosen["flavor"] == "admin":
         print("→ working dir: repo root (admin — maintains main directly)")
     print(f"→ wrote {work_dir / 'CLAUDE.md'}")

--- a/skills_sc/git.md
+++ b/skills_sc/git.md
@@ -22,6 +22,31 @@ everything except `.super-coder/`. The engine is a gitignored, materialized
 dependency (refreshed by `./sc update`); don't commit it or edit it as if it
 were your code. Engine changes are authored upstream in super-coder.
 
+## Sync before you start
+
+Your `shell/<shortname>` branch is a **moving base pinned to `origin/main`**,
+not a content branch — work happens on feature branches cut from it. A worktree
+is born at first-boot HEAD and drifts as other shells' PRs merge; a stale base
+means you read code that no longer exists and your PRs conflict on arrival.
+
+The launcher checks drift at every boot and **auto-syncs when provably nothing
+can be lost** (on the base branch, clean tree, no local-only commits). The
+result is the `sync:` line in ACTIVE SESSION above — read it. When it says
+**NOT auto-synced**, or mid-session before starting a new unit of work:
+
+1. `git fetch origin main && git rev-list --count HEAD..origin/main` — behind
+   count. Zero → carry on.
+2. Behind → take stock of local state BEFORE touching anything:
+   `git status` (uncommitted), `git rev-list origin/main..HEAD` (unmerged
+   commits), `git branch --no-merged origin/main` (unlanded branches).
+3. Anything local → **surface it to the FnB first**: list the commits/files and
+   ask — land it, stash it, or discard? No sync without their call (soft gate).
+4. Clean (or FnB said go) → `git checkout shell/<shortname> && git reset --hard
+   origin/main`. **Never `git pull`/merge on the base branch** — merge bubbles
+   accumulate forever, and your own squash-merged work replays as conflicts.
+5. Never reset a *feature* branch to `origin/main` — only the base. A stale
+   feature branch gets `git rebase origin/main` if it must catch up.
+
 ## Branch → commit → push → PR → stop
 
 1. **Never commit straight to the default branch.** Branch first:
@@ -29,7 +54,8 @@ were your code. Engine changes are authored upstream in super-coder.
    *Admin-flavor exception:* the admin shell boots in the repo root on `main`
    and maintains it directly (engine updates, migrations, applying approved
    patches) — the branch-guard exempts it. If that's you, commit to main is
-   your mandate; every other shell branches first, always.
+   your mandate; start each session with `git pull --ff-only` so you maintain
+   the real main. Every other shell branches first, always.
 2. Commit in logical units. End the message with your shell's attribution so
    parallel shells' work stays legible:
    ```
@@ -42,7 +68,11 @@ were your code. Engine changes are authored upstream in super-coder.
 
 Once the FnB merges your PR, tidy local so stale branches don't accumulate:
 
-1. `git checkout main && git pull` — fast-forward onto the merged commit.
+1. Re-pin your base onto the merged commit. In a worktree you **cannot**
+   `git checkout main` — main is checked out at the repo root, and git refuses
+   a branch already checked out in another worktree. Instead:
+   `git checkout shell/<shortname> && git fetch origin && git reset --hard
+   origin/main`. (Admin shell, repo root: `git pull --ff-only` on main.)
 2. Delete the merged branch: `git branch -d <branch>`. If it was
    **squash-merged**, git won't recognize it as merged and `-d` refuses — confirm
    the PR shows *merged* on the remote, then `git branch -D <branch>`.
@@ -73,9 +103,10 @@ text, then commit that text. See the `snapshot` skill.
 - Confirm you're in the intended repo before destructive ops (`git -C` if ever in
   doubt).
 - Multi-shell: shells each boot into their own git worktree at
-  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`. Parallel shells
-  never share a cwd — worktree isolation is automatic. The admin shell is the
-  one exception: it boots in the repo root on `main`.
+  `.sc-worktrees/<shortname>/` on branch `shell/<shortname>` — a moving base
+  the launcher keeps pinned to `origin/main` (see 'Sync before you start').
+  Parallel shells never share a cwd — worktree isolation is automatic. The
+  admin shell is the one exception: it boots in the repo root on `main`.
 - Preview UI work: because you edit in your worktree, your changes do NOT show on
   the fork's main dev server. `./sc preview` runs a router that serves every
   shell's worktree UI live (HMR) on the fork's `dev_port`, one subdomain each:

--- a/tests/test_worktree_sync.py
+++ b/tests/test_worktree_sync.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Tests for the launcher's worktree drift check (run.sync_worktree).
+
+Stdlib `unittest`, no pytest — matching the engine's no-dependency style.
+Each test builds a throwaway origin + clone + shell worktree with real git in
+a tmpdir, then drives the one decision that matters per case: auto-sync only
+when provably nothing can be lost.
+
+Run:
+    python3 tests/test_worktree_sync.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from run import sync_worktree  # noqa: E402
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def git(cwd: Path, *args: str) -> str:
+    res = subprocess.run(["git", "-C", str(cwd), *args],
+                         capture_output=True, text=True, env=GIT_ENV)
+    if res.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed: {res.stderr}")
+    return res.stdout.strip()
+
+
+def head(cwd: Path) -> str:
+    return git(cwd, "rev-parse", "HEAD")
+
+
+class WorktreeSyncTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        base = Path(self.tmp.name)
+        # Bare origin with one commit on main.
+        self.origin = base / "origin.git"
+        seed = base / "seed"
+        seed.mkdir()
+        git(seed, "init", "-q", "-b", "main")
+        (seed / "f.txt").write_text("v1\n")
+        git(seed, "add", "f.txt")
+        git(seed, "commit", "-qm", "c1")
+        subprocess.run(["git", "clone", "-q", "--bare", str(seed), str(self.origin)],
+                       check=True, capture_output=True, env=GIT_ENV)
+        # The fork's main checkout + the shell's worktree (born at HEAD, like
+        # ensure_worktree does).
+        self.repo = base / "fork"
+        subprocess.run(["git", "clone", "-q", str(self.origin), str(self.repo)],
+                       check=True, capture_output=True, env=GIT_ENV)
+        self.wt = self.repo / ".sc-worktrees" / "dev1"
+        git(self.repo, "worktree", "add", str(self.wt), "-b", "shell/dev1")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def advance_origin(self, msg: str = "c2") -> str:
+        """Land a new commit on origin/main (another shell's PR merging)."""
+        other = Path(self.tmp.name) / f"other-{msg}"
+        subprocess.run(["git", "clone", "-q", str(self.origin), str(other)],
+                       check=True, capture_output=True, env=GIT_ENV)
+        (other / "f.txt").write_text(f"{msg}\n")
+        git(other, "commit", "-qam", msg)
+        git(other, "push", "-q", "origin", "main")
+        return head(other)
+
+    def test_in_sync_reports_clean(self) -> None:
+        note = sync_worktree(self.wt, "DEV1")
+        self.assertIn("in sync", note)
+
+    def test_behind_and_clean_auto_syncs(self) -> None:
+        tip = self.advance_origin()
+        note = sync_worktree(self.wt, "DEV1")
+        self.assertIn("auto-synced", note)
+        self.assertEqual(head(self.wt), tip)
+        # Still on the base branch, not detached.
+        self.assertEqual(git(self.wt, "symbolic-ref", "--short", "HEAD"),
+                         "shell/dev1")
+
+    def test_dirty_tree_blocks_and_is_surfaced(self) -> None:
+        self.advance_origin()
+        (self.wt / "f.txt").write_text("local edit\n")
+        before = head(self.wt)
+        note = sync_worktree(self.wt, "DEV1")
+        self.assertIn("NOT auto-synced", note)
+        self.assertIn("uncommitted changes", note)
+        self.assertEqual(head(self.wt), before)
+        self.assertEqual((self.wt / "f.txt").read_text(), "local edit\n")
+
+    def test_local_commits_block_and_are_surfaced(self) -> None:
+        self.advance_origin()
+        (self.wt / "mine.txt").write_text("x\n")
+        git(self.wt, "add", "mine.txt")
+        git(self.wt, "commit", "-qm", "local work")
+        before = head(self.wt)
+        note = sync_worktree(self.wt, "DEV1")
+        self.assertIn("NOT auto-synced", note)
+        self.assertIn("unmerged local commit", note)
+        self.assertEqual(head(self.wt), before)
+
+    def test_feature_branch_left_alone(self) -> None:
+        git(self.wt, "checkout", "-qb", "feat/x")
+        self.advance_origin()
+        before = head(self.wt)
+        note = sync_worktree(self.wt, "DEV1")
+        self.assertIn("mid-work on `feat/x`", note)
+        self.assertEqual(head(self.wt), before)
+        self.assertEqual(git(self.wt, "symbolic-ref", "--short", "HEAD"), "feat/x")
+
+    def test_no_remote_soft_fails(self) -> None:
+        git(self.repo, "remote", "remove", "origin")
+        note = sync_worktree(self.wt, "DEV1")
+        self.assertIn("drift check skipped", note)
+
+    def test_in_sync_with_local_commits_notes_them(self) -> None:
+        (self.wt / "mine.txt").write_text("x\n")
+        git(self.wt, "add", "mine.txt")
+        git(self.wt, "commit", "-qm", "local work")
+        note = sync_worktree(self.wt, "DEV1")
+        self.assertIn("in sync", note)
+        self.assertIn("unmerged local commit", note)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Shell worktrees are born at first-boot HEAD and never updated — every merged PR widens the gap, so shells plan and edit against code that no longer exists on main. (Observed: worktree shells significantly out of sync.)

## Doctrine

`shell/<shortname>` is a **moving base pinned to `origin/main`**, not a content branch — work happens on feature branches cut from it. Sync = `fetch` + `reset --hard origin/main`, never pull/merge: merge bubbles accumulate forever on a long-lived branch, and squash-merged work replays as conflicts.

## What

**Boot-time layer (always fires, `run.py`):** `sync_worktree()` runs at every worktree boot — fetch origin (soft-fail offline, 20s timeout), then **auto-sync only when provably nothing can be lost**: on the base branch + clean tree + no local-only commits. Anything local → no touch; the status says to surface it to the FnB first. Mid-work on a feature branch → left alone. The status renders as a `sync:` line in the boot doc's ACTIVE SESSION and the launch print — drift is ambient knowledge, not something a lazy-loaded skill must remember to check.

**Skill layer (procedure, git skill):** new *'Sync before you start'* section — fetch → behind count → take stock of local state → **surface unmerged work to the FnB before executing (soft gate)** → reset on confirmation. Also fixes a latent bug: *'After a merge — clean up local'* told worktree shells to `git checkout main`, which is impossible — main is checked out at the repo root and git refuses a branch already checked out in another worktree. Admin exception now opens each session with `git pull --ff-only`.

## Status lines the shell can see

- `in sync with origin/main` (+ notes ahead/dirty if any)
- `auto-synced to origin/main (was N behind; nothing local to lose)`
- `⚠ N behind origin/main with M unmerged local commit(s) + uncommitted changes — NOT auto-synced. Surface the local work to the FnB…`
- `N behind origin/main, mid-work on \`feat/x\` — not auto-synced…`
- `drift check skipped (could not fetch origin — offline?)`

## Verification

- `tests/test_worktree_sync.py` — 7 cases over real git fixtures (bare origin + clone + worktree): in-sync, behind+clean auto-syncs onto the new tip while staying on the base branch, dirty tree blocks and preserves the edit, local commits block, feature branch untouched, no-remote soft-fails, ahead-only annotated.
- E2E in a scratch fork: all three live cases verified in launch print + rendered CLAUDE.md.
- All 4 test files pass; `render-check` mirror regenerated (`skills_sc/git.md` + seed migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)