### PR TITLE
feat(install): bootstrap the full team, not just a planner

### DIFF
--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
-"""Seed a fork's FIRST shell — the one-time fork-identity step.
+"""Seed a fork's STARTING TEAM — the one-time fork-identity step.
 
 A fresh fork's `.db` carries the *system* (schema + migrations: the skill
 catalogue, the render chain) but **no per-instance content** — a fork inherits
 the system, never super-coder's memory or roadmap. So a just-installed fork has
 no users and no shells, and `./sc launch` has nothing to authenticate or boot.
-This provisions the local user, then creates the first shell via the shared
-shell factory (a flavor template — default `dev`).
+This provisions the local user, then seeds the starting team via the shared
+shell factory: your primary shell (default `planner`) plus an `admin`, two
+`dev`, a `reviewer`, and the singleton `cartographer` — the full roster out of
+the box.
 
 Run ONCE, right after `./sc rebuild`, on a fresh fork. Refuses if a shell already
-exists. After it runs: `./sc snapshot`, then `./sc launch`. Additional shells are
-created later via the GUI (also through the factory).
+exists. After it runs: `./sc snapshot`, then `./sc launch`. More shells (or
+fewer) are managed later via the GUI (also through the factory).
 
 Usage:
     python3 .super-coder/scripts/init_fork.py            # interactive
     python3 .super-coder/scripts/init_fork.py \
