### PR TITLE
feat(boot): silent prune of provably-merged local branches at launch

### DIFF
--- a/.super-coder/scripts/git_prune.py
+++ b/.super-coder/scripts/git_prune.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Automated branch prune — the acting sibling of git_hygiene.py's read pass.
+
+`git_hygiene.py` reports which local branches are stale (PR provably merged,
+not a worktree base, not checked out anywhere); this deletes exactly that set
+and nothing else. It re-derives no criteria of its own: the safety predicate
+lives in one place — `git_hygiene.compute()` -> `branch['stale']` — and this
+consumes it verbatim.
+
+Where the `git_cleanup` skill is the human-driven, full-spectrum tidy (dirty
+worktrees, outstanding-work triage, remote sync), this is the narrow,
+unattended subset safe to run on every boot: provably-merged local branches.
+The launcher calls it once per boot from any shell; it is repo-global (one
+fork, one host repo, many worktrees sharing a branch namespace), so whichever
+shell boots next clears everyone's merged branches.
+
+Safety — all inherited from git_hygiene's `stale` flag:
+  - merged    authoritative via `gh pr list` (state == MERGED). When gh is
+              unavailable a squash-merge cannot be proven merged, so it is
+              NOT pruned (fail-safe: keep the branch).
+  - not base  never the default branch or a `shell/<shortname>` worktree base.
+  - not live  never a branch checked out in any worktree; `git branch -D`
+              refuses those too — a second, independent guard.
+
+Soft-fails by design: any git/gh/network hiccup yields an empty or partial
+result, never an exception — a prune must never block a launch.
+
+Run standalone:
+    python3 .super-coder/scripts/git_prune.py --dry-run   # show, don't delete
+    python3 .super-coder/scripts/git_prune.py             # delete, print JSON
+    python3 .super-coder/scripts/git_prune.py --text      # delete, human line
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import git_hygiene
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+
+
+def _delete_branch(name: str, repo: Path) -> bool:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo), "branch", "-D", name],
+            capture_output=True, text=True, timeout=12).returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def prune(repo: Path = REPO_ROOT, *, dry_run: bool = False,
+          fetch: bool = False, snapshot: dict | None = None) -> dict:
+    """Delete every branch git_hygiene marks stale. Acts only on the `stale`
+    set — never its own deletion criteria. Pass `snapshot` to reuse an existing
+    git_hygiene.compute() result (or to inject one in tests); otherwise it is
+    computed here. Soft-fails to an `error` result rather than raising."""
+    try:
+        snap = snapshot if snapshot is not None else git_hygiene.compute(fetch=fetch)
+    except Exception:
+        return {"deleted": [], "failed": [], "candidates": 0,
+                "gh_available": False, "dry_run": dry_run, "error": True}
+
+    stale = [b["name"] for b in snap.get("branches", []) if b.get("stale")]
+    deleted, failed = [], []
+    for name in stale:
+        if dry_run or _delete_branch(name, repo):
+            deleted.append(name)
+        else:
+            failed.append(name)
+    return {
+        "deleted": deleted,
+        "failed": failed,
+        "candidates": len(stale),
+        "gh_available": snap.get("gh_available", False),
+        "dry_run": dry_run,
+    }
+
+
+def status_line(result: dict) -> str | None:
+    """One-line boot note — None when nothing happened, so the launcher stays
+    silent on the common no-op boot and speaks only when a branch was removed."""
+    if result.get("error"):
+        return None
+    deleted, failed = result.get("deleted", []), result.get("failed", [])
+    if not deleted and not failed:
+        return None
+    verb = "would prune" if result.get("dry_run") else "pruned"
+    parts: list[str] = []
+    if deleted:
+        s = "es" if len(deleted) != 1 else ""
+        parts.append(f"{verb} {len(deleted)} merged branch{s} ({', '.join(deleted)})")
+    if failed:
+        parts.append(f"{len(failed)} could not be deleted ({', '.join(failed)})")
+    return "; ".join(parts)
+
+
+def main(argv: list[str]) -> int:
+    result = prune(dry_run="--dry-run" in argv, fetch="--no-fetch" not in argv)
+    if "--text" in argv:
+        print(status_line(result) or "nothing to prune")
+    else:
+        print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -37,6 +37,7 @@ import flat  # noqa: E402
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import install  # noqa: E402  — reuse its canonical HARNESS_BIN (one source of truth)
+import git_prune  # noqa: E402  — boot-time prune of provably-merged local branches
 
 ADAPTERS = ENGINE / "adapters"
 
