### PR TITLE
feat(skills): fork retire list — ./sc skill retire, durable engine-skill retirement (#238)

### DIFF
--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -2006,7 +2006,10 @@ Then `sc snapshot && sc render` and commit.
    sc skill rm <skill_name>
    ```
    Refuses engine skills — the seed would resurrect those on the next
-   update/rebuild; `sc skill revoke` them per-shell instead.
+   update/rebuild. For an engine skill this fork has superseded, retire it
+   fork-wide instead: `sc skill retire <name>` (writes the tracked
+   `.sc-state/skills_retired.json`, which rides updates; `sc skill unretire`
+   reverses). For a per-shell removal, `sc skill revoke`.
 
 2. **Remove the asset file** (`.super-coder/assets/skills/<name>/`) — otherwise
    the next `sc seed-skills` re-inserts the skill.

--- a/.super-coder/migrations/0046_reseed_local_skill_mgmt_retire.sql
+++ b/.super-coder/migrations/0046_reseed_local_skill_mgmt_retire.sql
@@ -1,11 +1,21 @@
----
-name: local_skill_management
-description: Create, persist, assign, and remove fork-specific skills — the correct authoring path so skills survive snapshot/rebuild cycles.
-category: substrate
-common: false
----
+-- 0046 — reseed local_skill_management: point engine-skill removal at retire (#238)
+--
+-- The removal section refused engine skills with only a per-shell `revoke` as
+-- the alternative; the fork retire list (`./sc skill retire <name>`,
+-- .sc-state/skills_retired.json) is now the durable fork-wide path for an
+-- engine skill a fork has superseded. 0001 is regenerated from the assets for
+-- fresh builds; this forward reseed carries the same body to already-installed
+-- forks (UPSERT by name; skill_id + grants preserved).
 
-# local_skill_management — fork-specific skills that survive
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'local_skill_management',
+  'Create, persist, assign, and remove fork-specific skills — the correct authoring path so skills survive snapshot/rebuild cycles.',
+  'substrate',
+  NULL,
+  0,
+  '# local_skill_management — fork-specific skills that survive
 
 Fork-specific skills live in the DB and are persisted via `.sc-state/content.sql`
 (the snapshot). The asset file under `.super-coder/assets/skills/<name>/` is the
@@ -55,7 +65,7 @@ The path: **file → seed → grant → snapshot → commit**.
    ```bash
    sc snapshot && sc render
    ```
-   `snapshot.py` serializes local skills (any skill the engine seed doesn't
+   `snapshot.py` serializes local skills (any skill the engine seed doesn''t
    own) into `.sc-state/content.sql`. This is what survives `sc update` and
    `sc rebuild` — the skill row and its grants are reconstructed from
    content.sql. Without this step the skill is lost on next update.
@@ -70,7 +80,7 @@ The path: **file → seed → grant → snapshot → commit**.
 
 Edit the asset file, then repeat seed → snapshot → commit (steps 2, 4, 5). If
 the asset file is gone (removed, or authored elsewhere), recreate it from the
-DB body first: `sc sql "SELECT content FROM skills WHERE name='<name>'"`.
+DB body first: `sc sql "SELECT content FROM skills WHERE name=''<name>''"`.
 
 ## Assigning an existing skill to additional shells
 
@@ -106,12 +116,12 @@ per-shell grant toggles on every skill. The Shells tab groups its grant list
 by the same sections.
 
 - **Repo skills** — the lead section: skills authored in this fork. Membership
-  is *derived*, not declared — a skill the engine seed doesn't own is
+  is *derived*, not declared — a skill the engine seed doesn''t own is
   repo-local. This is the same rule snapshot.py uses to decide what serializes
   into `.sc-state/content.sql`, so the section shows exactly what the snapshot
   keeps durable. No frontmatter flag exists or is needed.
 - **Substrate / Craft / …** — engine skills, sectioned by their `category`
-  frontmatter. A repo skill's `category` still displays as a label on its row,
+  frontmatter. A repo skill''s `category` still displays as a label on its row,
   but never moves it out of the Repo section.
 
 Grant toggles in the GUI hit the same DB table as `sc skill grant` — they
@@ -127,4 +137,12 @@ rebuild.
   update.
 - **Never use the GUI to create skills.** Toggling grants in the GUI is fine
   (snapshot after); creating is not — the GUI writes only to the DB and cannot
-  write the asset file or seed it. Use this procedure instead.
+  write the asset file or seed it. Use this procedure instead.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -37,6 +37,7 @@ import db_driver    # noqa: E402
 import migrate as migrate_mod  # noqa: E402
 import map_repo     # noqa: E402
 import backfill_shell_api_keys  # noqa: E402  (re-provision api_keys post-rebuild)
+import seed_skills  # noqa: E402  (re-assert the fork retire list post-seed)
 
 
 def snapshot_path() -> Path:
@@ -145,6 +146,18 @@ def main(argv: list[str]) -> int:
             con.close()
     else:
         print("rebuild: no .sc-state/content.sql — built empty (no per-instance content).")
+
+    # The migrations above seeded every engine skill live (is_deleted=0) —
+    # re-assert the fork retire list so a rebuilt DB doesn't resurrect skills
+    # this fork has retired (a shell created before the next launch/update
+    # would otherwise be granted them).
+    con = db_driver.connect(DB_PATH)
+    try:
+        flipped = seed_skills.apply_retired(con)
+    finally:
+        con.close()
+    if flipped:
+        print(f"rebuild: fork retire list applied ({', '.join(flipped)})")
 
     # Re-attach the keys carried over from the outgoing DB (content.sql never
     # carries api_key — it is a secret and content.sql is git-tracked, see

--- a/.super-coder/scripts/seed_skills.py
+++ b/.super-coder/scripts/seed_skills.py
@@ -35,6 +35,7 @@ Usage:
 """
 from __future__ import annotations
 
+import json
 import sqlite3
 import sys
 from pathlib import Path
@@ -43,6 +44,7 @@ ENGINE = Path(__file__).resolve().parents[1]
 SKILLS_DIR = ENGINE / "assets" / "skills"
 OUT = ENGINE / "migrations" / "0001_seed_skills.sql"
 DB_PATH = ENGINE / "shell_db.db"
+RETIRED_FILE = ENGINE.parent / ".sc-state" / "skills_retired.json"
 
 
 def sql_str(v) -> str:
@@ -122,6 +124,56 @@ def seeded_skill_names() -> list[str]:
         con.close()
 
 
+def retired_skill_names() -> list[str]:
+    """The fork's retire list — engine skills this fork has taken out of
+    service (`.sc-state/skills_retired.json`, tracked, fork-owned; written by
+    `./sc skill retire`). The seed/sync resurrects engine rows on every update,
+    so retirement must live OUTSIDE the DB and be re-applied after each sync —
+    same shape as the flavor overlays (#247). Loud on a malformed file: a
+    silently-ignored list means superseded skills quietly come back."""
+    if not RETIRED_FILE.exists():
+        return []
+    try:
+        names = json.loads(RETIRED_FILE.read_text())
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"fork retire list {RETIRED_FILE} is not valid JSON: {e}") from e
+    if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
+        raise ValueError(
+            f"fork retire list {RETIRED_FILE} must be a JSON array of skill names")
+    return names
+
+
+def apply_retired(con) -> list[str]:
+    """Converge the live DB's engine rows to the fork retire list: listed names
+    get is_deleted=1, unlisted engine names get is_deleted=0. is_deleted is the
+    one switch every surface already respects — the per-shell SKILL.md render,
+    the boot-doc SKILLS block, the catalogue render, common regrants, and
+    create_shell all filter on it — so one flip retires a skill everywhere.
+    Grant rows are left in place (inert while retired), so unretiring restores
+    who-had-what. Returns the names flipped; commits its own writes.
+
+    Only ENGINE names converge: local skills retire via `./sc skill rm`, and a
+    listed name that isn't engine (typo, or upstream removed the skill) is
+    warned about, never acted on."""
+    retired = set(retired_skill_names())
+    engine = set(seeded_skill_names())
+    for name in sorted(retired - engine):
+        print(f"  ⚠ retire list: '{name}' is not an engine skill — ignored "
+              "(local skills retire via `./sc skill rm`)")
+    flipped: list[str] = []
+    for name in sorted(engine):
+        want = 1 if name in retired else 0
+        cur = con.execute(
+            "UPDATE skills SET is_deleted=? WHERE name=? AND is_deleted<>?",
+            (want, name, want))
+        if cur.rowcount:
+            flipped.append(name)
+    if flipped:
+        con.commit()
+    return flipped
+
+
 def _engine_specs() -> list[dict]:
     """Asset specs that are genuinely ENGINE skills (name in the seed). A
     fork-local skill authored under assets/skills/ is excluded: it has no
@@ -176,8 +228,6 @@ def sync_engine_skills(con, specs: list[dict] | None = None) -> list[str]:
     if specs is None:
         specs = _engine_specs()
     stale = stale_engine_skills(con, specs)
-    if not stale:
-        return []
     by_name = {s["name"]: s for s in specs}
     for name in stale:                       # stale ⊆ spec names, so always hits
         s = by_name[name]
@@ -191,7 +241,12 @@ def sync_engine_skills(con, specs: list[dict] | None = None) -> list[str]:
             (s["name"], s["description"], s["category"], s["command"],
              s["common"], s["content"]),
         )
-    con.commit()
+    if stale:
+        con.commit()
+    # The heal above (and the full-seed sync on update) resurrects rows with
+    # is_deleted=0 — re-assert the fork retire list so a retired skill stays
+    # retired across heals, syncs, and rebuilds.
+    apply_retired(con)
     return stale
 
 

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -13,14 +13,25 @@ Catalogue rows themselves are authored as assets + `./sc seed-skills`
 (engine + fork-local alike); this command manages what's GRANTED where,
 and retires local skills.
 
+ENGINE skills can't be `rm`'d (the seed resurrects them on every update) —
+they retire via the fork retire list instead (#238): `retire` writes the
+name to `.sc-state/skills_retired.json` (tracked, fork-owned — commit it)
+and flips the row to is_deleted=1, which every surface already filters on.
+The list is re-applied after every seed sync/heal/rebuild, so it rides
+`./sc update` the same way flavor overlays do. Grant rows stay in place
+(inert) so `unretire` restores who-had-what.
+
 Usage:
     ./sc skill list                        catalogue: origin, common, grants
     ./sc skill grant  <name> <shell>...    grant a skill to shell(s) (id or shortname)
     ./sc skill revoke <name> <shell>...    revoke a skill from shell(s)
     ./sc skill rm     <name>               soft-delete a LOCAL skill + revoke all grants
+    ./sc skill retire   <name>             retire an ENGINE skill fork-wide (durable)
+    ./sc skill unretire <name>             restore a retired engine skill (+ its grants)
 """
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -61,9 +72,16 @@ def resolve_shell(con, ref: str) -> tuple[int, str]:
 def resolve_skill(con, name: str) -> int:
     """A live skill row by name. Loud on a miss — the silent-no-op killer."""
     row = con.execute(
-        "SELECT skill_id FROM skills WHERE name=? AND is_deleted=0", (name,)).fetchone()
-    if row:
+        "SELECT skill_id, is_deleted FROM skills WHERE name=?", (name,)).fetchone()
+    if row and not row[1]:
         return row[0]
+    if row and name in seed_skills.retired_skill_names():
+        sys.exit(f"sc skill: '{name}' is retired on this fork "
+                 f"(.sc-state/skills_retired.json) — `./sc skill unretire {name}` "
+                 "to restore it.")
+    if row:
+        sys.exit(f"sc skill: '{name}' is soft-deleted — re-author + `./sc seed-skills` "
+                 "to restore it.")
     sys.exit(f"sc skill: no skill '{name}' in the live DB — author "
              f".super-coder/assets/skills/{name}/SKILL.md then `./sc seed-skills`.")
 
@@ -74,6 +92,7 @@ def persist_note() -> None:
 
 def cmd_list(con) -> int:
     engine = set(seed_skills.seeded_skill_names())
+    retired = set(seed_skills.retired_skill_names())
     rows = con.execute(
         "SELECT s.skill_id, s.name, s.common, s.is_deleted, "
         "  (SELECT GROUP_CONCAT(COALESCE(sh.shortname, sh.shell_id), ', ') "
@@ -87,7 +106,7 @@ def cmd_list(con) -> int:
     for _, name, common, deleted, grants in rows:
         origin = "engine" if name in engine else "local "
         tag = "common" if common else "opt-in"
-        dead = "  [deleted]" if deleted else ""
+        dead = ("  [retired]" if name in retired else "  [deleted]") if deleted else ""
         print(f"{name:<{w}}  {origin}  {tag}  → {grants or '(ungranted)'}{dead}")
     return 0
 
@@ -120,12 +139,58 @@ def cmd_revoke(con, name: str, shell_refs: list[str]) -> int:
     return 0
 
 
+def _write_retire_list(names: list[str]) -> None:
+    seed_skills.RETIRED_FILE.parent.mkdir(parents=True, exist_ok=True)
+    seed_skills.RETIRED_FILE.write_text(json.dumps(sorted(set(names)), indent=2) + "\n")
+
+
+def cmd_retire(con, name: str) -> int:
+    if name not in set(seed_skills.seeded_skill_names()):
+        if con.execute("SELECT 1 FROM skills WHERE name=?", (name,)).fetchone():
+            sys.exit(f"sc skill: '{name}' is a LOCAL skill — `./sc skill rm {name}` "
+                     "retires it (the retire list is for engine skills the seed "
+                     "would resurrect).")
+        sys.exit(f"sc skill: no engine skill '{name}' — `./sc skill list` shows the "
+                 "catalogue.")
+    names = seed_skills.retired_skill_names()
+    already = name in names
+    if not already:
+        _write_retire_list(names + [name])
+    seed_skills.apply_retired(con)
+    dormant = con.execute(
+        "SELECT COUNT(*) FROM shell_skills ss JOIN skills s ON s.skill_id=ss.skill_id "
+        "WHERE s.name=?", (name,)).fetchone()[0]
+    rel = seed_skills.RETIRED_FILE.relative_to(seed_skills.RETIRED_FILE.parents[1])
+    print(f"retire: {name}" + ("  (already listed)" if already else "")
+          + f" — retired fork-wide; {dormant} grant(s) kept dormant "
+          "(restored on unretire).")
+    print(f"→ commit {rel} — the list rides `./sc update`.")
+    return 0
+
+
+def cmd_unretire(con, name: str) -> int:
+    names = seed_skills.retired_skill_names()
+    if name not in names:
+        sys.exit(f"sc skill: '{name}' is not on the retire list "
+                 f"({seed_skills.RETIRED_FILE}).")
+    _write_retire_list([n for n in names if n != name])
+    seed_skills.apply_retired(con)
+    grants = con.execute(
+        "SELECT COUNT(*) FROM shell_skills ss JOIN skills s ON s.skill_id=ss.skill_id "
+        "WHERE s.name=?", (name,)).fetchone()[0]
+    rel = seed_skills.RETIRED_FILE.relative_to(seed_skills.RETIRED_FILE.parents[1])
+    print(f"unretire: {name} — restored with {grants} grant(s) live again.")
+    print(f"→ commit {rel}.")
+    return 0
+
+
 def cmd_rm(con, name: str) -> int:
     skill_id = resolve_skill(con, name)
     if name in set(seed_skills.seeded_skill_names()):
         sys.exit(f"sc skill: '{name}' is an ENGINE skill — the seed re-inserts it "
-                 "on every update/rebuild, so a local rm cannot stick. Retire it "
-                 "upstream (or just `./sc skill revoke` it from your shells).")
+                 "on every update/rebuild, so a local rm cannot stick. "
+                 f"`./sc skill retire {name}` retires it fork-wide (durable), or "
+                 "`./sc skill revoke` removes it per shell.")
     n = con.execute("DELETE FROM shell_skills WHERE skill_id=?", (skill_id,)).rowcount
     con.execute("UPDATE skills SET is_deleted=1 WHERE skill_id=?", (skill_id,))
     con.commit()
@@ -140,7 +205,8 @@ def cmd_rm(con, name: str) -> int:
 
 def main(argv: list[str]) -> int:
     usage = ("usage: ./sc skill list | grant <name> <shell>... | "
-             "revoke <name> <shell>... | rm <name>")
+             "revoke <name> <shell>... | rm <name> | retire <name> | "
+             "unretire <name>")
     if not argv or argv[0] in ("-h", "--help", "help"):
         print(usage)
         return 0
@@ -155,6 +221,10 @@ def main(argv: list[str]) -> int:
             return cmd_revoke(con, args[0], args[1:])
         if cmd == "rm" and len(args) == 1:
             return cmd_rm(con, args[0])
+        if cmd == "retire" and len(args) == 1:
+            return cmd_retire(con, args[0])
+        if cmd == "unretire" and len(args) == 1:
+            return cmd_unretire(con, args[0])
         sys.exit(usage)
     finally:
         con.close()

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -273,9 +273,15 @@ def sync_skills() -> None:
     try:
         con.executescript(seed.read_text())
         con.commit()
+        # The seed just reset every engine row to is_deleted=0 — re-assert the
+        # fork retire list (.sc-state/skills_retired.json) before regrant()
+        # hands the common catalogue back to every shell.
+        flipped = seed_skills.apply_retired(con)
     finally:
         con.close()
     print(f"  synced catalogue from {seed.name}")
+    if flipped:
+        print(f"  fork retire list re-applied: {', '.join(flipped)}")
 
 
 def regrant() -> int:

--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ fits the **fork-owned extension points**, you never touch engine files, and
 |---|---|
 | **Local skills** | Fork-authored procedures (GUI → Skills) — serialized in `content.sql`, survive every update |
 | **Flavor overlays** | `.sc-state/flavors/<flavor>.json` — what a NEW shell of a flavor gets: `skills_add` / `skills_remove` against the engine template's list, plus role/mandate/focus overrides (e.g. swap the engine's `test_authoring` for a fork's own testing skill) |
+| **Skill retire list** | `.sc-state/skills_retired.json` (written by `./sc skill retire <name>`) — engine skills this fork has taken out of service, e.g. ones superseded by a fork-local skill. Retired skills leave every surface (boot doc, renders, grants) on ALL shells and stay retired across updates; `unretire` restores them, grants intact |
 | **`instance.json`** | Per-fork config: ports, harness default, the `pg` / `vm` / `ts` opt-in blocks |
 | **`.sc-state/`** | Your memory (content.sql), map tuning, engine pin — the fork's one tracked artifact |
 | **Per-shell identity** | `current_state`, connections, decisions, seed — all DB rows, all yours |

--- a/sc
+++ b/sc
@@ -808,8 +808,9 @@ super-coder — forkable shell substrate
   sc map-sql "<query>"     read-only passthrough to the repo-map DB (dr_* catalogue) — absolute path, cwd-independent
   sc sql-rw / map-sql-rw   read-WRITE passthroughs — bypass the API's triggers/caps; `sc mem` is the write path.
                              Only for procedures with no API surface (map authoring) where a skill names it
-  ./sc skill <cmd>         skill catalogue surface: list · grant <name> <shell>... · revoke <name> <shell>... · rm <name>
-                             shells by id or shortname; rm refuses engine skills; snapshot after writes to persist
+  ./sc skill <cmd>         skill catalogue surface: list · grant <name> <shell>... · revoke <name> <shell>... · rm <name> · retire <name> · unretire <name>
+                             shells by id or shortname; rm refuses engine skills — retire/unretire manages the fork retire
+                             list (.sc-state/skills_retired.json, rides updates); snapshot after writes to persist
   ./sc render              render tracked flat _sc files (specs/docs/skills/roadmap)
   ./sc render-check        fail if committed flat _sc files drift from the DB render (CI guard; rebuild first for a hermetic check)
   ./sc map                 scan the host repo into the dr_* catalogue (re-runnable)

--- a/skills_sc/local_skill_management.md
+++ b/skills_sc/local_skill_management.md
@@ -93,7 +93,10 @@ Then `sc snapshot && sc render` and commit.
    sc skill rm <skill_name>
    ```
    Refuses engine skills — the seed would resurrect those on the next
-   update/rebuild; `sc skill revoke` them per-shell instead.
+   update/rebuild. For an engine skill this fork has superseded, retire it
+   fork-wide instead: `sc skill retire <name>` (writes the tracked
+   `.sc-state/skills_retired.json`, which rides updates; `sc skill unretire`
+   reverses). For a per-shell removal, `sc skill revoke`.
 
 2. **Remove the asset file** (`.super-coder/assets/skills/<name>/`) — otherwise
    the next `sc seed-skills` re-inserts the skill.

--- a/tests/test_skill_retire.py
+++ b/tests/test_skill_retire.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Tests for the fork skill retire list (seed_skills.apply_retired + `./sc
+skill retire|unretire`, #238).
+
+The engine seed resurrects every engine skill (is_deleted=0) on each
+update/sync/rebuild, so a fork could not durably take a superseded engine
+skill out of service. The retire list (`.sc-state/skills_retired.json`,
+tracked, fork-owned) must: flip listed engine names to is_deleted=1 and
+unlisted ones back to 0 (converge, both directions), survive a full-seed
+re-run, never touch local skills or grant rows, and fail loud on a malformed
+file rather than silently resurrecting a retired skill.
+
+Run:
+    python3 tests/test_skill_retire.py
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+import seed_skills  # noqa: E402
+import skill as skill_cli  # noqa: E402
+
+ENGINE_SKILLS = ("test_authoring", "review", "git")
+
+SEED_SQL = "\n".join(
+    f"INSERT INTO skills (name, description, common, content, is_deleted) "
+    f"VALUES ('{n}', 'engine skill', 1, 'body', 0) "
+    f"ON CONFLICT(name) DO UPDATE SET is_deleted=0;"
+    for n in ENGINE_SKILLS)
+
+
+def make_db() -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.execute(
+        "CREATE TABLE skills (skill_id INTEGER PRIMARY KEY, "
+        "name TEXT NOT NULL UNIQUE, description TEXT, category TEXT, "
+        "content TEXT, command TEXT, common INTEGER NOT NULL DEFAULT 1, "
+        "is_deleted INTEGER NOT NULL DEFAULT 0)")
+    con.execute(
+        "CREATE TABLE shell_skills (shell_skill_id INTEGER PRIMARY KEY, "
+        "shell_id INTEGER, skill_id INTEGER, UNIQUE(shell_id, skill_id))")
+    con.executescript(SEED_SQL)
+    con.execute("INSERT INTO skills (name, description, content) "
+                "VALUES ('test_authoring_dosarch', 'fork skill', 'body')")
+    # one grant on the skill we retire, to prove grants stay put
+    con.execute("INSERT INTO shell_skills (shell_id, skill_id) "
+                "SELECT 1, skill_id FROM skills WHERE name='test_authoring'")
+    con.commit()
+    return con
+
+
+class RetireTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        seed = root / "0001_seed_skills.sql"
+        seed.write_text(SEED_SQL)
+        self._orig = (seed_skills.RETIRED_FILE, seed_skills.OUT)
+        seed_skills.RETIRED_FILE = root / ".sc-state" / "skills_retired.json"
+        seed_skills.OUT = seed
+        self.con = make_db()
+
+    def tearDown(self):
+        seed_skills.RETIRED_FILE, seed_skills.OUT = self._orig
+        self.con.close()
+        self.tmp.cleanup()
+
+    def _retire_file(self, names) -> None:
+        seed_skills.RETIRED_FILE.parent.mkdir(parents=True, exist_ok=True)
+        seed_skills.RETIRED_FILE.write_text(json.dumps(names))
+
+    def _deleted(self, name) -> int:
+        return self.con.execute(
+            "SELECT is_deleted FROM skills WHERE name=?", (name,)).fetchone()[0]
+
+    # ── retired_skill_names ─────────────────────────────────────────────────
+    def test_no_file_is_empty_list(self):
+        self.assertEqual(seed_skills.retired_skill_names(), [])
+
+    def test_bad_json_fails_loud(self):
+        seed_skills.RETIRED_FILE.parent.mkdir(parents=True, exist_ok=True)
+        seed_skills.RETIRED_FILE.write_text("{broken")
+        with self.assertRaises(ValueError):
+            seed_skills.retired_skill_names()
+
+    def test_non_list_fails_loud(self):
+        self._retire_file({"retire": ["test_authoring"]})
+        with self.assertRaises(ValueError):
+            seed_skills.retired_skill_names()
+
+    # ── apply_retired ───────────────────────────────────────────────────────
+    def test_retire_flips_engine_skill(self):
+        self._retire_file(["test_authoring"])
+        flipped = seed_skills.apply_retired(self.con)
+        self.assertEqual(flipped, ["test_authoring"])
+        self.assertEqual(self._deleted("test_authoring"), 1)
+        self.assertEqual(self._deleted("review"), 0)
+
+    def test_apply_is_idempotent(self):
+        self._retire_file(["test_authoring"])
+        seed_skills.apply_retired(self.con)
+        self.assertEqual(seed_skills.apply_retired(self.con), [],
+                         "second apply must flip nothing")
+
+    def test_unlisting_restores(self):
+        self._retire_file(["test_authoring"])
+        seed_skills.apply_retired(self.con)
+        self._retire_file([])
+        flipped = seed_skills.apply_retired(self.con)
+        self.assertEqual(flipped, ["test_authoring"])
+        self.assertEqual(self._deleted("test_authoring"), 0)
+
+    def test_survives_full_seed_rerun(self):
+        # update.sync_skills re-executes the whole seed → is_deleted=0; the
+        # re-apply must retire the skill again.
+        self._retire_file(["test_authoring"])
+        seed_skills.apply_retired(self.con)
+        self.con.executescript(SEED_SQL)      # the resurrect
+        self.assertEqual(self._deleted("test_authoring"), 0)
+        seed_skills.apply_retired(self.con)
+        self.assertEqual(self._deleted("test_authoring"), 1)
+
+    def test_sync_engine_skills_reapplies(self):
+        self._retire_file(["test_authoring"])
+        seed_skills.apply_retired(self.con)
+        self.con.executescript(SEED_SQL)      # simulate an upstream resurrect
+        seed_skills.sync_engine_skills(self.con, specs=[])
+        self.assertEqual(self._deleted("test_authoring"), 1)
+
+    def test_local_skill_never_touched(self):
+        self._retire_file(["test_authoring_dosarch"])   # local name — ignored
+        flipped = seed_skills.apply_retired(self.con)
+        self.assertEqual(flipped, [])
+        self.assertEqual(self._deleted("test_authoring_dosarch"), 0)
+
+    def test_grants_stay_dormant(self):
+        self._retire_file(["test_authoring"])
+        seed_skills.apply_retired(self.con)
+        n = self.con.execute(
+            "SELECT COUNT(*) FROM shell_skills ss "
+            "JOIN skills s ON s.skill_id=ss.skill_id "
+            "WHERE s.name='test_authoring'").fetchone()[0]
+        self.assertEqual(n, 1, "retire must not delete grant rows")
+
+    # ── CLI (skill.py) ──────────────────────────────────────────────────────
+    def test_cmd_retire_writes_file_and_flips(self):
+        skill_cli.cmd_retire(self.con, "test_authoring")
+        self.assertEqual(json.loads(seed_skills.RETIRED_FILE.read_text()),
+                         ["test_authoring"])
+        self.assertEqual(self._deleted("test_authoring"), 1)
+
+    def test_cmd_retire_refuses_local_skill(self):
+        with self.assertRaises(SystemExit):
+            skill_cli.cmd_retire(self.con, "test_authoring_dosarch")
+
+    def test_cmd_retire_refuses_unknown(self):
+        with self.assertRaises(SystemExit):
+            skill_cli.cmd_retire(self.con, "no_such_skill")
+
+    def test_cmd_unretire_restores(self):
+        skill_cli.cmd_retire(self.con, "test_authoring")
+        skill_cli.cmd_unretire(self.con, "test_authoring")
+        self.assertEqual(json.loads(seed_skills.RETIRED_FILE.read_text()), [])
+        self.assertEqual(self._deleted("test_authoring"), 0)
+
+    def test_cmd_unretire_unlisted_is_loud(self):
+        with self.assertRaises(SystemExit):
+            skill_cli.cmd_unretire(self.con, "review")
+
+    def test_grant_of_retired_skill_is_loud(self):
+        skill_cli.cmd_retire(self.con, "test_authoring")
+        with self.assertRaises(SystemExit):
+            skill_cli.resolve_skill(self.con, "test_authoring")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the structural half of #238 (the text half landed in #270).

**Mechanism.** A fork-owned, tracked retire list at `.sc-state/skills_retired.json` (same pattern as #247's flavor overlays), managed by `./sc skill retire <name>` / `unretire <name>`. `seed_skills.apply_retired()` converges engine rows to the list: listed names get `is_deleted=1` — the one switch every surface already filters on (per-shell SKILL.md render, boot-doc SKILLS block, catalogue render, `regrant()`, `create_shell` common grants) — so one flip retires a skill everywhere, for ALL shells, existing and new. It is re-applied after every resurrect path: the full-seed sync on `./sc update` (before `regrant()`), the stale-heal on render/launch, and `./sc rebuild`.

**Why not render-time pointer resolution** (the issue's other option): skill bodies are free text, so resolving cross-references would need a reference syntax across the catalogue plus per-shell rendering of shared files. With retirement, the superseded skill simply isn't present on any surface, and #270's deferral prose ("use the granted skill that supersedes the lens") covers the remaining text pointer. Same effect, a fraction of the machinery.

**Semantics worth noting**
- Engine names only: local skills keep using `skill rm`; a listed non-engine name warns and is ignored.
- Grant rows stay in place while retired (inert — every consumer filters `is_deleted`), so `unretire` restores exactly who had the skill. `snapshot`'s grant dump doesn't filter either, so dormant grants survive rebuilds.
- `skill rm`'s engine-name refusal and the `local_skill_management` skill now point at `retire`; reseed 0046 carries the text to installed forks. `skill list` shows `[retired]`; granting a retired skill errors with the unretire hint.
- dos-arch's case becomes: `./sc skill retire test_authoring && ./sc skill retire test_authoring_pg`, commit the JSON — done for every shell, durable across repins.

Tests: 16 new in `tests/test_skill_retire.py` (converge both directions, full-seed-rerun survival, local-skill immunity, dormant grants, CLI guards); 250 total pass; `render-check` green (0046 executes in the hermetic chain).

Note: numbered 0046 because open PR #278 takes 0045 — if #278 is not merged first, I'll renumber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)