### PR TITLE
fix(skills): Patch D — decisions read-trigger: sc mem get decisions in docs + blueprint, supersede nudge (#267)

### DIFF
--- a/.super-coder/assets/skills/blueprint/SKILL.md
+++ b/.super-coder/assets/skills/blueprint/SKILL.md
@@ -14,15 +14,19 @@ steps, so the work has a shape before you start cutting.
 
 1. **Restate the objective** in one sentence + the done-condition (how you'll
    know it's finished).
-2. **Decompose** into concrete steps — each a unit you could verify on its own.
-3. **Order by dependency** — what must precede what. Mark steps with no
+2. **Re-surface prior decisions** — `sc mem get decisions`: has any part of
+   this already been settled? A recorded decision constrains the plan; honor
+   it, or supersede it explicitly (`sc mem decision "…" --parent <old_id>`) —
+   never silently re-litigate.
+3. **Decompose** into concrete steps — each a unit you could verify on its own.
+4. **Order by dependency** — what must precede what. Mark steps with no
    dependency on each other as **parallelizable**.
-4. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
+5. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
    to ground this in the real repo), and its **verification** (test, run,
    review).
-5. **Risks / unknowns** — what could break the plan; resolve the riskiest
+6. **Risks / unknowns** — what could break the plan; resolve the riskiest
    unknown first (spike it) rather than last.
-6. **Gate** — the adversarial check before calling it done: does each step's
+7. **Gate** — the adversarial check before calling it done: does each step's
    verification actually prove the done-condition?
 
 ## Stance

--- a/.super-coder/assets/skills/docs/SKILL.md
+++ b/.super-coder/assets/skills/docs/SKILL.md
@@ -74,11 +74,17 @@ needs no work-stream.
 
 ## Review first
 
-Before writing, see what exists — don't duplicate:
+Before writing, see what exists — don't duplicate, and don't re-litigate:
 ```
 sc mem get documents      # every spec/doc in the engine DB (kind, seq, frozen, task_count)
+sc mem get decisions      # prior Major decisions — is what you're about to plan already settled?
 sc map-sql "SELECT path FROM dr_filepath WHERE role='doc';"  -- repo's own docs (map db)
 ```
+
+If the spec you're about to write touches a recorded decision, honor it or
+supersede it **explicitly** — say so in the spec, and record the new decision
+with `sc mem decision "…" --parent <old_id>`. Never silently re-decide a
+settled choice.
 
 ## Author
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -187,15 +187,19 @@ steps, so the work has a shape before you start cutting.
 
 1. **Restate the objective** in one sentence + the done-condition (how you''ll
    know it''s finished).
-2. **Decompose** into concrete steps — each a unit you could verify on its own.
-3. **Order by dependency** — what must precede what. Mark steps with no
+2. **Re-surface prior decisions** — `sc mem get decisions`: has any part of
+   this already been settled? A recorded decision constrains the plan; honor
+   it, or supersede it explicitly (`sc mem decision "…" --parent <old_id>`) —
+   never silently re-litigate.
+3. **Decompose** into concrete steps — each a unit you could verify on its own.
+4. **Order by dependency** — what must precede what. Mark steps with no
    dependency on each other as **parallelizable**.
-4. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
+5. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
    to ground this in the real repo), and its **verification** (test, run,
    review).
-5. **Risks / unknowns** — what could break the plan; resolve the riskiest
+6. **Risks / unknowns** — what could break the plan; resolve the riskiest
    unknown first (spike it) rather than last.
-6. **Gate** — the adversarial check before calling it done: does each step''s
+7. **Gate** — the adversarial check before calling it done: does each step''s
    verification actually prove the done-condition?
 
 ## Stance
@@ -927,11 +931,17 @@ needs no work-stream.
 
 ## Review first
 
