### PR TITLE
fix(git-skill): stop telling shells to `sc snapshot` after DB work (#293)

### DIFF
--- a/.super-coder/assets/skills/git/SKILL.md
+++ b/.super-coder/assets/skills/git/SKILL.md
@@ -138,18 +138,22 @@ Getting that text into the repo is the GUI **Publish** button (or the admin shel
 on `main`) — see 'After DB work' below. (In the super-coder SOURCE repo only,
 `schema.sql` + `migrations/` are tracked too — there the engine *is* the project.)
 
-## After DB work — snapshot persists it; Publish puts it in the repo
+## After DB work — your `sc mem` write is already saved; Publish puts it in the repo
 
-Your DB edits live only in the live `.db` until serialized, so run `sc
-snapshot` (+ `sc render` if docs/roadmap/skills changed) — that's the "save my
-work" step, so a `sc rebuild` can't lose it. But the serialization lands at the
-**main checkout root**, NOT your worktree (the shared engine + DB live there), so
-don't try to commit `content.sql` or the `_sc` renders onto your branch — from a
-worktree they aren't there. Committing that text to the repo is the GUI
-**Publish** button (snapshot → render → commit → push → PR on `sc_gui_content`),
-or the admin shell working in the repo root on `main`. Your feature-branch PRs
-carry your project files; the serialized DB content is published separately. See
-the `snapshot` skill.
+Your `sc mem` write is durable the moment it lands: it goes straight into the
+shared engine DB (visible to every shell at once), and a `sc rebuild` restores it
+from the serialized snapshot. There is **no per-shell "save" step** — do **not**
+run `sc snapshot` yourself. Snapshot serializes the shared main tree and refuses
+outside admin/GUI *by design* (`snapshot: refused — serializing to the shared main
+tree is an admin/GUI step`): run from a worktree it would only churn and collide
+with the tree other shells share. Getting that DB text *into the repo* is the
+admin/GUI **Publish** flow (snapshot → render → commit → push → PR on
+`sc_gui_content`) — the GUI **Publish** button, or the admin shell on `main`
+running `SC_ADMIN=1 sc snapshot` (+ `SC_ADMIN=1 sc render` if docs/roadmap/skills
+changed). It also lands at the **main checkout root**, NOT your worktree, so don't
+try to commit `content.sql` or the `_sc` renders onto your branch — from a
+worktree they aren't there. Your feature-branch PRs carry your project files; the
+serialized DB content is published separately. See the `snapshot` skill.
 
 ## Notes
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1586,18 +1586,22 @@ Getting that text into the repo is the GUI **Publish** button (or the admin shel
 on `main`) — see ''After DB work'' below. (In the super-coder SOURCE repo only,
 `schema.sql` + `migrations/` are tracked too — there the engine *is* the project.)
 
-## After DB work — snapshot persists it; Publish puts it in the repo
+## After DB work — your `sc mem` write is already saved; Publish puts it in the repo
 
-Your DB edits live only in the live `.db` until serialized, so run `sc
-snapshot` (+ `sc render` if docs/roadmap/skills changed) — that''s the "save my
-work" step, so a `sc rebuild` can''t lose it. But the serialization lands at the
-**main checkout root**, NOT your worktree (the shared engine + DB live there), so
-don''t try to commit `content.sql` or the `_sc` renders onto your branch — from a
-worktree they aren''t there. Committing that text to the repo is the GUI
-**Publish** button (snapshot → render → commit → push → PR on `sc_gui_content`),
-or the admin shell working in the repo root on `main`. Your feature-branch PRs
-carry your project files; the serialized DB content is published separately. See
-the `snapshot` skill.
+Your `sc mem` write is durable the moment it lands: it goes straight into the
+shared engine DB (visible to every shell at once), and a `sc rebuild` restores it
+from the serialized snapshot. There is **no per-shell "save" step** — do **not**
+run `sc snapshot` yourself. Snapshot serializes the shared main tree and refuses
+outside admin/GUI *by design* (`snapshot: refused — serializing to the shared main
+tree is an admin/GUI step`): run from a worktree it would only churn and collide
+with the tree other shells share. Getting that DB text *into the repo* is the
+admin/GUI **Publish** flow (snapshot → render → commit → push → PR on
+`sc_gui_content`) — the GUI **Publish** button, or the admin shell on `main`
+running `SC_ADMIN=1 sc snapshot` (+ `SC_ADMIN=1 sc render` if docs/roadmap/skills
+changed). It also lands at the **main checkout root**, NOT your worktree, so don''t
+try to commit `content.sql` or the `_sc` renders onto your branch — from a
+worktree they aren''t there. Your feature-branch PRs carry your project files; the
+serialized DB content is published separately. See the `snapshot` skill.
 
 ## Notes
 

--- a/skills_sc/git.md
+++ b/skills_sc/git.md
@@ -145,18 +145,22 @@ Getting that text into the repo is the GUI **Publish** button (or the admin shel
 on `main`) — see 'After DB work' below. (In the super-coder SOURCE repo only,
 `schema.sql` + `migrations/` are tracked too — there the engine *is* the project.)
 
-## After DB work — snapshot persists it; Publish puts it in the repo
+## After DB work — your `sc mem` write is already saved; Publish puts it in the repo
 
-Your DB edits live only in the live `.db` until serialized, so run `sc
-snapshot` (+ `sc render` if docs/roadmap/skills changed) — that's the "save my
-work" step, so a `sc rebuild` can't lose it. But the serialization lands at the
-**main checkout root**, NOT your worktree (the shared engine + DB live there), so
-don't try to commit `content.sql` or the `_sc` renders onto your branch — from a
-worktree they aren't there. Committing that text to the repo is the GUI
-**Publish** button (snapshot → render → commit → push → PR on `sc_gui_content`),
-or the admin shell working in the repo root on `main`. Your feature-branch PRs
-carry your project files; the serialized DB content is published separately. See
-the `snapshot` skill.
+Your `sc mem` write is durable the moment it lands: it goes straight into the
+shared engine DB (visible to every shell at once), and a `sc rebuild` restores it
+from the serialized snapshot. There is **no per-shell "save" step** — do **not**
+run `sc snapshot` yourself. Snapshot serializes the shared main tree and refuses
+outside admin/GUI *by design* (`snapshot: refused — serializing to the shared main
+tree is an admin/GUI step`): run from a worktree it would only churn and collide
+with the tree other shells share. Getting that DB text *into the repo* is the
+admin/GUI **Publish** flow (snapshot → render → commit → push → PR on
+`sc_gui_content`) — the GUI **Publish** button, or the admin shell on `main`
+running `SC_ADMIN=1 sc snapshot` (+ `SC_ADMIN=1 sc render` if docs/roadmap/skills
+changed). It also lands at the **main checkout root**, NOT your worktree, so don't
+try to commit `content.sql` or the `_sc` renders onto your branch — from a
+worktree they aren't there. Your feature-branch PRs carry your project files; the
+serialized DB content is published separately. See the `snapshot` skill.
 
 ## Notes
 


### PR DESCRIPTION
## Issue
Closes #293 — the `git` skill's "After DB work" section tells a dev shell to run `sc snapshot` after DB writes, but `sc snapshot` refuses: `snapshot: refused — serializing to the shared main tree is an admin/GUI step`.

## Root cause: the skill text was stale; the guard is correct
`_serialize_guard.require_admin()` gates `sc snapshot` / `sc render flat` to `SC_ADMIN=1` (GUI, API, install, update) — never set in a dev-shell boot. That's deliberate: a shell's `sc mem` write is **already** durable and shared in the engine DB the instant it commits, so per-write serialization from a worktree only churns and collides with the main tree other shells share. The `snapshot` skill already states this; the git skill's own *next paragraph* already says publish is the GUI Publish button / admin shell. So the "run `sc snapshot`" lead sentence contradicted the guard, the snapshot skill, **and itself**.

## Fix (skill text only — no code change)
Rewrite "After DB work":
- your `sc mem` write is durable the moment it lands — **no per-shell save step**;
- do **not** run `sc snapshot` yourself; it refuses outside admin/GUI by design (quotes the exact refusal);
- serialization to git is the admin/GUI **Publish** flow — the GUI button, or `SC_ADMIN=1 sc snapshot` on `main`.

`snapshot.py` / `_serialize_guard.py` are untouched — the behavior is correct.

## Files
- `assets/skills/git/SKILL.md` — canonical source.
- `migrations/0001_seed_skills.sql` — regenerated via `sc seed-skills` (diff scoped to the git skill body).
- `skills_sc/git.md` — regenerated mirror via `sc render`.

## Verification
- `tests/test_skills_freshness.py` — 8 green.
- `sc render-check` — ✓ flat mirror matches a hermetic rebuild-from-migrations.

## Propagation
Forks (dos-arch) pick up the corrected skill via `sc update` (sync_skills upserts the new asset body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)