### PR TITLE
fix(update): tolerate engine paths retired upstream

### DIFF
--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -131,6 +131,27 @@ def super_coder_remote() -> str:
              "  git remote add super-coder https://github.com/jedbjorn/super-coder.git")
 
 
+def _engine_paths_at(ref: str) -> list[str]:
+    """ENGINE_PATHS that actually exist at `ref` (blob or tree).
+
+    `git archive` aborts wholesale if any pathspec matches nothing, so a single
+    engine file retired upstream (e.g. a dropped schema variant) would otherwise
+    break every fork's update the one time it crosses that deletion. Filter to
+    the paths present at `ref` — and report what was dropped, never silently."""
+    present, missing = [], []
+    for p in ENGINE_PATHS:
+        exists = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "cat-file", "-e", f"{ref}:{p}"],
+            capture_output=True).returncode == 0
+        (present if exists else missing).append(p)
+    if missing:
+        print(f"  note: {len(missing)} engine path(s) absent at {ref[:12]} "
+              f"(retired upstream) — skipping: {', '.join(missing)}")
+    if not present:
+        sys.exit(f"update: no engine paths exist at {ref} — wrong ref or remote?")
+    return present
+
+
 def materialize_engine(ref: str) -> None:
     """Write the engine paths at `ref` into the working tree WITHOUT touching the
     git index — the engine is gitignored, so a `git checkout -- <paths>` (which
@@ -139,7 +160,7 @@ def materialize_engine(ref: str) -> None:
     in place. (Files deleted upstream linger until a future doctor sweep — same
     gap the old checkout had; acceptable for a wholesale-overwrite dependency.)"""
     archive = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "archive", ref, "--", *ENGINE_PATHS],
+        ["git", "-C", str(REPO_ROOT), "archive", ref, "--", *_engine_paths_at(ref)],
         capture_output=True)
     if archive.returncode != 0:
         sys.exit("update: git archive of the engine failed:\n"


### PR DESCRIPTION
## Why

`materialize_engine` builds the engine tree with `git archive <ref> -- *ENGINE_PATHS`. **`git archive` aborts wholesale if any pathspec matches nothing at the ref.** So the one time a fork's update crosses a commit that *deleted* an engine file, the fork's still-running *old* updater (whose `ENGINE_PATHS` still lists the now-deleted path) kills the entire update:

```
update: git archive of the engine failed:
fatal: pathspec '.super-coder/schema_pg.sql' did not match any files
```

This bit **every fork** updating across #207 (which dropped `schema_pg.sql`). The band-aid is to hand-remove the path from the fork's materialized updater once; this PR is the durable fix so the next engine-file deletion degrades gracefully instead of breaking fork updates.

## What

Add `_engine_paths_at(ref)`: filters `ENGINE_PATHS` to the paths that exist at the target ref (via `git cat-file -e <ref>:<path>`, which resolves blobs **and** trees), and `materialize_engine` archives only those.

- Dropped paths are **logged**, never silently skipped (`note: N engine path(s) absent at <ref> (retired upstream) — skipping: …`).
- Bails only if *nothing* resolves (wrong ref/remote).

## Scope

- Hardens **future** updates. A fork already mid-cross runs its *old* updater and still needs the deleted path removed by hand that one time — unavoidable (the running updater is the pre-fix one).
- Unchanged: files deleted upstream still linger on disk after `tar -x` (documented, doctor-sweep territory).

## Verification

- `cat-file -e` existence check distinguishes blob (`sc`) / tree (`.super-coder/scripts`, `migrations`) / missing (`.super-coder/schema_pg.sql`).
- `_engine_paths_at("HEAD")` with an injected deleted path drops only that path, keeps the rest, and emits the skip note.
- `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)