### PR TITLE
fix(publish): ephemeral sc_gui_content branch — open PR, no merge, clean up to main

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -361,15 +361,20 @@ def run_snapshot_render() -> str:
             + run_script("render")["output"]).strip()
 
 
-# ── Publish: serialize → commit → push → PR (the GUI "publish" button) ─────────
-# Single-rolling-branch model: every GUI edit lands on PUBLISH_BRANCH with ONE
-# open PR to main, so branches never proliferate and main stays clean until you
-# merge. Push + PR need a GitHub token in the env (GH_TOKEN); `./sc launch`
-# forwards it into the sandbox. Without a token the change is still COMMITTED
-# locally — the tree never goes dirty — only the push/PR is skipped, with a clear
-# message. A module lock serializes concurrent publishes (one git index).
+# ── Publish: serialize → render → commit → push → open/update one PR ──────────
+# Ephemeral-branch model: each publish (re)creates the local branch from HEAD,
+# commits the serialized content + renders onto it, force-pushes, opens/updates
+# ONE PR to main — then returns to main and DELETES the local branch. No merge:
+# the open PR is the gate (the FnB merges on GitHub). The branch NAME is stable
+# (one rolling PR) but the local branch is EPHEMERAL — rebuilt + dropped every
+# publish — so the working tree is always left clean on main and branches never
+# accumulate. Push + PR need a GitHub token (SC_GH_TOKEN / GH_TOKEN); `./sc
+# launch` forwards it into the sandbox. Without a token the change is still
+# COMMITTED locally (the unpushed branch is kept so the commit isn't lost) — only
+# push/PR is skipped, with a clear message. A module lock serializes concurrent
+# publishes (one git index).
 BASE_BRANCH = "main"
-PUBLISH_BRANCH = "gui-content"
+PUBLISH_BRANCH = "sc_gui_content"
 _PUBLISH_LOCK = threading.Lock()
 # The git-tracked text the DB rebuilds from + the flat renders. NOT the .db
 # (gitignored). schema.sql + migrations are engine paths: TRACKED in the source
@@ -413,43 +418,37 @@ def _redact(s: str, token: str) -> str:
 
 
 def git_publish() -> dict:
-    out: list[str] = []
-
-    # 1. serialize the DB → git-tracked text + render the flat files.
-    out.append(run_snapshot_render())
-
-    # publish borrows gui-content to commit/push, then returns the operator to
-    # the branch they started on. Parking them on gui-content silently was a
-    # footgun — later terminal/code work landed there unnoticed. main stays
-    # clean either way (the content commit lives on gui-content + its PR).
-    cur = _git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
-    result = _git_publish_on_branch(cur, out)
-    now = _git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
-    if now != cur:
-        back = _git("checkout", cur)
-        if back.returncode == 0:
-            result["output"] += f"\n\n↩ back on {cur}"
-        else:
-            result["output"] += (f"\n\n⚠ left on {now} — couldn't return to "
-                                  f"{cur}:\n{back.stderr.strip()}")
-    return result
+    # 1. serialize the DB → git-tracked text + render the flat files (repo root).
+    out: list[str] = [run_snapshot_render()]
+    # state survives into the finally so cleanup knows whether the commit reached
+    # origin (safe to drop the local branch) or only exists locally (keep it).
+    state: dict = {"ok": True, "pr_url": None, "pushed": False}
+    try:
+        _publish_content(out, state)
+    finally:
+        # Always land back on main and drop the ephemeral local branch — runs even
+        # if _publish_content raised or returned early, so the tree never gets
+        # stranded on the publish branch.
+        _land_on_base(out, state)
+    return {"ok": state["ok"], "output": "\n".join(out), "pr_url": state["pr_url"]}
 
 
-def _git_publish_on_branch(cur: str, out: list) -> dict:
-    # 2. land on the rolling branch (created from HEAD on first publish).
-    if cur != PUBLISH_BRANCH:
-        exists = _git("rev-parse", "--verify", "--quiet",
-                      f"refs/heads/{PUBLISH_BRANCH}").returncode == 0
-        sw = (_git("checkout", PUBLISH_BRANCH) if exists
-              else _git("checkout", "-b", PUBLISH_BRANCH))
-        if sw.returncode != 0:
-            return {"ok": False, "output": "\n".join(out) +
-                    f"\n\n✗ can't switch to '{PUBLISH_BRANCH}' from '{cur}':\n"
-                    f"{sw.stderr.strip()}\n\nCheck out '{PUBLISH_BRANCH}' (or commit/"
-                    "stash) before editing."}
-        out.append(f"on branch {PUBLISH_BRANCH} (from {cur})")
+def _publish_content(out: list, state: dict) -> None:
+    # 2. (re)create the ephemeral local branch from HEAD. It should not exist —
+    #    every publish drops it on the way out — but a crashed prior run can leave
+    #    one behind, so remove a stale one rather than failing the `checkout -b`.
+    if _git("rev-parse", "--verify", "--quiet",
+            f"refs/heads/{PUBLISH_BRANCH}").returncode == 0:
+        _git("branch", "-D", PUBLISH_BRANCH)
+        out.append(f"(dropped stale local {PUBLISH_BRANCH})")
+    sw = _git("checkout", "-b", PUBLISH_BRANCH)
+    if sw.returncode != 0:
+        state["ok"] = False
+        out.append(f"✗ can't create '{PUBLISH_BRANCH}':\n{sw.stderr.strip()}")
+        return
+    out.append(f"on ephemeral branch {PUBLISH_BRANCH}")
 
