### PR TITLE
guard: self-heal stale engine skills; make render-check hermetic

### DIFF
--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -77,7 +77,7 @@ def _write_if_changed(path: Path, content: str, written: list, skipped: list) ->
 
 # ── Flat visibility render ────────────────────────────────────────────────────
 
-def _render_documents(con, written, skipped) -> None:
+def _render_documents(con, written, skipped, root: Path) -> None:
     """specs (kind='spec') → specs_sc/, docs (kind='doc') → docs_sc/.
 
     The document's own `render_path` is authoritative when set; otherwise we
@@ -106,7 +106,7 @@ def _render_documents(con, written, skipped) -> None:
             f"roadmap_status: {r['roadmap_status'] or ''}",
             f"frozen: {'true' if r['frozen'] else 'false'}",
         ]
-        _write_if_changed(REPO_ROOT / rel, with_banner(r["body"], extra),
+        _write_if_changed(root / rel, with_banner(r["body"], extra),
                           written, skipped)
 
 
@@ -120,7 +120,7 @@ _ROADMAP_LABEL = {
 }
 
 
-def _render_roadmap(con, written, skipped) -> None:
+def _render_roadmap(con, written, skipped, root: Path) -> None:
     """roadmap_sc.md — the static board for outsiders. Status is a planning
     horizon; a feature's open flags are listed as its blockers (joined on
     feature_id)."""
@@ -166,14 +166,14 @@ def _render_roadmap(con, written, skipped) -> None:
                 parts.append("_No open flags._")
             parts.append("")
     body = "\n".join(parts).rstrip()
-    _write_if_changed(REPO_ROOT / "roadmap_sc.md", with_banner(body), written, skipped)
+    _write_if_changed(root / "roadmap_sc.md", with_banner(body), written, skipped)
 
 
 def _skill_slug(name: str) -> str:
     return name.strip().lower().replace(" ", "-")
 
 
-def _render_skills_catalogue(con, written, skipped) -> None:
+def _render_skills_catalogue(con, written, skipped, root: Path) -> None:
     """skills_sc/ — the substrate's skill catalogue for browsers: one file per
     skill plus a README index. This is the *catalogue* (every non-deleted
     skill), distinct from `.claude/skills/` which renders one shell's grants."""
@@ -200,20 +200,25 @@ def _render_skills_catalogue(con, written, skipped) -> None:
             parts += ["  ·  ".join(meta), ""]
         if r["content"]:
             parts += ["---", "", r["content"].strip()]