-Before writing, see what exists — don''t duplicate:
+Before writing, see what exists — don''t duplicate, and don''t re-litigate:
 ```
 sc mem get documents      # every spec/doc in the engine DB (kind, seq, frozen, task_count)
+sc mem get decisions      # prior Major decisions — is what you''re about to plan already settled?
 sc map-sql "SELECT path FROM dr_filepath WHERE role=''doc'';"  -- repo''s own docs (map db)
 ```
+
+If the spec you''re about to write touches a recorded decision, honor it or
+supersede it **explicitly** — say so in the spec, and record the new decision
+with `sc mem decision "…" --parent <old_id>`. Never silently re-decide a
+settled choice.
 
 ## Author
 

--- a/.super-coder/migrations/0043_reseed_decisions_read_trigger.sql
+++ b/.super-coder/migrations/0043_reseed_decisions_read_trigger.sql
@@ -1,18 +1,75 @@
----
-rendered_by: super-coder
-source: db
-edit: changes here are overwritten — author via the shell or localhost GUI
----
+-- 0043 — reseed decisions read-trigger (upstream #267, Patch D)
+--
+-- shell_decisions was write-only memory: nudged in three places on the write
+-- side, never read anywhere in the planning path. A settled choice could be
+-- silently re-litigated because nothing pulled the prior decision back into
+-- context at the moment it mattered.
+--
+-- Two skills gain the read-trigger + supersede nudge:
+--   docs      — "Review first" now includes `sc mem get decisions`; if a spec
+--               touches a recorded decision, honor or supersede explicitly
+--               (`sc mem decision "…" --parent <old_id>`).
+--   blueprint — new Produce step 2: re-surface prior decisions before
+--               decomposing; same supersede rule.
+--
+-- 0001 is regenerated from the assets for fresh builds; this forward reseed
+-- carries the same bodies to already-installed forks (UPSERT by name; skill_id
+-- + grants preserved).
 
-# docs
+BEGIN;
 
-Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'blueprint',
+  'Turn a one-line objective into a sequenced construction plan — decompose into steps, find the dependency order, mark what can run in parallel, name the verification gate. Use before multi-step builds.',
+  'craft',
+  NULL,
+  0,
+  '# blueprint — objective → sequenced plan
 
-**Category:** substrate
+Catalogue skill (opt-in). Use before a build that spans more than a couple of
+steps, so the work has a shape before you start cutting.
 
----
+## Produce
 
-# docs — author & review documents
+1. **Restate the objective** in one sentence + the done-condition (how you''ll
+   know it''s finished).
+2. **Re-surface prior decisions** — `sc mem get decisions`: has any part of
+   this already been settled? A recorded decision constrains the plan; honor
+   it, or supersede it explicitly (`sc mem decision "…" --parent <old_id>`) —
+   never silently re-litigate.
+3. **Decompose** into concrete steps — each a unit you could verify on its own.
+4. **Order by dependency** — what must precede what. Mark steps with no
+   dependency on each other as **parallelizable**.
+5. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
+   to ground this in the real repo), and its **verification** (test, run,
+   review).
+6. **Risks / unknowns** — what could break the plan; resolve the riskiest
+   unknown first (spike it) rather than last.
+7. **Gate** — the adversarial check before calling it done: does each step''s
+   verification actually prove the done-condition?
+
+## Stance
+- Plan to the **next solid checkpoint**, not the whole universe — re-plan as
+  reality lands. A plan that survives contact is short and concrete.
+- Sequence so something **works end-to-end early** (a thin slice), then deepen —
+  beats building all the pieces and integrating last.
+- In super-coder, land the plan as a **spec** on the roadmap (the `docs` skill):
+  a feature row + a `spec` document, so the plan is reviewable and freezes on
+  ship.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'docs',
+  'Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.',
+  'substrate',
+  NULL,
+  0,
+  '# docs — author & review documents
 
 In super-coder the **DB owns document bodies** — never loose `.md` files. A
 `documents` row is the source; `sc render` writes the read-only flat copy to
@@ -30,13 +87,13 @@ In super-coder the **DB owns document bodies** — never loose `.md` files. A
 A feature (the `roadmap` row) is the umbrella, and it exists from `brainstorm`
 onward — before any spec is written. **Specs hang off the feature, not off each
 other:** a feature can hold several unfrozen specs at once (the working pile),
