### PR TITLE
fix(branch-guard): env-independent engine resolution + absolute core.hooksPath

### DIFF
--- a/.super-coder/adapters/claude/README.md
+++ b/.super-coder/adapters/claude/README.md
@@ -21,10 +21,12 @@ the launch command. No extra config file to emit at v1.
 `merge_json` deep-merges a `PreToolUse` hook into **`.claude/settings.local.json`**
 (the gitignored personal layer — never the fork's tracked `.claude/settings.json`,
 so fork-owned config is untouched). The hook runs the shared branch-guard before
-every `Edit`/`Write`/`NotebookEdit`/`MultiEdit`. It resolves the script via
-**`$SC_ENGINE_DIR`** (absolute path to the installed engine, exported by run.py)
-— a fork gitignores `.super-coder/`, so a worktree-relative path found nothing
-and the hook failed open in exactly the shell worktrees it protects. It blocks
+every `Edit`/`Write`/`NotebookEdit`/`MultiEdit`. It resolves the script
+env-independently (walking to the main worktree root via `git rev-parse
+--git-common-dir`, the same way `sc` does; `$SC_ENGINE_DIR` is an optional
+fast-path override) — a fork gitignores `.super-coder/`, so a worktree-relative
+path found nothing and the hook failed open in exactly the shell worktrees it
+protects. It blocks
 the edit (exit 2) when the **target file's** repo HEAD is a protected default
 branch — so a worktree shell writing to the stale repo-root checkout is caught,
 not just one whose own cwd is on `main`; an out-of-worktree edit to a feature

--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -14,7 +14,7 @@
             "hooks": [
               {
                 "type": "command",
-                "command": "bash \"$SC_ENGINE_DIR/scripts/branch-guard.sh\""
+                "command": "bash -c 'eng=\"${SC_ENGINE_DIR:-$(cd \"$(git rev-parse --git-common-dir 2>/dev/null)/..\" 2>/dev/null && pwd)/.super-coder}\"; exec bash \"$eng/scripts/branch-guard.sh\"'"
               }
             ]
           }

--- a/.super-coder/adapters/codex/.codex/hooks.json
+++ b/.super-coder/adapters/codex/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$SC_ENGINE_DIR/scripts/branch-guard.sh\"",
+            "command": "bash -c 'eng=\"${SC_ENGINE_DIR:-$(cd \"$(git rev-parse --git-common-dir 2>/dev/null)/..\" 2>/dev/null && pwd)/.super-coder}\"; exec bash \"$eng/scripts/branch-guard.sh\"'",
             "statusMessage": "branch guard"
           }
         ]

