### PR TITLE
fix(pg): decouple engine DB from host-app DATABASE_URL

### DIFF
--- a/.super-coder/schema_pg.sql
+++ b/.super-coder/schema_pg.sql
@@ -310,7 +310,7 @@ CREATE TABLE IF NOT EXISTS dr_filepath (
     role     TEXT,
     bytes    INTEGER,
     lines    INTEGER,
-    desc     TEXT
+    "desc"   TEXT
 );
 
 CREATE TABLE IF NOT EXISTS dr_section (

--- a/.super-coder/scripts/db_driver.py
+++ b/.super-coder/scripts/db_driver.py
@@ -20,7 +20,7 @@ import os
 import re
 from typing import Any
 
-_URL: str = os.environ.get("DATABASE_URL", "").strip()
+_URL: str = os.environ.get("SC_DATABASE_URL", "").strip()
 
 
 def is_postgres() -> bool:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -73,6 +73,7 @@ ENGINE_PATHS = [
     ".super-coder/aliases.mk",
     ".super-coder/Dockerfile",
     ".super-coder/schema.sql",
+    ".super-coder/schema_pg.sql",
     ".super-coder/map_schema.sql",
     ".super-coder/ecosystem.config.cjs",
     ".super-coder/README.md",


### PR DESCRIPTION
## Summary

- **`db_driver.py`**: engine now reads `SC_DATABASE_URL` instead of `DATABASE_URL`. Host apps keep `DATABASE_URL`; the engine only uses PG when `SC_DATABASE_URL` is explicitly set.
- **`update.py`**: adds `schema_pg.sql` to `ENGINE_PATHS` so it propagates to forks on `./sc update`.
- **`schema_pg.sql`**: quotes the `desc` column name — it's a reserved word in PostgreSQL.

## Context

In forks like dos-arch, `DATABASE_URL` is injected into the sandbox container so the host app (FastAPI) can reach Postgres. The engine was unintentionally picking it up via `db_driver.py` and switching to PG mode, then crashing because the PG database has no engine schema.

The fix decouples them: `DATABASE_URL` stays for the host app, `SC_DATABASE_URL` is the explicit opt-in for running the engine itself on Postgres.

## Test plan
- [ ] `./sc launch` in dos-arch (with pg sidecar): `make enter` reaches the username prompt — engine stays on SQLite, `DATABASE_URL` available in shell env for app use
- [ ] Fresh fork with `SC_DATABASE_URL` set: engine connects to PG as before