### PR TITLE
feat(gui): Default Models sub-tab — flavor_defaults editor with live model catalog

### DIFF
--- a/.super-coder/api/model_catalog.py
+++ b/.super-coder/api/model_catalog.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Model catalog — live model-id suggestions for the Default Models GUI.
+
+Layered, best-effort sources. The GUI's model field stays free text, so none
+of this is load-bearing — a source that fails just thins the suggestions:
+
+  1. models.dev/api.json — the keyless catalog OpenCode itself consumes.
+     One fetch covers all four harness providers (anthropic / openai /
+     mistral / ollama-cloud), with release dates for newest-first sorting.
+  2. Provider list-models APIs — only when the matching env key is present.
+     Harness logins are OAuth, not API keys, so these are usually absent.
+  3. `opencode models` CLI — exactly what the local install can resolve.
+  4. A static floor (the ids the engine ships in flavor_defaults) when every
+     live source fails and no cache exists.
+
+Fetched server-side (no CORS), cached under the gitignored .super-coder/logs/
+(ephemeral like webapp.log — NOT .sc-state/, where an auto-written file would
+dirty the tree and trip the publish guard) with a TTL; a failed refresh serves
+the stale cache and says so. Claude aliases
+(opus / sonnet / haiku) lead their list: an alias floats to the newest model
+in its family, so a stored alias never goes stale — full ids cover NEW
+families, which is the case aliases can't (a fable-shaped release).
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+CACHE = ENGINE / "logs" / "model_catalog.json"
+TTL_HOURS = 24
+TIMEOUT = 8
+MODELS_DEV_URL = "https://models.dev/api.json"
+
+# harness -> models.dev provider key
+HARNESS_PROVIDER = {
+    "claude": "anthropic",
+    "codex": "openai",
+    "vibe": "mistral",
+    "opencode": "ollama-cloud",
+}
+# opencode model ids are provider-prefixed ("ollama-cloud/<model>") — the
+# format flavor_defaults already stores for that harness.
+PREFIXED_HARNESSES = {"opencode"}
+
+CLAUDE_ALIASES = ["opus", "sonnet", "haiku"]
+
+# provider APIs, keyed by harness: (env var, url, header builder). Responses
+# are the OpenAI-style {"data": [{"id": ...}, ...]} shape on all three.
+PROVIDER_APIS = {
+    "claude": ("ANTHROPIC_API_KEY", "https://api.anthropic.com/v1/models",
+               lambda k: {"x-api-key": k, "anthropic-version": "2023-06-01"}),
+    "codex": ("OPENAI_API_KEY", "https://api.openai.com/v1/models",
+              lambda k: {"Authorization": f"Bearer {k}"}),
+    "vibe": ("MISTRAL_API_KEY", "https://api.mistral.ai/v1/models",
+             lambda k: {"Authorization": f"Bearer {k}"}),
+}
+
+# The ids the engine ships in flavor_defaults — surfaced only when every live
+# source fails AND no cache exists, so the datalist is never empty.
+STATIC_FLOOR = {
+    "claude": ["opus", "sonnet", "haiku"],
+    "codex": ["gpt-5.5", "gpt-5.4-mini"],
+    "vibe": ["devstral-latest", "codestral-latest"],
+    "opencode": ["ollama-cloud/deepseek-v4-pro", "ollama-cloud/glm-5.1",
+                 "ollama-cloud/qwen3-coder-next", "ollama-cloud/gpt-oss:20b"],
+}
+
+
+def _http_json(url: str, headers: dict | None = None) -> dict:
+    # models.dev's CDN 403s python-urllib's default agent — always identify.
+    hdrs = {"User-Agent": "super-coder-model-catalog/1.0", **(headers or {})}
+    req = urllib.request.Request(url, headers=hdrs)
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+        return json.loads(r.read().decode())
+
+
+def _entry(mid: str, release_date: str = "", name: str = "") -> dict:
+    return {"id": mid, "release_date": release_date, "name": name or mid}
+
+
+def _from_models_dev(fetch) -> dict[str, list[dict]]:
+    data = fetch(MODELS_DEV_URL)
+    out: dict[str, list[dict]] = {}
+    for harness, provider in HARNESS_PROVIDER.items():
+        models = (data.get(provider) or {}).get("models") or {}
+        entries = []
+        for mid, m in models.items():
+            full = f"{provider}/{mid}" if harness in PREFIXED_HARNESSES else mid
+            entries.append(_entry(full, m.get("release_date") or "",
+                                  m.get("name") or mid))
+        entries.sort(key=lambda e: e["release_date"], reverse=True)
+        out[harness] = entries
+    return out
+
+
+def _from_provider_apis(fetch, env) -> dict[str, list[dict]]:
+    out: dict[str, list[dict]] = {}
+    for harness, (var, url, hdrs) in PROVIDER_APIS.items():
+        key = env.get(var)
+        if not key:
+            continue
+        try:
+            data = fetch(url, hdrs(key))
+        except Exception:
+            continue  # opportunistic — a bad key never degrades the catalog
+        ids = [m.get("id") for m in data.get("data") or [] if m.get("id")]
+        if ids:
+            out[harness] = [_entry(i) for i in ids]
+    return out
+
+
+def _from_opencode_cli(run) -> list[dict]:
+    """`opencode models` lists provider/model ids the LOCAL install resolves —
+    the most accurate opencode source, merged in when the binary exists."""
+    if not shutil.which("opencode"):
+        return []
+    try:
+        r = run(["opencode", "models"], capture_output=True, text=True,
+                timeout=15)
+    except Exception:
+        return []
+    if r.returncode != 0:
+        return []
+    # The CLI lists every provider/model the install resolves (hundreds).
+    # ollama-cloud leads (the engine's opencode defaults live there), the
+    # rest sorted — the datalist filters as the operator types.
+    ids = sorted({line.strip() for line in r.stdout.splitlines()
+                  if "/" in line.strip() and " " not in line.strip()},
+                 key=lambda i: (not i.startswith("ollama-cloud/"), i))
+    return [_entry(i) for i in ids]
+
+
+def _merge(base: list[dict], extra: list[dict]) -> list[dict]:
+    seen = {e["id"] for e in base}
+    return base + [e for e in extra if e["id"] not in seen]
+
+
+def build(fetch=_http_json, env=os.environ, run=subprocess.run) -> dict:
+    """One live sweep across all sources. Raises only if EVERY source fails —
+    partial results (e.g. models.dev down but a keyed API up) still count."""
+    harnesses: dict[str, list[dict]] = {}
+    sources: list[str] = []
+    errors: list[str] = []
+    try:
+        harnesses = _from_models_dev(fetch)
+        sources.append("models.dev")
+    except Exception as e:  # noqa: BLE001
+        errors.append(f"models.dev: {e}")
+    for harness, extra in _from_provider_apis(fetch, env).items():
+        harnesses[harness] = _merge(harnesses.get(harness, []), extra)
+        sources.append(f"{HARNESS_PROVIDER[harness]}-api")
+    oc = _from_opencode_cli(run)
+    if oc:
+        harnesses["opencode"] = _merge(harnesses.get("opencode", []), oc)
+        sources.append("opencode-cli")
+    if not sources:
+        raise RuntimeError("; ".join(errors) or "no catalog sources available")
+    # claude aliases lead — self-tracking within a family, so they never stale.
+    aliases = [_entry(a, name=f"{a} (alias — tracks the family's latest)")
+               for a in CLAUDE_ALIASES]
+    harnesses["claude"] = aliases + [e for e in harnesses.get("claude", [])
+                                     if e["id"] not in CLAUDE_ALIASES]
+    return {"fetched_at": datetime.now(timezone.utc).isoformat(),
+            "sources": sources, "harnesses": harnesses}
+
+
+def _load_cache() -> dict | None:
+    try:
+        return json.loads(CACHE.read_text())
+    except Exception:  # noqa: BLE001  (missing or corrupt — both mean "no cache")
+        return None
+
+
+def _fresh(cached: dict) -> bool:
+    try:
+        age = datetime.now(timezone.utc) - datetime.fromisoformat(cached["fetched_at"])
+        return age.total_seconds() < TTL_HOURS * 3600
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _floor() -> dict[str, list[dict]]:
+    return {h: [_entry(i) for i in ids] for h, ids in STATIC_FLOOR.items()}
+
+
+def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
+            run=subprocess.run) -> dict:
+    """The cached-with-fallbacks entry point the API serves.
+
+    fresh cache → serve it; miss/stale/refresh → live sweep, cache the result;
+    sweep failed → stale cache if any, else the static floor. Every response
+    carries `stale` + `fetched_at` so the GUI can say how current it is."""
+    cached = _load_cache()
+    if cached and not refresh and _fresh(cached):
+        return {**cached, "stale": False}
+    try:
+        fresh = build(fetch, env, run)
+    except Exception as e:  # noqa: BLE001
+        if cached:
+            return {**cached, "stale": True, "error": str(e)}
+        return {"fetched_at": None, "sources": ["static"], "stale": True,
+                "error": str(e), "harnesses": _floor()}
+    CACHE.parent.mkdir(parents=True, exist_ok=True)
+    CACHE.write_text(json.dumps(fresh, indent=1) + "\n")
+    return {**fresh, "stale": False}

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -60,6 +60,7 @@ import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
 import ports as ports_mod  # noqa: E402
 import shell_factory  # noqa: E402
 import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin rule)
