### PR TITLE
feat(map): extractor plug-in + tier-1 semantic dimensions

### DIFF
--- a/.sc-state/map_extractors/sqlite_schema.py
+++ b/.sc-state/map_extractors/sqlite_schema.py
@@ -1,0 +1,108 @@
+"""Reference extractor: SQL CREATE TABLE/VIEW → dr_db_table + dr_db_column.
+
+Parses `CREATE TABLE` / `CREATE VIEW` from the `.sql` files the map already
+knows about. Column parse is best-effort: a top-level comma split of the column
+body, skipping table-level constraints (PRIMARY KEY / FOREIGN KEY / UNIQUE /
+CHECK / CONSTRAINT). ORM-defined schemas (Django, SQLAlchemy models) are NOT
+covered — write a model extractor for those.
+
+Optional config in `.sc-state/map.config.json`:
+  "extractors": { "sqlite_schema": { "exclude_prefixes": ["vendor/", "test/"] } }
+"""
+import re
+
+_CREATE_RE = re.compile(
+    r"""CREATE\s+(TABLE|VIEW)\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`\[]?(\w+)["'`\]]?""", re.I)
+_CONSTRAINT_KW = ("primary", "foreign", "unique", "check", "constraint", "key")
+_LINE_COMMENT = re.compile(r"--[^\n]*")
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+
+
+def _strip_comments(text):
+    """Drop SQL line + block comments so they aren't parsed as columns."""
+    return _LINE_COMMENT.sub("", _BLOCK_COMMENT.sub("", text))
+
+
+def _sql_files(con, cfg):
+    excl = ((cfg.get("extractors", {}) or {}).get("sqlite_schema", {}) or {}).get(
+        "exclude_prefixes", [])
+    out = []
+    for r in con.execute("SELECT path FROM dr_filepath WHERE lang='SQL' ORDER BY path"):
+        if not any(r["path"].startswith(x) for x in excl):
+            out.append(r["path"])
+    return out
+
+
+def _balanced(text, start):
+    """Content between the first '(' at/after `start` and its matching ')'."""
+    i = text.find("(", start)
+    if i < 0:
+        return None
+    depth = 0
+    for j in range(i, len(text)):
+        if text[j] == "(":
+            depth += 1
+        elif text[j] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[i + 1:j]
+    return None
+
+
+def _columns(body):
+    cols, depth, buf = [], 0, ""
+    for ch in body:
+        if ch == "(":
+            depth += 1
+            buf += ch
+        elif ch == ")":
+            depth -= 1
+            buf += ch
+        elif ch == "," and depth == 0:
+            cols.append(buf)
+            buf = ""
+        else:
+            buf += ch
+    if buf.strip():
+        cols.append(buf)
+    out = []
+    for c in cols:
+        c = c.strip()
+        if not c:
+            continue
+        first = c.split()[0].strip('"`[]')
+        if first.lower() in _CONSTRAINT_KW:
+            continue
+        toks = c.split()
+        typ = toks[1].strip('"`[],') if len(toks) > 1 else None
+        pk = 1 if re.search(r"primary\s+key", c, re.I) else 0
+        nn = 1 if re.search(r"not\s+null", c, re.I) else 0
+        out.append((first, typ, pk, nn))
+    return out
+
+
+def extract(con, repo_root, cfg) -> str:
+    con.execute("DELETE FROM dr_db_table")
+    con.execute("DELETE FROM dr_db_column")
+    nt = nc = 0
+    for rel in _sql_files(con, cfg):
+        try:
+            text = _strip_comments((repo_root / rel).read_text(errors="ignore"))
+        except OSError:
+            continue
+        for m in _CREATE_RE.finditer(text):
+            kind, name = m.group(1).lower(), m.group(2)
+            con.execute(
+                "INSERT INTO dr_db_table (name, kind, source_file) VALUES (?,?,?)",
+                (name, kind, rel))
+            nt += 1
+            if kind == "table":
+                body = _balanced(text, m.end())
+                if body:
+                    for (cname, ctype, pk, nn) in _columns(body):
+                        con.execute(
+                            "INSERT INTO dr_db_column "
+                            "(table_name, name, type, pk, not_null, source_file) "
+                            "VALUES (?,?,?,?,?,?)", (name, cname, ctype, pk, nn, rel))
+                        nc += 1
+    return f"{nt} tables, {nc} columns"

--- a/.super-coder/assets/skills/cartographer/SKILL.md
+++ b/.super-coder/assets/skills/cartographer/SKILL.md
@@ -160,6 +160,43 @@ If this fork ships no database of its own, there is nothing to tag — skip it.
 After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
 ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).
 
