### PR TITLE
feat(harness): add Kimi Code (kimi) as a fifth harness adapter

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -2,7 +2,7 @@
 #
 # The repo is bind-mounted at runtime (see `./sc launch`); this image carries
 # what the harness needs to run: python3 + sqlite3, git/curl/ripgrep, gh, and the
-# harness CLIs (claude / opencode / codex / vibe) baked in via their official
+# harness CLIs (claude / opencode / codex / vibe / kimi) baked in via their official
 # native installers (the same ones install.py uses — keep the URLs in sync with
 # scripts/install.py HARNESS_INSTALL).
 # It also carries the dev-kit TOOLCHAIN super-coder develops against — node LTS for
@@ -14,8 +14,9 @@
 # ~/.local/share/claude/versions/<v> (awkward to bind-mount); opencode + codex
 # are fat self-contained binaries. Baking them sidesteps the symlink dance.
 # Auth/config (~/.claude, ~/.claude.json, ~/.config/opencode,
-# ~/.local/share/opencode, ~/.codex) is mounted rw from the host so the container
-# reuses the login you already did — no in-container `auth login`.
+# ~/.local/share/opencode, ~/.codex, ~/.vibe, ~/.kimi-code) is mounted rw from
+# the host so the container reuses the login you already did — no in-container
+# `auth login`.
 #
 # The container runs as your uid (compose `user:`) with HOME=/home/<user> equal
 # to the host, so paths match host==container and Path.home() finds everything.
@@ -103,6 +104,15 @@ RUN printf '%s\n' \
       > /usr/local/bin/sc \
  && chmod 0755 /usr/local/bin/sc
 
+# Kimi Code — baked HERE (root stage) with its binary DELIBERATELY redirected to
+# /usr/local/bin (root-writable, on every PATH), unlike the $HOME installs below.
+# Its default home, ~/.kimi-code, holds bin/ AND config in one dir, and
+# `./sc launch` bind-mounts the host's ~/.kimi-code for creds — installing there
+# would let the mount shadow the baked binary (fatal on a macOS host: darwin
+# binary, linux container). KIMI_NO_MODIFY_PATH skips its shell-rc edit.
+RUN curl -fsSL https://code.kimi.com/kimi-code/install.sh \
+      | env KIMI_INSTALL_DIR=/usr/local KIMI_NO_MODIFY_PATH=1 bash
+
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
 # A host GID may already exist in the base image — notably macOS's primary GID 20
 # (`staff`) collides with Debian's pre-existing `dialout` group — so creating it
@@ -121,6 +131,7 @@ ENV PATH=/home/${SC_USER}/.local/bin:/home/${SC_USER}/.opencode/bin:${PATH}
 # Harness CLIs — official native installers, no npm (mirrors install.py).
 # codex drops into ~/.local/bin (already on PATH above), same as claude. vibe's
 # installer self-bootstraps uv (astral.sh) then `uv tool install`s into ~/.local/bin.
+# (kimi is baked earlier, in the root stage — see the comment there.)
 RUN curl -fsSL https://claude.ai/install.sh | bash \
  && curl -fsSL https://opencode.ai/install | bash \
  && curl -fsSL https://chatgpt.com/codex/install.sh | sh \

--- a/.super-coder/README.md
+++ b/.super-coder/README.md
@@ -86,6 +86,11 @@ is harness-blind. Each holds an `adapter.json`:
   `--dangerously-bypass-approvals-and-sandbox`); model is selected via `--model`.
 - **`vibe/`** — reads `AGENTS.md` natively; nothing to emit. Launches `vibe
   --trust` (sandbox adds `--agent auto-approve`).
+- **`kimi/`** — reads `AGENTS.md` natively; nothing to emit. Launches `kimi`
+  (sandbox adds `--yolo` — interactive only: `kimi -p` rejects permission-mode
+  flags and always runs auto-approve). Headless via `kimi -p`; takes no model
+  from the launch seam (kimi's `-m` wants a user-local alias from
+  `~/.kimi-code/config.toml`, not a portable model id).
 
 The boot render dual-writes `CLAUDE.md` + `AGENTS.md` and the skills, so both
 harnesses consume the same substrate unchanged — that's the harness-agnostic bet.

--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -6,5 +6,8 @@
   "env": {},
   "model": { "flag": "--model" },
   "headless": { "launch": ["codex", "exec"], "model_flag": "-m" },
