### PR TITLE
fix(update): materialize map_schema.sql to forks + fail loud if absent

### DIFF
--- a/.super-coder/scripts/map_db.py
+++ b/.super-coder/scripts/map_db.py
@@ -33,10 +33,18 @@ ENGINE_DB = ENGINE / "shell_db.db"  # legacy source of pre-split dr_section
 
 
 def ensure_schema(con: sqlite3.Connection) -> None:
-    """Apply map_schema.sql to a fresh map DB (idempotent — CREATE IF NOT EXISTS)."""
-    if MAP_SCHEMA.exists():
-        con.executescript(MAP_SCHEMA.read_text())
-        con.commit()
+    """Apply map_schema.sql to the map DB (idempotent — CREATE IF NOT EXISTS).
+
+    Fail loudly if the schema file is absent: it ships with the engine, so a
+    missing one means an incomplete materialize (e.g. a fork updated by an engine
+    that predates map_schema.sql being in ENGINE_PATHS). Better a clear error here
+    than a cryptic 'no such table: dr_section' downstream in seed_authored."""
+    if not MAP_SCHEMA.exists():
+        raise SystemExit(
+            f"map_db: {MAP_SCHEMA} missing — engine materialize is incomplete. "
+            "Re-run `./sc update` with an engine that materializes map_schema.sql.")
+    con.executescript(MAP_SCHEMA.read_text())
+    con.commit()
 
 
 def seed_authored(con: sqlite3.Connection) -> None:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -72,6 +72,7 @@ ENGINE_PATHS = [
     ".super-coder/aliases.mk",
     ".super-coder/Dockerfile",
     ".super-coder/schema.sql",
+    ".super-coder/map_schema.sql",
     ".super-coder/ecosystem.config.cjs",
     ".super-coder/README.md",
     ".super-coder/migrations",

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Guard: every top-level engine file is materialized to forks on `./sc update`.
+
+The bug this prevents: a new top-level file under `.super-coder/` (e.g.
+map_schema.sql, added with the map split) that isn't in update.py's ENGINE_PATHS
+allowlist never reaches an updating fork — the fork gets the new code but not the
+file, and breaks. Subdirs (scripts/, templates/, …) are materialized whole, so
+files inside them are covered; only NEW TOP-LEVEL files are at risk. This asserts
+each one is in the allowlist (or is a deliberate per-instance exclusion).
+
+Run:
+    python3 tests/test_update_materialize.py
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import update  # noqa: E402
+
+# Deliberately NOT materialized — per-instance / gitignored / runtime, per the
+# ENGINE_PATHS comment in update.py.
+PER_INSTANCE = {
+    "instance.json", "shell_db.db", "shell_db.db-wal", "shell_db.db-shm", "map.db",
+}
+
+
+class EnginePathsCoverageTest(unittest.TestCase):
+    def test_every_top_level_engine_file_is_materialized(self):
+        listed = set(update.ENGINE_PATHS)
+        missing = []
+        for entry in sorted(ENGINE.iterdir()):
+            if not entry.is_file():
+                continue
+            if entry.name in PER_INSTANCE or entry.suffix == ".pyc":
+                continue
+            rel = f".super-coder/{entry.name}"
+            if rel not in listed:
+                missing.append(rel)
+        self.assertEqual(
+            missing, [],
+            f"top-level engine file(s) absent from update.ENGINE_PATHS — forks "
+            f"won't receive them on `./sc update`: {missing}")
+
+    def test_map_schema_specifically_present(self):
+        # The file whose omission caused the dos-arch update failure.
+        self.assertIn(".super-coder/map_schema.sql", update.ENGINE_PATHS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found by running `./sc update` on the **dos-arch** fork (the real-world rollout test). The map step crashed with `no such table: dr_section`.

## Root cause

`update.py`'s `ENGINE_PATHS` is an explicit allowlist of engine paths to materialize. `scripts/` and `templates/` are materialized whole (so `map_db.py` and `templates/map_extractors/` landed), but **`.super-coder/map_schema.sql` — the new top-level file from the map split (#81) — was never added to the allowlist.** The fork got the new map code but not the schema; `ensure_schema()` then silently no-op'd on the missing file (its `if exists()` guard), surfacing as a cryptic `no such table: dr_section` downstream in `seed_authored()`.

Only **new top-level** engine files are at risk — subdirs materialize whole.

## Fix

- **`update.py`** — add `.super-coder/map_schema.sql` to `ENGINE_PATHS` (next to `schema.sql`).
- **`map_db.ensure_schema()`** — fail **loudly** with a clear message if `map_schema.sql` is absent, instead of silently no-op'ing and crashing later. Self-diagnosing.
- **`tests/test_update_materialize.py`** — asserts *every* top-level engine file is covered by `ENGINE_PATHS` (would have caught this), plus `map_schema.sql` specifically.

## Verified
- New test fails against the old allowlist, passes with the fix.
- 39 tests pass.

This is the prerequisite for any fork to update onto the map split (#81) cleanly. dos-arch is being brought to a completed/verified state alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)