### PR TITLE
feat(cartographer): Sonnet default, GPT-5.4/GLM-5.2 alternates; stale section detection

### DIFF
--- a/.super-coder/assets/skills/cartographer/SKILL.md
+++ b/.super-coder/assets/skills/cartographer/SKILL.md
@@ -103,10 +103,14 @@ clone where the hooks never got wired.
 1. Re-inspect (step 1) — what changed?
 2. Edit `.sc-state/map.config.json` to match (step 2).
 3. `./sc map-setup` — re-wires hooks (idempotent) + re-maps.
-4. Verify (step 4).
-5. **Describe all NULLs.** Run the description worklist (see Standing jobs § 2)
+4. Verify (step 4). `dr_filepath` stale entries are pruned automatically by the
+   remap — paths that vanished from the repo are deleted from the catalogue.
+5. **Check stale sections.** `dr_section` is authored and never auto-pruned.
+   After any migration or restructure, run the stale-section worklist
+   (see Standing jobs § 1) and DELETE or repath any sections that come back.
+6. **Describe all NULLs.** Run the description worklist (see Standing jobs § 2)
    and fill every `desc IS NULL` file. The worklist must be empty when you leave.
-6. Commit.
+7. Commit.
 
 ## Standing jobs — sections, descriptions & the product DB (the navigation layer)
 
@@ -139,6 +143,14 @@ VALUES ('UI', 'shell_core/ui/', 'SvelteKit substrate UI', 5);
 SELECT path FROM dr_filepath f WHERE NOT EXISTS
   (SELECT 1 FROM dr_section s WHERE f.path LIKE s.path_prefix || '%')
 ORDER BY path;
+
+-- STALE SECTIONS (run after any migration or restructure — dr_filepath pruning
+-- is automatic; dr_section is authored and never auto-pruned):
+SELECT s.name, s.path_prefix, s.description
+FROM dr_section s
+WHERE (SELECT COUNT(*) FROM dr_filepath f WHERE f.path LIKE s.path_prefix || '%') = 0
+ORDER BY s.name;
+-- For each row: DELETE (area gone) or UPDATE path_prefix (area renamed).
 ```
 
 **2. Descriptions (`dr_filepath.desc`)** — fill per-file one-liners (≤100 chars).

--- a/.super-coder/migrations/0024_cartographer_model_refit.sql
+++ b/.super-coder/migrations/0024_cartographer_model_refit.sql
@@ -1,0 +1,28 @@
+-- 0024 — Cartographer flavor: Sonnet as primary, GPT-5.4 + GLM-5.2 as alternates
+--
+-- Cartographer's workload (scripting, semantic extraction, section curation) is
+-- heavier than haiku-tier, and the current codex default (gpt-5.4-mini) is the
+-- cheap/fast variant. Refit:
+--
+--   claude   haiku       -> sonnet    (becomes default harness — Claude over codex)
+--   codex    gpt-5.4-mini -> gpt-5.4  (non-mini; stays as named alternate)
+--   opencode qwen3-coder-next -> glm-5.2  (aligns with reviewer; strong SWE-Bench)
+--
+-- flavor_defaults is pure launch config (no FKs, no per-instance memory, not
+-- snapshotted into content.sql), so plain UPDATEs converge fresh rebuilds and
+-- already-installed forks alike. Idempotent / re-runnable: each targets one
+-- (flavor, harness) row by primary key.
+
+BEGIN;
+
+-- Make claude the default harness for cartographer (was codex)
+UPDATE flavor_defaults SET model = 'sonnet', is_default = 1
+    WHERE flavor = 'cartographer' AND harness = 'claude';
+
+UPDATE flavor_defaults SET model = 'gpt-5.4', is_default = 0
+    WHERE flavor = 'cartographer' AND harness = 'codex';
+
+UPDATE flavor_defaults SET model = 'ollama-cloud/glm-5.2'
+    WHERE flavor = 'cartographer' AND harness = 'opencode';
+
+COMMIT;


### PR DESCRIPTION
Cartographer flavor refit and map hygiene improvement.

**Model defaults (migration 0024):**
- `claude`: `haiku` → `sonnet`, now the default harness (was codex)
- `codex`: `gpt-5.4-mini` → `gpt-5.4` (non-mini, stays as named alternate)
- `opencode`: `qwen3-coder-next` → `glm-5.2` (aligns with reviewer's open-weight pick)

**Stale section detection (skill):**
- The Heal procedure now has an explicit step for checking stale `dr_section` entries — `dr_filepath` stale paths are already auto-pruned on every remap; `dr_section` (authored) is never auto-pruned
- New STALE SECTIONS worklist query surfaces sections whose `path_prefix` matches zero files, so post-migration orphans are visible and actionable

## Test plan
- [ ] `./sc migrate` on an existing install: migration 0024 applies cleanly
- [ ] Verify `flavor_defaults` for cartographer: `claude|sonnet|is_default=1`, `codex|gpt-5.4|0`, `opencode|glm-5.2|0`
- [ ] Boot a cartographer shell: picker shows `claude · sonnet` as default
- [ ] Stale section query returns empty on a clean repo; returns rows after removing a dir that was a section prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)