### PR TITLE
feat(db-broker): read-only diagnostic access to the live app DB (#296)

### DIFF
--- a/.super-coder/api/db_broker.py
+++ b/.super-coder/api/db_broker.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""db-broker — the host-side authority for read-only diagnostic reads of the
+fork's LIVE app Postgres.
+
+A fork's shells run in a sandbox that has an *empty* private pg sidecar (the
+dev/test target), no mounted host DSN, and no route to the host's live app DB.
+This broker runs ON THE HOST, where the DSN + route resolve, and exposes ONE
+narrow verb — a single SELECT, allowlisted + capped + timed — over a unix socket
+in the bind-mounted engine dir (`.super-coder/run/db-broker.sock`). The
+`db_query` skill curls that socket; the sandbox names a query and holds nothing.
+It is the fourth sibling of the pm2 / Windows-VM / tailnet brokers
+(api/pm2_broker.py, api/vm_broker.py, api/ts_broker.py). Config + validation +
+the query verb live in scripts/dbq.py. Spec: specs_sc/db-query.md.
+
+Routes (all JSON `{ok, ...}`):
+
+    GET  /health              liveness of the broker (not the DB)
+    POST /query   {sql}       one read-only SELECT → {ok, columns, rows, truncated}
+
+Every query is fail-closed: rejected unless it is a single SELECT/WITH touching
+only allowlisted tables (scripts/dbq.check), and the DSN must point at a
+read-only Postgres role (the DB-enforced backstop). The socket is fs-perm gated
+(0600) — reachable only by processes sharing the bind mount; no network surface,
+no auth token.
+
+Run on the HOST (never in the sandbox):
+    ./sc db-broker        foreground
+    ./sc db-broker-up     background (pidfile) ; ./sc db-broker-down to stop
+"""
+from __future__ import annotations
+
+import json
+import os
+import socketserver
+import sys
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import dbq  # noqa: E402  (config + validation + the query verb + socket path)
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    # AF_UNIX peers have no address — the default logger would IndexError on it.
+    def log_message(self, fmt: str, *args) -> None:
+        sys.stderr.write("[db-broker] " + (fmt % args) + "\n")
+
+    def _send(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self) -> dict:
+        n = int(self.headers.get("Content-Length") or 0)
+        if not n:
+            return {}
+        try:
+            return json.loads(self.rfile.read(n).decode() or "{}")
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return {}
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            return self._send(200, {"ok": True, "service": "db-broker"})
+        return self._send(404, {"ok": False, "error": "no such route"})
+
+    def do_POST(self) -> None:
+        try:
+            if self.path == "/query":
+                sql = self._body().get("sql", "")
+                if not isinstance(sql, str):
+                    return self._send(400, {"ok": False, "error": "sql must be a string"})
+                result = dbq.do_query(sql)
+                _audit(sql, result)
+                return self._send(200, result)
+        except Exception as e:  # never let one bad call kill a worker thread
+            return self._send(500, {"ok": False, "error": f"{type(e).__name__}: {e}"})
+        return self._send(404, {"ok": False, "error": "no such route"})
+
+
+def _audit(sql: str, result: dict) -> None:
+    """Append one line per brokered query to the host-side audit log — a read
+    path to live data must be legible after the fact. Best-effort: an audit
+    write failure must never fail the query."""
+    try:
+        dbq.RUN_DIR.mkdir(parents=True, exist_ok=True)
+        verdict = "ok" if result.get("ok") else "deny"
+        row = {
+            "verdict": verdict,
+            "rows": result.get("row_count"),
+            "truncated": result.get("truncated"),
+            "error": result.get("error"),
+            "sql": " ".join(sql.split()),
+        }
+        with open(dbq.RUN_DIR / "db-broker.audit.log", "a") as f:
+            f.write(json.dumps(row) + "\n")
+    except OSError:
+        pass
+
+
+class UnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    """HTTP over a unix socket. Clears a stale socket from a crashed prior run
+    (else bind fails EADDRINUSE) and locks the socket to the owner (0600)."""
+    daemon_threads = True
+
+    def server_bind(self) -> None:
+        try:
+            os.unlink(self.server_address)
+        except FileNotFoundError:
+            pass
+        super().server_bind()
+        os.chmod(self.server_address, 0o600)
+
+
+def main(argv: list[str]) -> int:
+    if os.environ.get("SC_SANDBOX"):
+        sys.exit("db-broker must run on the HOST (the live DSN + route live "
+                 "there), not inside the sandbox. Run `./sc db-broker` on the host.")
+    sock = dbq.SOCKET
+    sock.parent.mkdir(parents=True, exist_ok=True)
+    srv = UnixHTTPServer(str(sock), Handler)
+    sys.stderr.write(f"[db-broker] listening on {sock}\n")
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        srv.server_close()
+        try:
+            os.unlink(sock)
+        except OSError:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/docs/db-broker.md
+++ b/.super-coder/docs/db-broker.md
@@ -1,0 +1,110 @@
+# db broker
+
+Read-only diagnostic access to the fork's **live app Postgres** for a sandboxed
+shell — without handing that shell a credential or a network route. The fourth
+sibling of the pm2, Windows-VM, and tailnet brokers: one host process holds the
+capability so nothing downstream needs it.
+
+Code: `.super-coder/api/db_broker.py` (the HTTP-over-unix-socket server) +
+`.super-coder/scripts/dbq.py` (config, validation, the query verb, the socket
+client). The `db_query` skill curls the socket. Spec: `specs_sc/db-query.md`.
+
+## Why a broker, not the DSN in the container
+
+A fork's shells run in a sandbox with an **empty private pg sidecar**
+(`sc-pg-<fork>`, the dev/test target — see the dev_kit skill). That isolation is
+correct: dev/test writes must never touch live data. But it also means the
+live app DB — where the runtime/telemetry a shell needs to *confirm* a diagnosis
+lives — is unreachable:
+
+- the sidecar DSN resolves to the empty sidecar, not the live stack;
+- the host env file carrying the real DSN is not mounted in;
+- the live app Postgres sits on a host network the container has no route to.
+
+The two cruder ways to close that gap both widen the blast radius:
+
+- **mount the host DSN + open a route** → full SQL + host networking from
+  inside the sandbox;
+- **a read-only role whose DSN is mounted** → still needs a route, and leaks a
+  live credential into the sandbox — which is `-v $here:$here` bind-mounted, so
+  anything under the repo (`instance.json` included) is sandbox-readable.
+
+The broker keeps the credential and the route entirely host-side and hands the
+sandbox one narrow verb, exactly as pm2-broker does for `pm2` + the host app.
+
+## Read-only, enforced twice
+
+1. **The DSN points at a read-only Postgres role** (`GRANT SELECT` only) — the
+   DB-enforced backstop. The broker also connects with
+   `default_transaction_read_only=on`.
+2. **The broker rejects any statement that is not a single `SELECT`/`WITH`**
+   before `psql` ever runs — no stacked statements, no data-modifying CTEs, no
+   DDL/DML/session-or-transaction control.
+
+Table scoping is likewise belt-and-suspenders: the RO role should `GRANT SELECT`
+only on the allowlisted tables (DB-authoritative), and the broker additionally
+rejects a query whose `FROM`/`JOIN` targets a table outside `allow_tables`. The
+default allowlist is **ops/telemetry only** (`skill_runs`, `tool_call_attempts`,
+`models`); content/tenant tables (contacts, emails, chat bodies) are gated —
+added only by explicit operator scope. Every query also gets a
+`statement_timeout` and a row cap, and every call is logged to
+`.super-coder/run/db-broker.audit.log`.
+
+## Link config — the `db` block
+
+Held under the `db` key of `.super-coder/instance.json`. It carries **no secret**
+— instance.json is sandbox-readable, so the block names an *env var*, and the
+broker (host-side) resolves the DSN from it at query time:
+
+```json
+"db": {
+  "dsn_env": "SC_RO_DSN",
+  "allow_tables": ["skill_runs", "tool_call_attempts", "models"],
+  "row_cap": 1000,
+  "statement_timeout_ms": 5000,
+  "psql_bin": "psql"
+}
+```
+
+`./sc db-init` scaffolds the block and prints the one-time host steps (create the
+RO role, `GRANT SELECT` on the allowlisted tables, export `SC_RO_DSN`). The DSN
+is parsed into libpq `PG*` env vars for the `psql` subprocess, so the password
+never lands on a process argv.
+
+## Routes
+
+All JSON `{ok, ...}`, over the unix socket at `.super-coder/run/db-broker.sock`
+(`0600`; path from `./sc db-broker-sock`):
+
+| Verb | Call |
+|---|---|
+| **health** | `curl -s --unix-socket "$SOCK" http://db/health` → `{ok, service}` |
+| **query** | `curl -s --unix-socket "$SOCK" http://db/query -d '{"sql":"SELECT …"}'` → `{ok, columns, rows, row_count, truncated}` or `{ok:false, error}` |
+
+## Running it (on the HOST — never in the sandbox)
+
+```
+./sc db-init             scaffold the `db` block + print host setup steps
+export SC_RO_DSN=postgresql://sc_ro:…@<host>:5432/<db>
+./sc db-broker           foreground (unix socket)
+./sc db-broker-up        background (nohup + pidfile); self-skips if unlinked/up
+./sc db-broker-down      stop the backgrounded broker
+./sc db-broker-install   supervise via a systemd --user unit (EnvironmentFile
+                         carries SC_RO_DSN — a unit has no login shell)
+```
+
+`db_broker.py` guards on `SC_SANDBOX` and refuses to start inside the container.
+`db-broker-up` self-skips when no `db` block is linked and no-ops when the socket
+already answers; `db-broker-down` only stops what it started (a systemd-managed
+broker is left alone — use `db-broker-uninstall`).
+
+## Deferred (not in v1)
+
+- **Any write path.** Read-only forever; a write broker is a different tool with
+  a different threat model.
+- **Query builders / pagination beyond the row cap / result streaming.** The
+  verb takes raw `SELECT` text and returns capped rows.
+- **A review-GUI panel.** The surface is the `db_query` skill (CLI over the
+  socket); no `/api/db/*` route on the review server.
+- **Cross-fork / cross-host access.** One broker serves one fork's live DB on
+  its own host.

--- a/.super-coder/scripts/dbq.py
+++ b/.super-coder/scripts/dbq.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Host db-broker — read-only diagnostic access to the fork's LIVE app DB.
+
+Link-only, read-only, host-side by design. A sandbox shell diagnosing live app
+behaviour cannot reach the fork's live Postgres: `./sc launch` gives it an
+*empty* private sidecar (dev/test target), the host DSN is never mounted, and
+the live stack sits on a network the container has no route to. So a shell must
+hand the operator a SQL block and wait for a paste-back. This broker closes that
+loop for confirmation-grade reads — telemetry/ops tables a shell needs to
+confirm a diagnosis it has already reasoned out — without ever handing the
+sandbox a credential or a route.
+
+It is the fourth sibling of the pm2 / Windows-VM / tailnet brokers
+(api/pm2_broker.py, api/vm_broker.py, api/ts_broker.py): one host process holds
+the capability so nothing downstream needs it. The broker (api/db_broker.py)
+runs ON THE HOST, shells out to `psql` where the DSN + route resolve, and
+exposes one narrow verb over a unix socket in the bind-mounted engine dir
+(`.super-coder/run/db-broker.sock`). The `db_query` skill curls that socket.
+Spec: specs_sc/db-query.md · doc: .super-coder/docs/db-broker.md.
+
+The config lives under the `db` key of `.super-coder/instance.json`. Because the
+whole repo is bind-mounted into the sandbox (`-v $here:$here`), instance.json is
+sandbox-readable — so the block holds NO secret. It names an *env var*; the
+broker (host-side) resolves the DSN from that var at query time. Non-secret
+policy that IS safe to be sandbox-readable lives in the block:
+
+    dsn_env               name of the host env var holding the read-only DSN
+                          (default SC_RO_DSN) — the DSN itself never touches disk
+    allow_tables          fail-closed allowlist of tables a query may touch
+                          (default: ops/telemetry only — content tables are gated)
+    row_cap               max rows returned (default 1000; truncation is flagged)
+    statement_timeout_ms  server-side statement timeout (default 5000)
+    psql_bin              path/name of the psql CLI (default "psql")
+
+Read-only is enforced TWICE: (1) the DSN must point at a dedicated read-only
+Postgres role (GRANT SELECT only) — DB-enforced, the backstop; the broker also
+sets default_transaction_read_only=on on the session; and (2) the broker rejects
+any statement that is not a single SELECT/WITH before psql ever runs. The
+allowlist is likewise belt-and-suspenders: the RO role should GRANT SELECT only
+on the allowlisted tables (DB-authoritative), and the broker additionally
+rejects a query whose FROM/JOIN targets a table outside `allow_tables`.
+
+Run on the HOST (never in the sandbox):
+    ./sc db-broker        foreground
+    ./sc db-broker-up     background (pidfile) ; ./sc db-broker-down to stop
+"""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import urllib.parse
+from pathlib import Path
+
+import ports
+
+# The broker listens here — a unix socket inside the bind-mounted engine dir, so
+# the same absolute path resolves on the host (where the broker runs) and in the
+# sandbox (where the db_query skill curls it). No network surface; fs-perm gated.
+# Distinct filename from the sibling brokers' sockets so all four coexist.
+RUN_DIR = ports.ENGINE / "run"
+SOCKET = RUN_DIR / "db-broker.sock"
+
+DEFAULT_ALLOW_TABLES = ["skill_runs", "tool_call_attempts", "models"]
+DEFAULT_ROW_CAP = 1000
+DEFAULT_TIMEOUT_MS = 5000
+DEFAULT_DSN_ENV = "SC_RO_DSN"
+
+
+# -- config (instance.json `db` block) ----------------------------------------
+
+def read() -> dict | None:
+    """The persisted db block, or None if the fork has not linked a live DB."""
+    return ports.resolve(persist=False).get("db")
+
+
+def write(db: dict | None) -> dict | None:
+    """Persist (or clear) the db block, preserving every other config key
+    (ports, and the pm2/vm/ts blocks — all coexist)."""
+    cfg = ports.resolve(persist=False)
+    if db:
+        cfg["db"] = db
+    else:
+        cfg.pop("db", None)
+    ports.save(cfg)
+    return cfg.get("db")
+
+
+def _policy(cfg: dict) -> dict:
+    """Resolve the effective (defaulted) policy from a `db` block."""
+    return {
+        "dsn_env": cfg.get("dsn_env") or DEFAULT_DSN_ENV,
+        "allow_tables": [t.lower() for t in (cfg.get("allow_tables") or DEFAULT_ALLOW_TABLES)],
+        "row_cap": int(cfg.get("row_cap") or DEFAULT_ROW_CAP),
+        "statement_timeout_ms": int(cfg.get("statement_timeout_ms") or DEFAULT_TIMEOUT_MS),
+        "psql_bin": cfg.get("psql_bin") or "psql",
+    }
+
+
+# -- SELECT-only + allowlist validation (runs BEFORE psql) --------------------
+
+_STRING_LIT = re.compile(r"'(?:[^']|'')*'")          # 'single-quoted', '' escapes
+_LINE_COMMENT = re.compile(r"--[^\n]*")
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+# Mutating / DDL / session- and transaction-control verbs. A read path must
+# reject every one of these, including inside a CTE (WITH x AS (INSERT ...)).
+_FORBIDDEN = re.compile(
+    r"\b(insert|update|delete|drop|alter|truncate|create|grant|revoke|copy|"
+    r"merge|call|do|vacuum|reindex|refresh|comment|lock|reset|set|begin|"
+    r"commit|rollback|savepoint|prepare|execute|deallocate|listen|notify|"
+    r"unlisten|discard|cluster|attach|detach|import|load)\b",
+    re.I,
+)
+_TABLE_REF = re.compile(r"\b(?:from|join)\s+([a-zA-Z_][\w.$]*)", re.I)
+# CTE names defined by `WITH name AS (…)` (and each `, name AS (…)`). These are
+# query-local, not real tables — the RO role never gates them, so the broker's
+# allowlist must not either.
+_CTE_NAME = re.compile(r"\b([a-zA-Z_]\w*)\s+as\s*\(", re.I)
+
+
+def _strip(sql: str) -> str:
+    """Remove string literals + comments so keyword/table scans don't trip on
+    them (a column value 'please update the row' is not an UPDATE statement)."""
+    sql = _BLOCK_COMMENT.sub(" ", sql)
+    sql = _LINE_COMMENT.sub(" ", sql)
+    sql = _STRING_LIT.sub("''", sql)
+    return sql
+
+
+def _tables(stripped: str) -> list[str]:
+    """Best-effort FROM/JOIN targets, schema-stripped + lowercased, minus any
+    query-local CTE names. Defence in depth over the RO role's GRANTs — the role
+    is the authoritative boundary."""
+    ctes = {n.lower() for n in _CTE_NAME.findall(stripped)}
+    out = []
+    for ref in _TABLE_REF.findall(stripped):
+        name = ref.split(".")[-1].lower()          # drop schema qualifier
+        if name and name not in out and name not in ctes:
+            out.append(name)
+    return out
+
+
+def check(sql: str, cfg: dict) -> tuple[bool, str]:
+    """Validate a candidate query against the read-only + allowlist rules.
+    Returns (ok, reason). Fail-closed: anything not provably a single, read-only,
+    allowlisted SELECT is rejected."""
+    raw = (sql or "").strip()
+    if not raw:
+        return False, "empty query"
+    stripped = _strip(raw)
+    # Single statement only — no stacked statements. A trailing ';' is fine; any
+    # ';' with more query after it is a second statement → reject.
+    body = stripped.rstrip().rstrip(";")
+    if ";" in body:
+        return False, "only a single statement is allowed (no stacked statements)"
+    if not re.match(r"^\s*(select|with)\b", body, re.I):
+        return False, "only SELECT (or WITH … SELECT) queries are allowed"
+    if _FORBIDDEN.search(body):
+        bad = _FORBIDDEN.search(body).group(1).upper()
+        return False, f"disallowed keyword '{bad}' — this is a read-only surface"
+    pol = _policy(cfg)
+    tables = _tables(body)
+    unlisted = [t for t in tables if t not in pol["allow_tables"]]
+    if unlisted:
+        return False, (f"table(s) {unlisted} not in the allowlist "
+                       f"{pol['allow_tables']} — ask the operator to widen the "
+                       "`db` block's allow_tables (and the RO role's GRANTs)")
+    return True, "ok"
+
+
+# -- DSN resolution (host-side only; never on argv) ---------------------------
+
+def resolve_dsn(pol: dict) -> tuple[str | None, dict, str | None]:
+    """Read the DSN from the host env var named by the block. Returns
+    (dsn, libpq_env, error). The DSN is parsed into libpq PG* env vars so the
+    password never lands on a process argv (visible in `ps`)."""
+    var = pol["dsn_env"]
+    dsn = os.environ.get(var)
+    if not dsn:
+        return None, {}, (f"the read-only DSN is not set: export ${var} in the "
+                          "broker's host environment (it is never mounted into "
+                          "the sandbox). See `./sc db-init`.")
+    env: dict[str, str] = {}
+    u = urllib.parse.urlparse(dsn)
+    if u.scheme in ("postgres", "postgresql") and (u.hostname or u.path):
+        if u.hostname:
+            env["PGHOST"] = u.hostname
+        if u.port:
+            env["PGPORT"] = str(u.port)
+        if u.username:
+            env["PGUSER"] = urllib.parse.unquote(u.username)
+        if u.password:
+            env["PGPASSWORD"] = urllib.parse.unquote(u.password)
+        db = (u.path or "").lstrip("/")
+        if db:
+            env["PGDATABASE"] = db
+        return dsn, env, None
+    # Not a URI (libpq key=value conninfo). We can't split it into PG* vars
+    # cleanly; fall back to passing it on argv (host-side, trusted — the sandbox
+    # has its own pid namespace and cannot see the host's `ps`).
+    return dsn, {}, None
+
+
+# -- the query verb (host-side; the broker exposes this over the socket) ------
+
+def _run(argv: list[str], env: dict, timeout: int) -> tuple[int, str, str]:
+    """Run psql with an augmented environment. The mock seam for tests (no live
+    Postgres in CI) — sibling brokers mock their own `_run` the same way."""
+    full = dict(os.environ)
+    full.update(env)
+    try:
+        p = subprocess.run(argv, capture_output=True, text=True,
+                           timeout=timeout, env=full)
+        return p.returncode, p.stdout, p.stderr
+    except FileNotFoundError as e:
+        return 127, "", f"command not found: {e.filename} — is psql installed on the host?"
+    except subprocess.TimeoutExpired:
+        return 124, "", f"psql timed out (>{timeout}s)"
+
+
+def _parse_csv(out: str, cap: int) -> tuple[list[str], list[list[str]], bool]:
+    """Split psql --csv output into (columns, rows, truncated). The wrap query
+    fetches cap+1 rows so a full cap+1 signals there was more."""
+    reader = list(csv.reader(io.StringIO(out)))
+    if not reader:
+        return [], [], False
+    columns, data = reader[0], reader[1:]
+    truncated = len(data) > cap
+    return columns, data[:cap], truncated
+
+
+def do_query(sql: str) -> dict:
+    """Validate → run one SELECT against the live DB host-side → capped rows.
+    Returns {ok, columns, rows, truncated} or {ok:false, error}."""
+    cfg = read()
+    if cfg is None:
+        return {"ok": False, "error": "no `db` block in instance.json — run `./sc db-init`"}
+    pol = _policy(cfg)
+    ok, reason = check(sql, cfg)
+    if not ok:
+        return {"ok": False, "error": reason}
+    dsn, pgenv, err = resolve_dsn(pol)
+    if err:
+        return {"ok": False, "error": err}
+    cap = pol["row_cap"]
+    inner = _strip(sql).strip().rstrip(";")  # already validated single-statement
+    # Wrap to enforce the row cap in the DB; cap+1 so we can detect truncation.
+    wrapped = f"SELECT * FROM ({inner}) AS _sc_q LIMIT {cap + 1}"
+    # Session options via PGOPTIONS (applied at connect): a hard statement
+    # timeout and a read-only transaction default — belt to the RO role's braces.
+    pgenv = dict(pgenv)
+    pgenv["PGOPTIONS"] = (f"-c statement_timeout={pol['statement_timeout_ms']} "
+                          "-c default_transaction_read_only=on")
+    argv = [pol["psql_bin"], "--csv", "-v", "ON_ERROR_STOP=1", "-w"]
+    if not pgenv.get("PGHOST") and not pgenv.get("PGDATABASE") and dsn:
+        argv += ["-d", dsn]  # non-URI conninfo fallback
+    argv += ["-c", wrapped]
+    timeout_s = max(2, pol["statement_timeout_ms"] // 1000 + 5)
+    code, stdout, stderr = _run(argv, pgenv, timeout_s)
+    if code != 0:
+        return {"ok": False, "error": (stderr or stdout or "psql failed").strip()}
+    columns, rows, truncated = _parse_csv(stdout, cap)
+    return {"ok": True, "columns": columns, "rows": rows,
+            "row_count": len(rows), "truncated": truncated}
+
+
+# -- client: HTTP over the broker's unix socket -------------------------------
+
+def broker_call(method: str, path: str, body: dict | None = None,
+                timeout: int = 70) -> dict:
+    """Speak HTTP/1.1 to the db-broker over its unix socket and return parsed
+    JSON. Raises ConnectionError if the broker is not listening (so callers can
+    render a 'start the broker' hint)."""
+    payload = b"" if body is None else json.dumps(body).encode()
+    req = (
+        f"{method} {path} HTTP/1.1\r\nHost: db-broker\r\n"
+        f"Content-Type: application/json\r\nContent-Length: {len(payload)}\r\n"
+        f"Connection: close\r\n\r\n"
+    ).encode() + payload
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    chunks: list[bytes] = []
+    try:
+        s.connect(str(SOCKET))
+        s.sendall(req)
+        while True:
+            b = s.recv(65536)
+            if not b:
+                break
+            chunks.append(b)
+    except (FileNotFoundError, ConnectionRefusedError, OSError) as e:
+        raise ConnectionError(f"db-broker not reachable at {SOCKET}: {e}") from e
+    finally:
+        s.close()
+    _, _, raw_body = b"".join(chunks).partition(b"\r\n\r\n")
+    try:
+        return json.loads(raw_body.decode() or "{}")
+    except json.JSONDecodeError:
+        return {"ok": False, "error": "bad broker response",
+                "raw": raw_body[:200].decode("latin1")}
+
+
+# -- host CLI (path lookup for `sc`; verbs for manual no-broker testing) -------
+
+def main(argv: list[str]) -> int:
+    mode = argv[0] if argv else "sock"
+    if mode == "sock":
+        print(SOCKET)
+    elif mode == "configured":
+        # exit 0 if this fork has linked a live DB (so the launch hook self-skips)
+        return 0 if read() else 1
+    elif mode == "check":
+        # dbq.py check "<sql>" — validate only, no DB round-trip
+        ok, reason = check(argv[1] if len(argv) > 1 else "", read() or {})
+        print(json.dumps({"ok": ok, "reason": reason}))
+    elif mode == "query":
+        print(json.dumps(do_query(argv[1] if len(argv) > 1 else "")))
+    else:
+        sys.exit("usage: dbq.py [sock|configured|check <sql>|query <sql>]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import signal
 import sys
 import urllib.error
 import urllib.request
@@ -631,6 +632,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str]) -> int:
+    # Restore the default SIGPIPE disposition so piping a render into `head`
+    # (or any reader that closes early) terminates quietly like a normal Unix
+    # filter, instead of raising BrokenPipeError mid-render loop (#299). Python
+    # installs SIG_IGN by default, which turns the closed pipe into an
+    # exception; SIG_DFL makes the write kill the process cleanly. Guarded for
+    # platforms without SIGPIPE (Windows), though this only ever runs on Linux.
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
     args = build_parser().parse_args(argv)
     _require_api()  # every command goes through the API — fail loud if unwired
     return args.fn(args)

