### PR TITLE
fix(migrate): apply each migration + its ledger stamp atomically

### DIFF
--- a/.super-coder/scripts/migrate.py
+++ b/.super-coder/scripts/migrate.py
@@ -16,6 +16,7 @@ Usage:
 """
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -24,6 +25,13 @@ MIGRATIONS_DIR = ENGINE / "migrations"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import db_driver  # noqa: E402
+
+# A migration file's own outermost transaction control (on its own line). A
+# trigger body's `BEGIN` (no trailing `;`) and `END;` (not `COMMIT;`/`END
+# TRANSACTION;`) are deliberately NOT matched, so a `CREATE TRIGGER … BEGIN …
+# END;` stays intact when we strip the file's outer BEGIN/COMMIT.
+_TXN_BEGIN = re.compile(r"^\s*BEGIN(\s+TRANSACTION)?\s*;\s*$", re.IGNORECASE)
+_TXN_COMMIT = re.compile(r"^\s*(COMMIT|END\s+TRANSACTION)\s*;\s*$", re.IGNORECASE)
 
 
 def applied_set(con) -> set[str]:
@@ -41,9 +49,43 @@ def pending(con) -> list[Path]:
     return [f for f in files if f.name not in done]
 
 
+def _strip_outer_txn(sql: str) -> str:
+    """Drop the file's own outermost BEGIN (first) and COMMIT (last) so the
+    runner can wrap body + ledger stamp in a single transaction without nesting
+    (SQLite has no nested transactions). Files that run bare are unchanged."""
+    lines = sql.splitlines()
+    for i, ln in enumerate(lines):
+        if _TXN_BEGIN.match(ln):
+            lines[i] = ""
+            break
+    for i in range(len(lines) - 1, -1, -1):
+        if _TXN_COMMIT.match(lines[i]):
+            lines[i] = ""
+            break
+    return "\n".join(lines)
+
+
 def apply(con, path: Path) -> None:
-    con.executescript(path.read_text())
-    con.execute("INSERT INTO schema_migrations (filename) VALUES (?)", (path.name,))
+    """Apply one migration file and stamp the ledger ATOMICALLY.
+
+    executescript() disregards isolation_level and autocommits each statement of
+    a bare file, so a mid-file failure used to leave earlier statements applied
+    with no ledger row — re-running then re-ran the file from the top and died
+    (`duplicate column …`), wedging the chain. Wrapping body + stamp in one
+    explicit transaction (with rollback on error) makes a partial failure revert
+    whole, leaving the migration unstamped and cleanly re-runnable."""
+    stamp = path.name.replace("'", "''")
+    script = (
+        "BEGIN;\n"
+        f"{_strip_outer_txn(path.read_text()).strip()}\n"
+        f"INSERT INTO schema_migrations (filename) VALUES ('{stamp}');\n"
+        "COMMIT;"
+    )
+    try:
+        con.executescript(script)
+    except Exception:
+        con.rollback()
+        raise
 
 
 def migrate(db_path: str) -> int:
@@ -54,9 +96,8 @@ def migrate(db_path: str) -> int:
             print("migrate: nothing pending — DB is current.")
             return 0
         for path in todo:
-            apply(con, path)
+            apply(con, path)  # each file self-commits atomically with its stamp
             print(f"migrate: applied {path.name}")
-        con.commit()
         print(f"migrate: {len(todo)} migration(s) applied.")
     finally:
         con.close()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Atomicity tests for the migration runner (scripts/migrate.py).
+
+Stdlib `unittest`, no pytest — matching the engine's no-dependency style. These
+drive `migrate.migrate()` against a throwaway DB with synthetic migrations in a
+temp dir (MIGRATIONS_DIR monkeypatched), to prove a mid-file failure rolls back
+whole and never wedges the chain. The REAL 36-file chain is exercised end to end
+by `./sc render-check` (hermetic rebuild), so it isn't re-run here.
+
+Run:
+    python3 tests/test_migrate.py
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import db_driver  # noqa: E402
+import migrate  # noqa: E402
+
+
+class AtomicMigrateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="sc_mig_"))
+        self.db = str(self.tmp / "t.db")
+        con = db_driver.connect(self.db)
+        con.execute("CREATE TABLE t (a)")
+        con.commit()
+        con.close()
+        self.migdir = self.tmp / "migrations"
+        self.migdir.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, name: str, sql: str) -> None:
+        (self.migdir / name).write_text(sql)
+
+    def _run(self):
+        with mock.patch.object(migrate, "MIGRATIONS_DIR", self.migdir):
+            return migrate.migrate(self.db)
+
+    def _stamped(self) -> set[str]:
+        con = db_driver.connect(self.db)
+        try:
+            return {r[0] for r in con.execute("SELECT filename FROM schema_migrations")}
+        finally:
+            con.close()
+
+    def _cols(self) -> list[str]:
+        con = db_driver.connect(self.db)
+        try:
+            return [r[1] for r in con.execute("PRAGMA table_info(t)")]
+        finally:
+            con.close()
+
+    def test_bare_multistmt_failure_rolls_back_and_is_not_wedged(self):
+        # A bare (no BEGIN) migration whose 2nd statement fails.
+        self._write("0001_bad.sql",
+                    "ALTER TABLE t ADD COLUMN b;\nALTER TABLE t ADD COLUMN b;\n")
+        with self.assertRaises(Exception):
+            self._run()
+        # Rolled back whole: no partial column, no ledger stamp -> re-runnable.
+        self.assertNotIn("b", self._cols())
+        self.assertNotIn("0001_bad.sql", self._stamped())
+        # Fix the file; the chain applies cleanly (it was never wedged).
+        self._write("0001_bad.sql", "ALTER TABLE t ADD COLUMN b;\n")
+        self._run()
+        self.assertIn("b", self._cols())
+        self.assertIn("0001_bad.sql", self._stamped())
+
+    def test_ledger_stamp_is_atomic_with_body(self):
+        self._write("0001_ok.sql", "ALTER TABLE t ADD COLUMN b;\n")
+        self._run()
+        self.assertIn("0001_ok.sql", self._stamped())
+        # Re-run is a no-op (already stamped), not a duplicate-column crash.
+        self._run()
+        self.assertEqual(self._cols().count("b"), 1)
+
+    def test_file_with_its_own_begin_commit_is_stripped_and_applies(self):
+        self._write("0001_wrapped.sql",
+                    "BEGIN;\nALTER TABLE t ADD COLUMN b;\nCOMMIT;\n")
+        self._run()
+        self.assertIn("b", self._cols())
+        self.assertIn("0001_wrapped.sql", self._stamped())
+
+    def test_trigger_body_begin_end_survives_the_strip(self):
+        # A CREATE TRIGGER's BEGIN/END must not be mistaken for txn control.
+        self._write("0001_trig.sql",
+                    "BEGIN;\n"
+                    "CREATE TABLE log (m TEXT);\n"
+                    "CREATE TRIGGER trg AFTER INSERT ON t\n"
+                    "BEGIN\n"
+                    "  INSERT INTO log (m) VALUES ('hit');\n"
+                    "END;\n"
+                    "COMMIT;\n")
+        self._run()
+        self.assertIn("0001_trig.sql", self._stamped())
+        con = db_driver.connect(self.db)
+        try:
+            con.execute("INSERT INTO t (a) VALUES (1)")
+            con.commit()
+            n = con.execute("SELECT COUNT(*) FROM log").fetchone()[0]
+        finally:
+            con.close()
+        self.assertEqual(n, 1)  # trigger fired -> it was created intact
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`migrate.apply()` ran a migration file with `executescript()` and stamped the `schema_migrations` ledger in a *separate* statement. Two problems compounded:

1. `executescript` disregards `isolation_level` and **autocommits each statement** of a bare (no-`BEGIN`) file.
2. the ledger stamp committed later still.

So a multi-statement migration that failed partway — e.g. `0027_shell_api_keys.sql` (two `ALTER TABLE ADD COLUMN` + an index) — left the earlier statement(s) **applied with no ledger row**. Re-running `./sc migrate` then re-ran the file from the top → `duplicate column name: api_key` → the chain **wedged permanently** until someone hand-edited the DB. Reproduced in a scratch DB. Seven migrations run bare and were all exposed: `0008, 0009, 0012, 0013, 0016, 0027, 0035`.

## Fix

Wrap each file's **body + its ledger stamp** in one runner-owned transaction, with `rollback()` on error. A partial failure now reverts whole, leaving the migration unstamped and cleanly re-runnable. The file's own outer `BEGIN`/`COMMIT` is stripped first so we don't nest transactions (SQLite has none); a trigger body's `BEGIN`/`END;` is left intact — the strip matches only `BEGIN;`/`COMMIT;`/`END TRANSACTION;` on their own line, never a trigger's `BEGIN` (no `;`) or `END;`.

Empirically verified: a bare mid-file failure leaves `in_transaction=False` and a truly-committed partial (rollback can't help) — the wedge; the wrapped form leaves `in_transaction=True` and `rollback()` reverts cleanly.

## Verification

- New `tests/test_migrate.py`: bare-failure-doesn't-wedge (+ re-run succeeds), stamp atomicity, own-`BEGIN` stripping, and **trigger-body survival** (the `0005` case).
- The **real 36-migration chain** runs through the new runner in `./sc render-check` (hermetic rebuild) — green, so the strip corrupts nothing.
- `./sc test` — **126 passed**; `ruff` clean.

Also removes the now-redundant trailing `con.commit()` (each file self-commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)