### PR TITLE
feat(fork): first-class opt-ins (./sc feature) + explicit divergence (./sc eject)

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -26,14 +26,14 @@
 #
 #   LONG-ONLY: dos-build dos-logs dos-serve dos-health dos-ports dos-verify dos-map
 #              dos-render dos-snapshot dos-deps dos-install dos-rollback
-#              dos-update-harnesses
+#              dos-update-harnesses dos-feat/dos-feature dos-eject
 #              passthrough: make dos ARGS=health
 #
 SC := ./sc
 .PHONY: dos-e dos-enter dos-l dos-launch dos-r dos-restart dos-d dos-down dos-u dos-update \
         dos-t dos-test dos-h dos-help dos-build dos-logs dos-serve dos-health dos-ports \
         dos-verify dos-map dos-render dos-snapshot dos-deps dos-install dos-rollback \
-        dos-update-harnesses dos
+        dos-update-harnesses dos-feat dos-feature dos-eject dos
 
 # Hot commands — long form, with a one-letter alias delegating to it.
 dos-enter:            ; $(SC) $(if $(s),enter-$(s),enter)
@@ -63,6 +63,11 @@ dos-deps:             ; $(SC) deps
 dos-install:          ; $(SC) install
 dos-rollback:         ; $(SC) rollback
 dos-update-harnesses: ; $(SC) update-harnesses
+# Opt-in features: make dos-feat (list) · make dos-feat ARGS="enable pg"
+dos-feature:          ; $(SC) feature $(ARGS)
+dos-feat: dos-feature
+# One-way divergence — interactive warning + typed confirmation in ./sc eject.
+dos-eject:            ; $(SC) eject
 
 # Passthrough: run any ./sc subcommand — make dos ARGS=health
 dos:                  ; $(SC) $(ARGS)
@@ -111,6 +116,8 @@ dos-help:
 	@echo "  │ dos-install          │ first-launch bootstrap for a fork                        │"
 	@echo "  │ dos-rollback         │ undo a bad update — restore DB + engine together         │"
 	@echo "  │ dos-update-harnesses │ update claude + opencode + codex + vibe to latest        │"
+	@echo "  │ dos-feat ARGS=<x>    │ opt-in features — list / enable pg·windows·tailnet       │"
+	@echo "  │ dos-eject            │ ONE-WAY: own the engine — stop tracking upstream         │"
 	@echo "  ├──────────────────────┼──────────────────────────────────────────────────────────┤"
 	@echo "  │ dos ARGS=<cmd>       │ passthrough to any ./sc subcommand (make dos ARGS=doctor)│"
 	@echo "  └──────────────────────┴──────────────────────────────────────────────────────────┘"

