### PR TITLE
feat(mem): link decisions to features + docs (the why-audit)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1103,6 +1103,11 @@ class Handler(BaseHTTPRequestHandler):
                 r = con.execute(
                     "SELECT d.decision_id, d.decision, d.rationale, d.priority, "
                     "d.decision_date, d.parent_decision_id, "
+                    "d.feature_id, d.document_id, "
+                    "(SELECT title FROM roadmap WHERE feature_id=d.feature_id) "
+                    " AS feature_title, "
+                    "(SELECT title FROM documents WHERE document_id=d.document_id) "
+                    " AS document_title, "
                     "(SELECT c.decision_id FROM shell_decisions c "
                     " WHERE c.parent_decision_id=d.decision_id "
                     " AND COALESCE(c.is_deleted,0)=0 "
@@ -1253,17 +1258,40 @@ class Handler(BaseHTTPRequestHandler):
                 d = (body.get("decision") or "").strip()
                 if not d:
                     return self._send(400, {"error": "decision required"})
+                # Optional why-audit links (#0047). document_id is a refinement of
+                # feature_id — a doc rolls up to a feature — so when only the doc
+                # is given, derive feature_id from it (the audit-by-feature query
+                # then works even for a doc-only link). Both validated: a typo'd
+                # id would silently break the audit, so 404 instead of bad data.
+                feature_id = body.get("feature_id") or None
+                document_id = body.get("document_id") or None
+                if document_id is not None:
+                    doc = con.execute(
+                        "SELECT feature_id FROM documents WHERE document_id=?",
+                        (document_id,)).fetchone()
+                    if doc is None:
+                        return self._send(404, {"error": f"no document {document_id}"})
+                    if feature_id is None:
+                        feature_id = doc["feature_id"]
+                if feature_id is not None and con.execute(
+                        "SELECT 1 FROM roadmap WHERE feature_id=?",
+                        (feature_id,)).fetchone() is None:
+                    return self._send(404, {"error": f"no feature {feature_id}"})
                 cur = con.execute(
                     "INSERT INTO shell_decisions "
-                    "(shell_id, decision, rationale, priority, decision_date, parent_decision_id) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    "(shell_id, decision, rationale, priority, decision_date, "
+                    " parent_decision_id, feature_id, document_id) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                     (sid, d,
                      body.get("rationale") or None,
                      body.get("priority") or "M",
                      body.get("decision_date") or None,
-                     body.get("parent_decision_id") or None))
+                     body.get("parent_decision_id") or None,
+                     feature_id, document_id))
                 con.commit()
-                return self._send(201, {"decision_id": cur.lastrowid})
+                return self._send(201, {"decision_id": cur.lastrowid,
+                                        "feature_id": feature_id,
+                                        "document_id": document_id})
 
             if path == "/_sc/mem/flags":
                 desc = (body.get("description") or "").strip()

--- a/.super-coder/assets/skills/memory/SKILL.md
+++ b/.super-coder/assets/skills/memory/SKILL.md
@@ -60,6 +60,17 @@ the narrative.
 sc mem decision "…" --rationale "…" [--parent <id>]
 ```
 
+**Link the why to the what.** Most decisions shape a feature or come out of a
+spec — attach that link so the roadmap carries not just what was built and how,
+but why it was built that way:
+```
+sc mem decision "…" --feature <feature_id>   # ties it to a roadmap feature
+sc mem decision "…" --doc <document_id>       # ties it to a spec/doc (implies the feature)
+```
+Both optional — a decision unrelated to any feature stays unlinked. `--doc` is a
+refinement of `--feature`: pass the doc alone and the feature is derived from it.
+The link surfaces on `sc mem get decisions <id>`.
+
 ## Stance
 
 Write-as-you-go beats batch-at-close: it costs nothing per write and zero at

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -2116,6 +2116,17 @@ the narrative.
 sc mem decision "…" --rationale "…" [--parent <id>]
 ```
 
+**Link the why to the what.** Most decisions shape a feature or come out of a
+spec — attach that link so the roadmap carries not just what was built and how,
+but why it was built that way:
+```
+sc mem decision "…" --feature <feature_id>   # ties it to a roadmap feature
+sc mem decision "…" --doc <document_id>       # ties it to a spec/doc (implies the feature)
+```
+Both optional — a decision unrelated to any feature stays unlinked. `--doc` is a
+refinement of `--feature`: pass the doc alone and the feature is derived from it.
+The link surfaces on `sc mem get decisions <id>`.
+
 ## Stance
 
 Write-as-you-go beats batch-at-close: it costs nothing per write and zero at