-  "sandbox": { "launch_flags": ["--dangerously-bypass-approvals-and-sandbox"] }
+  "sandbox": {
+    "launch_flags": ["--dangerously-bypass-approvals-and-sandbox"],
+    "headless_flags": ["--dangerously-bypass-approvals-and-sandbox"]
+  }
 }

--- a/.super-coder/adapters/kimi/README.md
+++ b/.super-coder/adapters/kimi/README.md
@@ -1,0 +1,72 @@
+# adapters/kimi — Kimi Code CLI
+
+Kimi Code (`kimi`, Moonshot AI's coding CLI — repo `MoonshotAI/kimi-code`, the
+TypeScript successor to the legacy Python `kimi-cli`) reads the boot artifact
+(`AGENTS.md`) natively — already emitted by the render chain — so the adapter
+carries only the launch command, a headless block, and a sandbox approval flag.
+
+**Why it exists:** the Kimi-models sibling of the claude/codex/vibe harnesses —
+a first-party CLI billed against a Kimi membership (Moderato / Allegretto /
+Allegro / Vivace) or a Moonshot platform API key. K-series coding models
+(k3, kimi-for-coding-highspeed). opencode stays the universal metered
+catch-all; kimi is the native Moonshot path.
+
+`adapter.json` fields (the harness seam contract):
+
+| field | meaning |
+|---|---|
+| `launch` | argv exec'd to start the harness (`kimi` — cwd is the workspace; no dir flag exists) |
+| `boot_artifact` | the context file this harness reads (`AGENTS.md`, informational) |
+| `emit` | files copied to the repo root at launch (none — kimi reads `~/.kimi-code` + `AGENTS.md`) |
+| `headless.launch` | non-interactive argv (`kimi -p` — the prompt is `-p`'s option value, appended last) |
+| `sandbox.launch_flags` | flags appended ONLY inside the docker sandbox, interactive launches only (`--yolo`) |
+
+**`--yolo` (sandbox, interactive only):** auto-approves all actions inside the
+container, where the container itself is the safety boundary (matches how
+claude/opencode/codex/vibe get allow-all in-sandbox). It is a `launch_flags`
+entry — NOT `headless_flags` — because `kimi -p` hard-errors on any
+permission-mode flag (`Cannot combine --prompt with --yolo`, same for `--auto`):
+prompt mode always runs in auto permission mode by design, so headless needs no
+flag at all. This adapter is why the sandbox seam splits `launch_flags`
+(interactive) from `headless_flags` (headless) instead of folding one into the
+other. On the no-docker host path (`./sc boot`), kimi keeps its normal
+per-action approval prompts.
+
+**No `model` field:** kimi takes no model from the launch seam. Its `-m` flag
+selects a model *alias* defined in `~/.kimi-code/config.toml` (`[models."…"]`) —
+user-local names, not portable provider ids — so routing a flavor-default model
+here would be meaningless; kimi uses its configured `default_model` (or
+`/model` in-session). For the same reason the headless block declares no
+`model_flag` and kimi has no `flavor_defaults` seeds or model-catalog entry.
+
+**Skills:** kimi does not read `.claude/skills/` (its discovery dirs are
+`.kimi-code/skills/` + `.agents/skills/`), so like codex/vibe it loads skills
+through the canonical harness-agnostic path — the boot doc's `## SKILLS` block.
+
+## Branch guard — no in-line block (v1)
+
+Kimi Code has a hooks system, but wiring it is unverified here; for now kimi's
+branch enforcement is the same two layers as vibe: the always-loaded
+**VERSION CONTROL** rule in the boot artifact (advisory) plus the universal
+**git pre-commit backstop** (`.super-coder/hooks/pre-commit` via
+`core.hooksPath`) that refuses a commit on a protected default branch. If kimi's
+hook config proves to support a pre-tool gate, wire it here to match the others.
+
+**Host setup (one-time):** install + authenticate once on the host —
+`curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash` (single binary →
+`~/.kimi-code/bin/kimi`), then `kimi login` (device-code OAuth against a Kimi
+membership) or write a provider key into `~/.kimi-code/config.toml`. Note
+kimi does NOT read credentials from shell env vars (`export KIMI_API_KEY=…`
+does nothing); keys live in config.toml — the exception is the `KIMI_MODEL_*`
+env family, which synthesizes a temporary provider. `./sc install` /
+`./sc update` / `./sc ensure-harness` install the binary automatically; auth
+stays manual.
+
+**Sandbox credentials + the split install dir:** `~/.kimi-code` is BOTH kimi's
+binary home (`bin/`) and its config home — unlike the other harnesses, which
+keep those apart. `./sc launch` bind-mounts host `~/.kimi-code` in (config,
+sessions, login state flow straight to the container), so the sandbox image
+deliberately bakes its own binary to `/usr/local/bin` (`KIMI_INSTALL_DIR=/usr/local`
+in the Dockerfile) — otherwise the mount would shadow the baked binary with the
+host's (fatal on a macOS host: a darwin binary inside the linux container).
+Same reason `ensure_harness_path()` is a no-op under `SC_SANDBOX`.

--- a/.super-coder/adapters/kimi/adapter.json
+++ b/.super-coder/adapters/kimi/adapter.json
@@ -1,0 +1,9 @@
+{
+  "harness": "kimi",
+  "launch": ["kimi"],
+  "boot_artifact": "AGENTS.md",
+  "emit": [],
+  "env": {},
+  "headless": { "launch": ["kimi", "-p"] },
+  "sandbox": { "launch_flags": ["--yolo"] }
+}

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -237,11 +237,11 @@ def get_skills(con) -> dict:
 
 
 def known_harnesses() -> list[str]:
-    """The harness set = the shipped adapters (claude/codex/opencode/vibe)."""
+    """The harness set = the shipped adapters (claude/codex/kimi/opencode/vibe)."""
     d = ENGINE / "adapters"
     if d.exists():
         return sorted(p.name for p in d.iterdir() if p.is_dir())
-    return ["claude", "codex", "opencode", "vibe"]
+    return ["claude", "codex", "kimi", "opencode", "vibe"]
 
 
 def get_flavor_defaults(con) -> dict:

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -14,7 +14,8 @@ reverse):
     granted skills. A NON-load-bearing convenience cache for harnesses that
     auto-discover this path natively (Claude Code / OpenCode / Crush). It is NOT
     the source of truth and NOT the cross-harness load path: codex reads its own
