### PR TITLE
fix(flow): hide flow view when all features are shipped

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -604,6 +604,11 @@ async function renderRoadmapFlow(root, buckets, projects = []) {
     root.append(el("div", { className: "muted" }, "No features in the sequencing stages yet."));
     return;
   }
+  const activeFeats = feats.filter((f) => stageOf[f.feature_id] !== "shipped");
+  if (!activeFeats.length) {
+    root.append(el("div", { className: "muted" }, "All shipped — nothing in progress."));
+    return;
+  }
 
   // Group the sequencing features by work-stream (project_id; null = ungrouped).
   const byProj = new Map();   // key (project_id | null) → { title, features }


### PR DESCRIPTION
On `#roadmap-flow`, the view is meant for tracking in-progress work. If every feature in the sequencing stages is shipped, there's nothing to show — this adds an early return with a clean "All shipped — nothing in progress." message instead of rendering a shipped-only graph.

Board view is unaffected.