### PR TITLE
ci: tests + verify workflow on every PR (GitHub-hosted)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,11 @@ on:
   push:
     branches: [main]
 
+# Least-privilege GITHUB_TOKEN — both jobs only read the tree (CodeQL flags the
+# unbounded default). Nothing here pushes, comments, or releases.
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: tests
+
+# The PR gate: the full engine suite + the headless end-to-end proof, on every
+# PR and every push to main. GitHub-hosted BY DESIGN — this repo is public, and
+# a self-hosted runner on a public repo lets any fork PR execute code on the
+# host (the same host that carries the substrates). The suite is hermetic
+# (stdlib + pytest, no docker, no network), so ubuntu-latest covers it free.
+# Anything that ever genuinely needs house hardware belongs in a separate
+# push-to-main-only workflow, never a PR-triggered one.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      # pytest is the runner; every other test import is stdlib or engine-local.
+      - name: Install pytest
+        run: pip install pytest
+      - name: Run the suite
+        run: pytest tests/ -q
+
+  # The end-to-end proof `./sc verify` runs: rebuild the DB from committed text
+  # (schema + migrations + content.sql), flat-render, then a render-only boot —
+  # proving a fresh clone of this exact tree stands up. Complements
+  # render-check.yml (drift guard) with the boot half.
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Rebuild + render + headless boot
+        run: ./sc verify


### PR DESCRIPTION
Adds the PR gate discussed: a `tests` job (full pytest suite — 174 tests, hermetic, stdlib+pytest only) and a `verify` job (`./sc verify`: rebuild the DB from committed text → flat render → render-only headless boot, proving a fresh clone of the exact tree stands up). Runs on every PR and push to main, alongside the existing `render-check` drift guard.

**GitHub-hosted, deliberately not self-hosted:** this repo is public, and a self-hosted runner on a public repo lets any fork PR execute code on the host carrying the substrates. Public repos get hosted minutes free and the suite needs no docker/network, so `ubuntu-latest` covers it with zero new attack surface. If we ever add tests that need house hardware, they go in a separate push-to-main-only workflow (post-merge canary), never a PR-triggered one — that rule is written into the workflow header.

## Test plan
- [x] YAML parses; both commands green locally (`pytest tests/ -q` → 174 passed, `./sc verify` → clean headless boot)
- [ ] The PR's own checks runs are the live proof — tests + verify + render-check should all report here

🤖 Generated with [Claude Code](https://claude.com/claude-code)