### PR TITLE
feat(ui): spec-task checklist + completion side bar on roadmap cards

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -188,9 +188,18 @@ def get_roadmap(con) -> dict:
             "SELECT flag_id, feature_id, display_name, description FROM flags "
             "WHERE resolved=0 AND COALESCE(is_deleted,0)=0 AND feature_id IS NOT NULL")):
         flags_by.setdefault(f["feature_id"], []).append(f)
+    # Spec tasks (implementation plan) attach per feature, ordered by spec then
+    # seq so a multi-spec feature lists each spec's plan in order. Drives the
+    # feature card's task checklist + side-bar colour in the UI.
+    tasks_by: dict[int, list] = {}
+    for t in rows(con.execute(
+            "SELECT task_id, feature_id, document_id, seq, title, status "
+            "FROM spec_tasks ORDER BY feature_id, document_id, seq")):
+        tasks_by.setdefault(t["feature_id"], []).append(t)
     for f in feats:
         f["documents"] = docs_by.get(f["feature_id"], [])
         f["open_flags"] = flags_by.get(f["feature_id"], [])
+        f["tasks"] = tasks_by.get(f["feature_id"], [])
     buckets = [{"status": s, "label": _LABEL[s],
                 "features": [f for f in feats if f["roadmap_status"] == s]}
                for s in _ORDER]

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -510,6 +510,11 @@ function featureCard(f) {
   // Expandable box: collapsed shows title + status/owner pills + a one-line
   // summary preview; expanded reveals the editable fields, docs, and blockers.
   const c = el("details", { className: "card feature" });
+  // Spec tasks (implementation plan) → side-bar colour: all done = green,
+  // any still open = sunset orange. No tasks = no side bar.
+  const tasks = f.tasks || [];
+  const doneCount = tasks.filter((t) => t.status === "done").length;
+  if (tasks.length) c.classList.add("has-tasks", doneCount === tasks.length ? "tasks-done" : "tasks-open");
   const sum = el("summary", { className: "feature-head" });
   sum.append(el("span", { className: "feature-title" }, f.title || "(untitled)"));
   const meta = el("span", { className: "feature-meta" });
@@ -536,6 +541,20 @@ function featureCard(f) {
     el("span", { className: "k" }, "title"), title,
     el("span", { className: "k" }, "status"), status,
     el("span", { className: "k" }, "summary"), summary), save);
+
+  // tasks — the spec's implementation plan, in order; done = checked + struck
+  if (tasks.length) {
+    body.append(el("label", { className: "k", textContent: `tasks (${doneCount}/${tasks.length})` }));
+    const ul = el("ul", { className: "task-list" });
+    for (const t of tasks) {
+      const done = t.status === "done";
+      const li = el("li", { className: done ? "done" : (t.status === "in_progress" ? "wip" : "") });
+      li.append(el("span", { className: "box", textContent: done ? "☑" : "☐" }));
+      li.append(el("span", { className: "t" }, t.title || ""));
+      ul.append(li);
+    }
+    body.append(ul);
+  }
 
   // documents — specs (editable/frozen per state) then docs (read-only here;
   // the Docs tab is where docs are edited)

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -10,6 +10,7 @@
   --ink: #e8e8ec; --dim: #9a9aa5;
   --accent: #6ea8fe; --accent2: #26262e;
   --ok: #4caf7d; --warn: #d4914a; --lock: #6a6a75;
+  --task-open: #c46a1a;                          /* dark sunset yellow-orange — feature has open spec tasks */
   --menu-bg: #2e2e35; --menu-border: #3a3a42;
   --menu-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
   --r: 14px; font-synthesis: none;
@@ -129,6 +130,18 @@ details.feature > summary:hover { background: var(--accent2); }
 details.feature[open] > .feature-preview { display: none; }
 .feature-body { padding: 0 1.1rem 1.1rem; }
 .feature-body > .act:first-of-type { margin-top: .2rem; }
