### PR TITLE
fix(engine): fleet-wide decision reads, honest deps skip, pytest exit-5

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1139,49 +1139,62 @@ class Handler(BaseHTTPRequestHandler):
                 # rationale, newest-first, capped — with counts so the client
                 # can say what was hidden. ?all=1 = full log incl. superseded
                 # (still no rationale); /decisions/<id> = the full row.
+                #
+                # Shared on READ (#318/#340, the flags precedent): decisions
+                # coordinate the project — a planner's design lock cited in a
+                # kickoff message must resolve from every seat, or shells
+                # accuse each other of phantom citations. Rows are tagged with
+                # the author's shortname; writes stay token-scoped.
                 q = parse_qs(urlparse(self.path).query)
                 if q.get("all", ["0"])[0] in ("1", "true"):
                     ds = rows(con.execute(
                         "SELECT d.decision_id, d.decision, d.priority, d.decision_date, "
                         "d.parent_decision_id, "
+                        "(SELECT s.shortname FROM shells s WHERE s.shell_id=d.shell_id) "
+                        " AS shortname, "
                         "(SELECT c.decision_id FROM shell_decisions c "
                         " WHERE c.parent_decision_id=d.decision_id "
                         " AND COALESCE(c.is_deleted,0)=0 "
                         " ORDER BY c.decision_id DESC LIMIT 1) AS superseded_by "
                         "FROM shell_decisions d "
-                        "WHERE d.shell_id=? AND COALESCE(d.is_deleted,0)=0 "
-                        "ORDER BY d.decision_date, d.decision_id", (sid,)))
+                        "WHERE COALESCE(d.is_deleted,0)=0 "
+                        "ORDER BY d.decision_date, d.decision_id"))
                     return self._send(200, {"decisions": ds, "all": True})
                 active_sql = (
                     "FROM shell_decisions d "
-                    "WHERE d.shell_id=? AND COALESCE(d.is_deleted,0)=0 "
+                    "WHERE COALESCE(d.is_deleted,0)=0 "
                     "AND NOT EXISTS (SELECT 1 FROM shell_decisions c "
                     " WHERE c.parent_decision_id=d.decision_id "
                     " AND COALESCE(c.is_deleted,0)=0)")
                 total_active = con.execute(
-                    "SELECT COUNT(*) " + active_sql, (sid,)).fetchone()[0]
+                    "SELECT COUNT(*) " + active_sql).fetchone()[0]
                 superseded = con.execute(
                     "SELECT COUNT(*) FROM shell_decisions d "
-                    "WHERE d.shell_id=? AND COALESCE(d.is_deleted,0)=0 "
+                    "WHERE COALESCE(d.is_deleted,0)=0 "
                     "AND EXISTS (SELECT 1 FROM shell_decisions c "
                     " WHERE c.parent_decision_id=d.decision_id "
-                    " AND COALESCE(c.is_deleted,0)=0)", (sid,)).fetchone()[0]
+                    " AND COALESCE(c.is_deleted,0)=0)").fetchone()[0]
                 ds = rows(con.execute(
                     "SELECT d.decision_id, d.decision, d.priority, d.decision_date, "
-                    "d.parent_decision_id " + active_sql +
+                    "d.parent_decision_id, "
+                    "(SELECT s.shortname FROM shells s WHERE s.shell_id=d.shell_id) "
+                    " AS shortname " + active_sql +
                     " ORDER BY d.decision_id DESC LIMIT ?",
-                    (sid, DECISIONS_INDEX_CAP)))
+                    (DECISIONS_INDEX_CAP,)))
                 return self._send(200, {"decisions": ds,
                                         "total_active": total_active,
                                         "superseded": superseded})
 
             if len(parts) == 4 and parts[2] == "decisions":
                 # Single decision WITH rationale — the library half of the split.
