### PR TITLE
feat(vm): Windows Test VM opt-in — link, validate, drive

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -44,6 +44,7 @@ import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
 import ports as ports_mod  # noqa: E402
 import shell_factory  # noqa: E402
 import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin rule)
+import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
 
 _STATIC = {
     "/": ("index.html", "text/html; charset=utf-8"),
@@ -663,6 +664,8 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, get_flags(con))
             if path == "/api/scripts":
                 return self._send(200, {"scripts": script_list()})
+            if path == "/api/vm":
+                return self._send(200, {"vm": vm_mod.read()})
             return self._send(404, {"error": "not found"})
         except Exception as e:
             return self._fail(e)
@@ -699,6 +702,14 @@ class Handler(BaseHTTPRequestHandler):
                 if r is None:
                     return self._send(404, {"error": "no such script"})
                 return self._send(200 if r["ok"] else 500, r)
+            if path.startswith("/api/vm/validate/"):
+                # Run ONE live check against the candidate config in the body, so
+                # the wizard can test-before-save. A failed check is a normal
+                # result the UI renders red — 200 with {ok:false}, not an error.
+                r = vm_mod.validate(path.rsplit("/", 1)[1], self._body().get("vm") or {})
+                if r is None:
+                    return self._send(404, {"error": "no such check"})
+                return self._send(200, r)
             return self._send(404, {"error": "not found"})
         except Exception as e:
             return self._fail(e)
@@ -740,6 +751,7 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_PUT(self):
         # grant toggle: PUT /api/shells/{id}/skills/{skill_id}  {granted: bool}
+        # vm block:     PUT /api/vm  {vm: {...}}  (persists to instance.json)
         path = urlparse(self.path).path
         parts = path.strip("/").split("/")
         con = db()
@@ -748,6 +760,11 @@ class Handler(BaseHTTPRequestHandler):
                 set_grant(con, int(parts[2]), int(parts[4]),
                           bool(self._body().get("granted")))
                 return self._send(200, {"ok": True})
+            if path == "/api/vm":
+                vm = self._body().get("vm")
+                if vm is not None and not isinstance(vm, dict):
+                    return self._send(400, {"error": "vm must be an object"})
+                return self._send(200, {"ok": True, "vm": vm_mod.write(vm)})
             return self._send(404, {"error": "not found"})
         except Exception as e:
             return self._fail(e)

--- a/.super-coder/assets/skills/configure_winbox/SKILL.md
+++ b/.super-coder/assets/skills/configure_winbox/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: configure_winbox
+description: Provision the Windows Test VM — winget-install the fork's toolchain from a committed manifest, verify each tool, then bake the clean snapshot every test reverts to. Admin-only; runs before the snapshot, re-runs on any toolchain change. Use when standing up or updating a fork's Windows build/test box.
+category: substrate
+common: false
+---
+
+# configure_winbox — provisioning the Windows Test VM
+
+The admin half of the Windows Test VM capability. You install the build
+toolchain into the operator's Windows VM and bake the **clean snapshot** that
+every `windows-devkit` run reverts to. Sibling to `self_update` /
+`migration_management` — infrastructure work only the admin shell does. Grant is
+explicit, per-fork (`common=0`).
+
+## Scope boundary — what you do NOT do
+
+You do **not** create the VM, install the guest OS, or enable OpenSSH inside it.
+That bootstrap is the operator's, host-side, once (the engine can't reach inside
+a fresh OS install). You assume a reachable guest with key auth already working,
+and you provision the *toolchain* on top of it.
+
+## Order is the design — provision BEFORE the snapshot
+
+```
+operator: OS + OpenSSH + key   →   YOU: winget toolchain + verify   →   snapshot = clean   →   devs run loop
+```
+
+The clean snapshot is **pristine OS + toolchain**. Every test reverts to it, so
+the toolchain must be baked in. Provision *after* snapshotting and the first
+test hits an empty box. Bump the toolchain → re-run this skill → **re-snapshot**.
+
+## Procedure
+
+1. **Read the link.** `.super-coder/instance.json` `vm` block gives the domain +
+   SSH coordinates. Confirm SSH works: `ssh -i <ssh_key_path> -p <ssh_port>
+   <ssh_user>@<ssh_host> "echo ok"`.
+
+2. **Install the toolchain from the fork's committed manifest.** The fork commits
+   a `winget export` at a known path (e.g. `winget-manifest.json`); you supply
+   the *mechanism*, the fork supplies the *package list* — so this skill stays
+   generic across forks. Over SSH:
+   `winget import --import-file <manifest> --accept-package-agreements --accept-source-agreements`
+   (for dos-arch: WiX, .NET SDK, MSBuild.)
+
+3. **Verify each tool** over SSH — `dotnet --version`, `where.exe wix`, `msbuild
+   -version`. The `windows-devkit` wizard's `toolchain` check (`dotnet
+   --version`) is the same probe; it must go green after this step.
+
+4. **Bake the clean snapshot.** `virsh snapshot-create-as <domain> <snapshot>
+   --description "pristine OS + toolchain"`. Use the `snapshot` name from the
+   `vm` block (default `clean`). If re-provisioning, delete the old snapshot
+   first (`virsh snapshot-delete <domain> <snapshot>`) so the name is reused.
+
+## Stance
+
+- **Toolchain-as-code.** Install from the committed manifest, never ad hoc —
+  the package set is reproducible and reviewable, and re-provisioning is a
+  re-import, not a memory of what you clicked.
+- **Re-provision means re-snapshot.** A toolchain bump that isn't followed by a
+  fresh snapshot is invisible — every test still reverts to the old box.
+- **Verify before you snapshot.** A snapshot of a half-installed box is a clean
+  snapshot of a broken kit. Green checks first, snapshot second.

--- a/.super-coder/assets/skills/configure_winbox/SKILL.md
+++ b/.super-coder/assets/skills/configure_winbox/SKILL.md
@@ -9,7 +9,7 @@ common: false
 
 The admin half of the Windows Test VM capability. You install the build
 toolchain into the operator's Windows VM and bake the **clean snapshot** that
-every `windows-devkit` run reverts to. Sibling to `self_update` /
+every `windows_devkit` run reverts to. Sibling to `self_update` /
 `migration_management` — infrastructure work only the admin shell does. Grant is
 explicit, per-fork (`common=0`).
 
@@ -44,7 +44,7 @@ test hits an empty box. Bump the toolchain → re-run this skill → **re-snapsh
    (for dos-arch: WiX, .NET SDK, MSBuild.)
 
 3. **Verify each tool** over SSH — `dotnet --version`, `where.exe wix`, `msbuild