-    # 3. stage the publishable text + renders; commit if anything is new.
+    # 3. stage the publishable text + renders; commit if anything changed.
     #    Filter to paths that exist — `git add` is fatal on a missing pathspec, and
     #    a minimal fork may lack some (e.g. docs_sc/ before any doc is authored).
     #    Drop gitignored paths too: in a fork the engine (schema/migrations) is
@@ -462,48 +461,47 @@ def _git_publish_on_branch(cur: str, out: list) -> dict:
     if present:
         _git("add", "--", *present)
     staged = _git("diff", "--cached", "--name-only").stdout.strip()
-    if staged:
-        n = len(staged.splitlines())
-        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-        msg = (f"gui: publish content edits ({n} file{'s' if n != 1 else ''})\n\n"
-               f"Serialized + rendered from the review GUI at {stamp}.\n\n"
-               + "\n".join(f"- {f}" for f in staged.splitlines()))
-        c = _git("commit", "-m", msg)
-        if c.returncode != 0:
-            return {"ok": False, "output": "\n".join(out) +
-                    "\n\n✗ commit failed:\n" + (c.stderr or c.stdout).strip()}
-        out.append(f"committed {n} file(s)")
-    else:
-        out.append("no new content to commit")
+    if not staged:
+        out.append(f"✓ no content changes vs {BASE_BRANCH} — nothing to publish")
+        return
+    n = len(staged.splitlines())
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    msg = (f"gui: publish content edits ({n} file{'s' if n != 1 else ''})\n\n"
+           f"Serialized + rendered from the review GUI at {stamp}.\n\n"
+           + "\n".join(f"- {f}" for f in staged.splitlines()))
+    c = _git("commit", "-m", msg)
+    if c.returncode != 0:
+        state["ok"] = False
+        out.append("✗ commit failed:\n" + (c.stderr or c.stdout).strip())
+        return
+    out.append(f"committed {n} file(s)")
 
-    # 4. nothing ahead of main → nothing to publish.
-    ahead = _git("rev-list", "--count",
-                 f"{BASE_BRANCH}..{PUBLISH_BRANCH}").stdout.strip() or "0"
-    if ahead == "0":
-        return {"ok": True, "output": "\n".join(out) +
-                f"\n\n✓ {PUBLISH_BRANCH} matches {BASE_BRANCH} — nothing to publish."}
-
-    # 5. token gate: committed locally either way (tree clean), but push/PR needs it.
+    # 4. token gate: committed locally either way, but push/PR needs a token.
     token = _gh_token()
     if not token:
