### PR TITLE
feat(jobs): sc job — session-surviving local job runner (feature #16)

### DIFF
--- a/.sc-state/content.sql
+++ b/.sc-state/content.sql
@@ -265,6 +265,7 @@ INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (13, 'Agents skill — delegated waves', 'shipped', 0, 1, 'New engine skill ''agents'' (--agents [model]) for dev + reviewer flavors: delegate spec execution to implementer waves and reviews to adversarial finding-panels. Overlay on spec/review; parent-only memory writes; wave checkpoints as monitoring; parent-set timeouts (two-strike floor); AGENTS spawn ledger with hard 6h validity window as a verbatim guard. See specs_sc/agents-skill.md.', '2026-07-06 15:08:37', '2026-07-06 15:08:37', 1);
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (14, 'Sprint eventing — GitHub→inbox daemon + headless worker boot', 'shipped', 0, 1, NULL, '2026-07-12 16:58:16', '2026-07-13 05:30:04', 1);
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (15, 'Sprint reporting — unit reports, conformance pass, planner synthesis', 'next', 0, 1, 'Dev unit-report result rows at merge; pre-freeze conformance pass (review shells judge spec vs main, four-way verdicts); sprint report becomes a fixed skeleton the planner synthesizes from unit reports + conformance doc. Skill-text only — no schema, no CLI. See specs_sc/sprint-reporting.md.', '2026-07-13 20:04:22', '2026-07-13 20:04:22', 1);
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (16, 'Session-surviving job runner (sc job)', 'in_progress', 0, 1, NULL, '2026-07-14 07:14:59', '2026-07-14 07:14:59', NULL);
 
 DELETE FROM documents;
 INSERT INTO documents (document_id, feature_id, kind, seq, title, frozen, frozen_date, body, render_path, created_at, updated_at) VALUES (1, 1, 'spec', 1, 'super-coder — Founding Spec', 1, '2026-06-04', '---
@@ -2222,6 +2223,143 @@ to its named sources. Silent deviations are either zero or itemized
 findings with rulings — "all units merged" and "the spec shipped" are
 finally separately-checked claims, and the report states both.
 ', 'specs_sc/sprint-reporting.md', '2026-07-13 20:04:30', '2026-07-13 20:04:30');
+INSERT INTO documents (document_id, feature_id, kind, seq, title, frozen, frozen_date, body, render_path, created_at, updated_at) VALUES (9, 16, 'spec', 1, 'sc job — session-surviving job runner', 0, NULL, '---
+title: sc job — session-surviving job runner
+tags: [jobs, sprints, headless, eventing, supervision]
+date: 2026-07-14
+project: super-coder
+purpose: Local long-running work that survives the session that started it
+---
+
+# sc job — session-surviving local job runner
+
+## Overview
+
+`./sc job` runs a long local command — a test suite, a bench, a build —
+as a **detached, supervised process** that survives the harness session
+that started it, and reports its completion as a `result` row in the
+starting shell''s own inbox. The existing eventing loop (inbox watcher,
+headless boots on message rows) then covers local long jobs exactly the
+way it already covers PR transitions: the process outlives the session;
+the completion row wakes the shell.
+
+```
+./sc job start [--label <slug>] [--timeout <sec>] -- <cmd ...>
+./sc job list [--all]
+./sc job status <id>
+./sc job tail <id> [-n N]
+./sc job wait <id> [--for <sec>]
+./sc job kill <id>
+```
+
+## Problem
+
+The dos-arch sprint-221 report''s recurring failure (~6 occurrences):
+sessions ended turns with suite runs, benches, and watches parked on
+harness background tasks. In a headless (`-p`) session those tasks die
+with the session — "the harness will wake me" is false. Consequences
+observed in one sprint: a bench that died silently and contaminated a
+measurement decision; a 4-hour wedge on a deadlocked local suite; an
+evolving stack of hand-rolled mitigations (detached runs with manual
+kill-0 poll slices, drain-inbox-between-slices discipline), each shell
+reinventing its own waiter — one with a self-match bug that masked the
+dead bench.
+
+> [!class1]
+> A harness background task is session-scoped. Anything that must
+> outlive the turn — a suite, a bench, a build — must not be parked on
+> one. `sc job` is the engine-owned answer; hand-rolled `nohup` + poll
+> loops are the thing it replaces.
+
+## Job lifecycle
+
+`start` spawns a small **supervisor** (`job.py _supervise <dir>`) in a
+new session (`setsid`), which spawns the command as its own process
+group, then:
+
+1. records the child pid in `meta.json`,
+2. streams combined stdout+stderr to `log`,
+3. waits for exit (or kills the group at `--timeout` seconds),
+4. writes `exit_code` + `finished_at` to `meta.json`,
+5. posts ONE completion message to the starting shell''s own inbox via
+   the engine API — kind `result`, body one line:
+   `job <id> (<label>) exited <code> after <duration> — log: <path>`,
+   stamped with a `dedupe_key` so an API retry never double-sends.
+
+The message is the wake-up, not the payload — detail lives in
+`sc job status` / `tail`. If the API is unreachable at completion the
+supervisor retries briefly, then gives up: `meta.json` still holds the
+result, `status`/`wait` still see it. The completion row is the fast
+path, never the only path.
+
+State lives under `<engine>/run/jobs/<id>/` — `meta.json` (cmd, label,
+cwd, owner shortname, timestamps, pid, exit) + `log`. No DB schema
+changes: the only DB surface is the existing `shell_messages` bus, and
+the supervisor is the one writer, through the API like any shell-side
+actor (token from the environment it inherited at `start`).
+
+## The two wait patterns
+
+- **Event-driven (preferred, planner-visible):** `job start`, report
+  the job id in your `result`/board row, end the turn. The completion
+  row wakes the shell through the normal inbox path. Nothing polls.
+- **Wait-slice (when the result decides THIS turn''s next step):**
+  `job wait <id> --for <sec>` blocks in the foreground up to `--for`
+  seconds (default 300, cap 550 — under harness foreground-timeout
+  limits). Exit 0 = finished (status line printed); exit 2 = still
+  running. Between slices: drain your inbox, then slice again. The
+  canonical waiter every shell was hand-rolling, once, correctly.
+
+> [!class4]
+> `job wait` exit codes: 0 done · 2 still running · 1 no such job.
+> A wait-slice loop that never drains the inbox between slices
+> reproduces the stale-state failure the sprint hit — the slice is
+> bounded exactly so the inbox gets read.
+
+## Timeouts and the wedge case
+
+`--timeout <sec>` arms the supervisor to SIGTERM (then SIGKILL after a
+grace period) the whole process group and report
+`exited timeout(-15) …`. The sprint''s 4-hour deadlocked pytest wedge is
+the motivating case: a wedged suite becomes a bounded failure with a
+completion row, not a silent hole in the sprint.
+
+`job kill <id>` is the manual form: SIGTERM to the group, recorded as
+killed, completion row still posted (by the supervisor, which survives).
+
+## Surfaces to change
+
+| Surface | Change |
+|---|---|
+| `scripts/job.py` | new — verbs + the supervisor |
+| `sc` dispatcher | `job)` arm + help stanza |
+| `run/jobs/` | new state dir (gitignored with the rest of `run/`) |
+| `shell_messages` | none — existing kind `result` + `dedupe_key` |
+| skills (`sprint`, `sprint_orchestration`) | teach: long local work goes through `sc job`; wait-slice + drain-inbox discipline (separate reseed) |
+| `tests/test_job.py` | new — lifecycle, wait codes, timeout, completion row |
+
+## Non-goals
+
+- **Fleet-wide job registry.** Jobs are per-shell, state is
+  engine-local to the worktree that started them; the completion row on
+  the message bus is the fleet-visible surface. A cross-shell `job list`
+  is a later feature if wanted.
+- **Supervision beyond one shot.** No restarts, no cron, no queues —
+  a job runs once and reports once. The brokers own long-lived services.
+- **Replacing CI.** CI-vs-CI on the same runner stays the decision
+  number for measurements (sprint-221 ruling); `sc job` exists so local
+  runs that do happen can''t die silently.
+
+## Done condition
+
+A headless sprint worker starts a 30-minute suite with
+`./sc job start --timeout 3600 -- …`, ends its turn immediately, and
+the suite keeps running. On exit the worker''s inbox gets one `result`
+row; the planner''s next boot of that shell acts on the outcome.
+`job wait` covers the in-turn case in ≤550s slices with inbox drains
+between. A wedged run dies at its timeout with a completion row instead
+of wedging the sprint. Zero scheduled polling anywhere.
+', 'specs_sc/job-runner.md', '2026-07-14 07:15:07', '2026-07-14 07:15:07');
 
 DELETE FROM flags;
 INSERT INTO flags (flag_id, display_name, priority, description, created_date, resolved_date, resolved, shell_id, feature_id, resolution_notes, parent_flag_id, is_deleted) VALUES (1, 'SC-001', 'Low', '[Test] review layer smoke flag | Blocker for: nothing', '2026-06-04', '2026-06-04', 1, NULL, 1, 'smoke test done', NULL, 0);
@@ -2229,11 +2367,11 @@ INSERT INTO flags (flag_id, display_name, priority, description, created_date, r
 INSERT INTO flags (flag_id, display_name, priority, description, created_date, resolved_date, resolved, shell_id, feature_id, resolution_notes, parent_flag_id, is_deleted) VALUES (3, 'SC-002', 'Medium', '[Docs] sprint eventing shipped (PR #338), feature doc pending — and the loop is unproven until a real sprint runs on it | Blocker for: eventing feature doc + first eventing sprint', '2026-07-13', NULL, 0, NULL, 14, NULL, NULL, 0);
 
 DELETE FROM spec_tasks;
-INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, shell_id, created_date) VALUES (1, 13, 6, 0, 'Preparation', 'Trace seed_skills/sync/regrant pipeline, asset format, migration numbering', 'done', '2026-07-06', 1, '2026-07-06');
-INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, shell_id, created_date) VALUES (2, 13, 6, 1, 'Author agents SKILL.md asset', 'Full skill body per spec: contract, dev/review overlays, monitoring, timeouts, verbatim ledger check', 'done', '2026-07-06', 1, '2026-07-06');
-INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, shell_id, created_date) VALUES (3, 13, 6, 2, 'Seed regen + forward migration', './sc seed-skills; 0049 self-contained UPSERT agents + spec/review reseed + dev/reviewer grants', 'done', '2026-07-06', 1, '2026-07-06');
-INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, shell_id, created_date) VALUES (4, 13, 6, 3, 'Templates + overlay pointers', 'dev.json/reviewer.json skills arrays; pointer lines in spec + review assets', 'done', '2026-07-06', 1, '2026-07-06');
-INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, shell_id, created_date) VALUES (5, 13, 6, 4, 'Verification', 'render-check hermetic pass, tests, local apply, snapshot+render, grants verified', 'done', '2026-07-06', 1, '2026-07-06');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (1, 13, 6, 0, 'Preparation', 'Trace seed_skills/sync/regrant pipeline, asset format, migration numbering', 'done', '2026-07-06', NULL, 1, '2026-07-06');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (2, 13, 6, 1, 'Author agents SKILL.md asset', 'Full skill body per spec: contract, dev/review overlays, monitoring, timeouts, verbatim ledger check', 'done', '2026-07-06', NULL, 1, '2026-07-06');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (3, 13, 6, 2, 'Seed regen + forward migration', './sc seed-skills; 0049 self-contained UPSERT agents + spec/review reseed + dev/reviewer grants', 'done', '2026-07-06', NULL, 1, '2026-07-06');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (4, 13, 6, 3, 'Templates + overlay pointers', 'dev.json/reviewer.json skills arrays; pointer lines in spec + review assets', 'done', '2026-07-06', NULL, 1, '2026-07-06');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (5, 13, 6, 4, 'Verification', 'render-check hermetic pass, tests, local apply, snapshot+render, grants verified', 'done', '2026-07-06', NULL, 1, '2026-07-06');
 
 DELETE FROM feature_blockers;
 