-   -version`. The `windows-devkit` wizard's `toolchain` check (`dotnet
+   -version`. The `windows_devkit` wizard's `toolchain` check (`dotnet
    --version`) is the same probe; it must go green after this step.
 
 4. **Bake the clean snapshot.** `virsh snapshot-create-as <domain> <snapshot>

--- a/.super-coder/assets/skills/windows-devkit/SKILL.md
+++ b/.super-coder/assets/skills/windows-devkit/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: windows-devkit
+description: Drive the linked Windows Test VM — push a build artifact, exec the installer/test over SSH, capture output + a screenshot, then reset to the clean snapshot. High-fidelity installer/system-level testing where Wine is useless. Use when building or verifying Windows software in a fork that has a configured VM.
+category: substrate
+common: false
+---
+
+# windows-devkit — driving the Windows Test VM
+
+Real Windows, for the testing Wine can't fake: MSI installers, services, the
+registry, system-level behavior. This is **opt-in and link-only** — the operator
+runs the VM; you drive a verified loop against it. Devs build and test; the
+reviewer independently verifies a candidate build with **exec → capture →
+reset**. Grant is explicit, per-fork (`common=0`); you have it because someone
+granted it to your shell.
+
+## Precondition — the link is configured
+
+The VM lives in `.super-coder/instance.json` under the `vm` key (set via the GUI
+Scripts → **Windows Test VM** wizard, which live-tests every field before save):
+
+```json
+"vm": { "domain": "win-test", "ssh_host": "127.0.0.1", "ssh_port": 22,
+        "ssh_user": "tester", "ssh_key_path": "~/.ssh/sc_win_test",
+        "transfer_dir": "/var/sc/win-xfer", "snapshot": "clean" }
+```
+
+No `vm` block → no VM linked: stop and ask the operator to run the wizard. The
+admin `configure_winbox` skill must also have run, or the box has no toolchain
+(the `toolchain` check in the wizard is how you confirm it did).
+
+`ssh_key_path` is a **path**, never key material — read it, never echo it.
+
+## The loop — push → exec → capture → reset
+
+Every run starts from the clean snapshot, so installer side-effects never leak
+between runs. That property is the whole point — without the reset, system-level
+testing isn't trustworthy.
+
+| Verb | How |
+|---|---|
+| **push** | drop the build artifact into `transfer_dir` (the host side of the guest's virtio-fs share, or scp to the guest) |
+| **exec** | `ssh -i <ssh_key_path> -p <ssh_port> <ssh_user>@<ssh_host> "<installer / test cmd>"` |
+| **capture** | collect stdout + exit code; `virsh screenshot <domain> /tmp/win.ppm` for installer GUI state |
+| **reset** | `virsh snapshot-revert <domain> <snapshot>` — back to clean before the next run |
+
+SSH non-interactively: `-o BatchMode=yes -o ConnectTimeout=10`. A run that
+exec'd anything stateful **must** end with a reset, even on failure — leave the
+box clean for the next shell.
+
+## Stance
+
+- **Reset is not optional.** Test from clean, return to clean. A dirty box makes
+  the next run's result a lie.
+- **You drive, you don't provision.** Missing toolchain → that's the admin's
+  `configure_winbox` + re-snapshot, not an install from here. Never `winget
+  install` from this loop; it would poison the clean snapshot.
+- **The reviewer verifies, doesn't build.** Reviewer uses exec → capture → reset
+  on the dev's candidate artifact to confirm the claim independently.
+- **Link-only stays link-only.** If a field is wrong, fix it in the wizard (it
+  re-validates); don't hand-edit secrets into config.

--- a/.super-coder/assets/skills/windows_devkit/SKILL.md
+++ b/.super-coder/assets/skills/windows_devkit/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: windows-devkit
+name: windows_devkit
 description: Drive the linked Windows Test VM — push a build artifact, exec the installer/test over SSH, capture output + a screenshot, then reset to the clean snapshot. High-fidelity installer/system-level testing where Wine is useless. Use when building or verifying Windows software in a fork that has a configured VM.
 category: substrate
 common: false
 ---
 
-# windows-devkit — driving the Windows Test VM
+# windows_devkit — driving the Windows Test VM
 
 Real Windows, for the testing Wine can't fake: MSI installers, services, the
 registry, system-level behavior. This is **opt-in and link-only** — the operator

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -427,6 +427,75 @@ ON CONFLICT(name) DO UPDATE SET
   content=excluded.content, is_deleted=0;
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'configure_winbox',
+  'Provision the Windows Test VM — winget-install the fork''s toolchain from a committed manifest, verify each tool, then bake the clean snapshot every test reverts to. Admin-only; runs before the snapshot, re-runs on any toolchain change. Use when standing up or updating a fork''s Windows build/test box.',
+  'substrate',
+  NULL,
+  0,
+  '# configure_winbox — provisioning the Windows Test VM
+
+The admin half of the Windows Test VM capability. You install the build
+toolchain into the operator''s Windows VM and bake the **clean snapshot** that
+every `windows-devkit` run reverts to. Sibling to `self_update` /
+`migration_management` — infrastructure work only the admin shell does. Grant is
+explicit, per-fork (`common=0`).
+
+## Scope boundary — what you do NOT do
+
+You do **not** create the VM, install the guest OS, or enable OpenSSH inside it.
+That bootstrap is the operator''s, host-side, once (the engine can''t reach inside
+a fresh OS install). You assume a reachable guest with key auth already working,
+and you provision the *toolchain* on top of it.
+
+## Order is the design — provision BEFORE the snapshot
+
+```
+operator: OS + OpenSSH + key   →   YOU: winget toolchain + verify   →   snapshot = clean   →   devs run loop
+```
+
+The clean snapshot is **pristine OS + toolchain**. Every test reverts to it, so
+the toolchain must be baked in. Provision *after* snapshotting and the first
+test hits an empty box. Bump the toolchain → re-run this skill → **re-snapshot**.
+
+## Procedure
+
+1. **Read the link.** `.super-coder/instance.json` `vm` block gives the domain +
+   SSH coordinates. Confirm SSH works: `ssh -i <ssh_key_path> -p <ssh_port>
+   <ssh_user>@<ssh_host> "echo ok"`.
+
+2. **Install the toolchain from the fork''s committed manifest.** The fork commits
+   a `winget export` at a known path (e.g. `winget-manifest.json`); you supply
+   the *mechanism*, the fork supplies the *package list* — so this skill stays
+   generic across forks. Over SSH:
+   `winget import --import-file <manifest> --accept-package-agreements --accept-source-agreements`
+   (for dos-arch: WiX, .NET SDK, MSBuild.)
+
+3. **Verify each tool** over SSH — `dotnet --version`, `where.exe wix`, `msbuild
+   -version`. The `windows-devkit` wizard''s `toolchain` check (`dotnet
+   --version`) is the same probe; it must go green after this step.
+
+4. **Bake the clean snapshot.** `virsh snapshot-create-as <domain> <snapshot>
+   --description "pristine OS + toolchain"`. Use the `snapshot` name from the
+   `vm` block (default `clean`). If re-provisioning, delete the old snapshot
+   first (`virsh snapshot-delete <domain> <snapshot>`) so the name is reused.
+
+## Stance
+
+- **Toolchain-as-code.** Install from the committed manifest, never ad hoc —
+  the package set is reproducible and reviewable, and re-provisioning is a
+  re-import, not a memory of what you clicked.
+- **Re-provision means re-snapshot.** A toolchain bump that isn''t followed by a
+  fresh snapshot is invisible — every test still reverts to the old box.
+- **Verify before you snapshot.** A snapshot of a half-installed box is a clean
+  snapshot of a broken kit. Green checks first, snapshot second.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'database-migrations',
   'Database migration safety + how super-coder''s own migrations work (schema.sql baseline + ordered migrations/ deltas + ledger). Use when altering tables, adding columns, or running backfills — in the host repo''s DB or super-coder''s.',
   'craft',
@@ -2253,6 +2322,73 @@ to point back at this skill.
 - Let a count or status code stand in for "the right thing happened."
 - Test only the happy path for code that has error branches.
 - Ship a test whose assertions no realistic bug could violate.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'windows-devkit',
+  'Drive the linked Windows Test VM — push a build artifact, exec the installer/test over SSH, capture output + a screenshot, then reset to the clean snapshot. High-fidelity installer/system-level testing where Wine is useless. Use when building or verifying Windows software in a fork that has a configured VM.',
+  'substrate',
+  NULL,
+  0,
+  '# windows-devkit — driving the Windows Test VM
+
+Real Windows, for the testing Wine can''t fake: MSI installers, services, the
+registry, system-level behavior. This is **opt-in and link-only** — the operator
+runs the VM; you drive a verified loop against it. Devs build and test; the
+reviewer independently verifies a candidate build with **exec → capture →
+reset**. Grant is explicit, per-fork (`common=0`); you have it because someone
+granted it to your shell.
+
+## Precondition — the link is configured
+
+The VM lives in `.super-coder/instance.json` under the `vm` key (set via the GUI
+Scripts → **Windows Test VM** wizard, which live-tests every field before save):
+
+```json
+"vm": { "domain": "win-test", "ssh_host": "127.0.0.1", "ssh_port": 22,
+        "ssh_user": "tester", "ssh_key_path": "~/.ssh/sc_win_test",
+        "transfer_dir": "/var/sc/win-xfer", "snapshot": "clean" }
+```
+
+No `vm` block → no VM linked: stop and ask the operator to run the wizard. The
+admin `configure_winbox` skill must also have run, or the box has no toolchain
+(the `toolchain` check in the wizard is how you confirm it did).
+
+`ssh_key_path` is a **path**, never key material — read it, never echo it.
+
+## The loop — push → exec → capture → reset
+
+Every run starts from the clean snapshot, so installer side-effects never leak
+between runs. That property is the whole point — without the reset, system-level
+testing isn''t trustworthy.
+
+| Verb | How |
+|---|---|
+| **push** | drop the build artifact into `transfer_dir` (the host side of the guest''s virtio-fs share, or scp to the guest) |
+| **exec** | `ssh -i <ssh_key_path> -p <ssh_port> <ssh_user>@<ssh_host> "<installer / test cmd>"` |
+| **capture** | collect stdout + exit code; `virsh screenshot <domain> /tmp/win.ppm` for installer GUI state |
+| **reset** | `virsh snapshot-revert <domain> <snapshot>` — back to clean before the next run |
+
+SSH non-interactively: `-o BatchMode=yes -o ConnectTimeout=10`. A run that
+exec''d anything stateful **must** end with a reset, even on failure — leave the
+box clean for the next shell.
+
+## Stance
+
+- **Reset is not optional.** Test from clean, return to clean. A dirty box makes
+  the next run''s result a lie.
+- **You drive, you don''t provision.** Missing toolchain → that''s the admin''s
+  `configure_winbox` + re-snapshot, not an install from here. Never `winget
+  install` from this loop; it would poison the clean snapshot.
+- **The reviewer verifies, doesn''t build.** Reviewer uses exec → capture → reset
+  on the dev''s candidate artifact to confirm the claim independently.
+- **Link-only stays link-only.** If a field is wrong, fix it in the wizard (it
+  re-validates); don''t hand-edit secrets into config.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -436,7 +436,7 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
 
 The admin half of the Windows Test VM capability. You install the build
 toolchain into the operator''s Windows VM and bake the **clean snapshot** that
-every `windows-devkit` run reverts to. Sibling to `self_update` /
+every `windows_devkit` run reverts to. Sibling to `self_update` /
 `migration_management` — infrastructure work only the admin shell does. Grant is
 explicit, per-fork (`common=0`).
 
@@ -471,7 +471,7 @@ test hits an empty box. Bump the toolchain → re-run this skill → **re-snapsh
    (for dos-arch: WiX, .NET SDK, MSBuild.)
 
 3. **Verify each tool** over SSH — `dotnet --version`, `where.exe wix`, `msbuild
-   -version`. The `windows-devkit` wizard''s `toolchain` check (`dotnet
+   -version`. The `windows_devkit` wizard''s `toolchain` check (`dotnet
    --version`) is the same probe; it must go green after this step.
 
 4. **Bake the clean snapshot.** `virsh snapshot-create-as <domain> <snapshot>
@@ -2330,12 +2330,12 @@ ON CONFLICT(name) DO UPDATE SET
   content=excluded.content, is_deleted=0;
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
-  'windows-devkit',
+  'windows_devkit',
   'Drive the linked Windows Test VM — push a build artifact, exec the installer/test over SSH, capture output + a screenshot, then reset to the clean snapshot. High-fidelity installer/system-level testing where Wine is useless. Use when building or verifying Windows software in a fork that has a configured VM.',
   'substrate',
   NULL,
   0,
-  '# windows-devkit — driving the Windows Test VM
+  '# windows_devkit — driving the Windows Test VM
 
 Real Windows, for the testing Wine can''t fake: MSI installers, services, the
 registry, system-level behavior. This is **opt-in and link-only** — the operator

--- a/.super-coder/scripts/ports.py
+++ b/.super-coder/scripts/ports.py
@@ -101,6 +101,12 @@ def resolve(persist: bool = False) -> dict:
     return cfg
 
 
+def save(cfg: dict) -> None:
+    """Persist the full config dict to instance.json verbatim. Preserves any
+    keys this module doesn't own (e.g. the `vm` block written by vm.py)."""
+    CONFIG.write_text(json.dumps(cfg, indent=2) + "\n")
+
+
 def main(argv: list[str]) -> int:
     mode = argv[0] if argv else "show"
     if mode == "ensure":

--- a/.super-coder/scripts/vm.py
+++ b/.super-coder/scripts/vm.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Windows Test VM — config read/write + live connection checks.
+
+Link-only by design: the engine never creates the VM. The operator brings a
+ready Windows VM (OpenSSH enabled, a clean snapshot, a transfer dir, and — via
+the admin `configure_winbox` skill — a baked toolchain). These checks validate
+that the operator-supplied `vm` block actually reaches a reachable, provisioned
+box BEFORE it is saved to instance.json.
+
+The config lives under the `vm` key of `.super-coder/instance.json` (so there is
+no schema migration — the VM is a host resource, not shell state). It holds a
+key PATH, never key material — secrets posture matches the rest of the engine.
+
+Each check runs ONE real host-side command and returns {ok, output}, mirroring
+api/server.py's run_script contract so the GUI can render it the same way.
+
+    domain    virsh dominfo <domain>                 VM exists / visible to libvirt
+    ssh       ssh ... echo ok                        auth + remote exec work
+    transfer  write+read+rm a probe in transfer_dir  host side of the share works
+    snapshot  virsh snapshot-info <domain> <snap>    the named clean snapshot exists
+    toolchain ssh ... dotnet --version               box is provisioned (verify-only)
+
+The `toolchain` check is verify-only — it confirms `configure_winbox` has run;
+it never installs anything.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import ports
+
+CHECKS = ("domain", "ssh", "transfer", "snapshot", "toolchain")
+
+
+# -- config (instance.json `vm` block) ---------------------------------------
+
+def read() -> dict | None:
+    """The persisted vm block, or None if the fork has not configured one."""
+    return ports.resolve(persist=False).get("vm")
+
+
+def write(vm: dict | None) -> dict | None:
+    """Persist (or clear) the vm block, preserving every other config key."""
+    cfg = ports.resolve(persist=False)
+    if vm:
+        cfg["vm"] = vm
+    else:
+        cfg.pop("vm", None)
+    ports.save(cfg)
+    return cfg.get("vm")
+
+
+# -- check primitives --------------------------------------------------------
+
+def _run(argv: list[str], timeout: int = 30) -> tuple[bool, str]:
+    try:
+        p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+        return p.returncode == 0, (p.stdout + p.stderr).strip()
+    except FileNotFoundError as e:
+        return False, f"command not found: {e.filename} — is it installed on the host?"
+    except subprocess.TimeoutExpired:
+        return False, f"timed out (>{timeout}s)"
+
+
+def _missing(cfg: dict, *fields: str) -> str | None:
+    absent = [f for f in fields if not str(cfg.get(f, "")).strip()]
+    return ("missing required field(s): " + ", ".join(absent)) if absent else None
+
+
+def _ssh_argv(cfg: dict, remote: str) -> list[str]:
+    """An ssh invocation against the configured guest. BatchMode keeps it
+    non-interactive (no password/passphrase prompt can hang the server)."""
+    key = os.path.expanduser(str(cfg.get("ssh_key_path", "")))
+    return [
+        "ssh", "-i", key,
+        "-p", str(cfg.get("ssh_port", 22)),
+        "-o", "BatchMode=yes",
+        "-o", "ConnectTimeout=10",
+        "-o", "StrictHostKeyChecking=accept-new",
+        f"{cfg.get('ssh_user')}@{cfg.get('ssh_host')}", remote,
+    ]
+
+
+# -- the five checks ---------------------------------------------------------
+
+def _check_domain(cfg: dict) -> tuple[bool, str]:
+    if m := _missing(cfg, "domain"):
+        return False, m
+    return _run(["virsh", "dominfo", str(cfg["domain"])], timeout=15)
+
+
+def _check_ssh(cfg: dict) -> tuple[bool, str]:
+    if m := _missing(cfg, "ssh_host", "ssh_user", "ssh_key_path"):
+        return False, m
+    return _run(_ssh_argv(cfg, "echo ok"), timeout=20)
+
+
+def _check_transfer(cfg: dict) -> tuple[bool, str]:
+    if m := _missing(cfg, "transfer_dir"):
+        return False, m
+    d = Path(os.path.expanduser(str(cfg["transfer_dir"])))
+    if not d.is_dir():
+        return False, f"transfer_dir does not exist or is not a directory: {d}"
+    probe = d / ".sc_vm_probe"
+    try:
+        probe.write_text("ok")
+        back = probe.read_text()
+        probe.unlink()
+    except OSError as e:
+        return False, f"transfer_dir not writable host-side: {e}"
+    if back != "ok":
+        return False, "wrote a probe file but read back unexpected content"
+    return True, f"wrote + read back a probe in {d} (host side of the share OK)"
+
+
+def _check_snapshot(cfg: dict) -> tuple[bool, str]:
+    if m := _missing(cfg, "domain", "snapshot"):
+        return False, m
+    ok, out = _run(
+        ["virsh", "snapshot-info", str(cfg["domain"]),
+         "--snapshotname", str(cfg["snapshot"])], timeout=15)
+    if not ok and "Domain snapshot not found" in out:
+        return False, (f"snapshot '{cfg['snapshot']}' not found on domain "
+                       f"'{cfg['domain']}' — create the clean snapshot first.\n{out}")
+    return ok, out
+
+
+def _check_toolchain(cfg: dict) -> tuple[bool, str]:
+    if m := _missing(cfg, "ssh_host", "ssh_user", "ssh_key_path"):
+        return False, m
+    ok, out = _run(_ssh_argv(cfg, "dotnet --version"), timeout=20)
+    if ok:
+        return True, (f".NET SDK present: {out or '(version printed)'} — "
+                      "configure_winbox has run (verify-only; nothing installed).")
+    return False, ("toolchain probe failed — run the admin `configure_winbox` "
+                   f"skill to provision the box, then re-snapshot.\n{out}")
+
+
+_CHECKS = {
+    "domain": _check_domain,
+    "ssh": _check_ssh,
+    "transfer": _check_transfer,
+    "snapshot": _check_snapshot,
+    "toolchain": _check_toolchain,
+}
+
+
+def validate(check: str, cfg: dict) -> dict | None:
+    """Run one live check against the CANDIDATE config in `cfg` (the in-progress
+    wizard form, not necessarily what is saved). Returns {ok, output, check} or
+    None for an unknown check name (→ 404 at the API layer)."""
+    fn = _CHECKS.get(check)
+    if fn is None:
+        return None
+    ok, out = fn(cfg or {})
+    return {"ok": ok, "output": out or "(no output)", "check": check}

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -748,6 +748,22 @@ async function renderScripts(root) {
   root.replaceChildren();
   root.append(el("div", { className: "muted" },
     "Run a maintenance script. Output appears below it. Per-instance DB edits → run Snapshot, then Render flat, to persist them to git-tracked text."));
+
+  // Windows Test VM — opt-in, link-only. Links this fork to an operator-run
+  // Windows VM for installer/system-level testing. Config lives in instance.json
+  // (no secrets — a key PATH only); every field is live-tested before save.
+  const vmc = el("div", { className: "card" });
+  vmc.append(el("h2", {}, "Windows Test VM",
+    el("span", { className: "pill", textContent: " opt-in" })));
+  vmc.append(el("div", { className: "muted" },
+    "Link this fork to a Windows VM you already run, for high-fidelity installer/system-level testing. " +
+    "Link-only — the VM (OpenSSH, a clean snapshot, the transfer dir, the toolchain via the admin configure_winbox skill) is yours to set up. " +
+    "Every field is validated live before it saves."));
+  const vmbtn = el("button", { className: "act primary", textContent: "configure…" });
+  vmbtn.onclick = openWinVmModal;
+  vmc.append(vmbtn);
+  root.append(vmc);
+
   for (const s of scripts) {
     const c = el("div", { className: "card" });
     const h = el("h2", {}, s.name);
@@ -769,6 +785,104 @@ async function renderScripts(root) {
     c.append(run, out);
     root.append(c);
   }
+}
+
+// Windows Test VM wizard — a single link-only modal (the house openModal/el
+// pattern). The seven fields map 1:1 to the instance.json `vm` block; the five
+// checks each hit POST /api/vm/validate/{check} with the IN-PROGRESS form, so
+// the operator tests before saving. No secrets here — ssh_key_path is a PATH.
+const VM_FIELDS = [
+  ["domain", "win-test", "libvirt domain name (virsh target)"],
+  ["ssh_host", "127.0.0.1", "guest OpenSSH host"],
+  ["ssh_port", "22", "guest OpenSSH port"],
+  ["ssh_user", "tester", "guest SSH user"],
+  ["ssh_key_path", "~/.ssh/sc_win_test", "PATH to the private key — never the key itself"],
+  ["transfer_dir", "/var/sc/win-xfer", "host-side dir the guest sees (virtio-fs share / scp target)"],
+  ["snapshot", "clean", "named clean snapshot to revert to between runs"],
+];
+const VM_CHECKS = [
+  ["domain", "VM exists + visible to libvirt"],
+  ["ssh", "SSH auth + remote exec work"],
+  ["transfer", "artifact transfer dir reachable"],
+  ["snapshot", "named clean snapshot exists"],
+  ["toolchain", "box is provisioned (configure_winbox ran)"],
+];
+
+async function openWinVmModal() {
+  let saved = {};
+  try { saved = (await api("/vm")).vm || {}; } catch { /* none yet */ }
+
+  const inputs = {};
+  const form = el("div", { className: "modal-form" });
+  for (const [key, ph, hint] of VM_FIELDS) {
+    const inp = el("input", { type: "text", placeholder: ph, value: saved[key] ?? "", title: hint });
+    inputs[key] = inp;
+    form.append(el("span", { className: "k", title: hint }, key), inp);
+  }
+
+  const collect = () => {
+    const vm = {};
+    for (const [key] of VM_FIELDS) {
+      let v = inputs[key].value.trim();
+      if (key === "ssh_port") v = Number(v) || 22;
+      if (v !== "") vm[key] = v;
+    }
+    return vm;
+  };
+
+  // results panel: one row per check (✓/✗ + output), like the Scripts run block
+  const results = el("div", {});
+  const note = el("div", { className: "muted" },
+    "Your VM must already have OpenSSH, a clean snapshot, the transfer dir, and the toolchain " +
+    "(admin's configure_winbox). The wizard validates the link — it does not set the VM up.");
+
+  const runAll = el("button", { className: "act", textContent: "run all checks" });
+  runAll.onclick = async () => {
+    const vm = collect();
+    results.replaceChildren();
+    runAll.disabled = true;
+    for (const [check, label] of VM_CHECKS) {
+      const row = el("div", { className: "card" });
+      const head = el("div", {},
+        el("span", { className: "pill", textContent: "…" }),
+        el("span", {}, "  " + check + " — " + label));
+      const out = el("pre", { className: "doc-body", hidden: true });
+      row.append(head, out);
+      results.append(row);
+      try {
+        const r = await fetch("/api/vm/validate/" + check,
+          { method: "POST", headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ vm }) });
+        const data = await r.json();
+        const pill = head.firstChild;
+        pill.textContent = data.ok ? "✓" : "✗";
+        pill.className = "pill " + (data.ok ? "ok" : "warn");
+        out.hidden = false; out.textContent = data.output || "(no output)";
+      } catch (e) {
+        const pill = head.firstChild;
+        pill.textContent = "✗"; pill.className = "pill warn";
+        out.hidden = false; out.textContent = "error: " + e.message;
+      }
+    }
+    runAll.disabled = false;
+  };
+
+  const save = el("button", { className: "act primary", textContent: "save" });
+  const cancel = el("button", { className: "act", textContent: "close" });
+  const close = openModal({
+    title: "Windows Test VM", width: 680, height: 760,
+    bodyNode: el("div", {}, form, el("div", { className: "modal-form-foot" }, runAll), note, results),
+    footNodes: [save, cancel],
+  });
+  save.onclick = async () => {
+    save.disabled = true; setStatus("saving VM config…");
+    try {
+      await api("/vm", "PUT", { vm: collect() });
+      setStatus("VM config saved");
+      close();
+    } catch (e) { toast("error: " + e.message); save.disabled = false; }
+  };
+  cancel.onclick = close;
 }
 
 // ── Map (dr_* repo catalogue) ───────────────────────────────────────────────────

--- a/docs/windows-test-vm.md
+++ b/docs/windows-test-vm.md
@@ -30,7 +30,7 @@ Two design forks, both settled:
 | Fidelity need | High-fidelity, pre-merge | A gated validation loop, not a per-iteration smoke test |
 | Config scope | **Per-fork**, per-shell grant | One VM config per install; the capability grant decides which shells may use it |
 | Wizard scope | **Link-only** | Assume a ready VM (SSH + snapshot exist). Capture + validate only — no prereqs automation |
-| Skill + assignment | **`windows-devkit`**, engine `common=0`, granted to **dev + reviewer** | Reusable across forks; explicit per-fork grant, not in the base flavor arrays |
+| Skill + assignment | **`windows_devkit`**, engine `common=0`, granted to **dev + reviewer** | Reusable across forks; explicit per-fork grant, not in the base flavor arrays |
 | Provisioning | Admin shell via **`configure_winbox`** (engine `common=0`) — **winget** + fork-committed manifest | Toolchain is defined-as-code; installed *before* the clean snapshot so reverts preserve it |
 
 The per-fork decision removes the need for any schema change: the VM is a host resource, so its config lives in the fork-level config file, not on the `shells` table.
@@ -42,7 +42,7 @@ Three independent layers — a per-shell *gate*, a per-fork *config*, and a runt
 ```mermaid
 graph TD
   AD["configure_winbox (admin)"]:::class4 --> PROV["provision + snapshot"]:::class4
-  G["windows-devkit (dev+rev)"]:::class1 --> R["runtime loop"]:::class3
+  G["windows_devkit (dev+rev)"]:::class1 --> R["runtime loop"]:::class3
   C["instance.json vm block"]:::class1 --> R
   PROV --> R
   R --> P["push"]:::class3
@@ -54,7 +54,7 @@ graph TD
 - **Provision** — admin's `configure_winbox` installs the toolchain and bakes the clean snapshot, once.
 - **Gate** — reuses the existing `common=0` opt-in grant model. No new mechanism.
 - **Config** — one JSON block per fork. No secrets in it.
-- **Loop** — `windows-devkit` drives the four verbs against the linked VM.
+- **Loop** — `windows_devkit` drives the four verbs against the linked VM.
 
 ## Capability gate
 
@@ -63,7 +63,7 @@ The capability is delivered as **two role-split skills**, both authored in the *
 | Skill | Granted to | Does |
 |---|---|---|
 | **`configure_winbox`** | **admin** | provisions the box (winget toolchain) + bakes the clean snapshot. Sibling to `self_update`/`migration_management`. |
-| **`windows-devkit`** | **dev + reviewer** | drives the test loop. Devs build + test; the reviewer verifies. Same dual-role pattern as `test_authoring`. |
+| **`windows_devkit`** | **dev + reviewer** | drives the test loop. Devs build + test; the reviewer verifies. Same dual-role pattern as `test_authoring`. |
 
 - **Grant:** explicit `shell_skills` insert (or the `PUT /api/shells/{id}/skills/{skill_id}` toggle), then snapshot to persist fork-local.
 - Config is fork-wide; **who may use it is per-shell**. Configure the VM once, grant each skill to the shells that should hold it.
@@ -78,7 +78,7 @@ User: SSH foothold :::class4 -> Admin: install kit :::class1 -> Snapshot = clean
 
 1. **User (manual, once).** Install Windows, enable OpenSSH, authorize the key. The engine cannot reach inside a fresh OS install — this is the irreducible bootstrap.
 2. **Admin — `configure_winbox` (once / on toolchain change).** SSH in, **winget**-install the MSI toolchain from a fork-committed manifest, verify each tool, then take the `clean` snapshot.
-3. **Dev + reviewer — `windows-devkit` (every test).** push → exec → capture → reset against that snapshot.
+3. **Dev + reviewer — `windows_devkit` (every test).** push → exec → capture → reset against that snapshot.
 
 > [!class4]
 > **`configure_winbox` runs before the snapshot, not after.** The clean snapshot is *pristine OS + toolchain*; every test reverts to it, so the toolchain must be baked in. Bump the toolchain → re-run `configure_winbox` → re-snapshot. Provision after snapshotting and the first test hits an empty box.
@@ -155,7 +155,7 @@ Fill fields :::class1 -> Run checks :::class2 -> Green :::class3 -> Save :::clas
 
 ## The skill
 
-`windows-devkit` reads `instance.json.vm`, then runs the high-fidelity, installer-grade loop. Dev shells use the full loop to build and test; the reviewer uses **exec → capture → reset** to independently verify a candidate build during review:
+`windows_devkit` reads `instance.json.vm`, then runs the high-fidelity, installer-grade loop. Dev shells use the full loop to build and test; the reviewer uses **exec → capture → reset** to independently verify a candidate build during review:
 
 | Verb | How |
 |---|---|
@@ -170,7 +170,7 @@ Every run starts from the clean snapshot, so installer side-effects never leak b
 
 dos-arch is the proving-ground fork and the immediate need. Wiring it on this box, once the engine feature lands:
 
-1. Grant `windows-devkit` to `Arch-dev-01` (2), `Arch-dev-02` (5), `Arch-review-01` (3); grant `configure_winbox` to `Arch-Admin` (6). Snapshot to persist fork-local.
+1. Grant `windows_devkit` to `Arch-dev-01` (2), `Arch-dev-02` (5), `Arch-review-01` (3); grant `configure_winbox` to `Arch-Admin` (6). Snapshot to persist fork-local.
 2. User: confirm the Windows VM under VMM has OpenSSH + key auth and a transfer dir.
 3. Generate `~/.ssh/sc_win_test`, install the pubkey in the guest.
 4. Admin runs `configure_winbox` → winget-installs WiX + .NET SDK + MSBuild from the dos-arch manifest, verifies, takes the `clean` snapshot.


### PR DESCRIPTION
Implements the design in `docs/windows-test-vm.md` (session 0141). Gives a fork that builds Windows software a way to test on **real Windows** — installers, services, registry, system-level — where Wine is useless.

## What it is
**Opt-in, link-only, per-fork.** The engine ships the orchestration; the operator brings the VM (license/image/OS install/OpenSSH/snapshot are theirs, unreachable from the tool). Config lives under a `vm` key in `instance.json` → **no schema migration**. Holds a key *path*, never key material — secrets posture matches the rest of the engine.

## Pieces
- **`scripts/vm.py`** — read/write the `vm` block + five live checks (`domain`, `ssh`, `transfer`, `snapshot`, `toolchain`), each one real host-side command returning `{ok, output}`.
- **`scripts/ports.py`** — `save()` helper (persists full config, preserves keys it doesn't own).
- **`api/server.py`** — `GET`/`PUT /api/vm` + `POST /api/vm/validate/{check}`. Validate runs against the **candidate config in the body** so the wizard tests before save; a failed check is `200 {ok:false}` (a result the UI renders red), not a server error.
- **`ui/app.js`** — a "Windows Test VM" card in the Scripts tab opening a single link-only modal: 7 fields, a run-all-checks panel (green/red + output per check), save. House `openModal`/`el`/`fetch` pattern.
- **Skills** — `windows-devkit` (dev + reviewer; drives push → exec → capture → reset) and `configure_winbox` (admin; winget toolchain from a fork-committed manifest, then bakes the clean snapshot). Both engine-catalogue **`common=0`** — propagate to every fork, auto-grant to none, granted explicitly per-fork. **Not** added to any base flavor array.
- Regenerated `migrations/0001_seed_skills.sql` (24 skills).

## Verification
Smoke-tested all three routes end-to-end against a live server: GET/PUT round-trip, `instance.json` gains the `vm` block, unknown check → 404, bad-type body → 400, `transfer` check ok on a real dir, `domain` check fails gracefully when `virsh` can't find the VM. `py_compile` + `node --check` clean.

## First consumer
dos-arch — grant the two skills to its dev/reviewer/admin shells, run `configure_winbox`, fill the wizard, validate green. (Wiring steps in the design doc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)