-        _write_if_changed(REPO_ROOT / "skills_sc" / f"{slug}.md",
+        _write_if_changed(root / "skills_sc" / f"{slug}.md",
                           with_banner("\n".join(parts).rstrip()), written, skipped)
-    _write_if_changed(REPO_ROOT / "skills_sc" / "README.md",
+    _write_if_changed(root / "skills_sc" / "README.md",
                       with_banner("\n".join(index).rstrip()), written, skipped)
 
 
-def render_visibility(con: sqlite3.Connection) -> dict:
+def render_visibility(con: sqlite3.Connection, root: "Path | None" = None) -> dict:
     """Render the tracked flat `_sc` visibility files. Returns a written/skipped
-    summary. Incremental: unchanged artifacts are not rewritten."""
+    summary. Incremental: unchanged artifacts are not rewritten.
+
+    `root` overrides the write base (defaults to the real REPO_ROOT). The
+    hermetic render-check passes a temp dir so it can render the committed
+    SOURCE and diff it against the committed mirror without touching the tree."""
+    root = root or REPO_ROOT
     written: list[Path] = []
     skipped: list[Path] = []
-    _render_documents(con, written, skipped)
-    _render_roadmap(con, written, skipped)
-    _render_skills_catalogue(con, written, skipped)
+    _render_documents(con, written, skipped, root)
+    _render_roadmap(con, written, skipped, root)
+    _render_skills_catalogue(con, written, skipped, root)
     return {"written": written, "skipped": skipped}
 
 

--- a/.super-coder/scripts/render.py
+++ b/.super-coder/scripts/render.py
@@ -20,8 +20,10 @@ ENGINE = Path(__file__).resolve().parents[1]
 DB_PATH = ENGINE / "shell_db.db"
 
 sys.path.insert(0, str(ENGINE / "render"))
+sys.path.insert(0, str(ENGINE / "scripts"))
 import flat  # noqa: E402
 from _serialize_guard import require_admin  # noqa: E402
+from seed_skills import stale_engine_skills  # noqa: E402
 
 
 def _open() -> sqlite3.Connection:
@@ -42,6 +44,24 @@ def _resolve_shell(con, shortname: str) -> int:
     return row["shell_id"]
 
 
+def _guard_fresh(con) -> None:
+    """Refuse to render the tracked mirror from a DB whose engine skills lag
+    assets/skills/. Rendering a stale cache here is exactly how a shipped skill
+    body silently gets DELETED from the committed `_sc` mirror — so we fail loud
+    and point at the cure instead of writing the regression."""
+    stale = stale_engine_skills(con)
+    if stale:
+        sys.exit(
+            "render: refusing — the live DB's engine skills lag assets/skills/.\n"
+            "  The DB is a cache built before a `seed-skills` change; the migrate\n"
+            "  ledger won't re-seed `0001` in place, so rendering the flat mirror\n"
+            "  now would write STALE content (and can DELETE shipped doc/skill text).\n"
+            f"  stale: {', '.join(stale)}\n"
+            "  fix:  ./sc rebuild   (or ./sc update — both re-sync the catalogue;\n"
+            "        run ./sc seed-skills first if you just edited assets/skills/)"
+        )
+
+
 def _report(label: str, summary: dict) -> None:
     w, s = len(summary["written"]), len(summary["skipped"])
     print(f"render {label}: {w} written, {s} unchanged")
@@ -57,12 +77,14 @@ def main(argv: list[str]) -> int:
     try:
         if mode == "flat":
             require_admin("render flat")
+            _guard_fresh(con)
             _report("flat", flat.render_visibility(con))
         elif mode in ("skills", "all"):
             if len(argv) < 2:
                 sys.exit(f"render: `{mode}` needs a shell shortname")
             if mode == "all":
                 require_admin("render flat")
+                _guard_fresh(con)
                 _report("flat", flat.render_visibility(con))
             shell_id = _resolve_shell(con, argv[1])
             _report(f"skills[{argv[1]}]", flat.render_skill_md(con, shell_id))

--- a/.super-coder/scripts/render.py
+++ b/.super-coder/scripts/render.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(ENGINE / "render"))
 sys.path.insert(0, str(ENGINE / "scripts"))
 import flat  # noqa: E402
 from _serialize_guard import require_admin  # noqa: E402
-from seed_skills import stale_engine_skills  # noqa: E402
+from seed_skills import sync_engine_skills  # noqa: E402
 
 
 def _open() -> sqlite3.Connection:
@@ -44,22 +44,18 @@ def _resolve_shell(con, shortname: str) -> int:
     return row["shell_id"]
 
 
-def _guard_fresh(con) -> None:
-    """Refuse to render the tracked mirror from a DB whose engine skills lag
-    assets/skills/. Rendering a stale cache here is exactly how a shipped skill
-    body silently gets DELETED from the committed `_sc` mirror — so we fail loud
-    and point at the cure instead of writing the regression."""
-    stale = stale_engine_skills(con)
-    if stale:
-        sys.exit(
-            "render: refusing — the live DB's engine skills lag assets/skills/.\n"
-            "  The DB is a cache built before a `seed-skills` change; the migrate\n"
-            "  ledger won't re-seed `0001` in place, so rendering the flat mirror\n"
-            "  now would write STALE content (and can DELETE shipped doc/skill text).\n"
-            f"  stale: {', '.join(stale)}\n"
-            "  fix:  ./sc rebuild   (or ./sc update — both re-sync the catalogue;\n"
-            "        run ./sc seed-skills first if you just edited assets/skills/)"
-        )
+def _heal_fresh(con) -> None:
+    """Self-heal stale engine skills BEFORE rendering the tracked mirror.
+
+    Rendering from a DB whose engine skills lag assets/skills/ is exactly how a
+    shipped skill body silently gets DELETED from the committed `_sc` mirror.
+    Rather than refuse, we repair the cache from assets first (the same heal the
+    launcher runs at boot), so the mirror is always rendered from current engine
+    skills. Project-local skills are untouched. A no-op on a fresh DB."""
+    healed = sync_engine_skills(con)
+    if healed:
+        print(f"render: self-healed {len(healed)} stale engine skill(s) "
+              f"from assets/skills/ → {', '.join(healed)}")
 
 
 def _report(label: str, summary: dict) -> None:
@@ -77,14 +73,14 @@ def main(argv: list[str]) -> int:
     try:
         if mode == "flat":
             require_admin("render flat")
-            _guard_fresh(con)
+            _heal_fresh(con)
             _report("flat", flat.render_visibility(con))
         elif mode in ("skills", "all"):
             if len(argv) < 2:
                 sys.exit(f"render: `{mode}` needs a shell shortname")
             if mode == "all":
                 require_admin("render flat")
-                _guard_fresh(con)
+                _heal_fresh(con)
                 _report("flat", flat.render_visibility(con))
             shell_id = _resolve_shell(con, argv[1])
             _report(f"skills[{argv[1]}]", flat.render_skill_md(con, shell_id))

--- a/.super-coder/scripts/render_check.py
+++ b/.super-coder/scripts/render_check.py
@@ -1,61 +1,110 @@
 #!/usr/bin/env python3
-"""Fail if the committed flat `_sc` mirror drifts from the DB render.
+"""Fail if the committed flat `_sc` mirror drifts from the committed SOURCE.
 
 `roadmap_sc.md` and everything under `specs_sc/`, `docs_sc/`, `skills_sc/` are
-RENDERED from the DB (documents/roadmap/skills tables; a skill's source is
+RENDERED from the DB (documents/roadmap/skills; a skill's source is
 `assets/skills/<name>/SKILL.md` → seed migration → DB). Editing that source
 without re-rendering and committing the mirror drifts it silently — the DB and
 every shell's per-boot load stay correct, but the git-tracked browsable copy
-goes stale, and nothing else catches it. This is that guard: render, then fail
-on any diff in those paths.
+goes stale, and nothing else catches it.
 
-Hermetic use (CI / clean checkout):
+HERMETIC by construction: this builds a throwaway DB from git-tracked text
+(schema + migrations + `.sc-state/content.sql`), renders the mirror from THAT
+into a temp tree, and diffs it against the committed `_sc` files. It never opens
+the live `shell_db.db` and never writes into the working tree. So — unlike the
+old version, which rendered from the live DB *into the tree* and then told you to
+`git add` whatever fell out — a stale or dirty local cache DB can no longer make
+this pass or fail wrongly, and can never trick you into committing a regression.
+A local `./sc render-check` is now byte-identical to CI; no `./sc rebuild` first.
 
-    ./sc rebuild && ./sc render-check
-
-`rebuild` materializes the DB from committed text (schema + migrations +
-content.sql), so the check compares the committed mirror against the committed
-*source*. Local use assumes a current DB — snapshot first if you edited it live.
+    ./sc render-check
 """
 from __future__ import annotations
 
-import os
-import subprocess
+import sqlite3
 import sys
+import tempfile
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
+SCHEMA = ENGINE / "schema.sql"
+CONTENT = REPO_ROOT / ".sc-state" / "content.sql"
+CONTENT_LEGACY = ENGINE / "snapshot" / "content.sql"   # pre-B7 fallback
 RENDERED = ["roadmap_sc.md", "specs_sc", "docs_sc", "skills_sc"]
+
+sys.path.insert(0, str(ENGINE / "render"))
+sys.path.insert(0, str(ENGINE / "scripts"))
+import flat  # noqa: E402
+import migrate as migrate_mod  # noqa: E402
+
+
+def _build_tracked_db(path: Path) -> None:
+    """Materialize a DB from committed text only: schema → migrations →
+    content.sql. No map step (the dr_* cache isn't part of the mirror) and no
+    touch of the live DB. This is what a fresh `./sc rebuild` would produce, so
+    its engine skills are always current — the mirror is a pure function of the
+    sources about to be committed."""
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    con.commit()
+    con.close()
+    migrate_mod.migrate(str(path))
+    content = CONTENT if CONTENT.exists() else CONTENT_LEGACY
+    if content.exists():
+        con = sqlite3.connect(path)
+        con.executescript(content.read_text())
+        con.commit()
+        con.close()
+
+
+def _rel_files(base: Path) -> set[str]:
+    """Tracked-mirror files present under `base`, as repo-relative paths."""
+    found: set[str] = set()
+    for r in RENDERED:
+        p = base / r
+        if p.is_file():
+            found.add(r)
+        elif p.is_dir():
+            found.update(str(f.relative_to(base)) for f in p.rglob("*") if f.is_file())
+    return found
 
 
 def main() -> int:
-    # Render from the current DB into the tree (no-op for paths already current).
-    rendered = subprocess.run(
-        [sys.executable, str(ENGINE / "scripts" / "render.py"), "flat"],
-        cwd=str(REPO_ROOT),
-        env={**os.environ, "SC_ADMIN": "1"},  # CI/admin verify — clear serialize guard
-    )
-    if rendered.returncode != 0:
-        return rendered.returncode
+    with tempfile.TemporaryDirectory(prefix="sc-render-check-") as td:
+        tmp = Path(td)
+        db = tmp / "hermetic.db"
+        _build_tracked_db(db)
 
-    paths = [p for p in RENDERED if (REPO_ROOT / p).exists()]
-    drifted = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "diff", "--quiet", "--", *paths]
-    ).returncode != 0
-    if drifted:
-        stat = subprocess.run(
-            ["git", "-C", str(REPO_ROOT), "diff", "--stat", "--", *paths],
-            capture_output=True, text=True,
-        ).stdout
-        sys.stderr.write(
-            "✗ render drift: the committed flat _sc mirror does not match the DB "
-            "render.\n  A source edit (asset/DB) was committed without re-rendering "
-            "the mirror.\n\n" + stat + "\n"
-            "  fix:  ./sc render flat && git add " + " ".join(paths) + "\n"
+        out = tmp / "tree"
+        out.mkdir()
+        con = sqlite3.connect(db)
+        con.row_factory = sqlite3.Row
+        try:
+            flat.render_visibility(con, root=out)
+        finally:
+            con.close()
+
+        # Drift = committed mirror != mirror rendered from committed source.
+        rendered = _rel_files(out)
+        committed = _rel_files(REPO_ROOT)
+        drifted = sorted(
+            rel for rel in rendered | committed
+            if not ((out / rel).is_file() and (REPO_ROOT / rel).is_file()
+                    and (out / rel).read_bytes() == (REPO_ROOT / rel).read_bytes())
         )
-        return 1
-    print("✓ render-check: flat _sc mirror matches the DB render")
+        if drifted:
+            sys.stderr.write(
+                "✗ render drift: the committed flat _sc mirror does not match the\n"
+                "  mirror rendered from the tracked sources (schema + migrations +\n"
+                "  .sc-state/content.sql). A source edit was committed without\n"
+                "  re-rendering the mirror.\n\n  drifted:\n"
+                + "".join(f"    {p}\n" for p in drifted)
+                + "\n  fix:  ./sc rebuild && ./sc render flat && git add "
+                + " ".join(RENDERED) + "\n"
+            )
+            return 1
+    print("✓ render-check: flat _sc mirror matches the render of the tracked sources")
     return 0
 
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -38,6 +38,7 @@ import flat  # noqa: E402
 sys.path.insert(0, str(ENGINE / "scripts"))
 import install  # noqa: E402  — reuse its canonical HARNESS_BIN (one source of truth)
 import git_prune  # noqa: E402  — boot-time prune of provably-merged local branches
+import seed_skills  # noqa: E402  — boot-time self-heal of stale engine skills
 
 ADAPTERS = ENGINE / "adapters"
 
@@ -581,6 +582,21 @@ def main() -> None:
     requested = positional[0] if positional else None
 
     con = open_db()
+    # Self-heal stale engine skills before anything this boot reads them
+    # (compose's SKILLS block, render_skill_md). A DB stranded by an in-place
+    # `0001` regen repairs itself from assets/skills/ instead of needing a manual
+    # `./sc rebuild`. Project-local skills are never touched (no upstream to lag).
+    # Skipped under RENDER_ONLY: headless verify must not mutate, and it rebuilds
+    # fresh anyway. Best-effort — a heal failure never blocks a launch.
+    heal_note = None
+    if not os.environ.get("RENDER_ONLY"):
+        try:
+            healed = seed_skills.sync_engine_skills(con)
+            if healed:
+                heal_note = f"{len(healed)} stale engine skill(s) → {', '.join(healed)}"
+        except Exception:
+            heal_note = None
+
     user = authenticate(con)
     fdefaults = flavor_defaults(con)
     chosen = pick_shell(list_shells(con, user["user_id"]), requested, first, fdefaults)
@@ -670,6 +686,8 @@ def main() -> None:
         print(f"→ sync: {sync_note}")
     elif chosen["flavor"] == "admin":
         print("→ working dir: repo root (admin — maintains main directly)")
+    if heal_note:
+        print(f"→ heal: {heal_note}")
     if prune_note:
         print(f"→ prune: {prune_note}")
     print(f"→ wrote {work_dir / 'CLAUDE.md'}")

--- a/.super-coder/scripts/seed_skills.py
+++ b/.super-coder/scripts/seed_skills.py
@@ -67,6 +67,49 @@ def parse_skill(path: Path) -> dict:
     }
 
 
