### PR TITLE
fix(gui): stash stray non-content work around publish instead of refusing (#283)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -626,6 +626,7 @@ def run_snapshot_render() -> str:
 # publishes (one git index).
 BASE_BRANCH = "main"
 PUBLISH_BRANCH = "sc_gui_content"
+_STASH_MSG = "sc-publish: stray non-content work"
 _PUBLISH_LOCK = threading.Lock()
 # The git-tracked text the DB rebuilds from + the flat renders. NOT the .db
 # (gitignored). schema.sql + migrations are engine paths: TRACKED in the source
@@ -750,6 +751,18 @@ def git_publish() -> dict:
         # if a step raised or returned early, so the tree never stays stranded on
         # the publish branch.
         _land_on_base(out, state)
+        # Restore any stray non-content work stashed by _prepare_branch — only now,
+        # once we're back on base, so it lands where it was taken from. Non-content
+        # files are identical across base/publish tips, so pop can't conflict; if it
+        # somehow does, keep the stash and tell the operator loudly rather than drop.
+        if state.get("stashed"):
+            n = state["stashed"]
+            pop = _git("stash", "pop")
+            if pop.returncode == 0:
+                out.append(f"(restored {n} stashed non-content file(s))")
+            else:
+                out.append(f"⚠ {n} stashed non-content file(s) NOT restored — run "
+                           f"'git stash pop' manually:\n{pop.stderr.strip()}")
     # Record the full end-to-end trace (success OR failure) so a publish that
     # "looked done" can be inspected after the fact — the gap that made the live
     # incident unexplainable. _land_on_base above appends to `out`, so log here.
@@ -763,16 +776,28 @@ def _prepare_branch(out: list, state: dict) -> bool:
     Returns True only when the tree is sitting on a fresh PUBLISH_BRANCH ready for
     the snapshot. Recovers automatically from a tree stranded on a stale publish
     branch, but refuses (rather than clobbers) if unrelated user work is dirty."""
-    # Refuse to touch a tree carrying real, non-regenerable changes — that's user
-    # work, not publishable content, and branch moves below would disrupt it.
+    # Stash real, non-regenerable changes out of the tree for the duration of the
+    # publish — that's user work, not publishable content, and the branch moves
+    # below would otherwise carry it along (or, if pre-staged, `git commit` would
+    # sweep it into the content commit). Stashing isolates it; `git_publish`'s
+    # finally pops it back after landing on base. A stray dirty file no longer
+    # wedges publish (#283); it's restored untouched once publish is done.
     unexpected = _unexpected_dirty()
     if unexpected:
-        state["ok"] = False
-        out.append("✗ working tree has non-content changes — refusing to publish "
-                   "(commit or stash them first):\n"
-                   + "\n".join(f"  {p}" for p in unexpected[:20])
-                   + ("\n  …" if len(unexpected) > 20 else ""))
-        return False
+        st = _git("stash", "push", "-m", _STASH_MSG, "--", *unexpected)
+        if st.returncode != 0:
+            # Can't isolate the work — fall back to refusing rather than risk it.
+            state["ok"] = False
+            out.append("✗ working tree has non-content changes and they could not "
+                       "be stashed — refusing to publish (commit or stash them "
+                       "first):\n"
+                       + "\n".join(f"  {p}" for p in unexpected[:20])
+                       + ("\n  …" if len(unexpected) > 20 else "")
+                       + f"\n  (git stash failed: {st.stderr.strip()})")
+            return False
+        state["stashed"] = len(unexpected)
+        out.append(f"(stashed {len(unexpected)} non-content file(s); "
+                   "restored after publish)")
 
     # Discard regenerable dirt so the checkout below can't fail on a dirty tree.
     _restore_regenerable(out)

--- a/tests/test_publish_prepare.py
+++ b/tests/test_publish_prepare.py
@@ -106,9 +106,11 @@ class PrepareBranchTest(unittest.TestCase):
         self.assertTrue(server._prepare_branch(out, state), msg="\n".join(out))
         self.assertEqual(current_branch(self.repo), server.PUBLISH_BRANCH)
 
-    def test_refuses_when_unrelated_file_dirty(self) -> None:
+    def test_stashes_unrelated_file(self) -> None:
         # A non-regenerable tracked file with uncommitted edits is user work —
-        # publish must refuse rather than reset or clobber it.
+        # publish must no longer wedge on it (#283): _prepare_branch stashes it out
+        # of the way and proceeds onto a clean publish branch. git_publish's finally
+        # pops it back afterward (see PublishRestoreTest).
         write(self.repo / "notes.txt", "v1\n")
         git(self.repo, "add", "-A")
         git(self.repo, "commit", "-m", "add notes")
@@ -116,12 +118,81 @@ class PrepareBranchTest(unittest.TestCase):
         out: list[str] = []
         state = {"ok": True, "pr_url": None, "pushed": False}
         ok = server._prepare_branch(out, state)
+        self.assertTrue(ok, msg="\n".join(out))
+        self.assertTrue(state["ok"])
+        self.assertEqual(state.get("stashed"), 1)
+        self.assertTrue(any("stashed" in line for line in out), msg="\n".join(out))
+        # On a fresh publish branch with a clean tree — the stray file is stashed.
+        self.assertEqual(current_branch(self.repo), server.PUBLISH_BRANCH)
+        self.assertEqual(git(self.repo, "status", "--porcelain"), "")
+        # The work is preserved on the stash stack, not lost.
+        self.assertIn(server._STASH_MSG, git(self.repo, "stash", "list"))
+
+    def test_refuses_when_stash_fails(self) -> None:
+        # If the stray work can't be isolated, publish falls back to refusing rather
+        # than risking it. Force the stash to fail by pointing _git at a path with no
+        # git repo at all.
+        write(self.repo / "notes.txt", "v1\n")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "add notes")
+        write(self.repo / "notes.txt", "uncommitted edit\n")
+        orig = server._git
+        try:
+            def fake_git(*args):
+                if args and args[0] == "stash":
+                    return subprocess.CompletedProcess(args, 1, "", "boom")
+                return orig(*args)
+            server._git = fake_git
+            out: list[str] = []
+            state = {"ok": True, "pr_url": None, "pushed": False}
+            ok = server._prepare_branch(out, state)
+        finally:
+            server._git = orig
         self.assertFalse(ok)
         self.assertFalse(state["ok"])
+        self.assertNotIn("stashed", state)
         self.assertTrue(any("non-content changes" in line for line in out))
         # The dirty user file is untouched, still on base.
         self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
         self.assertEqual((self.repo / "notes.txt").read_text(), "uncommitted edit\n")
+
+
+class PublishRestoreTest(unittest.TestCase):
+    """End-to-end: a stray non-content file stashed at prepare time is popped back
+    onto base after publish, byte-identical (#283)."""
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="publish-restore-"))
+        self.repo = self.tmp / "repo"
+        self.repo.mkdir()
+        git(self.repo, "init", "-b", server.BASE_BRANCH)
+        write(self.repo / ".sc-state" / "content.sql", "base\n")
+        write(self.repo / "notes.txt", "committed\n")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "init")
+        self._orig_root = server.REPO_ROOT
+        self._orig_snapshot = server.run_snapshot_render
+        self._orig_token = server._gh_token
+        server.REPO_ROOT = self.repo
+        # Stub the DB serialize/render (needs a live DB) and the token (no push).
+        server.run_snapshot_render = lambda: "(snapshot stubbed)"
+        server._gh_token = lambda: ""
+
+    def tearDown(self) -> None:
+        server.REPO_ROOT = self._orig_root
+        server.run_snapshot_render = self._orig_snapshot
+        server._gh_token = self._orig_token
+        subprocess.run(["rm", "-rf", str(self.tmp)])
+
+    def test_stray_file_restored_after_publish(self) -> None:
+        write(self.repo / "notes.txt", "uncommitted edit\n")
+        r = server.git_publish()
+        self.assertTrue(r["ok"], msg=r["output"])
+        # Back on base with the stray edit restored exactly, and no leftover stash.
+        self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
+        self.assertEqual((self.repo / "notes.txt").read_text(), "uncommitted edit\n")
+        self.assertEqual(git(self.repo, "stash", "list"), "")
+        self.assertIn("restored", r["output"])
 
 
 class HelperTest(unittest.TestCase):


