### PR TITLE
feat(flavors): retune open-weight defaults — reviewer glm-5.2, cartographer qwen

### DIFF
--- a/.super-coder/migrations/0019_open_weight_reviewer_cartographer.sql
+++ b/.super-coder/migrations/0019_open_weight_reviewer_cartographer.sql
@@ -1,0 +1,26 @@
+-- 0019 — Open-weight retune: reviewer GLM-5.1→5.2, cartographer gpt-oss:20b→qwen
+--
+-- Two UPDATEs to flavor_defaults (pure launch config — no FKs, no per-instance
+-- memory — so they converge fresh-rebuild and existing forks alike; idempotent,
+-- re-runnable). Both stay inside the MIT/Apache license gate (0015) — no gate
+-- change, MiniMax/Kimi remain excluded.
+--
+--   reviewer      ollama-cloud/glm-5.2          (MIT)     GLM-5.2 supersedes 5.1;
+--                                                         stronger SWE-Bench Pro bug-finding.
+--   cartographer  ollama-cloud/qwen3-coder-next (Apache)  was gpt-oss:20b — too small now that
+--                                                         the cartographer authors script/map
+--                                                         updates, not just bulk file mapping.
+--                                                         qwen3-coder-next (already the dev pick)
+--                                                         is coding-tuned and well above a 20B.
+--
+-- Provider prefix stays `ollama-cloud/` (the live OpenCode provider, no suffix).
+
+BEGIN;
+
+UPDATE flavor_defaults SET model = 'ollama-cloud/glm-5.2'
+    WHERE flavor = 'reviewer'     AND harness = 'opencode';
+
+UPDATE flavor_defaults SET model = 'ollama-cloud/qwen3-coder-next'
+    WHERE flavor = 'cartographer' AND harness = 'opencode';
+
+COMMIT;

--- a/README.md
+++ b/README.md
@@ -357,9 +357,9 @@ default per harness (the `flavor_defaults` table — the picker pre-selects it;
 | Flavor | Job | Codex | Claude | OpenCode (open-weights) |
 |---|---|---|---|---|
 | **planner** | architecture, plans | `gpt-5.5` | `sonnet` ★ | `deepseek-v4-pro` |
-| **reviewer** | adversarial review | `gpt-5.5` | `opus` ★ | `glm-5.1` |
+| **reviewer** | adversarial review | `gpt-5.5` | `opus` ★ | `glm-5.2` |
 | **dev** | write the code | `gpt-5.4-mini` ★ | `sonnet` | `qwen3-coder-next` |
-| **cartographer** | map the repo | `gpt-5.4-mini` ★ | `haiku` | `gpt-oss:20b` |
+| **cartographer** | map the repo | `gpt-5.4-mini` ★ | `haiku` | `qwen3-coder-next` |
 | **admin** | own the substrate, maintain `main` | `gpt-5.5` ★ | `sonnet` | `deepseek-v4-pro` |
 
 ★ = the harness the picker pre-selects for that flavor.
@@ -380,7 +380,7 @@ The logic, three rules:
 - **Three lineages, always.** Every flavor offers Codex (OpenAI), Claude
   (Anthropic), and OpenCode (open-weights via Ollama Cloud) — pick any provider for
   any role at launch. The OpenCode column is constrained to **MIT- or
-  Apache-licensed** weights only (e.g. DeepSeek V4, GLM-5.1, Qwen3-Coder, gpt-oss);
+  Apache-licensed** weights only (e.g. DeepSeek V4, GLM-5.2, Qwen3-Coder, gpt-oss);
   Modified-MIT / unresolved-license models (Kimi, MiniMax) are excluded even when
   available on the provider.
 - **Admin decisions carry real risk** (a wrong rollback is data loss), so the


### PR DESCRIPTION
Updates the recommended open-weight (OpenCode) model for two flavors via migration `0019`, and brings the README model table in line.

| Flavor | Was | Now | Why |
|---|---|---|---|
| **reviewer** | `glm-5.1` | `glm-5.2` (MIT) | GLM-5.2 supersedes 5.1 — stronger SWE-Bench Pro bug-finding |
| **cartographer** | `gpt-oss:20b` | `qwen3-coder-next` (Apache) | the cartographer now authors script/map updates, not just bulk mapping — a 20B is underpowered; qwen3-coder-next is coding-tuned and already the dev pick |

Both stay inside the existing **MIT/Apache** license gate (0015) — no doctrine change, MiniMax/Kimi remain excluded. Applied to the live engine DB via `./sc migrate` (ledger recorded); `flavor_defaults` is substrate config, so no snapshot/render churn.