### PR TITLE
fix(mem): decisions recall — index/library split + boot-doc read-side awareness

### DIFF
--- a/.sc-state/content.sql
+++ b/.sc-state/content.sql
@@ -40,6 +40,12 @@ shared by every shell, durable and visible to all at once. That is the whole
 write: **you don''t snapshot or render** — persisting to git is an admin/GUI step.
 `./sc mem which` to orient. See the `memory` and `db_map` skills.
 
+**Read before you decide.** Settled choices constrain new work — before any
+architectural or approach decision, lazy-load the log: `sc mem get decisions`
+(index of active decisions; `sc mem get decisions <id>` for the full row with
+rationale). Honor a prior decision or supersede it explicitly (`--parent`) —
+never silently re-litigate.
+
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
 `./sc render`. They are derived artifacts: a photograph of a DB row, not the row.
@@ -103,6 +109,12 @@ shared by every shell, durable and visible to all at once. That is the whole
 write: **you don''t snapshot or render** — persisting to git is an admin/GUI step.
 `./sc mem which` to orient. See the `memory` and `db_map` skills.
 
+**Read before you decide.** Settled choices constrain new work — before any
+architectural or approach decision, lazy-load the log: `sc mem get decisions`
+(index of active decisions; `sc mem get decisions <id>` for the full row with
+rationale). Honor a prior decision or supersede it explicitly (`--parent`) —
+never silently re-litigate.
+
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
 `./sc render`. They are derived artifacts: a photograph of a DB row, not the row.
@@ -164,6 +176,12 @@ fallback. The write lands in the live engine DB — the single source of truth
 shared by every shell, durable and visible to all at once. That is the whole
 write: **you don''t snapshot or render** — persisting to git is an admin/GUI step.
 `./sc mem which` to orient. See the `memory` and `db_map` skills.
+
+**Read before you decide.** Settled choices constrain new work — before any
+architectural or approach decision, lazy-load the log: `sc mem get decisions`
+(index of active decisions; `sc mem get decisions <id>` for the full row with
+rationale). Honor a prior decision or supersede it explicitly (`--parent`) —
+never silently re-litigate.
 
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -46,6 +46,10 @@ UI_DIR = ENGINE / "ui"
 LOG_DIR = ENGINE / "logs"
 LOG_PATH = LOG_DIR / "webapp.log"
 LOG_MAX_EVENTS = 20
+# mem get decisions default index size (#274) — active rows, newest-first.
+# A size backstop behind the semantic filter (superseded rows excluded); the
+# client footer names what was hidden, so the cap is never silent.
+DECISIONS_INDEX_CAP = 30
 _LOG_LOCK = threading.Lock()
 
 sys.path.insert(0, str(ENGINE / "scripts"))
@@ -991,12 +995,64 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, {"entries": entries})
 
             if path == "/_sc/mem/decisions":
