### PR TITLE
feat(gui): rolling webapp event log + gh-auth fallback & docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@
 # ephemeral, host-only (the broker recreates them); never tracked.
 /.super-coder/run/
 
+# Webapp event log — rolling, last N end-to-end API events (publish/snapshot/
+# errors). Runtime visibility only; local + ephemeral, never tracked.
+/.super-coder/logs/
+
 # Shell worktrees — one per shell, at .sc-worktrees/<shortname>/. Git
 # worktrees inside the repo root; gitignored so the linked trees don't surface
 # as untracked content in the main working tree.

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -38,6 +38,17 @@ REPO_ROOT = ENGINE.parent
 DB_PATH = ENGINE / "shell_db.db"
 UI_DIR = ENGINE / "ui"
 
+# Rolling webapp event log — visibility into what the API actually did, since a
+# publish/snapshot that "looked done" gave no trace to inspect after the fact.
+# ONE file, last LOG_MAX_EVENTS end-to-end events, JSON-per-line so it's both
+# greppable and machine-parseable (the multi-line step trace rides in `detail`,
+# keeping each event a single physical line so the roll is a line-count trim).
+# Local + ephemeral: under the gitignored .super-coder/logs/, never committed.
+LOG_DIR = ENGINE / "logs"
+LOG_PATH = LOG_DIR / "webapp.log"
+LOG_MAX_EVENTS = 20
+_LOG_LOCK = threading.Lock()
+
 sys.path.insert(0, str(ENGINE / "scripts"))
 import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
@@ -69,6 +80,47 @@ def mdc_url(markdown: str) -> str:
     packed = base64.urlsafe_b64encode(
         gzip.compress((markdown or "").encode(), mtime=0)).rstrip(b"=").decode()
     return f"{MDC_BASE}/?c={packed}"
+
+
+def log_event(op: str, *, ok: bool, detail, **fields) -> None:
+    """Append one end-to-end event to the rolling webapp log, trimmed to the last
+    LOG_MAX_EVENTS. `op` names the operation (publish/snapshot/error/…), `detail`
+    is the step trace (a list, or a string we split on newlines), and **fields
+    carries op-specific keys (pushed, pr_url, path, …). Best-effort: a logging
+    failure must NEVER break the request it records — the log is for visibility,
+    not correctness, so any I/O error is swallowed."""
+    if isinstance(detail, str):
+        detail = detail.splitlines()
+    event = {"ts": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
+             "op": op, "ok": ok, **fields, "detail": detail}
+    line = json.dumps(event, ensure_ascii=False)
+    with _LOG_LOCK:
+        try:
+            LOG_DIR.mkdir(parents=True, exist_ok=True)
+            prev = LOG_PATH.read_text().splitlines() if LOG_PATH.exists() else []
+            prev.append(line)
+            LOG_PATH.write_text("\n".join(prev[-LOG_MAX_EVENTS:]) + "\n")
+        except OSError:
+            pass
+
+
+def read_log() -> list[dict]:
+    """The rolling log as a list of event dicts, oldest→newest. Tolerates a
+    partially-written or corrupt line rather than failing the whole read."""
+    out: list[dict] = []
+    try:
+        text = LOG_PATH.read_text()
+    except OSError:
+        return out
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            out.append({"op": "?", "ok": False, "detail": [line]})
+    return out
 
 
 # Shell fields the review layer may write. seed/L&S/system_prompt/mandate are
@@ -550,7 +602,22 @@ def _unexpected_dirty() -> list[str]:
 
 
 def _gh_token() -> str:
-    return (os.environ.get("SC_GH_TOKEN") or os.environ.get("GH_TOKEN") or "").strip()
+    env = (os.environ.get("SC_GH_TOKEN") or os.environ.get("GH_TOKEN") or "").strip()
+    if env:
+        return env
+    # Host-run server (started directly, not via `./sc launch` which forwards
+    # GH_TOKEN into the sandbox): fall back to the host's gh login so a web-authed
+    # `gh auth login` "just works" with no token to export. Mirrors what `sc`
+    # itself does. In the sandbox gh usually isn't installed, so this fails to ""
+    # cleanly and the token simply comes from the forwarded env above.
+    try:
+        r = subprocess.run(["gh", "auth", "token"],
+                           capture_output=True, text=True, timeout=10)
+        if r.returncode == 0:
+            return r.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return ""
 
 
 def _origin_https() -> str | None:
