### PR TITLE
fix(render): stop teaching shells raw sqlite3 against the substrate DB

### DIFF
--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -165,25 +165,25 @@ def render_skills(con, shell_id: int) -> str:
     ).fetchall()
     if not rows:
         return "(none)"
-    # Substrate skills load from the DB, not a harness skill dir — so they work
-    # on every harness (claude/codex/opencode/vibe), present and future, with no
-    # per-harness bridging. These are SEPARATE from and ADDITIONAL to whatever
-    # native skills your harness ships (codex's `.system` set, claude plugins,
-    # …; vibe ships none). Below: name, one-line description, and the exact query
-    # to load each skill's full procedure on demand.
+    # Each granted skill's full procedure is rendered to a flat file at
+    # `.claude/skills/<slug>/SKILL.md` (see flat.render_skill_md), rebuilt at
+    # every boot for whichever shell launches. These are SEPARATE from and
+    # ADDITIONAL to whatever native skills your harness ships (codex's `.system`
+    # set, claude plugins, …; vibe ships none). Below: name, one-line
+    # description, and the on-disk path to each skill's full procedure — a file
+    # read, never a DB query.
     lines = [
-        "Substrate skills granted to you — loaded from your memory DB, **in "
-        "addition to** any native skills your harness provides. Load a skill's "
-        "full procedure on demand with the query under it:",
+        "Substrate skills granted to you — **in addition to** any native skills "
+        "your harness provides. Each skill's full procedure is on disk at the "
+        "path under it; read that file to load the procedure — never query the "
+        "DB directly:",
         "",
     ]
     for r in rows:
         desc = (r["description"] or "").strip().splitlines()[0] if r["description"] else ""
+        slug = r["name"].strip().lower().replace(" ", "-")
         lines.append(f"- **{r['name']}** — {desc}")
-        lines.append(
-            "  - load: `sqlite3 .super-coder/shell_db.db \"SELECT content FROM "
-            f"skills WHERE name='{r['name']}' AND is_deleted=0;\"`"
-        )
+        lines.append(f"  - full procedure: `.claude/skills/{slug}/SKILL.md`")
     return "\n".join(lines)
 
 

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -97,14 +97,12 @@ you need. Section-first, one cheap query deep — never a full preload.
 
 ```
 # where to start (also rendered in ## CONNECTIONS below):
-sqlite3 .sc-state/map.db \
-  "SELECT name, path_prefix, description FROM dr_section ORDER BY sort_order, name;"
+sc map-sql "SELECT name, path_prefix, description FROM dr_section ORDER BY sort_order, name;"
 # a section's files — descriptions tell you which to open:
-sqlite3 .sc-state/map.db \
-  "SELECT path, desc, lines FROM dr_filepath WHERE path LIKE '<prefix>%' ORDER BY path;"
+sc map-sql "SELECT path, desc, lines FROM dr_filepath WHERE path LIKE '<prefix>%' ORDER BY path;"
 # find by area / stack / env:
-sqlite3 .sc-state/map.db "SELECT path FROM dr_filepath WHERE path LIKE '%auth%';"
-sqlite3 .sc-state/map.db "SELECT manager, name, version FROM dr_dependency;"
+sc map-sql "SELECT path FROM dr_filepath WHERE path LIKE '%auth%';"
+sc map-sql "SELECT manager, name, version FROM dr_dependency;"
 ```
 
 Map first, grep second; lazy-load only what the map points at. If the map looks


### PR DESCRIPTION
## What

Two live render sources still emitted raw `sqlite3 <path>` reads into every shell's boot context — the exact app-DB-vs-engine-DB path confusion the API/mem surface exists to eliminate, and a residual of the #225 cwd-trap sweep that the skills got but the renderer missed.

- **`compose.py` `render_skills`** — the per-skill `load:` line ran `sqlite3 .super-coder/shell_db.db "SELECT content FROM skills ..."`. That relative path silently opens an *empty* DB from a shell worktree or a fork (where gitignored `.super-coder/` is absent), and it's redundant: `flat.render_skill_md` already renders each granted skill's full procedure to `.claude/skills/<slug>/SKILL.md`. Now points at that file — a file read, no DB.
- **`boot.md` ORIENTATION** — four `sqlite3 .sc-state/map.db` reads → `sc map-sql`, the cwd-independent read wrapper the skills already use.

## Why

Reads/writes against the substrate DB should go through the API / sanctioned wrappers, never a hand-typed sqlite3 path. These two sites re-taught the anti-pattern at the top of every shell's context on every boot.

## Verification

- `./sc test` — 122 passed
- `./sc render-check` — clean (flat mirror matches render)
- `ruff` — clean
- Eyeballed the new `## SKILLS` block against the live DB: file pointers, no query.

Both files are read live at boot, so no reseed migration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)