### PR TITLE
feat(liveness): orphan detection — flag sessions that outlived their terminal

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -668,6 +668,17 @@ def main() -> None:
     if headless and chosen["shortname"] and chosen["flavor"] != "admin":
         snap = shell_liveness.compute()
         if snap.get("supported") and shell_liveness.is_active(chosen["shortname"], snap):
+            pids, orphans = shell_liveness.orphan_split(chosen["shortname"], snap)
+            if pids and len(orphans) == len(pids):
+                # The slot-holder outlived its terminal/parent — still refuse
+                # (it may be mid-work), but name the fix instead of a dead end.
+                sys.exit(
+                    f"sc run: shell '{chosen['shortname']}' slot is held by an "
+                    f"ORPHANED session (pid {', '.join(map(str, orphans))} — "
+                    f"terminal closed / parent gone). Verify it is idle "
+                    f"(`ps -o etime=,stat= -p <pid>`; no busy children), "
+                    f"`kill <pid>`, then re-run. An orphan can still be "
+                    f"mid-work — never kill unverified.")
             sys.exit(f"sc run: shell '{chosen['shortname']}' already has a live "
                      f"session — one shell, one session (see shell_liveness)")
         if snap.get("supported") and snap.get("indeterminate"):

--- a/.super-coder/scripts/shell_liveness.py
+++ b/.super-coder/scripts/shell_liveness.py
@@ -31,6 +31,17 @@ Permissions: /proc/<pid>/cwd is readable only for same-user processes. A harness
 owned by another OS user is counted but unreadable → `indeterminate`. When
 `indeterminate > 0` the admin must NOT assume all-clear — surface instead.
 
+Orphans: closing a terminal window does not reliably kill the harness on every
+host — the session survives, holds its shell's one-session slot, and blocks
+every headless boot of that shell until someone kills it by hand. Each process
+is therefore classified (`orphaned`): 'tty-gone' (had a controlling terminal;
+the pty vanished — the window closed under it), 'detached' (no controlling
+TTY and reparented to init — its spawning session is gone), or None (normal).
+Classification is reporting only — an orphan may still be mid-work (a merge,
+a suite), so nothing here kills anything. The consumer (`sc run`'s guard, the
+operator) verifies idleness first: `ps -o etime=,stat= -p <pid>`, no child
+processes doing work, then `kill <pid>`.
+
 Non-Linux: /proc is absent; compute() returns supported=False. Fall back to
 `lsof -a +D <worktree>` / `ps`. The substrate host is Linux.
 
@@ -82,18 +93,73 @@ def _read(p: Path) -> str:
         return ""
 
 
-def _ppid(pid: int) -> int | None:
-    """Parent pid from /proc/<pid>/stat. comm (field 2) may contain spaces and
-    parens, so split after the final ')': state, ppid, ... follow."""
+def _stat_fields(pid: int) -> "list[str]":
+    """Fields of /proc/<pid>/stat after comm. comm (field 2) may contain spaces
+    and parens, so split after the final ')': state, ppid, ... follow."""
     data = _read(PROC / str(pid) / "stat")
     rp = data.rfind(")")
     if rp == -1:
-        return None
-    rest = data[rp + 2:].split()
+        return []
+    return data[rp + 2:].split()
+
+
+def _ppid(pid: int) -> int | None:
+    rest = _stat_fields(pid)
     try:
         return int(rest[1])              # rest[0]=state, rest[1]=ppid
     except (IndexError, ValueError):
         return None
+
+
+def _tty_nr(pid: int) -> int | None:
+    rest = _stat_fields(pid)
+    try:
+        return int(rest[4])              # rest[4]=tty_nr; 0 = no controlling TTY
+    except (IndexError, ValueError):
+        return None
+
+
+def _tty_fd(pid: int) -> str | None:
+    """The terminal device behind the process's stdio, from /proc/<pid>/fd/0..2 —
+    the first fd whose link target is a tty device. A vanished pty keeps the
+    link but readlink may append ' (deleted)'. None when no stdio fd is a tty
+    (fully redirected) or the fds are unreadable (foreign user)."""
+    for n in ("0", "1", "2"):
+        try:
+            target = os.readlink(PROC / str(pid) / "fd" / n)
+        except OSError:
+            continue
+        base = target.removesuffix(" (deleted)")
+        if base.startswith("/dev/pts/") or base.startswith("/dev/tty"):
+            return target
+    return None
+
+
+def classify_orphan(tty_nr: "int | None", ppid: "int | None",
+                    tty_fd: "str | None",
+                    tty_exists: "bool | None" = None) -> "str | None":
+    """Orphan verdict for one harness process — pure, injectable for tests.
+
+    'tty-gone'  — has (had) a controlling TTY but the pty device is gone: the
+                  terminal window closed under the session.
+    'detached'  — no controlling TTY and reparented to init: whatever spawned
+                  it (a headless boot's parent, a dead terminal's shell) is
+                  gone. A NORMAL headless session still has a live parent, so
+                  ppid==1 is the discriminator.
+    None        — attached and normal, or not enough signal to say otherwise
+                  (conservative: never call an orphan on missing data).
+    """
+    if tty_nr is None:
+        return None
+    if tty_nr == 0:
+        return "detached" if ppid == 1 else None
+    if tty_fd is None:
+        return None
+    if tty_fd.endswith(" (deleted)"):
+        return "tty-gone"
+    if tty_exists is None:
+        tty_exists = os.path.exists(tty_fd)
+    return None if tty_exists else "tty-gone"
 
 
 def _self_harness_pid(harness_pids: set[int]) -> int | None:
@@ -188,10 +254,13 @@ def compute() -> dict:
             "shortname": shortname,
             "display_name": (labels.get(shortname or "", {}).get("display_name")),
             "is_self": pid == self_pid,
+            "orphaned": (None if pid == self_pid
+                         else classify_orphan(_tty_nr(pid), _ppid(pid), _tty_fd(pid))),
         })
 
     active_other = sorted(worktree_sessions)
     indeterminate = len(indeterminate_pids)
+    orphaned_pids = [p["pid"] for p in processes if p["orphaned"]]
     return {
         "supported": True,
         "repo": {"name": REPO_ROOT.name, "root": str(REPO_ROOT)},
@@ -203,6 +272,7 @@ def compute() -> dict:
         "admin_root_pids": admin_root_pids,
         "indeterminate": indeterminate,
         "indeterminate_pids": indeterminate_pids,
+        "orphaned_pids": orphaned_pids,
         # The gate: only the admin is live AND nothing is unreadable.
         "safe_to_clean_all": not active_other and indeterminate == 0,
     }
@@ -212,6 +282,16 @@ def is_active(shortname: str, snap: dict | None = None) -> bool:
     """Convenience for the admin gate: is THIS shell's worktree live right now?"""
     snap = snap or compute()
     return shortname.lower() in {s.lower() for s in snap.get("active_other_shells", [])}
+
+
+def orphan_split(shortname: str, snap: dict) -> "tuple[list[int], list[int]]":
+    """(all pids, orphaned pids) for one shell's worktree sessions — the shape
+    the `sc run` guard needs: every-session-orphaned means the slot is held by
+    survivors of closed terminals / dead parents, not by a working session."""
+    procs = [p for p in snap.get("processes", [])
+             if (p.get("shortname") or "").lower() == shortname.lower()]
+    return ([p["pid"] for p in procs],
+            [p["pid"] for p in procs if p.get("orphaned")])
 
 
 def _print_text(d: dict) -> None:
@@ -229,6 +309,8 @@ def _print_text(d: dict) -> None:
         tags = []
         if p["is_self"]:
             tags.append("SELF")
+        if p["orphaned"]:
+            tags.append(f"ORPHAN:{p['orphaned']}")
         tag = f"  [{', '.join(tags)}]" if tags else ""
         print(f"  pid {p['pid']:<7} {p['comm']:<9} {p['region']:<9} {who}{tag}")
         print(f"            {p['cwd']}")
@@ -236,6 +318,13 @@ def _print_text(d: dict) -> None:
         print(f"\n⚠ {d['indeterminate']} harness process(es) with unreadable cwd "
               f"(other OS user?): pids {d['indeterminate_pids']} — liveness "
               f"INDETERMINATE; do not assume all-clear.")
