### PR TITLE
feat(mem): CLI verbs for work-stream + dependencies; bring db_map in line

### DIFF
--- a/.super-coder/assets/skills/db_map/SKILL.md
+++ b/.super-coder/assets/skills/db_map/SKILL.md
@@ -31,11 +31,12 @@ memory/identity/content. Don't look for `dr_*` in `shell_db.db`.
 | `shell_identity_entries` | seed (cap 10) + L&S (`kind='lns'`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
 | `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
 | `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |
-| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row | INSERT/UPDATE |
+| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row. `project_id` (nullable) = the work-stream the feature belongs to; the GUI Flow view groups on it (NULL = Ungrouped) | INSERT/UPDATE |
+| `feature_blockers` | the roadmap's dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite must land first). Directed, kept acyclic (the GUI Flow view wires them; the card's "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `./sc mem roadmap depends` |
 | `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
 | `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | catalogue via migration; grants via snapshot |
-| `projects` / `project_shells` | project standing + shell linkage | UPDATE `standing`; INSERT to add |
+| `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a **work-stream** that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
 
 `<self>` = your `shell_id` (in the boot doc's ACTIVE SESSION block).
 
@@ -56,8 +57,12 @@ Each guards the engine DB and snapshots for you. `./sc mem which` orients;
 ./sc mem decision "…" --rationale "…"
 
 # roadmap: add a feature / move its horizon:
-./sc mem roadmap add "…" --status brainstorm --summary "…"
+./sc mem roadmap add "…" --status brainstorm --summary "…" [--project <shortname|id>]
 ./sc mem roadmap status <feature_id> shipped
+
+# roadmap grouping + sequencing (drive the GUI Flow view):
+./sc mem roadmap project <feature_id> <shortname|id>   # assign a work-stream (or 'none' to clear)
+./sc mem roadmap depends <feature_id> --on <id> [--on <id>]   # set dependencies (replaces; omit --on to clear; refuses cycles)
 
 # author a spec/doc body (--body-file reads the markdown), then freeze on ship:
 ./sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -574,11 +574,12 @@ memory/identity/content. Don''t look for `dr_*` in `shell_db.db`.
 | `shell_identity_entries` | seed (cap 10) + L&S (`kind=''lns''`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
 | `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
 | `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |
-| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row | INSERT/UPDATE |
+| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row. `project_id` (nullable) = the work-stream the feature belongs to; the GUI Flow view groups on it (NULL = Ungrouped) | INSERT/UPDATE |
+| `feature_blockers` | the roadmap''s dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite must land first). Directed, kept acyclic (the GUI Flow view wires them; the card''s "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `./sc mem roadmap depends` |
 | `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
 | `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | catalogue via migration; grants via snapshot |
-| `projects` / `project_shells` | project standing + shell linkage | UPDATE `standing`; INSERT to add |
+| `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a **work-stream** that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
 
 `<self>` = your `shell_id` (in the boot doc''s ACTIVE SESSION block).
 
@@ -599,8 +600,12 @@ Each guards the engine DB and snapshots for you. `./sc mem which` orients;
 ./sc mem decision "…" --rationale "…"
 
 # roadmap: add a feature / move its horizon:
-./sc mem roadmap add "…" --status brainstorm --summary "…"
+./sc mem roadmap add "…" --status brainstorm --summary "…" [--project <shortname|id>]
 ./sc mem roadmap status <feature_id> shipped
+
+# roadmap grouping + sequencing (drive the GUI Flow view):
+./sc mem roadmap project <feature_id> <shortname|id>   # assign a work-stream (or ''none'' to clear)
+./sc mem roadmap depends <feature_id> --on <id> [--on <id>]   # set dependencies (replaces; omit --on to clear; refuses cycles)
 
 # author a spec/doc body (--body-file reads the markdown), then freeze on ship:
 ./sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -29,8 +29,10 @@ Run from the repo root, like every engine command:
     ./sc mem decision "<decision>"   [--rationale "…"] [--date …] [--parent ID] [--shell …]
     ./sc mem flag open  "<description>" [--name CC-001] [--priority Medium] [--feature ID] [--shell …]
     ./sc mem flag close <flag_id>    [--notes "…"]
-    ./sc mem roadmap add "<title>"   [--status brainstorm] [--summary "…"] [--shell …]
+    ./sc mem roadmap add "<title>"   [--status brainstorm] [--summary "…"] [--project <shortname|id>] [--shell …]
     ./sc mem roadmap status <feature_id> <status>
+    ./sc mem roadmap project <feature_id> <shortname|id|none>   # set/clear the feature's work-stream
+    ./sc mem roadmap depends <feature_id> [--on <id> …]         # set dependencies (replaces; omit --on to clear)
     ./sc mem project add <shortname> "<title>" [--purpose …] [--standing …] [--status active] [--role …]
     ./sc mem project standing <shortname|id> "<text>"
     ./sc mem project status <shortname|id> active|inactive|paused
@@ -309,16 +311,79 @@ def cmd_roadmap(args) -> int:
                         "WHERE feature_id=?", (args.status, args.feature_id))
             con.commit()
             return finish(args, f"mem: feature #{args.feature_id} ('{r['title']}') → {args.status}")