--- a/.super-coder/scripts/eject.py
+++ b/.super-coder/scripts/eject.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""./sc eject — one-way: stop tracking upstream and OWN the engine.
+
+The B7 model keeps `.super-coder/` a gitignored, materialized dependency —
+upstream-owned, wholesale-overwritten by `./sc update`, never fork-edited. That
+is the right default: as long as customization fits the fork-owned extension
+points (local skills, instance.json, .sc-state/, everything outside the
+engine), a fork tracks upstream forever and keeps receiving fixes.
+
+Eject is for the moment that stops being true: the fork needs engine changes
+that upstream would rightly not take. It flips the model — the engine becomes
+FORK SOURCE, committed and edited like any other code in the repo:
+
+    1. .gitignore     drop the `/.super-coder/` rule; keep only the engine's
+                      runtime/per-instance files ignored (DB, instance.json,
+                      run/, logs/, the hash manifest)
+    2. .sc-state/     delete engine.ref + engine.ref.prev (there is no pin —
+                      no upstream); delete the hash manifest (git tracks edits
+                      now); write the `ejected` marker recording the SHA the
+                      fork diverged at
+    3. remote         remove the super-coder remote (unless --keep-remote)
+    4. stage          git add the engine + the edits above; COMMITTING STAYS
+                      YOURS (review the diff first)
+
+After eject, `./sc update` and `./sc rollback` refuse (the marker); everything
+else — launch, enter, snapshot, render, the GUI — works unchanged, reading the
+same engine files from the same paths.
+
+What you give up: upstream fixes, migrations, and new skills stop flowing.
+Upstream-first is the strong default — PR the change to super-coder instead if
+the next fork would want it too. Eject only when the divergence is genuinely
+yours. (README → 'Customize a fork vs diverge from it'.)
+
+Reversing: before the eject commit, `git reset` + restore .sc-state from HEAD
++ re-add the remote. After it, re-adopting upstream is a manual re-fork.
+
+Usage:
+    ./sc eject [--yes] [--keep-remote]
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+STATE_DIR = REPO_ROOT / ".sc-state"
+ENGINE_REF = STATE_DIR / "engine.ref"
+ENGINE_REF_PREV = STATE_DIR / "engine.ref.prev"
+EJECTED_MARKER = STATE_DIR / "ejected"
+MANIFEST = ENGINE / "engine.manifest"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import update as update_mod  # noqa: E402  (is_source_repo, git helper)
+
+# Post-eject .gitignore block: the engine is tracked now, but its runtime /
+# per-instance files never are (same set the SOURCE repo ignores — it tracks
+# its own engine too, so this is a proven ignore surface).
+EJECTED_IGNORE_MARKER = "# super-coder — EJECTED: engine is fork source (tracked);"
+EJECTED_IGNORE_BLOCK = f"""
+{EJECTED_IGNORE_MARKER} only its
+# runtime/per-instance files stay ignored.
+/.super-coder/shell_db.db
+/.super-coder/shell_db.db-wal
+/.super-coder/shell_db.db-shm
+/.super-coder/instance.json
+/.super-coder/run/
+/.super-coder/logs/
+/.super-coder/engine.manifest
+"""
+
+WARNING = """\
+╔══════════════════════════════════════════════════════════════════════════╗
+║  ./sc eject — ONE-WAY DOOR                                                ║
+╚══════════════════════════════════════════════════════════════════════════╝
+
+This makes the engine (.super-coder/ + sc) FORK SOURCE — tracked, committed,
+and edited like any other code in this repo. In exchange you give up the
+upstream lifeline, permanently:
+
+  · `./sc update` stops working — no more upstream fixes, migrations, or new
+    catalogue skills. Every engine change from here on is yours to author.
+  · `./sc rollback` stops working — use plain git on the tracked engine.
+  · Re-adopting upstream later is a manual re-fork, not a command.
+
+Everything else is unchanged: launch, enter, snapshot, render, the GUI, and
+your DB/memory are untouched. Nothing is committed by this command — it stages
+the change and you review + commit.
+
+Is this the right move? Only if you need engine changes upstream would rightly
+not take. If the next fork would want your change too, PR it to super-coder
+instead and stay on updates (the strong default).
+"""
+
+
+def _gitignore_eject() -> str:
+    """Drop the `/.super-coder/` rule; append the runtime-ignore block. Returns
+    a one-line status. Idempotent."""
+    gi = REPO_ROOT / ".gitignore"
+    if not gi.exists():
+        gi.write_text(EJECTED_IGNORE_BLOCK)
+        return "wrote .gitignore (engine runtime ignores)"
+    lines = gi.read_text().splitlines()
+    kept = [ln for ln in lines if ln.strip() != "/.super-coder/"]
+    dropped = len(lines) - len(kept)
+    text = "\n".join(kept) + ("\n" if kept else "")
+    if EJECTED_IGNORE_MARKER not in text:
+        text += EJECTED_IGNORE_BLOCK
+    gi.write_text(text)
+    return (f"dropped the /.super-coder/ rule ({dropped} line) + kept runtime files ignored"
+            if dropped else "runtime ignores ensured (/.super-coder/ rule was already gone)")
+
+
+def _confirm() -> None:
+    if not sys.stdin.isatty():
+        sys.exit("eject: refusing without confirmation on a non-interactive "
+                 "stdin — pass --yes to script it.")
+    try:
+        answer = input("Type 'eject' to proceed (anything else aborts): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        answer = ""
+    if answer != "eject":
+        sys.exit("eject: aborted — nothing changed.")
+
+
+def main(argv: list[str]) -> int:
+    yes = "--yes" in argv
+    keep_remote = "--keep-remote" in argv
+
+    if update_mod.is_source_repo():
+        sys.exit("eject: this is the super-coder SOURCE repo — the engine is "
+                 "already tracked source here; there is nothing to eject.")
+    if EJECTED_MARKER.exists():
+        print("eject: already ejected — the engine is fork source "
+              f"(marker: {EJECTED_MARKER.relative_to(REPO_ROOT)}).")
+        return 0
+
+    pinned = ENGINE_REF.read_text().strip() if ENGINE_REF.exists() else ""
+
+    print(WARNING)
+    print(f"  engine currently pinned at: {pinned[:12] if pinned else '(no engine.ref — unpinned)'}\n")
+    if not yes:
+        _confirm()
+
+    print("→ ejecting")
+
+    # 1. gitignore: the engine becomes visible to git; runtime files stay dark.
+    print(f"  .gitignore: {_gitignore_eject()}")
+
+    # 2. .sc-state: no upstream → no pin, no restore pointer, no edit manifest.
+    for p in (ENGINE_REF, ENGINE_REF_PREV, MANIFEST):
+        if p.exists():
+            p.unlink()
+            print(f"  removed {p.relative_to(REPO_ROOT)}")
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    remote_url = ""
+    r = update_mod.git("remote", "get-url", "super-coder", check=False)
+    if r.returncode == 0:
+        remote_url = r.stdout.strip()
+    EJECTED_MARKER.write_text(json.dumps({
+        "ejected_at": date.today().isoformat(),
+        "engine_ref": pinned,          # the upstream SHA the fork diverged at
+        "upstream": remote_url,
+    }, indent=2) + "\n")
+    print(f"  wrote .sc-state/ejected (diverged at {pinned[:12] if pinned else 'unknown'})")
+
+    # 3. The upstream remote: gone by default — eject means no upstream. It is
+    # one command to re-add, and --keep-remote preserves it for reference.
+    if keep_remote:
+        print("  --keep-remote: super-coder remote left in place (reference only)")
+    elif remote_url:
+        update_mod.git("remote", "remove", "super-coder", check=False)
+        print(f"  removed the super-coder remote ({remote_url})")
+    else:
+        print("  (no super-coder remote to remove)")
+
+    # 4. Stage — the operator reviews + commits. `git add .super-coder` works
+    # now that the ignore rule is gone; runtime files stay excluded by the new
+    # block. `.sc-state` stages the ref deletions + the marker.
+    update_mod.git("add", ".gitignore", ".sc-state", ".super-coder")
+    n = len(update_mod.git("diff", "--cached", "--name-only",
+                           check=False).stdout.splitlines())
+    print(f"  staged {n} file(s)")
+
+    print("\neject: done — the engine is fork source. Review + commit:")
+    print("    git status && git diff --cached --stat")
+    print(f"    git commit -m 'chore: eject super-coder engine (diverged at "
+          f"{pinned[:12] if pinned else 'unpinned'})'")
+    print("  From here, edit .super-coder/ directly; update/rollback now refuse.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/engine_manifest.py
+++ b/.super-coder/scripts/engine_manifest.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Engine hash manifest — the local-edit guard for the materialized engine.
+
+The engine (`.super-coder/` + `sc`) is a wholesale-overwritten dependency:
+`./sc update` materializes upstream's tree over the top with no merge. That is
+correct for the B7 model — engine files are not fork-edited — but it means a
+local patch to an engine file would be DISCARDED SILENTLY the next time the
+fork updates. This module closes that hole:
+
+    write_manifest()   after every materialize (and at install), record a
+                       sha256 per engine file → .super-coder/engine.manifest
+    local_edits()      before the next materialize, hash the same files and
+                       report any that were modified or deleted since
+
+update.py blocks on a non-empty local_edits() unless --force, pointing the
+operator at the real choices: revert the edit, upstream it, or `./sc eject`.
+
+The manifest is derived machine state, not fork content: it lives inside the
+gitignored engine dir and is never committed (eject deletes it — an ejected
+engine is fork source, and git itself tracks edits from there). Lives in its
+own module because update.py imports install.py (shared helpers) — putting
+this in either would make the other's import circular.
+
+Limits, by design: files ADDED locally under `.super-coder/` are not in the
+manifest and are not detected — materialize never touches them, so nothing is
+lost. A fork whose engine predates the manifest (no file yet) gets its first
+one written by the next update; that first update cannot check.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+MANIFEST = ENGINE / "engine.manifest"
+
+# The ENGINE = system content that propagates to every fork; all of it is safe
+# to materialize from the super-coder remote (it is wholesale-replaced, never
+# fork-edited). The per-instance set is deliberately NOT listed, so a materialize
+# never touches it: `.sc-state/` (this fork's content.sql + map tuning + engine
+# pin), shell_db.db* (gitignored), instance.json (gitignored). assets/seed/ is
+# super-coder-only (stripped on install); assets/shells/ is empty/vestigial.
+# Lives here (not update.py) so install.py can write the first manifest without
+# a circular import; update.py re-exports it as update.ENGINE_PATHS.
+ENGINE_PATHS = [
+    "sc",
+    ".super-coder/aliases.mk",
+    ".super-coder/Dockerfile",
+    ".super-coder/schema.sql",
+    ".super-coder/map_schema.sql",
+    ".super-coder/ecosystem.config.cjs",
+    ".super-coder/README.md",
+    ".super-coder/migrations",
+    ".super-coder/scripts",
+    ".super-coder/render",
+    ".super-coder/templates",
+    ".super-coder/adapters",
+    ".super-coder/api",
+    ".super-coder/ui",
+    ".super-coder/assets/skills",
+    ".super-coder/hooks",
+]
+
+# Never hashed: bytecode + caches that churn without a source edit.
+_SKIP_NAMES = {"__pycache__", "node_modules", ".svelte-kit"}
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _iter_files(engine_paths: list[str]) -> list[Path]:
+    """Every regular file the materialize set covers, as REPO_ROOT-relative
+    paths. `engine_paths` entries are files or directories (update.ENGINE_PATHS
+    form); directories are walked whole, mirroring what `git archive` emits."""
+    out: list[Path] = []
+    for entry in engine_paths:
+        p = REPO_ROOT / entry
+        if p.is_file():
+            out.append(p.relative_to(REPO_ROOT))
+        elif p.is_dir():
+            for f in sorted(p.rglob("*")):
+                if not f.is_file() or f.suffix == ".pyc":
+                    continue
+                if _SKIP_NAMES & set(f.relative_to(REPO_ROOT).parts):
+                    continue
+                out.append(f.relative_to(REPO_ROOT))
+    return out
+
+
+def write_manifest(engine_paths: list[str]) -> int:
+    """Record the engine's current on-disk state (call right after a
+    materialize, when disk == upstream). Returns the file count."""
+    entries = {str(rel): _sha256(REPO_ROOT / rel) for rel in _iter_files(engine_paths)}
+    MANIFEST.write_text(json.dumps(entries, indent=0, sort_keys=True) + "\n")
+    return len(entries)
+
+
+def local_edits() -> dict[str, str]:
+    """Engine files changed since the manifest was written: {path: 'modified' |
+    'deleted'}. Empty dict = clean, or no manifest yet (nothing to compare)."""
+    if not MANIFEST.exists():
+        return {}
+    try:
+        recorded: dict[str, str] = json.loads(MANIFEST.read_text())
+    except json.JSONDecodeError:
+        return {}  # corrupt manifest — treat as absent; the next write heals it
+    edits: dict[str, str] = {}
+    for rel, digest in recorded.items():
+        p = REPO_ROOT / rel
+        if not p.is_file():
+            edits[rel] = "deleted"
+        elif _sha256(p) != digest:
+            edits[rel] = "modified"
+    return edits

--- a/.super-coder/scripts/feature.py
+++ b/.super-coder/scripts/feature.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""./sc feature — the front door to the engine's opt-in features.
+
+Opt-ins have always existed as two mechanisms that compose:
+
+    1. an `instance.json` block (pg / vm / ts) — enables the INFRASTRUCTURE
+       (sidecar container, host-side broker) for this fork;
+    2. `common=0` skill grants — puts the PROCEDURE in the right shells' hands
+       (the skills ship to every fork's catalogue but auto-grant to none).
+
+This command makes the pair first-class: `list` shows every feature and the
+state of both halves; `enable` grants the feature's skills to the flavors that
+own them (and creates the config block where that is scriptable); `disable`
+reverses it. The mechanisms underneath are unchanged — feature.py only
+orchestrates them, so everything here can still be done by hand.
+
+The vm/ts blocks are NOT auto-created: they carry host-specific, operator-
+verified config (a linked VM, a tailnet scope) that `enable` cannot invent —
+it grants the skills and prints exactly how to link. `pg` needs no host input
+(the sidecar is fully derived), so its block IS auto-created.
+
+Grants land in shell_skills, which is fork memory — enable/disable therefore
+re-snapshots, so `.sc-state/content.sql` stays current and a rebuild keeps the
+grants.
+
+Usage:
+    ./sc feature                      # = list
+    ./sc feature list
+    ./sc feature enable  <name>       # pg · windows · tailnet
+    ./sc feature disable <name>
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+DB_PATH = ENGINE / "shell_db.db"
+INSTANCE = ENGINE / "instance.json"
+PY = sys.executable
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import db_driver  # noqa: E402
+
+# The registry. `block` is the instance.json key; `block_auto` says whether
+# enable may create it (only when it needs no operator-supplied host config).
+# `grants` maps skill name → the flavors whose shells own that procedure.
+# `link` is the printed how-to for the operator-supplied blocks.
+FEATURES: dict[str, dict] = {
+    "pg": {
+        "title": "Postgres sidecar (app-only)",
+        "block": "pg",
+        "block_auto": True,
+        "grants": {"test_authoring_pg": ["dev", "reviewer"]},
+        "next": ["./sc launch   # starts the sidecar + forwards DATABASE_URL "
+                 "(or: ./sc pg-up)"],
+    },
+    "windows": {
+        "title": "Windows Test VM (link-only)",
+        "block": "vm",
+        "block_auto": False,
+        "grants": {"windows_devkit": ["dev", "reviewer"],
+                   "configure_winbox": ["admin"]},
+        "link": ["link your VM: GUI → Scripts → 'Windows Test VM' wizard "
+                 "(live-checks each field), or hand-fill the `vm` block in "
+                 ".super-coder/instance.json — see README → 'Windows Test VM'",
+                 "./sc launch   # brings the vm-broker up once a VM is linked"],
+    },
+    "tailnet": {
+        "title": "Tailnet broker",
+        "block": "ts",
+        "block_auto": False,
+        "grants": {"tailscale": ["devops"]},
+        "link": ["hand-fill the `ts` block in .super-coder/instance.json "
+                 "(allowed_hosts is the fail-closed scope) — see README → "
+                 "'Tailnet broker'",
+                 "./sc launch   # brings the ts-broker up once a tailnet is linked"],
+    },
+}
+
+
+def _instance() -> dict:
+    if not INSTANCE.exists():
+        return {}
+    try:
+        return json.loads(INSTANCE.read_text())
+    except json.JSONDecodeError:
+        sys.exit(f"feature: {INSTANCE} is not valid JSON — fix it first.")
+
+
+def _write_instance(cfg: dict) -> None:
+    INSTANCE.write_text(json.dumps(cfg, indent=2) + "\n")
+
+
+def grant(con, skill: str, flavors: list[str]) -> int:
+    """Grant `skill` to every live shell of the given flavors. Idempotent."""
+    q = ",".join("?" for _ in flavors)
+    cur = con.execute(
+        f"INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
+        f"SELECT s.shell_id, k.skill_id FROM shells s, skills k "
+        f"WHERE COALESCE(s.is_deleted,0)=0 AND s.flavor IN ({q}) "
+        f"AND k.name=? AND k.is_deleted=0",
+        (*flavors, skill))
+    return cur.rowcount
+
+
+def revoke(con, skill: str, flavors: list[str]) -> int:
+    """Revoke `skill` from shells of the given flavors — only the grants enable
+    would have made; a grant to a bespoke/other-flavor shell is left alone."""
+    q = ",".join("?" for _ in flavors)
+    cur = con.execute(
+        f"DELETE FROM shell_skills WHERE skill_id IN "
+        f"(SELECT skill_id FROM skills WHERE name=? AND is_deleted=0) "
+        f"AND shell_id IN (SELECT shell_id FROM shells "
+        f"WHERE COALESCE(is_deleted,0)=0 AND flavor IN ({q}))",
+        (skill, *flavors))
+    return cur.rowcount
+
+
+def _grant_state(con, skill: str) -> list[str]:
+    """['dev(2)', 'reviewer(1)'] — live shells holding the skill, by flavor."""
+    rows = con.execute(
+        "SELECT COALESCE(s.flavor,'bespoke'), COUNT(*) FROM shell_skills g "
+        "JOIN shells s ON s.shell_id=g.shell_id "
+        "JOIN skills k ON k.skill_id=g.skill_id "
+        "WHERE k.name=? AND COALESCE(s.is_deleted,0)=0 AND k.is_deleted=0 "
+        "GROUP BY 1 ORDER BY 1", (skill,)).fetchall()
+    return [f"{flavor}({n})" for flavor, n in rows]
+
+
+def _snapshot() -> None:
+    """Grants are fork memory — persist them to the tracked serialization."""
+    env = {**os.environ, "SC_ADMIN": "1"}
+    r = subprocess.run([PY, str(ENGINE / "scripts" / "snapshot.py")], env=env)
+    if r.returncode != 0:
+        print("⚠ snapshot failed — grants are live in the DB but "
+              ".sc-state/content.sql is stale; run ./sc snapshot", file=sys.stderr)
+
+
+def cmd_list() -> int:
+    cfg = _instance()
+    con = db_driver.connect(DB_PATH) if DB_PATH.exists() else None
+    print("opt-in features — enable with: ./sc feature enable <name>\n")
+    for name, f in FEATURES.items():
+        blk = f["block"]
+        linked = blk in cfg
+        blk_state = f"✓ `{blk}` linked" if linked else (
+            f"✗ `{blk}` block absent" + ("" if f["block_auto"] else " (operator-linked)"))
+        print(f"  {name:8} {f['title']}")
+        print(f"           config: {blk_state}")
+        for skill in f["grants"]:
+            held = _grant_state(con, skill) if con else []
+            state = " ".join(held) if held else "none"
+            print(f"           skill:  {skill} → {state}")
+        print()
+    if con:
+        con.close()
+    return 0
+
+
+def _resolve(name: str) -> dict:
+    f = FEATURES.get(name)
+    if not f:
+        sys.exit(f"feature: unknown feature '{name}' "
+                 f"(have: {', '.join(FEATURES)})")
+    return f
+
+
+def cmd_enable(name: str) -> int:
+    f = _resolve(name)
+    if not DB_PATH.exists():
+        sys.exit("feature: no live DB — run ./sc rebuild (or ./sc install) first.")
+    print(f"→ enable {name} — {f['title']}")
+
+    con = db_driver.connect(DB_PATH)
+    try:
+        granted = 0
+        for skill, flavors in f["grants"].items():
+            n = grant(con, skill, flavors)
+            granted += n
+            state = " ".join(_grant_state(con, skill)) or "none"
+            missing = [fl for fl in flavors if con.execute(
+                "SELECT COUNT(*) FROM shells WHERE flavor=? AND COALESCE(is_deleted,0)=0",
+                (fl,)).fetchone()[0] == 0]
+            note = f"  (no live {'/'.join(missing)} shell yet — create one and re-run)" if missing else ""
+            print(f"  skill {skill} → {state}{note}")
+        con.commit()
+    finally:
+        con.close()
+
+    cfg = _instance()
+    blk = f["block"]
+    if blk in cfg:
+        print(f"  config `{blk}` already linked in instance.json")
+    elif f["block_auto"]:
+        cfg[blk] = {}
+        _write_instance(cfg)
+        print(f"  config `{blk}` added to instance.json")
+    else:
+        print(f"  config `{blk}` is operator-linked — next steps:")
+        for step in f.get("link", []):
+            print(f"    - {step}")
+
+    if granted:
+        _snapshot()
+    for step in f.get("next", []):
+        print(f"  next: {step}")
+    return 0
+
+
+def cmd_disable(name: str) -> int:
+    f = _resolve(name)
+    print(f"→ disable {name} — {f['title']}")
+
+    if DB_PATH.exists():
+        con = db_driver.connect(DB_PATH)
+        try:
+            revoked = 0
+            for skill, flavors in f["grants"].items():
+                n = revoke(con, skill, flavors)
+                revoked += n
+                print(f"  skill {skill}: revoked {n} grant(s) "
+                      f"(flavors: {', '.join(flavors)}; other shells untouched)")
+            con.commit()
+        finally:
+            con.close()
+        if revoked:
+            _snapshot()
+
+    cfg = _instance()
+    blk = f["block"]
+    if blk in cfg:
+        del cfg[blk]
+        _write_instance(cfg)
+        print(f"  config `{blk}` removed from instance.json")
+        if name == "pg":
+            print("  note: a running sidecar keeps running — stop it with ./sc pg-down "
+                  "(the data volume is retained)")
+    else:
+        print(f"  config `{blk}` was not linked")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    cmd = argv[0] if argv else "list"
+    if cmd == "list":
+        return cmd_list()
+    if cmd in ("enable", "disable"):
+        if len(argv) < 2:
+            sys.exit(f"feature: {cmd} needs a feature name "
+                     f"({', '.join(FEATURES)})")
+        return cmd_enable(argv[1]) if cmd == "enable" else cmd_disable(argv[1])
+    sys.exit(f"feature: unknown subcommand '{cmd}' (list · enable · disable)")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -49,6 +49,7 @@ PY = sys.executable
 IS_MAC = platform.system() == "Darwin"  # guidance arms differ (colima/brew vs systemd/apt)
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+import engine_manifest  # noqa: E402
 import ports as ports_mod  # noqa: E402
 
 
@@ -590,6 +591,11 @@ def main(argv: list[str]) -> int:
     pinned = pin_engine()
     print(f"  pinned engine.ref at {pinned[:12]}" if pinned
           else "  (could not resolve upstream ref — `./sc update` will pin it)")
+    # First engine hash manifest: the checkout just brought the engine in, so
+    # disk == upstream right now. From here, `./sc update` detects (and refuses
+    # to silently overwrite) any local edit to an engine file.
+    n = engine_manifest.write_manifest(engine_manifest.ENGINE_PATHS)
+    print(f"  engine manifest written ({n} files) — local engine edits now detected on update")
 
     # 3.6 Create the shared scratch / handoff dir -----------------------------
     # A host-repo dir for screenshots, drafts, quick handoffs. The CONNECTIONS

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -37,6 +37,7 @@ ENGINE_REF_PREV = STATE_DIR / "engine.ref.prev"
 BACKUP_DIR = Path.home() / "db_backups" / "super-coder"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+import engine_manifest  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402  (BACKUP_DIR, prune_backups, KEEP_BACKUPS)
 import update as update_mod    # noqa: E402  (materialize_engine, super_coder_remote, git)
 
@@ -79,10 +80,17 @@ def restore_engine(prev_sha: str) -> None:
         update_mod.git("fetch", remote)
         update_mod.materialize_engine(prev_sha)
     ENGINE_REF.write_text(prev_sha + "\n")
+    # Re-baseline the hash manifest at the restored engine — without this, the
+    # next update would read every rolled-back file as a "local edit" and block.
+    engine_manifest.write_manifest(update_mod._engine_paths_at(prev_sha))
     print(f"→ engine re-materialized at {prev_sha[:12]} (engine.ref restored)")
 
 
 def main() -> int:
+    if update_mod.EJECTED_MARKER.exists() and not update_mod.is_source_repo():
+        sys.exit("rollback: this fork has EJECTED (.sc-state/ejected) — the "
+                 "engine is fork source now, so update/rollback no longer apply. "
+                 "Use plain git (revert/reset) on the tracked .super-coder/.")
     src = latest_db_restore_point()
     if src is None:
         sys.exit("rollback: no shell_db.prerebuild.*.db restore point found in "

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -35,9 +35,15 @@ Flow:
 Then review + commit (only `.sc-state/` — content.sql + engine.ref — moves; the
 engine is ignored). Restart the session to boot onto the new floor.
 
+The materialize is guarded by the engine hash manifest (engine_manifest.py):
+an engine file locally modified since the last materialize BLOCKS the update
+(instead of being silently overwritten) until the operator reverts it,
+upstreams it, or passes --force to discard it. `--ref <tag|sha>` pins the
+materialize to a specific upstream version instead of the branch head.
+
 Usage:
-    ./sc update [--no-fetch] [--branch <name>]
-    python3 .super-coder/scripts/update.py [--no-fetch] [--branch <name>]
+    ./sc update [--no-fetch] [--branch <name>] [--ref <tag|sha>] [--force]
+    python3 .super-coder/scripts/update.py [same flags]
 """
 from __future__ import annotations
 
@@ -57,35 +63,18 @@ PY = sys.executable
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import db_driver  # noqa: E402
+import engine_manifest  # noqa: E402
 import install as install_mod  # noqa: E402  (ensure_harnesses)
 import migrate as migrate_mod  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402
 import seed_skills  # noqa: E402
 
-# The ENGINE = system content that propagates to every fork; all of it is safe
-# to materialize from the super-coder remote (it is wholesale-replaced, never
-# fork-edited). The per-instance set is deliberately NOT listed, so a materialize
-# never touches it: `.sc-state/` (this fork's content.sql + map tuning + engine
-# pin), shell_db.db* (gitignored), instance.json (gitignored). assets/seed/ is
-# super-coder-only (stripped on install); assets/shells/ is empty/vestigial.
-ENGINE_PATHS = [
-    "sc",
-    ".super-coder/aliases.mk",
-    ".super-coder/Dockerfile",
-    ".super-coder/schema.sql",
-    ".super-coder/map_schema.sql",
-    ".super-coder/ecosystem.config.cjs",
-    ".super-coder/README.md",
-    ".super-coder/migrations",
-    ".super-coder/scripts",
-    ".super-coder/render",
-    ".super-coder/templates",
-    ".super-coder/adapters",
-    ".super-coder/api",
-    ".super-coder/ui",
-    ".super-coder/assets/skills",
-    ".super-coder/hooks",
-]
+EJECTED_MARKER = STATE_DIR / "ejected"
+
+# The materialize set — canonical list lives in engine_manifest.py (shared with
+# install.py's first-manifest write); re-exported here as the name every caller
+# and test already knows.
+ENGINE_PATHS = engine_manifest.ENGINE_PATHS
 
 
 def git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
@@ -170,11 +159,44 @@ def materialize_engine(ref: str) -> None:
         sys.exit("update: extracting the engine archive failed.")
 
 
-def fetch_and_materialize(branch: str) -> None:
+def check_local_edits(force: bool) -> None:
+    """Block the materialize when engine files were edited locally since the
+    last one — a wholesale overwrite would discard those edits silently. The
+    operator's real options are stated; --force is the explicit discard."""
+    edits = engine_manifest.local_edits()
+    if not edits:
+        return
+    print(f"✗ {len(edits)} engine file(s) locally modified since the last materialize:")
+    for rel, kind in sorted(edits.items()):
+        print(f"    {kind:8} {rel}")
+    if force:
+        print("  --force: discarding the local edits (overwritten by the new engine).")
+        return
+    sys.exit(
+        "update: refusing to overwrite local engine edits. Your options:\n"
+        "  - revert them (the engine is upstream-owned; see README →\n"
+        "    'Customize a fork vs diverge from it')\n"
+        "  - upstream them: PR the change to super-coder, then update normally\n"
+        "  - ./sc update --force   discard the local edits and take upstream's engine\n"
+        "  - ./sc eject            one-way: stop tracking upstream and own the engine")
+
+
+def fetch_and_materialize(branch: str, ref: str | None = None,
+                          force: bool = False) -> None:
     remote = super_coder_remote()
-    print(f"→ fetch {remote} + materialize engine ({remote}/{branch})")
-    git("fetch", remote, branch)
-    sha = git("rev-parse", f"{remote}/{branch}").stdout.strip()
+    if ref:
+        # Pin to an explicit upstream version. `git fetch <remote> <ref>` serves
+        # a branch, a tag, or (on GitHub) a reachable commit SHA; FETCH_HEAD is
+        # the one name that works for all three.
+        print(f"→ fetch {remote} + materialize engine (pinned ref: {ref})")
+        git("fetch", remote, ref)
+        sha = git("rev-parse", "FETCH_HEAD").stdout.strip()
+    else:
+        print(f"→ fetch {remote} + materialize engine ({remote}/{branch})")
+        git("fetch", remote, branch)
+        sha = git("rev-parse", f"{remote}/{branch}").stdout.strip()
+
+    check_local_edits(force)
 
     # Restore point (engine half): remember where we were before overwriting.
     STATE_DIR.mkdir(parents=True, exist_ok=True)
@@ -187,7 +209,8 @@ def fetch_and_materialize(branch: str) -> None:
 
     materialize_engine(sha)
     ENGINE_REF.write_text(sha + "\n")
-    print(f"  engine pinned at {sha[:12]} (.sc-state/engine.ref)")
+    n = engine_manifest.write_manifest(_engine_paths_at(sha))
+    print(f"  engine pinned at {sha[:12]} (.sc-state/engine.ref) · manifest over {n} files")
 
 
 def migrate_engine_untrack() -> None:
@@ -261,13 +284,28 @@ def regrant() -> int:
 
 def main(argv: list[str]) -> int:
     no_fetch = "--no-fetch" in argv
+    force = "--force" in argv
     branch = "main"
     if "--branch" in argv:
         i = argv.index("--branch")
         if i + 1 < len(argv):
             branch = argv[i + 1]
+    ref = None
+    if "--ref" in argv:
+        i = argv.index("--ref")
+        if i + 1 < len(argv):
+            ref = argv[i + 1]
+        if "--branch" in argv:
+            sys.exit("update: --ref and --branch are mutually exclusive — a ref "
+                     "IS the pin; a branch is what to track.")
 
     source = is_source_repo()
+    if EJECTED_MARKER.exists() and not source:
+        sys.exit("update: this fork has EJECTED — the engine is fork source now, "
+                 "not an upstream dependency (.sc-state/ejected). There is no "
+                 "upstream to update from; edit .super-coder/ directly and commit "
+                 "like any other code. (To re-adopt upstream, that's a manual "
+                 "re-fork — see README → 'Customize a fork vs diverge from it'.)")
     if source:
         # The source repo IS the engine — it has no upstream to materialize from
         # and must keep tracking .super-coder/. Reconcile its own tree only.
@@ -286,7 +324,7 @@ def main(argv: list[str]) -> int:
         print("→ --no-fetch: reconciling against the current working tree "
               "(engine + engine.ref unchanged)")
     else:
-        fetch_and_materialize(branch)
+        fetch_and_materialize(branch, ref=ref, force=force)
 
     # Harnesses can be ADDED upstream between releases (e.g. codex landed after
     # dos-arch installed), so a fork that updates must pick up any newly-required

--- a/README.md
+++ b/README.md
@@ -456,8 +456,19 @@ new floor.
 
 - `./sc update --no-fetch` reconciles against the current working tree (offline /
   dev) — engine + `engine.ref` unchanged. `--branch <name>` to track a non-`main`
-  engine branch.
+  engine branch. `--ref <tag|sha>` pins the materialize to a specific upstream
+  version instead of the branch head — hold a fork at a known-good engine and
+  move deliberately.
 - Missing remote? `git remote add super-coder https://github.com/jedbjorn/super-coder.git`
+
+> [!class4]
+> **Local engine edits block the update — never silently overwritten.** The
+> materialize is a wholesale overwrite, so the engine keeps a hash manifest
+> (written at install and after every materialize) and `./sc update` refuses
+> when an engine file was locally modified since — listing the files and the
+> real options: revert the edit, **upstream it** (PR super-coder — the strong
+> default), `--force` to knowingly discard it, or `./sc eject` to own the
+> engine outright (see *Customize a fork vs diverge from it*, next).
 
 ### Roll back a bad update
 
@@ -475,6 +486,59 @@ only data lost is anything written between the update and the rollback.
 > [!class4]
 > **The contract:** every schema change *after* a fork exists ships as a `migrations/NNNN_*.sql` file, never an edit to `schema.sql` — the migration ledger is what carries a delta across to an existing fork. Additive where you can make it.
 
+## Customize a fork vs diverge from it
+
+> [!class2]
+> **UI** — a policy, not a tab · **Shells** admin (owns the engine boundary)
+
+The engine/fork boundary draws a clean decision rule for the question every
+fork operator eventually asks: *"the engine doesn't do what I need — now what?"*
+
+**Customize (the default — track upstream forever).** As long as what you need
+fits the **fork-owned extension points**, you never touch engine files, and
+`./sc update` keeps delivering fixes, migrations, and new skills indefinitely:
+
+| Extension point | What it carries |
+|---|---|
+| **Local skills** | Fork-authored procedures (GUI → Skills) — serialized in `content.sql`, survive every update |
+| **`instance.json`** | Per-fork config: ports, harness default, the `pg` / `vm` / `ts` opt-in blocks |
+| **`.sc-state/`** | Your memory (content.sql), map tuning, engine pin — the fork's one tracked artifact |
+| **Per-shell identity** | `current_state`, connections, decisions, seed — all DB rows, all yours |
+| **Your project** | Everything outside `.super-coder/` — the engine never touches it |
+
+**Upstream (when the extension points don't reach).** Need an actual engine
+change? **PR it to super-coder first.** If one fork needs it, the next fork
+probably does too — that's how the engine grows (dos-arch is exactly this
+proving-ground loop). Your fork then picks the change up through a normal
+`./sc update`, still on the lifeline.
+
+**Diverge (`./sc eject` — the one-way door).** Only when the change is
+genuinely yours and upstream would rightly not take it. Eject flips the model:
+`.super-coder/` becomes **fork source** — un-gitignored, committed, edited like
+any other code — and the upstream lifeline is cut for good:
+
+```linear
+Extension points fit :::class3 -> Upstream the change :::class1 -> Eject :::class4
+```
+
+```bash
+./sc eject          # interactive warning + typed confirmation, then stages the flip
+```
+
+What it does: drops the `/.super-coder/` gitignore rule (engine runtime files —
+DB, `instance.json`, `run/`, `logs/` — stay ignored), deletes the engine pin
+(`engine.ref`), writes a `.sc-state/ejected` marker recording the SHA you
+diverged at, removes the `super-coder` remote (`--keep-remote` to keep it for
+reference), and stages everything. **Committing stays yours** — review the diff
+first. After eject, `./sc update` and `./sc rollback` refuse (the marker);
+launch, enter, snapshot, render, and the GUI work unchanged.
+
+> [!class4]
+> **What you give up, permanently:** upstream fixes, schema migrations, and new
+> catalogue skills stop flowing — every engine change from here on is yours to
+> author and maintain. Re-adopting upstream later is a manual re-fork, not a
+> command. Exhaust the first two lanes before taking the third.
+
 ## Run (everyday)
 
 > [!class2]
@@ -491,8 +555,10 @@ only data lost is anything written between the update and the rollback.
 ./sc render-check        # fail if the committed _sc files drift from the DB render (CI guard)
 ./sc snapshot            # serialize per-instance tables → .sc-state/content.sql
 ./sc preview             # live worktree UI previews, one subdomain per shell
-./sc update              # fetch + materialize the engine, reconcile in place
+./sc update              # fetch + materialize the engine, reconcile in place (--ref <tag|sha> pins)
 ./sc rollback            # sound undo of a bad update (restore DB + engine)
+./sc feature             # opt-in features: list / enable / disable (pg · windows · tailnet)
+./sc eject               # ONE-WAY: own the engine — stop tracking upstream (confirm-gated)
 ./sc verify              # rebuild + flat render + headless boot (no exec) — the proof
 ./sc help                # all commands
 ```
@@ -554,6 +620,42 @@ a web GUI. Never restart the host stack from inside the sandbox; run your own
 instance instead. (The boot doc's `RUNNING THE APP` section and the `dev_kit` skill
 carry the full detail. For the FnB-facing review of a shell's UI changes, use
 `./sc preview` — see *How shells share one repo*.)
+
+## Opt-in features
+
+> [!class2]
+> **UI** Shells (skill grants) · Scripts (VM wizard) · **Shells** varies per feature
+
+Beyond the core loop, the engine ships **opt-in features** — capabilities every
+fork receives but none has on by default. Each one is the same pair underneath:
+a **config block** in the gitignored `.super-coder/instance.json` (enables the
+infrastructure — a sidecar container, a host-side broker) and **skill grants**
+(`common=0` — the skills ship to every fork's catalogue but auto-grant to no
+shell; the grant puts the procedure in the right hands). `./sc feature` is the
+front door to the pair:
+
+```bash
+./sc feature                 # list the features + the state of both halves
+./sc feature enable pg       # grant the skills to the owning flavors + wire the config
+./sc feature disable pg      # reverse it (other shells' grants untouched)
+```
+
+| Feature | Config block | Skills → flavors | What it gives the fork |
+|---|---|---|---|
+| **`pg`** | `pg` (auto-created) | `test_authoring_pg` → dev, reviewer | A `postgres:17` sidecar on `sc-net`, `DATABASE_URL` forwarded into the sandbox — develop + test the fork's **app** against real Postgres (the engine DB stays SQLite, always) |
+| **`windows`** | `vm` (operator-linked) | `windows_devkit` → dev, reviewer · `configure_winbox` → admin | The Windows Test VM loop — push → exec → capture → reset against a real Windows box, via the host-side broker (next section) |
+| **`tailnet`** | `ts` (operator-linked) | `tailscale` → devops | The tailnet broker — reach declared build/deploy hosts from the sandbox without holding a tailnet credential (section after) |
+
+`enable pg` is complete in one step — the sidecar needs no host input, so the
+block is auto-created and the next `./sc launch` starts it (data persists in a
+named volume; `./sc pg-down` stops it, volume retained). `windows` and
+`tailnet` are **link-only**: their blocks carry host-specific, operator-verified
+config (a ready VM, a tailnet scope), so `enable` grants the skills and prints
+exactly how to link — the two sections below are the full setup guides.
+
+Everything here can still be done by hand — the GUI's per-shell grant toggles
+and a hand-edited `instance.json` are the same mechanisms; `./sc feature` just
+makes the pair one visible, one-command surface.
 
 ## Windows Test VM (opt-in)
 
@@ -695,8 +797,9 @@ Re-provisioning later is delete-then-recreate the `clean` snapshot — and nothi
 default `qemu:///session` can't see it); omit it otherwise.
 
 **6 · Grant the skills + start the broker.** Both skills are engine `common=0` — they
-propagate to every fork but **auto-grant to none**. Grant `windows_devkit` to the dev
-+ reviewer shells and `configure_winbox` to admin (per fork). The broker comes up
+propagate to every fork but **auto-grant to none**. `./sc feature enable windows`
+grants them in one step (`windows_devkit` → dev + reviewer, `configure_winbox` →
+admin); or toggle them per shell in the GUI. The broker comes up
 automatically with `./sc launch` when a VM is linked; or drive it directly:
 
 ```bash
@@ -770,6 +873,8 @@ parameterized by `{host, command}` and the `ts` block carries a fail-closed
 declared. Config lives under a `ts` key in the gitignored
 `.super-coder/instance.json` (**no secrets** — the host node's identity is the
 credential and never leaves the host), coexisting with the `vm` block.
+`./sc feature enable tailnet` grants the `tailscale` skill to devops shells;
+the `ts` block itself is yours to fill (link-only, like the VM).
 
 ```bash
 ./sc ts-broker-up            # start backgrounded (also auto-started by ./sc launch when a tailnet is linked)

--- a/sc
+++ b/sc
@@ -489,6 +489,8 @@ case "$cmd" in
   update)            exec "$PY" "$S/update.py" "$@" ;;
   update-harnesses) exec "$PY" "$S/install.py" --update-harnesses ;;
   rollback)     exec "$PY" "$S/rollback.py" "$@" ;;
+  feature)      exec "$PY" "$S/feature.py" "$@" ;;
+  eject)        exec "$PY" "$S/eject.py" "$@" ;;
   init)         exec "$PY" "$S/init_fork.py" "$@" ;;
   rebuild)      exec "$PY" "$S/rebuild.py" "$@" ;;
   migrate)      exec "$PY" "$S/migrate.py" "$DB" ;;
