### PR TITLE
feat(roadmap): grey side-bar for shipped + park shipped at list bottom

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -220,7 +220,7 @@ def get_skills(con) -> dict:
 # (most-active → farthest-out) — items move LEFT toward shipped as long_term
 # matures to near_term, next, in_progress, shipped. brainstorm (idea inlet) and
 # retired (taken off the board) are the right-hand end caps.
-_ORDER = ["shipped", "in_progress", "next", "near_term", "long_term", "brainstorm", "retired"]
+_ORDER = ["in_progress", "next", "near_term", "long_term", "brainstorm", "retired", "shipped"]
 _LABEL = {"brainstorm": "Brainstorm", "in_progress": "In Progress", "next": "Next",
           "near_term": "Near Term", "long_term": "Long Term", "shipped": "Shipped",
           "retired": "Retired"}

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -485,9 +485,9 @@ function skillRow(s, shells) {
 }
 
 // ── Roadmap ───────────────────────────────────────────────────────────────────
-// Board order: delivered first, then the committed funnel backward (items move
-// LEFT toward shipped); brainstorm/retired are the right-hand end caps.
-const STATUSES = ["shipped", "in_progress", "next", "near_term", "long_term", "brainstorm", "retired"];
+// Board order: the committed funnel (in_progress → long_term), then brainstorm/
+// retired, with delivered (shipped) parked at the bottom of the list.
+const STATUSES = ["in_progress", "next", "near_term", "long_term", "brainstorm", "retired", "shipped"];
 const SLABEL = { brainstorm: "Brainstorm", in_progress: "In Progress", next: "Next", near_term: "Near Term", long_term: "Long Term", shipped: "Shipped", retired: "Retired" };
 // The five stages that sequence (carry dependency edges). brainstorm/retired are
 // excluded from the Flow graph and the blocker editor — they don't relate yet.
@@ -911,11 +911,13 @@ function featureCard(f, candidates = [], projects = []) {
   // summary preview; expanded reveals the editable fields, docs, and blockers.
   // The ⤢ button in the head opens the same editor in a modal.
   const c = el("details", { className: "card feature" });
-  // Spec tasks (implementation plan) → side-bar colour: all done = green,
-  // any still open = sunset orange. No tasks = no side bar.
+  // Side-bar colour: shipped specs are grey regardless of plan state. Otherwise
+  // by spec-task (implementation plan) completion — all done = green, any still
+  // open = sunset orange. No tasks (and not shipped) = no side bar.
   const tasks = f.tasks || [];
   const doneCount = tasks.filter((t) => t.status === "done").length;
-  if (tasks.length) c.classList.add("has-tasks", doneCount === tasks.length ? "tasks-done" : "tasks-open");
+  if (f.roadmap_status === "shipped") c.classList.add("shipped-bar");
+  else if (tasks.length) c.classList.add("has-tasks", doneCount === tasks.length ? "tasks-done" : "tasks-open");
   const sum = el("summary", { className: "feature-head" });
   sum.append(el("span", { className: "feature-title" }, f.title || "(untitled)"));
   const meta = el("span", { className: "feature-meta" });

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -155,9 +155,10 @@ details.feature[open] > .feature-preview { display: none; }
 
 /* spec-task side bar — colours the card's left edge by plan completion. These
    sit after the [open] rule above so they win the border-color cascade. */
-details.feature.has-tasks { border-left-width: 4px; }
+details.feature.has-tasks, details.feature.shipped-bar { border-left-width: 4px; }
 details.feature.tasks-done { border-left-color: var(--ok); }
 details.feature.tasks-open { border-left-color: var(--task-open); }
+details.feature.shipped-bar { border-left-color: var(--lock); }
 .task-list { list-style: none; margin: .2rem 0 .4rem; padding: 0; }
 .task-list li { display: flex; gap: .5rem; align-items: baseline; padding: .2rem 0; font-size: .85rem; }
 .task-list li .box { flex: none; color: var(--dim); }
@@ -535,7 +536,7 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .flow-card.next       { border-left-color: var(--accent); }
 .flow-card.near_term  { border-left-color: var(--lock); }
 .flow-card.long_term  { border-left-color: var(--lock); }
-.flow-card.shipped    { border-left-color: var(--ok); }
+.flow-card.shipped    { border-left-color: var(--lock); }
 .flow-card-title { font-weight: 600; font-size: .85rem; line-height: 1.3; }
 .flow-card-meta { display: flex; gap: .3rem; flex-wrap: wrap; margin-top: .45rem; }
 .flow-card-docs { display: flex; flex-wrap: wrap; gap: .25rem .7rem; margin-top: .45rem; }


### PR DESCRIPTION
## What

Roadmap UI tweaks for shipped specs.

### Side-bar colour
Shipped specs now render a **grey** left side-bar (`var(--lock)`) in both the **Board** and **Flow** views, overriding the existing task-completion colours:

| State | Bar |
|---|---|
| Shipped | **Grey** |
| Not shipped, all spec tasks done | Green |
| Not shipped, any spec task open | Orange |
| Not shipped, no tasks | No bar |

The grey bar shows even when a shipped spec has no plan tasks.

### Ordering
Shipped is moved from the **top** to the **bottom** of the roadmap status list, in both the API bucket order (`_ORDER`, `server.py`) and the UI chip/section order (`STATUSES`, `app.js`). New top→bottom order: In Progress → Next → Near Term → Long Term → Brainstorm → Retired → **Shipped**.

## Files
- `.super-coder/api/server.py` — `_ORDER` reorder
- `.super-coder/ui/app.js` — `shipped-bar` class on shipped cards; `STATUSES` reorder + comment
- `.super-coder/ui/style.css` — grey `details.feature.shipped-bar` rule; `.flow-card.shipped` → grey

## Notes
- Shipped is placed *after* Retired (literally the bottom). Can swap if Retired should stay last.
- In Flow view, shipped grey (`--lock`) now matches `near_term`/`long_term`. Can switch to lighter `--dim` to distinguish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)