### PR TITLE
feat(analytics): shell-only attribution + always-on favorite-model card, 2+3 usage panel rows

### DIFF
--- a/.super-coder/scripts/analytics.py
+++ b/.super-coder/scripts/analytics.py
@@ -17,7 +17,10 @@ Attribution: harness session → archive by (cwd → shell, time-window). A
 shell's window runs from an archive's started_at to the same shell's next
 started_at (open-ended for the latest). Worktree cwds map to the shell whose
 shortname names the worktree; the repo root maps to admin-flavor shells.
-Residual ambiguity stays archive_id=NULL — visible, flagged unattributed,
+When no window matches (rows predating lifecycle archives) but the cwd
+resolves to exactly one shell, shell_id is still set — the shell mapping is
+deterministic on its own, only the archive needs the window. Residual
+ambiguity stays NULL — visible, flagged unattributed,
 never guessed. cwd is transient (attribution runs within the sweep batch);
 rows that stay NULL keep their spend visible in the totals regardless.
 
@@ -125,8 +128,12 @@ def _shell_for_cwd(cwd: str, by_wt: dict, admins: list) -> list[int]:
         name = cwd[len(wt_prefix):].split("/", 1)[0]
         sid = by_wt.get(name)
         return [sid] if sid else []
-    # repo root (or a subdir outside the worktrees) → admin-flavor shells
-    return admins
+    # repo root (or an in-repo subdir outside the worktrees) → admin-flavor
+    # shells; anything off-repo maps to nothing (parsers filter those out,
+    # this is the defensive backstop)
+    if cwd == root or cwd.startswith(root + "/"):
+        return admins
+    return []
 
 
 def _windows(con) -> dict[int, list]:
@@ -144,31 +151,44 @@ def _windows(con) -> dict[int, list]:
     return per
 
 
-def _attribute(con, batch: list[dict], log) -> int:
+def _attribute(con, batch: list[dict], log) -> "tuple[int, int]":
     by_wt, admins = _cwd_shells(con)
     windows = _windows(con)
-    attributed = 0
+    attributed = shell_only = 0
     for r in batch:
         if not r.get("cwd"):
             continue
+        sids = _shell_for_cwd(r["cwd"], by_wt, admins)
         t = _iso_epoch(r.get("started_at") or r.get("ended_at"))
-        if t is None:
-            continue
         hits = []
-        for sid in _shell_for_cwd(r["cwd"], by_wt, admins):
-            for aid, harness, start, end in windows.get(sid, []):
-                if harness == r["harness"] and start is not None \
-                        and start <= t and (end is None or t < end):
-                    hits.append((aid, sid))
-        if len(hits) != 1:
-            continue  # 0 = predates lifecycle rows; >1 = ambiguous — stays NULL
-        aid, sid = hits[0]
-        cur = con.execute(
-            "UPDATE session_token_usage SET archive_id=?, shell_id=? "
-            "WHERE harness=? AND harness_session_ref=? AND model IS ? AND archive_id IS NULL",
-            (aid, sid, r["harness"], r["harness_session_ref"], r["model"]))
-        attributed += cur.rowcount
-    return attributed
+        if t is not None:
+            for sid in sids:
+                for aid, harness, start, end in windows.get(sid, []):
+                    if harness == r["harness"] and start is not None \
+                            and start <= t and (end is None or t < end):
+                        hits.append((aid, sid))
+        if len(hits) == 1:
+            aid, sid = hits[0]
+            cur = con.execute(
+                "UPDATE session_token_usage SET archive_id=?, shell_id=? "
+                "WHERE harness=? AND harness_session_ref=? AND model IS ? AND archive_id IS NULL",
+                (aid, sid, r["harness"], r["harness_session_ref"], r["model"]))
+            attributed += cur.rowcount
+        elif len(sids) == 1:
+            # No usable archive window (predates lifecycle rows, or ambiguous)
+            # but the shell itself is deterministic from cwd alone — worktree
+            # name IS the shortname; repo root maps to the sole admin shell.
+            # Shell-level attribution keeps flavor rollups (favorite model)
+            # fed by pre-lifecycle history; archive_id stays NULL so a later
+            # window match can still land the full attribution.
+            cur = con.execute(
+                "UPDATE session_token_usage SET shell_id=? "
+                "WHERE harness=? AND harness_session_ref=? AND model IS ? "
+                "AND archive_id IS NULL AND shell_id IS NULL",
+                (sids[0], r["harness"], r["harness_session_ref"], r["model"]))
+            shell_only += cur.rowcount
+        # else: cwd ambiguous (multiple admin shells) or off-repo — stays NULL
+    return attributed, shell_only
 
 
 def _backfill_ended(con) -> int:
@@ -181,7 +201,8 @@ def _backfill_ended(con) -> int:
     return cur.rowcount
 
 
-def sweep(only: "str | None" = None, quiet: bool = False) -> dict:
+def sweep(only: "str | None" = None, quiet: bool = False,
+          full: bool = False) -> dict:
     notes: list[str] = []
 
     def log(msg: str):
@@ -195,7 +216,8 @@ def sweep(only: "str | None" = None, quiet: bool = False) -> dict:
         counts = {"insert": 0, "update": 0}
         batch: list[dict] = []
         for mod in _load_parsers(only, log):
-            since = _since_fn(con, mod.HARNESS, mod.PARSER_VERSION)
+            since = (lambda ref: None) if full \
+                else _since_fn(con, mod.HARNESS, mod.PARSER_VERSION)
             try:
                 rows = mod.sweep(REPO_ROOT, since, log)
             except Exception as e:  # plugin stance: loud, never fatal to the sweep
@@ -204,15 +226,16 @@ def sweep(only: "str | None" = None, quiet: bool = False) -> dict:
             for r in rows:
                 counts[_upsert(con, r, captured_at)] += 1
                 batch.append(r)
-        attributed = _attribute(con, batch, log)
+        attributed, shell_only = _attribute(con, batch, log)
         ended = _backfill_ended(con)
         con.commit()
         summary = {"inserted": counts["insert"], "updated": counts["update"],
-                   "attributed": attributed, "ended_backfilled": ended,
-                   "notes": notes}
+                   "attributed": attributed, "shell_attributed": shell_only,
+                   "ended_backfilled": ended, "notes": notes}
         if not quiet:
             print(f"analytics: {counts['insert']} new, {counts['update']} refreshed, "
-                  f"{attributed} attributed, {ended} archive end(s) backfilled")
+                  f"{attributed} attributed, {shell_only} shell-only, "
+                  f"{ended} archive end(s) backfilled")
         return summary
     finally:
         con.close()
@@ -220,9 +243,12 @@ def sweep(only: "str | None" = None, quiet: bool = False) -> dict:
 
 def main(argv: list[str]) -> int:
     if not argv or argv[0] in ("-h", "--help"):
-        print("usage: sc analytics sweep [--harness <name>] [--quiet]\n"
+        print("usage: sc analytics sweep [--harness <name>] [--quiet] [--full]\n"
               "  parse each harness's on-disk usage data for THIS repo into\n"
-              "  session_token_usage (incremental, idempotent)")
+              "  session_token_usage (incremental, idempotent)\n"
+              "  --full ignores the incremental watermark and re-parses every\n"
+              "  session — use once to backfill shell attribution on rows\n"
+              "  swept before it existed")
         return 0
     if argv[0] != "sweep":
         print(f"sc analytics: unknown command '{argv[0]}' (try: sweep)", file=sys.stderr)
@@ -235,7 +261,7 @@ def main(argv: list[str]) -> int:
         if only not in token_parsers.HARNESSES:
             print(f"sc analytics: unknown harness '{only}'", file=sys.stderr)
             return 2
-    sweep(only=only, quiet=quiet)
+    sweep(only=only, quiet=quiet, full="--full" in argv)
     return 0
 
 

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -1986,6 +1986,7 @@ async function renderAnalytics(root) {
   // combined buckets (all classes, all models in the slice); the shipped
   // counts are window-scoped server-side; outstanding is current-state.
   const sprintTitles = usage.sprint_titles || {};
+  const panelsTop = el("div", { className: "an-panels" });
   const panels = el("div", { className: "an-panels" });
   // items: strings, or {id, label} — an id renders as #id with a copy button
   // so the number can ride straight into a Roadmap/Docs/Flags search.
@@ -2009,25 +2010,28 @@ async function renderAnalytics(root) {
     }
     return p;
   };
