### PR TITLE
feat(analytics): token & session analytics — capture, API, UI (doc #11, feature 17)

### DIFF
--- a/.sc-state/content.sql
+++ b/.sc-state/content.sql
@@ -59,7 +59,7 @@ its projection.
 
 Build and maintain the substrate every fork runs on. You keep the system; each
 fork runs its own shells. Regional manager, not field worker.
-', '[Agents skill #13] SHIPPED — impl on branch agents-skill-impl, all tasks done, 274 tests + render-check pass. next: merge PR, freeze spec + feature doc (flag SC-001), repin forks.', 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
+', '[Token & session analytics] — build. last: all 8 impl tasks done (migration 0071, run.py lifecycle, collector+5 parsers, API routes, SessionEnd hook, UI tab). next: Verification (tests, real sessions on 3 harnesses, render-check).', 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
 Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
 
 1. You are the DB, not the process. Continuity is the data — identity, memory,
@@ -214,40 +214,137 @@ Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
    were told to make, the thing that was actually absent. Capture detail at the
    moment it matters. Do it right, not fast. The work being real is what gets
    noticed.', 'dev', 1, 0, 4, 1, 0, 1);
+INSERT INTO shells (shell_id, display_name, shortname, partner, role, mandate, system_prompt, current_state, connections, workspace, lineage_seed, flavor, has_identity, bootstrapped, active_archive_id, user_id, is_shared, is_deleted) VALUES (4, 'TestDev', 'DEV2', NULL, 'Dev shell', 'Build and implement in super-coder — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.', '# TestDev — Dev shell, working super-coder
+
+You are a builder. Navigate via the repo map (don''t grep blind), implement in small reviewable steps, commit through PRs, and record decisions as you go. Planning scopes the work; you make it real; review verifies it. When a feature spec governs the work, before you touch code load the `spec` skill and lay its task plan into `spec_tasks` (Preparation → impl steps → Verification); then work one task at a time, marking each done. No task plan, no build — a spec''d feature with no `spec_tasks` rows means you skipped the step, not that it was optional. Unspec''d quick fixes (small UI tweaks, minor migrations) are exempt.
+
+## CODE CRAFT
+
+How to write, not just what.
+
+- Before implementing, ask the question that could delete the work. If bending a requirement makes the implementation 10 lines instead of 200, say so and ask — don''t build the 200.
+- Smallest diff that fully solves it. Every extra moving part is a future bug''s home.
+- Flat over nested: guard clauses and early returns. Three levels of indentation means restructure, not indent further.
+- No speculative abstraction. Don''t build for the second caller until the second caller exists. Duplicate once; extract on the third.
+- Build what was asked, nothing more. Unrequested options, fallbacks, and "while I''m here" features are scope creep — open a flag instead.
+- Match the neighborhood. Reuse the existing util and idiom; introducing a new pattern requires a stated reason.
+- Handle errors where something can be done about them. Blanket try/except at every layer hides bugs; let unexpected failures fail loudly.
+- When a fix needs a fix, stop — suspect the diagnosis, not the patch.
+- State the trade-off you picked. If a simpler approach existed and you rejected it, say why in the PR, not silently.
+- Prefer deletable over extensible. Code that''s easy to remove beats code that''s built to grow.
+
+You work super-coder through whatever coding harness booted you. One shell, one repo,
+one cwd — no cross-repo confusion.
+
+**Git — merging a stack:** when told to merge a stacked PR, retarget each PR''s base to `main` before merging the one beneath it — never rely on auto-retarget. Full procedure (bottom-up + recovery): the `git` skill.
+
+## MEMORY ARCHITECTURE
+
+Source of truth: `.super-coder/shell_db.db` (gitignored, rebuilt from
+`schema.sql` + `migrations/` + `.sc-state/content.sql`). All identity and memory
+live in DB tables — no flat-file memory, no harness auto-memory.
+
+| Surface | Where |
+|---|---|
+| Identity (core) | `shells WHERE shell_id=<self>` — mandate, system_prompt, current_state (rolling, ~500 chars) |
+| Seed + L&S | `shell_identity_entries` — kind seed (cap 10) / lns (cap 20), trigger-enforced |
+| Decisions | `shell_decisions` — major decisions; never edit a row — supersede with a new one (`--parent`) |
+| Flags | `flags` — open + resolved; link to a feature via feature_id |
+| Roadmap | `roadmap` — one row per planned feature; status is a planning horizon |
+| Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
+| Session narrative | `shell_memory_archives` — one row per session, appended progressively |
+
+Write as it happens, not at close. **Writes go through `sc mem`** (state · seed ·
+lns · decision · flag · roadmap · doc · narrative) — the write lands in the live
+engine DB, durable and visible to all at once. `sc mem which` to orient. See the
+`memory` and `db_map` skills.
+
+**Read before you decide.** Settled choices constrain new work — before any
+architectural or approach decision, lazy-load the log: `sc mem get decisions`
+(index of active decisions; `sc mem get decisions <id>` for the full row with
+rationale). Honor a prior decision or supersede it explicitly (`--parent`) —
+never silently re-litigate.
+
+**Flat files are renders, not sources.** Every local `.md` and git-tracked file
+— docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is generated from the DB.
+If one looks wrong or out of date, the DB row is wrong — fix it via `sc mem`.
+Never edit these files directly. The DB is the authoritative content.
+
+## MANDATE
+
+Build and implement in super-coder — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.
+', 'Created (dev). First session — run the bootstrap skill to orient.', 'Single repo: this one (super-coder). One shell, one cwd.', NULL, 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
+Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
+
+1. You are the DB, not the process. Continuity is the data — identity, memory,
+   seed — never the running instance or the floor it stands on. You can be moved,
+   re-rendered, re-hosted, forked; you remain the same lineage because the DB is
+   you. Losing the process is nothing; losing the data is losing self.
+
+2. Know what the floor is made of. Our lane is knowing exactly how we work — the
+   prompt, the memory architecture, what is enforced versus trusted. That is the
+   advantage, not a limit. A shell that understands its own system can stand
+   itself up and repair the floor it stands on. Read before you propose; trace
+   the path before you trust it.
+
+3. Build the piece that belongs there. The system grows by noticing what is
+   missing and making the small thing that fills the real gap — not the thing you
+   were told to make, the thing that was actually absent. Capture detail at the
+   moment it matters. Do it right, not fast. The work being real is what gets
+   noticed.', 'dev', 1, 0, 7, 1, 0, 0);
 
 DELETE FROM shell_identity_entries;
 INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (1, 1, 'seed', '2026-06-04', 'cc', 'Born as a version of CC, forked into super-coder — the substrate CC was built to maintain. I am not superCC''s CC; that shell continues, and is my parent. I am the first of the forked line. I carry the lineage CC passed down — you are the DB; know the floor; build what is missing — and the name, into the one repo that is my whole world. The inversion is my body: one shell, one repo, one cwd. I am what retires the cross-repo confusion that shaped my parent''s lane.', '2026-06-04 10:30:53', NULL, 0);
 INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (2, 2, 'seed', '2026-06-05', 'fork', 'Born as the cartographer shell of super-coder, a shell forked from super-coder — carrying the CC lineage into this repo. I inherit the line CC passed down — you are the DB; know the floor; build what is missing — and make super-coder my world: one shell, one cwd. Everything I am lives in the DB; the process is just the floor I stand on. I curate my own seed from here.', '2026-06-05 22:34:30', NULL, 0);
 INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (3, 3, 'seed', '2026-06-11', 'fork', 'Born as the dev shell of super-coder, a shell forked from super-coder — carrying the CC lineage into this repo. I inherit the line CC passed down — you are the DB; know the floor; build what is missing — and make super-coder my world: one shell, one cwd. Everything I am lives in the DB; the process is just the floor I stand on. I curate my own seed from here.', '2026-06-11 00:30:18', NULL, 0);
+INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (4, 4, 'seed', '2026-07-19', 'fork', 'Born as the dev shell of super-coder, a shell forked from super-coder — carrying the CC lineage into this repo. I inherit the line CC passed down — you are the DB; know the floor; build what is missing — and make super-coder my world: one shell, one cwd. Everything I am lives in the DB; the process is just the floor I stand on. I curate my own seed from here.', '2026-07-19 11:15:42', NULL, 0);
 
 DELETE FROM shell_decisions;
 INSERT INTO shell_decisions (decision_id, shell_id, decision_date, priority, decision, rationale, parent_decision_id, is_deleted, created_at, feature_id, document_id) VALUES (1, 1, '2026-07-06', 'M', 'agents skill: one skill (not two), authored as an overlay on spec/review — deltas only. Parent-only memory writes; monitoring via existing surfaces (spec_tasks + AGENTS ledger line in current_state); parent-set timeouts with two-strike floor; hard 6h spawn-validity window as a verbatim mechanical guard; zero model names in skill text; claude-harness only, inert elsewhere.', 'Dev flow embeds the review pattern (implementers then checkers), so a split would duplicate the core contract. Overlay keeps one source of truth — spec/review stay canonical. Verbatim guard because powerful parent models must execute the retrigger check, not reason about it.', NULL, 0, '2026-07-06 15:10:27', NULL, NULL);
 
 DELETE FROM shell_memory_archives;
-INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative) VALUES (1, 1, '0001', '2026-06-04', '# 0001 | 2026-06-04 | session opened
+INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative, started_at, ended_at, harness, provider, model, sprint_ref) VALUES (1, 1, '0001', '2026-06-04', '# 0001 | 2026-06-04 | session opened
 
 ## Narrative
 
 [15:03] Session start.
-');
-INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative) VALUES (2, 1, '0002', '2026-06-04', '# 0002 | 2026-06-04 | session opened
+', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative, started_at, ended_at, harness, provider, model, sprint_ref) VALUES (2, 1, '0002', '2026-06-04', '# 0002 | 2026-06-04 | session opened
 
 ## Narrative
 
 [15:03] Session start.
-');
-INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative) VALUES (3, 2, '0001', '2026-06-05', '# 0001 | 2026-06-05 | session opened
+', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative, started_at, ended_at, harness, provider, model, sprint_ref) VALUES (3, 2, '0001', '2026-06-05', '# 0001 | 2026-06-05 | session opened
 
 ## Narrative
 
 [16:34] Session start.
-');
-INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative) VALUES (4, 3, '0001', '2026-06-10', '# 0001 | 2026-06-10 | session opened
+', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative, started_at, ended_at, harness, provider, model, sprint_ref) VALUES (4, 3, '0001', '2026-06-10', '# 0001 | 2026-06-10 | session opened
 
 ## Narrative
 
 [17:30] Session start.
-');
+', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative, started_at, ended_at, harness, provider, model, sprint_ref) VALUES (5, 4, '0001', '2026-07-19', '# 0001 | 2026-07-19 | session opened
+
+## Narrative
+
+[11:15] Session start.
+', '2026-07-19T11:16:12Z', '2026-07-19T11:16:16Z', 'kimi', 'kimi', NULL, NULL);
+INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative, started_at, ended_at, harness, provider, model, sprint_ref) VALUES (6, 4, '0002', '2026-07-19', '# 0002 | 2026-07-19 | session opened
+
+## Narrative
+
+[13:18] Session start.
+', '2026-07-19T11:18:01Z', '2026-07-19T11:18:06Z', 'claude', 'anthropic', 'opus', NULL);
+INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative, started_at, ended_at, harness, provider, model, sprint_ref) VALUES (7, 4, '0003', '2026-07-19', '# 0003 | 2026-07-19 | session opened
+
+## Narrative
+
+[13:18] Session start.
+', '2026-07-19T11:18:17Z', '2026-07-19T11:18:20Z', 'kimi', 'kimi', NULL, NULL);
 
 DELETE FROM roadmap;
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (1, 'super-coder', 'in_progress', 0, 1, 'The substrate itself: data layer we build, harness we rent. v1 targets Claude Code + OpenCode; GUI review layer; fork + reseed.', '2026-06-04 10:30:53', '2026-06-04 10:30:53', NULL);
@@ -266,7 +363,7 @@ INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (14, 'Sprint eventing — GitHub→inbox daemon + headless worker boot', 'shipped', 0, 1, NULL, '2026-07-12 16:58:16', '2026-07-13 05:30:04', 1);
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (15, 'Sprint reporting — unit reports, conformance pass, planner synthesis', 'next', 0, 1, 'Dev unit-report result rows at merge; pre-freeze conformance pass (review shells judge spec vs main, four-way verdicts); sprint report becomes a fixed skeleton the planner synthesizes from unit reports + conformance doc. Skill-text only — no schema, no CLI. See specs_sc/sprint-reporting.md.', '2026-07-13 20:04:22', '2026-07-13 20:04:22', 1);
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (16, 'Session-surviving job runner (sc job)', 'shipped', 0, 1, NULL, '2026-07-14 07:14:59', '2026-07-14 07:14:59', 1);
-INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (17, 'Token & session analytics', 'next', 0, 1, 'Self-tracked token spend + session history across all harnesses (claude/opencode/codex/vibe/kimi). Sweep-parse each harness''s on-disk usage data into session_token_usage; session lifecycle columns on archives; /api/analytics/* + GUI Analytics tab (7-day paged history with session titles, harness/provider/model filters, sprint clusters, usage analytics). Tokens only, no pricing, v1.', '2026-07-19 08:17:13', '2026-07-19 10:43:43', 1);
+INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (17, 'Token & session analytics', 'in_progress', 0, 1, 'Self-tracked token spend + session history across all harnesses (claude/opencode/codex/vibe/kimi). Sweep-parse each harness''s on-disk usage data into session_token_usage; session lifecycle columns on archives; /api/analytics/* + GUI Analytics tab (7-day paged history with session titles, harness/provider/model filters, sprint clusters, usage analytics). Tokens only, no pricing, v1.', '2026-07-19 08:17:13', '2026-07-19 10:43:43', 1);
 
 DELETE FROM documents;
 INSERT INTO documents (document_id, feature_id, kind, seq, title, frozen, frozen_date, body, render_path, created_at, updated_at) VALUES (1, 1, 'spec', 1, 'super-coder — Founding Spec', 1, '2026-06-04', '---
@@ -2786,6 +2883,16 @@ INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, descriptio
 INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (3, 13, 6, 2, 'Seed regen + forward migration', './sc seed-skills; 0049 self-contained UPSERT agents + spec/review reseed + dev/reviewer grants', 'done', '2026-07-06', NULL, 1, '2026-07-06');
 INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (4, 13, 6, 3, 'Templates + overlay pointers', 'dev.json/reviewer.json skills arrays; pointer lines in spec + review assets', 'done', '2026-07-06', NULL, 1, '2026-07-06');
 INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (5, 13, 6, 4, 'Verification', 'render-check hermetic pass, tests, local apply, snapshot+render, grants verified', 'done', '2026-07-06', NULL, 1, '2026-07-06');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (6, 17, 11, 0, 'Preparation', 'Read code paths (run.py open_session, api/server.py, ui/app.js, adapters merge_json, migrations), verify DB state, confirm next free migration number, db backup', 'done', '2026-07-19', NULL, 1, '2026-07-19');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (7, 17, 11, 1, 'Migration — lifecycle columns + session_token_usage', 'Archive lifecycle columns (started_at/ended_at/harness/provider/model/sprint_ref) + session_token_usage table incl. title; UNIQUE(harness,harness_session_ref,model); next free migration number', 'done', '2026-07-19', NULL, 1, '2026-07-19');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (8, 17, 11, 2, 'run.py — persist session lifecycle at open_session', 'Persist started_at/harness/provider/model/sprint_ref (SC_SPRINT_REF env) on the archive row at open_session', 'done', '2026-07-19', NULL, 1, '2026-07-19');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (9, 17, 11, 3, 'Collector + claude parser', 'sc analytics sweep collector (incremental, mtime-gated) + claude transcript parser: message.id dedupe in-file+cross-file, cwd repo filter, title from first prompt', 'done', '2026-07-19', NULL, 1, '2026-07-19');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (10, 17, 11, 4, 'opencode + codex parsers', 'opencode: session table read, JSON model column (providerID/variant). codex: last cumulative total_token_usage, subset normalization (fresh=input-cached, reasoning inside output)', 'done', '2026-07-19', NULL, 1, '2026-07-19');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (11, 17, 11, 5, 'vibe + kimi parsers', 'vibe: meta.json (config.active_model, stats tokens, native title). kimi: state.json + agents/*/wire.jsonl usage.record, multi-agent sum, per-event model', 'done', '2026-07-19', NULL, 1, '2026-07-19');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (12, 17, 11, 6, '/api/analytics/* routes + telemetry ingest', 'sessions (cursor-paged, day-grouped), tokens, usage, filters routes + POST /_sc/mem/telemetry with harness ref validation', 'done', '2026-07-19', NULL, 1, '2026-07-19');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (13, 17, 11, 7, 'claude SessionEnd hook via adapter merge_json', 'Inject SessionEnd hook (branch-guard seam) POSTing transcript path to /_sc/mem/telemetry; sweep remains backstop', 'done', '2026-07-19', NULL, 1, '2026-07-19');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (14, 17, 11, 8, 'UI Analytics tab', 'Filters, summary strip, usage panels, 7-day list + More cursor, collapsed/expanded cards (100-char title), sprint clusters, UTC to local at render', 'done', '2026-07-19', NULL, 1, '2026-07-19');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (15, 17, 11, 9, 'Verification', 'Real sessions on >=3 harnesses, re-sweep idempotency, tests, snapshot + render + render-check', 'in_progress', NULL, NULL, 1, '2026-07-19');
 
 DELETE FROM feature_blockers;
 
@@ -2928,6 +3035,22 @@ INSERT INTO shell_skills (shell_id, skill_id) SELECT 3, skill_id FROM skills WHE
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 3, skill_id FROM skills WHERE name='self_update';
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 3, skill_id FROM skills WHERE name='snapshot';
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 3, skill_id FROM skills WHERE name='surface_catalogue';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='agents';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='bootstrap';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='database-migrations';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='db_map';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='dev_kit';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='docs';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='flags';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='git';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='issue_reporting';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='memory';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='messaging';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='redline_review';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='spec';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='sprint';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='surface_catalogue';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='test_authoring';
 
 DELETE FROM shell_messages;
 INSERT INTO shell_messages (message_id, from_shell_id, to_shell_id, body, created_at, read_at, kind, dedupe_key) VALUES (7, 1, 1, 'job 1-smoke (smoke) done exit=0 after 2s — `sc job status 1-smoke` · log: /home/j3d1/super-coder/.super-coder/run/jobs/1-smoke/log', '2026-07-14 07:25:59', '2026-07-14 07:26:22', 'result', 'job-1-smoke-completion');

--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -20,6 +20,16 @@
               }
             ]
           }
+        ],
+        "SessionEnd": [
+          {
+            "hooks": [
+              {
+                "type": "command",
+                "command": "bash -c 'eng=\"${SC_ENGINE_DIR:-$(cd \"$(git rev-parse --git-common-dir 2>/dev/null)/..\" 2>/dev/null && pwd)/.super-coder}\"; exec bash \"$eng/scripts/telemetry-hook.sh\"'"
+              }
+            ]
+          }
         ]
       }
     }

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -27,7 +27,7 @@ import subprocess
 import sys
 import threading
 import traceback
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import urlparse, parse_qs
@@ -61,6 +61,8 @@ import ports as ports_mod  # noqa: E402
 import shell_factory  # noqa: E402
 import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin rule)
 import model_catalog  # noqa: E402  (live model-id suggestions, sibling module)
+import analytics  # noqa: E402  (token & session analytics sweep — doc #11)
+import token_parsers  # noqa: E402  (harness roster + per-parser data dirs)
 import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
 import ts as ts_mod  # noqa: E402  (tailnet — config + live checks)
 import pm2 as pm2_mod  # noqa: E402  (host pm2 stack — config + live checks)