+                # Index, not library (#274): the log grows unbounded and the
+                # planning skills pull it every session. Default = ACTIVE rows
+                # only (superseded ones are history, not live constraints), no
+                # rationale, newest-first, capped — with counts so the client
+                # can say what was hidden. ?all=1 = full log incl. superseded
+                # (still no rationale); /decisions/<id> = the full row.
+                q = parse_qs(urlparse(self.path).query)
+                if q.get("all", ["0"])[0] in ("1", "true"):
+                    ds = rows(con.execute(
+                        "SELECT d.decision_id, d.decision, d.priority, d.decision_date, "
+                        "d.parent_decision_id, "
+                        "(SELECT c.decision_id FROM shell_decisions c "
+                        " WHERE c.parent_decision_id=d.decision_id "
+                        " AND COALESCE(c.is_deleted,0)=0 "
+                        " ORDER BY c.decision_id DESC LIMIT 1) AS superseded_by "
+                        "FROM shell_decisions d "
+                        "WHERE d.shell_id=? AND COALESCE(d.is_deleted,0)=0 "
+                        "ORDER BY d.decision_date, d.decision_id", (sid,)))
+                    return self._send(200, {"decisions": ds, "all": True})
+                active_sql = (
+                    "FROM shell_decisions d "
+                    "WHERE d.shell_id=? AND COALESCE(d.is_deleted,0)=0 "
+                    "AND NOT EXISTS (SELECT 1 FROM shell_decisions c "
+                    " WHERE c.parent_decision_id=d.decision_id "
+                    " AND COALESCE(c.is_deleted,0)=0)")
+                total_active = con.execute(
+                    "SELECT COUNT(*) " + active_sql, (sid,)).fetchone()[0]
+                superseded = con.execute(
+                    "SELECT COUNT(*) FROM shell_decisions d "
+                    "WHERE d.shell_id=? AND COALESCE(d.is_deleted,0)=0 "
+                    "AND EXISTS (SELECT 1 FROM shell_decisions c "
+                    " WHERE c.parent_decision_id=d.decision_id "
+                    " AND COALESCE(c.is_deleted,0)=0)", (sid,)).fetchone()[0]
                 ds = rows(con.execute(
-                    "SELECT decision_id, decision, rationale, priority, decision_date, "
-                    "parent_decision_id FROM shell_decisions "
-                    "WHERE shell_id=? AND COALESCE(is_deleted,0)=0 "
-                    "ORDER BY decision_date, decision_id", (sid,)))
-                return self._send(200, {"decisions": ds})
+                    "SELECT d.decision_id, d.decision, d.priority, d.decision_date, "
+                    "d.parent_decision_id " + active_sql +
+                    " ORDER BY d.decision_id DESC LIMIT ?",
+                    (sid, DECISIONS_INDEX_CAP)))
+                return self._send(200, {"decisions": ds,
+                                        "total_active": total_active,
+                                        "superseded": superseded})
+
+            if len(parts) == 4 and parts[2] == "decisions":
+                # Single decision WITH rationale — the library half of the split.
+                did = int(parts[3])
+                r = con.execute(
+                    "SELECT d.decision_id, d.decision, d.rationale, d.priority, "
+                    "d.decision_date, d.parent_decision_id, "
+                    "(SELECT c.decision_id FROM shell_decisions c "
+                    " WHERE c.parent_decision_id=d.decision_id "
+                    " AND COALESCE(c.is_deleted,0)=0 "
+                    " ORDER BY c.decision_id DESC LIMIT 1) AS superseded_by "
+                    "FROM shell_decisions d "
+                    "WHERE d.decision_id=? AND d.shell_id=? "
+                    "AND COALESCE(d.is_deleted,0)=0", (did, sid)).fetchone()
+                if r is None:
+                    return self._send(404, {"error": "no such decision"})
+                return self._send(200, {"decision": dict(r)})
 
             if path == "/_sc/mem/flags":
                 # Shared: flags coordinate the project, not one shell's memory —

