### PR TITLE
chore(make): unify make prefix to dos- across the family

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -7,78 +7,81 @@
 # one-line Makefile when the fork has none); it never overwrites a Makefile you
 # already have. Delete the include and you lose nothing — `./sc <cmd>` is identical.
 #
-# Every target is `sc-`prefixed so including this file can't collide with your
-# own `test` / `build` / `install` targets. The house standard: the hot commands
-# get a one-letter short form too; everything else is long-form only.
+# House command standard (designs-OS family): one prefix — `dos-` — across every
+# substrate, so switching repos never changes the muscle memory. Every target is
+# `dos-`prefixed so including this file can't collide with your own `test` /
+# `build` / `install` targets. The hot commands get a one-letter short form too;
+# everything else is long-form only. The `./sc` binary keeps its name (the engine
+# layer is separate from the make surface).
 #
 #   HOT (short + long):
-#   make sc-e   / sc-enter     attach a session (pick shell + harness); sc-e s=ap01 boots one
-#   make sc-l   / sc-launch    build + start the docker sandbox (+ review GUI)
-#   make sc-r   / sc-restart   down + launch — recreate the sandbox fresh
-#   make sc-d   / sc-down      stop the sandbox
-#   make sc-u   / sc-update    fetch + materialize the engine, reconcile in place
-#   make sc-t   / sc-test      backend (pytest/unittest) + UI (vitest) suites
-#   make sc-h                  list the commands
-#   make sc-help               list + describe the commands
+#   make dos-e   / dos-enter     attach a session (pick shell + harness); dos-e s=ap01 boots one
+#   make dos-l   / dos-launch    build + start the docker sandbox (+ review GUI)
+#   make dos-r   / dos-restart   down + launch — recreate the sandbox fresh
+#   make dos-d   / dos-down      stop the sandbox
+#   make dos-u   / dos-update    fetch + materialize the engine, reconcile in place
+#   make dos-t   / dos-test      backend (pytest/unittest) + UI (vitest) suites
+#   make dos-h                   list the commands
+#   make dos-help                list + describe the commands
 #
-#   LONG-ONLY: sc-build sc-logs sc-serve sc-health sc-ports sc-verify sc-map
-#              sc-render sc-snapshot sc-deps sc-install sc-rollback
-#              sc-update-harnesses · passthrough: make sc ARGS=health
+#   LONG-ONLY: dos-build dos-logs dos-serve dos-health dos-ports dos-verify dos-map
+#              dos-render dos-snapshot dos-deps dos-install dos-rollback
+#              dos-update-harnesses · passthrough: make dos ARGS=health
 #
 SC := ./sc
-.PHONY: sc-e sc-enter sc-l sc-launch sc-r sc-restart sc-d sc-down sc-u sc-update \
-        sc-t sc-test sc-h sc-help sc-build sc-logs sc-serve sc-health sc-ports \
-        sc-verify sc-map sc-render sc-snapshot sc-deps sc-install sc-rollback \
-        sc-update-harnesses sc
+.PHONY: dos-e dos-enter dos-l dos-launch dos-r dos-restart dos-d dos-down dos-u dos-update \
+        dos-t dos-test dos-h dos-help dos-build dos-logs dos-serve dos-health dos-ports \
+        dos-verify dos-map dos-render dos-snapshot dos-deps dos-install dos-rollback \
+        dos-update-harnesses dos
 
 # Hot commands — long form, with a one-letter alias delegating to it.
-sc-enter:            ; $(SC) $(if $(s),enter-$(s),enter)
-sc-e: sc-enter
-sc-launch:           ; $(SC) launch
-sc-l: sc-launch
-sc-restart:          ; $(SC) restart
-sc-r: sc-restart
-sc-down:             ; $(SC) down
-sc-d: sc-down
-sc-update:           ; $(SC) update
-sc-u: sc-update
-sc-test:             ; $(SC) test
-sc-t: sc-test
+dos-enter:            ; $(SC) $(if $(s),enter-$(s),enter)
+dos-e: dos-enter
+dos-launch:           ; $(SC) launch
+dos-l: dos-launch
+dos-restart:          ; $(SC) restart
+dos-r: dos-restart
+dos-down:             ; $(SC) down
+dos-d: dos-down
+dos-update:           ; $(SC) update
+dos-u: dos-update
+dos-test:             ; $(SC) test
+dos-t: dos-test
 
 # Long-only commands.
