### PR TITLE
fix(sandbox): bake a durable `sc` on PATH so bare sc works under codex (#291, #292)

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -80,6 +80,29 @@ RUN pip install --no-cache-dir "playwright==1.60.0" \
 # (dos-arch QAQC-02). _sc_devtool in ./sc resolves .venv → PATH in that order.
 RUN pip install --no-cache-dir ruff mypy
 
+# Durable bare `sc` on PATH for EVERY harness. run.py prepends the repo root to
+# PATH at exec, but that only survives into a harness that hands its env verbatim
+# to each command shell: claude's Bash tool does, so bare `sc` works there; codex
+# spawns a fresh login-ish shell per call that drops the inherited PATH, so bare
+# `sc` from a worktree hit `sc: command not found` (dos-arch #291, #292). A real
+# file on PATH fixes it independently of inherited env. It resolves the checkout
+# from the CALLER's cwd via git — never from $0 (a symlink would misresolve) and
+# never from env — then exec's that checkout's own tracked ./sc, which finds the
+# engine at the main worktree root and stays in cwd. /usr/local/bin is on PATH for
+# every shell; run.py's REPO_ROOT prepend still shadows this for claude (same wrapper).
+RUN printf '%s\n' \
+      '#!/bin/sh' \
+      '# Durable bare `sc` (baked in the sandbox image — see Dockerfile). Resolves the' \
+      '# checkout from the caller cwd via git and execs its tracked ./sc. Never uses' \
+      '# $0 or inherited env, so it survives whatever shell a harness spawns.' \
+      'top=$(git rev-parse --show-toplevel 2>/dev/null || true)' \
+      '[ -n "$top" ] && [ -x "$top/sc" ] && exec "$top/sc" "$@"' \
+      '[ -n "$SC_ROOT" ] && [ -x "$SC_ROOT/sc" ] && exec "$SC_ROOT/sc" "$@"' \
+      'echo "sc: not in a super-coder checkout (no ./sc via git toplevel or SC_ROOT)" >&2' \
+      'exit 127' \
+      > /usr/local/bin/sc \
+ && chmod 0755 /usr/local/bin/sc
+
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
 # A host GID may already exist in the base image — notably macOS's primary GID 20
 # (`staff`) collides with Debian's pre-existing `dialout` group — so creating it

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -37,9 +37,9 @@ different ways, so keep them straight:
 
 - **Engine memory DB** — `.super-coder/shell_db.db`. Fixed name, always under
   `.super-coder/`. Holds your identity, memory, roadmap, specs, and the repo map.
-  Gitignored and rebuilt from tracked text. **Write through `./sc mem`** — the
-  write lands in the live engine DB, durable and visible to all. `./sc mem which`
-  confirms the API is reachable and who your token resolves to. `./sc mem` routes
+  Gitignored and rebuilt from tracked text. **Write through `sc mem`** — the
+  write lands in the live engine DB, durable and visible to all. `sc mem which`
+  confirms the API is reachable and who your token resolves to. `sc mem` routes
   through the engine API (no direct-DB fallback). If it reports "API unreachable",
   the engine server is down — surface this to FnB; they restart it with
   `./sc restart` / `make dos-r`. Do not retry silently; surface the error and stop.
@@ -54,7 +54,7 @@ different ways, so keep them straight:
   the `dev_kit` skill.
 
 **Decision rule:** your memory / planning / specs / roadmap → **engine DB**,
-written via `./sc mem`. The product's data or schema → **app DB**, via its
+written via `sc mem`. The product's data or schema → **app DB**, via its
 migrations. If a task is about what the product stores or how its tables are
 shaped, it is never the engine DB.
 
@@ -151,7 +151,7 @@ the commit on every harness, vibe included. Both are escapable when you mean it 
 Finish before you stop. Before you go dormant, leave your tree **clean or on a
 pushed branch with a PR** — never a dirty or unpushed worktree for the admin to
 adopt. And **close the flags your work cleared**: an open flag is an open handoff,
-so resolve it (`./sc mem flag close <id> --notes "…"`) with a note on *how* —
+so resolve it (`sc mem flag close <id> --notes "…"`) with a note on *how* —
 scoped to the feature you're on (`WHERE feature_id=<current>`), never a scan of
 the whole flag table. Full procedure — sync gate, finish gate, attribution,
 cleanup, what not to commit: the `git` skill; flag detail: the `flags` skill.


### PR DESCRIPTION
## Issues
Closes #291, closes #292 — dos-arch DEV1 dev shell (codex/sandbox) ran bare `sc` from its worktree and got `sc: command not found`, despite boot L&S saying bare `sc` works from any cwd.

## Root cause
`run.py:793-794` prepends the repo root to PATH at exec — but that lives **only in the harness process env**. It survives only if the harness passes its env verbatim to each command shell. claude's Bash tool does → bare `sc` works. **codex** spawns a fresh login-ish shell per call that drops the inherited PATH → bare `sc` has nothing to resolve against. Nothing durably installs `sc` on PATH (the Dockerfile only adds harness bin dirs). So the L&S wasn't stale in intent — the mechanism just never reached codex's shells.

## Fix
Bake a real `/usr/local/bin/sc` shim into the sandbox image (`/usr/local/bin` is on PATH for every shell, every harness). The shim:
- resolves the checkout from the **caller's cwd** via `git rev-parse --show-toplevel` — not `$0` (a symlink would misresolve through the wrapper's `$0`-relative logic) and not inherited env (the thing codex drops);
- execs that checkout's own tracked `./sc`, which finds the engine at the main worktree root and stays in cwd;
- falls back to `$SC_ROOT`, else exits 127 with a clear message.

For claude, `run.py`'s REPO_ROOT prepend still shadows the shim (same wrapper, identical result) — this only *adds* a path for harnesses that drop the env.

Also reconciles boot.md's own inconsistency: the DATABASES block used `./sc mem` while ORIENTATION already used bare `sc map-sql`. Shell ops standardized to bare `sc`; `./sc restart` (FnB action) and `./sc launch` (host orchestration) stay `./sc`.

## Verification
- Shim resolution exercised against the real repo from: repo root, `.super-coder/` subdir, a linked worktree (`.sc-worktrees/cart1` — the failing case), and outside any checkout (SC_ROOT fallback + clean 127). `sc help` via the shim runs the real wrapper end-to-end.
- `sh -n` clean on the generated shim.
- `tests/test_devkit_sc.py` (5) and `tests/test_engine_manifest.py` (6) green.

## Propagation
Engine change → forks (dos-arch) pick it up via `sc update`, then rebuild the sandbox image on next `sc launch`.

## Note / follow-up
This covers the **sandbox** (all three issues are sandbox). A host-run codex (no docker) would still miss the shim; if that becomes real, the same shim can be dropped into `~/.local/bin/sc` at boot/install to cover host too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)