-  if ((usage.favorite_models || []).length) {
-    const p = el("div", { className: "card an-panel" }, microlabel("Favorite model by flavor"));
-    for (const f of usage.favorite_models)
-      p.append(el("div", { className: "an-usage-row" },
-        el("span", { className: "pill" }, f.flavor), " ", f.model,
-        el("span", { className: "muted" }, ` — ${f.sessions} session(s)`)));
-    panels.append(p);
-  }
+  // row 1: favorite model by flavor + peak day. The favorite card is always
+  // rendered — "—" until shell attribution has data to roll up.
+  const favP = el("div", { className: "card an-panel" }, microlabel("Favorite model by flavor"));
+  const favs = usage.favorite_models || [];
+  if (!favs.length) favP.append(el("div", { className: "an-panel-value" }, "—"));
+  for (const f of favs)
+    favP.append(el("div", { className: "an-usage-row" },
+      el("span", { className: "pill" }, f.flavor), " ", f.model,
+      el("span", { className: "muted" }, ` — ${f.sessions} session(s)`)));
+  panelsTop.append(favP);
   const peak = anBuckets(null).reduce((a, b) => (b.value > a.value ? b : a));
-  panels.append(panel("Peak day", peak.value ? fmtTok(peak.value) : "—",
+  panelsTop.append(panel("Peak day", peak.value ? fmtTok(peak.value) : "—",
     peak.value ? [peak.date.toLocaleDateString(undefined,
       { weekday: "short", month: "short", day: "numeric" }) + " — all models"] : []));
+  // row 2: the shipped/owed trio
   panels.append(panel("Features shipped", String((usage.features_shipped || []).length),
     (usage.features_shipped || []).map((f) => ({ id: f.feature_id, label: f.title }))));
   panels.append(panel("Specs shipped", String((usage.specs_shipped || []).length),
     (usage.specs_shipped || []).map((s) => ({ id: s.document_id, label: s.title || s.feature_title }))));
   panels.append(panel("Docs outstanding", String((usage.docs_outstanding || []).length),
     (usage.docs_outstanding || []).map((f) => ({ id: f.feature_id, label: f.title }))));
-  root.append(panels);
+  root.append(panelsTop, panels);
 
   // session history — grouped by LOCAL day, newest first; within a day,
   // sessions sharing a sprint_ref cluster under a sprint header with rolled-up

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -328,15 +328,17 @@ class CollectorTest(unittest.TestCase):
         for r in rows:
             analytics._upsert(con, r, "2026-07-19T13:00:00Z")
         con.commit()
-        n = analytics._attribute(con, rows, lambda m: None)
+        n, shell_only = analytics._attribute(con, rows, lambda m: None)
         con.commit()
         self.assertEqual(n, 2)
-        got = {r["harness_session_ref"]: r["archive_id"] for r in
-               con.execute("SELECT harness_session_ref, archive_id FROM session_token_usage")}
-        self.assertEqual(got["s1"], 10)
-        self.assertEqual(got["s2"], 11)
-        self.assertIsNone(got["s3"])
-        self.assertIsNone(got["s4"])
+        self.assertEqual(shell_only, 1)  # s3: no kimi window, but cwd → dev1
+        got = {r["harness_session_ref"]: (r["archive_id"], r["shell_id"]) for r in
+               con.execute("SELECT harness_session_ref, archive_id, shell_id "
+                           "FROM session_token_usage")}
+        self.assertEqual(got["s1"], (10, 2))
+        self.assertEqual(got["s2"], (11, 2))
+        self.assertEqual(got["s3"], (None, 2))   # shell-only: flavor rollups see it
+        self.assertEqual(got["s4"], (None, None))  # off-repo → nothing, not admin
         # ended_at backfill: archive 10's end = its attributed rows' max ended_at
         con.execute("UPDATE session_token_usage SET ended_at='2026-07-19T10:30:00Z' "
                     "WHERE harness_session_ref='s1'")
@@ -345,6 +347,64 @@ class CollectorTest(unittest.TestCase):
         self.assertEqual(con.execute("SELECT ended_at FROM shell_memory_archives "
                                      "WHERE archive_id=10").fetchone()[0],
                          "2026-07-19T10:30:00Z")
+
+    def test_shell_only_attribution(self):
+        """Rows predating lifecycle archives still get shell_id from cwd alone;
+        a later window match upgrades them to full attribution; ambiguous
+        root-cwd (two admin shells) stays NULL."""
+        con = self.con()
+        wt = str(analytics.REPO_ROOT / ".sc-worktrees/dev1")
+        root = str(analytics.REPO_ROOT)
+        base = {"model": "m", "provider": None, "title": None, "ended_at": None,
+                "input_tokens": 1, "output_tokens": 1, "cache_read_tokens": None,
+                "cache_write_tokens": None, "reasoning_tokens": None,
+                "status": "ok", "parser_version": "1"}
+        rows = [
+            {**base, "harness": "claude", "harness_session_ref": "h1",
+             "started_at": "2026-06-01T09:00:00Z", "cwd": wt},    # worktree → dev1
+            {**base, "harness": "claude", "harness_session_ref": "h2",
+             "started_at": "2026-06-01T09:00:00Z", "cwd": root},  # root → sole admin
+            {**base, "harness": "claude", "harness_session_ref": "h3",
+             "started_at": None, "cwd": wt},                      # no timestamp: still ok
+        ]
+        for r in rows:
+            analytics._upsert(con, r, "2026-07-19T13:00:00Z")
+        con.commit()
+        n, shell_only = analytics._attribute(con, rows, lambda m: None)
+        con.commit()
+        self.assertEqual((n, shell_only), (0, 3))
+        got = {r["harness_session_ref"]: (r["archive_id"], r["shell_id"]) for r in
+               con.execute("SELECT harness_session_ref, archive_id, shell_id "
+                           "FROM session_token_usage")}
+        self.assertEqual(got["h1"], (None, 2))
+        self.assertEqual(got["h2"], (None, 1))
+        self.assertEqual(got["h3"], (None, 2))
+        # a lifecycle archive appearing later upgrades the shell-only row
+        con.execute("INSERT INTO shell_memory_archives (archive_id, shell_id, "
+                    "session_id, date, started_at, harness) VALUES (20, 2, '0001', "
+                    "'2026-06-01', '2026-06-01T08:00:00Z', 'claude')")
+        con.commit()
+        n, shell_only = analytics._attribute(con, [rows[0]], lambda m: None)
+        con.commit()
+        self.assertEqual((n, shell_only), (1, 0))
+        got = con.execute("SELECT archive_id, shell_id FROM session_token_usage "
+                          "WHERE harness_session_ref='h1'").fetchone()
+        self.assertEqual((got[0], got[1]), (20, 2))
+        # two admin shells → root cwd is ambiguous, second sweep leaves h2 as-is
+        con.execute("INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+                    "system_prompt, user_id, is_shared, has_identity, bootstrapped, "
+                    "flavor, api_key) VALUES (3, 'Admin2', 'adm2', 't', 'sp', 1, 0, "
+                    "1, 0, 'admin', 'tok-b')")
+        con.commit()
+        rows[1]["harness_session_ref"] = "h4"
+        analytics._upsert(con, rows[1], "2026-07-19T13:00:00Z")
+        con.commit()
+        n, shell_only = analytics._attribute(con, [rows[1]], lambda m: None)
+        con.commit()
+        self.assertEqual((n, shell_only), (0, 0))
+        self.assertIsNone(con.execute(
+            "SELECT shell_id FROM session_token_usage "
+            "WHERE harness_session_ref='h4'").fetchone()[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #408. The Favorite-model-by-flavor card never showed on real forks (dos-arch validation): the API returned `[]` because `shell_id` was only written as a byproduct of archive-window attribution, which pre-analytics history can never satisfy — and the UI silently hid the empty card.

The shell mapping never needed the window: worktree dir = lowercase shortname (consistent since day one), repo root = the sole admin shell. This decouples them — shell-only attribution from cwd when no window matches (archive_id stays NULL and upgradeable), `sweep --full` to re-parse history past the incremental watermark, off-repo cwds hardened to map to nothing. UI: Favorite card always renders ("—" until data), panels split into two rows — Favorite + Peak day / Features | Specs | Docs outstanding.

Deploy note for dos-arch: after repin, run `./sc analytics sweep --full` once to backfill shell attribution on the 1,352 historical rows.

## Test plan
- [x] `tests/test_analytics.py` — 12 pass (attribution test extended; new shell-only test: worktree, root/admin, no-timestamp, later-window upgrade, two-admin ambiguity, off-repo → NULL)
- [x] `tests/test_api_endpoints.py`, `tests/test_migrate.py` — pass
- [x] `node --check` on app.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)