+## Extending the map — semantic extractors
+
+The engine maps the generic 80% on every repo: files, languages, roles, deps,
+env. The **semantic** dimensions — HTTP endpoints (`dr_endpoint`), the app DB
+schema (`dr_db_table`/`dr_db_column`), UI routes/components (`dr_route`/
+`dr_component`) — vary by stack, so the engine can't extract them generically.
+That is your job, via **extractors**: drop-in Python modules in
+`.sc-state/map_extractors/*.py` that `./sc map` discovers and runs after the core
+pass. They are fork-owned (outside the gitignored engine dir, so `./sc update`
+never clobbers them); the table *columns* are standardized in the engine
+(`map_schema.sql`), so a working shell's queries have a stable shape everywhere.
+
+**Adopt one per stack:**
+
+1. **Detect the stack** from the map: `SELECT manager, name FROM dr_dependency;`
+   (fastapi? flask? svelte? next?) and the file mix
+   (`SELECT lang, COUNT(*) FROM dr_filepath GROUP BY lang`).
+2. **Copy the matching reference** from the engine's
+   `.super-coder/templates/map_extractors/` into `.sc-state/map_extractors/`:
+   - `fastapi_endpoints.py` — decorator routes (`@app.get(...)`, Flask `@app.route`) → `dr_endpoint`
+   - `sqlite_schema.py` — SQL `CREATE TABLE/VIEW` → `dr_db_table`/`dr_db_column`
+   - `sveltekit_routes.py` — filesystem routes + `*.svelte` → `dr_route`/`dr_component`
+   Adapt the `framework` label and file filter to this repo. For a stack none
+   cover (Django URLs, Express, Spring, Rails), copy the closest as a skeleton
+   and rewrite the match — aim for the dominant pattern, not 100%.
+3. **Run + verify:** `./sc map`, then check the table populated and the rows look
+   right (`SELECT method, path FROM dr_endpoint LIMIT 10;`).
+4. **Commit** `.sc-state/map_extractors/` + `./sc snapshot`.
+
+**The contract** (full version in `templates/map_extractors/README.md`): each
+module defines `extract(con, repo_root, cfg) -> str`. `con` is the live map db
+(dr_filepath is already populated — query it for inputs); the module DELETEs +
+repopulates only its own `dr_*` table(s); returns a one-line summary for the map
+log. Be defensive — `map_repo` guards each extractor, but a module that needs the
+map should never assume a file parses. Static extraction is best-effort: log what
+you skip (dynamic routes, computed paths), never imply full coverage.
+
 ## Shape-change notices — the curation trigger
 
 The git hooks keep the *mechanical* catalogue fresh on their own (paths, langs,

--- a/.super-coder/assets/skills/surface_catalogue/SKILL.md
+++ b/.super-coder/assets/skills/surface_catalogue/SKILL.md
@@ -25,6 +25,15 @@ don't map it yourself.
 | `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines`, `desc` (cartographer one-liner, NULL until curated) |
 | `dr_dependency` | deps from the manifests: `manager` (npm/pip/poetry/go/cargo), `name`, `version`, `kind`, `source_file` |
 | `dr_env` | env-var names found in `.env.*` example files: `name`, `source_file` |
+| `dr_endpoint` | HTTP routes: `method`, `path`, `handler` (file:line), `framework`, `source_file` |
+| `dr_db_table` / `dr_db_column` | the app DB schema: tables/views + their columns (`type`, `pk`, `not_null`) |
+| `dr_route` / `dr_component` | UI routes (`path`, `kind`) + components (`name`, `path`) |
+
+The first five are mapped on **every** repo. The last three are the **semantic
+layer** — populated only when the cartographer has wired an extractor for this
+repo's stack (see the `cartographer` skill). An empty `dr_endpoint` means *no
+extractor wired*, not "no endpoints" — check before relying on it, and flag the
+cartographer if a dimension you need is missing.
 
 ## Orient fast
 
@@ -58,6 +67,12 @@ SELECT path FROM dr_filepath WHERE path LIKE '%auth%';
 -- stack + config surface:
 SELECT manager, name, version FROM dr_dependency ORDER BY manager, name;
 SELECT name, source_file FROM dr_env ORDER BY name;
+
+-- semantic layer (only if an extractor is wired for this repo — see cartographer):
+SELECT method, path, handler FROM dr_endpoint ORDER BY path;            -- the API surface
+SELECT name, kind, source_file FROM dr_db_table ORDER BY name;          -- the app DB schema
+SELECT name, type, pk, not_null FROM dr_db_column WHERE table_name='users';
+SELECT path, kind, file FROM dr_route ORDER BY path;                    -- UI routes
 ```
 
 ## Stance
@@ -70,6 +85,8 @@ SELECT name, source_file FROM dr_env ORDER BY name;
   mis-classified — that's the cartographer's to fix. Raise it; don't re-map.
   A file under "other / unsectioned", or a `desc IS NULL` where you needed one,
   is also a cartographer worklist item — flag it, don't author the map yourself.
-- Maps files / deps / env + the navigation layer (sections + per-file
-  descriptions). Symbol-level semantics (functions/classes) are a later pass —
-  until then, read the code the section + descriptions point you at.
+- Always maps files / deps / env + the navigation layer (sections + per-file
+  descriptions). The semantic layer (endpoints / DB schema / UI routes) is there
+  when the cartographer wired an extractor for this stack — query it to jump
+  straight to the API surface or schema; fall back to section + descriptions when
+  a dimension is empty. Symbol-level semantics (functions/classes) are a later pass.

--- a/.super-coder/map_schema.sql
+++ b/.super-coder/map_schema.sql
@@ -66,3 +66,60 @@ CREATE TABLE IF NOT EXISTS dr_env (
 CREATE INDEX IF NOT EXISTS idx_dr_filepath_role ON dr_filepath(role);
 CREATE INDEX IF NOT EXISTS idx_dr_filepath_lang ON dr_filepath(lang);
 CREATE INDEX IF NOT EXISTS idx_dr_dependency_mgr ON dr_dependency(manager);
+
+-- ── Tier-1 semantic dimensions ──────────────────────────────────────────────
+-- Beyond files/deps/env, these capture the "what is this app" surface: HTTP
+-- endpoints, the app's DB schema, and UI routes/components. They are DERIVED and
+-- fork-specific: the COLUMNS are standardized here (so skills + the boot render
+-- can rely on a stable shape across forks), but they stay EMPTY until the
+-- cartographer wires an extractor for this repo's stack (see the `cartographer`
+-- skill — `.sc-state/map_extractors/`). Each extractor owns its table: it
+-- DELETEs then repopulates on every map, exactly like dr_dependency/dr_env.
+-- Static extraction is best-effort ("most common, not 100%") — dynamically
+-- registered routes etc. are expected to be missed; an extractor logs what it
+-- could not parse rather than claiming completeness.
+
+CREATE TABLE IF NOT EXISTS dr_endpoint (
+    endpoint_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    method      TEXT,                 -- GET / POST / PUT / PATCH / DELETE / …
+    path        TEXT NOT NULL,        -- route path, e.g. /api/shells/{id}
+    handler     TEXT,                 -- handler symbol or file:line
+    framework   TEXT,                 -- fastapi / flask / express / … (which extractor)
+    source_file TEXT                  -- repo-relative file the route is declared in
+);
+
+CREATE TABLE IF NOT EXISTS dr_db_table (
+    db_table_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT NOT NULL,        -- table / view name
+    kind        TEXT,                 -- table / view
+    source_file TEXT                  -- schema / migration / model file it is defined in
+);
+
+CREATE TABLE IF NOT EXISTS dr_db_column (
+    db_column_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    table_name   TEXT NOT NULL,       -- string ref to dr_db_table.name (cache; no FK)
+    name         TEXT NOT NULL,
+    type         TEXT,
+    pk           INTEGER NOT NULL DEFAULT 0,
+    not_null     INTEGER NOT NULL DEFAULT 0,   -- 'notnull' is a SQLite keyword
+    source_file  TEXT
+);
+
+CREATE TABLE IF NOT EXISTS dr_route (
+    route_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    path        TEXT NOT NULL,        -- URL route derived from the file/router
+    file        TEXT,                 -- repo-relative file backing the route
+    kind        TEXT,                 -- page / endpoint / layout
+    framework   TEXT                  -- sveltekit / nextjs / …
+);
+
+CREATE TABLE IF NOT EXISTS dr_component (
+    component_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name         TEXT NOT NULL,
+    path         TEXT,                -- repo-relative file
+    framework    TEXT                 -- svelte / react / vue / …
+);
+
+CREATE INDEX IF NOT EXISTS idx_dr_endpoint_path ON dr_endpoint(path);
+CREATE INDEX IF NOT EXISTS idx_dr_db_column_table ON dr_db_column(table_name);
+CREATE INDEX IF NOT EXISTS idx_dr_route_path ON dr_route(path);

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -324,6 +324,43 @@ If this fork ships no database of its own, there is nothing to tag — skip it.
 After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
 ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).
 
+## Extending the map — semantic extractors
+
+The engine maps the generic 80% on every repo: files, languages, roles, deps,
+env. The **semantic** dimensions — HTTP endpoints (`dr_endpoint`), the app DB
+schema (`dr_db_table`/`dr_db_column`), UI routes/components (`dr_route`/
+`dr_component`) — vary by stack, so the engine can''t extract them generically.
+That is your job, via **extractors**: drop-in Python modules in
+`.sc-state/map_extractors/*.py` that `./sc map` discovers and runs after the core
+pass. They are fork-owned (outside the gitignored engine dir, so `./sc update`
+never clobbers them); the table *columns* are standardized in the engine
+(`map_schema.sql`), so a working shell''s queries have a stable shape everywhere.
+
+**Adopt one per stack:**
+
+1. **Detect the stack** from the map: `SELECT manager, name FROM dr_dependency;`
+   (fastapi? flask? svelte? next?) and the file mix
+   (`SELECT lang, COUNT(*) FROM dr_filepath GROUP BY lang`).
+2. **Copy the matching reference** from the engine''s
+   `.super-coder/templates/map_extractors/` into `.sc-state/map_extractors/`:
+   - `fastapi_endpoints.py` — decorator routes (`@app.get(...)`, Flask `@app.route`) → `dr_endpoint`
+   - `sqlite_schema.py` — SQL `CREATE TABLE/VIEW` → `dr_db_table`/`dr_db_column`
+   - `sveltekit_routes.py` — filesystem routes + `*.svelte` → `dr_route`/`dr_component`
+   Adapt the `framework` label and file filter to this repo. For a stack none
+   cover (Django URLs, Express, Spring, Rails), copy the closest as a skeleton
+   and rewrite the match — aim for the dominant pattern, not 100%.
+3. **Run + verify:** `./sc map`, then check the table populated and the rows look
+   right (`SELECT method, path FROM dr_endpoint LIMIT 10;`).
+4. **Commit** `.sc-state/map_extractors/` + `./sc snapshot`.
+
+**The contract** (full version in `templates/map_extractors/README.md`): each
+module defines `extract(con, repo_root, cfg) -> str`. `con` is the live map db
+(dr_filepath is already populated — query it for inputs); the module DELETEs +
+repopulates only its own `dr_*` table(s); returns a one-line summary for the map
+log. Be defensive — `map_repo` guards each extractor, but a module that needs the
+map should never assume a file parses. Static extraction is best-effort: log what
+you skip (dynamic routes, computed paths), never imply full coverage.
+
 ## Shape-change notices — the curation trigger
 
 The git hooks keep the *mechanical* catalogue fresh on their own (paths, langs,
@@ -1815,6 +1852,15 @@ don''t map it yourself.
 | `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines`, `desc` (cartographer one-liner, NULL until curated) |
 | `dr_dependency` | deps from the manifests: `manager` (npm/pip/poetry/go/cargo), `name`, `version`, `kind`, `source_file` |
 | `dr_env` | env-var names found in `.env.*` example files: `name`, `source_file` |
+| `dr_endpoint` | HTTP routes: `method`, `path`, `handler` (file:line), `framework`, `source_file` |
+| `dr_db_table` / `dr_db_column` | the app DB schema: tables/views + their columns (`type`, `pk`, `not_null`) |
+| `dr_route` / `dr_component` | UI routes (`path`, `kind`) + components (`name`, `path`) |
+
+The first five are mapped on **every** repo. The last three are the **semantic
+layer** — populated only when the cartographer has wired an extractor for this
+repo''s stack (see the `cartographer` skill). An empty `dr_endpoint` means *no
+extractor wired*, not "no endpoints" — check before relying on it, and flag the
+cartographer if a dimension you need is missing.
 
 ## Orient fast
 
@@ -1848,6 +1894,12 @@ SELECT path FROM dr_filepath WHERE path LIKE ''%auth%'';
 -- stack + config surface:
 SELECT manager, name, version FROM dr_dependency ORDER BY manager, name;
 SELECT name, source_file FROM dr_env ORDER BY name;
+
+-- semantic layer (only if an extractor is wired for this repo — see cartographer):
+SELECT method, path, handler FROM dr_endpoint ORDER BY path;            -- the API surface
+SELECT name, kind, source_file FROM dr_db_table ORDER BY name;          -- the app DB schema
+SELECT name, type, pk, not_null FROM dr_db_column WHERE table_name=''users'';
+SELECT path, kind, file FROM dr_route ORDER BY path;                    -- UI routes
 ```
 
 ## Stance
@@ -1860,9 +1912,11 @@ SELECT name, source_file FROM dr_env ORDER BY name;
   mis-classified — that''s the cartographer''s to fix. Raise it; don''t re-map.
   A file under "other / unsectioned", or a `desc IS NULL` where you needed one,
   is also a cartographer worklist item — flag it, don''t author the map yourself.
-- Maps files / deps / env + the navigation layer (sections + per-file
-  descriptions). Symbol-level semantics (functions/classes) are a later pass —
-  until then, read the code the section + descriptions point you at.',
+- Always maps files / deps / env + the navigation layer (sections + per-file
+  descriptions). The semantic layer (endpoints / DB schema / UI routes) is there
+  when the cartographer wired an extractor for this stack — query it to jump
+  straight to the API surface or schema; fall back to section + descriptions when
+  a dimension is empty. Symbol-level semantics (functions/classes) are a later pass.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/.super-coder/scripts/map_repo.py
+++ b/.super-coder/scripts/map_repo.py
@@ -20,6 +20,7 @@ descriptions + sections are the B5 navigation layer.
 from __future__ import annotations
 
 import fnmatch
+import importlib.util
 import json
 import re
 import sqlite3
@@ -231,6 +232,45 @@ def seed_sections(con: sqlite3.Connection) -> None:
             "VALUES (?, ?, NULL, ?)", (d, d + "/", i))
 
 
+def run_extractors(con: sqlite3.Connection, repo_root: Path, cfg: dict) -> list[str]:
+    """Run fork-owned extractor plug-ins after the core map pass.
+
+    The engine maps the generic 80% (files/deps/env). The semantic, per-repo
+    dimensions — HTTP endpoints, the app DB schema, UI routes — vary by stack, so
+    a fork owns them as drop-in modules in `.sc-state/map_extractors/*.py` (kept
+    outside the gitignored engine dir, so `./sc update` never clobbers them). The
+    cartographer adopts the right one for this repo's stack (reference extractors
+    ship in the engine's `templates/map_extractors/`).
+
+    Contract: each module defines `extract(con, repo_root, cfg) -> str`. `con` is
+    the live MAP db (dr_filepath is already populated + committed, so an extractor
+    reads it to find its inputs); it DELETEs + repopulates its own dr_* table(s),
+    like the core does for derived tables. The returned string is a short summary
+    for the map log. Each call is guarded — a broken extractor is logged and
+    skipped, never failing the map (the auto-remap hook must stay robust)."""
+    ext_dir = repo_root / ".sc-state" / "map_extractors"
+    if not ext_dir.is_dir():
+        return []
+    summaries: list[str] = []
+    for path in sorted(ext_dir.glob("*.py")):
+        if path.name.startswith("_"):
+            continue
+        try:
+            spec = importlib.util.spec_from_file_location(f"map_ext_{path.stem}", path)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            fn = getattr(mod, "extract", None)
+            if fn is None:
+                summaries.append(f"{path.stem}: no extract() — skipped")
+                continue
+            result = fn(con, repo_root, cfg) or "ok"
+            con.commit()
+            summaries.append(f"{path.stem}: {result}")
+        except Exception as e:  # noqa: BLE001 — an extractor must never fail the map
+            summaries.append(f"{path.stem}: FAILED ({e})")
+    return summaries
+
+
 def main() -> int:
     # The map lives in its OWN db (.sc-state/map.db), not shell_db.db. connect()
     # creates + schema-applies a fresh one and seeds its authored layer (sections
@@ -312,10 +352,14 @@ def main() -> int:
              git("rev-parse", "--abbrev-ref", "HEAD"), files,
              datetime.now().isoformat(timespec="seconds")))
         con.commit()
+        # Fork-owned semantic extractors (endpoints / db schema / routes), if any.
+        ext_summaries = run_extractors(con, REPO_ROOT, cfg)
         msg = f"map_repo: {files} files, {deps} deps, {envs} env vars → dr_* ({REPO_ROOT.name})"
         if truncated:
             msg += f"  ⚠ stopped at MAX_FILES={MAX_FILES}"
         print(msg)
+        for s in ext_summaries:
+            print(f"map_repo: extractor {s}")
     finally:
         con.close()
     return 0

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -101,7 +101,9 @@ sqlite3 .sc-state/map.db "SELECT manager, name, version FROM dr_dependency;"
 
 Map first, grep second; lazy-load only what the map points at. If the map looks
 empty, stale, or wrong, that's a cartographer task — flag it, don't map it
-yourself. Extended patterns (language mix, role filters) live in the
+yourself. Extended patterns (language mix, role filters) and the
+semantic layer — `dr_endpoint` / `dr_db_table` / `dr_route`, present when the
+cartographer has wired an extractor for this stack — live in the
 `surface_catalogue` skill. Before writing SQL against your memory DB, check the
 `db_map` skill — don't read `schema.sql` raw.
 

--- a/.super-coder/templates/map_extractors/README.md
+++ b/.super-coder/templates/map_extractors/README.md
@@ -1,0 +1,51 @@
+# Map extractors — reference plug-ins
+
+These are **reference** extractors. They are NOT run from here. To activate one,
+the cartographer copies it into the fork's `.sc-state/map_extractors/` (tracked,
+fork-owned, survives `./sc update`) and adapts it to the repo's stack.
+
+The engine maps the generic 80% — files, languages, roles, dependencies, env
+vars. Extractors add the semantic, per-repo dimensions the engine can't know
+generically: HTTP **endpoints**, the app **DB schema**, UI **routes/components**.
+
+## The contract
+
+Each module defines one function:
+
+```python
+def extract(con, repo_root, cfg) -> str:
+    ...
+    return "N things"   # short summary for the map log
+```
+
+- `con` — the live **map db** connection (`.sc-state/map.db`). `dr_filepath` is
+  already populated and committed when your extractor runs, so query it to find
+  your inputs (don't re-walk the tree).
+- `repo_root` — `pathlib.Path` to the repo root; read file bodies from here.
+- `cfg` — the parsed `.sc-state/map.config.json` (dict). Per-extractor settings
+  live under `cfg["extractors"]["<module_stem>"]` by convention.
+
+Rules:
+- **Own your table(s).** `DELETE` your rows then re-`INSERT` — the map is a
+  derived cache, re-run on every `./sc map`. Write only to the `dr_*` tables your
+  dimension owns (`dr_endpoint`, `dr_db_table`/`dr_db_column`, `dr_route`,
+  `dr_component`). Their columns are standardized in `map_schema.sql`.
+- **Best-effort, not exhaustive.** Match the dominant pattern; expect to miss
+  dynamically-registered routes, computed paths, ORM-built schemas. Return a
+  count, and log (in the summary) anything you knowingly skipped — never imply
+  100% coverage.
+- **Never raise fatally.** `map_repo` guards each extractor, but keep file reads
+  and parses defensive; a crash just means your dimension is empty that run.
+- Files named `_*.py` are ignored (use for shared helpers).
+
+## What ships here
+
+| File | Stack | Fills |
+|---|---|---|
+| `fastapi_endpoints.py` | FastAPI / Flask-style decorators | `dr_endpoint` |
+| `sqlite_schema.py` | SQL `CREATE TABLE`/`VIEW` files | `dr_db_table`, `dr_db_column` |
+| `sveltekit_routes.py` | SvelteKit filesystem routing | `dr_route`, `dr_component` |
+
+Adopt the one(s) matching your repo; rename the `framework` label and the file
+filter as needed. For a stack none of these cover (Django URLs, Express, Spring,
+Rails), copy the closest one as a skeleton and rewrite the match.

--- a/.super-coder/templates/map_extractors/fastapi_endpoints.py
+++ b/.super-coder/templates/map_extractors/fastapi_endpoints.py
@@ -1,0 +1,59 @@
+"""Reference extractor: decorator-style HTTP routes → dr_endpoint.
+
+Covers FastAPI (`@app.get("/x")`, `@router.post("/x")`) and Flask-style
+`@app.route("/x", methods=[...])`. Best-effort: routes with non-literal paths,
+computed methods, or registered via `add_api_route()` / `add_url_rule()` are NOT
+caught — by design (most, not 100%).
+
+Adopt by copying into `.sc-state/map_extractors/`; change FRAMEWORK / the file
+filter if your routers live somewhere specific.
+"""
+import re
+
+FRAMEWORK = "fastapi"
+
+# @app.get("/x")  ·  @router.post("/x")  — a method decorator with a literal path.
+_METHOD_RE = re.compile(
+    r"""@\s*[A-Za-z_][\w.]*\.(get|post|put|patch|delete|head|options)\s*\(\s*[frbu]*['"]([^'"]+)['"]""",
+    re.I)
+# @app.route("/x", methods=["GET", "POST"])  — Flask / generic.
+_ROUTE_RE = re.compile(
+    r"""@\s*[A-Za-z_][\w.]*\.route\s*\(\s*[frbu]*['"]([^'"]+)['"](.*)""", re.I)
+_METHODS_RE = re.compile(r"""methods\s*=\s*\[([^\]]*)\]""", re.I)
+
+
+def _py_files(con):
+    return [r["path"] for r in con.execute(
+        "SELECT path FROM dr_filepath WHERE lang='Python' ORDER BY path")]
+
+
+def extract(con, repo_root, cfg) -> str:
+    con.execute("DELETE FROM dr_endpoint WHERE framework=?", (FRAMEWORK,))
+    n = 0
+    for rel in _py_files(con):
+        try:
+            text = (repo_root / rel).read_text(errors="ignore")
+        except OSError:
+            continue
+        for i, line in enumerate(text.splitlines(), 1):
+            m = _METHOD_RE.search(line)
+            if m:
+                con.execute(
+                    "INSERT INTO dr_endpoint (method, path, handler, framework, source_file) "
+                    "VALUES (?,?,?,?,?)",
+                    (m.group(1).upper(), m.group(2), f"{rel}:{i}", FRAMEWORK, rel))
+                n += 1
+                continue
+            r = _ROUTE_RE.search(line)
+            if r:
+                methods = "GET"
+                mm = _METHODS_RE.search(r.group(2))
+                if mm:
+                    parts = [s.strip(" '\"") for s in mm.group(1).split(",") if s.strip()]
+                    methods = ",".join(parts) or "GET"
+                con.execute(
+                    "INSERT INTO dr_endpoint (method, path, handler, framework, source_file) "
+                    "VALUES (?,?,?,?,?)",
+                    (methods.upper(), r.group(1), f"{rel}:{i}", FRAMEWORK, rel))
+                n += 1
+    return f"{n} endpoints"

--- a/.super-coder/templates/map_extractors/sqlite_schema.py
+++ b/.super-coder/templates/map_extractors/sqlite_schema.py
@@ -1,0 +1,108 @@
+"""Reference extractor: SQL CREATE TABLE/VIEW → dr_db_table + dr_db_column.
+
+Parses `CREATE TABLE` / `CREATE VIEW` from the `.sql` files the map already
+knows about. Column parse is best-effort: a top-level comma split of the column
+body, skipping table-level constraints (PRIMARY KEY / FOREIGN KEY / UNIQUE /
+CHECK / CONSTRAINT). ORM-defined schemas (Django, SQLAlchemy models) are NOT
+covered — write a model extractor for those.
+
+Optional config in `.sc-state/map.config.json`:
+  "extractors": { "sqlite_schema": { "exclude_prefixes": ["vendor/", "test/"] } }
+"""
+import re
+
+_CREATE_RE = re.compile(
+    r"""CREATE\s+(TABLE|VIEW)\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`\[]?(\w+)["'`\]]?""", re.I)
+_CONSTRAINT_KW = ("primary", "foreign", "unique", "check", "constraint", "key")
+_LINE_COMMENT = re.compile(r"--[^\n]*")
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+
+
+def _strip_comments(text):
+    """Drop SQL line + block comments so they aren't parsed as columns."""
+    return _LINE_COMMENT.sub("", _BLOCK_COMMENT.sub("", text))
+
+
+def _sql_files(con, cfg):
+    excl = ((cfg.get("extractors", {}) or {}).get("sqlite_schema", {}) or {}).get(
+        "exclude_prefixes", [])
+    out = []
+    for r in con.execute("SELECT path FROM dr_filepath WHERE lang='SQL' ORDER BY path"):
+        if not any(r["path"].startswith(x) for x in excl):
+            out.append(r["path"])
+    return out
+
+
+def _balanced(text, start):
+    """Content between the first '(' at/after `start` and its matching ')'."""
+    i = text.find("(", start)
+    if i < 0:
+        return None
+    depth = 0
+    for j in range(i, len(text)):
+        if text[j] == "(":
+            depth += 1
+        elif text[j] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[i + 1:j]
+    return None
+
+
+def _columns(body):
+    cols, depth, buf = [], 0, ""
+    for ch in body:
+        if ch == "(":
+            depth += 1
+            buf += ch
+        elif ch == ")":
+            depth -= 1
+            buf += ch
+        elif ch == "," and depth == 0:
+            cols.append(buf)
+            buf = ""
+        else:
+            buf += ch
+    if buf.strip():
+        cols.append(buf)
+    out = []
+    for c in cols:
+        c = c.strip()
+        if not c:
+            continue
+        first = c.split()[0].strip('"`[]')
+        if first.lower() in _CONSTRAINT_KW:
+            continue
+        toks = c.split()
+        typ = toks[1].strip('"`[],') if len(toks) > 1 else None
+        pk = 1 if re.search(r"primary\s+key", c, re.I) else 0
+        nn = 1 if re.search(r"not\s+null", c, re.I) else 0
+        out.append((first, typ, pk, nn))
+    return out
+
+
+def extract(con, repo_root, cfg) -> str:
+    con.execute("DELETE FROM dr_db_table")
+    con.execute("DELETE FROM dr_db_column")
+    nt = nc = 0
+    for rel in _sql_files(con, cfg):
+        try:
+            text = _strip_comments((repo_root / rel).read_text(errors="ignore"))
+        except OSError:
+            continue
+        for m in _CREATE_RE.finditer(text):
+            kind, name = m.group(1).lower(), m.group(2)
+            con.execute(
+                "INSERT INTO dr_db_table (name, kind, source_file) VALUES (?,?,?)",
+                (name, kind, rel))
+            nt += 1
+            if kind == "table":
+                body = _balanced(text, m.end())
+                if body:
+                    for (cname, ctype, pk, nn) in _columns(body):
+                        con.execute(
+                            "INSERT INTO dr_db_column "
+                            "(table_name, name, type, pk, not_null, source_file) "
+                            "VALUES (?,?,?,?,?,?)", (name, cname, ctype, pk, nn, rel))
+                        nc += 1
+    return f"{nt} tables, {nc} columns"

--- a/.super-coder/templates/map_extractors/sveltekit_routes.py
+++ b/.super-coder/templates/map_extractors/sveltekit_routes.py
@@ -1,0 +1,55 @@
+"""Reference extractor: SvelteKit filesystem routes + components → dr_route / dr_component.
+
+SvelteKit routes are the filesystem — no decorators. Files under a `routes/` dir
+named `+page.svelte` / `+page.server.*` / `+server.*` / `+layout.svelte` map to a
+URL derived from the directory path: `[param]` → `:param`, `[...rest]` → `*rest`,
+`(group)` dropped. Every other `*.svelte` file is a component.
+
+Adapt the `routes/` anchor + `+file` convention for Next.js (`app/` + `route.ts`,
+`page.tsx`) or others.
+"""
+import re
+
+_ROUTE_FILE = re.compile(r"\+(page|layout|server)\b")
+_KIND = {"page": "page", "layout": "layout", "server": "endpoint"}
+
+
+def _svelte_files(con):
+    return [r["path"] for r in con.execute(
+        "SELECT path FROM dr_filepath WHERE path LIKE '%.svelte' "
+        "OR path LIKE '%/+server.%' OR path LIKE '%/+page.%' "
+        "OR path LIKE '%/+layout.%' ORDER BY path")]
+
+
+def _route_path(rel):
+    if "routes/" not in rel:
+        return None
+    tail = rel.rsplit("routes/", 1)[1]
+    segs = []
+    for p in tail.split("/")[:-1]:  # drop the +file leaf
+        if p.startswith("(") and p.endswith(")"):
+            continue  # layout group — not part of the URL
+        p = re.sub(r"\[\.\.\.(\w+)\]", r"*\1", p)
+        p = re.sub(r"\[(\w+)\]", r":\1", p)
+        segs.append(p)
+    return "/" + "/".join(segs)
+
+
+def extract(con, repo_root, cfg) -> str:
+    con.execute("DELETE FROM dr_route WHERE framework='sveltekit'")
+    con.execute("DELETE FROM dr_component WHERE framework='svelte'")
+    nr = ncomp = 0
+    for rel in _svelte_files(con):
+        base = rel.rsplit("/", 1)[-1]
+        m = _ROUTE_FILE.search(base)
+        if m and "routes/" in rel:
+            con.execute(
+                "INSERT INTO dr_route (path, file, kind, framework) VALUES (?,?,?,?)",
+                (_route_path(rel), rel, _KIND[m.group(1)], "sveltekit"))
+            nr += 1
+        elif base.endswith(".svelte"):
+            con.execute(
+                "INSERT INTO dr_component (name, path, framework) VALUES (?,?,?)",
+                (base[:-len(".svelte")], rel, "svelte"))
+            ncomp += 1
+    return f"{nr} routes, {ncomp} components"

--- a/skills_sc/cartographer.md
+++ b/skills_sc/cartographer.md
@@ -166,6 +166,43 @@ If this fork ships no database of its own, there is nothing to tag — skip it.
 After a curation pass, `./sc snapshot` (sections are snapshotted; descriptions
 ride the live DB + survive remap, refilled from the worklist if a rebuild drops them).
 
+## Extending the map — semantic extractors
+
+The engine maps the generic 80% on every repo: files, languages, roles, deps,
+env. The **semantic** dimensions — HTTP endpoints (`dr_endpoint`), the app DB
+schema (`dr_db_table`/`dr_db_column`), UI routes/components (`dr_route`/
+`dr_component`) — vary by stack, so the engine can't extract them generically.
+That is your job, via **extractors**: drop-in Python modules in
+`.sc-state/map_extractors/*.py` that `./sc map` discovers and runs after the core
+pass. They are fork-owned (outside the gitignored engine dir, so `./sc update`
+never clobbers them); the table *columns* are standardized in the engine
+(`map_schema.sql`), so a working shell's queries have a stable shape everywhere.
+
+**Adopt one per stack:**
+
+1. **Detect the stack** from the map: `SELECT manager, name FROM dr_dependency;`
+   (fastapi? flask? svelte? next?) and the file mix
+   (`SELECT lang, COUNT(*) FROM dr_filepath GROUP BY lang`).
+2. **Copy the matching reference** from the engine's
+   `.super-coder/templates/map_extractors/` into `.sc-state/map_extractors/`:
+   - `fastapi_endpoints.py` — decorator routes (`@app.get(...)`, Flask `@app.route`) → `dr_endpoint`
+   - `sqlite_schema.py` — SQL `CREATE TABLE/VIEW` → `dr_db_table`/`dr_db_column`
+   - `sveltekit_routes.py` — filesystem routes + `*.svelte` → `dr_route`/`dr_component`
+   Adapt the `framework` label and file filter to this repo. For a stack none
+   cover (Django URLs, Express, Spring, Rails), copy the closest as a skeleton
+   and rewrite the match — aim for the dominant pattern, not 100%.
+3. **Run + verify:** `./sc map`, then check the table populated and the rows look
+   right (`SELECT method, path FROM dr_endpoint LIMIT 10;`).
+4. **Commit** `.sc-state/map_extractors/` + `./sc snapshot`.
+
+**The contract** (full version in `templates/map_extractors/README.md`): each
+module defines `extract(con, repo_root, cfg) -> str`. `con` is the live map db
+(dr_filepath is already populated — query it for inputs); the module DELETEs +
+repopulates only its own `dr_*` table(s); returns a one-line summary for the map
+log. Be defensive — `map_repo` guards each extractor, but a module that needs the
+map should never assume a file parses. Static extraction is best-effort: log what
+you skip (dynamic routes, computed paths), never imply full coverage.
+
 ## Shape-change notices — the curation trigger
 
 The git hooks keep the *mechanical* catalogue fresh on their own (paths, langs,

--- a/skills_sc/surface_catalogue.md
+++ b/skills_sc/surface_catalogue.md
@@ -32,6 +32,15 @@ don't map it yourself.
 | `dr_filepath` | one row per file: `path`, `ext`, `lang`, `role` (code/doc/config/test/asset/env), `bytes`, `lines`, `desc` (cartographer one-liner, NULL until curated) |
 | `dr_dependency` | deps from the manifests: `manager` (npm/pip/poetry/go/cargo), `name`, `version`, `kind`, `source_file` |
 | `dr_env` | env-var names found in `.env.*` example files: `name`, `source_file` |
+| `dr_endpoint` | HTTP routes: `method`, `path`, `handler` (file:line), `framework`, `source_file` |
+| `dr_db_table` / `dr_db_column` | the app DB schema: tables/views + their columns (`type`, `pk`, `not_null`) |
+| `dr_route` / `dr_component` | UI routes (`path`, `kind`) + components (`name`, `path`) |
+
+The first five are mapped on **every** repo. The last three are the **semantic
+layer** — populated only when the cartographer has wired an extractor for this
+repo's stack (see the `cartographer` skill). An empty `dr_endpoint` means *no
+extractor wired*, not "no endpoints" — check before relying on it, and flag the
+cartographer if a dimension you need is missing.
 
 ## Orient fast
 
@@ -65,6 +74,12 @@ SELECT path FROM dr_filepath WHERE path LIKE '%auth%';
 -- stack + config surface:
 SELECT manager, name, version FROM dr_dependency ORDER BY manager, name;
 SELECT name, source_file FROM dr_env ORDER BY name;
+
+-- semantic layer (only if an extractor is wired for this repo — see cartographer):
+SELECT method, path, handler FROM dr_endpoint ORDER BY path;            -- the API surface
+SELECT name, kind, source_file FROM dr_db_table ORDER BY name;          -- the app DB schema
+SELECT name, type, pk, not_null FROM dr_db_column WHERE table_name='users';
+SELECT path, kind, file FROM dr_route ORDER BY path;                    -- UI routes
 ```
 
 ## Stance
@@ -77,6 +92,8 @@ SELECT name, source_file FROM dr_env ORDER BY name;
   mis-classified — that's the cartographer's to fix. Raise it; don't re-map.
   A file under "other / unsectioned", or a `desc IS NULL` where you needed one,
   is also a cartographer worklist item — flag it, don't author the map yourself.
-- Maps files / deps / env + the navigation layer (sections + per-file
-  descriptions). Symbol-level semantics (functions/classes) are a later pass —
-  until then, read the code the section + descriptions point you at.
+- Always maps files / deps / env + the navigation layer (sections + per-file
+  descriptions). The semantic layer (endpoints / DB schema / UI routes) is there
+  when the cartographer wired an extractor for this stack — query it to jump
+  straight to the API surface or schema; fall back to section + descriptions when
+  a dimension is empty. Symbol-level semantics (functions/classes) are a later pass.

--- a/tests/test_map_extractors.py
+++ b/tests/test_map_extractors.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Tests for the map extractor plug-in mechanism + the reference extractors.
+
+Stdlib `unittest`, no pytest (engine style). Each test builds a throwaway map db
+from map_schema.sql, lays a tiny source tree in a temp repo root, registers the
+files in dr_filepath the way map_repo does, then runs an extractor and asserts
+the dr_* rows. The reference extractors (FastAPI, SvelteKit) aren't live in this
+repo's own stack, so this is where they get exercised.
+
+Run:
+    python3 tests/test_map_extractors.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+MAP_SCHEMA = ENGINE / "map_schema.sql"
+TEMPLATES = ENGINE / "templates" / "map_extractors"
+
+
+def load_module(path: Path):
+    spec = importlib.util.spec_from_file_location(f"_t_{path.stem}", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def map_db() -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript(MAP_SCHEMA.read_text())
+    return con
+
+
+class _Fixture:
+    """A temp repo root with files registered in a fresh map db's dr_filepath."""
+
+    def __init__(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.con = map_db()
+
+    def add(self, rel: str, body: str, *, lang=None):
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+        self.con.execute(
+            "INSERT INTO dr_filepath (path, lang, role) VALUES (?,?,?)",
+            (rel, lang, "code"))
+        self.con.commit()
+
+    def close(self):
+        self.con.close()
+        self.tmp.cleanup()
+
+
+class FastapiExtractorTest(unittest.TestCase):
+    def test_decorator_and_route_styles(self):
+        fx = _Fixture()
+        self.addCleanup(fx.close)
+        mod = load_module(TEMPLATES / "fastapi_endpoints.py")
+        fx.add("api/routes.py", lang="Python", body=(
+            'from fastapi import APIRouter\n'
+            'router = APIRouter()\n'
+            '@router.get("/shells")\n'
+            'def list_shells(): ...\n'
+            '@app.post("/shells/{id}")\n'
+            'def create(): ...\n'
+            '@app.route("/legacy", methods=["GET", "POST"])\n'
+            'def legacy(): ...\n'
+            'x = obj.get("not-a-route")  # not a decorator → ignored\n'
+        ))
+        mod.extract(fx.con, fx.root, {})
+        rows = {(r["method"], r["path"]) for r in
+                fx.con.execute("SELECT method, path FROM dr_endpoint")}
+        self.assertIn(("GET", "/shells"), rows)
+        self.assertIn(("POST", "/shells/{id}"), rows)
+        self.assertIn(("GET,POST", "/legacy"), rows)
+        self.assertNotIn(("GET", "not-a-route"), rows)
+        # handler carries file:line; framework labeled
+        r = fx.con.execute(
+            "SELECT handler, framework FROM dr_endpoint WHERE path='/shells'").fetchone()
+        self.assertTrue(r["handler"].startswith("api/routes.py:"))
+        self.assertEqual(r["framework"], "fastapi")
+
+    def test_rerun_is_idempotent(self):
+        fx = _Fixture()
+        self.addCleanup(fx.close)
+        mod = load_module(TEMPLATES / "fastapi_endpoints.py")
+        fx.add("a.py", lang="Python", body='@app.get("/x")\ndef f(): ...\n')
+        mod.extract(fx.con, fx.root, {})
+        mod.extract(fx.con, fx.root, {})  # second run must not duplicate
+        n = fx.con.execute("SELECT COUNT(*) FROM dr_endpoint").fetchone()[0]
+        self.assertEqual(n, 1)
+
+
+class SqliteSchemaExtractorTest(unittest.TestCase):
+    def test_tables_columns_and_comments(self):
+        fx = _Fixture()
+        self.addCleanup(fx.close)
+        mod = load_module(TEMPLATES / "sqlite_schema.py")
+        fx.add("db/schema.sql", lang="SQL", body=(
+            "CREATE TABLE IF NOT EXISTS users (\n"
+            "  id INTEGER PRIMARY KEY,  -- the pk, not a column comment trap\n"
+            "  email TEXT NOT NULL,\n"
+            "  name TEXT,\n"
+            "  FOREIGN KEY (org_id) REFERENCES orgs(id)\n"  # constraint → skipped
+            ");\n"
+            "CREATE VIEW active_users AS SELECT * FROM users;\n"
+        ))
+        mod.extract(fx.con, fx.root, {})
+        tables = {(r["name"], r["kind"]) for r in
+                  fx.con.execute("SELECT name, kind FROM dr_db_table")}
+        self.assertIn(("users", "table"), tables)
+        self.assertIn(("active_users", "view"), tables)
+        cols = {r["name"]: r for r in fx.con.execute(
+            "SELECT name, type, pk, not_null FROM dr_db_column WHERE table_name='users'")}
+        self.assertEqual(set(cols), {"id", "email", "name"})  # FK constraint excluded
+        self.assertEqual(cols["id"]["pk"], 1)
+        self.assertEqual(cols["email"]["not_null"], 1)
+        self.assertEqual(cols["email"]["type"], "TEXT")
+        # the inline comment must not have become a column
+        self.assertNotIn("--", cols)
+
+
+class SveltekitExtractorTest(unittest.TestCase):
+    def test_routes_and_components(self):
+        fx = _Fixture()
+        self.addCleanup(fx.close)
+        mod = load_module(TEMPLATES / "sveltekit_routes.py")
+        fx.add("src/routes/+page.svelte", "x")
+        fx.add("src/routes/shells/[id]/+page.svelte", "x")
+        fx.add("src/routes/api/flags/+server.ts", "x")
+        fx.add("src/routes/(admin)/users/+page.svelte", "x")
+        fx.add("src/lib/Card.svelte", "x")
+        mod.extract(fx.con, fx.root, {})
+        routes = {(r["path"], r["kind"]) for r in
+                  fx.con.execute("SELECT path, kind FROM dr_route")}
+        self.assertIn(("/", "page"), routes)
+        self.assertIn(("/shells/:id", "page"), routes)
+        self.assertIn(("/api/flags", "endpoint"), routes)
+        self.assertIn(("/users", "page"), routes)  # (admin) group dropped from URL
+        comps = {r["name"] for r in fx.con.execute("SELECT name FROM dr_component")}
+        self.assertEqual(comps, {"Card"})  # +page.svelte files are routes, not components
+
+
+class ExtractorDiscoveryTest(unittest.TestCase):
+    """map_repo.run_extractors discovers + runs .sc-state/map_extractors/*.py."""
+
+    def test_discovery_runs_and_guards(self):
+        import sys
+        sys.path.insert(0, str(ENGINE / "scripts"))
+        import map_repo
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ext = root / ".sc-state" / "map_extractors"
+            ext.mkdir(parents=True)
+            (ext / "good.py").write_text(
+                "def extract(con, repo_root, cfg):\n"
+                "    con.execute(\"INSERT INTO dr_route (path) VALUES ('/hit')\")\n"
+                "    return '1 route'\n")
+            (ext / "broken.py").write_text(
+                "def extract(con, repo_root, cfg):\n    raise RuntimeError('boom')\n")
+            (ext / "_helper.py").write_text("# underscore = ignored\n")
+            con = map_db()
+            summaries = map_repo.run_extractors(con, root, {})
+            # good ran and wrote; broken was guarded (logged, not raised); _helper skipped
+            self.assertTrue(any("good: 1 route" in s for s in summaries))
+            self.assertTrue(any("broken: FAILED" in s for s in summaries))
+            self.assertFalse(any("_helper" in s for s in summaries))
+            self.assertEqual(
+                con.execute("SELECT path FROM dr_route").fetchone()["path"], "/hit")
+            con.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**PR 2 of 3** on the cartographer rework (PR1 #81 relocated the map to `.sc-state/map.db`). This adds the **fork-owned extractor plug-in** + the semantic dimension tables.

## The split

The engine maps the generic 80% — files, languages, roles, deps, env. The semantic dimensions (HTTP endpoints, app DB schema, UI routes) **vary by stack**, so the engine can't extract them generically. A fork owns them as drop-in modules; the engine discovers and runs them.

## What changed

- **`map_schema.sql`** — tier-1 tables: `dr_endpoint`, `dr_db_table`/`dr_db_column`, `dr_route`, `dr_component`. The **columns are standardized in the engine** (so a working shell's queries + the boot render have a stable shape on every fork), but the tables stay **empty until the cartographer wires an extractor**.
- **`map_repo.run_extractors()`** — after the core pass, discovers and runs `.sc-state/map_extractors/*.py` (fork-owned, outside the gitignored engine dir → survives `./sc update`). Each is **guarded**: a broken extractor is logged and skipped, never fails the map (the auto-remap hook must stay robust).
- **Reference extractors** in `templates/map_extractors/` (+ a README spelling out the contract): `fastapi_endpoints` (decorator routes / Flask `@route`), `sqlite_schema` (`CREATE TABLE/VIEW`), `sveltekit_routes` (filesystem routes + `*.svelte` components). The cartographer copies the matching one into `.sc-state/` and adapts it.
- **Dogfood**: `sqlite_schema` is installed in this repo's `.sc-state/map_extractors/` and runs on every `./sc map` — maps **39 tables / 268 columns** from the engine's own `.sql`.
- **Docs**: `surface_catalogue` documents the new dimensions (and that *empty = no extractor wired, not "none"*); `cartographer` gains an **"Extending the map"** section (detect stack → adopt a reference → verify → commit) + the full contract; boot.md ORIENTATION points at them.

## The contract

```python
def extract(con, repo_root, cfg) -> str:   # con = live map db; dr_filepath already populated
    con.execute("DELETE FROM dr_endpoint WHERE framework='fastapi'")
    ...                                      # own your table(s); best-effort; never raise
    return "N endpoints"                     # summary for the map log
```

Static extraction is **best-effort by design** ("most, not 100%") — dynamically registered routes, computed paths, ORM-built schemas are expected misses; extractors log what they skip rather than implying full coverage.

## Verified
- Dogfood `./sc map` populates `dr_db_table`/`dr_db_column` cleanly — SQL comments are stripped, not parsed as columns (caught + fixed a `notnull` keyword collision and a comment-as-column bug during dev).
- **33 tests pass**, including a new `tests/test_map_extractors.py` that exercises all three reference extractors against fixtures (FastAPI + SvelteKit aren't live in this repo's own stack) and the discovery/guard mechanism (good module runs, broken module is guarded, `_helper.py` skipped).

## Next
- **PR3** — cartographer-as-boot: move the mapping + extractor procedure into the cartographer flavor's `system_prompt`, and wire the hourly cron so the map stays live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)