### PR TITLE
fix(pg): rollback on heal failure so authenticate isn't poisoned

### DIFF
--- a/.super-coder/scripts/db_driver.py
+++ b/.super-coder/scripts/db_driver.py
@@ -276,6 +276,9 @@ class _PgConn:
     def commit(self) -> None:
         self._conn.commit()
 
+    def rollback(self) -> None:
+        self._conn.rollback()
+
     def close(self) -> None:
         self._conn.close()
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -591,6 +591,10 @@ def main() -> None:
             if healed:
                 heal_note = f"{len(healed)} stale engine skill(s) → {', '.join(healed)}"
         except Exception:
+            try:
+                con.rollback()
+            except Exception:
+                pass
             heal_note = None
 
     user = authenticate(con)


### PR DESCRIPTION
When `sync_engine_skills` raises (e.g. missing column in a fresh PG schema on first boot), psycopg leaves the transaction in an aborted state. The best-effort `except Exception:` block swallowed the error but never called `rollback()`, so the very next `execute()` in `authenticate()` hit `InFailedSqlTransaction` — a cryptic error that looked like auth was broken, not the self-heal step.

## Changes
- `_PgConn.rollback()` — adds the method that was missing from the sqlite3-compatible interface
- `run.py` heal-failure handler — calls `con.rollback()` before continuing so the connection is clean for `authenticate()`

## Test plan
- [ ] `./sc pg-init && ./sc pg-up && ./sc launch`, then `./sc enter` on a fork with a fresh PG DB that hasn't been fully migrated — should reach the username prompt instead of crashing
- [ ] Normal PG boot (fully migrated DB) unaffected