### PR TITLE
feat(sc): restart confirm gate + WAL-safe DB backups

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -17,7 +17,7 @@
 #   HOT (short + long):
 #   make dos-e   / dos-enter     attach a session (pick shell + harness); dos-e s=ap01 boots one
 #   make dos-l   / dos-launch    build + start the docker sandbox (+ review GUI)
-#   make dos-r   / dos-restart   down + launch — recreate the sandbox fresh
+#   make dos-r   / dos-restart   confirm (YES) + DB backup, then down + launch
 #   make dos-d   / dos-down      stop the sandbox
 #   make dos-u   / dos-update    fetch + materialize the engine, reconcile in place
 #   make dos-t   / dos-test      backend (pytest/unittest) + UI (vitest) suites
@@ -81,7 +81,7 @@ dos-h:
 	@echo "  ├───────┼─────────────┼──────────────────────────────────────────┤"
 	@echo "  │ dos-e │ dos-enter   │ attach a session (pick shell + harness)  │"
 	@echo "  │ dos-l │ dos-launch  │ build + start the docker sandbox + GUI   │"
-	@echo "  │ dos-r │ dos-restart │ recreate the sandbox fresh (down+launch) │"
+	@echo "  │ dos-r │ dos-restart │ confirm + DB backup, then recreate fresh │"
 	@echo "  │ dos-d │ dos-down    │ stop the sandbox                         │"
 	@echo "  │ dos-u │ dos-update  │ update the engine in place               │"
 	@echo "  │ dos-t │ dos-test    │ run backend + UI test suites             │"
@@ -96,7 +96,7 @@ dos-help:
 	@echo "  ├──────────────────────┼──────────────────────────────────────────────────────────┤"
 	@echo "  │ dos-e  dos-enter     │ attach a session — pick shell + harness (dos-e s=ap01)   │"
 	@echo "  │ dos-l  dos-launch    │ build + start the docker sandbox (server + review GUI)   │"
-	@echo "  │ dos-r  dos-restart   │ down + launch — recreate the sandbox fresh               │"
+	@echo "  │ dos-r  dos-restart   │ confirm (YES) + DB backup -> down + launch (fresh)       │"
 	@echo "  │ dos-d  dos-down      │ stop + remove the sandbox container                      │"
 	@echo "  │ dos-u  dos-update    │ fetch + materialize the engine, reconcile in place       │"
 	@echo "  │ dos-t  dos-test      │ backend (pytest/unittest) + UI (vitest) suites           │"