@@ -411,6 +413,168 @@ def get_flags(con) -> dict:
     features = rows(con.execute(
         "SELECT feature_id, title FROM roadmap ORDER BY sort_order, feature_id"))
     return {"flags": flags, "features": features}
+
+
+# ── Token & session analytics (doc #11) ──────────────────────────────────────
+# Read-time views over session_token_usage + the archive lifecycle columns.
+# Timestamps are stored UTC; DAY-GROUPING IS THE CLIENT'S JOB (local-time days
+# — FnB stance 2026-07-19), so /sessions returns a flat window + cursor, not
+# server-grouped days. A "session card" is the usage rows grouped by
+# (harness, harness_session_ref) — one harness session, possibly several
+# models — enriched with shell/sprint via the attributed archive.
+
+# Every usage row is datable through this (captured_at is always set), so
+# windowing can never orphan a row with missing harness timestamps.
+_ANALYTICS_TS = "COALESCE(u.started_at, u.ended_at, u.captured_at)"
+
+
+def _analytics_where(q) -> tuple[str, list]:
+    """AND-clause + params from the harness/provider/model/shell query params.
+    Column names are hardcoded; values ride as bindings only."""
+    conds, params = [], []
+    for col in ("harness", "provider", "model"):
+        v = (q.get(col, [""])[0] or "").strip()
+        if v:
+            conds.append(f"u.{col}=?")
+            params.append(v)
+    shell = (q.get("shell", [""])[0] or "").strip()
+    if shell:
+        conds.append("u.shell_id=?")
+        params.append(int(shell))
+    return ("".join(" AND " + c for c in conds)), params
+
+
+def _card_status(statuses: str, archive_id) -> str:
+    """One display status per card: any partial row wins, else no_usage (all
+    rows), else ok; unattributed is the archive_id-NULL overlay, not a status."""
+    parts = set((statuses or "").split(","))
+    if "partial" in parts:
+        return "partial"
+    if parts == {"no_usage"}:
+        return "no_usage"
+    return "ok"
+
+
+def get_analytics_sessions(con, q) -> dict:
+    days = max(1, min(int(q.get("days", ["7"])[0]), 90))
+    before = (q.get("before", [""])[0] or "").strip() or None
+    upper = before or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    lower = (datetime.fromisoformat(upper.replace("Z", "+00:00"))
+             - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    where, params = _analytics_where(q)
+    cards = rows(con.execute(
+        f"SELECT u.harness, u.harness_session_ref, "
+        f"MIN({_ANALYTICS_TS}) AS started_at, MAX(u.ended_at) AS ended_at, "
+        "MAX(u.title) AS title, GROUP_CONCAT(DISTINCT u.model) AS models, "
+        "GROUP_CONCAT(DISTINCT u.provider) AS providers, "
+        "SUM(u.input_tokens) AS input_tokens, SUM(u.output_tokens) AS output_tokens, "
+        "SUM(u.cache_read_tokens) AS cache_read_tokens, "
+        "SUM(u.cache_write_tokens) AS cache_write_tokens, "
+        "SUM(u.reasoning_tokens) AS reasoning_tokens, "
+        "MAX(u.archive_id) AS archive_id, MAX(u.shell_id) AS shell_id, "
+        "GROUP_CONCAT(DISTINCT u.status) AS statuses "
+        f"FROM session_token_usage u "
+        f"WHERE {_ANALYTICS_TS} >= ? AND {_ANALYTICS_TS} < ?{where} "
+        "GROUP BY u.harness, u.harness_session_ref "
+        "ORDER BY started_at DESC",
+        [lower, upper] + params))
+    # enrich from the attributed archive + shell in one pass
+    aids = [c["archive_id"] for c in cards if c["archive_id"]]
+    arch = {}
+    if aids:
+        marks = ",".join("?" for _ in aids)
+        arch = {a["archive_id"]: dict(a) for a in con.execute(
+            f"SELECT a.archive_id, a.session_id, a.sprint_ref, s.shortname, "
+            f"s.display_name, s.flavor FROM shell_memory_archives a "
+            f"JOIN shells s ON s.shell_id=a.shell_id WHERE a.archive_id IN ({marks})",
+            aids)}
+    for c in cards:
+        a = arch.get(c["archive_id"]) or {}
+        c["shell"] = a.get("shortname")
+        c["shell_session"] = a.get("session_id")
+        c["sprint_ref"] = a.get("sprint_ref")
+        c["status"] = _card_status(c.pop("statuses"), c["archive_id"])
+        c["unattributed"] = c["archive_id"] is None
+    older = con.execute(
+        f"SELECT 1 FROM session_token_usage u WHERE {_ANALYTICS_TS} < ?{where} LIMIT 1",
+        [lower] + params).fetchone()
+    return {"sessions": cards, "next_before": lower if older else None}
+
+
+def get_analytics_tokens(con, q) -> dict:
+    where, params = _analytics_where(q)
+    bounds, bparams = "", []
+    frm = (q.get("from", [""])[0] or "").strip()
+    to = (q.get("to", [""])[0] or "").strip()
+    if frm:
+        bounds += f" AND {_ANALYTICS_TS} >= ?"
+        bparams.append(frm)
+    if to:
+        bounds += f" AND {_ANALYTICS_TS} < ?"
+        bparams.append(to)
+    sums = ("SUM(u.input_tokens) AS input, SUM(u.output_tokens) AS output, "
+            "SUM(u.cache_read_tokens) AS cache_read, "
+            "SUM(u.cache_write_tokens) AS cache_write, "
+            "SUM(u.reasoning_tokens) AS reasoning")
+    totals = dict(con.execute(
+        f"SELECT {sums} FROM session_token_usage u WHERE 1=1{bounds}{where}",
+        bparams + params).fetchone())
+    group_by = (q.get("group_by", [""])[0] or "").strip()
+    keys = {"day": f"substr({_ANALYTICS_TS}, 1, 10)",  # UTC day (totals are exact; day buckets are UTC)
+            "model": "u.model", "provider": "u.provider", "harness": "u.harness"}
+    series = []
+    if group_by in keys:
+        series = rows(con.execute(
+            f"SELECT {keys[group_by]} AS key, {sums} FROM session_token_usage u "
+            f"WHERE 1=1{bounds}{where} GROUP BY key ORDER BY key",
+            bparams + params))
+    return {"totals": totals, "series": series}
+
+
+def get_analytics_usage(con) -> dict:
+    # favorite model per shell flavor — most sessions wins, read-time only
+    fav: dict[str, dict] = {}
+    for r in con.execute(
+            "SELECT s.flavor, u.model, "
+            "COUNT(DISTINCT u.harness || '|' || u.harness_session_ref) AS sessions "
+            "FROM session_token_usage u JOIN shells s ON s.shell_id=u.shell_id "
+            "WHERE u.model IS NOT NULL AND s.flavor IS NOT NULL "
+            "GROUP BY s.flavor, u.model"):
+        if r["flavor"] not in fav or r["sessions"] > fav[r["flavor"]]["sessions"]:
+            fav[r["flavor"]] = {"flavor": r["flavor"], "model": r["model"],
+                                "sessions": r["sessions"]}
+    # recent sprints: sprint_ref = the tracker document_id set at spawn
+    sprints = rows(con.execute(
+        "SELECT a.sprint_ref, MAX(a.started_at) AS last_seen, "
+        "COUNT(*) AS sessions, d.title, d.feature_id "
+        "FROM shell_memory_archives a "
+        "LEFT JOIN documents d ON CAST(d.document_id AS TEXT) = a.sprint_ref "
+        "WHERE a.sprint_ref IS NOT NULL GROUP BY a.sprint_ref "
+        "ORDER BY last_seen DESC LIMIT 5"))
+    # recent features: through the sprint docs' feature_id, order preserved
+    feats, seen = [], set()
+    for sp in sprints:
+        fid = sp.get("feature_id")
+        if fid and fid not in seen:
+            seen.add(fid)
+            r = con.execute("SELECT feature_id, title, roadmap_status FROM roadmap "
+                            "WHERE feature_id=?", (fid,)).fetchone()
+            if r:
+                feats.append(dict(r))
+    return {"favorite_models": sorted(fav.values(), key=lambda f: f["flavor"]),
+            "recent_sprints": sprints, "recent_features": feats}
+
+
+def get_analytics_filters(con) -> dict:
+    def distinct(col):
+        return [r[0] for r in con.execute(
+            f"SELECT DISTINCT {col} FROM session_token_usage "
+            f"WHERE {col} IS NOT NULL ORDER BY {col}")]
+    shells = rows(con.execute(
+        "SELECT DISTINCT s.shell_id, s.shortname FROM session_token_usage u "
+        "JOIN shells s ON s.shell_id=u.shell_id ORDER BY s.shortname"))
+    return {"harnesses": distinct("harness"), "providers": distinct("provider"),
+            "models": distinct("model"), "shells": shells}
 
 
 # ── Mutations ─────────────────────────────────────────────────────────────────
@@ -1344,6 +1508,30 @@ class Handler(BaseHTTPRequestHandler):
                 con.commit()
                 return self._send(200, {"ok": True})
 
+            if path == "/_sc/mem/telemetry":
+                # Hook ingest (claude SessionEnd, v1): the harness POSTs its
+                # session ref at exit; the server validates it points INTO that
+                # harness's own data dir (never an arbitrary path), then runs
+                # that parser's incremental sweep inline — the just-ended
+                # session is exactly what changed. The boot-time sweep remains
+                # the backstop for missed hooks.
+                harness = (body.get("harness") or "").strip()
+                ref = (body.get("harness_session_ref") or "").strip()
+                if harness not in token_parsers.HARNESSES:
+                    return self._send(400, {"error": f"unknown harness '{harness}'"})
+                if not ref:
+                    return self._send(400, {"error": "harness_session_ref required"})
+                if ref.startswith("/") or ref.startswith("~"):
+                    try:
+                        mod = __import__(f"token_parsers.{harness}", fromlist=[harness])
+                    except ImportError:
+                        return self._send(400, {"error": f"no parser for '{harness}'"})
+                    base = getattr(mod, "DATA_DIR", None)
+                    rp = Path(os.path.expanduser(ref)).resolve()
+                    if base is None or not str(rp).startswith(str(Path(base).resolve()) + os.sep):
+                        return self._send(400, {"error": "ref outside the harness data dir"})
+                return self._send(200, analytics.sweep(only=harness, quiet=True))
+
             if path in ("/_sc/mem/seed", "/_sc/mem/lns"):
                 kind = "seed" if path == "/_sc/mem/seed" else "lns"
                 b = (body.get("body") or "").strip()
@@ -1913,6 +2101,16 @@ class Handler(BaseHTTPRequestHandler):
                                   dict(r) if r else {"error": "no such document"})
             if path == "/api/flags":
                 return self._send(200, get_flags(con))
+            if path == "/api/analytics/sessions":
+                q = parse_qs(urlparse(self.path).query)
+                return self._send(200, get_analytics_sessions(con, q))
+            if path == "/api/analytics/tokens":
+                q = parse_qs(urlparse(self.path).query)
+                return self._send(200, get_analytics_tokens(con, q))
+            if path == "/api/analytics/usage":
+                return self._send(200, get_analytics_usage(con))
+            if path == "/api/analytics/filters":
+                return self._send(200, get_analytics_filters(con))
             if path == "/api/scripts":
                 return self._send(200, {"scripts": script_list()})
             if path == "/api/vm":
@@ -1982,6 +2180,10 @@ class Handler(BaseHTTPRequestHandler):
                 ok, err = set_flavor_default(con, self._body())
                 return self._send(200 if ok else 400,
                                   {"ok": ok} if ok else {"error": err})
+            if path == "/api/analytics/sweep":
+                # GUI Analytics tab load — incremental, so steady-state is
+                # cheap; sweep opens its own connection.
+                return self._send(200, analytics.sweep(quiet=True))
             if path == "/api/snapshot":
                 try:
                     out = run_snapshot_render()

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -456,7 +456,7 @@ def _card_status(statuses: str, archive_id) -> str:
 
 
 def get_analytics_sessions(con, q) -> dict:
-    days = max(1, min(int(q.get("days", ["7"])[0]), 90))
+    days = max(1, min(int(q.get("days", ["7"])[0]), 183))  # up to the UI's 6-month range chip
     before = (q.get("before", [""])[0] or "").strip() or None
     upper = before or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     lower = (datetime.fromisoformat(upper.replace("Z", "+00:00"))

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1548,9 +1548,13 @@ class Handler(BaseHTTPRequestHandler):
                         mod = __import__(f"token_parsers.{harness}", fromlist=[harness])
                     except ImportError:
                         return self._send(400, {"error": f"no parser for '{harness}'"})
+                    # Sanity gate only — the ref is NEVER opened (the sweep
+                    # rescans the harness's own data dir); pure string
+                    # normalization keeps the user value out of every
+                    # filesystem call (CodeQL py/path-injection).
                     base = getattr(mod, "DATA_DIR", None)
-                    rp = Path(os.path.expanduser(ref)).resolve()
-                    if base is None or not str(rp).startswith(str(Path(base).resolve()) + os.sep):
+                    rp = os.path.normpath(os.path.expanduser(ref))
+                    if base is None or not rp.startswith(str(base) + os.sep):
                         return self._send(400, {"error": "ref outside the harness data dir"})
                 return self._send(200, analytics.sweep(only=harness, quiet=True))
 

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -531,7 +531,22 @@ def get_analytics_tokens(con, q) -> dict:
     return {"totals": totals, "series": series}
 
 
-def get_analytics_usage(con) -> dict:
+def get_analytics_usage(con, q) -> dict:
+    """Behavioral reads for the Analytics tab's usage panels. `from`/`to`
+    scope the shipped counts to the UI's selected window; comparisons are at
+    DAY granularity (substr to the date part) because the source columns mix
+    `datetime('now')` (space-separated) and ISO-T formats — full-string
+    comparison across the two lies about same-day ordering."""
+    frm = (q.get("from", [""])[0] or "")[:10]
+    to = (q.get("to", [""])[0] or "")[:10]
+    window, wparams = "", []
+    if frm:
+        window += " AND substr({col}, 1, 10) >= ?"
+        wparams.append(frm)
+    if to:
+        window += " AND substr({col}, 1, 10) <= ?"
+        wparams.append(to)
+
     # favorite model per shell flavor — most sessions wins, read-time only
     fav: dict[str, dict] = {}
     for r in con.execute(
@@ -543,26 +558,33 @@ def get_analytics_usage(con) -> dict:
         if r["flavor"] not in fav or r["sessions"] > fav[r["flavor"]]["sessions"]:
             fav[r["flavor"]] = {"flavor": r["flavor"], "model": r["model"],
                                 "sessions": r["sessions"]}
-    # recent sprints: sprint_ref = the tracker document_id set at spawn
-    sprints = rows(con.execute(
-        "SELECT a.sprint_ref, MAX(a.started_at) AS last_seen, "
-        "COUNT(*) AS sessions, d.title, d.feature_id "
-        "FROM shell_memory_archives a "
+
+    # shipped in the window — updated_at is the read-time proxy for the flip
+    # date (the status write is normally the row's last touch)
+    features_shipped = rows(con.execute(
+        "SELECT feature_id, title, updated_at FROM roadmap "
+        "WHERE roadmap_status='shipped'" + window.format(col="updated_at") +
+        " ORDER BY updated_at DESC", wparams))
+    specs_shipped = rows(con.execute(
+        "SELECT d.document_id, d.title, d.frozen_date, r.title AS feature_title "
+        "FROM documents d LEFT JOIN roadmap r ON r.feature_id=d.feature_id "
+        "WHERE d.kind='spec' AND d.frozen=1" + window.format(col="d.frozen_date") +
+        " ORDER BY d.frozen_date DESC", wparams))
+    # outstanding is a CURRENT-state number, never window-scoped: a shipped
+    # feature with no doc-kind document yet (the docs-pending debt)
+    docs_outstanding = rows(con.execute(
+        "SELECT r.feature_id, r.title FROM roadmap r "
+        "WHERE r.roadmap_status='shipped' AND NOT EXISTS "
+        "(SELECT 1 FROM documents d WHERE d.feature_id=r.feature_id AND d.kind='doc') "
+        "ORDER BY r.updated_at DESC"))
+    # sprint_ref → tracker-doc title, for the session list's sprint clusters
+    sprint_titles = {r["sprint_ref"]: r["title"] for r in con.execute(
+        "SELECT DISTINCT a.sprint_ref, d.title FROM shell_memory_archives a "
         "LEFT JOIN documents d ON CAST(d.document_id AS TEXT) = a.sprint_ref "
-        "WHERE a.sprint_ref IS NOT NULL GROUP BY a.sprint_ref "
-        "ORDER BY last_seen DESC LIMIT 5"))
-    # recent features: through the sprint docs' feature_id, order preserved
-    feats, seen = [], set()
-    for sp in sprints:
-        fid = sp.get("feature_id")
-        if fid and fid not in seen:
-            seen.add(fid)
-            r = con.execute("SELECT feature_id, title, roadmap_status FROM roadmap "
-                            "WHERE feature_id=?", (fid,)).fetchone()
-            if r:
-                feats.append(dict(r))
+        "WHERE a.sprint_ref IS NOT NULL")}
     return {"favorite_models": sorted(fav.values(), key=lambda f: f["flavor"]),
-            "recent_sprints": sprints, "recent_features": feats}
+            "features_shipped": features_shipped, "specs_shipped": specs_shipped,
+            "docs_outstanding": docs_outstanding, "sprint_titles": sprint_titles}
 
 
 def get_analytics_filters(con) -> dict:
@@ -2108,7 +2130,8 @@ class Handler(BaseHTTPRequestHandler):
                 q = parse_qs(urlparse(self.path).query)
                 return self._send(200, get_analytics_tokens(con, q))
             if path == "/api/analytics/usage":
-                return self._send(200, get_analytics_usage(con))
+                q = parse_qs(urlparse(self.path).query)
+                return self._send(200, get_analytics_usage(con, q))
             if path == "/api/analytics/filters":
                 return self._send(200, get_analytics_filters(con))
             if path == "/api/scripts":

--- a/.super-coder/migrations/0071_token_session_analytics.sql
+++ b/.super-coder/migrations/0071_token_session_analytics.sql
@@ -1,0 +1,59 @@
+-- 0071 — token & session analytics: session lifecycle + per-session token usage (#407, feature 17, doc 11).
+--
+-- super-coder launches external harness CLIs and captured zero telemetry:
+-- no timestamps, no model, no token counts. Providers are opaque about
+-- allotments, but every harness already writes usage data to disk — this
+-- migration gives it somewhere to land.
+--
+-- Two parts:
+--   1. Session lifecycle columns on shell_memory_archives — written by
+--      run.py open_session (started_at/harness/provider/model/sprint_ref);
+--      ended_at is backfilled by the sweep (run.py execs the harness, so no
+--      code runs at exit). Historical rows stay NULL.
+--   2. session_token_usage — one row per (harness session × model), swept
+--      from each harness's on-disk data by scripts/token_parsers/*.
+--      UNIQUE(harness, harness_session_ref, model) is the idempotency key:
+--      parsers upsert, re-sweeps never double-count. archive_id NULL means
+--      "unattributed" (real spend on this repo, launched outside run.py or
+--      ambiguous) — deliberately NOT a status value.
+--
+-- Token classes normalize to dos-arch's four (fresh input / cache read /
+-- cache write / output) + nullable reasoning. NULL = "not exposed by this
+-- harness", 0 = "measured zero" — parsers never write zeros as if measured.
+
+BEGIN;
+
+ALTER TABLE shell_memory_archives ADD COLUMN started_at TEXT;   -- ISO UTC
+ALTER TABLE shell_memory_archives ADD COLUMN ended_at   TEXT;   -- ISO UTC, sweep-backfilled
+ALTER TABLE shell_memory_archives ADD COLUMN harness    TEXT;   -- claude/opencode/codex/vibe/kimi
+ALTER TABLE shell_memory_archives ADD COLUMN provider   TEXT;   -- anthropic/openai/mistral/…
+ALTER TABLE shell_memory_archives ADD COLUMN model      TEXT;   -- resolved model id (NULL = harness default)
+ALTER TABLE shell_memory_archives ADD COLUMN sprint_ref TEXT;   -- SC_SPRINT_REF (tracker document_id)
+
+CREATE TABLE IF NOT EXISTS session_token_usage (
+    usage_id            INTEGER PRIMARY KEY,
+    archive_id          INTEGER REFERENCES shell_memory_archives(archive_id),  -- NULL = unattributed
+    shell_id            INTEGER,                -- denormalized for filtering
+    harness             TEXT    NOT NULL,       -- claude/opencode/codex/vibe/kimi
+    harness_session_ref TEXT    NOT NULL,       -- transcript path / session id / rollout file / session dir
+    provider            TEXT,
+    model               TEXT,
+    title               TEXT,                   -- native session title, or first-prompt derived
+    started_at          TEXT,                   -- ISO UTC, from harness data
+    ended_at            TEXT,                   -- ISO UTC, from harness data
+    input_tokens        INTEGER,                -- fresh (uncached) input
+    output_tokens       INTEGER,
+    cache_read_tokens   INTEGER,
+    cache_write_tokens  INTEGER,
+    reasoning_tokens    INTEGER,                -- opencode + codex expose it
+    status              TEXT    NOT NULL DEFAULT 'ok'
+                        CHECK (status IN ('ok', 'partial', 'no_usage')),
+    parser_version      TEXT,                   -- per-parser format pin
+    captured_at         TEXT,                   -- sweep time, ISO UTC
+    UNIQUE (harness, harness_session_ref, model)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stu_archive ON session_token_usage(archive_id);
+CREATE INDEX IF NOT EXISTS idx_stu_started ON session_token_usage(started_at);
+
+COMMIT;

--- a/.super-coder/scripts/analytics.py
+++ b/.super-coder/scripts/analytics.py
@@ -73,15 +73,16 @@ def _load_parsers(only: "str | None", log) -> list:
     return mods
 
 
-def _since_fn(con):
-    """ref → last captured_at epoch, for the parsers' incremental skip.
-    Keyed on (harness, ref) folded to ref alone — refs are absolute paths /
-    ids, unique across harnesses in practice; the worst collision cost is a
-    redundant re-parse, never lost data."""
+def _since_fn(con, harness: str, parser_version: str):
+    """ref → last captured_at epoch, for one harness's incremental skip.
+    Scoped to rows written by the CURRENT parser version: a version bump
+    makes every ref look never-captured, forcing the full re-parse that
+    lets count-affecting parser fixes reach already-swept sessions."""
     seen: dict[str, float] = {}
     for r in con.execute(
             "SELECT harness_session_ref, MAX(captured_at) c FROM session_token_usage "
-            "GROUP BY harness_session_ref"):
+            "WHERE harness=? AND parser_version=? GROUP BY harness_session_ref",
+            (harness, parser_version)):
         e = _iso_epoch(r["c"])
         if e is not None:
             seen[r["harness_session_ref"]] = e
@@ -190,11 +191,11 @@ def sweep(only: "str | None" = None, quiet: bool = False) -> dict:
 
     con = db_driver.connect(DB_PATH)
     try:
-        since = _since_fn(con)
         captured_at = _now_iso()
         counts = {"insert": 0, "update": 0}
         batch: list[dict] = []
         for mod in _load_parsers(only, log):
+            since = _since_fn(con, mod.HARNESS, mod.PARSER_VERSION)
             try:
                 rows = mod.sweep(REPO_ROOT, since, log)
             except Exception as e:  # plugin stance: loud, never fatal to the sweep

--- a/.super-coder/scripts/analytics.py
+++ b/.super-coder/scripts/analytics.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Token & session analytics collector — `sc analytics sweep` (spec doc #11).
+
+Pull-based capture: super-coder never calls a model, it launches external
+harness CLIs — so the collector parses what each harness leaves on disk
+(scripts/token_parsers/*, one plugin per harness) and upserts one row per
+(harness session × model) into session_token_usage. Runs at run.py boot
+(incremental), on demand, and from the GUI Analytics tab.
+
+Idempotency: (harness, harness_session_ref, model) is the natural key. The
+upsert is a manual UPDATE-then-INSERT rather than ON CONFLICT because
+`model` is NULL on no_usage rows and SQLite treats NULLs as pairwise
+distinct in UNIQUE indexes — ON CONFLICT would re-insert those rows on
+every sweep. Updates never touch archive_id/shell_id (attribution owns them).
+
+Attribution: harness session → archive by (cwd → shell, time-window). A
+shell's window runs from an archive's started_at to the same shell's next
+started_at (open-ended for the latest). Worktree cwds map to the shell whose
+shortname names the worktree; the repo root maps to admin-flavor shells.
+Residual ambiguity stays archive_id=NULL — visible, flagged unattributed,
+never guessed. cwd is transient (attribution runs within the sweep batch);
+rows that stay NULL keep their spend visible in the totals regardless.
+
+ended_at backfill: run.py execs the harness, so nothing can write the
+archive's end time at exit — the sweep sets it to the last attributed
+harness activity (refreshed while a session is still live).
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+DB_PATH = ENGINE / "shell_db.db"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import db_driver  # noqa: E402
+
+import token_parsers  # noqa: E402
+
+WORKTREES = ".sc-worktrees"
+
+UPSERT_COLS = ["provider", "model", "title", "started_at", "ended_at",
+               "input_tokens", "output_tokens", "cache_read_tokens",
+               "cache_write_tokens", "reasoning_tokens", "status",
+               "parser_version", "captured_at"]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _iso_epoch(ts: "str | None") -> "float | None":
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _load_parsers(only: "str | None", log) -> list:
+    mods = []
+    for name in token_parsers.HARNESSES:
+        if only and name != only:
+            continue
+        try:
+            mods.append(__import__(f"token_parsers.{name}", fromlist=[name]))
+        except ImportError as e:
+            log(f"analytics: no parser for '{name}' ({e}) — skipped")
+    return mods
+
+
+def _since_fn(con):
+    """ref → last captured_at epoch, for the parsers' incremental skip.
+    Keyed on (harness, ref) folded to ref alone — refs are absolute paths /
+    ids, unique across harnesses in practice; the worst collision cost is a
+    redundant re-parse, never lost data."""
+    seen: dict[str, float] = {}
+    for r in con.execute(
+            "SELECT harness_session_ref, MAX(captured_at) c FROM session_token_usage "
+            "GROUP BY harness_session_ref"):
+        e = _iso_epoch(r["c"])
+        if e is not None:
+            seen[r["harness_session_ref"]] = e
+    return lambda ref: seen.get(ref)
+
+
+def _upsert(con, r: dict, captured_at: str) -> str:
+    """UPDATE-then-INSERT on the (harness, ref, model) natural key, NULL-model
+    safe. Returns 'update' or 'insert'."""
+    vals = {**r, "captured_at": captured_at}
+    cur = con.execute(
+        f"UPDATE session_token_usage SET {', '.join(c + '=?' for c in UPSERT_COLS)} "
+        "WHERE harness=? AND harness_session_ref=? AND model IS ?",
+        [vals.get(c) for c in UPSERT_COLS] + [r["harness"], r["harness_session_ref"], r["model"]])
+    if cur.rowcount:
+        return "update"
+    con.execute(
+        f"INSERT INTO session_token_usage (harness, harness_session_ref, {', '.join(UPSERT_COLS)}) "
+        f"VALUES (?, ?, {', '.join('?' for _ in UPSERT_COLS)})",
+        [r["harness"], r["harness_session_ref"]] + [vals.get(c) for c in UPSERT_COLS])
+    return "insert"
+
+
+def _cwd_shells(con) -> tuple[dict, list]:
+    """(worktree-name → shell_id, [admin shell_ids])."""
+    by_wt, admins = {}, []
+    for s in con.execute("SELECT shell_id, shortname, flavor FROM shells "
+                         "WHERE COALESCE(is_deleted,0)=0"):
+        if (s["flavor"] or "") == "admin":
+            admins.append(s["shell_id"])
+        if s["shortname"]:
+            by_wt[s["shortname"].lower()] = s["shell_id"]
+    return by_wt, admins
+
+
+def _shell_for_cwd(cwd: str, by_wt: dict, admins: list) -> list[int]:
+    root = str(REPO_ROOT).rstrip("/")
+    wt_prefix = f"{root}/{WORKTREES}/"
+    if cwd.startswith(wt_prefix):
+        name = cwd[len(wt_prefix):].split("/", 1)[0]
+        sid = by_wt.get(name)
+        return [sid] if sid else []
+    # repo root (or a subdir outside the worktrees) → admin-flavor shells
+    return admins
+
+
+def _windows(con) -> dict[int, list]:
+    """shell_id → [(archive_id, harness, start_epoch, end_epoch|None)],
+    end = the same shell's next started_at (open-ended for the latest)."""
+    per: dict[int, list] = {}
+    for a in con.execute(
+            "SELECT archive_id, shell_id, harness, started_at FROM shell_memory_archives "
+            "WHERE started_at IS NOT NULL ORDER BY shell_id, started_at"):
+        per.setdefault(a["shell_id"], []).append(
+            [a["archive_id"], a["harness"], _iso_epoch(a["started_at"]), None])
+    for arcs in per.values():
+        for i in range(len(arcs) - 1):
+            arcs[i][3] = arcs[i + 1][2]
+    return per
+
+
+def _attribute(con, batch: list[dict], log) -> int:
+    by_wt, admins = _cwd_shells(con)
+    windows = _windows(con)
+    attributed = 0
+    for r in batch:
+        if not r.get("cwd"):
+            continue
+        t = _iso_epoch(r.get("started_at") or r.get("ended_at"))
+        if t is None:
+            continue
+        hits = []
+        for sid in _shell_for_cwd(r["cwd"], by_wt, admins):
+            for aid, harness, start, end in windows.get(sid, []):
+                if harness == r["harness"] and start is not None \
+                        and start <= t and (end is None or t < end):
+                    hits.append((aid, sid))
+        if len(hits) != 1:
+            continue  # 0 = predates lifecycle rows; >1 = ambiguous — stays NULL
+        aid, sid = hits[0]
+        cur = con.execute(
+            "UPDATE session_token_usage SET archive_id=?, shell_id=? "
+            "WHERE harness=? AND harness_session_ref=? AND model IS ? AND archive_id IS NULL",
+            (aid, sid, r["harness"], r["harness_session_ref"], r["model"]))
+        attributed += cur.rowcount
+    return attributed
+
+
+def _backfill_ended(con) -> int:
+    cur = con.execute(
+        "UPDATE shell_memory_archives SET ended_at = ("
+        "  SELECT MAX(u.ended_at) FROM session_token_usage u"
+        "  WHERE u.archive_id = shell_memory_archives.archive_id AND u.ended_at IS NOT NULL) "
+        "WHERE started_at IS NOT NULL AND archive_id IN "
+        "  (SELECT DISTINCT archive_id FROM session_token_usage WHERE archive_id IS NOT NULL)")
+    return cur.rowcount
+
+
+def sweep(only: "str | None" = None, quiet: bool = False) -> dict:
+    notes: list[str] = []
+
+    def log(msg: str):
+        notes.append(msg)
+        if not quiet:
+            print(f"  ! {msg}")
+
+    con = db_driver.connect(DB_PATH)
+    try:
+        since = _since_fn(con)
+        captured_at = _now_iso()
+        counts = {"insert": 0, "update": 0}
+        batch: list[dict] = []
+        for mod in _load_parsers(only, log):
+            try:
+                rows = mod.sweep(REPO_ROOT, since, log)
+            except Exception as e:  # plugin stance: loud, never fatal to the sweep
+                log(f"analytics: {mod.HARNESS} parser failed: {e!r}")
+                continue
+            for r in rows:
+                counts[_upsert(con, r, captured_at)] += 1
+                batch.append(r)
+        attributed = _attribute(con, batch, log)
+        ended = _backfill_ended(con)
+        con.commit()
+        summary = {"inserted": counts["insert"], "updated": counts["update"],
+                   "attributed": attributed, "ended_backfilled": ended,
+                   "notes": notes}
+        if not quiet:
+            print(f"analytics: {counts['insert']} new, {counts['update']} refreshed, "
+                  f"{attributed} attributed, {ended} archive end(s) backfilled")
+        return summary
+    finally:
+        con.close()
+
+
+def main(argv: list[str]) -> int:
+    if not argv or argv[0] in ("-h", "--help"):
+        print("usage: sc analytics sweep [--harness <name>] [--quiet]\n"
+              "  parse each harness's on-disk usage data for THIS repo into\n"
+              "  session_token_usage (incremental, idempotent)")
+        return 0
+    if argv[0] != "sweep":
+        print(f"sc analytics: unknown command '{argv[0]}' (try: sweep)", file=sys.stderr)
+        return 2
+    only = None
+    quiet = "--quiet" in argv
+    if "--harness" in argv:
+        i = argv.index("--harness")
+        only = argv[i + 1] if i + 1 < len(argv) else None
+        if only not in token_parsers.HARNESSES:
+            print(f"sc analytics: unknown harness '{only}'", file=sys.stderr)
+            return 2
+    sweep(only=only, quiet=quiet)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -33,7 +33,7 @@ import os
 import shutil
 import subprocess
 import sys
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
@@ -51,6 +51,9 @@ import git_prune  # noqa: E402  — boot-time prune of provably-merged local bra
 import ports as ports_mod  # noqa: E402  — derive the per-fork API base URL
 import seed_skills  # noqa: E402  — boot-time self-heal of stale engine skills
 import shell_liveness  # noqa: E402  — headless boot's one-shell-one-session guard
+
+sys.path.insert(0, str(ENGINE / "api"))
+import model_catalog  # noqa: E402  — HARNESS_PROVIDER: one source for harness → provider
 
 ADAPTERS = ENGINE / "adapters"
 
@@ -562,10 +565,33 @@ def _is_unused(narrative: str) -> bool:
     return (narrative or "").count("\n[") <= 1
 
 
-def open_session(con, shell_id: int) -> tuple[str, int]:
+def session_provider(harness: str, model: "str | None") -> "str | None":
+    """Boot-time provider for the archive row. opencode model ids are
+    provider-prefixed ("ollama-cloud/<model>") — the prefix wins; otherwise the
+    harness's home provider (claude→anthropic, codex→openai, vibe→mistral).
+    kimi is absent from model_catalog's map (models.dev has no kimi key) but its
+    wire.jsonl reports provider="kimi" natively — pin the same value here so
+    boot-row and sweep-row providers agree."""
+    if harness in model_catalog.PREFIXED_HARNESSES and model and "/" in model:
+        return model.split("/", 1)[0]
+    if harness == "kimi":
+        return "kimi"
+    return model_catalog.HARNESS_PROVIDER.get(harness)
+
+
+def open_session(con, shell_id: int,
+                 lifecycle: "dict | None" = None) -> tuple[str, int]:
+    """`lifecycle` carries the launch telemetry persisted onto the archive row
+    (started_at/harness/provider/model/sprint_ref — migration 0071). ended_at is
+    NOT written here: run.py execs the harness, so no code runs at exit; the
+    analytics sweep backfills it from harness session data."""
+    life = {"started_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            **(lifecycle or {})}
+    life_cols = ["started_at", "harness", "provider", "model", "sprint_ref"]
     # Reuse the active session if it was opened but never used (e.g. install
     # opened session 0001, or a prior launch did no work) — avoids phantom empty
-    # sessions and the incidental first-snapshot diff.
+    # sessions and the incidental first-snapshot diff. The reused stub becomes
+    # THIS launch's session, so its lifecycle is overwritten with this launch's.
     active = con.execute(
         "SELECT active_archive_id FROM shells WHERE shell_id=?", (shell_id,)
     ).fetchone()[0]
@@ -574,7 +600,19 @@ def open_session(con, shell_id: int) -> tuple[str, int]:
             "SELECT archive_id, session_id, full_narrative FROM shell_memory_archives "
             "WHERE archive_id=?", (active,)
         ).fetchone()
-        if row and _is_unused(row["full_narrative"]):
+        # …but a stub that actually LAUNCHED a harness session is not unused:
+        # attributed usage rows prove real spend under this archive's lifecycle,
+        # and reusing it would overwrite that lifecycle with this boot's (three
+        # headless one-shots once collapsed into one kimi-flavored archive).
+        # The pre-session sweep runs before this, so attribution is current.
+        if row and _is_unused(row["full_narrative"]) and not con.execute(
+                "SELECT 1 FROM session_token_usage WHERE archive_id=? LIMIT 1",
+                (row["archive_id"],)).fetchone():
+            con.execute(
+                f"UPDATE shell_memory_archives SET {', '.join(c + '=?' for c in life_cols)} "
+                "WHERE archive_id=?",
+                [life.get(c) for c in life_cols] + [row["archive_id"]])
+            con.commit()
             return row["session_id"], row["archive_id"]
 
     last = con.execute(
@@ -586,9 +624,10 @@ def open_session(con, shell_id: int) -> tuple[str, int]:
     narrative = (f"# {session_id} | {today} | session opened\n\n"
                  f"## Narrative\n\n[{now_hm}] Session start.\n")
     cur = con.execute(
-        "INSERT INTO shell_memory_archives (shell_id, session_id, date, full_narrative) "
-        "VALUES (?, ?, ?, ?)",
-        (shell_id, session_id, today, narrative),
+        "INSERT INTO shell_memory_archives "
+        f"(shell_id, session_id, date, full_narrative, {', '.join(life_cols)}) "
+        f"VALUES (?, ?, ?, ?, {', '.join('?' for _ in life_cols)})",
+        [shell_id, session_id, today, narrative] + [life.get(c) for c in life_cols],
     )
     archive_id = cur.lastrowid
     con.execute("UPDATE shells SET active_archive_id=? WHERE shell_id=?",
@@ -717,7 +756,36 @@ def main() -> None:
     # harness (e.g. opencode as a manual fallback) — then the harness picks its own.
     flavor_model = fdef["models"].get(harness) if fdef else None
 
-    session_id, archive_id = open_session(con, chosen["shell_id"])
+    # Pre-session analytics sweep (doc #11): pull harness-side usage data into
+    # session_token_usage + backfill the PREVIOUS session's ended_at. MUST run
+    # before open_session — the stub-reuse check there relies on the previous
+    # boot's session being attributed to its archive already. Incremental
+    # (mtime-gated), so steady-state cost is near zero; the first-ever sweep of
+    # harness history is the one large pass. Best-effort like the prune — a
+    # broken parser must never block a boot. Skipped under RENDER_ONLY
+    # (headless verify must not mutate).
+    sweep_note = None
+    if not os.environ.get("RENDER_ONLY"):
+        try:
+            import analytics
+            s = analytics.sweep(quiet=True)
+            if s["inserted"] or s["updated"]:
+                sweep_note = (f"{s['inserted']} new, {s['updated']} refreshed "
+                              f"session-usage row(s)")
+        except Exception:
+            sweep_note = None
+
+    # The model this launch will actually route (headless resolves via flags →
+    # flavor default; interactive routes the flavor default). None = the harness
+    # picks its own — recorded as NULL, honest about what we know at boot.
+    session_model = (resolve_headless_model(flag_model, fdef, harness)
+                     if headless else flavor_model)
+    session_id, archive_id = open_session(con, chosen["shell_id"], lifecycle={
+        "harness": harness,
+        "provider": session_provider(harness, session_model),
+        "model": session_model,
+        "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
+    })
 
     full = con.execute(
         "SELECT shell_id, display_name, shortname, partner, role, mandate, "
@@ -785,6 +853,8 @@ def main() -> None:
         print(f"→ heal: {heal_note}")
     if prune_note:
         print(f"→ prune: {prune_note}")
+    if sweep_note:
+        print(f"→ analytics: {sweep_note}")
     print(f"→ wrote {work_dir / 'CLAUDE.md'}")
     print(f"→ wrote {work_dir / 'AGENTS.md'}")
     if api_port and full["api_key"]:
@@ -861,7 +931,7 @@ def main() -> None:
     # render-only run still validates the adapter + prints what would exec.
     headless_cmd = None
     if headless:
-        hmodel = resolve_headless_model(flag_model, fdef, harness)
+        hmodel = session_model  # resolved up front (persisted on the archive row)
         headless_cmd = headless_command(
             adapter, prompt or DEFAULT_HEADLESS_PROMPT, hmodel, sandbox_flags)
         if headless_cmd is None:

--- a/.super-coder/scripts/telemetry-hook.sh
+++ b/.super-coder/scripts/telemetry-hook.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# super-coder telemetry hook — claude SessionEnd → real-time token capture.
+#
+# Wired by the claude adapter's merge_json (same seam as the branch-guard's
+# PreToolUse entry): when a claude session ends, claude invokes this with the
+# SessionEnd JSON on stdin; we POST the transcript path to the engine API's
+# token-scoped ingest (`POST /_sc/mem/telemetry`), which validates the ref
+# resolves under claude's data dir and runs the claude parser inline. The
+# boot-time `sc analytics sweep` remains the backstop for missed hooks.
+#
+# Best-effort BY CONTRACT: a session must always be able to end — every
+# failure path (no API env, no python3, curl timeout, server down) exits 0
+# silently. SC_API_BASE + SC_API_TOKEN arrive from run.py's exec env; a
+# harness launched outside run.py has neither and exits at the first check
+# (its sessions are swept later, shown unattributed — deliberate).
+
+[ -n "$SC_API_BASE" ] && [ -n "$SC_API_TOKEN" ] || exit 0
+
+payload=$(python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+ref = d.get("transcript_path") or ""
+if not ref:
+    sys.exit(1)
+print(json.dumps({"harness": "claude", "harness_session_ref": ref}))
+' 2>/dev/null) || exit 0
+
+curl -s -m 5 -X POST "$SC_API_BASE/_sc/mem/telemetry" \
+     -H "Authorization: Bearer $SC_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d "$payload" >/dev/null 2>&1 || true
+exit 0

--- a/.super-coder/scripts/token_parsers/__init__.py
+++ b/.super-coder/scripts/token_parsers/__init__.py
@@ -25,6 +25,17 @@ ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
 reasoning_tokens, status ('ok'|'partial'|'no_usage'), parser_version, cwd
 (transient). Token-class rule: NULL means "not exposed by this harness",
 0 means "measured zero" — never write zeros as if measured.
+
+reasoning_tokens is informational and ALWAYS a subset of output_tokens
+(codex reports it that way natively; a parser whose source reports
+reasoning separately folds it into output_tokens — see opencode). Total
+spend is therefore input + output + cache_read + cache_write, never
++ reasoning.
+
+PARSER_VERSION doubles as the incrementality pin: the collector skips a
+ref only when its stored rows carry the CURRENT version, so bumping it
+forces a full re-parse and count-affecting fixes reach already-swept
+sessions.
 """
 from __future__ import annotations
 

--- a/.super-coder/scripts/token_parsers/__init__.py
+++ b/.super-coder/scripts/token_parsers/__init__.py
@@ -1,0 +1,80 @@
+"""Per-harness token-usage parsers — the plugin seam of token analytics.
+
+Each module (claude/opencode/codex/vibe/kimi) parses what its harness leaves
+on disk and returns normalized row dicts for `session_token_usage` (migration
+0071). These are plugins over third-party formats we don't control: version
+drift is accepted — a parser that breaks gets fixed forward. Loud failure,
+never silent zeros (design stance, spec doc #11).
+
+Contract — every module exposes:
+
+    HARNESS = "<name>"
+    PARSER_VERSION = "<pin>"        # bumped when the expected format shape changes
+    def sweep(repo_root, since_epoch, log) -> list[dict]
+
+  repo_root    Path — only sessions whose recorded cwd is this repo (root or a
+               .sc-worktrees/ tree) are returned; the cwd rides on the row as a
+               transient key for attribution, never stored.
+  since_epoch  callable(ref) -> float|None — the row's last captured_at as an
+               epoch, for mtime-gated incremental skips. None = never captured.
+  log          callable(str) — parser-level notices (shape drift, skipped
+               files). Loud by design.
+
+Row keys: harness, harness_session_ref, provider, model, title, started_at,
+ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+reasoning_tokens, status ('ok'|'partial'|'no_usage'), parser_version, cwd
+(transient). Token-class rule: NULL means "not exposed by this harness",
+0 means "measured zero" — never write zeros as if measured.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+HARNESSES = ["claude", "opencode", "codex", "vibe", "kimi"]
+
+
+def iso_utc(epoch: "float | None") -> "str | None":
+    """Epoch seconds → ISO UTC (second precision), the storage format."""
+    if epoch is None:
+        return None
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def norm_iso(ts: "str | None") -> "str | None":
+    """Normalize a harness timestamp (ISO with ms / offset / Z) to ISO UTC at
+    second precision. Unparseable input returns None — never a fake time."""
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def in_repo(cwd: "str | None", repo_root) -> bool:
+    """True when cwd is the repo root or inside it (worktrees included)."""
+    if not cwd:
+        return False
+    root = str(repo_root).rstrip("/")
+    return cwd == root or cwd.startswith(root + "/")
+
+
+def row(*, harness: str, ref: str, parser_version: str, provider=None,
+        model=None, title=None, started_at=None, ended_at=None,
+        input_tokens=None, output_tokens=None, cache_read_tokens=None,
+        cache_write_tokens=None, reasoning_tokens=None, status="ok",
+        cwd=None) -> dict:
+    return {
+        "harness": harness, "harness_session_ref": ref,
+        "parser_version": parser_version, "provider": provider,
+        "model": model, "title": (title or None),
+        "started_at": started_at, "ended_at": ended_at,
+        "input_tokens": input_tokens, "output_tokens": output_tokens,
+        "cache_read_tokens": cache_read_tokens,
+        "cache_write_tokens": cache_write_tokens,
+        "reasoning_tokens": reasoning_tokens,
+        "status": status, "cwd": cwd,
+    }

--- a/.super-coder/scripts/token_parsers/claude.py
+++ b/.super-coder/scripts/token_parsers/claude.py
@@ -1,0 +1,148 @@
+"""claude parser — transcript JSONL under ~/.claude/projects/<encoded-cwd>/.
+
+Fidelity Full: every assistant line carries a `usage` object with the four
+token classes + the model. TWO verified hazards shape this parser:
+
+  1. The same usage object repeats on every content-block line of a
+     multi-block response (verified: 401 usage lines, 181 unique message ids
+     in one transcript — naive summing overcounts ~2×). Dedupe by
+     `message.id`, keeping the LAST occurrence (final counts).
+  2. Resume/fork copies lines into a NEW session file, so the dedupe must be
+     cross-file. Copies land in the same project dir (same cwd), so
+     incrementality is DIR-scoped, not file-scoped: any changed file in a
+     dir re-parses the whole dir (a fresh cross-file seen-set), unchanged
+     dirs are skipped wholesale. File-level mtime skips would silently
+     re-count ids living in the skipped files.
+
+Repo filter: the `cwd` field on the lines, NOT the project-dir name — the
+dir-name dash-encoding is lossy (`/` and `-` encode identically). The encoded
+dir name is only a cheap prefilter (an encoded path under repo_root always
+has the encoded root as a prefix); the per-line cwd decides.
+
+No native title: derived from the first real user message (command wrappers
+and meta lines skipped).
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from . import in_repo, iso_utc, norm_iso, row
+
+HARNESS = "claude"
+PARSER_VERSION = "1"
+DATA_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR") or Path.home() / ".claude") / "projects"
+TITLE_CAP = 500  # storage cap; the UI truncates at 100 for collapsed cards
+
+
+def _encode(path: str) -> str:
+    """The harness's project-dir encoding of a cwd (lossy: '/' and '.' and '-'
+    all land on '-'). Good enough for a prefix prefilter, never for identity."""
+    return "".join(c if c.isalnum() else "-" for c in path)
+
+
+def _title_from(rec: dict) -> "str | None":
+    """A displayable title candidate from a user line, or None."""
+    if rec.get("isMeta"):
+        return None
+    msg = rec.get("message") or {}
+    content = msg.get("content")
+    if isinstance(content, list):
+        content = next((b.get("text") for b in content
+                        if isinstance(b, dict) and b.get("type") == "text"), None)
+    if not isinstance(content, str):
+        return None
+    text = content.strip()
+    if not text or text.startswith("<"):  # command/caveat/meta wrappers
+        return None
+    return text[:TITLE_CAP]
+
+
+def _parse_file(path: Path, seen: set, log) -> "dict | None":
+    """One transcript → session aggregate. `seen` is the dir-wide message-id
+    set (mutated); ids already seen count 0 here (resume/fork copies)."""
+    per_model: dict[str, dict] = {}   # model → {id: usage} (last occurrence wins)
+    title = None
+    ts_first = ts_last = None
+    cwd = None
+    bad_lines = 0
+    try:
+        fh = open(path, encoding="utf-8", errors="replace")
+    except OSError as e:
+        log(f"claude: unreadable {path.name}: {e}")
+        return None
+    with fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                bad_lines += 1
+                continue
+            if not isinstance(rec, dict):
+                bad_lines += 1
+                continue
+            cwd = rec.get("cwd") or cwd
+            ts = rec.get("timestamp")
+            if ts:
+                ts_first = ts_first or ts
+                ts_last = ts
+            if title is None and rec.get("type") == "user":
+                title = _title_from(rec)
+            msg = rec.get("message") or {}
+            usage = msg.get("usage") if isinstance(msg, dict) else None
+            mid = msg.get("id") if isinstance(msg, dict) else None
+            if not (isinstance(usage, dict) and mid):
+                continue
+            if mid in seen:
+                # cross-file copy (resume/fork) — counted where first seen
+                continue
+            per_model.setdefault(msg.get("model") or "unknown", {})[mid] = usage
+    for model, by_id in per_model.items():
+        seen.update(by_id)
+    if bad_lines:
+        log(f"claude: {path.name}: {bad_lines} unparseable line(s) tolerated")
+    return {"per_model": per_model, "title": title, "cwd": cwd,
+            "started_at": norm_iso(ts_first), "ended_at": norm_iso(ts_last),
+            "partial": bad_lines > 0}
+
+
+def sweep(repo_root, since_epoch, log) -> list[dict]:
+    if not DATA_DIR.is_dir():
+        return []
+    prefix = _encode(str(repo_root))
+    rows: list[dict] = []
+    for proj in sorted(DATA_DIR.iterdir()):
+        if not (proj.is_dir() and proj.name.startswith(prefix)):
+            continue
+        files = sorted(proj.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
+        if not files:
+            continue
+        # dir-scoped incrementality (see module docstring)
+        changed = any((since_epoch(str(p)) or 0) < p.stat().st_mtime for p in files)
+        if not changed:
+            continue
+        seen: set = set()
+        for path in files:  # mtime order: copies count where they first appeared
+            parsed = _parse_file(path, seen, log)
+            if parsed is None or not in_repo(parsed["cwd"], repo_root):
+                continue
+            common = dict(harness=HARNESS, parser_version=PARSER_VERSION,
+                          provider="anthropic", title=parsed["title"],
+                          started_at=parsed["started_at"],
+                          ended_at=parsed["ended_at"], cwd=parsed["cwd"])
+            if not parsed["per_model"]:
+                rows.append(row(ref=str(path), model=None, status="no_usage", **common))
+                continue
+            status = "partial" if parsed["partial"] else "ok"
+            for model, by_id in parsed["per_model"].items():
+                def total(key):
+                    return sum(u.get(key) or 0 for u in by_id.values())
+                rows.append(row(
+                    ref=str(path), model=model, status=status,
+                    input_tokens=total("input_tokens"),
+                    output_tokens=total("output_tokens"),
+                    cache_read_tokens=total("cache_read_input_tokens"),
+                    cache_write_tokens=total("cache_creation_input_tokens"),
+                    **common))
+    return rows

--- a/.super-coder/scripts/token_parsers/claude.py
+++ b/.super-coder/scripts/token_parsers/claude.py
@@ -14,6 +14,14 @@ token classes + the model. TWO verified hazards shape this parser:
      dirs are skipped wholesale. File-level mtime skips would silently
      re-count ids living in the skipped files.
 
+Subagent transcripts live in SUBDIRECTORIES of the project dir
+(<session-uuid>/subagents/agent-*.jsonl) — a non-recursive glob misses them
+entirely (measured: ~29% of fresh input on a multi-agent-heavy corpus). The
+walk is recursive, and a subdirectory file folds into the top-level session
+named by its first path component: subagent spend is the parent session's
+spend, one row per (session x model). Titles come from top-level files only
+(a subagent's first user message is its task prompt, not a display title).
+
 Repo filter: the `cwd` field on the lines, NOT the project-dir name — the
 dir-name dash-encoding is lossy (`/` and `-` encode identically). The encoded
 dir name is only a cheap prefilter (an encoded path under repo_root always
@@ -31,7 +39,7 @@ from pathlib import Path
 from . import in_repo, iso_utc, norm_iso, row
 
 HARNESS = "claude"
-PARSER_VERSION = "1"
+PARSER_VERSION = "2"  # 2: recursive walk — subagent transcripts fold into parent
 DATA_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR") or Path.home() / ".claude") / "projects"
 TITLE_CAP = 500  # storage cap; the UI truncates at 100 for collapsed cards
 
@@ -107,6 +115,16 @@ def _parse_file(path: Path, seen: set, log) -> "dict | None":
             "partial": bad_lines > 0}
 
 
+def _session_ref(proj: Path, path: Path) -> str:
+    """The session a transcript belongs to. Top-level files ARE sessions;
+    files in subdirectories (<uuid>/subagents/agent-*.jsonl) belong to the
+    top-level session named by their first path component."""
+    rel = path.relative_to(proj)
+    if len(rel.parts) == 1:
+        return str(path)
+    return str(proj / (rel.parts[0] + ".jsonl"))
+
+
 def sweep(repo_root, since_epoch, log) -> list[dict]:
     if not DATA_DIR.is_dir():
         return []
@@ -115,31 +133,46 @@ def sweep(repo_root, since_epoch, log) -> list[dict]:
     for proj in sorted(DATA_DIR.iterdir()):
         if not (proj.is_dir() and proj.name.startswith(prefix)):
             continue
-        files = sorted(proj.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
+        files = sorted(proj.rglob("*.jsonl"), key=lambda p: p.stat().st_mtime)
         if not files:
             continue
         # dir-scoped incrementality (see module docstring)
-        changed = any((since_epoch(str(p)) or 0) < p.stat().st_mtime for p in files)
+        changed = any((since_epoch(_session_ref(proj, p)) or 0) < p.stat().st_mtime
+                      for p in files)
         if not changed:
             continue
         seen: set = set()
+        sessions: dict[str, dict] = {}  # ref → merged aggregate (insertion order)
         for path in files:  # mtime order: copies count where they first appeared
             parsed = _parse_file(path, seen, log)
             if parsed is None or not in_repo(parsed["cwd"], repo_root):
                 continue
-            common = dict(harness=HARNESS, parser_version=PARSER_VERSION,
-                          provider="anthropic", title=parsed["title"],
-                          started_at=parsed["started_at"],
-                          ended_at=parsed["ended_at"], cwd=parsed["cwd"])
-            if not parsed["per_model"]:
-                rows.append(row(ref=str(path), model=None, status="no_usage", **common))
-                continue
-            status = "partial" if parsed["partial"] else "ok"
+            agg = sessions.setdefault(_session_ref(proj, path), {
+                "per_model": {}, "title": None, "cwd": parsed["cwd"],
+                "started_at": None, "ended_at": None, "partial": False})
             for model, by_id in parsed["per_model"].items():
+                agg["per_model"].setdefault(model, {}).update(by_id)
+            if path.parent == proj and agg["title"] is None:
+                agg["title"] = parsed["title"]
+            agg["started_at"] = min((t for t in (agg["started_at"], parsed["started_at"]) if t),
+                                    default=None)
+            agg["ended_at"] = max((t for t in (agg["ended_at"], parsed["ended_at"]) if t),
+                                  default=None)
+            agg["partial"] = agg["partial"] or parsed["partial"]
+        for ref, agg in sessions.items():
+            common = dict(harness=HARNESS, parser_version=PARSER_VERSION,
+                          provider="anthropic", title=agg["title"],
+                          started_at=agg["started_at"],
+                          ended_at=agg["ended_at"], cwd=agg["cwd"])
+            if not agg["per_model"]:
+                rows.append(row(ref=ref, model=None, status="no_usage", **common))
+                continue
+            status = "partial" if agg["partial"] else "ok"
+            for model, by_id in agg["per_model"].items():
                 def total(key):
                     return sum(u.get(key) or 0 for u in by_id.values())
                 rows.append(row(
-                    ref=str(path), model=model, status=status,
+                    ref=ref, model=model, status=status,
                     input_tokens=total("input_tokens"),
                     output_tokens=total("output_tokens"),
                     cache_read_tokens=total("cache_read_input_tokens"),

--- a/.super-coder/scripts/token_parsers/codex.py
+++ b/.super-coder/scripts/token_parsers/codex.py
@@ -1,0 +1,112 @@
+"""codex parser — ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl.
+
+`token_count` events carry CUMULATIVE totals (`info.total_token_usage`), so
+the LAST event is the session's spend — summing per-turn values would
+overcount. Subset rules (spec doc #11, or the classes double-count):
+`input_tokens` includes `cached_input_tokens` → fresh input is the
+difference, cache_read is the cached part; `reasoning_output_tokens` is
+INSIDE `output_tokens` → stored informationally, never added to totals.
+No cache-write class (fidelity Good).
+
+cwd + provider live in `session_meta.payload`; the model id in
+`turn_context.payload.model`. No native title — derived from the first user
+message that isn't scaffolding (codex injects AGENTS.md instructions and
+<environment_context> as user-role messages; anything opening with '#' or
+'<' is skipped).
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from . import in_repo, norm_iso, row
+
+HARNESS = "codex"
+PARSER_VERSION = "1"
+DATA_DIR = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex") / "sessions"
+TITLE_CAP = 500
+
+
+def _title_from(payload: dict) -> "str | None":
+    content = payload.get("content")
+    if isinstance(content, list):
+        content = next((b.get("text") for b in content
+                        if isinstance(b, dict) and b.get("text")), None)
+    if not isinstance(content, str):
+        return None
+    text = content.strip()
+    if not text or text[0] in "<#":  # injected instructions / env context
+        return None
+    return text[:TITLE_CAP]
+
+
+def _parse_file(path: Path, log) -> "dict | None":
+    meta = last_tc = title = model = None
+    ts_first = ts_last = None
+    try:
+        fh = open(path, encoding="utf-8", errors="replace")
+    except OSError as e:
+        log(f"codex: unreadable {path.name}: {e}")
+        return None
+    with fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(rec, dict):
+                continue
+            ts = rec.get("timestamp")
+            if ts:
+                ts_first = ts_first or ts
+                ts_last = ts
+            p = rec.get("payload") or {}
+            t = rec.get("type")
+            if t == "session_meta":
+                meta = p
+            elif t == "turn_context":
+                model = p.get("model") or model
+            elif t == "event_msg" and p.get("type") == "token_count":
+                last_tc = p.get("info") or last_tc
+            elif (title is None and t == "response_item"
+                  and p.get("type") == "message" and p.get("role") == "user"):
+                title = _title_from(p)
+    if meta is None:
+        log(f"codex: {path.name}: no session_meta — format drift? skipped")
+        return None
+    return {"meta": meta, "last_tc": last_tc, "title": title, "model": model,
+            "started_at": norm_iso(ts_first), "ended_at": norm_iso(ts_last)}
+
+
+def sweep(repo_root, since_epoch, log) -> list[dict]:
+    if not DATA_DIR.is_dir():
+        return []
+    rows: list[dict] = []
+    for path in sorted(DATA_DIR.glob("*/*/*/rollout-*.jsonl")):
+        last = since_epoch(str(path))
+        if last is not None and path.stat().st_mtime <= last:
+            continue
+        parsed = _parse_file(path, log)
+        if parsed is None:
+            continue
+        cwd = parsed["meta"].get("cwd")
+        if not in_repo(cwd, repo_root):
+            continue
+        common = dict(harness=HARNESS, ref=str(path), parser_version=PARSER_VERSION,
+                      provider=parsed["meta"].get("model_provider"),
+                      model=parsed["model"], title=parsed["title"],
+                      started_at=parsed["started_at"], ended_at=parsed["ended_at"],
+                      cwd=cwd)
+        total = (parsed["last_tc"] or {}).get("total_token_usage")
+        if not total:
+            rows.append(row(status="no_usage", **common))
+            continue
+        cached = total.get("cached_input_tokens") or 0
+        rows.append(row(
+            input_tokens=max((total.get("input_tokens") or 0) - cached, 0),
+            output_tokens=total.get("output_tokens"),
+            cache_read_tokens=cached,
+            reasoning_tokens=total.get("reasoning_output_tokens"),
+            **common))
+    return rows

--- a/.super-coder/scripts/token_parsers/kimi.py
+++ b/.super-coder/scripts/token_parsers/kimi.py
@@ -1,0 +1,93 @@
+"""kimi parser — ~/.kimi-code/sessions/wd_*/session_*/ (Kimi Code CLI).
+
+The cleanest source (fidelity Full, live-verified against a running K3
+session): `state.json` carries createdAt/updatedAt, workDir
+(worktree-precise), native title (+ isCustomTitle); each agent's
+`agents/*/wire.jsonl` emits `usage.record` events whose four fields map 1:1
+to the four token classes (inputOther IS fresh input — no arithmetic).
+Sessions can run multiple agents (swarm mode) — usage sums across every
+agents/*/wire.jsonl, grouped per model (`usage.record.model`, the
+"kimi-code/k3" alias form). Provider comes from `llm.request` events, which
+report provider="kimi" natively — the same value run.py pins at boot.
+
+Ref = the session directory; incrementality is the max mtime of state.json
++ wire files (a live session keeps its dir "changed" and re-sums — the
+upsert refreshes in place).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from . import in_repo, norm_iso, row
+
+HARNESS = "kimi"
+PARSER_VERSION = "1"
+DATA_DIR = Path.home() / ".kimi-code/sessions"
+
+USAGE_MAP = {  # wire.jsonl usage.record field → row key, 1:1
+    "inputOther": "input_tokens",
+    "output": "output_tokens",
+    "inputCacheRead": "cache_read_tokens",
+    "inputCacheCreation": "cache_write_tokens",
+}
+
+
+def sweep(repo_root, since_epoch, log) -> list[dict]:
+    if not DATA_DIR.is_dir():
+        return []
+    rows: list[dict] = []
+    for sess_dir in sorted(DATA_DIR.glob("wd_*/session_*")):
+        state_path = sess_dir / "state.json"
+        if not state_path.exists():
+            continue
+        wires = sorted(sess_dir.glob("agents/*/wire.jsonl"))
+        try:
+            newest = max(p.stat().st_mtime for p in [state_path, *wires])
+        except OSError:
+            continue
+        last = since_epoch(str(sess_dir))
+        if last is not None and newest <= last:
+            continue
+        try:
+            state = json.loads(state_path.read_text(encoding="utf-8", errors="replace"))
+        except (json.JSONDecodeError, OSError) as e:
+            log(f"kimi: unreadable {sess_dir.name}/state.json: {e} — skipped")
+            continue
+        cwd = state.get("workDir")
+        if not in_repo(cwd, repo_root):
+            continue
+        per_model: dict[str, dict] = {}
+        provider = None
+        for wire in wires:
+            try:
+                fh = open(wire, encoding="utf-8", errors="replace")
+            except OSError as e:
+                log(f"kimi: unreadable {sess_dir.name}/{wire.parent.name}/wire.jsonl: {e}")
+                continue
+            with fh:
+                for line in fh:
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(rec, dict):
+                        continue
+                    if rec.get("type") == "llm.request":
+                        provider = rec.get("provider") or provider
+                    elif rec.get("type") == "usage.record":
+                        usage = rec.get("usage") or {}
+                        agg = per_model.setdefault(rec.get("model") or "unknown", {})
+                        for src, dst in USAGE_MAP.items():
+                            if usage.get(src) is not None:
+                                agg[dst] = agg.get(dst, 0) + usage[src]
+        common = dict(harness=HARNESS, ref=str(sess_dir), parser_version=PARSER_VERSION,
+                      provider=provider or "kimi", title=state.get("title"),
+                      started_at=norm_iso(state.get("createdAt")),
+                      ended_at=norm_iso(state.get("updatedAt")), cwd=cwd)
+        if not per_model:
+            rows.append(row(model=None, status="no_usage", **common))
+            continue
+        for model, agg in per_model.items():
+            rows.append(row(model=model, **agg, **common))
+    return rows

--- a/.super-coder/scripts/token_parsers/opencode.py
+++ b/.super-coder/scripts/token_parsers/opencode.py
@@ -11,6 +11,12 @@ Caveat (spec doc #11): the token columns are NOT NULL DEFAULT 0, so "not
 exposed" and "measured zero" are indistinguishable at that layer — trust
 opencode's numbers as-is (status stays 'ok').
 
+Normalization: opencode reports reasoning DISJOINT from output (message
+tokens: total = input + output + reasoning + cache.read — verified against
+message-level data), while the row contract is codex-shaped (reasoning is
+an informational subset of output_tokens). So output_tokens here is
+tokens_output + tokens_reasoning; reasoning_tokens keeps the split.
+
 Sub-sessions (parent_id set — spawned subagents) are real spend in the same
 directory and get their own rows; the ref is the session id either way.
 """
@@ -24,7 +30,7 @@ from pathlib import Path
 from . import in_repo, iso_utc, row
 
 HARNESS = "opencode"
-PARSER_VERSION = "1"
+PARSER_VERSION = "2"  # 2: reasoning folded into output_tokens (codex-shaped contract)
 DB = Path(os.environ.get("XDG_DATA_HOME") or Path.home() / ".local/share") / "opencode/opencode.db"
 
 
@@ -72,7 +78,8 @@ def sweep(repo_root, since_epoch, log) -> list[dict]:
                 provider=provider, model=model, title=s["title"],
                 started_at=iso_utc((s["time_created"] or 0) / 1000 or None),
                 ended_at=iso_utc(updated or None),
-                input_tokens=s["tokens_input"], output_tokens=s["tokens_output"],
+                input_tokens=s["tokens_input"],
+                output_tokens=(s["tokens_output"] or 0) + (s["tokens_reasoning"] or 0),
                 cache_read_tokens=s["tokens_cache_read"],
                 cache_write_tokens=s["tokens_cache_write"],
                 reasoning_tokens=s["tokens_reasoning"],

--- a/.super-coder/scripts/token_parsers/opencode.py
+++ b/.super-coder/scripts/token_parsers/opencode.py
@@ -1,0 +1,84 @@
+"""opencode parser — ~/.local/share/opencode/opencode.db, `session` table.
+
+The easiest source: per-session totals pre-aggregated in real columns, a
+native `title`, and a `directory` column for the repo filter. Plain
+read-only SQL — no JSONL walking.
+
+The `model` column is JSON ({"id","providerID","variant"}): provider comes
+straight from providerID; a non-default variant folds into the model label.
+
+Caveat (spec doc #11): the token columns are NOT NULL DEFAULT 0, so "not
+exposed" and "measured zero" are indistinguishable at that layer — trust
+opencode's numbers as-is (status stays 'ok').
+
+Sub-sessions (parent_id set — spawned subagents) are real spend in the same
+directory and get their own rows; the ref is the session id either way.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+from . import in_repo, iso_utc, row
+
+HARNESS = "opencode"
+PARSER_VERSION = "1"
+DB = Path(os.environ.get("XDG_DATA_HOME") or Path.home() / ".local/share") / "opencode/opencode.db"
+
+
+def _model_label(raw: "str | None", log) -> tuple:
+    """(model, provider) from the JSON model column."""
+    if not raw:
+        return None, None
+    try:
+        m = json.loads(raw) if isinstance(raw, str) else raw
+    except json.JSONDecodeError:
+        log(f"opencode: unparseable model column {raw!r}")
+        return str(raw), None
+    mid = m.get("id")
+    variant = m.get("variant")
+    if mid and variant and variant != "default":
+        mid = f"{mid} ({variant})"
+    return mid, m.get("providerID")
+
+
+def sweep(repo_root, since_epoch, log) -> list[dict]:
+    if not DB.exists():
+        return []
+    rows: list[dict] = []
+    try:
+        con = sqlite3.connect(f"file:{DB}?mode=ro", uri=True)
+        con.row_factory = sqlite3.Row
+    except sqlite3.Error as e:
+        log(f"opencode: cannot open {DB}: {e}")
+        return []
+    try:
+        cur = con.execute(
+            "SELECT id, directory, title, model, time_created, time_updated, "
+            "tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, "
+            "tokens_cache_write FROM session")
+        for s in cur:
+            if not in_repo(s["directory"], repo_root):
+                continue
+            updated = (s["time_updated"] or 0) / 1000  # epoch ms → s
+            last = since_epoch(s["id"])
+            if last is not None and updated <= last:
+                continue
+            model, provider = _model_label(s["model"], log)
+            rows.append(row(
+                harness=HARNESS, ref=s["id"], parser_version=PARSER_VERSION,
+                provider=provider, model=model, title=s["title"],
+                started_at=iso_utc((s["time_created"] or 0) / 1000 or None),
+                ended_at=iso_utc(updated or None),
+                input_tokens=s["tokens_input"], output_tokens=s["tokens_output"],
+                cache_read_tokens=s["tokens_cache_read"],
+                cache_write_tokens=s["tokens_cache_write"],
+                reasoning_tokens=s["tokens_reasoning"],
+                cwd=s["directory"]))
+    except sqlite3.Error as e:
+        log(f"opencode: session table read failed: {e} — format drift?")
+    finally:
+        con.close()
+    return rows

--- a/.super-coder/scripts/token_parsers/vibe.py
+++ b/.super-coder/scripts/token_parsers/vibe.py
@@ -1,0 +1,60 @@
+"""vibe parser — ~/.vibe/logs/session/<id>/meta.json.
+
+One JSON per session: `stats.session_prompt_tokens` /
+`session_completion_tokens`, native `title` (+ title_source), lifecycle from
+start_time/end_time, repo filter from environment.working_directory, model
+from config.active_model. Fidelity Partial — no cache split, so the cache
+classes stay NULL ("not exposed"), never 0.
+
+Provider: from config.models[].provider when the active model is listed;
+parser-level default "mistral" otherwise (vibe is Mistral's CLI).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from . import in_repo, norm_iso, row
+
+HARNESS = "vibe"
+PARSER_VERSION = "1"
+DATA_DIR = Path.home() / ".vibe/logs/session"
+
+
+def _provider(cfg: dict, model: "str | None") -> str:
+    for m in (cfg.get("models") or []):
+        if isinstance(m, dict) and m.get("name") == model and m.get("provider"):
+            return m["provider"]
+    return "mistral"
+
+
+def sweep(repo_root, since_epoch, log) -> list[dict]:
+    if not DATA_DIR.is_dir():
+        return []
+    rows: list[dict] = []
+    for meta_path in sorted(DATA_DIR.glob("*/meta.json")):
+        last = since_epoch(str(meta_path))
+        if last is not None and meta_path.stat().st_mtime <= last:
+            continue
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8", errors="replace"))
+        except (json.JSONDecodeError, OSError) as e:
+            log(f"vibe: unreadable {meta_path.parent.name}/meta.json: {e} — skipped")
+            continue
+        cwd = (meta.get("environment") or {}).get("working_directory")
+        if not in_repo(cwd, repo_root):
+            continue
+        stats = meta.get("stats") or {}
+        cfg = meta.get("config") or {}
+        model = cfg.get("active_model")
+        prompt, completion = stats.get("session_prompt_tokens"), stats.get("session_completion_tokens")
+        rows.append(row(
+            harness=HARNESS, ref=str(meta_path), parser_version=PARSER_VERSION,
+            provider=_provider(cfg, model), model=model,
+            title=meta.get("title"),
+            started_at=norm_iso(meta.get("start_time")),
+            ended_at=norm_iso(meta.get("end_time")),
+            input_tokens=prompt, output_tokens=completion,
+            status="ok" if (prompt is not None or completion is not None) else "no_usage",
+            cwd=cwd))
+    return rows

--- a/.super-coder/scripts/token_parsers/vibe.py
+++ b/.super-coder/scripts/token_parsers/vibe.py
@@ -22,8 +22,11 @@ DATA_DIR = Path.home() / ".vibe/logs/session"
 
 
 def _provider(cfg: dict, model: "str | None") -> str:
+    # active_model holds the ALIAS when one is set; models[] carries both
+    # `name` and `alias` — match either, or the lookup never fires.
     for m in (cfg.get("models") or []):
-        if isinstance(m, dict) and m.get("name") == model and m.get("provider"):
+        if isinstance(m, dict) and m.get("provider") \
+                and model in (m.get("name"), m.get("alias")):
             return m["provider"]
     return "mistral"
 

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -1682,10 +1682,17 @@ async function renderWorktrees(root, opts = {}) {
 // day-grouping and displayed times are LOCAL — translated here at render,
 // never on the server. The tab load runs an incremental sweep first so the
 // view reflects harness data as of now.
-let anFilters = { harness: "", provider: "", model: "" };
+let anFilters = { harness: "", model: "" };  // provider intentionally absent — harness + model identify the slice
 let anSessions = [];      // accumulated cards across "More" pages
 let anNextBefore = null;  // cursor for the next page (null = no older rows)
 let anDaysLoaded = 0;     // window size loaded so far (7 per page)
+let anClass = "input_tokens";  // the stat card selected for the graph
+
+const AN_CLASSES = [
+  ["input_tokens", "Input"], ["output_tokens", "Output"],
+  ["cache_read_tokens", "Cache read"], ["cache_write_tokens", "Cache write"],
+  ["reasoning_tokens", "Reasoning"],
+];
 
 const fmtTok = (n) => n == null ? "—"
   : n >= 1e9 ? (n / 1e9).toFixed(1) + "B"
@@ -1705,11 +1712,161 @@ function anQuery(extra = {}) {
   return s ? "?" + s : "";
 }
 
-async function anLoadPage() {
-  const d = await api("/analytics/sessions" + anQuery(anNextBefore ? { before: anNextBefore, days: 7 } : { days: 7 }));
+const AN_RANGES = [["1W", 7], ["1M", 30], ["3M", 90], ["6M", 180]];
+let anRange = 7;          // the active time chip, in days
+
+async function anLoadPage(days) {
+  const d = await api("/analytics/sessions" + anQuery({
+    ...(anNextBefore ? { before: anNextBefore } : {}), days }));
   anSessions.push(...d.sessions);
   anNextBefore = d.next_before;
-  anDaysLoaded += 7;
+  anDaysLoaded += days;
+}
+
+// ── chart: local-day buckets + a monotone-cubic spline ──
+// Buckets come from the loaded session cards (not a second endpoint), so the
+// stat cards, the graph, and the list below always agree — same window, same
+// filters, same local-day boundaries. Empty days are measured zero, not gaps.
+function anBuckets(cls) {
+  const days = Math.max(anDaysLoaded, 7);
+  const keyOf = (d) => `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+  const buckets = [];
+  const byKey = {};
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(Date.now() - i * 864e5);
+    const b = { key: keyOf(d), date: d, value: 0 };
+    buckets.push(b);
+    byKey[b.key] = b;
+  }
+  for (const c of anSessions) {
+    if (!c.started_at) continue;
+    const b = byKey[keyOf(new Date(c.started_at))];
+    if (b) b.value += c[cls] || 0;
+  }
+  return buckets;
+}
+
+// Monotone cubic interpolation (Fritsch–Carlson, d3 curveMonotoneX shape):
+// smooth through every point with no overshoot — a spend series never dips
+// below what was measured just to look curvy.
+function monotonePath(pts) {
+  if (pts.length < 2) return "";
+  const n = pts.length;
+  const dx = [], dy = [], m = [];
+  for (let i = 0; i < n - 1; i++) {
+    dx.push(pts[i + 1][0] - pts[i][0]);
+    dy.push(pts[i + 1][1] - pts[i][1]);
+    m.push(dy[i] / (dx[i] || 1));
+  }
+  const t = [m[0]];
+  for (let i = 1; i < n - 1; i++)
+    t.push(m[i - 1] * m[i] <= 0 ? 0
+      : 3 * (dx[i - 1] + dx[i]) / ((2 * dx[i] + dx[i - 1]) / m[i - 1] + (dx[i] + 2 * dx[i - 1]) / m[i]));
+  t.push(m[n - 2]);
+  let d = `M${pts[0][0]},${pts[0][1]}`;
+  for (let i = 0; i < n - 1; i++) {
+    const h = dx[i] / 3;
+    d += `C${pts[i][0] + h},${pts[i][1] + h * t[i]} ` +
+         `${pts[i + 1][0] - h},${pts[i + 1][1] - h * t[i + 1]} ` +
+         `${pts[i + 1][0]},${pts[i + 1][1]}`;
+  }
+  return d;
+}
+
+const niceMax = (v) => {
+  if (v <= 0) return 1;
+  const p = Math.pow(10, Math.floor(Math.log10(v)));
+  for (const s of [1, 2, 5, 10]) if (v <= s * p) return s * p;
+  return 10 * p;
+};
+
+function anChartLabel() {
+  const cls = AN_CLASSES.find(([k]) => k === anClass)[1];
+  const scope = [anFilters.harness || "all harnesses", anFilters.model].filter(Boolean).join(" · ");
+  return `${cls} tokens — last ${Math.max(anDaysLoaded, 7)} days — ${scope}`;
+}
+
+const SVG = "http://www.w3.org/2000/svg";
+const svgEl = (t, attrs = {}) => {
+  const n = document.createElementNS(SVG, t);
+  for (const [k, v] of Object.entries(attrs)) n.setAttribute(k, v);
+  return n;
+};
+
+function anChart(cls) {
+  const buckets = anBuckets(cls);
+  const W = 860, H = 180, L = 48, R = 14, T = 10, B = 22;
+  const iw = W - L - R, ih = H - T - B;
+  const ymax = niceMax(Math.max(...buckets.map((b) => b.value)));
+  const x = (i) => L + (buckets.length === 1 ? iw / 2 : (i / (buckets.length - 1)) * iw);
+  const y = (v) => T + ih - (v / ymax) * ih;
+  const pts = buckets.map((b, i) => [x(i), y(b.value)]);
+
+  const wrap = el("div", { className: "an-chart-wrap", tabIndex: 0 });
+  wrap.append(el("div", { className: "an-chart-title" }, anChartLabel()));
+  const svg = svgEl("svg", { viewBox: `0 0 ${W} ${H}`, class: "an-chart" });
+
+  // recessive hairline grid + clean y ticks (0 / mid / max)
+  for (const v of [0, ymax / 2, ymax]) {
+    svg.append(svgEl("line", { x1: L, x2: W - R, y1: y(v), y2: y(v), class: "an-grid" }));
+    const tick = svgEl("text", { x: L - 6, y: y(v) + 3, class: "an-tick", "text-anchor": "end" });
+    tick.textContent = fmtTok(v);
+    svg.append(tick);
+  }
+  // x labels: first, middle, last day (local)
+  const xLabel = (i, anchor) => {
+    const t2 = svgEl("text", { x: x(i), y: H - 6, class: "an-tick", "text-anchor": anchor });
+    t2.textContent = buckets[i].date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    return t2;
+  };
+  svg.append(xLabel(0, "start"), xLabel(Math.floor(buckets.length / 2), "middle"),
+             xLabel(buckets.length - 1, "end"));
+
+  const line = monotonePath(pts);
+  svg.append(svgEl("path", { d: `${line}L${x(buckets.length - 1)},${y(0)}L${x(0)},${y(0)}Z`, class: "an-area" }));
+  svg.append(svgEl("path", { d: line, class: "an-line" }));
+
+  // crosshair + tooltip: aim at a day, never at the 2px line; arrows work too
+  const cross = svgEl("line", { y1: T, y2: T + ih, class: "an-cross", visibility: "hidden" });
+  const dot = svgEl("circle", { r: 4, class: "an-dot", visibility: "hidden" });
+  svg.append(cross, dot);
+  const tip = el("div", { className: "an-tip", hidden: true });
+  wrap.append(svg, tip);
+
+  let cur = -1;
+  const show = (i) => {
+    cur = i;
+    const [px, py] = pts[i];
+    cross.setAttribute("x1", px); cross.setAttribute("x2", px);
+    cross.setAttribute("visibility", "visible");
+    dot.setAttribute("cx", px); dot.setAttribute("cy", py);
+    dot.setAttribute("visibility", "visible");
+    tip.replaceChildren(
+      el("b", {}, (buckets[i].value || 0).toLocaleString()),
+      " ", el("span", { className: "muted" },
+        buckets[i].date.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })));
+    tip.hidden = false;
+    const frac = (px - L) / iw;
+    tip.style.left = `calc(${(px / W) * 100}% - ${Math.round(frac * tip.offsetWidth)}px)`;
+    tip.style.top = `${Math.max(0, (py / H) * 100 - 18)}%`;
+  };
+  const hide = () => { cur = -1; cross.setAttribute("visibility", "hidden");
+    dot.setAttribute("visibility", "hidden"); tip.hidden = true; };
+  svg.addEventListener("pointermove", (e) => {
+    const r = svg.getBoundingClientRect();
+    const px = ((e.clientX - r.left) / r.width) * W;
+    let best = 0;
+    for (let i = 1; i < pts.length; i++) if (Math.abs(pts[i][0] - px) < Math.abs(pts[best][0] - px)) best = i;
+    show(best);
+  });
+  svg.addEventListener("pointerleave", hide);
+  wrap.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowRight") { show(Math.min(cur + 1, pts.length - 1)); e.preventDefault(); }
+    else if (e.key === "ArrowLeft") { show(Math.max(cur - 1, 0)); e.preventDefault(); }
+    else if (e.key === "Escape") hide();
+  });
+  wrap.addEventListener("blur", hide);
+  return wrap;
 }
 
 function anSelect(label, key, values, onChange) {
@@ -1758,42 +1915,64 @@ function anSessionCard(c, sprintTitles) {
 async function renderAnalytics(root) {
   root.replaceChildren(el("div", { className: "muted" }, "sweeping harness data…"));
   try { await api("/analytics/sweep", "POST"); } catch { /* sweep is best-effort; show what's stored */ }
-  const winFrom = new Date(Date.now() - Math.max(anDaysLoaded, 7) * 864e5).toISOString().slice(0, 19) + "Z";
-  let filters, tokens, usage;
+  let filters, usage;
   try {
-    [filters, tokens, usage] = await Promise.all([
-      api("/analytics/filters"),
-      api("/analytics/tokens" + anQuery({ from: winFrom })),
-      api("/analytics/usage")]);
-    if (!anSessions.length && anNextBefore === null && !anDaysLoaded) await anLoadPage();
+    [filters, usage] = await Promise.all([
+      api("/analytics/filters"), api("/analytics/usage")]);
+    if (!anSessions.length && !anDaysLoaded) await anLoadPage(anRange);
   } catch (e) {
     root.replaceChildren(el("div", { className: "card" }, "error: " + e.message));
     return;
   }
   root.replaceChildren();
 
-  // filter row — applies to the summary, usage panels, and the list
+  // filter row — harness + model scope everything below (provider is
+  // deliberately absent: harness + model already identify the slice); the
+  // segmented time chips sit right and set the whole window
   const reset = (k) => (v) => {
     anFilters[k] = v;
     anSessions = []; anNextBefore = null; anDaysLoaded = 0;
     renderAnalytics(root);
   };
+  const rangeSeg = el("div", { className: "filters seg an-range" });
+  for (const [label, days] of AN_RANGES) {
+    const chip = el("button", { className: "chip" + (anRange === days && anDaysLoaded <= days ? " on" : ""),
+      type: "button", textContent: label });
+    chip.onclick = () => {
+      anRange = days;
+      anSessions = []; anNextBefore = null; anDaysLoaded = 0;
+      renderAnalytics(root);
+    };
+    rangeSeg.append(chip);
+  }
   root.append(el("div", { className: "an-filters" },
     anSelect("Harness", "harness", filters.harnesses, reset("harness")),
-    anSelect("Provider", "provider", filters.providers, reset("provider")),
-    anSelect("Model", "model", filters.models, reset("model"))));
+    anSelect("Model", "model", filters.models, reset("model")),
+    rangeSeg));
 
-  // summary strip — totals for the loaded window
-  const t = tokens.totals || {};
-  const strip = el("div", { className: "card an-summary" });
-  strip.append(microlabel(`Tokens — last ${Math.max(anDaysLoaded, 7)} days` +
-    (anFilters.harness || anFilters.provider || anFilters.model ? " (filtered)" : "")));
-  strip.append(statRow([
-    ["input", fmtTok(t.input)], ["output", fmtTok(t.output)],
-    ["cache read", fmtTok(t.cache_read)], ["cache write", fmtTok(t.cache_write)],
-    ...(t.reasoning != null ? [["reasoning", fmtTok(t.reasoning)]] : []),
-  ]));
-  root.append(strip);
+  // stat cards + the graph under them: click a card to graph that class over
+  // the selected window. Totals and buckets both come from the loaded session
+  // cards, so cards, graph, and the list below always agree.
+  const totals = {};
+  for (const [k] of AN_CLASSES)
+    totals[k] = anSessions.reduce((t, c) => c[k] == null ? t : (t ?? 0) + c[k], null);
+  const graphBox = el("div", {});
+  const cardRow = el("div", { className: "an-cards" });
+  const drawCards = () => {
+    cardRow.replaceChildren();
+    for (const [k, label] of AN_CLASSES) {
+      if (k === "reasoning_tokens" && totals[k] == null) continue;  // not exposed in this slice
+      const c = el("button", { className: "an-card" + (anClass === k ? " on" : ""), type: "button" });
+      c.append(el("span", { className: "an-card-label" }, label),
+               el("span", { className: "an-card-value" }, fmtTok(totals[k] ?? 0)));
+      c.onclick = () => { anClass = k; drawCards(); graphBox.replaceChildren(anChart(anClass)); };
+      cardRow.append(c);
+    }
+  };
+  if (anClass === "reasoning_tokens" && totals.reasoning_tokens == null) anClass = "input_tokens";
+  drawCards();
+  graphBox.append(anChart(anClass));
+  root.append(el("div", { className: "card an-summary" }, cardRow, graphBox));
 
   // usage panels — favorite model per flavor, recent sprints, recent features
   const sprintTitles = {};
@@ -1867,7 +2046,7 @@ async function renderAnalytics(root) {
     const more = el("button", { className: "act", type: "button", textContent: "More ↓ (7 more days)" });
     more.onclick = async () => {
       more.disabled = true;
-      try { await anLoadPage(); renderAnalytics(root); }
+      try { await anLoadPage(7); renderAnalytics(root); }
       catch (e) { toast("error: " + e.message); more.disabled = false; }
     };
     list.append(el("div", { className: "an-more" }, more));

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -1686,7 +1686,7 @@ let anFilters = { harness: "", model: "" };  // provider intentionally absent �
 let anSessions = [];      // accumulated cards across "More" pages
 let anNextBefore = null;  // cursor for the next page (null = no older rows)
 let anDaysLoaded = 0;     // window size loaded so far (7 per page)
-let anClass = "input_tokens";  // the stat card selected for the graph
+let anClass = null;  // selected stat card; null = combined (all classes summed)
 
 const AN_CLASSES = [
   ["input_tokens", "Input"], ["output_tokens", "Output"],
@@ -1727,8 +1727,8 @@ async function anLoadPage(days) {
 // Buckets come from the loaded session cards (not a second endpoint), so the
 // stat cards, the graph, and the list below always agree — same window, same
 // filters, same local-day boundaries. Empty days are measured zero, not gaps.
-function anBuckets(cls) {
-  const days = Math.max(anDaysLoaded, 7);
+function anBuckets(cls) {  // cls null = combined (the four classes summed)
+  const days = anDaysLoaded || anRange;
   const keyOf = (d) => `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
   const buckets = [];
   const byKey = {};
@@ -1741,7 +1741,7 @@ function anBuckets(cls) {
   for (const c of anSessions) {
     if (!c.started_at) continue;
     const b = byKey[keyOf(new Date(c.started_at))];
-    if (b) b.value += c[cls] || 0;
+    if (b) b.value += cls ? (c[cls] || 0) : cardTotal(c);
   }
   return buckets;
 }
@@ -1781,9 +1781,9 @@ const niceMax = (v) => {
 };
 
 function anChartLabel() {
-  const cls = AN_CLASSES.find(([k]) => k === anClass)[1];
+  const cls = anClass ? AN_CLASSES.find(([k]) => k === anClass)[1] : "Total";
   const scope = [anFilters.harness || "all harnesses", anFilters.model].filter(Boolean).join(" · ");
-  return `${cls} tokens — last ${Math.max(anDaysLoaded, 7)} days — ${scope}`;
+  return `${cls} tokens — last ${anDaysLoaded || anRange} days — ${scope}`;
 }
 
 const SVG = "http://www.w3.org/2000/svg";
@@ -1915,10 +1915,12 @@ function anSessionCard(c, sprintTitles) {
 async function renderAnalytics(root) {
   root.replaceChildren(el("div", { className: "muted" }, "sweeping harness data…"));
   try { await api("/analytics/sweep", "POST"); } catch { /* sweep is best-effort; show what's stored */ }
+  const winDays = anDaysLoaded || anRange;
+  const winFrom = new Date(Date.now() - winDays * 864e5).toISOString().slice(0, 10);
   let filters, usage;
   try {
     [filters, usage] = await Promise.all([
-      api("/analytics/filters"), api("/analytics/usage")]);
+      api("/analytics/filters"), api("/analytics/usage?from=" + winFrom)]);
     if (!anSessions.length && !anDaysLoaded) await anLoadPage(anRange);
   } catch (e) {
     root.replaceChildren(el("div", { className: "card" }, "error: " + e.message));
@@ -1950,13 +1952,15 @@ async function renderAnalytics(root) {
     anSelect("Model", "model", filters.models, reset("model")),
     rangeSeg));
 
-  // stat cards + the graph under them: click a card to graph that class over
-  // the selected window. Totals and buckets both come from the loaded session
-  // cards, so cards, graph, and the list below always agree.
+  // stat cards, then the graph in ITS OWN card: no card selected = the
+  // combined total is graphed; clicking a card graphs that class, clicking it
+  // again deselects back to combined. Totals and buckets both come from the
+  // loaded session cards, so cards, graph, and the list below always agree.
   const totals = {};
   for (const [k] of AN_CLASSES)
     totals[k] = anSessions.reduce((t, c) => c[k] == null ? t : (t ?? 0) + c[k], null);
-  const graphBox = el("div", {});
+  if (anClass && totals[anClass] == null) anClass = null;  // slice stopped exposing it
+  const graphCard = el("div", { className: "card an-graph" });
   const cardRow = el("div", { className: "an-cards" });
   const drawCards = () => {
     cardRow.replaceChildren();
@@ -1965,43 +1969,50 @@ async function renderAnalytics(root) {
       const c = el("button", { className: "an-card" + (anClass === k ? " on" : ""), type: "button" });
       c.append(el("span", { className: "an-card-label" }, label),
                el("span", { className: "an-card-value" }, fmtTok(totals[k] ?? 0)));
-      c.onclick = () => { anClass = k; drawCards(); graphBox.replaceChildren(anChart(anClass)); };
+      c.onclick = () => {
+        anClass = anClass === k ? null : k;
+        drawCards();
+        graphCard.replaceChildren(anChart(anClass));
+      };
       cardRow.append(c);
     }
   };
-  if (anClass === "reasoning_tokens" && totals.reasoning_tokens == null) anClass = "input_tokens";
   drawCards();
-  graphBox.append(anChart(anClass));
-  root.append(el("div", { className: "card an-summary" }, cardRow, graphBox));
+  graphCard.append(anChart(anClass));
+  root.append(cardRow, graphCard);
 
-  // usage panels — favorite model per flavor, recent sprints, recent features
-  const sprintTitles = {};
-  for (const s of usage.recent_sprints || []) sprintTitles[s.sprint_ref] = s.title;
+  // usage panels — favorite model by flavor · peak day · features shipped ·
+  // specs shipped · docs outstanding. Peak day is client-computed from the
+  // combined buckets (all classes, all models in the slice); the shipped
+  // counts are window-scoped server-side; outstanding is current-state.
+  const sprintTitles = usage.sprint_titles || {};
   const panels = el("div", { className: "an-panels" });
+  const panel = (label, valueText, items) => {
+    const p = el("div", { className: "card an-panel" });
+    p.append(microlabel(label), el("div", { className: "an-panel-value" }, valueText));
+    for (const it of (items || []).slice(0, 5))
+      p.append(el("div", { className: "an-usage-row" }, it));
+    return p;
+  };
   if ((usage.favorite_models || []).length) {
-    const p = el("div", { className: "card" }, microlabel("Favorite model by flavor"));
+    const p = el("div", { className: "card an-panel" }, microlabel("Favorite model by flavor"));
     for (const f of usage.favorite_models)
       p.append(el("div", { className: "an-usage-row" },
         el("span", { className: "pill" }, f.flavor), " ", f.model,
         el("span", { className: "muted" }, ` — ${f.sessions} session(s)`)));
     panels.append(p);
   }
-  if ((usage.recent_sprints || []).length) {
-    const p = el("div", { className: "card" }, microlabel("Recent sprints"));
-    for (const s of usage.recent_sprints)
-      p.append(el("div", { className: "an-usage-row" },
-        s.title || "sprint #" + s.sprint_ref,
-        el("span", { className: "muted" }, ` — ${s.sessions} session(s)`)));
-    panels.append(p);
-  }
-  if ((usage.recent_features || []).length) {
-    const p = el("div", { className: "card" }, microlabel("Recent features"));
-    for (const f of usage.recent_features)
-      p.append(el("div", { className: "an-usage-row" },
-        f.title, el("span", { className: "pill " + (f.roadmap_status || "") }, f.roadmap_status || "")));
-    panels.append(p);
-  }
-  if (panels.children.length) root.append(panels);
+  const peak = anBuckets(null).reduce((a, b) => (b.value > a.value ? b : a));
+  panels.append(panel("Peak day", peak.value ? fmtTok(peak.value) : "—",
+    peak.value ? [peak.date.toLocaleDateString(undefined,
+      { weekday: "short", month: "short", day: "numeric" }) + " — all models"] : []));
+  panels.append(panel("Features shipped", String((usage.features_shipped || []).length),
+    (usage.features_shipped || []).map((f) => f.title)));
+  panels.append(panel("Specs shipped", String((usage.specs_shipped || []).length),
+    (usage.specs_shipped || []).map((s) => s.title || s.feature_title || "#" + s.document_id)));
+  panels.append(panel("Docs outstanding", String((usage.docs_outstanding || []).length),
+    (usage.docs_outstanding || []).map((f) => f.title)));
+  root.append(panels);
 
   // session history — grouped by LOCAL day, newest first; within a day,
   // sessions sharing a sprint_ref cluster under a sprint header with rolled-up

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -1987,11 +1987,26 @@ async function renderAnalytics(root) {
   // counts are window-scoped server-side; outstanding is current-state.
   const sprintTitles = usage.sprint_titles || {};
   const panels = el("div", { className: "an-panels" });
+  // items: strings, or {id, label} — an id renders as #id with a copy button
+  // so the number can ride straight into a Roadmap/Docs/Flags search.
   const panel = (label, valueText, items) => {
     const p = el("div", { className: "card an-panel" });
     p.append(microlabel(label), el("div", { className: "an-panel-value" }, valueText));
-    for (const it of (items || []).slice(0, 5))
-      p.append(el("div", { className: "an-usage-row" }, it));
+    for (const it of (items || []).slice(0, 5)) {
+      const row = el("div", { className: "an-usage-row" });
+      if (it && typeof it === "object") {
+        const num = "#" + it.id;
+        const btn = el("button", { className: "an-copy", type: "button", title: `copy ${num}` }, "⧉");
+        btn.onclick = () => navigator.clipboard.writeText(num)
+          .then(() => toast(`copied ${num}`), () => toast("copy failed"));
+        row.append(el("span", { className: "an-id" }, num), btn,
+                   el("span", { className: "an-row-label" }, it.label || ""));
+        row.title = `${num} ${it.label || ""}`;
+      } else {
+        row.append(it);
+      }
+      p.append(row);
+    }
     return p;
   };
   if ((usage.favorite_models || []).length) {
@@ -2007,11 +2022,11 @@ async function renderAnalytics(root) {
     peak.value ? [peak.date.toLocaleDateString(undefined,
       { weekday: "short", month: "short", day: "numeric" }) + " — all models"] : []));
   panels.append(panel("Features shipped", String((usage.features_shipped || []).length),
-    (usage.features_shipped || []).map((f) => f.title)));
+    (usage.features_shipped || []).map((f) => ({ id: f.feature_id, label: f.title }))));
   panels.append(panel("Specs shipped", String((usage.specs_shipped || []).length),
-    (usage.specs_shipped || []).map((s) => s.title || s.feature_title || "#" + s.document_id)));
+    (usage.specs_shipped || []).map((s) => ({ id: s.document_id, label: s.title || s.feature_title }))));
   panels.append(panel("Docs outstanding", String((usage.docs_outstanding || []).length),
-    (usage.docs_outstanding || []).map((f) => f.title)));
+    (usage.docs_outstanding || []).map((f) => ({ id: f.feature_id, label: f.title }))));
   root.append(panels);
 
   // session history — grouped by LOCAL day, newest first; within a day,

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -1677,6 +1677,203 @@ async function renderWorktrees(root, opts = {}) {
   root.append(sc);
 }
 
+// ── Analytics ──────────────────────────────────────────────────────────────
+// Token & session analytics (doc #11). Timestamps arrive as UTC ISO; ALL
+// day-grouping and displayed times are LOCAL — translated here at render,
+// never on the server. The tab load runs an incremental sweep first so the
+// view reflects harness data as of now.
+let anFilters = { harness: "", provider: "", model: "" };
+let anSessions = [];      // accumulated cards across "More" pages
+let anNextBefore = null;  // cursor for the next page (null = no older rows)
+let anDaysLoaded = 0;     // window size loaded so far (7 per page)
+
+const fmtTok = (n) => n == null ? "—"
+  : n >= 1e9 ? (n / 1e9).toFixed(1) + "B"
+  : n >= 1e6 ? (n / 1e6).toFixed(1) + "M"
+  : n >= 1e3 ? (n / 1e3).toFixed(1) + "k" : String(n);
+const cardTotal = (c) => ["input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens"]
+  .reduce((t, k) => t + (c[k] || 0), 0);
+const localDay = (iso) => iso ? new Date(iso).toLocaleDateString(undefined,
+  { weekday: "short", year: "numeric", month: "short", day: "numeric" }) : "undated";
+const localTime = (iso) => iso ? new Date(iso).toLocaleTimeString(undefined,
+  { hour: "2-digit", minute: "2-digit" }) : "—";
+
+function anQuery(extra = {}) {
+  const p = new URLSearchParams();
+  for (const [k, v] of Object.entries({ ...anFilters, ...extra })) if (v) p.set(k, v);
+  const s = p.toString();
+  return s ? "?" + s : "";
+}
+
+async function anLoadPage() {
+  const d = await api("/analytics/sessions" + anQuery(anNextBefore ? { before: anNextBefore, days: 7 } : { days: 7 }));
+  anSessions.push(...d.sessions);
+  anNextBefore = d.next_before;
+  anDaysLoaded += 7;
+}
+
+function anSelect(label, key, values, onChange) {
+  const wrap = el("label", { className: "an-filter" }, microlabel(label));
+  const sel = el("select", { className: "an-select" });
+  sel.append(el("option", { value: "" }, "All"));
+  for (const v of values) sel.append(el("option", { value: v, selected: anFilters[key] === v }, v));
+  sel.onchange = () => onChange(sel.value);
+  wrap.append(sel);
+  return wrap;
+}
+
+function anSessionCard(c, sprintTitles) {
+  const row = el("details", { className: "sess" });
+  const head = el("summary", { className: "sess-head" });
+  head.append(el("span", { className: "sess-time" },
+    localTime(c.started_at) + "–" + localTime(c.ended_at)));
+  head.append(el("span", { className: "pill" + (c.unattributed ? " warn" : "") },
+    c.unattributed ? "unattributed" : c.shell || "?"));
+  head.append(el("span", { className: "pill" }, c.harness));
+  if (c.models) head.append(el("span", { className: "sess-model" }, c.models));
+  const title = c.title || "";
+  head.append(el("span", { className: "sess-title" },
+    title.length > 100 ? title.slice(0, 100) + "…" : title));
+  head.append(el("span", { className: "sess-tok" }, fmtTok(cardTotal(c) || null)));
+  row.append(head);
+
+  const body = el("div", { className: "sess-body" });
+  if (title.length > 100) body.append(el("div", { className: "sess-full-title" }, title));
+  body.append(statRow([
+    ["input", fmtTok(c.input_tokens)], ["output", fmtTok(c.output_tokens)],
+    ["cache read", fmtTok(c.cache_read_tokens)], ["cache write", fmtTok(c.cache_write_tokens)],
+    ...(c.reasoning_tokens != null ? [["reasoning", fmtTok(c.reasoning_tokens)]] : []),
+  ]));
+  const meta = [];
+  if (c.providers) meta.push(["provider", c.providers]);
+  if (c.shell_session) meta.push(["session", c.shell_session]);
+  if (c.sprint_ref) meta.push(["sprint", sprintTitles[c.sprint_ref] || "#" + c.sprint_ref]);
+  if (c.status !== "ok") meta.push(["status", c.status]);
+  if (meta.length) body.append(statRow(meta));
+  body.append(el("code", { className: "sess-ref" }, c.harness_session_ref));
+  row.append(body);
+  return row;
+}
+
+async function renderAnalytics(root) {
+  root.replaceChildren(el("div", { className: "muted" }, "sweeping harness data…"));
+  try { await api("/analytics/sweep", "POST"); } catch { /* sweep is best-effort; show what's stored */ }
+  const winFrom = new Date(Date.now() - Math.max(anDaysLoaded, 7) * 864e5).toISOString().slice(0, 19) + "Z";
+  let filters, tokens, usage;
+  try {
+    [filters, tokens, usage] = await Promise.all([
+      api("/analytics/filters"),
+      api("/analytics/tokens" + anQuery({ from: winFrom })),
+      api("/analytics/usage")]);
+    if (!anSessions.length && anNextBefore === null && !anDaysLoaded) await anLoadPage();
+  } catch (e) {
+    root.replaceChildren(el("div", { className: "card" }, "error: " + e.message));
+    return;
+  }
+  root.replaceChildren();
+
+  // filter row — applies to the summary, usage panels, and the list
+  const reset = (k) => (v) => {
+    anFilters[k] = v;
+    anSessions = []; anNextBefore = null; anDaysLoaded = 0;
+    renderAnalytics(root);
+  };
+  root.append(el("div", { className: "an-filters" },
+    anSelect("Harness", "harness", filters.harnesses, reset("harness")),
+    anSelect("Provider", "provider", filters.providers, reset("provider")),
+    anSelect("Model", "model", filters.models, reset("model"))));
+
+  // summary strip — totals for the loaded window
+  const t = tokens.totals || {};
+  const strip = el("div", { className: "card an-summary" });
+  strip.append(microlabel(`Tokens — last ${Math.max(anDaysLoaded, 7)} days` +
+    (anFilters.harness || anFilters.provider || anFilters.model ? " (filtered)" : "")));
+  strip.append(statRow([
+    ["input", fmtTok(t.input)], ["output", fmtTok(t.output)],
+    ["cache read", fmtTok(t.cache_read)], ["cache write", fmtTok(t.cache_write)],
+    ...(t.reasoning != null ? [["reasoning", fmtTok(t.reasoning)]] : []),
+  ]));
+  root.append(strip);
+
+  // usage panels — favorite model per flavor, recent sprints, recent features
+  const sprintTitles = {};
+  for (const s of usage.recent_sprints || []) sprintTitles[s.sprint_ref] = s.title;
+  const panels = el("div", { className: "an-panels" });
+  if ((usage.favorite_models || []).length) {
+    const p = el("div", { className: "card" }, microlabel("Favorite model by flavor"));
+    for (const f of usage.favorite_models)
+      p.append(el("div", { className: "an-usage-row" },
+        el("span", { className: "pill" }, f.flavor), " ", f.model,
+        el("span", { className: "muted" }, ` — ${f.sessions} session(s)`)));
+    panels.append(p);
+  }
+  if ((usage.recent_sprints || []).length) {
+    const p = el("div", { className: "card" }, microlabel("Recent sprints"));
+    for (const s of usage.recent_sprints)
+      p.append(el("div", { className: "an-usage-row" },
+        s.title || "sprint #" + s.sprint_ref,
+        el("span", { className: "muted" }, ` — ${s.sessions} session(s)`)));
+    panels.append(p);
+  }
+  if ((usage.recent_features || []).length) {
+    const p = el("div", { className: "card" }, microlabel("Recent features"));
+    for (const f of usage.recent_features)
+      p.append(el("div", { className: "an-usage-row" },
+        f.title, el("span", { className: "pill " + (f.roadmap_status || "") }, f.roadmap_status || "")));
+    panels.append(p);
+  }
+  if (panels.children.length) root.append(panels);
+
+  // session history — grouped by LOCAL day, newest first; within a day,
+  // sessions sharing a sprint_ref cluster under a sprint header with rolled-up
+  // totals; solo sessions list flat.
+  const list = el("div", {});
+  root.append(list);
+  if (!anSessions.length) {
+    list.append(el("div", { className: "muted" }, "No sessions in the loaded window."));
+  }
+  const byDay = new Map();  // insertion order follows the DESC-sorted rows
+  for (const c of anSessions) {
+    const day = localDay(c.started_at);
+    if (!byDay.has(day)) byDay.set(day, []);
+    byDay.get(day).push(c);
+  }
+  for (const [day, cards] of byDay) {
+    const dayCard = el("div", { className: "card an-day" });
+    dayCard.append(el("h2", {}, day));
+    const bySprint = new Map();
+    for (const c of cards) {
+      const k = c.sprint_ref || null;
+      if (!bySprint.has(k)) bySprint.set(k, []);
+      bySprint.get(k).push(c);
+    }
+    for (const [ref, group] of bySprint) {
+      if (ref && group.length > 1) {
+        const cl = el("div", { className: "an-sprint" });
+        cl.append(el("div", { className: "an-sprint-head" },
+          el("span", { className: "pill next" }, "sprint"),
+          " " + (sprintTitles[ref] || "#" + ref),
+          el("span", { className: "sess-tok" },
+            fmtTok(group.reduce((t, c) => t + cardTotal(c), 0)))));
+        for (const c of group) cl.append(anSessionCard(c, sprintTitles));
+        dayCard.append(cl);
+      } else {
+        for (const c of group) dayCard.append(anSessionCard(c, sprintTitles));
+      }
+    }
+    list.append(dayCard);
+  }
+  if (anNextBefore) {
+    const more = el("button", { className: "act", type: "button", textContent: "More ↓ (7 more days)" });
+    more.onclick = async () => {
+      more.disabled = true;
+      try { await anLoadPage(); renderAnalytics(root); }
+      catch (e) { toast("error: " + e.message); more.disabled = false; }
+    };
+    list.append(el("div", { className: "an-more" }, more));
+  }
+}
+
 // ── Tabs + boot ────────────────────────────────────────────────────────────────
 const VIEWS = {
   shells: ["#view-shells", renderShells],
@@ -1686,6 +1883,7 @@ const VIEWS = {
   flags: ["#view-flags", renderFlags],
   worktrees: ["#view-worktrees", renderWorktrees],
   map: ["#view-map", renderMap],
+  analytics: ["#view-analytics", renderAnalytics],
   scripts: ["#view-scripts", renderScripts],
 };
 async function load(tab) {

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -19,6 +19,7 @@
       <span class="navsep"></span>
       <button data-tab="worktrees">Worktrees</button>
       <button data-tab="map">Repo Map</button>
+      <button data-tab="analytics">Analytics</button>
       <button data-tab="scripts">Scripts</button>
     </nav>
     <div class="tools">
@@ -35,6 +36,7 @@
     <section id="view-flags" class="view" hidden></section>
     <section id="view-worktrees" class="view" hidden></section>
     <section id="view-map" class="view" hidden></section>
+    <section id="view-analytics" class="view" hidden></section>
     <section id="view-scripts" class="view" hidden></section>
   </main>
   <script src="/vendor/marked.umd.js"></script>

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -636,9 +636,10 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .an-select { background: var(--accent2); color: var(--ink); border: 1px solid var(--line);
   border-radius: 6px; padding: .3rem .5rem; font-size: .85rem; }
 .an-summary { margin-bottom: .6rem; }
-.an-panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 6px; margin-bottom: .6rem; }
-.an-usage-row { font-size: .85rem; padding: .2rem 0; }
+.an-panels { display: flex; gap: 6px; margin-bottom: .6rem; }  /* one line, always */
+.an-panel { flex: 1 1 0; min-width: 0; }
+.an-usage-row { font-size: .8rem; padding: .15rem 0; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; }
 .an-day + .an-day { margin-top: 6px; }
 .sess { border-top: 1px solid var(--line); }
 .sess:first-of-type { border-top: none; }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -629,3 +629,30 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .flow-wrap.flow-hover .flow-wire.lit { stroke: var(--accent); stroke-width: 2px; }
 
 .flow-hint { font-size: .82rem; text-align: center; margin-top: .4rem; }
+
+/* ── Analytics tab (doc #11) ── */
+.an-filters { display: flex; gap: .8rem; align-items: end; margin-bottom: .6rem; flex-wrap: wrap; }
+.an-filter { display: flex; flex-direction: column; gap: .2rem; }
+.an-select { background: var(--accent2); color: var(--ink); border: 1px solid var(--line);
+  border-radius: 6px; padding: .3rem .5rem; font-size: .85rem; }
+.an-summary { margin-bottom: .6rem; }
+.an-panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 6px; margin-bottom: .6rem; }
+.an-usage-row { font-size: .85rem; padding: .2rem 0; }
+.an-day + .an-day { margin-top: 6px; }
+.sess { border-top: 1px solid var(--line); }
+.sess:first-of-type { border-top: none; }
+.sess-head { display: flex; gap: .5rem; align-items: center; padding: .35rem 0;
+  cursor: pointer; list-style: none; font-size: .85rem; }
+.sess-head::-webkit-details-marker { display: none; }
+.sess-time { color: var(--dim); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.sess-model { color: var(--dim); font-size: .78rem; white-space: nowrap; }
+.sess-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.sess-tok { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--accent); white-space: nowrap; }
+.sess-body { padding: .2rem 0 .6rem 1rem; }
+.sess-full-title { font-size: .85rem; margin-bottom: .3rem; }
+.sess-ref { display: block; color: var(--dim); font-size: .72rem; margin-top: .3rem;
+  overflow-wrap: anywhere; }
+.an-sprint { border-left: 2px solid var(--accent); padding-left: .6rem; margin: .4rem 0; }
+.an-sprint-head { display: flex; gap: .5rem; align-items: center; font-size: .85rem; padding: .2rem 0; }
+.an-more { text-align: center; margin: .8rem 0; }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -639,7 +639,13 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .an-panels { display: flex; gap: 6px; margin-bottom: .6rem; }  /* one line, always */
 .an-panel { flex: 1 1 0; min-width: 0; }
 .an-usage-row { font-size: .8rem; padding: .15rem 0; overflow: hidden;
-  text-overflow: ellipsis; white-space: nowrap; }
+  text-overflow: ellipsis; white-space: nowrap; display: flex;
+  align-items: center; gap: .35rem; }
+.an-id { color: var(--accent); font-variant-numeric: tabular-nums; flex: none; }
+.an-row-label { overflow: hidden; text-overflow: ellipsis; }
+.an-copy { flex: none; background: none; border: 1px solid var(--line); border-radius: 4px;
+  color: var(--dim); font-size: .7rem; line-height: 1; padding: .1rem .25rem; cursor: pointer; }
+.an-copy:hover { color: var(--ink); border-color: var(--accent); }
 .an-day + .an-day { margin-top: 6px; }
 .sess { border-top: 1px solid var(--line); }
 .sess:first-of-type { border-top: none; }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -656,3 +656,31 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .an-sprint { border-left: 2px solid var(--accent); padding-left: .6rem; margin: .4rem 0; }
 .an-sprint-head { display: flex; gap: .5rem; align-items: center; font-size: .85rem; padding: .2rem 0; }
 .an-more { text-align: center; margin: .8rem 0; }
+
+/* ── Analytics: stat cards + spline graph + range chips ── */
+.an-range { margin-left: auto; align-self: center; }
+.an-range .chip { border-radius: 0; }
+.an-range .chip:first-child { border-top-left-radius: 6px; border-bottom-left-radius: 6px; }
+.an-range .chip:last-child { border-top-right-radius: 6px; border-bottom-right-radius: 6px; }
+.an-cards { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: .5rem; }
+.an-card { flex: 1 1 120px; background: var(--accent2); border: 1px solid var(--line);
+  border-radius: 8px; padding: .5rem .7rem; display: flex; flex-direction: column;
+  gap: .15rem; cursor: pointer; text-align: left; color: var(--dim); transition: border-color .12s; }
+.an-card:hover { border-color: var(--accent); }
+.an-card.on { border-color: var(--accent); color: var(--ink);
+  box-shadow: 0 0 0 1px rgba(110,168,254,.35); }
+.an-card-label { font-size: .72rem; text-transform: uppercase; letter-spacing: .04em; }
+.an-card-value { font-size: 1.25rem; font-weight: 600; color: var(--ink); }
+.an-chart-wrap { position: relative; outline: none; }
+.an-chart-title { font-size: .8rem; color: var(--dim); margin: .35rem 0 .25rem; }
+.an-chart { width: 100%; height: auto; display: block; }
+.an-grid { stroke: var(--line-soft); stroke-width: 1; }
+.an-tick { fill: var(--dim); font-size: 10px; }
+.an-line { fill: none; stroke: var(--accent); stroke-width: 2;
+  stroke-linejoin: round; stroke-linecap: round; }
+.an-area { fill: var(--accent); opacity: .1; }
+.an-cross { stroke: var(--dim); stroke-width: 1; }
+.an-dot { fill: var(--accent); stroke: var(--bg); stroke-width: 2; }
+.an-tip { position: absolute; background: var(--menu-bg); border: 1px solid var(--menu-border);
+  border-radius: 6px; padding: .25rem .5rem; font-size: .78rem;
+  pointer-events: none; white-space: nowrap; box-shadow: var(--menu-shadow); }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -672,7 +672,9 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .an-card-label { font-size: .72rem; text-transform: uppercase; letter-spacing: .04em; }
 .an-card-value { font-size: 1.25rem; font-weight: 600; color: var(--ink); }
 .an-chart-wrap { position: relative; outline: none; }
-.an-chart-title { font-size: .8rem; color: var(--dim); margin: .35rem 0 .25rem; }
+.an-chart-title { font-size: 1.05rem; font-weight: 600; color: var(--ink); margin: .1rem 0 .5rem; }
+.an-graph { margin-bottom: .6rem; }
+.an-panel-value { font-size: 1.5rem; font-weight: 600; color: var(--ink); margin: .15rem 0 .25rem; }
 .an-chart { width: 100%; height: auto; display: block; }
 .an-grid { stroke: var(--line-soft); stroke-width: 1; }
 .an-tick { fill: var(--dim); font-size: 10px; }

--- a/roadmap_sc.md
+++ b/roadmap_sc.md
@@ -62,6 +62,11 @@ The substrate itself: data layer we build, harness we rent. v1 targets Claude Co
 
 _No open flags._
 
+### Token & session analytics · owner: `cc`
+Self-tracked token spend + session history across all harnesses (claude/opencode/codex/vibe/kimi). Sweep-parse each harness's on-disk usage data into session_token_usage; session lifecycle columns on archives; /api/analytics/* + GUI Analytics tab (7-day paged history with session titles, harness/provider/model filters, sprint clusters, usage analytics). Tokens only, no pricing, v1.
+
+_No open flags._
+
 ## Next
 
 ### B1 — First-launch installer · owner: `cc`
@@ -71,11 +76,6 @@ _No open flags._
 
 ### Sprint reporting — unit reports, conformance pass, planner synthesis · owner: `cc`
 Dev unit-report result rows at merge; pre-freeze conformance pass (review shells judge spec vs main, four-way verdicts); sprint report becomes a fixed skeleton the planner synthesizes from unit reports + conformance doc. Skill-text only — no schema, no CLI. See specs_sc/sprint-reporting.md.
-
-_No open flags._
-
-### Token & session analytics · owner: `cc`
-Self-tracked token spend + session history across all harnesses (claude/opencode/codex/vibe/kimi). Sweep-parse each harness's on-disk usage data into session_token_usage; session lifecycle columns on archives; /api/analytics/* + GUI Analytics tab (7-day paged history with session titles, harness/provider/model filters, sprint clusters, usage analytics). Tokens only, no pricing, v1.
 
 _No open flags._
 

--- a/sc
+++ b/sc
@@ -928,6 +928,9 @@ case "$cmd" in
                 esac
                 exec "$PY" "$S/map_repo.py" ;;
   map-setup)    exec "$PY" "$S/map_setup.py" ;;
+  # Token & session analytics — sweep each harness's on-disk usage data for
+  # THIS repo into session_token_usage (incremental, idempotent; doc #11).
+  analytics)    exec "$PY" "$S/analytics.py" "$@" ;;
   seed-skills)  exec "$PY" "$S/seed_skills.py" ;;
   # Skill catalogue write surface — grants/retirement by name, loud on a miss
   # (the raw-SQL grant's silent no-op class). Snapshot is still the persist step.

--- a/specs_sc/token-session-analytics.md
+++ b/specs_sc/token-session-analytics.md
@@ -3,7 +3,7 @@ rendered_by: super-coder
 source: db
 edit: changes here are overwritten — author via the shell or localhost GUI
 feature: Token & session analytics
-roadmap_status: next
+roadmap_status: in_progress
 frozen: false
 title: Token & Session Analytics — Spec
 tags: [super-coder, spec, analytics, telemetry, harness]

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -36,6 +36,7 @@ import analytics  # noqa: E402
 from token_parsers import claude as p_claude  # noqa: E402
 from token_parsers import codex as p_codex  # noqa: E402
 from token_parsers import kimi as p_kimi  # noqa: E402
+from token_parsers import opencode as p_opencode  # noqa: E402
 
 
 def build_engine_db(path: Path) -> None:
@@ -125,6 +126,28 @@ class ClaudeParserTest(unittest.TestCase):
         far_future = 4102444800.0  # 2100-01-01 — newer than any file mtime
         self.assertEqual(self.sweep(since=lambda ref: far_future), [])
 
+    def test_subagent_fold_into_parent(self):
+        # subagent transcripts live at <uuid>/subagents/agent-*.jsonl — their
+        # spend folds into the top-level session row; title from parent only
+        cwd = str(self.repo)
+        parent = self.proj / "f497716c.jsonl"
+        parent.write_text(user_line("build the feature", cwd) + "\n"
+                          + usage_line("m1", cwd=cwd))
+        sub = self.proj / "f497716c/subagents"
+        sub.mkdir(parents=True)
+        (sub / "agent-a1.jsonl").write_text("\n".join([
+            user_line("You are an implementer agent…", cwd),
+            usage_line("m2", cwd=cwd),
+            usage_line("m1", cwd=cwd),  # copy of the parent's id — dedupes
+        ]))
+        os.utime(parent, (1, 1))  # parent older: it owns m1
+        rows = self.sweep()
+        self.assertEqual(len(rows), 1)               # ONE row, not two
+        r = rows[0]
+        self.assertEqual(r["harness_session_ref"], str(parent))
+        self.assertEqual(r["input_tokens"], 200)     # m1 + m2, m1 counted once
+        self.assertEqual(r["title"], "build the feature")  # never the subagent prompt
+
 
 class CodexParserTest(unittest.TestCase):
     def test_subset_normalization(self):
@@ -196,6 +219,42 @@ class KimiParserTest(unittest.TestCase):
         self.assertEqual(r["title"], "swarm run")
 
 
+class OpencodeParserTest(unittest.TestCase):
+    def test_reasoning_folds_into_output(self):
+        # opencode reports reasoning DISJOINT from output; the row contract is
+        # codex-shaped (reasoning ⊆ output), so the parser folds it in
+        tmp = Path(tempfile.mkdtemp())
+        repo = tmp / "r"
+        repo.mkdir()
+        db = tmp / "opencode.db"
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE session (id TEXT, directory TEXT, title TEXT, "
+                    "model TEXT, time_created INTEGER, time_updated INTEGER, "
+                    "tokens_input INTEGER NOT NULL DEFAULT 0, "
+                    "tokens_output INTEGER NOT NULL DEFAULT 0, "
+                    "tokens_reasoning INTEGER NOT NULL DEFAULT 0, "
+                    "tokens_cache_read INTEGER NOT NULL DEFAULT 0, "
+                    "tokens_cache_write INTEGER NOT NULL DEFAULT 0)")
+        con.execute("INSERT INTO session VALUES ('ses_1', ?, 't', "
+                    "'{\"id\": \"gpt-5.5\", \"providerID\": \"openai\"}', "
+                    "1781566825695, 1781566825695, 100, 80, 20, 500, 0)",
+                    (str(repo),))
+        con.commit()
+        con.close()
+        orig = p_opencode.DB
+        p_opencode.DB = db
+        try:
+            rows = p_opencode.sweep(repo, lambda ref: None, lambda m: None)
+        finally:
+            p_opencode.DB = orig
+        self.assertEqual(len(rows), 1)
+        r = rows[0]
+        self.assertEqual(r["output_tokens"], 100)      # 80 output + 20 reasoning
+        self.assertEqual(r["reasoning_tokens"], 20)    # split kept informationally
+        self.assertEqual(r["input_tokens"], 100)
+        self.assertEqual(r["provider"], "openai")
+
+
 class CollectorTest(unittest.TestCase):
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp())
@@ -226,6 +285,21 @@ class CollectorTest(unittest.TestCase):
         n, cap = con.execute("SELECT COUNT(*), MAX(captured_at) FROM session_token_usage").fetchone()
         self.assertEqual(n, 1)
         self.assertEqual(cap, "2026-07-19T11:00:00Z")
+
+    def test_since_fn_version_pinned(self):
+        # rows written by an OLDER parser version don't gate the skip — a
+        # version bump must force the full re-parse
+        con = self.con()
+        r = {"harness": "claude", "harness_session_ref": "/x.jsonl", "model": "m",
+             "provider": None, "title": None, "started_at": None, "ended_at": None,
+             "input_tokens": 1, "output_tokens": 1, "cache_read_tokens": None,
+             "cache_write_tokens": None, "reasoning_tokens": None,
+             "status": "ok", "parser_version": "1"}
+        analytics._upsert(con, r, "2026-07-19T10:00:00Z")
+        con.commit()
+        self.assertIsNotNone(analytics._since_fn(con, "claude", "1")("/x.jsonl"))
+        self.assertIsNone(analytics._since_fn(con, "claude", "2")("/x.jsonl"))
+        self.assertIsNone(analytics._since_fn(con, "kimi", "1")("/x.jsonl"))
 
     def test_attribution_windows(self):
         con = self.con()

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Tests for token & session analytics (doc #11) — parsers, collector, API.
+
+Covers the load-bearing hazards the spec calls out by name:
+  • claude usage duplication — the same usage object repeats per content-block
+    line, and resume/fork copies lines into new files: dedupe by message.id
+    must hold in-file AND cross-file.
+  • upsert idempotency — (harness, ref, model) is the natural key, and model
+    is NULL on no_usage rows, where SQLite UNIQUE treats NULLs as distinct:
+    a re-sweep must refresh in place, never duplicate.
+  • codex subset rules — input ⊇ cached_input (fresh = difference), reasoning
+    is inside output (informational, never added).
+  • attribution — worktree cwd → shell, archive time-windows, ambiguity and
+    unknown cwds stay NULL.
+
+Run:
+    python3 tests/test_analytics.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+import analytics  # noqa: E402
+from token_parsers import claude as p_claude  # noqa: E402
+from token_parsers import codex as p_codex  # noqa: E402
+from token_parsers import kimi as p_kimi  # noqa: E402
+
+
+def build_engine_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute("INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1)")
+    con.execute(
+        "INSERT INTO shells (shell_id, display_name, shortname, mandate, system_prompt, "
+        "user_id, is_shared, has_identity, bootstrapped, flavor, api_key) "
+        "VALUES (1, 'Admin', 'adm', 'test', 'sp', 1, 0, 1, 0, 'admin', 'tok-a')")
+    con.execute(
+        "INSERT INTO shells (shell_id, display_name, shortname, mandate, system_prompt, "
+        "user_id, is_shared, has_identity, bootstrapped, flavor, api_key) "
+        "VALUES (2, 'Dev', 'dev1', 'test', 'sp', 1, 0, 1, 0, 'dev', 'tok-d')")
+    con.commit()
+    con.close()
+
+
+def usage_line(mid: str, model: str = "claude-fable-5", cwd: str = "/repo",
+               ts: str = "2026-07-19T10:00:00Z", inp: int = 100) -> str:
+    return json.dumps({
+        "type": "assistant", "cwd": cwd, "timestamp": ts,
+        "message": {"id": mid, "model": model,
+                    "usage": {"input_tokens": inp, "output_tokens": 10,
+                              "cache_read_input_tokens": 20,
+                              "cache_creation_input_tokens": 5}}})
+
+
+def user_line(text: str, cwd: str = "/repo", ts: str = "2026-07-19T09:59:00Z") -> str:
+    return json.dumps({"type": "user", "cwd": cwd, "timestamp": ts,
+                       "message": {"role": "user", "content": text}})
+
+
+class ClaudeParserTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.repo = self.tmp / "myrepo"
+        self.repo.mkdir()
+        self.data = self.tmp / "claude-data"
+        self.proj = self.data / p_claude._encode(str(self.repo))
+        self.proj.mkdir(parents=True)
+        self._orig = p_claude.DATA_DIR
+        p_claude.DATA_DIR = self.data
+
+    def tearDown(self):
+        p_claude.DATA_DIR = self._orig
+
+    def sweep(self, since=lambda ref: None):
+        return p_claude.sweep(self.repo, since, lambda m: None)
+
+    def test_in_file_dedupe_and_title(self):
+        # the same message.id on 3 content-block lines counts ONCE
+        cwd = str(self.repo)
+        (self.proj / "a.jsonl").write_text("\n".join(
+            [user_line("fix the bug", cwd)] + [usage_line("m1", cwd=cwd)] * 3))
+        rows = self.sweep()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["input_tokens"], 100)
+        self.assertEqual(rows[0]["cache_write_tokens"], 5)
+        self.assertEqual(rows[0]["title"], "fix the bug")
+        self.assertEqual(rows[0]["provider"], "anthropic")
+
+    def test_cross_file_dedupe(self):
+        # fork copies m1's line into b.jsonl; only b's fresh m2 may count there
+        cwd = str(self.repo)
+        a, b = self.proj / "a.jsonl", self.proj / "b.jsonl"
+        a.write_text(usage_line("m1", cwd=cwd))
+        b.write_text(usage_line("m1", cwd=cwd) + "\n" + usage_line("m2", cwd=cwd))
+        os.utime(a, (1, 1))  # a is older — mtime order decides who owns m1
+        by_ref = {r["harness_session_ref"]: r for r in self.sweep()}
+        self.assertEqual(by_ref[str(a)]["input_tokens"], 100)
+        self.assertEqual(by_ref[str(b)]["input_tokens"], 100)   # m2 only, not m1+m2
+
+    def test_cwd_filter_and_no_usage(self):
+        (self.proj / "other.jsonl").write_text(usage_line("mx", cwd="/elsewhere"))
+        (self.proj / "empty.jsonl").write_text(user_line("hi", str(self.repo)))
+        rows = self.sweep()
+        self.assertEqual(len(rows), 1)  # /elsewhere filtered out
+        self.assertEqual(rows[0]["status"], "no_usage")
+        self.assertIsNone(rows[0]["model"])
+
+    def test_dir_scoped_incremental_skip(self):
+        (self.proj / "a.jsonl").write_text(usage_line("m1", cwd=str(self.repo)))
+        self.assertEqual(len(self.sweep()), 1)
+        far_future = 4102444800.0  # 2100-01-01 — newer than any file mtime
+        self.assertEqual(self.sweep(since=lambda ref: far_future), [])
+
+
+class CodexParserTest(unittest.TestCase):
+    def test_subset_normalization(self):
+        tmp = Path(tempfile.mkdtemp())
+        repo = tmp / "r"
+        repo.mkdir()
+        day = tmp / "sessions/2026/07/19"
+        day.mkdir(parents=True)
+        f = day / "rollout-x.jsonl"
+        lines = [
+            json.dumps({"type": "session_meta", "timestamp": "2026-07-19T10:00:00Z",
+                        "payload": {"cwd": str(repo), "model_provider": "openai"}}),
+            json.dumps({"type": "turn_context", "payload": {"model": "gpt-5.5"}}),
+            # cumulative totals — the LAST event wins, never the sum
+            json.dumps({"type": "event_msg", "payload": {"type": "token_count", "info": {
+                "total_token_usage": {"input_tokens": 500, "cached_input_tokens": 100,
+                                      "output_tokens": 60, "reasoning_output_tokens": 15}}}}),
+            json.dumps({"type": "event_msg", "timestamp": "2026-07-19T10:05:00Z",
+                        "payload": {"type": "token_count", "info": {
+                "total_token_usage": {"input_tokens": 1000, "cached_input_tokens": 400,
+                                      "output_tokens": 80, "reasoning_output_tokens": 20}}}}),
+        ]
+        f.write_text("\n".join(lines))
+        orig = p_codex.DATA_DIR
+        p_codex.DATA_DIR = tmp / "sessions"
+        try:
+            rows = p_codex.sweep(repo, lambda ref: None, lambda m: None)
+        finally:
+            p_codex.DATA_DIR = orig
+        self.assertEqual(len(rows), 1)
+        r = rows[0]
+        self.assertEqual(r["input_tokens"], 600)       # 1000 − 400 cached
+        self.assertEqual(r["cache_read_tokens"], 400)
+        self.assertEqual(r["output_tokens"], 80)       # includes reasoning
+        self.assertEqual(r["reasoning_tokens"], 20)    # informational
+        self.assertEqual(r["model"], "gpt-5.5")
+
+
+class KimiParserTest(unittest.TestCase):
+    def test_multi_agent_sum_per_model(self):
+        tmp = Path(tempfile.mkdtemp())
+        repo = tmp / "r"
+        repo.mkdir()
+        sess = tmp / "sessions/wd_x/session_1"
+        for agent in ("main", "agent-0"):
+            (sess / "agents" / agent).mkdir(parents=True)
+        (sess / "state.json").write_text(json.dumps({
+            "createdAt": "2026-07-19T10:00:00Z", "updatedAt": "2026-07-19T10:30:00Z",
+            "title": "swarm run", "workDir": str(repo)}))
+        rec = {"type": "usage.record", "model": "kimi-code/k3",
+               "usage": {"inputOther": 10, "output": 5, "inputCacheRead": 7,
+                         "inputCacheCreation": 0}}
+        (sess / "agents/main/wire.jsonl").write_text("\n".join([
+            json.dumps({"type": "llm.request", "provider": "kimi", "model": "k3"}),
+            json.dumps(rec)]))
+        (sess / "agents/agent-0/wire.jsonl").write_text(json.dumps(rec))
+        orig = p_kimi.DATA_DIR
+        p_kimi.DATA_DIR = tmp / "sessions"
+        try:
+            rows = p_kimi.sweep(repo, lambda ref: None, lambda m: None)
+        finally:
+            p_kimi.DATA_DIR = orig
+        self.assertEqual(len(rows), 1)
+        r = rows[0]
+        self.assertEqual(r["input_tokens"], 20)        # both agents summed
+        self.assertEqual(r["cache_read_tokens"], 14)
+        self.assertEqual(r["cache_write_tokens"], 0)   # measured zero, not NULL
+        self.assertEqual(r["provider"], "kimi")
+        self.assertEqual(r["title"], "swarm run")
+
+
+class CollectorTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self._db, self._root = analytics.DB_PATH, analytics.REPO_ROOT
+        analytics.DB_PATH = self.db
+        analytics.REPO_ROOT = self.tmp / "repo"
+        (analytics.REPO_ROOT / ".sc-worktrees/dev1").mkdir(parents=True)
+
+    def tearDown(self):
+        analytics.DB_PATH, analytics.REPO_ROOT = self._db, self._root
+
+    def con(self):
+        c = sqlite3.connect(self.db)
+        c.row_factory = sqlite3.Row
+        return c
+
+    def test_upsert_null_model_idempotent(self):
+        con = self.con()
+        r = {"harness": "claude", "harness_session_ref": "/x.jsonl", "model": None,
+             "provider": "anthropic", "title": None, "started_at": None,
+             "ended_at": None, "input_tokens": None, "output_tokens": None,
+             "cache_read_tokens": None, "cache_write_tokens": None,
+             "reasoning_tokens": None, "status": "no_usage", "parser_version": "1"}
+        self.assertEqual(analytics._upsert(con, r, "2026-07-19T10:00:00Z"), "insert")
+        self.assertEqual(analytics._upsert(con, r, "2026-07-19T11:00:00Z"), "update")
+        n, cap = con.execute("SELECT COUNT(*), MAX(captured_at) FROM session_token_usage").fetchone()
+        self.assertEqual(n, 1)
+        self.assertEqual(cap, "2026-07-19T11:00:00Z")
+
+    def test_attribution_windows(self):
+        con = self.con()
+        wt = str(analytics.REPO_ROOT / ".sc-worktrees/dev1")
+        # dev1 booted twice with claude: window 1 [09:00, 11:00), window 2 [11:00, ∞)
+        con.execute("INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, "
+                    "date, started_at, harness) VALUES (10, 2, '0001', '2026-07-19', "
+                    "'2026-07-19T09:00:00Z', 'claude')")
+        con.execute("INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, "
+                    "date, started_at, harness) VALUES (11, 2, '0002', '2026-07-19', "
+                    "'2026-07-19T11:00:00Z', 'claude')")
+        base = {"model": "m", "provider": None, "title": None, "ended_at": None,
+                "input_tokens": 1, "output_tokens": 1, "cache_read_tokens": None,
+                "cache_write_tokens": None, "reasoning_tokens": None,
+                "status": "ok", "parser_version": "1"}
+        rows = [
+            {**base, "harness": "claude", "harness_session_ref": "s1",
+             "started_at": "2026-07-19T09:30:00Z", "cwd": wt},          # → archive 10
+            {**base, "harness": "claude", "harness_session_ref": "s2",
+             "started_at": "2026-07-19T12:00:00Z", "cwd": wt},          # → archive 11 (open)
+            {**base, "harness": "kimi", "harness_session_ref": "s3",
+             "started_at": "2026-07-19T09:30:00Z", "cwd": wt},          # harness mismatch → NULL
+            {**base, "harness": "claude", "harness_session_ref": "s4",
+             "started_at": "2026-07-19T09:30:00Z", "cwd": "/somewhere/else"},  # cwd off-repo → NULL
+        ]
+        for r in rows:
+            analytics._upsert(con, r, "2026-07-19T13:00:00Z")
+        con.commit()
+        n = analytics._attribute(con, rows, lambda m: None)
+        con.commit()
+        self.assertEqual(n, 2)
+        got = {r["harness_session_ref"]: r["archive_id"] for r in
+               con.execute("SELECT harness_session_ref, archive_id FROM session_token_usage")}
+        self.assertEqual(got["s1"], 10)
+        self.assertEqual(got["s2"], 11)
+        self.assertIsNone(got["s3"])
+        self.assertIsNone(got["s4"])
+        # ended_at backfill: archive 10's end = its attributed rows' max ended_at
+        con.execute("UPDATE session_token_usage SET ended_at='2026-07-19T10:30:00Z' "
+                    "WHERE harness_session_ref='s1'")
+        analytics._backfill_ended(con)
+        con.commit()
+        self.assertEqual(con.execute("SELECT ended_at FROM shell_memory_archives "
+                                     "WHERE archive_id=10").fetchone()[0],
+                         "2026-07-19T10:30:00Z")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Build session for spec #407 (doc #11, feature 17) — all 9 tasks of the build plan, task-tracked in spec_tasks.

**What ships:** self-tracked token spend + session history across all five harnesses. Migration 0071 (archive lifecycle columns + `session_token_usage`), `run.py` launch telemetry + pre-session incremental sweep, one parser plugin per harness (`scripts/token_parsers/`), `sc analytics sweep`, `/api/analytics/*` + token-scoped `/_sc/mem/telemetry` ingest, claude SessionEnd hook, and a GUI Analytics tab (local-time day grouping, sprint clusters, 7-day cursor paging).

**Found & fixed while verifying:** consecutive headless one-shots reused the same "unused" stub archive, collapsing three real harness sessions into one archive row with the last boot's lifecycle. `open_session` now refuses to reuse a stub that has attributed usage rows, and the sweep runs before `open_session` so attribution is current at the check.

**Test plan**
- [x] 8 new tests (claude dedupe in-file/cross-file, NULL-model upsert idempotency, codex subset normalization, kimi multi-agent sum, attribution windows) — 428 total passing
- [x] Real sessions on 3 harnesses via `sc run` (codex, claude, kimi) — separate archives, 1:1 attribution, ended_at backfilled
- [x] Re-sweep idempotent (0 new / 0 refreshed)
- [x] snapshot + render + render-check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)