--- a/sc
+++ b/sc
@@ -527,6 +527,109 @@ sc_pm2_broker_uninstall() {
   echo "→ pm2-broker systemd unit removed ($PM2_BROKER_UNIT)"
 }
 
+# ── db broker (HOST-side; read-only diagnostic access to the LIVE app DB) ─────
+# A host-side broker that shells out to `psql` where the live DSN + route
+# resolve, exposing ONE narrow verb (a single allowlisted, capped, read-only
+# SELECT) over a unix socket in the bind-mounted engine dir so the `db_query`
+# skill (in the container) can curl it. The sandbox holds no DSN and no route.
+# Read-only twice: the DSN must point at a read-only PG role AND dbq.py rejects
+# any non-SELECT before psql runs. Refuses to run in the sandbox (db_broker.py
+# guards on SC_SANDBOX). Same lifecycle model as its siblings: `up` no-ops when
+# the socket already answers; `down` only stops what IT started.
+DB_BROKER_PID="$ENGINE/run/db-broker.pid"
+DB_BROKER_UNIT="sc-db-broker-$(basename "$here").service"
+
+sc_db_broker_alive() {
+  sock="$("$PY" "$S/dbq.py" sock)"
+  [ -S "$sock" ] || return 1
+  curl -s --unix-socket "$sock" http://db/health 2>/dev/null | grep -q '"ok": true'
+}
+sc_db_broker_up() {
+  if ! "$PY" "$S/dbq.py" configured; then
+    echo "→ db-broker: no live DB linked (instance.json has no \`db\` block) — nothing to serve"; return 0
+  fi
+  if sc_db_broker_alive; then echo "→ db-broker already serving $("$PY" "$S/dbq.py" sock)"; return 0; fi
+  mkdir -p "$ENGINE/run"
+  nohup "$PY" "$ENGINE/api/db_broker.py" >"$ENGINE/run/db-broker.log" 2>&1 &
+  echo $! > "$DB_BROKER_PID"
+  echo "→ db-broker up (pid $!) · socket $("$PY" "$S/dbq.py" sock) · log $ENGINE/run/db-broker.log"
+}
+sc_db_broker_down() {
+  if [ -f "$DB_BROKER_PID" ] && kill -0 "$(cat "$DB_BROKER_PID" 2>/dev/null)" 2>/dev/null; then
+    kill "$(cat "$DB_BROKER_PID")" && echo "→ db-broker stopped"
+  elif sc_db_broker_alive; then
+    echo "→ db-broker is running but not from \`db-broker-up\` (systemd?) — leaving it; use db-broker-uninstall"
+  else
+    echo "→ db-broker not running"
+  fi
+  rm -f "$DB_BROKER_PID"
+}
+sc_db_broker_install() {
+  command -v systemctl >/dev/null 2>&1 || { echo "✗ db-broker-install: systemd (systemctl) not found on this host" >&2; return 1; }
+  unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+  mkdir -p "$unit_dir"
+  # The DSN is read from the host env at query time; a systemd unit has no login
+  # shell, so point it at an EnvironmentFile the operator controls (host-side,
+  # never mounted). SC_RO_ENVFILE overrides the default path.
+  envfile="${SC_RO_ENVFILE:-$HOME/.config/$(basename "$here")/db-broker.env}"
+  cat > "$unit_dir/$DB_BROKER_UNIT" <<UNIT
+[Unit]
+Description=super-coder db-broker ($(basename "$here")) — host-side read-only DB broker
+After=network.target
+
+[Service]
+EnvironmentFile=-$envfile
+ExecStart=$PY $ENGINE/api/db_broker.py
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+UNIT
+  systemctl --user daemon-reload
+  loginctl enable-linger "$(id -un)" >/dev/null 2>&1 || true
+  sc_db_broker_down >/dev/null 2>&1 || true
+  systemctl --user enable --now "$DB_BROKER_UNIT"
+  echo "→ db-broker installed as systemd --user unit: $DB_BROKER_UNIT (enabled, started, linger on)"
+  echo "  DSN env-file: $envfile (create it host-side with: SC_RO_DSN=postgresql://…)"
+  echo "  status: systemctl --user status $DB_BROKER_UNIT   ·   logs: journalctl --user -u $DB_BROKER_UNIT"
+}
+sc_db_broker_uninstall() {
+  command -v systemctl >/dev/null 2>&1 || { echo "✗ db-broker-uninstall: systemd not found" >&2; return 1; }
+  systemctl --user disable --now "$DB_BROKER_UNIT" 2>/dev/null || true
+  rm -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/$DB_BROKER_UNIT"
+  systemctl --user daemon-reload
+  echo "→ db-broker systemd unit removed ($DB_BROKER_UNIT)"
+}
+sc_db_init() {
+  f="$ENGINE/instance.json"
+  if [ -f "$f" ] && "$PY" -c "import json,sys; d=json.load(open('$f')); sys.exit(0 if 'db' in d else 1)" 2>/dev/null; then
+    echo "→ db: already configured in $f"
+  elif [ -f "$f" ]; then
+    "$PY" -c "
+import json,pathlib
+p=pathlib.Path('$f')
+d=json.loads(p.read_text())
+d['db']={'dsn_env':'SC_RO_DSN','allow_tables':['skill_runs','tool_call_attempts','models'],'row_cap':1000,'statement_timeout_ms':5000}
+p.write_text(json.dumps(d,indent=2)+'\n')
+print('-> db: added to $f')
+"
+  else
+    printf '{\"db\":{\"dsn_env\":\"SC_RO_DSN\",\"allow_tables\":[\"skill_runs\",\"tool_call_attempts\",\"models\"],\"row_cap\":1000,\"statement_timeout_ms\":5000}}\n' > "$f"
+    echo "→ db: created $f with db block"
+  fi
+  echo "  Host-side setup (the sandbox never sees the credential):"
+  echo "    1. Provision a read-only role on the live DB, e.g.:"
+  echo "         CREATE ROLE sc_ro LOGIN PASSWORD '…';"
+  echo "         GRANT CONNECT ON DATABASE <db> TO sc_ro;"
+  echo "         GRANT USAGE ON SCHEMA public TO sc_ro;"
+  echo "         GRANT SELECT ON skill_runs, tool_call_attempts, models TO sc_ro;"
+  echo "    2. Export its DSN for the broker's environment:"
+  echo "         export SC_RO_DSN=postgresql://sc_ro:…@<host>:5432/<db>"
+  echo "    3. Start it host-side: ./sc db-broker-up   (or ./sc db-broker-install)"
+  echo "  Widen allow_tables (+ the role's GRANTs) to expose more; content tables stay gated."
+}
+
 # ── Postgres sidecar (HOST-side Docker container on $SC_NET — APP-ONLY) ───────
 # A named postgres:17 container alongside the sandbox on SC_NET. The sandbox
 # reaches it by hostname ($PGNAME) with DATABASE_URL forwarded in, so the fork's