-each a `documents (kind='spec')` row, ordered by `seq`. There are no
+each a `documents (kind=''spec'')` row, ordered by `seq`. There are no
 feature-to-feature links and no second roadmap row for related work — related
 work is just another spec under the same feature.
 
 A spec stays unfrozen until it ships; freeze is the ship-time record of what we
-built to, and it never gates the feature's other specs. So at any moment a
-feature's specs are in one of three states:
+built to, and it never gates the feature''s other specs. So at any moment a
+feature''s specs are in one of three states:
 
 | state | how to tell | meaning |
 |---|---|---|
@@ -44,7 +101,7 @@ feature's specs are in one of three states:
 | **active** | unfrozen **and** has rows in `spec_tasks` | the spec being built now |
 | **backlog** | unfrozen, no task plan yet | the pile, ordered by `seq` |
 
-The **doc** (`kind='doc'`) is the feature's readable face — write it when the
+The **doc** (`kind=''doc''`) is the feature''s readable face — write it when the
 first spec ships, under the same `feature_id`. It is a sibling of the specs, not
 a parent they point at.
 
@@ -52,15 +109,15 @@ a parent they point at.
 
 A feature attaches to a **work-stream** (a `projects` row) via
 `roadmap.project_id`; the GUI **Flow view groups on it**, and `NULL` shows as
-**Ungrouped**. An unassigned feature is invisible to the Flow view's grouping —
+**Ungrouped**. An unassigned feature is invisible to the Flow view''s grouping —
 so a roadmap of Ungrouped features is a roadmap with no flows. **Whenever you
 create a feature or author/update a spec, assess the work-stream** as part of the
