### PR TITLE
feat(gui): family-first model picker — search chips, inline collapsed list, per-flavor cards

### DIFF
--- a/.super-coder/api/model_catalog.py
+++ b/.super-coder/api/model_catalog.py
@@ -16,10 +16,15 @@ of this is load-bearing — a source that fails just thins the suggestions:
 Fetched server-side (no CORS), cached under the gitignored .super-coder/logs/
 (ephemeral like webapp.log — NOT .sc-state/, where an auto-written file would
 dirty the tree and trip the publish guard) with a TTL; a failed refresh serves
-the stale cache and says so. Claude aliases
-(opus / sonnet / haiku) lead their list: an alias floats to the newest model
-in its family, so a stored alias never goes stale — full ids cover NEW
-families, which is the case aliases can't (a fable-shaped release).
+the stale cache and says so.
+
+Payload (v2) is family-first, matching the picker: per harness, `families`
+([{family, latest, release_date, n}], newest-first — "pick opus / sonnet /
+fable / deepseek and track its latest") plus the flat `models` list for
+sub-version search. For claude, a family with a CLI alias (opus / sonnet /
+haiku) resolves `latest` to the alias — an alias floats to the newest model
+in its family, so the stored value never goes stale; families without one
+(the fable case) resolve to the newest concrete id.
 """
 from __future__ import annotations
 
@@ -49,6 +54,11 @@ HARNESS_PROVIDER = {
 PREFIXED_HARNESSES = {"opencode"}
 
 CLAUDE_ALIASES = ["opus", "sonnet", "haiku"]
+
+# Bump when the response/cache shape changes — a cached payload from another
+# version is ignored (treated as no cache) instead of being served to a
+# client that expects the new shape.
+PAYLOAD_VERSION = 2
 
 # provider APIs, keyed by harness: (env var, url, header builder). Responses
 # are the OpenAI-style {"data": [{"id": ...}, ...]} shape on all three.
@@ -80,8 +90,10 @@ def _http_json(url: str, headers: dict | None = None) -> dict:
         return json.loads(r.read().decode())
 
 
-def _entry(mid: str, release_date: str = "", name: str = "") -> dict:
-    return {"id": mid, "release_date": release_date, "name": name or mid}
+def _entry(mid: str, release_date: str = "", name: str = "",
+           family: str | None = None) -> dict:
+    return {"id": mid, "release_date": release_date, "name": name or mid,
+            "family": family}
 
 
 def _from_models_dev(fetch) -> dict[str, list[dict]]:
@@ -93,10 +105,34 @@ def _from_models_dev(fetch) -> dict[str, list[dict]]:
         for mid, m in models.items():
             full = f"{provider}/{mid}" if harness in PREFIXED_HARNESSES else mid
             entries.append(_entry(full, m.get("release_date") or "",
-                                  m.get("name") or mid))
+                                  m.get("name") or mid, m.get("family")))
         entries.sort(key=lambda e: e["release_date"], reverse=True)
         out[harness] = entries
     return out
+
+
+def _families(harness: str, entries: list[dict]) -> list[dict]:
+    """Group a harness's models by models.dev family, newest family first.
+    A family chip means "track this line's latest": `latest` is the newest
+    release in the family — except claude families with a CLI alias
+    (opus/sonnet/haiku), where it is the alias itself, which self-tracks
+    upstream so the stored value never goes stale. Entries from sources
+    without family data (keyed APIs, opencode CLI) simply don't group —
+    they stay reachable through model search."""
+    groups: dict[str, list[dict]] = {}
+    for e in entries:
+        if e.get("family"):
+            groups.setdefault(e["family"], []).append(e)
+    fams = []
+    for fam, es in groups.items():
+        newest = max(es, key=lambda x: x["release_date"] or "")
+        label = fam.removeprefix("claude-") if harness == "claude" else fam
+        latest = label if harness == "claude" and label in CLAUDE_ALIASES \
+            else newest["id"]
+        fams.append({"family": label, "latest": latest,
+                     "release_date": newest["release_date"], "n": len(es)})
+    fams.sort(key=lambda f: f["release_date"], reverse=True)
+    return fams
 
 
 def _from_provider_apis(fetch, env) -> dict[str, list[dict]]:
@@ -161,20 +197,22 @@ def build(fetch=_http_json, env=os.environ, run=subprocess.run) -> dict:
         sources.append("opencode-cli")
     if not sources:
         raise RuntimeError("; ".join(errors) or "no catalog sources available")
-    # claude aliases lead — self-tracking within a family, so they never stale.
-    aliases = [_entry(a, name=f"{a} (alias — tracks the family's latest)")
-               for a in CLAUDE_ALIASES]
-    harnesses["claude"] = aliases + [e for e in harnesses.get("claude", [])
-                                     if e["id"] not in CLAUDE_ALIASES]
-    return {"fetched_at": datetime.now(timezone.utc).isoformat(),
-            "sources": sources, "harnesses": harnesses}
+    return {"v": PAYLOAD_VERSION,
+            "fetched_at": datetime.now(timezone.utc).isoformat(),
+            "sources": sources,
+            "harnesses": {h: {"families": _families(h, entries),
+                              "models": entries}
+                          for h, entries in harnesses.items()}}
 
 
 def _load_cache() -> dict | None:
     try:
-        return json.loads(CACHE.read_text())
+        cached = json.loads(CACHE.read_text())
     except Exception:  # noqa: BLE001  (missing or corrupt — both mean "no cache")
         return None
+    # A cache written by another payload version would hand the client a
+    # shape it can't render — ignore it entirely.
+    return cached if cached.get("v") == PAYLOAD_VERSION else None
 
 
 def _fresh(cached: dict) -> bool:
@@ -185,8 +223,16 @@ def _fresh(cached: dict) -> bool:
         return False
 
 
-def _floor() -> dict[str, list[dict]]:
-    return {h: [_entry(i) for i in ids] for h, ids in STATIC_FLOOR.items()}
+_FLOOR_FAMILY = {"opus": "claude-opus", "sonnet": "claude-sonnet",
+                 "haiku": "claude-haiku"}
+
+
+def _floor() -> dict[str, dict]:
+    out = {}
+    for h, ids in STATIC_FLOOR.items():
+        entries = [_entry(i, family=_FLOOR_FAMILY.get(i)) for i in ids]
+        out[h] = {"families": _families(h, entries), "models": entries}
+    return out
 
 
 def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
@@ -204,7 +250,8 @@ def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
     except Exception as e:  # noqa: BLE001
         if cached:
             return {**cached, "stale": True, "error": str(e)}
-        return {"fetched_at": None, "sources": ["static"], "stale": True,
+        return {"v": PAYLOAD_VERSION, "fetched_at": None,
+                "sources": ["static"], "stale": True,
                 "error": str(e), "harnesses": _floor()}
     CACHE.parent.mkdir(parents=True, exist_ok=True)
     CACHE.write_text(json.dumps(fresh, indent=1) + "\n")

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -265,6 +265,9 @@ async function renderShells(root) {
   const newBtn = el("button", { className: "act", type: "button", textContent: "＋ New shell" });
   newBtn.onclick = () => openNewShellModal(templates, root);
   sub.append(newBtn);
+  // Default Models is fork-global config — the shell-scoped header (picker,
+  // role/mandate, ＋New shell) is greyed out and inert there, not load-bearing.
+  if (shellTab === "models") sub.classList.add("subbar-inert");
   root.append(sub);
 
   // sub-tabs — Harness / Skills scoped to the selected shell; Default Models
@@ -288,17 +291,89 @@ async function renderShells(root) {
 // Default Models — the flavor_defaults launch matrix: per flavor, a model per
 // harness and ONE starred default harness (the two launch defaults run.py
 // resolves at boot). Fork-global config — the selected shell's flavor leads,
-// but the matrix is the same from any shell. Model fields are free text
-// backed by datalist suggestions from /api/models (models.dev + keyed
-// provider APIs + opencode CLI, cached server-side, static floor last) —
-// the catalog is advisory, never a constraint.
+// but the matrix is the same from any shell.
+//
+// The model picker is family-first: the primary choices are model FAMILIES
+// (opus / sonnet / fable, deepseek / glm, …) whose chip stores "this line's
+// latest" (a self-tracking alias where one exists, else the newest concrete
+// id), with every sub-version reachable through the same search. Each cell is
+// a search bar over /api/models (v2: families + models per harness) with an
+// INLINE chip list that stays collapsed while the search is empty — vital for
+// ollama-cloud's hundreds of ids — and expands fully on "all" + Enter. The
+// catalog is advisory: any typed id can be stored as-is.
+const DM_MODEL_CAP = 60;   // rendered chips per query — "all" on opencode is huge
+
+function dmModelPicker(harness, cat, row, save) {
+  const data = cat.harnesses?.[harness] || { families: [], models: [] };
+  const current = el("span", { className: "dm-current" + (row.model ? "" : " dm-unset"),
+                               textContent: row.model || "harness default" });
+  const input = el("input", { className: "dm-search",
+                              placeholder: "search models · “all” ⏎ shows everything" });
+  const results = el("div", { className: "dm-results", hidden: true });
+
+  const pick = async (value) => {
+    await save(value);
+    current.textContent = value || "harness default";
+    current.classList.toggle("dm-unset", !value);
+    input.value = "";
+    render("");
+  };
+  const chip = (label, sub, cls, value) => {
+    const c = el("button", { className: "dm-chip" + (cls ? " " + cls : ""),
+                             type: "button", title: value });
+    c.append(el("b", {}, label));
+    if (sub) c.append(el("span", { className: "dm-chip-sub" }, sub));
+    c.onclick = () => pick(value);
+    return c;
+  };
+
+  // q: lowercased query; showAll renders the full catalog ("all" + Enter).
+  const render = (q, showAll = false) => {
+    results.textContent = "";
+    if (!q && !showAll) { results.hidden = true; return; }
+    const hit = (s) => showAll || (s || "").toLowerCase().includes(q);
+    const fams = (data.families || []).filter((f) => hit(f.family) || hit(f.latest));
+    const models = (data.models || []).filter(
+      (m) => hit(m.id) || hit(m.name) || hit(m.family));
+    if (fams.length) {
+      results.append(el("div", { className: "dm-sect" }, "families — pick one to track its latest"));
+      for (const f of fams)
+        results.append(chip(f.family,
+          `→ ${f.latest}` + (f.n > 1 ? ` · ${f.n} versions` : ""), "dm-fam", f.latest));
+    }
+    if (models.length) {
+      results.append(el("div", { className: "dm-sect" },
+        `models (${models.length})` + (models.length > DM_MODEL_CAP ? ` — first ${DM_MODEL_CAP}, type to narrow` : "")));
+      for (const m of models.slice(0, DM_MODEL_CAP))
+        results.append(chip(m.id, m.release_date, "", m.id));
+    }
+    if (!fams.length && !models.length && q)
+      results.append(el("div", { className: "dm-sect" }, "no catalog match"));
+    if (q && !showAll)
+      results.append(chip(`use “${input.value.trim()}” as-is`, "", "dm-raw",
+                          input.value.trim()));
+    results.hidden = false;
+  };
+
+  input.oninput = () => render(input.value.trim().toLowerCase());
+  input.onkeydown = (e) => {
+    if (e.key === "Escape") { input.value = ""; render(""); return; }
+    if (e.key !== "Enter") return;
+    const q = input.value.trim();
+    if (!q) return;
+    if (q.toLowerCase() === "all") render("", true);   // browse everything
+    else pick(q);                                       // store as typed
+  };
+  return { current, input, results };
+}
+
 async function renderDefaultModels(root, s) {
   root.textContent = "";
   let fd;
   try { fd = await api("/flavor-defaults"); }
   catch (e) { root.append(el("div", { className: "vpanel" }, "flavor-defaults error: " + e.message)); return; }
   let cat = { harnesses: {}, sources: [], fetched_at: null, stale: true };
-  try { cat = await api("/models"); } catch { /* inputs stay free text */ }
+  try { cat = await api("/models"); } catch { /* pickers still store typed ids */ }
 
   const head = el("div", { className: "viewer-head" }, microlabel("Default Models"));
   const refresh = el("button", { className: "act", type: "button", textContent: "↻ Refresh models" });
@@ -316,21 +391,14 @@ async function renderDefaultModels(root, s) {
     `catalog: ${(cat.sources || []).join(" + ") || "none"} · as of ${when}`
     + (cat.stale ? " (stale — live refresh failed)" : "")));
 
-  // one datalist per harness, shared by every flavor's input for that harness
-  for (const h of fd.harnesses) {
-    const dl = el("datalist", { id: "dm-list-" + h });
-    for (const m of cat.harnesses?.[h] || [])
-      dl.append(el("option", { value: m.id, label: m.release_date || m.name || "" }));
-    root.append(dl);
-  }
-
-  const flavors = Object.keys(fd.flavors).sort(
-    (a, b) => (a === s.flavor ? -1 : b === s.flavor ? 1 : a.localeCompare(b)));
-  const panel = el("div", { className: "vpanel" });
+  // App-wide config: flavors in a stable alphabetical order (no shell-scoped
+  // emphasis — the shell header above is inert on this tab), one card per
+  // flavor with docs-style separation between cards.
+  const flavors = Object.keys(fd.flavors).sort();
   for (const flavor of flavors) {
     const byHarness = Object.fromEntries((fd.flavors[flavor] || []).map((r) => [r.harness, r]));
-    panel.append(el("div", { className: "acc-group" },
-      flavor + (flavor === s.flavor ? " · this shell" : "")));
+    const panel = el("div", { className: "vpanel dm-card" });
+    panel.append(el("div", { className: "acc-group" }, flavor));
     for (const h of fd.harnesses) {
       const row = byHarness[h] || { model: null, is_default: false };
       const star = el("input", { type: "radio", name: "dm-star-" + flavor,
@@ -343,22 +411,21 @@ async function renderDefaultModels(root, s) {
         } catch (e) { toast("error: " + e.message); }
         renderDefaultModels(root, s);   // reflect the sibling un-star
       };
-      const input = el("input", { className: "dm-model", value: row.model || "",
-                                  placeholder: "harness default" });
-      input.setAttribute("list", "dm-list-" + h);
-      input.onchange = async () => {
+      const picker = dmModelPicker(h, cat, row, async (value) => {
         try {
-          await api("/flavor-defaults", "POST", { flavor, harness: h, model: input.value });
-          toast(`${flavor} · ${h} → ${input.value || "(harness default)"}`);
+          await api("/flavor-defaults", "POST", { flavor, harness: h, model: value });
+          toast(`${flavor} · ${h} → ${value || "(harness default)"}`);
         } catch (e) { toast("error: " + e.message); }
-      };
+      });
       panel.append(el("div", { className: "dm-row" },
-        star, el("span", { className: "dm-harness" }, h), input));
+        star, el("span", { className: "dm-harness" }, h),
+        picker.current, picker.input));
+      panel.append(picker.results);   // full-width, collapsed until typed into
     }
+    root.append(panel);
   }
-  root.append(panel);
   root.append(el("div", { className: "dm-note" },
-    "★ = default harness at launch. Suggestions are unfiltered — an open-model licence gate (e.g. MIT/Apache-only) stays operator policy."));
+    "★ = default harness at launch. Family chip = track that line's latest. Suggestions are unfiltered — an open-model licence gate (e.g. MIT/Apache-only) stays operator policy."));
 }
 
 // Harness — the shell's surfaces as grouped accordions: Operational

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -323,22 +323,54 @@ a { color: var(--accent); }
 .acc-panel > .acc-group:first-child { border-top: none; }
 
 /* ── Default Models sub-tab — flavor_defaults matrix ───────────────────────
-   One .dm-row per (flavor, harness): star radio (default harness) · harness
-   label · free-text model input backed by a per-harness datalist. */
+   Fork-global config: the shell-scoped subbar is inert here. One card per
+   flavor (docs-style separation); one .dm-row per (flavor, harness): star
+   radio (default harness) · harness label · current value · search bar.
+   Search results render INLINE as chips below the row — collapsed while the
+   search is empty; family chips first (pick = track that line's latest). */
+.subbar-inert { opacity: .4; pointer-events: none; }
+.dm-card + .dm-card { margin-top: 5px; }
 .dm-meta { padding: .1rem .2rem .4rem; font-size: 11px; color: var(--dim); }
 .dm-row {
-  display: grid; grid-template-columns: 24px 110px 1fr; align-items: center;
-  gap: .7rem; padding: .4rem 1.1rem; border-top: 1px solid var(--line-soft);
+  display: grid; grid-template-columns: 24px 100px minmax(8rem, 22rem) 1fr;
+  align-items: center; gap: .7rem; padding: .4rem 1.1rem;
+  border-top: 1px solid var(--line-soft);
 }
 .dm-row input[type="radio"] { accent-color: var(--accent); margin: 0; cursor: pointer; }
 .dm-harness { font: 600 12px/1.4 ui-monospace, "Cascadia Mono", "Menlo", monospace;
   letter-spacing: .06em; color: rgba(255,255,255,.85); }
-.dm-model {
+.dm-current {
+  font: 12px/1.4 ui-monospace, "Cascadia Mono", "Menlo", monospace;
+  color: rgba(255,255,255,.90); overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dm-current.dm-unset { color: var(--dim); font-style: italic; }
+.dm-search {
   background: var(--panel2); border: 1px solid var(--line-soft); color: inherit;
-  border-radius: var(--r); padding: .35rem .6rem; width: 100%; max-width: 34rem;
+  border-radius: var(--r); padding: .35rem .6rem; width: 100%;
   font: 12px/1.4 ui-monospace, "Cascadia Mono", "Menlo", monospace;
 }
-.dm-model:focus { outline: none; border-color: var(--accent); }
+.dm-search:focus { outline: none; border-color: var(--accent); }
+.dm-results {
+  padding: .5rem 1.1rem .7rem; border-top: 1px dashed var(--line-soft);
+  display: flex; flex-wrap: wrap; gap: .35rem; align-items: center;
+}
+.dm-sect {
+  flex-basis: 100%; font-size: 10px; text-transform: uppercase;
+  letter-spacing: .12em; color: var(--dim); padding-top: .25rem;
+}
+.dm-chip {
+  display: inline-flex; align-items: baseline; gap: .45rem; cursor: pointer;
+  background: var(--panel2); border: 1px solid var(--line-soft); color: inherit;
+  border-radius: 99px; padding: .22rem .7rem; max-width: 100%;
+  font: 12px/1.4 ui-monospace, "Cascadia Mono", "Menlo", monospace;
+}
+.dm-chip:hover { border-color: var(--accent); }
+.dm-chip b { font-weight: 600; }
+.dm-chip-sub { font-size: 10px; color: var(--dim); overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; max-width: 18rem; }
+.dm-chip.dm-fam { border-color: rgba(255,255,255,.25); background: rgba(255,255,255,.05); }
+.dm-chip.dm-raw { border-style: dashed; }
 .dm-note { padding: .5rem .2rem; font-size: 11px; color: var(--dim); }
 .acc { border-top: 1px solid var(--line-soft); }
 .acc > summary {

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -3,10 +3,13 @@
 
 The catalog is layered and best-effort: models.dev (keyless, all four
 harnesses) → provider APIs (only with env keys) → `opencode models` CLI →
-cache → static floor. These tests pin the layering contract: harness→provider
-mapping and opencode prefixing, newest-first sorting, claude aliases leading,
-opportunistic merges that never fail the sweep, stale-cache-on-failure, and
-the floor when everything is down. All sources are injected — no network.
+cache → static floor. Payload v2 is family-first: per harness `families`
+(newest-first; claude families with a CLI alias resolve `latest` to the
+alias) plus the flat `models` list for sub-version search. These tests pin
+that contract: harness→provider mapping and opencode prefixing, family
+grouping/alias resolution, opportunistic merges that never fail the sweep,
+stale-cache-on-failure, version-mismatched caches ignored, and the floor
+when everything is down. All sources are injected — no network.
 
 Run:
     python3 tests/test_model_catalog.py
@@ -26,12 +29,18 @@ import model_catalog as mc  # noqa: E402
 
 MODELS_DEV = {
     "anthropic": {"models": {
-        "claude-opus-4-8": {"name": "Claude Opus 4.8", "release_date": "2026-04-01"},
-        "claude-fable-5": {"name": "Claude Fable 5", "release_date": "2026-06-09"},
+        "claude-opus-4-8": {"name": "Claude Opus 4.8",
+                            "release_date": "2026-04-01", "family": "claude-opus"},
+        "claude-opus-4-7": {"name": "Claude Opus 4.7",
+                            "release_date": "2026-02-01", "family": "claude-opus"},
+        "claude-fable-5": {"name": "Claude Fable 5",
+                           "release_date": "2026-06-09", "family": "claude-fable"},
     }},
-    "openai": {"models": {"gpt-5.5": {"release_date": "2026-01-01"}}},
-    "mistral": {"models": {"devstral-latest": {"release_date": "2025-12-01"}}},
-    "ollama-cloud": {"models": {"deepseek-v4-pro": {"release_date": "2026-02-02"}}},
+    "openai": {"models": {"gpt-5.5": {"release_date": "2026-01-01", "family": "gpt"}}},
+    "mistral": {"models": {"devstral-latest": {"release_date": "2025-12-01",
+                                               "family": "devstral"}}},
+    "ollama-cloud": {"models": {"deepseek-v4-pro": {"release_date": "2026-02-02",
+                                                    "family": "deepseek"}}},
 }
 
 
@@ -47,6 +56,10 @@ def fetch_down(url, headers=None):
     raise OSError("network down")
 
 
+def ids(harness_block):
+    return [e["id"] for e in harness_block["models"]]
+
+
 class NoCLI(unittest.TestCase):
     """Base: opencode binary absent unless a test opts in."""
 
@@ -59,23 +72,32 @@ class NoCLI(unittest.TestCase):
 class BuildTest(NoCLI):
     def test_harness_mapping_and_prefixing(self):
         got = mc.build(fetch=fetch_ok, env={}, run=None)
-        self.assertIn("claude-fable-5", [e["id"] for e in got["harnesses"]["claude"]])
-        self.assertEqual([e["id"] for e in got["harnesses"]["codex"]], ["gpt-5.5"])
-        self.assertEqual([e["id"] for e in got["harnesses"]["opencode"]],
+        self.assertEqual(got["v"], mc.PAYLOAD_VERSION)
+        self.assertIn("claude-fable-5", ids(got["harnesses"]["claude"]))
+        self.assertEqual(ids(got["harnesses"]["codex"]), ["gpt-5.5"])
+        self.assertEqual(ids(got["harnesses"]["opencode"]),
                          ["ollama-cloud/deepseek-v4-pro"])
         self.assertEqual(got["sources"], ["models.dev"])
 
-    def test_claude_aliases_lead_then_newest_first(self):
-        ids = [e["id"] for e in mc.build(fetch=fetch_ok, env={}, run=None)
-               ["harnesses"]["claude"]]
-        self.assertEqual(ids[:3], mc.CLAUDE_ALIASES)
-        self.assertEqual(ids[3:5], ["claude-fable-5", "claude-opus-4-8"],
-                         "full ids must sort newest release first")
+    def test_families_newest_first_alias_latest(self):
+        fams = mc.build(fetch=fetch_ok, env={}, run=None)["harnesses"]["claude"]["families"]
+        self.assertEqual([f["family"] for f in fams], ["fable", "opus"],
+                         "families sort by newest release")
+        by = {f["family"]: f for f in fams}
+        self.assertEqual(by["fable"]["latest"], "claude-fable-5",
+                         "no alias → newest concrete id")
+        self.assertEqual(by["opus"]["latest"], "opus",
+                         "aliased family → the self-tracking alias")
+        self.assertEqual(by["opus"]["n"], 2)
+
+    def test_opencode_family_latest_is_prefixed(self):
+        fams = mc.build(fetch=fetch_ok, env={}, run=None)["harnesses"]["opencode"]["families"]
+        self.assertEqual(fams[0]["family"], "deepseek")
+        self.assertEqual(fams[0]["latest"], "ollama-cloud/deepseek-v4-pro")
 
     def test_provider_api_merges_and_dedupes(self):
         got = mc.build(fetch=fetch_ok, env={"OPENAI_API_KEY": "k"}, run=None)
-        ids = [e["id"] for e in got["harnesses"]["codex"]]
-        self.assertEqual(ids, ["gpt-5.5", "gpt-9-preview"],
+        self.assertEqual(ids(got["harnesses"]["codex"]), ["gpt-5.5", "gpt-9-preview"],
                          "keyed-API ids append deduped, models.dev order kept")
         self.assertIn("openai-api", got["sources"])
 
@@ -87,15 +109,16 @@ class BuildTest(NoCLI):
         got = mc.build(fetch=fetch, env={"OPENAI_API_KEY": "bad"}, run=None)
         self.assertEqual(got["sources"], ["models.dev"])
 
-    def test_opencode_cli_merges(self):
+    def test_opencode_cli_merges_ollama_cloud_first(self):
         with mock.patch.object(mc.shutil, "which", return_value="/usr/bin/opencode"):
             def run(cmd, **kw):
                 return mock.Mock(returncode=0,
-                                 stdout="ollama-cloud/deepseek-v4-pro\n"
-                                        "ollama-cloud/glm-5.1\nnot a model line\n")
+                                 stdout="zprovider/zeta\nollama-cloud/glm-5.1\n"
+                                        "not a model line\n")
             got = mc.build(fetch=fetch_ok, env={}, run=run)
-        ids = [e["id"] for e in got["harnesses"]["opencode"]]
-        self.assertEqual(ids, ["ollama-cloud/deepseek-v4-pro", "ollama-cloud/glm-5.1"])
+        self.assertEqual(ids(got["harnesses"]["opencode"]),
+                         ["ollama-cloud/deepseek-v4-pro", "ollama-cloud/glm-5.1",
+                          "zprovider/zeta"])
         self.assertIn("opencode-cli", got["sources"])
 
     def test_all_sources_down_raises(self):
@@ -129,21 +152,36 @@ class CatalogCacheTest(NoCLI):
         self.assertTrue(got["stale"])
         self.assertIn("claude", got["harnesses"])
 
+    def test_version_mismatched_cache_is_ignored(self):
+        # a v1-era cache (fresh timestamp, old shape) must not be served
+        mc.catalog(fetch=fetch_ok, env={}, run=None)
+        old = json.loads(mc.CACHE.read_text())
+        del old["v"]
+        mc.CACHE.write_text(json.dumps(old))
+        got = mc.catalog(fetch=fetch_down, env={}, run=None)
+        self.assertEqual(got["sources"], ["static"],
+                         "shape-mismatched cache → treated as absent → floor")
+
     def test_refresh_flag_bypasses_fresh_cache(self):
         mc.catalog(fetch=fetch_ok, env={}, run=None)
         def fetch2(url, headers=None):
             if url == mc.MODELS_DEV_URL:
-                return {"anthropic": {"models": {"claude-next": {"release_date": "2027-01-01"}}}}
+                return {"anthropic": {"models": {
+                    "claude-next": {"release_date": "2027-01-01"}}}}
             raise RuntimeError
         got = mc.catalog(refresh=True, fetch=fetch2, env={}, run=None)
-        self.assertIn("claude-next", [e["id"] for e in got["harnesses"]["claude"]])
+        self.assertIn("claude-next", ids(got["harnesses"]["claude"]))
 
     def test_static_floor_when_no_cache_and_no_network(self):
         got = mc.catalog(fetch=fetch_down, env={}, run=None)
         self.assertTrue(got["stale"])
         self.assertEqual(got["sources"], ["static"])
         for harness in ("claude", "codex", "vibe", "opencode"):
-            self.assertTrue(got["harnesses"][harness])
+            self.assertTrue(got["harnesses"][harness]["models"])
+        floor_fams = {f["family"]: f["latest"]
+                      for f in got["harnesses"]["claude"]["families"]}
+        self.assertEqual(floor_fams.get("opus"), "opus",
+                         "floor still offers alias family chips")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rework of the Default Models picker per review.

**Family-first.** The primary choices are now model families — claude: `sonnet` / `opus` / `haiku` / `fable`; ollama-cloud: `deepseek` / `glm` / `kimi-k2` / … — via models.dev's `family` field. A family chip stores "track this line's latest": the CLI alias where one exists (opus/sonnet/haiku — self-tracking, never goes stale), otherwise the newest concrete id (`fable` → `claude-fable-5`). Sub-versions remain fully reachable through the same search.

**Search-driven, inline, collapsed.** Each (flavor, harness) cell is a search bar; results render inline as chips directly under the row and stay collapsed while the search is empty. Live numbers: opencode's 439 models present as 18 family chips + narrowing search instead of one giant dropdown. `all` + Enter browses everything (60-chip cap with a keep-typing hint); Enter stores any typed id as-is (the catalog stays advisory); Escape collapses.

**App-wide framing + layout.** The shell-scoped subbar (+New shell, shell switcher, Role, Mandate) greys out and goes inert on this tab; the "this shell" emphasis is dropped; each flavor is its own card with the Docs-style 5px separation.

Payload is v2 (`families` + `models` per harness) with cache-version guarding — a v1 cache is ignored, the static floor emits v2. Verified live: `claude 4 families/24 models`, `codex 11/51`, `vibe 13/30`, `opencode 18/439`. 270 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)