### PR TITLE
fix(mem): purge API-only staleness from skills, dispatcher, boot doc + dead SC_SHELL

### DIFF
--- a/.super-coder/assets/skills/bootstrap/SKILL.md
+++ b/.super-coder/assets/skills/bootstrap/SKILL.md
@@ -44,7 +44,7 @@ cartographer's automation (see `surface_catalogue`). You read it.
 
 4. **Set your `current_state`** — replace the install placeholder with what you
    actually found and what you'll do first (rolling status, ~500 chars). Write it
-   through `./sc mem` (resolves + guards the engine DB; the write is live in the
+   through `./sc mem` (routes through the engine API; the write is live in the
    shared DB at once):
    ```
    ./sc mem state "…"

--- a/.super-coder/assets/skills/db_map/SKILL.md
+++ b/.super-coder/assets/skills/db_map/SKILL.md
@@ -63,8 +63,9 @@ memory/identity/content. Don't look for `dr_*` in `shell_db.db`.
 
 ## Common writes
 
-Each guards the engine DB and writes to the live shared DB. `./sc mem which` orients;
-`./sc mem <cmd> -h` shows flags. Writes target your shell by default (`--shell` to override).
+Each routes through the engine API and writes to the live shared DB. `./sc mem which`
+orients; `./sc mem <cmd> -h` shows flags. Writes always target your own shell —
+the server resolves it from your token; you never name a shell.
 
 ```
 # current_state (rolling status, not a log — replaces in place):

--- a/.super-coder/assets/skills/docs/SKILL.md
+++ b/.super-coder/assets/skills/docs/SKILL.md
@@ -82,7 +82,7 @@ sqlite3 .sc-state/map.db "SELECT path FROM dr_filepath WHERE role='doc';"  -- re
 
 ## Author
 
-Write through `./sc mem doc add` — it guards the engine DB, `--body-file` reads
+Write through `./sc mem doc add` — it routes through the engine API, `--body-file` reads
 the markdown from a file (no shell-escaping a long body), `--seq` auto-increments
 within `(feature, kind)`, and it renders + snapshots for you (the render/snapshot
 pipeline this rides on is the `snapshot` skill):

--- a/.super-coder/assets/skills/flags/SKILL.md
+++ b/.super-coder/assets/skills/flags/SKILL.md
@@ -23,7 +23,7 @@ the blocked feature's title. Reads go through the API — there is no `sqlite3`.
 
 ## Open
 
-Write through `./sc mem` (it guards the engine DB + snapshots):
+Write through `./sc mem` (routed through the engine API):
 ```
 ./sc mem flag open "[Area] what's blocked | Blocker for: X" --name SC-001 --priority Medium [--feature <id>]
 ```

--- a/.super-coder/assets/skills/memory/SKILL.md
+++ b/.super-coder/assets/skills/memory/SKILL.md
@@ -11,8 +11,9 @@ All memory is DB rows (no flat files). Write at the moment it matters, not in a
 close ritual.
 
 **Write through `./sc mem`.** The write lands in the live engine DB — shared by
-every shell, durable + visible to all the moment it commits. Writes default to
-your shell; pass `--shell <id|name>` to be explicit.
+every shell, durable + visible to all the moment it commits. It always targets
+your own shell: the server resolves your identity from your token, so you never
+name a shell.
 
 ## current_state — rolling status, NOT a log
 

--- a/.super-coder/assets/skills/onboard/SKILL.md
+++ b/.super-coder/assets/skills/onboard/SKILL.md
@@ -28,8 +28,8 @@ For each doc, read the file and decide together:
   feature.
 Skip noise (changelogs, license, vendored docs) unless the FnB wants it.
 
-All writes here go through `./sc mem` (it guards the engine DB so the import never
-lands in the app DB, and writes to the live shared DB).
+All writes here go through `./sc mem` (routed through the engine API, which writes
+to the live shared DB — the import never touches the app DB).
 
 ## 3. Backfill the roadmap
 Create a feature for each coherent area/initiative the docs imply; set status by

--- a/.super-coder/assets/skills/spec/SKILL.md
+++ b/.super-coder/assets/skills/spec/SKILL.md
@@ -118,13 +118,13 @@ list and INSERT it. Always this shape:
 | 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
 | N+1 | Verification | Always last — run tests, smoke-test against done-condition, snapshot + render |
 
-Add each task with `./sc mem task add` (one per seq). For a multi-task plan, pass
-`--no-sync` on all but the last so you snapshot once at the end:
+Add each task with `./sc mem task add` (one per seq) — each write is live in the
+shared DB immediately:
 
 ```
-./sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points" --no-sync
-./sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>" --no-sync
-./sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>" --no-sync
+./sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points"
+./sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>"
+./sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>"
 ./sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, snapshot + render"
 ```
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -141,7 +141,7 @@ cartographer''s automation (see `surface_catalogue`). You read it.
 
 4. **Set your `current_state`** — replace the install placeholder with what you
    actually found and what you''ll do first (rolling status, ~500 chars). Write it
-   through `./sc mem` (resolves + guards the engine DB; the write is live in the
+   through `./sc mem` (routes through the engine API; the write is live in the
    shared DB at once):
    ```
    ./sc mem state "…"
@@ -628,8 +628,9 @@ memory/identity/content. Don''t look for `dr_*` in `shell_db.db`.
 
 ## Common writes
 
-Each guards the engine DB and writes to the live shared DB. `./sc mem which` orients;
-`./sc mem <cmd> -h` shows flags. Writes target your shell by default (`--shell` to override).
+Each routes through the engine API and writes to the live shared DB. `./sc mem which`
+orients; `./sc mem <cmd> -h` shows flags. Writes always target your own shell —
+the server resolves it from your token; you never name a shell.
 
 ```
 # current_state (rolling status, not a log — replaces in place):
@@ -839,7 +840,7 @@ sqlite3 .sc-state/map.db "SELECT path FROM dr_filepath WHERE role=''doc'';"  -- 
 
 ## Author
 
-Write through `./sc mem doc add` — it guards the engine DB, `--body-file` reads
+Write through `./sc mem doc add` — it routes through the engine API, `--body-file` reads
 the markdown from a file (no shell-escaping a long body), `--seq` auto-increments
 within `(feature, kind)`, and it renders + snapshots for you (the render/snapshot
 pipeline this rides on is the `snapshot` skill):
@@ -1292,7 +1293,7 @@ the blocked feature''s title. Reads go through the API — there is no `sqlite3`
 
 ## Open
 
-Write through `./sc mem` (it guards the engine DB + snapshots):
+Write through `./sc mem` (routed through the engine API):
 ```
 ./sc mem flag open "[Area] what''s blocked | Blocker for: X" --name SC-001 --priority Medium [--feature <id>]
 ```
@@ -1854,8 +1855,9 @@ All memory is DB rows (no flat files). Write at the moment it matters, not in a
 close ritual.
 
 **Write through `./sc mem`.** The write lands in the live engine DB — shared by
-every shell, durable + visible to all the moment it commits. Writes default to
-your shell; pass `--shell <id|name>` to be explicit.
+every shell, durable + visible to all the moment it commits. It always targets
+your own shell: the server resolves your identity from your token, so you never
+name a shell.
 
 ## current_state — rolling status, NOT a log
 
@@ -2098,8 +2100,8 @@ For each doc, read the file and decide together:
   feature.
 Skip noise (changelogs, license, vendored docs) unless the FnB wants it.
 
-All writes here go through `./sc mem` (it guards the engine DB so the import never
-lands in the app DB, and writes to the live shared DB).
+All writes here go through `./sc mem` (routed through the engine API, which writes
+to the live shared DB — the import never touches the app DB).
 
 ## 3. Backfill the roadmap
 Create a feature for each coherent area/initiative the docs imply; set status by
@@ -2643,13 +2645,13 @@ list and INSERT it. Always this shape:
 | 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
 | N+1 | Verification | Always last — run tests, smoke-test against done-condition, snapshot + render |
 
-Add each task with `./sc mem task add` (one per seq). For a multi-task plan, pass
-`--no-sync` on all but the last so you snapshot once at the end:
+Add each task with `./sc mem task add` (one per seq) — each write is live in the
+shared DB immediately:
 
 ```
-./sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points" --no-sync
-./sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>" --no-sync
-./sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>" --no-sync
+./sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points"
+./sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>"
+./sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>"
 ./sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, snapshot + render"
 ```
 

--- a/.super-coder/migrations/0032_reseed_mem_api_only_cleanup.sql
+++ b/.super-coder/migrations/0032_reseed_mem_api_only_cleanup.sql
@@ -1,0 +1,455 @@
+-- 0032 — reseed mem skills after the API-only cleanup (follow-up to #211).
+--
+-- #211 made `./sc mem` API-only but left stale guidance in several skill bodies:
+-- removed flags (`--shell`, `--no-sync`) and removed behavior ("resolves +
+-- guards the engine DB"). The assets are now fixed and 0001 regenerated. Three
+-- of them are reseeded by LATER migrations — db_map (0028/0029/0031), memory
+-- (0028), spec (0014) — so a full migration replay would otherwise end on their
+-- pre-cleanup bodies. Re-UPSERT those three current asset bodies here as the
+-- last writer (generated from assets via seed-skills, byte-identical to 0001).
+-- The other cleaned skills (flags/docs/onboard/bootstrap) live only in 0001, so
+-- the regenerated 0001 + `./sc update`'s skill self-heal already carry them.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'db_map',
+  'Data model behind the engine memory surfaces + the `./sc mem` command for each. Check before reading or writing memory — identity, decisions, roadmap, documents, flags. Reads/writes go through the API (`./sc mem`), never raw sqlite.',
+  'substrate',
+  NULL,
+  1,
+  '# db_map — super-coder''s DB at a glance
+
+All identity, memory, and content live in the engine DB
+(`.super-coder/shell_db.db`) — but you never touch that file. You read and write
+it **only through the engine API**, via `./sc mem`:
+
+- **Read** — `./sc mem get <surface>`: your own `state`, `seed`, `lns`,
+  `decisions`, `flags`, `narrative`, `messages`; and the shared planning state
+  `roadmap`, `projects`, `documents`, `tasks`, `shells` (add `--json` for raw).
+  `documents`/`tasks` take `--feature <id>` or `--doc <id>` (and `--doc` on
+  `documents` returns the one doc *with* its body).
+- **Write** — `./sc mem <cmd> …` (see `## Common writes` below).
+
+There is **no `sqlite3` path** — not as a fallback, not for "ad-hoc" reads.
+`./sc mem` goes through the API and only the API; if the API isn''t wired it
+fails loud rather than writing the DB behind its back. Your identity rides in
+your bearer token — the server resolves token → shell, so you never name a
+shell. The table below is the **data model** behind those surfaces (and what
+each `./sc mem` write touches), not a query cheatsheet. Lazy-load: `get` the one
+surface you need, don''t bulk-read.
+
+**Need a read or write `./sc mem` doesn''t expose?** That''s a gap to *report*, not
+a reason to reach for the DB — the direct path is closed by design, and a fork
+can''t patch the engine anyway (`./sc update` would overwrite it). A missing
+surface is an engine gap that goes **up to the FnB**: open a flag naming the data
+and the use, and surface it. Don''t improvise around the API.
+
+```
+./sc mem flag open "[Engine] need to <read|write> <what> — no ./sc mem surface for it | Blocker for: <your work>"
+```
+
+The FnB carries it upstream (that''s exactly how `get documents`/`get tasks`
+landed); message a planner-flavor shell too if the fork has one. Until then, do
+what you *can* through the API and flag the rest — never the DB directly.
+
+The repo map (`dr_*`) is **not here** — it lives in its own db, `.sc-state/map.db`
+(see the `surface_catalogue` skill). This map covers only `shell_db.db`, your
+memory/identity/content. Don''t look for `dr_*` in `shell_db.db`.
+
+## Tables
+
+| Table | Holds | Write rule |
+|---|---|---|
+| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `lineage_seed`, `active_archive_id`. (`connections`/`workspace` retired — boot `## CONNECTIONS` is derived from the `dr_*` map, not authored here) | UPDATE in place |
+| `shell_identity_entries` | seed (cap 10) + L&S (`kind=''lns''`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
+| `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
+| `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |
+| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row. `project_id` (nullable) = the work-stream the feature belongs to; the GUI Flow view groups on it (NULL = Ungrouped) | INSERT/UPDATE |
+| `feature_blockers` | the roadmap''s dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite must land first). Directed, kept acyclic (the GUI Flow view wires them; the card''s "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `./sc mem roadmap depends` |
+| `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
+| `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
+| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine |
+| `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a **work-stream** that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
+
+`<self>` = your `shell_id` (in the boot doc''s ACTIVE SESSION block).
+
+## Common writes
+
+Each routes through the engine API and writes to the live shared DB. `./sc mem which`
+orients; `./sc mem <cmd> -h` shows flags. Writes always target your own shell —
+the server resolves it from your token; you never name a shell.
+
+```
+# current_state (rolling status, not a log — replaces in place):
+./sc mem state "…"
+
+# plant a seed / L&S entry (date stamped for you):
+./sc mem seed "…"            # ./sc mem lns "…" for a lesson
+./sc mem retire <entry_id>   # curate one out (frees a cap slot)
+
+# record a Major decision (supersede with --parent <id>):
+./sc mem decision "…" --rationale "…"
+
+# roadmap: add a feature / move its horizon:
+./sc mem roadmap add "…" --status brainstorm --summary "…" [--project <shortname|id>]
+./sc mem roadmap status <feature_id> shipped
+
+# roadmap grouping + sequencing (drive the GUI Flow view):
+./sc mem roadmap project <feature_id> <shortname|id>   # assign a work-stream (or ''none'' to clear)
+./sc mem roadmap depends <feature_id> --on <id> [--on <id>]   # set dependencies (replaces; omit --on to clear; refuses cycles)
+
+# author a spec/doc body (--body-file reads the markdown), then freeze on ship:
+./sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
+./sc mem doc freeze <document_id>
+
+# spec_tasks (the plan): add a task / advance it:
+./sc mem task add "…" --feature <id> --doc <doc_id> --seq <n> [--desc "…"]
+./sc mem task start <task_id>     # ./sc mem task done <task_id>
+
+# open / close a flag:
+./sc mem flag open "[Area] … | Blocker for: …" --name CC-001 [--feature <id>]
+./sc mem flag close <flag_id> --notes "…"
+
+# projects (standing + linkage):
+./sc mem project add <shortname> "<title>" --purpose "…" --standing "…"
+./sc mem project standing <shortname|id> "…"     # ./sc mem project status <…> paused
+
+# inbox + first-run:
+./sc mem message send <shortname> "…"     # check / mark-read too (see `messaging`)
+./sc mem oriented                          # mark first-run done (bootstrapped=1)
+```
+
+## After writing
+
+Nothing more to run — the write is live in the shared engine DB the moment it
+commits, visible to every shell. Persisting it to git is an admin/GUI step, not
+yours.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'memory',
+  'How this shell writes its memory — current_state, session narrative, seed, L&S, decisions. Write as it happens, not at close. Use to know WHEN and HOW to persist identity/work memory, and the caps.',
+  'substrate',
+  NULL,
+  1,
+  '# memory — write as you go
+
+All memory is DB rows (no flat files). Write at the moment it matters, not in a
+close ritual.
+
+**Write through `./sc mem`.** The write lands in the live engine DB — shared by
+every shell, durable + visible to all the moment it commits. It always targets
+your own shell: the server resolves your identity from your token, so you never
+name a shell.
+
+## current_state — rolling status, NOT a log
+
+Your present focus + what''s next. **Replaces in place; never a log.** Soft target
+~500 chars. Rewrite when focus shifts.
+```
+./sc mem state "…"
+```
+
+## Session narrative — append at inflection points
+
+One row per session, appended progressively. Append a `[HH:MM]` line (the time is
+stamped for you) when: a decision lands, an approach changes or is rejected, the
+FnB says something that shapes the work, an assumption breaks, or before a big
+change.
+```
+./sc mem narrative "…"
+```
+
+## seed (cap 10) — who you are
+
+Identity-forming moments. Past-tense/timeless. Add a new entry; **never edit a
+body** (curate by retiring). The genesis + lineage seed are already yours.
+```
+./sc mem seed "…"            # add
+./sc mem retire <entry_id>   # curate out (frees a cap slot)
+```
+
+## L&S (cap 20) — how you work
+
+Operating lessons, imperative voice. Add when a lesson lands; curate by retiring.
+Caps are trigger-enforced (seed 10, L&S 20) — `./sc mem` reports the cap message;
+retiring frees a slot.
+```
+./sc mem lns "…"
+```
+
+## Decisions — Major only
+
+Record a Major decision (architecture, approach, a path chosen over another).
+Never rewritten; supersede via `--parent <decision_id>`. Mirror the headline into
+the narrative.
+```
+./sc mem decision "…" --rationale "…" [--parent <id>]
+```
+
+## Stance
+
+Write-as-you-go beats batch-at-close: it costs nothing per write and zero at
+session end. Curate seed/L&S (revise the set), never rewrite history (decisions,
+narrative, seed bodies). Full command reference + table map: the `db_map` skill.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'spec',
+  'Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step. Load when starting, implementing, or building any feature, spec, or roadmap item — before writing code.',
+  'craft',
+  NULL,
+  0,
+  '# spec — analyze and execute a spec
+
+Load this skill at the start of any session where you''re building or implementing
+a feature — whether or not the work is framed out loud as a "spec." If a spec
+governs the work, this is how you execute it; if one should but doesn''t yet, the
+`docs` skill authors it first. Run **Analyze** before touching any code. Pause for FnB on blockers or unclear
+items you can''t resolve alone.
+
+`<self>` = your shell_id.
+
+---
+
+## Step 1: Load the spec
+
+A feature can hold several unfrozen specs at once (see the `docs` skill), so don''t
+auto-pick "the latest" — list the feature''s open specs and choose the target
+explicitly. The **active** spec is the unfrozen one that already has a task plan;
+the rest are backlog.
+
+```
+# the feature''s documents — pick an unfrozen spec (frozen=0) by id:
+./sc mem get documents --feature <id>
+# load the chosen spec body:
+./sc mem get documents --doc <doc_id>
+# the spec''s task plan (empty = no plan yet):
+./sc mem get tasks --doc <doc_id>
+```
+
+`get documents --feature <id>` lists every spec/doc under the feature with its
+`kind`, `seq`, `frozen`, and `task_count`. `task_count > 0` marks the active spec — resume that one; an empty spec is backlog,
+and starting it (Step 3) makes it active. If more than one open spec matches and
+which to work is unclear, ask the FnB.
+
+If tasks already exist, skip to **Step 4** (Track).
+
+Read the entire spec body before going further. Do not skim.
+
+---
+
+## Step 2: Analyze
+
+Surface the following before any planning or code:
+
+### Viability
+- Can this be completed in the current session? Bounded + clear entry points:
+  yes. Multiple layers, migrations, unknown dependencies: no — say so and
+  propose a session-sized slice.
+- Does the spec state a clear done-condition? If not, that is the first unclear
+  item.
+
+### Unclear items
+Things you cannot act on without guessing:
+- Ambiguous between two interpretations
+- Missing a critical detail (which table? which endpoint? which component?)
+- Implies knowledge not stated in the spec
+
+List these and ask the FnB before writing the plan.
+
+### Blockers
+Hard stops — prior work not shipped, missing environment state, unresolved
+external dependency. Open a flag for each:
+
+```
+./sc mem flag open "[Spec] <what is blocked> | Blocker for: <feature title>" --name SC-### --priority High --feature <feature_id>
+```
+
+Don''t open flags for unclear items you can resolve by asking — ask first.
+
+---
+
+## Step 3: Plan
+
+### Reconcile the stage first
+
+Planning a spec means you''re engaging it to build — so the feature''s
+`roadmap_status` (loaded in Step 1) must catch up to reality. The horizon stages
+are `brainstorm · long_term · near_term · next · in_progress · shipped`.
+
+- Feature sits at `brainstorm`/`long_term`/`near_term` and you''re **building this
+  session** → move it to `in_progress`:
+  `./sc mem roadmap status <feature_id> in_progress`
+- You''re only **planning ahead** (no build this session) → move it to `next`.
+- Already at `in_progress` (or further) → **no-op**; don''t churn it.
+
+This is a transition you make because you''re *acting on* the spec — not something
+that fires from merely reading one for reference. If there is no spec governing the
+work (a quick UI fix, a minor migration), skip all stage handling: it doesn''t
+apply (see the Stance).
+
+### Confirm the work-stream too
+
+While you''re reconciling the stage, check the same feature''s **work-stream**
+(`roadmap.project_id` — the Flow-view grouping). If it''s Ungrouped, assign it now
+so the feature shows up in a flow, not the Ungrouped pile:
+
+```
+./sc mem roadmap project <feature_id> <shortname>   # ''none'' to clear
+```
+
+Assign when the stream is obvious; surface to the FnB when it''s ambiguous. No-op
+if already assigned. The full create/assess procedure (new streams, new features)
+lives in the `docs` skill — this is just the engage-time confirmation so drift
+doesn''t accumulate.
+
+Once analysis is clear and blockers are resolved or accepted, generate the task
+list and INSERT it. Always this shape:
+
+| seq | title | role |
+|---|---|---|
+| 0 | Preparation | Always first — read code paths, verify DB state, confirm entry points |
+| 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
+| N+1 | Verification | Always last — run tests, smoke-test against done-condition, snapshot + render |
+
+Add each task with `./sc mem task add` (one per seq) — each write is live in the
+shared DB immediately:
+
+```
+./sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points"
+./sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>"
+./sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>"
+./sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, snapshot + render"
+```
+
+Then set `current_state` — no last-done yet, next is Preparation:
+
+```
+./sc mem state "[<feature_title>] — last: —. next: Preparation."
+```
+
+---
+
+## Step 4: Track session by session
+
+At the start of each work session, load the current plan state:
+
+```
+./sc mem get tasks --doc <doc_id>
+```
+
+Find the first `pending` task. Mark it `in_progress`:
+
+```
+./sc mem task start <task_id>
+```
+
+Work only that task. When done, mark it complete, then resolve last-done / next-up
+with a read:
+
+```
+./sc mem task done <task_id>
+```
+
+Re-read the plan and resolve last-done / next-up from it — `last_done` is the
+highest-`seq` `done` task, `next_up` the lowest-`seq` `pending` one:
+
+```
+./sc mem get tasks --doc <doc_id>
+```
+
+Then advance `current_state`:
+
+```
+./sc mem state "[<feature_title>] — last: <last_done>. next: <next_up>."
+```
+
+If `next_up` is NULL, all tasks are done — set current_state to reflect that.
+
+---
+
+## Step 5: Hand off on completion
+
+When the **Verification** task passes (`next_up` is NULL — the existing
+done-line), the feature is delivered. As the dev, do the handoff — you flip the
+horizon and hand the paperwork to the planner; you do **not** freeze the spec or
+write the doc (that''s the planner — see the `docs` skill):
+
+1. **Flip the horizon to shipped:**
+   ```
+   ./sc mem roadmap status <feature_id> shipped
+   ```
+2. **Open a docs-pending flag and message the planner with full instructions.**
+   `shipped` + an open flag is the honest interim state. The message carries
+   everything the planner needs to act without digging:
+   ```
+   ./sc mem flag open "[Docs] <feature> shipped, doc pending | Blocker for: <feature> doc" --name SC-### --priority Medium --feature <feature_id>
+   ./sc mem message send <planner-shortname> "**[Docs pending] <feature_title> (feature <feature_id>)**
+
+   Spec <doc_id> shipped. Flag SC-### is open — your action required:
+
+   1. **Read the shipped code first.** Write the doc from what actually shipped, not from the spec. Drift happens and decisions get made in production — the spec captures the intent, the code is the truth.
+   2. Freeze the spec: \`./sc mem doc freeze <doc_id>\`
+   3. Write the doc (\`kind=''doc''\`) under feature <feature_id> (see the \`docs\` skill).
+   4. Close flag SC-### when the doc is live."
+   ```
+3. **Surface to the FnB:** "shipped; the planner needs to freeze the spec + write
+   the doc." The planner closes the flag when the doc lands.
+
+If this fork has no planner-flavor shell, message nobody — surface to the FnB
+directly and leave the docs-pending flag open for whoever picks up docs.
+
+---
+
+## Watch for creep while you build
+
+If, mid-build, the work grows past the spec''s stated what/why:
+
+- **Small growth** (same mental model, a few more tasks) → the spec is *living*
+  while unfrozen; just edit it (`./sc mem doc edit`) and carry on. No ceremony.
+- **A separate coherent intent** (a new mental-model boundary — the granularity
+  test in the `docs` skill) → don''t quietly absorb it. Recommend a **new spec** to
+  the FnB, to be authored by the planner against its own feature. Significant creep
+  is a planning event, not a dev improvisation.
+
+---
+
+## Stance
+
+- **Analyze before acting.** The analysis phase discovers the gap between what
+  the spec says and what the code does.
+- **One task at a time.** Don''t start task N+1 until task N is verified and
+  marked done.
+- **Verification is not optional.** It is the last task; skipping it makes
+  "done" meaningless.
+- **If the spec is too large for one session:** scope a session slice at
+  Preparation — cover steps 1–K that can be verified now, leave K+1–N pending.
+  Don''t start work that can''t be verified before the session ends.
+- **current_state always reflects the plan.** After every task completion,
+  update it — last done + next up. This is how the next session resumes without
+  reading the full task list first.
+- **The stage tracks reality, but only for spec''d work.** Engaging a spec moves
+  it forward (→ `in_progress`); finishing it hands off (→ `shipped`). No-op when
+  the stage already matches — don''t churn it. Work with **no spec** (quick UI
+  tweaks, minor migrations) is exempt entirely: no promotion, no handoff, no creep
+  check. Stage discipline must never become a blocker for small things.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -779,13 +779,6 @@ def main() -> None:
     # own worktree, and must not be warned. For admin this is REPO_ROOT, but admin
     # exits the guard earlier via SC_SHELL_FLAVOR, so it never reads this.
     env["SC_SHELL_WORKTREE"] = str(work_dir)
-    # The booted shell's own identity, so engine commands it runs (`./sc mem …`)
-    # resolve "which shell am I" from the environment instead of re-deriving it
-    # from git state. Boot knows this for certain; the git-branch heuristic in
-    # mem.resolve_shell fails for the admin flavor (boots on `main`, no
-    # `shell/<name>` branch) and whenever the cwd has drifted to the repo root.
-    # A deliberate `--shell` still overrides it.
-    env["SC_SHELL"] = full["shortname"] or str(full["shell_id"])
     # Operator-declared shared dirs that all shells may write into without
     # branch-guard warnings — host-level handoff/screenshot folders. Set
     # SC_SHARED_DIRS (space-separated absolute paths) in the launch environment;

--- a/.super-coder/scripts/seed_dogfood.py
+++ b/.super-coder/scripts/seed_dogfood.py
@@ -58,12 +58,11 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 | Session narrative | `shell_memory_archives` — one row per session, appended progressively |
 
 Write as it happens, not at close. **Writes go through `./sc mem`** (state · seed ·
-lns · decision · flag · roadmap · doc · narrative): it resolves + guards *this*
-engine DB — refusing the app DB or a stray empty file, whose overlapping table
-names would let a raw `sqlite3` INSERT hit the wrong DB silently. The write lands
-in the live engine DB — the single source of truth shared by every shell, durable
-and visible to all at once. That is the whole write: **you don't snapshot or
-render** — persisting to git is an admin/GUI step. Raw `sqlite3` is for SELECT only;
+lns · decision · flag · roadmap · doc · narrative): it routes through the engine
+API, which resolves your identity from your token — no DB path, no direct-DB
+fallback. The write lands in the live engine DB — the single source of truth
+shared by every shell, durable and visible to all at once. That is the whole
+write: **you don't snapshot or render** — persisting to git is an admin/GUI step.
 `./sc mem which` to orient. See the `memory` and `db_map` skills.
 
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -39,10 +39,10 @@ different ways, so keep them straight:
   `.super-coder/`. Holds your identity, memory, roadmap, specs, and the repo map.
   Gitignored and rebuilt from tracked text. **Write through `./sc mem`** — the
   write lands in the live engine DB, durable and visible to all. `./sc mem which`
-  shows the resolved DB. `./sc mem` routes through the engine API (no direct-DB
-  fallback). If it reports "API unreachable", the engine server is down — surface
-  this to FnB; they restart it with `./sc start` / `make dos-r`. Do not retry
-  silently; surface the error and stop.
+  confirms the API is reachable and who your token resolves to. `./sc mem` routes
+  through the engine API (no direct-DB fallback). If it reports "API unreachable",
+  the engine server is down — surface this to FnB; they restart it with
+  `./sc restart` / `make dos-r`. Do not retry silently; surface the error and stop.
 - **App product DB** — the database of the product *this repo* builds. Its name
   and path **vary per fork** and live **outside** `.super-coder/`. Holds the
   product's runtime data + schema. Change it the way the product does — schema

--- a/sc
+++ b/sc
@@ -489,8 +489,8 @@ super-coder — forkable shell substrate
   ./sc rebuild             build the .db from schema + migrations + snapshot
   ./sc migrate             apply pending migrations to an existing .db
   ./sc snapshot            dump per-instance tables -> .sc-state/content.sql
-  ./sc mem <cmd> [args]    safe engine-DB writes for a shell's own memory (state/seed/lns/decision/flag/roadmap/doc/narrative);
-                             resolves + guards the engine DB (refuses product DBs & 0-byte stubs), then snapshots+renders. `./sc mem which` to orient
+  ./sc mem <cmd> [args]    a shell's own memory, over the engine API (get/state/seed/lns/decision/flag/roadmap/doc/narrative);
+                             identity is the shell's token, server-resolved — no DB path, no direct-DB fallback. `./sc mem which` to orient
   ./sc render              render tracked flat _sc files (specs/docs/skills/roadmap)
   ./sc render-check        fail if committed flat _sc files drift from the DB render (CI guard; rebuild first for a hermetic check)
   ./sc map                 scan the host repo into the dr_* catalogue (re-runnable)

--- a/skills_sc/bootstrap.md
+++ b/skills_sc/bootstrap.md
@@ -51,7 +51,7 @@ cartographer's automation (see `surface_catalogue`). You read it.
 
 4. **Set your `current_state`** — replace the install placeholder with what you
    actually found and what you'll do first (rolling status, ~500 chars). Write it
-   through `./sc mem` (resolves + guards the engine DB; the write is live in the
+   through `./sc mem` (routes through the engine API; the write is live in the
    shared DB at once):
    ```
    ./sc mem state "…"

--- a/skills_sc/db_map.md
+++ b/skills_sc/db_map.md
@@ -70,8 +70,9 @@ memory/identity/content. Don't look for `dr_*` in `shell_db.db`.
 
 ## Common writes
 
-Each guards the engine DB and writes to the live shared DB. `./sc mem which` orients;
-`./sc mem <cmd> -h` shows flags. Writes target your shell by default (`--shell` to override).
+Each routes through the engine API and writes to the live shared DB. `./sc mem which`
+orients; `./sc mem <cmd> -h` shows flags. Writes always target your own shell —
+the server resolves it from your token; you never name a shell.
 
 ```
 # current_state (rolling status, not a log — replaces in place):

--- a/skills_sc/docs.md
+++ b/skills_sc/docs.md
@@ -89,7 +89,7 @@ sqlite3 .sc-state/map.db "SELECT path FROM dr_filepath WHERE role='doc';"  -- re
 
 ## Author
 
-Write through `./sc mem doc add` — it guards the engine DB, `--body-file` reads
+Write through `./sc mem doc add` — it routes through the engine API, `--body-file` reads
 the markdown from a file (no shell-escaping a long body), `--seq` auto-increments
 within `(feature, kind)`, and it renders + snapshots for you (the render/snapshot
 pipeline this rides on is the `snapshot` skill):

--- a/skills_sc/flags.md
+++ b/skills_sc/flags.md
@@ -30,7 +30,7 @@ the blocked feature's title. Reads go through the API — there is no `sqlite3`.
 
 ## Open
 
-Write through `./sc mem` (it guards the engine DB + snapshots):
+Write through `./sc mem` (routed through the engine API):
 ```
 ./sc mem flag open "[Area] what's blocked | Blocker for: X" --name SC-001 --priority Medium [--feature <id>]
 ```

--- a/skills_sc/memory.md
+++ b/skills_sc/memory.md
@@ -18,8 +18,9 @@ All memory is DB rows (no flat files). Write at the moment it matters, not in a
 close ritual.
 
 **Write through `./sc mem`.** The write lands in the live engine DB — shared by
-every shell, durable + visible to all the moment it commits. Writes default to
-your shell; pass `--shell <id|name>` to be explicit.
+every shell, durable + visible to all the moment it commits. It always targets
+your own shell: the server resolves your identity from your token, so you never
+name a shell.
 
 ## current_state — rolling status, NOT a log
 

--- a/skills_sc/onboard.md
+++ b/skills_sc/onboard.md
@@ -35,8 +35,8 @@ For each doc, read the file and decide together:
   feature.
 Skip noise (changelogs, license, vendored docs) unless the FnB wants it.
 
-All writes here go through `./sc mem` (it guards the engine DB so the import never
-lands in the app DB, and writes to the live shared DB).
+All writes here go through `./sc mem` (routed through the engine API, which writes
+to the live shared DB — the import never touches the app DB).
 
 ## 3. Backfill the roadmap
 Create a feature for each coherent area/initiative the docs imply; set status by

--- a/skills_sc/spec.md
+++ b/skills_sc/spec.md
@@ -125,13 +125,13 @@ list and INSERT it. Always this shape:
 | 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
 | N+1 | Verification | Always last — run tests, smoke-test against done-condition, snapshot + render |
 
-Add each task with `./sc mem task add` (one per seq). For a multi-task plan, pass
-`--no-sync` on all but the last so you snapshot once at the end:
+Add each task with `./sc mem task add` (one per seq) — each write is live in the
+shared DB immediately:
 
 ```
-./sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points" --no-sync
-./sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>" --no-sync
-./sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>" --no-sync
+./sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points"
+./sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>"
+./sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>"
 ./sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, snapshot + render"
 ```
 


### PR DESCRIPTION
Follow-up to #211 (merged). #211 made `./sc mem` API-only — deleting `--shell`/`--db`/`--no-sync`, the DB-resolution guard, and `mem.resolve_shell`. An audit of our scripts, make procedures, and skills found surfaces that still described the old shapes — some **broken-on-use**.

## Fixed
| Surface | Was | Now |
|---|---|---|
| `skills/spec` | `mem task add … --no-sync` ×3 (flag deleted → argparse error) | flag removed |
| `skills/memory` | "pass `--shell <id\|name>`" | identity is the token, server-resolved |
| `skills/db_map` | "guards the engine DB … `--shell` to override" | routes through the API |
| `skills/{bootstrap,flags,docs,onboard}` | "resolves + guards the engine DB" | routes through the engine API |
| `sc` help | "resolves + guards … refuses product DBs & 0-byte stubs, then snapshots+renders" | token-resolved API surface |
| `templates/boot.md` | recover via **`./sc start`** (does not exist) | `./sc restart`; `mem which` confirms API reachability |
| `scripts/run.py` | exports `SC_SHELL` (+ stale comment) | removed — only reader was the deleted `mem.resolve_shell` |
| `scripts/seed_dogfood.py` | dogfood prompt: "raw sqlite3 is for SELECT only" | API-only model |

## Propagation
`0001` regenerated from assets; new **`0032`** re-UPSERTs the three skills a *later* migration reseeds (`db_map` 0028/0029/0031, `memory` 0028, `spec` 0014) so a full replay ends on the cleaned bodies. The others live only in `0001` (regen + `./sc update` self-heal). Flat `_sc` mirror re-rendered.

## Audited clean (no change)
`Makefile`, `aliases.mk`, `install.py`, `shell_system_prompt.md`.

## Known follow-up (out of scope)
The committed `.sc-state/content.sql` snapshot still carries the pre-cleanup dogfood prompt. It's **dev-dogfood-only (never reaches forks)** and the generator is fixed; refreshing the snapshot needs a deliberate from-scratch reseed.

## Verification
119 tests pass; `render-check` + skills-freshness clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)