### PR TITLE
feat(features): app-deploy — admin-authored deploy ritual scaffold for the fork's app

### DIFF
--- a/.sc-state/content.sql
+++ b/.sc-state/content.sql
@@ -1468,7 +1468,7 @@ DELETE FROM project_shells;
 INSERT INTO project_shells (project_shell_id, project_id, shell_id, role, added_date, is_deleted) VALUES (1, 1, 1, 'maintainer', '2026-06-04', 0);
 
 -- Project-local skills only. Engine-seeded skills come from migrations.
-DELETE FROM skills WHERE name NOT IN ('api-design', 'blueprint', 'bootstrap', 'cartographer', 'configure_winbox', 'database-migrations', 'db_map', 'docs', 'flag_sweep', 'flags', 'git', 'git_cleanup', 'issue_reporting', 'local_skill_management', 'memory', 'messaging', 'migration_management', 'onboard', 'redline_review', 'review', 'self_update', 'snapshot', 'spec', 'surface_catalogue', 'tailscale', 'test_authoring', 'test_authoring_pg', 'test_authoring_sqlite', 'windows_devkit');
+DELETE FROM skills WHERE name NOT IN ('api-design', 'app_deploy_setup', 'blueprint', 'bootstrap', 'cartographer', 'configure_winbox', 'database-migrations', 'db_map', 'docs', 'flag_sweep', 'flags', 'git', 'git_cleanup', 'issue_reporting', 'local_skill_management', 'memory', 'messaging', 'migration_management', 'onboard', 'redline_review', 'review', 'self_update', 'snapshot', 'spec', 'surface_catalogue', 'tailscale', 'test_authoring', 'test_authoring_pg', 'test_authoring_sqlite', 'windows_devkit');
 INSERT INTO skills (name, description, category, content, command, common, is_deleted) VALUES ('dev_kit', 'What the sandbox dev kit provides + how to drive it — ./sc deps, ./sc test, ./sc lint, ./sc typecheck, the .venv tools, rg/sqlite3, the baked browser, the container/host app boundary, and the optional app-only Postgres sidecar (DATABASE_URL). Use when building or testing in a fork.', 'substrate', '# dev_kit — the sandbox dev kit
 
 What you have to build, test, and inspect a fork — and the one boundary that

--- a/.super-coder/assets/skills/app_deploy_setup/SKILL.md
+++ b/.super-coder/assets/skills/app_deploy_setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: app_deploy_setup
+description: Admin-run, one-time scaffold — turn the shipped deploy template into this repo's own project-local `deploy` skill (migration dirs, DB backup, ff-only sync, apply + move migrations, restart), then grant it to every shell.
+category: substrate
+common: false
+---
+
+# app_deploy_setup — scaffold this app's deploy ritual (once, admin)
+
+The engine deploys itself (`sc update`). The HOST APP this fork lives in has
+its own deploy story — app process, app DB, app migrations — that the engine
+cannot know. This skill turns the template below into the repo's own `deploy`
+skill, filled in with this app's specifics.
+
+**Why a NEW project-local skill instead of editing this one:** engine skills
+self-heal on every `sc update` — a fork edit to any skill named in
+`assets/skills/` is detected as stale and reverted to the shipped body. A
+project-local skill (a name the engine doesn't ship) is never touched by that
+guard and persists through rebuilds via `sc snapshot` → `.sc-state/content.sql`.
+Fill in the template, save it under a NEW name, leave this scaffold as shipped.
+
+## 1. Scaffold the migration dirs
+
+```bash
+mkdir -p migrations_app/pending migrations_app/completed
+touch migrations_app/pending/.gitkeep migrations_app/completed/.gitkeep
+```
+
+Commit them. Rename to fit the repo's layout if you like (`db/migrations/…`,
+`deploy/migrations/…`) — keep `pending/` and `completed/` as siblings and use
+the same paths in the template. These are the APP's schema migrations —
+unrelated to `.super-coder/migrations/` (engine DB, ledger-tracked, owned by
+`sc update`).
+
+## 2. Fill the template
+
+Every `⟨ADMIN: …⟩` slot is app-specific. Get each answer from the operator or
+the repo itself, and **run each command once by hand** before writing it in —
+a deploy skill is no place for untested commands.
+
+```markdown
+# deploy — ⟨ADMIN: app name⟩ post-merge deploy ritual
+
+Run from the repo root on the host. Every step aborts loudly rather than
+guessing; if a step fails, stop — the app is down and the DB is backed up.
+
+1. **Down** — stop the app:
+   ⟨ADMIN: stop command — e.g. pm2 stop ecosystem.config.cjs / systemctl stop <app> / docker compose down⟩
+
+2. **Backup** — snapshot the app DB before anything mutates:
+   ⟨ADMIN: backup command + destination + how many to retain⟩
+
+3. **Sync main** — `git switch main` (if on a branch), then `git pull --ff-only`.
+   `--ff-only` aborts on a diverged or dirty main — resolve by hand; never
+   merge inside a deploy.
+
+4. **Migrate** — apply every file in `migrations_app/pending/` in sort order:
+   ⟨ADMIN: apply command per file — e.g. psql "$DB_URL" -f <file> / sqlite3 <db> < <file> / alembic upgrade head⟩
+   After each success: `git mv migrations_app/pending/<file> migrations_app/completed/`
+   On first failure: stop, restore the backup, investigate.
+
+5. **Record** — commit and push the moves — the move IS the applied-ledger,
+   and an uncommitted move dirties main and breaks the NEXT deploy's --ff-only:
+   `git add migrations_app && git commit -m "deploy: apply <files>" && git push`
+
+6. **Up** — restart the app:
+   ⟨ADMIN: start command⟩
+
+7. **Verify** — prove the new code is serving:
+   ⟨ADMIN: health check — e.g. curl -fsS http://127.0.0.1:<port>/health⟩
+```
+
+## 3. Save it as a project-local skill
+
+```sql
+INSERT INTO skills (name, description, category, content, common)
+VALUES ('deploy',
+        'Post-merge deploy ritual for this app — down, backup, ff-only sync, migrate pending→completed, restart, verify.',
+        'substrate',
+        '<the filled template>',
+        1);
+```
+
+`common=1` is the "grant to every shell" switch: new shells receive it at
+creation, and `sc update` re-grants every common skill to every live shell.
+Grant existing shells now without waiting for an update:
+
+```sql
+INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
+SELECT s.shell_id, k.skill_id FROM shells s, skills k
+WHERE COALESCE(s.is_deleted,0)=0 AND k.name='deploy' AND k.is_deleted=0;
+```
+
+Then persist: `sc snapshot` (project-local skills + grants live in
+`.sc-state/content.sql`).
+
+## 4. Optional make surface
+
+If the operator wants make muscle-memory, add a bare `deploy` target to the
+**repo's own root Makefile** — that is the fork's convention space. Do NOT add
+it to `.super-coder/aliases.mk`: that file is engine-owned, every target must
+delegate to `./sc`, and the engine knows nothing about the app.
+
+## 5. Done
+
+Dry-run the ritual once on a quiet window end-to-end. This scaffold stays
+granted to admin only; the finished `deploy` skill is the one every shell
+carries.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -56,6 +56,120 @@ ON CONFLICT(name) DO UPDATE SET
   content=excluded.content, is_deleted=0;
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'app_deploy_setup',
+  'Admin-run, one-time scaffold — turn the shipped deploy template into this repo''s own project-local `deploy` skill (migration dirs, DB backup, ff-only sync, apply + move migrations, restart), then grant it to every shell.',
+  'substrate',
+  NULL,
+  0,
+  '# app_deploy_setup — scaffold this app''s deploy ritual (once, admin)
+
+The engine deploys itself (`sc update`). The HOST APP this fork lives in has
+its own deploy story — app process, app DB, app migrations — that the engine
+cannot know. This skill turns the template below into the repo''s own `deploy`
+skill, filled in with this app''s specifics.
+
+**Why a NEW project-local skill instead of editing this one:** engine skills
+self-heal on every `sc update` — a fork edit to any skill named in
+`assets/skills/` is detected as stale and reverted to the shipped body. A
+project-local skill (a name the engine doesn''t ship) is never touched by that
+guard and persists through rebuilds via `sc snapshot` → `.sc-state/content.sql`.
+Fill in the template, save it under a NEW name, leave this scaffold as shipped.
+
+## 1. Scaffold the migration dirs
+
+```bash
+mkdir -p migrations_app/pending migrations_app/completed
+touch migrations_app/pending/.gitkeep migrations_app/completed/.gitkeep
+```
+
+Commit them. Rename to fit the repo''s layout if you like (`db/migrations/…`,
+`deploy/migrations/…`) — keep `pending/` and `completed/` as siblings and use
+the same paths in the template. These are the APP''s schema migrations —
+unrelated to `.super-coder/migrations/` (engine DB, ledger-tracked, owned by
+`sc update`).
+
+## 2. Fill the template
+
+Every `⟨ADMIN: …⟩` slot is app-specific. Get each answer from the operator or
+the repo itself, and **run each command once by hand** before writing it in —
+a deploy skill is no place for untested commands.
+
+```markdown
+# deploy — ⟨ADMIN: app name⟩ post-merge deploy ritual
+
+Run from the repo root on the host. Every step aborts loudly rather than
+guessing; if a step fails, stop — the app is down and the DB is backed up.
+
+1. **Down** — stop the app:
+   ⟨ADMIN: stop command — e.g. pm2 stop ecosystem.config.cjs / systemctl stop <app> / docker compose down⟩
+
+2. **Backup** — snapshot the app DB before anything mutates:
+   ⟨ADMIN: backup command + destination + how many to retain⟩
+
+3. **Sync main** — `git switch main` (if on a branch), then `git pull --ff-only`.
+   `--ff-only` aborts on a diverged or dirty main — resolve by hand; never
+   merge inside a deploy.
+
+4. **Migrate** — apply every file in `migrations_app/pending/` in sort order:
+   ⟨ADMIN: apply command per file — e.g. psql "$DB_URL" -f <file> / sqlite3 <db> < <file> / alembic upgrade head⟩
+   After each success: `git mv migrations_app/pending/<file> migrations_app/completed/`
+   On first failure: stop, restore the backup, investigate.
+
+5. **Record** — commit and push the moves — the move IS the applied-ledger,
+   and an uncommitted move dirties main and breaks the NEXT deploy''s --ff-only:
+   `git add migrations_app && git commit -m "deploy: apply <files>" && git push`
+
+6. **Up** — restart the app:
+   ⟨ADMIN: start command⟩
+
+7. **Verify** — prove the new code is serving:
+   ⟨ADMIN: health check — e.g. curl -fsS http://127.0.0.1:<port>/health⟩
+```
+
+## 3. Save it as a project-local skill
+
+```sql
+INSERT INTO skills (name, description, category, content, common)
+VALUES (''deploy'',
+        ''Post-merge deploy ritual for this app — down, backup, ff-only sync, migrate pending→completed, restart, verify.'',
+        ''substrate'',
+        ''<the filled template>'',
+        1);
+```
+
+`common=1` is the "grant to every shell" switch: new shells receive it at
+creation, and `sc update` re-grants every common skill to every live shell.
+Grant existing shells now without waiting for an update:
+
+```sql
+INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
+SELECT s.shell_id, k.skill_id FROM shells s, skills k
+WHERE COALESCE(s.is_deleted,0)=0 AND k.name=''deploy'' AND k.is_deleted=0;
+```
+
+Then persist: `sc snapshot` (project-local skills + grants live in
+`.sc-state/content.sql`).
+
+## 4. Optional make surface
+
+If the operator wants make muscle-memory, add a bare `deploy` target to the
+**repo''s own root Makefile** — that is the fork''s convention space. Do NOT add
+it to `.super-coder/aliases.mk`: that file is engine-owned, every target must
+delegate to `./sc`, and the engine knows nothing about the app.
+
+## 5. Done
+
+Dry-run the ritual once on a quiet window end-to-end. This scaffold stays
+granted to admin only; the finished `deploy` skill is the one every shell
+carries.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'blueprint',
   'Turn a one-line objective into a sequenced construction plan — decompose into steps, find the dependency order, mark what can run in parallel, name the verification gate. Use before multi-step builds.',
   'craft',

--- a/.super-coder/scripts/feature.py
+++ b/.super-coder/scripts/feature.py
@@ -17,7 +17,9 @@ orchestrates them, so everything here can still be done by hand.
 The vm/ts blocks are NOT auto-created: they carry host-specific, operator-
 verified config (a linked VM, a tailnet scope) that `enable` cannot invent —
 it grants the skills and prints exactly how to link. `pg` needs no host input
-(the sidecar is fully derived), so its block IS auto-created.
+(the sidecar is fully derived), so its block IS auto-created. A feature may
+also be procedure-only (`block: None`) — no infrastructure half at all, just
+grants; `app-deploy` is one.
 
 Grants land in shell_skills, which is fork memory — enable/disable therefore
 re-snapshots, so `.sc-state/content.sql` stays current and a rebuild keeps the
@@ -26,7 +28,7 @@ grants.
 Usage:
     ./sc feature                      # = list
     ./sc feature list
-    ./sc feature enable  <name>       # pg · windows · tailnet
+    ./sc feature enable  <name>       # pg · windows · tailnet · app-deploy
     ./sc feature disable <name>
 """
 from __future__ import annotations
@@ -46,10 +48,11 @@ PY = sys.executable
 sys.path.insert(0, str(ENGINE / "scripts"))
 import db_driver  # noqa: E402
 
-# The registry. `block` is the instance.json key; `block_auto` says whether
-# enable may create it (only when it needs no operator-supplied host config).
-# `grants` maps skill name → the flavors whose shells own that procedure.
-# `link` is the printed how-to for the operator-supplied blocks.
+# The registry. `block` is the instance.json key (None = procedure-only, no
+# infrastructure half); `block_auto` says whether enable may create it (only
+# when it needs no operator-supplied host config). `grants` maps skill name →
+# the flavors whose shells own that procedure. `link` is the printed how-to
+# for the operator-supplied blocks / procedure-only next steps.
 FEATURES: dict[str, dict] = {
     "pg": {
         "title": "Postgres sidecar (app-only)",
@@ -79,6 +82,16 @@ FEATURES: dict[str, dict] = {
                  "(allowed_hosts is the fail-closed scope) — see README → "
                  "'Tailnet broker'",
                  "./sc launch   # brings the ts-broker up once a tailnet is linked"],
+    },
+    "app-deploy": {
+        "title": "App deploy ritual (admin-authored)",
+        "block": None,          # procedure-only — nothing to link in instance.json
+        "block_auto": False,
+        "grants": {"app_deploy_setup": ["admin"]},
+        "link": ["run the app_deploy_setup skill in your admin shell — it "
+                 "authors this repo's own project-local `deploy` skill "
+                 "(migration dirs, backup, ff-only sync, migrate, restart) "
+                 "and grants it to every shell"],
     },
 }
 
@@ -147,15 +160,18 @@ def cmd_list() -> int:
     print("opt-in features — enable with: ./sc feature enable <name>\n")
     for name, f in FEATURES.items():
         blk = f["block"]
-        linked = blk in cfg
-        blk_state = f"✓ `{blk}` linked" if linked else (
-            f"✗ `{blk}` block absent" + ("" if f["block_auto"] else " (operator-linked)"))
-        print(f"  {name:8} {f['title']}")
-        print(f"           config: {blk_state}")
+        if blk is None:
+            blk_state = "— none needed (procedure-only)"
+        else:
+            linked = blk in cfg
+            blk_state = f"✓ `{blk}` linked" if linked else (
+                f"✗ `{blk}` block absent" + ("" if f["block_auto"] else " (operator-linked)"))
+        print(f"  {name:10} {f['title']}")
+        print(f"             config: {blk_state}")
         for skill in f["grants"]:
             held = _grant_state(con, skill) if con else []
             state = " ".join(held) if held else "none"
-            print(f"           skill:  {skill} → {state}")
+            print(f"             skill:  {skill} → {state}")
         print()
     if con:
         con.close()
@@ -194,7 +210,11 @@ def cmd_enable(name: str) -> int:
 
     cfg = _instance()
     blk = f["block"]
-    if blk in cfg:
+    if blk is None:
+        print("  config: none needed (procedure-only) — next steps:")
+        for step in f.get("link", []):
+            print(f"    - {step}")
+    elif blk in cfg:
         print(f"  config `{blk}` already linked in instance.json")
     elif f["block_auto"]:
         cfg[blk] = {}
@@ -233,7 +253,9 @@ def cmd_disable(name: str) -> int:
 
     cfg = _instance()
     blk = f["block"]
-    if blk in cfg:
+    if blk is None:
+        print("  config: none to remove (procedure-only)")
+    elif blk in cfg:
         del cfg[blk]
         _write_instance(cfg)
         print(f"  config `{blk}` removed from instance.json")

--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ launch, enter, snapshot, render, and the GUI work unchanged.
 ./sc preview             # live worktree UI previews, one subdomain per shell
 ./sc update              # fetch + materialize the engine, reconcile in place (--ref <tag|sha> pins)
 ./sc rollback            # sound undo of a bad update (restore DB + engine)
-./sc feature             # opt-in features: list / enable / disable (pg · windows · tailnet)
+./sc feature             # opt-in features: list / enable / disable (pg · windows · tailnet · app-deploy)
 ./sc eject               # ONE-WAY: own the engine — stop tracking upstream (confirm-gated)
 ./sc verify              # rebuild + flat render + headless boot (no exec) — the proof
 ./sc help                # all commands
@@ -646,6 +646,7 @@ front door to the pair:
 | **`pg`** | `pg` (auto-created) | `test_authoring_pg` → dev, reviewer | A `postgres:17` sidecar on `sc-net`, `DATABASE_URL` forwarded into the sandbox — develop + test the fork's **app** against real Postgres (the engine DB stays SQLite, always) |
 | **`windows`** | `vm` (operator-linked) | `windows_devkit` → dev, reviewer · `configure_winbox` → admin | The Windows Test VM loop — push → exec → capture → reset against a real Windows box, via the host-side broker (next section) |
 | **`tailnet`** | `ts` (operator-linked) | `tailscale` → devops | The tailnet broker — reach declared build/deploy hosts from the sandbox without holding a tailnet credential (section after) |
+| **`app-deploy`** | — (procedure-only) | `app_deploy_setup` → admin | A deploy-ritual scaffold for the fork's **app** (the engine deploys itself via `sc update`) — the admin fills the template (migration dirs, DB backup, ff-only sync, apply + move migrations, restart) and saves it as the repo's own project-local `deploy` skill, granted to every shell |
 
 `enable pg` is complete in one step — the sidecar needs no host input, so the
 block is auto-created and the next `./sc launch` starts it (data persists in a
@@ -653,6 +654,10 @@ named volume; `./sc pg-down` stops it, volume retained). `windows` and
 `tailnet` are **link-only**: their blocks carry host-specific, operator-verified
 config (a ready VM, a tailnet scope), so `enable` grants the skills and prints
 exactly how to link — the two sections below are the full setup guides.
+`app-deploy` has no config block at all: `enable` grants the scaffold skill to
+the admin shell, and the finished product is a **project-local** skill — engine
+skills self-heal to the shipped body on every `sc update`, so the fleshed-out
+ritual must live under a name the engine doesn't ship.
 
 Everything here can still be done by hand — the GUI's per-shell grant toggles
 and a hand-edited `instance.json` are the same mechanisms; `./sc feature` just

--- a/skills_sc/README.md
+++ b/skills_sc/README.md
@@ -9,6 +9,7 @@ edit: changes here are overwritten — author via the shell or localhost GUI
 > The substrate's skill catalogue, rendered from the DB. Per-shell grants live in `.claude/skills/` (rebuilt at boot).
 
 - [`api-design`](skills_sc/api-design.md) — REST/HTTP API design patterns — resource naming, status codes, pagination, filtering, errors, versioning, idempotency. Use when designing or reviewing API endpoints.
+- [`app_deploy_setup`](skills_sc/app_deploy_setup.md) — Admin-run, one-time scaffold — turn the shipped deploy template into this repo's own project-local `deploy` skill (migration dirs, DB backup, ff-only sync, apply + move migrations, restart), then grant it to every shell.
 - [`blueprint`](skills_sc/blueprint.md) — Turn a one-line objective into a sequenced construction plan — decompose into steps, find the dependency order, mark what can run in parallel, name the verification gate. Use before multi-step builds.
 - [`bootstrap`](skills_sc/bootstrap.md) — First-run orientation for a shell in a repo. Run ONCE when the boot doc shows "## FIRST RUN" (bootstrapped=0). Read the repo map + your identity, set your current_state, mark yourself oriented. Do this BEFORE other work on a fresh fork.
 - [`cartographer`](skills_sc/cartographer.md) — Own the repo map. Configure mapping to THIS repo, wire the auto-remap git hooks, and heal both when the repo or automation drifts. The cartographer's job alone — no working shell maps. Run on first boot, and again whenever the map looks wrong.

--- a/skills_sc/app_deploy_setup.md
+++ b/skills_sc/app_deploy_setup.md
@@ -1,0 +1,115 @@
+---
+rendered_by: super-coder
+source: db
+edit: changes here are overwritten — author via the shell or localhost GUI
+---
+
+# app_deploy_setup
+
+Admin-run, one-time scaffold — turn the shipped deploy template into this repo's own project-local `deploy` skill (migration dirs, DB backup, ff-only sync, apply + move migrations, restart), then grant it to every shell.
+
+**Category:** substrate
+
+---
+
+# app_deploy_setup — scaffold this app's deploy ritual (once, admin)
+
+The engine deploys itself (`sc update`). The HOST APP this fork lives in has
+its own deploy story — app process, app DB, app migrations — that the engine
+cannot know. This skill turns the template below into the repo's own `deploy`
+skill, filled in with this app's specifics.
+
+**Why a NEW project-local skill instead of editing this one:** engine skills
+self-heal on every `sc update` — a fork edit to any skill named in
+`assets/skills/` is detected as stale and reverted to the shipped body. A
+project-local skill (a name the engine doesn't ship) is never touched by that
+guard and persists through rebuilds via `sc snapshot` → `.sc-state/content.sql`.
+Fill in the template, save it under a NEW name, leave this scaffold as shipped.
+
+## 1. Scaffold the migration dirs
+
+```bash
+mkdir -p migrations_app/pending migrations_app/completed
+touch migrations_app/pending/.gitkeep migrations_app/completed/.gitkeep
+```
+
+Commit them. Rename to fit the repo's layout if you like (`db/migrations/…`,
+`deploy/migrations/…`) — keep `pending/` and `completed/` as siblings and use
+the same paths in the template. These are the APP's schema migrations —
+unrelated to `.super-coder/migrations/` (engine DB, ledger-tracked, owned by
+`sc update`).
+
+## 2. Fill the template
+
+Every `⟨ADMIN: …⟩` slot is app-specific. Get each answer from the operator or
+the repo itself, and **run each command once by hand** before writing it in —
+a deploy skill is no place for untested commands.
+
+```markdown
+# deploy — ⟨ADMIN: app name⟩ post-merge deploy ritual
+
+Run from the repo root on the host. Every step aborts loudly rather than
+guessing; if a step fails, stop — the app is down and the DB is backed up.
+
+1. **Down** — stop the app:
+   ⟨ADMIN: stop command — e.g. pm2 stop ecosystem.config.cjs / systemctl stop <app> / docker compose down⟩
+
+2. **Backup** — snapshot the app DB before anything mutates:
+   ⟨ADMIN: backup command + destination + how many to retain⟩
+
+3. **Sync main** — `git switch main` (if on a branch), then `git pull --ff-only`.
+   `--ff-only` aborts on a diverged or dirty main — resolve by hand; never
+   merge inside a deploy.
+
+4. **Migrate** — apply every file in `migrations_app/pending/` in sort order:
+   ⟨ADMIN: apply command per file — e.g. psql "$DB_URL" -f <file> / sqlite3 <db> < <file> / alembic upgrade head⟩
+   After each success: `git mv migrations_app/pending/<file> migrations_app/completed/`
+   On first failure: stop, restore the backup, investigate.
+
+5. **Record** — commit and push the moves — the move IS the applied-ledger,
+   and an uncommitted move dirties main and breaks the NEXT deploy's --ff-only:
+   `git add migrations_app && git commit -m "deploy: apply <files>" && git push`
+
+6. **Up** — restart the app:
+   ⟨ADMIN: start command⟩
+
+7. **Verify** — prove the new code is serving:
+   ⟨ADMIN: health check — e.g. curl -fsS http://127.0.0.1:<port>/health⟩
+```
+
+## 3. Save it as a project-local skill
+
+```sql
+INSERT INTO skills (name, description, category, content, common)
+VALUES ('deploy',
+        'Post-merge deploy ritual for this app — down, backup, ff-only sync, migrate pending→completed, restart, verify.',
+        'substrate',
+        '<the filled template>',
+        1);
+```
+
+`common=1` is the "grant to every shell" switch: new shells receive it at
+creation, and `sc update` re-grants every common skill to every live shell.
+Grant existing shells now without waiting for an update:
+
+```sql
+INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
+SELECT s.shell_id, k.skill_id FROM shells s, skills k
+WHERE COALESCE(s.is_deleted,0)=0 AND k.name='deploy' AND k.is_deleted=0;
+```
+
+Then persist: `sc snapshot` (project-local skills + grants live in
+`.sc-state/content.sql`).
+
+## 4. Optional make surface
+
+If the operator wants make muscle-memory, add a bare `deploy` target to the
+**repo's own root Makefile** — that is the fork's convention space. Do NOT add
+it to `.super-coder/aliases.mk`: that file is engine-owned, every target must
+delegate to `./sc`, and the engine knows nothing about the app.
+
+## 5. Done
+
+Dry-run the ritual once on a quiet window end-to-end. This scaffold stays
+granted to admin only; the finished `deploy` skill is the one every shell
+carries.

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -76,6 +76,17 @@ class RegistryIntegrityTest(unittest.TestCase):
                 self.assertTrue(f.get("link"),
                                 f"operator-linked feature '{name}' has no link steps")
 
+    def test_blockless_features_are_procedure_only(self):
+        # block: None = no infrastructure half — enable/disable must never
+        # touch instance.json for these, so block_auto cannot be True and the
+        # link steps are the whole how-to.
+        for name, f in feature.FEATURES.items():
+            if f["block"] is None:
+                self.assertFalse(f["block_auto"],
+                                 f"block-less feature '{name}' cannot auto-create a block")
+                self.assertTrue(f.get("link"),
+                                f"block-less feature '{name}' has no link steps")
+
     def test_pg_block_matches_pg_init(self):
         # `./sc pg-init` (in the sc dispatcher) and `feature enable pg` write the
         # same instance.json key — if this drifts, launch won't see the sidecar.


### PR DESCRIPTION
## Why

The engine deploys itself (`sc update`), but the host app a fork lives in has its own deploy story — app process, app DB, app migrations — that the engine cannot know. dos-arch solved this with its own `make deploy`; this ships the reusable, fill-in-the-blanks version for every future fork.

## What

- **`app_deploy_setup` skill** (`common: false`) — one-time admin scaffold: create `migrations_app/pending|completed/` dirs, fill the shipped template (down → backup → `git switch main` + `pull --ff-only` → apply pending migrations in order, `git mv` each to completed → commit+push the moves → restart → verify), then save it as a **project-local** `deploy` skill with `common=1` and grant to all shells.
- **Why project-local:** engine skills self-heal to the shipped body on every `sc update` — a fleshed-out engine skill would be silently reverted. Project-local names are exempt and snapshot-durable. The committed pending→completed move doubles as the applied-ledger; leaving it uncommitted would break the *next* deploy's `--ff-only`.
- **`feature.py`: block-less features** — `block: None` (procedure-only; enable/disable never touch `instance.json`), registered as `./sc feature enable app-deploy` → grants the scaffold to admin. New registry-shape test guards the form.
- README opt-in table row + seed regen + `skills_sc/` mirror render.

## Verified

- `python3 tests/test_*.py` — all pass (incl. new `test_blockless_features_are_procedure_only`)
- `./sc render-check` — flat mirror matches tracked sources
- `./sc feature list` smoke — app-deploy renders with "config: — none needed (procedure-only)"
- No `dos-deploy` in `aliases.mk` by design: that surface is engine-owned delegate-only; the fork's own root Makefile is where an admin adds a `deploy` target (template says so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)