--- a/.super-coder/adapters/opencode/protect-default-branch.js
+++ b/.super-coder/adapters/opencode/protect-default-branch.js
@@ -13,13 +13,19 @@ const WRITE_TOOLS = new Set(["write", "edit", "patch"]);
 export const ProtectDefaultBranch = async ({ $, worktree }) => ({
   "tool.execute.before": async (input) => {
     if (!WRITE_TOOLS.has(input.tool)) return;
-    // Resolve the guard via $SC_ENGINE_DIR (absolute path to the installed
-    // engine, exported by run.py). A fork gitignores .super-coder/, so it is
-    // absent from the worktree — a worktree-relative path found nothing. Fall
-    // back to the worktree-relative path for a non-engine launch.
-    const guard = process.env.SC_ENGINE_DIR
-      ? `${process.env.SC_ENGINE_DIR}/scripts/branch-guard.sh`
-      : `${worktree}/.super-coder/scripts/branch-guard.sh`;
+    // Resolve the installed engine the same env-independent way `sc` does: a
+    // fork gitignores .super-coder/, so it is absent from the worktree — walk to
+    // the MAIN worktree root via git's common dir (its parent owns the engine).
+    // $SC_ENGINE_DIR (exported by run.py) is an optional fast-path override; we
+    // do NOT depend on it, so a manual `opencode` launch still guards.
+    let eng = process.env.SC_ENGINE_DIR;
+    if (!eng) {
+      const r = await $`bash -c 'cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd'`
+        .cwd(worktree).quiet().nothrow();
+      const root = (r.stdout?.toString() || "").trim();
+      eng = root ? `${root}/.super-coder` : `${worktree}/.super-coder`;
+    }
+    const guard = `${eng}/scripts/branch-guard.sh`;
     // Bun shell: run the guard at the worktree root; .nothrow() so we read the
     // exit code, .quiet() so its output doesn't leak into the TUI.
     const res = await $`bash ${guard}`

--- a/.super-coder/scripts/branch-guard.sh
+++ b/.super-coder/scripts/branch-guard.sh
@@ -27,12 +27,13 @@
 #   2. CWD (all consumers, and the fallback when there is no stdin target) — the
 #      original behavior: block if HEAD of the cwd's repo is a protected branch.
 #
-# The harness hooks find this script via $SC_ENGINE_DIR (absolute path to the
-# installed engine, exported by run.py at launch). A fork gitignores
-# .super-coder/, so it is ABSENT from every shell worktree — a worktree-relative
-# path resolved to nothing and the hook failed open. The pre-commit hook can't
-# rely on that env (the FnB may commit from a plain terminal); it resolves the
-# script by its own $0 path instead.
+# The harness hooks locate this script env-independently, the same way `sc` does:
+# walk to the MAIN worktree root via `git rev-parse --git-common-dir`/.. and read
+# its .super-coder/. A fork gitignores the engine, so it is ABSENT from every
+# shell worktree — a worktree-relative path resolved to nothing and the hook
+# failed open; $SC_ENGINE_DIR (exported by run.py) is only an optional fast-path
+# override, never a dependency. The pre-commit hook resolves the script by its own
+# $0 path (it runs outside run.py's env).
 set -euo pipefail
 
 # Not a git work tree (rare for a fork, but be safe) → nothing to guard.

--- a/.super-coder/scripts/map_setup.py
+++ b/.super-coder/scripts/map_setup.py
@@ -27,9 +27,15 @@ from pathlib import Path
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
 HOOKS_DIR = ENGINE / "hooks"
-# core.hooksPath is interpreted relative to the repo top-level — keep it repo-
-# relative so it travels (no absolute host path baked into git config).
-HOOKS_REL = str(HOOKS_DIR.relative_to(REPO_ROOT))
+# core.hooksPath must be ABSOLUTE. Git interprets a relative hooksPath against
+# the *current working directory* — which in a linked worktree is the worktree
+# root, where a fork's gitignored .super-coder/ does NOT exist. So a relative
+# value made every git hook (pre-commit guard, post-commit preview URL, the
+# post-checkout/merge/rewrite catalogue remap) silently no-op in exactly the
+# shell worktrees they target. core.hooksPath is a per-clone setting (.git/config,
+# uncommitted) re-applied by this script on every install/update, so an absolute
+# host path costs nothing in portability and resolves from every worktree.
+HOOKS_ABS = str(HOOKS_DIR)
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import map_repo  # noqa: E402
@@ -46,7 +52,7 @@ def wire_hooks() -> bool:
     Returns True if the wiring is in place, False if it couldn't be (not a git
     repo / no hooks dir) — mapping still proceeds either way."""
     if not HOOKS_DIR.is_dir():
-        print(f"map-setup: no hooks dir at {HOOKS_REL} — skipping hook wiring")
+        print(f"map-setup: no hooks dir at {HOOKS_ABS} — skipping hook wiring")
         return False
     hooks = sorted(p for p in HOOKS_DIR.iterdir() if p.is_file())
     for h in hooks:
@@ -56,9 +62,9 @@ def wire_hooks() -> bool:
               "(auto-remap needs git; `./sc map` / rebuild still refresh)")
         return False
     subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "config", "core.hooksPath", HOOKS_REL],
+        ["git", "-C", str(REPO_ROOT), "config", "core.hooksPath", HOOKS_ABS],
         check=True)
-    print(f"map-setup: core.hooksPath -> {HOOKS_REL} "
+    print(f"map-setup: core.hooksPath -> {HOOKS_ABS} "
           f"({len(hooks)} hook(s): {', '.join(h.name for h in hooks)})")
     return True
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -625,12 +625,11 @@ def main() -> None:
     # branch-guard.sh reads it to exempt the admin shell (which works on main
     # by mandate); like SC_PROTECTED_BRANCHES it's a guardrail, not a boundary.
     env["SC_SHELL_FLAVOR"] = chosen["flavor"] or ""
-    # Absolute path to the installed engine, so the branch-guard hook resolves
-    # the script regardless of cwd. A fork gitignores .super-coder/, so it is
-    # ABSENT from every shell worktree (git checks out only tracked files) — a
-    # worktree-relative path (the old $CLAUDE_PROJECT_DIR/.super-coder/...) found
-    # nothing and the hook failed open. The engine is installed once at the repo
-    # root; pin to it. All three adapters reference $SC_ENGINE_DIR.
+    # Optional fast-path for the branch-guard hooks: the absolute engine path, so
+    # they skip the `git rev-parse --git-common-dir` walk. NOT load-bearing — the
+    # hooks resolve the engine env-independently (a fork gitignores .super-coder/,
+    # so it is absent from worktrees; a worktree-relative path failed open). This
+    # just saves a subshell per edit on the normal launch path.
     env["SC_ENGINE_DIR"] = str(ENGINE)
     os.chdir(work_dir)
     print(f"→ exec {' '.join(cmd)}\n")


### PR DESCRIPTION
**Stacked on #121** (base = `fix/branch-guard-fork-worktrees`). Retarget to `main` once #121 merges.

Follow-up from an end-to-end audit of a shell working inside a fork worktree — tracing boot → edit → test → commit → push → PR and checking that each guardrail actually fires. The core loop is sound (boot, `./sc`, edit, commit, push all work). Two gaps remained, both the *same root cause* the whole branch-guard saga has been about: **machinery assuming the engine is reachable at a worktree-relative path, when a fork gitignores it.**

## 1. Edit-guard fail-open when not launched via run.py

#121 resolved the guard through `$SC_ENGINE_DIR`, which **only run.py sets**. A shell or FnB starting the harness manually in a worktree had no var → `bash: /scripts/branch-guard.sh` → claude treats the hook error as non-blocking → **silent fail-open**. That was a *second* engine-resolution mechanism when `sc` already does it env-independently via `git rev-parse --git-common-dir`/.. (PR #116).

Converge on the one pattern: all three adapters (claude/codex/opencode) walk to the main worktree root themselves; `$SC_ENGINE_DIR` stays only as an optional fast-path override, never a dependency.

```
# verified, env var unset, worktree shell editing the stale main root:
Blocked: this edit targets '/.../root/app.py' ... on protected branch 'main'   exit=2
# in-worktree feature-branch edit, env var unset:                               exit=0
```

## 2. No git hooks fire in fork worktrees (relative `core.hooksPath`)

`map-setup` set `core.hooksPath=.super-coder/hooks` (**relative**). Git interprets that against the cwd — in a linked worktree that's the worktree root, where a fork's gitignored `.super-coder/` doesn't exist. So **every** git hook silently no-op'd in shell worktrees:
- **pre-commit** branch-guard backstop,
- **post-commit** preview-URL line — *its entire purpose is the worktree case* ("a dev shell commits from its worktree… print that line"), and it never ran there,
- **post-checkout / post-merge / post-rewrite** catalogue (dr_*) remap.

`core.hooksPath` is a per-clone setting (`.git/config`, uncommitted) re-applied by map-setup on every install/update, so an absolute host path costs nothing in portability. `map_setup.py` now sets it absolute.

```
# verified with absolute hooksPath — worktree commit now triggers the hook:
$ (in worktree, branch in protected set) git commit
Blocked: HEAD is on protected default branch 'probe'.   # hook FIRES (was skipped)
$ (normal feature branch) git commit → succeeds
```

## Scope / not in this PR

- The audit's third finding — orientation drift for **Bash** ops (a shell can still `cd` to the stale root and run *tests*/*git* there; only Edit/Write are hook-gated) — is left for a possible `cwd+branch` statusline, not addressed here.
- Existing forks (dos-arch) pick both fixes up on the next `./sc update`: map-setup re-runs, and the absolute hooksPath in the shared `.git/config` takes effect for all worktrees at once.

## Test

`./sc test`: 60 tests, the only failure is the pre-existing `test_get_map_empty_catalogue` (`get_map() takes 0 positional arguments`), unrelated to this diff. Hook command + hooksPath behavior verified against a faithful fork fixture (gitignored `.super-coder/`, relative→absolute hooksPath, real `branch-guard.sh`/`pre-commit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)