### PR TITLE
fix(sc): self-heal missing pytest in `./sc test` instead of green-washing

### DIFF
--- a/sc
+++ b/sc
@@ -190,18 +190,49 @@ sc_deps() {
   echo "✓ deps: done"
 }
 
+# True if the fork declares a pytest config — pytest.ini, a [tool.pytest…] table in
+# pyproject.toml, or [tool:pytest] in setup.cfg. The discriminator between "this
+# fork opted out of pytest" (→ stdlib unittest fallback) and "this fork needs
+# pytest but the .venv is unprovisioned" (→ hard error, never a silent downgrade).
+_sc_wants_pytest() {
+  [ -f "$here/pytest.ini" ] && return 0
+  [ -f "$here/pyproject.toml" ] && grep -q '\[tool\.pytest' "$here/pyproject.toml" 2>/dev/null && return 0
+  [ -f "$here/setup.cfg" ] && grep -q '\[tool:pytest\]' "$here/setup.cfg" 2>/dev/null && return 0
+  return 1
+}
+
 # Run the fork's test suites: backend (the .venv's pytest, honoring the fork's
 # pytest.ini; else the engine's own stdlib-unittest suite) + UI (npm run test /
 # vitest in any package.json dir that declares a test script). Non-zero if any fail.
 sc_test() {
-  rc=0
   venv="$here/.venv"
+  # Self-heal: a fork with python tests but no .venv/bin/pytest is an unprovisioned
+  # worktree (the .venv is only populated by the first `./sc deps`), NOT a fork that
+  # opted out of pytest. Provision the dev kit + fork deps rather than silently
+  # downgrading to stdlib unittest — under which a pytest-based suite fails with
+  # ModuleNotFoundError (pytest / the fork's own libs) that reads as a real test
+  # failure. We gate on the pytest binary, not sc_deps' exit code, so a partial
+  # provision (e.g. npm leg fails) still runs pytest if it landed.
+  if [ ! -x "$venv/bin/pytest" ] && ls "$here"/tests/test_*.py >/dev/null 2>&1; then
+    echo "→ test: $venv/bin/pytest missing — provisioning first (./sc deps)"
+    sc_deps || echo "→ test: provisioning incomplete — continuing" >&2
+  fi
+  rc=0
   if [ -x "$venv/bin/pytest" ]; then
     echo "→ test: $venv/bin/pytest"
     ( cd "$here" && "$venv/bin/pytest" "$@" ) || rc=1
   elif ls "$here"/tests/test_*.py >/dev/null 2>&1; then
-    echo "→ test: python3 -m unittest discover (stdlib)"
-    ( cd "$here" && "$PY" -m unittest discover -s tests -p 'test_*.py' ) || rc=1
+    # pytest still unavailable after provisioning (venv create failed, or a
+    # host-managed sandbox interpreter that skips pip). A fork that *declares*
+    # pytest must not be green-washed through stdlib unittest — fail loud with the
+    # fix. Only a fork with no pytest config keeps the legacy stdlib fallback.
+    if _sc_wants_pytest; then
+      echo "✗ test: pytest required (pytest config present) but unavailable in $venv — run ./sc deps to provision it" >&2
+      rc=1
+    else
+      echo "→ test: python3 -m unittest discover (stdlib)"
+      ( cd "$here" && "$PY" -m unittest discover -s tests -p 'test_*.py' ) || rc=1
+    fi
   else
     echo "→ test: no python tests found"
   fi


### PR DESCRIPTION
## Problem

`sc_test` runs `<repo>/.venv/bin/pytest` when present, **else silently downgrades to `python3 -m unittest discover`**. A fresh `.sc-worktrees/<name>/` `.venv` is unprovisioned until the first `./sc deps`, so in a pytest-based fork that downgrade runs the wrong runner and emits `ModuleNotFoundError: pytest / <fork lib>` — which reads as a real test failure, or green-washes a suite that never ran.

Found during dos-arch PG QAQC: **4 of 6 worktrees** (cart1, pln1, pln2, rev1) had no `.venv/bin/pytest`, so `./sc test` there reported spurious total failure unrelated to the code — making the whole suite untrustworthy regardless of the actual (separate) test bugs.

## Fix

In the engine `sc` (in `ENGINE_PATHS` → wholesale-materialized to every fork on `./sc update`, never fork-edited):

- **Self-heal** — fork has `tests/test_*.py` but no `.venv/bin/pytest` → run `sc_deps` to provision the dev kit + fork deps, then use pytest. Gates on the pytest binary, not `sc_deps`' exit code, so a partial provision still runs pytest if it landed.
- **Never green-wash** — a fork that *declares* pytest (`pytest.ini`, `[tool.pytest…]` in pyproject, `[tool:pytest]` in setup.cfg) but still has no pytest after provisioning **hard-errors** with the remediation, instead of falling through to stdlib unittest.
- **Backward-compatible** — the legacy stdlib-unittest fallback is preserved only for forks with no pytest config (e.g. the engine's own suite).

## Verification

- Branch-by-branch harness (stubbed `sc_deps`, no real installs): pytest-present (no self-heal) ✓ · self-heal-then-pytest ✓ · wants-pytest-but-unavailable → rc=1 ✓ · no-config stdlib fallback ✓
- Engine's own real `./sc test`: **122 passed**, exit 0.
- `sh -n` / `bash -n` clean (`sc` is `#!/bin/sh`).

## Compatibility at update

`sc` is wholesale-replaced from the engine on `./sc update` (update.py `ENGINE_PATHS`), so forks inherit this with no merge conflict. dos-arch declares `pytest.ini`, so post-update an unprovisioned worktree will self-heal (or hard-error with the fix) — never silently fail-as-unittest again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)