### PR TITLE
docs(skill): vertical linear diagrams + cap 48

### DIFF
--- a/.super-coder/assets/skills/docs/SKILL.md
+++ b/.super-coder/assets/skills/docs/SKILL.md
@@ -198,8 +198,8 @@ quote only the inner *text*, not the shape brackets.
 Step 1 :::class1 -> Step 2 :::class2 -> Step 3 :::class3
 ```
 ````
-Steps separated by `->`, optional class via `:::classN`. Step text cap ≤24
-(fixed-size cards).
+Steps separated by `->`, optional class via `:::classN`. Steps render
+**vertically** — one per row, top→bottom (never horizontal). Step text cap ≤48.
 
 ## Never
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -825,8 +825,8 @@ quote only the inner *text*, not the shape brackets.
 Step 1 :::class1 -> Step 2 :::class2 -> Step 3 :::class3
 ```
 ````
-Steps separated by `->`, optional class via `:::classN`. Step text cap ≤24
-(fixed-size cards).
+Steps separated by `->`, optional class via `:::classN`. Steps render
+**vertically** — one per row, top→bottom (never horizontal). Step text cap ≤48.
 
 ## Never
 

--- a/skills_sc/docs.md
+++ b/skills_sc/docs.md
@@ -205,8 +205,8 @@ quote only the inner *text*, not the shape brackets.
 Step 1 :::class1 -> Step 2 :::class2 -> Step 3 :::class3
 ```
 ````
-Steps separated by `->`, optional class via `:::classN`. Step text cap ≤24
-(fixed-size cards).
+Steps separated by `->`, optional class via `:::classN`. Steps render
+**vertically** — one per row, top→bottom (never horizontal). Step text cap ≤48.
 
 ## Never
 


### PR DESCRIPTION
## What
Update the `docs` (themed-markdown) skill to reflect that linear-flow diagrams now render **vertically** (top→bottom), and raise the per-step text cap from 24 to 48.

Horizontal linear flows kept getting crammed and unreadable as steps grew; the md-converter engine now renders them vertical-only. This keeps the authoring guidance in sync.

## Changes
- `.super-coder/assets/skills/docs/SKILL.md`: linear section — steps render vertically, one per row; cap 24 → 48.
- `.super-coder/migrations/0001_seed_skills.sql`: regenerated from the asset (`./sc seed-skills`).

## Pairs with
- md-converter engine PR (theme CSS, the actual vertical render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)