### PR TITLE
fix(rebuild): preserve shell api_keys across rebuild — stop orphaning live sessions

### DIFF
--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -43,6 +43,54 @@ def snapshot_path() -> Path:
     return SNAPSHOT if SNAPSHOT.exists() else SNAPSHOT_LEGACY
 
 
+def read_existing_keys() -> dict:
+    """shell_id -> (api_key, api_key_rotated_at) from the outgoing DB.
+
+    content.sql never serializes api_key (secret in a git-tracked file), so
+    without a carry-over every rebuild re-minted all keys — orphaning the
+    SC_API_TOKEN run.py injected into each live session at boot and 401-ing
+    every mem call engine-wide until the sessions re-entered (#265). Read the
+    keys before the old DB is deleted; restore_keys() puts them back after the
+    content load. A missing DB or a pre-0027 one (no api_key column) yields
+    empty — every shell gets minted fresh, same as a first build."""
+    if not DB_PATH.exists():
+        return {}
+    con = db_driver.connect(DB_PATH)
+    try:
+        rows = con.execute(
+            "SELECT shell_id, api_key, api_key_rotated_at FROM shells "
+            "WHERE api_key IS NOT NULL"
+        ).fetchall()
+        return {r[0]: (r[1], r[2]) for r in rows}
+    except db_driver.OperationalError:
+        return {}
+    finally:
+        con.close()
+
+
+def restore_keys(keys: dict) -> int:
+    """Re-attach carried keys to the rebuilt shells. Guarded on api_key IS
+    NULL so a loaded value (should content.sql ever carry one) is never
+    clobbered; a shell_id absent from the new content matches nothing and its
+    key is dropped with it."""
+    if not keys:
+        return 0
+    con = db_driver.connect(DB_PATH)
+    try:
+        restored = 0
+        for sid, (key, rotated) in keys.items():
+            cur = con.execute(
+                "UPDATE shells SET api_key=?, api_key_rotated_at=? "
+                "WHERE shell_id=? AND api_key IS NULL",
+                (key, rotated, sid),
+            )
+            restored += cur.rowcount
+        con.commit()
+        return restored
+    finally:
+        con.close()
+
+
 KEEP_BACKUPS = 5
 
 
@@ -70,6 +118,7 @@ def main(argv: list[str]) -> int:
 
     if "--no-backup" not in argv:
         backup_existing()
+    keys = read_existing_keys()
     for suffix in ("", "-wal", "-shm"):
         p = Path(str(DB_PATH) + suffix)
         if p.exists():
@@ -97,12 +146,15 @@ def main(argv: list[str]) -> int:
     else:
         print("rebuild: no .sc-state/content.sql — built empty (no per-instance content).")
 
-    # Re-provision api_keys. content.sql never carries api_key (it is a secret and
-    # content.sql is git-tracked — see snapshot.py's no-serialize set), so every
-    # shell comes back NULL-keyed from the load above. The server backfills NULL
-    # keys, but only at startup — a rebuild under an already-running server would
-    # otherwise leave the live DB NULL-keyed and 401 every shell's mem write until
-    # the API is bounced. Minting here makes a rebuilt DB self-sufficient.
+    # Re-attach the keys carried over from the outgoing DB (content.sql never
+    # carries api_key — it is a secret and content.sql is git-tracked, see
+    # snapshot.py's no-serialize set), then mint only what is still missing:
+    # new shells from the content load, or everything on a fresh/pre-key build.
+    # Rotation is never a rebuild side effect — live sessions keep the
+    # SC_API_TOKEN they booted with (#265). Rotate deliberately, not here.
+    restored = restore_keys(keys)
+    if restored:
+        print(f"rebuild: preserved {restored} shell api_key(s)")
     backfill_shell_api_keys.backfill(str(DB_PATH))
 
     try:

--- a/tests/test_rebuild_keys.py
+++ b/tests/test_rebuild_keys.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Tests that `./sc rebuild` preserves shell api_keys instead of rotating them.
+
+content.sql never serializes api_key (secret in a git-tracked file), so a
+rebuild reloads every shell NULL-keyed. Before #265 the post-rebuild backfill
+then minted brand-new keys — an implicit rotation that orphaned the
+SC_API_TOKEN run.py injected into every live session at boot and 401'd all mem
+traffic engine-wide until each session re-entered. rebuild.py now reads the
+keys from the outgoing DB before deleting it and restores them after the
+content load; the backfill mints only shells that had no key.
+
+These build a throwaway engine DB, exercise the real read_existing_keys /
+restore_keys seam around a simulated rebuild (schema + migrations + NULL-keyed
+content reload), and assert old keys survive verbatim while new shells still
+get minted.
+
+Run:
+    python3 tests/test_rebuild_keys.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import rebuild  # noqa: E402
+import backfill_shell_api_keys  # noqa: E402
+
+KEY_1 = "tok_shell1_KEEP_ME_across_rebuild_0000000000"
+KEY_2 = "tok_shell2_KEEP_ME_across_rebuild_1111111111"
+ROTATED_AT = "2026-07-01 00:00:00"
+
+
+def apply_engine_schema(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.commit()
+    con.close()
+
+
+def insert_shell(con, shell_id: int, shortname: str, api_key=None) -> None:
+    con.execute(
+        "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+        "system_prompt, user_id, is_shared, has_identity, bootstrapped, "
+        "api_key, api_key_rotated_at) "
+        "VALUES (?, ?, ?, 'test', 'sp', 1, 0, 1, 1, ?, ?)",
+        (shell_id, shortname.upper(), shortname, api_key,
+         ROTATED_AT if api_key else None),
+    )
+
+
+class RebuildKeysTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        self._orig_db_path = rebuild.DB_PATH
+        rebuild.DB_PATH = self.db
+
+    def tearDown(self):
+        rebuild.DB_PATH = self._orig_db_path
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def build_keyed_db(self):
+        apply_engine_schema(self.db)
+        con = sqlite3.connect(self.db)
+        con.execute("INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1)")
+        insert_shell(con, 1, "aa", KEY_1)
+        insert_shell(con, 2, "bb", KEY_2)
+        con.commit()
+        con.close()
+
+    def keys_by_shell(self) -> dict:
+        con = sqlite3.connect(self.db)
+        rows = con.execute(
+            "SELECT shell_id, api_key, api_key_rotated_at FROM shells").fetchall()
+        con.close()
+        return {r[0]: (r[1], r[2]) for r in rows}
+
+    def test_keys_survive_rebuild(self):
+        """Old shells keep their exact keys; a new shell gets minted."""
+        self.build_keyed_db()
+        keys = rebuild.read_existing_keys()
+        self.assertEqual(set(keys), {1, 2})
+
+        # Simulate the rebuild: delete the DB, re-apply schema + migrations,
+        # reload content — shells come back NULL-keyed (content.sql never
+        # carries api_key), plus one shell that did not exist before.
+        self.db.unlink()
+        apply_engine_schema(self.db)
+        con = sqlite3.connect(self.db)
+        con.execute("INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1)")
+        insert_shell(con, 1, "aa")
+        insert_shell(con, 2, "bb")
+        insert_shell(con, 3, "cc")
+        con.commit()
+        con.close()
+
+        restored = rebuild.restore_keys(keys)
+        self.assertEqual(restored, 2)
+        backfill_shell_api_keys.backfill(str(self.db))
+
+        after = self.keys_by_shell()
+        self.assertEqual(after[1], (KEY_1, ROTATED_AT))
+        self.assertEqual(after[2], (KEY_2, ROTATED_AT))
+        self.assertIsNotNone(after[3][0], "new shell not minted")
+        self.assertNotIn(after[3][0], {KEY_1, KEY_2})
+
+    def test_dropped_shell_key_is_dropped(self):
+        """A shell absent from the new content does not resurrect its key."""
+        self.build_keyed_db()
+        keys = rebuild.read_existing_keys()
+
+        self.db.unlink()
+        apply_engine_schema(self.db)
+        con = sqlite3.connect(self.db)
+        con.execute("INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1)")
+        insert_shell(con, 1, "aa")  # shell 2 gone
+        con.commit()
+        con.close()
+
+        self.assertEqual(rebuild.restore_keys(keys), 1)
+        after = self.keys_by_shell()
+        self.assertEqual(after[1], (KEY_1, ROTATED_AT))
+        self.assertNotIn(2, after)
+
+    def test_no_db_reads_empty(self):
+        """First build: no outgoing DB, nothing to preserve."""
+        self.assertEqual(rebuild.read_existing_keys(), {})
+        self.assertEqual(rebuild.restore_keys({}), 0)
+
+    def test_pre_key_db_reads_empty(self):
+        """A pre-0027 DB (no api_key column) yields empty — mint-all path."""
+        con = sqlite3.connect(self.db)
+        con.executescript(SCHEMA.read_text())  # baseline only, no migrations
+        con.commit()
+        con.close()
+        self.assertEqual(rebuild.read_existing_keys(), {})
+
+    def test_restore_never_clobbers_loaded_key(self):
+        """If a shell already has a key post-load, the carried key loses."""
+        self.build_keyed_db()
+        keys = rebuild.read_existing_keys()
+
+        self.db.unlink()
+        apply_engine_schema(self.db)
+        con = sqlite3.connect(self.db)
+        con.execute("INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1)")
+        insert_shell(con, 1, "aa", "tok_already_present_wins_2222222222222222")
+        con.commit()
+        con.close()
+
+        self.assertEqual(rebuild.restore_keys(keys), 0)
+        after = self.keys_by_shell()
+        self.assertEqual(after[1][0], "tok_already_present_wins_2222222222222222")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Investigation of #265 showed the reported "shell_api_keys table absent" is a red herring — that table never exists anywhere (migration 0027 adds `api_key` columns to `shells`; the reporter inferred a table from the filename, and the same query fails on any healthy DB). The real defect: `./sc rebuild` re-minted every shell's key (content.sql deliberately never serializes `api_key`, so all shells reload NULL-keyed and the #214 backfill minted fresh ones). That implicit rotation orphaned the `SC_API_TOKEN` run.py injects at boot — every live session 401'd engine-wide until re-entry. Forensics on dos-arch confirmed: all 9 shells re-keyed with one `api_key_rotated_at` timestamp minutes before the issue was filed.

Fix: read `shell_id → (api_key, api_key_rotated_at)` from the outgoing DB before deletion, restore after the content load, and let the backfill mint only shells with no prior key. Keys still never touch git — they carry over locally, old file → new file. Rotation is no longer a rebuild side effect; if we want it, it should be an explicit operation.

## Test plan
- [x] `tests/test_rebuild_keys.py` (new): keys survive verbatim, new shell still minted, dropped shell's key not resurrected, fresh/pre-0027 DB → mint-all, loaded key never clobbered
- [x] Real `./sc rebuild` on the dogfood DB: `SELECT shell_id, api_key` before/after — identical
- [x] Full tests/ suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)