+import model_catalog  # noqa: E402  (live model-id suggestions, sibling module)
 import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
 import ts as ts_mod  # noqa: E402  (tailnet — config + live checks)
 import pm2 as pm2_mod  # noqa: E402  (host pm2 stack — config + live checks)
@@ -222,6 +223,65 @@ def get_skills(con) -> dict:
     for s in skills:
         s["granted_shells"] = grants.get(s["skill_id"], [])
     return {"skills": skills, "shells": get_shells(con)}
+
+
+def known_harnesses() -> list[str]:
+    """The harness set = the shipped adapters (claude/codex/opencode/vibe)."""
+    d = ENGINE / "adapters"
+    if d.exists():
+        return sorted(p.name for p in d.iterdir() if p.is_dir())
+    return ["claude", "codex", "opencode", "vibe"]
+
+
+def get_flavor_defaults(con) -> dict:
+    """The launch-defaults matrix for the Default Models sub-tab: per flavor,
+    a model per harness + one starred default harness (flavor_defaults rows —
+    the exact table run.py's picker resolves at launch). Template flavors with
+    no rows yet are included empty so the GUI matrix is complete; missing
+    cells are created on first write (see set_flavor_default)."""
+    flavors: dict[str, list] = {}
+    for r in rows(con.execute(
+            "SELECT flavor, harness, model, is_default FROM flavor_defaults "
+            "ORDER BY flavor, harness")):
+        flavors.setdefault(r["flavor"], []).append(
+            {"harness": r["harness"], "model": r["model"],
+             "is_default": bool(r["is_default"])})
+    for t in shell_factory.flavors():
+        flavors.setdefault(t.get("flavor"), [])
+    return {"flavors": flavors, "harnesses": known_harnesses()}
+
+
+def set_flavor_default(con, body) -> tuple[bool, str | None]:
+    """One write to the launch-defaults matrix: set a (flavor, harness) cell's
+    model, and/or star the harness as the flavor's default. Starring is
+    transactional across the flavor's rows — exactly one is_default=1 after.
+    Upserts the row so template flavors / harnesses without a seeded row are
+    settable; an empty model clears the cell back to NULL (harness default)."""
+    flavor = (body.get("flavor") or "").strip()
+    harness = (body.get("harness") or "").strip()
+    if not flavor or not harness:
+        return False, "flavor and harness required"
+    if harness not in known_harnesses():
+        return False, f"unknown harness '{harness}'"
+    known_flavors = {t.get("flavor") for t in shell_factory.flavors()} | {
+        r[0] for r in con.execute("SELECT DISTINCT flavor FROM flavor_defaults")}
+    if flavor not in known_flavors:
+        return False, f"unknown flavor '{flavor}'"
+    if "model" not in body and not body.get("is_default"):
+        return False, "nothing to set — pass model and/or is_default"
+    con.execute(
+        "INSERT INTO flavor_defaults (flavor, harness, model, is_default) "
+        "VALUES (?, ?, NULL, 0) ON CONFLICT(flavor, harness) DO NOTHING",
+        (flavor, harness))
+    if "model" in body:
+        model = (body.get("model") or "").strip() or None
+        con.execute("UPDATE flavor_defaults SET model=? "
+                    "WHERE flavor=? AND harness=?", (model, flavor, harness))
+    if body.get("is_default"):
+        con.execute("UPDATE flavor_defaults SET is_default = (harness = ?) "
+                    "WHERE flavor = ?", (harness, flavor))
+    con.commit()
+    return True, None
 
 
 # Board order: delivered work first, then the committed funnel read backward
