### PR TITLE
feat(branch-guard): extend the edited-file check to opencode (+ codex finding)

### DIFF
--- a/.super-coder/adapters/opencode/README.md
+++ b/.super-coder/adapters/opencode/README.md
@@ -42,16 +42,21 @@ harness-specific file OpenCode wants and the launch command.
   default. Provider-scoped (all OpenRouter models); harmless for non-Qwen models.
   `reasoning` is intentionally left untouched — the next dial if noise persists.
 - **`protect-default-branch.js`** + its entry in `opencode.json` `plugin` — a
-  `tool.execute.before` hook that blocks `write`/`edit`/`patch` while HEAD is a
-  protected default branch (forcing a feature branch before work lands).
-  Registered by repo-relative path (like `tool-discipline.md`), so it is read
-  in-place from the engine dir — not emitted, survives regeneration. It shells
-  out to the shared `.super-coder/scripts/branch-guard.sh` (one branch-decision
-  source across all harnesses; honors `SC_PROTECTED_BRANCHES`). Throwing in the
-  hook aborts that one tool call and surfaces the reason to the model. This is
-  opencode's equivalent of the claude/codex `PreToolUse` deny hook; the git
-  pre-commit backstop (`.super-coder/hooks/pre-commit`) catches shell-driven
-  writes that route around the tool path.
+  `tool.execute.before` hook that blocks `write`/`edit`/`patch` while a protected
+  default branch is in play (forcing a feature branch before work lands). It
+  extracts the edited path from the tool args (`output.args.filePath`) and passes
+  it to the guard, so it blocks an edit aimed at the **stale main root** (or any
+  protected-branch checkout), not just one whose cwd is on a protected branch —
+  the same target-file check claude gets. `run.py` rewrites the `plugin` entry to
+  an **absolute** engine path at emit: the template's repo-relative
+  `./.super-coder/...` does not exist in a fork's shell worktree (the engine is
+  gitignored), so opencode would silently load no plugin and the guard would
+  never run. It shells out to the shared `.super-coder/scripts/branch-guard.sh`
+  (one branch-decision source across all harnesses; honors
+  `SC_PROTECTED_BRANCHES`). Throwing in the hook aborts that one tool call and
+  surfaces the reason to the model. The git pre-commit backstop
+  (`.super-coder/hooks/pre-commit`) catches shell-driven writes that route around
+  the tool path.
 
 ## Verify on live OpenCode (research flags from the spec)
 

