### PR TITLE
fix: keep api_keys out of git AND re-mint them on rebuild

### DIFF
--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(ENGINE / "scripts"))
 import db_driver    # noqa: E402
 import migrate as migrate_mod  # noqa: E402
 import map_repo     # noqa: E402
+import backfill_shell_api_keys  # noqa: E402  (re-provision api_keys post-rebuild)
 
 
 def snapshot_path() -> Path:
@@ -89,6 +90,14 @@ def main(argv: list[str]) -> int:
             con.close()
     else:
         print("rebuild: no .sc-state/content.sql — built empty (no per-instance content).")
+
+    # Re-provision api_keys. content.sql never carries api_key (it is a secret and
+    # content.sql is git-tracked — see snapshot.py's no-serialize set), so every
+    # shell comes back NULL-keyed from the load above. The server backfills NULL
+    # keys, but only at startup — a rebuild under an already-running server would
+    # otherwise leave the live DB NULL-keyed and 401 every shell's mem write until
+    # the API is bounced. Minting here makes a rebuilt DB self-sufficient.
+    backfill_shell_api_keys.backfill(str(DB_PATH))
 
     try:
         map_repo.main()

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -178,13 +178,15 @@ def dump_local_skills(con) -> list[str]:
 
 # Columns that must NEVER be serialized to content.sql — content.sql is
 # git-tracked, and these are live credentials managed at runtime, not memory to
-# preserve across a rebuild. `api_key` is (re)provisioned by the server's
-# startup backfill; `password_*` are launcher auth fields. Omitting them from the
-# INSERT means they load as NULL on rebuild, which is correct: the key is
-# re-minted at the next server start, and they never reach git. Without this, a
-# snapshot taken while keys are provisioned writes every shell's bearer token
-# into a committed file (the gitleaks default ruleset does not catch the bare
-# token format, so the gate would not flag it either).
+# preserve across a rebuild. `api_key` is (re)provisioned at rebuild time
+# (rebuild.py's final backfill step) and again at server startup; `password_*`
+# are launcher auth fields. Omitting them from the INSERT means they load as NULL
+# on rebuild, which is correct: the key is re-minted by rebuild itself (so a
+# rebuilt DB is never NULL-keyed, even under an already-running server) and they
+# never reach git. Without this, a snapshot taken while keys are provisioned
+# writes every shell's bearer token into a committed file (the gitleaks default
+# ruleset does not catch the bare token format, so the gate would not flag it
+# either).
 SENSITIVE_COLUMNS = {
     "shells": {"api_key", "api_key_rotated_at"},
     "users": {"password_hash", "password_salt"},


### PR DESCRIPTION
## Problem

A super-coder shell on the **dos-arch** fork hit `HTTP 401 "invalid or unknown token"` on every `./sc mem` write. Traced to a hole in the api_key lifecycle:

- The API validates `Authorization: Bearer <token>` against `shells.api_key` (`server.py:_resolve_shell`).
- `c7710cb` (this branch) correctly stopped serializing `api_key` to the git-tracked `content.sql` — so after a `rebuild`, every shell comes back **NULL-keyed**.
- That commit relied on **the server's *startup* backfill** to re-mint keys. But `rebuild` runs under an **already-running** server, which never re-backfills. Result: the live DB sits NULL-keyed and the API 401s every shell until the API is manually bounced.

So the serialization fix (correct, secrets must not reach git) opened an availability gap: **rebuild silently de-authenticates every shell.**

## Fix

Two commits, one logical change:

1. **`c7710cb`** — never serialize `api_key` / `password_*` to `content.sql` (secrets out of git).
2. **`a74ddca`** — `rebuild.py` calls `backfill_shell_api_keys.backfill(DB_PATH)` as its final provisioning step, so a rebuilt DB is **self-sufficiently keyed regardless of server state**. Comment in `snapshot.py` trued up to match.

Keys still rotate on rebuild (they're non-persisted secrets by design), so live shells `./sc enter` again to pick up the new token — but the API no longer rejects every write in the meantime.

## Verification

- Ran a real `rebuild` on the super-coder instance: all live shells came out keyed; a `is_deleted=1` shell was correctly skipped (matches `_resolve_shell`'s own `is_deleted=0` filter — a deleted shell can't auth and needs no key).
- Remediated the live dos-arch fork by running the backfill against its DB (8 shells re-keyed); its pending `./sc update` is in-place migrate, so it preserves the minted keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)