-    `$CODEX_HOME/skills` and vibe (Mistral) has no skill dir at all. The
+    `$CODEX_HOME/skills`, kimi its `.kimi-code/skills` / `.agents/skills`, and
+    vibe (Mistral) has no skill dir at all. The
     canonical, harness-agnostic load path is the DB — the boot doc's `## SKILLS`
     block renders each grant's exact `SELECT content FROM skills …` query
     (see compose.render_skills). Like the boot artifact (CLAUDE.md/AGENTS.md)

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -9,7 +9,7 @@ from "engine present" to "a team you can launch":
                  is already installed (both would destroy content). --force skips.
     2. Require — python3 + sqlite3 (+ a heads-up if git/curl missing, and a
                  docker preflight for the sandbox run path — advisory, not fatal).
-    3. Harness — ensure claude + opencode + codex + vibe are installed (official native
+    3. Harness — ensure claude + opencode + codex + vibe + kimi are installed (official native
                  installers, no npm); pick the launch default → instance.json.
     4. Strip   — super-coder's own per-instance content; a fork inherits the
                  SYSTEM (schema + skill catalogue + render chain), never the memory.
@@ -135,22 +135,24 @@ def already_installed() -> bool:
 
 
 def detect_harness() -> str | None:
-    for h in ("claude", "opencode", "codex", "vibe"):
+    for h in ("claude", "opencode", "codex", "vibe", "kimi"):
         if _harness_installed(h):
             return h
     return None
 
 
 # Official NATIVE installers — no npm. Claude Code dropped npm as the primary
-# path (https://code.claude.com/docs/en/setup); opencode + codex + vibe ship their own
-# scripts too. Pipe-to-shell, latest version. vibe installs via uv (its script
-# checks for / uses `uv tool install mistral-vibe`); a missing uv makes its
-# install fail best-effort, same as any other harness.
+# path (https://code.claude.com/docs/en/setup); opencode + codex + vibe + kimi ship
+# their own scripts too. Pipe-to-shell, latest version. vibe installs via uv (its
+# script checks for / uses `uv tool install mistral-vibe`); a missing uv makes its
+# install fail best-effort, same as any other harness. kimi (Kimi Code) is a
+# single binary dropped into its own config home, ~/.kimi-code/bin.
 HARNESS_INSTALL = {
     "claude":   "curl -fsSL https://claude.ai/install.sh | bash",
     "opencode": "curl -fsSL https://opencode.ai/install | bash",
     "codex":    "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
     "vibe":     "curl -LsSf https://mistral.ai/vibe/install.sh | bash",
+    "kimi":     "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
 }
 # Where each installer drops its binary. Checked post-install because the new
 # bin dir is NOT on this process's PATH — the installer edits shell rc files,
@@ -162,6 +164,7 @@ HARNESS_BIN = {
     "opencode": Path.home() / ".opencode" / "bin" / "opencode",
     "codex":    Path.home() / ".local" / "bin" / "codex",
     "vibe":     Path.home() / ".local" / "bin" / "vibe",
+    "kimi":     Path.home() / ".kimi-code" / "bin" / "kimi",
 }
 
 
@@ -254,7 +257,7 @@ def update_harnesses() -> dict[str, str]:
 
 def ensure_harnesses() -> dict[str, str]:
     """Install any missing harness CLI via its official native installer (no
-    npm) — claude + opencode + codex + vibe, so a fork can launch and run any. Best
+    npm) — claude + opencode + codex + vibe + kimi, so a fork can launch and run any. Best
     effort: a failed install warns and continues (the harness is only needed at
     launch and can be installed by hand later). Returns {name: status}."""
     status: dict[str, str] = {}
@@ -508,14 +511,14 @@ def main(argv: list[str]) -> int:
 
     # Standalone: force-update all harness CLIs to latest and exit.
     if "--update-harnesses" in argv:
-        step("Updating harness CLIs to latest (claude + opencode + codex + vibe)")
+        step("Updating harness CLIs to latest (claude + opencode + codex + vibe + kimi)")
         update_harnesses()
         return 0
 
     # Standalone: just ensure the harness CLIs and exit (for an already-installed
     # fork). Runs before the guards so it works anywhere.
     if "--ensure-harness" in argv:
-        step("Ensuring harness CLIs (claude + opencode + codex + vibe)")
+        step("Ensuring harness CLIs (claude + opencode + codex + vibe + kimi)")
         ensure_harnesses()
         return 0
 
@@ -556,12 +559,12 @@ def main(argv: list[str]) -> int:
     report_docker()
 
     # 3. Ensure harness CLIs --------------------------------------------------
-    # Install claude + opencode + codex + vibe if missing, via their official NATIVE
+    # Install claude + opencode + codex + vibe + kimi if missing, via their official NATIVE
     # installers (no npm). The harness picker lets a fork launch + run any, so we
     # want all present. --skip-harness-install detects only (CI / air-gapped).
     # instance.json's harness is the launch default; the picker overrides it
     # per-launch.
-    step("Ensuring harness CLIs (claude + opencode + codex + vibe)")
+    step("Ensuring harness CLIs (claude + opencode + codex + vibe + kimi)")
     if skip_harness:
         print("  --skip-harness-install set — detecting only, not installing")
         for n in HARNESS_INSTALL:

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -357,7 +357,15 @@ def ensure_harness_path() -> None:
     detect_harnesses() silently never offers opencode even though ensure-harness
     reported it installed: install.py trusts HARNESS_BIN, the launcher trusted
     PATH only, and they disagreed. Reuse install.HARNESS_BIN so there is one
-    source for where a harness lives."""
+    source for where a harness lives.
+
+    In the sandbox this is a no-op: the image's ENV PATH already carries every
+    baked binary dir, and folding host dirs in is actively wrong for kimi —
+    host `~/.kimi-code` (its bin/ + config in one dir) is bind-mounted for
+    creds, and prepending its bin/ would shadow the image's own kimi binary
+    with the host's (a darwin binary on a macOS host)."""
+    if os.environ.get("SC_SANDBOX"):
+        return
     try:
         bin_dirs = [p.parent for p in install.HARNESS_BIN.values()]
     except Exception:
@@ -826,17 +834,20 @@ def main() -> None:
 
     # Sandbox-only launch flags — e.g. codex's approval/sandbox bypass, safe
     # because the container is the safety boundary. The no-docker host path keeps
-    # the harness's normal prompts (SC_SANDBOX unset). Headless adds the
-    # adapter's `headless_flags`: a non-interactive run can't answer a
-    # permission prompt (it auto-denies and the worker silently stalls), so
-    # e.g. claude gets its bypass flag — in the sandbox ONLY, same doctrine.
+    # the harness's normal prompts (SC_SANDBOX unset). The two flag sets are
+    # disjoint by launch mode: `launch_flags` for interactive, `headless_flags`
+    # for headless — a non-interactive run can't answer a permission prompt (it
+    # auto-denies and the worker silently stalls), so e.g. claude gets its bypass
+    # flag there; codex declares the same flag in both. They are NOT folded
+    # together because a harness's interactive flag can be invalid headless —
+    # `kimi -p` hard-errors on `--yolo`/`--auto` (prompt mode is always
+    # auto-permission, no flag needed).
     sandbox_flags: list[str] = []
     sandbox_env: dict[str, str] = {}
     if os.environ.get("SC_SANDBOX"):
         scfg = adapter.get("sandbox") or {}
-        sandbox_flags = list(scfg.get("launch_flags") or [])
-        if headless:
-            sandbox_flags += scfg.get("headless_flags") or []
+        key = "headless_flags" if headless else "launch_flags"
+        sandbox_flags = list(scfg.get(key) or [])
         if sandbox_flags:
             print(f"→ sandbox: launch flags → {' '.join(sandbox_flags)}")
         # Sandbox-only launch env — e.g. claude's IS_SANDBOX=1, required because
@@ -855,7 +866,7 @@ def main() -> None:
             adapter, prompt or DEFAULT_HEADLESS_PROMPT, hmodel, sandbox_flags)
         if headless_cmd is None:
             sys.exit(f"sc run: harness '{harness}' has no headless adapter — "
-                     f"use claude, codex, or opencode")
+                     f"use claude, codex, opencode, or kimi")
         if hmodel:
             src = "explicit -m" if flag_model else f"flavor default for {chosen['flavor']}"
             print(f"→ model: {hmodel} ({src})")