-        return {"ok": True, "output": "\n".join(out) +
-                f"\n\n⚠ committed on {PUBLISH_BRANCH} ({ahead} commit(s) ahead of "
-                f"{BASE_BRANCH}), but no GH_TOKEN — can't push or open a PR. Set "
-                "SC_GH_TOKEN, or `./sc launch` with a host gh login."}
+        out.append("⚠ committed locally, but no GH_TOKEN — can't push or open a "
+                   "PR. Set SC_GH_TOKEN, or `./sc launch` with a host gh login.")
+        return
 
-    # 6. push over token-https (no ssh keys needed).
+    # 5. force-push: the branch is recreated from HEAD each publish (one commit
+    #    ahead of main — the full current state), so it intentionally overwrites
+    #    the prior rolling head. Only publish ever writes this branch, so --force
+    #    is safe and force-with-lease's tracking-ref dance is unnecessary.
     url = _origin_https()
     if not url:
-        return {"ok": False, "output": "\n".join(out) +
-                "\n\n✗ no 'origin' remote to push to."}
+        state["ok"] = False
+        out.append("✗ no 'origin' remote to push to.")
+        return
     push_url = url.replace("https://", f"https://x-access-token:{token}@", 1)
-    p = _git("push", push_url, f"{PUBLISH_BRANCH}:{PUBLISH_BRANCH}")
+    p = _git("push", "--force", push_url, f"{PUBLISH_BRANCH}:{PUBLISH_BRANCH}")
     if p.returncode != 0:
-        return {"ok": False, "output": "\n".join(out) +
-                "\n\n✗ push failed:\n" + _redact((p.stderr or p.stdout).strip(), token)}
-    out.append(f"pushed {PUBLISH_BRANCH} → origin ({ahead} commit(s) ahead)")
+        state["ok"] = False
+        out.append("✗ push failed:\n" + _redact((p.stderr or p.stdout).strip(), token))
+        return
+    state["pushed"] = True
+    out.append(f"force-pushed {PUBLISH_BRANCH} → origin")
 
-    # 7. upsert ONE PR (gh reads the token from the env).
+    # 6. upsert ONE PR — no merge; the open PR is the gate the FnB merges.
     env = {**os.environ, "GH_TOKEN": token}
 
     def gh(*args):
@@ -515,17 +513,41 @@ def _git_publish_on_branch(cur: str, out: list) -> dict:
         cr = gh("pr", "create", "--base", BASE_BRANCH, "--head", PUBLISH_BRANCH,
                 "--title", "GUI content edits",
                 "--body", "Rolling PR for content edited via the super-coder "
-                "review GUI (roadmap, docs, flags, identity). Auto-updated on each "
+                "review GUI (roadmap, docs, flags, identity). Refreshed on each "
                 "publish; merge to land on main.")
         if cr.returncode != 0:
-            return {"ok": False, "output": "\n".join(out) +
-                    "\n\n✗ PR create failed:\n" + _redact((cr.stderr or cr.stdout).strip(), token)}
+            state["ok"] = False
+            out.append("✗ PR create failed:\n" + _redact((cr.stderr or cr.stdout).strip(), token))
+            return
         pr_url = cr.stdout.strip()
         out.append(f"opened PR: {pr_url}")
     else:
         out.append(f"updated PR: {pr_url}")
+    state["pr_url"] = pr_url
 