+# Fields the seed UPSERT owns (seed_skills `main`'s ON CONFLICT DO UPDATE SET).
+# A live row that differs from its asset on any of these is stale.
+SEED_FIELDS = ("description", "category", "command", "common", "content")
+
+
+def engine_skill_specs() -> list[dict]:
+    """Parse every engine skill under assets/skills/ — the seed's source of
+    truth and, by name, the line between engine and project-local skills (the
+    same set snapshot.dump_local_skills uses to decide what is fork-local)."""
+    if not SKILLS_DIR.exists():
+        return []
+    return [parse_skill(d / "SKILL.md")
+            for d in sorted(SKILLS_DIR.iterdir())
+            if (d / "SKILL.md").exists()]
+
+
+def stale_engine_skills(con) -> list[str]:
+    """Engine skills whose live-DB row lags assets/skills/. Names only.
+
+    This is the drift the in-place `0001` regen can strand: a DB built before
+    `./sc seed-skills` ran carries the OLD body, and the migrate ledger marks
+    `0001` applied so `./sc migrate` never re-seeds it (currency is a per-update
+    sync — see update.sync_skills — or a `./sc rebuild`). Rendering the flat
+    mirror from such a DB writes STALE, possibly content-deleting, files.
+
+    Scoped to engine skills BY NAME: a project-local skill (name absent from
+    assets/skills/) has no upstream to lag, is never inspected here, and so can
+    never trip this guard — admin-authored repo-local skills are safe.
+    """
+    stale: list[str] = []
+    for want in engine_skill_specs():
+        row = con.execute(
+            "SELECT description, category, command, common, content "
+            "FROM skills WHERE name=?", (want["name"],),
+        ).fetchone()
+        if row is None:                       # engine skill missing from the DB
+            stale.append(want["name"])
+            continue
+        if any(row[i] != want[f] for i, f in enumerate(SEED_FIELDS)):
+            stale.append(want["name"])
+    return stale
+
+
 def main() -> int:
     if not SKILLS_DIR.exists():
         sys.exit(f"seed_skills: no {SKILLS_DIR}")

