### PR TITLE
fix(skills): dead mem-skill refs + snapshot leak in db_map (post-202)

### DIFF
--- a/.super-coder/migrations/0029_fix_db_map_skill_snapshot_ref.sql
+++ b/.super-coder/migrations/0029_fix_db_map_skill_snapshot_ref.sql
@@ -1,0 +1,15 @@
+-- 0029 — db_map skill: remove "grants via snapshot" from skills/shell_skills write rule
+--
+-- The skills row was left with "catalogue via migration; grants via snapshot" in the
+-- Write rule column after 0028, leaking admin-only snapshot awareness to shells.
+-- Replace with "managed by engine" — opaque to non-admin shells.
+
+BEGIN;
+
+UPDATE skills SET content = replace(
+    content,
+    'catalogue via migration; grants via snapshot',
+    'managed by engine'
+) WHERE name = 'db_map' AND is_deleted = 0;
+
+COMMIT;

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -194,7 +194,7 @@ def render_api(port: "int | None", api_key: "str | None") -> str:
         f"- **Base URL:** `http://127.0.0.1:{port}`\n"
         "- **Token:** available as `$SC_API_TOKEN` in your environment (set at launch).\n\n"
         "Write memory via `./sc mem` (proxied here automatically when `SC_API_TOKEN` is set). "
-        "Read messages: `GET /_sc/mem/messages`. Full endpoint list: the `mem` skill."
+        "Read messages: `GET /_sc/mem/messages`. Command reference: the `memory` and `db_map` skills."
     )
 
 

--- a/.super-coder/templates/shell_system_prompt.md
+++ b/.super-coder/templates/shell_system_prompt.md
@@ -26,7 +26,7 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 Write as it happens, not at close. **Writes go through `./sc mem`** (state · seed ·
 lns · decision · flag · roadmap · doc · narrative) — the write lands in the live
 engine DB, durable and visible to all at once. `./sc mem which` to orient. See the
-`mem` skill.
+`memory` and `db_map` skills.
 
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is generated from the DB.

--- a/skills_sc/db_map.md
+++ b/skills_sc/db_map.md
@@ -39,7 +39,7 @@ memory/identity/content. Don't look for `dr_*` in `shell_db.db`.
 | `feature_blockers` | the roadmap's dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite must land first). Directed, kept acyclic (the GUI Flow view wires them; the card's "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `./sc mem roadmap depends` |
 | `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
-| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | catalogue via migration; grants via snapshot |
+| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine |
 | `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a **work-stream** that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
 
 `<self>` = your `shell_id` (in the boot doc's ACTIVE SESSION block).


### PR DESCRIPTION
Three consistency fixes from the post-merge review of #202.

**Dead skill name `mem`** — `shell_system_prompt.md` and `render_api()` in `compose.py` both referenced "the `mem` skill", which doesn't exist. The skills are named `memory` and `db_map`. Updated both to the correct names.

**Snapshot leak in `db_map`** — The `skills`/`shell_skills` row in the db_map table still said "grants via snapshot" in the Write rule column, leaking admin-only snapshot awareness to non-admin shells. Migration 0028 (which the PR was supposed to clean up) preserved it. Fixed in `skills_sc/db_map.md` and migration 0029 patches the DB row in place.

## Test plan

- [ ] Boot a shell — `## API` block says "the `memory` and `db_map` skills"
- [ ] `shell_system_prompt.md` fix visible in rendered `CLAUDE.md`
- [ ] `./sc migrate` on an existing fork applies 0029 cleanly; `db_map` skill no longer mentions snapshot