### PR TITLE
fix(branch-guard): env-independent engine resolution + absolute core.hooksPath (re-land #122)

### DIFF
--- a/.super-coder/adapters/claude/README.md
+++ b/.super-coder/adapters/claude/README.md
@@ -21,10 +21,12 @@ the launch command. No extra config file to emit at v1.
 `merge_json` deep-merges a `PreToolUse` hook into **`.claude/settings.local.json`**
 (the gitignored personal layer — never the fork's tracked `.claude/settings.json`,
 so fork-owned config is untouched). The hook runs the shared branch-guard before
-every `Edit`/`Write`/`NotebookEdit`/`MultiEdit`. It resolves the script via
-**`$SC_ENGINE_DIR`** (absolute path to the installed engine, exported by run.py)
-— a fork gitignores `.super-coder/`, so a worktree-relative path found nothing
-and the hook failed open in exactly the shell worktrees it protects. It blocks
+every `Edit`/`Write`/`NotebookEdit`/`MultiEdit`. It resolves the script
+env-independently (walking to the main worktree root via `git rev-parse
+--git-common-dir`, the same way `sc` does; `$SC_ENGINE_DIR` is an optional
+fast-path override) — a fork gitignores `.super-coder/`, so a worktree-relative
+path found nothing and the hook failed open in exactly the shell worktrees it
+protects. It blocks
 the edit (exit 2) when the **target file's** repo HEAD is a protected default
 branch — so a worktree shell writing to the stale repo-root checkout is caught,
 not just one whose own cwd is on `main`; an out-of-worktree edit to a feature

--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -14,7 +14,7 @@
             "hooks": [
               {
                 "type": "command",
-                "command": "bash \"$SC_ENGINE_DIR/scripts/branch-guard.sh\""
+                "command": "bash -c 'eng=\"${SC_ENGINE_DIR:-$(cd \"$(git rev-parse --git-common-dir 2>/dev/null)/..\" 2>/dev/null && pwd)/.super-coder}\"; exec bash \"$eng/scripts/branch-guard.sh\"'"
               }
             ]
           }

--- a/.super-coder/adapters/codex/.codex/hooks.json
+++ b/.super-coder/adapters/codex/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$SC_ENGINE_DIR/scripts/branch-guard.sh\"",
+            "command": "bash -c 'eng=\"${SC_ENGINE_DIR:-$(cd \"$(git rev-parse --git-common-dir 2>/dev/null)/..\" 2>/dev/null && pwd)/.super-coder}\"; exec bash \"$eng/scripts/branch-guard.sh\"'",
             "statusMessage": "branch guard"
           }
         ]

