### PR TITLE
feat(make): sc- prefixed command standard + ./sc restart

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -1,43 +1,84 @@
 # super-coder make aliases — convenience wrappers around ./sc.
 #
 # The dispatcher ./sc is the canonical interface; these targets only delegate.
-# This file travels with the engine, so `make launch` / `make enter` work in a
-# fork exactly as in the source repo — WITHOUT super-coder ever owning or
-# clobbering the fork's Makefile (#13): install wires a fork to *include* this
-# file (or auto-creates a one-line Makefile when the fork has none); it never
-# overwrites a Makefile you already have. Delete the include and you lose
-# nothing — `./sc <cmd>` is identical.
+# This file travels with the engine, so the aliases work in a fork exactly as in
+# the source repo — WITHOUT super-coder ever owning or clobbering the fork's
+# Makefile (#13): install wires a fork to *include* this file (or auto-creates a
+# one-line Makefile when the fork has none); it never overwrites a Makefile you
+# already have. Delete the include and you lose nothing — `./sc <cmd>` is identical.
 #
-#   make launch         build + start the docker sandbox (+ review GUI)
-#   make enter          attach an interactive session (pick shell + harness)
-#   make enter s=ap01   attach + boot the 'ap01' shell directly
-#   make down           stop the sandbox
-#   make update         fetch + materialize the engine, reconcile in place
-#   make update-harnesses  update claude + opencode + codex + vibe to latest
-#   make rollback       sound undo of a bad update (restore DB + engine)
-#   make deps           install this fork's deps into the bind-mounted .venv + node_modules
-#   make test           run backend (.venv pytest / unittest) + UI (vitest) suites
-#   make sc ARGS=health run any ./sc subcommand (passthrough)
+# Every target is `sc-`prefixed so including this file can't collide with your
+# own `test` / `build` / `install` targets. The house standard: the hot commands
+# get a one-letter short form too; everything else is long-form only.
+#
+#   HOT (short + long):
+#   make sc-e   / sc-enter     attach a session (pick shell + harness); sc-e s=ap01 boots one
+#   make sc-l   / sc-launch    build + start the docker sandbox (+ review GUI)
+#   make sc-r   / sc-restart   down + launch — recreate the sandbox fresh
+#   make sc-d   / sc-down      stop the sandbox
+#   make sc-u   / sc-update    fetch + materialize the engine, reconcile in place
+#   make sc-t   / sc-test      backend (pytest/unittest) + UI (vitest) suites
+#   make sc-h                  list the commands
+#   make sc-help               list + describe the commands
+#
+#   LONG-ONLY: sc-build sc-logs sc-serve sc-health sc-ports sc-verify sc-map
+#              sc-render sc-snapshot sc-deps sc-install sc-rollback
+#              sc-update-harnesses · passthrough: make sc ARGS=health
 #
 SC := ./sc
-.PHONY: launch enter down build logs serve health ports verify update update-harnesses rollback snapshot render map install sc deps test
+.PHONY: sc-e sc-enter sc-l sc-launch sc-r sc-restart sc-d sc-down sc-u sc-update \
+        sc-t sc-test sc-h sc-help sc-build sc-logs sc-serve sc-health sc-ports \
+        sc-verify sc-map sc-render sc-snapshot sc-deps sc-install sc-rollback \
+        sc-update-harnesses sc
 