@@ -1509,7 +1569,6 @@ class Handler(BaseHTTPRequestHandler):
         # fetch for accurate behind-counts + fresh PR state; the default skips it
         # so the initial tab load is snappy.
         if urlparse(self.path).path == "/api/git-state":
-            from urllib.parse import parse_qs
             q = parse_qs(urlparse(self.path).query)
             fetch = q.get("fetch", ["0"])[0] in ("1", "true", "yes")
             try:
@@ -1532,6 +1591,12 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, {"shells": get_shells(con)})
             if path == "/api/shell-templates":
                 return self._send(200, {"templates": shell_factory.flavors()})
+            if path == "/api/flavor-defaults":
+                return self._send(200, get_flavor_defaults(con))
+            if path == "/api/models":
+                q = parse_qs(urlparse(self.path).query)
+                return self._send(200, model_catalog.catalog(
+                    refresh=q.get("refresh", ["0"])[0] in ("1", "true")))
             if path.startswith("/api/shells/"):
                 sid = int(path.rsplit("/", 1)[1])
                 shell = get_shell(con, sid)
@@ -1632,6 +1697,10 @@ class Handler(BaseHTTPRequestHandler):
                 sn = con.execute(
                     "SELECT shortname FROM shells WHERE shell_id=?", (sid,)).fetchone()[0]
                 return self._send(201, {"shell_id": sid, "shortname": sn})
