### PR TITLE
feat(vm): broker supervision + power the VM off when a run ends

### DIFF
--- a/.super-coder/api/vm_broker.py
+++ b/.super-coder/api/vm_broker.py
@@ -88,7 +88,9 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, vm.do_exec(b.get("command", ""),
                                                   int(b.get("timeout", 120))))
             if self.path == "/reset":
-                return self._send(200, vm.do_reset())
+                # {"running": false} ends a run clean + powered OFF (frees host
+                # RAM); default true boots a clean box to START a run.
+                return self._send(200, vm.do_reset(self._body().get("running", True)))
             if self.path == "/push":
                 b = self._body()
                 return self._send(200, vm.do_push(b.get("src", ""), b.get("dest")))

--- a/.super-coder/assets/skills/windows_devkit/SKILL.md
+++ b/.super-coder/assets/skills/windows_devkit/SKILL.md
@@ -66,21 +66,30 @@ testing isn't trustworthy.
 | **push** | `curl -s --unix-socket "$SOCK" http://vm/push -d '{"src":"<repo path to artifact>"}'` — stages it into `transfer_dir` (the guest's share) |
 | **exec** | `curl -s --unix-socket "$SOCK" http://vm/exec -d '{"command":"<installer / test cmd>"}'` → `{ok, exit, stdout, stderr}` |
 | **capture** | `curl -s --unix-socket "$SOCK" http://vm/capture -d '{"command":"<optional cmd>"}'` → stdout + a base64 `virsh screenshot` for GUI state |
-| **reset** | `curl -s --unix-socket "$SOCK" http://vm/reset -X POST` — `snapshot-revert … --running`, back to clean |
+| **reset** (start) | `curl -s --unix-socket "$SOCK" http://vm/reset -X POST` — revert to clean and **boot** it; begin a run from a clean box |
+| **reset** (done) | `curl -s --unix-socket "$SOCK" http://vm/reset -d '{"running":false}'` — revert to clean and leave it **powered OFF** |
 
 The broker runs ssh non-interactively and uses the saved `vm` block — you name a
-command, never a host or a key. A run that exec'd anything stateful **must** end
-with a `/reset`, even on failure — leave the box clean for the next shell.
+command, never a host or a key.
+
+**Bracket every run with reset.** Start with `/reset` (boots a clean box); when
+you're done — even on failure — end with `/reset {"running":false}` so the box
+returns to clean **and powers off**. The VM is large (~12 GB RAM); leaving it
+running idles that on the host. Powering off at the end frees it, and the next
+run's start-reset boots a fresh clean box anyway.
 
 > [!class4]
-> **`reset` reverts to an OFFLINE snapshot with `--running`** (the broker passes
-> it for you): the clean snapshot is powered-off because this CPU's
-> non-migratable `invtsc` flag refuses a live one, so the flag boots it back up.
+> **Why a flag, not two verbs.** The clean snapshot is OFFLINE (this CPU's
+> non-migratable `invtsc` flag refuses a live snapshot). So a bare revert already
+> lands powered-off; `--running` (the default, `{"running":true}`) boots it.
+> Ending with `{"running":false}` is therefore clean **and** off in a single op —
+> no wasteful boot-just-to-shut-down.
 
 ## Stance
 
-- **Reset is not optional.** Test from clean, return to clean. A dirty box makes
-  the next run's result a lie.
+- **Reset is not optional.** Test from clean, return to clean — and powered off
+  when you're done (`/reset {"running":false}`). A dirty box makes the next run's
+  result a lie; an idle running box wastes ~12 GB of the host's RAM.
 - **You drive, you don't provision.** Missing toolchain → that's the admin's
   `configure_winbox` + re-snapshot, not an install from here. Never `winget
   install` from this loop; it would poison the clean snapshot.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -2396,21 +2396,30 @@ testing isn''t trustworthy.
 | **push** | `curl -s --unix-socket "$SOCK" http://vm/push -d ''{"src":"<repo path to artifact>"}''` — stages it into `transfer_dir` (the guest''s share) |
 | **exec** | `curl -s --unix-socket "$SOCK" http://vm/exec -d ''{"command":"<installer / test cmd>"}''` → `{ok, exit, stdout, stderr}` |
 | **capture** | `curl -s --unix-socket "$SOCK" http://vm/capture -d ''{"command":"<optional cmd>"}''` → stdout + a base64 `virsh screenshot` for GUI state |
-| **reset** | `curl -s --unix-socket "$SOCK" http://vm/reset -X POST` — `snapshot-revert … --running`, back to clean |
+| **reset** (start) | `curl -s --unix-socket "$SOCK" http://vm/reset -X POST` — revert to clean and **boot** it; begin a run from a clean box |
+| **reset** (done) | `curl -s --unix-socket "$SOCK" http://vm/reset -d ''{"running":false}''` — revert to clean and leave it **powered OFF** |
 
 The broker runs ssh non-interactively and uses the saved `vm` block — you name a
-command, never a host or a key. A run that exec''d anything stateful **must** end
-with a `/reset`, even on failure — leave the box clean for the next shell.
+command, never a host or a key.
+
+**Bracket every run with reset.** Start with `/reset` (boots a clean box); when
+you''re done — even on failure — end with `/reset {"running":false}` so the box
+returns to clean **and powers off**. The VM is large (~12 GB RAM); leaving it
+running idles that on the host. Powering off at the end frees it, and the next
+run''s start-reset boots a fresh clean box anyway.
 
 > [!class4]
-> **`reset` reverts to an OFFLINE snapshot with `--running`** (the broker passes
-> it for you): the clean snapshot is powered-off because this CPU''s
-> non-migratable `invtsc` flag refuses a live one, so the flag boots it back up.
+> **Why a flag, not two verbs.** The clean snapshot is OFFLINE (this CPU''s
+> non-migratable `invtsc` flag refuses a live snapshot). So a bare revert already
+> lands powered-off; `--running` (the default, `{"running":true}`) boots it.
+> Ending with `{"running":false}` is therefore clean **and** off in a single op —
+> no wasteful boot-just-to-shut-down.
 
 ## Stance
 
-- **Reset is not optional.** Test from clean, return to clean. A dirty box makes
-  the next run''s result a lie.
+- **Reset is not optional.** Test from clean, return to clean — and powered off
+  when you''re done (`/reset {"running":false}`). A dirty box makes the next run''s
+  result a lie; an idle running box wastes ~12 GB of the host''s RAM.
 - **You drive, you don''t provision.** Missing toolchain → that''s the admin''s
   `configure_winbox` + re-snapshot, not an install from here. Never `winget
   install` from this loop; it would poison the clean snapshot.

--- a/.super-coder/scripts/vm.py
+++ b/.super-coder/scripts/vm.py
@@ -309,6 +309,9 @@ def main(argv: list[str]) -> int:
     mode = argv[0] if argv else "sock"
     if mode == "sock":
         print(SOCKET)
+    elif mode == "configured":
+        # exit 0 if this fork has linked a VM (so the launch hook can self-skip)
+        return 0 if read() else 1
     elif mode == "exec":
         print(json.dumps(do_exec(" ".join(argv[1:]))))
     elif mode == "reset":

--- a/.super-coder/scripts/vm.py
+++ b/.super-coder/scripts/vm.py
@@ -204,17 +204,22 @@ def do_exec(command: str, timeout: int = 120) -> dict:
         return {"ok": False, "exit": 124, "stdout": "", "stderr": f"timed out (>{timeout}s)"}
 
 
-def do_reset() -> dict:
-    """Revert to the clean snapshot. `--running` because the clean snapshot is
-    OFFLINE (this CPU's non-migratable invtsc flag refuses a live snapshot), so a
-    bare revert lands powered-off — the flag boots it back."""
+def do_reset(running: bool = True) -> dict:
+    """Revert to the clean snapshot. The clean snapshot is OFFLINE (this CPU's
+    non-migratable invtsc flag refuses a live snapshot), so a bare revert lands
+    powered-off. `running=True` adds `--running` to boot it — START a run from a
+    clean booted box. `running=False` leaves it OFF — END a run clean *and*
+    powered down in one op, so the 12 GB guest doesn't idle on the host."""
     cfg = read() or {}
     if m := _missing(cfg, "domain", "snapshot"):
         return {"ok": False, "output": m}
-    ok, out = _run(
-        _virsh(cfg, "snapshot-revert", str(cfg["domain"]),
-               "--snapshotname", str(cfg["snapshot"]), "--running"), timeout=60)
-    return {"ok": ok, "output": out or f"reverted '{cfg['domain']}' to '{cfg['snapshot']}' (running)"}
+    argv = _virsh(cfg, "snapshot-revert", str(cfg["domain"]),
+                  "--snapshotname", str(cfg["snapshot"]))
+    if running:
+        argv.append("--running")
+    ok, out = _run(argv, timeout=60)
+    state = "running" if running else "powered off"
+    return {"ok": ok, "output": out or f"reverted '{cfg['domain']}' to '{cfg['snapshot']}' ({state})"}
 
 
 def do_push(src: str, dest: str | None = None) -> dict:
@@ -315,7 +320,8 @@ def main(argv: list[str]) -> int:
     elif mode == "exec":
         print(json.dumps(do_exec(" ".join(argv[1:]))))
     elif mode == "reset":
-        print(json.dumps(do_reset()))
+        # `vm.py reset` boots clean; `vm.py reset off` lands clean + powered off
+        print(json.dumps(do_reset(running=(argv[1:2] != ["off"]))))
     elif mode == "push":
         print(json.dumps(do_push(argv[1] if len(argv) > 1 else "",
                                  argv[2] if len(argv) > 2 else None)))

--- a/docs/windows-vm-broker.md
+++ b/docs/windows-vm-broker.md
@@ -168,16 +168,24 @@ to `ssh`/`virsh` (which never worked from the container) and curls the socket.
 the broker too, or stay an explicit host-operator task. Either way its `virsh`
 snapshot step lives host-side.
 
-## Process & supervision
-
-Open for the build, with leanings:
+## Process & supervision (built)
 
 - **Separate process, not the in-container server.** The sandbox server cannot
-  hold the key or reach libvirt; the broker must be a distinct host process.
-- **Supervised like the rest of the host substrate** — pm2 alongside the fork's
-  other host-side processes (the credential broker is the model).
+  hold the key or reach libvirt, so the broker is a distinct host process
+  (`./sc vm-broker`).
+- **Tied to the sandbox lifecycle.** `./sc launch` brings the broker up when the
+  fork has linked a VM (it self-skips otherwise); `./sc down` stops it. So it
+  tracks the shells that need it with no separate step — the normal-workflow
+  default, dependency-free (nohup + pidfile).
+- **Reboot-survival is opt-in.** `./sc vm-broker-install` writes a systemd
+  `--user` unit (`Restart=on-failure`, `enable-linger`) so the broker comes back
+  after logout/reboot without a launch. The two mechanisms coexist: `vm-broker-up`
+  no-ops when the socket already answers (a launch after a systemd start is
+  harmless), and `vm-broker-down` only stops what it started, never the
+  systemd-managed broker. `vm-broker-uninstall` removes the unit.
 - **Per-fork.** One broker per fork, reading that fork's `instance.json.vm` and
-  socket path, so two forks never share a VM handle by accident.
+  socket path (the unit is named `sc-vm-broker-<repo>`), so two forks never share
+  a VM handle by accident.
 
 ## Phasing
 

--- a/sc
+++ b/sc
@@ -218,14 +218,30 @@ sc_typecheck() {
 # A separate host process — the sandbox server can't hold the ssh key or reach
 # libvirt. It listens on a unix socket in the bind-mounted engine dir so
 # windows_devkit (in the container) can curl it without a route or a key. Refuses
-# to run in the sandbox (vm_broker.py guards on SC_SANDBOX). Supervise it however
-# the host prefers; vm-broker-up is a dependency-free nohup+pidfile default.
+# to run in the sandbox (vm_broker.py guards on SC_SANDBOX).
+#
+# Supervision: `launch` brings it up (and `down` stops it) automatically when the
+# fork has linked a VM, so it tracks the sandbox lifecycle with no extra step. For
+# reboot-survival independent of launch, `vm-broker-install` writes a systemd
+# --user unit. The two coexist: `up` no-ops when the socket already answers (so a
+# launch after a systemd start is harmless), and `down` only stops what IT started
+# (the pidfile) — it never kills a systemd-managed broker.
 VM_BROKER_PID="$ENGINE/run/vm-broker.pid"
+VM_BROKER_UNIT="sc-vm-broker-$(basename "$here").service"
+
+# Is the broker already answering on its socket? (true regardless of who started
+# it — pidfile nohup or systemd — so `up` is idempotent across both mechanisms.)
+sc_vm_broker_alive() {
+  sock="$("$PY" "$S/vm.py" sock)"
+  [ -S "$sock" ] || return 1
+  curl -s --unix-socket "$sock" http://vm/health 2>/dev/null | grep -q '"ok": true'
+}
 sc_vm_broker_up() {
-  mkdir -p "$ENGINE/run"
-  if [ -f "$VM_BROKER_PID" ] && kill -0 "$(cat "$VM_BROKER_PID" 2>/dev/null)" 2>/dev/null; then
-    echo "→ vm-broker already running (pid $(cat "$VM_BROKER_PID"))"; return 0
+  if ! "$PY" "$S/vm.py" configured; then
+    echo "→ vm-broker: no VM linked (instance.json has no \`vm\` block) — nothing to serve"; return 0
   fi
+  if sc_vm_broker_alive; then echo "→ vm-broker already serving $("$PY" "$S/vm.py" sock)"; return 0; fi
+  mkdir -p "$ENGINE/run"
   nohup "$PY" "$ENGINE/api/vm_broker.py" >"$ENGINE/run/vm-broker.log" 2>&1 &
   echo $! > "$VM_BROKER_PID"
   echo "→ vm-broker up (pid $!) · socket $("$PY" "$S/vm.py" sock) · log $ENGINE/run/vm-broker.log"
@@ -233,10 +249,47 @@ sc_vm_broker_up() {
 sc_vm_broker_down() {
   if [ -f "$VM_BROKER_PID" ] && kill -0 "$(cat "$VM_BROKER_PID" 2>/dev/null)" 2>/dev/null; then
     kill "$(cat "$VM_BROKER_PID")" && echo "→ vm-broker stopped"
+  elif sc_vm_broker_alive; then
+    echo "→ vm-broker is running but not from \`vm-broker-up\` (systemd?) — leaving it; use vm-broker-uninstall"
   else
     echo "→ vm-broker not running"
   fi
   rm -f "$VM_BROKER_PID"
+}
+# Install a systemd --user unit so the broker survives logout/reboot without a
+# launch. enable-linger lets it run with no active session; Restart=on-failure
+# covers crashes. Idempotent — rewrites + re-enables.
+sc_vm_broker_install() {
+  command -v systemctl >/dev/null 2>&1 || { echo "✗ vm-broker-install: systemd (systemctl) not found on this host" >&2; return 1; }
+  unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+  mkdir -p "$unit_dir"
+  cat > "$unit_dir/$VM_BROKER_UNIT" <<UNIT
+[Unit]
+Description=super-coder vm-broker ($(basename "$here")) — host-side Windows VM broker
+After=network.target libvirtd.service
+
+[Service]
+ExecStart=$PY $ENGINE/api/vm_broker.py
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+UNIT
+  systemctl --user daemon-reload
+  loginctl enable-linger "$(id -un)" >/dev/null 2>&1 || true
+  # A pidfile-managed broker would hold the socket; stop it so systemd owns it.
+  sc_vm_broker_down >/dev/null 2>&1 || true
+  systemctl --user enable --now "$VM_BROKER_UNIT"
+  echo "→ vm-broker installed as systemd --user unit: $VM_BROKER_UNIT (enabled, started, linger on)"
+  echo "  status: systemctl --user status $VM_BROKER_UNIT   ·   logs: journalctl --user -u $VM_BROKER_UNIT"
+}
+sc_vm_broker_uninstall() {
+  command -v systemctl >/dev/null 2>&1 || { echo "✗ vm-broker-uninstall: systemd not found" >&2; return 1; }
+  systemctl --user disable --now "$VM_BROKER_UNIT" 2>/dev/null || true
+  rm -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/$VM_BROKER_UNIT"
+  systemctl --user daemon-reload
+  echo "→ vm-broker systemd unit removed ($VM_BROKER_UNIT)"
 }
 
 cmd="${1:-help}"; [ $# -gt 0 ] && shift
@@ -263,10 +316,12 @@ case "$cmd" in
   # ── in-container primitives (no docker; also the host escape hatch) ──
   serve)        exec "$PY" "$ENGINE/api/server.py" "$@" ;;
   # ── Windows VM broker (HOST-side primitive — runs where virsh + the key live) ──
-  vm-broker)      exec "$PY" "$ENGINE/api/vm_broker.py" "$@" ;;
-  vm-broker-up)   sc_vm_broker_up ;;
-  vm-broker-down) sc_vm_broker_down ;;
-  vm-broker-sock) exec "$PY" "$S/vm.py" sock ;;
+  vm-broker)         exec "$PY" "$ENGINE/api/vm_broker.py" "$@" ;;
+  vm-broker-up)      sc_vm_broker_up ;;
+  vm-broker-down)    sc_vm_broker_down ;;
+  vm-broker-sock)    exec "$PY" "$S/vm.py" sock ;;
+  vm-broker-install)   sc_vm_broker_install ;;
+  vm-broker-uninstall) sc_vm_broker_uninstall ;;
   boot)         exec "$PY" "$S/run.py" "$@" ;;
   boot-*)       exec "$PY" "$S/run.py" "${cmd#boot-}" "$@" ;;
   deps)         sc_deps "$@" ;;
