### PR TITLE
feat(mem): add `./sc mem doc edit` for unfrozen docs

### DIFF
--- a/.super-coder/assets/skills/docs/SKILL.md
+++ b/.super-coder/assets/skills/docs/SKILL.md
@@ -62,6 +62,16 @@ within `(feature, kind)`, and it renders + snapshots for you:
 ./sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
 ```
 
+## Revise before freeze
+
+While a doc is still unfrozen, revise it in place — no new row, no seq bump.
+Pass any of `--title` / `--body-file` / `--render-path`; it renders + snapshots
+like `add`. Refused once frozen (open a new spec instead — see below):
+```
+./sc mem doc edit <document_id> --body-file ./draft.md
+./sc mem doc edit <document_id> --title "New title" --render-path specs_sc/….md
+```
+
 ## Freeze on ship
 
 Freeze only at ship — it records what we built to, immutable thereafter. The

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -782,6 +782,16 @@ within `(feature, kind)`, and it renders + snapshots for you:
 ./sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
 ```
 
+## Revise before freeze
+
+While a doc is still unfrozen, revise it in place — no new row, no seq bump.
+Pass any of `--title` / `--body-file` / `--render-path`; it renders + snapshots
+like `add`. Refused once frozen (open a new spec instead — see below):
+```
+./sc mem doc edit <document_id> --body-file ./draft.md
+./sc mem doc edit <document_id> --title "New title" --render-path specs_sc/….md
+```
+
 ## Freeze on ship
 
 Freeze only at ship — it records what we built to, immutable thereafter. The

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -40,6 +40,7 @@ Run from the repo root, like every engine command:
     ./sc mem task start <task_id>    ./sc mem task done <task_id>
     ./sc mem oriented                # mark first-run complete (bootstrapped=1)
     ./sc mem doc add "<title>" --body-file PATH [--feature ID] [--kind spec|doc] [--seq N]
+    ./sc mem doc edit <document_id>  [--title "…"] [--body-file PATH] [--render-path …]   # unfrozen only
     ./sc mem doc freeze <document_id>
     ./sc mem narrative "<line>"      [--shell …]
     ./sc mem message check [N]       [--shell …]      # your unread inbox (read-only)
@@ -477,6 +478,8 @@ def cmd_oriented(args) -> int:
 def cmd_doc(args) -> int:
     if args.doc_cmd == "freeze":
         return _doc_freeze(args)
+    if args.doc_cmd == "edit":
+        return _doc_edit(args)
     body = Path(args.body_file).read_text()
     con = connect(Path(args.db))
     try:
@@ -513,6 +516,35 @@ def _doc_freeze(args) -> int:
     finally:
         con.close()
     return finish(args, f"mem: document #{args.document_id} frozen")
+
+
+def _doc_edit(args) -> int:
+    sets, vals, what = [], [], []
+    if args.title is not None:
+        sets.append("title=?"); vals.append(args.title); what.append("title")
+    if args.body_file is not None:
+        body = Path(args.body_file).read_text()
+        sets.append("body=?"); vals.append(body); what.append(f"body ({len(body)} chars)")
+    if args.render_path is not None:
+        sets.append("render_path=?"); vals.append(args.render_path); what.append("render_path")
+    if not sets:
+        die("nothing to edit — pass at least one of --title / --body-file / --render-path")
+    con = connect(Path(args.db))
+    try:
+        r = con.execute("SELECT frozen FROM documents WHERE document_id=?",
+                        (args.document_id,)).fetchone()
+        if r is None:
+            die(f"no document #{args.document_id}")
+        if r["frozen"]:
+            die(f"document #{args.document_id} is frozen — open a new spec under the "
+                "same feature instead of editing a frozen one")
+        sets.append("updated_at=datetime('now')")
+        con.execute(f"UPDATE documents SET {', '.join(sets)} WHERE document_id=?",
+                    (*vals, args.document_id))
+        con.commit()
+    finally:
+        con.close()
+    return finish(args, f"mem: document #{args.document_id} edited ({', '.join(what)})")
 
 
 def cmd_message(args) -> int:
@@ -661,12 +693,16 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("oriented", parents=[common],
                    help="mark this shell oriented (bootstrapped=1)").set_defaults(fn=cmd_oriented)
 
-    sp = sub.add_parser("doc", help="add or freeze a spec/doc document")
+    sp = sub.add_parser("doc", help="add, edit, or freeze a spec/doc document")
     dsub = sp.add_subparsers(dest="doc_cmd", required=True)
     da = dsub.add_parser("add", parents=[common]); da.add_argument("title")
     da.add_argument("--body-file", required=True, dest="body_file")
     da.add_argument("--feature", type=int); da.add_argument("--kind", default="spec", choices=["spec", "doc"])
     da.add_argument("--seq", type=int); da.add_argument("--render-path", dest="render_path")
+    de = dsub.add_parser("edit", parents=[common],
+                         help="revise an unfrozen doc's title/body/render-path"); de.add_argument("document_id", type=int)
+    de.add_argument("--title"); de.add_argument("--body-file", dest="body_file")
+    de.add_argument("--render-path", dest="render_path")
     df = dsub.add_parser("freeze", parents=[common]); df.add_argument("document_id", type=int)
     sp.set_defaults(fn=cmd_doc)
 

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -146,6 +146,30 @@ class MemTest(unittest.TestCase):
                                      (did,)).fetchone()[0], 1)
         con.close()
 
+    def test_doc_edit_unfrozen_then_refuse_frozen(self):
+        spec = self.tmp / "spec.md"
+        spec.write_text("# Spec\nv1\n")
+        self._run("doc", "add", "Editable", "--body-file", str(spec), "--kind", "spec")
+        con = sqlite3.connect(self.db)
+        did = con.execute("SELECT document_id FROM documents WHERE title='Editable'").fetchone()[0]
+        con.close()
+        # edit title + body while unfrozen
+        spec.write_text("# Spec\nv2\n")
+        self._run("doc", "edit", str(did), "--title", "Renamed", "--body-file", str(spec))
+        con = sqlite3.connect(self.db)
+        title, body = con.execute("SELECT title, body FROM documents WHERE document_id=?",
+                                  (did,)).fetchone()
+        con.close()
+        self.assertEqual(title, "Renamed")
+        self.assertEqual(body, "# Spec\nv2\n")
+        # no fields → error
+        with self.assertRaises(SystemExit):
+            self._run("doc", "edit", str(did))
+        # freeze, then editing is refused
+        self._run("doc", "freeze", str(did))
+        with self.assertRaises(SystemExit):
+            self._run("doc", "edit", str(did), "--title", "Nope")
+
     def test_message_send_check_mark_read(self):
         # second shell to send to
         con = sqlite3.connect(self.db)


### PR DESCRIPTION
## What

Adds `./sc mem doc edit <document_id>` — a guarded path to revise an **unfrozen** doc's `title` / `body` (`--body-file`) / `render_path` in place.

```
./sc mem doc edit <document_id> [--title "…"] [--body-file PATH] [--render-path …]   # unfrozen only
```

## Why

`./sc mem doc` only had `add`/`freeze`. Revising an in-progress doc meant raw `sqlite3 … UPDATE` against the engine DB — the exact foot-gun `mem.py` exists to prevent (engine/product DBs share table names; a mistyped path hits the wrong file). Shells on forks surfaced the gap.

## Behavior

- In place: no new row, no `seq` bump; bumps `updated_at`; snapshots+renders like the other writes.
- Refuses **frozen** docs (`open a new spec under the same feature instead`) — keeps "frozen = immutable record of what we shipped" intact.
- Errors when no fields are passed or the id is unknown.

## Changes

- `mem.py`: `_doc_edit` handler + routing, parser subcommand, docstring usage line.
- `docs` SKILL.md: new "Revise before freeze" section; regenerated `0001_seed_skills.sql` via `seed_skills.py`.
- `tests/test_mem.py`: edit unfrozen (title+body), no-field error, refuse-when-frozen.

## Tests

- `test_mem.py` 17/17 ✅ · full suite 86/86 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)