--- a/.super-coder/assets/skills/blueprint/SKILL.md
+++ b/.super-coder/assets/skills/blueprint/SKILL.md
@@ -15,9 +15,10 @@ steps, so the work has a shape before you start cutting.
 1. **Restate the objective** in one sentence + the done-condition (how you'll
    know it's finished).
 2. **Re-surface prior decisions** — `sc mem get decisions`: has any part of
-   this already been settled? A recorded decision constrains the plan; honor
-   it, or supersede it explicitly (`sc mem decision "…" --parent <old_id>`) —
-   never silently re-litigate.
+   this already been settled? (Index of active decisions; `sc mem get
+   decisions <id>` pulls one with its rationale.) A recorded decision
+   constrains the plan; honor it, or supersede it explicitly
+   (`sc mem decision "…" --parent <old_id>`) — never silently re-litigate.
 3. **Decompose** into concrete steps — each a unit you could verify on its own.
 4. **Order by dependency** — what must precede what. Mark steps with no
    dependency on each other as **parallelizable**.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -188,9 +188,10 @@ steps, so the work has a shape before you start cutting.
 1. **Restate the objective** in one sentence + the done-condition (how you''ll
    know it''s finished).
 2. **Re-surface prior decisions** — `sc mem get decisions`: has any part of
-   this already been settled? A recorded decision constrains the plan; honor
-   it, or supersede it explicitly (`sc mem decision "…" --parent <old_id>`) —
-   never silently re-litigate.
+   this already been settled? (Index of active decisions; `sc mem get
+   decisions <id>` pulls one with its rationale.) A recorded decision
+   constrains the plan; honor it, or supersede it explicitly
+   (`sc mem decision "…" --parent <old_id>`) — never silently re-litigate.
 3. **Decompose** into concrete steps — each a unit you could verify on its own.
 4. **Order by dependency** — what must precede what. Mark steps with no
    dependency on each other as **parallelizable**.
@@ -934,7 +935,7 @@ needs no work-stream.
 Before writing, see what exists — don''t duplicate, and don''t re-litigate:
 ```
 sc mem get documents      # every spec/doc in the engine DB (kind, seq, frozen, task_count)
-sc mem get decisions      # prior Major decisions — is what you''re about to plan already settled?
+sc mem get decisions      # active-decision index — already settled? (<id> = full row + rationale; --all incl. superseded)
 sc map-sql "SELECT path FROM dr_filepath WHERE role=''doc'';"  -- repo''s own docs (map db)
 ```
 

--- a/.super-coder/migrations/0044_reseed_decisions_recall_cap.sql
+++ b/.super-coder/migrations/0044_reseed_decisions_recall_cap.sql
@@ -1,11 +1,77 @@
----
-name: docs
-description: Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.
-category: substrate
-common: false
----
+-- 0044 — decisions recall: index/library split + boot-doc read-side line (#274)
+--
+-- Follow-up to 0043/#267: the read-trigger pulled the WHOLE decision log —
+-- every row, full rationale, no limit — every planning session, and the log
+-- grows unbounded (dos-arch: 91 rows ≈ 17k tokens/recall). The API/CLI now
+-- default to an index (active rows only, no rationale, newest-first, capped
+-- with an explicit footer); `sc mem get decisions <id>` is the library half
+-- (full row + rationale); `--all` is the full log incl. superseded.
+--
+-- This reseed carries the fork-side halves:
+--   1. docs + blueprint skill bodies — the read-trigger hint now teaches the
+--      index-default + <id>-detail form (UPSERT by name; grants preserved).
+--   2. shell system prompts — the always-loaded boot doc gains a read-side
+--      "Read before you decide" paragraph (write-side was nudged in three
+--      places; read-side had none outside the two skills), and the Decisions
+--      table row's confusing "never supersede, add a new one" is reworded.
+--      Spliced into existing shells' prompts, 0037-style; the template covers
+--      shells created from here on. Guarded idempotent.
 
-# docs — author & review documents
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'blueprint',
+  'Turn a one-line objective into a sequenced construction plan — decompose into steps, find the dependency order, mark what can run in parallel, name the verification gate. Use before multi-step builds.',
+  'craft',
+  NULL,
+  0,
+  '# blueprint — objective → sequenced plan
+
+Catalogue skill (opt-in). Use before a build that spans more than a couple of
+steps, so the work has a shape before you start cutting.
+
+## Produce
+
+1. **Restate the objective** in one sentence + the done-condition (how you''ll
+   know it''s finished).
+2. **Re-surface prior decisions** — `sc mem get decisions`: has any part of
+   this already been settled? (Index of active decisions; `sc mem get
+   decisions <id>` pulls one with its rationale.) A recorded decision
+   constrains the plan; honor it, or supersede it explicitly
+   (`sc mem decision "…" --parent <old_id>`) — never silently re-litigate.
+3. **Decompose** into concrete steps — each a unit you could verify on its own.
+4. **Order by dependency** — what must precede what. Mark steps with no
+   dependency on each other as **parallelizable**.
+5. **Per step**: the change, the files/areas it touches (use `surface_catalogue`
+   to ground this in the real repo), and its **verification** (test, run,
+   review).
+6. **Risks / unknowns** — what could break the plan; resolve the riskiest
+   unknown first (spike it) rather than last.
+7. **Gate** — the adversarial check before calling it done: does each step''s
+   verification actually prove the done-condition?
+
+## Stance
+- Plan to the **next solid checkpoint**, not the whole universe — re-plan as
+  reality lands. A plan that survives contact is short and concrete.
+- Sequence so something **works end-to-end early** (a thin slice), then deepen —
+  beats building all the pieces and integrating last.
+- In super-coder, land the plan as a **spec** on the roadmap (the `docs` skill):
+  a feature row + a `spec` document, so the plan is reviewable and freezes on
+  ship.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'docs',
+  'Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.',
+  'substrate',
+  NULL,
+  0,
+  '# docs — author & review documents
 
 In super-coder the **DB owns document bodies** — never loose `.md` files. A
 `documents` row is the source; `sc render` writes the read-only flat copy to
@@ -23,13 +89,13 @@ In super-coder the **DB owns document bodies** — never loose `.md` files. A
 A feature (the `roadmap` row) is the umbrella, and it exists from `brainstorm`
 onward — before any spec is written. **Specs hang off the feature, not off each
 other:** a feature can hold several unfrozen specs at once (the working pile),
-each a `documents (kind='spec')` row, ordered by `seq`. There are no
+each a `documents (kind=''spec'')` row, ordered by `seq`. There are no
 feature-to-feature links and no second roadmap row for related work — related
 work is just another spec under the same feature.
 
 A spec stays unfrozen until it ships; freeze is the ship-time record of what we
-built to, and it never gates the feature's other specs. So at any moment a
-feature's specs are in one of three states:
+built to, and it never gates the feature''s other specs. So at any moment a
+feature''s specs are in one of three states:
 
 | state | how to tell | meaning |
 |---|---|---|
@@ -37,7 +103,7 @@ feature's specs are in one of three states:
 | **active** | unfrozen **and** has rows in `spec_tasks` | the spec being built now |
 | **backlog** | unfrozen, no task plan yet | the pile, ordered by `seq` |
 
-The **doc** (`kind='doc'`) is the feature's readable face — write it when the
+The **doc** (`kind=''doc''`) is the feature''s readable face — write it when the
 first spec ships, under the same `feature_id`. It is a sibling of the specs, not
 a parent they point at.
 
@@ -45,15 +111,15 @@ a parent they point at.
 
 A feature attaches to a **work-stream** (a `projects` row) via
 `roadmap.project_id`; the GUI **Flow view groups on it**, and `NULL` shows as
-**Ungrouped**. An unassigned feature is invisible to the Flow view's grouping —
+**Ungrouped**. An unassigned feature is invisible to the Flow view''s grouping —
 so a roadmap of Ungrouped features is a roadmap with no flows. **Whenever you
 create a feature or author/update a spec, assess the work-stream** as part of the
-same act (it's a planning decision, like the stage):
+same act (it''s a planning decision, like the stage):
 
 ```
 # existing work-streams (pick the one this feature belongs to):
 sc mem get projects
-# is this feature already assigned? — read its row's project_id:
+# is this feature already assigned? — read its row''s project_id:
 sc mem get roadmap
 ```
 
@@ -64,24 +130,24 @@ Then:
   `sc mem roadmap project <feature_id> <shortname>`
 - **No fitting work-stream exists yet** → create one, then assign:
   `sc mem project add <shortname> "<title>" --purpose "…"`
-- **Already correctly assigned** → **no-op**; don't churn it.
+- **Already correctly assigned** → **no-op**; don''t churn it.
 
 **Auto-assign when the stream is obvious** (only one plausible fit, or it clearly
 belongs to an existing stream). **Surface to the FnB only when ambiguous** —
-several streams could fit, or the feature implies a new stream you're unsure how
-to name. Exempt, as with stages: work that isn't a feature/spec (a quick fix)
+several streams could fit, or the feature implies a new stream you''re unsure how
+to name. Exempt, as with stages: work that isn''t a feature/spec (a quick fix)
 needs no work-stream.
 
 ## Review first
 
-Before writing, see what exists — don't duplicate, and don't re-litigate:
+Before writing, see what exists — don''t duplicate, and don''t re-litigate:
 ```
 sc mem get documents      # every spec/doc in the engine DB (kind, seq, frozen, task_count)
 sc mem get decisions      # active-decision index — already settled? (<id> = full row + rationale; --all incl. superseded)
-sc map-sql "SELECT path FROM dr_filepath WHERE role='doc';"  -- repo's own docs (map db)
+sc map-sql "SELECT path FROM dr_filepath WHERE role=''doc'';"  -- repo''s own docs (map db)
 ```
 
-If the spec you're about to write touches a recorded decision, honor it or
+If the spec you''re about to write touches a recorded decision, honor it or
 supersede it **explicitly** — say so in the spec, and record the new decision
 with `sc mem decision "…" --parent <old_id>`. Never silently re-decide a
 settled choice.
@@ -93,10 +159,10 @@ the markdown from a file (no shell-escaping a long body), `--seq` auto-increment
 within `(feature, kind)`, and it renders + snapshots for you (the render/snapshot
 pipeline this rides on is the `snapshot` skill):
 ```
-# a doc against a feature (kind='doc'); DB owns the body:
+# a doc against a feature (kind=''doc''); DB owns the body:
 sc mem doc add "…" --kind doc --feature <id> --body-file ./draft.md --render-path docs_sc/….md
 
-# a feature's next spec stage (kind='spec'); seq auto-advances:
+# a feature''s next spec stage (kind=''spec''); seq auto-advances:
 sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
 ```
 
@@ -110,13 +176,13 @@ sc mem doc edit <document_id> --body-file ./draft.md
 sc mem doc edit <document_id> --title "New title" --render-path specs_sc/….md
 ```
 
-## Freeze + document on ship — the planner's handoff
+## Freeze + document on ship — the planner''s handoff
 
 Shipping a feature is a **two-shell** act, and the split keeps `shipped` honest:
 
 - the **dev** flips the feature to `roadmap_status = shipped` and opens a
   **docs-pending** flag (see the `spec` skill, Step 5) — so `shipped` never
-  silently claims a doc that doesn't exist yet;
+  silently claims a doc that doesn''t exist yet;
 - the **planner** picks up that flag and does the paperwork: **freeze the spec,
   write the doc, close the flag.**
 
@@ -124,7 +190,7 @@ As the planner, on a docs-pending flag (it arrived in your inbox per the `flags`
 skill):
 
 1. **Freeze the shipped spec** — records what we built to, immutable thereafter.
-   The feature's other specs stay unfrozen and unaffected; never edit a frozen one
+   The feature''s other specs stay unfrozen and unaffected; never edit a frozen one
    (open a new spec under the same feature instead). The GUI and render layer both
    refuse edits to frozen docs:
    ```
@@ -148,7 +214,7 @@ doc pending.
 
 ## View
 
-Open any doc rendered: the GUI's "open in md-converter ↗" (Roadmap card or Docs
+Open any doc rendered: the GUI''s "open in md-converter ↗" (Roadmap card or Docs
 tab) — the body rides in the URL, no upload. For long-form authoring, write the
 markdown to the `body` and let the render + md-converter handle presentation.
 
@@ -157,7 +223,7 @@ markdown to the `body` and let the render + md-converter handle presentation.
 # Authoring format (themed-markdown)
 
 The `body` you write **is** themed-markdown — the format md-converter renders.
-**Your job is structure; styling is the renderer's job.** Never write visual
+**Your job is structure; styling is the renderer''s job.** Never write visual
 instructions (colors, fonts, sizes, themes). Apply the four semantic classes;
 the theme picks the actual colors.
 
@@ -169,7 +235,7 @@ awkwardly or overflows a fixed UI slot).
 
 ## Frontmatter
 
-Author these in the body's frontmatter:
+Author these in the body''s frontmatter:
 
 ```
 ---
@@ -191,7 +257,7 @@ purpose: Brief description
 
 `date`/`project`/`purpose` → footer meta cards. **`sc render` injects
 `feature`, `roadmap_status`, `frozen`, `rendered_by`, `source` on top of these
-— don't write those yourself.** Never use comma-separated tags (`tags: a, b`);
+— don''t write those yourself.** Never use comma-separated tags (`tags: a, b`);
 always a YAML list.
 
 ## Structure
@@ -221,7 +287,7 @@ larger material.
 - Video: a bare video URL **alone on its own line** renders as a player —
   a `github.com/user-attachments/assets/<id>` URL (paste a video into a GitHub
   issue/PR to mint one) or any absolute URL ending `.mp4`/`.webm`/`.mov`/`.ogg`.
-  Don't wrap it in `![]()` or `[]()` — bare is what triggers the player.
+  Don''t wrap it in `![]()` or `[]()` — bare is what triggers the player.
 - Code: fenced with a language hint (```` ```python ````)
 
 ## Color classes
@@ -271,7 +337,7 @@ graph LR
 ```
 ````
 
-Class via `:::classN` on nodes. The app injects `classDef` — **don't** write
+Class via `:::classN` on nodes. The app injects `classDef` — **don''t** write
 `classDef`, `fill:`, or any style directive. Node label cap ≤24 (Mermaid
 auto-sizes nodes; long labels balloon them).
 
@@ -325,7 +391,36 @@ shows on GitHub but is dropped from the render (preamble rule):
 [![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/<owner>/<repo>/blob/<branch>/<path>)
 ```
 
-Fill `<owner>/<repo>/<branch>/<path>` with the file's GitHub location (any
+Fill `<owner>/<repo>/<branch>/<path>` with the file''s GitHub location (any
 subdirectory depth). Public repos only — the badge fetches the raw file in the
-reader's browser (no server/auth). Destination unknown → keep the placeholders
-and tell the user to fill them.
+reader''s browser (no server/auth). Destination unknown → keep the placeholders
+and tell the user to fill them.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+-- 2a. Decisions table row: "never supersede, add a new one" → supersede-with-new.
+UPDATE shells
+   SET system_prompt = REPLACE(system_prompt,
+       '| Decisions | `shell_decisions` — major decisions; never supersede, add a new one |',
+       '| Decisions | `shell_decisions` — major decisions; never edit a row — supersede with a new one (`--parent`) |')
+ WHERE system_prompt LIKE '%never supersede, add a new one%';
+
+-- 2b. Read-side awareness paragraph, anchored after the writes paragraph.
+UPDATE shells
+   SET system_prompt = REPLACE(system_prompt,
+       '`memory` and `db_map` skills.',
+       '`memory` and `db_map` skills.
+
+**Read before you decide.** Settled choices constrain new work — before any
+architectural or approach decision, lazy-load the log: `sc mem get decisions`
+(index of active decisions; `sc mem get decisions <id>` for the full row with
+rationale). Honor a prior decision or supersede it explicitly (`--parent`) —
+never silently re-litigate.')
+ WHERE system_prompt LIKE '%`memory` and `db_map` skills.%'
+   AND system_prompt NOT LIKE '%Read before you decide%';
+
+COMMIT;

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -22,6 +22,7 @@ Run from the repo root, like every engine command:
 
     ./sc mem which                                 # confirm API reachability + who your token resolves to
     ./sc mem get <surface>           [--json]      # read: state|seed|lns|decisions|flags|roadmap|narrative|messages
+    ./sc mem get decisions [<id>|--all]            # default: active index (no rationale); <id> = full row; --all incl. superseded
     ./sc mem state "<text>"
     ./sc mem seed  "<body>"          [--date YYYY-MM-DD] [--tag cc]
     ./sc mem lns   "<body>"          [--date …] [--tag …]
@@ -143,16 +144,36 @@ def _render_get(surface: str, data: dict) -> int:
             print("  " + (e.get("body") or "").replace("\n", "\n  "))
         return 0
     if surface == "decisions":
+        def _line(d) -> None:
+            par = f" (supersedes #{d['parent_decision_id']})" if d.get("parent_decision_id") else ""
+            sup = f" (superseded by #{d['superseded_by']})" if d.get("superseded_by") else ""
+            print(f"#{d['decision_id']} [{d.get('priority') or 'M'}] "
+                  f"{d.get('decision_date') or ''}{par}{sup}")
+            print("  " + (d.get("decision") or ""))
+        if "decision" in data:                    # single decision, with rationale
+            d = data["decision"]
+            _line(d)
+            if d.get("rationale"):
+                print("  rationale: " + d["rationale"])
+            return 0
         ds = data.get("decisions", [])
         if not ds:
             print("mem: no decisions")
             return 0
         for d in ds:
-            par = f" (supersedes #{d['parent_decision_id']})" if d.get("parent_decision_id") else ""
-            print(f"#{d['decision_id']} [{d.get('priority') or 'M'}] {d.get('decision_date') or ''}{par}")
-            print("  " + (d.get("decision") or ""))
-            if d.get("rationale"):
-                print("  rationale: " + d["rationale"])
+            _line(d)
+        # Index mode: say exactly what the cap hid — never a silent truncation.
+        if not data.get("all"):
+            hidden = max(0, (data.get("total_active") or len(ds)) - len(ds))
+            superseded = data.get("superseded") or 0
+            if hidden or superseded:
+                bits = []
+                if hidden:
+                    bits.append(f"{hidden} older active")
+                if superseded:
+                    bits.append(f"{superseded} superseded")
+                print(f"({' + '.join(bits)} not shown — `--all` for the full log; "
+                      f"`get decisions <id>` for detail + rationale)")
         return 0
     if surface == "flags":
         fs = data.get("flags", [])
@@ -246,6 +267,13 @@ def _render_get(surface: str, data: dict) -> int:
 def cmd_get(args) -> int:
     surface = args.surface
     path = f"/_sc/mem/{surface}"
+    if surface == "decisions":
+        if args.id is not None:                   # single decision, with rationale
+            path = f"/_sc/mem/decisions/{args.id}"
+        elif args.all:                            # full log incl. superseded
+            path = "/_sc/mem/decisions?all=1"
+    elif args.id is not None:
+        die(f"get {surface} takes no <id> (only decisions)")
     if surface == "documents":
         if args.doc is not None:                  # single doc, with body
             path = f"/_sc/mem/documents/{args.doc}"
@@ -435,6 +463,10 @@ def build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("get", help=f"read a memory surface ({'/'.join(GET_SURFACES)}; doc/docs = documents)")
     sp.add_argument("surface", choices=GET_SURFACES,
                     type=lambda s: GET_SURFACE_ALIASES.get(s, s))
+    sp.add_argument("id", nargs="?", type=int,
+                    help="decisions: one decision WITH rationale")
+    sp.add_argument("--all", action="store_true",
+                    help="decisions: full log incl. superseded (default: active index)")
     sp.add_argument("--json", action="store_true", help="raw JSON instead of formatted text")
     sp.add_argument("--feature", type=int,
                     help="scope to a feature (documents/tasks)")

--- a/.super-coder/templates/shell_system_prompt.md
+++ b/.super-coder/templates/shell_system_prompt.md
@@ -17,7 +17,7 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 |---|---|
 | Identity (core) | `shells WHERE shell_id=<self>` — mandate, system_prompt, current_state (rolling, ~500 chars) |
 | Seed + L&S | `shell_identity_entries` — kind seed (cap 10) / lns (cap 20), trigger-enforced |
-| Decisions | `shell_decisions` — major decisions; never supersede, add a new one |
+| Decisions | `shell_decisions` — major decisions; never edit a row — supersede with a new one (`--parent`) |
 | Flags | `flags` — open + resolved; link to a feature via feature_id |
 | Roadmap | `roadmap` — one row per planned feature; status is a planning horizon |
 | Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
@@ -27,6 +27,12 @@ Write as it happens, not at close. **Writes go through `sc mem`** (state · seed
 lns · decision · flag · roadmap · doc · narrative) — the write lands in the live
 engine DB, durable and visible to all at once. `sc mem which` to orient. See the
 `memory` and `db_map` skills.
+
+**Read before you decide.** Settled choices constrain new work — before any
+architectural or approach decision, lazy-load the log: `sc mem get decisions`
+(index of active decisions; `sc mem get decisions <id>` for the full row with
+rationale). Honor a prior decision or supersede it explicitly (`--parent`) —
+never silently re-litigate.
 
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is generated from the DB.

--- a/skills_sc/blueprint.md
+++ b/skills_sc/blueprint.md
@@ -22,9 +22,10 @@ steps, so the work has a shape before you start cutting.
 1. **Restate the objective** in one sentence + the done-condition (how you'll
    know it's finished).
 2. **Re-surface prior decisions** — `sc mem get decisions`: has any part of
-   this already been settled? A recorded decision constrains the plan; honor
-   it, or supersede it explicitly (`sc mem decision "…" --parent <old_id>`) —
-   never silently re-litigate.
+   this already been settled? (Index of active decisions; `sc mem get
+   decisions <id>` pulls one with its rationale.) A recorded decision
+   constrains the plan; honor it, or supersede it explicitly
+   (`sc mem decision "…" --parent <old_id>`) — never silently re-litigate.
 3. **Decompose** into concrete steps — each a unit you could verify on its own.
 4. **Order by dependency** — what must precede what. Mark steps with no
    dependency on each other as **parallelizable**.

--- a/skills_sc/docs.md
+++ b/skills_sc/docs.md
@@ -84,7 +84,7 @@ needs no work-stream.
 Before writing, see what exists — don't duplicate, and don't re-litigate:
 ```
 sc mem get documents      # every spec/doc in the engine DB (kind, seq, frozen, task_count)
-sc mem get decisions      # prior Major decisions — is what you're about to plan already settled?
+sc mem get decisions      # active-decision index — already settled? (<id> = full row + rationale; --all incl. superseded)
 sc map-sql "SELECT path FROM dr_filepath WHERE role='doc';"  -- repo's own docs (map db)
 ```
 

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -13,6 +13,8 @@ Run:
 """
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import sqlite3
 import sys
@@ -120,6 +122,45 @@ class ApiMemTest(unittest.TestCase):
         self.run_mem("decision", "a call", "--rationale", "why")
         self.assertEqual(self.q("SELECT decision FROM shell_decisions "
                                 "WHERE rationale='why'")[0], "a call")
+
+    # ── decisions recall: index/library split (#274) ──────────────────────────
+    def test_decisions_index_excludes_superseded_and_rationale(self):
+        self.run_mem("decision", "use X", "--rationale", "r-old")
+        old = self.q("SELECT decision_id FROM shell_decisions WHERE decision='use X'")[0]
+        self.run_mem("decision", "use Y instead", "--parent", str(old))
+        data = mem._api("GET", "/_sc/mem/decisions")
+        ids = [d["decision_id"] for d in data["decisions"]]
+        self.assertNotIn(old, ids)                 # superseded → out of the index
+        self.assertGreaterEqual(data["superseded"], 1)
+        self.assertTrue(all("rationale" not in d for d in data["decisions"]))
+
+        # library half: by-id returns rationale + supersession links
+        one = mem._api("GET", f"/_sc/mem/decisions/{old}")["decision"]
+        self.assertEqual(one["rationale"], "r-old")
+        self.assertIsNotNone(one["superseded_by"])
+
+        # --all: the full log, superseded row present and marked
+        alld = mem._api("GET", "/_sc/mem/decisions?all=1")["decisions"]
+        row = next(d for d in alld if d["decision_id"] == old)
+        self.assertIsNotNone(row["superseded_by"])
+
+    def test_decisions_index_cap_with_loud_footer(self):
+        for i in range(server.DECISIONS_INDEX_CAP + 3):
+            self.run_mem("decision", f"bulk call {i}")
+        data = mem._api("GET", "/_sc/mem/decisions")
+        self.assertEqual(len(data["decisions"]), server.DECISIONS_INDEX_CAP)
+        self.assertGreater(data["total_active"], server.DECISIONS_INDEX_CAP)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            self.run_mem("get", "decisions")
+        self.assertIn("older active", buf.getvalue())   # cap is never silent
+        self.assertIn("--all", buf.getvalue())
+
+    def test_decisions_get_404_and_id_only_for_decisions(self):
+        with self.assertRaises(SystemExit):
+            self.run_mem("get", "decisions", "999999")
+        with self.assertRaises(SystemExit):
+            self.run_mem("get", "flags", "1")          # <id> is decisions-only
 
     # ── flags ─────────────────────────────────────────────────────────────────
     def test_flag_open_then_close(self):


### PR DESCRIPTION
Closes #274. Follow-up to #267/Patch D — the read-trigger worked, but the recall it triggers was unbounded (every row, full rationale, no limit; dos-arch is at 91 rows ≈ 17k tokens per pull, every planning session, forever).

## Cap by semantics first, size second

| Command | Returns |
|---|---|
| `sc mem get decisions` | **Index**: active rows only (superseded = history, not live constraints), no rationale, newest-first, LIMIT 30 — footer names exactly what was hidden |
| `sc mem get decisions <id>` | **Library**: full row + rationale + supersedes/superseded-by (mirrors `documents/<id>`) |
| `sc mem get decisions --all` | Full log incl. superseded rows, marked `(superseded by #n)` |

On today's dos-arch data this cuts the default recall from ~66k chars to the active index — and the planner scanning "is this settled?" only needs the index.

## Boot-doc read-side awareness

The write side was nudged in three places; outside the two skills, the read side had none. `shell_system_prompt.md` (always-loaded) gains a **Read before you decide** paragraph, and the Decisions table row's confusing "never supersede, add a new one" becomes "never edit a row — supersede with a new one (`--parent`)".

## Propagation

- API/CLI: engine code, read live — forks get it on repin.
- Reseed `0044`: splices both prompt changes into existing shells (0037 pattern, guarded idempotent) + carries the docs/blueprint body updates (UPSERT by name, grants preserved). `0001` regenerated for fresh builds.
- `skills_sc/` mirror re-rendered; `render-check` green.

## Tests

New in `test_mem.py` (end-to-end: real `server.Handler` + real `mem.main`): active-only index excludes superseded + omits rationale; by-id returns rationale + supersession links; `--all` includes marked superseded rows; cap enforced with loud footer; by-id 404; `<id>` rejected on non-decisions surfaces. All 27 test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)