### PR TITLE
fix(docker): tolerate pre-existing host GID in sandbox image build (#102)

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -74,7 +74,12 @@ RUN pip install --no-cache-dir "playwright==1.60.0" \
  && chmod -R a+rX /opt/ms-playwright
 
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
-RUN groupadd -g ${SC_GID} ${SC_USER} \
+# A host GID may already exist in the base image — notably macOS's primary GID 20
+# (`staff`) collides with Debian's pre-existing `dialout` group — so creating it
+# unconditionally fails the build there. Reuse an existing GID; only create when
+# absent. The group's *name* is irrelevant; only the numeric GID must match the
+# host for bind-mounted ownership to line up.
+RUN if ! getent group ${SC_GID} >/dev/null; then groupadd -g ${SC_GID} ${SC_USER}; fi \
  && useradd -m -u ${SC_UID} -g ${SC_GID} -s /bin/bash ${SC_USER}
 
 USER ${SC_USER}


### PR DESCRIPTION
## Problem

`./sc launch` fails the Docker build on macOS (reported in #102):

```
Step 10/17 : RUN groupadd -g ${SC_GID} ${SC_USER} ...
groupadd: GID '20' already exists
```

`sc` builds with `--build-arg SC_GID=$(id -g)`. On macOS a user's primary group is `staff` (**GID 20**), which already exists in the `python:3.12-slim` base as Debian's `dialout` group — so `groupadd -g 20` aborts the build. Linux hosts (GID 1000) never hit this.

## Fix

Guard `groupadd` with a `getent group` check: reuse the existing GID, create only when absent. The group **name** doesn't matter — only the numeric GID must match the host so bind-mounted files aren't root-owned. `useradd -g <numeric gid>` binds the user to the reused group.

## Verification

Ran the exact build step against `python:3.12-slim` for both cases:

- **macOS-like** (uid 501, gid 20): user created with `gid=20(dialout)` ✓ (build previously failed here)
- **Linux** (uid 1000, gid 1000): unchanged — fresh group created ✓

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)