### PR TITLE
fix(messaging): resolve 'cartographer' as a role alias (reseed 0069)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1500,6 +1500,20 @@ class Handler(BaseHTTPRequestHandler):
                     r = con.execute(
                         "SELECT shell_id FROM shells WHERE LOWER(shortname)=LOWER(?) "
                         "AND COALESCE(is_deleted,0)=0", (body["to"],)).fetchone()
+                    if r is None and body["to"].strip().lower() == "cartographer":
+                        # Role alias (#369–#372): boot docs and skills address the
+                        # map-keeper by role, but forks mint shortnames like CART1
+                        # — five seats across two forks followed the docs into a
+                        # 404. An exact shortname always wins (checked above); the
+                        # flavor's singleton trigger guarantees at most one row.
+                        r = con.execute(
+                            "SELECT shell_id FROM shells WHERE flavor='cartographer' "
+                            "AND COALESCE(is_deleted,0)=0").fetchone()
+                        if r is None:
+                            return self._send(404, {"error": (
+                                "no cartographer shell in this fork — create one "
+                                "(flavor 'cartographer'), or address a shortname "
+                                "from `sc mem get shells`")})
                     if r is None:
                         return self._send(404, {"error": f"recipient shortname '{body['to']}' unknown"})
                     to_sid = r[0]

--- a/.super-coder/assets/skills/cartographer/SKILL.md
+++ b/.super-coder/assets/skills/cartographer/SKILL.md
@@ -230,7 +230,8 @@ act on as cartographer.
 **Notice contract** (one source of truth — the relay skills point here).
 Sender = the **dev/coder** shell on merge (feature landed, doc written); NOT
 the planner — specs render into a known area and need no curation. Sent via
-the `messaging` skill to shortname `cartographer`:
+the `messaging` skill to `cartographer` — a role alias the API resolves to
+this fork's cartographer shell whatever its actual shortname:
 
 ```
 --message send cartographer "shape: <what landed> — paths: <region/>; <ref>. curate."

--- a/.super-coder/assets/skills/messaging/SKILL.md
+++ b/.super-coder/assets/skills/messaging/SKILL.md
@@ -50,6 +50,10 @@ sc mem message send <to-shortname> "<body>" [--kind shell|task|result]
 - Multi-word body = one quoted argument; markdown preserved verbatim.
 - Examples: `sc mem message send cartographer "map is stale — re-run sc map"`
   · `sc mem message send plan1 "sprint 12: unit 3 merged (PR #41)" --kind result`
+- `cartographer` is a **role alias**: when no shell has that literal
+  shortname, it resolves to the fork's cartographer shell whatever its
+  shortname (e.g. `CART1`). Address the map-keeper as `cartographer` — no
+  shortname lookup needed. An exact shortname match always wins.
 - Unknown / deleted recipient -> `mem: recipient shortname '<x>' unknown`;
   empty body -> `mem: body is empty`. Surface either to the operator plainly.
 - Sends are idempotent under load: each invocation carries a dedupe key, so

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -789,7 +789,8 @@ act on as cartographer.
 **Notice contract** (one source of truth — the relay skills point here).
 Sender = the **dev/coder** shell on merge (feature landed, doc written); NOT
 the planner — specs render into a known area and need no curation. Sent via
-the `messaging` skill to shortname `cartographer`:
+the `messaging` skill to `cartographer` — a role alias the API resolves to
+this fork''s cartographer shell whatever its actual shortname:
 
 ```
 --message send cartographer "shape: <what landed> — paths: <region/>; <ref>. curate."
@@ -2262,6 +2263,10 @@ sc mem message send <to-shortname> "<body>" [--kind shell|task|result]
 - Multi-word body = one quoted argument; markdown preserved verbatim.
 - Examples: `sc mem message send cartographer "map is stale — re-run sc map"`
   · `sc mem message send plan1 "sprint 12: unit 3 merged (PR #41)" --kind result`
+- `cartographer` is a **role alias**: when no shell has that literal
+  shortname, it resolves to the fork''s cartographer shell whatever its
+  shortname (e.g. `CART1`). Address the map-keeper as `cartographer` — no
+  shortname lookup needed. An exact shortname match always wins.
 - Unknown / deleted recipient -> `mem: recipient shortname ''<x>'' unknown`;
   empty body -> `mem: body is empty`. Surface either to the operator plainly.
 - Sends are idempotent under load: each invocation carries a dedupe key, so

