### PR TITLE
feat(flavors): planner claude model → opus (0045)

### DIFF
--- a/.super-coder/migrations/0045_planner_claude_opus.sql
+++ b/.super-coder/migrations/0045_planner_claude_opus.sql
@@ -1,0 +1,16 @@
+-- 0045 — planner claude model → opus
+--
+-- Operator decision (2026-07-04): planning shells default to Opus. 0015 moved
+-- planner's claude row opus→sonnet when it made claude the picker default;
+-- this restores opus as planner's claude model — planning is a low-volume,
+-- high-leverage reasoning role and the stronger model is worth it there. The
+-- picker default stays claude (unchanged since 0015). Pure launch config
+-- (flavor_defaults has no FKs, no per-instance memory), so a plain UPDATE
+-- converges fresh rebuilds and existing forks alike; idempotent, re-runnable.
+
+BEGIN;
+
+UPDATE flavor_defaults SET model = 'opus'
+    WHERE flavor = 'planner' AND harness = 'claude';
+
+COMMIT;


### PR DESCRIPTION
Per operator decision: planning shells default to Opus. Migration 0045 sets `flavor_defaults` planner/claude model back to `opus` (0015 had retuned it to sonnet); the picker default harness for planner stays claude, so a new planning shell now boots claude · opus. Forks pick it up on their next `./sc update` (migrate-in-place applies 0045).

Test suite: 234 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)