-    return {"ok": True, "output": "\n".join(out), "pr_url": pr_url}
+
+def _land_on_base(out: list, state: dict) -> None:
+    """Return to main and drop the ephemeral local branch — the pushed remote
+    branch + its PR are what persist. If the commit was NOT pushed (no token /
+    push failed), KEEP the local branch so its commit isn't lost; the live DB is
+    still the source of truth and a later `snapshot` regenerates the same text."""
+    now = _git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    if now != BASE_BRANCH:
+        co = _git("checkout", BASE_BRANCH)
+        if co.returncode != 0:
+            out.append(f"⚠ left on {now} — couldn't return to {BASE_BRANCH}:\n"
+                       f"{co.stderr.strip()}")
+            return
+    local_exists = _git("rev-parse", "--verify", "--quiet",
+                        f"refs/heads/{PUBLISH_BRANCH}").returncode == 0
+    if local_exists and state["pushed"]:
+        _git("branch", "-D", PUBLISH_BRANCH)
+        out.append(f"↩ back on {BASE_BRANCH}; local {PUBLISH_BRANCH} cleaned up")
+    elif local_exists:
+        out.append(f"↩ back on {BASE_BRANCH}; kept local {PUBLISH_BRANCH} "
+                   "(unpushed commit preserved)")
+    else:
+        out.append(f"↩ back on {BASE_BRANCH}")
 
 
 # ── HTTP ──────────────────────────────────────────────────────────────────────

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -24,7 +24,7 @@
     <div class="tools">
       <span id="status" class="status"></span>
       <button id="snapshot" title="serialize the DB → content.sql + render the flat _sc files (local only, no git)">snapshot ⤓</button>
-      <button id="publish" class="primary" title="snapshot + render, then commit → push → open/update one PR on the gui-content branch">publish ⤴</button>
+      <button id="publish" class="primary" title="snapshot + render, then commit → force-push → open/update one PR from an ephemeral sc_gui_content branch (no merge; returns to main + cleans up)">publish ⤴</button>
     </div>
   </header>
   <main>

--- a/README.md
+++ b/README.md
@@ -600,9 +600,10 @@ grants; edit the roadmap (linear status buckets, with toggle-filters) and
 **non-frozen** documents; create and resolve flags. **seed and L&S are
 read-only** — the laws say the shell curates them, so the API ships no endpoint
 to write them at all. A `snapshot ⤓` button re-serializes + renders after
-edits; **publish** goes one further — it snapshots, then lands your content
-edits as a commit on a rolling `gui-content` branch, so `main` stays clean and
-merging stays yours.
+edits; **publish** goes one further — it snapshots, then commits your content
+edits onto an ephemeral `sc_gui_content` branch, force-pushes it, and opens (or
+refreshes) one PR to `main` — then returns to `main` and drops the local branch.
+No merge: `main` stays clean and merging the PR stays yours.
 
 The **Scripts** tab lists the maintenance scripts (snapshot, render, seed-skills,
 migrate, rebuild) — each with a description and a **run** button, so the common

