### PR TITLE
fix(devkit): reachable lint/typecheck + prune worktrees from the manifest walk (dos-arch QAQC-02)

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -73,6 +73,13 @@ RUN pip install --no-cache-dir "playwright==1.60.0" \
  && playwright install --with-deps chromium \
  && chmod -R a+rX /opt/ms-playwright
 
+# Dev-kit fallback tools. `./sc lint` / `./sc typecheck` prefer the fork's .venv
+# copy (its pins + config), but a host-managed .venv (pinned out-of-tree
+# interpreter mounted by launch) is pip-skipped in the sandbox — so bake the
+# PATH fallback here or the tools are unobtainable from inside the box
+# (dos-arch QAQC-02). _sc_devtool in ./sc resolves .venv → PATH in that order.
+RUN pip install --no-cache-dir ruff mypy
+
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
 # A host GID may already exist in the base image — notably macOS's primary GID 20
 # (`staff`) collides with Debian's pre-existing `dialout` group — so creating it

--- a/sc
+++ b/sc
@@ -111,12 +111,41 @@ dbuild() {
 # does: a vendored/submodule package.json (e.g. ui/vendor/md-converter) is built by
 # its parent, and a stray `npm ci`/`pip install` there runs third-party lifecycle
 # scripts we don't own. We install only the manifests the fork itself authors.
+# `.sc-worktrees/` is pruned too — each shell worktree is a sibling checkout of
+# the SAME repo, so descending it would install/test every manifest N× (QAQC-02).
 _sc_find_manifests() {  # $1 = filename glob, e.g. 'requirements*.txt'
   find "$here" \
     \( -name node_modules -o -name .venv -o -name venv -o -name .super-coder \
-       -o -name .sc-state -o -name .git -o -name __pycache__ \
+       -o -name .sc-state -o -name .sc-worktrees -o -name .git -o -name __pycache__ \
        -o -name dist -o -name build -o -name vendor \) -prune -o \
     -name "$1" -type f -print
+}
+
+# Resolve a dev-kit tool (ruff / mypy): the fork's .venv copy wins (its pins +
+# config), else the image/PATH copy (baked into the sandbox for exactly this
+# case), else fail with the honest fix. A host-managed .venv (pinned out-of-tree
+# interpreter mounted by launch) is pip-skipped in the sandbox BY DESIGN, so
+# "run ./sc deps first" was a closed loop there — the tool was unobtainable from
+# inside the box (dos-arch QAQC-02). Say what is actually wrong and where the
+# fix runs instead.
+_sc_devtool() {  # $1 = tool name → prints the executable path, or fails
+  venv="$here/.venv"
+  if [ -x "$venv/bin/$1" ]; then printf '%s\n' "$venv/bin/$1"; return 0; fi
+  if command -v "$1" >/dev/null 2>&1; then command -v "$1"; return 0; fi
+  hostmanaged=""
+  if [ -n "${SC_SANDBOX:-}" ] && [ -e "$venv/bin/python" ]; then
+    case "$(readlink -f "$venv/bin/python" 2>/dev/null || true)" in
+      "$here"/*) : ;;                       # sandbox-built venv — deps can provision it
+      *) hostmanaged=1 ;;                   # pinned host interpreter — pip skipped here
+    esac
+  fi
+  if [ -n "$hostmanaged" ]; then
+    echo "✗ $1: unavailable, and this .venv is host-managed (pinned out-of-tree interpreter) — in-sandbox pip is skipped by design, so \`./sc deps\` cannot provision it here." >&2
+    echo "  Fix on the HOST: install $1 into the pinned venv (e.g. uv pip install $1) — or \`./sc build\` to refresh the sandbox image, which bakes $1 as the PATH fallback." >&2
+  else
+    echo "✗ $1: not provisioned — run ./sc deps first" >&2
+  fi
+  return 1
 }
 
 # Install the fork's deps into the bind-mounted repo: always a repo-root .venv with
@@ -252,24 +281,24 @@ sc_test() {
   echo "✓ test: all suites passed"
 }
 
-# Lint + format-check the fork's python with the .venv's ruff (honors the fork's
-# [tool.ruff] config). Defaults to the repo root; pass paths/flags through. The
-# tool is available, not enforced — a fork opts in by running this. Needs `./sc deps`.
+# Lint + format-check the fork's python with ruff (the .venv copy when present —
+# honors the fork's [tool.ruff] config — else the image's baked fallback).
+# Defaults to the repo root; pass paths/flags through. The tool is available,
+# not enforced — a fork opts in by running this.
 sc_lint() {
-  venv="$here/.venv"
-  [ -x "$venv/bin/ruff" ] || { echo "✗ lint: no .venv/bin/ruff — run ./sc deps first" >&2; return 1; }
-  echo "→ lint: $venv/bin/ruff check"
-  ( cd "$here" && "$venv/bin/ruff" check "$@" )
+  tool="$(_sc_devtool ruff)" || return 1
+  echo "→ lint: $tool check"
+  ( cd "$here" && "$tool" check "$@" )
 }
 
-# Type-check the fork's python with the .venv's mypy (honors the fork's
-# [tool.mypy] config). Same available-not-enforced stance as lint. Needs `./sc deps`.
+# Type-check the fork's python with mypy (.venv copy → image fallback, same
+# resolution as lint; honors the fork's [tool.mypy] config when the .venv copy
+# runs). Same available-not-enforced stance as lint.
 sc_typecheck() {
-  venv="$here/.venv"
-  [ -x "$venv/bin/mypy" ] || { echo "✗ typecheck: no .venv/bin/mypy — run ./sc deps first" >&2; return 1; }
-  echo "→ typecheck: $venv/bin/mypy"
-  if [ $# -gt 0 ]; then ( cd "$here" && "$venv/bin/mypy" "$@" )
-  else ( cd "$here" && "$venv/bin/mypy" . ); fi
+  tool="$(_sc_devtool mypy)" || return 1
+  echo "→ typecheck: $tool"
+  if [ $# -gt 0 ]; then ( cd "$here" && "$tool" "$@" )
+  else ( cd "$here" && "$tool" . ); fi
 }
 
 # ── Windows VM broker (HOST-side; drives the test VM for sandboxed forks) ──────

--- a/tests/test_devkit_sc.py
+++ b/tests/test_devkit_sc.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Contract pins for the dev-kit surface in the `sc` dispatcher (QAQC-02).
+
+`sc` is POSIX sh, so these pin the wiring textually (the same style as the
+refusal pins in test_eject.py) plus one live probe of the find-prune behavior:
+
+  - `_sc_find_manifests` must prune `.sc-worktrees/` — each shell worktree is a
+    sibling checkout of the same repo; descending would install/test every
+    manifest N×.
+  - `_sc_devtool` must resolve .venv → PATH in that order, and lint/typecheck
+    must go through it (the ".venv or die" guard was a closed loop when the
+    .venv is host-managed and in-sandbox pip is skipped).
+  - The sandbox image must bake ruff + mypy — the PATH fallback _sc_devtool
+    lands on in that host-managed case.
+
+Run:
+    python3 tests/test_devkit_sc.py
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SC = (ROOT / "sc").read_text()
+DOCKERFILE = (ROOT / ".super-coder" / "Dockerfile").read_text()
+
+
+def _extract_find_manifests() -> str:
+    """The _sc_find_manifests function body, for a live run in a scratch tree."""
+    m = re.search(r"_sc_find_manifests\(\) \{.*?\n\}", SC, re.S)
+    assert m, "_sc_find_manifests not found in sc"
+    return m.group(0)
+
+
+class FindManifestsTest(unittest.TestCase):
+    def test_prunes_sc_worktrees_live(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "app").mkdir()
+            (root / "app" / "package.json").write_text("{}")
+            wt = root / ".sc-worktrees" / "dev" / "app"
+            wt.mkdir(parents=True)
+            (wt / "package.json").write_text("{}")
+            script = f'here="{root}"\n{_extract_find_manifests()}\n' \
+                     f"_sc_find_manifests 'package.json'\n"
+            out = subprocess.run(["sh", "-c", script], capture_output=True,
+                                 text=True).stdout.splitlines()
+            self.assertEqual(out, [str(root / "app" / "package.json")],
+                             "worktree copies must be pruned — one repo, one "
+                             "manifest walk")
+
+
+class DevtoolResolutionTest(unittest.TestCase):
+    def test_devtool_prefers_venv_then_path(self):
+        body = re.search(r"_sc_devtool\(\) \{.*?\n\}", SC, re.S)
+        self.assertIsNotNone(body, "_sc_devtool missing from sc")
+        text = body.group(0)
+        venv_at = text.index('"$venv/bin/$1"')
+        path_at = text.index("command -v")
+        self.assertLess(venv_at, path_at,
+                        ".venv copy must win over the PATH fallback — fork "
+                        "pins + [tool.*] config ride the venv copy")
+
+    def test_lint_and_typecheck_use_devtool(self):
+        for fn in ("sc_lint", "sc_typecheck"):
+            body = re.search(fn + r"\(\) \{.*?\n\}", SC, re.S).group(0)
+            self.assertIn("_sc_devtool", body,
+                          f"{fn} must resolve its tool via _sc_devtool — a "
+                          f"bare '.venv or die' guard is the QAQC-02 dead loop")
+
+    def test_host_managed_error_names_the_host_fix(self):
+        self.assertIn("host-managed", SC)
+        self.assertNotIn("no .venv/bin/ruff — run ./sc deps first", SC,
+                         "the closed-loop error copy must be gone")
+
+
+class ImageFallbackTest(unittest.TestCase):
+    def test_image_bakes_ruff_and_mypy(self):
+        self.assertRegex(DOCKERFILE, r"pip install[^\n]*ruff[^\n]*mypy",
+                         "the sandbox image must bake ruff + mypy — the PATH "
+                         "fallback for host-managed-.venv forks")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
From the dos-arch QAQC sweep (fork flag **QAQC-02**), two dev-kit dead-ends:

1. **lint/typecheck closed loop.** With a host-managed `.venv` (pinned out-of-tree interpreter mounted by launch), `sc_deps` skips all pip work in the sandbox *by design* — but `./sc lint`/`typecheck` still said "run `./sc deps` first", a remedy that can never work there. Fix: a `_sc_devtool` resolver — the fork's `.venv` copy wins (its pins + `[tool.*]` config), else the PATH copy (**ruff + mypy now baked into the sandbox image** as the fallback), else an honest error that names the actual host-side fix.
2. **Worktree glob leak.** `_sc_find_manifests` descended `.sc-worktrees/` — each shell worktree is a sibling checkout of the same repo, so `./sc deps`/`test` processed every manifest N×. `.sc-worktrees` joins the prune list.

## Test plan
- [x] full suite green (159 passed; 5 new in `test_devkit_sc.py`: live sh prune run, .venv→PATH order, lint/typecheck via `_sc_devtool`, closed-loop copy gone, image bake)
- [x] `sh -n sc` clean; `./sc lint` resolves on the source repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)