### PR TITLE
feat(vm-broker): MCP seam — GUI-drive the guest's Windows-MCP from a sandboxed seat

### DIFF
--- a/.super-coder/api/vm_broker.py
+++ b/.super-coder/api/vm_broker.py
@@ -20,6 +20,10 @@ Routes (all JSON `{ok, ...}`):
     POST /push      {src,dest?} stage a host-visible artifact into transfer_dir
     POST /capture   {command?}  optional exec + a virsh screenshot (base64)
     POST /validate/{check}      one live setup check against the body's candidate cfg
+    POST /mcp/up                open the GUI seam: ssh-forward run/vm-mcp.sock
+                                to the guest's Windows-MCP port (idempotent)
+    POST /mcp/down              close it (idempotent)
+    GET  /mcp/status            {ok, running, pid, socket}
 
 Verbs act on the SAVED `vm` block; `/validate` tests the CANDIDATE block in the
 body (the wizard, before save). The socket is fs-perm gated (0600) — reachable
@@ -71,6 +75,8 @@ class Handler(BaseHTTPRequestHandler):
             return self._send(200, {"ok": True, "service": "vm-broker"})
         if self.path == "/vm":
             return self._send(200, {"vm": vm.read()})
+        if self.path == "/mcp/status":
+            return self._send(200, vm.mcp_status())
         return self._send(404, {"ok": False, "error": "no such route"})
 
     def do_PUT(self) -> None:
@@ -96,6 +102,13 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, vm.do_push(b.get("src", ""), b.get("dest")))
             if self.path == "/capture":
                 return self._send(200, vm.do_capture(self._body().get("command")))
+            if self.path == "/mcp/up":
+                # The GUI seam (#263): forward run/vm-mcp.sock to the guest's
+                # Windows-MCP. Target port comes from the SAVED block, never
+                # the caller — the sandbox names an action, not a destination.
+                return self._send(200, vm.do_mcp_up())
+            if self.path == "/mcp/down":
+                return self._send(200, vm.do_mcp_down())
             if self.path.startswith("/validate/"):
                 r = vm.validate(self.path.rsplit("/", 1)[1], self._body().get("vm") or {})
                 if r is None:

--- a/.super-coder/assets/skills/windows_vm_gui/SKILL.md
+++ b/.super-coder/assets/skills/windows_vm_gui/SKILL.md
@@ -71,13 +71,35 @@ unreachable unless the server itself runs elevated.
    (`schtasks /run /tn windows-mcp-server` over SSH) — and if the task is
    missing, the snapshot was baked without the prep above.
 