@@ -688,6 +791,14 @@ case "$cmd" in
   pm2-broker-sock)    exec "$PY" "$S/pm2.py" sock ;;
   pm2-broker-install)   sc_pm2_broker_install ;;
   pm2-broker-uninstall) sc_pm2_broker_uninstall ;;
+  # ── db broker (HOST-side primitive — runs where the live DSN + route live) ──
+  db-broker)         exec "$PY" "$ENGINE/api/db_broker.py" "$@" ;;
+  db-broker-up)      sc_db_broker_up ;;
+  db-broker-down)    sc_db_broker_down ;;
+  db-broker-sock)    exec "$PY" "$S/dbq.py" sock ;;
+  db-broker-install)   sc_db_broker_install ;;
+  db-broker-uninstall) sc_db_broker_uninstall ;;
+  db-init)      sc_db_init ;;
   # ── Postgres sidecar (app-only) ──
   pg-init)      sc_pg_init ;;
   pg-up)        sc_pg_up ;;
@@ -926,6 +1037,18 @@ super-coder — forkable shell substrate
   ./sc pm2-broker-sock     print the broker's socket path
   ./sc pm2-broker-install  supervise via a systemd --user unit (survives logout/reboot)
   ./sc pm2-broker-uninstall remove the systemd unit
+
+  db broker (run on the HOST — read-only diagnostic reads of the fork's LIVE app
+  DB for a sandboxed shell, without handing it a DSN or a route. Shells out to
+  psql host-side; SELECT-only + table allowlist + row cap; the DSN must be a
+  read-only role. One-time: ./sc db-init. See .super-coder/docs/db-broker.md.
+  ./sc db-init             add the "db" block to instance.json + print host setup steps
+  ./sc db-broker           run the broker in the foreground (unix socket)
+  ./sc db-broker-up        start it in the background (nohup + pidfile); self-skips if unlinked/already up
+  ./sc db-broker-down      stop the backgrounded broker
+  ./sc db-broker-sock      print the broker's socket path
+  ./sc db-broker-install   supervise via a systemd --user unit (survives logout/reboot)
+  ./sc db-broker-uninstall remove the systemd unit
 
   Postgres sidecar (app-only; docker container on SC_NET, data in a named volume).
   For developing/testing the fork's APP against real Postgres in the sandbox — the

--- a/tests/test_db_broker.py
+++ b/tests/test_db_broker.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Smoke tests for the db broker (api/db_broker.py + scripts/dbq.py).
+
+Stdlib `unittest`, no pytest — matching the engine's no-dependency style and the
+sibling tests (test_pm2_broker.py, test_vm_broker.py). The broker shells out to
+`psql` against a live Postgres, which no CI box has; so we mock at the subprocess
+seam (`dbq._run`) and exercise the parts that DO run everywhere: the SELECT-only
++ allowlist validator, the CSV parse + row-cap truncation, the JSON shapes the
+`db_query` skill depends on, and the real unix-socket HTTP transport end to end
+(a live broker on a temp socket, driven by the same `dbq.broker_call` client).
+
+Run:
+    python3 tests/test_db_broker.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+
+import dbq  # noqa: E402
+import db_broker  # noqa: E402
+
+BLOCK = {
+    "dsn_env": "SC_TEST_RO_DSN",
+    "allow_tables": ["skill_runs", "tool_call_attempts", "models"],
+    "row_cap": 3,
+    "statement_timeout_ms": 5000,
+}
+
+
+class ValidationTests(unittest.TestCase):
+    """check() is the fail-closed gate — everything but a single, read-only,
+    allowlisted SELECT is rejected before psql ever runs."""
+
+    def ok(self, sql):
+        return dbq.check(sql, BLOCK)
+
+    def test_plain_select_on_allowlisted_table_passes(self):
+        ok, _ = self.ok("SELECT error_class, count(*) FROM tool_call_attempts GROUP BY 1")
+        self.assertTrue(ok)
+
+    def test_with_cte_select_passes(self):
+        ok, _ = self.ok("WITH r AS (SELECT * FROM skill_runs) SELECT count(*) FROM r")
+        self.assertTrue(ok)
+
+    def test_empty_is_rejected(self):
+        ok, why = self.ok("   ")
+        self.assertFalse(ok)
+        self.assertIn("empty", why)
+
+    def test_non_select_is_rejected(self):
+        for sql in ("UPDATE models SET x=1",
+                    "DELETE FROM skill_runs",
+                    "INSERT INTO models VALUES (1)",
+                    "DROP TABLE models"):
+            ok, why = self.ok(sql)
+            self.assertFalse(ok, sql)
+            self.assertIn("SELECT", why)
+
+    def test_stacked_statement_is_rejected(self):
+        ok, why = self.ok("SELECT 1 FROM models; DROP TABLE models")
+        self.assertFalse(ok)
+        self.assertIn("single statement", why)
+
+    def test_trailing_semicolon_is_fine(self):
+        ok, _ = self.ok("SELECT 1 FROM models;")
+        self.assertTrue(ok)
+
+    def test_writing_cte_is_rejected(self):
+        # A data-modifying CTE is still a write — the leading token is WITH but
+        # the forbidden-keyword scan catches the INSERT inside.
+        ok, why = self.ok("WITH x AS (INSERT INTO models VALUES (1) RETURNING id) SELECT * FROM x")
+        self.assertFalse(ok)
+        self.assertIn("INSERT", why)
+
+    def test_unlisted_table_is_rejected(self):
+        ok, why = self.ok("SELECT * FROM contacts")
+        self.assertFalse(ok)
+        self.assertIn("allowlist", why)
+        self.assertIn("contacts", why)
+
+    def test_join_onto_unlisted_table_is_rejected(self):
+        ok, why = self.ok("SELECT * FROM skill_runs s JOIN emails e ON e.run_id = s.id")
+        self.assertFalse(ok)
+        self.assertIn("emails", why)
+
+    def test_schema_qualified_allowlisted_table_passes(self):
+        ok, _ = self.ok("SELECT * FROM public.skill_runs")
+        self.assertTrue(ok)
+
+    def test_keyword_substring_in_column_is_not_a_false_positive(self):
+        # `update_time` / `created_at` contain forbidden substrings but are not
+        # the keywords — word boundaries must not trip on them.
+        ok, _ = self.ok("SELECT update_time, created_at FROM models")
+        self.assertTrue(ok)
+
+    def test_forbidden_word_inside_a_string_literal_is_ignored(self):
+        ok, _ = self.ok("SELECT id FROM models WHERE note = 'please update this'")
+        self.assertTrue(ok)
+
+
+class QueryVerbTests(unittest.TestCase):
+    """do_query() validates, then shells to psql (mocked) and shapes results."""
+
+    def _psql_csv(self, header, *rows):
+        return 0, "\n".join([",".join(header)] + [",".join(r) for r in rows]) + "\n", ""
+
+    def test_query_returns_columns_and_rows(self):
+        out = self._psql_csv(["error_class", "n"], ["confirm_only", "4"], ["timeout", "1"])
+        with mock.patch.object(dbq, "read", return_value=BLOCK), \
+             mock.patch.dict("os.environ", {"SC_TEST_RO_DSN": "postgresql://ro@h/db"}), \
+             mock.patch.object(dbq, "_run", return_value=out) as run:
+            r = dbq.do_query("SELECT error_class, count(*) n FROM tool_call_attempts GROUP BY 1")
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["columns"], ["error_class", "n"])
+        self.assertEqual(r["row_count"], 2)
+        self.assertFalse(r["truncated"])
+        # DSN parsed into PG* env, never onto argv; a row cap wrap + read-only opts applied.
+        argv, env = run.call_args[0][0], run.call_args[0][1]
+        self.assertNotIn("postgresql://ro@h/db", " ".join(argv))
+        self.assertIn("LIMIT 4", " ".join(argv))  # row_cap 3 → cap+1
+        self.assertIn("default_transaction_read_only=on", env["PGOPTIONS"])
+        self.assertIn("statement_timeout=5000", env["PGOPTIONS"])
+        self.assertEqual(env["PGHOST"], "h")
+
+    def test_row_cap_truncation_is_flagged(self):
+        # row_cap is 3; psql returns cap+1 = 4 rows (the wrap fetches one extra).
+        out = self._psql_csv(["id"], ["1"], ["2"], ["3"], ["4"])
+        with mock.patch.object(dbq, "read", return_value=BLOCK), \
+             mock.patch.dict("os.environ", {"SC_TEST_RO_DSN": "postgresql://ro@h/db"}), \
+             mock.patch.object(dbq, "_run", return_value=out):
+            r = dbq.do_query("SELECT id FROM models")
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["row_count"], 3)      # clipped to cap
+        self.assertTrue(r["truncated"])
+
+    def test_validation_failure_never_reaches_psql(self):
+        with mock.patch.object(dbq, "read", return_value=BLOCK), \
+             mock.patch.object(dbq, "_run") as run:
+            r = dbq.do_query("DELETE FROM models")
+        self.assertFalse(r["ok"])
+        run.assert_not_called()
+
+    def test_missing_dsn_is_a_clean_error(self):
+        with mock.patch.object(dbq, "read", return_value=BLOCK), \
+             mock.patch.dict("os.environ", {}, clear=True), \
+             mock.patch.object(dbq, "_run") as run:
+            r = dbq.do_query("SELECT 1 FROM models")
+        self.assertFalse(r["ok"])
+        self.assertIn("SC_TEST_RO_DSN", r["error"])
+        run.assert_not_called()
+
+    def test_psql_error_surfaces(self):
+        with mock.patch.object(dbq, "read", return_value=BLOCK), \
+             mock.patch.dict("os.environ", {"SC_TEST_RO_DSN": "postgresql://ro@h/db"}), \
+             mock.patch.object(dbq, "_run",
+                               return_value=(1, "", "permission denied for table models")):
+            r = dbq.do_query("SELECT * FROM models")
+        self.assertFalse(r["ok"])
+        self.assertIn("permission denied", r["error"])
+
+    def test_no_db_block_is_a_clean_error(self):
+        with mock.patch.object(dbq, "read", return_value=None):
+            r = dbq.do_query("SELECT 1 FROM models")
+        self.assertFalse(r["ok"])
+        self.assertIn("db-init", r["error"])
+
+    def test_configured_cli_reflects_a_linked_db(self):
+        with mock.patch.object(dbq, "read", return_value=BLOCK):
+            self.assertEqual(dbq.main(["configured"]), 0)
+        with mock.patch.object(dbq, "read", return_value=None):
+            self.assertEqual(dbq.main(["configured"]), 1)
+
+
+class SocketTransportTests(unittest.TestCase):
+    """A live broker on a temp socket, driven by the real broker_call client —
+    proves the unix-socket HTTP transport the container relies on actually works."""
+
+    def setUp(self):
+        self.sock = Path(__file__).resolve().parent / "_test_db_broker.sock"
+        self._orig = dbq.SOCKET
+        dbq.SOCKET = self.sock  # both server (db_broker path) + client read this
+        self.srv = db_broker.UnixHTTPServer(str(self.sock), db_broker.Handler)
+        self.t = threading.Thread(target=self.srv.serve_forever, daemon=True)
+        self.t.start()
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+        dbq.SOCKET = self._orig
+        self.sock.unlink(missing_ok=True)
+
+    def test_health(self):
+        r = dbq.broker_call("GET", "/health")
+        self.assertEqual(r, {"ok": True, "service": "db-broker"})
+
+    def test_unknown_route_is_404_shaped(self):
+        r = dbq.broker_call("GET", "/nope")
+        self.assertFalse(r["ok"])
+
+    def test_query_round_trips_over_the_socket(self):
+        out = (0, "id\n1\n2\n", "")
+        with mock.patch.object(dbq, "read", return_value=BLOCK), \
+             mock.patch.dict("os.environ", {"SC_TEST_RO_DSN": "postgresql://ro@h/db"}), \
+             mock.patch.object(dbq, "_run", return_value=out):
+            r = dbq.broker_call("POST", "/query", {"sql": "SELECT id FROM models"})
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["columns"], ["id"])
+        self.assertEqual(r["row_count"], 2)
+
+    def test_rejected_query_round_trips_the_denial(self):
+        with mock.patch.object(dbq, "read", return_value=BLOCK), \
+             mock.patch.object(dbq, "_run") as run:
+            r = dbq.broker_call("POST", "/query", {"sql": "DROP TABLE models"})
+        self.assertFalse(r["ok"])
+        run.assert_not_called()
+
+    def test_non_string_sql_is_400_shaped(self):
+        r = dbq.broker_call("POST", "/query", {"sql": {"nope": 1}})
+        self.assertFalse(r["ok"])
+
+    def test_broker_call_raises_when_nothing_listens(self):
+        dbq.SOCKET = self.sock.with_name("_absent.sock")
+        with self.assertRaises(ConnectionError):
+            dbq.broker_call("GET", "/health")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Implements #296.

