### PR TITLE
fix(mem): restore default SIGPIPE so `sc mem get | head` exits quietly (#299)

### DIFF
--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import signal
 import sys
 import urllib.error
 import urllib.request
@@ -631,6 +632,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str]) -> int:
+    # Restore the default SIGPIPE disposition so piping a render into `head`
+    # (or any reader that closes early) terminates quietly like a normal Unix
+    # filter, instead of raising BrokenPipeError mid-render loop (#299). Python
+    # installs SIG_IGN by default, which turns the closed pipe into an
+    # exception; SIG_DFL makes the write kill the process cleanly. Guarded for
+    # platforms without SIGPIPE (Windows), though this only ever runs on Linux.
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
     args = build_parser().parse_args(argv)
     _require_api()  # every command goes through the API — fail loud if unwired
     return args.fn(args)


### PR DESCRIPTION
Fixes #299.

`sc mem get <surface>` renders rows in a `print` loop. Python installs `SIG_IGN` for `SIGPIPE` by default, so when a downstream reader like `head` closes the pipe early, the next `print` raises `BrokenPipeError` and tracebacks mid-loop (with a second `BrokenPipeError` from the stdout flush at interpreter shutdown). It's not flags-specific — any `mem get` surface whose output exceeds what the reader consumes hits it.

Sets `signal(SIGPIPE, SIG_DFL)` at the top of `main()` so a closed pipe terminates the process the way every well-behaved Unix filter does — no traceback. Guarded with `hasattr(signal, "SIGPIPE")` for platforms without it (this only ever runs on Linux). Exit is via SIGPIPE (128+13), conventional for a producer killed by a closed pipe.

**Test plan**
- [x] Repro of the render-loop-into-`head` pattern tracebacks with `BrokenPipeError` (loop + shutdown flush) without the line; clean stdout + empty stderr with it.
- [x] `python3 -m py_compile mem.py` passes.