-launch:            ; $(SC) launch
-enter:             ; $(SC) $(if $(s),enter-$(s),enter)
-down:              ; $(SC) down
-build:             ; $(SC) build
-logs:              ; $(SC) logs
-serve:             ; $(SC) serve
-health:            ; $(SC) health
-ports:             ; $(SC) ports
-verify:            ; $(SC) verify
-update:            ; $(SC) update
-update-harnesses:  ; $(SC) update-harnesses
-rollback:          ; $(SC) rollback
-snapshot: ; $(SC) snapshot
-render:   ; $(SC) render $(ARGS)
-map:      ; $(SC) map
-install:  ; $(SC) install
-deps:     ; $(SC) deps
-test:     ; $(SC) test
-sc:       ; $(SC) $(ARGS)
+# Hot commands — long form, with a one-letter alias delegating to it.
+sc-enter:            ; $(SC) $(if $(s),enter-$(s),enter)
+sc-e: sc-enter
+sc-launch:           ; $(SC) launch
+sc-l: sc-launch
+sc-restart:          ; $(SC) restart
+sc-r: sc-restart
+sc-down:             ; $(SC) down
+sc-d: sc-down
+sc-update:           ; $(SC) update
+sc-u: sc-update
+sc-test:             ; $(SC) test
+sc-t: sc-test
+
+# Long-only commands.
+sc-build:            ; $(SC) build
+sc-logs:             ; $(SC) logs
+sc-serve:            ; $(SC) serve
+sc-health:           ; $(SC) health
+sc-ports:            ; $(SC) ports
+sc-verify:           ; $(SC) verify
+sc-map:              ; $(SC) map
+sc-render:           ; $(SC) render $(ARGS)
+sc-snapshot:         ; $(SC) snapshot
+sc-deps:             ; $(SC) deps
+sc-install:          ; $(SC) install
+sc-rollback:         ; $(SC) rollback
+sc-update-harnesses: ; $(SC) update-harnesses
+
+# Passthrough: run any ./sc subcommand — make sc ARGS=health
+sc:                  ; $(SC) $(ARGS)
+
+# Help — sc-h lists, sc-help lists + describes.
+sc-h:
+	@echo "sc-e(nter) sc-l(aunch) sc-r(estart) sc-d(own) sc-u(pdate) sc-t(est) sc-h/sc-help"
+	@echo "long-only: sc-build sc-logs sc-serve sc-health sc-ports sc-verify sc-map sc-render sc-snapshot sc-deps sc-install sc-rollback sc-update-harnesses | passthrough: make sc ARGS=<cmd>"
+sc-help:
+	@echo "super-coder make aliases — every target delegates to ./sc"
+	@echo ""
+	@echo "  hot (short + long):"
+	@echo "    sc-e  / sc-enter     attach a session (pick shell + harness); sc-e s=ap01 boots one"
+	@echo "    sc-l  / sc-launch    build + start the docker sandbox (+ review GUI)"
+	@echo "    sc-r  / sc-restart   down + launch — recreate the sandbox fresh"
+	@echo "    sc-d  / sc-down      stop the sandbox"
+	@echo "    sc-u  / sc-update    fetch + materialize the engine, reconcile in place"
+	@echo "    sc-t  / sc-test      backend (pytest/unittest) + UI (vitest) suites"
+	@echo "    sc-h                 list commands   ·   sc-help   this view"
+	@echo ""
+	@echo "  long-only: sc-build sc-logs sc-serve sc-health sc-ports sc-verify"
+	@echo "             sc-map sc-render sc-snapshot sc-deps sc-install sc-rollback sc-update-harnesses"
+	@echo "  passthrough: make sc ARGS=<subcommand>   (e.g. make sc ARGS=doctor)"

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -518,20 +518,21 @@ def main(argv: list[str]) -> int:
     subprocess.run([PY, str(ENGINE / "scripts/render.py"), "flat"])
 
     # 8.5 Wire `make` aliases — opt-in, never clobber a host Makefile (#13).
-    # No Makefile → drop a one-line include so `make launch`/`enter` work out of
-    # the box. Already have one → leave it; just print the line to opt in.
+    # No Makefile → drop a one-line include so `make sc-*` works out of the box.
+    # Already have one → leave it; just print the line to opt in. Every target is
+    # `sc-`prefixed, so the include can't collide with the fork's own targets.
     step("Wiring make aliases")
     mk = REPO_ROOT / "Makefile"
     if mk.exists():
-        print("  Makefile present — left untouched. For `make launch`/`enter`, add:")
+        print("  Makefile present — left untouched. For `make sc-e`/`sc-enter`, add:")
         print("    include .super-coder/aliases.mk")
     else:
         mk.write_text(
-            "# Fork Makefile — super-coder convenience aliases (make launch / enter).\n"
-            "# Edit freely; add your own targets below the include.\n"
+            "# Fork Makefile — super-coder convenience aliases (make sc-e / sc-enter).\n"
+            "# Every target is sc-prefixed; add your own targets below the include.\n"
             "include .super-coder/aliases.mk\n"
         )
-        print("  wrote Makefile (include .super-coder/aliases.mk) → `make launch` works")
+        print("  wrote Makefile (include .super-coder/aliases.mk) → `make sc-e` works")
 
     # Record harness + installed marker in instance.json ---------------------
     cfg = ports_mod.resolve(persist=False)

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@
 # shared with forks (install wires a fork to include the same file). Edit the
 # aliases there, not here.
 #
-#   make launch            build + start the docker sandbox
-#   make enter             attach an interactive session (pick shell + harness)
-#   make enter s=cc        attach + boot the 'cc' shell directly
-#   make down              stop the sandbox
+#   make sc-l / sc-launch  build + start the docker sandbox
+#   make sc-e / sc-enter   attach an interactive session (pick shell + harness)
+#   make sc-e s=cc         attach + boot the 'cc' shell directly
+#   make sc-r / sc-restart down + launch — recreate the sandbox fresh
+#   make sc-d / sc-down    stop the sandbox
+#   make sc-h / sc-help    list / describe all commands
 include .super-coder/aliases.mk