@@ -528,6 +529,20 @@ def main() -> None:
         ensure_worktree(work_dir, chosen["shortname"])
         sync_note = sync_worktree(work_dir, chosen["shortname"])
 
+    # Repo-global branch hygiene: delete local branches whose PR is provably
+    # merged (git_hygiene's `stale` set — gh-confirmed MERGED, never a base or a
+    # checked-out branch). The unattended subset of the git_cleanup skill, run
+    # once per boot from whichever shell launches next. Best-effort and silent:
+    # soft-fails so it never blocks a launch, and surfaces a line only when it
+    # actually removed something. Skipped under RENDER_ONLY (headless verify must
+    # not mutate) and opt-out-able per fork via SC_NO_AUTOPRUNE=1.
+    prune_note = None
+    if not os.environ.get("SC_NO_AUTOPRUNE") and not os.environ.get("RENDER_ONLY"):
+        try:
+            prune_note = git_prune.status_line(git_prune.prune(fetch=False))
+        except Exception:
+            prune_note = None
+
     content = compose_boot(con, full, user, session_id, archive_id,
                            work_dir=work_dir if work_dir != REPO_ROOT else None,
                            sync_note=sync_note)
@@ -549,6 +564,8 @@ def main() -> None:
         print(f"→ sync: {sync_note}")
     elif chosen["flavor"] == "admin":
         print("→ working dir: repo root (admin — maintains main directly)")
+    if prune_note:
+        print(f"→ prune: {prune_note}")
     print(f"→ wrote {work_dir / 'CLAUDE.md'}")
     print(f"→ wrote {work_dir / 'AGENTS.md'}")
     print(f"→ skills: {len(skills['written'])} written, "

--- a/tests/test_git_prune.py
+++ b/tests/test_git_prune.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Tests for the boot-time branch prune (git_prune.prune).
+
+Stdlib `unittest`, real git in a tmpdir — matching test_worktree_sync.py's
+no-dependency style.
+
+Boundary note: git_hygiene._git/_out bind `cwd=REPO_ROOT` as a default argument
+(at import), so the *detection* layer can't be retargeted at a tmp repo by
+patching a global — and it doesn't need to be: that layer ships with git_hygiene
+and the review server already exercises it. What's new here is prune's *action*
+layer — "delete exactly the `stale` set, refuse anything git refuses, stay
+silent on a no-op" — so the tests feed a hand-built snapshot (the documented
+`snapshot=` seam) and assert the deletions against a real git repo.
+
+Run:
+    python3 tests/test_git_prune.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import git_hygiene  # noqa: E402
+import git_prune  # noqa: E402
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def git(cwd: Path, *args: str) -> str:
+    res = subprocess.run(["git", "-C", str(cwd), *args],
+                         capture_output=True, text=True, env=GIT_ENV)
+    if res.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed: {res.stderr}")
+    return res.stdout.strip()
+
+
+def local_branches(cwd: Path) -> set[str]:
+    return set(git(cwd, "for-each-ref", "--format=%(refname:short)",
+                   "refs/heads/").split())
+
+
+def snap(*branches: tuple[str, bool], gh: bool = True) -> dict:
+    """A minimal git_hygiene-shaped snapshot: (name, stale) pairs."""
+    return {"gh_available": gh,
+            "branches": [{"name": n, "stale": s} for n, s in branches]}
+
+
+class PruneTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="prune-test-"))
+        self.repo = self.tmp / "repo"
+        self.repo.mkdir()
+        git(self.repo, "init", "-b", "main")
+        git(self.repo, "commit", "--allow-empty", "-m", "init")
+        for b in ("feature-merged", "feature-open"):
+            git(self.repo, "branch", b, "main")
+
+    def tearDown(self) -> None:
+        subprocess.run(["rm", "-rf", str(self.tmp)])
+
+    def test_deletes_exactly_the_stale_set(self) -> None:
+        result = git_prune.prune(
+            repo=self.repo,
+            snapshot=snap(("feature-merged", True), ("feature-open", False)))
+        self.assertEqual(result["deleted"], ["feature-merged"])
+        self.assertEqual(result["failed"], [])
+        remaining = local_branches(self.repo)
+        self.assertNotIn("feature-merged", remaining)
+        self.assertIn("feature-open", remaining)   # not stale — kept
+        self.assertIn("main", remaining)
+
+    def test_dry_run_deletes_nothing(self) -> None:
+        result = git_prune.prune(
+            repo=self.repo, dry_run=True,
+            snapshot=snap(("feature-merged", True)))
+        self.assertEqual(result["deleted"], ["feature-merged"])
+        self.assertTrue(result["dry_run"])
+        self.assertIn("feature-merged", local_branches(self.repo))  # untouched
+
+    def test_checked_out_branch_is_refused_by_git(self) -> None:
+        # Even if a snapshot wrongly marked a checked-out branch stale (a race),
+        # `git branch -D` refuses it — the independent second guard. It lands in
+        # `failed`, never silently lost, and survives on disk.
+        wt = self.tmp / "wt"
+        git(self.repo, "worktree", "add", "-b", "feature-live", str(wt), "main")
+        result = git_prune.prune(
+            repo=self.repo, snapshot=snap(("feature-live", True)))
+        self.assertEqual(result["deleted"], [])
+        self.assertEqual(result["failed"], ["feature-live"])
+        self.assertIn("feature-live", local_branches(self.repo))
+
+    def test_compute_failure_soft_fails(self) -> None:
+        # A git_hygiene blow-up must yield an error result, never an exception
+        # that could block a boot.
+        orig = git_hygiene.compute
+        git_hygiene.compute = lambda **kw: (_ for _ in ()).throw(RuntimeError("boom"))
+        try:
+            result = git_prune.prune(repo=self.repo)
+        finally:
+            git_hygiene.compute = orig
+        self.assertTrue(result["error"])
+        self.assertEqual(result["deleted"], [])
+        self.assertIsNone(git_prune.status_line(result))
+
+    def test_status_line_silent_on_noop(self) -> None:
+        self.assertIsNone(git_prune.status_line(
+            {"deleted": [], "failed": [], "candidates": 0}))
+        self.assertIsNone(git_prune.status_line({"error": True}))
+        line = git_prune.status_line({"deleted": ["a", "b"], "failed": []})
+        self.assertIn("pruned 2 merged branches", line)
+        one = git_prune.status_line({"deleted": ["a"], "failed": []})
+        self.assertIn("pruned 1 merged branch ", one)  # singular, no plural 'es'
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Answers the question: how should forks reclaim merged feature branches — let each shell clean its own at boot, or sweep at intervals via admin? This adds the **self-at-boot, silent** path; the admin `git_cleanup` skill stays for the messy cases.

