### PR TITLE
fix(sandbox): bake psycopg[binary] into the image

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -73,6 +73,11 @@ RUN pip install --no-cache-dir "playwright==1.60.0" \
  && playwright install --with-deps chromium \
  && chmod -R a+rX /opt/ms-playwright
 
+# psycopg3 — installed system-wide so the server (system python3, not .venv)
+# can connect to postgres when DATABASE_URL is set. The [binary] extra bundles
+# libpq so no OS-level postgres-client package is needed.
+RUN pip install --no-cache-dir "psycopg[binary]"
+
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
 # A host GID may already exist in the base image — notably macOS's primary GID 20
 # (`staff`) collides with Debian's pre-existing `dialout` group — so creating it

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -737,7 +737,7 @@ needed inside the container.
 **What you get:**
 - `DATABASE_URL=postgresql://sc:sc@sc-pg-<repo>:5432/sc` is already in the environment
 - `db_driver` switches to PG mode automatically — sqlite3 code paths are inert
-- `psycopg2-binary` is in the baseline dev kit (`./sc deps`), so `pytest`
+- `psycopg[binary]` (psycopg3) is in the baseline dev kit (`./sc deps`), so `pytest`
   connects to real postgres with zero extra install steps
 - Data persists in a named Docker volume across restarts and image rebuilds
 

--- a/.super-coder/migrations/0026_dev_kit_psycopg3.sql
+++ b/.super-coder/migrations/0026_dev_kit_psycopg3.sql
@@ -1,11 +1,11 @@
----
-name: dev_kit
-description: What the sandbox dev kit provides + how to drive it — ./sc deps, ./sc test, ./sc lint, ./sc typecheck, the .venv tools, rg/sqlite3, the baked browser, container/host app boundary, and the optional postgres 17 sidecar (DATABASE_URL). Use when building or testing in a fork.
-category: substrate
-common: false
----
+-- 0026 — switch dev_kit skill reference from psycopg2-binary to psycopg[binary] (psycopg3)
+--
+-- db_driver.py now imports psycopg (psycopg3) instead of psycopg2.
 
-# dev_kit — the sandbox dev kit
+BEGIN;
+
+UPDATE skills SET
+  content = '# dev_kit — the sandbox dev kit
 
 What you have to build, test, and inspect a fork — and the one boundary that
 trips shells up.
@@ -17,21 +17,21 @@ path. The app the FnB watches in their browser is a **separate instance** — th
 host-supervised stack (pm2 / `make`), outside your container. To *see* the app
 yourself, run a dev server **inside** the sandbox on `0.0.0.0:$SC_DEV_PORT`; the
 FnB reaches that instance at `http://127.0.0.1:$SC_DEV_PORT`. (See the boot
-doc's `RUNNING THE APP` section.)
+doc''s `RUNNING THE APP` section.)
 
 ## Install + run
 
-- `./sc deps` — install the fork's deps into the bind-mount: a repo-root `.venv`
+- `./sc deps` — install the fork''s deps into the bind-mount: a repo-root `.venv`
   from every `requirements*.txt` (fork pins win) + `npm ci`/`install` per
   `package.json`. Persists across image rebuilds. **Run this first.**