-**Sandboxed seat** (the engine default): not wired yet. The sandbox has no
-`ssh`, no key, and no route to the VM — that is the broker design — and the
-vm-broker does not yet expose an MCP seam. Tracked upstream:
-[super-coder#263](https://github.com/jedbjorn/super-coder/issues/263). Until
-it lands: screenshots via `/capture`, scriptable checks via `windows_devkit`'s
-exec loop. Do **not** fake GUI driving by guessing pixel coordinates off
-`/capture` screenshots — that is the exact failure mode this skill bans.
+**Sandboxed seat** (the engine default): the sandbox has no `ssh`, no key,
+and no route to the VM — that is the broker design — so the connection is
+brokered in two halves. The vm-broker (host-side, holds the key) ssh-forwards
+a unix socket in the bind-mounted `run/` dir to the guest's Windows-MCP; a
+tiny in-sandbox relay gives that socket the TCP URL `claude mcp add` needs:
+
+1. Start from a clean box (`windows_devkit`'s `/reset`); wait until SSH
+   answers.
+2. Open the broker tunnel:
+   `curl --unix-socket $(./sc vm-broker-sock) -X POST http://vm/mcp/up`
+   (idempotent; forwards `run/vm-mcp.sock` to the guest's `mcp_port`,
+   default 8000).
+3. Start the in-sandbox relay: `./sc vm-mcp-relay up` (listens on
+   `127.0.0.1:18000`, pipes to the tunnel socket; also idempotent).
+4. Verify the endpoint answers: `curl -s http://127.0.0.1:18000/mcp`.
+5. Connect the harness:
+   `claude mcp add --transport http windows-mcp http://127.0.0.1:18000/mcp`
+6. Endpoint dead → `./sc vm-mcp-relay status` first (`upstream: false` means
+   the broker tunnel is down — redo step 2; a reset drops it, so reconnect
+   after every `/reset`), then the guest task
+   (`schtasks /run /tn windows-mcp-server` via broker `/exec`) — and if the
+   task is missing, the snapshot was baked without the prep above.
+7. Done driving: `./sc vm-mcp-relay down` and
+   `curl --unix-socket $(./sc vm-broker-sock) -X POST http://vm/mcp/down`.
+
+No key, no ssh, no network surface enters the sandbox — both hops are unix
+sockets in the bind mount, same posture as every other broker verb. Do
+**not** fake GUI driving by guessing pixel coordinates off `/capture`
+screenshots — that is the exact failure mode this skill bans.
 
 ## Driving rules
 

--- a/.super-coder/docs/windows-vm-broker.md
+++ b/.super-coder/docs/windows-vm-broker.md
@@ -129,6 +129,9 @@ endpoints (which presume host access the container doesn't have). All return
 | `POST` | `/reset` | revert to the clean baseline | `virsh snapshot-revert <domain> clean --running` |
 | `POST` | `/validate/{check}` | the five setup checks | relocated from the host-presuming in-server endpoints |
 | `GET`/`PUT` | `/vm` | read / write the `vm` config block | `instance.json` |
+| `POST` | `/mcp/up` | open the GUI seam (idempotent) | broker-owned `ssh -N -L` unix-socket forward |
+| `POST` | `/mcp/down` | close it (idempotent) | SIGTERM the forward |
+| `GET` | `/mcp/status` | `{ok, running, pid, socket}` | pidfile + socket presence |
 
 > [!class4]
 > **`reset` uses `--running`.** The `clean` snapshot is **offline** — this CPU
@@ -167,6 +170,39 @@ to `ssh`/`virsh` (which never worked from the container) and curls the socket.
 `configure_winbox` (admin provisioning) is rare and host-weighted; it can call
 the broker too, or stay an explicit host-operator task. Either way its `virsh`
 snapshot step lives host-side.
+
+## MCP seam — GUI driving from the sandbox (#263)
+
+The `windows_vm_gui` skill drives the guest's **Windows-MCP** server (UIA
+tree, localhost-bound, baked into `clean`). A host-run seat just ssh-tunnels
+to it; a sandboxed seat cannot (no ssh, no key, no route — the gap above).
+The seam stays on the socket posture, and the broker never parses a byte of
+MCP traffic:
+
+```linear
+claude mcp add (TCP 127.0.0.1:18000) :::class1 -> vm_mcp_relay.py (in-sandbox) :::class1 -> run/vm-mcp.sock (bind mount) :::class2 -> ssh -N -L (broker-owned, host) :::class2 -> guest 127.0.0.1:8000 Windows-MCP :::class3
+```
+
+- **`POST /mcp/up`** — the broker spawns one `ssh -N -L run/vm-mcp.sock:127.0.0.1:<mcp_port>`
+  (OpenSSH forwards a *unix socket* to a remote TCP port; `StreamLocalBindMask=0177`
+  lands it 0600, `ExitOnForwardFailure` keeps a dead forward from lingering as a
+  live pid). The socket sits next to `vm-broker.sock` in the bind mount — no
+  network surface, no auth token, exactly the transport decision above. SSE /
+  chunked streaming is free: it is a byte pipe, not an HTTP proxy.
+- **`./sc vm-mcp-relay up`** — in-sandbox, stdlib-only TCP→socket relay on
+  `127.0.0.1:18000`, because `claude mcp add --transport http` only speaks TCP
+  URLs. The TCP listener exists *inside the container's own namespace*; nothing
+  is exposed on `sc-net` or the docker bridge.
+- **Port comes from the saved block** (`vm.mcp_port`, default 8000), never the
+  caller — the sandbox names an action, not a destination, same as every verb.
+- **Trust class:** raw access to guest UIA ≈ `/exec` (arbitrary commands in the
+  guest), which the sandbox already holds. The tunnel reaches one port on the
+  configured guest's loopback; hypervisor control still never leaves the host.
+
+The rejected alternatives from the design round: a tunnel sidecar container on
+`sc-net` (moves the key off the host process + needs an auth story on a shared
+network) and a gateway-bind TCP tunnel (re-opens the network-surface decision
+this spec closed).
 
 ## Process & supervision (built)
 
@@ -231,6 +267,7 @@ Built per the architecture above:
 |---|---|
 | Broker process | `.super-coder/api/vm_broker.py` — AF_UNIX `ThreadingHTTPServer`, refuses to run under `SC_SANDBOX` |
 | Loop verbs + socket client | `.super-coder/scripts/vm.py` — `do_exec` / `do_reset` / `do_push` / `do_capture`, `broker_call` (unix-socket HTTP), `SOCKET` |
+| MCP seam | `vm.py` — `do_mcp_up` / `do_mcp_down` / `mcp_status` (broker-owned ssh socket-forward); `.super-coder/scripts/vm_mcp_relay.py` — in-sandbox TCP→socket relay (`./sc vm-mcp-relay`) |
 | Supervision | `./sc vm-broker` (foreground), `./sc vm-broker-up` / `-down` (nohup + pidfile), `./sc vm-broker-sock` |
 | Server proxy | `.super-coder/api/server.py` — `/api/vm/validate/{check}` proxies to the broker in-sandbox |
 | Skill | `windows_devkit` — drives the four verbs via `curl --unix-socket`, holds no key |

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3678,13 +3678,35 @@ unreachable unless the server itself runs elevated.
    (`schtasks /run /tn windows-mcp-server` over SSH) — and if the task is
    missing, the snapshot was baked without the prep above.
 
-**Sandboxed seat** (the engine default): not wired yet. The sandbox has no
-`ssh`, no key, and no route to the VM — that is the broker design — and the
-vm-broker does not yet expose an MCP seam. Tracked upstream:
-[super-coder#263](https://github.com/jedbjorn/super-coder/issues/263). Until
-it lands: screenshots via `/capture`, scriptable checks via `windows_devkit`''s
-exec loop. Do **not** fake GUI driving by guessing pixel coordinates off
-`/capture` screenshots — that is the exact failure mode this skill bans.
+**Sandboxed seat** (the engine default): the sandbox has no `ssh`, no key,
+and no route to the VM — that is the broker design — so the connection is
+brokered in two halves. The vm-broker (host-side, holds the key) ssh-forwards
+a unix socket in the bind-mounted `run/` dir to the guest''s Windows-MCP; a
+tiny in-sandbox relay gives that socket the TCP URL `claude mcp add` needs:
+
+1. Start from a clean box (`windows_devkit`''s `/reset`); wait until SSH
+   answers.
+2. Open the broker tunnel:
+   `curl --unix-socket $(./sc vm-broker-sock) -X POST http://vm/mcp/up`
+   (idempotent; forwards `run/vm-mcp.sock` to the guest''s `mcp_port`,
+   default 8000).
+3. Start the in-sandbox relay: `./sc vm-mcp-relay up` (listens on
+   `127.0.0.1:18000`, pipes to the tunnel socket; also idempotent).
+4. Verify the endpoint answers: `curl -s http://127.0.0.1:18000/mcp`.
+5. Connect the harness:
+   `claude mcp add --transport http windows-mcp http://127.0.0.1:18000/mcp`
+6. Endpoint dead → `./sc vm-mcp-relay status` first (`upstream: false` means
+   the broker tunnel is down — redo step 2; a reset drops it, so reconnect
+   after every `/reset`), then the guest task
+   (`schtasks /run /tn windows-mcp-server` via broker `/exec`) — and if the
+   task is missing, the snapshot was baked without the prep above.
+7. Done driving: `./sc vm-mcp-relay down` and
+   `curl --unix-socket $(./sc vm-broker-sock) -X POST http://vm/mcp/down`.
+
+No key, no ssh, no network surface enters the sandbox — both hops are unix
+sockets in the bind mount, same posture as every other broker verb. Do
+**not** fake GUI driving by guessing pixel coordinates off `/capture`
+screenshots — that is the exact failure mode this skill bans.
 
 ## Driving rules
 

--- a/.super-coder/scripts/vm.py
+++ b/.super-coder/scripts/vm.py
@@ -29,6 +29,7 @@ import base64
 import json
 import os
 import shutil
+import signal
 import socket
 import subprocess
 import sys
@@ -45,6 +46,13 @@ CHECKS = ("domain", "ssh", "transfer", "snapshot", "toolchain")
 # sandbox (where windows_devkit curls it). No network surface; fs-perm gated.
 RUN_DIR = ports.ENGINE / "run"
 SOCKET = RUN_DIR / "vm-broker.sock"
+
+# The GUI seam (#263): a broker-owned `ssh -N -L` forwards this unix socket to
+# the guest's localhost-bound Windows-MCP port. Same posture as the broker
+# socket — lives in the bind mount, fs-perm gated (0600), no network surface.
+MCP_SOCKET = RUN_DIR / "vm-mcp.sock"
+MCP_PIDFILE = RUN_DIR / "vm-mcp-tunnel.pid"
+MCP_LOG = RUN_DIR / "vm-mcp-tunnel.log"
 
 
 # -- config (instance.json `vm` block) ---------------------------------------
@@ -348,6 +356,104 @@ def do_capture(command: str | None = None) -> dict:
     return result
 
 
+# -- MCP tunnel (the GUI seam — broker-owned ssh forward, #263) ---------------
+#
+# Sandboxed seats cannot hold a live MCP session against the guest's Windows-MCP
+# server: no ssh, no key, no route across libvirt NAT, and a host-loopback
+# tunnel is invisible to the container. The seam: the broker (host-side, where
+# the key lives) opens ONE `ssh -N -L` that forwards a UNIX SOCKET in the
+# bind-mounted run/ dir straight to the guest's localhost-bound Windows-MCP
+# port. OpenSSH does the byte plumbing — no HTTP proxying in the broker, so
+# SSE/chunked streaming passes through untouched. In-sandbox, vm_mcp_relay.py
+# bridges TCP→socket because `claude mcp add --transport http` only speaks TCP.
+
+def _tunnel_pid() -> int | None:
+    """The live tunnel's pid, or None (no pidfile / stale pidfile)."""
+    try:
+        pid = int(MCP_PIDFILE.read_text().strip())
+    except (OSError, ValueError):
+        return None
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError):
+        return None
+    return pid
+
+
+def mcp_status() -> dict:
+    pid = _tunnel_pid()
+    running = pid is not None and MCP_SOCKET.exists()
+    return {"ok": True, "running": running, "pid": pid,
+            "socket": str(MCP_SOCKET) if running else None}
+
+
+def do_mcp_up(wait: float = 15) -> dict:
+    """Open the MCP tunnel. Idempotent — an already-live tunnel is reported, not
+    doubled. The forward target is the SAVED block's `mcp_port` (default 8000,
+    what `windows_vm_gui`'s guest prep bakes), never a caller-named port — same
+    rule as every other verb: the sandbox names an action, not a destination."""
+    cfg = read() or {}
+    if m := _missing(cfg, "ssh_host", "ssh_user", "ssh_key_path"):
+        return {"ok": False, "output": m}
+    if (pid := _tunnel_pid()) and MCP_SOCKET.exists():
+        return {"ok": True, "output": f"tunnel already up (pid {pid})",
+                "socket": str(MCP_SOCKET), "pid": pid}
+    do_mcp_down()  # clear any half-dead remnant (stale pid or orphaned socket)
+    port = int(cfg.get("mcp_port", 8000))
+    key = os.path.expanduser(str(cfg.get("ssh_key_path", "")))
+    argv = [
+        "ssh", "-i", key,
+        "-p", str(cfg.get("ssh_port", 22)),
+        "-o", "BatchMode=yes",
+        "-o", "ConnectTimeout=10",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ExitOnForwardFailure=yes",   # a dead forward must not linger as a live pid
+        "-o", "ServerAliveInterval=30",     # drop (and surface) a hung guest, don't wedge
+        "-o", "StreamLocalBindUnlink=yes",  # replace a stale socket file on reopen
+        "-o", "StreamLocalBindMask=0177",   # socket lands 0600, matching the broker's
+        "-N", "-L", f"{MCP_SOCKET}:127.0.0.1:{port}",
+        f"{cfg.get('ssh_user')}@{cfg.get('ssh_host')}",
+    ]
+    RUN_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(MCP_LOG, "wb") as log:
+            p = subprocess.Popen(argv, stdin=subprocess.DEVNULL, stdout=log,
+                                 stderr=log, start_new_session=True)
+    except FileNotFoundError as e:
+        return {"ok": False,
+                "output": f"command not found: {e.filename} — is ssh installed on the host?"}
+    MCP_PIDFILE.write_text(str(p.pid))
+    deadline = time.monotonic() + wait
+    while time.monotonic() < deadline:
+        if p.poll() is not None:  # ssh died — auth/route/forward failure
+            err = MCP_LOG.read_text(errors="replace").strip()[-500:]
+            MCP_PIDFILE.unlink(missing_ok=True)
+            return {"ok": False,
+                    "output": f"ssh tunnel exited (rc {p.returncode}): {err or '(no output)'}"}
+        if MCP_SOCKET.exists():
+            return {"ok": True,
+                    "output": f"tunnel up — {MCP_SOCKET} -> guest 127.0.0.1:{port}",
+                    "socket": str(MCP_SOCKET), "pid": p.pid, "port": port}
+        time.sleep(0.2)
+    p.terminate()
+    MCP_PIDFILE.unlink(missing_ok=True)
+    return {"ok": False, "output": f"tunnel socket did not appear within {wait}s"}
+
+
+def do_mcp_down() -> dict:
+    """Close the MCP tunnel. Idempotent — safe to call with nothing running."""
+    pid = _tunnel_pid()
+    if pid:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+    MCP_PIDFILE.unlink(missing_ok=True)
+    MCP_SOCKET.unlink(missing_ok=True)
+    return {"ok": True,
+            "output": f"tunnel stopped (pid {pid})" if pid else "tunnel not running"}
+
+
 # -- client: HTTP over the broker's unix socket ------------------------------
 
 def broker_call(method: str, path: str, body: dict | None = None,
@@ -407,10 +513,21 @@ def main(argv: list[str]) -> int:
         r = do_bake()
         print(json.dumps(r))
         return 0 if r["ok"] else 1
+    elif mode == "mcp-sock":
+        print(MCP_SOCKET)
+    elif mode == "mcp-up":
+        r = do_mcp_up()
+        print(json.dumps(r))
+        return 0 if r["ok"] else 1
+    elif mode == "mcp-down":
+        print(json.dumps(do_mcp_down()))
+    elif mode == "mcp-status":
+        print(json.dumps(mcp_status()))
     elif mode == "validate":
         print(json.dumps(validate(argv[1] if len(argv) > 1 else "", read() or {})))
     else:
-        sys.exit("usage: vm.py [sock|exec <cmd>|reset|bake|push <src> [dest]|capture [cmd]|validate <check>]")
+        sys.exit("usage: vm.py [sock|exec <cmd>|reset|bake|push <src> [dest]|capture [cmd]"
+                 "|mcp-sock|mcp-up|mcp-down|mcp-status|validate <check>]")
     return 0
 
 

--- a/.super-coder/scripts/vm_mcp_relay.py
+++ b/.super-coder/scripts/vm_mcp_relay.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""In-sandbox TCP→unix relay — the last inch of the Windows-MCP GUI seam (#263).
+
+The broker's `/mcp/up` forwards `run/vm-mcp.sock` (visible in the sandbox via
+the bind mount) to the guest's localhost-bound Windows-MCP server. But
+`claude mcp add --transport http` only speaks TCP URLs, and a host-side TCP
+tunnel would be invisible to the container (and was rejected by the broker
+spec as a network surface). So this relay runs INSIDE the container: it
+listens on 127.0.0.1:<port> (default 18000) and pipes each connection's bytes
+to the socket, both directions. A raw byte pipe — SSE/chunked streaming pass
+through untouched, no HTTP parsing anywhere.
+
+Stdlib only (the sandbox has python3 and nothing else). Run IN the sandbox:
+
+    ./sc vm-mcp-relay up [port]     background (pidfile); idempotent
+    ./sc vm-mcp-relay down          stop it
+    ./sc vm-mcp-relay status        {ok, running, pid, port, upstream}
+    ./sc vm-mcp-relay fg [port]     foreground (what `up` daemonizes)
+
+Then connect the harness:
+
+    claude mcp add --transport http windows-mcp http://127.0.0.1:18000/mcp
+
+The pidfile lives in run/ next to the sockets, but pids are namespace-local:
+this relay is started, inspected, and stopped from inside the container only.
+The broker never touches it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import vm  # single source for RUN_DIR / MCP_SOCKET
+
+DEFAULT_PORT = 18000
+PIDFILE = vm.RUN_DIR / "vm-mcp-relay.pid"
+PORTFILE = vm.RUN_DIR / "vm-mcp-relay.port"
+LOG = vm.RUN_DIR / "vm-mcp-relay.log"
+
+
+# -- the pipe -----------------------------------------------------------------
+
+def _pump(src: socket.socket, dst: socket.socket) -> None:
+    """Copy bytes src→dst until EOF, then half-close dst so the peer sees the
+    EOF too (streamable-http holds long-lived SSE responses — a full close
+    here would cut the other direction mid-stream)."""
+    try:
+        while True:
+            data = src.recv(65536)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    finally:
+        try:
+            dst.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def _handle(client: socket.socket) -> None:
+    upstream = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        upstream.connect(str(vm.MCP_SOCKET))
+    except OSError as e:
+        sys.stderr.write(f"[vm-mcp-relay] upstream connect failed: {e} — "
+                         "is the broker tunnel up? (POST /mcp/up)\n")
+        client.close()
+        upstream.close()
+        return
+    t = threading.Thread(target=_pump, args=(upstream, client), daemon=True)
+    t.start()
+    _pump(client, upstream)
+    t.join()
+    client.close()
+    upstream.close()
+
+
+def make_server(port: int) -> socket.socket:
+    """Bind the loopback listener (port 0 → ephemeral, for tests)."""
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen(16)
+    return srv
+
+
+def run(srv: socket.socket) -> None:
+    """Accept loop — one thread per connection; MCP sessions are few."""
+    while True:
+        try:
+            client, _ = srv.accept()
+        except OSError:  # listener closed — shutting down
+            return
+        threading.Thread(target=_handle, args=(client,), daemon=True).start()
+
+
+# -- supervision (nohup-style, mirroring the sc broker pattern) ---------------
+
+def _pid_alive() -> int | None:
+    try:
+        pid = int(PIDFILE.read_text().strip())
+        os.kill(pid, 0)
+    except (OSError, ValueError):
+        return None
+    return pid
+
+
+def status() -> dict:
+    pid = _pid_alive()
+    port = None
+    try:
+        port = int(PORTFILE.read_text().strip())
+    except (OSError, ValueError):
+        pass
+    return {"ok": True, "running": pid is not None, "pid": pid, "port": port,
+            # upstream = the broker's tunnel socket; the relay works only when
+            # both halves are up, so surface the other half here too
+            "upstream": vm.MCP_SOCKET.exists()}
+
+
+def up(port: int) -> dict:
+    if pid := _pid_alive():
+        return {"ok": True, "output": f"relay already up (pid {pid})", **status()}
+    vm.RUN_DIR.mkdir(parents=True, exist_ok=True)
+    with open(LOG, "wb") as log:
+        p = subprocess.Popen([sys.executable, str(Path(__file__).resolve()), "fg", str(port)],
+                             stdin=subprocess.DEVNULL, stdout=log, stderr=log,
+                             start_new_session=True)
+    PIDFILE.write_text(str(p.pid))
+    PORTFILE.write_text(str(port))
+    # verify the listener answers before reporting success
+    for _ in range(25):
+        if p.poll() is not None:
+            err = LOG.read_text(errors="replace").strip()[-500:]
+            PIDFILE.unlink(missing_ok=True)
+            return {"ok": False, "output": f"relay exited (rc {p.returncode}): {err or '(no output)'}"}
+        try:
+            socket.create_connection(("127.0.0.1", port), timeout=0.2).close()
+            r = {"ok": True, "pid": p.pid, "port": port,
+                 "url": f"http://127.0.0.1:{port}/mcp",
+                 "upstream": vm.MCP_SOCKET.exists()}
+            if not r["upstream"]:
+                r["output"] = ("relay up, but the broker tunnel socket is absent — "
+                               "connections will fail until POST /mcp/up on the vm-broker")
+            return r
+        except OSError:
+            pass
+    p.terminate()
+    PIDFILE.unlink(missing_ok=True)
+    return {"ok": False, "output": f"relay did not start listening on 127.0.0.1:{port}"}
+
+
+def down() -> dict:
+    pid = _pid_alive()
+    if pid:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+    PIDFILE.unlink(missing_ok=True)
+    PORTFILE.unlink(missing_ok=True)
+    return {"ok": True,
+            "output": f"relay stopped (pid {pid})" if pid else "relay not running"}
+
+
+def main(argv: list[str]) -> int:
+    mode = argv[0] if argv else "status"
+    port = int(argv[1]) if len(argv) > 1 else DEFAULT_PORT
+    if mode == "fg":
+        srv = make_server(port)
+        sys.stderr.write(f"[vm-mcp-relay] 127.0.0.1:{port} -> {vm.MCP_SOCKET}\n")
+        run(srv)
+    elif mode == "up":
+        r = up(port)
+        print(json.dumps(r))
+        return 0 if r["ok"] else 1
+    elif mode == "down":
+        print(json.dumps(down()))
+    elif mode == "status":
+        print(json.dumps(status()))
+    else:
+        sys.exit("usage: vm_mcp_relay.py [up [port]|down|status|fg [port]]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/sc
+++ b/sc
@@ -621,6 +621,10 @@ case "$cmd" in
   vm-broker-up)      sc_vm_broker_up ;;
   vm-broker-down)    sc_vm_broker_down ;;
   vm-broker-sock)    exec "$PY" "$S/vm.py" sock ;;
+  # In-sandbox half of the GUI seam (#263): TCP→unix relay so `claude mcp add
+  # --transport http` can reach the broker's vm-mcp.sock tunnel. Runs IN the
+  # container; the broker-side half is `POST /mcp/up` on the vm-broker socket.
+  vm-mcp-relay)      exec "$PY" "$S/vm_mcp_relay.py" "$@" ;;
   vm-broker-install)   sc_vm_broker_install ;;
   vm-broker-uninstall) sc_vm_broker_uninstall ;;
   # ── Tailnet broker (HOST-side primitive — runs where the tailnet node lives) ──
