### PR TITLE
feat(worktrees): live git-hygiene tab — dirty / stale / clean across a fork's worktrees

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -39,6 +39,7 @@ DB_PATH = ENGINE / "shell_db.db"
 UI_DIR = ENGINE / "ui"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import ports as ports_mod  # noqa: E402
 import shell_factory  # noqa: E402
 import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin rule)
@@ -550,6 +551,18 @@ class Handler(BaseHTTPRequestHandler):
             return self._send(200, f.read_text(), ctype)
         if not path.startswith("/api/"):
             return self._send(404, {"error": "not found"})
+        # git-hygiene is a live filesystem/git read — no DB, computed on demand
+        # (the UI refresh button is the only trigger). `?fetch=1` does the network
+        # fetch for accurate behind-counts + fresh PR state; the default skips it
+        # so the initial tab load is snappy.
+        if urlparse(self.path).path == "/api/git-state":
+            from urllib.parse import parse_qs
+            q = parse_qs(urlparse(self.path).query)
+            fetch = q.get("fetch", ["0"])[0] in ("1", "true", "yes")
+            try:
+                return self._send(200, git_hygiene.compute(fetch=fetch))
+            except Exception as e:
+                return self._fail(e)
         con = db()
         try:
             if path == "/api/health":

--- a/.super-coder/scripts/git_hygiene.py
+++ b/.super-coder/scripts/git_hygiene.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Repo git-hygiene snapshot — what's dirty, stale, or clean across this fork's
+worktrees, computed live in one pass from a single vantage point.
+
+A fork manages ONE host repo with many shells, each in its own worktree under
+`.sc-worktrees/<shortname>/` (the dev-worktree model). Any single process on
+the host can see every worktree on disk — `git worktree list` enumerates them
+and `git -C <path> status` reads each one's dirtiness — so this never has to
+poll a shell. The review server calls compute() on demand (the UI's refresh
+button is the only trigger); no DB, no hooks, no persistence.
+
+Reporting only, by design: it surfaces state, it never prunes or mutates.
+
+Three buckets:
+  - dirty worktree   — uncommitted changes in a working tree (yellow/orange)
+  - stale branch     — a local branch whose PR is merged (prunable, reported)
+  - clean            — in sync, nothing outstanding
+
+"Stale" is best-effort. A squash-merge (the project default) makes a branch's
+commits non-ancestors of main, so ancestry alone can't see it — authoritative
+merge state comes from `gh pr list`. When gh is absent/unauthed/offline we fall
+back to git ancestry (catches non-squash merges) and otherwise report
+merged=null ("unknown") rather than guess. That's the "as best we can" line.
+
+Run standalone:
+    python3 .super-coder/scripts/git_hygiene.py            # JSON
+    python3 .super-coder/scripts/git_hygiene.py --text      # human table
+    python3 .super-coder/scripts/git_hygiene.py --no-fetch  # skip network fetch
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+
+# Infrastructure branches that are never "stale prunable work": the default
+# branch and the per-shell worktree bases (`shell/<shortname>`), which are
+# long-lived moving bases pinned to origin/<default>, not feature branches.
+_DIRTY_SAMPLE = 8     # cap the file-name sample carried per dirty worktree
+
+
+def _git(*args: str, cwd: Path = REPO_ROOT, timeout: int = 12) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(cwd), *args],
+                          capture_output=True, text=True, timeout=timeout)
+
+
+def _out(*args: str, cwd: Path = REPO_ROOT, timeout: int = 12) -> str:
+    try:
+        r = _git(*args, cwd=cwd, timeout=timeout)
+        return r.stdout.strip() if r.returncode == 0 else ""
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+
+
+def default_branch() -> str:
+    """The repo's default branch — SC_PROTECTED_BRANCHES[0] is authoritative in a
+    fork (the launcher sets it); fall back to origin/HEAD, then 'main'."""
+    env = (os.environ.get("SC_PROTECTED_BRANCHES") or "").split()
+    if env:
+        return env[0]
+    head = _out("symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+    if head.startswith("origin/"):
+        return head[len("origin/"):]
+    return "main"
+
+
+def _porcelain_worktrees() -> list[dict]:
+    """Parse `git worktree list --porcelain` into one dict per worktree."""
+    blocks: list[dict] = []
+    cur: dict = {}
+    for line in _out("worktree", "list", "--porcelain").splitlines():
+        if not line.strip():
+            if cur:
+                blocks.append(cur)
+                cur = {}
+            continue
+        key, _, val = line.partition(" ")
+        if key == "worktree":
+            cur = {"abs": val}
+        elif key == "branch":
+            cur["branch"] = val.replace("refs/heads/", "", 1)
+        elif key == "detached":
+            cur["detached"] = True
+        elif key == "HEAD":
+            cur["head"] = val
+    if cur:
+        blocks.append(cur)
+    return blocks
+
+
+def _ahead_behind(cwd: Path, base: str) -> tuple[int, int]:
+    """(ahead, behind) of HEAD vs base — (0,0) if base is unresolvable."""
+    raw = _out("rev-list", "--left-right", "--count", f"{base}...HEAD", cwd=cwd)
+    parts = raw.split()
+    if len(parts) != 2:
+        return 0, 0
+    try:
+        behind, ahead = int(parts[0]), int(parts[1])
+    except ValueError:
+        return 0, 0
+    return ahead, behind
+
+
+def _dirty(cwd: Path) -> tuple[int, list[str]]:
+    """(changed-entry count, sample of 'XY path' lines) for a working tree."""
+    out = _out("status", "--porcelain", cwd=cwd)
+    if not out:
+        return 0, []
+    lines = out.splitlines()
+    return len(lines), lines[:_DIRTY_SAMPLE]
+
+
+def _gh_merged_prs() -> tuple[dict[str, dict] | None, bool]:
+    """Map headRefName -> {number, state} from gh, or (None, False) if gh is
+    unavailable. Best-effort: any failure (no gh, no auth, offline) degrades."""
+    if shutil.which("gh") is None:
+        return None, False
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "list", "--state", "all", "--limit", "300",
+             "--json", "number,headRefName,state,mergedAt"],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=20)
+        if r.returncode != 0:
+            return None, False
+        by_branch: dict[str, dict] = {}
+        for pr in json.loads(r.stdout or "[]"):
+            ref = pr.get("headRefName")
+            # keep the most decisive: a MERGED PR wins over an older OPEN/CLOSED
+            if ref and (ref not in by_branch or pr.get("state") == "MERGED"):
+                by_branch[ref] = {"number": pr.get("number"), "state": pr.get("state")}
+        return by_branch, True
+    except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):
+        return None, False
+
+
+def compute(fetch: bool = True) -> dict:
+    """Live git-hygiene snapshot of the whole repo. Pure read — never mutates."""
+    default = default_branch()
+    upstream = f"origin/{default}"
+
+    fetched = False
+    if fetch:
+        try:
+            fetched = _git("fetch", "origin", default, "--quiet",
+                           timeout=20).returncode == 0
+        except (subprocess.TimeoutExpired, OSError):
+            fetched = False
+
+    has_upstream = bool(_out("rev-parse", "--verify", "--quiet", upstream))
+    base = upstream if has_upstream else default
+
+    # ── worktrees ──────────────────────────────────────────────────────────
+    worktrees = []
+    wt_branches = set()
+    for wt in _porcelain_worktrees():
+        abs_path = Path(wt["abs"])
+        try:
+            rel = str(abs_path.relative_to(REPO_ROOT)) or "."
+        except ValueError:
+            rel = str(abs_path)
+        branch = wt.get("branch")
+        if branch:
+            wt_branches.add(branch)
+        dirty_n, sample = _dirty(abs_path)
+        ahead, behind = _ahead_behind(abs_path, base)
+        worktrees.append({
+            "path": "." if rel == os.curdir else rel,
+            "abs": str(abs_path),
+            "branch": branch,
+            "detached": wt.get("detached", False),
+            "is_main": abs_path.resolve() == REPO_ROOT.resolve(),
+            "dirty": dirty_n,
+            "dirty_files": sample,
+            "ahead": ahead,
+            "behind": behind,
+        })
+
+    # ── branches (staleness) ───────────────────────────────────────────────
+    pr_map, gh_available = _gh_merged_prs()
+    local = [b for b in _out("for-each-ref", "--format=%(refname:short)",
+                             "refs/heads/").splitlines() if b]
+    branches = []
+    for name in local:
+        is_base = name == default or name.startswith("shell/")
+        checked_out = name in wt_branches
+        pr = (pr_map or {}).get(name)
+        if pr is not None:
+            merged = pr.get("state") == "MERGED"
+        elif gh_available:
+            merged = False            # gh ran and reported no PR for this branch
+        else:
+            # gh unavailable — fall back to git ancestry (squash-merges miss this)
+            anc = _git("merge-base", "--is-ancestor", name, base)
+            merged = (anc.returncode == 0) or None  # None = genuinely unknown
+        stale = bool(merged) and not is_base and not checked_out
+        branches.append({
+            "name": name,
+            "is_base": is_base,
+            "checked_out": checked_out,
+            "merged": merged,                 # True / False / None(unknown)
+            "pr": pr,
+            "stale": stale,
+        })
+
+    dirty_wts = sum(1 for w in worktrees if w["dirty"])
+    stale_n = sum(1 for b in branches if b["stale"])
+    return {
+        "repo": {
+            "name": REPO_ROOT.name,
+            "root": str(REPO_ROOT),
+            "default_branch": default,
+        },
+        "fetched": fetched,
+        "gh_available": gh_available,
+        "worktrees": worktrees,
+        "branches": branches,
+        "summary": {
+            "worktrees": len(worktrees),
+            "dirty_worktrees": dirty_wts,
+            "stale_branches": stale_n,
+            "all_clean": dirty_wts == 0 and stale_n == 0,
+        },
+    }
+
+
+def _print_text(d: dict) -> None:
+    r = d["repo"]
+    print(f"{r['name']}  (default: {r['default_branch']})"
+          f"   fetch={'ok' if d['fetched'] else 'skipped'}"
+          f"  gh={'ok' if d['gh_available'] else 'unavailable'}")
+    print("\nWORKTREES")
+    for w in d["worktrees"]:
+        if w["dirty"]:
+            state = f"✎ dirty ({w['dirty']} file{'s' if w['dirty'] != 1 else ''})"
+        else:
+            state = "✅ clean"
+        drift = []
+        if w["behind"]:
+            drift.append(f"{w['behind']} behind")
+        if w["ahead"]:
+            drift.append(f"{w['ahead']} ahead")
+        tail = f"  [{', '.join(drift)}]" if drift else ""
+        print(f"  {w['path']:<28} {w['branch'] or '(detached)':<22} {state}{tail}")
+    stale = [b for b in d["branches"] if b["stale"]]
+    print(f"\nSTALE BRANCHES (PR merged, prunable) — {len(stale)}")
+    for b in stale:
+        pr = f"PR #{b['pr']['number']}" if b.get("pr") else "merged"
+        print(f"  ⊘ {b['name']:<34} {pr:<10} git branch -D {b['name']}")
+    if not stale:
+        print("  (none)")
+
+
+def main(argv: list[str]) -> int:
+    d = compute(fetch="--no-fetch" not in argv)
+    if "--text" in argv:
+        _print_text(d)
+    else:
+        print(json.dumps(d, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -840,6 +840,91 @@ async function renderMap(root) {
   }
 }
 
+// ── Worktrees (git hygiene) ──────────────────────────────────────────────────
+// Live, report-only view of the repo: which worktrees are dirty (yellow/orange),
+// which local branches are stale (PR merged → prunable), what's clean. The
+// server computes it on demand from disk in one pass — no shell is ever polled.
+// The refresh button is the ONLY trigger; it does the network fetch (origin +
+// `gh`) for fresh behind-counts and PR state. Nothing here mutates the repo.
+async function renderWorktrees(root, opts = {}) {
+  if (!opts.fetch) root.replaceChildren(el("div", { className: "card muted" }, "Reading repo state…"));
+  let d;
+  try { d = await api("/git-state?fetch=" + (opts.fetch ? "1" : "0")); }
+  catch (e) { root.replaceChildren(el("div", { className: "card" }, "error: " + e.message)); return; }
+  root.replaceChildren();
+
+  // header: repo + summary pills + provenance + the one trigger (refresh)
+  const s = d.summary;
+  const head = el("div", { className: "card" });
+  head.append(el("h2", {}, d.repo.name));
+  head.append(el("div", { className: "wt-summary" },
+    el("span", { className: "pill" + (s.dirty_worktrees ? " warn" : " ok") }, `${s.dirty_worktrees} dirty`),
+    el("span", { className: "pill" }, `${s.stale_branches} stale`),
+    el("span", { className: "pill" + (s.all_clean ? " ok" : "") },
+      s.all_clean ? "all clean" : `${s.worktrees} worktree${s.worktrees !== 1 ? "s" : ""}`)));
+  head.append(el("div", { className: "muted wt-prov" },
+    [`default: ${d.repo.default_branch}`,
+     `fetch: ${d.fetched ? "fresh" : "skipped — click refresh"}`,
+     `gh: ${d.gh_available ? "ok" : "unavailable — merge state best-effort"}`].join("  ·  ")));
+  const refresh = el("button", { className: "act", textContent: "refresh ↻" });
+  refresh.title = "re-scan worktrees + fetch origin & gh for fresh behind-counts and PR state";
+  refresh.onclick = async () => {
+    refresh.disabled = true; setStatus("scanning…");
+    try { await renderWorktrees(root, { fetch: true }); setStatus("scanned"); }
+    catch { setStatus("scan failed"); }
+  };
+  head.append(refresh);
+  root.append(head);
+
+  // worktrees — dot is green (clean) or yellow/orange (dirty)
+  const wc = el("div", { className: "card" });
+  wc.append(el("h2", {}, "Worktrees"));
+  for (const w of d.worktrees) {
+    const dirty = w.dirty > 0;
+    const main = el("div", { className: "wt-main" });
+    const top = el("div", { className: "wt-top" });
+    top.append(el("span", { className: "wt-path" }, w.path === "." ? ".  (main)" : w.path));
+    top.append(el("span", { className: "mono wt-branch" }, w.branch || "(detached)"));
+    main.append(top);
+    const bits = [dirty ? `✎ ${w.dirty} uncommitted` : "clean"];
+    if (w.behind) bits.push(`${w.behind} behind`);
+    if (w.ahead) bits.push(`${w.ahead} ahead`);
+    main.append(el("div", { className: "wt-meta muted" }, bits.join("  ·  ")));
+    if (dirty && w.dirty_files.length) {
+      const det = el("details", { className: "wt-files" });
+      det.append(el("summary", {}, `${w.dirty} changed file${w.dirty !== 1 ? "s" : ""}`));
+      const extra = w.dirty > w.dirty_files.length ? `\n… +${w.dirty - w.dirty_files.length} more` : "";
+      det.append(el("pre", {}, w.dirty_files.join("\n") + extra));
+      main.append(det);
+    }
+    wc.append(el("div", { className: "wt-row" },
+      el("span", { className: "wt-dot " + (dirty ? "dirty" : "clean") }), main));
+  }
+  root.append(wc);
+
+  // stale branches — report only, copy-paste prune command, never auto-deleted
+  const stale = d.branches.filter((b) => b.stale);
+  const sc = el("div", { className: "card" });
+  sc.append(el("h2", {}, `Stale branches — ${stale.length}`));
+  sc.append(el("div", { className: "muted wt-prov" },
+    "Local branches whose PR is merged. Reported only — copy a command to prune. Nothing is deleted for you."));
+  if (!stale.length) sc.append(el("div", { className: "muted" }, "None — no merged branches lingering."));
+  for (const b of stale) {
+    const main = el("div", { className: "wt-main" });
+    const top = el("div", { className: "wt-top" });
+    top.append(el("span", { className: "mono wt-branch" }, b.name));
+    if (b.pr) top.append(el("span", { className: "pill" }, "PR #" + b.pr.number));
+    main.append(top);
+    main.append(el("code", { className: "wt-cmd" }, "git branch -D " + b.name));
+    sc.append(el("div", { className: "wt-row" },
+      el("span", { className: "wt-dot stale" }), main));
+  }
+  const unknown = d.branches.filter((b) => b.merged === null);
+  if (unknown.length) sc.append(el("div", { className: "muted wt-prov" },
+    `${unknown.length} branch(es) with unknown merge state (gh unavailable): ${unknown.map((b) => b.name).join(", ")}`));
+  root.append(sc);
+}
+
 // ── Tabs + boot ────────────────────────────────────────────────────────────────
 const VIEWS = {
   shells: ["#view-shells", renderShells],
@@ -847,6 +932,7 @@ const VIEWS = {
   roadmap: ["#view-roadmap", renderRoadmap],
   docs: ["#view-docs", renderDocs],
   flags: ["#view-flags", renderFlags],
+  worktrees: ["#view-worktrees", renderWorktrees],
   map: ["#view-map", renderMap],
   scripts: ["#view-scripts", renderScripts],
 };

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -17,6 +17,7 @@
       <button data-tab="docs">Docs</button>
       <button data-tab="flags">Flags</button>
       <span class="navsep"></span>
+      <button data-tab="worktrees">Worktrees</button>
       <button data-tab="map">Map</button>
       <button data-tab="scripts">Scripts</button>
     </nav>
@@ -32,6 +33,7 @@
     <section id="view-roadmap" class="view" hidden></section>
     <section id="view-docs" class="view" hidden></section>
     <section id="view-flags" class="view" hidden></section>
+    <section id="view-worktrees" class="view" hidden></section>
     <section id="view-map" class="view" hidden></section>
     <section id="view-scripts" class="view" hidden></section>
   </main>

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -447,3 +447,30 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .toast { animation: toast-in .18s ease-out; }
 @keyframes toast-in { from { opacity: 0; transform: translateY(.4rem); } to { opacity: 1; transform: none; } }
 @media (prefers-reduced-motion: reduce) { * { transition: none !important; animation: none !important; } }
+
+/* ── Worktrees / git-hygiene tab ─────────────────────────────────────────────
+   Report-only repo state. Status dot carries the colour: green=clean,
+   yellow-orange (--warn) = dirty working tree, sunset (--task-open) = stale
+   merged branch. Tight card-to-card rhythm to match the list tabs. */
+#view-worktrees { gap: 5px; }
+.wt-summary { display: flex; gap: .5rem; flex-wrap: wrap; margin: .1rem 0 .5rem; }
+.wt-prov { font-size: .78rem; margin: .15rem 0; }
+.wt-row { display: flex; align-items: flex-start; gap: .7rem; padding: .5rem 0; border-top: 1px solid var(--line-soft); }
+.wt-row:first-of-type { border-top: none; }
+.wt-dot { flex: none; width: 9px; height: 9px; border-radius: 99px; margin-top: .35rem; background: var(--dim); }
+.wt-dot.clean { background: var(--ok); }
+.wt-dot.dirty { background: var(--warn); box-shadow: 0 0 0 3px rgba(212,145,74,.18); }   /* yellow-orange */
+.wt-dot.stale { background: var(--task-open); }
+.wt-main { min-width: 0; flex: 1; }
+.wt-top { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; }
+.wt-path { font-weight: 600; }
+.wt-branch { color: var(--dim); }
+.wt-meta { font-size: .8rem; margin-top: .1rem; }
+.wt-files { margin-top: .3rem; }
+.wt-files summary { color: var(--dim); font-size: .8rem; }
+.wt-files pre { margin: .3rem 0 0; padding: .5rem .6rem; background: var(--panel2);
+  border: 1px solid var(--line); border-radius: 8px; overflow-x: auto;
+  font: 12px/1.5 ui-monospace, monospace; color: rgba(255,255,255,.78); }
+.wt-cmd { display: inline-block; margin-top: .25rem; padding: .15rem .5rem;
+  background: var(--panel2); border: 1px solid var(--line); border-radius: 6px;
+  font: 12px/1.5 ui-monospace, monospace; color: var(--ink); user-select: all; }


### PR DESCRIPTION
## What

A fork manages one host repo with many shells, each in its own worktree under `.sc-worktrees/<shortname>/`. Forks accumulate **dirty working trees** and **stale (PR-merged) branches**, and today the only way to see it is to boot each shell and ask, one by one. This ships a single **Worktrees** tab that shows the whole repo's git hygiene at a glance — dirty / stale / clean — computed live, server-side, in one pass from disk. No shell is ever polled.

## How it's scoped (the decisions baked in)

- **Surface:** a tab in the fork's own web UI.
- **Trigger:** the **refresh button is the only trigger** — the server computes on demand. No hooks, no DB table, no migration, no boot-path (`run.py`) changes. Lowest-risk footprint.
- **Remediation:** **none.** Report-only. Dirty worktrees get a yellow-orange indicator; stale branches show a copy-paste `git branch -D` command. Nothing is pruned or auto-deleted.

## Pieces

| File | Change |
|---|---|
| `.super-coder/scripts/git_hygiene.py` | New. Pure read-only snapshot: parses `git worktree list`, reads each tree's dirtiness + ahead/behind, classifies branches as stale. Runnable standalone (`--text` / `--no-fetch`). |
| `.super-coder/api/server.py` | `GET /api/git-state` (no DB; `?fetch=1` does the network pass for fresh behind-counts + PR state). |
| `.super-coder/ui/{index.html,app.js,style.css}` | New Worktrees tab. Status dot colour: 🟢 clean · 🟡 dirty (`--warn`) · sunset stale (`--task-open`). |

## Staleness detection ("as best we can")

Squash-merge (the project default) makes a branch's commits non-ancestors of `main`, so ancestry alone can't detect a merged branch. Authoritative merge state comes from `gh pr list`. When `gh` is absent/unauthed/offline, it falls back to git ancestry (catches non-squash merges) and otherwise reports `merged=unknown` rather than guessing — surfaced as a caveat line in the UI.

## Verification

- Engine + server smoke-tested live: `GET /api/git-state` returns correct worktree dirtiness (5 changed files detected), branch PR-merge state (4 stale branches via `gh`, current branch correctly `checked_out`/not-stale), and `?fetch=1` does the network fetch.
- Multi-worktree case validated with a throwaway worktree (clean/dirty mix renders, paths relativised), then cleaned up.
- `python3 -m ast` parse + `node --check app.js` pass.
- Not yet visually screenshotted in a browser — markup mirrors existing tabs; happy to spin up `./sc preview` for a visual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)