### PR TITLE
fix(snapshot): PRAGMA foreign_keys=OFF must be outside BEGIN/COMMIT

### DIFF
--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -11,10 +11,11 @@ stays local. It never propagates to forks (that is migrations' job). Engine
 skills are seeded from assets/ via migrations. Project-local skills are dumped
 here so a fork can author its own skills without upstreaming them.
 
-The snapshot wraps its body in PRAGMA foreign_keys=OFF/ON so tables can be
-dumped in readability order (parents before children) rather than strict FK
-dependency order — useful when a self-referential or circular FK makes a strict
-ordering impossible, and the rebuild's db_driver.connect() sets FK enforcement ON.
+The snapshot wraps its body in PRAGMA foreign_keys=OFF/ON (outside the
+transaction — SQLite ignores the pragma inside BEGIN/COMMIT) so tables can
+be dumped in readability order rather than strict FK dependency order.
+Needed because db_driver.connect() sets PRAGMA foreign_keys=ON on the
+connection that rebuild.py uses to load the snapshot.
 
 Usage:
     python3 .super-coder/scripts/snapshot.py
@@ -248,14 +249,14 @@ def main() -> int:
             "-- propagates to forks). Do not hand-edit — author via the shell or GUI, then",
             "-- `./sc snapshot`.",
             "",
-            "BEGIN;",
             "PRAGMA foreign_keys=OFF;",
+            "BEGIN;",
             "",
         ]
         for table in PER_INSTANCE_TABLES:
             if table_exists(con, table):
                 out.extend(dump_table(con, table))
-        out.extend(["PRAGMA foreign_keys=ON;", "COMMIT;"])
+        out.extend(["COMMIT;", "PRAGMA foreign_keys=ON;"])
         OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
         OUT_PATH.write_text("\n".join(out) + "\n")
     finally:


### PR DESCRIPTION
Follow-up to #199. The pragma placement was wrong — SQLite silently ignores `PRAGMA foreign_keys` inside an active transaction. Placing it inside `BEGIN;...COMMIT;` had no effect; shells FK on `active_archive_id` still fired during rebuild.

Fix: move both pragmas outside the transaction block.

**Before (#199):**
```sql
BEGIN;
PRAGMA foreign_keys=OFF;   ← ignored inside transaction
...
PRAGMA foreign_keys=ON;    ← also ignored
COMMIT;
```

**After:**
```sql
PRAGMA foreign_keys=OFF;   ← takes effect
BEGIN;
...
COMMIT;
PRAGMA foreign_keys=ON;    ← restores
```

Verified: `./sc rebuild` passes clean on dos-arch with a full 8-shell snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)