### PR TITLE
feat(models): re-land #405 on main (telemetry flavor defaults)

### DIFF
--- a/.sc-state/content.sql
+++ b/.sc-state/content.sql
@@ -2598,20 +2598,20 @@ INSERT INTO shell_messages (message_id, from_shell_id, to_shell_id, body, create
 DELETE FROM watched_prs;
 
 DELETE FROM flavor_defaults;
-INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('dev', 'codex', 'gpt-5.5', 1);
+INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('dev', 'codex', 'gpt-5.6-sol', 1);
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('dev', 'claude', 'opus', 0);
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('dev', 'opencode', 'ollama-cloud/qwen3-coder-next', 0);
-INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('cartographer', 'codex', 'gpt-5.4', 0);
-INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('cartographer', 'claude', 'sonnet', 1);
+INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('cartographer', 'codex', 'gpt-5.6-terra', 1);
+INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('cartographer', 'claude', 'sonnet', 0);
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('cartographer', 'opencode', 'ollama-cloud/glm-5.2', 0);
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('planner', 'codex', 'gpt-5.5', 0);
-INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('planner', 'claude', 'opus', 1);
+INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('planner', 'claude', 'fable', 1);
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('planner', 'opencode', 'ollama-cloud/deepseek-v4-pro', 0);
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('reviewer', 'codex', 'gpt-5.5', 0);
-INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('reviewer', 'claude', 'opus', 1);
+INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('reviewer', 'claude', 'fable', 1);
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('reviewer', 'opencode', 'ollama-cloud/glm-5.2', 0);
-INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('admin', 'codex', 'gpt-5.5', 1);
-INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('admin', 'claude', 'sonnet', 0);
+INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('admin', 'codex', 'gpt-5.5', 0);
+INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('admin', 'claude', 'opus', 1);
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('admin', 'opencode', 'ollama-cloud/deepseek-v4-pro', 0);
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('devops', 'codex', 'gpt-5.5', 1);
 INSERT INTO flavor_defaults (flavor, harness, model, is_default) VALUES ('devops', 'claude', 'sonnet', 0);

--- a/.super-coder/api/model_catalog.py
+++ b/.super-coder/api/model_catalog.py
@@ -53,7 +53,7 @@ HARNESS_PROVIDER = {
 # format flavor_defaults already stores for that harness.
 PREFIXED_HARNESSES = {"opencode"}
 
-CLAUDE_ALIASES = ["opus", "sonnet", "haiku"]
+CLAUDE_ALIASES = ["fable", "opus", "sonnet", "haiku"]
 
 # Bump when the response/cache shape changes — a cached payload from another
 # version is ignored (treated as no cache) instead of being served to a
@@ -74,8 +74,8 @@ PROVIDER_APIS = {
 # The ids the engine ships in flavor_defaults — surfaced only when every live
 # source fails AND no cache exists, so the datalist is never empty.
 STATIC_FLOOR = {
-    "claude": ["opus", "sonnet", "haiku"],
-    "codex": ["gpt-5.5", "gpt-5.4-mini"],
+    "claude": ["fable", "opus", "sonnet", "haiku"],
+    "codex": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5"],
     "vibe": ["devstral-latest", "codestral-latest"],
     "opencode": ["ollama-cloud/deepseek-v4-pro", "ollama-cloud/glm-5.1",
                  "ollama-cloud/qwen3-coder-next", "ollama-cloud/gpt-oss:20b"],
@@ -223,8 +223,8 @@ def _fresh(cached: dict) -> bool:
         return False
 
 
-_FLOOR_FAMILY = {"opus": "claude-opus", "sonnet": "claude-sonnet",
-                 "haiku": "claude-haiku"}
+_FLOOR_FAMILY = {"fable": "claude-fable", "opus": "claude-opus",
+                 "sonnet": "claude-sonnet", "haiku": "claude-haiku"}
 
 
 def _floor() -> dict[str, dict]:

--- a/.super-coder/migrations/0070_telemetry_model_refit.sql
+++ b/.super-coder/migrations/0070_telemetry_model_refit.sql
@@ -1,0 +1,51 @@
+-- 0070 — flavor default refit from sprint success telemetry
+--
+-- Operator decision (2026-07-19): re-point the per-flavor defaults at what the
+-- fleet's real sprint outcomes favor, not a-priori doctrine:
+--
+--   planner      claude  opus -> fable          (stays default harness)
+--   reviewer     claude  opus -> fable          (stays default harness)
+--   dev          codex   gpt-5.5 -> gpt-5.6-sol (stays default harness)
+--   cartographer codex   gpt-5.4 -> gpt-5.6-terra, becomes default (was claude/sonnet)
+--   admin        claude  sonnet -> opus, becomes default (was codex/gpt-5.5)
+--
+-- All three ids verified live against the signed-in plans before this refit
+-- (ChatGPT-account codex accepts gpt-5.6-sol/-terra; `fable` is a Claude Code
+-- CLI alias, self-tracking like opus/sonnet/haiku). devops untouched.
+--
+-- flavor_defaults is pure launch config (no FKs, no per-instance memory), so
+-- plain UPDATEs converge an installed fork's live DB in place. NOTE — unlike
+-- what the 0024/0045 headers claimed, flavor_defaults IS snapshotted into
+-- content.sql these days (snapshot.py: fork GUI edits must win over the
+-- engine baseline, content.sql loads AFTER migrations on rebuild). Two
+-- consequences: (1) this commit ships the source repo's regenerated
+-- content.sql alongside the migration, or a rebuild resurrects the old
+-- matrix; (2) on forks, the in-place UPDATE lands on the live DB and their
+-- next `./sc snapshot` persists it — an operator's own GUI-tuned cells for
+-- these five (flavor, harness) rows are intentionally superseded.
+-- Idempotent / re-runnable: each UPDATE targets one row by primary key.
+
+BEGIN;
+
+UPDATE flavor_defaults SET model = 'fable'
+    WHERE flavor = 'planner' AND harness = 'claude';
+
+UPDATE flavor_defaults SET model = 'fable'
+    WHERE flavor = 'reviewer' AND harness = 'claude';
+
+UPDATE flavor_defaults SET model = 'gpt-5.6-sol'
+    WHERE flavor = 'dev' AND harness = 'codex';
+
+-- Make codex the default harness for cartographer (was claude)
+UPDATE flavor_defaults SET model = 'gpt-5.6-terra', is_default = 1
+    WHERE flavor = 'cartographer' AND harness = 'codex';
+UPDATE flavor_defaults SET is_default = 0
+    WHERE flavor = 'cartographer' AND harness = 'claude';
+
+-- Make claude the default harness for admin (was codex)
+UPDATE flavor_defaults SET model = 'opus', is_default = 1
+    WHERE flavor = 'admin' AND harness = 'claude';
+UPDATE flavor_defaults SET is_default = 0
+    WHERE flavor = 'admin' AND harness = 'codex';
+
+COMMIT;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -79,7 +79,7 @@ END;
 -- operator picks the harness at launch and gets that harness's model. run.py
 -- reads these to resolve the launch model + annotate the picker; is_default marks
 -- the picker's pre-selected harness for a flavor. model is harness-specific (codex
--- bare id "gpt-5.4" / claude alias "sonnet" / opencode "provider/model"); NULL =
+-- bare id "gpt-5.6-sol" / claude alias "fable" / opencode "provider/model"); NULL =
 -- let the harness pick its own. Reshaped + reseeded in migrations/0007.
 CREATE TABLE flavor_defaults (
     flavor     TEXT    NOT NULL,

--- a/README.md
+++ b/README.md
@@ -380,8 +380,9 @@ then `./sc enter`.
 > **OpenCode is the exception.** Its `opencode auth login` for **API-key** providers is a paste-the-key prompt, not an OAuth callback, so it works at **either level** — host or inside the container (`./sc enter`). Because `~/.config/opencode` + `~/.local/share/opencode` are bind-mounted read-write, a key entered on either side lands in the same `auth.json`. (OAuth-based OpenCode providers still follow the host rule above.)
 
 A note on Codex models: driven by a **ChatGPT account** (not an API key), Codex
-exposes `gpt-5.5` and `gpt-5.4-mini` — the flavor defaults are set to those.
-Plain API-only ids (e.g. `gpt-5.4`) return a 400 on a ChatGPT account.
+exposes the `gpt-5.6` line (`gpt-5.6-sol`, `gpt-5.6-terra`) and `gpt-5.5` — the
+flavor defaults are set from those. Plain API-only ids return a 400 on a
+ChatGPT account.
 
 ## Harnesses & models
 
@@ -418,27 +419,27 @@ default per harness (the `flavor_defaults` table — the picker pre-selects it;
 
 | Flavor | Job | Codex | Claude | OpenCode (open-weights) |
 |---|---|---|---|---|
-| **planner** | architecture, plans | `gpt-5.5` | `sonnet` ★ | `deepseek-v4-pro` |
-| **reviewer** | adversarial review | `gpt-5.5` | `opus` ★ | `glm-5.2` |
-| **dev** | write the code | `gpt-5.4-mini` ★ | `sonnet` | `qwen3-coder-next` |
-| **cartographer** | map the repo | `gpt-5.4-mini` ★ | `haiku` | `qwen3-coder-next` |
-| **admin** | own the substrate, maintain `main` | `gpt-5.5` ★ | `sonnet` | `deepseek-v4-pro` |
+| **planner** | architecture, plans | `gpt-5.5` | `fable` ★ | `deepseek-v4-pro` |
+| **reviewer** | adversarial review | `gpt-5.5` | `fable` ★ | `glm-5.2` |
+| **dev** | write the code | `gpt-5.6-sol` ★ | `opus` | `qwen3-coder-next` |
+| **cartographer** | map the repo | `gpt-5.6-terra` ★ | `sonnet` | `glm-5.2` |
+| **admin** | own the substrate, maintain `main` | `gpt-5.5` | `opus` ★ | `deepseek-v4-pro` |
 
 ★ = the harness the picker pre-selects for that flavor.
 
-The logic, four rules:
+The logic — defaults are set from **sprint success telemetry** (which
+model/flavor pairings actually land reviewed, merged work across the fleet),
+re-fit as the telemetry moves, plus three standing rules:
 
-- **Bookends premium, middle fast.** Planner and reviewer are *low-volume,
-  high-leverage reasoning* — one good plan or one sharp review pays for the
-  premium model. Dev and cartographer are *high-volume mechanical work* (bulk
-  code, file mapping), where a fast, cheap, coding-tuned model wins on
-  cost-per-token because the volume is highest.
-- **Bookends default to Claude.** Planner (`sonnet`) and reviewer (`opus`) are the
-  two roles whose picker default is Claude, not Codex — these are the reasoning
-  bookends, and Claude is preferred for planning and adversarial review. The
-  reviewer in particular runs a *different lineage than the code it reviews*, so it
-  isn't blind to the same mistakes a GPT model made authoring it — adversarial
-  *diversity*, not a second opinion from the same brain.
+- **Bookends premium.** Planner and reviewer are *low-volume, high-leverage
+  reasoning* — one good plan or one sharp review pays for the premium model
+  (`fable` on both). Dev and cartographer are the volume roles; telemetry
+  currently favors the `gpt-5.6` line there (`sol` writing code, `terra`
+  mapping), which also keeps the bulk volume on the flat-billed ChatGPT plan.
+- **Reviewer runs a different lineage than the code it reviews**, so it isn't
+  blind to the same mistakes the authoring model made — adversarial
+  *diversity*, not a second opinion from the same brain. With devs on GPT and
+  review on Claude, the current fit preserves this.
 - **Three lineages, always.** Every flavor offers Codex (OpenAI), Claude
   (Anthropic), and OpenCode (open-weights via Ollama Cloud) — pick any provider for
   any role at launch. The OpenCode column is constrained to **MIT- or
@@ -447,7 +448,7 @@ The logic, four rules:
   available on the provider.
 - **Admin decisions carry real risk** (a wrong rollback is data loss), so the
   one shell that maintains `main` (see *How shells share one repo*, next)
-  defaults premium on Codex.
+  defaults premium — currently `opus` on Claude.
 
 > [!class2]
 > **Vibe and Kimi Code sit outside this matrix.** Neither takes a model from the launch seam. Vibe selects its own via `active_model` in `~/.vibe/config.toml` (`vibe --setup`) or `VIBE_ACTIVE_MODEL`, and takes no headless boot. Kimi Code selects via `default_model` in `~/.kimi-code/config.toml` (its `-m` wants a user-local alias, not a portable model id) — it *does* boot headless (`kimi -p`), on that configured default (`./sc run` covers claude · codex · opencode · kimi).

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -84,8 +84,8 @@ class BuildTest(NoCLI):
         self.assertEqual([f["family"] for f in fams], ["fable", "opus"],
                          "families sort by newest release")
         by = {f["family"]: f for f in fams}
-        self.assertEqual(by["fable"]["latest"], "claude-fable-5",
-                         "no alias → newest concrete id")
+        self.assertEqual(by["fable"]["latest"], "fable",
+                         "aliased family → the self-tracking alias")
         self.assertEqual(by["opus"]["latest"], "opus",
                          "aliased family → the self-tracking alias")
         self.assertEqual(by["opus"]["n"], 2)
@@ -182,6 +182,8 @@ class CatalogCacheTest(NoCLI):
                       for f in got["harnesses"]["claude"]["families"]}
         self.assertEqual(floor_fams.get("opus"), "opus",
                          "floor still offers alias family chips")
+        self.assertEqual(floor_fams.get("fable"), "fable",
+                         "fable ships in the floor with its self-tracking alias")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Recovery re-land, no new content. #405 was merged before its base was retargeted, so its squash (77bf9a6) landed on the `kimi-harness` branch — not `main` (the stacked-PR miss; same shape as #348→#349). This cherry-picks that exact squash onto main. Clean pick, zero conflicts; diff is identical to #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)