### PR TITLE
fix(api): coerce bytes at the JSON response boundary so a stray BLOB can't 500 a read

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -139,6 +139,16 @@ def rows(cur) -> list[dict]:
     return [dict(r) for r in cur.fetchall()]
 
 
+def _json_default(o):
+    # SQLite hands back bytes for BLOB columns (and for TEXT rows written as
+    # bytes by some path); json.dumps can't serialize them and 500s the whole
+    # endpoint. Decode UTF-8 with a lossy fallback so one stray bytes value
+    # never takes down a read.
+    if isinstance(o, (bytes, bytearray)):
+        return bytes(o).decode("utf-8", "replace")
+    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+
+
 # ── Data assembly ─────────────────────────────────────────────────────────────
 
 def get_shells(con) -> list[dict]:
@@ -860,7 +870,8 @@ class Handler(BaseHTTPRequestHandler):
     server_version = "super-coder/1.0"
 
     def _send(self, code, payload, ctype="application/json"):
-        body = (json.dumps(payload) if ctype.startswith("application/json")
+        body = (json.dumps(payload, default=_json_default)
+                if ctype.startswith("application/json")
                 else payload).encode()
         self.send_response(code)
         self.send_header("Content-Type", ctype)


### PR DESCRIPTION
## Problem

`GET /_sc/mem/messages` returns **HTTP 500** — `Object of type bytes is not JSON serializable` — on a fork engine API. Reported by a shell whose inbox check (`./sc mem message check`) was blocked; the API is reachable (`./sc mem which` resolves), so this is an endpoint bug, not downtime. A restart won't fix it — it's a serialization bug.

## Root cause

`_send` serializes with a bare `json.dumps(payload)`. SQLite hands back `bytes` for any BLOB column (or a TEXT row written as bytes by some path). One stray bytes value in the returned rows aborts serialization and 500s the entire endpoint. This is the same class as the earlier `render_skill_md` bytes fix.

## Fix

- Add `_json_default(o)`: `bytes`/`bytearray` decode UTF-8 with a lossy `replace` fallback; anything else still raises `TypeError`.
- Pass it as `default=` to `json.dumps` in `_send`.

`_send` is the single response-serialization boundary, so this hardens **every** read endpoint at once, not just messages. The best-effort log writer (line ~97) and the POST insert path (stores `str`) are unaffected.

## Verification

- `ast.parse` clean.
- `json.dumps({"messages":[{"body": b"hello from bytes", ...}]}, default=_json_default)` → `{"messages": [{..., "body": "hello from bytes", ...}]}` (no raise).

API code — read live, no reseed migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)