--- a/.super-coder/scripts/seed_skills.py
+++ b/.super-coder/scripts/seed_skills.py
@@ -110,6 +110,38 @@ def stale_engine_skills(con) -> list[str]:
     return stale
 
 
+def sync_engine_skills(con) -> list[str]:
+    """Self-heal: bring the live DB's engine skills current with assets/skills/.
+
+    Idempotent UPSERT BY NAME of exactly the engine skills that lag (per
+    stale_engine_skills); returns the names healed, empty when already fresh.
+    This is the cure the tripwire used to only point at — a DB stranded by an
+    in-place `0001` regen repairs itself instead of needing a manual rebuild.
+
+    Project-local skills (name absent from assets/skills/) are never touched:
+    they aren't in the stale set, have no upstream to heal from, and stay
+    durable via content.sql. The caller owns the transaction boundary intent;
+    we commit our own writes."""
+    stale = stale_engine_skills(con)
+    if not stale:
+        return []
+    specs = {s["name"]: s for s in engine_skill_specs()}
+    for name in stale:                       # stale ⊆ asset names, so always hits
+        s = specs[name]
+        con.execute(
+            "INSERT INTO skills (name, description, category, command, common, "
+            "content, is_deleted) VALUES (?, ?, ?, ?, ?, ?, 0) "
+            "ON CONFLICT(name) DO UPDATE SET "
+            "description=excluded.description, category=excluded.category, "
+            "command=excluded.command, common=excluded.common, "
+            "content=excluded.content, is_deleted=0",
+            (s["name"], s["description"], s["category"], s["command"],
+             s["common"], s["content"]),
+        )
+    con.commit()
+    return stale
+
+
 def main() -> int:
     if not SKILLS_DIR.exists():
         sys.exit(f"seed_skills: no {SKILLS_DIR}")