--- a/README.md
+++ b/README.md
@@ -457,11 +457,15 @@ per-launch and never written back — so two terminals can run the **same** shel
 different harnesses at once (one Claude Code, one OpenCode). A fork with a single
 harness on `PATH` skips the prompt.
 
-**`make`.** The source repo ships a thin root `Makefile` that delegates to
-`./sc` (`make launch` / `make enter` / `make enter s=cc` / `make down`). It is
-source-repo ergonomics only — `install.py` checks out `.super-coder` + `sc`, not
-the `Makefile`, so it never propagates to a fork or clobbers a fork's own
-`Makefile`. In a fork, use `./sc <cmd>` (or alias it in your own `Makefile`).
+**`make`.** Every command has a `make sc-<name>` alias; the hot ones also get a
+letter — `sc-e` (enter), `sc-l` (launch), `sc-r` (restart), `sc-d` (down),
+`sc-u` (update), `sc-t` (test) — and `sc-h` / `sc-help` list / describe them.
+`make sc-e s=cc` boots one shell directly; `make sc ARGS=<cmd>` is the
+passthrough. The targets live in `.super-coder/aliases.mk`, which **travels with
+the engine** — install wires a fork to `include` it, and because **every target
+is `sc-`prefixed it can't collide** with the fork's own `test` / `build` /
+`install`. The source repo's thin root `Makefile` just includes the same file;
+`./sc <cmd>` is always identical.
 
 ## Dev kit
 

--- a/sc
+++ b/sc
@@ -279,6 +279,7 @@ case "$cmd" in
   enter)        exec docker exec -it "$CNAME" ./sc boot "$@" ;;
   enter-*)      exec docker exec -it "$CNAME" ./sc boot "${cmd#enter-}" "$@" ;;
   down)         docker rm -f "$CNAME" >/dev/null 2>&1 && echo "→ sandbox stopped" || echo "→ not running" ;;
+  restart)      "$0" down; exec "$0" launch "$@" ;;
   build)        dcheck; dbuild ;;
   logs)         exec docker logs -f "$CNAME" ;;
   verify)
@@ -315,6 +316,7 @@ super-coder — forkable shell substrate
                              harness: --harness <name> or HARNESS=<name> forces it; else when
                              >1 harness is on PATH you're prompted (per-launch, not persisted)
   ./sc down                stop + remove the sandbox container
+  ./sc restart             down + launch — recreate the sandbox fresh
   ./sc build               (re)build the sandbox image
   ./sc logs                tail the sandbox server logs
 


### PR DESCRIPTION
## Why

The shipped `aliases.mk` had **bare** target names (`test`, `build`, `install`, `launch`…). The moment a fork added `include .super-coder/aliases.mk` to its own Makefile, ours would **shadow the fork's same-named targets**. `install.py` only protected the *file* (#13), never the target *names*.

## What

Establishes the house make-command standard: `make <prefix>-<cmd>`, every target `sc-`prefixed so the include is collision-safe.

- **`aliases.mk`** — all targets renamed `sc-*`. The **hot** commands get a one-letter short form delegating to the long form:

  | | | | |
  |---|---|---|---|
  | `sc-e` /`sc-enter` | `sc-l` /`sc-launch` | `sc-r` /`sc-restart` | `sc-d` /`sc-down` |
  | `sc-u` /`sc-update` | `sc-t` /`sc-test` | `sc-h` (lists) | `sc-help` (describes) |

  Everything else is **long-only** (`sc-build`, `sc-logs`, `sc-map`, `sc-verify`, …). Passthrough stays `make sc ARGS=<cmd>`. `make sc-e s=ap01` still boots one shell.
- **`./sc restart`** — new subcommand: `down` + `launch` (recreate the sandbox fresh). `sc-r`/`sc-restart` delegate to it.
- **`install.py` §8.5** + root `Makefile` doc strings updated to the `sc-*` forms.

## Verified

`bash -n sc` clean; `make -n sc-r` → `./sc restart`; `make -n sc-e s=cc` → `./sc enter-cc`; `make sc-h`/`sc-help` print; `./sc help` lists restart.

## Notes

- Source-repo root Makefile is now strictly `sc-*` (no bare aliases) — nothing in CI/scripts used the bare forms (only the Makefile's own comment + rendered `.sc-state/content.sql` spec text). Say the word if you want bare `launch`/`enter` kept here for muscle memory.
- **Follow-up:** the README Run section's `make` paragraph still shows bare forms; I'll update it once #91 (loop-skills) merges, to avoid a cross-PR README conflict.
- The superCC `cc-*` side + the CC `command_standard` skill are coming as separate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)