### PR TITLE
feat(gui): rename a shell's display_name

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -132,7 +132,8 @@ def read_log() -> list[dict]:
 
 # Shell fields the review layer may write. seed/L&S/system_prompt/mandate are
 # deliberately ABSENT — the law says the shell curates them, so there is no door.
-SHELL_EDITABLE = {"current_state"}  # workspace + connections both retired (B5) → current_state is the one writable surface; "where things live" is the derived dr_* map
+# display_name is operator-set at creation, so the operator may also correct it.
+SHELL_EDITABLE = {"current_state", "display_name"}  # workspace + connections both retired (B5); "where things live" is the derived dr_* map
 FLAG_EDITABLE = {"resolved", "resolution_notes", "description", "feature_id", "priority"}
 ROADMAP_EDITABLE = {"title", "roadmap_status", "summary", "sort_order", "project_id"}
 
@@ -471,6 +472,31 @@ def set_blockers(con, feature_id, blocked_by):
         [(feature_id, b) for b in ids])
     con.commit()
     return True, None
+
+
+def patch_shell(con, shell_id, body):
+    """PATCH /api/shells/{id}. A display_name change (fixing a name that got
+    wonked at creation) also re-stamps the system_prompt H1 — but ONLY when the
+    H1 still exactly carries the creation-time render (`# <old name> — …`).
+    That prefix is shell_factory machinery output, not shell curation; anything
+    the shell has since made its own no longer matches and is never touched."""
+    if "display_name" in body:
+        dn = body["display_name"]
+        if not isinstance(dn, str) or not dn.strip():
+            return False, "display_name must be a non-empty string"
+        body["display_name"] = dn = dn.strip()
+        r = con.execute(
+            "SELECT display_name, system_prompt FROM shells WHERE shell_id=?",
+            (shell_id,)).fetchone()
+        if r is None:
+            return False, "not found"
+        old_h1 = f"# {r['display_name']} — "
+        if r["system_prompt"].startswith(old_h1):
+            con.execute(
+                "UPDATE shells SET system_prompt=? WHERE shell_id=?",
+                (f"# {dn} — " + r["system_prompt"][len(old_h1):], shell_id))
+    return patch_columns(con, "shells", "shell_id", shell_id, body,
+                         SHELL_EDITABLE)
 
 
 def patch_document(con, doc_id, body):
@@ -1855,8 +1881,7 @@ class Handler(BaseHTTPRequestHandler):
         try:
             if path.startswith("/api/shells/") and path.count("/") == 3:
                 sid = int(path.rsplit("/", 1)[1])
-                ok, err = patch_columns(con, "shells", "shell_id", sid, body,
-                                        SHELL_EDITABLE)
+                ok, err = patch_shell(con, sid, body)
                 return self._send(200 if ok else 400, {"ok": ok, "error": err})
             if path.startswith("/api/flags/"):
                 fid = int(path.rsplit("/", 1)[1])

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -266,6 +266,18 @@ async function renderShells(root) {
   newBtn.onclick = () => openNewShellModal(templates, root);
   sub.append(newBtn);
 
+  // rename shell — fix a display_name that got wonked at creation
+  const renBtn = el("button", { className: "act", type: "button", textContent: "✎ Rename" });
+  renBtn.onclick = async () => {
+    const name = (prompt("New display name", s.display_name) || "").trim();
+    if (!name || name === s.display_name) return;
+    try {
+      await api("/shells/" + selectedShell, "PATCH", { display_name: name });
+      setStatus("shell renamed — " + name); renderShells(root);
+    } catch (e) { toast("error: " + e.message); }
+  };
+  sub.append(renBtn);
+
   // delete shell — soft-delete the selected shell, then re-render
   const delBtn = el("button", { className: "act", type: "button", textContent: "✕ Delete shell" });
   delBtn.onclick = async () => {

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -296,5 +296,77 @@ class FlavorDefaultsTest(unittest.TestCase):
             self.con, {"flavor": "planner", "harness": "claude"})[0])
 
 
