### PR TITLE
feat(sc): watch-daemon-install + ./sc persist — reboot-proof the host-side daemons

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1724,6 +1724,24 @@ class Handler(BaseHTTPRequestHandler):
     # the whole board. The daemon never calls these — it owns the DB side
     # (last_seen, closed_at) directly.
 
+    def _daemon_state(self, con) -> "dict | None":
+        """Watcher-daemon liveness (#359): the heartbeat row → age + verdict.
+        Stale = beat older than 3× the daemon's own poll interval (one slow gh
+        call + the sleep fit comfortably inside). None = never run (or a
+        pre-0068 DB with no heartbeat table yet) — the client renders both
+        None and stale as "watches are NOT being polled"."""
+        try:
+            r = con.execute(
+                "SELECT beat_at, interval_s, CAST((julianday('now') - "
+                "julianday(beat_at)) * 86400 AS INTEGER) AS age_s "
+                "FROM daemon_heartbeats WHERE name='watch'").fetchone()
+        except Exception:
+            return None
+        if r is None:
+            return None
+        return {"beat_at": r["beat_at"], "interval_s": r["interval_s"],
+                "age_s": r["age_s"], "stale": r["age_s"] > 3 * r["interval_s"]}
+
     def _watches_get(self):
         sid = self._require_shell_auth()
         if sid is None:
@@ -1738,7 +1756,8 @@ class Handler(BaseHTTPRequestHandler):
             if not include_closed:
                 sql += " WHERE w.closed_at IS NULL"
             sql += " ORDER BY w.repo, w.pr_number, w.watch_id"
-            return self._send(200, {"watches": rows(con.execute(sql))})
+            return self._send(200, {"watches": rows(con.execute(sql)),
+                                    "daemon": self._daemon_state(con)})
         except Exception as e:
             return self._fail(e)
         finally:
@@ -1772,22 +1791,25 @@ class Handler(BaseHTTPRequestHandler):
                 "SELECT watch_id, closed_at FROM watched_prs "
                 "WHERE repo=? AND pr_number=? AND shell_id=?",
                 (repo, pr, target)).fetchone()
+            # daemon liveness rides every registration response (#359): a
+            # watch registered while nobody is polling must say so up front.
+            daemon = self._daemon_state(con)
             if existing is not None:
                 if existing["closed_at"] is None:
                     return self._send(200, {"watch_id": existing["watch_id"],
-                                            "existing": True})
+                                            "existing": True, "daemon": daemon})
                 con.execute(
                     "UPDATE watched_prs SET closed_at=NULL, last_seen=NULL, "
                     "created_at=datetime('now') WHERE watch_id=?",
                     (existing["watch_id"],))
                 con.commit()
                 return self._send(201, {"watch_id": existing["watch_id"],
-                                        "reopened": True})
+                                        "reopened": True, "daemon": daemon})
             cur = con.execute(
                 "INSERT INTO watched_prs (repo, pr_number, shell_id) VALUES (?, ?, ?)",
                 (repo, pr, target))
             con.commit()
-            return self._send(201, {"watch_id": cur.lastrowid})
+            return self._send(201, {"watch_id": cur.lastrowid, "daemon": daemon})
         except Exception as e:
             return self._fail(e)
         finally:

--- a/.super-coder/migrations/0068_watch_daemon_heartbeat.sql
+++ b/.super-coder/migrations/0068_watch_daemon_heartbeat.sql
@@ -1,0 +1,25 @@
+-- 0068 — daemon_heartbeats: watcher-daemon liveness the watch surface can see (#359).
+--
+-- The dos-arch incident: a host reboot killed the nohup'd watcher daemon while
+-- the docker sandbox auto-restarted — the fork looked healthy, `./sc watch
+-- list` kept reporting registered watches "live" (it reads only watched_prs),
+-- and two PRs went green with nobody polling. Nothing distinguished "no
+-- transition yet" from "nobody watching".
+--
+-- One row per daemon (name-keyed; only 'watch' today): the daemon UPSERTs
+-- beat_at + its poll interval once per cycle — even idle ones — and the
+-- /_sc/watches API turns the row into a live/stale/never verdict that
+-- `./sc watch list` and `./sc watch pr` print. Stale = age > 3× interval.
+--
+-- Convergent with the baseline schema.sql CREATE (0059/watched_prs precedent):
+-- IF NOT EXISTS carries an existing fork; a fresh build already has the table.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS daemon_heartbeats (
+    name        TEXT PRIMARY KEY,              -- 'watch' — one row per daemon
+    beat_at     TEXT    NOT NULL,              -- datetime('now') at last poll cycle
+    interval_s  INTEGER NOT NULL               -- the daemon's configured poll interval
+);
+
+COMMIT;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -303,6 +303,18 @@ CREATE TABLE watched_prs (
     UNIQUE (repo, pr_number, shell_id)
 );
 
+-- Daemon liveness (#359): the watcher daemon UPSERTs its row once per poll
+-- cycle; the /_sc/watches API turns beat age into a live/stale/never verdict
+-- so `./sc watch list` can't report watches "live" with nobody polling.
+-- See migrations/0068_watch_daemon_heartbeat.sql (convergent — carries an
+-- existing fork).
+
+CREATE TABLE daemon_heartbeats (
+    name        TEXT PRIMARY KEY,              -- 'watch' — one row per daemon
+    beat_at     TEXT    NOT NULL,              -- datetime('now') at last poll cycle
+    interval_s  INTEGER NOT NULL               -- the daemon's configured poll interval
+);
+
 -- ── Skills (system content — seeded from assets/, propagates) ────────────────
 
 CREATE TABLE skills (

--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -25,7 +25,10 @@ addressed to the watch's shell. Events: checks concluded (green or red),
 review submitted, merged, closed. On merge/close the final event is emitted
 and `closed_at` set — the watch retires itself. The daemon only ever writes
 message rows + its own registry state: it never boots shells, never marks
-anything read, never touches git.
+anything read, never touches git. Each cycle it also beats a heartbeat row
+(daemon_heartbeats) so `list`/`pr` can say whether anybody is actually
+polling (#359) — a dead daemon otherwise leaves watches reporting "live"
+with no eventing behind them.
 
 A `pr_event` body is one line — repo, PR, what changed, head SHA. Detail
 lives in `gh`; the message is the wake-up, not the payload.
@@ -100,6 +103,27 @@ def _api(method: str, path: str, payload: "dict | None" = None) -> dict:
         die(f"API unreachable ({SC_API_BASE}): {exc}")
 
 
+def _age_str(seconds: int) -> str:
+    if seconds < 90:
+        return f"{seconds}s"
+    if seconds < 5400:
+        return f"{seconds // 60}m"
+    return f"{seconds // 3600}h"
+
+
+def daemon_line(d: "dict | None") -> str:
+    """Render the /_sc/watches `daemon` block as the liveness line (#359):
+    a watch is only as live as its poller, and `list` saying "live" while the
+    daemon is dead was the lying half of the dos-arch incident."""
+    dead = "watches are NOT being polled (host: ./sc watch-daemon-up)"
+    if not d or not d.get("beat_at"):
+        return f"  daemon: never run — {dead}"
+    age = _age_str(int(d.get("age_s") or 0))
+    if d.get("stale"):
+        return f"  daemon: STALE — last poll {age} ago ({d['beat_at']}Z); {dead}"
+    return f"  daemon: live — last poll {age} ago (interval {d.get('interval_s')}s)"
+
+
 def cmd_pr(args) -> int:
     _require_api()
     repo = args.repo.strip().strip("/")
@@ -116,12 +140,16 @@ def cmd_pr(args) -> int:
         state = "re-armed" if r.get("reopened") else "registered"
         print(f"watch: {repo}#{args.number} {state} for {who} (watch #{r['watch_id']})")
         print("  (pr_event rows land in the shell's inbox as the daemon sees transitions)")
+    d = r.get("daemon")
+    if not d or not d.get("beat_at") or d.get("stale"):
+        print(daemon_line(d))
     return 0
 
 
 def cmd_list(args) -> int:
     _require_api()
     r = _api("GET", "/_sc/watches" + ("?all=1" if args.all else ""))
+    print(daemon_line(r.get("daemon")))
     ws = r.get("watches", [])
     if not ws:
         print("watch: no watches" if args.all else "watch: no live watches")
@@ -323,6 +351,17 @@ def poll_once(con, fetch=_gh_graphql) -> int:
     return emitted
 
 
+def beat(con, interval: int) -> None:
+    """Heartbeat (#359): one UPSERT per poll cycle — idle cycles included —
+    so the watch surface can tell "no transition yet" from "nobody watching"."""
+    con.execute(
+        "INSERT INTO daemon_heartbeats (name, beat_at, interval_s) "
+        "VALUES ('watch', datetime('now'), ?) "
+        "ON CONFLICT(name) DO UPDATE SET beat_at=excluded.beat_at, "
+        "interval_s=excluded.interval_s", (interval,))
+    con.commit()
+
+
 def cmd_daemon(args) -> int:
     if not DB_PATH.exists() or DB_PATH.stat().st_size == 0:
         die(f"no usable DB at {DB_PATH} — rebuild with ./sc rebuild")
@@ -331,6 +370,7 @@ def cmd_daemon(args) -> int:
     while True:
         con = db_driver.connect(DB_PATH)
         try:
+            beat(con, interval)
             n = poll_once(con)
             if n:
                 print(f"watch daemon: {n} pr_event(s) emitted", flush=True)

--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -370,7 +370,15 @@ def cmd_daemon(args) -> int:
     while True:
         con = db_driver.connect(DB_PATH)
         try:
-            beat(con, interval)
+            # The beat must never block the poll: on a pre-0068 DB (code newer
+            # than schema — a dev tree between migrate runs) the table is
+            # missing, and a beat raising into the poll's except would turn a
+            # working daemon into a dead-with-noise one. Liveness degrades to
+            # "never run"; eventing keeps flowing.
+            try:
+                beat(con, interval)
+            except Exception as e:
+                print(f"watch daemon: heartbeat error ({e})", flush=True)
             n = poll_once(con)
             if n:
                 print(f"watch daemon: {n} pr_event(s) emitted", flush=True)

--- a/sc
+++ b/sc
@@ -753,7 +753,14 @@ print('-> pg: added to $f')
 WATCH_DAEMON_PID="$ENGINE/run/watch-daemon.pid"
 
 sc_watch_daemon_alive() {
-  [ -f "$WATCH_DAEMON_PID" ] && kill -0 "$(cat "$WATCH_DAEMON_PID" 2>/dev/null)" 2>/dev/null
+  # pid exists AND is actually the daemon — a stale pidfile surviving a host
+  # reboot can point at a reused pid, and a bare kill -0 would false-skip the
+  # relaunch (#359: reboot killed the daemon; the sandbox auto-restarted, so
+  # nothing else looked wrong).
+  [ -f "$WATCH_DAEMON_PID" ] || return 1
+  pid="$(cat "$WATCH_DAEMON_PID" 2>/dev/null)"
+  [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null || return 1
+  ps -p "$pid" -o args= 2>/dev/null | grep -q "watch\.py daemon"
 }
 sc_watch_daemon_up() {
   if ! command -v gh >/dev/null 2>&1; then

--- a/sc
+++ b/sc
@@ -750,8 +750,15 @@ print('-> pg: added to $f')
 # gh login — with the same supervision: `launch` brings it up, `down` stops it.
 # No socket, so aliveness is the pidfile, not a health curl. Self-skips when gh
 # is absent (the fork degrades to task-boundary inbox checks, never breaks).
+# `watch-daemon-install` writes a systemd --user unit for reboot-survival
+# (#359: a host reboot killed the nohup'd daemon while the sandbox
+# auto-restarted); `up`/`down` defer to systemd when the unit is active.
 WATCH_DAEMON_PID="$ENGINE/run/watch-daemon.pid"
+WATCH_DAEMON_UNIT="sc-watch-daemon-$(basename "$here").service"
 
+sc_watch_daemon_unit_active() {
+  command -v systemctl >/dev/null 2>&1 && systemctl --user is-active --quiet "$WATCH_DAEMON_UNIT" 2>/dev/null
+}
 sc_watch_daemon_alive() {
   # pid exists AND is actually the daemon — a stale pidfile surviving a host
   # reboot can point at a reused pid, and a bare kill -0 would false-skip the
@@ -766,6 +773,9 @@ sc_watch_daemon_up() {
   if ! command -v gh >/dev/null 2>&1; then
     echo "→ watch-daemon: gh CLI not found on the host — PR eventing disabled (install gh + login to enable)"; return 0
   fi
+  if sc_watch_daemon_unit_active; then
+    echo "→ watch-daemon systemd-managed ($WATCH_DAEMON_UNIT) — already running"; return 0
+  fi
   if sc_watch_daemon_alive; then
     echo "→ watch-daemon already running (pid $(cat "$WATCH_DAEMON_PID"))"; return 0
   fi
@@ -777,10 +787,68 @@ sc_watch_daemon_up() {
 sc_watch_daemon_down() {
   if sc_watch_daemon_alive; then
     kill "$(cat "$WATCH_DAEMON_PID")" && echo "→ watch-daemon stopped"
+  elif sc_watch_daemon_unit_active; then
+    echo "→ watch-daemon is systemd-managed ($WATCH_DAEMON_UNIT) — leaving it; use watch-daemon-uninstall"
   else
     echo "→ watch-daemon not running"
   fi
   rm -f "$WATCH_DAEMON_PID"
+}
+sc_watch_daemon_install() {
+  command -v systemctl >/dev/null 2>&1 || { echo "✗ watch-daemon-install: systemd (systemctl) not found on this host" >&2; return 1; }
+  command -v gh >/dev/null 2>&1 || { echo "✗ watch-daemon-install: gh CLI not found — nothing to poll GitHub with (install gh + login first)" >&2; return 1; }
+  unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+  mkdir -p "$unit_dir"
+  cat > "$unit_dir/$WATCH_DAEMON_UNIT" <<UNIT
+[Unit]
+Description=super-coder watch-daemon ($(basename "$here")) — GitHub PR watcher (sprint eventing)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=$PY $S/watch.py daemon
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+UNIT
+  systemctl --user daemon-reload
+  loginctl enable-linger "$(id -un)" >/dev/null 2>&1 || true
+  # A pidfile-managed daemon would double-poll and double-emit pr_events;
+  # stop it so systemd owns the one poller.
+  sc_watch_daemon_down >/dev/null 2>&1 || true
+  systemctl --user enable --now "$WATCH_DAEMON_UNIT"
+  echo "→ watch-daemon installed as systemd --user unit: $WATCH_DAEMON_UNIT (enabled, started, linger on)"
+  echo "  status: systemctl --user status $WATCH_DAEMON_UNIT   ·   logs: journalctl --user -u $WATCH_DAEMON_UNIT"
+}
+sc_watch_daemon_uninstall() {
+  command -v systemctl >/dev/null 2>&1 || { echo "✗ watch-daemon-uninstall: systemd not found" >&2; return 1; }
+  systemctl --user disable --now "$WATCH_DAEMON_UNIT" 2>/dev/null || true
+  rm -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/$WATCH_DAEMON_UNIT"
+  systemctl --user daemon-reload
+  echo "→ watch-daemon systemd unit removed ($WATCH_DAEMON_UNIT)"
+}
+
+# ── persist: reboot-proof every applicable host-side daemon in one verb ───────
+# The #359 incident shape: a host reboot kills the nohup'd daemons while the
+# docker sandbox resurrects itself — the fork looks healthy with nobody
+# polling. One idempotent verb installs the systemd --user unit for each
+# daemon that applies to this fork (skips the rest with a reason); linger is
+# enabled by the installs, so units start at boot with no login.
+sc_persist() {
+  command -v systemctl >/dev/null 2>&1 || {
+    echo "✗ persist: systemd (systemctl) not found — nohup + \`./sc launch\` is the only supervision on this host" >&2; return 1; }
+  if command -v gh >/dev/null 2>&1; then
+    sc_watch_daemon_install
+  else
+    echo "→ persist: gh CLI not found — watch-daemon skipped (PR eventing disabled)"
+  fi
+  if "$PY" "$S/vm.py" configured;  then sc_vm_broker_install;  else echo "→ persist: no VM linked — vm-broker skipped"; fi
+  if "$PY" "$S/ts.py" configured;  then sc_ts_broker_install;  else echo "→ persist: no tailnet linked — ts-broker skipped"; fi
+  if "$PY" "$S/pm2.py" configured; then sc_pm2_broker_install; else echo "→ persist: no pm2 stack linked — pm2-broker skipped"; fi
+  if "$PY" "$S/dbq.py" configured; then sc_db_broker_install;  else echo "→ persist: no live DB linked — db-broker skipped"; fi
+  echo "→ persist: done — units survive reboot + logout; remove per daemon with ./sc <name>-uninstall"
 }
 
 
@@ -831,6 +899,10 @@ case "$cmd" in
   watch)             exec "$PY" "$S/watch.py" "$@" ;;
   watch-daemon-up)   sc_watch_daemon_up ;;
   watch-daemon-down) sc_watch_daemon_down ;;
+  watch-daemon-install)   sc_watch_daemon_install ;;
+  watch-daemon-uninstall) sc_watch_daemon_uninstall ;;
+  # ── persist (HOST-side): reboot-proof all applicable daemons via systemd ──
+  persist)           sc_persist ;;
   # ── session-surviving local jobs: detached supervised one-shots whose
   # completion posts a result row to the starting shell's inbox ──
   job)               exec "$PY" "$S/job.py" "$@" ;;
@@ -1181,6 +1253,14 @@ super-coder — forkable shell substrate
   ./sc watch daemon        run the daemon in the foreground (--once = single cycle)
   ./sc watch-daemon-up     start it in the background (nohup + pidfile); self-skips if gh missing/already up
   ./sc watch-daemon-down   stop the backgrounded daemon
+  ./sc watch-daemon-install   supervise via a systemd --user unit (survives logout/reboot)
+  ./sc watch-daemon-uninstall remove the systemd unit
+
+  Persist (HOST-side — reboot-proof the fork in one verb; #359): installs the
+  systemd --user unit for every daemon that applies here (watch-daemon when gh
+  is present; vm/ts/pm2/db brokers when linked), enables linger, skips the
+  rest with a reason. Idempotent — re-run any time:
+  ./sc persist             install + enable --now every applicable unit
 
   Postgres sidecar (app-only; docker container on SC_NET, data in a named volume).
   For developing/testing the fork's APP against real Postgres in the sandbox — the

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -274,6 +274,65 @@ class PollOnceTest(unittest.TestCase):
         self.assertIn("pullRequest(number: 22)", q)
 
 
+# ── daemon heartbeat (#359): beat upsert + liveness rendering ────────────────
+
+class HeartbeatTest(unittest.TestCase):
+    def setUp(self):
+        self.con = build_db()
+
+    def tearDown(self):
+        self.con.close()
+
+    def beat_rows(self):
+        return self.con.execute(
+            "SELECT name, beat_at, interval_s FROM daemon_heartbeats").fetchall()
+
+    def test_beat_inserts_then_updates_one_row(self):
+        watch.beat(self.con, 75)
+        rows = self.beat_rows()
+        self.assertEqual([(r["name"], r["interval_s"]) for r in rows], [("watch", 75)])
+        watch.beat(self.con, 30)   # re-beat upserts — never a second row
+        rows = self.beat_rows()
+        self.assertEqual([(r["name"], r["interval_s"]) for r in rows], [("watch", 30)])
+
+    def test_daemon_once_beats_even_with_no_watches(self):
+        tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
+        build_db(tmp).close()
+        old = watch.DB_PATH
+        watch.DB_PATH = tmp
+        try:
+            self.assertEqual(watch.main(["daemon", "--once"]), 0)
+        finally:
+            watch.DB_PATH = old
+        con = sqlite3.connect(tmp)
+        try:
+            self.assertEqual(con.execute(
+                "SELECT COUNT(*) FROM daemon_heartbeats WHERE name='watch'"
+            ).fetchone()[0], 1)
+        finally:
+            con.close()
+
+
+class DaemonLineTest(unittest.TestCase):
+    def test_never_run(self):
+        self.assertIn("never run", watch.daemon_line(None))
+        self.assertIn("NOT being polled", watch.daemon_line(None))
+
+    def test_live(self):
+        line = watch.daemon_line(
+            {"beat_at": "2026-07-15 09:00:00", "interval_s": 75, "age_s": 14, "stale": False})
+        self.assertIn("live", line)
+        self.assertIn("14s ago", line)
+        self.assertNotIn("NOT being polled", line)
+
+    def test_stale(self):
+        line = watch.daemon_line(
+            {"beat_at": "2026-07-14 20:22:19", "interval_s": 75, "age_s": 14520, "stale": True})
+        self.assertIn("STALE", line)
+        self.assertIn("4h ago", line)
+        self.assertIn("NOT being polled", line)
+
+
 # ── API: /_sc/watches + message kinds, over the real server ─────────────────
 
 class ApiTest(unittest.TestCase):
@@ -428,6 +487,73 @@ class HeadlessTest(unittest.TestCase):
         cmd = run.headless_command(self.adapter("claude"), "trailing prompt", "opus",
                                    ["--dangerously-skip-permissions"])
         self.assertEqual(cmd[-1], "trailing prompt")
+
+
+# ── API: daemon liveness on /_sc/watches (#359) ──────────────────────────────
+# Own DB + server so heartbeat state can't leak into ApiTest. Method names are
+# alphabetically ordered on purpose — the class DB is shared and the sequence
+# never → live → stale → dropped-table walks one heartbeat row through its
+# states.
+
+class DaemonLivenessApiTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = Path(tempfile.mkdtemp())
+        cls.db = cls.tmp / "shell_db.db"
+        con = build_db(cls.db)
+        seed_shells(con)
+        con.close()
+        server.DB_PATH = cls.db
+        cls.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        cls.port = cls.httpd.server_address[1]
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+        watch.SC_API_BASE = f"http://127.0.0.1:{cls.port}"
+        watch.SC_API_TOKEN = TOKEN
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+
+    def x(self, sql, *params):
+        con = sqlite3.connect(self.db)
+        try:
+            con.execute(sql, params)
+            con.commit()
+        finally:
+            con.close()
+
+    def test_a_no_heartbeat_reports_never_run(self):
+        r = watch._api("GET", "/_sc/watches")
+        self.assertIsNone(r["daemon"])
+
+    def test_b_fresh_beat_reports_live(self):
+        self.x("INSERT INTO daemon_heartbeats (name, beat_at, interval_s) "
+               "VALUES ('watch', datetime('now'), 75)")
+        d = watch._api("GET", "/_sc/watches")["daemon"]
+        self.assertFalse(d["stale"])
+        self.assertEqual(d["interval_s"], 75)
+        self.assertLessEqual(d["age_s"], 5)
+
+    def test_c_old_beat_reports_stale(self):
+        self.x("UPDATE daemon_heartbeats SET beat_at=datetime('now', '-1 hour') "
+               "WHERE name='watch'")
+        d = watch._api("GET", "/_sc/watches")["daemon"]
+        self.assertTrue(d["stale"])
+        self.assertGreaterEqual(d["age_s"], 3600)
+
+    def test_d_registration_response_carries_daemon(self):
+        r = watch._api("POST", "/_sc/watches", {"repo": "own/repo", "pr_number": 44})
+        self.assertTrue(r["daemon"]["stale"])   # still the -1h beat from test_c
+        r = watch._api("POST", "/_sc/watches", {"repo": "own/repo", "pr_number": 44})
+        self.assertTrue(r.get("existing"))      # idempotent path carries it too
+        self.assertTrue(r["daemon"]["stale"])
+
+    def test_e_pre_migration_db_degrades_to_never_run(self):
+        self.x("DROP TABLE daemon_heartbeats")
+        r = watch._api("GET", "/_sc/watches")
+        self.assertIsNone(r["daemon"])
 
 
 if __name__ == "__main__":

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -312,6 +312,27 @@ class HeartbeatTest(unittest.TestCase):
         finally:
             con.close()
 
+    def test_beat_failure_never_blocks_the_poll(self):
+        # Pre-0068 DB (code newer than schema): the beat raises, the poll must
+        # still run — heartbeat error, not poll error, and never a crash.
+        import contextlib
+        import io
+        tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
+        con = build_db(tmp)
+        con.execute("DROP TABLE daemon_heartbeats")
+        con.commit()
+        con.close()
+        old = watch.DB_PATH
+        watch.DB_PATH = tmp
+        out = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(out):
+                self.assertEqual(watch.main(["daemon", "--once"]), 0)
+        finally:
+            watch.DB_PATH = old
+        self.assertIn("heartbeat error", out.getvalue())
+        self.assertNotIn("poll error", out.getvalue())
+
 
 class DaemonLineTest(unittest.TestCase):
     def test_never_run(self):


### PR DESCRIPTION
Stacked on #360 (retarget to main before merging this one).

The reboot-supervision half of #359 (flag CC-142): the engine already had the mechanism — per-fork systemd `--user` units with linger, which is exactly why the vm-broker survived the 07-14 reboot — but the watch-daemon was the only host-side long-runner without an install verb. This adds `./sc watch-daemon-install`/`-uninstall` as a straight clone of the vm/ts/pm2/db pattern, makes `watch-daemon-up`/`-down` defer to systemd when the unit is active, and adds **`./sc persist`** — one idempotent verb that installs every unit applicable to the fork (watch-daemon when gh is present; vm/ts/pm2/db brokers when linked) and skips the rest with a reason.

Non-systemd hosts fail gracefully (same as the existing broker installs); the nohup+pidfile path stays as the fallback.

**Verified live** on super-coder's own engine: `./sc persist` installed + started the unit (brokers correctly skipped as unlinked), journald shows clean polling, heartbeat row lands, `up`/`down` correctly defer to systemd. The smoke also caught a pre-0068-DB regression in the heartbeat commit (beat raising into the poll's except killed eventing) — fixed on #360 with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)