@@ -656,9 +658,13 @@ super-coder — forkable shell substrate
   ./sc install             first-launch bootstrap for a fork (requirements, harness, first shell)
   ./sc ensure-harness      install claude + opencode + codex if missing (official native installers, no npm)
   ./sc doctor              sandbox readiness: docker (rootless/rootful) + harness login
-  ./sc update              fetch + materialize the engine (gitignored dep) + reconcile IN PLACE (migrate, sync skills, map); --no-fetch to skip fetch
+  ./sc update              fetch + materialize the engine (gitignored dep) + reconcile IN PLACE (migrate, sync skills, map);
+                             --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
   ./sc update-harnesses    update claude + opencode + codex + vibe to latest (force-reruns official installers)
   ./sc rollback            sound undo of a bad update — restore the DB + engine (engine.ref.prev) together
+  ./sc feature             list the opt-in features (pg · windows · tailnet) and the state of both halves (config block + skill grants)
+  ./sc feature enable <f>  enable one: grant its skills to the owning flavors + create/point-at its instance.json block (disable reverses)
+  ./sc eject               ONE-WAY: stop tracking upstream and own the engine — un-gitignore + stage .super-coder/ as fork source (confirm-gated)
   ./sc rebuild             build the .db from schema + migrations + snapshot
   ./sc migrate             apply pending migrations to an existing .db
   ./sc snapshot            dump per-instance tables -> .sc-state/content.sql

