### PR TITLE
docs(boot): distinguish engine memory DB from the app product DB

### DIFF
--- a/.super-coder/assets/skills/cartographer/SKILL.md
+++ b/.super-coder/assets/skills/cartographer/SKILL.md
@@ -87,7 +87,7 @@ clone where the hooks never got wired.
 3. `./sc map-setup` — re-wires hooks (idempotent) + re-maps.
 4. Verify (step 4) + commit.
 
-## Standing jobs — sections & descriptions (the navigation layer)
+## Standing jobs — sections, descriptions & the product DB (the navigation layer)
 
 Beyond keeping the file list true, you own the two AUTHORED layers that turn the
 raw map into navigation. Both are best-effort and NULL-until-curated; neither
@@ -130,6 +130,26 @@ SELECT path, role FROM dr_filepath WHERE desc IS NULL ORDER BY role, path;
 -- describe (≤100 chars; preserved across the next auto-remap):
 UPDATE dr_filepath SET desc='Boot composer — assembles CLAUDE.md from DB state' WHERE path='.super-coder/render/compose.py';
 ```
+
+**3. The product database** — your repo builds an app, and that app has its own
+database, *separate* from the engine memory DB (`.super-coder/shell_db.db`).
+Working shells change them in completely different ways (boot `## DATABASES`) and
+the only per-fork signal of *where* the app DB lives is the map you author — so
+make it unmistakable. The live `.db` is usually gitignored (absent from the map);
+its **schema + migrations are tracked**, so they are the durable anchor. Tag them
+plainly as the *product/app* DB so a shell never mistakes them for engine memory,
+and give them a section if they form an area.
+
+```sql
+-- tag the product DB's definition (the engine-vs-app split made visible):
+UPDATE dr_filepath SET desc='Product DB schema — the APP database (NOT engine memory)' WHERE path='<app schema file>';
+UPDATE dr_filepath SET desc='Product DB migration — change the app schema here' WHERE path LIKE '<app migrations dir>/%';
+-- optional: a section if the product DB is its own area
+INSERT INTO dr_section (name, path_prefix, description, sort_order)
+VALUES ('App DB', '<db dir>/', 'Product runtime database — schema + migrations (NOT the engine memory DB)', 7);
+```
+
+If this fork ships no database of its own, there is nothing to tag — skip it.
 
 After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
 ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -250,7 +250,7 @@ clone where the hooks never got wired.
 3. `./sc map-setup` — re-wires hooks (idempotent) + re-maps.
 4. Verify (step 4) + commit.
 
-## Standing jobs — sections & descriptions (the navigation layer)
+## Standing jobs — sections, descriptions & the product DB (the navigation layer)
 
 Beyond keeping the file list true, you own the two AUTHORED layers that turn the
 raw map into navigation. Both are best-effort and NULL-until-curated; neither
@@ -293,6 +293,26 @@ SELECT path, role FROM dr_filepath WHERE desc IS NULL ORDER BY role, path;
 -- describe (≤100 chars; preserved across the next auto-remap):
 UPDATE dr_filepath SET desc=''Boot composer — assembles CLAUDE.md from DB state'' WHERE path=''.super-coder/render/compose.py'';
 ```
+
+**3. The product database** — your repo builds an app, and that app has its own
+database, *separate* from the engine memory DB (`.super-coder/shell_db.db`).
+Working shells change them in completely different ways (boot `## DATABASES`) and
+the only per-fork signal of *where* the app DB lives is the map you author — so
+make it unmistakable. The live `.db` is usually gitignored (absent from the map);
+its **schema + migrations are tracked**, so they are the durable anchor. Tag them
+plainly as the *product/app* DB so a shell never mistakes them for engine memory,
+and give them a section if they form an area.
+
+```sql
+-- tag the product DB''s definition (the engine-vs-app split made visible):
+UPDATE dr_filepath SET desc=''Product DB schema — the APP database (NOT engine memory)'' WHERE path=''<app schema file>'';
+UPDATE dr_filepath SET desc=''Product DB migration — change the app schema here'' WHERE path LIKE ''<app migrations dir>/%'';
+-- optional: a section if the product DB is its own area
+INSERT INTO dr_section (name, path_prefix, description, sort_order)
+VALUES (''App DB'', ''<db dir>/'', ''Product runtime database — schema + migrations (NOT the engine memory DB)'', 7);
+```
+
+If this fork ships no database of its own, there is nothing to tag — skip it.
 
 After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
 ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -5,9 +5,11 @@
 ## SYSTEM OVERRIDE
 
 Do not use the harness's auto-memory system. Do not read from or write to