--- a/.super-coder/scripts/shell_liveness.py
+++ b/.super-coder/scripts/shell_liveness.py
@@ -63,7 +63,7 @@ ADAPTERS = ENGINE / "adapters"
 DB_PATH = ENGINE / "shell_db.db"
 PROC = Path("/proc")
 
-_FALLBACK_BINS = {"claude", "codex", "opencode", "vibe"}
+_FALLBACK_BINS = {"claude", "codex", "opencode", "vibe", "kimi"}
 
 
 def harness_binaries() -> set[str]:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -349,7 +349,7 @@ def main(argv: list[str]) -> int:
     # harness — not just the ones present at first install. Best-effort + native
     # installers (no npm); a failure warns and continues (install by hand later).
     # Auth/login stays manual; this only ensures the CLI binary is present.
-    print("→ ensure harnesses installed (claude + opencode + codex + vibe)")
+    print("→ ensure harnesses installed (claude + opencode + codex + vibe + kimi)")
     install_mod.ensure_harnesses()
 
     migrate_or_rebuild()

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ purpose: Forkable shell substrate for a repo
 A **forkable shell substrate for a single code repository.** You install it into
 a project repo; it brings the shell system — DB-backed identity, memory, seed/L&S,
 decisions, flags, a roadmap, and spec/doc content — and runs that repo through