@@ -826,6 +830,10 @@ super-coder — forkable shell substrate
   ./sc vm-broker-sock      print the broker's socket path
   ./sc vm-broker-install   supervise via a systemd --user unit (survives logout/reboot)
   ./sc vm-broker-uninstall remove the systemd unit
+  ./sc vm-mcp-relay        in-SANDBOX half of the GUI seam: up [port] / down / status —
+                             TCP 127.0.0.1:18000 → the broker's vm-mcp.sock tunnel, so
+                             `claude mcp add --transport http` reaches the guest's Windows-MCP
+                             (broker half: POST /mcp/up on the vm-broker socket)
 
   Tailnet broker (run on the HOST — drives the tailnet for sandboxed forks; holds
   the already-`tailscale up` node so the fork never holds a tailnet credential.

--- a/skills_sc/windows_vm_gui.md
+++ b/skills_sc/windows_vm_gui.md
@@ -78,13 +78,35 @@ unreachable unless the server itself runs elevated.
    (`schtasks /run /tn windows-mcp-server` over SSH) — and if the task is
    missing, the snapshot was baked without the prep above.
 
-**Sandboxed seat** (the engine default): not wired yet. The sandbox has no
-`ssh`, no key, and no route to the VM — that is the broker design — and the
-vm-broker does not yet expose an MCP seam. Tracked upstream:
-[super-coder#263](https://github.com/jedbjorn/super-coder/issues/263). Until
-it lands: screenshots via `/capture`, scriptable checks via `windows_devkit`'s
-exec loop. Do **not** fake GUI driving by guessing pixel coordinates off
-`/capture` screenshots — that is the exact failure mode this skill bans.
+**Sandboxed seat** (the engine default): the sandbox has no `ssh`, no key,
+and no route to the VM — that is the broker design — so the connection is
+brokered in two halves. The vm-broker (host-side, holds the key) ssh-forwards
+a unix socket in the bind-mounted `run/` dir to the guest's Windows-MCP; a
+tiny in-sandbox relay gives that socket the TCP URL `claude mcp add` needs:
+
+1. Start from a clean box (`windows_devkit`'s `/reset`); wait until SSH
+   answers.
+2. Open the broker tunnel:
+   `curl --unix-socket $(./sc vm-broker-sock) -X POST http://vm/mcp/up`
+   (idempotent; forwards `run/vm-mcp.sock` to the guest's `mcp_port`,
+   default 8000).
+3. Start the in-sandbox relay: `./sc vm-mcp-relay up` (listens on
+   `127.0.0.1:18000`, pipes to the tunnel socket; also idempotent).
+4. Verify the endpoint answers: `curl -s http://127.0.0.1:18000/mcp`.
+5. Connect the harness:
+   `claude mcp add --transport http windows-mcp http://127.0.0.1:18000/mcp`
+6. Endpoint dead → `./sc vm-mcp-relay status` first (`upstream: false` means
+   the broker tunnel is down — redo step 2; a reset drops it, so reconnect
+   after every `/reset`), then the guest task
+   (`schtasks /run /tn windows-mcp-server` via broker `/exec`) — and if the
+   task is missing, the snapshot was baked without the prep above.
+7. Done driving: `./sc vm-mcp-relay down` and
+   `curl --unix-socket $(./sc vm-broker-sock) -X POST http://vm/mcp/down`.
+
+No key, no ssh, no network surface enters the sandbox — both hops are unix
+sockets in the bind mount, same posture as every other broker verb. Do
+**not** fake GUI driving by guessing pixel coordinates off `/capture`
+screenshots — that is the exact failure mode this skill bans.
 
 ## Driving rules
 

--- a/tests/test_vm_broker.py
+++ b/tests/test_vm_broker.py
@@ -14,6 +14,8 @@ Run:
 """
 from __future__ import annotations
 
+import os
+import socket
 import sys
 import tempfile
 import threading
@@ -27,6 +29,7 @@ sys.path.insert(0, str(ENGINE / "api"))
 
 import vm  # noqa: E402
 import vm_broker  # noqa: E402
+import vm_mcp_relay  # noqa: E402
 
 SAVED = {
     "domain": "win-test", "ssh_host": "127.0.0.1", "ssh_port": 22,
@@ -149,6 +152,165 @@ class VerbDispatchTests(unittest.TestCase):
         self.assertEqual(r["screenshot_bytes"], len(b"P6 fake ppm bytes"))
 
 
+class McpTunnelTests(unittest.TestCase):
+    """The GUI seam's broker half (#263): a broker-owned `ssh -N -L` that
+    forwards a unix socket in run/ to the guest's Windows-MCP port."""
+
+    def setUp(self):
+        # Redirect every tunnel artifact into a temp dir so tests never touch
+        # (or depend on) the real run/ state.
+        d = Path(tempfile.mkdtemp(prefix="sc_mcp_"))
+        self._patches = [
+            mock.patch.object(vm, "MCP_SOCKET", d / "vm-mcp.sock"),
+            mock.patch.object(vm, "MCP_PIDFILE", d / "vm-mcp-tunnel.pid"),
+            mock.patch.object(vm, "MCP_LOG", d / "vm-mcp-tunnel.log"),
+        ]
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
+    def test_mcp_up_missing_config_is_a_clean_error(self):
+        with mock.patch.object(vm, "read", return_value={}):
+            r = vm.do_mcp_up()
+        self.assertFalse(r["ok"])
+        self.assertIn("missing required field", r["output"])
+
+    def test_mcp_up_forwards_a_unix_socket_to_the_saved_mcp_port(self):
+        # The ssh argv is the security posture: socket forward (not a TCP
+        # bind), 0600 socket, dead-forward = dead pid, target from the SAVED
+        # block only.
+        def fake_popen(argv, **kw):
+            vm.MCP_SOCKET.touch()  # "ssh" bound its forward socket
+            return mock.Mock(pid=4242, poll=mock.Mock(return_value=None))
+        cfg = dict(SAVED, mcp_port=9000)
+        with mock.patch.object(vm, "read", return_value=cfg), \
+             mock.patch("subprocess.Popen", side_effect=fake_popen) as popen:
+            r = vm.do_mcp_up(wait=5)
+        self.assertTrue(r["ok"], r)
+        self.assertEqual(r["pid"], 4242)
+        self.assertEqual(r["port"], 9000)
+        argv = popen.call_args[0][0]
+        self.assertEqual(argv[0], "ssh")
+        self.assertIn("-N", argv)
+        self.assertIn(f"{vm.MCP_SOCKET}:127.0.0.1:9000", argv)
+        self.assertIn("ExitOnForwardFailure=yes", argv)
+        self.assertIn("StreamLocalBindUnlink=yes", argv)
+        self.assertIn("StreamLocalBindMask=0177", argv)
+        self.assertIn("tester@127.0.0.1", argv)
+
+    def test_mcp_port_defaults_to_8000(self):
+        def fake_popen(argv, **kw):
+            vm.MCP_SOCKET.touch()
+            return mock.Mock(pid=4242, poll=mock.Mock(return_value=None))
+        with mock.patch.object(vm, "read", return_value=SAVED), \
+             mock.patch("subprocess.Popen", side_effect=fake_popen) as popen:
+            r = vm.do_mcp_up(wait=5)
+        self.assertTrue(r["ok"], r)
+        self.assertIn(f"{vm.MCP_SOCKET}:127.0.0.1:8000", popen.call_args[0][0])
+
+    def test_mcp_up_is_idempotent_when_already_live(self):
+        # A live pid + present socket → report it, never stack a second ssh.
+        vm.MCP_PIDFILE.write_text(str(os.getpid()))  # this test process: alive
+        vm.MCP_SOCKET.touch()
+        with mock.patch.object(vm, "read", return_value=SAVED), \
+             mock.patch("subprocess.Popen") as popen:
+            r = vm.do_mcp_up()
+        self.assertTrue(r["ok"])
+        self.assertIn("already up", r["output"])
+        popen.assert_not_called()
+
+    def test_mcp_up_surfaces_a_dying_ssh_with_its_stderr(self):
+        def fake_popen(argv, **kw):
+            vm.MCP_LOG.write_bytes(b"Permission denied (publickey).")
+            return mock.Mock(pid=4242, returncode=255,
+                             poll=mock.Mock(return_value=255))
+        with mock.patch.object(vm, "read", return_value=SAVED), \
+             mock.patch("subprocess.Popen", side_effect=fake_popen):
+            r = vm.do_mcp_up(wait=5)
+        self.assertFalse(r["ok"])
+        self.assertIn("Permission denied", r["output"])
+        self.assertIsNone(vm._tunnel_pid())  # no stale pidfile left behind
+
+    def test_mcp_down_is_idempotent(self):
+        r = vm.do_mcp_down()
+        self.assertTrue(r["ok"])
+        self.assertIn("not running", r["output"])
+
+    def test_mcp_status_reports_not_running_without_a_tunnel(self):
+        r = vm.mcp_status()
+        self.assertTrue(r["ok"])
+        self.assertFalse(r["running"])
+        self.assertIsNone(r["socket"])
+
+
+class McpRelayTests(unittest.TestCase):
+    """The GUI seam's sandbox half: TCP 127.0.0.1 → the tunnel's unix socket,
+    exercised END TO END — a real unix echo server behind a real relay, driven
+    by a real TCP client. Bytes must survive both directions unmodified."""
+
+    def setUp(self):
+        self.upstream_path = Path(tempfile.mkdtemp(prefix="sc_relay_")) / "vm-mcp.sock"
+        self._patch = mock.patch.object(vm, "MCP_SOCKET", self.upstream_path)
+        self._patch.start()
+        # the stand-in for the guest's Windows-MCP behind the ssh forward
+        self.upstream = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.upstream.bind(str(self.upstream_path))
+        self.upstream.listen(4)
+        threading.Thread(target=self._echo_forever, daemon=True).start()
+        # the relay under test, on an ephemeral port
+        self.srv = vm_mcp_relay.make_server(0)
+        self.port = self.srv.getsockname()[1]
+        threading.Thread(target=vm_mcp_relay.run, args=(self.srv,), daemon=True).start()
+
+    def tearDown(self):
+        self.srv.close()
+        self.upstream.close()
+        self._patch.stop()
+        self.upstream_path.unlink(missing_ok=True)
+
+    def _echo_forever(self):
+        while True:
+            try:
+                conn, _ = self.upstream.accept()
+            except OSError:
+                return
+            def echo(c):
+                while data := c.recv(65536):
+                    c.sendall(data)
+                c.close()
+            threading.Thread(target=echo, args=(conn,), daemon=True).start()
+
+    def test_bytes_round_trip_through_the_relay(self):
+        c = socket.create_connection(("127.0.0.1", self.port), timeout=5)
+        payload = b"POST /mcp HTTP/1.1\r\n\r\n" + bytes(range(256))  # incl. non-UTF-8
+        c.sendall(payload)
+        got = b""
+        while len(got) < len(payload):
+            got += c.recv(65536)
+        c.close()
+        self.assertEqual(got, payload)
+
+    def test_concurrent_connections_do_not_cross_streams(self):
+        conns = [socket.create_connection(("127.0.0.1", self.port), timeout=5)
+                 for _ in range(4)]
+        for i, c in enumerate(conns):
+            c.sendall(f"stream-{i}".encode())
+        for i, c in enumerate(conns):
+            self.assertEqual(c.recv(65536), f"stream-{i}".encode())
+            c.close()
+
+    def test_relay_closes_cleanly_when_upstream_is_absent(self):
+        # Tunnel not up yet → the client sees EOF, not a hang.
+        with mock.patch.object(vm, "MCP_SOCKET", self.upstream_path.with_name("absent.sock")):
+            c = socket.create_connection(("127.0.0.1", self.port), timeout=5)
+            c.settimeout(5)
+            self.assertEqual(c.recv(1), b"")  # clean close
+            c.close()
+
+
 class SocketTransportTests(unittest.TestCase):
     """A live broker on a temp socket, driven by the real broker_call client —
     proves the unix-socket HTTP transport the container relies on actually works."""
@@ -189,6 +351,23 @@ class SocketTransportTests(unittest.TestCase):
             r = vm.broker_call("POST", "/exec", {"command": "exit 2"})
         self.assertEqual(r["exit"], 2)
         self.assertEqual(r["stdout"], "out")
+
+    def test_mcp_routes_dispatch_over_the_socket(self):
+        # The sandbox drives the GUI seam through exactly these routes.
+        with mock.patch.object(vm, "mcp_status",
+                               return_value={"ok": True, "running": False,
+                                             "pid": None, "socket": None}):
+            r = vm.broker_call("GET", "/mcp/status")
+        self.assertFalse(r["running"])
+        with mock.patch.object(vm, "do_mcp_up",
+                               return_value={"ok": True, "output": "tunnel up"}) as up:
+            r = vm.broker_call("POST", "/mcp/up")
+        self.assertTrue(r["ok"])
+        up.assert_called_once_with()
+        with mock.patch.object(vm, "do_mcp_down",
+                               return_value={"ok": True, "output": "tunnel stopped"}):
+            r = vm.broker_call("POST", "/mcp/down")
+        self.assertTrue(r["ok"])
 
     def test_broker_call_raises_when_nothing_listens(self):
         vm.SOCKET = self.sock.with_name("_absent.sock")


### PR DESCRIPTION
Closes #263.

Lands the broker-mediated path from a sandboxed seat to the guest's Windows-MCP endpoint — the issue's option 1, minus its flagged hard part: OpenSSH forwards a **unix socket** to a remote TCP port (`-L run/vm-mcp.sock:127.0.0.1:8000`), so the broker owns the byte plumbing and never proxies HTTP. No chunked/SSE handling in `BaseHTTPRequestHandler`; streaming passes through untouched.

```
claude mcp add (TCP :18000) → vm_mcp_relay.py (in-sandbox) → run/vm-mcp.sock (bind mount) → ssh -N -L (broker, host) → guest 127.0.0.1:8000
```

**Broker half** — `POST /mcp/up` / `/mcp/down` / `GET /mcp/status` on the existing vm-broker socket. One broker-owned ssh forward: `StreamLocalBindMask=0177` (socket lands 0600), `ExitOnForwardFailure` (a dead forward can't linger as a live pid), target port from the **saved** vm block (`mcp_port`, default 8000) — the sandbox names an action, never a destination.

**Sandbox half** — `./sc vm-mcp-relay up|down|status`: stdlib-only TCP→socket relay on `127.0.0.1:18000` inside the container's namespace (python3 is all the sandbox has; `claude mcp add --transport http` only speaks TCP URLs). Nothing binds on `sc-net` or the docker bridge.

Posture unchanged: key stays in the host process, both hops are fs-perm-gated unix sockets in the bind mount — the transport decision the broker spec made, extended, not widened. Trust class of the new surface ≈ `/exec`, which the sandbox already holds. Options 2 (key-holding sidecar on shared `sc-net`) and 3 (gateway-bind + auth key) re-open decisions the spec closed; dropped.

`windows_vm_gui`'s sandboxed-seat section goes from "not wired yet" to the real 7-step connect (asset + seed migration + flat render; `render-check` clean). Broker doc gains the MCP-seam section.

Test plan:
- [x] 10 new tests: tunnel argv posture, idempotence, dying-ssh error surfacing, `/mcp/*` route dispatch over the live broker socket, end-to-end relay (real unix echo server + real TCP client, non-UTF-8 bytes, concurrent streams, absent-upstream clean close)
- [x] `./sc test` — 218/218 pass
- [x] **Live against the dos-arch Windows guest**: `do_mcp_up` → relay → TCP client read `SSH-2.0-OpenSSH_for_Windows_9.5` through both hops (forwarded to guest sshd; Windows-MCP itself lands with rst-c's guest prep + re-bake), then clean `down`

🤖 Generated with [Claude Code](https://claude.com/claude-code)