### PR TITLE
fix(api): shared project artifacts writable by any shell (was owner-gated)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -996,11 +996,15 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, {"decisions": ds})
 
             if path == "/_sc/mem/flags":
+                # Shared: flags coordinate the project, not one shell's memory —
+                # return every open flag in the fleet, tagged with its author's
+                # shortname so a caller can tell whose blocker it is.
                 fs = rows(con.execute(
-                    "SELECT flag_id, display_name, priority, description, feature_id, "
-                    "created_date FROM flags "
-                    "WHERE shell_id=? AND COALESCE(resolved,0)=0 AND COALESCE(is_deleted,0)=0 "
-                    "ORDER BY created_date, flag_id", (sid,)))
+                    "SELECT f.flag_id, f.display_name, f.priority, f.description, "
+                    "f.feature_id, f.created_date, s.shortname AS owner FROM flags f "
+                    "LEFT JOIN shells s ON s.shell_id=f.shell_id "
+                    "WHERE COALESCE(f.resolved,0)=0 AND COALESCE(f.is_deleted,0)=0 "
+                    "ORDER BY f.created_date, f.flag_id"))
                 return self._send(200, {"flags": fs})
 
             if path == "/_sc/mem/roadmap":
@@ -1304,11 +1308,14 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, {"ok": True})
 
             # PATCH /_sc/mem/flags/{id}
+            # Shared: flags coordinate a project, not one shell's memory — any
+            # authenticated shell may resolve/edit any flag. Authorship stays
+            # on the row's shell_id (set at open).
             if len(parts) == 4 and parts[2] == "flags":
                 fid = int(parts[3])
                 if not con.execute(
-                        "SELECT 1 FROM flags WHERE flag_id=? AND shell_id=? "
-                        "AND COALESCE(is_deleted,0)=0", (fid, sid)).fetchone():
+                        "SELECT 1 FROM flags WHERE flag_id=? "
+                        "AND COALESCE(is_deleted,0)=0", (fid,)).fetchone():
                     return self._send(404, {"error": "no such flag"})
                 if body.get("resolved"):
                     body.setdefault("resolved_date", date.today().isoformat())
@@ -1317,11 +1324,14 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200 if ok else 400, {"ok": ok, "error": err})
 
             # PATCH /_sc/mem/roadmap/{id}
+            # Shared board (matches the fleet-wide GET /roadmap): any shell may
+            # advance a feature it did not author — planner→dev handoff needs
+            # this. owning_shell records the author and is left untouched.
             if len(parts) == 4 and parts[2] == "roadmap":
                 fid = int(parts[3])
                 if not con.execute(
-                        "SELECT 1 FROM roadmap WHERE feature_id=? AND owning_shell=?",
-                        (fid, sid)).fetchone():
+                        "SELECT 1 FROM roadmap WHERE feature_id=?",
+                        (fid,)).fetchone():
                     return self._send(404, {"error": "no such feature"})
                 # work-stream assignment: shortname|id|none → project_id
                 if "project" in body:
@@ -1354,11 +1364,14 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200 if ok else 400, {"ok": ok, "error": err})
 
             # PATCH /_sc/mem/tasks/{id}
+            # Shared: a spec's task plan is collaborative (the builder starts/
+            # completes tasks the planner laid in). shell_id records who added
+            # the task and is left untouched.
             if len(parts) == 4 and parts[2] == "tasks":
                 tid = int(parts[3])
                 if not con.execute(
-                        "SELECT 1 FROM spec_tasks WHERE task_id=? AND shell_id=?",
-                        (tid, sid)).fetchone():
+                        "SELECT 1 FROM spec_tasks WHERE task_id=?",
+                        (tid,)).fetchone():
                     return self._send(404, {"error": "no such task"})
                 if body.get("status") == "done":
                     body.setdefault("completed_date", date.today().isoformat())
@@ -1367,13 +1380,14 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200 if ok else 400, {"ok": ok, "error": err})
 
             # PATCH /_sc/mem/docs/{id}/freeze — must precede the bare /docs/{id} check
