### PR TITLE
fix(gui): surface publish refusal trace instead of bare statusText

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -54,14 +54,18 @@ async function api(path, method = "GET", body) {
     body: body ? JSON.stringify(body) : undefined,
   });
   const data = await r.json().catch(() => ({}));
-  if (!r.ok) throw new Error(data.error || r.statusText);
+  // publish/scripts report failure as {ok:false, output:<step trace>} with no
+  // `error` key — the trace names the refusing guard and the remedy, so it is
+  // the message, not statusText.
+  if (!r.ok) throw new Error(data.error || data.output || r.statusText);
   return data;
 }
 
 function toast(msg) {
   const t = el("div", { className: "toast" }, msg);
   document.body.append(t);
-  setTimeout(() => t.remove(), 4000);
+  // Multi-line traces (publish refusals) need longer than one-liners.
+  setTimeout(() => t.remove(), Math.min(12000, Math.max(4000, String(msg).length * 30)));
 }
 function setStatus(s) { $("#status").textContent = s; }
 


### PR DESCRIPTION
Addresses the surfacing defect in #276: a refused publish showed only "publish failed" while the server's step trace (which guard refused, which file, the remedy) was discarded client-side.

- `api()` now falls back to `data.output` for the thrown error message — publish and `/api/scripts/` failures return their trace there with no `error` key. This fixes every caller at the single consumer, so the optional server-side `error` duplication (item 3) isn't needed.
- `toast()` duration scales with message length (4–12s) so a multi-line refusal trace is actually readable; `.toast` already renders `pre-wrap`.

Item 4 of #276 (the guard blocking all publishes on any stray non-content file) is deliberately not touched here — it's a behavior change to the guard, worth its own discussion. Suggest keeping #276 open for that or splitting it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)