--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -13,7 +13,7 @@ Usage:
 """
 from __future__ import annotations
 
-import shutil
+import sqlite3
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -124,13 +124,28 @@ def prune_backups(prefix: str) -> None:
         old.unlink(missing_ok=True)
 
 
+def backup_db(dst: Path, src: Path = DB_PATH) -> None:
+    """WAL-safe snapshot via sqlite3's online-backup API. A plain file copy of
+    a live WAL database misses every un-checkpointed page (they live in the
+    -wal sidecar), so a copy2 restore point could silently drop the most
+    recent writes — the exact rows it exists to protect."""
+    src_con = sqlite3.connect(src)
+    dst_con = sqlite3.connect(dst)
+    try:
+        with dst_con:
+            src_con.backup(dst_con)
+    finally:
+        dst_con.close()
+        src_con.close()
+
+
 def backup_existing() -> None:
     if not DB_PATH.exists():
         return
     BACKUP_DIR.mkdir(parents=True, exist_ok=True)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     dst = BACKUP_DIR / f"shell_db.prerebuild.{ts}.db"
-    shutil.copy2(DB_PATH, dst)
+    backup_db(dst)
     prune_backups("shell_db.prerebuild")
     print(f"rebuild: backed up existing DB -> {dst}")
 

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -37,7 +37,7 @@ ENGINE_REF_PREV = STATE_DIR / "engine.ref.prev"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import engine_manifest  # noqa: E402
-import rebuild as rebuild_mod  # noqa: E402  (BACKUP_DIR, prune_backups, KEEP_BACKUPS)
+import rebuild as rebuild_mod  # noqa: E402  (BACKUP_DIR, backup_db, prune_backups, KEEP_BACKUPS)
 import update as update_mod    # noqa: E402  (materialize_engine, super_coder_remote, git)
 
 # One source of truth with rebuild.py — the PER-FORK dir. A restore point must
@@ -59,7 +59,7 @@ def backup_current_db() -> None:
     BACKUP_DIR.mkdir(parents=True, exist_ok=True)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     dst = BACKUP_DIR / f"shell_db.prerollback.{ts}.db"
-    shutil.copy2(DB_PATH, dst)
+    rebuild_mod.backup_db(dst)
     rebuild_mod.prune_backups("shell_db.prerollback")
     print(f"→ backed up current DB -> {dst}")
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   make dos-l / dos-launch  build + start the docker sandbox
 #   make dos-e / dos-enter   attach an interactive session (pick shell + harness)
 #   make dos-e s=cc          attach + boot the 'cc' shell directly
-#   make dos-r / dos-restart down + launch — recreate the sandbox fresh
+#   make dos-r / dos-restart confirm (YES) + DB backup, then down + launch
 #   make dos-d / dos-down    stop the sandbox
 #   make dos-h / dos-help    list / describe all commands
 include .super-coder/aliases.mk

--- a/sc
+++ b/sc
@@ -581,6 +581,32 @@ print('-> pg: added to $f')
 }
 
 
+# WAL-safe DB backup via sqlite3's online-backup API — a plain file copy of a
+# live WAL database misses un-checkpointed pages (they live in the -wal
+# sidecar). Same dir + naming + keep-5 pruning as rebuild.py/rollback.py.
+sc_db_backup() {
+  "$PY" - "$DB" "$(basename "$ROOT")" "${1:-manual}" <<'EOF'
+import sqlite3, sys, time
+from pathlib import Path
+db, repo, prefix = sys.argv[1:4]
+if not Path(db).exists():
+    print("→ no DB yet — nothing to back up"); raise SystemExit(0)
+bdir = Path.home() / "db_backups" / repo
+bdir.mkdir(parents=True, exist_ok=True)
+dst = bdir / f"shell_db.{prefix}.{time.strftime('%Y%m%d_%H%M%S')}.db"
+src = sqlite3.connect(db); out = sqlite3.connect(dst)
+try:
+    with out:
+        src.backup(out)
+finally:
+    out.close(); src.close()
+for old in sorted(bdir.glob(f"shell_db.{prefix}.*.db"))[:-5]:
+    old.unlink()
+print(f"→ DB backed up -> {dst}")
+EOF
+}
+
+
 cmd="${1:-help}"; [ $# -gt 0 ] && shift
 
 case "$cmd" in
@@ -776,7 +802,26 @@ case "$cmd" in
                 sc_ts_broker_down
                 sc_pm2_broker_down
                 sc_pg_down ;;
-  restart)      "$0" down; exec "$0" launch "$@" ;;
+  # restart is a hard bounce — down runs `docker rm -f`, which SIGKILLs every
+  # live session inside the sandbox along with whatever those sessions had not
+  # yet written to the DB. Too easy to reach by accident (dos-r sits next to
+  # dos-e), so: typed confirmation (only YES / Yes / yes proceed — anything
+  # else, including a closed stdin, aborts) + a WAL-safe DB backup BEFORE
+  # anything is torn down. --yes/-y skips the prompt for scripted callers.
+  restart)
+    case "${1:-}" in
+      -y|--yes) shift ;;
+      *)
+        echo "restart recreates the sandbox — live sessions inside it are killed."
+        printf "ARE YOU SURE YOU WANT TO RESTART? (YES/no): "
+        ans=""; read -r ans || true
+        case "$ans" in
+          YES|Yes|yes) ;;
+          *) echo "→ restart aborted (nothing touched)"; exit 1 ;;
+        esac ;;
+    esac
+    sc_db_backup prerestart
+    "$0" down; exec "$0" launch "$@" ;;
   build)        dcheck; dbuild ;;
   logs)         exec docker logs -f "$CNAME" ;;
   verify)
@@ -826,7 +871,7 @@ super-coder — forkable shell substrate
                              harness: --harness <name> or HARNESS=<name> forces it; else when
                              >1 harness is on PATH you're prompted (per-launch, not persisted)
   ./sc down                stop + remove the sandbox container
-  ./sc restart             down + launch — recreate the sandbox fresh
+  ./sc restart             confirm (YES) + DB backup, then down + launch — recreate fresh (--yes skips the prompt)
   ./sc build               (re)build the sandbox image
   ./sc logs                tail the sandbox server logs
 

--- a/tests/test_backup_dir.py
+++ b/tests/test_backup_dir.py
@@ -8,12 +8,19 @@ another fork's DB. The contract now: the dir is keyed by the host repo's dir
 name, and rollback shares rebuild's object rather than keeping a private copy
 (a private copy of the path is exactly how the pooling happened).
 
+Also pins the WAL-safety contract: backups go through sqlite3's online-backup
+API, never a plain file copy — the DB runs journal_mode=WAL, so a copy2 of the
+main file silently drops every un-checkpointed page (they live in the -wal
+sidecar), i.e. the most recent writes are exactly what the restore point loses.
+
 Run:
     python3 tests/test_backup_dir.py
 """
 from __future__ import annotations
 