+            # Shared: specs/docs are collaborative (matches the fleet-wide GET
+            # /documents); any shell may freeze/edit regardless of the feature's
+            # authoring shell.
             if len(parts) == 5 and parts[2] == "docs" and parts[4] == "freeze":
                 did = int(parts[3])
                 r = con.execute(
-                    "SELECT d.frozen FROM documents d "
-                    "JOIN roadmap r ON r.feature_id=d.feature_id "
-                    "WHERE d.document_id=? AND r.owning_shell=?",
-                    (did, sid)).fetchone()
+                    "SELECT frozen FROM documents WHERE document_id=?",
+                    (did,)).fetchone()
                 if r is None:
                     return self._send(404, {"error": "no such document"})
                 if r[0]:
@@ -1388,10 +1402,8 @@ class Handler(BaseHTTPRequestHandler):
             if len(parts) == 4 and parts[2] == "docs":
                 did = int(parts[3])
                 if not con.execute(
-                        "SELECT 1 FROM documents d "
-                        "JOIN roadmap r ON r.feature_id=d.feature_id "
-                        "WHERE d.document_id=? AND r.owning_shell=?",
-                        (did, sid)).fetchone():
+                        "SELECT 1 FROM documents WHERE document_id=?",
+                        (did,)).fetchone():
                     return self._send(404, {"error": "no such document"})
                 ok, err = patch_document(con, did, body)
                 return self._send(200 if ok else 400, {"ok": ok, "error": err})

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -157,7 +157,8 @@ def _render_get(surface: str, data: dict) -> int:
             return 0
         for f in fs:
             nm = f.get("display_name") or f"#{f['flag_id']}"
-            print(f"[{nm}] ({f.get('priority') or 'Medium'}) {f.get('description') or ''}")
+            who = f" @{f['owner']}" if f.get("owner") else ""
+            print(f"[{nm}]{who} ({f.get('priority') or 'Medium'}) {f.get('description') or ''}")
         return 0
     if surface == "roadmap":
         rm = data.get("roadmap", [])


### PR DESCRIPTION
## Problem

The API resolves `shell_id` from the Bearer key (**authn**) — correct. But every write `PATCH` also used that resolved `sid` as an **authz** gate (*"you may only touch rows you own"*), even for artifacts whose **reads are already fleet-wide**.

Reported by DEV1 in a dos-arch fork: he could `./sc mem get roadmap` and see feature 74 (owned by planner PLN1), then got `404 no such feature` trying to flip its status `next → in_progress`. The read path and write path disagreed about whether the board is shared — the roadmap GET even carries a comment *"The board is shared, not per-shell"* while the PATCH four lines away still enforced sole ownership. The planner→dev handoff was walled off mid-workflow.

This is a cooperative single-user substrate (everything resolves to `user_id=1`); owner-gating shared tables guards nothing real — it's a footgun, not a boundary.

## Change

Split authz by memory class:

- **Personal memory** — identity entries, seed/L&S, decisions, current_state, narrative, messages inbox — **stays owner-gated** (correct; nobody writes your seed).
- **Shared project artifacts** — roadmap, docs/specs, tasks, flags — **drop the owner gate for writes**. Existence check only. Authorship still stamped via `owning_shell`/`shell_id` at create, left untouched on edit.

The write path now agrees with the already-shared read path.

| | before | after |
|---|---|---|
| roadmap/docs/tasks/flags PATCH | `WHERE … AND owning_shell/shell_id = sid` → 404 for non-owner | existence check only |
| flags GET | per-shell (`shell_id=sid`) | fleet-wide, tagged with author `shortname` |
| mem.py | — | renders the flag owner tag (`@cc`) |

## Verification

- Code-only, **no schema change** — forks pick it up via `./sc update`.
- Existing 17 API tests pass.
- Live two-shell HTTP smoke test replicating the DEV1 scenario: shell B flips status on a feature owned by shell A → `200`, status advances, `owning_shell` preserved; unknown feature still `404`; B sees + resolves A's flag fleet-wide.

## Note

Chose shared-writable (surgical, no migration) over a heavier `assignee_shell` assignment model. If the fleet grows and you want real accountability boundaries, the assignment model can layer on top later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)