### PR TITLE
feat(vm): libvirt_uri so virsh can target a system-scope domain

### DIFF
--- a/.super-coder/assets/skills/windows_devkit/SKILL.md
+++ b/.super-coder/assets/skills/windows_devkit/SKILL.md
@@ -22,8 +22,12 @@ Scripts → **Windows Test VM** wizard, which live-tests every field before save
 ```json
 "vm": { "domain": "win-test", "ssh_host": "127.0.0.1", "ssh_port": 22,
         "ssh_user": "tester", "ssh_key_path": "~/.ssh/sc_win_test",
-        "transfer_dir": "/var/sc/win-xfer", "snapshot": "clean" }
+        "transfer_dir": "/var/sc/win-xfer", "snapshot": "clean",
+        "libvirt_uri": "qemu:///system" }
 ```
+
+`libvirt_uri` is optional — set it when the domain is system-scope (the default
+`qemu:///session` can't see it); omit it otherwise.
 
 No `vm` block → no VM linked: stop and ask the operator to run the wizard. The
 admin `configure_winbox` skill must also have run, or the box has no toolchain

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -2352,8 +2352,12 @@ Scripts → **Windows Test VM** wizard, which live-tests every field before save
 ```json
 "vm": { "domain": "win-test", "ssh_host": "127.0.0.1", "ssh_port": 22,
         "ssh_user": "tester", "ssh_key_path": "~/.ssh/sc_win_test",
-        "transfer_dir": "/var/sc/win-xfer", "snapshot": "clean" }
+        "transfer_dir": "/var/sc/win-xfer", "snapshot": "clean",
+        "libvirt_uri": "qemu:///system" }
 ```
+
+`libvirt_uri` is optional — set it when the domain is system-scope (the default
+`qemu:///session` can''t see it); omit it otherwise.
 
 No `vm` block → no VM linked: stop and ask the operator to run the wizard. The
 admin `configure_winbox` skill must also have run, or the box has no toolchain

--- a/.super-coder/scripts/vm.py
+++ b/.super-coder/scripts/vm.py
@@ -81,6 +81,15 @@ def _missing(cfg: dict, *fields: str) -> str | None:
     return ("missing required field(s): " + ", ".join(absent)) if absent else None
 
 
+def _virsh(cfg: dict, *args: str) -> list[str]:
+    """A virsh argv against the configured connection. `libvirt_uri` in the vm
+    block selects the hypervisor — set it to `qemu:///system` for a system-scope
+    domain, which the default `qemu:///session` cannot see. Absent, virsh uses
+    its own default (the `LIBVIRT_DEFAULT_URI` env var, else `qemu:///session`)."""
+    uri = str(cfg.get("libvirt_uri", "")).strip()
+    return ["virsh", *(["--connect", uri] if uri else []), *args]
+
+
 def _ssh_argv(cfg: dict, remote: str) -> list[str]:
     """An ssh invocation against the configured guest. BatchMode keeps it
     non-interactive (no password/passphrase prompt can hang the server)."""
@@ -100,7 +109,7 @@ def _ssh_argv(cfg: dict, remote: str) -> list[str]:
 def _check_domain(cfg: dict) -> tuple[bool, str]:
     if m := _missing(cfg, "domain"):
         return False, m
-    return _run(["virsh", "dominfo", str(cfg["domain"])], timeout=15)
+    return _run(_virsh(cfg, "dominfo", str(cfg["domain"])), timeout=15)
 
 
 def _check_ssh(cfg: dict) -> tuple[bool, str]:
@@ -131,8 +140,8 @@ def _check_snapshot(cfg: dict) -> tuple[bool, str]:
     if m := _missing(cfg, "domain", "snapshot"):
         return False, m
     ok, out = _run(
-        ["virsh", "snapshot-info", str(cfg["domain"]),
-         "--snapshotname", str(cfg["snapshot"])], timeout=15)
+        _virsh(cfg, "snapshot-info", str(cfg["domain"]),
+               "--snapshotname", str(cfg["snapshot"])), timeout=15)
     if not ok and "Domain snapshot not found" in out:
         return False, (f"snapshot '{cfg['snapshot']}' not found on domain "
                        f"'{cfg['domain']}' — create the clean snapshot first.\n{out}")
@@ -203,8 +212,8 @@ def do_reset() -> dict:
     if m := _missing(cfg, "domain", "snapshot"):
         return {"ok": False, "output": m}
     ok, out = _run(
-        ["virsh", "snapshot-revert", str(cfg["domain"]),
-         "--snapshotname", str(cfg["snapshot"]), "--running"], timeout=60)
+        _virsh(cfg, "snapshot-revert", str(cfg["domain"]),
+               "--snapshotname", str(cfg["snapshot"]), "--running"), timeout=60)
     return {"ok": ok, "output": out or f"reverted '{cfg['domain']}' to '{cfg['snapshot']}' (running)"}
 
 
@@ -242,7 +251,7 @@ def do_capture(command: str | None = None) -> dict:
         result["screenshot_error"] = m
         return result
     shot = Path(tempfile.gettempdir()) / f"sc_vm_{cfg['domain']}.ppm"
