### PR TITLE
fix(publish): return to original branch after publish

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -405,9 +405,25 @@ def git_publish() -> dict:
     # 1. serialize the DB → git-tracked text + render the flat files.
     out.append(run_snapshot_render())
 
-    # 2. land on the rolling branch (created from HEAD on first publish; the
-    #    operator stays on it — editing lives on gui-content, main stays clean).
+    # publish borrows gui-content to commit/push, then returns the operator to
+    # the branch they started on. Parking them on gui-content silently was a
+    # footgun — later terminal/code work landed there unnoticed. main stays
+    # clean either way (the content commit lives on gui-content + its PR).
     cur = _git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    result = _git_publish_on_branch(cur, out)
+    now = _git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    if now != cur:
+        back = _git("checkout", cur)
+        if back.returncode == 0:
+            result["output"] += f"\n\n↩ back on {cur}"
+        else:
+            result["output"] += (f"\n\n⚠ left on {now} — couldn't return to "
+                                  f"{cur}:\n{back.stderr.strip()}")
+    return result
+
+
+def _git_publish_on_branch(cur: str, out: list) -> dict:
+    # 2. land on the rolling branch (created from HEAD on first publish).
     if cur != PUBLISH_BRANCH:
         exists = _git("rev-parse", "--verify", "--quiet",
                       f"refs/heads/{PUBLISH_BRANCH}").returncode == 0


### PR DESCRIPTION
## Problem

The GUI **Publish** button left the working tree parked on `gui-content`. `git_publish()` checked out `gui-content` to commit/push and then just ended — no switch back (the old "operator stays on it" design). Result: later terminal/code work landed on `gui-content` without you realizing it.

**Snapshot** touches git not at all; this is purely a Publish issue.

## Fix

Split the branch-borrowing body into `_git_publish_on_branch()`. `git_publish()` now records the branch HEAD started on, runs the publish, and checks out back to it — but only if HEAD actually moved (so a failed switch-to-`gui-content` is a clean no-op). Output gets a `↩ back on <branch>` note (or a warning if the return checkout fails).

`main` stays clean either way: the content commit still lives on `gui-content` with its rolling PR. Staying on `gui-content` bought the GUI flow nothing — Publish re-checks-out `gui-content` itself every time, and GUI edits route through DB → snapshot → render regardless of the working branch.

## Test

- `python -m py_compile` passes.
- Logic: returns to `cur` only when `now != cur`; `result["output"]` always present on every return path in the inner fn, so the append is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)