-        --username Jed --name Dev --shortname dev --flavor dev
+        --username Jed --name Lead --shortname lead --flavor planner
 """
 from __future__ import annotations
 
@@ -26,6 +28,11 @@ from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
 DB_PATH = ENGINE / "shell_db.db"
+
+# The starting team seeded at install, besides the singleton cartographer (added
+# separately below). Your interviewed primary shell — default planner — fills one
+# of these slots; the rest are auto-named team members (ADM1, DEV1, DEV2, REV1).
+TEAM_ROSTER = ["admin", "planner", "dev", "dev", "reviewer"]
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 from shell_factory import create_shell, flavors  # noqa: E402
@@ -83,8 +90,9 @@ def main(argv: list[str]) -> int:
                      "(non-interactive run needs the flag)")
 
         username = need(a.username, "Your username")
-        # The first shell is a PLANNER shell — every fork needs a planner to
-        # scope the work. (--flavor overrides; the GUI creates other flavors.)
+        # Your primary shell — default planner (every fork needs a planner to
+        # scope the work). --flavor picks which roster slot is *yours* (the one
+        # interviewed for name/role/mandate); the rest of the team seeds with it.
         flavor = a.flavor or "planner"
         if flavor not in flavor_names:
             sys.exit(f"init_fork: unknown flavor '{flavor}' (have: {', '.join(flavor_names)})")
@@ -96,29 +104,47 @@ def main(argv: list[str]) -> int:
         con.execute(
             "INSERT INTO users (user_id, username, is_active) VALUES (1, ?, 1)",
             (username,))
+        # Your interviewed primary shell.
         shell_id = create_shell(
             con, flavor=flavor, name=name, shortname=shortname,
             partner=a.partner or username, repo=repo,
             role=a.role, mandate=a.mandate)
-        # Every fork also gets a dedicated Cartographer: it owns the repo map so
-        # no working shell ever maps. Configured + wired by `./sc map-setup`
-        # (install runs it); re-bootable to heal the map automation later.
-        cart_id = create_shell(
-            con, flavor="cartographer", name="Cartographer",
-            partner=a.partner or username, repo=repo)
+        # The rest of the starting team — the full roster minus the slot your
+        # primary already fills — auto-named by the factory (ADM1/DEV1/DEV2/REV1).
+        rest = list(TEAM_ROSTER)
+        if flavor in rest:
+            rest.remove(flavor)
+        team = []
+        for fl in rest:
+            sid = create_shell(con, flavor=fl, name=fl.capitalize(),
+                               partner=a.partner or username, repo=repo)
+            team.append((fl, sid))
+        # The singleton Cartographer owns the repo map so no working shell ever
+        # maps; configured + wired by `./sc map-setup` (install runs it). Skip if
+        # your primary already is the cartographer.
+        cart_id = None
+        if flavor != "cartographer":
+            cart_id = create_shell(
+                con, flavor="cartographer", name="Cartographer",
+                partner=a.partner or username, repo=repo)
         con.commit()
-        shortname = con.execute(
-            "SELECT shortname FROM shells WHERE shell_id=?", (shell_id,)).fetchone()[0]
-        cart_sn = con.execute(
-            "SELECT shortname FROM shells WHERE shell_id=?", (cart_id,)).fetchone()[0]
+
+        def _sn(sid):
+            return con.execute(
+                "SELECT shortname FROM shells WHERE shell_id=?", (sid,)).fetchone()[0]
 
         n = con.execute(
             "SELECT COUNT(*) FROM shell_skills WHERE shell_id=?", (shell_id,)).fetchone()[0]
-        print(f"init_fork: created '{shortname}' ({flavor}, shell_id={shell_id}) "
-              f"for user '{username}' — {n} skills, lineage + genesis seed, session opened.")
-        print(f"init_fork: created '{cart_sn}' (cartographer, shell_id={cart_id}) "
-              "— owns the repo map.")
-        print("init_fork: next -> `./sc snapshot` (serialize), then `./sc launch`.")
+        print(f"init_fork: created '{_sn(shell_id)}' ({flavor}, shell_id={shell_id}) "
+              f"for user '{username}' — your primary, {n} skills, lineage + genesis seed.")
+        for fl, sid in team:
+            print(f"init_fork: created '{_sn(sid)}' ({fl}, shell_id={sid}).")
+        if cart_id:
+            print(f"init_fork: created '{_sn(cart_id)}' (cartographer, shell_id={cart_id}) "
+                  "— owns the repo map.")
+        total = 1 + len(team) + (1 if cart_id else 0)
+        print(f"init_fork: seeded a {total}-shell team. "
+              "next -> `./sc snapshot` (serialize), then `./sc launch`.")
     finally:
         con.close()
     return 0

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ that must survive is its DB, serialized to the tracked `.sc-state/content.sql`.
 ## Quick start
 
 > [!class2]
-> **UI** Shells (your landing tab) · **Shells** your first shell + Cartographer
+> **UI** Shells (your landing tab) · **Shells** your starting team — planner · 2×dev · reviewer · admin · cartographer
 
 Drop super-coder into an existing git repo and boot a shell. Requires `docker`
 (rootless is fine) and an account for one coding harness — Claude Code, OpenCode,
@@ -91,7 +91,7 @@ git remote add super-coder https://github.com/jedbjorn/super-coder.git
 git fetch super-coder
 git checkout super-coder/main -- .super-coder sc
 
-# 2. Bootstrap the fork — installs harness CLIs, builds the DB, seeds your first shell:
+# 2. Bootstrap the fork — installs harness CLIs, builds the DB, seeds your starting team:
 ./sc install
 
 # 3. Sign in to your harness once, on the HOST (not inside the sandbox):
@@ -149,9 +149,9 @@ it owns:
 | **reviewer** | `test_authoring` · `database-migrations` · `redline_review` · `api-design` · `flags` | review |
 | **admin** | `git_cleanup` · `self_update` · `migration_management` · `local_skill_management` | engine · verify-clean |
 
-1. **Install** — `./sc install` seeds your first shell (planner-flavor by
-   default) plus the **Cartographer**, and stands up the `admin` shell that owns
-   `main` and the engine thereafter. *(admin · `self_update`, `migration_management` · UI: Shells)*
+1. **Install** — `./sc install` seeds your **starting team**: a `planner` (your
+   primary), two `dev`, a `reviewer`, the `admin` that owns `main` + the engine,
+   and the singleton `cartographer`. *(admin · `self_update`, `migration_management` · UI: Shells)*
 2. **Map the repo** — the cartographer configures the index once with
    `./sc map-setup`, then `./sc map` builds it; git hooks re-map on every pull.
    It's infrastructure working shells *read* via `surface_catalogue`.
@@ -199,7 +199,7 @@ it owns:
 ## Install
 
 > [!class2]
-> **UI** Shells · Scripts · **Shells** seeds your first shell (planner-flavor) + Cartographer
+> **UI** Shells · Scripts · **Shells** seeds the starting team — planner · 2×dev · reviewer · admin · cartographer
 
 super-coder installs **alongside** your code — it renders to `_sc` dirs, so it
 never collides with your repo's own `/docs`, `/specs`, or skills. A fork
@@ -247,20 +247,22 @@ npm — if any are missing; `--skip-harness-install` to detect only), wires your
 files stay on disk; pins its upstream SHA in `.sc-state/engine.ref`), **strips
 super-coder's own per-instance content** (a fork inherits the *system* — schema +
 skill catalogue + render chain — never the memory or roadmap), builds the system
-DB, seeds your fork's **first shell** (your user + a planner-flavor shell by
-default, carrying the CC Lineage Seed and its own genesis seed) plus the
-**Cartographer** (the singleton repo-map owner), and renders. So after install
+DB, seeds your fork's **starting team** (your user + a planner-flavor *primary*
+carrying the CC Lineage Seed and its own genesis seed, plus two `dev`, a
+`reviewer`, the `admin` that owns `main`, and the singleton **Cartographer**
+repo-map owner), and renders. So after install
 your git surfaces show only your project — the engine no longer appears in
 `git status`. It refuses to run in the super-coder source repo or on an
 already-installed fork (guarding against content loss).
 
-Interactive by default (prompts for the shell's name/role/mandate); pass flags
-to script it:
+Interactive by default (prompts for your **primary** shell's name/role/mandate —
+the rest of the team is auto-named); pass flags to script it. `--flavor` picks
+which roster slot is your primary (default `planner`):
 
 ```bash
 python3 .super-coder/scripts/install.py \
-    --username Jed --name Dev --shortname dev \
-    --role "Dev shell" --mandate "Build and maintain this repo."
+    --username Jed --name Lead --shortname lead \
+    --role "Planning lead" --mandate "Scope and steer the work in this repo."
 ```
 
 After `./sc enter` you're talking to the shell, working your repo. Author
@@ -369,8 +371,9 @@ The logic, three rules:
 > [!class2]
 > **UI** Shells · Worktrees · **Shells** all flavors; admin is the only one on `main`
 
-A fork can run a whole team — create more shells from the GUI, one per flavor
-as needed. They all work the same repo without clobbering each other:
+A fork boots a **whole team** out of the box — `planner` · 2×`dev` · `reviewer`
+· `admin` · `cartographer` — and you add or retire shells from the GUI as
+needed. They all work the same repo without clobbering each other:
 
 - **Every shell boots into its own git worktree** at
   `.sc-worktrees/<shortname>/` on branch `shell/<shortname>` — parallel shells


### PR DESCRIPTION
## Why

You asked for the out-of-the-box roster to match **dos-arch** (which works well). But I verified `init_fork.py` and today `./sc install` seeds only **2 shells** — a primary (default planner) + the cartographer. dos-arch's 6-shell roster was **hand-authored into `.sc-state/content.sql`**, never produced by `init_fork`. (This also caught a README bug: loop step 1 claimed install "stands up the admin shell" — it didn't. Now it does.)

## What

`./sc install` now seeds the full working team, all owned by the local user:

| shortname | flavor |
|---|---|
| PLN1 | planner (your primary) |
| DEV1, DEV2 | dev |
| REV1 | reviewer |
| ADM1 | admin (owns `main` + the engine) |
| CART1 | cartographer (singleton) |

- **`init_fork.py`** — `TEAM_ROSTER = [admin, planner, dev, dev, reviewer]`; your interviewed primary (`--flavor`, default `planner`) fills one slot, the rest auto-name via the factory; the cartographer stays the singleton.
- **`--flavor`** now means "which roster slot is *yours*" (the interviewed one) — the team still seeds either way. `--flavor dev` → your primary is DEV1, team still has 2 devs total.
- **README** — every "seeds your first shell" spot → the team; fixed step 1's admin claim and the "create more shells from the GUI" framing.

## No migration

Install-time only. Existing forks already ran `init_fork` (their shells exist); you don't retroactively inject a team via migration. New forks get it.

## Tested

Fresh content-stripped DB → ran `init_fork`: **6-shell roster, all owned by user 1**, in both default (planner primary) and `--flavor dev` modes. README still parses (12 tabs).

## Note

Independent of #93 (spec→dev) — disjoint README sections (step 1 + install prose here; steps 3–6 + flavor table there). Merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)