@@ -317,10 +372,15 @@ case "$cmd" in
       "$IMG" ./sc serve --port "$p" >/dev/null
     echo "→ sandbox up · review GUI at http://127.0.0.1:$p"
     echo "  dev server:    bind 0.0.0.0:$dp inside (\$SC_DEV_PORT) → http://127.0.0.1:$dp"
-    echo "  boot a shell:  ./sc enter   (or ./sc enter-<shortname>)" ;;
+    echo "  boot a shell:  ./sc enter   (or ./sc enter-<shortname>)"
+    # Bring the VM broker up alongside the sandbox when a VM is linked (self-skips
+    # otherwise, and no-ops if systemd already owns it). The shells need it to
+    # drive the VM; this keeps it from being a forgotten manual step.
+    sc_vm_broker_up || true ;;
   enter)        exec docker exec -it "$CNAME" ./sc boot "$@" ;;
   enter-*)      exec docker exec -it "$CNAME" ./sc boot "${cmd#enter-}" "$@" ;;
-  down)         docker rm -f "$CNAME" >/dev/null 2>&1 && echo "→ sandbox stopped" || echo "→ not running" ;;
+  down)         docker rm -f "$CNAME" >/dev/null 2>&1 && echo "→ sandbox stopped" || echo "→ not running"
+                sc_vm_broker_down ;;
   restart)      "$0" down; exec "$0" launch "$@" ;;
   build)        dcheck; dbuild ;;
   logs)         exec docker logs -f "$CNAME" ;;
