### PR TITLE
chore(prompt): consistent MEMORY ARCHITECTURE block across all shells

### DIFF
--- a/.sc-state/content.sql
+++ b/.sc-state/content.sql
@@ -31,8 +31,13 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 | Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
 | Session narrative | `shell_memory_archives` — one row per session, appended progressively |
 
-Write as it happens, not at close. The `.db` is a cache: after content edits,
-`make snapshot` re-serializes to text, which is what git tracks.
+Write as it happens, not at close. **Writes go through `./sc mem`** (state · seed ·
+lns · decision · flag · roadmap · doc · narrative): it resolves + guards *this*
+engine DB — refusing the app DB or a stray empty file, whose overlapping table
+names would let a raw `sqlite3` INSERT hit the wrong DB silently — and snapshots
+the change for you. Raw `sqlite3` is for SELECT only. `./sc mem which` to orient;
+`./sc snapshot` (+ `./sc render` for docs/roadmap/skills) after any non-`mem`
+edit. See the `memory`, `db_map`, and `snapshot` skills.
 
 ## MANDATE
 
@@ -80,9 +85,13 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 | Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
 | Session narrative | `shell_memory_archives` — one row per session, appended progressively |
 
-Write as it happens, not at close. The `.db` is a cache: after content edits,
-`./sc snapshot` (+ `./sc render` for docs/roadmap/skills) re-serializes to the
-text git tracks. See the `db_map` and `snapshot` skills.
+Write as it happens, not at close. **Writes go through `./sc mem`** (state · seed ·
+lns · decision · flag · roadmap · doc · narrative): it resolves + guards *this*
+engine DB — refusing the app DB or a stray empty file, whose overlapping table
+names would let a raw `sqlite3` INSERT hit the wrong DB silently — and snapshots
+the change for you. Raw `sqlite3` is for SELECT only. `./sc mem which` to orient;
+`./sc snapshot` (+ `./sc render` for docs/roadmap/skills) after any non-`mem`
+edit. See the `memory`, `db_map`, and `snapshot` skills.
 
 ## MANDATE
 

--- a/.super-coder/scripts/seed_dogfood.py
+++ b/.super-coder/scripts/seed_dogfood.py
@@ -58,9 +58,12 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 | Session narrative | `shell_memory_archives` — one row per session, appended progressively |
 
 Write as it happens, not at close. **Writes go through `./sc mem`** (state · seed ·
-lns · decision · flag · roadmap · doc · narrative): it resolves + guards this
-engine DB and snapshots the change for you. Raw `sqlite3` is for SELECT only; run
-`./sc snapshot` after any non-`mem` edit. See the `memory` skill.
+lns · decision · flag · roadmap · doc · narrative): it resolves + guards *this*
+engine DB — refusing the app DB or a stray empty file, whose overlapping table
+names would let a raw `sqlite3` INSERT hit the wrong DB silently — and snapshots
+the change for you. Raw `sqlite3` is for SELECT only. `./sc mem which` to orient;
+`./sc snapshot` (+ `./sc render` for docs/roadmap/skills) after any non-`mem`
+edit. See the `memory`, `db_map`, and `snapshot` skills.
 
 ## MANDATE
 


### PR DESCRIPTION
## Why

#114 routed engine-memory writes through `./sc mem` in the template + skills, but the per-shell `system_prompt` **MEMORY ARCHITECTURE** block had drifted into four different versions — and the two live shells didn't mention `./sc mem` at all:

| Source | Said |
|---|---|
| template `shell_system_prompt.md` | full `./sc mem` block (post-#114) |
| `seed_dogfood.py` MAINTAINER_PROMPT | a *shorter* `./sc mem` variant |
| `cc` live prompt | `make snapshot` (pre-`./sc` era!) |
| `CART1` live prompt | `./sc snapshot`, no `./sc mem` |

## What

Unify on one canonical block (the template's):
- **Source:** `seed_dogfood.py` MAINTAINER_PROMPT block → identical to the template, so a fresh re-seed stays consistent.
- **Live:** `cc` + `CART1` `system_prompt` MEMORY ARCHITECTURE block replaced **in place** with the canonical block (regex-scoped to the block; each shell's title/focus/mandate preserved) → `content.sql`.

The block is now **byte-identical (sha1 `4a0688f`)** across template, `seed_dogfood`, and both live shells.

## Consistency note

This matches the **dos-arch fork**, whose 6 shells (PLN1/DEV1/REV1/CART1/DEV2/ADM1) were updated to the same canonical block in place after `./sc update`. So every shell everywhere — substrate-of-record + fork — now carries the same `./sc mem` write-path guidance.

render-check clean; `seed_dogfood` compiles; only `content.sql` + `seed_dogfood.py` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)