--- a/.super-coder/scripts/job.py
+++ b/.super-coder/scripts/job.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""sc job — session-surviving local job runner (specs_sc/job-runner.md).
+
+A harness background task is session-scoped: in a headless (-p) boot it dies
+with the session, silently. `sc job` runs a long local command — a suite, a
+bench, a build — as a detached, supervised process that survives the session
+that started it, and posts ONE completion message (`result` row) to the
+starting shell's own inbox, so the existing eventing loop (inbox watcher,
+headless boots on message rows) covers local long jobs the way it already
+covers PR transitions.
+
+    ./sc job start [--label <slug>] [--timeout <sec>] -- <cmd ...>
+    ./sc job list [--all]
+    ./sc job status <id>
+    ./sc job tail <id> [-n N]
+    ./sc job wait <id> [--for <sec>]     bounded foreground wait (wait-slice)
+    ./sc job kill <id>
+
+State: <engine>/run/jobs/<id>/ — meta.json + log. No DB surface except the
+completion message, sent through the API with the token the environment
+carried at `start` (the `sc mem` doctrine: shell-side writes go through the
+API, stamped with a dedupe_key so a retry never double-sends). If the API is
+unreachable at completion the supervisor retries briefly and gives up —
+meta.json still holds the result; the row is the fast path, never the only
+path.
+
+The supervisor (`job.py _supervise <dir>`, spawned with start_new_session)
+is the job's parent: it survives the harness session, streams the child's
+output to the log, enforces --timeout on the whole process group, records
+the exit, and sends the wake-up.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+JOBS = ENGINE / "run" / "jobs"
+
+# API proxy — run.py injects these at boot; the supervisor inherits them.
+SC_API_TOKEN = os.environ.get("SC_API_TOKEN", "")
+SC_API_BASE = os.environ.get("SC_API_BASE", "")
+
+WAIT_DEFAULT = 300          # `job wait` default slice (seconds)
+WAIT_CAP = 550              # hard cap — under harness foreground-timeout limits
+KILL_GRACE = 10             # SIGTERM → SIGKILL grace (seconds)
+POLL = 2                    # supervisor/wait poll interval (seconds)
+
+
+def die(msg: str) -> "NoReturn":  # noqa: F821
+    sys.exit(f"job: {msg}")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _dur(started: str, finished: str) -> str:
+    """Human duration between two _now() stamps — best-effort."""
+    try:
+        fmt = "%Y-%m-%dT%H:%M:%SZ"
+        secs = int((datetime.strptime(finished, fmt)
+                    - datetime.strptime(started, fmt)).total_seconds())
+    except ValueError:
+        return "?"
+    if secs < 60:
+        return f"{secs}s"
+    if secs < 3600:
+        return f"{secs // 60}m{secs % 60:02d}s"
+    return f"{secs // 3600}h{(secs % 3600) // 60:02d}m"
+
+
+# ── meta.json — the job's one record ─────────────────────────────────────────
+
+def _meta_path(jobdir: Path) -> Path:
+    return jobdir / "meta.json"
+
+
+def read_meta(jobdir: Path) -> dict:
+    try:
+        return json.loads(_meta_path(jobdir).read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_meta(jobdir: Path, meta: dict) -> None:
+    tmp = _meta_path(jobdir).with_suffix(".tmp")
+    tmp.write_text(json.dumps(meta, indent=2) + "\n")
+    os.replace(tmp, _meta_path(jobdir))
+
+
+def job_dir(job_id: str) -> Path:
+    d = JOBS / job_id
+    if not d.is_dir():
+        die(f"no such job '{job_id}' (see `sc job list --all`)")
+    return d
+
+
+def next_job_id(label: "str | None") -> str:
+    """Sequential id, readable: '7' or '7-pytest'. The number never repeats
+    (max over existing dirs + 1), the label is display sugar."""
+    JOBS.mkdir(parents=True, exist_ok=True)
+    seqs = [0]
+    for d in JOBS.iterdir():
+        head = d.name.split("-", 1)[0]
+        if head.isdigit():
+            seqs.append(int(head))
+    n = max(seqs) + 1
+    return f"{n}-{label}" if label else str(n)
+
+
+def is_finished(meta: dict) -> bool:
+    return meta.get("finished_at") is not None
+
+
+def is_running(meta: dict) -> bool:
+    """Running = not finished AND the supervisor is still alive. A dead
+    supervisor with no finish record is 'lost' (host reboot, SIGKILL) —
+    reported, never silently running forever."""
+    if is_finished(meta):
+        return False
+    spid = meta.get("supervisor_pid")
+    if not spid:
+        return False
+    try:
+        os.kill(int(spid), 0)
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def state_of(meta: dict) -> str:
+    if is_finished(meta):
+        if meta.get("timed_out"):
+            return "timeout"
+        if meta.get("killed"):
+            return "killed"
+        return "done" if meta.get("exit_code") == 0 else "failed"
+    return "running" if is_running(meta) else "lost"
+
+
+# ── completion message (supervisor-side) ─────────────────────────────────────
+
+def _api(method: str, path: str, payload: "dict | None" = None) -> dict:
+    url = SC_API_BASE.rstrip("/") + path
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers: dict = {"Authorization": f"Bearer {SC_API_TOKEN}"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def completion_body(meta: dict) -> str:
+    state = state_of(meta)
+    exit_code = meta.get("exit_code")
+    dur = _dur(meta.get("started_at", ""), meta.get("finished_at", ""))
+    label = meta.get("label") or meta.get("cmd", ["?"])[0]
+    return (f"job {meta.get('job_id')} ({label}) {state}"
+            f" exit={exit_code} after {dur} — `sc job status"
+            f" {meta.get('job_id')}` · log: {meta.get('log')}")
+
+
+def send_completion(meta: dict, retries: int = 5, delay: float = 3.0) -> bool:
+    """One result row to the starting shell's OWN inbox — the wake-up. The
+    dedupe_key makes retries safe (#333 doctrine); API down after `retries`
+    attempts → give up quietly (meta.json still has the result)."""
+    if not (SC_API_TOKEN and SC_API_BASE):
+        return False
+    for attempt in range(retries):
+        try:
+            me = _api("GET", "/_sc/mem/whoami")
+            _api("POST", "/_sc/mem/messages", {
+                "to_shell_id": me["shell_id"],
+                "body": completion_body(meta),
+                "kind": "result",
+                "dedupe_key": f"job-{meta.get('job_id')}-completion",
+            })
+            return True
+        except (urllib.error.URLError, OSError, KeyError, json.JSONDecodeError):
+            time.sleep(delay * (attempt + 1))
+    return False
+
+
+# ── the supervisor (detached; the part that survives the session) ────────────
+
+def supervise(jobdir: Path, notify=send_completion) -> int:
+    """Run the job to completion: spawn the command as its own process group,
+    stream output to log, enforce the timeout, record the exit, send the
+    wake-up. `notify` is injectable for tests."""
+    meta = read_meta(jobdir)
+    meta["supervisor_pid"] = os.getpid()
+    write_meta(jobdir, meta)
+
+    log = open(jobdir / "log", "ab", buffering=0)
+    try:
+        child = subprocess.Popen(
+            meta["cmd"], cwd=meta.get("cwd") or None,
+            stdout=log, stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL, start_new_session=True)
+    except OSError as e:
+        meta.update(finished_at=_now(), exit_code=127, spawn_error=str(e))
+        write_meta(jobdir, meta)
+        notify(meta)
+        return 127
+
+    meta["pid"] = child.pid
+    write_meta(jobdir, meta)
+
+    timeout = meta.get("timeout")
+    deadline = time.monotonic() + timeout if timeout else None
+    timed_out = False
+    while True:
+        try:
+            rc = child.wait(timeout=POLL)
+            break
+        except subprocess.TimeoutExpired:
+            if deadline and time.monotonic() >= deadline:
+                timed_out = True
+                _kill_group(child.pid)
+                rc = child.wait()
+                break
+
+    # Re-read before the final write: `kill` may have stamped killed=True on
+    # disk while we held a stale copy — never clobber it.
+    meta = read_meta(jobdir) or meta
+    meta.update(finished_at=_now(), exit_code=rc, timed_out=timed_out)
+    write_meta(jobdir, meta)
+    log.close()
+    notify(meta)
+    return rc
+
+
+def _kill_group(pid: int) -> None:
+    """SIGTERM the job's process group; SIGKILL what remains after the grace
+    period. The group is the child's own session (start_new_session at spawn),
+    so a suite's worker processes die with it — no half-dead pytest trees."""
+    for sig, wait_s in ((signal.SIGTERM, KILL_GRACE), (signal.SIGKILL, 0)):
+        try:
+            os.killpg(pid, sig)
+        except (ProcessLookupError, PermissionError):
+            return
+        end = time.monotonic() + wait_s
+        while time.monotonic() < end:
+            try:
+                os.killpg(pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.2)
+
+
+def cmd_supervise(args) -> int:
+    return supervise(Path(args.jobdir))
+
+
+# ── verbs ─────────────────────────────────────────────────────────────────────
+
+def cmd_start(args) -> int:
+    if not args.cmd:
+        die("nothing to run — usage: sc job start [--label x] [--timeout N] -- <cmd ...>")
+    cmd = args.cmd[1:] if args.cmd and args.cmd[0] == "--" else list(args.cmd)
+    if not cmd:
+        die("nothing to run after --")
+    job_id = next_job_id(args.label)
+    jobdir = JOBS / job_id
+    jobdir.mkdir(parents=True)
+    (jobdir / "log").touch()
+    write_meta(jobdir, {
+        "job_id": job_id,
+        "label": args.label,
+        "cmd": cmd,
+        "cwd": os.getcwd(),
+        "timeout": args.timeout,
+        "started_at": _now(),
+        "log": str(jobdir / "log"),
+    })
+    # Detach: the supervisor gets its own session so it survives this process,
+    # the harness turn, and the harness session itself.
+    sup = subprocess.Popen(
+        [sys.executable, str(Path(__file__).resolve()), "_supervise", str(jobdir)],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL, start_new_session=True)
+    # Only the supervisor writes meta after this point (no lost-update races);
+    # wait for its first write so an immediate `status`/`wait` never reads a
+    # pre-supervisor meta and mis-calls the job 'lost'.
+    end = time.monotonic() + 5
+    while time.monotonic() < end:
+        if read_meta(jobdir).get("supervisor_pid"):
+            break
+        time.sleep(0.05)
+    else:
+        print(f"job: WARNING — supervisor (pid {sup.pid}) has not checked in "
+              f"after 5s; `sc job status {job_id}` before trusting it")
+    print(f"job: {job_id} started (supervisor pid {sup.pid}) — "
+          f"`sc job wait {job_id}` or end the turn; completion lands in "
+          f"your inbox as a result row")
+    return 0
+
+
+def cmd_list(args) -> int:
+    if not JOBS.is_dir():
+        print("job: none")
+        return 0
+    rows = []
+    for d in sorted(JOBS.iterdir(), key=lambda p: p.name):
+        meta = read_meta(d)
+        if not meta:
+            continue
+        st = state_of(meta)
+        if not args.all and st not in ("running", "lost"):
+            continue
+        rows.append((d.name, st, meta))
+    if not rows:
+        print("job: none live" + ("" if args.all else " (--all includes finished)"))
+        return 0
+    for name, st, meta in rows:
+        dur = (_dur(meta.get("started_at", ""), meta.get("finished_at") or _now()))
+        print(f"  {name:<20} {st:<8} {dur:>8}  {' '.join(meta.get('cmd', []))[:60]}")
+    return 0
+
+
+def cmd_status(args) -> int:
+    meta = read_meta(job_dir(args.id))
+    st = state_of(meta)
+    print(f"job {meta.get('job_id')}: {st}")
+    for k in ("label", "cmd", "cwd", "pid", "supervisor_pid", "started_at",
+              "finished_at", "exit_code", "timed_out", "killed", "timeout",
+              "spawn_error", "log"):
+        v = meta.get(k)
+        if v is not None and v is not False:   # `v not in (None, False)` hides exit_code=0
+            print(f"  {k}: {v if not isinstance(v, list) else ' '.join(v)}")
+    if st == "lost":
+        print("  ! supervisor died without recording an exit (reboot/SIGKILL) —"
+              " check the log; the job may or may not have finished its work.")
+    return 0 if st != "lost" else 1
+
+
+def cmd_tail(args) -> int:
+    log = job_dir(args.id) / "log"
+    if not log.exists():
+        die(f"no log for job '{args.id}'")
+    lines = log.read_bytes().decode(errors="replace").splitlines()
+    for line in lines[-args.n:]:
+        print(line)
+    return 0
+
+
+def cmd_wait(args) -> int:
+    """Bounded foreground wait — THE wait-slice primitive. Exit 0 = finished
+    (status line printed) · 2 = still running after the slice (drain your
+    inbox, then slice again) · 1 = no such job / lost."""
+    jobdir = job_dir(args.id)
+    slice_s = min(args.for_seconds or WAIT_DEFAULT, WAIT_CAP)
+    deadline = time.monotonic() + slice_s
+    while True:
+        meta = read_meta(jobdir)
+        if is_finished(meta):
+            print(f"job: {completion_body(meta)}")
+            return 0
+        if not is_running(meta):
+            print(f"job {args.id}: LOST — supervisor died without recording an "
+                  f"exit; check `sc job status {args.id}` and the log.")
+            return 1
+        if time.monotonic() >= deadline:
+            print(f"job {args.id}: still running after {slice_s}s slice — "
+                  f"drain your inbox, then `sc job wait {args.id}` again "
+                  f"(or end the turn; the completion row wakes you).")
+            return 2
+        time.sleep(POLL)
+
+
+def cmd_kill(args) -> int:
+    jobdir = job_dir(args.id)
+    meta = read_meta(jobdir)
+    if is_finished(meta):
+        die(f"job '{args.id}' already finished ({state_of(meta)})")
+    pid = meta.get("pid")
+    if not pid:
+        die(f"job '{args.id}' has no recorded pid yet — try again in a moment")
+    meta["killed"] = True
+    write_meta(jobdir, meta)
+    _kill_group(int(pid))
+    print(f"job: {args.id} killed (SIGTERM→SIGKILL on the process group) — "
+          f"the supervisor records the exit and sends the completion row")
+    return 0
+
+
+# ── arg parsing ───────────────────────────────────────────────────────────────
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sc job",
+        description="session-surviving local job runner (specs_sc/job-runner.md)")
+    sub = p.add_subparsers(dest="cmd_name", required=True)
+
+    sp = sub.add_parser("start", help="run a command detached; completion lands in your inbox")
+    sp.add_argument("--label", help="short slug for the id + the completion row")
+    sp.add_argument("--timeout", type=int,
+                    help="kill the whole process group after N seconds")
+    sp.add_argument("cmd", nargs=argparse.REMAINDER,
+                    help="-- <command and args>")
+    sp.set_defaults(fn=cmd_start)
+
+    sp = sub.add_parser("list", help="live jobs (--all includes finished)")
+    sp.add_argument("--all", action="store_true")
+    sp.set_defaults(fn=cmd_list)
+
+    sp = sub.add_parser("status", help="one job's state, exit, paths")
+    sp.add_argument("id")
+    sp.set_defaults(fn=cmd_status)
+
+    sp = sub.add_parser("tail", help="last N log lines")
+    sp.add_argument("id")
+    sp.add_argument("-n", type=int, default=50)
+    sp.set_defaults(fn=cmd_tail)
+
+    sp = sub.add_parser("wait", help="bounded foreground wait — exit 0 done · 2 still running")
+    sp.add_argument("id")
+    sp.add_argument("--for", dest="for_seconds", type=int, default=WAIT_DEFAULT,
+                    help=f"slice seconds (default {WAIT_DEFAULT}, cap {WAIT_CAP})")
+    sp.set_defaults(fn=cmd_wait)
+
+    sp = sub.add_parser("kill", help="SIGTERM→SIGKILL the job's process group")
+    sp.add_argument("id")
+    sp.set_defaults(fn=cmd_kill)
+
+    sp = sub.add_parser("_supervise", help=argparse.SUPPRESS)
+    sp.add_argument("jobdir")
+    sp.set_defaults(fn=cmd_supervise)
+    return p
+
+
+def main(argv: "list[str]") -> int:
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    args = build_parser().parse_args(argv)
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/roadmap_sc.md
+++ b/roadmap_sc.md
@@ -58,6 +58,10 @@ The substrate itself: data layer we build, harness we rent. v1 targets Claude Co
 
 _No open flags._
 
+### Session-surviving job runner (sc job) · owner: `cc`
+
+_No open flags._
+
 ## Next
 
 ### B1 — First-launch installer · owner: `cc`

--- a/sc
+++ b/sc
@@ -824,6 +824,9 @@ case "$cmd" in
   watch)             exec "$PY" "$S/watch.py" "$@" ;;
   watch-daemon-up)   sc_watch_daemon_up ;;
   watch-daemon-down) sc_watch_daemon_down ;;