+    if d.get("orphaned_pids"):
+        print(f"\n⚠ {len(d['orphaned_pids'])} orphaned session(s): pids "
+              f"{d['orphaned_pids']} — terminal closed / parent gone. Each "
+              f"holds its shell's one-session slot. Verify idle "
+              f"(`ps -o etime=,stat= -p <pid>`; no busy children), then "
+              f"`kill <pid>`. An orphan can still be mid-work — never kill "
+              f"unverified.")
     print("\nVERDICT")
     if d["active_other_shells"]:
         print(f"  Live OTHER shells: {', '.join(d['active_other_shells'])}"

--- a/tests/test_shell_liveness.py
+++ b/tests/test_shell_liveness.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Tests for shell_liveness orphan detection: the pure classifier
+(classify_orphan), the guard-shaping helper (orphan_split), and a compute()
+smoke pass against the live /proc.
+
+Stdlib `unittest`, matching the sibling suites.
+
+Run:
+    python3 tests/test_shell_liveness.py
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import shell_liveness  # noqa: E402
+
+
+class ClassifyOrphanTest(unittest.TestCase):
+    """The pure verdict: (tty_nr, ppid, tty_fd, tty_exists) → orphan state."""
+
+    def test_attached_normal_session(self):
+        # Interactive session, pty alive → not an orphan.
+        self.assertIsNone(shell_liveness.classify_orphan(
+            34816, 4242, "/dev/pts/3", True))
+
+    def test_tty_gone_deleted_suffix(self):
+        # Terminal window closed; readlink flags the dead pty.
+        self.assertEqual("tty-gone", shell_liveness.classify_orphan(
+            34816, 4242, "/dev/pts/3 (deleted)", True))
+
+    def test_tty_gone_device_missing(self):
+        # Same closure, no (deleted) marker — the pts node just isn't there.
+        self.assertEqual("tty-gone", shell_liveness.classify_orphan(
+            34816, 4242, "/dev/pts/3", False))
+
+    def test_detached_reparented_to_init(self):
+        # Headless survivor: no controlling TTY, parent gone → init.
+        self.assertEqual("detached", shell_liveness.classify_orphan(
+            0, 1, None, None))
+
+    def test_headless_with_live_parent_is_not_orphaned(self):
+        # A NORMAL headless boot: no TTY but its spawner is alive.
+        self.assertIsNone(shell_liveness.classify_orphan(0, 4242, None, None))
+
+    def test_missing_stat_is_conservative(self):
+        # No /proc data → never call an orphan.
+        self.assertIsNone(shell_liveness.classify_orphan(None, None, None, None))
+
+    def test_tty_present_but_stdio_redirected_is_conservative(self):
+        # tty_nr says attached, but no stdio fd resolves to a tty → no verdict.
+        self.assertIsNone(shell_liveness.classify_orphan(34816, 4242, None, None))
+
+
+class OrphanSplitTest(unittest.TestCase):
+    """orphan_split shapes the sc run guard: (all pids, orphaned pids)."""
+
+    SNAP = {
+        "processes": [
+            {"pid": 100, "shortname": "dev1", "orphaned": "tty-gone"},
+            {"pid": 101, "shortname": "dev1", "orphaned": None},
+            {"pid": 200, "shortname": "dev2", "orphaned": "detached"},
+            {"pid": 300, "shortname": None, "orphaned": None},  # admin root
+        ],
+    }
+
+    def test_mixed_shell_is_not_all_orphaned(self):
+        pids, orphans = shell_liveness.orphan_split("dev1", self.SNAP)
+        self.assertEqual([100, 101], pids)
+        self.assertEqual([100], orphans)
+        self.assertNotEqual(len(pids), len(orphans))
+
+    def test_fully_orphaned_shell(self):
+        pids, orphans = shell_liveness.orphan_split("dev2", self.SNAP)
+        self.assertEqual(pids, orphans)
+        self.assertEqual([200], orphans)
+
+    def test_case_insensitive_shortname(self):
+        pids, _ = shell_liveness.orphan_split("DEV2", self.SNAP)
+        self.assertEqual([200], pids)
+
+    def test_unknown_shell_is_empty(self):
+        self.assertEqual(([], []), shell_liveness.orphan_split("ghost", self.SNAP))
+
+
+class ComputeSmokeTest(unittest.TestCase):
+    """compute() against the real /proc: shape only, no liveness assumptions."""
+
+    def test_snapshot_shape(self):
+        snap = shell_liveness.compute()
+        if not snap.get("supported"):
+            self.skipTest("non-Linux: /proc unavailable")
+        self.assertIn("orphaned_pids", snap)
+        self.assertIsInstance(snap["orphaned_pids"], list)
+        for p in snap["processes"]:
+            self.assertIn("orphaned", p)
+            self.assertIn(p["orphaned"], (None, "tty-gone", "detached"))
+            if p["is_self"]:
+                # The scanning session is by definition not an orphan.
+                self.assertIsNone(p["orphaned"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
From the dos-arch sprint-221 report: five interactive sessions outlived their closed terminal windows and held their shells' liveness slots; the planner found and killed them by hand via /proc, sparing one that was mid-merge. The `sc run` guard refused those boots with a message that gave no path forward.

- `shell_liveness.py` classifies every harness process: `tty-gone` (pty vanished under an interactive session), `detached` (no controlling TTY + reparented to init), or `None` — conservative on missing signal, never for the scanning session itself. Snapshot gains `orphaned_pids`; `--text` tags orphans and prints the verify-then-kill procedure.
- The `sc run` one-shell-one-session guard now distinguishes: a slot held only by orphans still refuses (the spared mid-merge session is exactly why auto-kill is off the table) but names the pids and the verification + kill steps.

Test plan: `python3 tests/test_shell_liveness.py` (12 new — pure classifier, guard-shaping helper, /proc smoke) and `python3 tests/test_sprint_eventing.py` (45, imports run.py) both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)