### PR TITLE
fix(host): bounded pm2 log tail, branch-guard gitignored exemption

### DIFF
--- a/.super-coder/scripts/branch-guard.sh
+++ b/.super-coder/scripts/branch-guard.sh
@@ -164,6 +164,17 @@ if [ -n "$target" ]; then
   [ -d "${tdir:-}" ] || tdir="."
   tgt_top="$(toplevel_of "$tdir")"
   if [ -n "$tgt_top" ]; then
+    # ── Gitignored exemption (#317) ─────────────────────────────────────────
+    # A target git itself refuses to track can never land on ANY branch, so the
+    # protected-branch rule has nothing to protect. Concretely: the boot-granted
+    # shared/ handoff dir is gitignored in the main-root checkout, and blocking
+    # it forced shells to side-step the hook (write to /tmp, cp via Bash) to
+    # complete a documented workflow. check-ignore answers for not-yet-existing
+    # paths too; tracked files are never "ignored", so no real repo file gains
+    # a bypass.
+    if git -C "$tdir" check-ignore -q -- "$target" 2>/dev/null; then
+      exit 0
+    fi
     tgt_branch="$(branch_of "$tdir")"
     if is_protected "$tgt_branch"; then
       echo "Blocked: this edit targets '$target', which is in repo '$tgt_top' on protected branch '$tgt_branch'." >&2

