### PR TITLE
docs(skill): add Open-in-md-converter badge to the docs skill

### DIFF
--- a/.super-coder/assets/skills/docs/SKILL.md
+++ b/.super-coder/assets/skills/docs/SKILL.md
@@ -209,3 +209,22 @@ Steps separated by `->`, optional class via `:::classN`. Steps render
 - Comma-separated `tags` (must be a YAML list)
 - `classDef` / `fill:` / style directives inside Mermaid
 - Unquoted Mermaid labels containing special characters
+
+## Open in md-converter
+
+A doc whose `body` lives in the DB already opens in the app from the GUI
+("open in md-converter ↗" on the Roadmap/Docs card) — nothing to author there.
+
+When you instead **commit a standalone themed-markdown file** to the repo (a
+README, or a rendered `docs_sc/` page meant to be read on GitHub), drop a
+one-click badge in its preamble — between `# Title` and the first `##`, so it
+shows on GitHub but is dropped from the render (preamble rule):
+
+```markdown
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/<owner>/<repo>/blob/<branch>/<path>)
+```
+
+Fill `<owner>/<repo>/<branch>/<path>` with the file's GitHub location (any
+subdirectory depth). Public repos only — the badge fetches the raw file in the
+reader's browser (no server/auth). Destination unknown → keep the placeholders
+and tell the user to fill them.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -835,7 +835,26 @@ Steps separated by `->`, optional class via `:::classN`. Steps render
 - Content between H1 and the first H2 (silently dropped — use an H2)
 - Comma-separated `tags` (must be a YAML list)
 - `classDef` / `fill:` / style directives inside Mermaid
-- Unquoted Mermaid labels containing special characters',
+- Unquoted Mermaid labels containing special characters
+
+## Open in md-converter
+
+A doc whose `body` lives in the DB already opens in the app from the GUI
+("open in md-converter ↗" on the Roadmap/Docs card) — nothing to author there.
+
+When you instead **commit a standalone themed-markdown file** to the repo (a
+README, or a rendered `docs_sc/` page meant to be read on GitHub), drop a
+one-click badge in its preamble — between `# Title` and the first `##`, so it
+shows on GitHub but is dropped from the render (preamble rule):
+
+```markdown
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/<owner>/<repo>/blob/<branch>/<path>)
+```
+
+Fill `<owner>/<repo>/<branch>/<path>` with the file''s GitHub location (any
+subdirectory depth). Public repos only — the badge fetches the raw file in the
+reader''s browser (no server/auth). Destination unknown → keep the placeholders
+and tell the user to fill them.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/skills_sc/docs.md
+++ b/skills_sc/docs.md
@@ -216,3 +216,22 @@ Steps separated by `->`, optional class via `:::classN`. Steps render
 - Comma-separated `tags` (must be a YAML list)
 - `classDef` / `fill:` / style directives inside Mermaid
 - Unquoted Mermaid labels containing special characters
+
+## Open in md-converter
+
+A doc whose `body` lives in the DB already opens in the app from the GUI
+("open in md-converter ↗" on the Roadmap/Docs card) — nothing to author there.
+
+When you instead **commit a standalone themed-markdown file** to the repo (a
+README, or a rendered `docs_sc/` page meant to be read on GitHub), drop a
+one-click badge in its preamble — between `# Title` and the first `##`, so it
+shows on GitHub but is dropped from the render (preamble rule):
+
+```markdown
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/<owner>/<repo>/blob/<branch>/<path>)
+```
+
+Fill `<owner>/<repo>/<branch>/<path>` with the file's GitHub location (any
+subdirectory depth). Public repos only — the badge fetches the raw file in the
+reader's browser (no server/auth). Destination unknown → keep the placeholders
+and tell the user to fill them.


### PR DESCRIPTION
Mirrors the badge guidance now shipped in md-converter's themed-markdown skill (§14).

The `docs` skill gains an **"Open in md-converter"** section: when you commit a standalone themed-markdown file (a README, or a rendered `docs_sc/` page meant to be read on GitHub), drop a one-click badge in its preamble so readers open it rendered. DB-bodied docs are unaffected — they still open via the GUI's "open in md-converter ↗" button, which is called out.

- `assets/skills/docs/SKILL.md` — new section (source of truth)
- `migrations/0001_seed_skills.sql` — regenerated via `seed_skills.py`
- `skills_sc/docs.md` — re-rendered mirror

`./sc render-check` passes (mirror matches the DB render).