### PR TITLE
fix(dev): make spec-task creation an always-loaded trip-wire

### DIFF
--- a/.super-coder/templates/shells/dev.json
+++ b/.super-coder/templates/shells/dev.json
@@ -3,6 +3,6 @@
   "abbr": "DEV",
   "role": "Dev shell",
   "mandate": "Build and implement in {{repo}} — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.",
-  "focus": "You are a builder. Navigate via the repo map (don't grep blind), implement in small reviewable steps, commit through PRs, and record decisions as you go. Planning scopes the work; you make it real; review verifies it.",
+  "focus": "You are a builder. Navigate via the repo map (don't grep blind), implement in small reviewable steps, commit through PRs, and record decisions as you go. Planning scopes the work; you make it real; review verifies it. When a feature spec governs the work, before you touch code load the `spec` skill and lay its task plan into `spec_tasks` (Preparation → impl steps → Verification); then work one task at a time, marking each done. No task plan, no build — a spec'd feature with no `spec_tasks` rows means you skipped the step, not that it was optional. Unspec'd quick fixes (small UI tweaks, minor migrations) are exempt.",
   "skills": ["docs", "spec", "flags", "git", "database-migrations", "redline_review", "dev_kit", "test_authoring"]
 }


### PR DESCRIPTION
## Problem

Dev shells sometimes skipped creating and using `spec_tasks` — "it doesn't fire." Root cause: the whole create/track procedure lives only in the `spec` skill, which is **lazy-loaded** (`common: false`). A dev shell that jumped straight to building never loaded the skill, so Step 3 (create `spec_tasks`) and Step 4 (work them one at a time) never ran. The always-loaded dev prompt never mentioned specs or tasks.

## Fix

Put the trigger on the always-loaded path. The dev `focus` (baked into `system_prompt` at create time) now carries an explicit trip-wire naming the skill, the table, and the discipline:

> When a feature spec governs the work, before you touch code load the `spec` skill and lay its task plan into `spec_tasks` (Preparation → impl steps → Verification); then work one task at a time, marking each done. No task plan, no build … Unspec'd quick fixes are exempt.

The detailed procedure stays in the `spec` skill — this is just the trigger. The unspec'd-quick-fix exemption matches the skill's existing Stance so it doesn't over-fire on small work.

## Scope / propagation

- Affects every dev shell **created or forked from here on** (`focus` → `render_prompt` → `system_prompt` at `create_shell`).
- `system_prompt` is baked at create time and never re-rendered at boot, so **existing** dev shells were patched directly in their live DBs out of band (super-coder `#3`, dos-arch `#2`/`#5`) — not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)