### PR TITLE
fix(git-hygiene): newest PR decides branch state, not merged-always-wins

### DIFF
--- a/.super-coder/scripts/git_hygiene.py
+++ b/.super-coder/scripts/git_hygiene.py
@@ -131,8 +131,16 @@ def _gh_merged_prs() -> tuple[dict[str, dict] | None, bool]:
         by_branch: dict[str, dict] = {}
         for pr in json.loads(r.stdout or "[]"):
             ref = pr.get("headRefName")
-            # keep the most decisive: a MERGED PR wins over an older OPEN/CLOSED
-            if ref and (ref not in by_branch or pr.get("state") == "MERGED"):
+            if not ref:
+                continue
+            # A reused branch name carries several PRs; the NEWEST (highest
+            # number) is authoritative. MERGED-always-wins was unsafe: a new
+            # OPEN PR on a branch whose earlier PR merged got misread as merged,
+            # marking the branch stale -> `git branch -D` on live work. Newest-
+            # wins also handles reopen-then-merge (newest merged -> prunable).
+            num = pr.get("number") or 0
+            prev = by_branch.get(ref)
+            if prev is None or num > (prev.get("number") or 0):
                 by_branch[ref] = {"number": pr.get("number"), "state": pr.get("state")}
         return by_branch, True
     except (subprocess.TimeoutExpired, OSError, json.JSONDecodeError):

--- a/tests/test_git_prune.py
+++ b/tests/test_git_prune.py
@@ -17,12 +17,14 @@ Run:
 """
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parents[1] / ".super-coder" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
@@ -121,6 +123,48 @@ class PruneTest(unittest.TestCase):
         self.assertIn("pruned 2 merged branches", line)
         one = git_prune.status_line({"deleted": ["a"], "failed": []})
         self.assertIn("pruned 1 merged branch ", one)  # singular, no plural 'es'
+
+
+class MergedPrClassificationTests(unittest.TestCase):
+    """`_gh_merged_prs` must let the NEWEST PR per branch decide state, so a
+    reused branch name whose latest PR is OPEN is never misread as merged (which
+    would mark it stale and `git branch -D` live work)."""
+
+    def _run(self, prs: list[dict]) -> dict:
+        fake = mock.Mock(returncode=0, stdout=json.dumps(prs))
+        with mock.patch.object(git_hygiene.shutil, "which", return_value="/usr/bin/gh"), \
+             mock.patch.object(git_hygiene.subprocess, "run", return_value=fake):
+            by_branch, available = git_hygiene._gh_merged_prs()
+        self.assertTrue(available)
+        return by_branch
+
+    def test_open_pr_on_reused_branch_wins_over_older_merged(self):
+        # feat/x: #10 merged long ago, #20 open now on the same name.
+        by_branch = self._run([
+            {"number": 20, "headRefName": "feat/x", "state": "OPEN", "mergedAt": None},
+            {"number": 10, "headRefName": "feat/x", "state": "MERGED",
+             "mergedAt": "2026-01-01T00:00:00Z"},
+        ])
+        self.assertEqual(by_branch["feat/x"]["state"], "OPEN")   # not prunable
+        self.assertEqual(by_branch["feat/x"]["number"], 20)
+
+    def test_reopen_then_merge_is_still_prunable(self):
+        # newest PR is the merged one -> branch is genuinely done.
+        by_branch = self._run([
+            {"number": 30, "headRefName": "feat/y", "state": "MERGED",
+             "mergedAt": "2026-02-02T00:00:00Z"},
+            {"number": 12, "headRefName": "feat/y", "state": "CLOSED", "mergedAt": None},
+        ])
+        self.assertEqual(by_branch["feat/y"]["state"], "MERGED")
+
+    def test_order_independence(self):
+        # same inputs, merged-first ordering, must still pick the open #20.
+        by_branch = self._run([
+            {"number": 10, "headRefName": "feat/x", "state": "MERGED",
+             "mergedAt": "2026-01-01T00:00:00Z"},
+            {"number": 20, "headRefName": "feat/x", "state": "OPEN", "mergedAt": None},
+        ])
+        self.assertEqual(by_branch["feat/x"]["state"], "OPEN")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`git_hygiene._gh_merged_prs` collapses the PRs on a branch name with the rule *"a MERGED PR wins over an older OPEN/CLOSED."* On a **reused branch name** — an old PR merged, then a **new OPEN PR** opened on the same name — the merged PR overwrote the open one. The branch was then classified merged → `git_hygiene` marks it `stale` → `git_prune` runs `git branch -D` on a branch **backing an open PR**, destroying any unpushed commits.

The existing `checked_out` guard only spares a branch that is *currently checked out* in a worktree; an open-PR branch that's been switched away from is unprotected.

## Fix

Keep the **newest** PR (highest number) per branch, whatever its state:
- latest PR OPEN → branch reads OPEN → **not** pruned (live work preserved).
- reopen-then-merge → latest PR MERGED → still pruned (genuinely done).

`git branch -D` stays as-is — squash-merged branches are never git-"contained", which is exactly why merge is proven via `gh` rather than ancestry; switching to `-d` would refuse every squash-merged branch.

## Verification

- New `MergedPrClassificationTests`: open-beats-older-merged, reopen-then-merge, and order-independence — the stale-derivation layer had **no** coverage before (the existing prune tests inject hand-built snapshots by design).
- `./sc test` — **125 passed**; `ruff` clean.

## Residual (not addressed here)

`-D` on a genuinely-merged branch still doesn't detect local commits added *after* the merge with no new PR — a rare, user-driven case. Called out for a follow-up if you want a hard "unpushed local commits" guard in the `stale` predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)