--- a/tests/test_skills_freshness.py
+++ b/tests/test_skills_freshness.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Tests for the engine-skill staleness guard (seed_skills.stale_engine_skills)
+and the render-flat refusal it backs (render._guard_fresh).
+
+Stdlib `unittest`, matching the engine's no-dependency style. Builds a throwaway
+file DB shaped like the shipped engine (schema.sql + every migration), which
+seeds the engine catalogue from 0001 — i.e. the DB starts FRESH, exactly current
+with assets/skills/. The tests then perturb it to prove the guard:
+
+  • fresh DB → no stale skills
+  • an engine skill whose live body was rolled back → flagged (the real bug:
+    a DB built before a `seed-skills` regen carries the old body)
+  • a PROJECT-LOCAL skill (name absent from assets/skills/) → never flagged,
+    even when its body differs from everything. This is the load-bearing
+    property: admin-authored repo-local skills must be safe from a guard that
+    only knows the engine catalogue.
+  • render flat refuses (SystemExit) when an engine skill is stale.
+
+Run:
+    python3 tests/test_skills_freshness.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "render"))
+sys.path.insert(0, str(ENGINE / "scripts"))
+import seed_skills  # noqa: E402
+import render as render_mod  # noqa: E402
+
+
+def build_engine_db(path: Path) -> None:
+    """A throwaway file DB shaped like the shipped engine: schema + every
+    migration (so 0001 seeds the engine catalogue, current with assets)."""
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.commit()
+    con.close()
+
+
+class SkillsFreshnessTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db)
+        self.con.row_factory = sqlite3.Row
+        # A real engine skill name to perturb (first under assets/skills/).
+        self.engine_name = seed_skills.engine_skill_specs()[0]["name"]
+
+    def tearDown(self):
+        self.con.close()
+        for p in sorted(self.tmp.rglob("*"), reverse=True):
+            p.unlink() if p.is_file() else p.rmdir()
+        self.tmp.rmdir()
+
+    def test_fresh_db_has_no_stale_skills(self):
+        self.assertEqual(seed_skills.stale_engine_skills(self.con), [])
+
+    def test_rolled_back_engine_skill_is_flagged(self):
+        # Simulate a DB built before a seed-skills regen: the body lags assets.
+        self.con.execute(
+            "UPDATE skills SET content = content || '\n<stale tail>' WHERE name=?",
+            (self.engine_name,),
+        )
+        self.con.commit()
+        self.assertIn(self.engine_name, seed_skills.stale_engine_skills(self.con))
+
+    def test_missing_engine_skill_is_flagged(self):
+        self.con.execute("DELETE FROM skills WHERE name=?", (self.engine_name,))
+        self.con.commit()
+        self.assertIn(self.engine_name, seed_skills.stale_engine_skills(self.con))
+
+    def test_project_local_skill_never_flagged(self):
+        # A fork-authored skill: name absent from assets/skills/. It has no
+        # upstream to lag, so the guard must ignore it entirely — even though
+        # its content matches nothing in assets.
+        self.con.execute(
+            "INSERT INTO skills (name, description, category, command, common, "
+            "content, is_deleted) VALUES "
+            "('fork_only_skill', 'local', 'fork', NULL, 0, 'bespoke body', 0)"
+        )
+        self.con.commit()
+        stale = seed_skills.stale_engine_skills(self.con)
+        self.assertNotIn("fork_only_skill", stale)
+        self.assertEqual(stale, [])  # local skill didn't perturb the verdict
+
+    def test_render_flat_refuses_when_stale(self):
+        self.con.execute(
+            "UPDATE skills SET content = 'WRONG' WHERE name=?", (self.engine_name,)
+        )
+        self.con.commit()
+        with self.assertRaises(SystemExit):
+            render_mod._guard_fresh(self.con)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skills_freshness.py
+++ b/tests/test_skills_freshness.py
@@ -14,7 +14,8 @@ with assets/skills/. The tests then perturb it to prove the guard:
     even when its body differs from everything. This is the load-bearing
     property: admin-authored repo-local skills must be safe from a guard that
     only knows the engine catalogue.
