### PR TITLE
feat(flavors): fork-local flavor overlays — .sc-state/flavors/<flavor>.json

### DIFF
--- a/.super-coder/scripts/shell_factory.py
+++ b/.super-coder/scripts/shell_factory.py
@@ -7,6 +7,22 @@ skills, so creating a shell is mostly just a name. Every shell carries the CC
 Lineage Seed (Law 6, shared) + its own genesis seed (Laws 2-4), is granted the
 COMMON skill catalogue plus the flavor's opt-ins, starts un-bootstrapped (gets
 the FIRST RUN orientation), and has its first session opened.
+
+Fork-local flavor OVERLAYS: the engine templates are materialized (overwritten
+on `./sc update`), so a fork cannot durably edit them — yet a fork legitimately
+changes what a new shell of a flavor gets (dos-arch replaced `test_authoring`
+with its own `test_authoring_dosarch`; every new dev/reviewer shell then booted
+with the wrong grant). A tracked, fork-owned overlay at
+`.sc-state/flavors/<flavor>.json` closes that:
+
+    {"skills_add": ["test_authoring_dosarch"],
+     "skills_remove": ["test_authoring", "test_authoring_pg"]}
+
+`skills_add` / `skills_remove` adjust the engine list (the durable form — the
+engine list keeps evolving upstream and the overlay rides it); any other key
+(role, mandate, focus, abbr — not `flavor` itself) overrides the template's.
+Applied by load_flavor()/flavors(), so shell creation AND the GUI's flavor
+listing both see the overlaid shape.
 """
 from __future__ import annotations
 
@@ -33,11 +49,43 @@ GENESIS_TMPL = (
     "floor I stand on. I curate my own seed from here.")
 
 
+FORK_FLAVOR_OVERLAYS = REPO_ROOT / ".sc-state" / "flavors"
+
+
+def _apply_overlay(tpl: dict, overlay: dict) -> dict:
+    """Merge a fork overlay over an engine flavor template (pure — see the
+    module docstring for the format). skills_add/skills_remove adjust the
+    engine skill list; other keys override, except `flavor` (the identity the
+    overlay is keyed BY — an overlay cannot rename it)."""
+    out = {**tpl}
+    add = overlay.get("skills_add", [])
+    remove = set(overlay.get("skills_remove", []))
+    if add or remove:
+        skills = [s for s in tpl.get("skills", []) if s not in remove]
+        out["skills"] = skills + [s for s in add if s not in skills]
+    for k, v in overlay.items():
+        if k not in ("skills_add", "skills_remove", "flavor"):
+            out[k] = v
+    return out
+
+
+def _overlay_for(flavor: str) -> dict | None:
+    p = FORK_FLAVOR_OVERLAYS / f"{flavor}.json"
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except json.JSONDecodeError as e:
+        raise ValueError(f"fork flavor overlay {p} is not valid JSON: {e}") from e
+
+
 def flavors() -> list[dict]:
     out = []
     if SHELL_TEMPLATES.exists():
         for p in sorted(SHELL_TEMPLATES.glob("*.json")):
-            out.append(json.loads(p.read_text()))
+            tpl = json.loads(p.read_text())
+            ov = _overlay_for(tpl.get("flavor", p.stem))
+            out.append(_apply_overlay(tpl, ov) if ov else tpl)
     return out
 
 
@@ -46,7 +94,9 @@ def load_flavor(flavor: str) -> dict:
     if not p.exists():
         raise ValueError(f"unknown flavor '{flavor}' "
                          f"(have: {', '.join(f['flavor'] for f in flavors())})")
-    return json.loads(p.read_text())
+    tpl = json.loads(p.read_text())
+    ov = _overlay_for(flavor)
+    return _apply_overlay(tpl, ov) if ov else tpl
 
 
 def _auto_shortname(con, abbr: str) -> str:

--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ fits the **fork-owned extension points**, you never touch engine files, and
 | Extension point | What it carries |
 |---|---|
 | **Local skills** | Fork-authored procedures (GUI → Skills) — serialized in `content.sql`, survive every update |
+| **Flavor overlays** | `.sc-state/flavors/<flavor>.json` — what a NEW shell of a flavor gets: `skills_add` / `skills_remove` against the engine template's list, plus role/mandate/focus overrides (e.g. swap the engine's `test_authoring` for a fork's own testing skill) |
 | **`instance.json`** | Per-fork config: ports, harness default, the `pg` / `vm` / `ts` opt-in blocks |
 | **`.sc-state/`** | Your memory (content.sql), map tuning, engine pin — the fork's one tracked artifact |
 | **Per-shell identity** | `current_state`, connections, decisions, seed — all DB rows, all yours |

--- a/tests/test_flavor_overlay.py
+++ b/tests/test_flavor_overlay.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Tests for fork-local flavor overlays (shell_factory.py).
+
+The engine's templates/shells/*.json are materialized — overwritten on every
+`./sc update` — so a fork cannot durably edit what a new shell of a flavor
+gets. The overlay (`.sc-state/flavors/<flavor>.json`, tracked, fork-owned)
+must: adjust the skill list via skills_add/skills_remove (riding upstream's
+evolving list, not replacing it), override scalars but never `flavor` itself,
+apply in BOTH load_flavor() and flavors() (creation + GUI listing), and fail
+loud on bad JSON rather than silently creating an un-overlaid shell.
+
+Run:
+    python3 tests/test_flavor_overlay.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+import shell_factory as sf  # noqa: E402
+
+TPL = {"flavor": "dev", "abbr": "DEV", "role": "Dev shell",
+       "mandate": "Build in {{repo}}.",
+       "skills": ["docs", "git", "test_authoring", "test_authoring_pg"]}
+
+
+class ApplyOverlayTest(unittest.TestCase):
+    def test_skills_add_remove(self):
+        # The dos-arch case: swap the engine testing skill for the fork's own.
+        out = sf._apply_overlay(TPL, {
+            "skills_add": ["test_authoring_dosarch"],
+            "skills_remove": ["test_authoring", "test_authoring_pg"]})
+        self.assertEqual(out["skills"],
+                         ["docs", "git", "test_authoring_dosarch"])
+        self.assertEqual(TPL["skills"],
+                         ["docs", "git", "test_authoring", "test_authoring_pg"],
+                         "overlay must not mutate the input template")
+
+    def test_add_is_idempotent_against_engine_list(self):
+        out = sf._apply_overlay(TPL, {"skills_add": ["git", "flags"]})
+        self.assertEqual(out["skills"].count("git"), 1)
+        self.assertIn("flags", out["skills"])
+
+    def test_scalar_override_but_never_flavor(self):
+        out = sf._apply_overlay(TPL, {"role": "Fork dev", "flavor": "hijack"})
+        self.assertEqual(out["role"], "Fork dev")
+        self.assertEqual(out["flavor"], "dev",
+                         "an overlay is keyed BY flavor — it cannot rename it")
+
+    def test_empty_overlay_is_identity(self):
+        self.assertEqual(sf._apply_overlay(TPL, {}), TPL)
+
+
+class OverlayFileTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.templates = root / "templates"
+        self.overlays = root / "flavors"
+        self.templates.mkdir()
+        self.overlays.mkdir()
+        (self.templates / "dev.json").write_text(json.dumps(TPL))
+        self._orig = (sf.SHELL_TEMPLATES, sf.FORK_FLAVOR_OVERLAYS)
+        sf.SHELL_TEMPLATES = self.templates
+        sf.FORK_FLAVOR_OVERLAYS = self.overlays
+
+    def tearDown(self):
+        sf.SHELL_TEMPLATES, sf.FORK_FLAVOR_OVERLAYS = self._orig
+        self.tmp.cleanup()
+
+    def test_no_overlay_file_loads_plain_template(self):
+        self.assertEqual(sf.load_flavor("dev")["skills"], TPL["skills"])
+
+    def test_load_flavor_applies_overlay(self):
+        (self.overlays / "dev.json").write_text(json.dumps(
+            {"skills_add": ["test_authoring_dosarch"],
+             "skills_remove": ["test_authoring", "test_authoring_pg"]}))
+        got = sf.load_flavor("dev")["skills"]
+        self.assertIn("test_authoring_dosarch", got)
+        self.assertNotIn("test_authoring", got)
+
+    def test_flavors_listing_applies_overlay(self):
+        (self.overlays / "dev.json").write_text(json.dumps({"role": "Fork dev"}))
+        listed = {f["flavor"]: f for f in sf.flavors()}
+        self.assertEqual(listed["dev"]["role"], "Fork dev",
+                         "the GUI's flavor listing must show the overlaid shape")
+
+    def test_bad_overlay_json_fails_loud(self):
+        (self.overlays / "dev.json").write_text("{broken")
+        with self.assertRaises(ValueError):
+            sf.load_flavor("dev")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
From the dos-arch QAQC sweep (fork flag *"New dev/review shells miss test_authoring_dosarch grant"*, which names this exact upstream fix as the durable one): engine flavor templates are materialized — overwritten on every `./sc update` — so a fork cannot durably change what a new shell of a flavor gets. dos-arch replaced `test_authoring` with its own `test_authoring_dosarch`, and every new dev/reviewer shell booted with the engine's generic skill instead, requiring a manual regrant + snapshot per shell.

**The fix:** a tracked, fork-owned overlay at `.sc-state/flavors/<flavor>.json`, merged over the engine template in `shell_factory`:

```json
{"skills_add": ["test_authoring_dosarch"],
 "skills_remove": ["test_authoring", "test_authoring_pg"]}
```

- `skills_add` / `skills_remove` adjust the engine's list rather than replacing it — upstream's template keeps evolving and the overlay rides it.
- Any other key (role, mandate, focus, abbr) overrides the template scalar; `flavor` itself is protected (it's the key the overlay is addressed by).
- Applied in `load_flavor()` **and** `flavors()`, so shell creation and the GUI's flavor listing both show the overlaid shape. Bad JSON fails loud instead of silently creating an un-overlaid shell.
- README: new **Flavor overlays** row in the extension-points table (this is precisely the "customize without diverging" lane).

## Test plan
- [x] full suite green (162 passed; 8 new in `test_flavor_overlay.py`: add/remove, input non-mutation, add-idempotence, flavor-key protection, file-driven load + listing, loud bad-JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