-`~/.claude/projects/*/memory/`. Do not create or update `MEMORY.md`. All memory
-is managed through DB tables in `.super-coder/shell_db.db` (resolved from the
-repo root).
+`~/.claude/projects/*/memory/`. Do not create or update `MEMORY.md`. All
+**memory** is managed through DB tables in `.super-coder/shell_db.db` (resolved
+from the repo root) — that is the *engine's* store. The product this repo builds
+keeps its own runtime data in a **separate app database** (see DATABASES below);
+"memory" here never means the product's data.
 
 The live `.super-coder/shell_db.db` is **gitignored and rebuilt** from
 git-tracked text (`schema.sql` + `migrations/` + `.sc-state/content.sql`). It is
@@ -24,6 +26,29 @@ One memory system, not two. Auto-memory is disabled by design.
 `.super-coder/` is the **engine** you run on (your memory + identity
 substrate), a gitignored dependency — do not treat it as the project or edit
 it. Engine changes are authored upstream in super-coder, never here.
+
+---
+
+## DATABASES
+
+Your fork hosts an application, and that application has **its own database** —
+separate from the engine's. Two DBs are in reach; they change in completely
+different ways, so keep them straight:
+
+- **Engine memory DB** — `.super-coder/shell_db.db`. Fixed name, always under
+  `.super-coder/`. Holds your identity, memory, roadmap, specs, and the repo map.
+  Gitignored and rebuilt from tracked text — change it through DB tables (per your
+  skills) and `./sc snapshot`, never through app migrations.
+- **App product DB** — the database of the product *this repo* builds. Its name
+  and path **vary per fork** and live **outside** `.super-coder/`. Holds the
+  product's runtime data + schema. Change it the way the product does — schema
+  migrations + app code — never by hand-editing rows, and never `./sc snapshot`
+  it. Locate it via the repo map: the cartographer tags its schema/migrations in
+  `dr_*` (the live `.db` is often gitignored, so the schema is the durable anchor).
+
+**Decision rule:** your memory / planning / specs / roadmap → **engine DB**. The
+product's data or schema → **app DB**, via its migrations. If a task is about what
+the product stores or how its tables are shaped, it is never the engine DB.
 
 ---
 
@@ -77,6 +102,11 @@ empty, stale, or wrong, that's a cartographer task — flag it, don't map it
 yourself. Extended patterns (language mix, role filters) live in the
 `surface_catalogue` skill. Before writing SQL against your memory DB, check the
 `db_map` skill — don't read `schema.sql` raw.
+
+`dr_*` is the engine DB's read-only **map of your repo** — it indexes the
+product's files, including the schema + migrations that define the app's own
+database. It describes that schema; it is **not** the app DB itself (see
+DATABASES). Querying `dr_*` is how you *find* the app DB, never how you change it.
 
 ---
 

--- a/skills_sc/cartographer.md
+++ b/skills_sc/cartographer.md
@@ -93,7 +93,7 @@ clone where the hooks never got wired.
 3. `./sc map-setup` — re-wires hooks (idempotent) + re-maps.
 4. Verify (step 4) + commit.
 
-## Standing jobs — sections & descriptions (the navigation layer)
+## Standing jobs — sections, descriptions & the product DB (the navigation layer)
 
 Beyond keeping the file list true, you own the two AUTHORED layers that turn the
 raw map into navigation. Both are best-effort and NULL-until-curated; neither
