### PR TITLE
fix(flavor-defaults): Claude-default bookends + relicense OpenCode model ids

### DIFF
--- a/.super-coder/migrations/0014_claude_bookends_opencode_relicense.sql
+++ b/.super-coder/migrations/0014_claude_bookends_opencode_relicense.sql
@@ -1,0 +1,49 @@
+-- 0014 — Claude-default bookends + corrected/retuned OpenCode model ids
+--
+-- Two corrections, both to flavor_defaults (pure launch config — no FKs, no
+-- per-instance memory — so UPDATEs converge fresh-rebuild and existing forks
+-- alike; idempotent, re-runnable).
+--
+-- 1. BOOKEND PICKER DEFAULT → CLAUDE. planner and reviewer are low-volume,
+--    high-leverage reasoning roles where the Claude lineage is preferred for
+--    planning and adversarial review. planner now defaults to claude/sonnet
+--    (was codex/gpt-5.5) and its claude model moves opus→sonnet. reviewer
+--    already defaulted to claude/opus (unchanged). The middle/ops roles
+--    (dev, cartographer, admin) keep codex as their picker default.
+--
+-- 2. OPENCODE MODEL IDS WERE STALE + RELICENSED. They were seeded as
+--    `ollama/<model>:cloud`, but the live OpenCode provider is
+--    `ollama-cloud/<model>` with NO suffix — none of the old ids resolved.
+--    Corrected to the real provider prefix, and retuned to current open
+--    weights under a hard constraint: open models MUST be MIT or Apache.
+--      planner       ollama-cloud/deepseek-v4-pro     (MIT)     top long-horizon planner
+--      reviewer      ollama-cloud/glm-5.1             (MIT)     #1 SWE-Bench Pro bug-finder
+--      dev           ollama-cloud/qwen3-coder-next    (Apache)  fast/cheap agentic coder
+--      cartographer  ollama-cloud/gpt-oss:20b         (Apache)  cheapest bulk mapper
+--      admin         ollama-cloud/deepseek-v4-pro     (MIT)     premium ops reasoning
+--    Excluded by the license gate: Kimi (Modified-MIT branding clause) and
+--    MiniMax (license unresolved at time of writing) — both available on
+--    ollama, neither cleanly MIT/Apache.
+
+BEGIN;
+
+-- 1. Bookend picker default → Claude (planner: codex→claude, opus→sonnet).
+UPDATE flavor_defaults SET is_default = 0
+    WHERE flavor = 'planner' AND harness = 'codex';
+UPDATE flavor_defaults SET is_default = 1, model = 'sonnet'
+    WHERE flavor = 'planner' AND harness = 'claude';
+-- reviewer already claude/opus is_default=1 — no change needed.
+
+-- 2. OpenCode ids: correct provider prefix + retune to MIT/Apache models.
+UPDATE flavor_defaults SET model = 'ollama-cloud/deepseek-v4-pro'
+    WHERE flavor = 'planner'      AND harness = 'opencode';
+UPDATE flavor_defaults SET model = 'ollama-cloud/glm-5.1'
+    WHERE flavor = 'reviewer'     AND harness = 'opencode';
+UPDATE flavor_defaults SET model = 'ollama-cloud/qwen3-coder-next'
+    WHERE flavor = 'dev'          AND harness = 'opencode';
+UPDATE flavor_defaults SET model = 'ollama-cloud/gpt-oss:20b'
+    WHERE flavor = 'cartographer' AND harness = 'opencode';
+UPDATE flavor_defaults SET model = 'ollama-cloud/deepseek-v4-pro'
+    WHERE flavor = 'admin'        AND harness = 'opencode';
+
+COMMIT;