+        if args.roadmap_cmd == "project":
+            # assign / clear the feature's work-stream (the Flow view groups on it)
+            feat = _resolve_feature(con, args.feature_id)
+            if str(args.project).lower() in ("none", "-", ""):
+                con.execute("UPDATE roadmap SET project_id=NULL, updated_at=datetime('now') "
+                            "WHERE feature_id=?", (args.feature_id,))
+                con.commit()
+                return finish(args, f"mem: feature #{args.feature_id} ('{feat['title']}') "
+                                    f"→ unassigned (no work-stream)")
+            proj = _resolve_project(con, args.project)
+            con.execute("UPDATE roadmap SET project_id=?, updated_at=datetime('now') "
+                        "WHERE feature_id=?", (proj["project_id"], args.feature_id))
+            con.commit()
+            return finish(args, f"mem: feature #{args.feature_id} ('{feat['title']}') "
+                                f"→ work-stream '{proj['shortname']}'")
+        if args.roadmap_cmd == "depends":
+            # replace the feature's dependency set (feature_blockers): each --on is a
+            # prerequisite that must land first. Validate before mutating; refuse cycles.
+            feat = _resolve_feature(con, args.feature_id)
+            ons: list[int] = []
+            for x in (args.on or []):
+                if x == args.feature_id:
+                    die("a feature can't depend on itself")
+                _resolve_feature(con, x)
+                if x in ons:
+                    continue
+                if args.feature_id in _depends_on(con, x):
+                    die(f"refusing: #{x} already depends on #{args.feature_id} — "
+                        f"this edge would create a cycle")
+                ons.append(x)
+            con.execute("DELETE FROM feature_blockers WHERE feature_id=?", (args.feature_id,))
+            for dep in ons:
+                con.execute("INSERT INTO feature_blockers (feature_id, blocked_by) "
+                            "VALUES (?, ?)", (args.feature_id, dep))
+            con.commit()
+            desc = ", ".join(f"#{d}" for d in ons) if ons else "— (cleared)"
+            return finish(args, f"mem: feature #{args.feature_id} ('{feat['title']}') "
+                                f"depends on {desc}")
         # add
         sid = resolve_shell(con, args.shell)
+        pid = _resolve_project(con, args.project)["project_id"] if args.project else None
         cur = con.execute(
-            "INSERT INTO roadmap (title, roadmap_status, sort_order, owning_shell, summary) "
-            "VALUES (?, ?, 0, ?, ?)", (args.title, args.status, sid, args.summary))
+            "INSERT INTO roadmap (title, roadmap_status, sort_order, owning_shell, summary, project_id) "
+            "VALUES (?, ?, 0, ?, ?, ?)", (args.title, args.status, sid, args.summary, pid))
         con.commit()
         fid = cur.lastrowid
     finally:
         con.close()
     return finish(args, f"mem: roadmap feature #{fid} added ('{args.title}', {args.status})")
+
+
+def _resolve_feature(con, fid: int) -> sqlite3.Row:
+    r = con.execute("SELECT feature_id, title FROM roadmap WHERE feature_id=?",
+                    (fid,)).fetchone()
+    if r is None:
+        die(f"no roadmap feature #{fid}")
+    return r
+
+
+def _depends_on(con, start: int) -> set:
+    """Features `start` (transitively) depends on, walking blocked_by edges. Used
+    to keep the dependency graph acyclic: an edge (F depends on D) closes a cycle
+    iff F is already in D's dependency set."""
+    seen, stack = set(), [start]
+    while stack:
+        n = stack.pop()
+        for row in con.execute(
+                "SELECT blocked_by FROM feature_blockers WHERE feature_id=?", (n,)):
+            b = row["blocked_by"]
+            if b not in seen:
+                seen.add(b)
+                stack.append(b)
+    return seen
 
 
 def _resolve_project(con, spec: str) -> sqlite3.Row:
@@ -557,13 +622,21 @@ def build_parser() -> argparse.ArgumentParser:
 
     ROADMAP_STATUSES = ["brainstorm", "in_progress", "next", "near_term",
                         "long_term", "shipped", "retired"]
