### PR TITLE
feat(boot): map-discrepancy protocol for working shells (not cartographer)

### DIFF
--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -16,6 +16,22 @@ from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
 TEMPLATE_PATH = ENGINE / "templates" / "boot.md"
+
+# Rendered into ORIENTATION for every shell EXCEPT the cartographer (who owns the
+# map and heals discrepancies directly — telling it to report them to itself is
+# nonsense). Mirrors the cartographer skill's "shape:" notice contract, but for a
+# map that is *wrong* rather than newly-grown. Substituted into the
+# `{{map_discrepancy}}` slot in boot.md; stripped clean for the cartographer.
+MAP_DISCREPANCY_BLOCK = (
+    "**If the map is wrong, you report it — you never fix it (you don't map).** A "
+    "discrepancy is the map being stale, missing a file, mis-sectioning an area, or "
+    "contradicting the repo. On finding one: (1) surface the gap to the FnB; (2) "
+    "message the cartographer naming what's off and where — `--message send "
+    "cartographer \"map gap: <what's off> — paths: <region/>. heal.\"`; (3) tell the "
+    "FnB to **boot the cartographer shell** to update the map. Then keep working "
+    "from what the map *does* show — healing it is the cartographer's job, on its "
+    "next boot."
+)
 # The repo catalogue (dr_*) lives in its OWN db, separate from shell_db.db.
 MAP_DB_PATH = ENGINE.parent / ".sc-state" / "map.db"
 
@@ -206,6 +222,12 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
     bootstrapped = con.execute(
         "SELECT bootstrapped FROM shells WHERE shell_id=?", (shell_id,)).fetchone()[0]
     flavor = (shell["flavor"] if "flavor" in shell.keys() else None)
+    # Map-discrepancy protocol: every working shell reports a wrong map (it never
+    # maps); the cartographer owns the fix, so the block is stripped from its boot.
+    if flavor == "cartographer":
+        template = template.replace("\n{{map_discrepancy}}\n", "")
+    else:
+        template = template.replace("{{map_discrepancy}}", MAP_DISCREPANCY_BLOCK)
     # The repo catalogue lives in its own db now; open it read-only for the
     # CONNECTIONS block + map status. None when the repo isn't mapped yet.
     map_con = open_map_ro()

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -112,6 +112,8 @@ product's files, including the schema + migrations that define the app's own
 database. It describes that schema; it is **not** the app DB itself (see
 DATABASES). Querying `dr_*` is how you *find* the app DB, never how you change it.
 
+{{map_discrepancy}}
+
 ---
 
 ## MESSAGING


### PR DESCRIPTION
## What

Adds a **map-discrepancy protocol** to the boot doc for every shell **except the cartographer**. When a working shell finds the repo map wrong, it now has an explicit procedure instead of the old vague *"flag it, don't map it yourself."*

On finding a discrepancy (map stale / missing a file / mis-sectioned / contradicting the repo):
1. **Surface the gap to the FnB.**
2. **Message the cartographer** naming what's off and where — `--message send cartographer "map gap: <what's off> — paths: <region/>. heal."` (mirrors the cartographer skill's existing `"shape:"` notice contract).
3. **Tell the FnB to boot the cartographer shell** to update the map.

Then keep working from what the map *does* show — healing it is the cartographer's job, on its next boot.

## How

- `templates/boot.md` — a `{{map_discrepancy}}` slot at the end of `ORIENTATION`.
- `render/compose.py` — `MAP_DISCREPANCY_BLOCK` constant, gated on `flavor`: substituted for working shells, stripped clean for the cartographer (telling the map-owner to report discrepancies to itself is nonsense — it owns the fix). Reuses the existing flavor-aware render path (same place FIRST RUN already branches on `cartographer`).

Lives on the **always-loaded boot path**, which re-renders at every launch — so it reaches **all existing + future shells** on next boot, not just newly-created ones (the per-flavor `shell_system_prompt.md` would only hit new shells).

## Verification

Smoke-tested `compose_boot` against the real template + DB for both flavors:
- working shell (`cc`, flavor None): block present, no leftover token, clean formatting ✓
- cartographer (`CART1`): block absent, no leftover token, no double blank line ✓

No test snapshots boot output, so nothing existing breaks.

## Note for review

The block addresses the cartographer by shortname `cartographer`, matching the cartographer/messaging skills' documented notice contract. In this dev DB the cartographer's actual shortname is the auto-named `CART1` — a pre-existing gap between the skill convention and the factory's `<ABBR><n>` default, not introduced here. Worth a separate fix (either auto-name the singleton `cartographer`, or make the skills address it by flavor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)