### PR TITLE
feat(roadmap): per-project Board grouping + Flow-view width & md-converter links

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -55,8 +55,6 @@ _STATIC = {
     # local copies so the no-build UI renders sanitized GFM without a CDN.
     "/vendor/marked.umd.js": ("vendor/marked.umd.js", "application/javascript; charset=utf-8"),
     "/vendor/purify.min.js": ("vendor/purify.min.js", "application/javascript; charset=utf-8"),
-    # mermaid (MIT) — draws the roadmap Flow view (feature dependency graph).
-    "/vendor/mermaid.min.js": ("vendor/mermaid.min.js", "application/javascript; charset=utf-8"),
 }
 
 # md-converter inline deep-link. The doc's markdown rides IN the URL as the `c=`
@@ -76,7 +74,7 @@ def mdc_url(markdown: str) -> str:
 # deliberately ABSENT — the law says the shell curates them, so there is no door.
 SHELL_EDITABLE = {"current_state"}  # workspace + connections both retired (B5) → current_state is the one writable surface; "where things live" is the derived dr_* map
 FLAG_EDITABLE = {"resolved", "resolution_notes", "description", "feature_id", "priority"}
-ROADMAP_EDITABLE = {"title", "roadmap_status", "summary", "sort_order"}
+ROADMAP_EDITABLE = {"title", "roadmap_status", "summary", "sort_order", "project_id"}
 
 
 def db() -> sqlite3.Connection:
@@ -176,8 +174,11 @@ _LABEL = {"brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Nex
 def get_roadmap(con) -> dict:
     feats = rows(con.execute(
         "SELECT r.feature_id, r.title, r.roadmap_status, r.sort_order, r.summary, "
-        "s.shortname AS owner FROM roadmap r LEFT JOIN shells s "
-        "ON s.shell_id=r.owning_shell ORDER BY r.sort_order, r.feature_id"))
+        "r.project_id, p.title AS project_title, "
+        "s.shortname AS owner FROM roadmap r "
+        "LEFT JOIN shells s ON s.shell_id=r.owning_shell "
+        "LEFT JOIN projects p ON p.project_id=r.project_id "
+        "ORDER BY r.sort_order, r.feature_id"))
     # Roadmap tracks the development cycle = the SPECS, with each feature's DOCS
     # (kind='doc') listed underneath so specs and docs sit together. Docs are
     # read-only here (open-link only); the Docs tab is where they're edited.
@@ -215,7 +216,12 @@ def get_roadmap(con) -> dict:
     buckets = [{"status": s, "label": _LABEL[s],
                 "features": [f for f in feats if f["roadmap_status"] == s]}
                for s in _ORDER]
-    return {"buckets": [b for b in buckets if b["features"]]}
+    # Active work-streams, for the Board's per-project grouping + the feature
+    # card's project picker. Each feature already carries project_id/project_title.
+    projects = rows(con.execute(
+        "SELECT project_id, shortname, title FROM projects "
+        "WHERE COALESCE(is_deleted,0)=0 AND status='active' ORDER BY title"))
+    return {"buckets": [b for b in buckets if b["features"]], "projects": projects}
 
 
 def get_docs(con) -> dict:
@@ -360,6 +366,38 @@ def create_flag(con, body):
          body.get("shell_id")))
     con.commit()
     return cur.lastrowid, None