+                # Fleet-wide by id (#318/#340): cross-shell citations resolve.
                 did = int(parts[3])
                 r = con.execute(
                     "SELECT d.decision_id, d.decision, d.rationale, d.priority, "
                     "d.decision_date, d.parent_decision_id, "
                     "d.feature_id, d.document_id, "
+                    "(SELECT s.shortname FROM shells s WHERE s.shell_id=d.shell_id) "
+                    " AS shortname, "
                     "(SELECT title FROM roadmap WHERE feature_id=d.feature_id) "
                     " AS feature_title, "
                     "(SELECT title FROM documents WHERE document_id=d.document_id) "
@@ -1191,8 +1204,8 @@ class Handler(BaseHTTPRequestHandler):
                     " AND COALESCE(c.is_deleted,0)=0 "
                     " ORDER BY c.decision_id DESC LIMIT 1) AS superseded_by "
                     "FROM shell_decisions d "
-                    "WHERE d.decision_id=? AND d.shell_id=? "
-                    "AND COALESCE(d.is_deleted,0)=0", (did, sid)).fetchone()
+                    "WHERE d.decision_id=? "
+                    "AND COALESCE(d.is_deleted,0)=0", (did,)).fetchone()
                 if r is None:
                     return self._send(404, {"error": "no such decision"})
                 return self._send(200, {"decision": dict(r)})

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -23,6 +23,7 @@ Run from the repo root, like every engine command:
     ./sc mem which                                 # confirm API reachability + who your token resolves to
     ./sc mem get <surface>           [--json]      # read: state|seed|lns|decisions|flags|roadmap|narrative|messages
     ./sc mem get decisions [<id>|--all]            # default: active index (no rationale); <id> = full row; --all incl. superseded
+                                                   # decisions read FLEET-WIDE (author tagged @shortname); writes stay your own
     ./sc mem state "<text>"
     ./sc mem seed  "<body>"          [--date YYYY-MM-DD] [--tag cc]
     ./sc mem lns   "<body>"          [--date …] [--tag …]
@@ -192,8 +193,9 @@ def _render_get(surface: str, data: dict) -> int:
         def _line(d) -> None:
             par = f" (supersedes #{d['parent_decision_id']})" if d.get("parent_decision_id") else ""
             sup = f" (superseded by #{d['superseded_by']})" if d.get("superseded_by") else ""
+            who = f" @{d['shortname']}" if d.get("shortname") else ""
             print(f"#{d['decision_id']} [{d.get('priority') or 'M'}] "
-                  f"{d.get('decision_date') or ''}{par}{sup}")
+                  f"{d.get('decision_date') or ''}{who}{par}{sup}")
             print("  " + (d.get("decision") or ""))
         if "decision" in data:                    # single decision, with rationale
             d = data["decision"]

