### PR TITLE
feat(skills): spec is a dev skill; correct the loop ownership

### DIFF
--- a/.super-coder/migrations/0014_dev_spec_skill.sql
+++ b/.super-coder/migrations/0014_dev_spec_skill.sql
@@ -1,0 +1,17 @@
+-- 0014 — grant the `spec` skill to dev shells
+--
+-- `spec` (the spec_tasks lifecycle: read the ask → break it into a
+-- Preparation → steps → Verification task list → execute + track across
+-- sessions) is now a dev-flavor skill (dev.json lists it). It was previously
+-- granted to no flavor. Grant it to existing dev shells so installed forks pick
+-- it up on ./sc update; new shells get it from the template at creation.
+
+BEGIN;
+
+INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
+SELECT s.shell_id, k.skill_id
+FROM shells s
+JOIN skills k ON k.name = 'spec' AND k.is_deleted = 0
+WHERE s.flavor = 'dev' AND s.is_deleted = 0;
+
+COMMIT;

--- a/.super-coder/templates/shells/dev.json
+++ b/.super-coder/templates/shells/dev.json
@@ -4,5 +4,5 @@
   "role": "Dev shell",
   "mandate": "Build and implement in {{repo}} — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.",
   "focus": "You are a builder. Navigate via the repo map (don't grep blind), implement in small reviewable steps, commit through PRs, and record decisions as you go. Planning scopes the work; you make it real; review verifies it.",
-  "skills": ["docs", "flags", "git", "database-migrations", "redline_review", "dev_kit", "test_authoring"]
+  "skills": ["docs", "spec", "flags", "git", "database-migrations", "redline_review", "dev_kit", "test_authoring"]
 }

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ it owns:
 | Flavor | Flavor skills | Owns |
 |---|---|---|
 | **cartographer** | `cartographer` | map · re-map |
-| **planner** | `docs` · `blueprint` · `flags` · `api-design` · `onboard` | spec · plan · freeze + docs |
-| **dev** | `dev_kit` · `test_authoring` · `database-migrations` · `redline_review` · `docs` · `flags` | implement · patch + test |
+| **planner** | `docs` · `blueprint` · `flags` · `api-design` · `onboard` | spec doc · approach · freeze + docs |
+| **dev** | `spec` · `dev_kit` · `test_authoring` · `database-migrations` · `redline_review` · `docs` · `flags` | break into tasks · implement · patch + test |
 | **reviewer** | `test_authoring` · `database-migrations` · `redline_review` · `api-design` · `flags` | review |
 | **admin** | `git_cleanup` · `self_update` · `migration_management` · `local_skill_management` | engine · verify-clean |
 
@@ -157,19 +157,19 @@ it owns:
    It's infrastructure working shells *read* via `surface_catalogue`.
    *(cartographer · `cartographer` · UI: Map)*
 3. **Spec it** — the **planner** authors a spec document against a roadmap
-   feature — viability, blockers, the staged plan. (Specs ride the `docs` skill,
-   which owns both docs and specs; there's no separate grant.)
-   *(planner · `docs`, `flags` · UI: Roadmap)*
-4. **Plan the build** — the planner decomposes the spec into an ordered task
-   list (Prep → steps → Verification gates) — `blueprint` is a **planner** skill,
-   so the plan is cut before the hand-off to dev. *(planner · `blueprint` · UI: Roadmap)*
-5. **Switch to dev** — `./sc enter-dev` boots the **dev** shell into its own git
+   feature — viability, blockers, the done-condition. `blueprint` shapes the
+   approach in a single session (no DB writes); both the spec and the docs ride
+   the `docs` skill. *(planner · `docs`, `blueprint`, `flags` · UI: Roadmap)*
+4. **Switch to dev** — `./sc enter-dev` boots the **dev** shell into its own git
    worktree on `shell/dev`, a base pinned to `origin/main`.
    *(dev · `bootstrap`, `memory` · UI: Shells)*
-6. **Implement across sessions** — dev cuts a feature branch off `shell/dev`,
-   writes code, schema, and tests, and runs `./sc test`. `memory` carries
-   `current_state` ("last / next task") across sessions so they resume cleanly.
-   *(dev · `dev_kit`, `test_authoring`, `database-migrations`, `redline_review`, `git`, `memory` · UI: Shells)*
+5. **Break it into tasks** — dev reads the spec and uses `spec` to decompose it
+   into `spec_tasks` (Preparation → steps → Verification), then works one task
+   per session. `memory` rolls `current_state` ("last / next task") so sessions
+   resume cleanly. *(dev · `spec`, `memory` · UI: Roadmap)*
+6. **Implement** — within each task, dev cuts a feature branch off `shell/dev`,
+   writes code, schema, and tests, and runs `./sc test`.
+   *(dev · `dev_kit`, `test_authoring`, `database-migrations`, `redline_review`, `git` · UI: Shells)*
 7. **Send to review** — dev pushes and opens a PR (the `git` skill is
    branch → commit → push → **PR → stop**; dev never merges), then messages the
    reviewer. *(dev · `git`, `messaging` · UI: Flags)*


### PR DESCRIPTION
## Why

`spec` — the `spec_tasks` lifecycle skill (analyze → decompose into Preparation → steps → Verification → execute/track across sessions) — was granted to **no flavor** (confirmed: never in any template per git `-S '"spec"'`). It's the skill that literally "breaks a spec into a task list," and its Step 4 (track/execute session-by-session in `shell/dev`) is squarely **dev** work. So it belongs to dev.

This also fixes the loop's ownership story: `blueprint` is a planner **single-session** skill that **does not write the DB** (its stance: "land the plan as a spec via the `docs` skill") — it was never the thing that produces `spec_tasks`. `spec` is, and it's dev's.

## Changes

- **`dev.json`** — grant `spec`.
- **`0014_dev_spec_skill.sql`** — grant `spec` to existing dev shells (so installed forks pick it up on `./sc update`; new shells get it from the template). Idempotent `INSERT OR IGNORE`, matches the `0011`/`0013` grant precedent.
- **README loop** — step 3 = planner authors the spec + shapes the approach (`docs`, `blueprint`); new step 5 = dev breaks it into `spec_tasks` via `spec`; flavor table updated (dev gains `spec`).

## Clean split now

| Skill | Does | Owner |
|---|---|---|
| `docs` | authors the spec **and** the doc | planner |
| `blueprint` | single-session plan, **no DB writes** | planner |
| `spec` | `spec_tasks` checklist + execute across sessions | **dev** |

## Verified

`dev.json` valid JSON; migration applies cleanly against a DB copy (no-op where no dev shells exist); README still parses (12 tabs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)