### PR TITLE
fix(roadmap): tighten gap between shipped flow cards

### DIFF
--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -538,6 +538,7 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .flow-card { cursor: pointer; }
 .flow-card:hover { border-color: rgba(255,255,255,.25); }
 /* Shipped column — a compact, wire-free "done" list on the left. */
+.flow-col.shipped { gap: 4px; }
 .flow-col.shipped .flow-card { padding: .45rem .6rem; }
 .flow-col.shipped .flow-card-title { font-size: .8rem; font-weight: 500; }
 .flow-doc-link { font-size: .72rem; color: var(--accent); text-decoration: none; white-space: nowrap; }


### PR DESCRIPTION
Shipped flow cards inherited the column's `1.4rem` item gap, which read too loose for a compact "done" list. This gives the shipped column its own `4px` gap so the cards stack tight, while every other flow column keeps the standard spacing.

One-line CSS change in `.super-coder/ui/style.css`, scoped to `.flow-col.shipped`.