### PR DESCRIPTION
Closes #283 (split from #276 item 4; #277 handled the surfacing).

## Problem
The publish guard (`_prepare_branch` in `.super-coder/api/server.py`) refused whenever **any** tracked non-content file was dirty in the working tree — even though such a file can never intersect the publishable content set (`_unexpected_dirty()` is precisely "dirty ∧ not in `REGENERABLE_PATHS`", and publish only ever stages `PUBLISH_PATHS`). A long-lived legitimately-uncommitted file (dos-arch hit it with `install/deploy-blade.md`) wedged GUI publish indefinitely; since #277 the operator at least saw *why*, but still had to resolve an unrelated file before any content could ship.

## Fix
Replace the outright refusal with a **stash-around-publish**:
- `_prepare_branch` runs `git stash push -- <unexpected paths>` (staged + unstaged), records `state["stashed"]`, and proceeds onto a clean publish branch.
- `git_publish`'s `finally` pops the stash **after** `_land_on_base` returns the tree to `main`, so the work lands where it was taken from.
- If the stash itself fails, fall back to the original refusal — isolation is never assumed.

This keeps the guard's protective intent (user work is never carried across the branch swaps, and never swept into the content commit — `git commit -m` commits the whole index, so a *pre-staged* stray would otherwise ship) while making publish genuinely one-click. Non-content files are byte-identical across the base/publish tips, so the pop can't conflict; if it somehow does, the stash is kept and the operator is told loudly.

No GUI change: the success trace now carries `(stashed N…)` / `(restored N…)` notes, and #277's failure surfacing still covers the stash-failure fallback.

## Tests (`tests/test_publish_prepare.py`)
- `test_stashes_unrelated_file` — prepare stashes the stray and lands on a clean publish branch.
- `test_refuses_when_stash_fails` — forced stash failure falls back to the refusal.
- `PublishRestoreTest.test_stray_file_restored_after_publish` — end-to-end `git_publish` (snapshot/token stubbed): stray edit restored byte-identical on `main`, no leftover stash.
- Existing prepare/cleanup/helper tests unchanged and green.

## Propagation
Engine API code read live by the webapp — no migration, no reseed. Restart the super-coder webapp after merge; forks pick it up on their next `./sc update` / repin (none urgent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)