+  # ── session-surviving local jobs: detached supervised one-shots whose
+  # completion posts a result row to the starting shell's inbox ──
+  job)               exec "$PY" "$S/job.py" "$@" ;;
   # Raw read passthrough to the engine + map DBs, resolved by absolute path so no
   # skill example ever needs a cwd-relative `sqlite3 .super-coder/…` (which pulls a
   # shell into `cd`-ing to the root — the cwd trap). Read-only is ENFORCED
@@ -1071,6 +1074,11 @@ super-coder — forkable shell substrate
   ./sc watch list          live PR watches (--all includes retired)
   ./sc watch inbox         block until this shell has unread messages, then exit — the zero-token
                              inbox watcher; arm as a background task and its exit is your wake-up
+  ./sc job start -- <cmd>  run a long local command (suite/bench/build) detached + supervised — it
+                             survives your session; completion lands in YOUR inbox as a result row
+                             (--label <slug> names it, --timeout <s> kills the wedged process group)
+  ./sc job wait <id>       bounded foreground wait, ≤550s slice — exit 0 done · 2 still running
+                             (drain your inbox between slices); list/status/tail/kill complete the set
   sc sql "<query>"         read-only passthrough to the engine DB (schema/skills/flags) — absolute path, cwd-independent (no `cd` to root)
   sc map-sql "<query>"     read-only passthrough to the repo-map DB (dr_* catalogue) — absolute path, cwd-independent
   sc sql-rw / map-sql-rw   read-WRITE passthroughs — bypass the API's triggers/caps; `sc mem` is the write path.