-whatever coding harness you point at it — **Claude Code, OpenCode, Codex, and
-Mistral Vibe**, all sandbox-integrated (or run on the no-docker host path).
+whatever coding harness you point at it — **Claude Code, OpenCode, Codex,
+Mistral Vibe, and Kimi Code**, all sandbox-integrated (or run on the no-docker
+host path).
 Free to use, open source, MIT License.
 
 > [!class2]
@@ -92,9 +93,9 @@ This repo is also **dogfood**: super-coder maintains super-coder. Its own
 
 ```stats
 :::class1
-value: 4
+value: 5
 label: Coding harnesses
-description: Claude · Codex · OpenCode · Vibe
+description: Claude · Codex · OpenCode · Vibe · Kimi
 :::class3
 value: 5
 label: Shell flavors
@@ -143,8 +144,8 @@ coding harness.
 |---|---|---|
 | **Container engine** | `sudo pacman -S docker`, then start a daemon — rootless default: `dockerd-rootless-setuptool.sh install && systemctl --user enable --now docker` | `brew install colima docker && colima start` (or Docker Desktop) |
 | **Base tools** | `sudo pacman -S git curl python sqlite` (usually already present) | `xcode-select --install` (git/curl); python3 + sqlite3 ship with macOS |
-| **Harness CLI** | installed for you by `./sc install` (`claude` · `opencode` · `codex` · `vibe`, native installers). Repair by hand: `curl -fsSL https://claude.ai/install.sh \| bash` | same — **and put `~/.local/bin` on your PATH** (a fresh macOS shell omits it) |
-| **Harness account** | a plan for one of Claude Code · OpenCode · Codex · Vibe; sign in once on the host (step 3) | same |
+| **Harness CLI** | installed for you by `./sc install` (`claude` · `opencode` · `codex` · `vibe` · `kimi`, native installers). Repair by hand: `curl -fsSL https://claude.ai/install.sh \| bash` | same — **and put `~/.local/bin` on your PATH** (a fresh macOS shell omits it) |
+| **Harness account** | a plan for one of Claude Code · OpenCode · Codex · Vibe · Kimi Code; sign in once on the host (step 3) | same |
 
 > [!class4]
 > **The bar: a reachable docker daemon + a harness CLI on PATH.** `./sc doctor` reports the docker mode it finds (rootless / rootful) and the exact next command; `python3` + `sqlite3` are the only *hard* requirements (the engine runtime). **macOS PATH gotcha:** if `claude` reports *"missing or broken — run claude install to repair"*, the CLI installed fine but `~/.local/bin` isn't on your PATH. Add `export PATH="$HOME/.local/bin:$PATH"` to your shell profile (`~/.zshrc`), open a new shell, then `claude install`. No docker at all? The `./sc serve` + `./sc boot` escape hatch runs the shell on the host.