@@ -374,11 +434,14 @@ super-coder — forkable shell substrate
   ./sc typecheck [paths]   mypy the fork's python (.venv mypy; honors [tool.mypy]) — available, not enforced
 
   Windows VM broker (run on the HOST — drives the test VM for sandboxed forks;
-  holds the ssh key + virsh so the fork never does. See docs/windows-vm-broker.md):
+  holds the ssh key + virsh so the fork never does. See docs/windows-vm-broker.md).
+  `launch` brings it up automatically when a VM is linked; `down` stops it:
   ./sc vm-broker           run the broker in the foreground (unix socket)
-  ./sc vm-broker-up        start it in the background (nohup + pidfile)
+  ./sc vm-broker-up        start it in the background (nohup + pidfile); self-skips if unlinked/already up
   ./sc vm-broker-down      stop the backgrounded broker
   ./sc vm-broker-sock      print the broker's socket path
+  ./sc vm-broker-install   supervise via a systemd --user unit (survives logout/reboot)
+  ./sc vm-broker-uninstall remove the systemd unit
 
   ./sc verify              rebuild + flat render + render-only boot (headless proof)
   ./sc health              curl the review layer's /api/health

--- a/tests/test_vm_broker.py
+++ b/tests/test_vm_broker.py
@@ -56,6 +56,13 @@ class VerbDispatchTests(unittest.TestCase):
         self.assertFalse(r["ok"])
         self.assertIn("missing required field", r["stderr"])
 