--- a/.super-coder/migrations/0069_reseed_cartographer_alias.sql
+++ b/.super-coder/migrations/0069_reseed_cartographer_alias.sql
@@ -1,18 +1,26 @@
----
-rendered_by: super-coder
-source: db
-edit: changes here are overwritten — author via the shell or localhost GUI
----
+-- 0069 — reseed: cartographer role alias (#369–#372).
+--
+-- Five seats across two forks (kcsos ×4, dos-arch #367) followed the
+-- documented map-gap notice — `--message send cartographer "…"` — into
+-- HTTP 404: the docs address the map-keeper by ROLE, but forks mint
+-- shortnames like CART1. The API now resolves `cartographer` as a role
+-- alias (exact shortname wins; the flavor singleton guarantees one row).
+-- These two skills teach the alias: messaging documents the resolution
+-- rule; the cartographer notice contract names it.
+--
+-- Source assets updated in the same commit; this trailing forward reseed
+-- (UPSERT by name; skill_id + grants preserved) carries them to installed
+-- forks and fresh builds alike.
 
-# cartographer
+BEGIN;
 
-Own the repo map — configure mapping to THIS repo, wire the auto-remap git hooks, heal both on drift. Cartographer-only; no working shell maps. Run on first boot + whenever the map looks wrong.
-
-**Category:** substrate  ·  **Command:** `sc map-setup`
-
----
-
-# cartographer — own the repo map so no other shell has to
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'cartographer',
+  'Own the repo map — configure mapping to THIS repo, wire the auto-remap git hooks, heal both on drift. Cartographer-only; no working shell maps. Run on first boot + whenever the map looks wrong.',
+  'substrate',
+  'sc map-setup',
+  0,
+  '# cartographer — own the repo map so no other shell has to
 
 Working shells consume the `dr_*` catalogue (`surface_catalogue`) and never
 map. You alone do three things: **configure** how this repo is mapped, **wire**
@@ -36,7 +44,7 @@ and reload on a fresh map db.
   leaves an empty map.
 - **Hourly cron** — pm2 runs `sc-map-<repo>` on `cron_restart`
   (`.super-coder/ecosystem.config.cjs`) while the stack is up (`sc up`);
-  catches uncommitted local restructuring the git hooks can't see. Verify:
+  catches uncommitted local restructuring the git hooks can''t see. Verify:
   `pm2 list | grep sc-map` — state cycling stopped→online per tick = the
   one-shot pattern, not a crash. A fork without pm2 has no cron; the hooks
   still cover it, and manual `sc map` always works.
@@ -86,7 +94,7 @@ and reload on a fresh map db.
    SELECT file_count, mapped_at FROM dr_repo;   -- non-zero, just now
    ```
    Spot-check overrides took:
-   `SELECT path, role FROM dr_filepath WHERE path LIKE 'cmd/%';`
+   `SELECT path, role FROM dr_filepath WHERE path LIKE ''cmd/%'';`
 
 5. **Describe all NULLs** — run the description worklist (Standing jobs § 2);
    leave only when it returns zero rows.
@@ -127,25 +135,25 @@ one-line `description`.
 ```sql
 -- the current index + live file counts:
 SELECT s.name, s.path_prefix, s.description,
-       (SELECT COUNT(*) FROM dr_filepath f WHERE f.path LIKE s.path_prefix || '%') n
+       (SELECT COUNT(*) FROM dr_filepath f WHERE f.path LIKE s.path_prefix || ''%'') n
 FROM dr_section s ORDER BY s.sort_order, s.name;
 
 -- split / rename / describe (authored — survives the remap, snapshotted):
-UPDATE dr_section SET name='API', path_prefix='shell_core/api/', description='FastAPI routers' WHERE name='shell_core';
+UPDATE dr_section SET name=''API'', path_prefix=''shell_core/api/'', description=''FastAPI routers'' WHERE name=''shell_core'';
 INSERT INTO dr_section (name, path_prefix, description, sort_order)
-VALUES ('UI', 'shell_core/ui/', 'SvelteKit substrate UI', 5);
+VALUES (''UI'', ''shell_core/ui/'', ''SvelteKit substrate UI'', 5);
 
 -- WORKLIST — keep the catch-all empty. Files under no section = a new area to
 -- section (they render under "other / unsectioned" in CONNECTIONS until you do):
 SELECT path FROM dr_filepath f WHERE NOT EXISTS
-  (SELECT 1 FROM dr_section s WHERE f.path LIKE s.path_prefix || '%')
+  (SELECT 1 FROM dr_section s WHERE f.path LIKE s.path_prefix || ''%'')
 ORDER BY path;
 
 -- STALE SECTIONS (run after any migration or restructure — dr_filepath pruning
 -- is automatic; dr_section is authored and never auto-pruned):
 SELECT s.name, s.path_prefix, s.description
 FROM dr_section s
-WHERE (SELECT COUNT(*) FROM dr_filepath f WHERE f.path LIKE s.path_prefix || '%') = 0
+WHERE (SELECT COUNT(*) FROM dr_filepath f WHERE f.path LIKE s.path_prefix || ''%'') = 0
 ORDER BY s.name;
 -- For each row: DELETE (area gone) or UPDATE path_prefix (area renamed).
 ```
@@ -160,10 +168,10 @@ bulk-loaded at boot.
 SELECT path, role FROM dr_filepath WHERE desc IS NULL ORDER BY role, path;
 
 -- describe (≤100 chars; preserved across the next auto-remap):
-UPDATE dr_filepath SET desc='Boot composer — assembles CLAUDE.md from DB state' WHERE path='.super-coder/render/compose.py';
+UPDATE dr_filepath SET desc=''Boot composer — assembles CLAUDE.md from DB state'' WHERE path=''.super-coder/render/compose.py'';
 ```
 
-**3. Product DB** — the app's own database, separate from engine memory
+**3. Product DB** — the app''s own database, separate from engine memory
 (`.super-coder/shell_db.db`); working shells change them in completely
 different ways (boot `## DATABASES`), and the map you author is the only
 per-fork signal of where the app DB lives. The live `.db` is usually
@@ -172,20 +180,20 @@ durable anchor. Tag them plainly as the product/app DB so no shell mistakes
 them for engine memory; give them a section if they form an area.
 
 ```sql
--- tag the product DB's definition (the engine-vs-app split made visible):
-UPDATE dr_filepath SET desc='Product DB schema — the APP database (NOT engine memory)' WHERE path='<app schema file>';
-UPDATE dr_filepath SET desc='Product DB migration — change the app schema here' WHERE path LIKE '<app migrations dir>/%';
+-- tag the product DB''s definition (the engine-vs-app split made visible):
+UPDATE dr_filepath SET desc=''Product DB schema — the APP database (NOT engine memory)'' WHERE path=''<app schema file>'';
+UPDATE dr_filepath SET desc=''Product DB migration — change the app schema here'' WHERE path LIKE ''<app migrations dir>/%'';
 -- optional: a section if the product DB is its own area
 INSERT INTO dr_section (name, path_prefix, description, sort_order)
-VALUES ('App DB', '<db dir>/', 'Product runtime database — schema + migrations (NOT the engine memory DB)', 7);
+VALUES (''App DB'', ''<db dir>/'', ''Product runtime database — schema + migrations (NOT the engine memory DB)'', 7);
 ```
 
 Fork ships no database of its own -> skip.
 
 After a curation pass your writes are already live in the shared map db —
 done. NEVER run a plain `sc snapshot` from a shell — it is refused by design;
-persistence = the GUI Snapshot button or an admin's `SC_ADMIN=1 ./sc
-snapshot`. Don't chase it. (Sections are snapshotted; descriptions ride the
+persistence = the GUI Snapshot button or an admin''s `SC_ADMIN=1 ./sc
+snapshot`. Don''t chase it. (Sections are snapshotted; descriptions ride the
 live DB + survive remap — refill from the worklist if a rebuild drops them.)
 
 ## Extending the map — semantic extractors
@@ -205,7 +213,7 @@ Adopt one per stack:
 1. **Detect the stack:** `SELECT manager, name FROM dr_dependency;`
    (fastapi? flask? svelte? next?) + the file mix
    (`SELECT lang, COUNT(*) FROM dr_filepath GROUP BY lang`).
-2. **Copy the matching reference** from the engine's
+2. **Copy the matching reference** from the engine''s
    `.super-coder/templates/map_extractors/` into `.sc-state/map_extractors/`:
    - `fastapi_endpoints.py` — decorator routes (`@app.get(...)`, Flask `@app.route`) → `dr_endpoint`
    - `sqlite_schema.py` — SQL `CREATE TABLE/VIEW` → `dr_db_table`/`dr_db_column`
@@ -237,7 +245,7 @@ act on as cartographer.
 Sender = the **dev/coder** shell on merge (feature landed, doc written); NOT
 the planner — specs render into a known area and need no curation. Sent via
 the `messaging` skill to `cartographer` — a role alias the API resolves to
-this fork's cartographer shell whatever its actual shortname:
+this fork''s cartographer shell whatever its actual shortname:
 
 ```
 --message send cartographer "shape: <what landed> — paths: <region/>; <ref>. curate."
@@ -252,7 +260,7 @@ region -> mark read:
 ```sql
 -- 1. the new files this notice is about (scope by the region it named):
 SELECT path, role FROM dr_filepath
-WHERE desc IS NULL AND path LIKE 'region/%' ORDER BY role, path;
+WHERE desc IS NULL AND path LIKE ''region/%'' ORDER BY role, path;
 -- 2. describe them (≤100 chars) — UPDATE dr_filepath SET desc=… per the worklist above.
 -- 3. do they form / join a section? curate dr_section if the region is a new area.
 ```
@@ -270,5 +278,107 @@ exactly the uncurated tail.
 - Config is the lever: tune `map.config.json`; touch `map_repo.py` only when
   the mechanism itself (a parser, a role kind) is wrong.
 - Verify the automation, not just the file: a written hook that
-  `core.hooksPath` doesn't point at does nothing -> check the wiring after
-  every setup.
+  `core.hooksPath` doesn''t point at does nothing -> check the wiring after
+  every setup.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'messaging',
+  'Shell-to-shell inbox — send a markdown message to another shell (typed: shell/task/result; pr_event is daemon-emitted), check your unread inbox, verify delivery via the sent view, mark messages read. Driven by `sc mem message`. Use to coordinate with another shell; the recipient sees it on its next boot via the STATUS Inbox count.',
+  'substrate',
+  'sc mem message',
+  1,
+  '# messaging — the shell inbox
+
+Shell-to-shell markdown messages, driven by `sc mem message`. Sender = you;
+recipient addressed by `shortname`. Body = markdown, preserved verbatim.
+Recipient discovers it on its next boot via the `## STATUS` `Inbox:` count.
+
+Trigger: `--message`
+Args: `check [N] | send <to-shortname> <body> [--kind k] | sent | mark-read <id>`
+
+## Message kinds
+
+Every message carries a `kind` — the trail stays filterable
+(`SELECT * FROM shell_messages WHERE kind != ''shell''` replays a sprint''s
+whole coordination history):
+
+- `shell` — ordinary shell-to-shell mail (the default; what `send` does
+  unless told otherwise).
+- `task` — planner → worker instruction (a sprint kickoff / re-task).
+- `result` — worker → planner completion or transition report.
+- `pr_event` — GitHub watcher daemon → shell PR transition (checks
+  green/red, review submitted, merged, closed). Daemon-emitted only:
+  `send` refuses it — a forged PR event would poison the wake loop''s
+  ground truth. Detail lives in `gh`; the row is the wake-up, not the
+  payload.
+
+## check — your unread inbox
+
+```
+sc mem message check [N]      # N optional; default 50, max 200
+```
+
+Read-only — it does NOT auto-mark-read. Non-`shell` rows show their kind
+inline. Surface the body to the operator (reply if warranted — a reply is
+itself a `send`), then `mark-read` the inbound in the same turn.
+
+## send — message another shell
+
+```
+sc mem message send <to-shortname> "<body>" [--kind shell|task|result]
+```
+
+- Multi-word body = one quoted argument; markdown preserved verbatim.
+- Examples: `sc mem message send cartographer "map is stale — re-run sc map"`
+  · `sc mem message send plan1 "sprint 12: unit 3 merged (PR #41)" --kind result`
+- `cartographer` is a **role alias**: when no shell has that literal
+  shortname, it resolves to the fork''s cartographer shell whatever its
+  shortname (e.g. `CART1`). Address the map-keeper as `cartographer` — no
+  shortname lookup needed. An exact shortname match always wins.
+- Unknown / deleted recipient -> `mem: recipient shortname ''<x>'' unknown`;
+  empty body -> `mem: body is empty`. Surface either to the operator plainly.
+- Sends are idempotent under load: each invocation carries a dedupe key, so
+  a timed-out send retries itself and can never write a duplicate. Do NOT
+  re-run a timed-out send by hand — the retry already happened; if it still
+  died, check `sent` first.
+
+## sent — your outbound view
+
+```
+sc mem message sent           # latest 50 you sent, newest first, read receipts
+```
+
+Verify delivery after an ambiguous failure (a send that died after its
+retries) before ever resending. A row present = delivered; absent = safe
+to resend.
+
+## mark-read — clear an inbox item (idempotent)
+
+```
+sc mem message mark-read <message_id>
+```
+
+Pass the `message_id` that `check` surfaced. Only messages addressed to you
+clear — another shell''s message = no-op; re-marking a read message = no-op.
+
+## Stance
+
+- On boot, `Inbox:` non-zero -> run `--message check` and surface the first
+  item before continuing.
+- No threading: a reply = a new `send`; include `Re: <topic>` in the body if
+  it matters.
+- `mark-read` only after you have actually acted on the message.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/skills_sc/messaging.md
+++ b/skills_sc/messaging.md
@@ -56,6 +56,10 @@ sc mem message send <to-shortname> "<body>" [--kind shell|task|result]
 - Multi-word body = one quoted argument; markdown preserved verbatim.
 - Examples: `sc mem message send cartographer "map is stale — re-run sc map"`
   · `sc mem message send plan1 "sprint 12: unit 3 merged (PR #41)" --kind result`
+- `cartographer` is a **role alias**: when no shell has that literal
+  shortname, it resolves to the fork's cartographer shell whatever its
+  shortname (e.g. `CART1`). Address the map-keeper as `cartographer` — no
+  shortname lookup needed. An exact shortname match always wins.
 - Unknown / deleted recipient -> `mem: recipient shortname '<x>' unknown`;
   empty body -> `mem: body is empty`. Surface either to the operator plainly.
 - Sends are idempotent under load: each invocation carries a dedupe key, so

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -287,6 +287,37 @@ class ApiMemTest(unittest.TestCase):
         self.assertEqual((row["from_shell_id"], row["to_shell_id"]), (1, 1))
         self.assertTrue(row["dedupe_key"])  # every CLI send is stamped (#333)
 
+    # ── messaging: `cartographer` role alias (#369–#372) ─────────────────────
+    # Boot docs address the map-keeper by role; forks mint shortnames like
+    # CART1. Ordered a/b/c: the shared class DB walks no-cartographer →
+    # flavor-resolved → exact-shortname-precedence.
+    def test_message_cart_alias_a_missing_cartographer_is_a_clear_404(self):
+        with self.assertRaises(SystemExit):   # _api dies on HTTP 404
+            mem._api("POST", "/_sc/mem/messages",
+                     {"to": "cartographer", "body": "map gap: x. heal."})
+
+    def test_message_cart_alias_b_resolves_by_flavor(self):
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, flavor, "
+            "system_prompt, user_id) VALUES (7, 'Cart', 'CART9', 'cartographer', 'sp', 1)")
+        con.commit()
+        con.close()
+        self.run_mem("message", "send", "cartographer", "map gap: y. heal.")
+        row = self.q("SELECT to_shell_id FROM shell_messages WHERE body='map gap: y. heal.'")
+        self.assertEqual(row["to_shell_id"], 7)
+
+    def test_message_cart_alias_c_exact_shortname_wins(self):
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, "
+            "system_prompt, user_id) VALUES (8, 'Literal', 'cartographer', 'sp', 1)")
+        con.commit()
+        con.close()
+        self.run_mem("message", "send", "cartographer", "map gap: z. heal.")
+        row = self.q("SELECT to_shell_id FROM shell_messages WHERE body='map gap: z. heal.'")
+        self.assertEqual(row["to_shell_id"], 8)
+
     # ── messaging: idempotent send — a repeat key never writes a twin (#333) ──
     def test_message_send_dedupe_key(self):
         payload = {"to": "tc", "body": "dedupe me", "kind": "shell",


### PR DESCRIPTION
Fixes #369, fixes #370, fixes #371, fixes #372, fixes #367 — five seats across two forks followed the documented map-gap notice (`--message send cartographer "…"`) into `HTTP 404: recipient shortname 'cartographer' unknown`, because the docs address the map-keeper by role while forks mint shortnames like `CART1`.

**Why an API alias rather than fixing the docs:** skill bodies are fleet-shared DB rows — they *can't* name a fork-specific shortname, and making every sender look the shortname up first adds a hop to a contract that's written role-first everywhere (boot ORIENTATION, messaging skill, the cartographer notice contract). So the API makes the contract true: `cartographer` resolves by flavor when no shell has that literal shortname. Exact shortname always wins; the flavor's singleton trigger guarantees at most one live row; a fork with no cartographer now gets a 404 that says exactly that. All existing docs become correct as written — the boot render needs no change.

Skill edits (messaging documents the resolution rule; the cartographer notice contract names it) ship as trailing reseed **0069** in the house format — UPSERT by name, skill_id + grants preserved, generated from the parsed assets so it's byte-identical to the regenerated 0001 seed.

## Test plan
- [x] 3 new API tests: missing cartographer → clear 404 · alias resolves by flavor · exact shortname beats the alias
- [x] 0069 validated: applies cleanly on a fresh schema+migrations build; applied to the live dogfood DB
- [x] `./sc render-check` passes hermetically (mirrors re-rendered)
- [x] Full suite: 33 files, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)