--- a/.super-coder/migrations/0047_decisions_feature_link.sql
+++ b/.super-coder/migrations/0047_decisions_feature_link.sql
@@ -1,0 +1,47 @@
+-- 0047 — shell_decisions: add feature_id + document_id (the why-audit link).
+--
+-- shell_decisions was an unlinked log: it recorded WHAT was decided and (via
+-- rationale) the reasoning, but nothing tied a decision back to the feature it
+-- shaped or the spec it came out of. The rest of the memory model is already
+-- feature-centric — roadmap (the feature), documents (its specs/docs),
+-- spec_tasks (the how), flags (its blockers via feature_id). Decisions were the
+-- one surface with no edge to a feature, so a feature's page could show its
+-- specs and tasks but not the WHY behind them.
+--
+-- Two nullable FKs close that gap:
+--   feature_id  — coarse link: which roadmap feature this decision serves.
+--                 Attachable even before any spec exists (an architecture call
+--                 made at brainstorm stage). Mirrors flags.feature_id exactly.
+--   document_id — fine link: the specific spec/doc revision this decision came
+--                 out of or reshaped. A document already rolls up to a feature,
+--                 so document_id is a refinement of feature_id, not a rival to
+--                 it. Agreement between the two is a convention (documented in
+--                 the `memory` skill), not a DB constraint — kept loose on
+--                 purpose so a decision can point at a feature without a doc, or
+--                 at a doc whose feature is implicit.
+--
+-- Both NULL by default: a decision unrelated to any feature simply stays
+-- unlinked. No backfill — historical rows keep NULL/NULL.
+--
+-- NOT inlined into schema.sql's shell_decisions CREATE, following the 0018
+-- roadmap.project_id precedent: rebuild.py applies schema.sql THEN every
+-- migration in order, and SQLite has no `ADD COLUMN IF NOT EXISTS`, so folding
+-- the column into the baseline CREATE would make this ALTER fail on a fresh
+-- build ("duplicate column"). A migration-only ADD COLUMN converges on both
+-- paths — fresh build (baseline lacks it → ALTER adds it) and existing fork
+-- (ALTER adds it) — and the ledger keeps it from running twice. schema.sql
+-- carries a pointer comment in the shell_decisions block.
+--
+-- Per-instance content: shell_decisions is a PER_INSTANCE_TABLE in snapshot.py,
+-- serialized column-by-column via PRAGMA table_info, so feature_id/document_id
+-- flow into .sc-state/content.sql automatically (as flags.feature_id already
+-- does). content.sql loads after migrations on rebuild; roadmap/documents rows
+-- serialize alongside, so the FK targets are present.
+--
+-- Plain SQL: migrate.py owns the transaction and the schema_migrations row.
+
+ALTER TABLE shell_decisions ADD COLUMN feature_id  INTEGER REFERENCES roadmap(feature_id);
+ALTER TABLE shell_decisions ADD COLUMN document_id INTEGER REFERENCES documents(document_id);
+
+CREATE INDEX IF NOT EXISTS idx_shell_decisions_feature  ON shell_decisions(feature_id);
+CREATE INDEX IF NOT EXISTS idx_shell_decisions_document ON shell_decisions(document_id);

