### PR TITLE
Default coder shells to opus / gpt-5.5

### DIFF
--- a/.super-coder/migrations/0023_dev_flavor_model_upgrade.sql
+++ b/.super-coder/migrations/0023_dev_flavor_model_upgrade.sql
@@ -1,0 +1,22 @@
+-- 0023 — dev (coder) flavor: default to the premium model on codex + claude
+--
+-- Coder shells should lead with the strongest model their harness offers, not the
+-- fast/cheap tier:
+--   codex   gpt-5.4-mini  -> gpt-5.5   (full, not the mini)
+--   claude  sonnet        -> opus
+-- opencode (open-weight) is left as-is.
+--
+-- flavor_defaults is pure launch config (no FKs, no per-instance memory, not
+-- snapshotted into content.sql), so plain UPDATEs converge fresh rebuilds and
+-- already-installed forks alike. Idempotent / re-runnable: each targets one
+-- (flavor, harness) row by primary key.
+
+BEGIN;
+
+UPDATE flavor_defaults SET model = 'gpt-5.5'
+    WHERE flavor = 'dev' AND harness = 'codex';
+
+UPDATE flavor_defaults SET model = 'opus'
+    WHERE flavor = 'dev' AND harness = 'claude';
+
+COMMIT;


### PR DESCRIPTION
## Why

Coder (`dev`-flavor) shells should lead with the strongest model their harness offers, not the fast/cheap tier.

## What

New migration `0023_dev_flavor_model_upgrade.sql` updates the `flavor_defaults` matrix for the `dev` flavor:

| harness | before | after |
|---|---|---|
| codex | `gpt-5.4-mini` | `gpt-5.5` |
| claude | `sonnet` | `opus` |
| opencode | `ollama-cloud/qwen3-coder-next` | *(unchanged)* |

> Note: the codex default was `gpt-5.4-mini` (there's no "5.5-mini"); the full model is `gpt-5.5`.

## Mechanics

`flavor_defaults` is pure launch config — no FKs, no per-instance memory, **not** snapshotted into `content.sql` — so the `UPDATE`s converge fresh rebuilds and already-installed forks alike (idempotent, keyed by `(flavor, harness)`). The model is resolved at launch in `run.py` (`flavor_defaults()`), not stored per-shell, so existing dev shells pick up the new default on their next boot — no data backfill needed.

Applied locally + `./sc render-check` green (hermetic rebuild applies all 23 migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)