-same act (it's a planning decision, like the stage):
+same act (it''s a planning decision, like the stage):
 
 ```
 # existing work-streams (pick the one this feature belongs to):
 sc mem get projects
-# is this feature already assigned? — read its row's project_id:
+# is this feature already assigned? — read its row''s project_id:
 sc mem get roadmap
 ```
 
@@ -71,24 +128,24 @@ Then:
   `sc mem roadmap project <feature_id> <shortname>`
 - **No fitting work-stream exists yet** → create one, then assign:
   `sc mem project add <shortname> "<title>" --purpose "…"`
-- **Already correctly assigned** → **no-op**; don't churn it.
+- **Already correctly assigned** → **no-op**; don''t churn it.
 
 **Auto-assign when the stream is obvious** (only one plausible fit, or it clearly
 belongs to an existing stream). **Surface to the FnB only when ambiguous** —
-several streams could fit, or the feature implies a new stream you're unsure how
-to name. Exempt, as with stages: work that isn't a feature/spec (a quick fix)
+several streams could fit, or the feature implies a new stream you''re unsure how
+to name. Exempt, as with stages: work that isn''t a feature/spec (a quick fix)
 needs no work-stream.
 
 ## Review first
 
-Before writing, see what exists — don't duplicate, and don't re-litigate:
+Before writing, see what exists — don''t duplicate, and don''t re-litigate:
 ```
 sc mem get documents      # every spec/doc in the engine DB (kind, seq, frozen, task_count)
-sc mem get decisions      # prior Major decisions — is what you're about to plan already settled?
-sc map-sql "SELECT path FROM dr_filepath WHERE role='doc';"  -- repo's own docs (map db)
+sc mem get decisions      # prior Major decisions — is what you''re about to plan already settled?
+sc map-sql "SELECT path FROM dr_filepath WHERE role=''doc'';"  -- repo''s own docs (map db)
 ```
 
-If the spec you're about to write touches a recorded decision, honor it or
+If the spec you''re about to write touches a recorded decision, honor it or
 supersede it **explicitly** — say so in the spec, and record the new decision
 with `sc mem decision "…" --parent <old_id>`. Never silently re-decide a
 settled choice.
@@ -100,10 +157,10 @@ the markdown from a file (no shell-escaping a long body), `--seq` auto-increment
 within `(feature, kind)`, and it renders + snapshots for you (the render/snapshot
 pipeline this rides on is the `snapshot` skill):
 ```
-# a doc against a feature (kind='doc'); DB owns the body:
+# a doc against a feature (kind=''doc''); DB owns the body:
 sc mem doc add "…" --kind doc --feature <id> --body-file ./draft.md --render-path docs_sc/….md
 
-# a feature's next spec stage (kind='spec'); seq auto-advances:
+# a feature''s next spec stage (kind=''spec''); seq auto-advances:
 sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
 ```
 
@@ -117,13 +174,13 @@ sc mem doc edit <document_id> --body-file ./draft.md
 sc mem doc edit <document_id> --title "New title" --render-path specs_sc/….md
 ```
 
-## Freeze + document on ship — the planner's handoff
+## Freeze + document on ship — the planner''s handoff
 
 Shipping a feature is a **two-shell** act, and the split keeps `shipped` honest:
 
 - the **dev** flips the feature to `roadmap_status = shipped` and opens a
   **docs-pending** flag (see the `spec` skill, Step 5) — so `shipped` never
-  silently claims a doc that doesn't exist yet;
+  silently claims a doc that doesn''t exist yet;
 - the **planner** picks up that flag and does the paperwork: **freeze the spec,
   write the doc, close the flag.**
 
@@ -131,7 +188,7 @@ As the planner, on a docs-pending flag (it arrived in your inbox per the `flags`
 skill):
 
 1. **Freeze the shipped spec** — records what we built to, immutable thereafter.
-   The feature's other specs stay unfrozen and unaffected; never edit a frozen one
+   The feature''s other specs stay unfrozen and unaffected; never edit a frozen one
    (open a new spec under the same feature instead). The GUI and render layer both
    refuse edits to frozen docs:
    ```
@@ -155,7 +212,7 @@ doc pending.
 
 ## View
 
-Open any doc rendered: the GUI's "open in md-converter ↗" (Roadmap card or Docs
+Open any doc rendered: the GUI''s "open in md-converter ↗" (Roadmap card or Docs
 tab) — the body rides in the URL, no upload. For long-form authoring, write the
 markdown to the `body` and let the render + md-converter handle presentation.
 
@@ -164,7 +221,7 @@ markdown to the `body` and let the render + md-converter handle presentation.
 # Authoring format (themed-markdown)
 
 The `body` you write **is** themed-markdown — the format md-converter renders.
-**Your job is structure; styling is the renderer's job.** Never write visual
+**Your job is structure; styling is the renderer''s job.** Never write visual
 instructions (colors, fonts, sizes, themes). Apply the four semantic classes;
 the theme picks the actual colors.
 
@@ -176,7 +233,7 @@ awkwardly or overflows a fixed UI slot).
 
 ## Frontmatter
 
-Author these in the body's frontmatter:
+Author these in the body''s frontmatter:
 
 ```
 ---
@@ -198,7 +255,7 @@ purpose: Brief description
 
 `date`/`project`/`purpose` → footer meta cards. **`sc render` injects
 `feature`, `roadmap_status`, `frozen`, `rendered_by`, `source` on top of these
-— don't write those yourself.** Never use comma-separated tags (`tags: a, b`);
+— don''t write those yourself.** Never use comma-separated tags (`tags: a, b`);
 always a YAML list.
 
 ## Structure
@@ -228,7 +285,7 @@ larger material.
 - Video: a bare video URL **alone on its own line** renders as a player —
   a `github.com/user-attachments/assets/<id>` URL (paste a video into a GitHub
   issue/PR to mint one) or any absolute URL ending `.mp4`/`.webm`/`.mov`/`.ogg`.
-  Don't wrap it in `![]()` or `[]()` — bare is what triggers the player.
+  Don''t wrap it in `![]()` or `[]()` — bare is what triggers the player.
 - Code: fenced with a language hint (```` ```python ````)
 
 ## Color classes
