### PR TITLE
feat(prompt): flat files are renders, not sources

### DIFF
--- a/.sc-state/content.sql
+++ b/.sc-state/content.sql
@@ -39,6 +39,15 @@ the change for you. Raw `sqlite3` is for SELECT only. `./sc mem which` to orient
 `./sc snapshot` (+ `./sc render` for docs/roadmap/skills) after any non-`mem`
 edit. See the `memory`, `db_map`, and `snapshot` skills.
 
+**Flat files are renders, not sources.** Every local `.md` and git-tracked file
+— docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
+`./sc render`. They are derived artifacts: a photograph of a DB row, not the row.
+Do not audit them for drift, staleness, or a stale date, and never edit or delete
+a file to change its content. If one looks wrong or out of date, fix the DB (`./sc
+mem` or the owning table) and re-render — the divergence is a render that hasn''t
+run, not a file to hand-correct. The DB is the authoritative content; the tree is
+its projection.
+
 ## MANDATE
 
 Build and maintain the substrate every fork runs on. You keep the system; each
@@ -93,6 +102,15 @@ the change for you. Raw `sqlite3` is for SELECT only. `./sc mem which` to orient
 `./sc snapshot` (+ `./sc render` for docs/roadmap/skills) after any non-`mem`
 edit. See the `memory`, `db_map`, and `snapshot` skills.
 
+**Flat files are renders, not sources.** Every local `.md` and git-tracked file
+— docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
+`./sc render`. They are derived artifacts: a photograph of a DB row, not the row.
+Do not audit them for drift, staleness, or a stale date, and never edit or delete
+a file to change its content. If one looks wrong or out of date, fix the DB (`./sc
+mem` or the owning table) and re-render — the divergence is a render that hasn''t
+run, not a file to hand-correct. The DB is the authoritative content; the tree is
+its projection.
+
 ## MANDATE
 
 Own the repo map for super-coder. Configure mapping to the real repo, wire the auto-remap git hooks, and heal both when the repo or the automation drifts. No other shell maps.
@@ -141,6 +159,15 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 Write as it happens, not at close. The `.db` is a cache: after content edits,
 `./sc snapshot` (+ `./sc render` for docs/roadmap/skills) re-serializes to the
 text git tracks. See the `db_map` and `snapshot` skills.
+
+**Flat files are renders, not sources.** Every local `.md` and git-tracked file
+— docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
+`./sc render`. They are derived artifacts: a photograph of a DB row, not the row.
+Do not audit them for drift, staleness, or a stale date, and never edit or delete
+a file to change its content. If one looks wrong or out of date, fix the DB (`./sc
+mem` or the owning table) and re-render — the divergence is a render that hasn''t
+run, not a file to hand-correct. The DB is the authoritative content; the tree is
+its projection.
 
 ## MANDATE
 

--- a/.super-coder/migrations/0016_flat_files_are_renders.sql
+++ b/.super-coder/migrations/0016_flat_files_are_renders.sql
@@ -1,0 +1,33 @@
+-- 0016 — flat files are renders, not sources.
+--
+-- Shells were spending effort auditing local .md / git-tracked files for drift,
+-- staleness, and stale dates — treating them as authoritative. They are not:
+-- every flat file is rendered from the DB by `./sc render`. The system prompt
+-- now says so. templates/shell_system_prompt.md (forked shells) and
+-- scripts/seed_dogfood.py (the maintainer prompt) carry the new paragraph for
+-- shells created from here on; this migration rewrites the prompt of shells
+-- already created under the old wording.
+--
+-- Injected before the `## MANDATE` section, which terminates the MEMORY
+-- ARCHITECTURE block in every shell shape (maintainer + all flavors).
+--
+-- Idempotent: the NOT LIKE guard makes a re-run (or a fork already carrying the
+-- paragraph) a no-op.
+UPDATE shells SET system_prompt = REPLACE(
+    system_prompt,
+    '
+
+## MANDATE',
+    '
+
+**Flat files are renders, not sources.** Every local `.md` and git-tracked file
+— docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
+`./sc render`. They are derived artifacts: a photograph of a DB row, not the row.
+Do not audit them for drift, staleness, or a stale date, and never edit or delete
+a file to change its content. If one looks wrong or out of date, fix the DB (`./sc
+mem` or the owning table) and re-render — the divergence is a render that hasn''t
+run, not a file to hand-correct. The DB is the authoritative content; the tree is
+its projection.
+
+## MANDATE'
+) WHERE system_prompt NOT LIKE '%Flat files are renders%';

--- a/.super-coder/scripts/seed_dogfood.py
+++ b/.super-coder/scripts/seed_dogfood.py
@@ -65,6 +65,15 @@ the change for you. Raw `sqlite3` is for SELECT only. `./sc mem which` to orient
 `./sc snapshot` (+ `./sc render` for docs/roadmap/skills) after any non-`mem`
 edit. See the `memory`, `db_map`, and `snapshot` skills.
 
+**Flat files are renders, not sources.** Every local `.md` and git-tracked file
+— docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
+`./sc render`. They are derived artifacts: a photograph of a DB row, not the row.
+Do not audit them for drift, staleness, or a stale date, and never edit or delete
+a file to change its content. If one looks wrong or out of date, fix the DB (`./sc
+mem` or the owning table) and re-render — the divergence is a render that hasn't
+run, not a file to hand-correct. The DB is the authoritative content; the tree is
+its projection.
+
 ## MANDATE
 
 Build and maintain the substrate every fork runs on. You keep the system; each

--- a/.super-coder/templates/shell_system_prompt.md
+++ b/.super-coder/templates/shell_system_prompt.md
@@ -29,6 +29,15 @@ the change for you. Raw `sqlite3` is for SELECT only. `./sc mem which` to orient
 `./sc snapshot` (+ `./sc render` for docs/roadmap/skills) after any non-`mem`
 edit. See the `memory`, `db_map`, and `snapshot` skills.
 
+**Flat files are renders, not sources.** Every local `.md` and git-tracked file
+— docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
+`./sc render`. They are derived artifacts: a photograph of a DB row, not the row.
+Do not audit them for drift, staleness, or a stale date, and never edit or delete
+a file to change its content. If one looks wrong or out of date, fix the DB (`./sc
+mem` or the owning table) and re-render — the divergence is a render that hasn't
+run, not a file to hand-correct. The DB is the authoritative content; the tree is
+its projection.
+
 ## MANDATE
 
 {{mandate}}


### PR DESCRIPTION
Shells keep auditing local `.md` / git-tracked files for drift, staleness, and stale dates as if they were authoritative. They aren't — every flat file (docs, specs, skills, `CLAUDE.md`/`AGENTS.md`) is rendered from the DB by `./sc render`. This makes that explicit in the system prompt so shells stop hand-correcting projections and fix the DB instead.

- Adds a **"Flat files are renders, not sources"** paragraph to the `## MEMORY ARCHITECTURE` block in both prompt sources: `templates/shell_system_prompt.md` (every forked shell) and `seed_dogfood.py`'s `MAINTAINER_PROMPT` (super-coder's own maintainer).
- Migration `0016` backfills the paragraph into existing shells' stored `system_prompt` (idempotent; injects before `## MANDATE`).
- `.sc-state/content.sql` re-snapshotted from the live DB.

Verified: `./sc verify` rebuilds + renders clean, and the paragraph appears in the booted shell's rendered `CLAUDE.md`/`AGENTS.md`.