### PR TITLE
fix(backups): per-fork BACKUP_DIR — stop pooling every fork's dumps in one dir

### DIFF
--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -24,7 +24,13 @@ DB_PATH = ENGINE / "shell_db.db"
 SCHEMA_SQLITE = ENGINE / "schema.sql"
 SNAPSHOT       = REPO_ROOT / ".sc-state" / "content.sql"
 SNAPSHOT_LEGACY = ENGINE / "snapshot" / "content.sql"
-BACKUP_DIR = Path.home() / "db_backups" / "super-coder"
+# PER-FORK backup dir, keyed by the host repo's dir name. This was a fixed
+# "super-coder" for every fork, which pooled all forks' pre-update dumps in one
+# dir — and rollback restores the MOST RECENT dump, so a multi-fork update
+# sweep could roll one fork back onto ANOTHER FORK'S DB. In the source repo the
+# name IS super-coder, so its path is unchanged. Old pooled dumps stay where
+# they are: they cannot be attributed to a fork after the fact.
+BACKUP_DIR = Path.home() / "db_backups" / REPO_ROOT.name
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import db_driver    # noqa: E402

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -34,12 +34,16 @@ DB_PATH = ENGINE / "shell_db.db"
 STATE_DIR = REPO_ROOT / ".sc-state"
 ENGINE_REF = STATE_DIR / "engine.ref"
 ENGINE_REF_PREV = STATE_DIR / "engine.ref.prev"
-BACKUP_DIR = Path.home() / "db_backups" / "super-coder"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import engine_manifest  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402  (BACKUP_DIR, prune_backups, KEEP_BACKUPS)
 import update as update_mod    # noqa: E402  (materialize_engine, super_coder_remote, git)
+
+# One source of truth with rebuild.py — the PER-FORK dir. A restore point must
+# come from THIS fork's backups: a private copy of the path is exactly how the
+# pooled-dir hazard happened (rollback restoring another fork's dump).
+BACKUP_DIR = rebuild_mod.BACKUP_DIR
 
 
 def latest_db_restore_point() -> Path | None:

--- a/tests/test_backup_dir.py
+++ b/tests/test_backup_dir.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Pin the per-fork backup dir contract (rebuild.py / rollback.py).
+
+The hazard this guards: BACKUP_DIR was a fixed ~/db_backups/super-coder for
+EVERY fork, pooling all forks' pre-update dumps — and rollback restores the
+most recent dump, so a multi-fork update sweep could roll one fork back onto
+another fork's DB. The contract now: the dir is keyed by the host repo's dir
+name, and rollback shares rebuild's object rather than keeping a private copy
+(a private copy of the path is exactly how the pooling happened).
+
+Run:
+    python3 tests/test_backup_dir.py
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+import rebuild  # noqa: E402
+import rollback  # noqa: E402
+
+
+class BackupDirTest(unittest.TestCase):
+    def test_backup_dir_is_keyed_by_repo_dir_name(self):
+        self.assertEqual(rebuild.BACKUP_DIR.name, ROOT.name,
+                         "backups must be per-fork — a fixed name pools every "
+                         "fork's dumps into one dir")
+        self.assertEqual(rebuild.BACKUP_DIR.parent.name, "db_backups")
+
+    def test_rollback_shares_rebuilds_dir(self):
+        self.assertIs(rollback.BACKUP_DIR, rebuild.BACKUP_DIR,
+                      "rollback must restore from the SAME per-fork dir rebuild "
+                      "writes to — a private copy re-creates the pooling hazard")
+
+    def test_no_hardcoded_fork_name_remains(self):
+        for script in ("rebuild.py", "rollback.py"):
+            src = (ROOT / ".super-coder" / "scripts" / script).read_text()
+            self.assertNotIn('"db_backups" / "super-coder"', src,
+                             f"{script}: the fixed-name path is the bug")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Surfaced by today's four-fork repin sweep: every fork's pre-update DB backup landed in the same `~/db_backups/super-coder/`, and `./sc rollback` restores the **most recent** dump — so a rollback in dos-arch right now would have restored ami's database.

- `rebuild.BACKUP_DIR` is now keyed by the host repo's dir name (`~/db_backups/<repo>/`); the source repo's own name is `super-coder`, so its path is unchanged.
- `rollback.py` drops its private copy of the path and shares `rebuild.BACKUP_DIR` — the private copy is exactly how the pooling happened.
- Old pooled dumps stay where they are (they can't be attributed to a fork after the fact); each fork's next update writes the first dump into its own dir, and rollback fails safe ("no restore point found") rather than restoring cross-fork until then.

## Test plan
- [x] full suite green (177 passed; 3 new in `test_backup_dir.py`: per-repo keying, rollback↔rebuild identity, fixed-name literal gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)