-sc-build:            ; $(SC) build
-sc-logs:             ; $(SC) logs
-sc-serve:            ; $(SC) serve
-sc-health:           ; $(SC) health
-sc-ports:            ; $(SC) ports
-sc-verify:           ; $(SC) verify
-sc-map:              ; $(SC) map
-sc-render:           ; $(SC) render $(ARGS)
-sc-snapshot:         ; $(SC) snapshot
-sc-deps:             ; $(SC) deps
-sc-install:          ; $(SC) install
-sc-rollback:         ; $(SC) rollback
-sc-update-harnesses: ; $(SC) update-harnesses
+dos-build:            ; $(SC) build
+dos-logs:             ; $(SC) logs
+dos-serve:            ; $(SC) serve
+dos-health:           ; $(SC) health
+dos-ports:            ; $(SC) ports
+dos-verify:           ; $(SC) verify
+dos-map:              ; $(SC) map
+dos-render:           ; $(SC) render $(ARGS)
+dos-snapshot:         ; $(SC) snapshot
+dos-deps:             ; $(SC) deps
+dos-install:          ; $(SC) install
+dos-rollback:         ; $(SC) rollback
+dos-update-harnesses: ; $(SC) update-harnesses
 
-# Passthrough: run any ./sc subcommand — make sc ARGS=health
-sc:                  ; $(SC) $(ARGS)
+# Passthrough: run any ./sc subcommand — make dos ARGS=health
+dos:                  ; $(SC) $(ARGS)
 
-# Help — sc-h lists, sc-help lists + describes.
-sc-h:
-	@echo "sc-e(nter) sc-l(aunch) sc-r(estart) sc-d(own) sc-u(pdate) sc-t(est) sc-h/sc-help"
-	@echo "long-only: sc-build sc-logs sc-serve sc-health sc-ports sc-verify sc-map sc-render sc-snapshot sc-deps sc-install sc-rollback sc-update-harnesses | passthrough: make sc ARGS=<cmd>"
-sc-help:
-	@echo "super-coder make aliases — every target delegates to ./sc"
+# Help — dos-h lists, dos-help lists + describes.
+dos-h:
+	@echo "dos-e(nter) dos-l(aunch) dos-r(estart) dos-d(own) dos-u(pdate) dos-t(est) dos-h/dos-help"
+	@echo "long-only: dos-build dos-logs dos-serve dos-health dos-ports dos-verify dos-map dos-render dos-snapshot dos-deps dos-install dos-rollback dos-update-harnesses | passthrough: make dos ARGS=<cmd>"
+dos-help:
+	@echo "super-coder make aliases — every target delegates to ./sc (designs-OS 'dos-' standard)"
 	@echo ""
 	@echo "  hot (short + long):"
-	@echo "    sc-e  / sc-enter     attach a session (pick shell + harness); sc-e s=ap01 boots one"
-	@echo "    sc-l  / sc-launch    build + start the docker sandbox (+ review GUI)"
-	@echo "    sc-r  / sc-restart   down + launch — recreate the sandbox fresh"
-	@echo "    sc-d  / sc-down      stop the sandbox"
-	@echo "    sc-u  / sc-update    fetch + materialize the engine, reconcile in place"
-	@echo "    sc-t  / sc-test      backend (pytest/unittest) + UI (vitest) suites"
-	@echo "    sc-h                 list commands   ·   sc-help   this view"
+	@echo "    dos-e  / dos-enter     attach a session (pick shell + harness); dos-e s=ap01 boots one"
+	@echo "    dos-l  / dos-launch    build + start the docker sandbox (+ review GUI)"
+	@echo "    dos-r  / dos-restart   down + launch — recreate the sandbox fresh"
+	@echo "    dos-d  / dos-down      stop the sandbox"
+	@echo "    dos-u  / dos-update    fetch + materialize the engine, reconcile in place"
+	@echo "    dos-t  / dos-test      backend (pytest/unittest) + UI (vitest) suites"
+	@echo "    dos-h                  list commands   ·   dos-help   this view"
 	@echo ""
-	@echo "  long-only: sc-build sc-logs sc-serve sc-health sc-ports sc-verify"
-	@echo "             sc-map sc-render sc-snapshot sc-deps sc-install sc-rollback sc-update-harnesses"
-	@echo "  passthrough: make sc ARGS=<subcommand>   (e.g. make sc ARGS=doctor)"
+	@echo "  long-only: dos-build dos-logs dos-serve dos-health dos-ports dos-verify"
+	@echo "             dos-map dos-render dos-snapshot dos-deps dos-install dos-rollback dos-update-harnesses"
+	@echo "  passthrough: make dos ARGS=<subcommand>   (e.g. make dos ARGS=doctor)"

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -585,21 +585,21 @@ def main(argv: list[str]) -> int:
     subprocess.run([PY, str(ENGINE / "scripts/render.py"), "flat"])
 
     # 8.5 Wire `make` aliases — opt-in, never clobber a host Makefile (#13).
-    # No Makefile → drop a one-line include so `make sc-*` works out of the box.
+    # No Makefile → drop a one-line include so `make dos-*` works out of the box.
     # Already have one → leave it; just print the line to opt in. Every target is
-    # `sc-`prefixed, so the include can't collide with the fork's own targets.
+    # `dos-`prefixed, so the include can't collide with the fork's own targets.
     step("Wiring make aliases")
     mk = REPO_ROOT / "Makefile"
     if mk.exists():