-  • render flat refuses (SystemExit) when an engine skill is stale.
+  • the self-heal (sync_engine_skills / render._heal_fresh) repairs stale
+    engine skills from assets and leaves project-local skills untouched.
 
 Run:
     python3 tests/test_skills_freshness.py
@@ -95,13 +96,43 @@ class SkillsFreshnessTest(unittest.TestCase):
         self.assertNotIn("fork_only_skill", stale)
         self.assertEqual(stale, [])  # local skill didn't perturb the verdict
 
-    def test_render_flat_refuses_when_stale(self):
+    def test_sync_engine_skills_is_noop_when_fresh(self):
+        self.assertEqual(seed_skills.sync_engine_skills(self.con), [])
+
+    def test_sync_engine_skills_heals_stale(self):
         self.con.execute(
             "UPDATE skills SET content = 'WRONG' WHERE name=?", (self.engine_name,)
         )
         self.con.commit()
-        with self.assertRaises(SystemExit):
-            render_mod._guard_fresh(self.con)
+        healed = seed_skills.sync_engine_skills(self.con)
+        self.assertIn(self.engine_name, healed)
+        # After healing, the DB matches assets again — nothing left stale.
+        self.assertEqual(seed_skills.stale_engine_skills(self.con), [])
+
+    def test_render_heal_fresh_repairs_and_proceeds(self):
+        self.con.execute(
+            "UPDATE skills SET content = 'WRONG' WHERE name=?", (self.engine_name,)
+        )
+        self.con.commit()
+        render_mod._heal_fresh(self.con)          # heals, does not raise
+        self.assertEqual(seed_skills.stale_engine_skills(self.con), [])
+
+    def test_heal_never_touches_project_local_skill(self):
+        self.con.execute(
+            "INSERT INTO skills (name, description, category, command, common, "
+            "content, is_deleted) VALUES "
+            "('fork_only_skill', 'local', 'fork', NULL, 0, 'bespoke body', 0)"
+        )
+        # Force an engine skill stale so the heal actually runs.
+        self.con.execute(
+            "UPDATE skills SET content = 'WRONG' WHERE name=?", (self.engine_name,)
+        )
+        self.con.commit()
+        seed_skills.sync_engine_skills(self.con)
+        body = self.con.execute(
+            "SELECT content FROM skills WHERE name='fork_only_skill'"
+        ).fetchone()[0]
+        self.assertEqual(body, "bespoke body")    # local skill survived untouched
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the "scary" failure from the docs-freshness audit: a live engine DB that lags `assets/skills/` can silently render a **content-deleting** flat mirror, and `render-check`'s old fix-hint (`render flat && git add skills_sc`) told you to commit it.

