### PR TITLE
feat(roadmap): exclude shipped from the Flow view

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -542,18 +542,23 @@ async function renderRoadmap(root) {
 // and an SVG overlay wires dependencies (prerequisite → dependent). Pure DOM +
 // measured coordinates — no diagram library. Work-streams are the user's
 // "feature" (e.g. "Meeting Intelligence" = the mi-capture project); unassigned
-// features collect in a trailing "Ungrouped" section. Flows with no active steps
-// left (every feature shipped) are hidden here — they live on in Board view.
+// features collect in a trailing "Ungrouped" section. Shipped features are
+// excluded from the Flow view entirely — it's for what's still in play; shipped
+// work lives on in Board view (and stays depend-on-able in its blocker picker).
 const SVGNS = "http://www.w3.org/2000/svg";
 async function renderRoadmapFlow(root, buckets, projects = []) {
-  const feats = flowCandidates(buckets);   // features in the sequencing stages
-  if (!feats.length) {
-    root.append(el("div", { className: "muted" }, "No features in the sequencing stages yet."));
-    return;
-  }
   const stageOf = {};
   for (const b of buckets) if (FLOW_STAGES.includes(b.status))
     for (const f of b.features) stageOf[f.feature_id] = b.status;
+  // Candidate pool minus shipped — the Flow view never renders shipped cards.
+  const feats = flowCandidates(buckets).filter((f) => stageOf[f.feature_id] !== "shipped");
+  if (!feats.length) {
+    const anyShipped = Object.values(stageOf).some((s) => s === "shipped");
+    root.append(el("div", { className: "muted" }, anyShipped
+      ? "No flows with active steps — every work-stream is fully shipped. See Board view for shipped features."
+      : "No features in the sequencing stages yet."));
+    return;
+  }
 
   // Group the sequencing features by work-stream (project_id; null = ungrouped).
   const byProj = new Map();   // key (project_id | null) → { title, features }
@@ -567,14 +572,8 @@ async function renderRoadmapFlow(root, buckets, projects = []) {
   if (byProj.has(null)) order.push(null);
 
   let anyEdge = false;
-  let shown = 0;
   for (const key of order) {
     const grp = byProj.get(key);
-    // Hide a fully-shipped flow — it has no active steps left to sequence. Its
-    // shipped features stay visible in Board view; the Flow view is for what's
-    // still in play. (A flow with any non-shipped feature renders in full,
-    // shipped columns included, so you still see what's already delivered.)
-    if (grp.features.every((f) => stageOf[f.feature_id] === "shipped")) continue;
     const title = key === null ? "Ungrouped" : (grp.title || ("project #" + key));
     const section = el("div", { className: "flow-stream" });
     section.append(el("h2", { className: "flow-stream-head" }, title));
@@ -582,13 +581,6 @@ async function renderRoadmapFlow(root, buckets, projects = []) {
     anyEdge = anyEdge || edges > 0;
     section.append(wrap);
     root.append(section);
-    shown++;
-  }
-
-  if (!shown) {
-    root.append(el("div", { className: "muted" },
-      "No flows with active steps — every work-stream is fully shipped. See Board view for shipped features."));
-    return;
   }
 
   root.append(el("div", { className: "muted flow-hint" }, anyEdge


### PR DESCRIPTION
The Flow view (`/roadmap-flow`) was still showing shipped features as a Shipped column inside any work-stream that had at least one active feature. PR #154 only hid *fully*-shipped flows, not shipped cards within mixed flows — so shipped kept appearing.

This filters shipped out of the Flow render path entirely: build `stageOf` first, then drop shipped from the candidate pool. The Shipped column, the fully-shipped special-case (now dead), and the unreachable `shown` guard all go away. Board view, its filter chips, and the "blocked by" picker are untouched (`FLOW_STAGES`/`flowCandidates` unchanged), so shipped work stays visible on the Board and remains depend-on-able.

Test plan: open `/roadmap-flow` on a work-stream with mixed shipped + active features — no Shipped column renders; the Board view still shows shipped.