### PR TITLE
fix(branch-guard): trust codex worktrees so the branch-guard hook loads

### DIFF
--- a/.super-coder/adapters/codex/README.md
+++ b/.super-coder/adapters/codex/README.md
@@ -24,23 +24,33 @@ billing. opencode stays as the universal metered catch-all.
 
 ## Branch-guard hook
 
-Codex reads project-local hooks from `<repo>/.codex/hooks.json`, layered above the
-host-global `~/.codex/config.toml` — so the engine installs the guard there and
-**never touches the host-mounted `~/.codex`** (auth/config/history stay clean). The
-hook is a `PreToolUse` matcher on `^apply_patch$` (codex's file-edit tool) that runs
-the shared `.super-coder/scripts/branch-guard.sh` and denies the edit (exit 2) while
-HEAD is a protected default branch. `.codex/hooks.json` is emitted (gitignored) each
-launch, kept apart from a fork's own tracked `.codex/config.toml`.
+Codex reads project-local hooks from `<repo>/.codex/hooks.json`. The hook is a
+`PreToolUse` matcher on `^apply_patch$` (codex's file-edit tool) that runs the
+shared `.super-coder/scripts/branch-guard.sh` and denies the edit (exit 2) while a
+protected default branch is in play. `.codex/hooks.json` is emitted (gitignored)
+each launch. Codex only delivers the apply_patch *patch text* (`tool_input.command`),
+not a file path, so the guard uses its cwd-branch check (not the target-file check
+claude/opencode get).
 
-`--dangerously-bypass-hook-trust` (base launch): project-local hooks otherwise
-require an interactive per-hook trust step. The flag runs the engine-authored hook
-without it — the launcher itself vetted the source. It bypasses *hook trust only*,
-not approvals/sandbox (that is the separate sandbox-only flag below).
+**Two things gate whether this hook actually enforces — both verified empirically:**
 
-`--dangerously-bypass-approvals-and-sandbox` is appended only in the container,
-where the container itself is the safety boundary (matches how claude/opencode
-get allow-all permissions in-sandbox). On the no-docker host path (`./sc boot`),
-codex keeps its normal approval prompts.
+1. **Trust (LOADING).** Codex loads project-local hooks only when the project's
+   `.codex/` layer is *trusted*, keyed per-directory. A shell runs in a worktree
+   (`.sc-worktrees/<name>`), which is NOT the trusted main root — so without help
+   the hook never loads. `run.py` (`trust_codex_worktree`) marks the worktree
+   trusted in `$CODEX_HOME/config.toml` at boot. This is the one place the engine
+   writes under the codex home — additive project-trust only, never auth/history.
+   (`--dangerously-bypass-hook-trust` only skips the per-hook hash review, NOT this
+   layer-load trust. And `codex exec` runs no hooks at all — interactive only.)
+
+2. **YOLO flag (ENFORCING).** `--dangerously-bypass-approvals-and-sandbox` is
+   appended only in the container (the container is the safety boundary). That flag
+   **ignores the hook's exit-2 deny** — verified: the hook fires and returns 2, but
+   the edit proceeds. So **in-sandbox, codex's edit-time branch-guard cannot block**;
+   the git **pre-commit backstop** is the real guard there (it blocks
+   protected-branch *commits* regardless of harness flags). On the no-docker host
+   path (`./sc boot`), the flag is absent, approvals are normal, and the exit-2 deny
+   IS honored — so the host edit-time guard blocks.
 
 **Host setup (one-time):** the binary is baked into the sandbox image, but auth is
 mounted from the host — so `codex` must be installed + logged in on the host once:

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -218,6 +218,38 @@ def link_worktree_map(work_dir: Path) -> None:
         print(f"→ map link: skipped ({e})")
 
 
+def trust_codex_worktree(work_dir: Path) -> None:
+    """Mark a codex shell's worktree as a trusted project in codex's config, so
+    its project-local .codex/hooks.json (the branch-guard) actually LOADS.
+
+    codex loads project-local hooks ONLY when the project's .codex/ layer is
+    trusted, and trust is keyed per-directory. Shells run in worktrees, which are
+    NOT the trusted main root — so without this the branch-guard never loads and
+    codex worktree shells run with NO edit-time guard. (Verified: interactive
+    codex fires the PreToolUse hook iff the project is trusted; `codex exec` runs
+    no hooks at all, and `--dangerously-bypass-hook-trust` only skips per-hook
+    hash review, not this layer-load trust.)
+
+    Idempotent text-append to $CODEX_HOME/config.toml (default ~/.codex). This is
+    the one place the engine writes under the codex home — additive project-trust
+    only, never auth/history (an FnB-approved deviation from the otherwise
+    hands-off ~/.codex policy)."""
+    home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+    cfg = home / "config.toml"
+    header = f'[projects."{work_dir}"]'
+    try:
+        text = cfg.read_text() if cfg.exists() else ""
+        if header in text:
+            return  # already trusted (codex writes exactly this stanza)
+        home.mkdir(parents=True, exist_ok=True)
+        sep = "" if (not text or text.endswith("\n")) else "\n"
+        with cfg.open("a") as f:
+            f.write(f'{sep}\n{header}\ntrust_level = "trusted"\n')
+        print(f"→ codex: trusted worktree layer (hooks load) → {cfg}")
+    except OSError as e:
+        print(f"→ codex trust: skipped ({e})")
+
+
 def _git(work_dir: Path, *args: str, timeout: int = 15) -> "subprocess.CompletedProcess[str]":
     return subprocess.run(["git", "-C", str(work_dir), *args],
                           capture_output=True, text=True, timeout=timeout)
@@ -600,6 +632,8 @@ def main() -> None:
         ensure_worktree(work_dir, chosen["shortname"])
         sync_note = sync_worktree(work_dir, chosen["shortname"])
         link_worktree_map(work_dir)  # .sc-state/map.db -> root's map DB (heals shadows)
+        if harness == "codex":
+            trust_codex_worktree(work_dir)  # so codex loads the worktree's branch-guard hook
 
     # Repo-global branch hygiene: delete local branches whose PR is provably
     # merged (git_hygiene's `stale` set — gh-confirmed MERGED, never a base or a


### PR DESCRIPTION
Closes the codex half of the branch-guard work (CC-124). Investigated with interactive pty probes — `codex exec` runs **no** hooks, so all my earlier exec-based probes were the wrong lens; only interactive codex fires them.

## Root cause — two compounding issues
1. **Hook never loads.** Codex loads project-local `.codex/hooks.json` only when the project's `.codex/` layer is **trusted** (per-directory). Shells run in **worktrees**, which aren't trusted (only the main root is) → the branch-guard hook never loaded → codex worktree shells had **no edit-time guard**. (`--dangerously-bypass-hook-trust` only skips the per-hook hash review, not this layer-load trust.)
2. **YOLO flag ignores the deny.** Even trusted + firing, `--dangerously-bypass-approvals-and-sandbox` (sandbox-only) **ignores the hook's exit-2 deny** — verified: hook fires, returns 2, edit proceeds anyway.

## This PR
`run.py` → `trust_codex_worktree()`: marks the worktree trusted in `$CODEX_HOME/config.toml` at boot, for codex launches only. Idempotent, additive project-trust only, never auth/history (an approved, narrow deviation from the otherwise hands-off `~/.codex` policy).

## What it does / doesn't fix (documented in the codex adapter README)
| codex mode | edit-time guard after this PR |
|---|---|
| **Host** (`./sc boot`, no sandbox) | **loads + blocks** ✅ (exit-2 deny honored; approvals normal) |
| **Sandboxed** (YOLO) | hook now **loads + fires**, but the bypass flag ignores the deny → can't block at edit-time *by design*; the **git pre-commit backstop** is the guard (blocks protected-branch commits regardless of flags) ✅ |

Per your call: ship the trust fix (fixes host codex), accept the pre-commit backstop for sandboxed codex. Codex also delivers only the patch text (`tool_input.command`), not a file path, so it uses the **cwd-branch** check, not the target-file check claude/opencode get.

## Verification
- Interactive pty: project trusted → PreToolUse hook fires with full payload; untrusted → no fire. Disambiguation run: hook fired + `guard_exit=2` + edit still happened under the YOLO flag (proves the deny is ignored there).
- `trust_codex_worktree` unit-tested (idempotent stanza append). `run.py` compiles. `./sc test`: 60 tests, only the pre-existing `test_get_map_empty_catalogue` failure (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)