### PR TITLE
fix(render): re-render skills_sc/docs.md mirror for doc-edit

### DIFF
--- a/skills_sc/docs.md
+++ b/skills_sc/docs.md
@@ -69,6 +69,16 @@ within `(feature, kind)`, and it renders + snapshots for you:
 ./sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
 ```
 
+## Revise before freeze
+
+While a doc is still unfrozen, revise it in place — no new row, no seq bump.
+Pass any of `--title` / `--body-file` / `--render-path`; it renders + snapshots
+like `add`. Refused once frozen (open a new spec instead — see below):
+```
+./sc mem doc edit <document_id> --body-file ./draft.md
+./sc mem doc edit <document_id> --title "New title" --render-path specs_sc/….md
+```
+
 ## Freeze on ship
 
 Freeze only at ship — it records what we built to, immutable thereafter. The


### PR DESCRIPTION
## What

Re-renders the flat mirror `skills_sc/docs.md` so it matches the DB render. PR #148 edited the `docs` skill asset (the "Revise before freeze" section) and regenerated `0001_seed_skills.sql`, but didn't re-render the flat `_sc` mirror — so `render-check` went **red on main** (the rebuilt DB render drifted 10 lines from the committed mirror).

No source change — pure render catch-up.

## Verify

```
./sc rebuild && ./sc render-check   # green with this commit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)