### PR TITLE
fix(skills): agents — carry the field-run defenses from the first fork runs (#303, #304)

### DIFF
--- a/.super-coder/assets/skills/agents/SKILL.md
+++ b/.super-coder/assets/skills/agents/SKILL.md
@@ -19,6 +19,17 @@ judgment work warrants a heavier worker, and you may bump a single agent's
 tier when a task is judged hard. You — the parent — never change tier; you
 stay the judge.
 
+**The core loop is `implement → you verify → adversarially refute → you
+fix` — the refute step is where the quality comes from.** Parallel
+implementers are an optional scale-up for genuinely large, file-disjoint
+work, not the headline. The spend buys verification depth and an audit
+trail, not wall-clock: your loop (compose → wait → adjudicate → re-verify)
+is serial, and field runs measured hundreds of k of subagent tokens even
+on small waves. Fit test before spawning: multi-surface, file-disjoint,
+spec'd work with high correctness stakes → waves. A single-file or small
+fix → run the base procedure solo; at most, spawn one adversarial skeptic
+against your own diff — that is the cheap, high-ROI slice of this skill.
+
 - **Harness:** subagent tooling exists in the claude harness only. No
   subagent tooling in your harness → this skill is inert; run the base
   procedure.
@@ -39,13 +50,41 @@ stay the judge.
 2. **Prompt ingredients, not canned prompts.** You compose every agent
    prompt fresh, and it must carry: the spec excerpt / done-condition it
    serves, the exact file paths in play, the fork conventions that apply,
-   the deadline block (see the ledger check), and a required return shape.
-3. **Isolation by role.** More than one implementer in flight → each works
-   in its own isolated worktree (writers never share a tree). Reviewer and
-   checker agents are read-only; no isolation needed.
+   the expected base commit (the agent verifies it via `git log -1` before
+   editing and REPORTS a mismatch instead of silently proceeding), the
+   deadline block (see the ledger check), and a required return shape.
+3. **Isolation by conflict risk.** Concurrent writers on the same files —
+   or any writer that must touch git state — each work in their own
+   isolated worktree (writers never share a tree's index). A file-disjoint
+   wave may share your tree, edits only: agents run no `git
+   add`/`stash`/`checkout`/`commit`. Read *Worktree reality* below before
+   reaching for isolation — it has real costs. Reviewer and checker agents
+   are read-only; no isolation needed.
 4. **Agent claims are inputs, not results.** Re-run the real check yourself
    — `./sc test`, lint, the spec's done-condition — before marking anything
-   done. "Agent says tests pass" is not verification.
+   done. "Agent says tests pass" is not verification. Same for diffs: pull
+   them yourself (`git -C <worktree> diff`); never adjudicate pasted diffs
+   or pasted test output — pastes are lossy and unverifiable.
+
+---
+
+## Worktree reality — what isolation actually gives an agent
+
+Harness worktrees are fresh trees, and two properties bite (both observed
+on first fork runs — super-coder #303, #304):
+
+- **They seed from the default branch (origin/main), not your branch
+  HEAD.** In a stacked feature, a later-wave implementer authors — and
+  "verifies" — against a base missing the earlier waves' commits. Hence
+  the base-commit ingredient in contract rule 2, and hence: writers
+  return diffs, you apply each one to YOUR tree with `git apply --3way`
+  (note: it STAGES — inspect via `git diff HEAD`), and every check runs
+  on the merged state.
+- **They lack untracked toolchains.** No `node_modules`; sandboxed
+  interpreters are typically mounted only into the primary worktree. An
+  isolated agent often cannot run the app's suite at all. Say so in the
+  prompt so it doesn't burn a turn rediscovering it, and treat its tree
+  as an authoring surface: verification is yours, in your tree.
 
 ---
 
@@ -93,7 +132,9 @@ Every agent prompt ends with this deadline block, filled in:
 ```
 Your deadline is <spawned + timeout> UTC. Past it, stop and return
 partial results. If the current time is after <spawned + 6h>, do no
-work — return immediately.
+work — return immediately. Run all verification synchronously; never
+end your turn waiting on a background task — your final message is
+your only channel back.
 ```
 
 The 6-hour window is a hard constant. You choose timeouts freely under it;
@@ -110,12 +151,14 @@ never evidence.
 After the task plan exists (base skill, Steps 1–3, unchanged):
 
 1. Classify pending tasks into **dependency waves** — independent tasks may
-   run in parallel; dependent tasks sequence. Use `blueprint` for the
-   dependency read; don't reimplement it.
+   run in parallel; dependent tasks sequence. When the ordering is
+   non-obvious, use `blueprint` for the dependency read; a task plan that
+   already encodes the order stands on its own.
 2. Per wave: run the ledger check → mark each wave task `in_progress`
-   (`sc mem task start`) → spawn one implementer per task (worktrees if
-   more than one) → on each returned diff, spawn checker agent(s) prompted
-   to **refute** it → adjudicate, apply, run the real tests → `sc mem task
+   (`sc mem task start`) → spawn one implementer per task (isolation per
+   contract rule 3) → pull each returned diff yourself and apply it to
+   your tree → spawn checker agent(s) prompted to **refute** it →
+   adjudicate, run the real tests on the merged state → `sc mem task
    done` → update current_state → next wave.
 3. One wave live at a time.
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -27,6 +27,17 @@ judgment work warrants a heavier worker, and you may bump a single agent''s
 tier when a task is judged hard. You — the parent — never change tier; you
 stay the judge.
 
+**The core loop is `implement → you verify → adversarially refute → you
+fix` — the refute step is where the quality comes from.** Parallel
+implementers are an optional scale-up for genuinely large, file-disjoint
+work, not the headline. The spend buys verification depth and an audit
+trail, not wall-clock: your loop (compose → wait → adjudicate → re-verify)
+is serial, and field runs measured hundreds of k of subagent tokens even
+on small waves. Fit test before spawning: multi-surface, file-disjoint,
+spec''d work with high correctness stakes → waves. A single-file or small
+fix → run the base procedure solo; at most, spawn one adversarial skeptic
+against your own diff — that is the cheap, high-ROI slice of this skill.
+
 - **Harness:** subagent tooling exists in the claude harness only. No
   subagent tooling in your harness → this skill is inert; run the base
   procedure.
@@ -47,13 +58,41 @@ stay the judge.
 2. **Prompt ingredients, not canned prompts.** You compose every agent
    prompt fresh, and it must carry: the spec excerpt / done-condition it
    serves, the exact file paths in play, the fork conventions that apply,
-   the deadline block (see the ledger check), and a required return shape.
-3. **Isolation by role.** More than one implementer in flight → each works
-   in its own isolated worktree (writers never share a tree). Reviewer and
-   checker agents are read-only; no isolation needed.
+   the expected base commit (the agent verifies it via `git log -1` before
+   editing and REPORTS a mismatch instead of silently proceeding), the
+   deadline block (see the ledger check), and a required return shape.
+3. **Isolation by conflict risk.** Concurrent writers on the same files —
+   or any writer that must touch git state — each work in their own
+   isolated worktree (writers never share a tree''s index). A file-disjoint
+   wave may share your tree, edits only: agents run no `git
+   add`/`stash`/`checkout`/`commit`. Read *Worktree reality* below before
+   reaching for isolation — it has real costs. Reviewer and checker agents
+   are read-only; no isolation needed.
 4. **Agent claims are inputs, not results.** Re-run the real check yourself
    — `./sc test`, lint, the spec''s done-condition — before marking anything
-   done. "Agent says tests pass" is not verification.
+   done. "Agent says tests pass" is not verification. Same for diffs: pull
+   them yourself (`git -C <worktree> diff`); never adjudicate pasted diffs
+   or pasted test output — pastes are lossy and unverifiable.
+
+---
+
+## Worktree reality — what isolation actually gives an agent
+
+Harness worktrees are fresh trees, and two properties bite (both observed
+on first fork runs — super-coder #303, #304):
+
+- **They seed from the default branch (origin/main), not your branch
+  HEAD.** In a stacked feature, a later-wave implementer authors — and
+  "verifies" — against a base missing the earlier waves'' commits. Hence
+  the base-commit ingredient in contract rule 2, and hence: writers
+  return diffs, you apply each one to YOUR tree with `git apply --3way`
+  (note: it STAGES — inspect via `git diff HEAD`), and every check runs
+  on the merged state.
+- **They lack untracked toolchains.** No `node_modules`; sandboxed
+  interpreters are typically mounted only into the primary worktree. An
+  isolated agent often cannot run the app''s suite at all. Say so in the
+  prompt so it doesn''t burn a turn rediscovering it, and treat its tree
+  as an authoring surface: verification is yours, in your tree.
 
 ---
 
@@ -101,7 +140,9 @@ Every agent prompt ends with this deadline block, filled in:
 ```
 Your deadline is <spawned + timeout> UTC. Past it, stop and return
 partial results. If the current time is after <spawned + 6h>, do no
-work — return immediately.
+work — return immediately. Run all verification synchronously; never
+end your turn waiting on a background task — your final message is
+your only channel back.
 ```
 
 The 6-hour window is a hard constant. You choose timeouts freely under it;
@@ -118,12 +159,14 @@ never evidence.
 After the task plan exists (base skill, Steps 1–3, unchanged):
 
 1. Classify pending tasks into **dependency waves** — independent tasks may
-   run in parallel; dependent tasks sequence. Use `blueprint` for the
-   dependency read; don''t reimplement it.
+   run in parallel; dependent tasks sequence. When the ordering is
+   non-obvious, use `blueprint` for the dependency read; a task plan that
+   already encodes the order stands on its own.
 2. Per wave: run the ledger check → mark each wave task `in_progress`
-   (`sc mem task start`) → spawn one implementer per task (worktrees if
-   more than one) → on each returned diff, spawn checker agent(s) prompted
-   to **refute** it → adjudicate, apply, run the real tests → `sc mem task
+   (`sc mem task start`) → spawn one implementer per task (isolation per
+   contract rule 3) → pull each returned diff yourself and apply it to
+   your tree → spawn checker agent(s) prompted to **refute** it →
+   adjudicate, run the real tests on the merged state → `sc mem task
    done` → update current_state → next wave.
 3. One wave live at a time.
 

--- a/.super-coder/migrations/0050_reseed_agents_field_fixes.sql
+++ b/.super-coder/migrations/0050_reseed_agents_field_fixes.sql
@@ -1,0 +1,237 @@
+-- 0050 — reseed agents: field-run defenses from the first fork runs (#303, #304)
+--
+-- The agents skill body was amended after the first two live --agents runs
+-- (kcsos #303, dos-arch #304): core loop reframed to implement -> verify ->
+-- adversarially refute -> fix, expected base commit as a mandatory prompt
+-- ingredient, parent-pulls-diffs (pasted output is not evidence), a new
+-- Worktree reality section, and synchronous verification in the deadline block.
+--
+-- 0049 carries the OLD body and runs after 0001, so a fresh build (schema +
+-- every migration) lands 0049's stale text; 0001 regen alone is not enough.
+-- This forward reseed carries the amended body to installed forks and to fresh
+-- builds alike (UPSERT by name; skill_id + existing grants preserved).
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'agents',
+  '--agents [model] — delegate work to spawned subagents under the system''s discipline. Dev — execute a spec''s task plan as implementer waves; reviewer — fan the three review axes out to an adversarial finding-panel. Overlay on spec/review; parent-only memory writes; AGENTS spawn ledger with a hard 6h validity window; parent-set timeouts. Load ONLY when the FnB invokes --agents.',
+  'craft',
+  NULL,
+  0,
+  '# agents — delegated waves under your discipline
+
+The FnB invokes this as `--agents [model]`. It is an **overlay** on `spec`
+(dev mode) and `review` (review mode): it changes only what is written here.
+Everything upstream and downstream of the named steps — loading the spec,
+task tracking, flags, the FnB handoff gate — is the base skill, unchanged.
+Load the base skill first; apply this on top of it.
+
+`[model]` sets the **worker tier**, passed through verbatim to the harness''s
+agent tool. No arg → agents inherit your model. Guidance is one line: heavier
+judgment work warrants a heavier worker, and you may bump a single agent''s
+tier when a task is judged hard. You — the parent — never change tier; you
+stay the judge.
+
+**The core loop is `implement → you verify → adversarially refute → you
+fix` — the refute step is where the quality comes from.** Parallel
+implementers are an optional scale-up for genuinely large, file-disjoint
+work, not the headline. The spend buys verification depth and an audit
+trail, not wall-clock: your loop (compose → wait → adjudicate → re-verify)
+is serial, and field runs measured hundreds of k of subagent tokens even
+on small waves. Fit test before spawning: multi-surface, file-disjoint,
+spec''d work with high correctness stakes → waves. A single-file or small
+fix → run the base procedure solo; at most, spawn one adversarial skeptic
+against your own diff — that is the cheap, high-ROI slice of this skill.
+
+- **Harness:** subagent tooling exists in the claude harness only. No
+  subagent tooling in your harness → this skill is inert; run the base
+  procedure.
+- **Not a workflow-script system.** No deterministic orchestration scripts —
+  you spawn agents directly and stay in the loop between waves. Do not
+  "upgrade" this to scripted workflows; the point is that you decide scale,
+  batching, and prompts live, per this session''s demands.
+
+---
+
+## The contract — four rules, non-negotiable
+
+1. **You are the only memory writer.** Agents never run `sc mem` — no task
+   status, no flags, no messages, no current_state, no narrative — and never
+   `git push`, open PRs, or message shells. They return diffs and findings;
+   you adjudicate and record. This keeps the shared DB coherent and leaves
+   the reviewer''s FnB handoff gate untouched.
+2. **Prompt ingredients, not canned prompts.** You compose every agent
+   prompt fresh, and it must carry: the spec excerpt / done-condition it
+   serves, the exact file paths in play, the fork conventions that apply,
+   the expected base commit (the agent verifies it via `git log -1` before
+   editing and REPORTS a mismatch instead of silently proceeding), the
+   deadline block (see the ledger check), and a required return shape.
+3. **Isolation by conflict risk.** Concurrent writers on the same files —
+   or any writer that must touch git state — each work in their own
+   isolated worktree (writers never share a tree''s index). A file-disjoint
+   wave may share your tree, edits only: agents run no `git
+   add`/`stash`/`checkout`/`commit`. Read *Worktree reality* below before
+   reaching for isolation — it has real costs. Reviewer and checker agents
+   are read-only; no isolation needed.
+4. **Agent claims are inputs, not results.** Re-run the real check yourself
+   — `./sc test`, lint, the spec''s done-condition — before marking anything
+   done. "Agent says tests pass" is not verification. Same for diffs: pull
+   them yourself (`git -C <worktree> diff`); never adjudicate pasted diffs
+   or pasted test output — pastes are lossy and unverifiable.
+
+---
+
+## Worktree reality — what isolation actually gives an agent
+
+Harness worktrees are fresh trees, and two properties bite (both observed
+on first fork runs — super-coder #303, #304):
+
+- **They seed from the default branch (origin/main), not your branch
+  HEAD.** In a stacked feature, a later-wave implementer authors — and
+  "verifies" — against a base missing the earlier waves'' commits. Hence
+  the base-commit ingredient in contract rule 2, and hence: writers
+  return diffs, you apply each one to YOUR tree with `git apply --3way`
+  (note: it STAGES — inspect via `git diff HEAD`), and every check runs
+  on the merged state.
+- **They lack untracked toolchains.** No `node_modules`; sandboxed
+  interpreters are typically mounted only into the primary worktree. An
+  isolated agent often cannot run the app''s suite at all. Say so in the
+  prompt so it doesn''t burn a turn rediscovering it, and treat its tree
+  as an authoring surface: verification is yours, in your tree.
+
+---
+
+## The ledger check — before EVERY spawn, before acting on ANY result
+
+The ledger is a single line embedded in current_state (one wave live at a
+time, so one line is the complete record):
+
+```
+AGENTS wave=2/3 spawned=2026-07-06T14:32Z timeout=30m out=task4,task5
+```
+
+Review mode uses axis/lens names in `out=` (e.g.
+`out=quality,edges,conformance,api-design`). Stamp `spawned=` from the
+clock (UTC) at the moment you spawn — never recalled or recomputed from
+context. Remove the line at wave close.
+
+Execute this check verbatim; do not interpret it:
+
+```
+1. Read current_state.
+   No AGENTS line → you may spawn. Write the AGENTS line,
+   spawned=<now UTC>, in the same act as spawning.
+2. AGENTS line present → age = now(UTC) − spawned.
+3. age > 6h → the wave is DEAD. Unconditionally:
+   a. Stop any agent still running.
+   b. Discard their output UNREAD — do not apply, adjudicate, or "just
+      check" it, even if it looks correct.
+   c. Reconcile the task plan against reality: a task is done only if its
+      diff is on the branch and verification passes NOW.
+   d. Remove the AGENTS line; narrative: "wave expired (spawned <ts>);
+      reconciled <n> tasks".
+   e. Only now may current-session judgment start a NEW wave — fresh
+      spawn, fresh timestamp.
+4. age ≤ 6h → the wave is LIVE:
+   - agents running → monitor; never spawn a duplicate for anything
+     listed in out=.
+   - agents not running (a prior session died) → their tasks revert to
+     pending; respawning is a NEW wave: check no orphan diff already
+     landed, then rewrite the AGENTS line with a fresh timestamp.
+```
+
+Every agent prompt ends with this deadline block, filled in:
+
+```
+Your deadline is <spawned + timeout> UTC. Past it, stop and return
+partial results. If the current time is after <spawned + 6h>, do no
+work — return immediately. Run all verification synchronously; never
+end your turn waiting on a background task — your final message is
+your only channel back.
+```
+
+The 6-hour window is a hard constant. You choose timeouts freely under it;
+nothing extends it. Step 3b is deliberate: expired output is discarded even
+when it looks correct — "looks correct" hours later against a moved tree is
+exactly the trap. Step 3c recovers anything real: a diff that genuinely
+landed and verifies passes reconciliation as done. Stale ledger text is
+never evidence.
+
+---
+
+## Dev mode — overlay on `spec` Step 4
+
+After the task plan exists (base skill, Steps 1–3, unchanged):
+
+1. Classify pending tasks into **dependency waves** — independent tasks may
+   run in parallel; dependent tasks sequence. When the ordering is
+   non-obvious, use `blueprint` for the dependency read; a task plan that
+   already encodes the order stands on its own.
+2. Per wave: run the ledger check → mark each wave task `in_progress`
+   (`sc mem task start`) → spawn one implementer per task (isolation per
+   contract rule 3) → pull each returned diff yourself and apply it to
+   your tree → spawn checker agent(s) prompted to **refute** it →
+   adjudicate, run the real tests on the merged state → `sc mem task
+   done` → update current_state → next wave.
+3. One wave live at a time.
+
+Stance amendment: `spec`''s "one task at a time" becomes "one **wave** at a
+time" under `--agents`. Each task is still independently verified before it
+is marked done — the spirit holds. Step 5 of `spec` (handoff on completion)
+is unchanged and is yours, never an agent''s.
+
+## Review mode — overlay on `review` Step 2
+
+Steps 1, 3, and 4 of `review` — loading the diff and its spec, flags, the
+FnB-gated handoff — are unchanged. Agents never open flags.
+
+1. Run the ledger check, then fan out **one agent per axis** (code quality /
+   edge cases & gaps / spec conformance) **plus one per applicable lens**
+   from the base skill''s lens table. Each agent is read-only and returns
+   candidate findings in a fixed shape:
+   `file:line · claim · severity · how to reproduce`.
+2. Dedupe the returns. For an uncertain finding, optionally spawn a skeptic
+   prompted to refute it. Adjudicate every survivor yourself — re-read the
+   code path; an agent''s finding is a lead, not a verdict.
+3. Proceed to base Step 3 with the adjudicated findings. The agents widen
+   the search; you remain the gate.
+
+---
+
+## Monitoring
+
+Agents cannot self-report (contract rule 1) — monitoring is your checkpoint
+discipline, written to surfaces the FnB already watches:
+
+| Surface | What it shows |
+|---|---|
+| task plan (`sc mem get tasks`) | live board — wave tasks flip `in_progress` at spawn, `done` at adjudication; the GUI Tasks tab renders it |
+| `current_state` | the in-flight AGENTS ledger line, rewritten at every wave boundary |
+| narrative | one line per inflection: wave landed, timeout, checker refuted an implementation |
+| on demand | "status?" from the FnB → inspect your running agents'' output, answer in two lines |
+
+Honest limitation: mid-task granularity inside a single agent is only
+visible by inspecting its output on demand. There is no per-agent progress
+bar — giving agents a write surface would break rule 1.
+
+## Timeouts
+
+Set a timeout per agent at spawn, sized to the task, and record it in the
+ledger line — the budget is visible, not private.
+
+At expiry: inspect the agent''s partial output → stop it → either respawn
+with a **narrower** prompt (a timeout usually means the prompt was too
+broad) or take the task inline.
+
+**Two-strike rule:** a task whose agent times out twice is done inline by
+you, full stop. No respawn loops. Every timeout gets a narrative line —
+timeouts are signal about the plan''s granularity.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/skills_sc/agents.md
+++ b/skills_sc/agents.md
@@ -26,6 +26,17 @@ judgment work warrants a heavier worker, and you may bump a single agent's
 tier when a task is judged hard. You — the parent — never change tier; you
 stay the judge.
 
+**The core loop is `implement → you verify → adversarially refute → you
+fix` — the refute step is where the quality comes from.** Parallel
+implementers are an optional scale-up for genuinely large, file-disjoint
+work, not the headline. The spend buys verification depth and an audit
+trail, not wall-clock: your loop (compose → wait → adjudicate → re-verify)
+is serial, and field runs measured hundreds of k of subagent tokens even
+on small waves. Fit test before spawning: multi-surface, file-disjoint,
+spec'd work with high correctness stakes → waves. A single-file or small
+fix → run the base procedure solo; at most, spawn one adversarial skeptic
+against your own diff — that is the cheap, high-ROI slice of this skill.
+
 - **Harness:** subagent tooling exists in the claude harness only. No
   subagent tooling in your harness → this skill is inert; run the base
   procedure.
@@ -46,13 +57,41 @@ stay the judge.
 2. **Prompt ingredients, not canned prompts.** You compose every agent
    prompt fresh, and it must carry: the spec excerpt / done-condition it
    serves, the exact file paths in play, the fork conventions that apply,
-   the deadline block (see the ledger check), and a required return shape.
-3. **Isolation by role.** More than one implementer in flight → each works
-   in its own isolated worktree (writers never share a tree). Reviewer and
-   checker agents are read-only; no isolation needed.
+   the expected base commit (the agent verifies it via `git log -1` before
+   editing and REPORTS a mismatch instead of silently proceeding), the
+   deadline block (see the ledger check), and a required return shape.
+3. **Isolation by conflict risk.** Concurrent writers on the same files —
+   or any writer that must touch git state — each work in their own
+   isolated worktree (writers never share a tree's index). A file-disjoint
+   wave may share your tree, edits only: agents run no `git
+   add`/`stash`/`checkout`/`commit`. Read *Worktree reality* below before
+   reaching for isolation — it has real costs. Reviewer and checker agents
+   are read-only; no isolation needed.
 4. **Agent claims are inputs, not results.** Re-run the real check yourself
    — `./sc test`, lint, the spec's done-condition — before marking anything
-   done. "Agent says tests pass" is not verification.
+   done. "Agent says tests pass" is not verification. Same for diffs: pull
+   them yourself (`git -C <worktree> diff`); never adjudicate pasted diffs
+   or pasted test output — pastes are lossy and unverifiable.
+
+---
+
+## Worktree reality — what isolation actually gives an agent
+
+Harness worktrees are fresh trees, and two properties bite (both observed
+on first fork runs — super-coder #303, #304):
+
+- **They seed from the default branch (origin/main), not your branch
+  HEAD.** In a stacked feature, a later-wave implementer authors — and
+  "verifies" — against a base missing the earlier waves' commits. Hence
+  the base-commit ingredient in contract rule 2, and hence: writers
+  return diffs, you apply each one to YOUR tree with `git apply --3way`
+  (note: it STAGES — inspect via `git diff HEAD`), and every check runs
+  on the merged state.
+- **They lack untracked toolchains.** No `node_modules`; sandboxed
+  interpreters are typically mounted only into the primary worktree. An
+  isolated agent often cannot run the app's suite at all. Say so in the
+  prompt so it doesn't burn a turn rediscovering it, and treat its tree
+  as an authoring surface: verification is yours, in your tree.
 
 ---
 
@@ -100,7 +139,9 @@ Every agent prompt ends with this deadline block, filled in:
 ```
 Your deadline is <spawned + timeout> UTC. Past it, stop and return
 partial results. If the current time is after <spawned + 6h>, do no
-work — return immediately.
+work — return immediately. Run all verification synchronously; never
+end your turn waiting on a background task — your final message is
+your only channel back.
 ```
 
 The 6-hour window is a hard constant. You choose timeouts freely under it;
@@ -117,12 +158,14 @@ never evidence.
 After the task plan exists (base skill, Steps 1–3, unchanged):
 
 1. Classify pending tasks into **dependency waves** — independent tasks may
-   run in parallel; dependent tasks sequence. Use `blueprint` for the
-   dependency read; don't reimplement it.
+   run in parallel; dependent tasks sequence. When the ordering is
+   non-obvious, use `blueprint` for the dependency read; a task plan that
+   already encodes the order stands on its own.
 2. Per wave: run the ledger check → mark each wave task `in_progress`
-   (`sc mem task start`) → spawn one implementer per task (worktrees if
-   more than one) → on each returned diff, spawn checker agent(s) prompted
-   to **refute** it → adjudicate, apply, run the real tests → `sc mem task
+   (`sc mem task start`) → spawn one implementer per task (isolation per
+   contract rule 3) → pull each returned diff yourself and apply it to
+   your tree → spawn checker agent(s) prompted to **refute** it →
+   adjudicate, run the real tests on the merged state → `sc mem task
    done` → update current_state → next wave.
 3. One wave live at a time.
 


### PR DESCRIPTION
Skill-text amendments distilled from the first two live `--agents` field reports (#303 kcsos, #304 dos-arch). Both runs shipped clean features but converged on the same findings: the adversarial checker is where the value is, and mandated worktree isolation breaks the agent self-verify loop (base seeded from origin/main, no toolchains in fresh trees). This PR makes the skill carry those defenses instead of each fork's memory re-deriving them.

**Taken from the reports:**
- Reframed headline + fit/cost heuristic — refute loop is the core, fan-out is the optional scale-up (#303 net rec, #304 item 7)
- Expected base commit as a mandatory prompt ingredient, verify-and-report-mismatch (#304 item 4a)
- Writers return diffs; parent applies `--3way` and re-verifies on the merged state; pasted output is never evidence (#304 item 4b, #303 friction 2)
- New *Worktree reality* section: origin/main seeding + missing toolchains, parent is always the test runner (#303 body, #304 items 4/6)
- Synchronous-verification line in the deadline block — no stranded reports (#304 item 5)
- Rule 3 trigger is conflict risk, not headcount (#303 suggestion 2, narrowed: shared-tree agents are edits-only, no git state)
- `blueprint` only when ordering is non-obvious (#304 item 8)

**Declined:** light/full ledger split (#303 friction 1) — the ledger is one line, its value is exactly the unplanned mid-wave session death, and #304 item 10 ran it 4 waves with no friction. Kept mandatory.

`migrations/0001_seed_skills.sql` regenerated via `./sc seed-skills` (scoped to the agents row). The deeper kcsos suggestion 3 (mount the interpreter into agent worktrees) is a dev-kit track and stays open on #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)