-        print("  Makefile present — left untouched. For `make sc-e`/`sc-enter`, add:")
+        print("  Makefile present — left untouched. For `make dos-e`/`dos-enter`, add:")
         print("    include .super-coder/aliases.mk")
     else:
         mk.write_text(
-            "# Fork Makefile — super-coder convenience aliases (make sc-e / sc-enter).\n"
-            "# Every target is sc-prefixed; add your own targets below the include.\n"
+            "# Fork Makefile — super-coder convenience aliases (make dos-e / dos-enter).\n"
+            "# Every target is dos-prefixed; add your own targets below the include.\n"
             "include .super-coder/aliases.mk\n"
         )
-        print("  wrote Makefile (include .super-coder/aliases.mk) → `make sc-e` works")
+        print("  wrote Makefile (include .super-coder/aliases.mk) → `make dos-e` works")
 
     # Record harness + installed marker in instance.json ---------------------
     cfg = ports_mod.resolve(persist=False)

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@
 # shared with forks (install wires a fork to include the same file). Edit the
 # aliases there, not here.
 #
-#   make sc-l / sc-launch  build + start the docker sandbox
-#   make sc-e / sc-enter   attach an interactive session (pick shell + harness)
-#   make sc-e s=cc         attach + boot the 'cc' shell directly
-#   make sc-r / sc-restart down + launch — recreate the sandbox fresh
-#   make sc-d / sc-down    stop the sandbox
-#   make sc-h / sc-help    list / describe all commands
+#   make dos-l / dos-launch  build + start the docker sandbox
+#   make dos-e / dos-enter   attach an interactive session (pick shell + harness)
+#   make dos-e s=cc          attach + boot the 'cc' shell directly
+#   make dos-r / dos-restart down + launch — recreate the sandbox fresh
+#   make dos-d / dos-down    stop the sandbox
+#   make dos-h / dos-help    list / describe all commands
 include .super-coder/aliases.mk

--- a/README.md
+++ b/README.md
@@ -501,15 +501,17 @@ per-launch and never written back — so two terminals can run the **same** shel
 different harnesses at once (one Claude Code, one OpenCode). A fork with a single
 harness on `PATH` skips the prompt.
 
-**`make`.** Every command has a `make sc-<name>` alias; the hot ones also get a
-letter — `sc-e` (enter), `sc-l` (launch), `sc-r` (restart), `sc-d` (down),
-`sc-u` (update), `sc-t` (test) — and `sc-h` / `sc-help` list / describe them.
-`make sc-e s=cc` boots one shell directly; `make sc ARGS=<cmd>` is the
-passthrough. The targets live in `.super-coder/aliases.mk`, which **travels with
-the engine** — install wires a fork to `include` it, and because **every target
-is `sc-`prefixed it can't collide** with the fork's own `test` / `build` /
-`install`. The source repo's thin root `Makefile` just includes the same file;
-`./sc <cmd>` is always identical.
+**`make`.** One prefix across the whole designs-OS family — `dos-` — so switching
+repos never changes the muscle memory. Every command has a `make dos-<name>`
+alias; the hot ones also get a letter — `dos-e` (enter), `dos-l` (launch),
+`dos-r` (restart), `dos-d` (down), `dos-u` (update), `dos-t` (test) — and
+`dos-h` / `dos-help` list / describe them. `make dos-e s=cc` boots one shell
+directly; `make dos ARGS=<cmd>` is the passthrough. The targets live in
+`.super-coder/aliases.mk`, which **travels with the engine** — install wires a
+fork to `include` it, and because **every target is `dos-`prefixed it can't
+collide** with the fork's own `test` / `build` / `install`. The source repo's
+thin root `Makefile` just includes the same file; the `./sc <cmd>` binary keeps
+its name and is always identical.
 
 ## Dev kit
 


### PR DESCRIPTION
## What

One make prefix — `dos-` — for every designs-OS substrate, replacing the per-repo `sc-`/`cc-` split. Switching repos was confusing because the same hot command had a different prefix in each repo; now it's `dos-e` / `dos-r` / `dos-h` everywhere.

The `./sc` engine **binary keeps its name** — only the `make` surface changes (the engine layer is separate from the make ergonomics).

## Changes

- **`.super-coder/aliases.mk`** (single source, ships to forks): every `sc-*` target → `dos-*`; passthrough is now `make dos ARGS=<cmd>` → `./sc <cmd>`. Collision-safety still holds (every target `dos-`prefixed).
- **`Makefile`** / **`README.md`**: header + docs refs.
- **`install.py`**: fork-scaffold Makefile + opt-in hints now say `make dos-e`.

## Verified

`make dos-h`, `make -n dos-e` → `./sc enter`, `make -n dos ARGS=health` → `./sc health`. All resolve.

## Notes

- Clean replace — `sc-*` make targets no longer exist (the `./sc` binary is unchanged).
- Forks pick this up on their next engine repin/update; **dos-arch** uses bare targets in its own Makefile (separate convention) and is a follow-up.
- Canonical `command_standard` skill updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)