### PR TITLE
docs(spec): host-side VM broker for sandboxed forks

### DIFF
--- a/docs/windows-vm-broker.md
+++ b/docs/windows-vm-broker.md
@@ -1,0 +1,203 @@
+---
+title: Windows VM Broker — Spec
+tags: [super-coder, design, testing, windows, broker]
+date: 2026-06-17
+project: super-coder
+purpose: Host-side broker so sandboxed forks can drive the test VM
+---
+
+# Windows VM Broker — Spec
+
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/super-coder/blob/cc/windows-vm-broker-spec/docs/windows-vm-broker.md)
+
+## Overview
+
+The [Windows Test VM](windows-test-vm.md) capability shipped the skills, the
+config, and a host-side **validation** path — but not a way for the shells that
+hold `windows_devkit` to actually *drive* the VM. Those shells run inside the
+super-coder **sandbox container**, and the test VM lives on the host's libvirt
+NAT network. A container cannot reach it, and cannot run `virsh`.
+
+This spec adds a **host-side VM broker**: one process that holds the SSH key and
+has libvirt access, exposes the four loop verbs over a local socket, and is
+called by `windows_devkit` from inside the container. The key never enters the
+fork; `virsh` runs where it works.
+
+> [!class1]
+> The broker is the **generic test-target seam** the Windows VM design deferred
+> to "out of scope." The reachability test below proves it is **required**, not
+> optional, for any containerized fork — Windows-via-VM is just provider #1.
+
+## The gap (measured)
+
+From inside the live `sc-dos-arch` container (`172.19.0.2` on `sc-net`):
+
+```stats
+:::class4
+value: timeout
+label: container → VM:22
+description: 192.168.122.100 unreachable — no route across libvirt NAT
+:::class4
+value: none
+label: ssh / scp / virsh
+description: container has python3 only; no client, no hypervisor control
+:::class3
+value: refused
+label: container → host:8804
+description: route to host exists; services bind 127.0.0.1, so nothing answers
+:::class3
+value: mounted
+label: repo bind-mount
+description: /home/j3d1/dos-arch visible both sides — a unix socket can live here
+```
+
+## Why creds-in-container fails
+
+The tempting shortcut — mount the SSH key into the sandbox — hits three walls,
+and clears none of the important one:
+
+| Wall | Detail |
+|---|---|
+| **No route** | container `sc-net` (172.19) cannot reach libvirt NAT (192.168.122). A key is useless if packets never arrive. |
+| **No client** | the sandbox image has no `ssh`/`scp`. You'd have to bake OpenSSH into every fork image. |
+| **`virsh` verbs** | `reset` (snapshot-revert) and `capture` (screenshot) are **host libvirt** ops. No credential makes a container revert a host snapshot — and a fork sandbox must never hold hypervisor control. |
+
+Even if you mounted the key, installed `ssh`, *and* punched a firewall route,
+you'd get `exec`/`push` and still could not `reset` between tests — the one verb
+the isolated loop exists for. And the key would now live in the fork, the exact
+posture the credential broker was built to avoid.
+
+## Architecture
+
+The broker is a **host process** — not the in-container API server. It mirrors
+dos-arch's credential-broker precedent: the one host-side authority that holds a
+secret so nothing downstream needs it.
+
+```mermaid
+graph LR
+  subgraph Container["sandbox (sc-net)"]
+    WDK["windows_devkit"]:::class1
+  end
+  subgraph Host["host"]
+    BRK["vm-broker"]:::class2
+    KEY["sc_win_test key"]:::class4
+    LV["libvirt / virsh"]:::class3
+  end
+  VM["Windows VM"]:::class3
+  WDK -->|"unix socket"| BRK
+  BRK --> KEY
+  BRK -->|"ssh / scp"| VM
+  BRK -->|"virsh"| LV
+  LV --> VM
+```
+
+- **Container side** — `windows_devkit` makes local socket calls. No key, no
+  `ssh`, no `virsh`, no route to the VM. Nothing changes about its isolation.
+- **Host side** — the broker reads `instance.json.vm`, holds the key path, and
+  is the only thing that touches the guest or the hypervisor.
+
+## Transport
+
+Two options, both grounded in the measured facts. Recommend the socket.
+
+> [!class3]
+> **Unix socket in the bind-mounted repo (recommended).** The broker listens on
+> e.g. `.super-coder/run/vm-broker.sock` inside the fork repo, which is mounted
+> into the container at the same path. No network surface, no firewall, gated by
+> filesystem permissions. `windows_devkit` calls it with `curl --unix-socket`.
+
+The TCP fallback: bind the broker on the docker-bridge gateway (`172.19.0.1`) or
+`0.0.0.0`. The container *can* reach that (refused, not dropped — a listener is
+all that's missing), but it is a real network surface that then needs its own
+auth token. The socket avoids that entirely.
+
+```linear
+windows_devkit :::class1 -> unix socket :::class2 -> vm-broker (host) :::class2 -> ssh / virsh :::class3 -> VM :::class3
+```
+
+## API
+
+Four verb endpoints, plus the validation surface relocated from the in-server
+endpoints (which presume host access the container doesn't have). All return
+`{ok, ...}` and stream output, mirroring the existing `validate/{check}` shape.
+
+| Method | Path | Does | Mechanism |
+|---|---|---|---|
+| `POST` | `/push` | stage a build artifact for the guest | copy into `transfer_dir` (virtio-fs share) or `scp` |
+| `POST` | `/exec` | run a command in the guest | `ssh`; returns `{ok, exit, stdout, stderr}` |
+| `POST` | `/capture` | collect output / installer GUI state | stdout passthrough; `virsh screenshot` for the screen |
+| `POST` | `/reset` | revert to the clean baseline | `virsh snapshot-revert <domain> clean --running` |
+| `POST` | `/validate/{check}` | the five setup checks | relocated from the host-presuming in-server endpoints |
+| `GET`/`PUT` | `/vm` | read / write the `vm` config block | `instance.json` |
+
+> [!class4]
+> **`reset` uses `--running`.** The `clean` snapshot is **offline** — this CPU
+> exposes the non-migratable `invtsc` flag, so a live (memory) snapshot is
+> refused. Revert therefore lands in a powered-off state; `--running` boots it
+> back. `windows_devkit`'s reset verb must pass it, or the box comes back dark.
+
+## Security
+
+The broker is the trust boundary, and it tightens the current posture rather
+than loosening it.
+
+- **Key stays host-side.** `~/.ssh` is not mounted into the sandbox today; the
+  broker preserves that. The fork never holds the credential.
+- **No hypervisor in the fork.** `virsh` runs only in the broker. A compromised
+  sandbox can ask for a `reset`; it cannot script libvirt.
+- **Scope the surface.** `exec` runs arbitrary commands *on the VM* by design —
+  that is the test loop. The broker scopes to the configured guest only, never
+  shells out on the host on behalf of the caller.
+- **One door per caller class.** The broker is reached only by fork shells over
+  the socket; admin provisioning (`configure_winbox`) is a separate, host-run
+  path. Do not widen one gate to serve both.
+
+## windows_devkit changes
+
+The skill's four verbs map one-to-one onto broker calls — it stops shelling out
+to `ssh`/`virsh` (which never worked from the container) and curls the socket.
+
+| Verb | Was (broken in container) | Becomes |
+|---|---|---|
+| push | `scp` / share write | `POST /push` |
+| exec | `ssh host cmd` | `POST /exec` |
+| capture | `ssh` + `virsh screenshot` | `POST /capture` |
+| reset | `virsh snapshot-revert` | `POST /reset` |
+
+`configure_winbox` (admin provisioning) is rare and host-weighted; it can call
+the broker too, or stay an explicit host-operator task. Either way its `virsh`
+snapshot step lives host-side.
+
+## Process & supervision
+
+Open for the build, with leanings:
+
+- **Separate process, not the in-container server.** The sandbox server cannot
+  hold the key or reach libvirt; the broker must be a distinct host process.
+- **Supervised like the rest of the host substrate** — pm2 alongside the fork's
+  other host-side processes (the credential broker is the model).
+- **Per-fork.** One broker per fork, reading that fork's `instance.json.vm` and
+  socket path, so two forks never share a VM handle by accident.
+
+## Phasing
+
+```linear
+MVP: exec + reset over socket :::class1 -> full: push + capture + validate :::class2 -> generalize: test-target interface :::class3
+```
+
+1. **MVP** — socket + `exec` + `reset --running`. Proves the loop end-to-end
+   from the container against the `clean` snapshot.
+2. **Full** — `push`, `capture` (incl. screenshot), relocate `validate`.
+3. **Generalize** — lift the four verbs into a provider-agnostic test-target
+   interface; Windows-via-VM becomes provider #1, with containers/devices later.
+
+## Open questions
+
+- **Where do the #129 `validate` endpoints actually run?** If they live in the
+  in-container server, they presume host access the sandbox lacks — and should
+  move into the broker. Confirm before building.
+- **Socket vs bridge-TCP** as the default transport (recommend socket).
+- **Broker auth** — is filesystem permission on the socket sufficient, or does a
+  per-fork token still belong on the call?
+- **Artifact transfer** — keep the virtio-fs share as the `push` fast path, or
+  route everything through `scp` for a single mechanism?


### PR DESCRIPTION
## What

Specs a **host-side VM broker** so the shells that hold `windows_devkit` can actually drive the Windows Test VM from inside the super-coder sandbox container.

## Why

Measured from the live `sc-dos-arch` container:
- container → VM:22 **times out** (no route across libvirt NAT)
- container has **no ssh/scp/virsh** (python3 only)
- container → host gateway is **refused, not dropped** (route exists; host services bind 127.0.0.1)
- the fork repo is **bind-mounted** both sides → a unix socket can live there; `~/.ssh` is **not** mounted

So 'just pass the SSH creds into the container' fails on three walls — and even past them, `reset`/`capture` are host `virsh` ops a container can't (and shouldn't) run.

## Design

A host process holds the key + libvirt access and exposes `push/exec/capture/reset` (+ relocated `validate`) over a **unix socket in the bind-mounted repo**. `windows_devkit` curls the socket; the key never enters the fork; `virsh` runs host-side. Mirrors dos-arch's credential-broker precedent and is the generic test-target seam the [Windows Test VM design](docs/windows-test-vm.md) deferred.

Includes the `reset --running` note (offline snapshot, `invtsc` blocks live snapshots), phasing (MVP exec+reset → full → generalize), and open questions (where the #129 validate endpoints actually run, socket vs TCP, broker auth).

Doc only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)