### PR TITLE
feat(roadmap): Flow-view polish — deep-link URL, no backward-from-shipped wires, more spacing

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -491,11 +491,13 @@ async function renderRoadmap(root) {
   const { buckets, projects = [] } = await api("/roadmap");
   root.replaceChildren();
 
-  // Board ⇄ Flow toggle. Board = bucketed cards; Flow = the dependency graph.
+  // Board ⇄ Flow toggle. The sub-view rides in the URL hash (#roadmap = board,
+  // #roadmap-flow = flow) so it's deep-linkable and refresh-stable; routeFromHash
+  // sets roadmapView and re-renders.
   const toggle = el("div", { className: "filters centered view-toggle" });
   for (const [mode, label] of [["board", "Board"], ["flow", "Flow"]]) {
     const b = el("button", { className: "chip" + (roadmapView === mode ? " on" : ""), textContent: label });
-    b.onclick = () => { roadmapView = mode; renderRoadmap(root); };
+    b.onclick = () => { location.hash = mode === "flow" ? "roadmap-flow" : "roadmap"; };
     toggle.append(b);
   }
   root.append(toggle);
@@ -1305,10 +1307,16 @@ function show(tab) {
 }
 // Hash routing: the active tab lives in the URL (#roadmap), so a refresh stays
 // put (and re-fetches that tab) instead of snapping back to Shells. Tabs set the
-// hash; hashchange drives show — back/forward and deep links work too.
+// hash; hashchange drives show — back/forward and deep links work too. The
+// roadmap tab carries its sub-view in the hash: #roadmap (board) | #roadmap-flow.
 function routeFromHash() {
-  const tab = location.hash.slice(1);
-  show(VIEWS[tab] ? tab : "shells");
+  const raw = location.hash.slice(1);
+  if (raw === "roadmap" || raw.startsWith("roadmap-")) {
+    roadmapView = raw === "roadmap-flow" ? "flow" : "board";
+    show("roadmap");
+    return;
+  }
+  show(VIEWS[raw] ? raw : "shells");
 }
 document.querySelectorAll("nav button").forEach((b) => (b.onclick = () => { location.hash = b.dataset.tab; }));
 window.addEventListener("hashchange", routeFromHash);

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -627,9 +627,12 @@ function buildFlowGraph(features, stageOf) {
   wrap.append(inner);
 
   // Dependency edges (prerequisite → dependent), endpoints both in this section.
+  // Skip edges whose prerequisite is already shipped: shipped is the rightmost
+  // stage, so the wire would point backward to earlier work — and a done
+  // prerequisite isn't worth drawing.
   const edgeList = [];
   for (const f of features) for (const b of (f.blockers || []))
-    if (shownIds.has(b)) edgeList.push([b, f.feature_id]);
+    if (shownIds.has(b) && stageOf[b] !== "shipped") edgeList.push([b, f.feature_id]);
 
   // Draw once the columns have laid out. Coordinates are relative to .flow-inner;
   // connect the source card's right edge to the target's left, horizontal-tangent.

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -497,7 +497,7 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   align-items: flex-start; padding: 0 .2rem; }
 /* Columns share the window width evenly (flex:1); min-width keeps them legible
    and lets .flow-wrap scroll as a fallback when too many stages are present. */
-.flow-col { flex: 1 1 0; min-width: 150px; display: flex; flex-direction: column; gap: .7rem; }
+.flow-col { flex: 1 1 0; min-width: 150px; display: flex; flex-direction: column; gap: 1.4rem; }
 .flow-col-head { font-size: .72rem; text-transform: uppercase; letter-spacing: .08em;
   color: var(--dim); padding-bottom: .35rem; border-bottom: 1px solid var(--line-soft); }
 


### PR DESCRIPTION
Flow-view refinements (held; mid-work batch):

- **Deep-linkable sub-view** — board/flow now rides in the URL hash (`#roadmap` = board, `#roadmap-flow` = flow). The toggle sets the hash; `routeFromHash` parses it, sets the view, and renders, so deep links / refresh / back-forward all work.
- **No backward wires from shipped** — dependency edges whose prerequisite is already shipped are skipped (shipped is the rightmost stage, so the wire points backward, and a done prereq isn't worth drawing).
- **More breathing room** — doubled the vertical gap between cards in a column (.7rem → 1.4rem).

app.js + style.css only; `node --check` clean.