### PR TITLE
fix(mem): resolve shell id from SC_SHELL exported at boot

### DIFF
--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -51,6 +51,11 @@ Run from the repo root, like every engine command:
     ./sc mem message send <to-shortname> "<body>"     # from = you
     ./sc mem message mark-read <message_id>
 
+Shell resolution: writes target the booted shell — `$SC_SHELL` (exported at boot
+by run.py), else the `shell/<name>` worktree branch, else the sole non-shared
+shell. Pass `--shell <id|shortname>` (AFTER the leaf command) to override and
+write as another shell.
+
 Common flags: --db <path> (override target; still guarded — used by tests).
 (`--no-sync` is accepted but now a no-op: mem never serializes — that is an
 admin/GUI step.)
@@ -58,6 +63,7 @@ admin/GUI step.)
 from __future__ import annotations
 
 import argparse
+import os
 import sqlite3
 import subprocess
 import sys
@@ -127,8 +133,16 @@ def git_branch() -> str | None:
 
 
 def resolve_shell(con: sqlite3.Connection, spec: str | None) -> int:
-    """--shell wins; else infer from a `shell/<name>` worktree branch; else the
-    sole non-shared shell; else make the caller pick."""
+    """--shell wins; else SC_SHELL (the booted shell's own identity, exported at
+    boot by run.py); else infer from a `shell/<name>` worktree branch; else the
+    sole non-shared shell; else make the caller pick.
+
+    SC_SHELL is the authoritative answer to "which shell am I" — boot knows it
+    for certain, where the git-branch heuristic below fails (admin flavor boots
+    on `main`, or the cwd has drifted to the repo root). An explicit --shell
+    still overrides it, so a shell can deliberately write as another."""
+    if spec is None:
+        spec = os.environ.get("SC_SHELL") or None
     if spec is not None:
         if str(spec).isdigit():
             r = con.execute("SELECT shell_id FROM shells WHERE shell_id=? "
@@ -156,7 +170,12 @@ def resolve_shell(con: sqlite3.Connection, spec: str | None) -> int:
     if len(rs) == 1:
         return rs[0]["shell_id"]
     listing = ", ".join(f"{r['shortname']}(#{r['shell_id']})" for r in rs) or "none"
-    die(f"could not infer the shell — pass --shell <id|shortname>. candidates: {listing}")
+    ex = rs[0]["shortname"] if rs else "<id|shortname>"
+    die("could not infer the shell — name it explicitly.\n"
+        f"     candidates: {listing}\n"
+        f"     the --shell flag goes AFTER the leaf command, e.g.:\n"
+        f"         ./sc mem message check --shell {ex}\n"
+        f"     or export it once for the session:  export SC_SHELL={ex}")
 
 
 # ── write durability ──────────────────────────────────────────────────────────
@@ -615,7 +634,8 @@ def build_parser() -> argparse.ArgumentParser:
     common.add_argument("--db", default=str(DEFAULT_DB), help="engine DB path (default: the fork's)")
     common.add_argument("--no-sync", action="store_true",
                         help="accepted for back-compat; no-op (mem never serializes — admin/GUI step)")
-    common.add_argument("--shell", help="target shell id or shortname (default: inferred)")
+    common.add_argument("--shell", help="target shell id or shortname "
+                        "(default: $SC_SHELL, else inferred from the worktree branch)")
 
     p = argparse.ArgumentParser(prog="sc mem", description="engine memory write surface")
     sub = p.add_subparsers(dest="cmd", required=True)

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -772,6 +772,13 @@ def main() -> None:
     # own worktree, and must not be warned. For admin this is REPO_ROOT, but admin
     # exits the guard earlier via SC_SHELL_FLAVOR, so it never reads this.
     env["SC_SHELL_WORKTREE"] = str(work_dir)
+    # The booted shell's own identity, so engine commands it runs (`./sc mem …`)
+    # resolve "which shell am I" from the environment instead of re-deriving it
+    # from git state. Boot knows this for certain; the git-branch heuristic in
+    # mem.resolve_shell fails for the admin flavor (boots on `main`, no
+    # `shell/<name>` branch) and whenever the cwd has drifted to the repo root.
+    # A deliberate `--shell` still overrides it.
+    env["SC_SHELL"] = full["shortname"] or str(full["shell_id"])
     set_terminal_tab_title(full["display_name"])
     os.chdir(work_dir)
     print(f"→ exec {' '.join(cmd)}\n")

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -17,6 +17,7 @@ Run:
 """
 from __future__ import annotations
 
+import os
 import sqlite3
 import sys
 import tempfile
@@ -51,8 +52,16 @@ class MemTest(unittest.TestCase):
         self.tmp = Path(tempfile.mkdtemp())
         self.db = self.tmp / "shell_db.db"
         build_engine_db(self.db)
+        # resolve_shell now consults SC_SHELL; a value inherited from the dev's
+        # own shell would make inference non-deterministic. Neutralize it here
+        # and let the env-path tests set it explicitly.
+        self._sc_shell = os.environ.pop("SC_SHELL", None)
 
     def tearDown(self):
+        if self._sc_shell is None:
+            os.environ.pop("SC_SHELL", None)
+        else:
+            os.environ["SC_SHELL"] = self._sc_shell
         for p in self.tmp.glob("*"):
             p.unlink()
         self.tmp.rmdir()
@@ -99,6 +108,32 @@ class MemTest(unittest.TestCase):
         try:
             with self.assertRaises(SystemExit):
                 mem.resolve_shell(con, "ghost")
+        finally:
+            con.close()
+
+    def _add_second_shell(self, con):
+        # A second non-shared shell makes the sole-shell fallback ambiguous, so
+        # resolution must come from SC_SHELL or an explicit --shell.
+        con.execute(
+            "INSERT INTO shells (display_name, shortname, mandate, system_prompt, "
+            "user_id, is_shared, has_identity, bootstrapped) "
+            "VALUES ('TD', 'td', 'test', 'sp', 1, 0, 1, 1)")
+        con.commit()
+
+    def test_resolve_from_env(self):
+        con = mem.connect(self.db)
+        try:
+            self._add_second_shell(con)
+            # Ambiguous with no signal — must fail rather than guess.
+            with self.assertRaises(SystemExit):
+                mem.resolve_shell(con, None)
+            # SC_SHELL names the shell, so inference succeeds.
+            os.environ["SC_SHELL"] = "td"
+            self.assertEqual(mem.resolve_shell(con, None),
+                             con.execute("SELECT shell_id FROM shells WHERE "
+                                         "shortname='td'").fetchone()[0])
+            # An explicit --shell still overrides SC_SHELL.
+            self.assertEqual(mem.resolve_shell(con, "tc"), 1)
         finally:
             con.close()
 


### PR DESCRIPTION
## What review caught

Super-coder shells have a hard time with tooling, **especially resolving their own id**. A shell running `./sc mem message check` gets `could not infer the shell — pass --shell …`, then burns several commands discovering that `--shell` is positionally fussy (must come *after* the leaf command) and isn't shown in `./sc mem message --help`.

## Root cause

`mem.resolve_shell()` re-derives *"which shell am I"* on every call from git state — the `shell/<name>` worktree branch — and **throws away what boot already knew for certain**. The launcher exports `SC_SHELL_FLAVOR`, `SC_ENGINE_DIR`, `SC_SHELL_WORKTREE`, but not the shell's own identity. The git-branch heuristic fails for:

- the **admin flavor** (boots on `main`, no `shell/<name>` branch),
- a **cwd that drifted to the repo root** (running a root-level command),
- any **multi-shell fork** where the sole-non-shared-shell fallback can't fire.

## Fix

- **`run.py`** — export `SC_SHELL` (shortname, else id) at exec, so the booted shell's identity travels in the environment.
- **`mem.resolve_shell`** — consult `SC_SHELL` right after the explicit `--shell` flag (which still wins, for deliberate cross-shell writes) and before the git heuristic. In normal operation a shell never resolves its own id from git again.
- **Better failure** — the `could not infer` message now prints a copy-pasteable example with the correct `--shell` position *and* the `SC_SHELL` export. `--help` + the module docstring document the resolution order.

```
could not infer the shell — name it explicitly.
     candidates: dev1(#1), rev1(#2)
     the --shell flag goes AFTER the leaf command, e.g.:
         ./sc mem message check --shell dev1
     or export it once for the session:  export SC_SHELL=dev1
```

## Not in scope (deliberately)

- Making `--shell` position-flexible via argparse parents on both the top parser and leaves hits the well-known subparser default-clobber bug (the leaf's `--shell=None` default wipes a top-level value). `SC_SHELL` sidesteps it.
- The `messaging` / `memory` skill docs could note `SC_SHELL` too, but they propagate to installed forks via a regenerated `0001_seed_skills.sql` — a separable change. The improved error already teaches the flag position inline.

## Tests

`test_resolve_from_env` covers env resolution, ambiguity-fails-loud, and `--shell` override. `setUp` neutralizes an inherited `SC_SHELL` so existing inference tests stay deterministic. Full `test_mem.py` (18) + `test_shell_messaging.py` (7) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)