## Root cause (deterministic)
`./sc seed-skills` rewrites `migrations/0001_seed_skills.sql` **in place**, but the migrate ledger marks `0001` applied by name — so `./sc migrate` never re-seeds it. A DB built before a `seed-skills` regen keeps the **old** skill body until a `./sc rebuild` / `./sc update`. `render flat` faithfully renders that stale cache → a deletion diff that reads as intentional.

## Self-heal (repair, not just detect)
- `seed_skills.stale_engine_skills(con)` — engine skills whose live row lags `assets/skills/`, **scoped by asset-name** (the same partition `snapshot.dump_local_skills` uses).
- `seed_skills.sync_engine_skills(con)` — idempotent UPSERT-by-name of exactly the lagging engine skills, from assets. Returns healed names; no-op when fresh.
- **`run.py` heals at boot** (right after `open_db()`, before anything reads skills) → every booting shell self-repairs. Surfaced as `→ heal:`. Skipped under `RENDER_ONLY`.
- **`render.py` heals then renders** (`_heal_fresh`) → the tracked mirror is always rendered from current engine skills; the content-deleting regression can't happen.

## Hermetic render-check (verification independent of the cache)
- `render_check.py` builds a throwaway DB from **tracked text** (schema + migrations + `.sc-state/content.sql`), renders to a **temp tree**, and diffs vs the committed `_sc` files. Never opens the live DB, never writes the tree. Byte-identical to CI; no `./sc rebuild` first. Still catches a forgotten `seed-skills` (0001 ≠ assets) at commit time.
- `flat.render_visibility` gained an optional `root` (defaults to `REPO_ROOT`). Backward compatible.

## Why repo-local admin skills are safe
They're never in the stale set (no upstream to lag), so the heal never touches them; they stay durable via `content.sql`. Pinned by a test that heals an engine skill while a project-local skill sits byte-for-byte untouched beside it.

## Verification
- `tests/test_skills_freshness.py`: detection (fresh/rolled-back/missing) · heal no-op-when-fresh · heal repairs · `render._heal_fresh` repairs-and-proceeds · **project-local skill never touched**.
- Full suite **121 passed**; `ruff` clean.
- E2E: tampered live `docs` skill → `render flat` **self-healed it from assets** and wrote **no** mirror regression → hermetic `render-check` green.

Independent of #181 (docs freshness) — no file overlap. Engine *code*, so forks pick it up on `./sc update` (no reseed).