### PR TITLE
docs(readme): make the Overview architecture diagram vertical

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ tools, the model API are the harness's job. We own identity + memory + content
 and render a boot artifact the harness reads natively.
 
 ```mermaid
-graph LR
+graph TD
   DB[(shell DB)]:::class1 --> REN[render chain]:::class2
   REN --> BOOT[CLAUDE.md / AGENTS.md]:::class2
   BOOT --> H[harness loop]:::class3


### PR DESCRIPTION
Follow-up to #89. That PR's squash-merge only landed the loop-diagram flip — the second commit (Overview architecture diagram) was dropped, so on `main` the Overview mermaid was still `graph LR`.

This flips it to `graph TD` so **both** README diagrams read vertically. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)