+
+/* spec-task side bar — colours the card's left edge by plan completion. These
+   sit after the [open] rule above so they win the border-color cascade. */
+details.feature.has-tasks { border-left-width: 4px; }
+details.feature.tasks-done { border-left-color: var(--ok); }
+details.feature.tasks-open { border-left-color: var(--task-open); }
+.task-list { list-style: none; margin: .2rem 0 .4rem; padding: 0; }
+.task-list li { display: flex; gap: .5rem; align-items: baseline; padding: .2rem 0; font-size: .85rem; }
+.task-list li .box { flex: none; color: var(--dim); }
+.task-list li.wip .box { color: var(--task-open); }
+.task-list li.done { color: var(--dim); text-decoration: line-through; }
+.task-list li.done .box { color: var(--ok); text-decoration: none; }
 .search { margin: 0 0 1rem; }
 .filters { display: flex; gap: .4rem; flex-wrap: wrap; margin: 0 0 1rem; }
 .chip {

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -66,6 +66,18 @@ main { padding: 1.2rem; }
 .view { display: grid; grid-template-columns: minmax(0, 1fr); gap: 1rem; margin: 0 auto; width: 100%; max-width: 1000px; }
 .view[hidden] { display: none; }  /* class selector would otherwise beat [hidden] */
 
+/* ── 1px card rhythm (Skills / Roadmap / Docs / Flags) ──────────────────────
+   Stacked card panels on these tabs sit a hairline apart. Section headers
+   (funnel stages, skill categories) keep enough room to read as group labels;
+   only the card-to-card spacing tightens. */
+#view-roadmap .bucket > details.feature + details.feature { margin-top: 1px; }
+#view-docs .card + .card { margin-top: 1px; }
+#view-flags { gap: 1px; }
+#view-flags .flagbar { margin-bottom: calc(1rem - 1px); }   /* restore bar→cards spacing */
+#view-skills { gap: 1px; }
+#view-skills > .muted:first-child { margin-bottom: calc(1rem - 1px); }  /* intro keeps room */
+#view-skills .bucket > h2 { margin-top: 0; }                 /* header rides on its own card */
+
 .card {
   background: var(--panel); border: 1px solid var(--line); border-radius: var(--r);
   padding: 1rem 1.1rem;

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -66,16 +66,16 @@ main { padding: 1.2rem; }
 .view { display: grid; grid-template-columns: minmax(0, 1fr); gap: 1rem; margin: 0 auto; width: 100%; max-width: 1000px; }
 .view[hidden] { display: none; }  /* class selector would otherwise beat [hidden] */
 
-/* ── 1px card rhythm (Skills / Roadmap / Docs / Flags) ──────────────────────
-   Stacked card panels on these tabs sit a hairline apart. Section headers
+/* ── Tight card rhythm (Skills / Roadmap / Docs / Flags) ────────────────────
+   Stacked card panels on these tabs sit a small 3px apart. Section headers
    (funnel stages, skill categories) keep enough room to read as group labels;
    only the card-to-card spacing tightens. */
-#view-roadmap .bucket > details.feature + details.feature { margin-top: 1px; }
-#view-docs .card + .card { margin-top: 1px; }
-#view-flags { gap: 1px; }
-#view-flags .flagbar { margin-bottom: calc(1rem - 1px); }   /* restore bar→cards spacing */
-#view-skills { gap: 1px; }
-#view-skills > .muted:first-child { margin-bottom: calc(1rem - 1px); }  /* intro keeps room */
+#view-roadmap .bucket > details.feature + details.feature { margin-top: 3px; }
+#view-docs .card + .card { margin-top: 3px; }
+#view-flags { gap: 3px; }
+#view-flags .flagbar { margin-bottom: calc(1rem - 3px); }   /* restore bar→cards spacing */
+#view-skills { gap: 3px; }
+#view-skills > .muted:first-child { margin-bottom: calc(1rem - 3px); }  /* intro keeps room */
 #view-skills .bucket > h2 { margin-top: 0; }                 /* header rides on its own card */
 
 .card {

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -67,15 +67,15 @@ main { padding: 1.2rem; }
 .view[hidden] { display: none; }  /* class selector would otherwise beat [hidden] */
 
 /* ── Tight card rhythm (Skills / Roadmap / Docs / Flags) ────────────────────
-   Stacked card panels on these tabs sit a small 3px apart. Section headers
+   Stacked card panels on these tabs sit a small 5px apart. Section headers
    (funnel stages, skill categories) keep enough room to read as group labels;
    only the card-to-card spacing tightens. */
-#view-roadmap .bucket > details.feature + details.feature { margin-top: 3px; }
-#view-docs .card + .card { margin-top: 3px; }
-#view-flags { gap: 3px; }
-#view-flags .flagbar { margin-bottom: calc(1rem - 3px); }   /* restore bar→cards spacing */
-#view-skills { gap: 3px; }
-#view-skills > .muted:first-child { margin-bottom: calc(1rem - 3px); }  /* intro keeps room */
+#view-roadmap .bucket > details.feature + details.feature { margin-top: 5px; }
+#view-docs .card + .card { margin-top: 5px; }
+#view-flags { gap: 5px; }
+#view-flags .flagbar { margin-bottom: calc(1rem - 5px); }   /* restore bar→cards spacing */
+#view-skills { gap: 5px; }
+#view-skills > .muted:first-child { margin-bottom: calc(1rem - 5px); }  /* intro keeps room */
 #view-skills .bucket > h2 { margin-top: 0; }                 /* header rides on its own card */
 
 .card {


### PR DESCRIPTION
A feature with spec tasks now shows a coloured left **side bar** and, when expanded, its **task checklist**.

## What
- **Side bar** on the feature card by plan completion:
  - **green** (`--ok`) when every task is `done`
  - **dark sunset orange** (`--task-open: #c46a1a`) while any task is open
  - no bar when the feature has no spec tasks
- **Checklist** under the summary (expanded view), tasks in `seq` order:
  - done → `☑` checked + struck through
  - `in_progress`/`pending` → `☐`
  - header counts `tasks (done/total)`

## How
- **API** (`get_roadmap`): attaches `tasks` per feature, ordered by spec (`document_id`) then `seq`.
- **UI** (`featureCard`): `has-tasks` + `tasks-done`/`tasks-open` classes; renders the list.
- **CSS**: side-bar + checklist styles placed after the `[open]` rule so they win the border-color cascade.

Multi-spec features aggregate all their specs' tasks (all done → green; any open → orange).

## Test
No new endpoint or migration (`spec_tasks` table already existed, was empty). Verified `get_roadmap` against temporary rows: all-done feature → green, partial → orange, correct seq order; temp rows removed after. No headless browser available locally for a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)