### PR TITLE
fix(branch-guard): judge out-of-tree edits against assigned worktree, not cwd

### DIFF
--- a/.super-coder/scripts/branch-guard.sh
+++ b/.super-coder/scripts/branch-guard.sh
@@ -77,6 +77,21 @@ branch_of() {
 }
 toplevel_of() { git -C "$1" rev-parse --show-toplevel 2>/dev/null || echo ""; }
 
+# The shell's HOME worktree — the tree it is MEANT to edit in. run.py exports
+# SC_SHELL_WORKTREE (the dir it exec's the harness from) for every non-admin
+# shell. "Outside your worktree" is judged against THIS, not the live cwd: a
+# planner/dev/reviewer whose cwd has drifted to the repo root (to run a
+# root-level command) is still working correctly when it edits into its own
+# worktree, so it must not be warned. Falls back to the cwd for callers run.py
+# didn't launch — the git pre-commit backstop, which has no SC_SHELL_WORKTREE.
+home_toplevel() {
+  if [ -n "${SC_SHELL_WORKTREE:-}" ] && [ -d "${SC_SHELL_WORKTREE}" ]; then
+    toplevel_of "$SC_SHELL_WORKTREE"
+  else
+    toplevel_of .
+  fi
+}
+
 feature_branch_hint() {
   echo "    git checkout -b feat/<short-desc>   # or fix/ chore/ docs/" >&2
   echo "then retry. One branch per unit of work — see the 'git' skill (branch -> commit -> push -> PR -> stop)." >&2
@@ -138,9 +153,9 @@ if [ -n "$target" ]; then
     if is_protected "$tgt_branch"; then
       echo "Blocked: this edit targets '$target', which is in repo '$tgt_top' on protected branch '$tgt_branch'." >&2
       echo "You are about to write to a default-branch checkout (often the stale repo root, NOT your worktree)." >&2
-      cwd_top="$(toplevel_of .)"
-      if [ -n "$cwd_top" ] && [ "$cwd_top" != "$tgt_top" ]; then
-        echo "Your worktree is '$cwd_top' (on '$(branch_of .)'). Edit there, or create a feature branch:" >&2
+      home_top="$(home_toplevel)"
+      if [ -n "$home_top" ] && [ "$home_top" != "$tgt_top" ]; then
+        echo "Your worktree is '$home_top' (on '$(branch_of "$home_top")'). Edit there, or create a feature branch:" >&2
       else
         echo "Create a feature branch first:" >&2
       fi
@@ -151,9 +166,9 @@ if [ -n "$target" ]; then
     # allow with a loud warning (the chosen "block protected + warn out-of-tree"
     # policy). additionalContext puts the warning in claude's context; stderr
     # shows it to the human. Other harnesses never reach here (no stdin target).
-    cwd_top="$(toplevel_of .)"
-    if [ -n "$cwd_top" ] && [ "$tgt_top" != "$cwd_top" ]; then
-      warn="⚠ branch-guard: editing '$target' OUTSIDE your worktree. That file is in '$tgt_top' (on '$tgt_branch'); your worktree is '$cwd_top'. Allowed because it is not a protected branch — but cross-tree edits are how stale-tree/wrong-tree mistakes happen. Confirm this path is intentional."
+    home_top="$(home_toplevel)"
+    if [ -n "$home_top" ] && [ "$tgt_top" != "$home_top" ]; then
+      warn="⚠ branch-guard: editing '$target' OUTSIDE your worktree. That file is in '$tgt_top' (on '$tgt_branch'); your worktree is '$home_top'. Allowed because it is not a protected branch — but cross-tree edits are how stale-tree/wrong-tree mistakes happen. Confirm this path is intentional."
       printf '%s\n' "$warn" >&2
       python3 -c 'import json,sys; print(json.dumps({"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":sys.argv[1]}}))' "$warn" 2>/dev/null || true
       exit 0

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -765,6 +765,13 @@ def main() -> None:
     # so it is absent from worktrees; a worktree-relative path failed open). This
     # just saves a subshell per edit on the normal launch path.
     env["SC_ENGINE_DIR"] = str(ENGINE)
+    # The shell's HOME worktree — the dir we exec the harness from (below). The
+    # branch-guard reads it to judge "outside your worktree" against the assigned
+    # tree, not the live cwd: a shell whose cwd has drifted to the repo root (to
+    # run a root-level command) is still working correctly when it edits into its
+    # own worktree, and must not be warned. For admin this is REPO_ROOT, but admin
+    # exits the guard earlier via SC_SHELL_FLAVOR, so it never reads this.
+    env["SC_SHELL_WORKTREE"] = str(work_dir)
     set_terminal_tab_title(full["display_name"])
     os.chdir(work_dir)
     print(f"→ exec {' '.join(cmd)}\n")


### PR DESCRIPTION
Planner/dev/reviewer shells in forks (super-coder, dos-arch) report the branch-guard warning firing on **correct** edits. Cause: the out-of-tree warning compared the edit target's repo against the *live cwd's* repo, but a shell's cwd drifts to the repo root whenever it runs a root-level command. After that drift, a correct edit into the shell's own worktree resolves as `cwd != target-tree` and trips the "editing OUTSIDE your worktree" warning — a pure false positive.

Fix is intent-based: `run.py` exports `SC_SHELL_WORKTREE` (the dir it already `chdir`s the harness into) for every shell, and `branch-guard.sh` judges "outside your worktree" against that **assigned** tree instead of the live cwd. The warning now fires only when a shell genuinely edits outside its worktree; editing correctly into the worktree from any cwd is silent. When the var is absent (the git pre-commit backstop, non-run.py callers) it falls back to the old cwd check, so nothing else changes. The protected-branch **block** and the admin exemption are untouched.

Verified in a real worktree sandbox: cwd-drifted edit into own worktree → silent (was: warn); protected-main target → still blocks; edit into a *different* worktree → still warns; happy path, admin exemption, and stale-var fallback all hold.