### PR TITLE
fix(seed): purge stale "shells snapshot/render" guidance from content.sql

### DIFF
--- a/.sc-state/content.sql
+++ b/.sc-state/content.sql
@@ -33,12 +33,12 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 | Session narrative | `shell_memory_archives` — one row per session, appended progressively |
 
 Write as it happens, not at close. **Writes go through `./sc mem`** (state · seed ·
-lns · decision · flag · roadmap · doc · narrative): it resolves + guards *this*
-engine DB — refusing the app DB or a stray empty file, whose overlapping table
-names would let a raw `sqlite3` INSERT hit the wrong DB silently — and snapshots
-the change for you. Raw `sqlite3` is for SELECT only. `./sc mem which` to orient;
-`./sc snapshot` (+ `./sc render` for docs/roadmap/skills) after any non-`mem`
-edit. See the `memory`, `db_map`, and `snapshot` skills.
+lns · decision · flag · roadmap · doc · narrative): it routes through the engine
+API, which resolves your identity from your token — no DB path, no direct-DB
+fallback. The write lands in the live engine DB — the single source of truth
+shared by every shell, durable and visible to all at once. That is the whole
+write: **you don''t snapshot or render** — persisting to git is an admin/GUI step.
+`./sc mem which` to orient. See the `memory` and `db_map` skills.
 
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
@@ -96,12 +96,12 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 | Session narrative | `shell_memory_archives` — one row per session, appended progressively |
 
 Write as it happens, not at close. **Writes go through `./sc mem`** (state · seed ·
-lns · decision · flag · roadmap · doc · narrative): it resolves + guards *this*
-engine DB — refusing the app DB or a stray empty file, whose overlapping table
-names would let a raw `sqlite3` INSERT hit the wrong DB silently — and snapshots
-the change for you. Raw `sqlite3` is for SELECT only. `./sc mem which` to orient;
-`./sc snapshot` (+ `./sc render` for docs/roadmap/skills) after any non-`mem`
-edit. See the `memory`, `db_map`, and `snapshot` skills.
+lns · decision · flag · roadmap · doc · narrative): it routes through the engine
+API, which resolves your identity from your token — no DB path, no direct-DB
+fallback. The write lands in the live engine DB — the single source of truth
+shared by every shell, durable and visible to all at once. That is the whole
+write: **you don''t snapshot or render** — persisting to git is an admin/GUI step.
+`./sc mem which` to orient. See the `memory` and `db_map` skills.
 
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
@@ -157,9 +157,13 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 | Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
 | Session narrative | `shell_memory_archives` — one row per session, appended progressively |
 
-Write as it happens, not at close. The `.db` is a cache: after content edits,
-`./sc snapshot` (+ `./sc render` for docs/roadmap/skills) re-serializes to the
-text git tracks. See the `db_map` and `snapshot` skills.
+Write as it happens, not at close. **Writes go through `./sc mem`** (state · seed ·
+lns · decision · flag · roadmap · doc · narrative): it routes through the engine
+API, which resolves your identity from your token — no DB path, no direct-DB
+fallback. The write lands in the live engine DB — the single source of truth
+shared by every shell, durable and visible to all at once. That is the whole
+write: **you don''t snapshot or render** — persisting to git is an admin/GUI step.
+`./sc mem which` to orient. See the `memory` and `db_map` skills.
 
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by


### PR DESCRIPTION
## Why

cart1 (dos-arch fork) flagged that the boot doc's `MEMORY ARCHITECTURE` block tells a shell to persist its own writes — which the engine actively blocks:
- `./sc mem` does **not** snapshot (no snapshot calls in `mem.py` / the `/_sc/mem/*` handlers).
- `./sc snapshot` / `./sc render` **refuse without `SC_ADMIN=1`** — a shell cannot run them.

This contradicts the `snapshot` and `db_map` skills, which correctly say persisting to git is an admin/GUI step, not a per-write shell action.

## Root cause

The **template** (`shell_system_prompt.md`) and **seed script** (`seed_dogfood.py`) were already fixed in **#212**. The stale text survived only in the committed dogfood snapshot `.sc-state/content.sql`, last regenerated in **#205** — *before* #212. `make update` does in-place migrations and never rewrites a shell's `system_prompt`, so the stale seed was never refreshed.

Three seeded shells, **two** stale variants:
- `cc` + `CART1`: *"…and snapshots the change for you. Raw `sqlite3` is for SELECT only. … `./sc snapshot` (+ `./sc render`) after any non-`mem` edit."*
- `DEV1`: *"The `.db` is a cache: after content edits, `./sc snapshot` (+ `./sc render`) re-serializes…"*

## Fix

Replaced all three write-paragraphs with the canonical clean text from `seed_dogfood.py`'s `MAINTAINER_PROMPT` — *"…you don't snapshot or render — persisting to git is an admin/GUI step."* Also drops the over-permissive *"raw `sqlite3` is for SELECT only"* line (cart1's secondary point).

## Heads-up for a follow-up (not fixed here)

The `seed_dogfood.py` regen flow (`clean-db` + `seed_dogfood` + `snapshot`) only authors shell #1 (the maintainer) — it does **not** create `CART1` or `DEV1`. Running the documented from-scratch regen today would **drop those two shells** from the seed. That's why this is a surgical `content.sql` edit, not a re-author. The regen flow / dogfood seed authoring is stale and worth a separate fix.

## Verification

- Hermetic rebuild (schema + migrations + content.sql) parses; all three shells' `system_prompt` verified clean (no `snapshots`/`SELECT only`/`after … edit`).
- The `./sc render-check` drift on `skills_sc/{dev_kit,test_authoring_pg,README}.md` is **pre-existing #218 drift**, unrelated to this diff (which touches only `content.sql`) and fixed by #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)