### PR TITLE
feat(vm): host-side Windows VM broker for sandboxed forks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@
 # propagates (re-derived from the repo path if absent). Hand-overridable.
 /.super-coder/instance.json
 
+# vm-broker runtime — the unix socket + pidfile + log it writes at start. Local,
+# ephemeral, host-only (the broker recreates them); never tracked.
+/.super-coder/run/
+
 # Shell worktrees — one per shell, at .sc-worktrees/<shortname>/. Git
 # worktrees inside the repo root; gitignored so the linked trees don't surface
 # as untracked content in the main working tree.

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -706,7 +706,24 @@ class Handler(BaseHTTPRequestHandler):
                 # Run ONE live check against the candidate config in the body, so
                 # the wizard can test-before-save. A failed check is a normal
                 # result the UI renders red — 200 with {ok:false}, not an error.
-                r = vm_mod.validate(path.rsplit("/", 1)[1], self._body().get("vm") or {})
+                #
+                # The checks run virsh/ssh, which only work on the HOST. In the
+                # sandbox we can't reach the VM, so proxy to the host vm-broker
+                # over its unix socket; on the no-docker host path, call directly.
+                check = path.rsplit("/", 1)[1]
+                cfg = self._body().get("vm") or {}
+                if os.environ.get("SC_SANDBOX"):
+                    try:
+                        r = vm_mod.broker_call("POST", f"/validate/{check}", {"vm": cfg})
+                    except ConnectionError:
+                        return self._send(503, {
+                            "ok": False, "check": check,
+                            "output": "live checks need the host vm-broker — start it "
+                                      "with `./sc vm-broker-up` on the host, then retry."})
+                    if r.get("error") == "no such check":
+                        return self._send(404, {"error": "no such check"})
+                    return self._send(200, r)
+                r = vm_mod.validate(check, cfg)
                 if r is None:
                     return self._send(404, {"error": "no such check"})
                 return self._send(200, r)