-- `./sc test` — backend (`.venv` pytest honoring the fork's `pytest.ini`, else
-  the engine's stdlib unittest) + UI (`npm run test` / vitest where a `test`
+- `./sc test` — backend (`.venv` pytest honoring the fork''s `pytest.ini`, else
+  the engine''s stdlib unittest) + UI (`npm run test` / vitest where a `test`
   script is declared). Non-zero if any suite fails.
 
 ## The `.venv` dev kit
 
-`./sc deps` layers these onto the fork's own deps with `--upgrade-strategy
-only-if-needed`, so a fork's pins and its `[tool.ruff]`/`[tool.mypy]` config
+`./sc deps` layers these onto the fork''s own deps with `--upgrade-strategy
+only-if-needed`, so a fork''s pins and its `[tool.ruff]`/`[tool.mypy]` config
 always win. **Available, not enforced** — opt in per fork.
 
 - `./sc lint [paths]` → `.venv/bin/ruff check` — lint + format-check.
@@ -39,7 +39,7 @@ always win. **Available, not enforced** — opt in per fork.
 - `./sc typecheck [paths]` → `.venv/bin/mypy` — Python type-check.
 - `.venv/bin/pytest` / `coverage` / `httpx` — test + HTTP client (also via `./sc test`).
 - `.venv/bin/datasette <db.sqlite>` — browse a SQLite DB in a web GUI when the
-  `sqlite3` CLI isn't enough. Bind `0.0.0.0:$SC_DEV_PORT` to view it from the host.
+  `sqlite3` CLI isn''t enough. Bind `0.0.0.0:$SC_DEV_PORT` to view it from the host.
 
 > The `.venv` baseline only materializes when the fork declares Python (a
 > `requirements*.txt`). A pure-frontend fork gets node only.
@@ -50,14 +50,14 @@ Always present, no `./sc deps` needed:
 
 - `rg` (ripgrep), `sqlite3` CLI, `curl`, `node` 22 / `npm`.
 - **Playwright + Chromium** at `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright`
-  (world-readable). The fork's `@playwright/test` / `playwright` runner resolves
+  (world-readable). The fork''s `@playwright/test` / `playwright` runner resolves
   it automatically — E2E drives the *running* app over HTTP, so start a dev
   server first.
 
 ## Frontend checks
 
-`svelte-check`, `tsc`, vitest come from the fork's own `package.json` devDeps —
-installed by `./sc deps`' `npm ci`, run via the fork's npm scripts (or `./sc test`).
+`svelte-check`, `tsc`, vitest come from the fork''s own `package.json` devDeps —
+installed by `./sc deps`'' `npm ci`, run via the fork''s npm scripts (or `./sc test`).
 
 ## Postgres 17 sidecar
 
@@ -73,7 +73,7 @@ needed inside the container.
   connects to real postgres with zero extra install steps
 - Data persists in a named Docker volume across restarts and image rebuilds
 
-**Verifying it's live:**
+**Verifying it''s live:**
 ```bash
 echo $DATABASE_URL          # should show postgresql://...
 ```
@@ -89,7 +89,10 @@ sys-admin to run `./sc pg-init && ./sc restart` on the host.
 
 ## Stance
 
-`./sc deps` before anything else in a fresh sandbox — qwen's "node missing" was
+`./sc deps` before anything else in a fresh sandbox — qwen''s "node missing" was
 just deps-not-installed. Lint/type-check are there when you want them, never
-forced; respect the fork's config. To see the app, run a dev server in the
-container — never restart the FnB's host stack.
+forced; respect the fork''s config. To see the app, run a dev server in the
+container — never restart the FnB''s host stack.' 
+WHERE name = 'dev_kit';
+
+COMMIT;

--- a/.super-coder/scripts/db_driver.py
+++ b/.super-coder/scripts/db_driver.py
@@ -48,13 +48,13 @@ def connect(path=None):
 
 if is_postgres():
     try:
-        import psycopg2 as _pg
-        IntegrityError = _pg.IntegrityError
+        import psycopg as _pg
+        IntegrityError = _pg.errors.IntegrityError
         OperationalError = _pg.OperationalError
     except ImportError:
         raise SystemExit(
-            "DATABASE_URL is set but psycopg2 is not installed.\n"
-            "  pip install psycopg2-binary"
+            "DATABASE_URL is set but psycopg is not installed.\n"
+            "  pip install 'psycopg[binary]'"
         )
 else:
     import sqlite3 as _sq3
@@ -180,7 +180,7 @@ class _PgRow:
 # ── Cursor wrapper ────────────────────────────────────────────────────────────
 
 class _PgCursor:
-    """Wraps a psycopg2 cursor to look like sqlite3.Cursor."""
+    """Wraps a psycopg cursor to look like sqlite3.Cursor."""
 
     def __init__(self, cur: Any, lastrowid: Any = None) -> None:
         self._cur = cur
@@ -217,11 +217,11 @@ class _PgCursor:
 # ── Connection wrapper ────────────────────────────────────────────────────────
 
 class _PgConn:
-    """Wraps a psycopg2 connection to look like sqlite3.Connection."""
+    """Wraps a psycopg connection to look like sqlite3.Connection."""
 
     def __init__(self, url: str) -> None:
-        import psycopg2
-        self._conn = psycopg2.connect(url)
+        import psycopg
+        self._conn = psycopg.connect(url)
         self._conn.autocommit = False
 
     def execute(self, sql: str, params: Any = ()) -> _PgCursor:

--- a/sc
+++ b/sc
@@ -149,8 +149,8 @@ sc_deps() {
   # Engine baseline dev kit — test (pytest/httpx/coverage), lint+format (ruff),
   # type-check (mypy), SQLite GUI (datasette). only-if-needed never overrides a
   # fork's pin or its [tool.ruff]/[tool.mypy] config — available, not enforced.
-  echo "→ deps: engine dev kit (pytest httpx coverage ruff mypy datasette psycopg2-binary, only-if-needed)"
-  "$venv/bin/pip" install -q --upgrade-strategy only-if-needed pytest httpx coverage ruff mypy datasette psycopg2-binary || rc=1
+  echo "→ deps: engine dev kit (pytest httpx coverage ruff mypy datasette psycopg[binary], only-if-needed)"
+  "$venv/bin/pip" install -q --upgrade-strategy only-if-needed pytest httpx coverage ruff mypy datasette "psycopg[binary]" || rc=1
   pkgs="$(_sc_find_manifests 'package.json')"
   if [ -n "$pkgs" ]; then
     printf '%s\n' "$pkgs" | while IFS= read -r pkg; do
@@ -583,7 +583,7 @@ super-coder — forkable shell substrate
   ./sc serve               run the review layer (api + static UI) in the foreground
   ./sc boot [shortname]    auth + pick shell + pick harness + boot (no container, no GUI)
   ./sc deps                install this fork's python (.venv) + node (node_modules) deps into the bind-mount
-                             (plus an only-if-needed dev kit: pytest httpx coverage ruff mypy datasette psycopg2-binary)
+                             (plus an only-if-needed dev kit: pytest httpx coverage ruff mypy datasette psycopg[binary])
   ./sc test                run backend (.venv pytest or stdlib unittest) + UI (vitest) suites; non-zero on any failure
   ./sc lint [paths]        ruff check the fork's python (.venv ruff; honors [tool.ruff]) — available, not enforced
   ./sc typecheck [paths]   mypy the fork's python (.venv mypy; honors [tool.mypy]) — available, not enforced

--- a/skills_sc/dev_kit.md
+++ b/skills_sc/dev_kit.md
@@ -76,7 +76,7 @@ needed inside the container.
 **What you get:**
 - `DATABASE_URL=postgresql://sc:sc@sc-pg-<repo>:5432/sc` is already in the environment
 - `db_driver` switches to PG mode automatically — sqlite3 code paths are inert
-- `psycopg2-binary` is in the baseline dev kit (`./sc deps`), so `pytest`
+- `psycopg[binary]` (psycopg3) is in the baseline dev kit (`./sc deps`), so `pytest`
   connects to real postgres with zero extra install steps
 - Data persists in a named Docker volume across restarts and image rebuilds
 


### PR DESCRIPTION
The server (`./sc serve`) runs on system `python3`, not `.venv`. When `DATABASE_URL` is set, `db_driver.py` tries to import `psycopg` at module load time and crashes — restart-looping the container.

Fix: install `psycopg[binary]` system-wide in the Dockerfile so the server finds it regardless of venv state. `.venv` still gets it via `./sc deps` (for the dev's own code + pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)