--- a/specs_sc/job-runner.md
+++ b/specs_sc/job-runner.md
@@ -1,0 +1,142 @@
+---
+rendered_by: super-coder
+source: db
+edit: changes here are overwritten — author via the shell or localhost GUI
+feature: Session-surviving job runner (sc job)
+roadmap_status: in_progress
+frozen: false
+title: sc job — session-surviving job runner
+tags: [jobs, sprints, headless, eventing, supervision]
+date: 2026-07-14
+project: super-coder
+purpose: Local long-running work that survives the session that started it
+---
+
+# sc job — session-surviving local job runner
+
+## Overview
+
+`./sc job` runs a long local command — a test suite, a bench, a build —
+as a **detached, supervised process** that survives the harness session
+that started it, and reports its completion as a `result` row in the
+starting shell's own inbox. The existing eventing loop (inbox watcher,
+headless boots on message rows) then covers local long jobs exactly the
+way it already covers PR transitions: the process outlives the session;
+the completion row wakes the shell.
+
+```
+./sc job start [--label <slug>] [--timeout <sec>] -- <cmd ...>
+./sc job list [--all]
+./sc job status <id>
+./sc job tail <id> [-n N]
+./sc job wait <id> [--for <sec>]
+./sc job kill <id>
+```
+
+## Problem
+
+The dos-arch sprint-221 report's recurring failure (~6 occurrences):
+sessions ended turns with suite runs, benches, and watches parked on
+harness background tasks. In a headless (`-p`) session those tasks die
+with the session — "the harness will wake me" is false. Consequences
+observed in one sprint: a bench that died silently and contaminated a
+measurement decision; a 4-hour wedge on a deadlocked local suite; an
+evolving stack of hand-rolled mitigations (detached runs with manual
+kill-0 poll slices, drain-inbox-between-slices discipline), each shell
+reinventing its own waiter — one with a self-match bug that masked the
+dead bench.
+
+> [!class1]
+> A harness background task is session-scoped. Anything that must
+> outlive the turn — a suite, a bench, a build — must not be parked on
+> one. `sc job` is the engine-owned answer; hand-rolled `nohup` + poll
+> loops are the thing it replaces.
+
+## Job lifecycle
+
+`start` spawns a small **supervisor** (`job.py _supervise <dir>`) in a
+new session (`setsid`), which spawns the command as its own process
+group, then:
+
+1. records the child pid in `meta.json`,
+2. streams combined stdout+stderr to `log`,
+3. waits for exit (or kills the group at `--timeout` seconds),
+4. writes `exit_code` + `finished_at` to `meta.json`,
+5. posts ONE completion message to the starting shell's own inbox via
+   the engine API — kind `result`, body one line:
+   `job <id> (<label>) exited <code> after <duration> — log: <path>`,
+   stamped with a `dedupe_key` so an API retry never double-sends.
+
+The message is the wake-up, not the payload — detail lives in
+`sc job status` / `tail`. If the API is unreachable at completion the
+supervisor retries briefly, then gives up: `meta.json` still holds the
+result, `status`/`wait` still see it. The completion row is the fast
+path, never the only path.
+
+State lives under `<engine>/run/jobs/<id>/` — `meta.json` (cmd, label,
+cwd, owner shortname, timestamps, pid, exit) + `log`. No DB schema
+changes: the only DB surface is the existing `shell_messages` bus, and
+the supervisor is the one writer, through the API like any shell-side
+actor (token from the environment it inherited at `start`).
+
+## The two wait patterns
+
+- **Event-driven (preferred, planner-visible):** `job start`, report
+  the job id in your `result`/board row, end the turn. The completion
+  row wakes the shell through the normal inbox path. Nothing polls.
+- **Wait-slice (when the result decides THIS turn's next step):**
+  `job wait <id> --for <sec>` blocks in the foreground up to `--for`
+  seconds (default 300, cap 550 — under harness foreground-timeout
+  limits). Exit 0 = finished (status line printed); exit 2 = still
+  running. Between slices: drain your inbox, then slice again. The
+  canonical waiter every shell was hand-rolling, once, correctly.
+
+> [!class4]
+> `job wait` exit codes: 0 done · 2 still running · 1 no such job.
+> A wait-slice loop that never drains the inbox between slices
+> reproduces the stale-state failure the sprint hit — the slice is
+> bounded exactly so the inbox gets read.
+
+## Timeouts and the wedge case
+
+`--timeout <sec>` arms the supervisor to SIGTERM (then SIGKILL after a
+grace period) the whole process group and report
+`exited timeout(-15) …`. The sprint's 4-hour deadlocked pytest wedge is
+the motivating case: a wedged suite becomes a bounded failure with a
+completion row, not a silent hole in the sprint.
+
+`job kill <id>` is the manual form: SIGTERM to the group, recorded as
+killed, completion row still posted (by the supervisor, which survives).
+
+## Surfaces to change
+
+| Surface | Change |
+|---|---|
+| `scripts/job.py` | new — verbs + the supervisor |
+| `sc` dispatcher | `job)` arm + help stanza |
+| `run/jobs/` | new state dir (gitignored with the rest of `run/`) |
+| `shell_messages` | none — existing kind `result` + `dedupe_key` |
+| skills (`sprint`, `sprint_orchestration`) | teach: long local work goes through `sc job`; wait-slice + drain-inbox discipline (separate reseed) |
+| `tests/test_job.py` | new — lifecycle, wait codes, timeout, completion row |
+
+## Non-goals
+
+- **Fleet-wide job registry.** Jobs are per-shell, state is
+  engine-local to the worktree that started them; the completion row on
+  the message bus is the fleet-visible surface. A cross-shell `job list`
+  is a later feature if wanted.
+- **Supervision beyond one shot.** No restarts, no cron, no queues —
+  a job runs once and reports once. The brokers own long-lived services.
+- **Replacing CI.** CI-vs-CI on the same runner stays the decision
+  number for measurements (sprint-221 ruling); `sc job` exists so local
+  runs that do happen can't die silently.
+
+## Done condition
+
+A headless sprint worker starts a 30-minute suite with
+`./sc job start --timeout 3600 -- …`, ends its turn immediately, and
+the suite keeps running. On exit the worker's inbox gets one `result`
+row; the planner's next boot of that shell acts on the outcome.
+`job wait` covers the in-turn case in ≤550s slices with inbox drains
+between. A wedged run dies at its timeout with a completion row instead
+of wedging the sprint. Zero scheduled polling anywhere.

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Tests for sc job (specs_sc/job-runner.md): the job lifecycle (start →
+supervise → meta), wait's exit-code contract, --timeout group kill, kill's
+flag surviving the supervisor's final write, and the completion result row
+landing in the starting shell's own inbox through the real API.
+
+Stdlib `unittest`, matching the sibling suites. The supervisor is exercised
+synchronously (supervise(jobdir) is a plain function; `notify` is injectable),
+so no test depends on detached-process timing. API tests stand up the real
+server.Handler on an ephemeral port (the test_mem harness pattern).
+
+Run:
+    python3 tests/test_job.py
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+import job  # noqa: E402
+import server  # noqa: E402
+
+TOKEN = "test-token-jobrunner"
+
+
+def build_db(path: str) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for mig in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(mig.read_text())
+    con.execute("INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1)")
+    con.execute(
+        "INSERT INTO shells (shell_id, display_name, shortname, system_prompt, user_id, api_key) "
+        "VALUES (1, 'Dev One', 'dev1', 'x', 1, ?)", (TOKEN,))
+    con.commit()
+    con.close()
+
+
+def start_job(jobs_dir: Path, cmd: list, timeout=None, label=None) -> Path:
+    """Author a job dir the way cmd_start does, minus the detach — the
+    supervisor is then driven synchronously."""
+    job_id = f"1-{label}" if label else "1"
+    jobdir = jobs_dir / job_id
+    jobdir.mkdir(parents=True)
+    (jobdir / "log").touch()
+    job.write_meta(jobdir, {
+        "job_id": job_id, "label": label, "cmd": cmd, "cwd": str(jobs_dir),
+        "timeout": timeout, "started_at": job._now(),
+        "log": str(jobdir / "log"),
+    })
+    return jobdir
+
+
+class SupervisorTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.sent: list = []
+        self.notify = lambda meta: self.sent.append(meta) or True
+
+    def test_success_lifecycle(self):
+        jd = start_job(self.tmp, ["sh", "-c", "echo out; echo err >&2; exit 0"])
+        rc = job.supervise(jd, notify=self.notify)
+        self.assertEqual(0, rc)
+        meta = job.read_meta(jd)
+        self.assertEqual("done", job.state_of(meta))
+        self.assertEqual(0, meta["exit_code"])
+        self.assertIsNotNone(meta["finished_at"])
+        log = (jd / "log").read_text()
+        self.assertIn("out", log)
+        self.assertIn("err", log)          # stderr folds into the one log
+        self.assertEqual(1, len(self.sent))
+
+    def test_failure_exit_code(self):
+        jd = start_job(self.tmp, ["sh", "-c", "exit 3"])
+        rc = job.supervise(jd, notify=self.notify)
+        self.assertEqual(3, rc)
+        self.assertEqual("failed", job.state_of(job.read_meta(jd)))
+
+    def test_spawn_error_is_a_recorded_failure(self):
+        jd = start_job(self.tmp, ["/nonexistent/binary"])
+        rc = job.supervise(jd, notify=self.notify)
+        self.assertEqual(127, rc)
+        meta = job.read_meta(jd)
+        self.assertEqual("failed", job.state_of(meta))
+        self.assertIn("spawn_error", meta)
+        self.assertEqual(1, len(self.sent))   # even a spawn failure wakes the shell
+
+    def test_timeout_kills_the_group(self):
+        old_grace = job.KILL_GRACE
+        job.KILL_GRACE = 1
+        try:
+            jd = start_job(self.tmp, ["sh", "-c", "sleep 60"], timeout=1)
+            t0 = time.monotonic()
+            job.supervise(jd, notify=self.notify)
+            self.assertLess(time.monotonic() - t0, 30)
+            meta = job.read_meta(jd)
+            self.assertEqual("timeout", job.state_of(meta))
+            self.assertTrue(meta["timed_out"])
+        finally:
+            job.KILL_GRACE = old_grace
+
+    def test_killed_flag_survives_final_write(self):
+        # kill stamps killed=True on disk while the supervisor holds a stale
+        # copy — the supervisor's final write must not clobber it.
+        jd = start_job(self.tmp, ["sh", "-c", "exit 0"])
+        real_read = job.read_meta
+        stamped = {"done": False}
+
+        def stamping_read(jobdir):
+            meta = real_read(jobdir)
+            if meta.get("pid") and not stamped["done"] and not meta.get("finished_at"):
+                stamped["done"] = True
+                disk = real_read(jobdir)
+                disk["killed"] = True
+                job.write_meta(jobdir, disk)
+                meta = real_read(jobdir)
+            return meta
+
+        job.read_meta = stamping_read
+        try:
+            job.supervise(jd, notify=self.notify)
+        finally:
+            job.read_meta = real_read
+        meta = job.read_meta(jd)
+        self.assertTrue(meta.get("killed"))
+        self.assertEqual("killed", job.state_of(meta))
+
+    def test_completion_body_shape(self):
+        jd = start_job(self.tmp, ["sh", "-c", "exit 0"], label="suite")
+        job.supervise(jd, notify=self.notify)
+        body = job.completion_body(job.read_meta(jd))
+        self.assertIn("1-suite", body)
+        self.assertIn("done", body)
+        self.assertIn("exit=0", body)
+        self.assertIn("sc job status", body)
+
+
+class StateTest(unittest.TestCase):
+    def test_lost_when_supervisor_dead_and_unfinished(self):
+        meta = {"supervisor_pid": 2**22 + 1234567, "job_id": "1"}  # not a real pid
+        self.assertEqual("lost", job.state_of(meta))
+
+    def test_running_when_supervisor_alive(self):
+        import os
+        meta = {"supervisor_pid": os.getpid(), "job_id": "1"}
+        self.assertEqual("running", job.state_of(meta))
+
+    def test_next_job_id_monotonic(self):
+        tmp = Path(tempfile.mkdtemp())
+        old = job.JOBS
+        job.JOBS = tmp
+        try:
+            self.assertEqual("1", job.next_job_id(None))
+            (tmp / "1").mkdir()
+            (tmp / "2-bench").mkdir()
+            self.assertEqual("3-suite", job.next_job_id("suite"))
+        finally:
+            job.JOBS = old
+
+
+class WaitTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.old_jobs, self.old_poll = job.JOBS, job.POLL
+        job.JOBS, job.POLL = self.tmp, 0.05
+
+    def tearDown(self):
+        job.JOBS, job.POLL = self.old_jobs, self.old_poll
+
+    def _args(self, id, for_seconds=1):
+        import argparse
+        return argparse.Namespace(id=id, for_seconds=for_seconds)
+
+    def test_wait_finished_is_zero(self):
+        jd = start_job(self.tmp, ["sh", "-c", "exit 0"])
+        job.supervise(jd, notify=lambda m: True)
+        self.assertEqual(0, job.cmd_wait(self._args(jd.name)))
+
+    def test_wait_slice_expiry_is_two(self):
+        import os
+        jd = start_job(self.tmp, ["sh", "-c", "sleep 60"])
+        meta = job.read_meta(jd)
+        meta["supervisor_pid"] = os.getpid()   # "supervisor" alive = running
+        job.write_meta(jd, meta)
+        self.assertEqual(2, job.cmd_wait(self._args(jd.name, for_seconds=1)))
+
+    def test_wait_lost_is_one(self):
+        jd = start_job(self.tmp, ["sh", "-c", "exit 0"])
+        meta = job.read_meta(jd)
+        meta["supervisor_pid"] = 2**22 + 1234567
+        job.write_meta(jd, meta)
+        self.assertEqual(1, job.cmd_wait(self._args(jd.name)))
+
+
+class CompletionRowTest(unittest.TestCase):
+    """send_completion against the real API server: the result row lands in
+    the starting shell's own inbox, and the dedupe_key makes a resend a no-op."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp()
+        cls.db = str(Path(cls.tmpdir) / "shell_db.db")
+        build_db(cls.db)
+        server.DB_PATH = cls.db
+        cls.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        threading.Thread(target=cls.httpd.serve_forever, daemon=True).start()
+        job.SC_API_BASE = f"http://127.0.0.1:{cls.httpd.server_address[1]}"
+        job.SC_API_TOKEN = TOKEN
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+
+    def q(self, sql, *params):
+        con = sqlite3.connect(self.db)
+        try:
+            return con.execute(sql, params).fetchall()
+        finally:
+            con.close()
+
+    def test_completion_row_lands_and_dedupes(self):
+        meta = {"job_id": "9-suite", "label": "suite", "cmd": ["pytest"],
+                "started_at": "2026-07-14T10:00:00Z",
+                "finished_at": "2026-07-14T10:05:00Z",
+                "exit_code": 0, "log": "/tmp/x/log"}
+        self.assertTrue(job.send_completion(meta, retries=1, delay=0))
+        self.assertTrue(job.send_completion(meta, retries=1, delay=0))  # retry
+        rows = self.q(
+            "SELECT from_shell_id, to_shell_id, kind, body FROM shell_messages "
+            "WHERE dedupe_key='job-9-suite-completion'")
+        self.assertEqual(1, len(rows))          # deduped, not twinned
+        frm, to, kind, body = rows[0]
+        self.assertEqual((1, 1, "result"), (frm, to, kind))  # own inbox
+        self.assertIn("9-suite", body)
+        self.assertIn("done", body)
+
+    def test_no_api_env_gives_up_quietly(self):
+        old_base, old_tok = job.SC_API_BASE, job.SC_API_TOKEN
+        job.SC_API_BASE, job.SC_API_TOKEN = "", ""
+        try:
+            self.assertFalse(job.send_completion({"job_id": "x"}, retries=1, delay=0))
+        finally:
+            job.SC_API_BASE, job.SC_API_TOKEN = old_base, old_tok
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implementation of the `sc job` spec (#354, stacked on it). A detached supervisor runs the command as its own process group, survives the harness session, enforces `--timeout` group-kill, and posts one dedupe-keyed `result` row to the starting shell's own inbox — so the existing eventing loop covers local long jobs the way it covers PR transitions. `job wait` is the canonical bounded wait-slice (exit 0 done · 2 still running).

Test plan: `python3 tests/test_job.py` (14 — lifecycle, spawn-error, timeout group-kill, killed-flag race, wait exit codes, completion row + dedupe against the real API server) green; `tests/test_mem.py` (31) green. Live E2E on this instance: detached start survived the shell, `result` row landed in the inbox, `status`/`tail`/`list` verified, smoke artifacts removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)