### PR TITLE
fix(help): feature list names all five opt-ins (pm2 + app-deploy were missing)

### DIFF
--- a/.super-coder/scripts/feature.py
+++ b/.super-coder/scripts/feature.py
@@ -28,7 +28,7 @@ grants.
 Usage:
     ./sc feature                      # = list
     ./sc feature list
-    ./sc feature enable  <name>       # pg · windows · tailnet · app-deploy
+    ./sc feature enable  <name>       # pg · windows · tailnet · pm2 · app-deploy
     ./sc feature disable <name>
 """
 from __future__ import annotations

--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ sc sql "<query>"         # read-only passthrough to the engine DB; `sc map-sql` 
 ./sc preview             # live worktree UI previews, one subdomain per shell
 ./sc update              # fetch + materialize the engine, reconcile in place (--ref <tag|sha> pins)
 ./sc rollback            # sound undo of a bad update (restore DB + engine)
-./sc feature             # opt-in features: list / enable / disable (pg · windows · tailnet · app-deploy)
+./sc feature             # opt-in features: list / enable / disable (pg · windows · tailnet · pm2 · app-deploy)
 ./sc eject               # ONE-WAY: own the engine — stop tracking upstream (confirm-gated)
 ./sc verify              # rebuild + flat render + headless boot (no exec) — the proof
 ./sc help                # all commands

--- a/sc
+++ b/sc
@@ -1140,7 +1140,7 @@ super-coder — forkable shell substrate
                              --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
   ./sc update-harnesses    update claude + opencode + codex + vibe to latest (force-reruns official installers)
   ./sc rollback            sound undo of a bad update — restore the DB + engine (engine.ref.prev) together
-  ./sc feature             list the opt-in features (pg · windows · tailnet) and the state of both halves (config block + skill grants)
+  ./sc feature             list the opt-in features (pg · windows · tailnet · pm2 · app-deploy) and the state of both halves (config block + skill grants)
   ./sc feature enable <f>  enable one: grant its skills to the owning flavors + create/point-at its instance.json block (disable reverses)
   ./sc eject               ONE-WAY: stop tracking upstream and own the engine — un-gitignore + stage .super-coder/ as fork source (confirm-gated)
   ./sc rebuild             build the .db from schema + migrations + snapshot


### PR DESCRIPTION
Follow-up to #399: `./sc help` still listed the opt-in features as "pg · windows · tailnet" and `feature.py`'s usage docstring + the README's Run line stopped at four — the `FEATURES` registry ships five. All three stale surfaces now name `pg · windows · tailnet · pm2 · app-deploy`. Smoke-tested: `./sc help` and `./sc feature` both render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)