+    def test_configured_cli_reflects_a_linked_vm(self):
+        # `./sc vm-broker-up` calls `vm.py configured` to self-skip when unlinked.
+        with mock.patch.object(vm, "read", return_value=SAVED):
+            self.assertEqual(vm.main(["configured"]), 0)
+        with mock.patch.object(vm, "read", return_value=None):
+            self.assertEqual(vm.main(["configured"]), 1)
+
     def test_virsh_calls_honor_libvirt_uri(self):
         cfg = dict(SAVED, libvirt_uri="qemu:///system")
         with mock.patch.object(vm, "read", return_value=cfg), \

--- a/tests/test_vm_broker.py
+++ b/tests/test_vm_broker.py
@@ -88,6 +88,18 @@ class VerbDispatchTests(unittest.TestCase):
         self.assertEqual(argv[:3], ["virsh", "snapshot-revert", "win-test"])
         self.assertIn("--running", argv)  # else the box comes back powered-off
 
+    def test_reset_running_false_lands_clean_and_powered_off(self):
+        # End-of-loop: revert to the offline clean snapshot WITHOUT --running, so
+        # the box returns clean *and* powered off (frees the host's ~12 GB).
+        with mock.patch.object(vm, "read", return_value=SAVED), \
+             mock.patch.object(vm, "_run", return_value=(True, "")) as run:
+            r = vm.do_reset(running=False)
+        self.assertTrue(r["ok"])
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[:3], ["virsh", "snapshot-revert", "win-test"])
+        self.assertNotIn("--running", argv)  # left powered off
+        self.assertIn("powered off", r["output"])
+
     def test_push_rejects_a_missing_source(self):
         with mock.patch.object(vm, "read", return_value=SAVED):
             r = vm.do_push("/no/such/artifact.msi")