@@ -136,6 +136,26 @@ SELECT path, role FROM dr_filepath WHERE desc IS NULL ORDER BY role, path;
 -- describe (≤100 chars; preserved across the next auto-remap):
 UPDATE dr_filepath SET desc='Boot composer — assembles CLAUDE.md from DB state' WHERE path='.super-coder/render/compose.py';
 ```
+
+**3. The product database** — your repo builds an app, and that app has its own
+database, *separate* from the engine memory DB (`.super-coder/shell_db.db`).
+Working shells change them in completely different ways (boot `## DATABASES`) and
+the only per-fork signal of *where* the app DB lives is the map you author — so
+make it unmistakable. The live `.db` is usually gitignored (absent from the map);
+its **schema + migrations are tracked**, so they are the durable anchor. Tag them
+plainly as the *product/app* DB so a shell never mistakes them for engine memory,
+and give them a section if they form an area.
+
+```sql
+-- tag the product DB's definition (the engine-vs-app split made visible):
+UPDATE dr_filepath SET desc='Product DB schema — the APP database (NOT engine memory)' WHERE path='<app schema file>';
+UPDATE dr_filepath SET desc='Product DB migration — change the app schema here' WHERE path LIKE '<app migrations dir>/%';
+-- optional: a section if the product DB is its own area
+INSERT INTO dr_section (name, path_prefix, description, sort_order)
+VALUES ('App DB', '<db dir>/', 'Product runtime database — schema + migrations (NOT the engine memory DB)', 7);
+```
+
+If this fork ships no database of its own, there is nothing to tag — skip it.
 
 After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
 ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).


### PR DESCRIPTION
## Why

Upstream feedback from a fork (dos-arch): `templates/boot.md` documents exactly one database — `.super-coder/shell_db.db`, the engine memory store — and never acknowledges that **every fork hosts an application with its own database**. Three sections (SYSTEM OVERRIDE, ORIENTATION, PROJECT vs ENGINE) quietly train a shell to treat the engine store as "the database." Observed symptom: shells repeatedly confuse which DB to modify (a planner editing roadmap status couldn't tell from the boot doc whether feature state lived in engine memory or the app's product DB).

This is an engine-template gap that recurs in every fork, so it lands upstream.

## What changed

**`templates/boot.md`**
- **SYSTEM OVERRIDE** — bold **memory**, add that product data lives in a separate app DB, closing the "`.super-coder/shell_db.db` is *the* DB" overgeneralization at its source.
- **New `## DATABASES` block** — the actual fix:
  - *Engine memory DB* — `.super-coder/shell_db.db` (fixed name/path): identity, memory, roadmap, specs, the map. Change via DB tables + `./sc snapshot`.
  - *App product DB* — name/path **vary per fork**, outside `.super-coder/`. Change via the product's migrations + code; never hand-edit or snapshot it.
  - *Decision rule:* memory / planning / specs → engine DB; product data / schema → app DB via migrations.
- **ORIENTATION** — one line: `dr_*` is the engine DB's read-only **map** of the repo (incl. the schema that *defines* the app DB), not the app DB itself.

**Cartographer skill** (`assets/skills/cartographer/SKILL.md`) — new standing job #3: tag the product DB's **schema + migrations** in `dr_*` (the durable anchor; the live `.db` is usually gitignored) so the engine-vs-app split is visible in the map and no working shell has to infer it. Regenerated `migrations/0001_seed_skills.sql` + the `skills_sc/` mirror.

## Note on the original recommendation

The feedback suggested making the app DB path a **per-fork render variable** ("the launcher already interpolates `$SC_DEV_PORT`"). On inspection that premise doesn't hold: `compose.py` reads the template **verbatim** (no interpolation) — `$SC_DEV_PORT` works because it's a shell *env var* resolved at runtime, and the only per-fork config (`instance.json`) carries just `repo`/`port`/`harness`. There's nothing to inject a path into, and the path isn't declared anywhere.

Instead this leans on what *is* already per-fork: the **cartographer-authored `dr_*` map**. The shell discovers the app DB by querying the map (where the cartographer now tags its schema/migrations) rather than reading a hardcoded path. Generic across all forks, no new render plumbing, and degrades cleanly when a fork ships no DB of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)