### PR TITLE
fix(vm): contain do_push src/dest — close the sandbox→host escape

### DIFF
--- a/.super-coder/scripts/vm.py
+++ b/.super-coder/scripts/vm.py
@@ -225,17 +225,32 @@ def do_reset(running: bool = True) -> dict:
 def do_push(src: str, dest: str | None = None) -> dict:
     """Stage a host-visible artifact into transfer_dir (the host side of the
     guest's virtio-fs share). `src` is a path in the bind-mounted repo; the guest
-    sees the copy under its mapped share. The fast path — no scp, no guest auth."""
+    sees the copy under its mapped share. The fast path — no scp, no guest auth.
+
+    Contained by design: `src` must resolve inside the repo and `dest` must stay
+    inside transfer_dir. The broker socket is reachable from the sandbox (same
+    uid, socket in the bind-mount), so without these an in-sandbox caller could
+    read host files (`src: ~/.ssh/...`) or write outside the share as the host
+    user (`dest: ../../..`) — a sandbox→host escape. fs-perm (0600) gates other
+    users, not the sandbox."""
     cfg = read() or {}
     if m := _missing(cfg, "transfer_dir"):
         return {"ok": False, "output": m}
+    repo_root = ports.ENGINE.parent.resolve()
     src_p = Path(os.path.expanduser(str(src)))
+    if not src_p.is_absolute():
+        src_p = repo_root / src_p
+    src_p = src_p.resolve()
+    if not src_p.is_relative_to(repo_root):
+        return {"ok": False, "output": f"push: src must be inside the repo: {src}"}
     if not src_p.is_file():
         return {"ok": False, "output": f"push: source not found: {src_p}"}
-    d = Path(os.path.expanduser(str(cfg["transfer_dir"])))
+    d = Path(os.path.expanduser(str(cfg["transfer_dir"]))).resolve()
     if not d.is_dir():
         return {"ok": False, "output": f"transfer_dir does not exist: {d}"}
-    target = d / (dest or src_p.name)
+    target = (d / (dest or src_p.name)).resolve()
+    if not target.is_relative_to(d):
+        return {"ok": False, "output": f"push: dest escapes transfer_dir: {dest}"}
     try:
         shutil.copy2(src_p, target)
     except OSError as e:

--- a/tests/test_vm_broker.py
+++ b/tests/test_vm_broker.py
@@ -14,8 +14,8 @@ Run:
 """
 from __future__ import annotations
 
-import json
 import sys
+import tempfile
 import threading
 import unittest
 from pathlib import Path
@@ -101,10 +101,40 @@ class VerbDispatchTests(unittest.TestCase):
         self.assertIn("powered off", r["output"])
 
     def test_push_rejects_a_missing_source(self):
+        # In-repo but nonexistent → clean "source not found", not a crash.
         with mock.patch.object(vm, "read", return_value=SAVED):
-            r = vm.do_push("/no/such/artifact.msi")
+            r = vm.do_push(str(vm.ports.ENGINE / "no" / "such-artifact.msi"))
         self.assertFalse(r["ok"])
         self.assertIn("source not found", r["output"])
+
+    def test_push_rejects_a_src_outside_the_repo(self):
+        # A sandbox-reachable broker must not exfiltrate host files (~, absolute)
+        # into the guest share — src is contained to the bind-mounted repo.
+        with mock.patch.object(vm, "read", return_value=SAVED):
+            r = vm.do_push("~/.ssh/id_ed25519")
+        self.assertFalse(r["ok"])
+        self.assertIn("inside the repo", r["output"])
+
+    def test_push_rejects_a_dest_that_escapes_transfer_dir(self):
+        # `dest` with .. must not walk out of transfer_dir and clobber host files.
+        share = tempfile.mkdtemp(prefix="sc_share_")
+        cfg = dict(SAVED, transfer_dir=share)
+        src = str(vm.ports.ENGINE / "scripts" / "vm.py")  # a real in-repo file
+        with mock.patch.object(vm, "read", return_value=cfg):
+            r = vm.do_push(src, "../../etc/sc_escape_probe")
+        self.assertFalse(r["ok"])
+        self.assertIn("escapes transfer_dir", r["output"])
+        self.assertFalse(Path("/etc/sc_escape_probe").exists())  # nothing written
+
+    def test_push_stages_a_legit_repo_file_into_the_share(self):
+        # The contained happy path still works: in-repo src → inside the share.
+        share = tempfile.mkdtemp(prefix="sc_share_")
+        cfg = dict(SAVED, transfer_dir=share)
+        src = str(vm.ports.ENGINE / "scripts" / "vm.py")
+        with mock.patch.object(vm, "read", return_value=cfg):
+            r = vm.do_push(src, "staged.py")
+        self.assertTrue(r["ok"], r)
+        self.assertTrue((Path(share) / "staged.py").is_file())
 
     def test_capture_returns_a_base64_screenshot(self):
         def fake_run(argv, timeout=30):


### PR DESCRIPTION
## What

The VM broker's `POST /push {src, dest?}` (`vm.do_push`) copies `src` into `transfer_dir`, the host side of the guest's virtio-fs share. The broker's unix socket lives under `.super-coder/run/` (inside the repo bind-mount) and the sandbox runs as the **same uid**, so an in-sandbox process can connect — the `0600` perm gates *other host users*, not the sandbox. `do_push` enforced neither end of its own contract:

- **Read escape (`src`):** `Path(os.path.expanduser(src))` with no bound — `src: "~/.ssh/id_ed25519"` resolves the host key and stages it into the guest-readable share.
- **Write escape (`dest`):** `d / (dest or src_p.name)` joined raw — `dest: "../../../.ssh/authorized_keys"` walks out of `transfer_dir` and `copy2` writes as the host user. Because the sandbox controls repo file *content*, this is arbitrary host write with attacker-chosen content → host account takeover (a sandbox→host escape, defeating the sandbox's core promise).

## Fix

The docstring already declared "`src` is a path in the bind-mounted repo" — now enforced:
- `src` must resolve **inside the repo root** (drops the `~`/absolute/`..` read escapes).
- the resolved `dest` must stay **inside `transfer_dir`** (drops the `..` write escape).

Legitimate repo-file → share pushes are unchanged.

## Scope / sibling audit

`/push` is the only file-transfer verb — there's **no `do_pull`** to patch, and `do_exec` runs in the *guest* over SSH by design, so the fix is localized to `do_push`.

## Verification

- New tests: `src` outside repo rejected, `dest` traversal rejected (asserts nothing is written), and the contained happy path still stages a real repo file into the share.
- `./sc test` — **125 passed**; `ruff` clean.

Latent until the VM broker is running (the Windows/VM devkit path, not the default docker sandbox), but it's the boundary you rely on the day the sandbox runs untrusted code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)