### PR DESCRIPTION
Two operational-hygiene fixes for the VM broker (follow-up to #132/#133), so it doesn't become a forgotten daemon or an idle 12 GB guest.

## 1. Supervision — the broker tracks the sandbox
The broker was a manual `vm-broker-up` nohup, one forgotten step from `windows_devkit` failing.
- **Lifecycle hook** — `./sc launch` brings the **broker** up when the fork has a linked VM (self-skips otherwise, via a new `vm.py configured` guard); `./sc down` stops it. This starts only the ~4 MB broker daemon — **never the VM**, which still boots on-demand.
- **Idempotent across mechanisms** — `vm-broker-up` no-ops when the socket already answers `/health`; `vm-broker-down` only stops what *it* started (pidfile), never a systemd-managed broker.
- **Opt-in reboot-survival** — `vm-broker-install` / `-uninstall` manage a systemd `--user` unit (`Restart=on-failure`, `enable-linger`, `sc-vm-broker-<repo>`).

Coexistence verified live: `up → up(skip) → install(systemd takes over) → up(skip, no dup) → down(leaves systemd's) → uninstall`.

## 2. Power the VM off when a run ends
`reset` left the guest clean+**running**, idling ~12 GB after every test. The clean snapshot is offline, so reverting **without** `--running` lands clean *and* powered off in one op.
- `/reset` takes `{"running": bool}` — default `true` boots (start a run), `false` leaves it off (end a run).
- `windows_devkit` now brackets each run: `/reset` to start, `/reset {"running":false}` to finish clean + off.

Verified live against the dos-arch guest: `/reset` boots it; `/reset {"running":false}` powers a running box off.

## Notes
- Launch starts only the tiny broker; the VM is never auto-booted.
- `vm-broker-install` errors cleanly on a host without `systemctl`.
- No DB migration. **14/14** tests green (added `configured`, `running:false`). Forks pick this up on `./sc update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)