### PR TITLE
feat(install): macOS-aware docker + deps guidance (colima/brew)

### DIFF
--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -37,6 +38,7 @@ from pathlib import Path
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
 PY = sys.executable
+IS_MAC = platform.system() == "Darwin"  # guidance arms differ (colima/brew vs systemd/apt)
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import ports as ports_mod  # noqa: E402
@@ -202,13 +204,20 @@ def report_docker() -> dict:
         print("            (no claude-as-root wart). Either mode works; duser() adapts.")
     elif state == "no-daemon":
         print("  docker    ⚠ CLI present but no daemon reachable. Start one:")
-        print(f"            rootful : sudo usermod -aG docker {user} && sudo systemctl enable --now docker.socket  (re-login)")
-        print("            rootless: dockerd-rootless-setuptool.sh install && systemctl --user enable --now docker")
+        if IS_MAC:
+            print("            colima  : colima start   (or launch Docker Desktop)")
+        else:
+            print(f"            rootful : sudo usermod -aG docker {user} && sudo systemctl enable --now docker.socket  (re-login)")
+            print("            rootless: dockerd-rootless-setuptool.sh install && systemctl --user enable --now docker")
         if st.get("detail"):
             print(f"            ({st['detail']})")
     else:  # absent
         print("  docker    ⚠ not found — the default run mode is a sandbox container.")
-        print("            Install it (e.g. Arch: sudo pacman -S docker), then `./sc doctor`.")
+        if IS_MAC:
+            print("            Install it (e.g. colima: brew install colima docker && colima start),")
+            print("            then `./sc doctor`.")
+        else:
+            print("            Install it (e.g. Arch: sudo pacman -S docker), then `./sc doctor`.")
         print("            Or run without docker via the escape hatch: ./sc serve + ./sc boot")
     return st
 
@@ -425,11 +434,13 @@ def main(argv: list[str]) -> int:
         import sqlite3  # noqa: F401
         print("  python3 + sqlite3 ✓")
     except ImportError:
-        sys.exit("  python3 is missing the sqlite3 module — install it and retry.")
+        hint = "brew install python" if IS_MAC else "your package manager"
+        sys.exit(f"  python3 is missing the sqlite3 module — install it ({hint}) and retry.")
+    brew = " (brew install git curl)" if IS_MAC else ""
     if not shutil.which("git"):
-        print("  ⚠ git not on PATH — needed for the commit→PR flow later.")
+        print(f"  ⚠ git not on PATH — needed for the commit→PR flow later.{brew}")
     if not shutil.which("curl"):
-        print("  ⚠ curl not on PATH — needed to auto-install a missing harness.")
+        print(f"  ⚠ curl not on PATH — needed to auto-install a missing harness.{brew}")
     # Docker is the default run path (the sandbox); guide if it's missing or
     # under-configured. Never fatal — `./sc serve`+`boot` run without it.
     report_docker()


### PR DESCRIPTION
## What

`install.py` printed Linux-only setup commands (`systemctl`/`usermod`/`pacman`) regardless of host OS. On a Mac these are all dead ends. This makes the three guidance spots OS-aware.

## Changes
- Add `IS_MAC = platform.system() == "Darwin"` constant.
- `report_docker()` **no-daemon** arm → `colima start` (or Docker Desktop) on mac.
- `report_docker()` **absent** arm → `brew install colima docker && colima start` on mac.
- Requirements check → `brew install ...` hints for missing python/git/curl on mac.

## Why this is the whole footprint
Everything else already works on macOS unchanged:
- `HARNESS_BIN["claude"] = ~/.local/bin/claude` — verified current on macOS.
- The four `curl | bash` harness installers self-detect OS.
- `docker_status()` logic is runtime-agnostic — colima reports as `rootful`, hitting the existing (correct) arm with no change.

**Guidance-only — no executed logic changed.** The no-docker escape hatch (`./sc serve` + `./sc boot`, python3+sqlite3 only) is first-class on mac since both ship with the Xcode CLT.

## Verification
- Forced `IS_MAC` True/False against each docker state; mac arms render colima/brew, **Linux output is byte-identical to before**.
- `py_compile` clean.
- Pending: real run on a Mac (Jed has one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)