### PR TITLE
feat(flags): badge + title collapsed, description + link cards on expand

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -978,17 +978,34 @@ async function renderFlags(root) {
 }
 
 function flagRow(f) {
-  // Expandable: collapsed row shows priority + name + description on one line;
-  // expanding reveals the resolution note (resolved) or the resolve action (open).
+  // Expandable: collapsed row shows the priority badge + title + #id;
+  // expanding reveals the full description, linked items as cards, and the
+  // resolution note (resolved) or the resolve action (open).
   const row = el("details", { className: "flag" + (f.resolved ? " resolved" : "") });
   const head = el("summary", { className: "flag-head" });
-  head.append(el("span", { className: "pill " + (f.priority || "").toLowerCase() }, f.priority || ""));
+  const prio = f.priority || "—";
+  head.append(el("span", { className: "pill prio-" + prio.toLowerCase() }, prio));
   const d = el("span", { className: "desc" });
-  d.append(el("b", {}, (f.display_name ? f.display_name + " " : "")), esc(f.description || ""));
+  d.append(el("b", {}, f.display_name || "Flag"),
+    el("span", { className: "flag-num" }, " #" + f.flag_id));
   head.append(d);
   row.append(head);
 
   const body = el("div", { className: "flag-body" });
+
+  // Longer description, full text (no longer shown on the collapsed row).
+  if (f.description) body.append(el("div", { className: "flag-desc" }, f.description));
+
+  // Linked items as small cards. Today a flag links to at most one feature.
+  const links = [];
+  if (f.feature_title) links.push(["feature", f.feature_title]);
+  if (links.length) {
+    const lc = el("div", { className: "flag-links" });
+    for (const [k, v] of links) lc.append(el("div", { className: "link-card" },
+      el("span", { className: "link-k" }, k), el("span", { className: "link-v" }, v)));
+    body.append(lc);
+  }
+
   if (f.resolved) {
     body.append(el("div", { className: "tag" }, `resolved ${f.resolved_date || ""} — ${f.resolution_notes || ""}`));
   } else {

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -196,7 +196,20 @@ details.feature.tasks-open { border-left-color: var(--task-open); }
 .flag[open] > summary::before { transform: rotate(90deg); }
 .flag > summary:hover { background: var(--accent2); }
 .flag .desc { flex: 1; }
+.flag .flag-num { color: var(--dim); font-weight: 400; }
+.pill.prio-high { color: var(--warn); border-color: var(--warn); }
+.pill.prio-medium { color: var(--accent); }
+.pill.prio-low { color: var(--dim); }
 .flag-body { padding: 0 .4rem .7rem 1.8rem; }
+.flag-desc { white-space: pre-wrap; font-size: .85rem; line-height: 1.55; margin-bottom: .6rem; }
+.flag-links { display: flex; flex-wrap: wrap; gap: .4rem; margin-bottom: .6rem; }
+.link-card {
+  display: inline-flex; flex-direction: column; gap: .1rem;
+  background: var(--panel2); border: 1px solid var(--line); border-radius: 6px;
+  padding: .35rem .55rem; max-width: 22rem;
+}
+.link-card .link-k { font-size: .65rem; text-transform: uppercase; letter-spacing: .04em; color: var(--dim); }
+.link-card .link-v { font-size: .82rem; color: var(--ink); }
 .tag { font-size: .72rem; color: var(--dim); }
 
 /* ── Skills catalogue (Skills tab) — expandable rows, like flags ──────────── */


### PR DESCRIPTION
Reworks the flag rows in the review GUI so the collapsed row reads as a header and the detail lives in the expansion.

- **Collapsed:** color-coded priority badge + `display_name` title + `#flag_id`. The long description no longer crowds this line.
- **Expanded:** full description block, then linked items as small cards (today a flag links to at most one feature, so it renders one card; the code is a list so future relations drop in).

Pure front-end change in `.super-coder/ui/` (vanilla JS + CSS, no build step).