--- a/tests/test_eject.py
+++ b/tests/test_eject.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Tests for `./sc eject` (scripts/eject.py) — the one-way divergence door.
+
+The pieces with teeth: the .gitignore surgery (the /.super-coder/ rule must go,
+the runtime files must STAY ignored, and re-running must not stack blocks), and
+the refusal surface (update + rollback must hard-stop on the ejected marker —
+an ejected fork that still materializes upstream over its edited engine would
+be the exact data loss eject exists to prevent).
+
+Run:
+    python3 tests/test_eject.py
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+import eject  # noqa: E402
+import update  # noqa: E402
+
+FORK_GITIGNORE = """\
+# my fork's own rules
+*.log
+.env
+
+# super-coder — rebuilt/derived; never commit
+/.super-coder/
+/CLAUDE.md
+/AGENTS.md
+/.sc-worktrees/
+/.sc-state/engine.ref.prev
+"""
+
+
+class GitignoreEjectTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self._orig = eject.REPO_ROOT
+        eject.REPO_ROOT = self.root
+
+    def tearDown(self):
+        eject.REPO_ROOT = self._orig
+        self.tmp.cleanup()
+
+    def _lines(self) -> list[str]:
+        return (self.root / ".gitignore").read_text().splitlines()
+
+    def test_drops_engine_rule_keeps_everything_else(self):
+        (self.root / ".gitignore").write_text(FORK_GITIGNORE)
+        status = eject._gitignore_eject()
+        self.assertIn("dropped", status)
+        lines = [ln.strip() for ln in self._lines()]
+        self.assertNotIn("/.super-coder/", lines,
+                         "the engine-dir rule must be gone — git must see the engine")
+        for kept in ("*.log", ".env", "/CLAUDE.md", "/.sc-worktrees/"):
+            self.assertIn(kept, lines, f"unrelated rule '{kept}' must survive")
+
+    def test_runtime_files_stay_ignored(self):
+        (self.root / ".gitignore").write_text(FORK_GITIGNORE)
+        eject._gitignore_eject()
+        lines = [ln.strip() for ln in self._lines()]
+        for runtime in ("/.super-coder/shell_db.db", "/.super-coder/instance.json",
+                        "/.super-coder/run/", "/.super-coder/logs/",
+                        "/.super-coder/engine.manifest"):
+            self.assertIn(runtime, lines,
+                          f"'{runtime}' must stay ignored after eject — it is "
+                          f"per-instance runtime, never fork source")
+
+    def test_idempotent(self):
+        (self.root / ".gitignore").write_text(FORK_GITIGNORE)
+        eject._gitignore_eject()
+        once = (self.root / ".gitignore").read_text()
+        eject._gitignore_eject()
+        self.assertEqual((self.root / ".gitignore").read_text(), once,
+                         "re-running must not stack a second runtime block")
+
+    def test_no_gitignore_at_all(self):
+        status = eject._gitignore_eject()
+        self.assertIn("wrote", status)
+        self.assertIn("/.super-coder/shell_db.db",
+                      [ln.strip() for ln in self._lines()])
+
+
+class EjectedMarkerRefusalTest(unittest.TestCase):
+    """update/rollback consult EJECTED_MARKER + is_source_repo(); the guard
+    itself is a two-line early-exit in each main(). Assert the wiring exists —
+    the marker path is shared and the exits mention 'eject'."""
+
+    def test_update_knows_the_marker(self):
+        self.assertEqual(update.EJECTED_MARKER.name, "ejected")
+        self.assertEqual(update.EJECTED_MARKER.parent.name, ".sc-state")
+
+    def test_update_main_guards_on_marker(self):
+        src = (ROOT / ".super-coder" / "scripts" / "update.py").read_text()
+        self.assertIn("EJECTED_MARKER.exists()", src)
+        self.assertIn("has EJECTED", src)
+
+    def test_rollback_main_guards_on_marker(self):
+        src = (ROOT / ".super-coder" / "scripts" / "rollback.py").read_text()
+        self.assertIn("EJECTED_MARKER.exists()", src)
+
+    def test_eject_and_update_agree_on_marker_path(self):
+        self.assertEqual(str(eject.EJECTED_MARKER), str(update.EJECTED_MARKER))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine_manifest.py
+++ b/tests/test_engine_manifest.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Tests for the engine hash manifest (scripts/engine_manifest.py) — the guard
+that keeps `./sc update` from silently overwriting local engine edits.
+
+The contract: write_manifest() right after a materialize records upstream's
+on-disk state; local_edits() before the next one reports exactly the files an
+overwrite would clobber (modified/deleted), and nothing else — no manifest, a
+clean tree, or a locally-ADDED file (materialize never touches those) all
+report clean.
+
+Run:
+    python3 tests/test_engine_manifest.py
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+import engine_manifest  # noqa: E402
+
+
+class EngineManifestTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        (root / ".super-coder" / "scripts").mkdir(parents=True)
+        (root / "sc").write_text("#!/bin/sh\n")
+        (root / ".super-coder" / "schema.sql").write_text("CREATE TABLE t(x);\n")
+        (root / ".super-coder" / "scripts" / "a.py").write_text("A = 1\n")
+        (root / ".super-coder" / "scripts" / "b.py").write_text("B = 2\n")
+        # skipped noise: bytecode + __pycache__ must never enter the manifest
+        (root / ".super-coder" / "scripts" / "__pycache__").mkdir()
+        (root / ".super-coder" / "scripts" / "__pycache__" / "a.cpython-312.pyc").write_bytes(b"\x00")
+        self.root = root
+        self.paths = ["sc", ".super-coder/schema.sql", ".super-coder/scripts",
+                      ".super-coder/missing-upstream.txt"]  # absent entries are skipped
+        self._orig = (engine_manifest.REPO_ROOT, engine_manifest.ENGINE,
+                      engine_manifest.MANIFEST)
+        engine_manifest.REPO_ROOT = root
+        engine_manifest.ENGINE = root / ".super-coder"
+        engine_manifest.MANIFEST = root / ".super-coder" / "engine.manifest"
+
+    def tearDown(self):
+        (engine_manifest.REPO_ROOT, engine_manifest.ENGINE,
+         engine_manifest.MANIFEST) = self._orig
+        self.tmp.cleanup()
+
+    def test_no_manifest_reports_clean(self):
+        self.assertEqual(engine_manifest.local_edits(), {})
+
+    def test_clean_tree_after_write(self):
+        n = engine_manifest.write_manifest(self.paths)
+        self.assertEqual(n, 4)  # sc, schema.sql, a.py, b.py — pyc excluded
+        self.assertEqual(engine_manifest.local_edits(), {})
+
+    def test_modified_and_deleted_are_detected(self):
+        engine_manifest.write_manifest(self.paths)
+        (self.root / ".super-coder" / "scripts" / "a.py").write_text("A = 999\n")
+        (self.root / ".super-coder" / "scripts" / "b.py").unlink()
+        self.assertEqual(engine_manifest.local_edits(),
+                         {".super-coder/scripts/a.py": "modified",
+                          ".super-coder/scripts/b.py": "deleted"})
+
+    def test_locally_added_file_is_not_flagged(self):
+        engine_manifest.write_manifest(self.paths)
+        (self.root / ".super-coder" / "scripts" / "local_extra.py").write_text("X\n")
+        self.assertEqual(engine_manifest.local_edits(), {},
+                         "materialize never touches locally-added files — they "
+                         "must not block an update")
+
+    def test_rewrite_rebaselines(self):
+        engine_manifest.write_manifest(self.paths)
+        (self.root / ".super-coder" / "scripts" / "a.py").write_text("A = 999\n")
+        engine_manifest.write_manifest(self.paths)  # e.g. after the next materialize
+        self.assertEqual(engine_manifest.local_edits(), {})
+
+    def test_corrupt_manifest_reports_clean(self):
+        engine_manifest.MANIFEST.write_text("{not json")
+        self.assertEqual(engine_manifest.local_edits(), {},
+                         "a corrupt manifest must not brick update — treat as "
+                         "absent; the next write heals it")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Tests for `./sc feature` (scripts/feature.py) — the opt-in front door.
+
+Two layers: the REGISTRY must stay consistent with the assets it points at
+(every granted skill exists in assets/skills/ and is common:false — a feature
+must never grant a skill the seed doesn't ship, or auto-grant a common one
+twice; every flavor has a template), and the GRANT/REVOKE SQL must do what the
+registry means (grant to live shells of the named flavors only, revoke without
+touching other shells' grants).
+
+Run:
+    python3 tests/test_feature.py
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import feature  # noqa: E402
+
+SKILLS_DIR = ENGINE / "assets" / "skills"
+SHELL_TEMPLATES = ENGINE / "templates" / "shells"
+
+
+def _mini_db() -> sqlite3.Connection:
+    """The minimal slice of the schema grant()/revoke() touch."""
+    con = sqlite3.connect(":memory:")
+    con.executescript("""
+        CREATE TABLE shells (shell_id INTEGER PRIMARY KEY, flavor TEXT,
+                             is_deleted INTEGER DEFAULT 0);
+        CREATE TABLE skills (skill_id INTEGER PRIMARY KEY, name TEXT UNIQUE,
+                             is_deleted INTEGER DEFAULT 0);
+        CREATE TABLE shell_skills (shell_id INTEGER, skill_id INTEGER,
+                                   PRIMARY KEY (shell_id, skill_id));
+    """)
+    con.executemany("INSERT INTO shells (shell_id, flavor, is_deleted) VALUES (?,?,?)",
+                    [(1, "dev", 0), (2, "dev", 0), (3, "reviewer", 0),
+                     (4, "admin", 0), (5, "dev", 1),      # deleted — never granted
+                     (6, "planner", 0)])
+    con.execute("INSERT INTO skills (skill_id, name) VALUES (10, 'test_authoring_pg')")
+    return con
+
+
+class RegistryIntegrityTest(unittest.TestCase):
+    def test_granted_skills_exist_and_are_opt_in(self):
+        for name, f in feature.FEATURES.items():
+            for skill in f["grants"]:
+                md = SKILLS_DIR / skill / "SKILL.md"
+                self.assertTrue(md.exists(),
+                                f"feature '{name}' grants '{skill}' but "
+                                f"assets/skills/{skill}/SKILL.md does not exist")
+                self.assertIn("common: false", md.read_text(),
+                              f"feature '{name}' grants '{skill}' which is not "
+                              f"common:false — a common skill is already auto-granted")
+
+    def test_granted_flavors_have_templates(self):
+        for name, f in feature.FEATURES.items():
+            for skill, flavors in f["grants"].items():
+                for fl in flavors:
+                    self.assertTrue((SHELL_TEMPLATES / f"{fl}.json").exists(),
+                                    f"feature '{name}' grants {skill} to flavor "
+                                    f"'{fl}' which has no shell template")
+
+    def test_registry_shape(self):
+        for name, f in feature.FEATURES.items():
+            self.assertIn("block", f, name)
+            self.assertIn("block_auto", f, name)
+            self.assertTrue(f["grants"], f"feature '{name}' grants nothing")
+            if not f["block_auto"]:
+                self.assertTrue(f.get("link"),
+                                f"operator-linked feature '{name}' has no link steps")
+
+    def test_pg_block_matches_pg_init(self):
+        # `./sc pg-init` (in the sc dispatcher) and `feature enable pg` write the
+        # same instance.json key — if this drifts, launch won't see the sidecar.
+        self.assertEqual(feature.FEATURES["pg"]["block"], "pg")
+        sc = (ROOT / "sc").read_text()
+        self.assertIn("d['pg']={}", sc.replace(" ", ""),
+                      "sc pg-init no longer writes the `pg` key feature.py expects")
+
+
+class GrantRevokeTest(unittest.TestCase):
+    def test_grant_targets_live_shells_of_named_flavors(self):
+        con = _mini_db()
+        n = feature.grant(con, "test_authoring_pg", ["dev", "reviewer"])
+        self.assertEqual(n, 3)  # dev(1,2) + reviewer(3); deleted dev(5) skipped
+        rows = {r[0] for r in con.execute("SELECT shell_id FROM shell_skills")}
+        self.assertEqual(rows, {1, 2, 3})
+
+    def test_grant_is_idempotent(self):
+        con = _mini_db()
+        feature.grant(con, "test_authoring_pg", ["dev"])
+        n = feature.grant(con, "test_authoring_pg", ["dev"])
+        self.assertEqual(n, 0)
+
+    def test_grant_unknown_skill_grants_nothing(self):
+        con = _mini_db()
+        self.assertEqual(feature.grant(con, "no_such_skill", ["dev"]), 0)
+
+    def test_revoke_leaves_other_flavors_grants(self):
+        con = _mini_db()
+        feature.grant(con, "test_authoring_pg", ["dev", "reviewer"])
+        # A manual grant to a planner shell — outside the feature's flavors.
+        con.execute("INSERT INTO shell_skills VALUES (6, 10)")
+        n = feature.revoke(con, "test_authoring_pg", ["dev", "reviewer"])
+        self.assertEqual(n, 3)
+        rows = {r[0] for r in con.execute("SELECT shell_id FROM shell_skills")}
+        self.assertEqual(rows, {6}, "revoke must not touch grants outside the "
+                                    "feature's flavors")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -26,6 +26,7 @@ import update  # noqa: E402
 # ENGINE_PATHS comment in update.py.
 PER_INSTANCE = {
     "instance.json", "shell_db.db", "shell_db.db-wal", "shell_db.db-shm", "map.db",
+    "engine.manifest",  # derived hash baseline — rewritten by each materialize
 }
 
 


### PR DESCRIPTION
From the intention-vs-state review: opt-in features existed as two uncoordinated mechanisms (instance.json blocks + `common=0` skill grants) with no discoverable surface, `./sc update` silently overwrote local engine edits, and the "when should a fork stop tracking upstream" question had no documented (or coded) answer.

## What this adds

- **`./sc feature`** (+ `make dos-feat`) — front door over the existing pair, mechanisms unchanged. `list` shows both halves per feature (pg · windows · tailnet); `enable` grants the skills to the owning flavors, auto-creates the `pg` block, prints link steps for the operator-linked `vm`/`ts` blocks, and re-snapshots; `disable` reverses without touching grants outside the feature's flavors.
- **`./sc eject`** (+ `make dos-eject`) — the one-way door, confirm-gated (type `eject`; `--yes` to script). Un-gitignores `.super-coder/` as fork source (runtime files stay ignored), drops the pin, writes `.sc-state/ejected` recording the divergence SHA, removes the remote (`--keep-remote` opts out), stages — committing stays the operator's. `update`/`rollback` refuse on the marker.
- **Local-edit guard** — engine hash manifest written at install, every materialize, and rollback restore; `update` now blocks on locally-modified engine files and lists the real options (revert / upstream it / `--force` / eject) instead of silently discarding them.
- **`./sc update --ref <tag|sha>`** — pin the materialize to a specific upstream version (branch/tag/SHA via FETCH_HEAD).
- **README** — new "Opt-in features" section (also the pg sidecar's first docs home) and "Customize a fork vs diverge from it" (extension points → upstream-first → eject, with the costs stated).

## Test plan
- [x] `./sc test` — 154 pass, 22 new (feature registry↔assets integrity, grant/revoke SQL, gitignore surgery + idempotency, refusal wiring, manifest modified/deleted/added/corrupt cases)
- [x] `./sc feature list` renders against the dogfood DB; `./sc eject` refuses in the source repo
- [x] `make dos-feat`, `make dos-feat ARGS="enable pg"`, `make dos-eject` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)