--- a/.super-coder/scripts/pm2.py
+++ b/.super-coder/scripts/pm2.py
@@ -145,12 +145,27 @@ def _proc_row(p: dict) -> dict:
 
 def _tail(path: str | None, lines: int) -> str:
     """Last `lines` lines of a pm2 log file — read host-side, never streamed
-    (`pm2 logs` streams forever; a broker verb must return)."""
+    (`pm2 logs` streams forever; a broker verb must return).
+
+    Reverse-seek, bounded (#308): pm2 never rotates logs by default, so a
+    long-lived app's out log is arbitrarily large — `readlines()` slurped the
+    whole file and a multi-GB log turned the verb into a minutes-long hang
+    ending in an empty reply. Read backward in chunks until enough newlines,
+    with a hard byte cap against pathological line lengths."""
     if not path:
         return ""
+    chunk, cap = 64 * 1024, 8 * 1024 * 1024
     try:
         with open(path, "rb") as f:
-            return b"".join(f.readlines()[-lines:]).decode("utf-8", "replace")
+            f.seek(0, os.SEEK_END)
+            pos = f.tell()
+            buf = b""
+            while pos > 0 and buf.count(b"\n") <= lines and len(buf) < cap:
+                step = min(chunk, pos)
+                pos -= step
+                f.seek(pos)
+                buf = f.read(step) + buf
+            return b"\n".join(buf.splitlines()[-lines:]).decode("utf-8", "replace")
     except OSError as e:
         return f"(unreadable: {e})"
 

--- a/tests/test_branch_guard.py
+++ b/tests/test_branch_guard.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Live probes for branch-guard.sh (#317).
+
+The guard blocks default-branch edits, but a gitignored target (the shared/
+handoff dir pattern) can never land on a branch — blocking it forced shells to
+side-step the hook via Bash `cp` to complete a documented workflow. These tests
+drive the real script against a scratch repo.
+
+The scratch repo deliberately lives under $HOME, NOT /tmp — the guard's scratch
+exemption allows /tmp/* outright, which would short-circuit every case here.
+
+Run:
+    python3 tests/test_branch_guard.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARD = ROOT / ".super-coder" / "scripts" / "branch-guard.sh"
+
+GIT_ENV = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+
+class BranchGuardTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.repo = Path(tempfile.mkdtemp(prefix="sc-bg-test-", dir=Path.home()))
+        run = lambda *a: subprocess.run(a, cwd=cls.repo, check=True,  # noqa: E731
+                                        capture_output=True,
+                                        env={**os.environ, **GIT_ENV})
+        run("git", "init", "-q", "-b", "main")
+        (cls.repo / ".gitignore").write_text("shared/\n")
+        (cls.repo / "shared" / "specs").mkdir(parents=True)
+        (cls.repo / "src").mkdir()
+        (cls.repo / "src" / "app.py").write_text("x = 1\n")
+        run("git", "add", ".gitignore", "src/app.py")
+        run("git", "commit", "-q", "-m", "init")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.repo, ignore_errors=True)
+
+    def guard(self, target: str) -> subprocess.CompletedProcess:
+        """Run the guard the way the claude PreToolUse hook does: JSON on stdin,
+        cwd inside the repo, no admin/shared-dir/TMPDIR escape hatches."""
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("SC_SHELL_FLAVOR", "SC_SHARED_DIRS", "TMPDIR",
+                            "SC_PROTECTED_BRANCHES", "SC_SHELL_WORKTREE")}
+        payload = json.dumps({"tool_input": {"file_path": target}})
+        return subprocess.run(["bash", str(GUARD)], input=payload, text=True,
+                              cwd=self.repo, env=env, capture_output=True)
+
+    def test_gitignored_target_allowed_on_protected_branch(self):
+        # the #317 case: shared/ is gitignored — a write there can't land on main
+        r = self.guard(str(self.repo / "shared" / "specs" / "handoff.md"))
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_tracked_area_target_blocked_on_protected_branch(self):
+        r = self.guard(str(self.repo / "src" / "new_module.py"))
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("protected branch 'main'", r.stderr)
+
+    def test_tracked_area_target_allowed_on_feature_branch(self):
+        subprocess.run(["git", "checkout", "-q", "-b", "feat/x"],
+                       cwd=self.repo, check=True, capture_output=True)
+        try:
+            r = self.guard(str(self.repo / "src" / "new_module.py"))
+            self.assertEqual(r.returncode, 0, r.stderr)
+        finally:
+            subprocess.run(["git", "checkout", "-q", "main"],
+                           cwd=self.repo, check=True, capture_output=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pm2_broker.py
+++ b/tests/test_pm2_broker.py
@@ -138,6 +138,31 @@ class VerbDispatchTests(unittest.TestCase):
         self.assertFalse(r["ok"])
         self.assertIn("not in processes", r["output"])
 
+    def test_tail_is_bounded_not_a_whole_file_read(self):
+        # #308: pm2 never rotates by default — a multi-GB log slurped via
+        # readlines() hung the verb into an empty reply. _tail must return the
+        # last N lines while reading only a bounded window from the end.
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as f:
+            for i in range(10_000):
+                f.write(f"line-{i}\n")
+            path = f.name
+        try:
+            out = pm2._tail(path, 3)
+            self.assertEqual(out.splitlines(), ["line-9997", "line-9998", "line-9999"])
+            # reads stay bounded even when the file has no newlines at all
+            with open(path, "w") as f:
+                f.write("x" * (9 * 1024 * 1024))
+            capped = pm2._tail(path, 5)
+            self.assertLessEqual(len(capped), 9 * 1024 * 1024)
+            self.assertTrue(capped)  # still returns the tail window, no hang
+        finally:
+            Path(path).unlink()
+
+    def test_tail_missing_file_reports_unreadable(self):
+        self.assertIn("unreadable", pm2._tail("/nonexistent/x.log", 5))
+        self.assertEqual(pm2._tail(None, 5), "")
+
     def test_health_curls_the_saved_url_host_side(self):
         with mock.patch.object(pm2, "read", return_value=SAVED), \
              mock.patch.object(pm2, "_fetch",


### PR DESCRIPTION
Two host-side fixes (base: `main`, independent of #350):

- **pm2-broker `/logs` hang** (#308): `_tail` read the *entire* log file into memory (`readlines()[-N:]`). pm2 never rotates logs by default, so a long-lived app's multi-GB out-log turned the verb into a minutes-long hang ending in curl 52 — exactly kcsos's symptoms, while `/status`/`/restart` (which never touch log files) stayed fine. Now a reverse-seek bounded tail: 64K chunks from the end until enough newlines, 8MB hard cap. Checked against dos-arch's in-flight F118 testing work — no overlap (F118 touches app code only; the broker is engine-side and reaches forks via repin).
- **branch-guard blocks the gitignored `shared/` handoff dir** (#317): a target `git check-ignore` accepts can never land on any branch, yet the guard blocked it on main-root checkouts — forcing shells to complete a *documented* workflow by side-stepping the hook (`cp` via Bash). Gitignored targets are now exempt before the protected-branch rule; tracked files are never "ignored", so no real repo file gains a bypass.

Fixes #308. Fixes #317.

Test plan:
- [x] new: `_tail` bounded-read unit tests (10k-line tail correctness; 9MB newline-free file stays within cap; missing-file/None edges), live branch-guard probes against a scratch repo outside /tmp (ignored path allowed on main; tracked-area path blocked on main, allowed on feature branch)
- [x] full suite: 366 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)