### PR TITLE
fix(readme): render roadmap image as markdown, not raw indented <img>

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ it owns:
     index reflects the new shape — and the loop turns to the next feature.
     *(cartographer · `cartographer` · UI: Map)*
 
-    <img width="1669" height="1036" alt="roadamap" src="https://github.com/user-attachments/assets/36016883-35ad-42b8-8d70-da2eee899506" />
+![Review GUI, Roadmap tab — the full dev-cycle loop laid out across the planning stages](https://github.com/user-attachments/assets/36016883-35ad-42b8-8d70-da2eee899506)
 
 ## Install
 


### PR DESCRIPTION
The roadmap screenshot (#156) was added as a raw HTML `<img>` tag indented 4 spaces under the dev-cycle list. Two breakages for md-converter:

- **Raw `<img>` HTML** — the themed-markdown contract is `![alt](url)`; the parser doesn't render raw `<img>` tags.
- **4-space indent** under the list makes markdown treat it as a code block, so it renders as literal text.

Fix: convert to markdown image syntax at top-level block depth, and fix the `alt="roadamap"` typo with descriptive alt text. Image URL unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)