+import sqlite3
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -40,6 +47,37 @@ class BackupDirTest(unittest.TestCase):
             src = (ROOT / ".super-coder" / "scripts" / script).read_text()
             self.assertNotIn('"db_backups" / "super-coder"', src,
                              f"{script}: the fixed-name path is the bug")
+
+
+class WalSafeBackupTest(unittest.TestCase):
+    def test_backup_captures_uncheckpointed_wal_pages(self):
+        """A row committed to the -wal sidecar (autocheckpoint off, writer
+        still connected) must appear in the backup — copy2 would miss it."""
+        with tempfile.TemporaryDirectory() as td:
+            live = Path(td) / "live.db"
+            con = sqlite3.connect(live)
+            try:
+                con.execute("PRAGMA journal_mode=WAL")
+                con.execute("PRAGMA wal_autocheckpoint=0")
+                con.execute("CREATE TABLE t (x)")
+                con.execute("INSERT INTO t VALUES (42)")
+                con.commit()
+                dst = Path(td) / "backup.db"
+                rebuild.backup_db(dst, src=live)
+                got = sqlite3.connect(dst).execute("SELECT x FROM t").fetchall()
+                self.assertEqual(got, [(42,)],
+                                 "backup missed WAL-resident writes — is it "
+                                 "copying the file instead of using the "
+                                 "online-backup API?")
+            finally:
+                con.close()
+
+    def test_no_plain_file_copy_of_the_live_db_remains(self):
+        for script in ("rebuild.py", "rollback.py"):
+            src = (ROOT / ".super-coder" / "scripts" / script).read_text()
+            self.assertNotIn("shutil.copy2(DB_PATH", src,
+                             f"{script}: backing up the live WAL DB with a "
+                             "file copy drops un-checkpointed writes")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`make dos-r` sits one key from `make dos-e`, and a fat-fingered restart hard-kills (docker rm -f) every live session in the sandbox — with whatever they hadn't persisted yet. Two protections, plus a latent backup bug found on the way:

- **Confirm gate on `./sc restart`** — proceeds only on `YES`/`Yes`/`yes`; any other answer (or a closed stdin) aborts before anything is torn down. `--yes`/`-y` bypasses for scripts. Same pattern as `eject`'s typed confirmation.
- **Pre-restart DB backup** — `shell_db.prerestart.<ts>.db` into the per-fork `~/db_backups/<repo>/` dir (keep-5 pruning), taken before `down` so a failed backup stops the bounce.
- **WAL-safety fix for the existing restore points** — `rebuild.backup_existing` and `rollback.backup_current_db` copied the live DB with `shutil.copy2`, but the DB runs `journal_mode=WAL`: un-checkpointed pages live in the `-wal` sidecar, so the copy silently missed the most recent writes — i.e. the update restore point could itself lose data. All backups now go through sqlite3's online-backup API (`rebuild.backup_db`).

## Test plan
- [x] `tests/test_backup_dir.py` — new pins: backup captures WAL-resident writes with a live writer attached; no `shutil.copy2(DB_PATH` remains in rebuild/rollback
- [x] `sh -n sc` + neighboring suites (test_rebuild_keys, test_update_materialize, test_eject) green
- [x] `./sc restart` with `no` and with closed stdin: aborts, exit 1, nothing torn down
- [x] embedded `sc_db_backup` python exercised against a scratch WAL DB; `make dos-h` / `dos-help` charts still aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)