--- a/sc
+++ b/sc
@@ -178,6 +178,48 @@ sc_deps() {
   base_reqs="$(printf '%s\n' "$reqs" | grep -v 'requirements-dev\.txt' || true)"
   if [ -n "$skip_py" ]; then
     echo "→ deps: python deps are host-managed (pinned interpreter mounted by launch) — skipping venv/pip in the sandbox"
+    # Never green-lie the skip (#314/#324/#339): the pinned tree carries what
+    # the host installed at launch time, which silently lags the fork's
+    # declared pins (a branch adds requirements → deps says done → 12 mystery
+    # ModuleNotFoundError test failures). Verify every declared pin resolves
+    # in the mounted tree; a missing one is a hard failure with the fix named,
+    # not a ✓. (Installing from in here stays off-limits by design — the tree
+    # is host-managed and shared.)
+    if [ -n "$base_reqs" ]; then
+      missing="$(printf '%s\n' "$base_reqs" | "$venv/bin/python" -c '
+import importlib.metadata as md, re, sys
+missing = []
+for path in (l.strip() for l in sys.stdin):
+    if not path:
+        continue
+    try:
+        lines = open(path).read().splitlines()
+    except OSError:
+        continue
+    for raw in lines:
+        line = raw.split("#", 1)[0].strip()
+        # skip options (-r/-e/--hash), URL/path requirements — only plain pins verify
+        if not line or line.startswith("-") or "://" in line or line.startswith((".", "/")):
+            continue
+        name = re.split(r"[<>=!~\[; ]", line, 1)[0].strip()
+        if not name:
+            continue
+        try:
+            md.version(name)
+        except md.PackageNotFoundError:
+            missing.append(line)
+print("\n".join(missing))
+')"
+      if [ -n "$missing" ]; then
+        echo "✗ deps: host-managed venv is missing declared python deps:" >&2
+        printf '%s\n' "$missing" | sed 's/^/    /' >&2
+        echo "  Fix: install the pins above into the pinned venv — on the host (e.g. uv pip install …)," >&2
+        echo "  or \`$venv/bin/pip install <pins>\` (the mounted tree accepts installs; ownership lands root)." >&2
+        rc=1
+      else
+        echo "→ deps: host-managed tree verified — every declared python pin present"
+      fi
+    fi
   else
   # The engine dev kit lives in this .venv, so create it unconditionally — a fork
   # that declares no requirements*.txt still needs pytest on hand for `./sc test`
@@ -255,7 +297,18 @@ sc_test() {
   rc=0
   if [ -x "$venv/bin/pytest" ]; then
     echo "→ test: $venv/bin/pytest"
-    ( cd "$here" && "$venv/bin/pytest" "$@" ) || rc=1
+    ( cd "$here" && "$venv/bin/pytest" "$@" )
+    prc=$?
+    if [ "$prc" -eq 5 ] && [ $# -eq 0 ]; then
+      # pytest exit 5 = collected nothing. On a bare `./sc test` in a fork with
+      # no python tests (JS-only forks: vitest is the real suite) that is not a
+      # failure — counting it as one left every JS-only fork permanently red
+      # (#310). With explicit args a collection miss stays red: a typo'd path
+      # must not pass green.
+      echo "→ test: pytest collected no python tests — not counted as a failure (JS-only fork)"
+    elif [ "$prc" -ne 0 ]; then
+      rc=1
+    fi
   elif ls "$here"/tests/test_*.py >/dev/null 2>&1; then
     # pytest still unavailable after provisioning (venv create failed, or a
     # host-managed sandbox interpreter that skips pip). A fork that *declares*

--- a/tests/test_devkit_sc.py
+++ b/tests/test_devkit_sc.py
@@ -85,5 +85,51 @@ class ImageFallbackTest(unittest.TestCase):
                          "fallback for host-managed-.venv forks")
 
 
+class DepsHostManagedVerifyTest(unittest.TestCase):
+    """#314/#324/#339 — the sandbox pip-skip must never green-lie: declared
+    pins missing from the host-managed tree are a hard failure, not a ✓."""
+
+    def test_skip_branch_verifies_and_fails_loud(self):
+        body = re.search(r"sc_deps\(\) \{.*?\n\}", SC, re.S).group(0)
+        self.assertIn("host-managed venv is missing declared python deps", body)
+        self.assertIn("importlib.metadata", body)
+        # the failure sets rc, so `✓ deps: done` can't follow a missing pin
+        miss_at = body.index("missing declared python deps")
+        self.assertIn("rc=1", body[miss_at:miss_at + 600])
+
+    def test_verify_snippet_flags_missing_pins_live(self):
+        import sys
+        m = re.search(r'-c \'\n(import importlib.*?)\n\'\)"', SC, re.S)
+        self.assertIsNotNone(m, "deps verify python snippet missing from sc")
+        snippet = m.group(1)
+        import importlib.metadata as md
+        present = next(iter(md.distributions())).metadata["Name"]
+        with tempfile.TemporaryDirectory() as tmp:
+            req = Path(tmp) / "requirements.txt"
+            req.write_text(f"{present}\n"
+                           "definitely-not-a-real-dist-xyz==9.9\n"
+                           "# a comment\n"
+                           "-e ./local\n"
+                           "https://example.com/wheel.whl\n")
+            out = subprocess.run([sys.executable, "-c", snippet],
+                                 input=f"{req}\n", capture_output=True, text=True)
+            self.assertEqual(out.returncode, 0, out.stderr)
+            flagged = [l for l in out.stdout.splitlines() if l]
+            self.assertEqual(flagged, ["definitely-not-a-real-dist-xyz==9.9"],
+                             "exactly the missing plain pin — present dists, "
+                             "comments, editables, URLs all pass through")
+
+
+class TestVerbExitFiveTest(unittest.TestCase):
+    """#310 — pytest exit 5 (nothing collected) on a bare `./sc test` is a
+    JS-only fork, not a failed suite; with explicit args it stays a failure."""
+
+    def test_exit_five_handled_only_for_bare_invocation(self):
+        body = re.search(r"sc_test\(\) \{.*?\n\}", SC, re.S).group(0)
+        self.assertIn('"$prc" -eq 5', body)
+        self.assertIn('[ $# -eq 0 ]', body)
+        self.assertIn("not counted as a failure", body)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -34,6 +34,7 @@ import mem  # noqa: E402
 import server  # noqa: E402
 
 TOKEN = "test-token-deadbeef"
+PEER_TOKEN = "peer-token-cafebabe"   # second shell — cross-shell read coverage
 
 
 def build_engine_db(path: Path) -> None:
@@ -48,6 +49,10 @@ def build_engine_db(path: Path) -> None:
         "INSERT INTO shells (shell_id, display_name, shortname, mandate, system_prompt, "
         "user_id, is_shared, has_identity, bootstrapped, api_key) "
         "VALUES (1, 'TC', 'tc', 'test', 'sp', 1, 0, 1, 0, ?)", (TOKEN,))
+    con.execute(
+        "INSERT INTO shells (shell_id, display_name, shortname, mandate, system_prompt, "
+        "user_id, is_shared, has_identity, bootstrapped, api_key) "
+        "VALUES (2, 'Peer', 'peer', 'test', 'sp', 1, 0, 1, 0, ?)", (PEER_TOKEN,))
     con.execute(
         "INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date) "
         "VALUES (1, 1, '0001', '2026-01-01')")
@@ -202,6 +207,28 @@ class ApiMemTest(unittest.TestCase):
         self.assertEqual(
             self.q("SELECT COUNT(*) FROM shell_decisions "
                    "WHERE decision IN ('bad feature','bad doc')")[0], 0)
+
+    # ── decisions read fleet-wide; writes stay token-scoped (#318/#340) ───────
+    def test_decisions_read_fleet_wide(self):
+        saved = mem.SC_API_TOKEN
+        mem.SC_API_TOKEN = PEER_TOKEN
+        try:
+            self.run_mem("decision", "peer design lock", "--rationale", "peer why")
+        finally:
+            mem.SC_API_TOKEN = saved
+        did = self.q("SELECT decision_id FROM shell_decisions "
+                     "WHERE decision='peer design lock'")[0]
+        # by-id resolves from another seat — a cross-shell citation is live
+        one = mem._api("GET", f"/_sc/mem/decisions/{did}")["decision"]
+        self.assertEqual(one["rationale"], "peer why")
+        self.assertEqual(one["shortname"], "peer")
+        # the full log carries it too, attributed to its author
+        alld = mem._api("GET", "/_sc/mem/decisions?all=1")["decisions"]
+        row = next(d for d in alld if d["decision_id"] == did)
+        self.assertEqual(row["shortname"], "peer")
+        # the write itself stayed scoped to the author's token
+        self.assertEqual(self.q("SELECT shell_id FROM shell_decisions "
+                                "WHERE decision_id=?", did)[0], 2)
 
     # ── flags ─────────────────────────────────────────────────────────────────
     def test_flag_open_then_close(self):


### PR DESCRIPTION
Three independent engine fixes from the issue sweep (all base on `main` — no stacking):

- **Decisions read fleet-wide** (#318, #340): scoped reads made cross-shell decision citations 404 — to the point of one shell formally reporting another's real decision as a *phantom citation*. Reads (index, `--all`, by-id) now cover the whole log with `@shortname` attribution, exactly the flags precedent ("coordinate the project, not one shell's memory"). **Writes stay token-scoped.** The per-shell boot render is untouched.
- **`sc deps` honest skip** (#314, #324, #339 — three forks hit it): the sandbox host-managed pip-skip reported `✓ done` while declared pins were missing, yielding mystery `ModuleNotFoundError` failures downstream. The skip now verifies every plain pin in `requirements*.txt` against the mounted tree (`importlib.metadata`; options/URLs/editables pass through) and fails loud naming the fix. Deliberately does NOT install from inside the sandbox — the tree is host-managed by design; if we'd rather auto-install missing pins into the mounted venv, that's a one-line follow-up, but it writes root-owned files into a host-managed tree, so I kept it verify-only.
- **`sc test` pytest exit 5** (#310): nothing-collected on a bare `./sc test` = JS-only fork, not a failed suite; with explicit args a collection miss stays red (typo'd path must not pass green).

Fixes #318. Fixes #340. Fixes #314. Fixes #324. Fixes #339. Fixes #310.

Test plan:
- [x] new: cross-shell decision read (second keyed shell fixture; by-id + index attribution; write stays author-scoped), live probe of the deps verify snippet (missing pin flagged; present/comment/editable/URL pass), exit-5 contract pins
- [x] full suite: 365 passed; `sh -n sc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)