@@ -597,6 +664,11 @@ def git_publish() -> dict:
         # if a step raised or returned early, so the tree never stays stranded on
         # the publish branch.
         _land_on_base(out, state)
+    # Record the full end-to-end trace (success OR failure) so a publish that
+    # "looked done" can be inspected after the fact — the gap that made the live
+    # incident unexplainable. _land_on_base above appends to `out`, so log here.
+    log_event("publish", ok=state["ok"], pushed=state["pushed"],
+              pr_url=state["pr_url"], detail=out)
     return {"ok": state["ok"], "output": "\n".join(out), "pr_url": state["pr_url"]}
 
 
@@ -812,6 +884,10 @@ class Handler(BaseHTTPRequestHandler):
         `{"error": "'feature_id'"}`, no stack, status 400). Log the full
         traceback to stderr and return 500 so it reads as a server fault."""
         traceback.print_exc()
+        # Also land it in the rolling log so a failed request is visible after the
+        # fact, not only in stderr that may have scrolled away / not been captured.
+        log_event("error", ok=False, path=getattr(self, "path", "?"),
+                  detail=traceback.format_exc().strip().splitlines()[-15:])
         return self._send(500, {"error": str(exc)})
 
     # -- static + GET --
@@ -837,6 +913,12 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, git_hygiene.compute(fetch=fetch))
             except Exception as e:
                 return self._fail(e)
+        # Rolling webapp event log — no DB, just the last LOG_MAX_EVENTS events.
+        # Newest-first for the reader; reachable from the browser/curl so you don't
+        # have to shell into the sandbox to see what a publish/snapshot did.
+        if path == "/api/logs":
+            return self._send(200, {"events": list(reversed(read_log())),
+                                    "max": LOG_MAX_EVENTS})
         con = db()
         try:
             if path == "/api/health":
@@ -932,7 +1014,15 @@ class Handler(BaseHTTPRequestHandler):
                     "SELECT shortname FROM shells WHERE shell_id=?", (sid,)).fetchone()[0]
                 return self._send(201, {"shell_id": sid, "shortname": sn})
             if path == "/api/snapshot":
-                return self._send(200, {"output": run_snapshot_render()})
+                try:
+                    out = run_snapshot_render()
+                except Exception as e:
+                    # run_snapshot_render raises on a failed serialize/render; log
+                    # the failure before re-raising so it's in the rolling log too.
+                    log_event("snapshot", ok=False, detail=str(e))
+                    raise
+                log_event("snapshot", ok=True, detail=out)
+                return self._send(200, {"output": out})
             if path == "/api/publish":
                 with _PUBLISH_LOCK:
                     r = git_publish()

--- a/README.md
+++ b/README.md
@@ -769,6 +769,12 @@ refers to:
 | **Map** | The repo catalogue — language mix, file roles, dependencies, env vars — with a re-map button. |
 | **Scripts** | Run the maintenance chores (snapshot, render, seed-skills, migrate, rebuild) from a button. |
 
+The header's **snapshot ⤓** / **publish ⤴** buttons serialize the DB and open a
+rolling content PR. How they authenticate to GitHub (`gh auth login` or a scoped
+`SC_GH_TOKEN`), and the rolling event log (`.super-coder/logs/webapp.log` /
+`GET /api/logs`, last 20 events) for seeing what a publish actually did:
+[`docs/publish-and-gh-auth.md`](docs/publish-and-gh-auth.md).
+
 ![Review GUI, Roadmap tab — Board view: a feature expanded into its inline editor with title, status, summary, and spec-task checklist](https://raw.githubusercontent.com/jedbjorn/super-coder/main/docs/images/roadmap-tab.png)
 
 ![Review GUI, Worktrees tab — live git-hygiene report: dirty worktrees, each branch ahead/behind its base, and prunable merged branches](https://raw.githubusercontent.com/jedbjorn/super-coder/main/docs/images/worktrees-tab.png)

--- a/docs/publish-and-gh-auth.md
+++ b/docs/publish-and-gh-auth.md
@@ -1,0 +1,123 @@
+---
+title: Publish, GitHub auth & the webapp event log
+tags: [super-coder, gui, publish, github, auth, logging]
+date: 2026-06-26
+project: super-coder
+purpose: How the Review GUI's snapshot/publish work, how they authenticate to GitHub, and how to see what they did
+---
+
+# Publish, GitHub auth & the webapp event log
+
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/super-coder/blob/main/docs/publish-and-gh-auth.md)
+
+## What snapshot & publish do
+
+The Review GUI header has two buttons:
+
+- **snapshot ⤓** — serialize the live DB → `.sc-state/content.sql` and render the
+  flat files (`specs_sc/`, `docs_sc/`, `skills_sc/`, `roadmap_sc.md`). **Local
+  only, no git.** This is what makes your edits durable as git-tracked text the
+  DB can be rebuilt from.
+- **publish ⤴** — snapshot + render, then **commit → force-push → open/update one
+  PR** from an ephemeral `sc_gui_content` branch, and return to `main`. It never
+  merges; the open PR is the gate you merge on GitHub.
+
+### The ephemeral-branch model
+
+Each publish (re)creates the local `sc_gui_content` branch **from a clean
+`main`**, commits the serialized content onto it, force-pushes, and opens/updates
+**one rolling PR** — then returns to `main` and deletes the local branch. The
+branch *name* is stable (one rolling PR); the local branch is *ephemeral* (rebuilt
+and dropped every publish), so the working tree is always left clean on `main` and
+branches never accumulate.
+
+Everything publish touches is **regenerated from the live DB**, so its working-tree
+edits are disposable — publish exploits this to recover from a tree left dirty or
+stranded on the publish branch by a previous run. If *unrelated* files are dirty,
+publish refuses rather than clobbering them: commit or stash them first.
+
+## GitHub authentication
+
+Push + PR need a GitHub token. `publish` resolves one in this order:
+
+1. **`SC_GH_TOKEN`** env var (a repo-scoped PAT — the tightest option), else
+2. **`GH_TOKEN`** env var (what `./sc launch` forwards into the sandbox), else
+3. **`gh auth token`** from the host's `gh` login — the fallback for a
+   **host-run** server (one started directly, not via the launch sandbox).
+
+So you have two ways to be authenticated:
+
+### Option A — `gh auth login` (web flow; recommended)
+
+A normal browser-based `gh` login is enough — no token to copy or export.
+
+```bash
+gh auth login          # choose GitHub.com → HTTPS → Login with a web browser
+gh auth status         # verify: "Logged in to github.com as <you>"
+gh auth token          # should print a token (this is what publish falls back to)
+```
+
+- **Launch sandbox (`./sc launch`):** the launcher runs `gh auth token` on the
+  **host** and forwards it as `GH_TOKEN` into the container. Web auth on the host
+  is all you need; nothing to do inside the sandbox (where `gh` isn't installed).
+- **Host-run server:** `_gh_token()` calls `gh auth token` directly, so a
+  web-authed host `gh` works with no env var set.
+
+> [!class3]
+> **Run `gh auth login` on the host, not inside the sandbox.** The web flow opens a
+> localhost callback your browser must reach; from inside the container that port
+> isn't published. Same rule as harness sign-in.
+
+Make sure the login grants the **`repo`** scope (push + PR). `gh auth status`
+lists granted scopes; re-run `gh auth login -s repo` if it's missing.
+
+### Option B — a scoped PAT in `SC_GH_TOKEN`
+
+Tighter: a fine-grained / classic PAT limited to the one repo, with
+**Contents: read/write** + **Pull requests: read/write** (classic: `repo`).
+
+```bash
+export SC_GH_TOKEN=ghp_xxx          # in the env that launches the server / ./sc
+```
+
+`SC_GH_TOKEN` wins over `GH_TOKEN`, and `./sc launch` prefers it when forwarding.
+
+## Seeing what happened — the webapp event log
+
+Every snapshot and publish (and any unhandled API error) is recorded to a
+**rolling log**: one file, the **last 20 end-to-end events**, JSON-per-line.
+
+- **File:** `.super-coder/logs/webapp.log` (gitignored — local + ephemeral).
+- **API:** `GET /api/logs` → `{"events": [...newest first...], "max": 20}`.
+- **Each event:** `ts`, `op` (`publish` / `snapshot` / `error`), `ok`, the
+  op-specific fields (`pushed`, `pr_url`, `path`), and `detail` — the full
+  step-by-step trace as a list, so each event stays one greppable line.
+
+```bash
+# tail the raw log (inside the sandbox, or on the host)
+tail -n 20 .super-coder/logs/webapp.log
+
+# or pretty-print the last publish from the API
+curl -s localhost:$PORT/api/logs | python3 -m json.tool | less
+```
+
+A publish that "looked done" but didn't land is now answerable: read its event
+and you'll see exactly where it stopped — `no GH_TOKEN`, `push failed`,
+`force-pushed`, `opened/updated PR`, or `nothing to publish`.
+
+## Troubleshooting
+
+| Symptom in the log / toast | Cause | Fix |
+|---|---|---|
+| `⚠ committed locally, but no GH_TOKEN` | No token resolved | `gh auth login` on the host (web), or set `SC_GH_TOKEN`; relaunch so the server's env picks it up. |
+| `✗ push failed: … 403` | Token lacks scope, or no write access | Ensure the token has `repo` (Contents + PRs write). `gh auth status` shows scopes. |
+| `✗ push failed: … could not resolve host` | No network from the server | Check the sandbox network / proxy. |
+| Publish succeeds but **no open PR** after you merged the last one | Expected — you merged the rolling PR; the next publish opens a fresh one when there are new edits | Just publish again with new content. |
+| `✗ working tree has non-content changes — refusing to publish` | Unrelated edits are dirty | Commit or stash them, then publish. |
+| `✓ no content changes vs main — nothing to publish` | DB already matches `main` | Nothing to do; your edits were already published/merged. |
+| `recovered onto main from stranded sc_gui_content` | A previous run left the tree on the publish branch | None — publish auto-recovers; this line is informational. |
+
+## See also
+
+- [`README.md` → Review GUI](../README.md#review-gui)
+- [`README.md` → Harness sign-in](../README.md#harness-sign-in) (same host-vs-sandbox login rule)

--- a/tests/test_webapp_log.py
+++ b/tests/test_webapp_log.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Tests for the rolling webapp event log (server.log_event / read_log).
+
+The live publish incident was unexplainable because nothing recorded what the
+API did. This log is that record: ONE file, last server.LOG_MAX_EVENTS
+end-to-end events, JSON-per-line so each event is a single physical line and the
+roll is a line-count trim. Stdlib unittest, tmp log path, no dependencies —
+matching test_publish_*.py's style.
+
+Run:
+    python3 tests/test_webapp_log.py
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "api"))
+import server  # noqa: E402
+
+
+class RollingLogTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="webapp-log-"))
+        self._orig_dir, self._orig_path = server.LOG_DIR, server.LOG_PATH
+        server.LOG_DIR = self.tmp / "logs"
+        server.LOG_PATH = server.LOG_DIR / "webapp.log"
+
+    def tearDown(self) -> None:
+        server.LOG_DIR, server.LOG_PATH = self._orig_dir, self._orig_path
+        subprocess.run(["rm", "-rf", str(self.tmp)])
+
+    def test_caps_at_max_events_keeping_newest(self) -> None:
+        n = server.LOG_MAX_EVENTS + 5
+        for i in range(n):
+            server.log_event("publish", ok=True, detail=[f"event {i}"])
+        lines = server.LOG_PATH.read_text().splitlines()
+        self.assertEqual(len(lines), server.LOG_MAX_EVENTS)
+        events = server.read_log()
+        self.assertEqual(len(events), server.LOG_MAX_EVENTS)
+        # Oldest dropped, newest kept, in order.
+        self.assertEqual(events[0]["detail"], [f"event {n - server.LOG_MAX_EVENTS}"])
+        self.assertEqual(events[-1]["detail"], [f"event {n - 1}"])
+
+    def test_one_physical_line_per_event_despite_multiline_trace(self) -> None:
+        server.log_event("publish", ok=False, pushed=False, pr_url=None,
+                         detail="line one\nline two\nline three")
+        lines = server.LOG_PATH.read_text().splitlines()
+        self.assertEqual(len(lines), 1)
+        ev = json.loads(lines[0])
+        self.assertEqual(ev["detail"], ["line one", "line two", "line three"])
+        self.assertEqual(ev["op"], "publish")
+        self.assertFalse(ev["ok"])
+        self.assertIn("ts", ev)
+
+    def test_custom_fields_are_recorded(self) -> None:
+        server.log_event("publish", ok=True, pushed=True,
+                         pr_url="https://x/pr/1", detail=["done"])
+        ev = server.read_log()[0]
+        self.assertEqual(ev["pushed"], True)
+        self.assertEqual(ev["pr_url"], "https://x/pr/1")
+
+    def test_read_log_tolerates_a_corrupt_line(self) -> None:
+        server.LOG_DIR.mkdir(parents=True, exist_ok=True)
+        good = json.dumps({"op": "snapshot", "ok": True, "detail": ["ok"]})
+        server.LOG_PATH.write_text(good + "\n" + "{not valid json\n")
+        events = server.read_log()
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0]["op"], "snapshot")
+        self.assertFalse(events[1]["ok"])  # corrupt line surfaced, not dropped
+
+    def test_read_log_empty_when_no_file(self) -> None:
+        self.assertEqual(server.read_log(), [])
+
+    def test_logging_never_raises_on_bad_path(self) -> None:
+        # Best-effort contract: a logging I/O failure must not break the caller.
+        server.LOG_DIR = self.tmp / "logs"
+        server.LOG_PATH = self.tmp  # a directory — write_text would raise
+        try:
+            server.log_event("publish", ok=True, detail=["x"])
+        except Exception as e:  # noqa: BLE001
+            self.fail(f"log_event raised: {e}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #179 (publish hardening). The live publish incident was unexplainable because nothing recorded what the API did — this adds the visibility, plus closes the gh-auth gap that motivated it.

## Rolling webapp event log
- **One file, last 20 end-to-end events, JSON-per-line** at `.super-coder/logs/webapp.log` (gitignored, local/ephemeral). The multi-line step trace rides in a `detail` array, so each event is one greppable/parseable physical line and the roll is a line-count trim.
- `log_event()` / `read_log()` wired into the single chokepoints: `git_publish()` (success *and* failure, with `pushed`/`pr_url`), `/api/snapshot` (both outcomes), and `_fail()` (every unhandled API error + traceback tail).
- **`GET /api/logs`** returns events newest-first — reachable from the browser/curl, no shelling into the sandbox.
- Best-effort: a logging failure never breaks the request it records.

## gh-auth fallback
- `_gh_token()` falls back to `gh auth token` when no `SC_GH_TOKEN`/`GH_TOKEN` is in the env, so a **host-run** server with a web-authed `gh` works with nothing to export. Sandbox path unchanged (forwarded `GH_TOKEN`); gh-absent fails to `""` cleanly. Mirrors what `sc launch` already does.

## Docs
- `docs/publish-and-gh-auth.md`: how snapshot/publish work, the token chain (`SC_GH_TOKEN → GH_TOKEN → host gh login`), web-auth vs PAT setup, the event log, and a troubleshooting table. Linked from the README Review GUI section.

## Tests
- `tests/test_webapp_log.py` — cap-at-20 + keep-newest, one physical line per multi-line event, custom fields, corrupt-line tolerance, best-effort no-raise. Full suite: **113 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)