--- a/.super-coder/adapters/opencode/protect-default-branch.js
+++ b/.super-coder/adapters/opencode/protect-default-branch.js
@@ -13,13 +13,19 @@ const WRITE_TOOLS = new Set(["write", "edit", "patch"]);
 export const ProtectDefaultBranch = async ({ $, worktree }) => ({
   "tool.execute.before": async (input) => {
     if (!WRITE_TOOLS.has(input.tool)) return;
-    // Resolve the guard via $SC_ENGINE_DIR (absolute path to the installed
-    // engine, exported by run.py). A fork gitignores .super-coder/, so it is
-    // absent from the worktree — a worktree-relative path found nothing. Fall
-    // back to the worktree-relative path for a non-engine launch.
-    const guard = process.env.SC_ENGINE_DIR
-      ? `${process.env.SC_ENGINE_DIR}/scripts/branch-guard.sh`
-      : `${worktree}/.super-coder/scripts/branch-guard.sh`;
+    // Resolve the installed engine the same env-independent way `sc` does: a
+    // fork gitignores .super-coder/, so it is absent from the worktree — walk to
+    // the MAIN worktree root via git's common dir (its parent owns the engine).
+    // $SC_ENGINE_DIR (exported by run.py) is an optional fast-path override; we
+    // do NOT depend on it, so a manual `opencode` launch still guards.
+    let eng = process.env.SC_ENGINE_DIR;
+    if (!eng) {
+      const r = await $`bash -c 'cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd'`
+        .cwd(worktree).quiet().nothrow();
+      const root = (r.stdout?.toString() || "").trim();
+      eng = root ? `${root}/.super-coder` : `${worktree}/.super-coder`;
+    }
+    const guard = `${eng}/scripts/branch-guard.sh`;
     // Bun shell: run the guard at the worktree root; .nothrow() so we read the
     // exit code, .quiet() so its output doesn't leak into the TUI.
     const res = await $`bash ${guard}`

--- a/.super-coder/scripts/branch-guard.sh
+++ b/.super-coder/scripts/branch-guard.sh
@@ -27,12 +27,13 @@
 #   2. CWD (all consumers, and the fallback when there is no stdin target) — the
 #      original behavior: block if HEAD of the cwd's repo is a protected branch.
 #
-# The harness hooks find this script via $SC_ENGINE_DIR (absolute path to the
-# installed engine, exported by run.py at launch). A fork gitignores
-# .super-coder/, so it is ABSENT from every shell worktree — a worktree-relative
-# path resolved to nothing and the hook failed open. The pre-commit hook can't
-# rely on that env (the FnB may commit from a plain terminal); it resolves the
-# script by its own $0 path instead.
+# The harness hooks locate this script env-independently, the same way `sc` does:
+# walk to the MAIN worktree root via `git rev-parse --git-common-dir`/.. and read
+# its .super-coder/. A fork gitignores the engine, so it is ABSENT from every
+# shell worktree — a worktree-relative path resolved to nothing and the hook
+# failed open; $SC_ENGINE_DIR (exported by run.py) is only an optional fast-path
+# override, never a dependency. The pre-commit hook resolves the script by its own
+# $0 path (it runs outside run.py's env).
 set -euo pipefail
 
 # Not a git work tree (rare for a fork, but be safe) → nothing to guard.

--- a/.super-coder/scripts/map_setup.py
+++ b/.super-coder/scripts/map_setup.py
@@ -27,9 +27,15 @@ from pathlib import Path
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
 HOOKS_DIR = ENGINE / "hooks"
-# core.hooksPath is interpreted relative to the repo top-level — keep it repo-
-# relative so it travels (no absolute host path baked into git config).
-HOOKS_REL = str(HOOKS_DIR.relative_to(REPO_ROOT))
+# core.hooksPath must be ABSOLUTE. Git interprets a relative hooksPath against
+# the *current working directory* — which in a linked worktree is the worktree
+# root, where a fork's gitignored .super-coder/ does NOT exist. So a relative
+# value made every git hook (pre-commit guard, post-commit preview URL, the
+# post-checkout/merge/rewrite catalogue remap) silently no-op in exactly the
+# shell worktrees they target. core.hooksPath is a per-clone setting (.git/config,
+# uncommitted) re-applied by this script on every install/update, so an absolute
+# host path costs nothing in portability and resolves from every worktree.
+HOOKS_ABS = str(HOOKS_DIR)
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import map_repo  # noqa: E402
@@ -46,7 +52,7 @@ def wire_hooks() -> bool:
     Returns True if the wiring is in place, False if it couldn't be (not a git
     repo / no hooks dir) — mapping still proceeds either way."""
     if not HOOKS_DIR.is_dir():
-        print(f"map-setup: no hooks dir at {HOOKS_REL} — skipping hook wiring")
+        print(f"map-setup: no hooks dir at {HOOKS_ABS} — skipping hook wiring")
         return False
     hooks = sorted(p for p in HOOKS_DIR.iterdir() if p.is_file())
     for h in hooks:
@@ -56,9 +62,9 @@ def wire_hooks() -> bool:
               "(auto-remap needs git; `./sc map` / rebuild still refresh)")
         return False
     subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "config", "core.hooksPath", HOOKS_REL],
+        ["git", "-C", str(REPO_ROOT), "config", "core.hooksPath", HOOKS_ABS],
         check=True)
-    print(f"map-setup: core.hooksPath -> {HOOKS_REL} "
+    print(f"map-setup: core.hooksPath -> {HOOKS_ABS} "
           f"({len(hooks)} hook(s): {', '.join(h.name for h in hooks)})")
     return True
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -625,12 +625,11 @@ def main() -> None:
     # branch-guard.sh reads it to exempt the admin shell (which works on main
     # by mandate); like SC_PROTECTED_BRANCHES it's a guardrail, not a boundary.
     env["SC_SHELL_FLAVOR"] = chosen["flavor"] or ""
-    # Absolute path to the installed engine, so the branch-guard hook resolves
-    # the script regardless of cwd. A fork gitignores .super-coder/, so it is
-    # ABSENT from every shell worktree (git checks out only tracked files) — a
-    # worktree-relative path (the old $CLAUDE_PROJECT_DIR/.super-coder/...) found
-    # nothing and the hook failed open. The engine is installed once at the repo
-    # root; pin to it. All three adapters reference $SC_ENGINE_DIR.
+    # Optional fast-path for the branch-guard hooks: the absolute engine path, so
+    # they skip the `git rev-parse --git-common-dir` walk. NOT load-bearing — the
+    # hooks resolve the engine env-independently (a fork gitignores .super-coder/,
+    # so it is absent from worktrees; a worktree-relative path failed open). This
+    # just saves a subshell per edit on the normal launch path.
     env["SC_ENGINE_DIR"] = str(ENGINE)
     os.chdir(work_dir)
     print(f"→ exec {' '.join(cmd)}\n")


### PR DESCRIPTION
Re-lands **#122**, whose changes never reached `main`.

**What happened:** #122 was stacked on #121's branch (base `fix/branch-guard-fork-worktrees`, never retargeted). #121 squash-merged to `main` first — capturing only its own commits — then #122 merged into the *stacked branch*, not `main`. So #122's content (env-independent `git-common-dir` resolution + absolute `core.hooksPath`) ended up stranded on `fix/branch-guard-fork-worktrees` and `main` has only #121. The classic stacked-PR + squash hazard.

This PR cherry-picks the #122 commit cleanly onto current `main`. Diff is byte-identical to the original #122 (7 files, +45/-31); JSON/py/node all validate.

Content recap (see #122 for full detail + verification):
1. All three adapters resolve the guard env-independently (walk to the main worktree root via `git rev-parse --git-common-dir`/.. like `sc` does); `$SC_ENGINE_DIR` is only a fast-path override — fixes #121's silent fail-open when the harness is launched outside run.py.
2. `map_setup.py` sets `core.hooksPath` **absolute** — a relative value resolved against the worktree cwd, where a fork's gitignored `.super-coder/` is absent, so every git hook silently no-op'd in shell worktrees (pre-commit guard, post-commit preview URL, catalogue remap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)