### PR TITLE
docs(readme): make workflow loop diagram vertical

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Install :::class1 -> Map :::class2 -> Spec :::class1 -> Build :::class1 -> Revie
 ```
 
 ```mermaid
-graph LR
+graph TD
   I[Install]:::class1 --> C[Map the repo]:::class2
   C --> S[Spec it]:::class1
   S --> D[Build in dev]:::class1


### PR DESCRIPTION
The `## The loop` mermaid diagram was laid out left-to-right (`graph LR`) — with 9 nodes plus two back-edges (`R -->|issues| D`, `V --> C`), it rendered too small/cramped to read.

Switches it to top-down (`graph TD`) so the steps stack vertically and render large.

Single-line change. The Overview architecture diagram stays `LR` — a short 5-node linear chain reads fine horizontally; happy to flip that too if you'd prefer consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)