### PR TITLE
feat(gui): delete a shell from the Web UI

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1921,6 +1921,29 @@ class Handler(BaseHTTPRequestHandler):
         finally:
             con.close()
 
+    def do_DELETE(self):
+        # DELETE /api/shells/{id} — soft-delete a shell (flip is_deleted=1).
+        # Matches the house pattern (skill.py): every read path filters on
+        # COALESCE(is_deleted,0)=0, so this hides the shell everywhere without
+        # touching its child rows, and frees the cartographer singleton slot.
+        path = urlparse(self.path).path
+        con = db()
+        try:
+            if path.startswith("/api/shells/") and path.count("/") == 3:
+                sid = int(path.rsplit("/", 1)[1])
+                cur = con.execute(
+                    "UPDATE shells SET is_deleted=1 "
+                    "WHERE shell_id=? AND COALESCE(is_deleted,0)=0", (sid,))
+                con.commit()
+                if cur.rowcount == 0:
+                    return self._send(404, {"error": "no such shell"})
+                return self._send(200, {"ok": True, "shell_id": sid})
+            return self._send(404, {"error": "not found"})
+        except Exception as e:
+            return self._fail(e)
+        finally:
+            con.close()
+
 
 def main(argv):
     port = None

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -265,6 +265,16 @@ async function renderShells(root) {
   const newBtn = el("button", { className: "act", type: "button", textContent: "＋ New shell" });
   newBtn.onclick = () => openNewShellModal(templates, root);
   sub.append(newBtn);
+
+  // delete shell — soft-delete the selected shell, then re-render
+  const delBtn = el("button", { className: "act", type: "button", textContent: "✕ Delete shell" });
+  delBtn.onclick = async () => {
+    if (!confirm("Delete shell “" + s.display_name + "”?")) return;
+    await api("/shells/" + selectedShell, "DELETE");
+    selectedShell = null;
+    renderShells(root);
+  };
+  sub.append(delBtn);
   // Default Models is fork-global config — the shell-scoped header (picker,
   // role/mandate, ＋New shell) is greyed out and inert there, not load-bearing.
   if (shellTab === "models") sub.classList.add("subbar-inert");


### PR DESCRIPTION
Adds a simple delete for shells created by mistake in the Web UI — no guardrails beyond a single confirm.

- **API:** new `DELETE /api/shells/{id}` does a soft-delete (`is_deleted=1`), the same pattern `skill.py` uses. All read paths already filter `COALESCE(is_deleted,0)=0`, so the shell vanishes from every surface without cascading into its child rows; deleting a cartographer also frees the singleton slot via the existing trigger. A repeat or unknown id returns 404.
- **UI:** a `✕ Delete shell` button in the Shells subbar removes the selected shell (confirm on its display name), clears the selection, and re-renders.

Verified the soft-delete SQL end-to-end against a throwaway copy of the live DB: delete hides the shell, repeat/missing id affects 0 rows (→404).