--- a/README.md
+++ b/README.md
@@ -335,11 +335,11 @@ default per harness (the `flavor_defaults` table — the picker pre-selects it;
 
 | Flavor | Job | Codex | Claude | OpenCode (open-weights) |
 |---|---|---|---|---|
-| **planner** | architecture, plans | `gpt-5.5` ★ | `opus` | `deepseek-v4-pro` |
-| **reviewer** | adversarial review | `gpt-5.5` | `opus` ★ | `kimi-k2.6` |
-| **dev** | write the code | `gpt-5.4-mini` ★ | `sonnet` | `qwen3-coder:480b` |
+| **planner** | architecture, plans | `gpt-5.5` | `sonnet` ★ | `deepseek-v4-pro` |
+| **reviewer** | adversarial review | `gpt-5.5` | `opus` ★ | `glm-5.1` |
+| **dev** | write the code | `gpt-5.4-mini` ★ | `sonnet` | `qwen3-coder-next` |
 | **cartographer** | map the repo | `gpt-5.4-mini` ★ | `haiku` | `gpt-oss:20b` |
-| **admin** | own the substrate, maintain `main` | `gpt-5.5` ★ | `sonnet` | `qwen3-coder:480b` |
+| **admin** | own the substrate, maintain `main` | `gpt-5.5` ★ | `sonnet` | `deepseek-v4-pro` |
 
 ★ = the harness the picker pre-selects for that flavor.
 
@@ -350,13 +350,18 @@ The logic, three rules:
   premium model. Dev and cartographer are *high-volume mechanical work* (bulk
   code, file mapping), where a fast, cheap, coding-tuned model wins on
   cost-per-token because the volume is highest.
-- **The reviewer runs a different lineage than the code it reviews.** It defaults
-  to **Claude (Opus)** so it isn't blind to the same mistakes a GPT model made
-  authoring the code — adversarial *diversity*, not a second opinion from the same
-  brain.
+- **Bookends default to Claude.** Planner (`sonnet`) and reviewer (`opus`) are the
+  two roles whose picker default is Claude, not Codex — these are the reasoning
+  bookends, and Claude is preferred for planning and adversarial review. The
+  reviewer in particular runs a *different lineage than the code it reviews*, so it
+  isn't blind to the same mistakes a GPT model made authoring it — adversarial
+  *diversity*, not a second opinion from the same brain.
 - **Three lineages, always.** Every flavor offers Codex (OpenAI), Claude
-  (Anthropic), and OpenCode (open-weights via Ollama) — pick any provider for any
-  role at launch.
+  (Anthropic), and OpenCode (open-weights via Ollama Cloud) — pick any provider for
+  any role at launch. The OpenCode column is constrained to **MIT- or
+  Apache-licensed** weights only (e.g. DeepSeek V4, GLM-5.1, Qwen3-Coder, gpt-oss);
+  Modified-MIT / unresolved-license models (Kimi, MiniMax) are excluded even when
+  available on the provider.
 - **Admin decisions carry real risk** (a wrong rollback is data loss), so the
   one shell that maintains `main` (see *How shells share one repo*, next)
   defaults premium on Codex.


### PR DESCRIPTION
## What

Fixes the launch picker's per-flavor defaults — what the CLI advertises as each shell's default harness + model. Migration `0014`, pure idempotent `UPDATE`s on `flavor_defaults`.

### 1. Bookends default to Claude
`planner` and `reviewer` are the reasoning bookends; Claude is preferred for planning and adversarial review.

- **planner** now pre-selects **`claude · sonnet`** (was `codex · gpt-5.5`; its Claude model also moves `opus → sonnet`)
- **reviewer** stays **`claude · opus`** ★
- `dev` / `cartographer` / `admin` keep **codex** as their picker default

### 2. OpenCode ids were stale → corrected + license-gated
The OpenCode column was seeded as `ollama/<model>:cloud`, but the live provider is `ollama-cloud/<model>` with **no suffix** — *none of the old ids resolved*, so the picker advertised a default it couldn't launch. Corrected to the real prefix and retuned to **MIT/Apache weights only** (hard constraint):

| Flavor | OpenCode model | License |
|---|---|---|
| planner | `ollama-cloud/deepseek-v4-pro` | MIT |
| reviewer | `ollama-cloud/glm-5.1` | MIT |
| dev | `ollama-cloud/qwen3-coder-next` | Apache 2.0 |
| cartographer | `ollama-cloud/gpt-oss:20b` | Apache 2.0 |
| admin | `ollama-cloud/deepseek-v4-pro` | MIT |

Kimi (Modified-MIT branding clause) and MiniMax (license unresolved) are **excluded by the gate** even though both are available on the provider.

## Why
The picker was "lying" — advertising codex/stale-OpenCode defaults that either weren't the intended pre-selection (bookends should be Claude) or couldn't resolve at all (OpenCode prefix/suffix wrong).

## Verification
- Migration applied to super-coder's live DB via `migrate.py`; both `flavor_defaults` tables verified row-for-row.
- Runtime smoke test of `run._default_label()` confirms the picker renders `planner → claude · sonnet`, `reviewer → claude · opus`, others unchanged.
- Forks pick this up on `./sc update` (idempotent UPDATEs converge fresh-rebuild and existing forks alike).

README harness/model doctrine table + bullets updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)