### PR TITLE
feat(roadmap): shipped flow column + title-only cards

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -618,20 +618,24 @@ function buildFlowGraph(features, stageOf, candidates = [], projects = []) {
       const full = f.title || "(untitled)";
       const shown = s === "shipped" && full.length > 32 ? full.slice(0, 31).trimEnd() + "…" : full;
       card.append(el("div", { className: "flow-card-title", title: full }, shown));
-      const m = el("div", { className: "flow-card-meta" });
-      if (f.owner) m.append(el("span", { className: "pill " + s }, f.owner));
-      if (f.open_flags?.length) m.append(el("span", { className: "pill warn" }, f.open_flags.length + " ⚑"));
-      if (m.childNodes.length) card.append(m);
-      // md-converter open-links, one per spec/doc (same /open redirect the Board
-      // card uses). Compact: "spec v1 ↗" / "doc ↗".
-      const docs = f.documents || [];
-      if (docs.length) {
-        const dl = el("div", { className: "flow-card-docs" });
-        for (const d of docs) dl.append(el("a", {
-          className: "flow-doc-link", href: "/api/documents/" + d.document_id + "/open",
-          target: "_blank", rel: "noopener",
-          textContent: (d.kind === "doc" ? "doc" : `${d.kind} v${d.seq}`) + " ↗" }));
-        card.append(dl);
+      // Shipped cards are a title-only "done" list — no owner pill, flag count,
+      // or doc links. The other stages carry the full meta + doc rows.
+      if (s !== "shipped") {
+        const m = el("div", { className: "flow-card-meta" });
+        if (f.owner) m.append(el("span", { className: "pill " + s }, f.owner));
+        if (f.open_flags?.length) m.append(el("span", { className: "pill warn" }, f.open_flags.length + " ⚑"));
+        if (m.childNodes.length) card.append(m);
+        // md-converter open-links, one per spec/doc (same /open redirect the Board
+        // card uses). Compact: "spec v1 ↗" / "doc ↗".
+        const docs = f.documents || [];
+        if (docs.length) {
+          const dl = el("div", { className: "flow-card-docs" });
+          for (const d of docs) dl.append(el("a", {
+            className: "flow-doc-link", href: "/api/documents/" + d.document_id + "/open",
+            target: "_blank", rel: "noopener",
+            textContent: (d.kind === "doc" ? "doc" : `${d.kind} v${d.seq}`) + " ↗" }));
+          card.append(dl);
+        }
       }
       // Click anywhere on the card (except a doc link) opens the edit modal.
       card.onclick = (e) => { if (e.target.closest("a")) return; openFeatureModal(f, candidates, projects); };


### PR DESCRIPTION
Adds the **Shipped** column to the Roadmap **Flow** view as a wire-free "done" list, makes every flow card click-to-open the edit modal, and collapses shipped cards to a single title line.

## Changes
- **Shipped column** in Flow view (leftmost, wire-free) + click-anywhere-to-edit on all flow cards (`9f77801`)
- **Shipped cards = title-only** (`936a3c0`): suppress owner/plan pill, open-flag count, and spec/doc links for shipped cards; keep the truncated title (full name in tooltip) and the edit-on-click. Other stages (in_progress / next / near_term / long_term) keep the full meta + doc rows.

Resolves the `smallcard` redline — shipped cards were showing plan badge + spec/doc rows; they should be one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)