### PR TITLE
fix(update): top up fork .gitignore with new engine ignore rules

### DIFF
--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -296,13 +296,36 @@ _GITIGNORE_BLOCK = f"""
 """
 
 
-def ensure_gitignore() -> bool:
-    gi = REPO_ROOT / ".gitignore"
+def _required_ignores() -> list[str]:
+    """The ignore PATTERNS in the block (path lines, not comments). Single source
+    of truth — adding a line to _GITIGNORE_BLOCK above is enough for both fresh
+    installs and `./sc update` top-ups."""
+    return [ln.strip() for ln in _GITIGNORE_BLOCK.splitlines()
+            if ln.strip() and not ln.strip().startswith("#")]
+
+
+def ensure_gitignore(repo_root: Path = REPO_ROOT) -> bool:
+    """Ensure the host repo's .gitignore covers every engine-derived path.
+
+    First install (marker absent): append the full annotated block. On a fork
+    that already has the block, **top up** any patterns added in later releases
+    (e.g. the map DB cache `/.sc-state/map.db`) — line-additive, so a fork that
+    picks up new engine ignore rules via `./sc update` self-heals instead of
+    silently committing a churning derived cache. Returns True if it changed."""
+    gi = repo_root / ".gitignore"
     existing = gi.read_text() if gi.exists() else ""
-    if _GITIGNORE_MARKER in existing:
+    if _GITIGNORE_MARKER not in existing:
+        with gi.open("a") as f:
+            f.write(("" if existing.endswith("\n") or not existing else "\n") + _GITIGNORE_BLOCK)
+        return True
+    present = {ln.strip() for ln in existing.splitlines()}
+    missing = [p for p in _required_ignores() if p not in present]
+    if not missing:
         return False
     with gi.open("a") as f:
-        f.write(("" if existing.endswith("\n") or not existing else "\n") + _GITIGNORE_BLOCK)
+        f.write(("" if existing.endswith("\n") else "\n")
+                + "# super-coder — engine ignore rules added by `./sc update`\n"
+                + "\n".join(missing) + "\n")
     return True
 
 

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -250,6 +250,11 @@ def main(argv: list[str]) -> int:
         no_fetch = True
     else:
         migrate_engine_untrack()  # one-time B7: untrack the engine (idempotent)
+        # Top up the fork's .gitignore with any engine ignore rules added since it
+        # was installed (e.g. the map DB cache /.sc-state/map.db) — line-additive,
+        # so an already-installed fork never silently commits a new derived cache.
+        if install_mod.ensure_gitignore():
+            print("→ .gitignore: added engine ignore rule(s) for this release")
 
     if no_fetch:
         print("→ --no-fetch: reconciling against the current working tree "

--- a/tests/test_gitignore_sync.py
+++ b/tests/test_gitignore_sync.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for ensure_gitignore — fresh append + line-additive top-up.
+
+The bug this guards: a fork installed before a new engine ignore rule (e.g. the
+map DB cache) would never receive that rule, because the old check was
+all-or-nothing on the marker. ensure_gitignore must top up missing patterns on
+`./sc update` without duplicating existing ones.
+
+Run:
+    python3 tests/test_gitignore_sync.py
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".super-coder" / "scripts"))
+import install  # noqa: E402
+
+MAP_DB = "/.sc-state/map.db"
+
+
+class EnsureGitignoreTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.gi = self.root / ".gitignore"
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_fresh_appends_full_block(self):
+        changed = install.ensure_gitignore(self.root)
+        self.assertTrue(changed)
+        text = self.gi.read_text()
+        self.assertIn(install._GITIGNORE_MARKER, text)
+        for pat in install._required_ignores():
+            self.assertIn(pat, text)
+
+    def test_idempotent(self):
+        install.ensure_gitignore(self.root)
+        self.assertFalse(install.ensure_gitignore(self.root))  # nothing to add
+
+    def test_tops_up_missing_line_on_old_fork(self):
+        # Simulate a fork installed before the map.db rule existed: the marker
+        # block is present but missing the map DB patterns.
+        old = "\n".join(
+            ln for ln in install._GITIGNORE_BLOCK.splitlines() if "map.db" not in ln)
+        self.gi.write_text(old + "\n")
+        self.assertNotIn(MAP_DB, self.gi.read_text())
+
+        changed = install.ensure_gitignore(self.root)
+        self.assertTrue(changed)
+        text = self.gi.read_text()
+        self.assertIn(MAP_DB, text)
+        # existing lines are not duplicated
+        self.assertEqual(text.count("/.super-coder/"), 1)
+        # and a second run is a no-op
+        self.assertFalse(install.ensure_gitignore(self.root))
+
+    def test_no_marker_unrelated_content_appends_once(self):
+        self.gi.write_text("node_modules/\n*.log\n")
+        install.ensure_gitignore(self.root)
+        text = self.gi.read_text()
+        self.assertIn(install._GITIGNORE_MARKER, text)
+        self.assertIn(MAP_DB, text)
+        self.assertEqual(text.count(install._GITIGNORE_MARKER), 1)
+        self.assertIn("node_modules/", text)  # pre-existing content preserved
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the one sharp edge in the fork update path surfaced while reviewing the map-split rollout (#81).

## The bug

The map DB cache `.sc-state/map.db` is created on a fork's next `./sc update` (the map now lives there). But its gitignore rule never reached **already-installed** forks:
- `ensure_gitignore()` was all-or-nothing on its marker — marker present → no-op, so the new `map.db` line was never added to a fork that already had the block.
- `update.py` never called `ensure_gitignore()` anyway.

Result: a fork installed before #81 (e.g. dos-arch) updates, gets an untracked **churning binary cache**, and one `git add -A` commits it. Fresh installs were fine (the line was in the install block); existing forks were not.

## The fix

- **`ensure_gitignore()` is now line-additive.** First install still appends the full annotated block; a fork that already has the block gets any patterns **added in later releases topped up**. The required patterns are derived from the block itself, so it stays single-source — adding a line to the block is enough for both install and update.
- **`update.py` calls it** in the fork path. An updating fork self-heals, and *any* future engine ignore-rule addition propagates the same way — not just `map.db`.

## Verified
- New `tests/test_gitignore_sync.py`: fresh append, idempotent re-run, **top-up of a pre-`map.db` fork** (asserts `/.sc-state/map.db` added and `/.super-coder/` not duplicated), and append-once on a `.gitignore` with unrelated content.
- 37 tests pass.

## Sequencing
This should land **before any existing fork runs `./sc update`** to pick up the merged #81 — it's what makes that update safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)