### PR TITLE
fix(vm): decode guest output lossily — non-UTF-8 no longer kills /exec

### DIFF
--- a/.super-coder/scripts/vm.py
+++ b/.super-coder/scripts/vm.py
@@ -69,7 +69,10 @@ def write(vm: dict | None) -> dict | None:
 
 def _run(argv: list[str], timeout: int = 30) -> tuple[bool, str]:
     try:
-        p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+        # errors="replace": Windows guests emit non-UTF-8 constantly (UTF-16
+        # files, OEM-codepage console output) — decode lossily, never raise.
+        p = subprocess.run(argv, capture_output=True, text=True,
+                           encoding="utf-8", errors="replace", timeout=timeout)
         return p.returncode == 0, (p.stdout + p.stderr).strip()
     except FileNotFoundError as e:
         return False, f"command not found: {e.filename} — is it installed on the host?"
@@ -194,8 +197,13 @@ def do_exec(command: str, timeout: int = 120) -> dict:
     if not str(command).strip():
         return {"ok": False, "exit": -1, "stdout": "", "stderr": "exec: empty command"}
     try:
+        # errors="replace": guest output is routinely non-UTF-8 (UTF-16 files,
+        # OEM codepages). A strict decode turned the whole exec into a 500 with
+        # no exit code or partial output (#261) — lossy beats fatal here; callers
+        # needing byte-exact output base64 it guest-side.
         p = subprocess.run(_ssh_argv(cfg, command), capture_output=True,
-                           text=True, timeout=timeout)
+                           text=True, encoding="utf-8", errors="replace",
+                           timeout=timeout)
         return {"ok": p.returncode == 0, "exit": p.returncode,
                 "stdout": p.stdout, "stderr": p.stderr}
     except FileNotFoundError as e:

--- a/tests/test_vm_broker.py
+++ b/tests/test_vm_broker.py
@@ -136,6 +136,29 @@ class VerbDispatchTests(unittest.TestCase):
         self.assertTrue(r["ok"], r)
         self.assertTrue((Path(share) / "staged.py").is_file())
 
+    def test_exec_survives_non_utf8_guest_output(self):
+        # #261: Windows guests routinely emit non-UTF-8 (UTF-16 files, OEM
+        # codepages). A strict decode raised UnicodeDecodeError and the broker
+        # 500'd the whole exec. Real subprocess, real bytes: decode must be
+        # lossy (U+FFFD), never fatal, with exit + surrounding output intact.
+        raw = [sys.executable, "-c",
+               "import sys; sys.stdout.buffer.write(b'pre \\x83\\xff post')"]
+        with mock.patch.object(vm, "read", return_value=SAVED), \
+             mock.patch.object(vm, "_ssh_argv", return_value=raw):
+            r = vm.do_exec("type addin-manifest")
+        self.assertTrue(r["ok"], r)
+        self.assertEqual(r["exit"], 0)
+        self.assertIn("pre ", r["stdout"])
+        self.assertIn(" post", r["stdout"])
+        self.assertIn("�", r["stdout"])  # lossy marker, not an exception
+
+    def test_run_survives_non_utf8_output(self):
+        # Same seam for reset/capture/validate — _run shares the decode policy.
+        ok, out = vm._run([sys.executable, "-c",
+                           "import sys; sys.stdout.buffer.write(b'ok \\x9d')"])
+        self.assertTrue(ok)
+        self.assertIn("ok", out)
+
     def test_capture_returns_a_base64_screenshot(self):
         def fake_run(argv, timeout=30):
             # virsh screenshot writes the file the broker then reads back


### PR DESCRIPTION
Fixes #261.

`/exec` died with a raw `UnicodeDecodeError` whenever the guest printed any non-UTF-8 byte (UTF-16 `.addin` manifests, OEM-codepage console output) — the broker's catch-all turned the strict decode failure into a whole-call 500 with no exit code and no partial output. Windows tooling emits non-UTF-8 constantly, so every fork driving the VM trips this.

Fix: `encoding="utf-8", errors="replace"` on both subprocess seams — `do_exec` (the reported path) and `_run` (behind reset/capture/validate, same latent bug). Lossy U+FFFD beats fatal; callers needing byte-exact output keep the guest-side base64 path.

Test plan:
- [x] two new regression tests run real subprocesses emitting `\x83`/`\xff`/`\x9d` through both seams — exit code + surrounding output intact, U+FFFD present, no exception
- [x] `python3 tests/test_vm_broker.py` — 19/19 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)