### PR TITLE
docs(git_cleanup): note the boot-time auto-prune (#119) admin inherits

### DIFF
--- a/.super-coder/assets/skills/git_cleanup/SKILL.md
+++ b/.super-coder/assets/skills/git_cleanup/SKILL.md
@@ -13,6 +13,15 @@ the one vantage that sits in the repo root on `main`, sees every worktree on
 disk, and is exempted from the branch-guard. No working shell runs this; a
 working shell tidies only its own worktree via the `git` skill.
 
+**What the launcher already does for you.** Since #119, `git_prune.py` deletes
+the *provably-merged* branch subset automatically on every boot (the same
+`stale` set described in Tier A.1), repo-global across the fork's worktrees — so
+in practice you will often find that tier already clear. This pass remains the
+backstop for everything the automation deliberately won't touch: merges it could
+not prove (a `gh`-down boot keeps the branch), dirty worktrees, outstanding
+unpushed work, `main` fast-forward, and remote-ref pruning. Don't be surprised by
+an empty Tier A; do still run the report.
+
 The governing asymmetry — internalize it before you touch anything:
 
 > You can **prove** something is safe to **delete** (its PR shows MERGED).
@@ -68,6 +77,9 @@ Only these three. Each has hard proof of safety:
    ```bash
    git branch -D <branch>
    ```
+   `git_prune.py` already does exactly this at boot, so most of these are gone
+   before you look. What survives to here is the residue: branches merged since
+   the last boot, or merged during a `gh`-down boot that couldn't prove it.
 2. **Dead remote-tracking refs.**
    ```bash
    git fetch --prune

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1063,6 +1063,15 @@ the one vantage that sits in the repo root on `main`, sees every worktree on
 disk, and is exempted from the branch-guard. No working shell runs this; a
 working shell tidies only its own worktree via the `git` skill.
 
+**What the launcher already does for you.** Since #119, `git_prune.py` deletes
+the *provably-merged* branch subset automatically on every boot (the same
+`stale` set described in Tier A.1), repo-global across the fork''s worktrees — so
+in practice you will often find that tier already clear. This pass remains the
+backstop for everything the automation deliberately won''t touch: merges it could
+not prove (a `gh`-down boot keeps the branch), dirty worktrees, outstanding
+unpushed work, `main` fast-forward, and remote-ref pruning. Don''t be surprised by
+an empty Tier A; do still run the report.
+
 The governing asymmetry — internalize it before you touch anything:
 
 > You can **prove** something is safe to **delete** (its PR shows MERGED).
@@ -1118,6 +1127,9 @@ Only these three. Each has hard proof of safety:
    ```bash
    git branch -D <branch>
    ```
+   `git_prune.py` already does exactly this at boot, so most of these are gone
+   before you look. What survives to here is the residue: branches merged since
+   the last boot, or merged during a `gh`-down boot that couldn''t prove it.
 2. **Dead remote-tracking refs.**
    ```bash
    git fetch --prune

--- a/skills_sc/git_cleanup.md
+++ b/skills_sc/git_cleanup.md
@@ -20,6 +20,15 @@ the one vantage that sits in the repo root on `main`, sees every worktree on
 disk, and is exempted from the branch-guard. No working shell runs this; a
 working shell tidies only its own worktree via the `git` skill.
 
+**What the launcher already does for you.** Since #119, `git_prune.py` deletes
+the *provably-merged* branch subset automatically on every boot (the same
+`stale` set described in Tier A.1), repo-global across the fork's worktrees — so
+in practice you will often find that tier already clear. This pass remains the
+backstop for everything the automation deliberately won't touch: merges it could
+not prove (a `gh`-down boot keeps the branch), dirty worktrees, outstanding
+unpushed work, `main` fast-forward, and remote-ref pruning. Don't be surprised by
+an empty Tier A; do still run the report.
+
 The governing asymmetry — internalize it before you touch anything:
 
 > You can **prove** something is safe to **delete** (its PR shows MERGED).
@@ -75,6 +84,9 @@ Only these three. Each has hard proof of safety:
    ```bash
    git branch -D <branch>
    ```
+   `git_prune.py` already does exactly this at boot, so most of these are gone
+   before you look. What survives to here is the residue: branches merged since
+   the last boot, or merged during a `gh`-down boot that couldn't prove it.
 2. **Dead remote-tracking refs.**
    ```bash
    git fetch --prune


### PR DESCRIPTION
Follow-up to #119. The admin `git_cleanup` pass now sits on top of an automated layer — `git_prune.py` deletes the provably-merged branch subset on every boot — so the skill should say so, or admin will read an empty Tier A as a stale report.

## Changes (all regenerated from the one asset)
- **`assets/skills/git_cleanup/SKILL.md`** (canonical source) — adds a "what the launcher already does" note in the intro and a one-liner in Tier A.1 framing the residue the manual pass still owns: branches merged since the last boot, or merged during a `gh`-down boot that couldn't prove the merge.
- **`migrations/0001_seed_skills.sql`** + **`skills_sc/git_cleanup.md`** — regenerated via `./sc seed-skills` → `./sc rebuild` → `./sc render flat`. `./sc render-check` is clean (mirror matches DB render).

No behavior change — documentation only. Forks pick up the new skill content through the seed migration on `./sc update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)