### PR TITLE
fix(watch): retain the watch when a PR merges with checks still pending

### DIFF
--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -22,10 +22,14 @@ row is folded into ONE batched GraphQL query per poll (~1% of an authenticated
 rate limit at 60–90s), each PR is diffed against its stored `last_seen`
 fingerprint, and every transition becomes a `pr_event` row in shell_messages
 addressed to the watch's shell. Events: checks concluded (green or red),
-review submitted, merged, closed. On merge/close the final event is emitted
-and `closed_at` set — the watch retires itself. The daemon only ever writes
-message rows + its own registry state: it never boots shells, never marks
-anything read, never touches git. Each cycle it also beats a heartbeat row
+review submitted, merged, closed. On close — and on merge with no checks
+still running — the final event is emitted and `closed_at` set: the watch
+retires itself. A merge with checks still PENDING retains the watch (#375):
+the merge event is emitted immediately, the watch stays live until the
+rollup concludes, then the green/red event retires it — an early merge must
+not swallow the terminal CI verdict the planner is waiting on. The daemon
+only ever writes message rows + its own registry state: it never boots
+shells, never marks anything read, never touches git. Each cycle it also beats a heartbeat row
 (daemon_heartbeats) so `list`/`pr` can say whether anybody is actually
 polling (#359) — a dead daemon otherwise leaves watches reporting "live"
 with no eventing behind them.
@@ -260,24 +264,40 @@ def diff_events(prev: "dict | None", cur: dict, repo: str, number: int) -> "tupl
 
     A head-SHA change resets the checks comparison implicitly: the fingerprint
     compares (sha, checks) together, so a new push going green is a fresh
-    transition even if the old head was green too."""
+    transition even if the old head was green too.
+
+    Merge is terminal ONLY once no checks are still running (#375): a PR
+    merged while its rollup is PENDING keeps its watch — the merge event
+    fires now, the checks conclusion fires (and retires the watch) when the
+    already-running workflows finish. Retiring at merge dropped that verdict
+    on the floor and silently stalled the planner's sprint gate. Close
+    without merge retires immediately regardless — its pending checks get
+    cancelled, no conclusion is coming."""
     events: list[str] = []
     sha7 = (cur.get("sha") or "")[:7]
     tag = f"{repo}#{number}"
 
+    merged = cur.get("state") == "MERGED"
     checks = cur.get("checks")
+    checks_pending = checks is not None and checks not in CONCLUDED  # PENDING/EXPECTED
+    terminal = cur.get("state") == "CLOSED" or (merged and not checks_pending)
+
     checks_changed = prev is None or (prev.get("checks"), prev.get("sha")) != (checks, cur.get("sha"))
     if checks in CONCLUDED and checks_changed:
         word = "green" if checks == "SUCCESS" else "red"
-        events.append(f"pr_event {tag}: checks {word} ({checks}) @ {sha7}")
+        # On a retained post-merge watch this conclusion is the retiring event.
+        tail = " — watch retired" if merged and prev is not None and prev.get("state") == "MERGED" else ""
+        events.append(f"pr_event {tag}: checks {word} ({checks}) @ {sha7}{tail}")
 
     if prev is not None and (cur.get("reviews") or 0) > (prev.get("reviews") or 0):
         state = cur.get("review_state") or "REVIEW"
         events.append(f"pr_event {tag}: review submitted ({state}) @ {sha7}")
 
-    terminal = cur.get("state") in ("MERGED", "CLOSED")
-    if cur.get("state") == "MERGED" and (prev is None or prev.get("state") != "MERGED"):
-        events.append(f"pr_event {tag}: merged @ {sha7} — watch retired")
+    if merged and (prev is None or prev.get("state") != "MERGED"):
+        if checks_pending:
+            events.append(f"pr_event {tag}: merged @ {sha7} — checks still pending, watch retained")
+        else:
+            events.append(f"pr_event {tag}: merged @ {sha7} — watch retired")
     elif cur.get("state") == "CLOSED" and (prev is None or prev.get("state") != "CLOSED"):
         events.append(f"pr_event {tag}: closed without merge — watch retired")
     return events, terminal

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -173,6 +173,54 @@ class DiffEventsTest(unittest.TestCase):
         self.assertTrue(terminal)
         self.assertTrue(any("merged" in e for e in events))
 
+    # ── merge with checks still running (#375) ──────────────────────────────
+
+    def test_merged_with_pending_checks_retains_the_watch(self):
+        events, terminal = self.diff(snap(checks="PENDING"),
+                                     snap(state="MERGED", checks="PENDING"))
+        self.assertFalse(terminal)
+        self.assertEqual(len(events), 1)
+        self.assertIn("merged", events[0])
+        self.assertIn("watch retained", events[0])
+        self.assertNotIn("watch retired", events[0])
+
+    def test_baseline_merged_with_pending_checks_wakes_and_retains(self):
+        events, terminal = self.diff(None, snap(state="MERGED", checks="PENDING"))
+        self.assertFalse(terminal)
+        self.assertTrue(any("watch retained" in e for e in events))
+
+    def test_retained_watch_is_silent_until_checks_conclude(self):
+        events, terminal = self.diff(snap(state="MERGED", checks="PENDING"),
+                                     snap(state="MERGED", checks="PENDING"))
+        self.assertEqual(events, [])
+        self.assertFalse(terminal)
+
+    def test_post_merge_green_emits_and_retires(self):
+        events, terminal = self.diff(snap(state="MERGED", checks="PENDING"),
+                                     snap(state="MERGED", checks="SUCCESS"))
+        self.assertTrue(terminal)
+        self.assertEqual(len(events), 1)          # no duplicate merged event
+        self.assertIn("checks green", events[0])
+        self.assertIn("watch retired", events[0])
+
+    def test_post_merge_red_emits_and_retires(self):
+        events, terminal = self.diff(snap(state="MERGED", checks="PENDING"),
+                                     snap(state="MERGED", checks="FAILURE"))
+        self.assertTrue(terminal)
+        self.assertIn("checks red", events[0])
+        self.assertIn("watch retired", events[0])
+
+    def test_merged_with_no_checks_retires_immediately(self):
+        events, terminal = self.diff(snap(), snap(state="MERGED", checks=None))
+        self.assertTrue(terminal)
+        self.assertTrue(any("watch retired" in e for e in events))
+
+    def test_closed_with_pending_checks_retires_immediately(self):
+        events, terminal = self.diff(snap(checks="PENDING"),
+                                     snap(state="CLOSED", checks="PENDING"))
+        self.assertTrue(terminal)
+        self.assertIn("closed without merge", events[0])
+
     def test_event_bodies_are_one_line_with_repo_pr_sha(self):
         events, _ = self.diff(snap(checks="PENDING"), snap(checks="SUCCESS"))
         self.assertNotIn("\n", events[0])
@@ -247,6 +295,32 @@ class PollOnceTest(unittest.TestCase):
         n = watch.poll_once(self.con, lambda q: (self.assertNotIn("number: 2", q)
                                                  or {"r0": {"pullRequest": self.gh_node(checks="PENDING")}}))
         self.assertEqual(n, 0)
+
+    def test_early_merge_keeps_watch_until_checks_conclude(self):
+        # The #375 incident, end to end: merge lands while checks are PENDING
+        # → merge event now, watch stays live, conclusion event + retirement
+        # when the already-running workflows finish.
+        watch.poll_once(self.con, self.fetch_returning(
+            self.gh_node(checks="PENDING"), self.gh_node(checks="PENDING")))
+        n = watch.poll_once(self.con, self.fetch_returning(
+            self.gh_node(checks="PENDING"),
+            self.gh_node(state="MERGED", checks="PENDING")))
+        self.assertEqual(n, 1)                    # merge event only, PR 2's single subscriber
+        live = self.con.execute(
+            "SELECT pr_number FROM watched_prs WHERE closed_at IS NULL").fetchall()
+        self.assertEqual({r["pr_number"] for r in live}, {1, 2})  # PR 2 retained
+        n = watch.poll_once(self.con, self.fetch_returning(
+            self.gh_node(checks="PENDING"),
+            self.gh_node(state="MERGED", checks="SUCCESS")))
+        self.assertEqual(n, 1)                    # the deferred conclusion
+        bodies = [m["body"] for m in self.messages() if "#2" in m["body"]]
+        self.assertEqual(len(bodies), 2)          # merge + conclusion, nothing else
+        self.assertIn("checks still pending, watch retained", bodies[0])
+        self.assertIn("checks green", bodies[1])
+        self.assertIn("watch retired", bodies[1])
+        live = self.con.execute(
+            "SELECT pr_number FROM watched_prs WHERE closed_at IS NULL").fetchall()
+        self.assertEqual({r["pr_number"] for r in live}, {1})     # now retired
 
     def test_failed_fetch_changes_nothing(self):
         n = watch.poll_once(self.con, lambda q: None)


### PR DESCRIPTION
Fixes #375 — the dos-arch incident where PR #900 merged at 22:45 with its full-suite lanes still running; the watcher retired the watch at 22:46 (stored fingerprint literally `checks: PENDING`), and the 23:03 green was never delivered. The planner's sprint gate stalled silently.

**Change:** merge is terminal only once no observed checks are running. A merge with a PENDING/EXPECTED rollup emits `merged @ sha — checks still pending, watch retained`, keeps the watch live, and the eventual conclusion emits `checks green/red — watch retired`. No-checks merges and closes-without-merge retire immediately, exactly as before. GraphQL-side this is free: `statusCheckRollup` stays queryable on a merged PR's head commit, and the retained watch is just one more node in the existing batched query.

**Event budget unchanged:** transitions only, no polling messages — one extra `pr_event` row per early-merged PR, which is precisely the verdict the planner was missing. This matters more post dos-arch #900 (full suite on PRs only): the PR-lane run is now the *sole* automated verdict for merged code, so the retained watch is the only path that delivers it.

**Known edge (deliberate):** if a pending check is cancelled and its rollup never concludes, the watch stays live indefinitely — visible in `watch list`, harmless to the poll budget. No timeout cap invented; flag if you want one.

**Docs note:** spec #14 (`specs_sc/sprint-eventing.md`, frozen 2026-07-13) states the old rule — "On merge/close: emit the final event, set closed_at." Spec is frozen so this PR doesn't touch it; say the word if you want a spec amendment or a feature-doc note as follow-up.

## Test plan
- [x] 7 new `diff_events` cases: merge+pending retains, baseline merged+pending wakes+retains, retained watch silent until conclusion, post-merge green/red retire, no-checks merge retires, close+pending retires
- [x] End-to-end `poll_once` cycle reproducing the #900 timeline: baseline → merge-while-pending (watch live, merge event) → conclusion (event + retirement), exactly 2 rows
- [x] Full test suite: 33 files, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)