### PR TITLE
feat(gui): hide fully-shipped flows on the Flow view

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -542,7 +542,8 @@ async function renderRoadmap(root) {
 // and an SVG overlay wires dependencies (prerequisite → dependent). Pure DOM +
 // measured coordinates — no diagram library. Work-streams are the user's
 // "feature" (e.g. "Meeting Intelligence" = the mi-capture project); unassigned
-// features collect in a trailing "Ungrouped" section.
+// features collect in a trailing "Ungrouped" section. Flows with no active steps
+// left (every feature shipped) are hidden here — they live on in Board view.
 const SVGNS = "http://www.w3.org/2000/svg";
 async function renderRoadmapFlow(root, buckets, projects = []) {
   const feats = flowCandidates(buckets);   // features in the sequencing stages
@@ -566,8 +567,14 @@ async function renderRoadmapFlow(root, buckets, projects = []) {
   if (byProj.has(null)) order.push(null);
 
   let anyEdge = false;
+  let shown = 0;
   for (const key of order) {
     const grp = byProj.get(key);
+    // Hide a fully-shipped flow — it has no active steps left to sequence. Its
+    // shipped features stay visible in Board view; the Flow view is for what's
+    // still in play. (A flow with any non-shipped feature renders in full,
+    // shipped columns included, so you still see what's already delivered.)
+    if (grp.features.every((f) => stageOf[f.feature_id] === "shipped")) continue;
     const title = key === null ? "Ungrouped" : (grp.title || ("project #" + key));
     const section = el("div", { className: "flow-stream" });
     section.append(el("h2", { className: "flow-stream-head" }, title));
@@ -575,6 +582,13 @@ async function renderRoadmapFlow(root, buckets, projects = []) {
     anyEdge = anyEdge || edges > 0;
     section.append(wrap);
     root.append(section);
+    shown++;
+  }
+
+  if (!shown) {
+    root.append(el("div", { className: "muted" },
+      "No flows with active steps — every work-stream is fully shipped. See Board view for shipped features."));
+    return;
   }
 
   root.append(el("div", { className: "muted flow-hint" }, anyEdge


### PR DESCRIPTION
## Why

The Flow view showed every work-stream, including ones where all features had already shipped — clutter with no active steps. Surface only flows still in play; shipped work stays on the **Board** (list) view.

## What changed
`renderRoadmapFlow` (`.super-coder/ui/app.js`) now **skips a work-stream whose every feature is `shipped`**:
- A flow with *any* non-shipped feature renders in full — shipped columns included — so delivered steps stay in context.
- A flow with *only* shipped features is hidden (visible in Board view).
- When every flow is fully shipped, a 'see Board view' note renders instead of an empty page.

## Verify
- `node --check` passes; `stageOf[feature_id]` is defined for every flow feature, so the `.every(... === 'shipped')` test is sound.
- Visual: load the Roadmap → **Flow** toggle. (Note: the central instance's only work-stream — `super-coder` — has active features, so it correctly still shows; a fully-shipped work-stream is needed to eyeball the hide.)

## Independent
GUI-only, off `main` — no dependency on the dev-cycle PRs (#152/#153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)