-    sp = sub.add_parser("roadmap", help="add a feature or move its status")
+    sp = sub.add_parser("roadmap", help="add a feature, move its status, set its work-stream or dependencies")
     rsub = sp.add_subparsers(dest="roadmap_cmd", required=True)
     ra = rsub.add_parser("add", parents=[common]); ra.add_argument("title")
     ra.add_argument("--status", default="brainstorm", choices=ROADMAP_STATUSES)
     ra.add_argument("--summary")
+    ra.add_argument("--project", help="assign to a work-stream (projects shortname|id)")
     rt = rsub.add_parser("status", parents=[common])
     rt.add_argument("feature_id", type=int); rt.add_argument("status", choices=ROADMAP_STATUSES)
+    rp = rsub.add_parser("project", parents=[common], help="set/clear a feature's work-stream")
+    rp.add_argument("feature_id", type=int)
+    rp.add_argument("project", help="work-stream shortname|id, or 'none' to clear")
+    rd = rsub.add_parser("depends", parents=[common], help="set a feature's dependencies (replaces the set)")
+    rd.add_argument("feature_id", type=int)
+    rd.add_argument("--on", type=int, action="append", metavar="FEATURE_ID",
+                    help="a prerequisite that must land first (repeatable); omit all to clear")
     sp.set_defaults(fn=cmd_roadmap)
 
     sp = sub.add_parser("project", help="add a project or update its standing/status")

--- a/skills_sc/db_map.md
+++ b/skills_sc/db_map.md
@@ -38,11 +38,12 @@ memory/identity/content. Don't look for `dr_*` in `shell_db.db`.
 | `shell_identity_entries` | seed (cap 10) + L&S (`kind='lns'`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
 | `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
 | `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |
-| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row | INSERT/UPDATE |
+| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row. `project_id` (nullable) = the work-stream the feature belongs to; the GUI Flow view groups on it (NULL = Ungrouped) | INSERT/UPDATE |
+| `feature_blockers` | the roadmap's dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite must land first). Directed, kept acyclic (the GUI Flow view wires them; the card's "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `./sc mem roadmap depends` |
 | `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
 | `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | catalogue via migration; grants via snapshot |
-| `projects` / `project_shells` | project standing + shell linkage | UPDATE `standing`; INSERT to add |
+| `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a **work-stream** that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
 
 `<self>` = your `shell_id` (in the boot doc's ACTIVE SESSION block).
 
@@ -63,8 +64,12 @@ Each guards the engine DB and snapshots for you. `./sc mem which` orients;
 ./sc mem decision "…" --rationale "…"
 
 # roadmap: add a feature / move its horizon:
-./sc mem roadmap add "…" --status brainstorm --summary "…"
+./sc mem roadmap add "…" --status brainstorm --summary "…" [--project <shortname|id>]
 ./sc mem roadmap status <feature_id> shipped
+
+# roadmap grouping + sequencing (drive the GUI Flow view):
+./sc mem roadmap project <feature_id> <shortname|id>   # assign a work-stream (or 'none' to clear)
+./sc mem roadmap depends <feature_id> --on <id> [--on <id>]   # set dependencies (replaces; omit --on to clear; refuses cycles)
 
 # author a spec/doc body (--body-file reads the markdown), then freeze on ship:
 ./sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md


### PR DESCRIPTION
Answers "is the skill in line with the data?" — it wasn't. The roadmap data model gained `roadmap.project_id` (work-streams, #142/migration 0018) and `feature_blockers` (dependency edges, migration 0017), and the GUI uses both, but the `./sc mem` CLI couldn't set either and `db_map` didn't document them.

**CLI (`mem.py`):**
- `roadmap add … --project <shortname|id>` — assign a work-stream on create.
- `roadmap project <feature_id> <shortname|id|none>` — set/clear a feature's work-stream.
- `roadmap depends <feature_id> --on <id> [--on <id>…]` — set the dependency set (replace semantics; omit `--on` to clear). Validates the features exist, rejects self-dependency, and refuses any edge that would close a cycle (mirrors the API's DAG guarantee).

**Doc (`db_map` skill):** documents `roadmap.project_id`, adds a `feature_blockers` table row, notes `projects`' work-stream role, and lists the new verbs. Reseeded `0001_seed_skills.sql` so forks pick it up on `./sc update`.

**Verified:** `mem.py` parses; all verbs exercised against a DB copy (assign/clear, dependency set, cycle guard, self-dep guard all correct); seed SQL applies and the catalogued `db_map` content carries the new bits.