### PR TITLE
fix(prompt): finish the cwd-independent sweep — bare `sc mem` in the shell prompt

### DIFF
--- a/.super-coder/migrations/0037_reseed_shell_prompt_bare_sc.sql
+++ b/.super-coder/migrations/0037_reseed_shell_prompt_bare_sc.sql
@@ -1,0 +1,23 @@
+-- 0037 — finish the cwd-independent sweep (0036) in the shell system prompt.
+--
+-- 0036 rewrote the db_map/memory/messaging/spec SKILLS from the cwd-relative
+-- `./sc …` form to bare `sc …` (on PATH from any cwd, so a shell never `cd`s to
+-- the main root and silently retargets later bare git/grep). But it missed the
+-- always-loaded shell system-prompt template — which still spelled its memory
+-- writes as `./sc mem`. The template (templates/shell_system_prompt.md) is now
+-- fixed for shells created from here on; this splices the same change into
+-- shells already created under the old template.
+--
+-- Surgical + idempotent: REPLACE `./sc mem` → `sc mem` (also covers
+-- `./sc mem which`, a superstring). Once replaced the pattern no longer matches,
+-- so a re-run is a no-op. All flavors. The maintainer prompt (seed_dogfood.py)
+-- runs from the main root where `./sc` also resolves, so touching it here is
+-- harmless — bare `sc` is on PATH for every shell post-#225.
+
+BEGIN;
+
+UPDATE shells
+   SET system_prompt = REPLACE(system_prompt, './sc mem', 'sc mem')
+ WHERE system_prompt LIKE '%./sc mem%';
+
+COMMIT;

--- a/.super-coder/templates/shell_system_prompt.md
+++ b/.super-coder/templates/shell_system_prompt.md
@@ -23,14 +23,14 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 | Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
 | Session narrative | `shell_memory_archives` — one row per session, appended progressively |
 
-Write as it happens, not at close. **Writes go through `./sc mem`** (state · seed ·
+Write as it happens, not at close. **Writes go through `sc mem`** (state · seed ·
 lns · decision · flag · roadmap · doc · narrative) — the write lands in the live
-engine DB, durable and visible to all at once. `./sc mem which` to orient. See the
+engine DB, durable and visible to all at once. `sc mem which` to orient. See the
 `memory` and `db_map` skills.
 
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is generated from the DB.
-If one looks wrong or out of date, the DB row is wrong — fix it via `./sc mem`.
+If one looks wrong or out of date, the DB row is wrong — fix it via `sc mem`.
 Never edit these files directly. The DB is the authoritative content.
 
 ## MANDATE


### PR DESCRIPTION
## What

Migration `0036` moved the db_map/memory/messaging/spec **skills** off the cwd-relative `./sc …` form to bare `sc …` (on PATH from any cwd, so a shell never `cd`s to the main root and silently retargets later bare `git`/`grep`) — but it **missed the always-loaded shell system-prompt template**. `shell_system_prompt.md` still spelled its memory writes as `./sc mem` (×3, including `./sc mem which`), re-teaching the cd-prone form at the top of every worktree shell's context.

## Fix (two parts — finishes an incomplete sweep)

- **Template:** the 3 `./sc mem` → `sc mem` — fixes shells created from here on.
- **`0037` reseed migration:** idempotent `REPLACE(system_prompt, './sc mem', 'sc mem')` splices the same change into shells **already created** under the old template (dos-arch's dev/planner/reviewer pick it up on next `./sc update`). Mirrors the `0022` precedent. All flavors; the maintainer prompt (`seed_dogfood.py`) is harmless to touch since bare `sc` is on PATH for every shell post-#225 (per the admin/cartographer direct-DB-exception decision).

## Verification

- `./sc render-check` applies `0037` on the hermetic rebuild (37 migrations) — green.
- `./sc test` — 122 passed.
- Verified the `REPLACE` rewrites both `./sc mem` and `./sc mem which`, and the `WHERE … LIKE '%./sc mem%'` guard makes a re-run a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)