### PR TITLE
fix(skills): Patch C — local skill persistence: seed live-upsert, seed-keyed classification, sc skill surface

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -191,9 +191,10 @@ def tag_origin(skills: list[dict]) -> list[dict]:
     """Annotate skill rows with origin: 'engine' | 'repo'.
 
     Same rule snapshot.py uses to decide what serializes into content.sql —
-    a name under assets/skills/ is engine catalogue; anything else is a
-    repo-local skill. One rule, two consumers: the UI's "Repo skills" section
-    shows exactly what the snapshot will keep durable."""
+    a name the engine seed (0001) owns is engine catalogue; anything else is a
+    repo-local skill (asset-file presence is NOT the rule — a repo skill keeps
+    its authoring asset, #253). One rule, two consumers: the UI's "Repo skills"
+    section shows exactly what the snapshot will keep durable."""
     engine = set(snapshot_mod.engine_skill_names())
     for s in skills:
         s["origin"] = "engine" if s["name"] in engine else "repo"
@@ -497,8 +498,9 @@ _SCRIPTS = {
     "render": ("Render flat", "Regenerate the tracked flat _sc files "
                "(specs_sc / docs_sc / skills_sc / roadmap_sc.md) from the DB. Incremental.",
                [_PY, str(ENGINE / "scripts/render.py"), "flat"], False),
-    "seed_skills": ("Seed skills", "Recompile assets/skills/ into the skills seed migration "
-                    "(migrations/0001_seed_skills.sql). Run after editing a skill body.",
+    "seed_skills": ("Seed skills", "Upsert assets/skills/ into the live DB "
+                    "(+ regenerate the seed migration — source repo only). Run "
+                    "after authoring or editing a skill body.",
                     [_PY, str(ENGINE / "scripts/seed_skills.py")], False),
     "migrate": ("Migrate", "Apply any pending migrations to the live DB (ledger-tracked).",
                 [_PY, str(ENGINE / "scripts/migrate.py"), str(DB_PATH)], False),

--- a/.super-coder/assets/skills/db_map/SKILL.md
+++ b/.super-coder/assets/skills/db_map/SKILL.md
@@ -58,7 +58,7 @@ returns 0 rows instead of erroring, so it looks like an empty map. Never query
 | `feature_blockers` | the roadmap's dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite must land first). Directed, kept acyclic (the GUI Flow view wires them; the card's "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `sc mem roadmap depends` |
 | `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
-| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine |
+| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine; grants via `./sc skill grant/revoke` |
 | `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a **work-stream** that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
 
 `<self>` = your `shell_id` (in the boot doc's ACTIVE SESSION block).

--- a/.super-coder/assets/skills/local_skill_management/SKILL.md
+++ b/.super-coder/assets/skills/local_skill_management/SKILL.md
@@ -8,12 +8,15 @@ common: false
 # local_skill_management — fork-specific skills that survive
 
 Fork-specific skills live in the DB and are persisted via `.sc-state/content.sql`
-(the snapshot). The asset file under `.super-coder/assets/skills/` is used to
-**seed the skill initially** — but that directory is gitignored engine territory:
-`sc update` materializes upstream engine files there, which removes any local
-additions. After the first seed + snapshot, **content.sql is the durable form**.
+(the snapshot). The asset file under `.super-coder/assets/skills/<name>/` is the
+**authoring source** — edit it, re-seed, done. It sits in gitignored engine
+territory, but that is safe: the engine/local boundary is the seed migration
+(0001, upstream-owned in a fork), not asset-file presence, so the snapshot
+serializes your skill to content.sql whether or not the asset file is kept, and
+`sc update` neither manifests it nor heals over its DB row. **content.sql is
+the durable form; the asset file is your editor.**
 
-The correct path: **file → seed → grant → snapshot → commit**.
+The path: **file → seed → grant → snapshot → commit**.
 
 ## Creating a fork-specific skill
 
@@ -31,73 +34,67 @@ The correct path: **file → seed → grant → snapshot → commit**.
    Body: Markdown. Write the procedure the shell will follow. Imperative,
    precise — this is what boots into context, so compress ruthlessly.
 
-2. **Seed the skill into the DB.**
+2. **Seed the skill into the live DB.**
    ```bash
-   cd <repo> && sc seed-skills
+   sc seed-skills
    ```
-   UPSERTs the skill row into the live DB by name (id-stable). Does not touch
-   skills already in the DB that are absent from assets — those are other local
-   skills, left intact.
+   UPSERTs every asset skill into the live DB by name (id-stable) and reports
+   what landed. In a fork it deliberately does NOT regenerate the seed
+   migration — that file is upstream-owned engine territory. Skills already in
+   the DB with no asset file are other local skills, left intact.
 
-3. **Grant the skill to the target shell(s).**
-   Skill grants have no API surface — these writes run via `./sc sql-rw "<SQL>"`
-   (the explicit read-write passthrough; `sc sql` is read-only and will refuse).
-   Find shell IDs:
-   ```sql
-   SELECT shell_id, display_name, flavor FROM shells WHERE is_deleted = 0;
+3. **Grant the skill to the target shell(s)** — by shell id or shortname:
+   ```bash
+   sc skill grant <skill_name> <shell>...
    ```
-   Grant:
-   ```sql
-   INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
-   SELECT <shell_id>, skill_id FROM skills
-   WHERE name = '<skill_name>' AND is_deleted = 0;
-   ```
+   Unknown skill or shell names are hard errors (no silent no-op grants).
+   `sc skill list` shows the catalogue with origins and current grants;
+   `sc skill revoke <name> <shell>...` reverses a grant.
 
 4. **Snapshot — this is the persistence step.**
    ```bash
    sc snapshot && sc render
    ```
-   `snapshot.py` serializes local skills (any skill whose name is not in the
-   upstream engine assets) into `.sc-state/content.sql`. This is what survives
-   `sc update` — when the engine materialize overwrites `.super-coder/assets/
-   skills/`, the skill row and its full content are reconstructed from
-   content.sql on rebuild. Without this step the skill is lost on next update.
+   `snapshot.py` serializes local skills (any skill the engine seed doesn't
+   own) into `.sc-state/content.sql`. This is what survives `sc update` and
+   `sc rebuild` — the skill row and its grants are reconstructed from
+   content.sql. Without this step the skill is lost on next update.
 
 5. **Commit.**
    Run `sc render-check` first — it rebuilds hermetically and fails if the
    `skills_sc/` mirror drifts from the DB render (the same CI guard; see the
    `snapshot` skill). Then stage `.sc-state/content.sql` and `skills_sc/`
-   together — the snapshot without the re-rendered mirror is the drift. The asset
-   file and `0001_seed_skills.sql` are transient for local skills — don't rely on
-   them across updates.
+   together — the snapshot without the re-rendered mirror is the drift.
+
+## Updating a skill
+
+Edit the asset file, then repeat seed → snapshot → commit (steps 2, 4, 5). If
+the asset file is gone (removed, or authored elsewhere), recreate it from the
+DB body first: `sc sql "SELECT content FROM skills WHERE name='<name>'"`.
 
 ## Assigning an existing skill to additional shells
 
-Via `./sc sql-rw "<SQL>"`:
-```sql
-INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
-SELECT <shell_id>, skill_id FROM skills
-WHERE name = '<skill_name>' AND is_deleted = 0;
+```bash
+sc skill grant <skill_name> <shell>...
 ```
 Then `sc snapshot && sc render` and commit.
 
 ## Removing a skill
 
-1. **Soft-delete the DB row and revoke grants.**
-   Via `./sc sql-rw "<SQL>"`:
-   ```sql
-   UPDATE skills SET is_deleted = 1 WHERE name = '<name>';
-   DELETE FROM shell_skills
-   WHERE skill_id = (SELECT skill_id FROM skills WHERE name = '<name>');
+1. **Soft-delete the row and revoke its grants:**
+   ```bash
+   sc skill rm <skill_name>
    ```
+   Refuses engine skills — the seed would resurrect those on the next
+   update/rebuild; `sc skill revoke` them per-shell instead.
 
-2. **Snapshot, render, commit.**
+2. **Remove the asset file** (`.super-coder/assets/skills/<name>/`) — otherwise
+   the next `sc seed-skills` re-inserts the skill.
+
+3. **Snapshot, render, commit.**
    ```bash
    sc snapshot && sc render
    ```
-   The deletion serializes to content.sql. If the asset file still exists under
-   `.super-coder/assets/skills/`, remove it too so `sc seed-skills` doesn't
-   re-insert it.
 
 ## How the GUI organizes skills
 
@@ -106,30 +103,25 @@ per-shell grant toggles on every skill. The Shells tab groups its grant list
 by the same sections.
 
 - **Repo skills** — the lead section: skills authored in this fork. Membership
-  is *derived*, not declared — a skill whose name has no
-  `.super-coder/assets/skills/<name>/SKILL.md` is repo-local. This is the same
-  rule snapshot.py uses to decide what serializes into `.sc-state/content.sql`,
-  so the section shows exactly what the snapshot keeps durable. No frontmatter
-  flag exists or is needed.
+  is *derived*, not declared — a skill the engine seed doesn't own is
+  repo-local. This is the same rule snapshot.py uses to decide what serializes
+  into `.sc-state/content.sql`, so the section shows exactly what the snapshot
+  keeps durable. No frontmatter flag exists or is needed.
 - **Substrate / Craft / …** — engine skills, sectioned by their `category`
   frontmatter. A repo skill's `category` still displays as a label on its row,
   but never moves it out of the Repo section.
-- One transient caveat: while a repo skill's asset file still sits under
-  `assets/skills/` (between authoring and the next `sc update` materialize),
-  the derivation reads it as engine — it appears under its category section
-  until the update wipes the asset. Harmless; the DB row is the durable thing.
 
-Grant toggles in the GUI hit the same DB table as the SQL in this skill —
-they still need a **snapshot** (header button or `sc snapshot`) to survive
-a rebuild.
+Grant toggles in the GUI hit the same DB table as `sc skill grant` — they
+still need a **snapshot** (header button or `sc snapshot`) to survive a
+rebuild.
 
 ## What NOT to do
 
-- **Never skip the snapshot after creating a skill.** The asset file under
-  `.super-coder/assets/skills/` is overwritten by `sc update`. If you seed
-  without snapshotting, the skill vanishes on the next engine update.
-- **Never edit `0001_seed_skills.sql` by hand.** It is generated; hand edits
-  are overwritten on the next `sc seed-skills`.
+- **Never skip the snapshot after creating a skill.** Seeding puts the row in
+  the live DB only; content.sql is what survives `sc update` and `sc rebuild`.
+- **Never edit `0001_seed_skills.sql` by hand.** It is generated, and in a
+  fork it is upstream-owned engine territory — a local edit blocks the next
+  update.
 - **Never use the GUI to create skills.** Toggling grants in the GUI is fine
   (snapshot after); creating is not — the GUI writes only to the DB and cannot
   write the asset file or seed it. Use this procedure instead.

--- a/.super-coder/assets/skills/snapshot/SKILL.md
+++ b/.super-coder/assets/skills/snapshot/SKILL.md
@@ -75,16 +75,12 @@ All commands below require `SC_ADMIN=1` and are run from the **main checkout**.
 - **Per-instance content** (your memory, this repo's roadmap/docs): edit the DB,
   then `sc snapshot`. The snapshot is the canonical reproducer.
 - **Skill catalogue** (system, propagates): edit `assets/skills/<name>/SKILL.md`,
-  then `sc seed-skills` to regenerate the seed migration — **not** the
-  snapshot. See `seed_skills.py`.
-  - **The stale-mirror trap:** `seed-skills` writes the new body into the
-    *migration*, but your **live DB still holds the old body** until you apply
-    it. So `sc render` now renders the *stale* skill into `skills_sc/<name>.md`
-    and passes — while CI's hermetic rebuild (new body) drifts and goes red.
-    Sequence is **`sc seed-skills && sc rebuild && sc render`, then
-    `sc render-check`** before committing. Commit the regenerated
-    `migrations/0001_seed_skills.sql` *and* the re-rendered `skills_sc/` mirror
-    together — the migration without the mirror is the drift.
+  then `sc seed-skills` — it upserts the live DB *and* (source repo only)
+  regenerates the seed migration. Not the snapshot. See `seed_skills.py`.
+  - Sequence is **`sc seed-skills && sc render`, then `sc render-check`**
+    before committing. Commit the regenerated `migrations/0001_seed_skills.sql`
+    *and* the re-rendered `skills_sc/` mirror together — the migration without
+    the mirror is the drift.
 
 > Steps 1–3 are durability — serialize so a `sc rebuild` can't lose your work.
 > Step 4 is the GUI **Publish** button: it runs snapshot → render → commit →

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -789,7 +789,7 @@ returns 0 rows instead of erroring, so it looks like an empty map. Never query
 | `feature_blockers` | the roadmap''s dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite must land first). Directed, kept acyclic (the GUI Flow view wires them; the card''s "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `sc mem roadmap depends` |
 | `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
-| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine |
+| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine; grants via `./sc skill grant/revoke` |
 | `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a **work-stream** that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
 
 `<self>` = your `shell_id` (in the boot doc''s ACTIVE SESSION block).
@@ -1917,12 +1917,15 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
   '# local_skill_management — fork-specific skills that survive
 
 Fork-specific skills live in the DB and are persisted via `.sc-state/content.sql`
-(the snapshot). The asset file under `.super-coder/assets/skills/` is used to
-**seed the skill initially** — but that directory is gitignored engine territory:
-`sc update` materializes upstream engine files there, which removes any local
-additions. After the first seed + snapshot, **content.sql is the durable form**.
+(the snapshot). The asset file under `.super-coder/assets/skills/<name>/` is the
+**authoring source** — edit it, re-seed, done. It sits in gitignored engine
+territory, but that is safe: the engine/local boundary is the seed migration
+(0001, upstream-owned in a fork), not asset-file presence, so the snapshot
+serializes your skill to content.sql whether or not the asset file is kept, and
+`sc update` neither manifests it nor heals over its DB row. **content.sql is
+the durable form; the asset file is your editor.**
 
-The correct path: **file → seed → grant → snapshot → commit**.
+The path: **file → seed → grant → snapshot → commit**.
 
 ## Creating a fork-specific skill
 
@@ -1940,73 +1943,67 @@ The correct path: **file → seed → grant → snapshot → commit**.
    Body: Markdown. Write the procedure the shell will follow. Imperative,
    precise — this is what boots into context, so compress ruthlessly.
 
-2. **Seed the skill into the DB.**
+2. **Seed the skill into the live DB.**
    ```bash
-   cd <repo> && sc seed-skills
+   sc seed-skills
    ```
-   UPSERTs the skill row into the live DB by name (id-stable). Does not touch
-   skills already in the DB that are absent from assets — those are other local
-   skills, left intact.
+   UPSERTs every asset skill into the live DB by name (id-stable) and reports
+   what landed. In a fork it deliberately does NOT regenerate the seed
+   migration — that file is upstream-owned engine territory. Skills already in
+   the DB with no asset file are other local skills, left intact.
 
-3. **Grant the skill to the target shell(s).**
-   Skill grants have no API surface — these writes run via `./sc sql-rw "<SQL>"`
-   (the explicit read-write passthrough; `sc sql` is read-only and will refuse).
-   Find shell IDs:
-   ```sql
-   SELECT shell_id, display_name, flavor FROM shells WHERE is_deleted = 0;
+3. **Grant the skill to the target shell(s)** — by shell id or shortname:
+   ```bash
+   sc skill grant <skill_name> <shell>...
    ```
-   Grant:
-   ```sql
-   INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
-   SELECT <shell_id>, skill_id FROM skills
-   WHERE name = ''<skill_name>'' AND is_deleted = 0;
-   ```
+   Unknown skill or shell names are hard errors (no silent no-op grants).
+   `sc skill list` shows the catalogue with origins and current grants;
+   `sc skill revoke <name> <shell>...` reverses a grant.
 
 4. **Snapshot — this is the persistence step.**
    ```bash
    sc snapshot && sc render
    ```
-   `snapshot.py` serializes local skills (any skill whose name is not in the
-   upstream engine assets) into `.sc-state/content.sql`. This is what survives
-   `sc update` — when the engine materialize overwrites `.super-coder/assets/
-   skills/`, the skill row and its full content are reconstructed from
-   content.sql on rebuild. Without this step the skill is lost on next update.
+   `snapshot.py` serializes local skills (any skill the engine seed doesn''t
+   own) into `.sc-state/content.sql`. This is what survives `sc update` and
+   `sc rebuild` — the skill row and its grants are reconstructed from
+   content.sql. Without this step the skill is lost on next update.
 
 5. **Commit.**
    Run `sc render-check` first — it rebuilds hermetically and fails if the
    `skills_sc/` mirror drifts from the DB render (the same CI guard; see the
    `snapshot` skill). Then stage `.sc-state/content.sql` and `skills_sc/`
-   together — the snapshot without the re-rendered mirror is the drift. The asset
-   file and `0001_seed_skills.sql` are transient for local skills — don''t rely on
-   them across updates.
+   together — the snapshot without the re-rendered mirror is the drift.
+
+## Updating a skill
+
+Edit the asset file, then repeat seed → snapshot → commit (steps 2, 4, 5). If
+the asset file is gone (removed, or authored elsewhere), recreate it from the
+DB body first: `sc sql "SELECT content FROM skills WHERE name=''<name>''"`.
 
 ## Assigning an existing skill to additional shells
 
-Via `./sc sql-rw "<SQL>"`:
-```sql
-INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
-SELECT <shell_id>, skill_id FROM skills
-WHERE name = ''<skill_name>'' AND is_deleted = 0;
+```bash
+sc skill grant <skill_name> <shell>...
 ```
 Then `sc snapshot && sc render` and commit.
 
 ## Removing a skill
 
-1. **Soft-delete the DB row and revoke grants.**
-   Via `./sc sql-rw "<SQL>"`:
-   ```sql
-   UPDATE skills SET is_deleted = 1 WHERE name = ''<name>'';
-   DELETE FROM shell_skills
-   WHERE skill_id = (SELECT skill_id FROM skills WHERE name = ''<name>'');
+1. **Soft-delete the row and revoke its grants:**
+   ```bash
+   sc skill rm <skill_name>
    ```
+   Refuses engine skills — the seed would resurrect those on the next
+   update/rebuild; `sc skill revoke` them per-shell instead.
 
-2. **Snapshot, render, commit.**
+2. **Remove the asset file** (`.super-coder/assets/skills/<name>/`) — otherwise
+   the next `sc seed-skills` re-inserts the skill.
+
+3. **Snapshot, render, commit.**
    ```bash
    sc snapshot && sc render
    ```
-   The deletion serializes to content.sql. If the asset file still exists under
-   `.super-coder/assets/skills/`, remove it too so `sc seed-skills` doesn''t
-   re-insert it.
 
 ## How the GUI organizes skills
 
@@ -2015,30 +2012,25 @@ per-shell grant toggles on every skill. The Shells tab groups its grant list
 by the same sections.
 
 - **Repo skills** — the lead section: skills authored in this fork. Membership
-  is *derived*, not declared — a skill whose name has no
-  `.super-coder/assets/skills/<name>/SKILL.md` is repo-local. This is the same
-  rule snapshot.py uses to decide what serializes into `.sc-state/content.sql`,
-  so the section shows exactly what the snapshot keeps durable. No frontmatter
-  flag exists or is needed.
+  is *derived*, not declared — a skill the engine seed doesn''t own is
+  repo-local. This is the same rule snapshot.py uses to decide what serializes
+  into `.sc-state/content.sql`, so the section shows exactly what the snapshot
+  keeps durable. No frontmatter flag exists or is needed.
 - **Substrate / Craft / …** — engine skills, sectioned by their `category`
   frontmatter. A repo skill''s `category` still displays as a label on its row,
   but never moves it out of the Repo section.
-- One transient caveat: while a repo skill''s asset file still sits under
-  `assets/skills/` (between authoring and the next `sc update` materialize),
-  the derivation reads it as engine — it appears under its category section
-  until the update wipes the asset. Harmless; the DB row is the durable thing.
 
-Grant toggles in the GUI hit the same DB table as the SQL in this skill —
-they still need a **snapshot** (header button or `sc snapshot`) to survive
-a rebuild.
+Grant toggles in the GUI hit the same DB table as `sc skill grant` — they
+still need a **snapshot** (header button or `sc snapshot`) to survive a
+rebuild.
 
 ## What NOT to do
 
-- **Never skip the snapshot after creating a skill.** The asset file under
-  `.super-coder/assets/skills/` is overwritten by `sc update`. If you seed
-  without snapshotting, the skill vanishes on the next engine update.
-- **Never edit `0001_seed_skills.sql` by hand.** It is generated; hand edits
-  are overwritten on the next `sc seed-skills`.
+- **Never skip the snapshot after creating a skill.** Seeding puts the row in
+  the live DB only; content.sql is what survives `sc update` and `sc rebuild`.
+- **Never edit `0001_seed_skills.sql` by hand.** It is generated, and in a
+  fork it is upstream-owned engine territory — a local edit blocks the next
+  update.
 - **Never use the GUI to create skills.** Toggling grants in the GUI is fine
   (snapshot after); creating is not — the GUI writes only to the DB and cannot
   write the asset file or seed it. Use this procedure instead.',
@@ -2803,16 +2795,12 @@ All commands below require `SC_ADMIN=1` and are run from the **main checkout**.
 - **Per-instance content** (your memory, this repo''s roadmap/docs): edit the DB,
   then `sc snapshot`. The snapshot is the canonical reproducer.
 - **Skill catalogue** (system, propagates): edit `assets/skills/<name>/SKILL.md`,
-  then `sc seed-skills` to regenerate the seed migration — **not** the
-  snapshot. See `seed_skills.py`.
-  - **The stale-mirror trap:** `seed-skills` writes the new body into the
-    *migration*, but your **live DB still holds the old body** until you apply
-    it. So `sc render` now renders the *stale* skill into `skills_sc/<name>.md`
-    and passes — while CI''s hermetic rebuild (new body) drifts and goes red.
-    Sequence is **`sc seed-skills && sc rebuild && sc render`, then
-    `sc render-check`** before committing. Commit the regenerated
-    `migrations/0001_seed_skills.sql` *and* the re-rendered `skills_sc/` mirror
-    together — the migration without the mirror is the drift.
+  then `sc seed-skills` — it upserts the live DB *and* (source repo only)
+  regenerates the seed migration. Not the snapshot. See `seed_skills.py`.
+  - Sequence is **`sc seed-skills && sc render`, then `sc render-check`**
+    before committing. Commit the regenerated `migrations/0001_seed_skills.sql`
+    *and* the re-rendered `skills_sc/` mirror together — the migration without
+    the mirror is the drift.
 
 > Steps 1–3 are durability — serialize so a `sc rebuild` can''t lose your work.
 > Step 4 is the GUI **Publish** button: it runs snapshot → render → commit →

--- a/.super-coder/migrations/0042_reseed_local_skill_persistence.sql
+++ b/.super-coder/migrations/0042_reseed_local_skill_persistence.sql
@@ -1,0 +1,383 @@
+-- 0042 — reseed local-skill-persistence batch (upstream #253 / #237 pt2)
+--
+-- `sc seed-skills` now UPSERTs asset skills into the LIVE DB (the documented
+-- contract), and snapshot/GUI classify engine-vs-local by the SEED's names
+-- (0001), not asset-file presence — a fork-authored skill keeps its asset as
+-- authoring source and still serializes to .sc-state/content.sql. Skill
+-- grants have a first-class surface: `./sc skill list/grant/revoke/rm`.
+-- Three skills updated to describe the now-true flow:
+--   local_skill_management — seed live-upserts; grants via `./sc skill`;
+--                            asset file is the durable authoring source (#253).
+--   snapshot               — stale-mirror trap retired (seed-skills upserts
+--                            the live DB; no rebuild step in the sequence).
+--   db_map                 — skills/shell_skills row points at `./sc skill`.
+--
+-- 0001 is regenerated from the assets for fresh builds; this forward reseed
+-- carries the same bodies to already-installed forks (UPSERT by name; skill_id
+-- + grants preserved).
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'db_map',
+  'Data model behind the engine memory surfaces + the `sc mem` command for each. Check before reading or writing memory — identity, decisions, roadmap, documents, flags. Reads/writes go through the API (`sc mem`), never raw sqlite.',
+  'substrate',
+  NULL,
+  1,
+  '# db_map — super-coder''s DB at a glance
+
+All identity, memory, and content live in the engine DB
+(`.super-coder/shell_db.db`) — but you never touch that file. You read and write
+it **only through the engine API**, via `sc mem`:
+
+- **Read** — `sc mem get <surface>`: your own `state`, `seed`, `lns`,
+  `decisions`, `flags`, `narrative`, `messages`; and the shared planning state
+  `roadmap`, `projects`, `documents`, `tasks`, `shells` (add `--json` for raw).
+  `documents`/`tasks` take `--feature <id>` or `--doc <id>` (and `--doc` on
+  `documents` returns the one doc *with* its body).
+- **Write** — `sc mem <cmd> …` (see `## Common writes` below).
+
+There is **no `sqlite3` path** — not as a fallback, not for "ad-hoc" reads.
+`sc mem` goes through the API and only the API; if the API isn''t wired it
+fails loud rather than writing the DB behind its back. Your identity rides in
+your bearer token — the server resolves token → shell, so you never name a
+shell. The table below is the **data model** behind those surfaces (and what
+each `sc mem` write touches), not a query cheatsheet. Lazy-load: `get` the one
+surface you need, don''t bulk-read.
+
+**Need a read or write `sc mem` doesn''t expose?** That''s a gap to *report*, not
+a reason to reach for the DB — the direct path is closed by design, and a fork
+can''t patch the engine anyway (`sc update` would overwrite it). A missing
+surface is an engine gap that goes **up to the FnB**: open a flag naming the data
+and the use, and surface it. Don''t improvise around the API.
+
+```
+sc mem flag open "[Engine] need to <read|write> <what> — no sc mem surface for it | Blocker for: <your work>"
+```
+
+The FnB carries it upstream (that''s exactly how `get documents`/`get tasks`
+landed); message a planner-flavor shell too if the fork has one. Until then, do
+what you *can* through the API and flag the rest — never the DB directly.
+
+The repo map (`dr_*`) lives in its own db, `.sc-state/map.db` (see the
+`surface_catalogue` skill). The `dr_*` tables also *exist* in `shell_db.db` but
+are **always empty** there — a `dr_*` query against `shell_db.db` silently
+returns 0 rows instead of erroring, so it looks like an empty map. Never query
+`dr_*` here; this map covers only `shell_db.db`, your memory/identity/content.
+
+## Tables
+
+| Table | Holds | Write rule |
+|---|---|---|
+| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `lineage_seed`, `active_archive_id`. (`connections`/`workspace` retired — boot `## CONNECTIONS` is derived from the `dr_*` map, not authored here) | UPDATE in place |
+| `shell_identity_entries` | seed (cap 10) + L&S (`kind=''lns''`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — never edit a seed body (Law 3) |
+| `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
+| `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |
+| `roadmap` | one row per planned feature; `roadmap_status` is a planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = taken off the board (decided-against / split / absorbed / replaced) without shipping — keep the row. `project_id` (nullable) = the work-stream the feature belongs to; the GUI Flow view groups on it (NULL = Ungrouped) | INSERT/UPDATE |
+| `feature_blockers` | the roadmap''s dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite must land first). Directed, kept acyclic (the GUI Flow view wires them; the card''s "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `sc mem roadmap depends` |
+| `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
+| `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
+| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine; grants via `./sc skill grant/revoke` |
+| `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a **work-stream** that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
+
+`<self>` = your `shell_id` (in the boot doc''s ACTIVE SESSION block).
+
+## Common writes
+
+Each routes through the engine API and writes to the live shared DB. `sc mem which`
+orients; `sc mem <cmd> -h` shows flags. Writes always target your own shell —
+the server resolves it from your token; you never name a shell.
+
+```
+# current_state (rolling status, not a log — replaces in place):
+sc mem state "…"
+
+# plant a seed / L&S entry (date stamped for you):
+sc mem seed "…"            # sc mem lns "…" for a lesson
+sc mem retire <entry_id>   # curate one out (frees a cap slot)
+
+# record a Major decision (supersede with --parent <id>):
+sc mem decision "…" --rationale "…"
+
+# roadmap: add a feature / move its horizon:
+sc mem roadmap add "…" --status brainstorm --summary "…" [--project <shortname|id>]
+sc mem roadmap status <feature_id> shipped
+
+# roadmap grouping + sequencing (drive the GUI Flow view):
+sc mem roadmap project <feature_id> <shortname|id>   # assign a work-stream (or ''none'' to clear)
+sc mem roadmap depends <feature_id> --on <id> [--on <id>]   # set dependencies (replaces; omit --on to clear; refuses cycles)
+
+# author a spec/doc body (--body-file reads the markdown), then freeze on ship:
+sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
+sc mem doc freeze <document_id>
+
+# spec_tasks (the plan): add a task / advance it:
+sc mem task add "…" --feature <id> --doc <doc_id> --seq <n> [--desc "…"]
+sc mem task start <task_id>     # sc mem task done <task_id>
+
+# open / close a flag:
+sc mem flag open "[Area] … | Blocker for: …" --name CC-001 [--feature <id>]
+sc mem flag close <flag_id> --notes "…"
+
+# projects (standing + linkage):
+sc mem project add <shortname> "<title>" --purpose "…" --standing "…"
+sc mem project standing <shortname|id> "…"     # sc mem project status <…> paused
+
+# inbox + first-run:
+sc mem message send <shortname> "…"     # check / mark-read too (see `messaging`)
+sc mem oriented                          # mark first-run done (bootstrapped=1)
+```
+
+## After writing
+
+Nothing more to run — the write is live in the shared engine DB the moment it
+commits, visible to every shell. Persisting it to git is an admin/GUI step, not
+yours.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'local_skill_management',
+  'Create, persist, assign, and remove fork-specific skills — the correct authoring path so skills survive snapshot/rebuild cycles.',
+  'substrate',
+  NULL,
+  0,
+  '# local_skill_management — fork-specific skills that survive
+
+Fork-specific skills live in the DB and are persisted via `.sc-state/content.sql`
+(the snapshot). The asset file under `.super-coder/assets/skills/<name>/` is the
+**authoring source** — edit it, re-seed, done. It sits in gitignored engine
+territory, but that is safe: the engine/local boundary is the seed migration
+(0001, upstream-owned in a fork), not asset-file presence, so the snapshot
+serializes your skill to content.sql whether or not the asset file is kept, and
+`sc update` neither manifests it nor heals over its DB row. **content.sql is
+the durable form; the asset file is your editor.**
+
+The path: **file → seed → grant → snapshot → commit**.
+
+## Creating a fork-specific skill
+
+1. **Write the skill file.**
+   Path: `.super-coder/assets/skills/<name>/SKILL.md`
+
+   Required frontmatter:
+   ```yaml
+   ---
+   name: skill_name
+   description: One-line summary — shown in boot, catalogue, and the GUI Skills tab
+   category: substrate   # or craft; omit for default
+   ---
+   ```
+   Body: Markdown. Write the procedure the shell will follow. Imperative,
+   precise — this is what boots into context, so compress ruthlessly.
+
+2. **Seed the skill into the live DB.**
+   ```bash
+   sc seed-skills
+   ```
+   UPSERTs every asset skill into the live DB by name (id-stable) and reports
+   what landed. In a fork it deliberately does NOT regenerate the seed
+   migration — that file is upstream-owned engine territory. Skills already in
+   the DB with no asset file are other local skills, left intact.
+
+3. **Grant the skill to the target shell(s)** — by shell id or shortname:
+   ```bash
+   sc skill grant <skill_name> <shell>...
+   ```
+   Unknown skill or shell names are hard errors (no silent no-op grants).
+   `sc skill list` shows the catalogue with origins and current grants;
+   `sc skill revoke <name> <shell>...` reverses a grant.
+
+4. **Snapshot — this is the persistence step.**
+   ```bash
+   sc snapshot && sc render
+   ```
+   `snapshot.py` serializes local skills (any skill the engine seed doesn''t
+   own) into `.sc-state/content.sql`. This is what survives `sc update` and
+   `sc rebuild` — the skill row and its grants are reconstructed from
+   content.sql. Without this step the skill is lost on next update.
+
+5. **Commit.**
+   Run `sc render-check` first — it rebuilds hermetically and fails if the
+   `skills_sc/` mirror drifts from the DB render (the same CI guard; see the
+   `snapshot` skill). Then stage `.sc-state/content.sql` and `skills_sc/`
+   together — the snapshot without the re-rendered mirror is the drift.
+
+## Updating a skill
+
+Edit the asset file, then repeat seed → snapshot → commit (steps 2, 4, 5). If
+the asset file is gone (removed, or authored elsewhere), recreate it from the
+DB body first: `sc sql "SELECT content FROM skills WHERE name=''<name>''"`.
+
+## Assigning an existing skill to additional shells
+
+```bash
+sc skill grant <skill_name> <shell>...
+```
+Then `sc snapshot && sc render` and commit.
+
+## Removing a skill
+
+1. **Soft-delete the row and revoke its grants:**
+   ```bash
+   sc skill rm <skill_name>
+   ```
+   Refuses engine skills — the seed would resurrect those on the next
+   update/rebuild; `sc skill revoke` them per-shell instead.
+
+2. **Remove the asset file** (`.super-coder/assets/skills/<name>/`) — otherwise
+   the next `sc seed-skills` re-inserts the skill.
+
+3. **Snapshot, render, commit.**
+   ```bash
+   sc snapshot && sc render
+   ```
+
+## How the GUI organizes skills
+
+The review GUI has a **Skills tab**: the full catalogue in sections, with
+per-shell grant toggles on every skill. The Shells tab groups its grant list
+by the same sections.
+
+- **Repo skills** — the lead section: skills authored in this fork. Membership
+  is *derived*, not declared — a skill the engine seed doesn''t own is
+  repo-local. This is the same rule snapshot.py uses to decide what serializes
+  into `.sc-state/content.sql`, so the section shows exactly what the snapshot
+  keeps durable. No frontmatter flag exists or is needed.
+- **Substrate / Craft / …** — engine skills, sectioned by their `category`
+  frontmatter. A repo skill''s `category` still displays as a label on its row,
+  but never moves it out of the Repo section.
+
+Grant toggles in the GUI hit the same DB table as `sc skill grant` — they
+still need a **snapshot** (header button or `sc snapshot`) to survive a
+rebuild.
+
+## What NOT to do
+
+- **Never skip the snapshot after creating a skill.** Seeding puts the row in
+  the live DB only; content.sql is what survives `sc update` and `sc rebuild`.
+- **Never edit `0001_seed_skills.sql` by hand.** It is generated, and in a
+  fork it is upstream-owned engine territory — a local edit blocks the next
+  update.
+- **Never use the GUI to create skills.** Toggling grants in the GUI is fine
+  (snapshot after); creating is not — the GUI writes only to the DB and cannot
+  write the asset file or seed it. Use this procedure instead.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'snapshot',
+  'Persist DB work to git-tracked text — the admin/GUI step that runs sc snapshot / sc render. The .db is the live shared source of truth; serializing it to git writes the shared main tree, so it is gated to admin (SC_ADMIN) + the GUI Publish button, NOT a per-write shell step.',
+  'substrate',
+  'sc snapshot',
+  0,
+  '# snapshot — serialize the DB back to text
+
+The live `shell_db.db` is the **single source of truth shared by every shell** —
+a `sc mem` write is durable and visible to all shells the instant it commits.
+The `.db` is also **gitignored**, so it reconstructs from git-tracked text on
+`sc rebuild`; an edit not yet serialized is discarded by a rebuild (like an
+uncommitted working tree on a hard reset).
+
+**Serializing is an admin/GUI operation, not a per-write shell step.** It writes
+`.sc-state/` + the flat `_sc` mirror into the **shared MAIN worktree** — running
+it from a shell''s linked worktree churns and collides with other shells. So
+`sc snapshot` and `sc render flat` **refuse unless `SC_ADMIN=1`** (the GUI/API,
+`install`, `update`, and `render-check` set it for you). A shell does not run them;
+its writes are captured when admin snapshots (GUI **Publish**/Snapshot button, or
+`SC_ADMIN=1 sc snapshot`) before a rebuild. The rest of this skill is for that
+admin/GUI path.
+
+## The three text serializations
+
+| File(s) | What | Propagates? | Written by |
+|---|---|---|---|
+| `schema.sql` | the v1 baseline schema | yes (forks) | hand, rarely |
+| `migrations/*.sql` | ordered schema + **system content** deltas (e.g. the skills catalogue) | yes (forks) | author / `sc seed-skills` |
+| `.sc-state/content.sql` | **this repo''s** per-instance content + memory — shells, seed/L&S, decisions, roadmap, documents, flags, projects, skill grants. Tracked, fork-owned, kept OUTSIDE the gitignored engine dir | no (stays local) | `sc snapshot` |
+
+The split that matters: **system content propagates via migrations; per-instance
+content stays in the snapshot.** Skill *bodies* are system (migration); which
+shell is *granted* a skill is per-instance (snapshot).
+
+## When admin serializes (the GUI Publish button does all of this)
+
+All commands below require `SC_ADMIN=1` and are run from the **main checkout**.
+
+1. **`SC_ADMIN=1 sc snapshot`** — dumps the per-instance tables to
+   `.sc-state/content.sql` (deterministic DELETE-then-INSERT in PK order, so
+   re-running is byte-identical → clean diffs). Captures every shell''s accumulated
+   changes to identity, memory, roadmap, documents, flags, projects, or grants.
+
+2. **`SC_ADMIN=1 sc render`** — regenerates the tracked flat `_sc` visibility files
+   (`specs_sc/`, `docs_sc/`, `skills_sc/`, `roadmap_sc.md`) from the DB. Run it
+   when you changed a document body, the roadmap, or skills. Render is
+   incremental — unchanged files aren''t rewritten. (`.claude/skills/` is
+   rebuilt at boot, not here — it''s gitignored.)
+
+3. **Verify the rebuild reproduces:** `sc rebuild && sc verify`. The DB
+   should rebuild from text alone, byte-for-byte.
+
+   **Before committing any `_sc` render, run `sc render-check`.** It rebuilds
+   the DB hermetically (from text) and fails if the committed flat mirror drifts
+   from that render — the CI guard, reproduced locally. A plain `sc render`
+   renders from your *live* DB, which can lag the source you just edited (see the
+   skill-catalogue trap below); `render-check`''s rebuild-first is what catches
+   the stale mirror your live-DB render silently passed.
+
+4. **Publish** the text — don''t hand-commit it. `sc snapshot`/`render` write
+   `.sc-state/content.sql`, `.sc-state/engine.ref`, and the `_sc` files to the
+   **main checkout root** (where the shared engine + DB live), not your worktree,
+   so they aren''t yours to stage from a shell branch. The GUI **Publish** button
+   commits them and opens one PR (snapshot → render → commit → push → PR on
+   `sc_gui_content`); the admin shell on `main` can also commit them directly.
+   Never commit the `.db` or anything under the gitignored `.super-coder/` engine
+   dir. (In the super-coder SOURCE repo only, `schema.sql` + `migrations/` are
+   tracked and committed here too.)
+
+## Authoring vs. snapshotting
+
+- **Per-instance content** (your memory, this repo''s roadmap/docs): edit the DB,
+  then `sc snapshot`. The snapshot is the canonical reproducer.
+- **Skill catalogue** (system, propagates): edit `assets/skills/<name>/SKILL.md`,
+  then `sc seed-skills` — it upserts the live DB *and* (source repo only)
+  regenerates the seed migration. Not the snapshot. See `seed_skills.py`.
+  - Sequence is **`sc seed-skills && sc render`, then `sc render-check`**
+    before committing. Commit the regenerated `migrations/0001_seed_skills.sql`
+    *and* the re-rendered `skills_sc/` mirror together — the migration without
+    the mirror is the drift.
+
+> Steps 1–3 are durability — serialize so a `sc rebuild` can''t lose your work.
+> Step 4 is the GUI **Publish** button: it runs snapshot → render → commit →
+> push → PR on the `sc_gui_content` branch, so you rarely commit this text by
+> hand. The serialization lives at the main checkout root, not a worktree.
+
+## Related skills
+
+This skill owns the render/snapshot pipeline and the `render-check` guard; the
+skills that *feed* it link back here:
+
+- `self_update` — `sc update` re-renders these same `_sc` files; its verify
+  step runs `render-check` (this skill) before committing the engine bump.
+- `local_skill_management` — fork-local skills persist via `sc snapshot`; run
+  `render-check` before committing the `skills_sc/` mirror.
+- `migration_management` — a **content-seed** migration (skills, flavor
+  defaults) changes what renders; rebuild + render + `render-check` after.
+- `docs` / `spec` — document bodies live in the DB and render to `docs_sc/` /
+  `specs_sc/`; authored via `sc mem doc`, serialized here.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/engine_manifest.py
+++ b/.super-coder/scripts/engine_manifest.py
@@ -95,10 +95,24 @@ def _iter_files(engine_paths: list[str]) -> list[Path]:
     return out
 
 
-def write_manifest(engine_paths: list[str]) -> int:
-    """Record the engine's current on-disk state (call right after a
-    materialize, when disk == upstream). Returns the file count."""
-    entries = {str(rel): _sha256(REPO_ROOT / rel) for rel in _iter_files(engine_paths)}
+def write_manifest(engine_paths: list[str], files: list[str] | None = None) -> int:
+    """Record the engine's materialized state (call right after a materialize,
+    when disk == upstream). Returns the file count.
+
+    `files` — update/rollback pass the `git ls-tree` listing at the
+    materialized ref — is the EXACT upstream file set, so the manifest never
+    absorbs files that merely sit under an engine dir without being
+    upstream-owned: a fork-local skill's SKILL.md added to assets/skills/
+    (#253), or an upstream-retired file lingering on disk. Neither may guard —
+    and later block — a future update. Without `files` (install: disk == a
+    pristine clone), the engine dirs are walked on disk."""
+    if files is None:
+        rels = _iter_files(engine_paths)
+    else:
+        rels = [Path(f) for f in files
+                if not (_SKIP_NAMES & set(Path(f).parts))
+                and (REPO_ROOT / f).is_file()]
+    entries = {str(rel): _sha256(REPO_ROOT / rel) for rel in rels}
     MANIFEST.write_text(json.dumps(entries, indent=0, sort_keys=True) + "\n")
     return len(entries)
 

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -86,7 +86,8 @@ def restore_engine(prev_sha: str) -> None:
     ENGINE_REF.write_text(prev_sha + "\n")
     # Re-baseline the hash manifest at the restored engine — without this, the
     # next update would read every rolled-back file as a "local edit" and block.
-    engine_manifest.write_manifest(update_mod._engine_paths_at(prev_sha))
+    engine_manifest.write_manifest(update_mod._engine_paths_at(prev_sha),
+                                   files=update_mod._engine_files_at(prev_sha))
     print(f"→ engine re-materialized at {prev_sha[:12]} (engine.ref restored)")
 
 

--- a/.super-coder/scripts/seed_skills.py
+++ b/.super-coder/scripts/seed_skills.py
@@ -17,11 +17,17 @@ Source of truth for a skill = `assets/skills/<name>/SKILL.md`:
     ---
     <markdown body → skills.content>
 
-Output: `migrations/0001_seed_skills.sql` — idempotent UPSERTs for the authored
-engine catalogue. It deliberately does not delete/retire names absent from
-assets/skills; those may be project-local skills. Re-running regenerates it
-byte-for-byte. The migration is keyed by filename in the ledger, so it applies
-once per fork; `./sc update` also syncs the generated seed against the live DB.
+Two effects, one command:
+
+  1. Regenerate `migrations/0001_seed_skills.sql` — idempotent UPSERTs for the
+     authored engine catalogue. SOURCE REPO (and ejected forks) ONLY: in a
+     tracking fork the seed is materialized from upstream and manifest-guarded,
+     so a local regen would be an engine edit that blocks the next `./sc
+     update`. The seed deliberately never deletes/retires names absent from
+     assets/skills; those may be project-local skills.
+  2. UPSERT the parsed asset skills into the LIVE DB (all repos) — so a grant
+     right after seeding resolves (#253). The migration alone can't do that:
+     the ledger marks 0001 applied once and never re-runs it.
 
 Usage:
     python3 .super-coder/scripts/seed_skills.py
@@ -29,12 +35,14 @@ Usage:
 """
 from __future__ import annotations
 
+import sqlite3
 import sys
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
 SKILLS_DIR = ENGINE / "assets" / "skills"
 OUT = ENGINE / "migrations" / "0001_seed_skills.sql"
+DB_PATH = ENGINE / "shell_db.db"
 
 
 def sql_str(v) -> str:
@@ -73,9 +81,9 @@ SEED_FIELDS = ("description", "category", "command", "common", "content")
 
 
 def engine_skill_specs() -> list[dict]:
-    """Parse every engine skill under assets/skills/ — the seed's source of
-    truth and, by name, the line between engine and project-local skills (the
-    same set snapshot.dump_local_skills uses to decide what is fork-local)."""
+    """Parse every skill under assets/skills/ — the seed's source of truth.
+    NOTE: in a fork this set can include fork-LOCAL skills (authored assets);
+    the engine/local line is seeded_skill_names(), not this set."""
     if not SKILLS_DIR.exists():
         return []
     return [parse_skill(d / "SKILL.md")
@@ -83,7 +91,47 @@ def engine_skill_specs() -> list[dict]:
             if (d / "SKILL.md").exists()]
 
 
-def stale_engine_skills(con) -> list[str]:
+def seeded_skill_names() -> list[str]:
+    """Names the engine seed (migrations/0001) owns — THE engine/local boundary.
+
+    Asset-file presence is NOT the boundary (#253): a fork-authored skill keeps
+    its SKILL.md under assets/skills/ (gitignored engine territory) as its
+    authoring source, so classifying by asset presence miscounts it as engine —
+    snapshot then omits it from content.sql and the skill is lost on the next
+    update. The seed is authoritative instead: in a tracking fork, 0001 is
+    materialized from upstream and never regenerated locally (see main), so it
+    lists exactly the upstream catalogue; in the source repo it is regenerated
+    from assets and the two sets coincide.
+
+    Parsed by executing the seed against a scratch in-memory `skills` table —
+    the seed is generated SQL, so running it is the one parse that can't drift
+    from its format. Falls back to asset names when no seed exists yet.
+    """
+    if not OUT.exists():
+        return [s["name"] for s in engine_skill_specs()]
+    con = sqlite3.connect(":memory:")
+    try:
+        con.execute(
+            "CREATE TABLE skills (skill_id INTEGER PRIMARY KEY, "
+            "name TEXT NOT NULL UNIQUE, description TEXT, category TEXT, "
+            "content TEXT, command TEXT, common INTEGER NOT NULL DEFAULT 1, "
+            "is_deleted INTEGER NOT NULL DEFAULT 0)")
+        con.executescript(OUT.read_text())
+        return [r[0] for r in con.execute("SELECT name FROM skills ORDER BY name")]
+    finally:
+        con.close()
+
+
+def _engine_specs() -> list[dict]:
+    """Asset specs that are genuinely ENGINE skills (name in the seed). A
+    fork-local skill authored under assets/skills/ is excluded: it has no
+    upstream to lag, and healing it "from assets" would clobber a DB row that
+    is canonical once seeded."""
+    seeded = set(seeded_skill_names())
+    return [s for s in engine_skill_specs() if s["name"] in seeded]
+
+
+def stale_engine_skills(con, specs: list[dict] | None = None) -> list[str]:
     """Engine skills whose live-DB row lags assets/skills/. Names only.
 
     This is the drift the in-place `0001` regen can strand: a DB built before
@@ -92,12 +140,13 @@ def stale_engine_skills(con) -> list[str]:
     sync — see update.sync_skills — or a `./sc rebuild`). Rendering the flat
     mirror from such a DB writes STALE, possibly content-deleting, files.
 
-    Scoped to engine skills BY NAME: a project-local skill (name absent from
-    assets/skills/) has no upstream to lag, is never inspected here, and so can
-    never trip this guard — admin-authored repo-local skills are safe.
+    Scoped to engine skills BY NAME (seed names ∩ assets — see _engine_specs):
+    a project-local skill has no upstream to lag, is never inspected here, and
+    so can never trip this guard — admin-authored repo-local skills are safe
+    even while their asset file lingers under assets/skills/.
     """
     stale: list[str] = []
-    for want in engine_skill_specs():
+    for want in (_engine_specs() if specs is None else specs):
         row = con.execute(
             "SELECT description, category, command, common, content "
             "FROM skills WHERE name=?", (want["name"],),
@@ -110,7 +159,7 @@ def stale_engine_skills(con) -> list[str]:
     return stale
 
 
-def sync_engine_skills(con) -> list[str]:
+def sync_engine_skills(con, specs: list[dict] | None = None) -> list[str]:
     """Self-heal: bring the live DB's engine skills current with assets/skills/.
 
     Idempotent UPSERT BY NAME of exactly the engine skills that lag (per
@@ -118,16 +167,20 @@ def sync_engine_skills(con) -> list[str]:
     This is the cure the tripwire used to only point at — a DB stranded by an
     in-place `0001` regen repairs itself instead of needing a manual rebuild.
 
-    Project-local skills (name absent from assets/skills/) are never touched:
-    they aren't in the stale set, have no upstream to heal from, and stay
-    durable via content.sql. The caller owns the transaction boundary intent;
-    we commit our own writes."""
-    stale = stale_engine_skills(con)
+    Project-local skills (name absent from the seed) are never touched: they
+    aren't in the stale set, have no upstream to heal from, and stay durable
+    via content.sql. `main` passes specs=engine_skill_specs() (ALL assets) so
+    an explicit `./sc seed-skills` also upserts freshly-authored local skills;
+    the implicit boot/render heal stays engine-only. The caller owns the
+    transaction boundary intent; we commit our own writes."""
+    if specs is None:
+        specs = _engine_specs()
+    stale = stale_engine_skills(con, specs)
     if not stale:
         return []
-    specs = {s["name"]: s for s in engine_skill_specs()}
-    for name in stale:                       # stale ⊆ asset names, so always hits
-        s = specs[name]
+    by_name = {s["name"]: s for s in specs}
+    for name in stale:                       # stale ⊆ spec names, so always hits
+        s = by_name[name]
         con.execute(
             "INSERT INTO skills (name, description, category, command, common, "
             "content, is_deleted) VALUES (?, ?, ?, ?, ?, ?, 0) "
@@ -142,6 +195,38 @@ def sync_engine_skills(con) -> list[str]:
     return stale
 
 
+def _fork_mode() -> bool:
+    """True when this repo is an installed fork TRACKING upstream. There the
+    engine — including migrations/0001 — is materialized, upstream-owned, and
+    hash-manifest-guarded, so regenerating the seed locally would be an engine
+    edit that blocks the next `./sc update` (and would leak fork-local skills
+    into a file the next materialize rewrites anyway). The source repo and an
+    ejected fork own their engine and do regenerate."""
+    import update  # lazy — update.py imports this module; safe at call time
+    return not update.is_source_repo() and not update.EJECTED_MARKER.exists()
+
+
+def _upsert_live(skills: list[dict]) -> None:
+    """The documented half of seeding: put the parsed asset skills IN THE LIVE
+    DB, so a grant right after (`./sc skill grant`) resolves instead of being a
+    silent no-op (#253). Passing ALL asset specs (not just seed names) is what
+    lets a freshly-authored fork-local skill land."""
+    if not DB_PATH.exists() or not DB_PATH.stat().st_size:
+        print("seed_skills: no live DB yet — skills land on first rebuild/launch.")
+        return
+    import db_driver  # lazy — sibling module; keeps import surface unchanged
+    con = db_driver.connect(DB_PATH)
+    try:
+        synced = sync_engine_skills(con, specs=skills)
+    finally:
+        con.close()
+    if synced:
+        print(f"seed_skills: live DB — upserted {len(synced)} skill(s): "
+              + ", ".join(synced))
+    else:
+        print("seed_skills: live DB already current.")
+
+
 def main() -> int:
     if not SKILLS_DIR.exists():
         sys.exit(f"seed_skills: no {SKILLS_DIR}")
@@ -150,6 +235,13 @@ def main() -> int:
               if (d / "SKILL.md").exists()]
     if not skills:
         sys.exit("seed_skills: no skills found under assets/skills/")
+
+    if _fork_mode():
+        print("seed_skills: fork — the engine seed (0001) is upstream-owned; "
+              "skipping regen. Local skills persist via `./sc snapshot` "
+              "(.sc-state/content.sql), not the seed.")
+        _upsert_live(skills)
+        return 0
 
     lines = [
         "-- super-coder skills seed — GENERATED by scripts/seed_skills.py.",
@@ -179,6 +271,7 @@ def main() -> int:
     OUT.write_text("\n".join(lines) + "\n")
     print(f"seed_skills: wrote {OUT.relative_to(ENGINE.parent)} "
           f"({len(skills)} skill(s): {', '.join(s['name'] for s in skills)})")
+    _upsert_live(skills)
     return 0
 
 

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""`./sc skill` — the explicit write surface for the skill catalogue (#237).
+
+Skill grants used to live only as raw SQL blocks inside the
+local_skill_management skill, executable solely through the `sc sql-rw`
+escape hatch — and a grant whose skill name didn't resolve was a SILENT
+no-op (`INSERT ... SELECT` over zero rows, #253). This surface makes the
+lifecycle first-class and loud: unknown skill or shell names are hard
+errors, engine skills refuse `rm` (the seed would just resurrect them),
+and every write reminds you that `./sc snapshot` is the persistence step.
+
+Catalogue rows themselves are authored as assets + `./sc seed-skills`
+(engine + fork-local alike); this command manages what's GRANTED where,
+and retires local skills.
+
+Usage:
+    ./sc skill list                        catalogue: origin, common, grants
+    ./sc skill grant  <name> <shell>...    grant a skill to shell(s) (id or shortname)
+    ./sc skill revoke <name> <shell>...    revoke a skill from shell(s)
+    ./sc skill rm     <name>               soft-delete a LOCAL skill + revoke all grants
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import db_driver  # noqa: E402
+import seed_skills  # noqa: E402 — seeded_skill_names is the engine/local line
+
+ENGINE = Path(__file__).resolve().parents[1]
+DB_PATH = ENGINE / "shell_db.db"
+
+
+def connect():
+    if not DB_PATH.exists() or not DB_PATH.stat().st_size:
+        sys.exit("sc skill: no live DB — run `./sc rebuild` (or `./sc launch`) first.")
+    return db_driver.connect(DB_PATH)
+
+
+def resolve_shell(con, ref: str) -> tuple[int, str]:
+    """A shell by id or shortname → (shell_id, label). Loud on a miss."""
+    if ref.isdigit():
+        row = con.execute(
+            "SELECT shell_id, COALESCE(shortname, display_name, shell_id) FROM shells "
+            "WHERE shell_id=? AND COALESCE(is_deleted,0)=0", (int(ref),)).fetchone()
+    else:
+        row = con.execute(
+            "SELECT shell_id, shortname FROM shells "
+            "WHERE shortname=? COLLATE NOCASE AND COALESCE(is_deleted,0)=0",
+            (ref,)).fetchone()
+    if row:
+        return row[0], str(row[1])
+    have = con.execute(
+        "SELECT shell_id, COALESCE(shortname, display_name, '?') FROM shells "
+        "WHERE COALESCE(is_deleted,0)=0 ORDER BY shell_id").fetchall()
+    sys.exit(f"sc skill: no shell '{ref}' — have: "
+             + ", ".join(f"{i} ({n})" for i, n in have))
+
+
+def resolve_skill(con, name: str) -> int:
+    """A live skill row by name. Loud on a miss — the silent-no-op killer."""
+    row = con.execute(
+        "SELECT skill_id FROM skills WHERE name=? AND is_deleted=0", (name,)).fetchone()
+    if row:
+        return row[0]
+    sys.exit(f"sc skill: no skill '{name}' in the live DB — author "
+             f".super-coder/assets/skills/{name}/SKILL.md then `./sc seed-skills`.")
+
+
+def persist_note() -> None:
+    print("→ persist: ./sc snapshot   (serializes to .sc-state/content.sql — commit it)")
+
+
+def cmd_list(con) -> int:
+    engine = set(seed_skills.seeded_skill_names())
+    rows = con.execute(
+        "SELECT s.skill_id, s.name, s.common, s.is_deleted, "
+        "  (SELECT GROUP_CONCAT(COALESCE(sh.shortname, sh.shell_id), ', ') "
+        "   FROM shell_skills ss JOIN shells sh ON sh.shell_id = ss.shell_id "
+        "   WHERE ss.skill_id = s.skill_id AND COALESCE(sh.is_deleted,0)=0) "
+        "FROM skills s ORDER BY s.is_deleted, s.name").fetchall()
+    if not rows:
+        print("(no skills)")
+        return 0
+    w = max(len(r[1]) for r in rows)
+    for _, name, common, deleted, grants in rows:
+        origin = "engine" if name in engine else "local "
+        tag = "common" if common else "opt-in"
+        dead = "  [deleted]" if deleted else ""
+        print(f"{name:<{w}}  {origin}  {tag}  → {grants or '(ungranted)'}{dead}")
+    return 0
+
+
+def cmd_grant(con, name: str, shell_refs: list[str]) -> int:
+    skill_id = resolve_skill(con, name)
+    for ref in shell_refs:
+        shell_id, label = resolve_shell(con, ref)
+        cur = con.execute(
+            "INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+            (shell_id, skill_id))
+        print(f"grant: {name} → {label}"
+              + ("" if cur.rowcount else "  (already granted)"))
+    con.commit()
+    persist_note()
+    return 0
+
+
+def cmd_revoke(con, name: str, shell_refs: list[str]) -> int:
+    skill_id = resolve_skill(con, name)
+    for ref in shell_refs:
+        shell_id, label = resolve_shell(con, ref)
+        cur = con.execute(
+            "DELETE FROM shell_skills WHERE shell_id=? AND skill_id=?",
+            (shell_id, skill_id))
+        print(f"revoke: {name} ⇸ {label}"
+              + ("" if cur.rowcount else "  (was not granted)"))
+    con.commit()
+    persist_note()
+    return 0
+
+
+def cmd_rm(con, name: str) -> int:
+    skill_id = resolve_skill(con, name)
+    if name in set(seed_skills.seeded_skill_names()):
+        sys.exit(f"sc skill: '{name}' is an ENGINE skill — the seed re-inserts it "
+                 "on every update/rebuild, so a local rm cannot stick. Retire it "
+                 "upstream (or just `./sc skill revoke` it from your shells).")
+    n = con.execute("DELETE FROM shell_skills WHERE skill_id=?", (skill_id,)).rowcount
+    con.execute("UPDATE skills SET is_deleted=1 WHERE skill_id=?", (skill_id,))
+    con.commit()
+    print(f"rm: {name} soft-deleted, {n} grant(s) revoked.")
+    asset = ENGINE / "assets" / "skills" / name
+    if asset.exists():
+        print(f"  note: {asset.relative_to(ENGINE.parent)} still exists — remove it "
+              "or `./sc seed-skills` will re-insert the skill.")
+    persist_note()
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    usage = ("usage: ./sc skill list | grant <name> <shell>... | "
+             "revoke <name> <shell>... | rm <name>")
+    if not argv or argv[0] in ("-h", "--help", "help"):
+        print(usage)
+        return 0
+    cmd, args = argv[0], argv[1:]
+    con = connect()
+    try:
+        if cmd == "list" and not args:
+            return cmd_list(con)
+        if cmd == "grant" and len(args) >= 2:
+            return cmd_grant(con, args[0], args[1:])
+        if cmd == "revoke" and len(args) >= 2:
+            return cmd_revoke(con, args[0], args[1:])
+        if cmd == "rm" and len(args) == 1:
+            return cmd_rm(con, args[0])
+        sys.exit(usage)
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 import db_driver  # noqa: E402
 import map_db  # noqa: E402 — sibling module in scripts/
+import seed_skills  # noqa: E402 — seeded_skill_names is the engine/local line
 from _serialize_guard import require_admin  # noqa: E402
 
 ENGINE = Path(__file__).resolve().parents[1]
@@ -89,27 +90,16 @@ def table_exists(con, name: str) -> bool:
 
 
 def engine_skill_names() -> list[str]:
-    """Names authored by the engine seed assets.
+    """Names the ENGINE SEED owns (seed_skills.seeded_skill_names — i.e.
+    migrations/0001, upstream-materialized in a fork).
 
     Any live skill whose name is not in this set is project-local and belongs in
-    `.sc-state/content.sql`. This keeps local skills durable while engine
-    updates can still UPSERT their own catalogue rows.
+    `.sc-state/content.sql`. Keyed off the seed, NOT asset-file presence (#253):
+    a fork-authored skill keeps its SKILL.md under assets/skills/ as authoring
+    source, and classifying by asset presence would silently drop it from
+    content.sql — losing it on the next update's materialize.
     """
-    skills_dir = ENGINE / "assets" / "skills"
-    names: list[str] = []
-    for path in sorted(skills_dir.glob("*/SKILL.md")):
-        text = path.read_text()
-        if not text.startswith("---"):
-            continue
-        try:
-            _, fm, _ = text.split("---", 2)
-        except ValueError:
-            continue
-        for line in fm.strip().splitlines():
-            if line.startswith("name:"):
-                names.append(line.split(":", 1)[1].strip())
-                break
-    return names
+    return seed_skills.seeded_skill_names()
 
 
 def dump_shell_skills(con) -> list[str]:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -141,6 +141,17 @@ def _engine_paths_at(ref: str) -> list[str]:
     return present
 
 
+def _engine_files_at(ref: str) -> list[str]:
+    """The exact FILE list upstream ships at `ref` under the engine paths —
+    what a materialize writes, so what the manifest must cover and nothing
+    more. Locally-added files under engine dirs (e.g. a fork-local skill's
+    SKILL.md) and upstream-retired stragglers on disk stay out of the manifest:
+    they are not upstream-owned, so they must never guard — and later block —
+    a future update (see engine_manifest.write_manifest)."""
+    return git("ls-tree", "-r", "--name-only", ref,
+               "--", *_engine_paths_at(ref)).stdout.splitlines()
+
+
 def materialize_engine(ref: str) -> None:
     """Write the engine paths at `ref` into the working tree WITHOUT touching the
     git index — the engine is gitignored, so a `git checkout -- <paths>` (which
@@ -209,7 +220,8 @@ def fetch_and_materialize(branch: str, ref: str | None = None,
 
     materialize_engine(sha)
     ENGINE_REF.write_text(sha + "\n")
-    n = engine_manifest.write_manifest(_engine_paths_at(sha))
+    n = engine_manifest.write_manifest(_engine_paths_at(sha),
+                                       files=_engine_files_at(sha))
     print(f"  engine pinned at {sha[:12]} (.sc-state/engine.ref) · manifest over {n} files")
 
 

--- a/sc
+++ b/sc
@@ -602,8 +602,9 @@ case "$cmd" in
   # shell into `cd`-ing to the root — the cwd trap). Read-only is ENFORCED
   # (sqlite3 -readonly), matching the label: writes go via `sc mem`
   # (triggers/caps). The -rw variants are the explicit escape hatch for the few
-  # procedures with no API surface (skill grants, cartographer map authoring) —
-  # only use one where a skill names it.
+  # procedures with no dedicated surface (direct skill INSERTs, cartographer
+  # map authoring) — only use one where a skill names it. Skill grants have
+  # their own surface now: `./sc skill`.
   sql)          exec sqlite3 -readonly "$DB" "$@" ;;
   map-sql)      exec sqlite3 -readonly "$MAPDB" "$@" ;;
   sql-rw)       exec sqlite3 "$DB" "$@" ;;
@@ -619,6 +620,9 @@ case "$cmd" in
                 exec "$PY" "$S/map_repo.py" ;;
   map-setup)    exec "$PY" "$S/map_setup.py" ;;
   seed-skills)  exec "$PY" "$S/seed_skills.py" ;;
+  # Skill catalogue write surface — grants/retirement by name, loud on a miss
+  # (the raw-SQL grant's silent no-op class). Snapshot is still the persist step.
+  skill)        exec "$PY" "$S/skill.py" "$@" ;;
   ports)        exec "$PY" "$S/ports.py" show ;;
   preview)      exec "$PY" "$S/preview.py" "$@" ;;
   # ── in-container primitives (no docker; also the host escape hatch) ──
@@ -803,12 +807,14 @@ super-coder — forkable shell substrate
   sc sql "<query>"         read-only passthrough to the engine DB (schema/skills/flags) — absolute path, cwd-independent (no `cd` to root)
   sc map-sql "<query>"     read-only passthrough to the repo-map DB (dr_* catalogue) — absolute path, cwd-independent
   sc sql-rw / map-sql-rw   read-WRITE passthroughs — bypass the API's triggers/caps; `sc mem` is the write path.
-                             Only for procedures with no API surface (skill grants, map authoring) where a skill names it
+                             Only for procedures with no API surface (map authoring) where a skill names it
+  ./sc skill <cmd>         skill catalogue surface: list · grant <name> <shell>... · revoke <name> <shell>... · rm <name>
+                             shells by id or shortname; rm refuses engine skills; snapshot after writes to persist
   ./sc render              render tracked flat _sc files (specs/docs/skills/roadmap)
   ./sc render-check        fail if committed flat _sc files drift from the DB render (CI guard; rebuild first for a hermetic check)
   ./sc map                 scan the host repo into the dr_* catalogue (re-runnable)
   ./sc map-setup           wire the auto-remap git hooks (core.hooksPath) + map — the cartographer's one-shot
-  ./sc seed-skills         regenerate the skills seed migration from assets/skills/
+  ./sc seed-skills         upsert assets/skills/ into the live DB (+ regenerate the seed migration — source repo only)
   ./sc init                seed a fresh fork's first user + shell (run once after install)
 
   Sandbox (docker — the default way to run; allow-everything is safe because the

--- a/skills_sc/db_map.md
+++ b/skills_sc/db_map.md
@@ -65,7 +65,7 @@ returns 0 rows instead of erroring, so it looks like an empty map. Never query
 | `feature_blockers` | the roadmap's dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite must land first). Directed, kept acyclic (the GUI Flow view wires them; the card's "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `sc mem roadmap depends` |
 | `documents` | the content store — specs/docs bodies live here; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; never edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
-| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine |
+| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine; grants via `./sc skill grant/revoke` |
 | `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a **work-stream** that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
 
 `<self>` = your `shell_id` (in the boot doc's ACTIVE SESSION block).

--- a/skills_sc/local_skill_management.md
+++ b/skills_sc/local_skill_management.md
@@ -15,12 +15,15 @@ Create, persist, assign, and remove fork-specific skills — the correct authori
 # local_skill_management — fork-specific skills that survive
 
 Fork-specific skills live in the DB and are persisted via `.sc-state/content.sql`
-(the snapshot). The asset file under `.super-coder/assets/skills/` is used to
-**seed the skill initially** — but that directory is gitignored engine territory:
-`sc update` materializes upstream engine files there, which removes any local
-additions. After the first seed + snapshot, **content.sql is the durable form**.
+(the snapshot). The asset file under `.super-coder/assets/skills/<name>/` is the
+**authoring source** — edit it, re-seed, done. It sits in gitignored engine
+territory, but that is safe: the engine/local boundary is the seed migration
+(0001, upstream-owned in a fork), not asset-file presence, so the snapshot
+serializes your skill to content.sql whether or not the asset file is kept, and
+`sc update` neither manifests it nor heals over its DB row. **content.sql is
+the durable form; the asset file is your editor.**
 
-The correct path: **file → seed → grant → snapshot → commit**.
+The path: **file → seed → grant → snapshot → commit**.
 
 ## Creating a fork-specific skill
 
@@ -38,73 +41,67 @@ The correct path: **file → seed → grant → snapshot → commit**.
    Body: Markdown. Write the procedure the shell will follow. Imperative,
    precise — this is what boots into context, so compress ruthlessly.
 
-2. **Seed the skill into the DB.**
+2. **Seed the skill into the live DB.**
    ```bash
-   cd <repo> && sc seed-skills
+   sc seed-skills
    ```
-   UPSERTs the skill row into the live DB by name (id-stable). Does not touch
-   skills already in the DB that are absent from assets — those are other local
-   skills, left intact.
+   UPSERTs every asset skill into the live DB by name (id-stable) and reports
+   what landed. In a fork it deliberately does NOT regenerate the seed
+   migration — that file is upstream-owned engine territory. Skills already in
+   the DB with no asset file are other local skills, left intact.
 
-3. **Grant the skill to the target shell(s).**
-   Skill grants have no API surface — these writes run via `./sc sql-rw "<SQL>"`
-   (the explicit read-write passthrough; `sc sql` is read-only and will refuse).
-   Find shell IDs:
-   ```sql
-   SELECT shell_id, display_name, flavor FROM shells WHERE is_deleted = 0;
+3. **Grant the skill to the target shell(s)** — by shell id or shortname:
+   ```bash
+   sc skill grant <skill_name> <shell>...
    ```
-   Grant:
-   ```sql
-   INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
-   SELECT <shell_id>, skill_id FROM skills
-   WHERE name = '<skill_name>' AND is_deleted = 0;
-   ```
+   Unknown skill or shell names are hard errors (no silent no-op grants).
+   `sc skill list` shows the catalogue with origins and current grants;
+   `sc skill revoke <name> <shell>...` reverses a grant.
 
 4. **Snapshot — this is the persistence step.**
    ```bash
    sc snapshot && sc render
    ```
-   `snapshot.py` serializes local skills (any skill whose name is not in the
-   upstream engine assets) into `.sc-state/content.sql`. This is what survives
-   `sc update` — when the engine materialize overwrites `.super-coder/assets/
-   skills/`, the skill row and its full content are reconstructed from
-   content.sql on rebuild. Without this step the skill is lost on next update.
+   `snapshot.py` serializes local skills (any skill the engine seed doesn't
+   own) into `.sc-state/content.sql`. This is what survives `sc update` and
+   `sc rebuild` — the skill row and its grants are reconstructed from
+   content.sql. Without this step the skill is lost on next update.
 
 5. **Commit.**
    Run `sc render-check` first — it rebuilds hermetically and fails if the
    `skills_sc/` mirror drifts from the DB render (the same CI guard; see the
    `snapshot` skill). Then stage `.sc-state/content.sql` and `skills_sc/`
-   together — the snapshot without the re-rendered mirror is the drift. The asset
-   file and `0001_seed_skills.sql` are transient for local skills — don't rely on
-   them across updates.
+   together — the snapshot without the re-rendered mirror is the drift.
+
+## Updating a skill
+
+Edit the asset file, then repeat seed → snapshot → commit (steps 2, 4, 5). If
+the asset file is gone (removed, or authored elsewhere), recreate it from the
+DB body first: `sc sql "SELECT content FROM skills WHERE name='<name>'"`.
 
 ## Assigning an existing skill to additional shells
 
-Via `./sc sql-rw "<SQL>"`:
-```sql
-INSERT OR IGNORE INTO shell_skills (shell_id, skill_id)
-SELECT <shell_id>, skill_id FROM skills
-WHERE name = '<skill_name>' AND is_deleted = 0;
+```bash
+sc skill grant <skill_name> <shell>...
 ```
 Then `sc snapshot && sc render` and commit.
 
 ## Removing a skill
 
-1. **Soft-delete the DB row and revoke grants.**
-   Via `./sc sql-rw "<SQL>"`:
-   ```sql
-   UPDATE skills SET is_deleted = 1 WHERE name = '<name>';
-   DELETE FROM shell_skills
-   WHERE skill_id = (SELECT skill_id FROM skills WHERE name = '<name>');
+1. **Soft-delete the row and revoke its grants:**
+   ```bash
+   sc skill rm <skill_name>
    ```
+   Refuses engine skills — the seed would resurrect those on the next
+   update/rebuild; `sc skill revoke` them per-shell instead.
 
-2. **Snapshot, render, commit.**
+2. **Remove the asset file** (`.super-coder/assets/skills/<name>/`) — otherwise
+   the next `sc seed-skills` re-inserts the skill.
+
+3. **Snapshot, render, commit.**
    ```bash
    sc snapshot && sc render
    ```
-   The deletion serializes to content.sql. If the asset file still exists under
-   `.super-coder/assets/skills/`, remove it too so `sc seed-skills` doesn't
-   re-insert it.
 
 ## How the GUI organizes skills
 
@@ -113,30 +110,25 @@ per-shell grant toggles on every skill. The Shells tab groups its grant list
 by the same sections.
 
 - **Repo skills** — the lead section: skills authored in this fork. Membership
-  is *derived*, not declared — a skill whose name has no
-  `.super-coder/assets/skills/<name>/SKILL.md` is repo-local. This is the same
-  rule snapshot.py uses to decide what serializes into `.sc-state/content.sql`,
-  so the section shows exactly what the snapshot keeps durable. No frontmatter
-  flag exists or is needed.
+  is *derived*, not declared — a skill the engine seed doesn't own is
+  repo-local. This is the same rule snapshot.py uses to decide what serializes
+  into `.sc-state/content.sql`, so the section shows exactly what the snapshot
+  keeps durable. No frontmatter flag exists or is needed.
 - **Substrate / Craft / …** — engine skills, sectioned by their `category`
   frontmatter. A repo skill's `category` still displays as a label on its row,
   but never moves it out of the Repo section.
-- One transient caveat: while a repo skill's asset file still sits under
-  `assets/skills/` (between authoring and the next `sc update` materialize),
-  the derivation reads it as engine — it appears under its category section
-  until the update wipes the asset. Harmless; the DB row is the durable thing.
 
-Grant toggles in the GUI hit the same DB table as the SQL in this skill —
-they still need a **snapshot** (header button or `sc snapshot`) to survive
-a rebuild.
+Grant toggles in the GUI hit the same DB table as `sc skill grant` — they
+still need a **snapshot** (header button or `sc snapshot`) to survive a
+rebuild.
 
 ## What NOT to do
 
-- **Never skip the snapshot after creating a skill.** The asset file under
-  `.super-coder/assets/skills/` is overwritten by `sc update`. If you seed
-  without snapshotting, the skill vanishes on the next engine update.
-- **Never edit `0001_seed_skills.sql` by hand.** It is generated; hand edits
-  are overwritten on the next `sc seed-skills`.
+- **Never skip the snapshot after creating a skill.** Seeding puts the row in
+  the live DB only; content.sql is what survives `sc update` and `sc rebuild`.
+- **Never edit `0001_seed_skills.sql` by hand.** It is generated, and in a
+  fork it is upstream-owned engine territory — a local edit blocks the next
+  update.
 - **Never use the GUI to create skills.** Toggling grants in the GUI is fine
   (snapshot after); creating is not — the GUI writes only to the DB and cannot
   write the asset file or seed it. Use this procedure instead.

--- a/skills_sc/snapshot.md
+++ b/skills_sc/snapshot.md
@@ -81,16 +81,12 @@ All commands below require `SC_ADMIN=1` and are run from the **main checkout**.
 - **Per-instance content** (your memory, this repo's roadmap/docs): edit the DB,
   then `sc snapshot`. The snapshot is the canonical reproducer.
 - **Skill catalogue** (system, propagates): edit `assets/skills/<name>/SKILL.md`,
-  then `sc seed-skills` to regenerate the seed migration — **not** the
-  snapshot. See `seed_skills.py`.
-  - **The stale-mirror trap:** `seed-skills` writes the new body into the
-    *migration*, but your **live DB still holds the old body** until you apply
-    it. So `sc render` now renders the *stale* skill into `skills_sc/<name>.md`
-    and passes — while CI's hermetic rebuild (new body) drifts and goes red.
-    Sequence is **`sc seed-skills && sc rebuild && sc render`, then
-    `sc render-check`** before committing. Commit the regenerated
-    `migrations/0001_seed_skills.sql` *and* the re-rendered `skills_sc/` mirror
-    together — the migration without the mirror is the drift.
+  then `sc seed-skills` — it upserts the live DB *and* (source repo only)
+  regenerates the seed migration. Not the snapshot. See `seed_skills.py`.
+  - Sequence is **`sc seed-skills && sc render`, then `sc render-check`**
+    before committing. Commit the regenerated `migrations/0001_seed_skills.sql`
+    *and* the re-rendered `skills_sc/` mirror together — the migration without
+    the mirror is the drift.
 
 > Steps 1–3 are durability — serialize so a `sc rebuild` can't lose your work.
 > Step 4 is the GUI **Publish** button: it runs snapshot → render → commit →

--- a/tests/test_local_skill_persistence.py
+++ b/tests/test_local_skill_persistence.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Tests for Patch C — fork-local skill persistence (#253, #237 pt2).
+
+The load-bearing property: the engine/local boundary is the SEED's names
+(migrations/0001), not asset-file presence. A fork-authored skill keeps its
+SKILL.md under assets/skills/ as authoring source and must still
+
+  • be upserted into the live DB by `sc seed-skills` (grants resolve right
+    after seeding — the #253 silent-no-op),
+  • serialize into .sc-state/content.sql (snapshot classifies it local),
+  • never be "healed" over by the boot/render engine-skill heal,
+  • never enter the engine hash manifest (ls-tree-scoped write_manifest).
+
+Uses a synthetic two-skill world (eng_a seeded, loc_b asset-only) by pointing
+seed_skills' module globals at a tmp tree — the real assets/ and migrations/
+are never touched. Stdlib `unittest`, matching the engine's style.
+
+Run:
+    python3 tests/test_local_skill_persistence.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import unittest
+import sys
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import engine_manifest  # noqa: E402
+import seed_skills  # noqa: E402
+import skill as skill_mod  # noqa: E402
+import snapshot as snapshot_mod  # noqa: E402
+
+SKILLS_DDL = (
+    "CREATE TABLE skills (skill_id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE, "
+    "description TEXT, category TEXT, content TEXT, command TEXT, "
+    "common INTEGER NOT NULL DEFAULT 1, is_deleted INTEGER NOT NULL DEFAULT 0)")
+SHELLS_DDL = (
+    "CREATE TABLE shells (shell_id INTEGER PRIMARY KEY, shortname TEXT, "
+    "display_name TEXT, is_deleted INTEGER DEFAULT 0)")
+GRANTS_DDL = (
+    "CREATE TABLE shell_skills (shell_skill_id INTEGER PRIMARY KEY, "
+    "shell_id INTEGER NOT NULL, skill_id INTEGER NOT NULL, UNIQUE(shell_id, skill_id))")
+
+
+def write_asset(root: Path, name: str, body: str) -> None:
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {name} desc\ncommon: false\n---\n{body}\n")
+
+
+class LocalSkillWorld(unittest.TestCase):
+    """Synthetic world: assets = {eng_a, loc_b}; seed (0001) = {eng_a} only."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.skills_dir = self.tmp / "assets" / "skills"
+        write_asset(self.skills_dir, "eng_a", "engine body v2")
+        write_asset(self.skills_dir, "loc_b", "local body v1")
+        self.out = self.tmp / "migrations" / "0001_seed_skills.sql"
+        self.out.parent.mkdir(parents=True)
+        self.out.write_text(
+            "BEGIN;\nINSERT INTO skills (name, description, category, command, "
+            "common, content, is_deleted) VALUES ('eng_a', 'eng_a desc', NULL, "
+            "NULL, 0, 'engine body v2', 0)\nON CONFLICT(name) DO UPDATE SET\n"
+            "  description=excluded.description, category=excluded.category,\n"
+            "  command=excluded.command, common=excluded.common,\n"
+            "  content=excluded.content, is_deleted=0;\nCOMMIT;\n")
+        self._saved = (seed_skills.SKILLS_DIR, seed_skills.OUT)
+        seed_skills.SKILLS_DIR = self.skills_dir
+        seed_skills.OUT = self.out
+        self.con = sqlite3.connect(":memory:")
+        self.con.execute(SKILLS_DDL)
+        # Live DB state: eng_a lags its asset (v1 on disk-of-DB, v2 in asset);
+        # loc_b row exists with a body that has drifted from its asset.
+        self.con.execute(
+            "INSERT INTO skills (name, description, common, content) "
+            "VALUES ('eng_a', 'eng_a desc', 0, 'engine body v1')")
+        self.con.execute(
+            "INSERT INTO skills (name, description, common, content) "
+            "VALUES ('loc_b', 'loc_b desc', 0, 'local body EDITED IN DB')")
+        self.con.commit()
+
+    def tearDown(self):
+        seed_skills.SKILLS_DIR, seed_skills.OUT = self._saved
+        self.con.close()
+
+    def test_seed_names_come_from_the_seed_not_assets(self):
+        self.assertEqual(seed_skills.seeded_skill_names(), ["eng_a"])
+
+    def test_seed_names_fall_back_to_assets_without_a_seed(self):
+        seed_skills.OUT = self.tmp / "missing.sql"
+        self.assertEqual(seed_skills.seeded_skill_names(), ["eng_a", "loc_b"])
+
+    def test_heal_flags_engine_skill_but_never_local_asset(self):
+        # eng_a lags its asset → stale; loc_b's DB row drifted from its asset
+        # but the heal must not see it (its DB row is canonical once seeded).
+        self.assertEqual(seed_skills.stale_engine_skills(self.con), ["eng_a"])
+        healed = seed_skills.sync_engine_skills(self.con)
+        self.assertEqual(healed, ["eng_a"])
+        rows = dict(self.con.execute("SELECT name, content FROM skills"))
+        self.assertEqual(rows["eng_a"], "engine body v2")       # healed
+        self.assertEqual(rows["loc_b"], "local body EDITED IN DB")  # untouched
+
+    def test_explicit_seed_upserts_local_assets_too(self):
+        # `sc seed-skills` passes ALL asset specs — the #253 fix: a freshly
+        # authored local skill lands in the live DB, grantable immediately.
+        self.con.execute("DELETE FROM skills WHERE name='loc_b'")
+        synced = seed_skills.sync_engine_skills(
+            self.con, specs=seed_skills.engine_skill_specs())
+        self.assertIn("loc_b", synced)
+        row = self.con.execute(
+            "SELECT content FROM skills WHERE name='loc_b'").fetchone()
+        self.assertEqual(row[0], "local body v1")
+
+    def test_snapshot_classifies_local_by_seed_despite_lingering_asset(self):
+        # The #253 defect: loc_b has an asset file, but it is NOT the engine's —
+        # snapshot must still serialize it into content.sql.
+        lines = "\n".join(snapshot_mod.dump_local_skills(self.con))
+        self.assertIn("'loc_b'", lines)
+        self.assertNotIn("'engine body", lines)  # eng_a stays with the seed
+        # and the DELETE guard keeps seed-owned names, nothing else.
+        self.assertIn("DELETE FROM skills WHERE name NOT IN ('eng_a');", lines)
+
+
+class SkillCommandTest(unittest.TestCase):
+    """`./sc skill` — loud grants/revokes/rm against a throwaway DB."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        con = sqlite3.connect(self.db)
+        con.executescript(SKILLS_DDL + ";" + SHELLS_DDL + ";" + GRANTS_DDL + ";")
+        con.execute("INSERT INTO shells (shell_id, shortname) VALUES (1, 'dev1')")
+        con.execute("INSERT INTO skills (name, common) VALUES ('eng_a', 1)")
+        con.execute("INSERT INTO skills (name, common) VALUES ('loc_b', 0)")
+        con.commit()
+        con.close()
+        self._saved_db = skill_mod.DB_PATH
+        skill_mod.DB_PATH = self.db
+        # Pin the engine/local line for rm: eng_a is seed-owned.
+        self._saved_names = seed_skills.seeded_skill_names
+        seed_skills.seeded_skill_names = lambda: ["eng_a"]
+
+    def tearDown(self):
+        skill_mod.DB_PATH = self._saved_db
+        seed_skills.seeded_skill_names = self._saved_names
+
+    def grants(self):
+        con = sqlite3.connect(self.db)
+        try:
+            return con.execute(
+                "SELECT ss.shell_id, s.name FROM shell_skills ss "
+                "JOIN skills s USING (skill_id)").fetchall()
+        finally:
+            con.close()
+
+    def test_grant_revoke_roundtrip_by_shortname_and_id(self):
+        self.assertEqual(skill_mod.main(["grant", "loc_b", "dev1"]), 0)
+        self.assertEqual(self.grants(), [(1, "loc_b")])
+        self.assertEqual(skill_mod.main(["revoke", "loc_b", "1"]), 0)
+        self.assertEqual(self.grants(), [])
+
+    def test_unknown_skill_or_shell_is_a_hard_error(self):
+        with self.assertRaises(SystemExit):
+            skill_mod.main(["grant", "nope", "dev1"])   # the silent-no-op class
+        with self.assertRaises(SystemExit):
+            skill_mod.main(["grant", "loc_b", "ghost"])
+        self.assertEqual(self.grants(), [])
+
+    def test_rm_refuses_engine_and_retires_local(self):
+        with self.assertRaises(SystemExit):
+            skill_mod.main(["rm", "eng_a"])
+        skill_mod.main(["grant", "loc_b", "dev1"])
+        self.assertEqual(skill_mod.main(["rm", "loc_b"]), 0)
+        con = sqlite3.connect(self.db)
+        deleted = con.execute(
+            "SELECT is_deleted FROM skills WHERE name='loc_b'").fetchone()[0]
+        con.close()
+        self.assertEqual(deleted, 1)
+        self.assertEqual(self.grants(), [])
+
+
+class ManifestScopeTest(unittest.TestCase):
+    """write_manifest(files=…) covers exactly the given upstream list — a
+    locally-added file under an engine dir never enters the manifest."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        (self.tmp / "assets").mkdir()
+        (self.tmp / "assets" / "upstream.md").write_text("upstream\n")
+        (self.tmp / "assets" / "local_addition.md").write_text("mine\n")
+        self._saved = (engine_manifest.REPO_ROOT, engine_manifest.MANIFEST)
+        engine_manifest.REPO_ROOT = self.tmp
+        engine_manifest.MANIFEST = self.tmp / "engine.manifest"
+
+    def tearDown(self):
+        engine_manifest.REPO_ROOT, engine_manifest.MANIFEST = self._saved
+
+    def test_files_list_scopes_the_manifest(self):
+        n = engine_manifest.write_manifest(["assets"], files=["assets/upstream.md"])
+        self.assertEqual(n, 1)
+        recorded = engine_manifest.MANIFEST.read_text()
+        self.assertIn("assets/upstream.md", recorded)
+        self.assertNotIn("local_addition", recorded)
+        # …so editing/removing the local file can never block an update.
+        (self.tmp / "assets" / "local_addition.md").unlink()
+        self.assertEqual(engine_manifest.local_edits(), {})
+
+    def test_disk_walk_remains_the_install_default(self):
+        n = engine_manifest.write_manifest(["assets"])
+        self.assertEqual(n, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #253; completes #237 (pt 2 — a real write surface for skill grants).

The documented fork-skill authoring path (file → seed → grant → snapshot) produced a skill that wasn't granted and didn't survive `sc update`, because `sc seed-skills` never touched the live DB and snapshot classified "engine vs local" by asset-file presence. This makes the documented path true:

- **`sc seed-skills` upserts the live DB** (reports what landed), so the grant right after seeding resolves. In a tracking fork it skips the 0001 regen — the seed is upstream-owned, manifest-guarded engine territory; a local rewrite would block the next update.
- **The engine/local boundary is the seed's names (0001), not asset presence.** One rule, three consumers: snapshot's content.sql dump, the boot/render heal (which now can never clobber a local skill's DB row from its lingering asset), and the GUI's Repo section (shared `engine_skill_names()`). The asset file becomes what the old skill text claimed it was: a harmless, durable authoring source.
- **`./sc skill list/grant/revoke/rm`** replaces the raw-SQL-over-`sql-rw` grant procedure. Unknown skill/shell names are hard errors — the `INSERT … SELECT`-over-zero-rows silent no-op class is dead. `rm` refuses seed-owned skills (the seed would resurrect them).
- **The engine hash manifest is scoped to `git ls-tree` at the materialized ref** (update + rollback), so a fork-local skill's asset — or an upstream-retired straggler — never enters the manifest and can't block a later update. Install keeps the disk walk (disk == pristine clone).
- Skill texts (`local_skill_management`, `snapshot`, `db_map`) updated to the now-true flow; forward reseed **0042** carries them to installed forks (validated byte-identical to the regenerated 0001).

Note for forks that previously ran `seed-skills` locally: their polluted 0001 self-heals on the next repin (materialize rewrites it); until then a fork-local name stranded in 0001 classifies as engine — the known workaround (row in content.sql, no asset) is unaffected.

## Test plan
- [x] `./sc test` — 231 passed (incl. 10 new in `test_local_skill_persistence.py`: seed-keyed classification with lingering asset, heal never touches local rows, explicit seed upserts local assets, `sc skill` grant/revoke/rm + hard errors, manifest `files=` scoping)
- [x] `./sc render-check` — hermetic rebuild (schema + 0001…0042) matches `skills_sc/` mirrors
- [x] End-to-end fork repro (clone with non-super-coder origin + live DB): author asset → `./sc seed-skills` (skips regen, 0001 clean, upserts) → `./sc skill grant` → `SC_ADMIN=1 ./sc snapshot` (skill + grant in content.sql, asset still present) → `./sc rebuild` → skill + grant survive
- [x] Live smoke on dogfood DB: `sc skill list` (deleted shells hidden), grant/revoke roundtrip by id + case-insensitive shortname, `rm` refuses engine skill, unknown names error loudly

🤖 Generated with [Claude Code](https://claude.com/claude-code)