--- a/.super-coder/api/vm_broker.py
+++ b/.super-coder/api/vm_broker.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Windows VM Broker — the host-side authority that drives the test VM.
+
+A fork's shells run in a sandbox container that cannot reach the VM (no route
+across libvirt NAT), holds no ssh key, and has no `virsh`. This broker runs ON
+THE HOST, where the key + libvirt live, and exposes the loop verbs over a unix
+socket inside the bind-mounted engine dir (`.super-coder/run/vm-broker.sock`).
+`windows_devkit` curls that socket; the key never enters the fork and `virsh`
+runs where it works. It mirrors dos-arch's credential-broker precedent: one host
+process holds the secret so nothing downstream needs it. Spec:
+docs/windows-vm-broker.md.
+
+Routes (all JSON `{ok, ...}`):
+
+    GET  /health               liveness
+    GET  /vm                   read the saved vm block
+    PUT  /vm        {vm}        write the vm block
+    POST /exec      {command}   ssh the guest -> {ok, exit, stdout, stderr}
+    POST /reset                 virsh snapshot-revert <dom> <snap> --running
+    POST /push      {src,dest?} stage a host-visible artifact into transfer_dir
+    POST /capture   {command?}  optional exec + a virsh screenshot (base64)
+    POST /validate/{check}      one live setup check against the body's candidate cfg
+
+Verbs act on the SAVED `vm` block; `/validate` tests the CANDIDATE block in the
+body (the wizard, before save). The socket is fs-perm gated (0600) — reachable
+only by processes sharing the bind mount; no network surface, no auth token.
+
+Run on the HOST (never in the sandbox):
+    ./sc vm-broker        foreground
+    ./sc vm-broker-up     background (pidfile) ; ./sc vm-broker-down to stop
+"""
+from __future__ import annotations
+
+import json
+import os
+import socketserver
+import sys
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import vm  # noqa: E402  (config + checks + loop verbs + socket path)
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    # AF_UNIX peers have no address — the default logger would IndexError on it.
+    def log_message(self, fmt: str, *args) -> None:
+        sys.stderr.write("[vm-broker] " + (fmt % args) + "\n")
+
+    def _send(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self) -> dict:
+        n = int(self.headers.get("Content-Length") or 0)
+        if not n:
+            return {}
+        try:
+            return json.loads(self.rfile.read(n).decode() or "{}")
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return {}
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            return self._send(200, {"ok": True, "service": "vm-broker"})
+        if self.path == "/vm":
+            return self._send(200, {"vm": vm.read()})
+        return self._send(404, {"ok": False, "error": "no such route"})
+
+    def do_PUT(self) -> None:
+        if self.path == "/vm":
+            block = self._body().get("vm")
+            if block is not None and not isinstance(block, dict):
+                return self._send(400, {"ok": False, "error": "vm must be an object"})
+            return self._send(200, {"ok": True, "vm": vm.write(block)})
+        return self._send(404, {"ok": False, "error": "no such route"})
+
+    def do_POST(self) -> None:
+        try:
+            if self.path == "/exec":
+                b = self._body()
+                return self._send(200, vm.do_exec(b.get("command", ""),
+                                                  int(b.get("timeout", 120))))
+            if self.path == "/reset":
+                return self._send(200, vm.do_reset())
+            if self.path == "/push":
+                b = self._body()
+                return self._send(200, vm.do_push(b.get("src", ""), b.get("dest")))
+            if self.path == "/capture":
+                return self._send(200, vm.do_capture(self._body().get("command")))
+            if self.path.startswith("/validate/"):
+                r = vm.validate(self.path.rsplit("/", 1)[1], self._body().get("vm") or {})
+                if r is None:
+                    return self._send(404, {"ok": False, "error": "no such check"})
+                return self._send(200, r)
+        except Exception as e:  # never let one bad call kill a worker thread
+            return self._send(500, {"ok": False, "error": f"{type(e).__name__}: {e}"})
+        return self._send(404, {"ok": False, "error": "no such route"})
+
+
+class UnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    """HTTP over a unix socket. Clears a stale socket from a crashed prior run
+    (else bind fails EADDRINUSE) and locks the socket to the owner (0600)."""
+    daemon_threads = True
+
+    def server_bind(self) -> None:
+        try:
+            os.unlink(self.server_address)
+        except FileNotFoundError:
+            pass
+        super().server_bind()
+        os.chmod(self.server_address, 0o600)
+
+
+def main(argv: list[str]) -> int:
+    if os.environ.get("SC_SANDBOX"):
+        sys.exit("vm-broker must run on the HOST (virsh + the ssh key live there), "
+                 "not inside the sandbox. Run `./sc vm-broker` on the host.")
+    sock = vm.SOCKET
+    sock.parent.mkdir(parents=True, exist_ok=True)
+    srv = UnixHTTPServer(str(sock), Handler)
+    sys.stderr.write(f"[vm-broker] listening on {sock}\n")
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        srv.server_close()
+        try:
+            os.unlink(sock)
+        except OSError:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/assets/skills/windows_devkit/SKILL.md
+++ b/.super-coder/assets/skills/windows_devkit/SKILL.md
@@ -29,7 +29,27 @@ No `vm` block → no VM linked: stop and ask the operator to run the wizard. The
 admin `configure_winbox` skill must also have run, or the box has no toolchain
 (the `toolchain` check in the wizard is how you confirm it did).
 
-`ssh_key_path` is a **path**, never key material — read it, never echo it.
+`ssh_key_path` is a **path**, never key material — and your shell never reads it
+anyway: the key lives host-side with the broker (below). You never hold it.
+
+## You drive the VM through the host broker — not ssh/virsh directly
+
+You run inside the sandbox container. The VM lives on the host's libvirt NAT,
+unreachable from here, and the container has no `ssh`, no `virsh`, and no key.
+So you do **not** shell out — you call the **host-side vm-broker** over a unix
+socket in the bind-mounted repo. The broker holds the key + libvirt and does the
+work; nothing about your isolation changes. (See `docs/windows-vm-broker.md`.)
+
+The socket path comes from `./sc vm-broker-sock`. Every verb is a `curl`:
+
+```bash
+SOCK="$(./sc vm-broker-sock)"
+curl -s --unix-socket "$SOCK" http://vm/health      # liveness check first
+```
+
+If the curl fails with "not reachable", the broker isn't running — ask the
+operator to start it on the host: `./sc vm-broker-up`. You cannot start it
+yourself (it must run on the host, not in your sandbox).
 
 ## The loop — push → exec → capture → reset
 
@@ -37,16 +57,21 @@ Every run starts from the clean snapshot, so installer side-effects never leak
 between runs. That property is the whole point — without the reset, system-level
 testing isn't trustworthy.
 
-| Verb | How |
+| Verb | Call |
 |---|---|
-| **push** | drop the build artifact into `transfer_dir` (the host side of the guest's virtio-fs share, or scp to the guest) |
-| **exec** | `ssh -i <ssh_key_path> -p <ssh_port> <ssh_user>@<ssh_host> "<installer / test cmd>"` |
-| **capture** | collect stdout + exit code; `virsh screenshot <domain> /tmp/win.ppm` for installer GUI state |
-| **reset** | `virsh snapshot-revert <domain> <snapshot>` — back to clean before the next run |
+| **push** | `curl -s --unix-socket "$SOCK" http://vm/push -d '{"src":"<repo path to artifact>"}'` — stages it into `transfer_dir` (the guest's share) |
+| **exec** | `curl -s --unix-socket "$SOCK" http://vm/exec -d '{"command":"<installer / test cmd>"}'` → `{ok, exit, stdout, stderr}` |
+| **capture** | `curl -s --unix-socket "$SOCK" http://vm/capture -d '{"command":"<optional cmd>"}'` → stdout + a base64 `virsh screenshot` for GUI state |
+| **reset** | `curl -s --unix-socket "$SOCK" http://vm/reset -X POST` — `snapshot-revert … --running`, back to clean |
 
-SSH non-interactively: `-o BatchMode=yes -o ConnectTimeout=10`. A run that
-exec'd anything stateful **must** end with a reset, even on failure — leave the
-box clean for the next shell.
+The broker runs ssh non-interactively and uses the saved `vm` block — you name a
+command, never a host or a key. A run that exec'd anything stateful **must** end
+with a `/reset`, even on failure — leave the box clean for the next shell.
+
+> [!class4]
+> **`reset` reverts to an OFFLINE snapshot with `--running`** (the broker passes
+> it for you): the clean snapshot is powered-off because this CPU's
+> non-migratable `invtsc` flag refuses a live one, so the flag boots it back up.
 
 ## Stance
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -2359,7 +2359,27 @@ No `vm` block → no VM linked: stop and ask the operator to run the wizard. The
 admin `configure_winbox` skill must also have run, or the box has no toolchain
 (the `toolchain` check in the wizard is how you confirm it did).
 
-`ssh_key_path` is a **path**, never key material — read it, never echo it.
+`ssh_key_path` is a **path**, never key material — and your shell never reads it
+anyway: the key lives host-side with the broker (below). You never hold it.
+
+## You drive the VM through the host broker — not ssh/virsh directly
+
+You run inside the sandbox container. The VM lives on the host''s libvirt NAT,
+unreachable from here, and the container has no `ssh`, no `virsh`, and no key.
+So you do **not** shell out — you call the **host-side vm-broker** over a unix
+socket in the bind-mounted repo. The broker holds the key + libvirt and does the
+work; nothing about your isolation changes. (See `docs/windows-vm-broker.md`.)
+
+The socket path comes from `./sc vm-broker-sock`. Every verb is a `curl`:
+
+```bash
+SOCK="$(./sc vm-broker-sock)"
+curl -s --unix-socket "$SOCK" http://vm/health      # liveness check first
+```
+
+If the curl fails with "not reachable", the broker isn''t running — ask the
+operator to start it on the host: `./sc vm-broker-up`. You cannot start it
+yourself (it must run on the host, not in your sandbox).
 
 ## The loop — push → exec → capture → reset
 
@@ -2367,16 +2387,21 @@ Every run starts from the clean snapshot, so installer side-effects never leak
 between runs. That property is the whole point — without the reset, system-level
 testing isn''t trustworthy.
 
-| Verb | How |
+| Verb | Call |
 |---|---|
-| **push** | drop the build artifact into `transfer_dir` (the host side of the guest''s virtio-fs share, or scp to the guest) |
-| **exec** | `ssh -i <ssh_key_path> -p <ssh_port> <ssh_user>@<ssh_host> "<installer / test cmd>"` |
-| **capture** | collect stdout + exit code; `virsh screenshot <domain> /tmp/win.ppm` for installer GUI state |
-| **reset** | `virsh snapshot-revert <domain> <snapshot>` — back to clean before the next run |
+| **push** | `curl -s --unix-socket "$SOCK" http://vm/push -d ''{"src":"<repo path to artifact>"}''` — stages it into `transfer_dir` (the guest''s share) |
+| **exec** | `curl -s --unix-socket "$SOCK" http://vm/exec -d ''{"command":"<installer / test cmd>"}''` → `{ok, exit, stdout, stderr}` |
+| **capture** | `curl -s --unix-socket "$SOCK" http://vm/capture -d ''{"command":"<optional cmd>"}''` → stdout + a base64 `virsh screenshot` for GUI state |
+| **reset** | `curl -s --unix-socket "$SOCK" http://vm/reset -X POST` — `snapshot-revert … --running`, back to clean |
 
-SSH non-interactively: `-o BatchMode=yes -o ConnectTimeout=10`. A run that
-exec''d anything stateful **must** end with a reset, even on failure — leave the
-box clean for the next shell.
+The broker runs ssh non-interactively and uses the saved `vm` block — you name a
+command, never a host or a key. A run that exec''d anything stateful **must** end
+with a `/reset`, even on failure — leave the box clean for the next shell.
+
+> [!class4]
+> **`reset` reverts to an OFFLINE snapshot with `--running`** (the broker passes
+> it for you): the clean snapshot is powered-off because this CPU''s
+> non-migratable `invtsc` flag refuses a live one, so the flag boots it back up.
 
 ## Stance
 

--- a/.super-coder/scripts/vm.py
+++ b/.super-coder/scripts/vm.py
@@ -25,13 +25,25 @@ it never installs anything.
 """
 from __future__ import annotations
 
