### PR TITLE
feat(roadmap): order the board with shipped first

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -163,9 +163,11 @@ def get_skills(con) -> dict:
     return {"skills": skills, "shells": get_shells(con)}
 
 
-# Funnel order: idea inlet → most-active committed work → done (shipped) →
-# taken-off-the-board (retired). shipped = delivered; retired = chose not to.
-_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped", "retired"]
+# Board order: delivered work first, then the committed funnel read backward
+# (most-active → farthest-out) — items move LEFT toward shipped as long_term
+# matures to near_term, next, in_progress, shipped. brainstorm (idea inlet) and
+# retired (taken off the board) are the right-hand end caps.
+_ORDER = ["shipped", "in_progress", "next", "near_term", "long_term", "brainstorm", "retired"]
 _LABEL = {"brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Next",
           "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped",
           "retired": "Retired"}

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -110,7 +110,9 @@ def _render_documents(con, written, skipped) -> None:
                           written, skipped)
 
 
-_ROADMAP_ORDER = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped", "retired"]
+# Board order: delivered first, then the committed funnel backward, with
+# brainstorm/retired as end caps (see server.py _ORDER for the rationale).
+_ROADMAP_ORDER = ["shipped", "in_progress", "next", "near_term", "long_term", "brainstorm", "retired"]
 _ROADMAP_LABEL = {
     "brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Next",
     "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped",

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -652,8 +652,10 @@ def build_parser() -> argparse.ArgumentParser:
     fc = fsub.add_parser("close", parents=[common]); fc.add_argument("flag_id", type=int); fc.add_argument("--notes")
     sp.set_defaults(fn=cmd_flag)
 
-    ROADMAP_STATUSES = ["brainstorm", "in_progress", "next", "near_term",
-                        "long_term", "shipped", "retired"]
+    # Board order (see api/server.py _ORDER). Order here only affects --help
+    # display; `add` still defaults to brainstorm (new items enter as ideas).
+    ROADMAP_STATUSES = ["shipped", "in_progress", "next", "near_term",
+                        "long_term", "brainstorm", "retired"]
     sp = sub.add_parser("roadmap", help="add a feature, move its status, set its work-stream or dependencies")
     rsub = sp.add_subparsers(dest="roadmap_cmd", required=True)
     ra = rsub.add_parser("add", parents=[common]); ra.add_argument("title")

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -468,8 +468,9 @@ function skillRow(s, shells) {
 }
 
 // ── Roadmap ───────────────────────────────────────────────────────────────────
-// Funnel order: idea inlet → most-active committed work → done.
-const STATUSES = ["brainstorm", "in_progress", "next", "near_term", "long_term", "shipped", "retired"];
+// Board order: delivered first, then the committed funnel backward (items move
+// LEFT toward shipped); brainstorm/retired are the right-hand end caps.
+const STATUSES = ["shipped", "in_progress", "next", "near_term", "long_term", "brainstorm", "retired"];
 const SLABEL = { brainstorm: "Brainstorm", in_progress: "In Progress", next: "Next", near_term: "Near Term", long_term: "Long Term", shipped: "Shipped", retired: "Retired" };
 // The five stages that sequence (carry dependency edges). brainstorm/retired are
 // excluded from the Flow graph and the blocker editor — they don't relate yet.

--- a/roadmap_sc.md
+++ b/roadmap_sc.md
@@ -8,10 +8,30 @@ edit: changes here are overwritten — author via the shell or localhost GUI
 
 > Rendered from the DB. Status is a planning horizon; a feature's open flags are its blockers.
 
-## Brainstorm
+## Shipped
 
-### Fork to sibling repos · owner: `cc`
-Fork super-coder into dos-arch / rst-c / emergence / md-converter; reseed pattern.
+### B0 — Core spine · owner: `cc`
+Repo skeleton, schema, migrations, DB rebuild-from-text, render→boot (CLAUDE.md + AGENTS.md). PR #-/a1cc1e2.
+
+_No open flags._
+
+### Dev shell git worktrees · owner: `cc`
+Give each dev shell its own git worktree so multiple dev shells can run in parallel without sharing a tree. Reviewer/planner stay on the main tree (read-only on git).
+
+_No open flags._
+
+### B2 — Content & render · owner: `cc`
+Flat _sc render, per-shell SKILL.md, skill seed pipeline. PR #1.
+
+_No open flags._
+
+### B3 — Review layer · owner: `cc`
+Dependency-free localhost GUI (shells/roadmap/flags), per-fork ports. PR #3.
+
+_No open flags._
+
+### Dev shell live UI preview · owner: `cc`
+One router on the fork's dev_port fans out to each dev shell's worktree vite, routed by subdomain (http://<shortname>.localhost:<dev_port>/) — live HMR per worktree, no base-path config, no concurrent-edit conflict. post-commit hook prints the URL. See specs_sc/dev-preview.md.
 
 _No open flags._
 
@@ -51,29 +71,9 @@ Base dr_* code map shipped (files/deps/env, ./sc map, surface_catalogue). NEXT �
 
 _No open flags._
 
-## Shipped
+## Brainstorm
 
-### B0 — Core spine · owner: `cc`
-Repo skeleton, schema, migrations, DB rebuild-from-text, render→boot (CLAUDE.md + AGENTS.md). PR #-/a1cc1e2.
-
-_No open flags._
-
-### Dev shell git worktrees · owner: `cc`
-Give each dev shell its own git worktree so multiple dev shells can run in parallel without sharing a tree. Reviewer/planner stay on the main tree (read-only on git).
-
-_No open flags._
-
-### B2 — Content & render · owner: `cc`
-Flat _sc render, per-shell SKILL.md, skill seed pipeline. PR #1.
-
-_No open flags._
-
-### B3 — Review layer · owner: `cc`
-Dependency-free localhost GUI (shells/roadmap/flags), per-fork ports. PR #3.
-
-_No open flags._
-
-### Dev shell live UI preview · owner: `cc`
-One router on the fork's dev_port fans out to each dev shell's worktree vite, routed by subdomain (http://<shortname>.localhost:<dev_port>/) — live HMR per worktree, no base-path config, no concurrent-edit conflict. post-commit hook prints the URL. See specs_sc/dev-preview.md.
+### Fork to sibling repos · owner: `cc`
+Fork super-coder into dos-arch / rst-c / emergence / md-converter; reseed pattern.
 
 _No open flags._


### PR DESCRIPTION
## What

Reverses the kanban column order so **delivered work leads** and the committed funnel reads backward — items move LEFT toward shipped as `long_term` matures to `near_term → next → in_progress → shipped`. `brainstorm` (idea inlet) and `retired` (off-board) sit as the right-hand end caps.

New left→right order:
```
Shipped · In Progress · Next · Near Term · Long Term · Brainstorm · Retired
```

## Changes

Mirrored the order across the four board consumers + regenerated the tracked render:

- `api/server.py` — `_ORDER` (REST `/roadmap` bucket order)
- `render/flat.py` — `_ROADMAP_ORDER` (the tracked `roadmap_sc.md`)
- `ui/app.js` — `STATUSES` (board columns + filter pills)
- `scripts/mem.py` — `ROADMAP_STATUSES` choices (CLI `--help`; default still `brainstorm`)
- `roadmap_sc.md` — regenerated, Shipped first

**No schema/migration change** — the `CHECK` constraint validates the status *set*, not order, so no feature moves.

The **Flow graph** view (`FLOW_STAGES`) is intentionally left as-is — there order is dependency-wire direction, not board layout.

## Tests

- Full suite 86/86 ✅ · `node --check app.js` ✅ · `roadmap_sc.md` section order confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)