### PR TITLE
docs(readme): lead Quick start with a Preparation section (Arch + macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 title: super-coder
 tags: [substrate, shells, agentic-coding, harness-agnostic, sqlite]
-date: 2026-06-13
+date: 2026-06-14
 project: super-coder
 purpose: Forkable shell substrate for a repo
 ---
@@ -79,9 +79,27 @@ that must survive is its DB, serialized to the tracked `.sc-state/content.sql`.
 > [!class2]
 > **UI** Shells (your landing tab) · **Shells** your starting team — planner · 2×dev · reviewer · admin · cartographer
 
-Drop super-coder into an existing git repo and boot a shell. Requires `docker`
-(rootless is fine) and an account for one coding harness — Claude Code, OpenCode,
-Codex, or Mistral Vibe.
+### Preparation
+
+One-time host setup — get this right and the rest is `./sc install`. super-coder
+runs the harness in a **docker sandbox**; the installer bootstraps everything
+else. The host needs a container engine, a few base tools, and one signed-in
+coding harness.
+
+| Need | Arch Linux | macOS |
+|---|---|---|
+| **Container engine** | `sudo pacman -S docker`, then start a daemon — rootless default: `dockerd-rootless-setuptool.sh install && systemctl --user enable --now docker` | `brew install colima docker && colima start` (or Docker Desktop) |
+| **Base tools** | `sudo pacman -S git curl python sqlite` (usually already present) | `xcode-select --install` (git/curl); python3 + sqlite3 ship with macOS |
+| **Harness CLI** | installed for you by `./sc install` (`claude` · `opencode` · `codex` · `vibe`, native installers). Repair by hand: `curl -fsSL https://claude.ai/install.sh \| bash` | same — **and put `~/.local/bin` on your PATH** (a fresh macOS shell omits it) |
+| **Harness account** | a plan for one of Claude Code · OpenCode · Codex · Vibe; sign in once on the host (step 3) | same |
+
+> [!class4]
+> **The bar: a reachable docker daemon + a harness CLI on PATH.** `./sc doctor` reports the docker mode it finds (rootless / rootful) and the exact next command; `python3` + `sqlite3` are the only *hard* requirements (the engine runtime). **macOS PATH gotcha:** if `claude` reports *"missing or broken — run claude install to repair"*, the CLI installed fine but `~/.local/bin` isn't on your PATH. Add `export PATH="$HOME/.local/bin:$PATH"` to your shell profile (`~/.zshrc`), open a new shell, then `claude install`. No docker at all? The `./sc serve` + `./sc boot` escape hatch runs the shell on the host.
+
+### Install & launch
+
+With the prerequisites in place, drop super-coder into an existing git repo and
+boot a shell:
 
 ```bash
 cd your-repo                                                  # an existing git repo


### PR DESCRIPTION
## What

Adds a **Preparation** subsection as the *first* part of Quick start — the host prerequisites for a clean first run, before the install/launch steps. Split per-OS so an Arch or Mac user sees their exact commands.

| Need | Arch Linux | macOS |
|---|---|---|
| Container engine | `pacman -S docker` + rootless daemon | `brew install colima docker && colima start` |
| Base tools | `pacman -S git curl python sqlite` | `xcode-select --install`; python3/sqlite3 ship with macOS |
| Harness CLI | auto-installed by `./sc install`; manual repair via native installer | same — **plus `~/.local/bin` on PATH** |
| Harness account | a plan for one harness | same |

## Why

Surfaced from a real macOS first-run (#102 + follow-up): the harness CLIs install fine but a fresh mac shell omits `~/.local/bin` from PATH, so `claude` self-reports *"missing or broken — run claude install to repair"*. The new section documents that gotcha and the fix, and gives both OSes their container-engine path up front (colima vs rootless docker) instead of the old one-line `Requires docker`.

The per-OS guidance mirrors what `./sc install` / `./sc doctor` already print at runtime — now it's in the README before you hit it.

## Structure

Old single happy-path lead → **Preparation** + **Install & launch** subsections; dropped the now-redundant inline requirements line. Themed-markdown contract preserved (callouts, table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)