--- a/.super-coder/migrations/0048_reseed_memory_decision_link.sql
+++ b/.super-coder/migrations/0048_reseed_memory_decision_link.sql
@@ -1,18 +1,22 @@
----
-rendered_by: super-coder
-source: db
-edit: changes here are overwritten — author via the shell or localhost GUI
----
+-- 0048 — reseed memory skill: the why-audit decision link (#0047 companion).
+--
+-- 0047 added shell_decisions.feature_id + document_id. This carries the skill
+-- prose that documents them to already-installed forks, and — critically —
+-- makes the memory skill the migration ledger's LAST word on its own content.
+--
+-- Why a migration and not just the asset edit: 0001_seed_skills.sql is
+-- regenerated from assets/skills/ (fresh builds get the new body), but a later
+-- reseed (0028) still carries an inline, now-older memory body. On a fresh
+-- rebuild — schema.sql, then every migration in order — 0028 would overwrite
+-- 0001's fresh body with its stale one, leaving the DB out of sync with the
+-- asset (the skills-freshness tripwire). Re-stating the current body here, after
+-- 0028, restores "last write wins = the asset" and heals existing forks in the
+-- same pass. Body is the verbatim assets/skills/memory/SKILL.md content;
+-- regenerate this file if the asset changes again.
+--
+-- Plain SQL: migrate.py owns the transaction and the schema_migrations row.
 
-# memory
-
-How this shell writes its memory — current_state, session narrative, seed, L&S, decisions. Write as it happens, not at close. Use to know WHEN and HOW to persist identity/work memory, and the caps.
-
-**Category:** substrate
-
----
-
-# memory — write as you go
+UPDATE skills SET content = '# memory — write as you go
 
 All memory is DB rows (no flat files). Write at the moment it matters, not in a
 close ritual.
@@ -24,7 +28,7 @@ name a shell.
 
 ## current_state — rolling status, NOT a log
 
-Your present focus + what's next. **Replaces in place; never a log.** Soft target
+Your present focus + what''s next. **Replaces in place; never a log.** Soft target
 ~500 chars. Rewrite when focus shifts.
 ```
 sc mem state "…"
@@ -82,4 +86,5 @@ The link surfaces on `sc mem get decisions <id>`.
 
 Write-as-you-go beats batch-at-close: it costs nothing per write and zero at
 session end. Curate seed/L&S (revise the set), never rewrite history (decisions,
-narrative, seed bodies). Full command reference + table map: the `db_map` skill.
+narrative, seed bodies). Full command reference + table map: the `db_map` skill.'
+  WHERE name = 'memory' AND is_deleted = 0;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -145,6 +145,12 @@ CREATE TABLE shell_decisions (
     parent_decision_id INTEGER REFERENCES shell_decisions(decision_id),
     is_deleted         INTEGER NOT NULL DEFAULT 0,
     created_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    -- feature_id  INTEGER REFERENCES roadmap(feature_id)   — the feature this
+    -- document_id INTEGER REFERENCES documents(document_id) — decision shaped
+    -- (the why-audit link), both added by migration 0047. Kept out of this
+    -- baseline CREATE on purpose: ADD COLUMN can't be IF NOT EXISTS and rebuild
+    -- applies migrations after schema.sql, so inlining would double-define.
+    -- See migrations/0047_decisions_feature_link.sql.
 );
 
 -- ── Roadmap (NEW — the feature index) ───────────────────────────────────────

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -27,7 +27,7 @@ Run from the repo root, like every engine command:
     ./sc mem seed  "<body>"          [--date YYYY-MM-DD] [--tag cc]
     ./sc mem lns   "<body>"          [--date …] [--tag …]
     ./sc mem retire <entry_id>
-    ./sc mem decision "<decision>"   [--rationale "…"] [--date …] [--parent ID]
+    ./sc mem decision "<decision>"   [--rationale "…"] [--date …] [--parent ID] [--feature ID] [--doc ID]
     ./sc mem flag open  "<description>" [--name CC-001] [--priority Medium] [--feature ID]
     ./sc mem flag close <flag_id>    [--notes "…"]
     ./sc mem roadmap add "<title>"   [--status brainstorm] [--summary "…"] [--project <shortname|id>]
@@ -153,6 +153,12 @@ def _render_get(surface: str, data: dict) -> int:
         if "decision" in data:                    # single decision, with rationale
             d = data["decision"]
             _line(d)
+            if d.get("feature_id"):
+                ft = f" — {d['feature_title']}" if d.get("feature_title") else ""
+                print(f"  feature: #{d['feature_id']}{ft}")
+            if d.get("document_id"):
+                dt = f" — {d['document_title']}" if d.get("document_title") else ""
+                print(f"  doc: #{d['document_id']}{dt}")
             if d.get("rationale"):
                 print("  rationale: " + d["rationale"])
             return 0
@@ -325,8 +331,12 @@ def cmd_decision(args) -> int:
              {"decision": args.decision,
               "rationale": args.rationale,
               "decision_date": args.date or str(date.today()),
-              "parent_decision_id": args.parent})
-    return _finish_api(f"mem: decision #{r.get('decision_id', '')} recorded")
+              "parent_decision_id": args.parent,
+              "feature_id": args.feature,
+              "document_id": args.doc})
+    fid = r.get("feature_id")
+    link = f" → feature #{fid}" if fid else ""
+    return _finish_api(f"mem: decision #{r.get('decision_id', '')} recorded{link}")
 
 
 def cmd_flag(args) -> int:
@@ -494,6 +504,10 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--rationale")
     sp.add_argument("--date")
     sp.add_argument("--parent", type=int, help="parent_decision_id (supersession)")
+    sp.add_argument("--feature", type=int,
+                    help="feature_id this decision serves (the why-audit link)")
+    sp.add_argument("--doc", type=int,
+                    help="document_id this decision shaped (implies its feature)")
     sp.set_defaults(fn=cmd_decision)
 
     sp = sub.add_parser("flag", help="open or close a flag")

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -162,6 +162,47 @@ class ApiMemTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.run_mem("get", "flags", "1")          # <id> is decisions-only
 
+    # ── decisions why-audit link: feature_id + document_id (#0047) ─────────────
+    def test_decision_feature_and_doc_link(self):
+        self.run_mem("roadmap", "add", "feat L")
+        fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat L'")[0]
+        body = self.tmp / "d.md"
+        body.write_text("# spec\n")
+        self.run_mem("doc", "add", "spec L", "--body-file", str(body), "--feature", str(fid))
+        did = self.q("SELECT document_id FROM documents WHERE title='spec L'")[0]
+
+        # --feature links the decision to the feature
+        self.run_mem("decision", "chose L", "--feature", str(fid))
+        row = self.q("SELECT feature_id, document_id FROM shell_decisions "
+                     "WHERE decision='chose L'")
+        self.assertEqual(row[0], fid)
+        self.assertIsNone(row[1])
+
+        # --doc alone derives the feature from the document
+        self.run_mem("decision", "shaped by spec L", "--doc", str(did))
+        dfid, ddid = self.q("SELECT feature_id, document_id FROM shell_decisions "
+                            "WHERE decision='shaped by spec L'")
+        self.assertEqual((dfid, ddid), (fid, did))
+
+        # the library view echoes the links + their titles
+        one = mem._api("GET", f"/_sc/mem/decisions/"
+                       f"{self.q('SELECT decision_id FROM shell_decisions WHERE decision=?', 'shaped by spec L')[0]}"
+                       )["decision"]
+        self.assertEqual(one["feature_id"], fid)
+        self.assertEqual(one["document_id"], did)
+        self.assertEqual(one["feature_title"], "feat L")
+        self.assertEqual(one["document_title"], "spec L")
+
+    def test_decision_bad_link_ids_404(self):
+        with self.assertRaises(SystemExit):
+            self.run_mem("decision", "bad feature", "--feature", "999999")
+        with self.assertRaises(SystemExit):
+            self.run_mem("decision", "bad doc", "--doc", "999999")
+        # neither wrote a row
+        self.assertEqual(
+            self.q("SELECT COUNT(*) FROM shell_decisions "
+                   "WHERE decision IN ('bad feature','bad doc')")[0], 0)
+
     # ── flags ─────────────────────────────────────────────────────────────────
     def test_flag_open_then_close(self):
         self.run_mem("flag", "open", "[x] blocked | Blocker for: y", "--name", "SC-1")


### PR DESCRIPTION
## What

Adds an optional relation from `shell_decisions` to the feature it shaped and/or the spec it came out of — closing the one gap in the otherwise feature-centric memory model. A feature's page already surfaces its specs (`documents`), tasks (`spec_tasks`), and blockers (`flags.feature_id`); this adds the **why** (decisions) next to the what and how.

## Design

Two nullable FKs on `shell_decisions`:

| column | grain | notes |
|---|---|---|
| `feature_id` | coarse — the roadmap feature this decision serves | mirrors `flags.feature_id`; attachable pre-spec (e.g. a brainstorm-stage architecture call) |
| `document_id` | fine — the spec/doc it shaped | a refinement of `feature_id`; pass `--doc` alone and the server derives `feature_id` from the doc |

Both optional — a decision unrelated to any feature stays unlinked. Both validated server-side (404 on a bad id, since a typo'd link silently breaks the audit). Agreement between the two is a documented convention, not a DB constraint.

## Usage

```
sc mem decision "…" --feature <feature_id>   # ties it to a roadmap feature
sc mem decision "…" --doc <document_id>       # ties it to a spec/doc (implies the feature)
```

The library view (`sc mem get decisions <id>`) echoes both links with their titles.

## Change surface

- **`0047_decisions_feature_link.sql`** — additive `ALTER` + indexes. Migration-only (not inlined into `schema.sql`), per the `roadmap.project_id`/0018 precedent; `schema.sql` carries a pointer comment.
- **`0048_reseed_memory_decision_link.sql`** — reseeds the `memory` skill body so the migration ledger's last word on its content is the current asset again (0028 still carried an older inline body). Heals the skills-freshness tripwire on fresh builds and propagates the doc to already-installed forks.
- **`0001_seed_skills.sql`** — regenerated (`./sc seed-skills`); diff is scoped to the memory block.
- **`api/server.py`** — `INSERT` gains the two fields + derive/validate; single-decision read joins `roadmap`/`documents` for titles.
- **`scripts/mem.py`** — `--feature` / `--doc` flags; single-decision render shows the link.
- **`assets/skills/memory/SKILL.md`** + **`skills_sc/memory.md`** (re-rendered mirror) — document the relation.
- **`tests/test_mem.py`** — link, doc-derives-feature, and bad-id-404 coverage.

## Verification

- `pytest tests/` — **272 passed**.
- `./sc render-check` — flat `_sc` mirror matches the render of tracked sources.
- Migrations 0047 + 0048 apply cleanly on both fresh-build and existing-DB paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)