+
+
+def _slug(text: str) -> str:
+    """title → kebab shortname: keep alnum, fold spaces/_-/ to single dashes."""
+    out = []
+    for ch in (text or "").lower().strip():
+        if ch.isalnum():
+            out.append(ch)
+        elif ch in " -_/":
+            out.append("-")
+    slug = "".join(out).strip("-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug or "project"
+
+
+def create_project(con, body):
+    """Create a work-stream (projects row) from a title. shortname is slugified
+    from the title, de-duped with a numeric suffix. Used by the roadmap Board's
+    inline '＋ new work-stream' so features can be grouped without leaving the UI."""
+    title = (body.get("title") or "").strip()
+    if not title:
+        return None, "title required"
+    base = _slug(title)
+    shortname, n = base, 2
+    while con.execute("SELECT 1 FROM projects WHERE shortname=?",
+                      (shortname,)).fetchone():
+        shortname, n = f"{base}-{n}", n + 1
+    cur = con.execute("INSERT INTO projects (shortname, title) VALUES (?, ?)",
+                      (shortname, title))
+    con.commit()
+    return {"project_id": cur.lastrowid, "shortname": shortname, "title": title}, None
 
 
 def set_grant(con, sid, skill_id, granted):
@@ -741,6 +779,10 @@ class Handler(BaseHTTPRequestHandler):
                 fid, err = create_flag(con, self._body())
                 return self._send(400 if err else 201,
                                   {"error": err} if err else {"flag_id": fid})
+            if path == "/api/projects":
+                proj, err = create_project(con, self._body())
+                return self._send(400 if err else 201,
+                                  {"error": err} if err else proj)
             if path == "/api/shells":
                 body = self._body()
                 if not body.get("name") or not body.get("flavor"):

--- a/.super-coder/migrations/0018_roadmap_project.sql
+++ b/.super-coder/migrations/0018_roadmap_project.sql
@@ -1,0 +1,31 @@
+-- 0018 — Roadmap project grouping: roadmap.project_id (work-stream the feature
+-- belongs to).
+--
+-- One additive change: a nullable FK from roadmap → projects. NULL = unassigned
+-- (the feature shows under the "Unassigned" board in the GUI). Lets the Board
+-- view split into one board per work-stream (e.g. "mi-capture" = F52+F53), each
+-- keeping its internal status sections.
+--
+-- NOT inlined into schema.sql, unlike the 0017 table precedent: roadmap is
+-- FK-referenced by feature_blockers / documents / spec_tasks / flags, and SQLite
+-- has no `ADD COLUMN IF NOT EXISTS`. Folding the column into schema.sql's roadmap
+-- CREATE would make this migration's ALTER fail on a fresh rebuild ("duplicate
+-- column"), and the table-rebuild dance (0003) is unsafe for a referenced table.
+-- rebuild.py applies schema.sql THEN every migration in order, so a
+-- migration-only ADD COLUMN converges on both paths: fresh build (baseline lacks
+-- the column → ALTER adds it) and existing fork (ALTER adds it). The ledger keeps
+-- it from running twice. schema.sql carries a pointer comment in the roadmap block.
+--
+-- Per-instance content: roadmap rows are serialized to .sc-state/content.sql by
+-- snapshot.py, which reads columns via PRAGMA table_info — project_id flows into
+-- the dumped INSERTs automatically, no snapshot change needed. A pre-migration
+-- content.sql (INSERT without project_id) still loads: the omitted column
+-- defaults NULL, then the next snapshot regenerates the INSERT with project_id.
+
+BEGIN;
+
+ALTER TABLE roadmap ADD COLUMN project_id INTEGER REFERENCES projects(project_id);
+
+CREATE INDEX IF NOT EXISTS idx_roadmap_project ON roadmap(project_id);
+
+COMMIT;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -166,6 +166,11 @@ CREATE TABLE roadmap (
     summary        TEXT,
     created_at     TEXT    NOT NULL DEFAULT (datetime('now')),
     updated_at     TEXT    NOT NULL DEFAULT (datetime('now'))
+    -- project_id INTEGER REFERENCES projects(project_id) — work-stream this
+    -- feature belongs to (NULL = unassigned), added by migration 0018. Kept out
+    -- of this baseline CREATE on purpose: ADD COLUMN can't be IF NOT EXISTS and
+    -- rebuild applies migrations after schema.sql, so inlining it would
+    -- double-define the column. See migrations/0018_roadmap_project.sql.
 );
 
 -- ── Feature blockers (the roadmap's sequencing edges) ───────────────────────

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -602,6 +602,17 @@ async function renderRoadmapFlow(root, buckets) {
       if (f.owner) m.append(el("span", { className: "pill " + s }, f.owner));
       if (f.open_flags?.length) m.append(el("span", { className: "pill warn" }, f.open_flags.length + " ⚑"));
       if (m.childNodes.length) card.append(m);
+      // md-converter open-links, one per spec/doc (same /open redirect the Board
+      // card uses). Compact: "spec v1 ↗" / "doc ↗".
+      const docs = f.documents || [];
+      if (docs.length) {
+        const dl = el("div", { className: "flow-card-docs" });
+        for (const d of docs) dl.append(el("a", {
+          className: "flow-doc-link", href: "/api/documents/" + d.document_id + "/open",
+          target: "_blank", rel: "noopener",
+          textContent: (d.kind === "doc" ? "doc" : `${d.kind} v${d.seq}`) + " ↗" }));
+        card.append(dl);
+      }
       col.append(card);
       cardOf[f.feature_id] = card;
     }

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -476,7 +476,8 @@ const SLABEL = { brainstorm: "Brainstorm", in_progress: "In Progress", next: "Ne
 const FLOW_STAGES = ["in_progress", "next", "near_term", "long_term", "shipped"];
 let roadmapFilter = null;            // null = show all (default); single-select
 let roadmapView = "board";           // "board" | "flow"
-const roadmapCollapsed = new Set();  // statuses whose section is collapsed
+const roadmapCollapsed = new Set();  // statuses whose section is collapsed (global, across boards)
+const projectCollapsed = new Set();  // project-board keys (project_id | null) collapsed
 
 // All features in the sequencing stages, flattened — the candidate pool for a
 // feature's "blocked by" picker and the node set of the Flow graph.
@@ -488,7 +489,7 @@ function flowCandidates(buckets) {
 }
 
 async function renderRoadmap(root) {
-  const { buckets } = await api("/roadmap");
+  const { buckets, projects = [] } = await api("/roadmap");
   root.replaceChildren();
 
   // Board ⇄ Flow toggle. Board = bucketed cards; Flow = the dependency graph.
@@ -516,19 +517,52 @@ async function renderRoadmap(root) {
   }
   root.append(bar);
 
-  // buckets arrive linear from the API; filter to the single selected status
+  // buckets arrive linear from the API; filter to the single selected status,
+  // then flatten to features and group into one board per project (work-stream).
   const shown = roadmapFilter ? buckets.filter((b) => b.status === roadmapFilter) : buckets;
-  if (!shown.length) { root.append(el("div", { className: "muted" }, "No features in the selected stage.")); return; }
-  for (const b of shown) {
-    const sec = el("div", { className: "bucket" + (roadmapCollapsed.has(b.status) ? " collapsed" : "") });
-    const h = el("h2", {}, b.label);
-    h.onclick = () => {
-      roadmapCollapsed.has(b.status) ? roadmapCollapsed.delete(b.status) : roadmapCollapsed.add(b.status);
+  const flat = shown.flatMap((b) => b.features);
+  if (!flat.length) { root.append(el("div", { className: "muted" }, "No features in the selected stage.")); return; }
+
+  // Group features by project_id (null = unassigned).
+  const byProject = new Map();   // key (project_id | null) → { title, features }
+  for (const f of flat) {
+    const key = f.project_id ?? null;
+    if (!byProject.has(key)) byProject.set(key, { title: f.project_title || null, features: [] });
+    byProject.get(key).features.push(f);
+  }
+  // Board order: projects in payload order (sorted by title) first, any leftover
+  // project keys next, then the Unassigned board last.
+  const order = projects.map((p) => p.project_id).filter((id) => byProject.has(id));
+  for (const key of byProject.keys())
+    if (key !== null && !order.includes(key)) order.push(key);
+  if (byProject.has(null)) order.push(null);
+
+  for (const key of order) {
+    const grp = byProject.get(key);
+    const title = key === null ? "Unassigned" : (grp.title || ("project #" + key));
+    const board = el("div", { className: "project-board" + (projectCollapsed.has(key) ? " collapsed" : "") });
+    const bh = el("h2", { className: "project-board-head" }, title);
+    bh.append(el("span", { className: "count" }, String(grp.features.length)));
+    bh.onclick = () => {
+      projectCollapsed.has(key) ? projectCollapsed.delete(key) : projectCollapsed.add(key);
       renderRoadmap(root);
     };
-    sec.append(h);
-    for (const f of b.features) sec.append(featureCard(f, candidates));
-    root.append(sec);
+    board.append(bh);
+    // status sub-sections within the board, in funnel order; collapse is global per status
+    for (const s of STATUSES) {
+      const inStatus = grp.features.filter((f) => f.roadmap_status === s);
+      if (!inStatus.length) continue;
+      const sec = el("div", { className: "bucket" + (roadmapCollapsed.has(s) ? " collapsed" : "") });
+      const h = el("h2", {}, SLABEL[s]);
+      h.onclick = () => {
+        roadmapCollapsed.has(s) ? roadmapCollapsed.delete(s) : roadmapCollapsed.add(s);
+        renderRoadmap(root);
+      };
+      sec.append(h);
+      for (const f of inStatus) sec.append(featureCard(f, candidates, projects));
+      board.append(sec);
+    }
+    root.append(board);
   }
 }
 
@@ -650,7 +684,7 @@ async function renderRoadmapFlow(root, buckets) {
     : "No blocking relationships yet — open a feature in Board view and set its “blocked by”."));
 }
 
-function featureCard(f, candidates = []) {
+function featureCard(f, candidates = [], projects = []) {
   // Expandable box: collapsed shows title + status/owner pills + a one-line
   // summary preview; expanded reveals the editable fields, docs, and blockers.
   const c = el("details", { className: "card feature" });
@@ -677,6 +711,30 @@ function featureCard(f, candidates = []) {
   for (const s of STATUSES) status.append(el("option", { value: s, selected: s === f.roadmap_status, textContent: s }));
   const summary = el("textarea", { value: f.summary || "", rows: 7 });
 
+  // project (work-stream) picker — drives the Board's grouping. Options: none,
+  // each active work-stream, then "＋ new…" which creates one inline (POST) and
+  // selects it without a reload, so unsaved title/summary edits survive.
+  const project = el("select", { className: "project-select" });
+  const NEW = "__new__";
+  project.append(el("option", { value: "", selected: !f.project_id, textContent: "— none —" }));
+  for (const p of projects) project.append(el("option", {
+    value: String(p.project_id), selected: p.project_id === f.project_id, textContent: p.title }));
+  const newOpt = el("option", { value: NEW, textContent: "＋ new work-stream…" });
+  project.append(newOpt);
+  let prevProject = project.value;
+  project.onchange = async () => {
+    if (project.value !== NEW) { prevProject = project.value; return; }
+    const title = (prompt("New work-stream name:") || "").trim();
+    if (!title) { project.value = prevProject; return; }
+    try {
+      const p = await api("/projects", "POST", { title });
+      const opt = el("option", { value: String(p.project_id), textContent: p.title });
+      project.insertBefore(opt, newOpt);
+      project.value = String(p.project_id);
+      prevProject = project.value;
+    } catch (e) { project.value = prevProject; toast("error: " + e.message); }
+  };
+
   // "blocked by" editor — a multi-select of OTHER sequencing-stage features.
   // Only shown for the five real stages; brainstorm/retired don't relate yet.
   const realStage = FLOW_STAGES.includes(f.roadmap_status);
@@ -697,7 +755,8 @@ function featureCard(f, candidates = []) {
   save.onclick = async () => {
     try {
       await api("/roadmap/" + f.feature_id, "PATCH",
-                { title: title.value, roadmap_status: status.value, summary: summary.value });
+                { title: title.value, roadmap_status: status.value, summary: summary.value,
+                  project_id: project.value && project.value !== NEW ? Number(project.value) : null });
       if (blockerSelect) {
         const ids = [...blockerSelect.selectedOptions].map((o) => Number(o.value));
         await api("/roadmap/" + f.feature_id + "/blockers", "PUT", { blocked_by: ids });
@@ -708,6 +767,7 @@ function featureCard(f, candidates = []) {
   const gridKids = [
     el("span", { className: "k" }, "title"), title,
     el("span", { className: "k" }, "status"), status,
+    el("span", { className: "k" }, "project"), project,
     el("span", { className: "k" }, "summary"), summary,
   ];
   if (blockerSelect) gridKids.push(

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -180,6 +180,24 @@ details.feature.tasks-open { border-left-color: var(--task-open); }
 .bucket > h2::before { content: "▾"; display: inline-block; width: 1em; color: var(--dim); transition: transform .12s; }
 .bucket.collapsed > h2::before { transform: rotate(-90deg); }
 .bucket.collapsed > .card { display: none; }
+
+/* Project boards — the roadmap Board groups features into one board per
+   work-stream (projects row); status buckets nest inside each board. */
+.project-board { margin-top: 1.8rem; }
+.project-board:first-of-type { margin-top: .5rem; }
+.project-board > h2.project-board-head {
+  display: flex; align-items: center; gap: .5rem; cursor: pointer; user-select: none;
+  font-size: 1rem; font-weight: 650; color: var(--ink); letter-spacing: .01em;
+  margin: 0 0 .2rem; padding-bottom: .45rem; border-bottom: 1px solid var(--line);
+}
+.project-board-head::before { content: "▾"; width: 1em; color: var(--dim); transition: transform .12s; }
+.project-board.collapsed > .project-board-head::before { transform: rotate(-90deg); }
+.project-board.collapsed > .bucket { display: none; }
+.project-board-head .count {
+  font-size: .72rem; font-weight: 500; color: var(--dim); letter-spacing: 0;
+  background: var(--accent2); border: 1px solid var(--line); border-radius: 99px; padding: .02rem .5rem;
+}
+.project-board > .bucket:first-of-type > h2 { margin-top: .7rem; }
 .doc-body { white-space: pre-wrap; background: var(--panel2); border: 1px solid var(--line); border-radius: 6px; padding: .8rem; max-height: 420px; overflow: auto; font: 12.5px/1.55 ui-monospace, monospace; }
 .flag { border-bottom: 1px solid var(--line); }
 .flag.resolved { opacity: .5; }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -502,12 +502,14 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .blocker-select option { padding: .15rem .2rem; }
 
 .flow-wrap { overflow-x: auto; padding: .3rem 0 .5rem; }
-.flow-inner { position: relative; width: max-content; min-width: 100%; }
+.flow-inner { position: relative; width: 100%; }
 .flow-wires { position: absolute; top: 0; left: 0; z-index: 0;
   pointer-events: none; overflow: visible; }
-.flow-cols { position: relative; z-index: 1; display: flex; gap: 2.6rem;
+.flow-cols { position: relative; z-index: 1; display: flex; gap: 1.6rem;
   align-items: flex-start; padding: 0 .2rem; }
-.flow-col { flex: none; width: 220px; display: flex; flex-direction: column; gap: .7rem; }
+/* Columns share the window width evenly (flex:1); min-width keeps them legible
+   and lets .flow-wrap scroll as a fallback when too many stages are present. */
+.flow-col { flex: 1 1 0; min-width: 150px; display: flex; flex-direction: column; gap: .7rem; }
 .flow-col-head { font-size: .72rem; text-transform: uppercase; letter-spacing: .08em;
   color: var(--dim); padding-bottom: .35rem; border-bottom: 1px solid var(--line-soft); }
 
@@ -521,6 +523,9 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .flow-card.shipped    { border-left-color: var(--ok); }
 .flow-card-title { font-weight: 600; font-size: .85rem; line-height: 1.3; }
 .flow-card-meta { display: flex; gap: .3rem; flex-wrap: wrap; margin-top: .45rem; }
+.flow-card-docs { display: flex; flex-wrap: wrap; gap: .25rem .7rem; margin-top: .45rem; }
+.flow-doc-link { font-size: .72rem; color: var(--accent); text-decoration: none; white-space: nowrap; }
+.flow-doc-link:hover { text-decoration: underline; }
 
 .flow-wire { fill: none; stroke: rgba(110,168,254,.42); stroke-width: 1.6px; }
 /* Spotlight on hover: dim everything, light the incident wires + their cards. */


### PR DESCRIPTION
Roadmap GUI improvements, two parts:

**Board — per-project work-stream grouping.** A grouping level above the status sections: one board per project, each keeping its status buckets, with an **Unassigned** board last. Features gain `project_id`; the feature card gets a project picker with inline **＋ new work-stream** creation.
- migration `0018`: `roadmap.project_id` (nullable FK → `projects`) + index. Migration-only `ADD COLUMN` (not inlined into `schema.sql`: FK-referenced table, no `ADD COLUMN IF NOT EXISTS`; rebuild applies migrations after the baseline → converges; verified fresh-rebuild + existing-fork). `snapshot.py` picks it up via `PRAGMA table_info`.
- API: `/roadmap` returns per-feature `project_id`/`project_title` + a `projects` list; `project_id` PATCH-editable (null = unassign); `POST /api/projects {title}` creates a slugified work-stream. Drops the dead `/vendor/mermaid.min.js` route (#141).

**Flow view — width + doc links.** Columns flex to fill the window width (was fixed 220px; `.flow-wrap` scrolls as fallback), and each flow card lists its spec/doc as `kind vN ↗` open-links to md-converter (same `/open` redirect the Board card uses).

UI is vanilla JS/CSS, no new deps. **Verified:** migration applies + idempotent + converges on fresh rebuild; `node --check` clean; live API exercised end-to-end (create/assign/unassign work-streams; `/open` redirect resolves to md-converter). Not visually screenshotted (no local browser).