### PR TITLE
fix(ui): center nav tabs over content column

### DIFF
--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -35,7 +35,7 @@ header {
   border-bottom: 1px solid var(--line); position: sticky; top: 0;
   background: var(--bg); z-index: 5;
 }
-h1 { font-size: 1.05rem; margin: 0; font-weight: 650; letter-spacing: .2px; }
+h1 { font-size: 1.05rem; margin: 0; font-weight: 650; letter-spacing: .2px; flex: 1 1 0; }
 h1 span { color: var(--dim); font-weight: 400; }
 h1 span::before { content: " / "; color: var(--line); }
 nav { display: flex; gap: 1.1rem; align-items: center; align-self: stretch; }
@@ -51,7 +51,9 @@ nav button.active::after {
   content: ""; position: absolute; left: 0; right: 0; bottom: -1px; height: 2px;
   background: var(--accent);
 }
-.tools { margin-left: auto; display: flex; align-items: center; gap: .8rem; }
+/* brand + tools are equal-flex side zones so nav centers on the window
+   midpoint — i.e. over the centered .view content column below it. */
+.tools { flex: 1 1 0; justify-content: flex-end; display: flex; align-items: center; gap: .8rem; }
 .status { color: var(--dim); font-size: .8rem; }
 #snapshot {
   background: var(--panel2); color: var(--ink); border: 1px solid var(--line);


### PR DESCRIPTION
## Redline

`center tabs over content` — tabs were left-aligned against the brand with a big empty gap before snapshot/publish.

## Fix

The header is a 3-child flex row (`h1` brand · `nav` · `.tools`). `.tools` used `margin-left:auto`, shoving brand+nav left and tools right.

Now the two side zones are equal-flex:
- `h1` → `flex: 1 1 0`
- `.tools` → `flex: 1 1 0; justify-content: flex-end` (drops `margin-left:auto`)
- `nav` unchanged — natural width, lands dead-center

Equal side zones mean nav centers on the **window midpoint** regardless of the side widths, which is exactly where the centered content column below it sits (`.view { margin: 0 auto; max-width: 1000px }`). So the tabs line up over the content, per the redline note.

CSS-only, 3 lines, no markup change. Engine file → reaches dos-arch on its next `./sc update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)