@@ -166,7 +167,7 @@ git checkout super-coder/main -- .super-coder sc
 ./sc install
 
 # 3. Sign in to your harness once, on the HOST (not inside the sandbox):
-claude                          # or:  opencode auth login  ·  codex login  ·  vibe --setup
+claude                          # or:  opencode auth login  ·  codex login  ·  vibe --setup  ·  kimi login
 
 # 4. Launch the sandbox (server + GUI) and attach a session:
 ./sc launch
@@ -315,7 +316,7 @@ via git (no history merge; super-coder never touches your repo's own
 `Makefile`), `./sc install`, sign in, launch, commit.
 
 `./sc install` does the rest: checks requirements, **installs the harness CLIs**
-(`claude` + `opencode` + `codex` + `vibe`, via their official native installers — no
+(`claude` + `opencode` + `codex` + `vibe` + `kimi`, via their official native installers — no
 npm — if any are missing; `--skip-harness-install` to detect only), wires your `.gitignore`,
 **makes the engine a gitignored dependency** (`git rm -r --cached .super-coder` —
 files stay on disk; pins its upstream SHA in `.sc-state/engine.ref`), **strips
@@ -357,18 +358,23 @@ claude                      # Claude Code — prompts to sign in on first run
 opencode auth login         # OpenCode
 codex login                 # Codex (OpenAI / ChatGPT account)
 vibe --setup                # Mistral Vibe — stores the API key (or export MISTRAL_API_KEY)
+kimi login                  # Kimi Code — device-code OAuth against your Kimi membership
 ```
 
 `./sc launch` bind-mounts each harness's credential dir into the sandbox
 (`~/.claude` + `~/.claude.json`, `~/.config/opencode` + `~/.local/share/opencode`,
-`~/.codex`, `~/.vibe`), so host auth flows straight into the container — **you
-never sign in inside the sandbox.** Authenticate on the host, then `./sc enter`.
+`~/.codex`, `~/.vibe`, `~/.kimi-code`), so host auth flows straight into the
+container — **you never sign in inside the sandbox.** Authenticate on the host,
+then `./sc enter`.
 
 > [!class4]
 > **Sign in on the host, not inside the sandbox.** OAuth logins spin up a localhost callback server (Codex uses `:1455`). Run the login on the **host** so your browser's callback reaches it — from *inside* the sandbox that port isn't published, so the browser gets `ERR_CONNECTION_REFUSED`.
 
 > [!class2]
 > **Vibe creds.** `vibe --setup` stores your key under `~/.vibe`, which the sandbox now mounts — so Vibe works inside the container like the others. Prefer the env-var path? `export MISTRAL_API_KEY` on the host before `./sc launch` and it's forwarded in (only when set). Re-run `./sc launch` after first authenticating, so the mount picks up `~/.vibe`.
+
+> [!class2]
+> **Kimi creds.** `kimi login` (device-code OAuth) stores its state under `~/.kimi-code`, which the sandbox mounts — host auth flows in. Note kimi does **not** read keys from shell env vars (`export KIMI_API_KEY=…` does nothing); provider keys live in `~/.kimi-code/config.toml`. Re-run `./sc launch` after first authenticating, so the mount picks it up.
 
 > [!class2]
 > **OpenCode is the exception.** Its `opencode auth login` for **API-key** providers is a paste-the-key prompt, not an OAuth callback, so it works at **either level** — host or inside the container (`./sc enter`). Because `~/.config/opencode` + `~/.local/share/opencode` are bind-mounted read-write, a key entered on either side lands in the same `auth.json`. (OAuth-based OpenCode providers still follow the host rule above.)
@@ -395,6 +401,7 @@ against its plan rather than its pay-as-you-go API:
 | **Claude Code** | Anthropic | [Claude Pro / Max](https://claude.com/pricing) |
 | **Codex** | OpenAI | [ChatGPT Plus / Pro](https://openai.com/chatgpt/pricing/) |
 | **Vibe** | Mistral | [Mistral plans](https://mistral.ai/pricing) |
+| **Kimi Code** | Moonshot AI | [Kimi memberships (Moderato / Allegretto / …)](https://www.kimi.com/help/membership/membership-pricing) |
 | **OpenCode** → open-weights | Ollama | [Ollama Cloud (or run local, free)](https://ollama.com/) |
 
 Codex exists for exactly this reason — a ChatGPT account bills **flat, with no
@@ -443,7 +450,7 @@ The logic, four rules:
   defaults premium on Codex.
 
 > [!class2]
-> **Vibe sits outside this matrix.** Mistral Vibe takes no model from the launch seam — it selects its own via `active_model` in `~/.vibe/config.toml` (`vibe --setup`) or `VIBE_ACTIVE_MODEL`. It's a fourth harness option, not a fourth column here — and for the same reason it takes no headless boot (`./sc run` covers claude · codex · opencode).
+> **Vibe and Kimi Code sit outside this matrix.** Neither takes a model from the launch seam. Vibe selects its own via `active_model` in `~/.vibe/config.toml` (`vibe --setup`) or `VIBE_ACTIVE_MODEL`, and takes no headless boot. Kimi Code selects via `default_model` in `~/.kimi-code/config.toml` (its `-m` wants a user-local alias, not a portable model id) — it *does* boot headless (`kimi -p`), on that configured default (`./sc run` covers claude · codex · opencode · kimi).
 
 ### The sprint interview — models per role, per sprint
 

--- a/sc
+++ b/sc
@@ -68,7 +68,7 @@ dcheck() {
 # breaks claude — so seed it with empty json. Real creds come from a one-time
 # host login (`./sc doctor` guides it); this just keeps the mounts valid.
 dcreds() {
-  mkdir -p "$HOME/.claude" "$HOME/.config/opencode" "$HOME/.local/share/opencode" "$HOME/.codex" "$HOME/.vibe" 2>/dev/null || true
+  mkdir -p "$HOME/.claude" "$HOME/.config/opencode" "$HOME/.local/share/opencode" "$HOME/.codex" "$HOME/.vibe" "$HOME/.kimi-code" 2>/dev/null || true
   [ -e "$HOME/.claude.json" ] || echo '{}' > "$HOME/.claude.json"
 }
 
@@ -1074,6 +1074,7 @@ case "$cmd" in
       -v "$HOME/.local/share/opencode:$HOME/.local/share/opencode" \
       -v "$HOME/.codex:$HOME/.codex" \
       -v "$HOME/.vibe:$HOME/.vibe" \
+      -v "$HOME/.kimi-code:$HOME/.kimi-code" \
       -p "127.0.0.1:$p:$p" \
       -p "127.0.0.1:$dp:$dp" \
       "$IMG" ./sc serve --port "$p" >/dev/null
@@ -1134,11 +1135,11 @@ case "$cmd" in
 super-coder — forkable shell substrate
 
   ./sc install             first-launch bootstrap for a fork (requirements, harness, first shell)
-  ./sc ensure-harness      install claude + opencode + codex if missing (official native installers, no npm)
+  ./sc ensure-harness      install claude + opencode + codex + vibe + kimi if missing (official native installers, no npm)
   ./sc doctor              sandbox readiness: docker (rootless/rootful) + harness login
   ./sc update              fetch + materialize the engine (gitignored dep) + reconcile IN PLACE (migrate, sync skills, map);
                              --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
-  ./sc update-harnesses    update claude + opencode + codex + vibe to latest (force-reruns official installers)
+  ./sc update-harnesses    update claude + opencode + codex + vibe + kimi to latest (force-reruns official installers)
   ./sc rollback            sound undo of a bad update — restore the DB + engine (engine.ref.prev) together
   ./sc feature             list the opt-in features (pg · windows · tailnet · pm2 · app-deploy) and the state of both halves (config block + skill grants)
   ./sc feature enable <f>  enable one: grant its skills to the owning flavors + create/point-at its instance.json block (disable reverses)

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -578,6 +578,17 @@ class HeadlessTest(unittest.TestCase):
     def test_vibe_has_no_headless_seam(self):
         self.assertIsNone(run.headless_command(self.adapter("vibe"), "p"))
 
+    def test_kimi_headless_argv(self):
+        cmd = run.headless_command(self.adapter("kimi"), "do it")
+        self.assertEqual(cmd, ["kimi", "-p", "do it"])
+
+    def test_kimi_takes_no_model_from_the_seam(self):
+        # kimi declares no model_flag (its -m wants a config.toml alias, not a
+        # portable id) — a resolved model must NOT leak into the argv, where it
+        # would land between -p and its prompt value.
+        cmd = run.headless_command(self.adapter("kimi"), "p", "k3")
+        self.assertEqual(cmd, ["kimi", "-p", "p"])
+
     def test_prompt_is_the_final_positional(self):
         cmd = run.headless_command(self.adapter("claude"), "trailing prompt", "opus",
                                    ["--dangerously-skip-permissions"])


### PR DESCRIPTION
Adds Moonshot's Kimi Code CLI (`kimi`, MoonshotAI/kimi-code — the TypeScript successor to the legacy Python kimi-cli) as a fifth harness. It reads `AGENTS.md` natively, so the render chain needed zero changes — this is the vibe-shaped minimal path plus a headless block.

**Seam change worth reviewing:** sandbox `launch_flags` no longer fold into the headless argv. `kimi -p` hard-errors on any permission-mode flag (`Cannot combine --prompt with --yolo`, same for `--auto`; verified against the real 0.27.0 binary) because prompt mode always runs auto-permission. The split is now honest: `launch_flags` = interactive, `headless_flags` = headless. Codex declares its bypass flag in both (same final argv as before); claude/opencode/vibe are unchanged. Verified via RENDER_ONLY runs for kimi/codex/claude in both modes.

**Install-dir wrinkle:** kimi's installer drops its binary *into* its config home (`~/.kimi-code/bin`), which `./sc launch` now bind-mounts for creds. The image therefore bakes the binary to `/usr/local/bin` (`KIMI_INSTALL_DIR=/usr/local`, root stage), and `ensure_harness_path()` is a no-op under `SC_SANDBOX` (it already was one in practice) — otherwise a macOS host's darwin binary would shadow the baked linux one through the mount.

**No model seam** (like vibe): kimi's `-m` takes a user-local `config.toml` alias, not a portable model id — so no `flavor_defaults` seeds and no model-catalog entry; headless boots on kimi's configured `default_model`. Branch guard is the pre-commit backstop for now (kimi has a hooks system, wiring unverified — noted in the adapter README).

Not touched: `assets/seed/super-coder-founding-spec.md` (historical narrative).

Test plan:
- [x] `./sc test` — 420 passed (incl. new kimi headless argv tests)
- [x] `./sc verify`
- [x] `RENDER_ONLY` boots: kimi interactive (host + sandbox `--yolo`), kimi headless sandbox (no flags), codex headless sandbox (bypass flag kept), claude interactive sandbox (unchanged)
- [x] real binary probed: `kimi -p` accepts a plain prompt; rejects `--yolo`/`--auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)