### PR TITLE
fix(api): restore optional feature_id on POST /_sc/mem/docs (dos-arch QAQC-04)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1196,19 +1196,22 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(201, {"task_id": cur.lastrowid})
 
             if path == "/_sc/mem/docs":
+                # feature_id is OPTIONAL — standalone (feature-less) docs are part
+                # of the contract: the docs/onboard skills and `sc mem doc add`
+                # document them, and forks carry them. The seq scope is per
+                # (feature, kind), with NULL its own scope (`IS ?` matches NULL).
                 fid = body.get("feature_id")
-                if fid is None:
-                    return self._send(400, {"error": "feature_id required"})
+                fid = int(fid) if fid is not None else None
                 kind = body.get("kind") or "spec"
                 seq = body.get("seq")
                 if seq is None:  # next seq for this (feature, kind) — mirrors the old CLI
                     seq = con.execute(
                         "SELECT COALESCE(MAX(seq),0)+1 FROM documents "
-                        "WHERE feature_id IS ? AND kind=?", (int(fid), kind)).fetchone()[0]
+                        "WHERE feature_id IS ? AND kind=?", (fid, kind)).fetchone()[0]
                 cur = con.execute(
                     "INSERT INTO documents (feature_id, kind, seq, title, body, render_path) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
-                    (int(fid),
+                    (fid,
                      kind,
                      seq,
                      (body.get("title") or "").strip() or None,

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -187,6 +187,25 @@ class ApiMemTest(unittest.TestCase):
         self.run_mem("task", "done", str(tid))
         self.assertEqual(self.q("SELECT status FROM spec_tasks WHERE task_id=?", tid)[0], "done")
 
+    def test_doc_add_standalone_no_feature(self):
+        # feature_id is optional — standalone docs are contract (the docs +
+        # onboard skills and `sc mem doc add [--feature ID]` all say so; the
+        # server used to 400 on it, the QAQC-04 regression this pins).
+        body = self.tmp / "s.md"
+        body.write_text("# standalone\n")
+        self.assertEqual(
+            self.run_mem("doc", "add", "standalone D", "--kind", "doc",
+                         "--body-file", str(body)), 0)
+        fid, seq = self.q("SELECT feature_id, seq FROM documents WHERE title='standalone D'")
+        self.assertIsNone(fid)
+        self.assertEqual(seq, 1)  # NULL feature is its own seq scope
+        # a second standalone doc of the same kind seqs within that scope
+        self.assertEqual(
+            self.run_mem("doc", "add", "standalone E", "--kind", "doc",
+                         "--body-file", str(body)), 0)
+        self.assertEqual(
+            self.q("SELECT seq FROM documents WHERE title='standalone E'")[0], 2)
+
     # ── narrative + oriented ──────────────────────────────────────────────────
     def test_narrative_and_oriented(self):
         self.run_mem("narrative", "a beat")


### PR DESCRIPTION
From the dos-arch QAQC sweep (fork flag **QAQC-04**): the API and the skills disagreed — `POST /_sc/mem/docs` rejected doc creation without `feature_id` (HTTP 400), while the `docs` + `onboard` skills and `sc mem doc add [--feature ID]` all document standalone docs, and 10 feature-less docs already exist in dos-arch from before the regression.

Server-side only: `feature_id` becomes optional again; NULL is its own seq scope (the seq query's `feature_id IS ?` already handled NULL — only the 400 guard and the unconditional `int(fid)` blocked it). New test pins standalone add + per-scope seq numbering.

## Test plan
- [x] `tests/test_mem.py` — 16 pass (1 new: standalone doc add, NULL seq scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)