-    ok, out = _run(["virsh", "screenshot", str(cfg["domain"]), str(shot)], timeout=30)
+    ok, out = _run(_virsh(cfg, "screenshot", str(cfg["domain"]), str(shot)), timeout=30)
     if ok and shot.exists():
         data = shot.read_bytes()
         result["screenshot_b64"] = base64.b64encode(data).decode()

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -788,9 +788,9 @@ async function renderScripts(root) {
 }
 
 // Windows Test VM wizard — a single link-only modal (the house openModal/el
-// pattern). The seven fields map 1:1 to the instance.json `vm` block; the five
-// checks each hit POST /api/vm/validate/{check} with the IN-PROGRESS form, so
-// the operator tests before saving. No secrets here — ssh_key_path is a PATH.
+// pattern). The fields map 1:1 to the instance.json `vm` block; the five checks
+// each hit POST /api/vm/validate/{check} with the IN-PROGRESS form, so the
+// operator tests before saving. No secrets here — ssh_key_path is a PATH.
 const VM_FIELDS = [
   ["domain", "win-test", "libvirt domain name (virsh target)"],
   ["ssh_host", "127.0.0.1", "guest OpenSSH host"],
@@ -799,6 +799,7 @@ const VM_FIELDS = [
   ["ssh_key_path", "~/.ssh/sc_win_test", "PATH to the private key — never the key itself"],
   ["transfer_dir", "/var/sc/win-xfer", "host-side dir the guest sees (virtio-fs share / scp target)"],
   ["snapshot", "clean", "named clean snapshot to revert to between runs"],
+  ["libvirt_uri", "qemu:///system", "OPTIONAL — virsh connection; set for a system-scope domain (default: qemu:///session)"],
 ];
 const VM_CHECKS = [
   ["domain", "VM exists + visible to libvirt"],

--- a/docs/windows-test-vm.md
+++ b/docs/windows-test-vm.md
@@ -98,7 +98,8 @@ Lives in the existing fork-level `instance.json` (where the port is already pers
     "ssh_user": "tester",
     "ssh_key_path": "~/.ssh/sc_win_test",
     "transfer_dir": "/var/sc/win-xfer",
-    "snapshot": "clean"
+    "snapshot": "clean",
+    "libvirt_uri": "qemu:///system"
   }
 }
 ```
@@ -110,6 +111,7 @@ Lives in the existing fork-level `instance.json` (where the port is already pers
 | `ssh_key_path` | **path** to the private key — never the key itself |
 | `transfer_dir` | host-side dir the guest sees (virtio-fs share) or scp target |
 | `snapshot` | named clean snapshot to revert to between runs |
+| `libvirt_uri` | **optional** — `virsh` connection. Set `qemu:///system` for a system-scope domain; the default `qemu:///session` can't see it. Omit otherwise. |
 
 > [!class3]
 > **Secrets posture matches the rest of the engine.** Super-coder stores zero credentials in the DB or on disk today — harness keys live in operator home, git uses the SSH agent. The `vm` block holds a key *path*, never key material. The wizard can generate a keypair into operator home and show the **public** key to install in the guest's `authorized_keys`; the DB/config never sees the private half.

--- a/tests/test_vm_broker.py
+++ b/tests/test_vm_broker.py
@@ -56,6 +56,22 @@ class VerbDispatchTests(unittest.TestCase):
         self.assertFalse(r["ok"])
         self.assertIn("missing required field", r["stderr"])
 
+    def test_virsh_calls_honor_libvirt_uri(self):
+        cfg = dict(SAVED, libvirt_uri="qemu:///system")
+        with mock.patch.object(vm, "read", return_value=cfg), \
+             mock.patch.object(vm, "_run", return_value=(True, "")) as run:
+            vm.do_reset()
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[:3], ["virsh", "--connect", "qemu:///system"])
+
+    def test_virsh_omits_connect_when_no_uri(self):
+        with mock.patch.object(vm, "read", return_value=SAVED), \
+             mock.patch.object(vm, "_run", return_value=(True, "")) as run:
+            vm.do_reset()
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[0], "virsh")
+        self.assertNotIn("--connect", argv)  # default URI / env, unchanged behavior
+
     def test_reset_passes_running_for_the_offline_clean_snapshot(self):
         with mock.patch.object(vm, "read", return_value=SAVED), \
              mock.patch.object(vm, "_run", return_value=(True, "")) as run:


### PR DESCRIPTION
Surfaced while wiring **dos-arch** as the broker's first consumer (follow-up to #132). Its test VM `W10C_DOS-ARCH_Testing` lives under `qemu:///system`, but `vm.py`'s `virsh` calls passed no `--connect`, so they hit the default `qemu:///session` and returned `failed to get domain`. Proven live against the broker before this fix.

## Change
- **`vm.py`** — new `_virsh(cfg, *args)` helper prepends `--connect <uri>` when the vm block sets `libvirt_uri`; all four virsh callsites (domain / snapshot / reset / capture) route through it. Absent → no `--connect` (unchanged: respects `LIBVIRT_DEFAULT_URI`, else `qemu:///session`).
- **`app.js`** — `libvirt_uri` added to the wizard `VM_FIELDS`, so it renders, validates, saves, and round-trips (no overwrite footgun).
- **`windows_devkit` + `windows-test-vm.md`** — documented as optional.
- **tests** — virsh honors `libvirt_uri` when set, omits `--connect` when not (12/12 green).

Backward-compatible: forks that omit the field behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)