## What it does
- New `.super-coder/scripts/git_prune.py` — the automated acting sibling of `git_hygiene.py`'s read pass. It consumes git_hygiene's `stale` flag verbatim (gh-confirmed `MERGED`, never a base/`shell/*` branch, never checked-out anywhere) and `git branch -D`s exactly that set. It derives no deletion criteria of its own — one source of truth for "is this prunable."
- `run.py` calls it once per boot from whichever shell launches next (repo-global across the fork's shared worktrees), right after the worktree drift check.

## Safety
- **Fail-safe merge proof.** When `gh` is unavailable a squash-merge can't be proven merged → the branch is **kept**, never deleted. gh-down only ever *misses* branches, never wrongly removes one.
- **Two independent guards on checked-out branches** — git_hygiene's `checked_out` filter, and `git branch -D` itself refusing any branch live in a worktree.
- **Soft-fails** — any git/gh/network hiccup yields an empty result, never an exception that could block a launch.
- **Skipped under `RENDER_ONLY`** (headless verify must not mutate) and **opt-out per fork** via `SC_NO_AUTOPRUNE=1`.

## Silent, but traced
No noise on the common no-op boot; prints a `→ prune:` line **only when it actually removed something**, so a deletion is visible to whoever launched.

## Scope
`git_cleanup` (admin) still owns the full-spectrum tidy — dirty worktrees, outstanding-work triage, remote sync. This is only the unattended, unambiguous subset. Skill-doc cross-reference deferred (the `skills_sc`/`assets`/migration triplet is synced — a separate change).

## Test plan
- `python3 tests/test_git_prune.py` — deletes exactly the stale set, dry-run mutates nothing, checked-out branch refused→`failed` (survives), compute-failure soft-fails, status_line silent on no-op + singular/plural.
- `python3 tests/test_worktree_sync.py` — green (regression on `run.py` import).
- `python3 .super-coder/scripts/git_prune.py --dry-run --text` against this repo correctly flagged a merged branch without deleting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)