### PR TITLE
feat(branch-guard): SC_SHARED_DIRS exemption for host-level shared folders

### DIFF
--- a/.super-coder/adapters/claude/README.md
+++ b/.super-coder/adapters/claude/README.md
@@ -32,10 +32,13 @@ branch — so a worktree shell writing to the stale repo-root checkout is caught
 not just one whose own cwd is on `main`; an out-of-worktree edit to a feature
 branch is allowed with a warning. With no stdin target it falls back to the cwd's
 branch. Protected set defaults to `main master`; override per-fork with
-`SC_PROTECTED_BRANCHES` (space-separated). This is the enforcement behind the
-`git` skill and the boot-template VERSION CONTROL rule — a skill loads too late to
-stop the first edit; the hook fires before it. Re-emitted (idempotently) each
-launch, so it survives `./sc update`.
+`SC_PROTECTED_BRANCHES` (space-separated). Set `SC_SHARED_DIRS` (space-separated
+absolute paths) to declare host-level shared directories that all shells may write
+into without warnings — handoff folders, screenshot dirs, cross-shell scratch.
+These are fully exempt from both the branch block and the out-of-worktree warning.
+This is the enforcement behind the `git` skill and the boot-template VERSION
+CONTROL rule — a skill loads too late to stop the first edit; the hook fires
+before it. Re-emitted (idempotently) each launch, so it survives `./sc update`.
 
 `scripts/branch-guard.sh` is the **one** branch-decision script shared by all four
 harnesses (claude + codex hooks, the opencode plugin, the git pre-commit backstop)

--- a/.super-coder/scripts/branch-guard.sh
+++ b/.super-coder/scripts/branch-guard.sh
@@ -139,6 +139,21 @@ if [ -n "$target" ]; then
   fi
 fi
 
+# ── Shared-dir exemption: SC_SHARED_DIRS ────────────────────────────────────
+# Operator-declared dirs that all shells may write into regardless of branch or
+# worktree — host-level shared folders used for handoffs, screenshots, drafts.
+# Set SC_SHARED_DIRS to a space-separated list of absolute paths in the launch
+# environment; run.py passes it through unchanged. Only applies when we have a
+# resolved target (no-target callers like codex apply_patch still use Check 2).
+if [ -n "$target" ] && [ -n "${SC_SHARED_DIRS:-}" ]; then
+  abs_target="$(realpath -m "$target" 2>/dev/null || echo "$target")"
+  for _sd in $SC_SHARED_DIRS; do
+    case "$abs_target" in
+      "${_sd%/}" | "${_sd%/}"/* ) exit 0 ;;
+    esac
+  done
+fi
+
 if [ -n "$target" ]; then
   # Deepest existing ancestor dir of the target (a new file's dir exists; its
   # path does not yet) so `git -C` has a real dir to resolve from.

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -787,6 +787,12 @@ def main() -> None:
     # `shell/<name>` branch) and whenever the cwd has drifted to the repo root.
     # A deliberate `--shell` still overrides it.
     env["SC_SHELL"] = full["shortname"] or str(full["shell_id"])
+    # Operator-declared shared dirs that all shells may write into without
+    # branch-guard warnings — host-level handoff/screenshot folders. Set
+    # SC_SHARED_DIRS (space-separated absolute paths) in the launch environment;
+    # run.py passes it through automatically (via {**os.environ} above), so no
+    # explicit assignment is needed. This comment documents it as a first-class
+    # supported env var alongside SC_PROTECTED_BRANCHES and SC_SHELL_WORKTREE.
     set_terminal_tab_title(full["display_name"])
     os.chdir(work_dir)
     print(f"→ exec {' '.join(cmd)}\n")


### PR DESCRIPTION
Shells writing to host-level shared dirs (handoffs, screenshots, cross-shell scratch) were hitting the **protected-branch block** — not just the out-of-tree warning — because those dirs sit inside the substrate repo on `main`.

## What changed

- **`branch-guard.sh`**: new `SC_SHARED_DIRS` exemption block, placed after the scratch exemption and before Check 1's git resolution. Any target whose resolved path starts with a declared shared dir exits 0 immediately — exempt from both the branch block and the out-of-tree warning.
- **`run.py`**: comment documents `SC_SHARED_DIRS` as a first-class supported env var (no code change needed — `{**os.environ}` already passes it through).
- **`adapters/claude/README.md`**: documents the env var alongside `SC_PROTECTED_BRANCHES`.

## Usage

Set `SC_SHARED_DIRS` in the launch environment before calling `./sc run`:

```bash
export SC_SHARED_DIRS="/home/user/substrate/shared"
```

Space-separated for multiple paths. The guard uses `realpath -m` so unresolved symlinks and not-yet-created files match correctly.

## Test plan

- [ ] Write to a path under `SC_SHARED_DIRS` while cwd is on `main` → allowed, no block
- [ ] Write to a path under `SC_SHARED_DIRS` while in a feature-branch worktree → allowed, no warning
- [ ] Write to an unrelated out-of-tree path → existing warning still fires
- [ ] Write to a protected-branch repo outside shared → still blocked
- [ ] `SC_SHARED_DIRS` unset → no change to existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)