+import base64
+import json
 import os
+import shutil
+import socket
 import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
 import ports
 
 CHECKS = ("domain", "ssh", "transfer", "snapshot", "toolchain")
+
+# The broker listens here — a unix socket inside the bind-mounted engine dir, so
+# the same absolute path resolves on the host (where the broker runs) and in the
+# sandbox (where windows_devkit curls it). No network surface; fs-perm gated.
+RUN_DIR = ports.ENGINE / "run"
+SOCKET = RUN_DIR / "vm-broker.sock"
 
 
 # -- config (instance.json `vm` block) ---------------------------------------
@@ -156,3 +168,153 @@ def validate(check: str, cfg: dict) -> dict | None:
         return None
     ok, out = fn(cfg or {})
     return {"ok": ok, "output": out or "(no output)", "check": check}
+
+
+# -- the loop verbs (host-side; the broker exposes these over the socket) -----
+#
+# Verbs operate on the SAVED `vm` block — windows_devkit names a command, not a
+# config. (validate() above is the exception: it tests a CANDIDATE block the
+# wizard passes in, before it is saved.)
+
+def do_exec(command: str, timeout: int = 120) -> dict:
+    """Run one command in the guest over SSH. Returns {ok, exit, stdout, stderr}."""
+    cfg = read() or {}
+    if m := _missing(cfg, "ssh_host", "ssh_user", "ssh_key_path"):
+        return {"ok": False, "exit": -1, "stdout": "", "stderr": m}
+    if not str(command).strip():
+        return {"ok": False, "exit": -1, "stdout": "", "stderr": "exec: empty command"}
+    try:
+        p = subprocess.run(_ssh_argv(cfg, command), capture_output=True,
+                           text=True, timeout=timeout)
+        return {"ok": p.returncode == 0, "exit": p.returncode,
+                "stdout": p.stdout, "stderr": p.stderr}
+    except FileNotFoundError as e:
+        return {"ok": False, "exit": 127, "stdout": "",
+                "stderr": f"command not found: {e.filename} — is ssh installed on the host?"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "exit": 124, "stdout": "", "stderr": f"timed out (>{timeout}s)"}
+
+
+def do_reset() -> dict:
+    """Revert to the clean snapshot. `--running` because the clean snapshot is
+    OFFLINE (this CPU's non-migratable invtsc flag refuses a live snapshot), so a
+    bare revert lands powered-off — the flag boots it back."""
+    cfg = read() or {}
+    if m := _missing(cfg, "domain", "snapshot"):
+        return {"ok": False, "output": m}
+    ok, out = _run(
+        ["virsh", "snapshot-revert", str(cfg["domain"]),
+         "--snapshotname", str(cfg["snapshot"]), "--running"], timeout=60)
+    return {"ok": ok, "output": out or f"reverted '{cfg['domain']}' to '{cfg['snapshot']}' (running)"}
+
+
+def do_push(src: str, dest: str | None = None) -> dict:
+    """Stage a host-visible artifact into transfer_dir (the host side of the
+    guest's virtio-fs share). `src` is a path in the bind-mounted repo; the guest
+    sees the copy under its mapped share. The fast path — no scp, no guest auth."""
+    cfg = read() or {}
+    if m := _missing(cfg, "transfer_dir"):
+        return {"ok": False, "output": m}
+    src_p = Path(os.path.expanduser(str(src)))
+    if not src_p.is_file():
+        return {"ok": False, "output": f"push: source not found: {src_p}"}
+    d = Path(os.path.expanduser(str(cfg["transfer_dir"])))
+    if not d.is_dir():
+        return {"ok": False, "output": f"transfer_dir does not exist: {d}"}
+    target = d / (dest or src_p.name)
+    try:
+        shutil.copy2(src_p, target)
+    except OSError as e:
+        return {"ok": False, "output": f"push failed: {e}"}
+    return {"ok": True, "output": f"staged {src_p.name} -> {target} (guest sees it via the share)"}
+
+
+def do_capture(command: str | None = None) -> dict:
+    """Collect installer/test state: optionally exec a command for its stdout,
+    and always grab a `virsh screenshot` of the guest console (GUI installers
+    show state on-screen, not on stdout). Screenshot returned base64."""
+    cfg = read() or {}
+    result: dict = {"ok": True}
+    if command and str(command).strip():
+        result["exec"] = do_exec(command)
+        result["ok"] = bool(result["exec"].get("ok"))
+    if m := _missing(cfg, "domain"):
+        result["screenshot_error"] = m
+        return result
+    shot = Path(tempfile.gettempdir()) / f"sc_vm_{cfg['domain']}.ppm"
+    ok, out = _run(["virsh", "screenshot", str(cfg["domain"]), str(shot)], timeout=30)
+    if ok and shot.exists():
+        data = shot.read_bytes()
+        result["screenshot_b64"] = base64.b64encode(data).decode()
+        result["screenshot_bytes"] = len(data)
+        result["screenshot_format"] = "ppm"
+        try:
+            shot.unlink()
+        except OSError:
+            pass
+    else:
+        result["ok"] = False
+        result["screenshot_error"] = out or "virsh screenshot produced no file"
+    return result
+
+
+# -- client: HTTP over the broker's unix socket ------------------------------
+
+def broker_call(method: str, path: str, body: dict | None = None,
+                timeout: int = 130) -> dict:
+    """Speak HTTP/1.1 to the broker over its unix socket and return parsed JSON.
+    Raises ConnectionError if the broker is not listening (so callers can render
+    a 'start the broker' hint). Used by the in-sandbox server to proxy validate."""
+    payload = b"" if body is None else json.dumps(body).encode()
+    req = (
+        f"{method} {path} HTTP/1.1\r\nHost: vm-broker\r\n"
+        f"Content-Type: application/json\r\nContent-Length: {len(payload)}\r\n"
+        f"Connection: close\r\n\r\n"
+    ).encode() + payload
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    chunks: list[bytes] = []
+    try:
+        s.connect(str(SOCKET))
+        s.sendall(req)
+        while True:
+            b = s.recv(65536)
+            if not b:
+                break
+            chunks.append(b)
+    except (FileNotFoundError, ConnectionRefusedError, OSError) as e:
+        raise ConnectionError(f"vm-broker not reachable at {SOCKET}: {e}") from e
+    finally:
+        s.close()
+    _, _, raw_body = b"".join(chunks).partition(b"\r\n\r\n")
+    try:
+        return json.loads(raw_body.decode() or "{}")
+    except json.JSONDecodeError:
+        return {"ok": False, "error": "bad broker response",
+                "raw": raw_body[:200].decode("latin1")}
+
+
+# -- host CLI (path lookup for `sc`; verbs for manual no-broker testing) ------
+
+def main(argv: list[str]) -> int:
+    mode = argv[0] if argv else "sock"
+    if mode == "sock":
+        print(SOCKET)
+    elif mode == "exec":
+        print(json.dumps(do_exec(" ".join(argv[1:]))))
+    elif mode == "reset":
+        print(json.dumps(do_reset()))
+    elif mode == "push":
+        print(json.dumps(do_push(argv[1] if len(argv) > 1 else "",
+                                 argv[2] if len(argv) > 2 else None)))
+    elif mode == "capture":
+        print(json.dumps(do_capture(" ".join(argv[1:]) or None)))
+    elif mode == "validate":
+        print(json.dumps(validate(argv[1] if len(argv) > 1 else "", read() or {})))
+    else:
+        sys.exit("usage: vm.py [sock|exec <cmd>|reset|push <src> [dest]|capture [cmd]|validate <check>]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/docs/windows-vm-broker.md
+++ b/docs/windows-vm-broker.md
@@ -8,7 +8,7 @@ purpose: Host-side broker so sandboxed forks can drive the test VM
 
 # Windows VM Broker — Spec
 
-[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/super-coder/blob/cc/windows-vm-broker-spec/docs/windows-vm-broker.md)
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/super-coder/blob/cc/windows-vm-broker/docs/windows-vm-broker.md)
 
 ## Overview
 