A sandboxed shell can't reach the fork's **live** app Postgres — `./sc launch` gives it an empty private sidecar (the dev/test target), the host DSN is never mounted, and the live stack sits on an unreachable network. Today a shell hands the operator a SQL block and waits for a paste-back. This adds a host-side **db-broker** — the 4th sibling of the pm2 / Windows-VM / tailnet brokers — that closes that loop for confirmation-grade reads *without handing the sandbox a credential or a route*.

## Design
- **Broker runs on the host**, shells out to `psql` where the DSN + route resolve, exposes one verb (`POST /query`) over a `0600` unix socket in the bind-mounted engine dir. The `db_query` skill curls it. Mirrors `pm2_broker.py` structurally; config/validation/verb live in `scripts/dbq.py`.
- **No secret in `instance.json`.** The whole repo is `-v $here:$here` bind-mounted, so `instance.json` is sandbox-readable — the `db` block names an *env var*, and the broker resolves the DSN host-side, parsing it into libpq `PG*` env so the password never hits a process argv.
- **Read-only enforced twice:** the DSN must point at a read-only PG role (`GRANT SELECT`, + `default_transaction_read_only=on`), **and** `dbq.check()` rejects anything but a single `SELECT`/`WITH` before psql runs (no stacked statements, no writing CTEs, no DDL/DML).
- **Tenancy the same way:** the RO role's GRANTs are authoritative; the broker also rejects `FROM`/`JOIN` targets outside `allow_tables` (default: telemetry only — `skill_runs`, `tool_call_attempts`, `models`; content tables gated). Statement timeout + row cap on every query; every call audited to `run/db-broker.audit.log`.

## Surfaces
New: `api/db_broker.py`, `scripts/dbq.py`, `docs/db-broker.md`, `tests/test_db_broker.py` (25 tests). `sc` gains `db-init` + `db-broker[-up/-down/-sock/-install/-uninstall]`. New files ride the existing `.super-coder/` manifest; no manifest edit.

## Test plan
- [x] 25 unit tests (validators, CSV parse + row-cap truncation, socket transport, `SC_SANDBOX` guard) — and the full suite: **301 passed**.
- [x] **End-to-end against a live `postgres:17` + a read-only role**: allowed reads return rows; row-cap truncation flagged; write / non-allowlisted-table / timeout all rejected; the RO **role** independently denies writes (`permission denied for table models`) and gated tables (`contacts`); `SC_SANDBOX=1` refuses to start; DSN never appears on argv; audit log records every verdict.
- [x] `sc help` renders the block; `db-broker-up` self-skips when unconfigured.

## Follow-ups (DB-authored, not in this PR)
The `db_query` skill, the spec doc (`specs_sc/db-query.md`), and the roadmap feature are engine-DB records (rendered, not hand-edited files) — authored via the shell/GUI as a separate step.