### PR TITLE
fix(rebuild): abort on unreadable outgoing keys instead of silently rotating the fleet (#279)

### DIFF
--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -52,21 +52,44 @@ def read_existing_keys() -> dict:
     SC_API_TOKEN run.py injected into each live session at boot and 401-ing
     every mem call engine-wide until the sessions re-entered (#265). Read the
     keys before the old DB is deleted; restore_keys() puts them back after the
-    content load. A missing DB or a pre-0027 one (no api_key column) yields
-    empty — every shell gets minted fresh, same as a first build."""
+    content load.
+
+    Only the shapes that GENUINELY mean "no keys to carry" yield empty: a
+    missing DB, or a pre-0027 one (no shells table / no api_key column). Any
+    other read failure ABORTS the rebuild while the outgoing DB still exists —
+    a `database is locked` here (a >5s exclusive lock: VACUUM, a checkpoint,
+    a CLI transaction racing `sc verify`) used to be swallowed into {}, which
+    silently rotated every key and 401'd all live sessions (#279). A rebuild
+    that cannot read the keys it is about to destroy must not proceed."""
     if not DB_PATH.exists():
+        print("rebuild: no outgoing DB — every shell will be minted a fresh key.")
         return {}
-    con = db_driver.connect(DB_PATH)
+    con = None
     try:
+        con = db_driver.connect(DB_PATH)
         rows = con.execute(
             "SELECT shell_id, api_key, api_key_rotated_at FROM shells "
             "WHERE api_key IS NOT NULL"
         ).fetchall()
-        return {r[0]: (r[1], r[2]) for r in rows}
-    except db_driver.OperationalError:
-        return {}
+        keys = {r[0]: (r[1], r[2]) for r in rows}
+    except db_driver.OperationalError as e:
+        msg = str(e)
+        if "no such column" in msg or "no such table" in msg:
+            print(f"rebuild: outgoing DB pre-dates api keys ({msg}) — "
+                  "every shell will be minted a fresh key.")
+            return {}
+        sys.exit(
+            f"rebuild: cannot read shell api_keys from the outgoing DB ({msg}) "
+            "— aborting while it still exists. Proceeding would silently "
+            "rotate every key and 401 every live session (#279). Free the DB "
+            "(close writers, let VACUUM/checkpoints finish) and retry.")
     finally:
-        con.close()
+        if con is not None:
+            con.close()
+    # Always name the branch taken — a carry of 0 used to be indistinguishable
+    # from a working carry in the rebuild log, which is what made #279 opaque.
+    print(f"rebuild: carrying {len(keys)} shell api_key(s) across the rebuild.")
+    return keys
 
 
 def restore_keys(keys: dict) -> int:

--- a/tests/test_rebuild_keys.py
+++ b/tests/test_rebuild_keys.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 SCHEMA = ENGINE / "schema.sql"
@@ -163,6 +164,28 @@ class RebuildKeysTest(unittest.TestCase):
         self.assertEqual(rebuild.restore_keys(keys), 0)
         after = self.keys_by_shell()
         self.assertEqual(after[1][0], "tok_already_present_wins_2222222222222222")
+
+    def test_missing_shells_table_reads_empty(self):
+        """A DB with no shells table at all is the other genuinely-keyless
+        shape — mint-all, not abort."""
+        sqlite3.connect(self.db).close()   # zero-byte DB file, no tables
+        self.assertEqual(rebuild.read_existing_keys(), {})
+
+    def test_locked_db_aborts_instead_of_rotating(self):
+        """#279: a keyed DB that can't be READ (e.g. `database is locked`
+        after the busy timeout — a >5s exclusive lock from VACUUM/checkpoint
+        racing `sc verify`) must ABORT the rebuild, not return {} and let the
+        backfill silently rotate every key. Simulated at the driver seam; the
+        real 5s-lock reproduction is documented on the issue."""
+        self.build_keyed_db()
+        with mock.patch.object(
+                rebuild.db_driver, "connect",
+                side_effect=sqlite3.OperationalError("database is locked")):
+            with self.assertRaises(SystemExit) as cm:
+                rebuild.read_existing_keys()
+        self.assertIn("aborting", str(cm.exception))
+        # the outgoing DB is untouched — nothing was deleted or rotated
+        self.assertEqual(self.keys_by_shell()[1], (KEY_1, ROTATED_AT))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #279.

Root cause (full diagnosis on the issue): `read_existing_keys`' blanket `except OperationalError: return {}` treats *any* read failure as "pre-0027 DB, mint fresh". Reproduced: an exclusive lock held past the 5s busy timeout (VACUUM — which the db-backup sanitize procedure itself runs — a WAL checkpoint, or a CLI transaction racing `sc verify`) raises `database is locked`, the catch swallows it, the rebuild deletes the keyed DB, and backfill mints every shell — kcsos's exact `6 shell(s) keyed` + fleet-wide 401.

The fix keeps the two genuinely-keyless shapes (missing DB, missing `shells` table / `api_key` column → mint fresh, as before) and makes every other failure **abort the rebuild while the outgoing DB still exists** — nothing has been unlinked at that point, so the abort is safe and the retry trivial. The error message names the cause and the remedy. Rebuilds also now always print the carry count (`carrying N shell api_key(s)` / the 0-carry reason) — the silent 0-carry is what made #279 undiagnosable from its own log.

Tests: locked-read aborts with the DB untouched (driver-seam simulation; the real 5s-lock repro is on the issue), missing-table mints fresh; existing carry/restore/clobber tests unchanged. 268 pass.

kcsos note: after their next repin, the workaround (re-export from DB) stops being needed; a verify racing a lock now fails fast with a retry message instead of rotating the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)