+            if path == "/api/flavor-defaults":
+                ok, err = set_flavor_default(con, self._body())
+                return self._send(200 if ok else 400,
+                                  {"ok": ok} if ok else {"error": err})
             if path == "/api/snapshot":
                 try:
                     out = run_snapshot_render()

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -67,6 +67,11 @@ PER_INSTANCE_TABLES = [
     # cache. Loads after `shells` (its FK target). read_at is preserved, so an
     # unread message stays unread across a rebuild.
     "shell_messages",
+    # flavor_defaults is operator-tuned launch config (the Default Models GUI:
+    # model per harness + starred default harness, per flavor). Migrations seed
+    # the engine's baseline; content.sql loads AFTER migrations on rebuild, so
+    # the fork's edits win — without this the GUI's changes vanish on rebuild.
+    "flavor_defaults",
     # NOTE: dr_section is authored navigation but lives in the MAP DB now
     # (.sc-state/map.db), not shell_db.db — it is serialized separately to
     # .sc-state/map_content.sql by snapshot_map() below, not here.

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -95,7 +95,7 @@ function groupSkills(skills, { alwaysRepo = false } = {}) {
 // Skills sub-tabs scoped to the selected shell. Flat panels, accordions,
 // popover pickers, and a unified edit modal.
 let selectedShell = null;
-let shellTab = "harness";     // 'harness' | 'skills'
+let shellTab = "harness";     // 'harness' | 'skills' | 'models'
 let activeSkillId = null;     // skill-viewer selection; reset on shell switch
 
 // Rough token estimator — BPE-ish, ~15% off for English; the tilde in the
@@ -263,9 +263,11 @@ async function renderShells(root) {
   sub.append(newBtn);
   root.append(sub);
 
-  // sub-tabs — Harness / Skills, both scoped to the selected shell
+  // sub-tabs — Harness / Skills scoped to the selected shell; Default Models
+  // is the fork-global launch matrix (same content from any shell)
   const tabs = el("div", { className: "vtabs" });
-  for (const [key, label] of [["harness", "Harness"], ["skills", "Skills"]]) {
+  for (const [key, label] of [["harness", "Harness"], ["skills", "Skills"],
+                              ["models", "Default Models"]]) {
     const b = el("button", { className: shellTab === key ? "active-tab" : "", type: "button", textContent: label });
     b.onclick = () => { shellTab = key; renderShells(root); };
     tabs.append(b);
@@ -275,7 +277,84 @@ async function renderShells(root) {
   const pane = el("div", { className: "shell-pane" });
   root.append(pane);
   if (shellTab === "harness") renderHarness(pane, s);
+  else if (shellTab === "models") renderDefaultModels(pane, s);
   else renderSkillViewer(pane, s);
+}
+
+// Default Models — the flavor_defaults launch matrix: per flavor, a model per
+// harness and ONE starred default harness (the two launch defaults run.py
+// resolves at boot). Fork-global config — the selected shell's flavor leads,
+// but the matrix is the same from any shell. Model fields are free text
+// backed by datalist suggestions from /api/models (models.dev + keyed
+// provider APIs + opencode CLI, cached server-side, static floor last) —
+// the catalog is advisory, never a constraint.
+async function renderDefaultModels(root, s) {
+  root.textContent = "";
+  let fd;
+  try { fd = await api("/flavor-defaults"); }
+  catch (e) { root.append(el("div", { className: "vpanel" }, "flavor-defaults error: " + e.message)); return; }
+  let cat = { harnesses: {}, sources: [], fetched_at: null, stale: true };
+  try { cat = await api("/models"); } catch { /* inputs stay free text */ }
+
+  const head = el("div", { className: "viewer-head" }, microlabel("Default Models"));
+  const refresh = el("button", { className: "act", type: "button", textContent: "↻ Refresh models" });
+  refresh.onclick = async () => {
+    refresh.disabled = true;
+    setStatus("refreshing model catalog…");
+    try { await api("/models?refresh=1"); setStatus("model catalog refreshed"); }
+    catch (e) { toast("catalog refresh error: " + e.message); setStatus("catalog refresh failed"); }
+    renderDefaultModels(root, s);
+  };
+  head.append(refresh);
+  root.append(head);
+  const when = cat.fetched_at ? new Date(cat.fetched_at).toLocaleString() : "never";
+  root.append(el("div", { className: "dm-meta" },
+    `catalog: ${(cat.sources || []).join(" + ") || "none"} · as of ${when}`
+    + (cat.stale ? " (stale — live refresh failed)" : "")));
+
+  // one datalist per harness, shared by every flavor's input for that harness
+  for (const h of fd.harnesses) {
+    const dl = el("datalist", { id: "dm-list-" + h });
+    for (const m of cat.harnesses?.[h] || [])
+      dl.append(el("option", { value: m.id, label: m.release_date || m.name || "" }));
+    root.append(dl);
+  }
+
+  const flavors = Object.keys(fd.flavors).sort(
+    (a, b) => (a === s.flavor ? -1 : b === s.flavor ? 1 : a.localeCompare(b)));
+  const panel = el("div", { className: "vpanel" });
+  for (const flavor of flavors) {
+    const byHarness = Object.fromEntries((fd.flavors[flavor] || []).map((r) => [r.harness, r]));
+    panel.append(el("div", { className: "acc-group" },
+      flavor + (flavor === s.flavor ? " · this shell" : "")));
+    for (const h of fd.harnesses) {
+      const row = byHarness[h] || { model: null, is_default: false };
+      const star = el("input", { type: "radio", name: "dm-star-" + flavor,
+                                 title: "star = default harness at launch" });
+      star.checked = row.is_default;
+      star.onchange = async () => {
+        try {
+          await api("/flavor-defaults", "POST", { flavor, harness: h, is_default: true });
+          toast(`default harness: ${flavor} → ${h}`);
+        } catch (e) { toast("error: " + e.message); }
+        renderDefaultModels(root, s);   // reflect the sibling un-star
+      };
+      const input = el("input", { className: "dm-model", value: row.model || "",
+                                  placeholder: "harness default" });
+      input.setAttribute("list", "dm-list-" + h);
+      input.onchange = async () => {
+        try {
+          await api("/flavor-defaults", "POST", { flavor, harness: h, model: input.value });
+          toast(`${flavor} · ${h} → ${input.value || "(harness default)"}`);
+        } catch (e) { toast("error: " + e.message); }
+      };
+      panel.append(el("div", { className: "dm-row" },
+        star, el("span", { className: "dm-harness" }, h), input));
+    }
+  }
+  root.append(panel);
+  root.append(el("div", { className: "dm-note" },
+    "★ = default harness at launch. Suggestions are unfiltered — an open-model licence gate (e.g. MIT/Apache-only) stays operator policy."));
 }
 
 // Harness — the shell's surfaces as grouped accordions: Operational

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -321,6 +321,25 @@ a { color: var(--accent); }
   background: rgba(255,255,255,.02); border-top: 1px solid var(--line-soft);
 }
 .acc-panel > .acc-group:first-child { border-top: none; }
+
+/* ── Default Models sub-tab — flavor_defaults matrix ───────────────────────
+   One .dm-row per (flavor, harness): star radio (default harness) · harness
+   label · free-text model input backed by a per-harness datalist. */
+.dm-meta { padding: .1rem .2rem .4rem; font-size: 11px; color: var(--dim); }
+.dm-row {
+  display: grid; grid-template-columns: 24px 110px 1fr; align-items: center;
+  gap: .7rem; padding: .4rem 1.1rem; border-top: 1px solid var(--line-soft);
+}
+.dm-row input[type="radio"] { accent-color: var(--accent); margin: 0; cursor: pointer; }
+.dm-harness { font: 600 12px/1.4 ui-monospace, "Cascadia Mono", "Menlo", monospace;
+  letter-spacing: .06em; color: rgba(255,255,255,.85); }
+.dm-model {
+  background: var(--panel2); border: 1px solid var(--line-soft); color: inherit;
+  border-radius: var(--r); padding: .35rem .6rem; width: 100%; max-width: 34rem;
+  font: 12px/1.4 ui-monospace, "Cascadia Mono", "Menlo", monospace;
+}
+.dm-model:focus { outline: none; border-color: var(--accent); }
+.dm-note { padding: .5rem .2rem; font-size: 11px; color: var(--dim); }
 .acc { border-top: 1px solid var(--line-soft); }
 .acc > summary {
   list-style: none; cursor: pointer; user-select: none;

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -229,5 +229,72 @@ class FeatureBlockerTest(unittest.TestCase):
         self.assertIn("cycle", err)
 
 
+class FlavorDefaultsTest(unittest.TestCase):
+    """The Default Models matrix: get_flavor_defaults / set_flavor_default.
+
+    flavor_defaults is migration-seeded launch config the GUI now edits — the
+    contract is upsert-on-write (template flavors / harnesses may lack seeded
+    rows), a transactional star (exactly one is_default per flavor after), and
+    loud validation for unknown names."""
+
+    def setUp(self) -> None:
+        self.con = build_db()
+
+    def _row(self, flavor, harness):
+        return self.con.execute(
+            "SELECT model, is_default FROM flavor_defaults "
+            "WHERE flavor=? AND harness=?", (flavor, harness)).fetchone()
+
+    def test_matrix_includes_template_flavors_and_harnesses(self) -> None:
+        got = server.get_flavor_defaults(self.con)
+        self.assertIn("planner", got["flavors"])
+        self.assertIn("admin", got["flavors"], "template flavors appear even unseeded")
+        for h in ("claude", "codex", "opencode", "vibe"):
+            self.assertIn(h, got["harnesses"])
+
+    def test_set_model(self) -> None:
+        ok, err = server.set_flavor_default(
+            self.con, {"flavor": "planner", "harness": "claude", "model": "opus"})
+        self.assertTrue(ok, err)
+        self.assertEqual(self._row("planner", "claude")["model"], "opus")
+
+    def test_star_is_transactional_across_the_flavor(self) -> None:
+        self.assertTrue(server.set_flavor_default(
+            self.con, {"flavor": "planner", "harness": "codex",
+                       "is_default": True})[0])
+        rows = self.con.execute(
+            "SELECT harness, is_default FROM flavor_defaults "
+            "WHERE flavor='planner'").fetchall()
+        stars = {r["harness"]: r["is_default"] for r in rows}
+        self.assertEqual(sum(stars.values()), 1)
+        self.assertEqual(stars["codex"], 1)
+
+    def test_upsert_missing_cell(self) -> None:
+        # 'vibe' has no seeded row for planner — a write must create it
+        self.assertIsNone(self._row("planner", "vibe"))
+        ok, err = server.set_flavor_default(
+            self.con, {"flavor": "planner", "harness": "vibe",
+                       "model": "devstral-latest", "is_default": True})
+        self.assertTrue(ok, err)
+        row = self._row("planner", "vibe")
+        self.assertEqual(row["model"], "devstral-latest")
+        self.assertEqual(row["is_default"], 1)
+
+    def test_empty_model_clears_to_null(self) -> None:
+        server.set_flavor_default(
+            self.con, {"flavor": "planner", "harness": "claude", "model": "opus"})
+        server.set_flavor_default(
+            self.con, {"flavor": "planner", "harness": "claude", "model": ""})
+        self.assertIsNone(self._row("planner", "claude")["model"])
+
+    def test_unknown_names_and_empty_writes_are_loud(self) -> None:
+        self.assertFalse(server.set_flavor_default(
+            self.con, {"flavor": "planner", "harness": "emacs", "model": "x"})[0])
+        self.assertFalse(server.set_flavor_default(
+            self.con, {"flavor": "nope", "harness": "claude", "model": "x"})[0])
+        self.assertFalse(server.set_flavor_default(
+            self.con, {"flavor": "planner", "harness": "claude"})[0])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Tests for the model-catalog service (api/model_catalog.py).
+
+The catalog is layered and best-effort: models.dev (keyless, all four
+harnesses) → provider APIs (only with env keys) → `opencode models` CLI →
+cache → static floor. These tests pin the layering contract: harness→provider
+mapping and opencode prefixing, newest-first sorting, claude aliases leading,
+opportunistic merges that never fail the sweep, stale-cache-on-failure, and
+the floor when everything is down. All sources are injected — no network.
+
+Run:
+    python3 tests/test_model_catalog.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "api"))
+import model_catalog as mc  # noqa: E402
+
+MODELS_DEV = {
+    "anthropic": {"models": {
+        "claude-opus-4-8": {"name": "Claude Opus 4.8", "release_date": "2026-04-01"},
+        "claude-fable-5": {"name": "Claude Fable 5", "release_date": "2026-06-09"},
+    }},
+    "openai": {"models": {"gpt-5.5": {"release_date": "2026-01-01"}}},
+    "mistral": {"models": {"devstral-latest": {"release_date": "2025-12-01"}}},
+    "ollama-cloud": {"models": {"deepseek-v4-pro": {"release_date": "2026-02-02"}}},
+}
+
+
+def fetch_ok(url, headers=None):
+    if url == mc.MODELS_DEV_URL:
+        return MODELS_DEV
+    if "openai" in url:
+        return {"data": [{"id": "gpt-9-preview"}, {"id": "gpt-5.5"}]}
+    raise RuntimeError(f"unexpected fetch: {url}")
+
+
+def fetch_down(url, headers=None):
+    raise OSError("network down")
+
+
+class NoCLI(unittest.TestCase):
+    """Base: opencode binary absent unless a test opts in."""
+
+    def setUp(self):
+        p = mock.patch.object(mc.shutil, "which", return_value=None)
+        p.start()
+        self.addCleanup(p.stop)
+
+
+class BuildTest(NoCLI):
+    def test_harness_mapping_and_prefixing(self):
+        got = mc.build(fetch=fetch_ok, env={}, run=None)
+        self.assertIn("claude-fable-5", [e["id"] for e in got["harnesses"]["claude"]])
+        self.assertEqual([e["id"] for e in got["harnesses"]["codex"]], ["gpt-5.5"])
+        self.assertEqual([e["id"] for e in got["harnesses"]["opencode"]],
+                         ["ollama-cloud/deepseek-v4-pro"])
+        self.assertEqual(got["sources"], ["models.dev"])
+
+    def test_claude_aliases_lead_then_newest_first(self):
+        ids = [e["id"] for e in mc.build(fetch=fetch_ok, env={}, run=None)
+               ["harnesses"]["claude"]]
+        self.assertEqual(ids[:3], mc.CLAUDE_ALIASES)
+        self.assertEqual(ids[3:5], ["claude-fable-5", "claude-opus-4-8"],
+                         "full ids must sort newest release first")
+
+    def test_provider_api_merges_and_dedupes(self):
+        got = mc.build(fetch=fetch_ok, env={"OPENAI_API_KEY": "k"}, run=None)
+        ids = [e["id"] for e in got["harnesses"]["codex"]]
+        self.assertEqual(ids, ["gpt-5.5", "gpt-9-preview"],
+                         "keyed-API ids append deduped, models.dev order kept")
+        self.assertIn("openai-api", got["sources"])
+
+    def test_bad_provider_key_never_fails_the_sweep(self):
+        def fetch(url, headers=None):
+            if url == mc.MODELS_DEV_URL:
+                return MODELS_DEV
+            raise OSError("401")
+        got = mc.build(fetch=fetch, env={"OPENAI_API_KEY": "bad"}, run=None)
+        self.assertEqual(got["sources"], ["models.dev"])
+
+    def test_opencode_cli_merges(self):
+        with mock.patch.object(mc.shutil, "which", return_value="/usr/bin/opencode"):
+            def run(cmd, **kw):
+                return mock.Mock(returncode=0,
+                                 stdout="ollama-cloud/deepseek-v4-pro\n"
+                                        "ollama-cloud/glm-5.1\nnot a model line\n")
+            got = mc.build(fetch=fetch_ok, env={}, run=run)
+        ids = [e["id"] for e in got["harnesses"]["opencode"]]
+        self.assertEqual(ids, ["ollama-cloud/deepseek-v4-pro", "ollama-cloud/glm-5.1"])
+        self.assertIn("opencode-cli", got["sources"])
+
+    def test_all_sources_down_raises(self):
+        with self.assertRaises(RuntimeError):
+            mc.build(fetch=fetch_down, env={}, run=None)
+
+
+class CatalogCacheTest(NoCLI):
+    def setUp(self):
+        super().setUp()
+        self.tmp = tempfile.TemporaryDirectory()
+        self._orig = mc.CACHE
+        mc.CACHE = Path(self.tmp.name) / "model_catalog.json"
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(lambda: setattr(mc, "CACHE", self._orig))
+
+    def test_writes_cache_and_serves_it_without_refetch(self):
+        first = mc.catalog(fetch=fetch_ok, env={}, run=None)
+        self.assertFalse(first["stale"])
+        self.assertTrue(mc.CACHE.exists())
+        second = mc.catalog(fetch=fetch_down, env={}, run=None)  # would fail live
+        self.assertFalse(second["stale"], "fresh cache must serve without a fetch")
+        self.assertEqual(second["harnesses"], first["harnesses"])
+
+    def test_stale_cache_served_when_refresh_fails(self):
+        mc.catalog(fetch=fetch_ok, env={}, run=None)
+        aged = json.loads(mc.CACHE.read_text())
+        aged["fetched_at"] = "2020-01-01T00:00:00+00:00"
+        mc.CACHE.write_text(json.dumps(aged))
+        got = mc.catalog(fetch=fetch_down, env={}, run=None)
+        self.assertTrue(got["stale"])
+        self.assertIn("claude", got["harnesses"])
+
+    def test_refresh_flag_bypasses_fresh_cache(self):
+        mc.catalog(fetch=fetch_ok, env={}, run=None)
+        def fetch2(url, headers=None):
+            if url == mc.MODELS_DEV_URL:
+                return {"anthropic": {"models": {"claude-next": {"release_date": "2027-01-01"}}}}
+            raise RuntimeError
+        got = mc.catalog(refresh=True, fetch=fetch2, env={}, run=None)
+        self.assertIn("claude-next", [e["id"] for e in got["harnesses"]["claude"]])
+
+    def test_static_floor_when_no_cache_and_no_network(self):
+        got = mc.catalog(fetch=fetch_down, env={}, run=None)
+        self.assertTrue(got["stale"])
+        self.assertEqual(got["sources"], ["static"])
+        for harness in ("claude", "codex", "vibe", "opencode"):
+            self.assertTrue(got["harnesses"][harness])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the `defaultModels.png` redline: a third sub-tab on the Shells page editing the `flavor_defaults` launch matrix — a model per harness plus one starred default harness per flavor, the exact two defaults `run.py` resolves at boot. The selected shell's flavor leads; the matrix is fork-global.

**API.** `GET/POST /api/flavor-defaults` — writes upsert the (flavor, harness) cell (template flavors and harnesses without seeded rows are settable), an empty model clears back to harness default, and starring flips `is_default` transactionally across the flavor's rows. Unknown flavor/harness names are loud 400s. `GET /api/models[?refresh=1]` serves the suggestion catalog.

**Live model catalog** (`api/model_catalog.py`), layered best-effort so a new release is one click instead of a migration:
- **models.dev/api.json** (keyless; the catalog OpenCode itself uses) covers all four harness providers — verified live: claude 27, codex 51, vibe 30, opencode 439 suggestions, with release dates for newest-first sorting. Its CDN 403s bare python-urllib, so the fetcher always sends a User-Agent.
- **Provider list-models APIs** merge in only when `ANTHROPIC/OPENAI/MISTRAL_API_KEY` env keys exist (opportunistic — harness logins are OAuth, and a bad key never degrades the sweep).
- **`opencode models` CLI** when installed — what the local install actually resolves, `ollama-cloud/*` first.
- Cached under gitignored `.super-coder/logs/` (deliberately not `.sc-state/` — an auto-written tracked file would trip the publish guard), 24h TTL, stale-cache on failed refresh, static floor when everything is down. Model inputs stay free text throughout — the catalog is advisory, never a constraint.
- Claude aliases (`opus`/`sonnet`/`haiku`) lead their list since they self-track releases within a family; full ids cover new families (the fable case). The GUI notes that any open-model licence gate stays operator policy — the catalog carries no license data.

**Persistence.** `flavor_defaults` joins snapshot's `PER_INSTANCE_TABLES` — without this, GUI edits would silently vanish on the next rebuild (content.sql loads after migrations, so the fork's values win; the section appears in content.sql on the next snapshot).

**Drive-by fix.** `do_GET` had a function-local `from urllib.parse import parse_qs` that made the name local to the whole function — any earlier route using it hit `UnboundLocalError`. Removed (module-level import exists).

Verified end-to-end on a live server: GET matrix, live models.dev+CLI sweep, POST round-trip, validation errors, snapshot dump. Tests: 16 new (catalog layering/cache/floor in `test_model_catalog.py`, matrix semantics in `test_api_endpoints.py`); 250 total pass.

After merge this supersedes migration-per-model-change for routine retunes (e.g. #278's planner→opus becomes a click); forks pick the feature up on repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)