@@ -278,7 +335,7 @@ graph LR
 ```
 ````
 
-Class via `:::classN` on nodes. The app injects `classDef` — **don't** write
+Class via `:::classN` on nodes. The app injects `classDef` — **don''t** write
 `classDef`, `fill:`, or any style directive. Node label cap ≤24 (Mermaid
 auto-sizes nodes; long labels balloon them).
 
@@ -332,7 +389,15 @@ shows on GitHub but is dropped from the render (preamble rule):
 [![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/<owner>/<repo>/blob/<branch>/<path>)
 ```
 
-Fill `<owner>/<repo>/<branch>/<path>` with the file's GitHub location (any
+Fill `<owner>/<repo>/<branch>/<path>` with the file''s GitHub location (any
 subdirectory depth). Public repos only — the badge fetches the raw file in the
-reader's browser (no server/auth). Destination unknown → keep the placeholders
-and tell the user to fill them.
+reader''s browser (no server/auth). Destination unknown → keep the placeholders
+and tell the user to fill them.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/skills_sc/blueprint.md
+++ b/skills_sc/blueprint.md
@@ -21,15 +21,19 @@ steps, so the work has a shape before you start cutting.
 
 1. **Restate the objective** in one sentence + the done-condition (how you'll
    know it's finished).
-2. **Decompose** into concrete steps — each a unit you could verify on its own.
-3. **Order by dependency** — what must precede what. Mark steps with no
+2. **Re-surface prior decisions** — `sc mem get decisions`: has any part of
+   this already been settled? A recorded decision constrains the plan; honor
+   it, or supersede it explicitly (`sc mem decision "…" --parent <old_id>`) —
+   never silently re-litigate.
+3. **Decompose** into concrete steps — each a unit you could verify on its own.
+4. **Order by dependency** — what must precede what. Mark steps with no
    dependency on each other as **parallelizable**.
-4. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
+5. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
    to ground this in the real repo), and its **verification** (test, run,
    review).
-5. **Risks / unknowns** — what could break the plan; resolve the riskiest
+6. **Risks / unknowns** — what could break the plan; resolve the riskiest
    unknown first (spike it) rather than last.
-6. **Gate** — the adversarial check before calling it done: does each step's
+7. **Gate** — the adversarial check before calling it done: does each step's
    verification actually prove the done-condition?
 
 ## Stance


### PR DESCRIPTION
## Problem (#267, kcsos fork, FnB-endorsed)

`shell_decisions` works on the write side — three nudges (boot doc MEMORY ARCHITECTURE table, `memory` stub, `memory` SKILL.md body) and forks are verifiably writing decisions. The read side had **zero triggers anywhere**: `db_map` documents the capability but only cautions against over-reading, `docs` pulls `projects`/`roadmap`/`documents` but never `decisions`, `blueprint` doesn't mention them at all. A reliably-written-never-read log is write-only memory — settled architectural choices get silently re-litigated because nothing pulls the prior decision back into context at the moment a planner is about to decide the same thing again.

## Fix — mirror the write-side pattern at the two planning entry points

- **`docs` skill** — "Review first" (which already instructs `sc mem get documents`) now also instructs `sc mem get decisions`, plus the supersede rule: a spec that touches a recorded decision must honor it or supersede **explicitly** (`sc mem decision "…" --parent <old_id>`) — never silently re-decide.
- **`blueprint` skill** — new Produce step 2, between restating the objective and decomposing: re-surface prior decisions; same supersede nudge. Steps renumbered 1–7.

## Plumbing

- `0001_seed_skills.sql` regenerated from assets (`./sc seed-skills`) — fresh builds.
- **Reseed `0043_reseed_decisions_read_trigger.sql`** — carries the two updated bodies to already-installed forks (UPSERT by name; skill_id + grants preserved). Test-applied against a DB copy: clean.
- `skills_sc/` flat mirror re-rendered; `./sc render-check` green (hermetic rebuild → 43 migrations applied → mirror matches).

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)