--- a/tests/test_publish_cleanup.py
+++ b/tests/test_publish_cleanup.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for publish's cleanup contract (server._land_on_base).
+
+Stdlib `unittest`, real git in a tmpdir — matching test_git_prune.py's
+no-dependency style. The full git_publish() round-trip shells out to snapshot/
+render + a real remote + `gh`, so it isn't unit-testable here; what IS isolable
+(and is the behavior change) is the ephemeral-branch cleanup: always land back
+on main, drop the local branch ONLY when its commit reached origin, keep it
+otherwise so an unpushed commit isn't lost. server._git binds cwd to the
+module global REPO_ROOT at call time, so pointing that at a tmp repo retargets
+the whole helper.
+
+Run:
+    python3 tests/test_publish_cleanup.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "api"))
+import server  # noqa: E402  (server.py adds scripts/ to the path on import)
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def git(cwd: Path, *args: str) -> str:
+    res = subprocess.run(["git", "-C", str(cwd), *args],
+                         capture_output=True, text=True, env=GIT_ENV)
+    if res.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed: {res.stderr}")
+    return res.stdout.strip()
+
+
+def local_branches(cwd: Path) -> set[str]:
+    return set(git(cwd, "for-each-ref", "--format=%(refname:short)",
+                   "refs/heads/").split())
+
+
+def current_branch(cwd: Path) -> str:
+    return git(cwd, "rev-parse", "--abbrev-ref", "HEAD")
+
+
+class LandOnBaseTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="publish-test-"))
+        self.repo = self.tmp / "repo"
+        self.repo.mkdir()
+        git(self.repo, "init", "-b", server.BASE_BRANCH)
+        git(self.repo, "commit", "--allow-empty", "-m", "init")
+        # Sit on the ephemeral publish branch with a commit, as publish would
+        # right before cleanup runs.
+        git(self.repo, "checkout", "-b", server.PUBLISH_BRANCH)
+        git(self.repo, "commit", "--allow-empty", "-m", "gui: publish content")
+        self._orig_root = server.REPO_ROOT
+        server.REPO_ROOT = self.repo
+
+    def tearDown(self) -> None:
+        server.REPO_ROOT = self._orig_root
+        subprocess.run(["rm", "-rf", str(self.tmp)])
+
+    def test_pushed_drops_local_branch(self) -> None:
+        # commit reached origin → the local branch is disposable.
+        out: list[str] = []
+        server._land_on_base(out, {"ok": True, "pr_url": "x", "pushed": True})
+        self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
+        self.assertNotIn(server.PUBLISH_BRANCH, local_branches(self.repo))
+        self.assertTrue(any("cleaned up" in line for line in out))
+
+    def test_unpushed_keeps_local_branch(self) -> None:
+        # no token / push failed → keep the branch so the commit isn't lost.
+        out: list[str] = []
+        server._land_on_base(out, {"ok": True, "pr_url": None, "pushed": False})
+        self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
+        self.assertIn(server.PUBLISH_BRANCH, local_branches(self.repo))
+        self.assertTrue(any("kept local" in line for line in out))
+
+    def test_already_on_base_is_a_noop_return(self) -> None:
+        # Nothing to do but report — e.g. branch creation failed earlier so we
+        # never left main and no publish branch exists.
+        git(self.repo, "checkout", server.BASE_BRANCH)
+        git(self.repo, "branch", "-D", server.PUBLISH_BRANCH)
+        out: list[str] = []
+        server._land_on_base(out, {"ok": False, "pr_url": None, "pushed": False})
+        self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
+        self.assertEqual(out, [f"↩ back on {server.BASE_BRANCH}"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Follow-up to the worktree-hardening sweep. Shells working in a worktree were confused that `./sc snapshot` / `./sc mem` write `content.sql` + the `_sc` renders into the **main** checkout (the shared engine + DB live at the main worktree root by design), not their worktree — and the `git` skill told them to commit that text on their branch, where it can't land. The resolution (per Jed): shells shouldn't own that commit at all — the GUI **Publish** button does. So harden Publish.

## What

Reworks `git_publish` (`.super-coder/api/server.py`) from a rolling `gui-content` branch to an **ephemeral, stable-named** `sc_gui_content` branch:

- **Rename** `gui-content` → `sc_gui_content` (namespaced `sc_` prefix).
- Each publish **(re)creates the local branch from HEAD**, commits the serialized content + renders, **force-pushes** (branch = always `main` + one full-state commit), and **opens/updates ONE PR**. **No merge** — the open PR stays the gate the FnB merges.
- **Cleanup always runs** (`try/finally`): return to `main` and **delete** the local branch. Stable name → one rolling PR; ephemeral local branch → tree always left clean on `main`, branches never accumulate.
- **Don't lose unpushed work:** the local branch is dropped only when the commit reached origin. No token / push failed → the branch is **kept** (the commit survives; the live DB is still the source and a later `snapshot` regenerates the same text).
- Defensively drops a stale local branch left by a crashed prior run before recreating it.

## Test

`tests/test_publish_cleanup.py` — covers the cleanup contract (drop-on-pushed, keep-on-unpushed, no-op return-to-main) against a real git tmp repo. All existing tests still pass (the one `test_api_endpoints::test_get_map_empty_catalogue` failure is pre-existing on `main`, unrelated).

README + publish button tooltip updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)