### PR TITLE
feat(make): auto-wire dos-* aliases into a fork's existing Makefile

### DIFF
--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -44,6 +45,53 @@ IS_MAC = platform.system() == "Darwin"  # guidance arms differ (colima/brew vs s
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import ports as ports_mod  # noqa: E402
+
+
+# --- make-alias wiring (shared by install + update) -------------------------
+ALIASES_INCLUDE = "-include .super-coder/aliases.mk"
+# Matches an existing include of the alias file in any form: hard `include` or
+# soft `-include`, with arbitrary surrounding whitespace.
+_ALIASES_RE = re.compile(r"^\s*-?include\s+\.super-coder/aliases\.mk\s*$", re.M)
+
+
+def wire_make_aliases(repo_root: Path | None = None) -> str:
+    """Ensure the fork's Makefile pulls in the engine's `dos-*` aliases.
+
+    The house `dos-` prefix is collision-proof by design — every alias target is
+    `dos-`prefixed — so wiring is safe to script rather than leave to the
+    operator. A fork almost always already has its own Makefile; #13 ("never
+    clobber a host Makefile") forbids *overwriting* it, not *appending* a single
+    additive, non-colliding `-include` line. So:
+
+      - no Makefile      → write a one-line one;
+      - Makefile present → append the include if missing, else leave it alone.
+
+    `-include` (not hard `include`) so a not-yet-materialized engine (fresh fork
+    clone before the first `./sc update`) is a silent no-op, never a fatal `make`
+    error. Idempotent — safe to call on every install AND every update. Returns a
+    one-line status for the caller to print.
+    """
+    mk = (repo_root or REPO_ROOT) / "Makefile"
+    if not mk.exists():
+        mk.write_text(
+            "# Fork Makefile — super-coder convenience aliases (make dos-e / dos-enter).\n"
+            "# Every target is dos--prefixed; add your own targets below the include.\n"
+            f"{ALIASES_INCLUDE}\n"
+        )
+        return "wrote Makefile (-include .super-coder/aliases.mk) → `make dos-e` works"
+    text = mk.read_text()
+    if _ALIASES_RE.search(text):
+        return "Makefile already wired (-include .super-coder/aliases.mk) — left as-is"
+    sep = "" if text.endswith("\n") else "\n"
+    mk.write_text(
+        text + sep
+        + "\n# super-coder convenience aliases (designs-OS 'dos-' command standard).\n"
+        + "# Appended by ./sc; every target is dos--prefixed so it can't collide with\n"
+        + "# this Makefile's own targets. Delete this line to opt out — `./sc <cmd>`\n"
+        + "# stays equivalent.\n"
+        + f"{ALIASES_INCLUDE}\n"
+    )
+    return "appended -include .super-coder/aliases.mk to existing Makefile → `make dos-e` works"
 
 # super-coder's own per-instance content — present in a freshly-pulled fork
 # because the git checkout brought it along. A fork must not inherit it.
@@ -584,22 +632,11 @@ def main(argv: list[str]) -> int:
     subprocess.run([PY, str(ENGINE / "scripts/snapshot.py")])
     subprocess.run([PY, str(ENGINE / "scripts/render.py"), "flat"])
 
-    # 8.5 Wire `make` aliases — opt-in, never clobber a host Makefile (#13).
-    # No Makefile → drop a one-line include so `make dos-*` works out of the box.
-    # Already have one → leave it; just print the line to opt in. Every target is
-    # `dos-`prefixed, so the include can't collide with the fork's own targets.
+    # 8.5 Wire `make` aliases. The `dos-` prefix can't collide with the fork's own
+    # targets, so we append the include rather than leave it to the operator (#13
+    # forbids clobbering a host Makefile, not appending one non-colliding line).
     step("Wiring make aliases")
-    mk = REPO_ROOT / "Makefile"
-    if mk.exists():
-        print("  Makefile present — left untouched. For `make dos-e`/`dos-enter`, add:")
-        print("    include .super-coder/aliases.mk")
-    else:
-        mk.write_text(
-            "# Fork Makefile — super-coder convenience aliases (make dos-e / dos-enter).\n"
-            "# Every target is dos-prefixed; add your own targets below the include.\n"
-            "include .super-coder/aliases.mk\n"
-        )
-        print("  wrote Makefile (include .super-coder/aliases.mk) → `make dos-e` works")
+    print(f"  {wire_make_aliases()}")
 
     # Record harness + installed marker in instance.json ---------------------
     cfg = ports_mod.resolve(persist=False)

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -282,8 +282,16 @@ def main(argv: list[str]) -> int:
     print("→ snapshot the live state")
     run_script("snapshot.py")
 
+    # Self-heal the make wiring: forks installed before the engine scripted this
+    # (or whose include was removed) get the `dos-*` aliases appended now. Source
+    # repo manages its own Makefile — skip it. Idempotent; a no-op if already wired.
+    if not source:
+        print("→ wire make aliases (dos- command standard)")
+        print(f"  {install_mod.wire_make_aliases()}")
+
     print("\nupdate: done — new floor laid in place; your rows are intact.")
-    print("  Review + commit: .sc-state/ (content.sql + engine.ref) + _sc renders.")
+    print("  Review + commit: .sc-state/ (content.sql + engine.ref) + _sc renders")
+    print("  (+ Makefile if the wiring step just appended the alias include).")
     print("  (The engine is gitignored — nothing under .super-coder/ to commit.)")
     print("  A bad update? `./sc rollback` restores the DB + engine together.")
     print("  Restart your session to boot onto the new floor.")


### PR DESCRIPTION
`./sc install` only wrote the `-include .super-coder/aliases.mk` line when a fork had **no** Makefile; if one existed it merely *printed* the line for the operator to add by hand. Since forks almost always have their own Makefile, the `dos-*` command surface silently never got wired — which is exactly what bit the dos-arch proving ground (`make dos-help` → no such target, despite a current engine).

The `dos-` prefix is collision-proof by design (every alias target is `dos-`prefixed), so wiring is safe to script. #13's "never clobber a host Makefile" forbids *overwriting* one, not *appending* a single additive, non-colliding `-include` line.

**Change**
- Factor wiring into `install.wire_make_aliases()`: no Makefile → write a one-liner; Makefile present → append the include if missing, else leave it.
- Call it from **both** `install` and `update`, so forks installed before this (dos-arch) self-heal on the next `./sc update`.
- Switch hard `include` → `-include` so a not-yet-materialized engine is a no-op, not a fatal `make` error.
- Idempotent: regex-guarded, exactly one include guaranteed.

**Test plan**
- Unit smoke across no-Makefile / existing-without-include / existing-without-trailing-newline / already-hard-include / already-`-include` — each yields exactly one include and preserves the fork's own targets; second call is a no-op.
- `py_compile` both scripts; `update.py` resolves the shared helper.