@@ -185,19 +185,50 @@ Open for the build, with leanings:
 MVP: exec + reset over socket :::class1 -> full: push + capture + validate :::class2 -> generalize: test-target interface :::class3
 ```
 
-1. **MVP** — socket + `exec` + `reset --running`. Proves the loop end-to-end
+1. **MVP** ✅ — socket + `exec` + `reset --running`. Proves the loop end-to-end
    from the container against the `clean` snapshot.
-2. **Full** — `push`, `capture` (incl. screenshot), relocate `validate`.
+2. **Full** ✅ — `push`, `capture` (incl. screenshot), `validate` relocated to
+   the broker (server proxies in-sandbox).
 3. **Generalize** — lift the four verbs into a provider-agnostic test-target
    interface; Windows-via-VM becomes provider #1, with containers/devices later.
 
+## Resolved (built)
+
+The build settled the four open questions:
+
+- **Where do the #129 `validate` endpoints run?** They lived in the in-container
+  server and presumed host access the sandbox lacks. The broker now owns the
+  live checks; the in-sandbox server **proxies** `/api/vm/validate/{check}` to
+  the broker socket (and on the no-docker host path calls `vm.validate` directly,
+  unchanged). `GET/PUT /api/vm` stay in the server — they are pure
+  `instance.json` I/O that works anywhere. So the wizard's test-before-save works
+  again from the dockerized default.
+- **Socket vs bridge-TCP.** Unix socket, as recommended:
+  `.super-coder/run/vm-broker.sock` in the bind-mounted engine dir. Unix sockets
+  are filesystem objects, not network-namespace objects, so a container process
+  connects to the host listener through the shared mount — no route, no firewall,
+  no network surface.
+- **Broker auth.** Filesystem permission is sufficient for now: the socket is
+  `chmod 0600`, reachable only by processes sharing the mount. No per-fork token
+  in MVP. (A token belongs only if the socket ever moves to TCP.)
+- **Artifact transfer.** Keep the virtio-fs share as the `push` fast path —
+  `/push` copies a host-visible (bind-mounted) artifact into `transfer_dir`. No
+  scp, no guest auth on the hot path.
+
+## Implementation
+
+Built per the architecture above:
+
+| Piece | Where |
+|---|---|
+| Broker process | `.super-coder/api/vm_broker.py` — AF_UNIX `ThreadingHTTPServer`, refuses to run under `SC_SANDBOX` |
+| Loop verbs + socket client | `.super-coder/scripts/vm.py` — `do_exec` / `do_reset` / `do_push` / `do_capture`, `broker_call` (unix-socket HTTP), `SOCKET` |
+| Supervision | `./sc vm-broker` (foreground), `./sc vm-broker-up` / `-down` (nohup + pidfile), `./sc vm-broker-sock` |
+| Server proxy | `.super-coder/api/server.py` — `/api/vm/validate/{check}` proxies to the broker in-sandbox |
+| Skill | `windows_devkit` — drives the four verbs via `curl --unix-socket`, holds no key |
+| Tests | `tests/test_vm_broker.py` — verb dispatch + live unix-socket transport |
+
 ## Open questions
 
-- **Where do the #129 `validate` endpoints actually run?** If they live in the
-  in-container server, they presume host access the sandbox lacks — and should
-  move into the broker. Confirm before building.
-- **Socket vs bridge-TCP** as the default transport (recommend socket).
-- **Broker auth** — is filesystem permission on the socket sufficient, or does a
-  per-fork token still belong on the call?
-- **Artifact transfer** — keep the virtio-fs share as the `push` fast path, or
-  route everything through `scp` for a single mechanism?
+- **Phase 3 generalization** — lifting the four verbs into a provider-agnostic
+  test-target interface (containers/devices as providers #2+) is still ahead.

--- a/docs/windows-vm-broker.md
+++ b/docs/windows-vm-broker.md
@@ -1,0 +1,203 @@
+---
+title: Windows VM Broker — Spec
+tags: [super-coder, design, testing, windows, broker]
+date: 2026-06-17
+project: super-coder
+purpose: Host-side broker so sandboxed forks can drive the test VM
+---
+
+# Windows VM Broker — Spec
+
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/super-coder/blob/cc/windows-vm-broker-spec/docs/windows-vm-broker.md)
+
+## Overview
+
+The [Windows Test VM](windows-test-vm.md) capability shipped the skills, the
+config, and a host-side **validation** path — but not a way for the shells that
+hold `windows_devkit` to actually *drive* the VM. Those shells run inside the
+super-coder **sandbox container**, and the test VM lives on the host's libvirt
+NAT network. A container cannot reach it, and cannot run `virsh`.
+
+This spec adds a **host-side VM broker**: one process that holds the SSH key and
+has libvirt access, exposes the four loop verbs over a local socket, and is
+called by `windows_devkit` from inside the container. The key never enters the
+fork; `virsh` runs where it works.
+
+> [!class1]
+> The broker is the **generic test-target seam** the Windows VM design deferred
+> to "out of scope." The reachability test below proves it is **required**, not
+> optional, for any containerized fork — Windows-via-VM is just provider #1.
+
+## The gap (measured)
+
+From inside the live `sc-dos-arch` container (`172.19.0.2` on `sc-net`):
+
+```stats
+:::class4
+value: timeout
+label: container → VM:22
+description: 192.168.122.100 unreachable — no route across libvirt NAT
+:::class4
+value: none
+label: ssh / scp / virsh
+description: container has python3 only; no client, no hypervisor control
+:::class3
+value: refused
+label: container → host:8804
+description: route to host exists; services bind 127.0.0.1, so nothing answers
+:::class3
+value: mounted
+label: repo bind-mount
+description: /home/j3d1/dos-arch visible both sides — a unix socket can live here
+```
+
+## Why creds-in-container fails
+
+The tempting shortcut — mount the SSH key into the sandbox — hits three walls,
+and clears none of the important one:
+
+| Wall | Detail |
+|---|---|
+| **No route** | container `sc-net` (172.19) cannot reach libvirt NAT (192.168.122). A key is useless if packets never arrive. |
+| **No client** | the sandbox image has no `ssh`/`scp`. You'd have to bake OpenSSH into every fork image. |
+| **`virsh` verbs** | `reset` (snapshot-revert) and `capture` (screenshot) are **host libvirt** ops. No credential makes a container revert a host snapshot — and a fork sandbox must never hold hypervisor control. |
+
+Even if you mounted the key, installed `ssh`, *and* punched a firewall route,
+you'd get `exec`/`push` and still could not `reset` between tests — the one verb
+the isolated loop exists for. And the key would now live in the fork, the exact
+posture the credential broker was built to avoid.
+
+## Architecture
+
+The broker is a **host process** — not the in-container API server. It mirrors
+dos-arch's credential-broker precedent: the one host-side authority that holds a
+secret so nothing downstream needs it.
+
+```mermaid
+graph LR
+  subgraph Container["sandbox (sc-net)"]
+    WDK["windows_devkit"]:::class1
+  end
+  subgraph Host["host"]
+    BRK["vm-broker"]:::class2
+    KEY["sc_win_test key"]:::class4
+    LV["libvirt / virsh"]:::class3
+  end
+  VM["Windows VM"]:::class3
+  WDK -->|"unix socket"| BRK
+  BRK --> KEY
+  BRK -->|"ssh / scp"| VM
+  BRK -->|"virsh"| LV
+  LV --> VM
+```
+
+- **Container side** — `windows_devkit` makes local socket calls. No key, no
+  `ssh`, no `virsh`, no route to the VM. Nothing changes about its isolation.
+- **Host side** — the broker reads `instance.json.vm`, holds the key path, and
+  is the only thing that touches the guest or the hypervisor.
+
+## Transport
+
+Two options, both grounded in the measured facts. Recommend the socket.
+
+> [!class3]
+> **Unix socket in the bind-mounted repo (recommended).** The broker listens on
+> e.g. `.super-coder/run/vm-broker.sock` inside the fork repo, which is mounted
+> into the container at the same path. No network surface, no firewall, gated by
+> filesystem permissions. `windows_devkit` calls it with `curl --unix-socket`.
+
+The TCP fallback: bind the broker on the docker-bridge gateway (`172.19.0.1`) or
+`0.0.0.0`. The container *can* reach that (refused, not dropped — a listener is
+all that's missing), but it is a real network surface that then needs its own
+auth token. The socket avoids that entirely.
+
+```linear
+windows_devkit :::class1 -> unix socket :::class2 -> vm-broker (host) :::class2 -> ssh / virsh :::class3 -> VM :::class3
+```
+
+## API
+
+Four verb endpoints, plus the validation surface relocated from the in-server
+endpoints (which presume host access the container doesn't have). All return
+`{ok, ...}` and stream output, mirroring the existing `validate/{check}` shape.
+
+| Method | Path | Does | Mechanism |
+|---|---|---|---|
+| `POST` | `/push` | stage a build artifact for the guest | copy into `transfer_dir` (virtio-fs share) or `scp` |
+| `POST` | `/exec` | run a command in the guest | `ssh`; returns `{ok, exit, stdout, stderr}` |
+| `POST` | `/capture` | collect output / installer GUI state | stdout passthrough; `virsh screenshot` for the screen |
+| `POST` | `/reset` | revert to the clean baseline | `virsh snapshot-revert <domain> clean --running` |
+| `POST` | `/validate/{check}` | the five setup checks | relocated from the host-presuming in-server endpoints |
+| `GET`/`PUT` | `/vm` | read / write the `vm` config block | `instance.json` |
+
+> [!class4]
+> **`reset` uses `--running`.** The `clean` snapshot is **offline** — this CPU
+> exposes the non-migratable `invtsc` flag, so a live (memory) snapshot is
+> refused. Revert therefore lands in a powered-off state; `--running` boots it
+> back. `windows_devkit`'s reset verb must pass it, or the box comes back dark.
+
+## Security
+
+The broker is the trust boundary, and it tightens the current posture rather
+than loosening it.
+
+- **Key stays host-side.** `~/.ssh` is not mounted into the sandbox today; the
+  broker preserves that. The fork never holds the credential.
+- **No hypervisor in the fork.** `virsh` runs only in the broker. A compromised
+  sandbox can ask for a `reset`; it cannot script libvirt.
+- **Scope the surface.** `exec` runs arbitrary commands *on the VM* by design —
+  that is the test loop. The broker scopes to the configured guest only, never
+  shells out on the host on behalf of the caller.
+- **One door per caller class.** The broker is reached only by fork shells over
+  the socket; admin provisioning (`configure_winbox`) is a separate, host-run
+  path. Do not widen one gate to serve both.
+
+## windows_devkit changes
+
+The skill's four verbs map one-to-one onto broker calls — it stops shelling out
+to `ssh`/`virsh` (which never worked from the container) and curls the socket.
+
+| Verb | Was (broken in container) | Becomes |
+|---|---|---|
+| push | `scp` / share write | `POST /push` |
+| exec | `ssh host cmd` | `POST /exec` |
+| capture | `ssh` + `virsh screenshot` | `POST /capture` |
+| reset | `virsh snapshot-revert` | `POST /reset` |
+
+`configure_winbox` (admin provisioning) is rare and host-weighted; it can call
+the broker too, or stay an explicit host-operator task. Either way its `virsh`
+snapshot step lives host-side.
+
+## Process & supervision
+
+Open for the build, with leanings:
+
+- **Separate process, not the in-container server.** The sandbox server cannot
+  hold the key or reach libvirt; the broker must be a distinct host process.
+- **Supervised like the rest of the host substrate** — pm2 alongside the fork's
+  other host-side processes (the credential broker is the model).
+- **Per-fork.** One broker per fork, reading that fork's `instance.json.vm` and
+  socket path, so two forks never share a VM handle by accident.
+
+## Phasing
+
+```linear
+MVP: exec + reset over socket :::class1 -> full: push + capture + validate :::class2 -> generalize: test-target interface :::class3
+```
+
+1. **MVP** — socket + `exec` + `reset --running`. Proves the loop end-to-end
+   from the container against the `clean` snapshot.
+2. **Full** — `push`, `capture` (incl. screenshot), relocate `validate`.
+3. **Generalize** — lift the four verbs into a provider-agnostic test-target
+   interface; Windows-via-VM becomes provider #1, with containers/devices later.
+
+## Open questions
+
+- **Where do the #129 `validate` endpoints actually run?** If they live in the
+  in-container server, they presume host access the sandbox lacks — and should
+  move into the broker. Confirm before building.
+- **Socket vs bridge-TCP** as the default transport (recommend socket).
+- **Broker auth** — is filesystem permission on the socket sufficient, or does a
+  per-fork token still belong on the call?
+- **Artifact transfer** — keep the virtio-fs share as the `push` fast path, or
+  route everything through `scp` for a single mechanism?

--- a/sc
+++ b/sc
@@ -214,6 +214,31 @@ sc_typecheck() {
   else ( cd "$here" && "$venv/bin/mypy" . ); fi
 }
 
+# ── Windows VM broker (HOST-side; drives the test VM for sandboxed forks) ──────
+# A separate host process — the sandbox server can't hold the ssh key or reach
+# libvirt. It listens on a unix socket in the bind-mounted engine dir so
+# windows_devkit (in the container) can curl it without a route or a key. Refuses
+# to run in the sandbox (vm_broker.py guards on SC_SANDBOX). Supervise it however
+# the host prefers; vm-broker-up is a dependency-free nohup+pidfile default.
+VM_BROKER_PID="$ENGINE/run/vm-broker.pid"
+sc_vm_broker_up() {
+  mkdir -p "$ENGINE/run"
+  if [ -f "$VM_BROKER_PID" ] && kill -0 "$(cat "$VM_BROKER_PID" 2>/dev/null)" 2>/dev/null; then
+    echo "→ vm-broker already running (pid $(cat "$VM_BROKER_PID"))"; return 0
+  fi
+  nohup "$PY" "$ENGINE/api/vm_broker.py" >"$ENGINE/run/vm-broker.log" 2>&1 &
+  echo $! > "$VM_BROKER_PID"
+  echo "→ vm-broker up (pid $!) · socket $("$PY" "$S/vm.py" sock) · log $ENGINE/run/vm-broker.log"
+}
+sc_vm_broker_down() {
+  if [ -f "$VM_BROKER_PID" ] && kill -0 "$(cat "$VM_BROKER_PID" 2>/dev/null)" 2>/dev/null; then
+    kill "$(cat "$VM_BROKER_PID")" && echo "→ vm-broker stopped"
+  else
+    echo "→ vm-broker not running"
+  fi
+  rm -f "$VM_BROKER_PID"
+}
+
 cmd="${1:-help}"; [ $# -gt 0 ] && shift
 
 case "$cmd" in
@@ -237,6 +262,11 @@ case "$cmd" in
   preview)      exec "$PY" "$S/preview.py" "$@" ;;
   # ── in-container primitives (no docker; also the host escape hatch) ──
   serve)        exec "$PY" "$ENGINE/api/server.py" "$@" ;;
+  # ── Windows VM broker (HOST-side primitive — runs where virsh + the key live) ──
+  vm-broker)      exec "$PY" "$ENGINE/api/vm_broker.py" "$@" ;;
+  vm-broker-up)   sc_vm_broker_up ;;
+  vm-broker-down) sc_vm_broker_down ;;
+  vm-broker-sock) exec "$PY" "$S/vm.py" sock ;;
   boot)         exec "$PY" "$S/run.py" "$@" ;;
   boot-*)       exec "$PY" "$S/run.py" "${cmd#boot-}" "$@" ;;
   deps)         sc_deps "$@" ;;
@@ -342,6 +372,13 @@ super-coder — forkable shell substrate
   ./sc test                run backend (.venv pytest or stdlib unittest) + UI (vitest) suites; non-zero on any failure
   ./sc lint [paths]        ruff check the fork's python (.venv ruff; honors [tool.ruff]) — available, not enforced
   ./sc typecheck [paths]   mypy the fork's python (.venv mypy; honors [tool.mypy]) — available, not enforced
+
+  Windows VM broker (run on the HOST — drives the test VM for sandboxed forks;
+  holds the ssh key + virsh so the fork never does. See docs/windows-vm-broker.md):
+  ./sc vm-broker           run the broker in the foreground (unix socket)
+  ./sc vm-broker-up        start it in the background (nohup + pidfile)
+  ./sc vm-broker-down      stop the backgrounded broker
+  ./sc vm-broker-sock      print the broker's socket path
 
   ./sc verify              rebuild + flat render + render-only boot (headless proof)
   ./sc health              curl the review layer's /api/health

--- a/tests/test_vm_broker.py
+++ b/tests/test_vm_broker.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Smoke tests for the Windows VM broker (api/vm_broker.py + scripts/vm.py).
+
+Stdlib `unittest`, no pytest — matching the engine's no-dependency style and the
+sibling tests. The broker drives a real Windows VM via ssh/virsh, which no CI box
+has; so we mock at the subprocess seam (`vm._run` / `subprocess.run`) and exercise
+the parts that DO run everywhere: the verb dispatch + field validation, the JSON
+shapes windows_devkit depends on, and the real unix-socket HTTP transport end to
+end (a live broker on a temp socket, driven by the same `vm.broker_call` client
+the in-sandbox server proxies through).
+
+Run:
+    python3 tests/test_vm_broker.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+
+import vm  # noqa: E402
+import vm_broker  # noqa: E402
+
+SAVED = {
+    "domain": "win-test", "ssh_host": "127.0.0.1", "ssh_port": 22,
+    "ssh_user": "tester", "ssh_key_path": "~/.ssh/sc_win_test",
+    "transfer_dir": "/tmp", "snapshot": "clean",
+}
+
+
+class VerbDispatchTests(unittest.TestCase):
+    """The verbs operate on the SAVED block and shape their result correctly."""
+
+    def test_exec_returns_exit_stdout_stderr(self):
+        fake = mock.Mock(returncode=0, stdout="hello\n", stderr="")
+        with mock.patch.object(vm, "read", return_value=SAVED), \
+             mock.patch("subprocess.run", return_value=fake) as run:
+            r = vm.do_exec("echo hello")
+        self.assertEqual(r, {"ok": True, "exit": 0, "stdout": "hello\n", "stderr": ""})
+        # SSH non-interactive + targets the saved guest, not a caller-named host.
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[0], "ssh")
+        self.assertIn("BatchMode=yes", argv)
+        self.assertIn("tester@127.0.0.1", argv)
+
+    def test_exec_missing_config_is_a_clean_error_not_a_crash(self):
+        with mock.patch.object(vm, "read", return_value={}):
+            r = vm.do_exec("whoami")
+        self.assertFalse(r["ok"])
+        self.assertIn("missing required field", r["stderr"])
+
+    def test_reset_passes_running_for_the_offline_clean_snapshot(self):
+        with mock.patch.object(vm, "read", return_value=SAVED), \
+             mock.patch.object(vm, "_run", return_value=(True, "")) as run:
+            r = vm.do_reset()
+        self.assertTrue(r["ok"])
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[:3], ["virsh", "snapshot-revert", "win-test"])
+        self.assertIn("--running", argv)  # else the box comes back powered-off
+
+    def test_push_rejects_a_missing_source(self):
+        with mock.patch.object(vm, "read", return_value=SAVED):
+            r = vm.do_push("/no/such/artifact.msi")
+        self.assertFalse(r["ok"])
+        self.assertIn("source not found", r["output"])
+
+    def test_capture_returns_a_base64_screenshot(self):
+        def fake_run(argv, timeout=30):
+            # virsh screenshot writes the file the broker then reads back
+            Path(argv[-1]).write_bytes(b"P6 fake ppm bytes")
+            return True, "Screenshot saved"
+        with mock.patch.object(vm, "read", return_value=SAVED), \
+             mock.patch.object(vm, "_run", side_effect=fake_run):
+            r = vm.do_capture()
+        self.assertTrue(r["ok"])
+        self.assertIn("screenshot_b64", r)
+        self.assertEqual(r["screenshot_bytes"], len(b"P6 fake ppm bytes"))
+
+
+class SocketTransportTests(unittest.TestCase):
+    """A live broker on a temp socket, driven by the real broker_call client —
+    proves the unix-socket HTTP transport the container relies on actually works."""
+
+    def setUp(self):
+        self.sock = Path(__file__).resolve().parent / "_test_vm_broker.sock"
+        self._orig_socket = vm.SOCKET
+        vm.SOCKET = self.sock  # both server (vm_broker.main path) + client read this
+        self.srv = vm_broker.UnixHTTPServer(str(self.sock), vm_broker.Handler)
+        self.t = threading.Thread(target=self.srv.serve_forever, daemon=True)
+        self.t.start()
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+        vm.SOCKET = self._orig_socket
+        self.sock.unlink(missing_ok=True)
+
+    def test_health(self):
+        r = vm.broker_call("GET", "/health")
+        self.assertEqual(r, {"ok": True, "service": "vm-broker"})
+
+    def test_unknown_route_is_404_shaped(self):
+        r = vm.broker_call("GET", "/nope")
+        self.assertFalse(r["ok"])
+
+    def test_validate_proxies_the_candidate_cfg_in_the_body(self):
+        # The in-sandbox server proxies validate through exactly this path.
+        with mock.patch.object(vm, "_run", return_value=(True, "Id: 3")):
+            r = vm.broker_call("POST", "/validate/domain", {"vm": SAVED})
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["check"], "domain")
+
+    def test_exec_round_trips_over_the_socket(self):
+        fake = mock.Mock(returncode=2, stdout="out", stderr="err")
+        with mock.patch.object(vm, "read", return_value=SAVED), \
+             mock.patch("subprocess.run", return_value=fake):
+            r = vm.broker_call("POST", "/exec", {"command": "exit 2"})
+        self.assertEqual(r["exit"], 2)
+        self.assertEqual(r["stdout"], "out")
+
+    def test_broker_call_raises_when_nothing_listens(self):
+        vm.SOCKET = self.sock.with_name("_absent.sock")
+        with self.assertRaises(ConnectionError):
+            vm.broker_call("GET", "/health")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Builds the host-side VM broker specced in #131. Sandboxed fork shells can't reach the Windows test VM (no route across libvirt NAT) and hold no ssh key / `virsh` — so `windows_devkit`'s push/exec/capture/reset never worked from the container (flag CC-125). This adds a **host process** that holds the key + libvirt and exposes the loop over a unix socket in the bind-mounted repo. The fork curls the socket; the key never leaves the host, `virsh` runs where it works.

This branch includes the spec commit, so it **supersedes #131** (spec-only) — that PR can close in favour of this one.

## What's here
- **`vm_broker.py`** — `AF_UNIX` `ThreadingHTTPServer`: `POST /exec /reset /push /capture`, `POST /validate/{check}`, `GET/PUT /vm`, `GET /health`. Refuses to run under `SC_SANDBOX` (host-only).
- **`vm.py`** — host verbs `do_exec`/`do_reset`/`do_push`/`do_capture` (reset passes `--running` — the clean snapshot is offline) + `broker_call` unix-socket HTTP client + `SOCKET` path.
- **`sc`** — `vm-broker` (foreground), `vm-broker-up`/`-down` (nohup + pidfile), `vm-broker-sock`.
- **`server.py`** — `/api/vm/validate/{check}` proxies to the broker in-sandbox (and calls `vm` directly on the no-docker host path). Fixes the wizard's live checks, which ran `virsh` in-container and always failed.
- **`windows_devkit`** — drives the four verbs via `curl --unix-socket`; holds no key. Seed migration regenerated.
- **`tests/test_vm_broker.py`** — verb dispatch + a live end-to-end unix-socket transport test.

## Resolved (spec open questions)
Socket over bridge-TCP · fs-perm (0600) auth, no token · `validate` relocated to the broker · virtio-fs share as the `push` fast path.

## Testing
- `python3 tests/test_vm_broker.py` → 10 pass (incl. real socket round-trips).
- Live smoke: `./sc vm-broker-up` → `curl --unix-socket` health / `/vm` / graceful `/exec` errors / 404 / `-down` all green.
- `SC_SANDBOX=1 ./sc vm-broker` correctly refuses.
- The **full** loop against a real Windows guest (push→exec→capture→reset) needs the host VM + a configured `vm` block — that's yours to run.

## Note
`tests/test_api_endpoints.py::test_get_map_empty_catalogue` fails on this branch — **pre-existing** (`get_map()` signature drift), confirmed on the base branch, unrelated to this change. Left for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)