+class PatchShellTest(unittest.TestCase):
+    """server.patch_shell — display_name rename + the strictly-guarded
+    system_prompt H1 re-stamp (creation-time render only, never curation)."""
+
+    def setUp(self) -> None:
+        self.con = build_db()
+
+    def tearDown(self) -> None:
+        self.con.close()
+
+    def _mk(self, name, prompt) -> int:
+        sid = self.con.execute(
+            "INSERT INTO shells (display_name, system_prompt) VALUES (?, ?)",
+            (name, prompt)).lastrowid
+        self.con.commit()
+        return sid
+
+    def _shell(self, sid):
+        return self.con.execute(
+            "SELECT display_name, system_prompt, current_state FROM shells "
+            "WHERE shell_id=?", (sid,)).fetchone()
+
+    def test_rename_restamps_pristine_h1(self) -> None:
+        sid = self._mk("DEV1", "# DEV1 — dev shell, working repo\n\nfocus")
+        ok, err = server.patch_shell(self.con, sid, {"display_name": "Forge"})
+        self.assertTrue(ok, err)
+        row = self._shell(sid)
+        self.assertEqual(row["display_name"], "Forge")
+        self.assertEqual(row["system_prompt"],
+                         "# Forge — dev shell, working repo\n\nfocus")
+
+    def test_rename_never_touches_curated_prompt(self) -> None:
+        # H1 no longer carries the creation-time name → shell curation, no door
+        sid = self._mk("DEV1", "# The Floorwright\n\nmy own words")
+        ok, _ = server.patch_shell(self.con, sid, {"display_name": "Forge"})
+        self.assertTrue(ok)
+        row = self._shell(sid)
+        self.assertEqual(row["display_name"], "Forge")
+        self.assertEqual(row["system_prompt"], "# The Floorwright\n\nmy own words")
+
+    def test_rename_trims_whitespace(self) -> None:
+        sid = self._mk("DEV1", "x")
+        ok, _ = server.patch_shell(self.con, sid, {"display_name": "  Forge  "})
+        self.assertTrue(ok)
+        self.assertEqual(self._shell(sid)["display_name"], "Forge")
+
+    def test_empty_and_nonstring_names_rejected(self) -> None:
+        sid = self._mk("DEV1", "x")
+        for bad in ("", "   ", None, 7):
+            ok, err = server.patch_shell(self.con, sid, {"display_name": bad})
+            self.assertFalse(ok)
+            self.assertIn("non-empty", err)
+        self.assertEqual(self._shell(sid)["display_name"], "DEV1")
+
+    def test_missing_shell_is_not_found(self) -> None:
+        ok, err = server.patch_shell(self.con, 999999, {"display_name": "X"})
+        self.assertFalse(ok)
+        self.assertEqual(err, "not found")
+
+    def test_current_state_path_unchanged(self) -> None:
+        sid = self._mk("DEV1", "x")
+        ok, _ = server.patch_shell(self.con, sid, {"current_state": "building"})
+        self.assertTrue(ok)
+        self.assertEqual(self._shell(sid)["current_state"], "building")
+
+    def test_system_prompt_stays_doorless(self) -> None:
+        sid = self._mk("DEV1", "x")
+        ok, err = server.patch_shell(self.con, sid, {"system_prompt": "hijack"})
+        self.assertFalse(ok)
+        self.assertEqual(self._shell(sid)["system_prompt"], "x")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Shell names sometimes get wonked at creation and there was no door to fix them short of `./sc sql-rw`. This opens a narrow one:

- **API** — `display_name` joins `SHELL_EDITABLE`; `PATCH /api/shells/{id}` now routes through a new `patch_shell()` that rejects empty/non-string names and trims whitespace.
- **GUI** — a `✎ Rename` button in the shells subbar (next to New/Delete), prompt-based like the delete confirm.
- **H1 re-stamp** — creation bakes the name into the system_prompt H1 (`# <name> — …`). A rename re-stamps that H1 **only when it still exactly matches the creation-time render**; anything the shell has since curated no longer matches and is never touched. `system_prompt` itself stays out of the allowlist (doorless — verified by test).

**Doctrine flag for review:** the allowlist comment declares system_prompt has *no door* from the review layer. The guarded H1 re-stamp technically writes it — my read is that a still-pristine creation render is shell_factory output, not shell curation, so the law's spirit holds. If you'd rather keep the letter absolute, dropping the re-stamp is a self-contained ~10-line removal (rename still works, H1 just stays stale until the shell curates it).

`shortname` is deliberately not editable — it's load-bearing (enter-<shortname>, subdomain routing, worktree dirs).

## Test plan
- [x] 7 new `PatchShellTest` cases: pristine-H1 re-stamp, curated-prompt untouched, trim, empty/non-string rejected, missing shell 404s, current_state path unchanged, system_prompt stays doorless
- [x] `tests/test_api_endpoints.py` — 30/30 pass
- [x] `node --check` on app.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)