--- a/.super-coder/adapters/opencode/protect-default-branch.js
+++ b/.super-coder/adapters/opencode/protect-default-branch.js
@@ -11,7 +11,9 @@
 const WRITE_TOOLS = new Set(["write", "edit", "patch"]);
 
 export const ProtectDefaultBranch = async ({ $, worktree }) => ({
-  "tool.execute.before": async (input) => {
+  // opencode puts the tool ARGS in the second param (output.args), not input —
+  // input carries only {tool, sessionID, callID}.
+  "tool.execute.before": async (input, output) => {
     if (!WRITE_TOOLS.has(input.tool)) return;
     // Resolve the installed engine the same env-independent way `sc` does: a
     // fork gitignores .super-coder/, so it is absent from the worktree — walk to
@@ -26,12 +28,20 @@ export const ProtectDefaultBranch = async ({ $, worktree }) => ({
       eng = root ? `${root}/.super-coder` : `${worktree}/.super-coder`;
     }
     const guard = `${eng}/scripts/branch-guard.sh`;
+    // Pass the edited file as $1 so the guard checks the TARGET file's branch —
+    // blocking an edit aimed at the stale main root (or any protected-branch
+    // checkout), not just one whose cwd is on a protected branch. write/edit/
+    // patch carry the path under one of these keys; if none is a string we pass
+    // nothing and the guard falls back to its cwd-branch check.
+    const a = (output && output.args) || {};
+    const target = [a.filePath, a.file_path, a.path, a.filename].find(
+      (v) => typeof v === "string" && v.length > 0,
+    );
     // Bun shell: run the guard at the worktree root; .nothrow() so we read the
     // exit code, .quiet() so its output doesn't leak into the TUI.
-    const res = await $`bash ${guard}`
-      .cwd(worktree)
-      .quiet()
-      .nothrow();
+    const res = await (target
+      ? $`bash ${guard} ${target}`.cwd(worktree).quiet().nothrow()
+      : $`bash ${guard}`.cwd(worktree).quiet().nothrow());
     if (res.exitCode !== 0) {
       const msg = (res.stderr?.toString() || "").trim();
       throw new Error(

--- a/.super-coder/scripts/branch-guard.sh
+++ b/.super-coder/scripts/branch-guard.sh
@@ -16,15 +16,16 @@
 # commit and prints it.
 #
 # TWO checks, in order of authority:
-#   1. TARGET FILE (claude only) — claude passes the edit's PreToolUse JSON on
-#      stdin (tool_input.file_path/notebook_path). We resolve the branch of the
-#      repo that OWNS that file and block if it is protected. This catches the
+#   1. TARGET FILE (claude + opencode) — the edited path arrives as $1 (opencode
+#      plugin) or in claude's PreToolUse JSON on stdin. We resolve the branch of
+#      the repo that OWNS that file and block if it is protected. This catches the
 #      foot-gun a cwd-only check misses: a worktree shell editing files in the
 #      stale main checkout (a DIFFERENT repo dir on `main`) — the cwd is a clean
 #      feature branch, so the old cwd check waved it through. If the target is
 #      outside the shell's own worktree but NOT on a protected branch, we ALLOW
-#      but emit a loud warning (claude additionalContext + stderr).
-#   2. CWD (all consumers, and the fallback when there is no stdin target) — the
+#      but emit a loud warning (claude additionalContext + stderr). codex's
+#      apply_patch hook supplies no usable target → it uses Check 2 only.
+#   2. CWD (all consumers, and the fallback when there is no target) — the
 #      original behavior: block if HEAD of the cwd's repo is a protected branch.
 #
 # The harness hooks locate this script env-independently, the same way `sc` does:
@@ -76,14 +77,19 @@ feature_branch_hint() {
   echo "then retry. One branch per unit of work — see the 'git' skill (branch -> commit -> push -> PR -> stop)." >&2
 }
 
-# ── Check 1: the target file (claude PreToolUse stdin) ──────────────────────
-# Read any JSON on stdin; other consumers pass nothing → target stays empty and
-# we fall through to the cwd check. python3 is an engine dependency wherever the
-# claude hook runs; if it is somehow absent we simply skip the target check.
-payload="$(cat 2>/dev/null || true)"
-target=""
-if [ -n "$payload" ] && command -v python3 >/dev/null 2>&1; then
-  target="$(printf '%s' "$payload" | python3 -c '
+# ── Check 1: the target file ────────────────────────────────────────────────
+# Resolve the edited file, in priority order:
+#   1. an explicit $1 arg — the opencode plugin extracts the path from the tool
+#      args and passes it here (it has the path structured; nothing to pipe).
+#   2. a PreToolUse JSON payload on stdin — claude pipes tool_input.file_path /
+#      notebook_path. (codex's apply_patch hook pipes no usable target, so it
+#      falls through to the cwd check — see the codex adapter README.)
+#   3. neither → empty → fall through to the cwd check (Check 2).
+target="${1:-}"
+if [ -z "$target" ]; then
+  payload="$(cat 2>/dev/null || true)"
+  if [ -n "$payload" ] && command -v python3 >/dev/null 2>&1; then
+    target="$(printf '%s' "$payload" | python3 -c '
 import sys, json
 try:
     ti = (json.load(sys.stdin).get("tool_input") or {})
@@ -91,6 +97,7 @@ try:
 except Exception:
     print("")
 ' 2>/dev/null || echo "")"
+  fi
 fi
 
 if [ -n "$target" ]; then

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -69,6 +69,39 @@ def emit_adapter(adapter: dict, root: Path = REPO_ROOT) -> list[str]:
     return written
 
 
+def resolve_opencode_plugins(work_dir: Path) -> None:
+    """Rewrite opencode.json `plugin` entries that point into the engine to
+    ABSOLUTE paths. The template registers
+    `./.super-coder/adapters/opencode/protect-default-branch.js` — relative to the
+    opencode.json location (the worktree root). A fork gitignores .super-coder/,
+    so from a shell worktree that path does not exist and opencode silently loads
+    NO plugin → the branch-guard never runs. Same trap the hooks fell into;
+    resolve to the installed engine (verified: opencode loads plugins by absolute
+    path). No-op when no engine-relative plugin entry is present (e.g. the source
+    repo, where the relative path already resolves)."""
+    cfg_path = work_dir / "opencode.json"
+    if not cfg_path.exists():
+        return
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return
+    plugins = cfg.get("plugin")
+    if not isinstance(plugins, list):
+        return
+    changed = False
+    resolved = []
+    for p in plugins:
+        if isinstance(p, str) and ".super-coder/" in p:
+            resolved.append(str(ENGINE / p.split(".super-coder/", 1)[1]))
+            changed = True
+        else:
+            resolved.append(p)
+    if changed:
+        cfg["plugin"] = resolved
+        atomic_write(cfg_path, json.dumps(cfg, indent=2) + "\n")
+
+
 def _deep_merge(base: dict, patch: dict) -> dict:
     """Recursively merge patch into base (patch wins on scalar conflicts);
     mutates and returns base. Nested dicts merge key-wise so a fork's other
@@ -614,6 +647,7 @@ def main() -> None:
     # seam owns the launch command + any harness-specific config to emit.
     adapter = load_adapter(harness)
     emitted = emit_adapter(adapter, work_dir)
+    resolve_opencode_plugins(work_dir)  # engine-relative plugin path → absolute (loads in worktrees)
     print(f"→ harness: {harness} (reads {adapter.get('boot_artifact', 'AGENTS.md')})")
     if emitted:
         print(f"→ emitted {', '.join(emitted)}")


### PR DESCRIPTION
Follow-up to extend the #121 **"guard the file you're about to edit"** layer beyond claude. I probed both harnesses live before writing code — the results split them.

## opencode — fully covered (this PR)

Verified with a live `opencode run`: plugins fire, tool args live in the **second** hook param (`output.args`), and the file-path key is **`filePath`**.

1. **branch-guard.sh** now accepts the target path as **`$1`** (alongside claude's stdin JSON). The opencode plugin has the path structured and no stdin to pipe, so an arg is the natural channel. claude (stdin) and codex/cwd-fallback are unchanged.
2. **plugin** reads `output.args.filePath` and passes it to the guard → opencode now blocks an edit aimed at the **stale main root** / any protected-branch checkout, not just one whose cwd is on a protected branch.

### Latent hole this surfaced
`opencode.json` registered the plugin by the repo-relative path `./.super-coder/...`, which **doesn't exist in a fork's shell worktree** (the engine is gitignored) — so opencode silently loaded **no plugin** and the guard never ran there. Same class as the #123 hook-command fix. `run.py` now rewrites the plugin entry to an **absolute** engine path at emit (verified opencode loads plugins by absolute path).

## codex — NOT covered, and a bigger question flagged

A live `codex exec` probe: the `apply_patch` edit ran, but project-local `.codex/hooks.json` **PreToolUse *and* PostToolUse hooks did not fire at all** (broad `.*` matcher, `--dangerously-bypass-hook-trust`). So:
- codex's `apply_patch` supplies no usable target → the file-target check can't apply, **and**
- it's unclear codex's branch-guard fires **at all** in v0.139 (at least non-interactively). If it doesn't fire interactively either, dos-arch's codex dev shells have **no edit-time guard** — only the git pre-commit backstop (which does still fire).

I did **not** ship a codex guess. This needs interactive verification of whether `.codex/hooks.json` PreToolUse fires before any codex work — flagging rather than faking it.

## Coverage after this PR

| Layer | claude | opencode | codex |
|---|---|---|---|
| Guard findable / loads in worktrees | ✅ | ✅ (this PR) | ✅ hook *present* |
| Edit-time **cwd-branch** check | ✅ | ✅ | ⚠️ only if hooks fire |
| Edit-time **file-target** check (block stale-main edit) | ✅ | ✅ (this PR) | ❌ |
| Commit-time (pre-commit) | ✅ | ✅ | ✅ |

## Test
`branch-guard.sh` $1-target verified (block stale-main / allow in-worktree / claude-stdin still works / codex-style fallback). `resolve_opencode_plugins` unit-tested (engine entry → absolute, npm entries untouched). `run.py` compiles, plugin `node --check` clean. `./sc test`: 60 tests, only the pre-existing `test_get_map_empty_catalogue` failure (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)