### PR TITLE
fix(sc): resolve the engine from a worktree, not just the repo root

### DIFF
--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -109,8 +109,12 @@ def connect(path: Path) -> sqlite3.Connection:
 # ── shell resolution ──────────────────────────────────────────────────────────
 
 def git_branch() -> str | None:
-    r = subprocess.run(["git", "-C", str(REPO_ROOT), "rev-parse",
-                        "--abbrev-ref", "HEAD"], capture_output=True, text=True)
+    # Read the branch of the CALLER's cwd, not the engine root: a shell runs from
+    # its `.sc-worktrees/<name>/` worktree (on `shell/<name>`), while the engine
+    # root sits on the default branch. Inferring the shell needs the worktree's
+    # branch, so don't pin `-C` to REPO_ROOT.
+    r = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                       capture_output=True, text=True)
     return r.stdout.strip() if r.returncode == 0 else None
 
 

--- a/sc
+++ b/sc
@@ -8,7 +8,18 @@ set -e
 here="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 cd "$here"
 
-ENGINE=.super-coder
+# The engine (`.super-coder/`) and its gitignored live DB sit at the MAIN worktree
+# root. A linked worktree (a shell's `.sc-worktrees/<name>/`) has a tracked copy of
+# THIS script — and, in the canonical repo where `.super-coder/` is tracked, even a
+# DB-less engine copy — but never the live DB. So always resolve the engine at the
+# main root via git's common dir (its parent is the main worktree), so `./sc` works
+# from any worktree. We do NOT cd there: cwd stays the caller's worktree so git ops
+# + shell inference see it. Fall back to $here outside a git checkout.
+ROOT="$here"
+_root="$(cd "$here" 2>/dev/null && cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd || true)"
+[ -n "$_root" ] && [ -d "$_root/.super-coder" ] && ROOT="$_root"
+
+ENGINE="$ROOT/.super-coder"
 PY="${SC_PYTHON:-python3}"
 DB="$ENGINE/shell_db.db"
 S="$ENGINE/scripts"


### PR DESCRIPTION
## The live failure

A shell booted in the dos-arch fork ran `./sc mem message check` from its worktree and got:
```
sc: unknown command 'mem'
```

## Root cause (two stacked issues)

1. A shell runs from its `.sc-worktrees/<name>/` worktree (run.py `os.chdir`s there), and the boot doc tells it to use `./sc mem`. But `./sc` resolved `ENGINE=.super-coder` **relative to the script's own dir** — and the engine (plus its gitignored live DB) lives only at the **main worktree root**. From a worktree, `./sc <anything>` either fails outright (a fork worktree has no `.super-coder/`) or hits a **DB-less** engine copy (in canonical, `.super-coder/` is tracked but the DB isn't).
2. The worktree also had a *stale* tracked `sc` (no `mem` verb) because the fork's `./sc update` artifacts weren't committed — but even a fresh copy couldn't have found the DB. This PR fixes the resolution; committing the fork update is separate.

## Fix

- **`sc`** resolves the engine at the main worktree root via `git rev-parse --git-common-dir` (whose parent *is* the main worktree), falling back to `$here` outside a git checkout. cwd is left at the caller's worktree so git ops + shell inference still see it. The python scripts already resolve paths via `__file__`, so they were root-correct the moment `$S`/`$ENGINE` point there.
- **`mem.py`** `git_branch()` now reads the **caller's cwd** branch instead of `REPO_ROOT`, so `./sc mem` infers the shell from its `shell/<name>` worktree branch rather than the engine root's default branch.

## Verified

From a real linked worktree on `shell/cc`:
```
engine DB : /home/j3d1/super-coder/.super-coder/shell_db.db   ← main root, not the worktree
guard     : OK
active sh : CC (cc) #1  [branch shell/cc]                      ← inferred from the worktree branch
```
Root invocation unchanged; `sh -n sc` clean; 16/16 mem tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)