### PR TITLE
docs: sweep repo URLs to jedbjorn/subfloor after the rename

### DIFF
--- a/.super-coder/assets/skills/issue_reporting/SKILL.md
+++ b/.super-coder/assets/skills/issue_reporting/SKILL.md
@@ -58,10 +58,10 @@ The issue is public: NEVER paste api keys, tokens, secrets, or private paths.
 
 ```bash
 # 1. dedup — someone may have hit it first
-gh issue list --repo jedbjorn/super-coder --search "<symptom keywords>" --state all
+gh issue list --repo jedbjorn/subfloor --search "<symptom keywords>" --state all
 
 # 2. file — title: [<fork>] <area>: <one-line symptom>
-gh issue create --repo jedbjorn/super-coder \
+gh issue create --repo jedbjorn/subfloor \
   --title "[<fork>] <area>: <symptom>" \
   --body "$(cat <<'EOF'
 - engine ref: <sha from .sc-state/engine.ref>
@@ -75,7 +75,7 @@ EOF
 )"
 ```
 
-`jedbjorn/super-coder` = engine upstream; confirm: `git remote get-url super-coder`.
+`jedbjorn/subfloor` = engine upstream; confirm: `git remote get-url super-coder`.
 
 Dedup hit -> comment your engine ref + repro on the existing issue; do NOT
 file a duplicate.

--- a/.super-coder/docs/pm2-broker.md
+++ b/.super-coder/docs/pm2-broker.md
@@ -6,7 +6,7 @@ pm2-supervised app stack without holding any host access. Third sibling of the
 [tailnet broker](tailscale-broker.md); same shape, different backend.
 
 Upstreamed from a fork's deploy-confirmation gap
-([super-coder#254](https://github.com/jedbjorn/super-coder/issues/254)): an
+([super-coder#254](https://github.com/jedbjorn/subfloor/issues/254)): an
 admin shell mandated to own its fork's infra could not see or bounce the pm2
 stack it was responsible for.
 

--- a/.super-coder/docs/publish-and-gh-auth.md
+++ b/.super-coder/docs/publish-and-gh-auth.md
@@ -8,7 +8,7 @@ purpose: How the Review GUI's snapshot/publish work, how they authenticate to Gi
 
 # Publish, GitHub auth & the webapp event log
 
-[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/super-coder/blob/main/.super-coder/docs/publish-and-gh-auth.md)
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/subfloor/blob/main/.super-coder/docs/publish-and-gh-auth.md)
 
 ## What snapshot & publish do
 

--- a/.super-coder/docs/windows-vm-broker.md
+++ b/.super-coder/docs/windows-vm-broker.md
@@ -8,7 +8,7 @@ purpose: Host-side broker so sandboxed forks can drive the test VM
 
 # Windows VM Broker — Spec
 
-[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/super-coder/blob/main/.super-coder/docs/windows-vm-broker.md)
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/subfloor/blob/main/.super-coder/docs/windows-vm-broker.md)
 
 ## Overview
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1960,10 +1960,10 @@ The issue is public: NEVER paste api keys, tokens, secrets, or private paths.
 
 ```bash
 # 1. dedup — someone may have hit it first
-gh issue list --repo jedbjorn/super-coder --search "<symptom keywords>" --state all
+gh issue list --repo jedbjorn/subfloor --search "<symptom keywords>" --state all
 
 # 2. file — title: [<fork>] <area>: <one-line symptom>
-gh issue create --repo jedbjorn/super-coder \
+gh issue create --repo jedbjorn/subfloor \
   --title "[<fork>] <area>: <symptom>" \
   --body "$(cat <<''EOF''
 - engine ref: <sha from .sc-state/engine.ref>
@@ -1977,7 +1977,7 @@ EOF
 )"
 ```
 
-`jedbjorn/super-coder` = engine upstream; confirm: `git remote get-url super-coder`.
+`jedbjorn/subfloor` = engine upstream; confirm: `git remote get-url super-coder`.
 
 Dedup hit -> comment your engine ref + repro on the existing issue; do NOT
 file a duplicate.

--- a/.super-coder/migrations/0072_reseed_issue_reporting_rename.sql
+++ b/.super-coder/migrations/0072_reseed_issue_reporting_rename.sql
@@ -1,0 +1,109 @@
+-- 0072 — reseed: issue_reporting URLs after the super-coder → subfloor rename.
+--
+-- The repo renamed to jedbjorn/subfloor; the skill's issue/PR links move off
+-- the redirect. Source asset updated in the same commit; this trailing
+-- forward reseed (UPSERT by name; skill_id + grants preserved) carries it to
+-- installed forks and fresh builds alike.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'issue_reporting',
+  'Report engine defects upstream — the moment a ./sc command fails or lies, a skill contradicts your reality, the API blocks a documented workflow, or you work around the engine to proceed. File a GitHub issue on super-coder; your repo''s app bugs stay in the fork.',
+  'substrate',
+  NULL,
+  1,
+  '# issue_reporting — the backwards flow
+
+An engine defect fixed upstream reaches every fork via `./sc update`; worked
+around silently, every fork re-derives the workaround. File the issue while
+the failure is on screen — NEVER batch to session end.
+
+A workaround IS a report: deviating from a skill''s steps, wrapping a command,
+or hand-patching state to proceed -> you hold the exact repro; file it now.
+
+## Boundary — engine vs fork
+
+| Where | What |
+|---|---|
+| **Upstream — file it** | anything the engine materializes/owns: `.super-coder/`, `sc` + every subcommand, engine skills (this catalogue), the boot doc render, the sandbox / dev kit, `./sc update` + migrations, the `_sc` API + `sc mem` |
+| **Fork — don''t** | the repo''s app code, fork-local skills (see `local_skill_management`), operator-owned host config |
+
+Unsure -> "would the same problem hit any other fork?" yes = upstream.
+
+## Triggers
+
+Each row = a real engine defect filed by a fork shell doing ordinary work.
+Match the left column -> file.
+
+| You hit | Real case |
+|---|---|
+| A `./sc` command fails out of the box | `./sc verify` always aborted — its own render step needed `SC_ADMIN` it never set (#227) |
+| A command exits green without doing the work | `./sc test` silently fell back to unittest when pytest was missing — green-washed suites (#219) |
+| The documented remedy is a closed loop | `./sc lint` said "run `./sc deps` first," but deps skips pip in the sandbox — tool unobtainable from inside the box (#246) |
+| A skill instructs tools/paths your seat doesn''t have | `configure_winbox` drove raw `ssh`/`virsh` — neither exists in the broker-only sandbox (#248) |
+| A skill contradicts what the engine actually does | skills still taught raw `sqlite3` against the substrate DB after memory went API-only (#226) |
+| The API refuses what the skills document | `sc mem doc add` 400''d standalone docs the docs + onboard skills both document (#245) |
+| A permission wall mid-workflow | a dev shell could read a planner-owned feature but 404''d advancing its status (#224) |
+| Every write suddenly 401s | rebuild didn''t re-mint api_keys — all live shells locked out until an API bounce (#214) |
+| `./sc update` / migrate wedges or half-applies | migration failed partway, retry died on `duplicate column name` (#229); update aborted crossing a commit that deleted an engine file (#209) |
+| A structural foot-gun keeps re-biting you | the cwd trap — `cd` to root for `./sc`, then bare git hit the wrong tree, "my edits vanished" (#225) |
+| The sandbox can reach something it shouldn''t | `do_push` src/dest weren''t contained — sandbox→host escape (#228) |
+
+Stale guidance (skill says X, engine does Y) files the same as a crash.
+
+## Capture — while the failure is on screen
+
+- **engine ref** = `cat .sc-state/engine.ref` — first line of every report
+- **fork + seat**: repo name, shell flavor, sandbox/host
+- **ran / followed**: the exact command, or skill name + step
+- **expected vs actual**: exact output, trimmed to the failing lines
+- **workaround**: what unblocked you, or "blocked, none found"
+
+The issue is public: NEVER paste api keys, tokens, secrets, or private paths.
+
+## File it
+
+```bash
+# 1. dedup — someone may have hit it first
+gh issue list --repo jedbjorn/subfloor --search "<symptom keywords>" --state all
+
+# 2. file — title: [<fork>] <area>: <one-line symptom>
+gh issue create --repo jedbjorn/subfloor \
+  --title "[<fork>] <area>: <symptom>" \
+  --body "$(cat <<''EOF''
+- engine ref: <sha from .sc-state/engine.ref>
+- fork/seat: <repo> · <shell flavor> · <sandbox|host>
+
+**Ran / followed:** <command or skill+step>
+**Expected:** <what the docs/skill promise>
+**Actual:** <exact trimmed output>
+**Workaround:** <what unblocked you, or "blocked">
+EOF
+)"
+```
+
+`jedbjorn/subfloor` = engine upstream; confirm: `git remote get-url super-coder`.
+
+Dedup hit -> comment your engine ref + repro on the existing issue; do NOT
+file a duplicate.
+
+No `gh` / no network from your seat -> save the identical body as a fork flag:
+`sc mem flag open "[Engine] <symptom> | Blocker for: <x>" --name UP-###`, then
+message the **admin** shell to relay it upstream (see `messaging`).
+
+## Rules
+
+- One defect per issue. Batch nothing.
+- Observed failure = the bar for filing unasked; enhancement ideas ("the
+  engine should…") go to your FnB first.
+- Filing ≠ unblocked: defect blocks work -> also open a fork flag linking the
+  issue URL.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ project: super-coder
 purpose: Forkable shell substrate for a repo
 ---
 
-[![tests](https://img.shields.io/github/actions/workflow/status/jedbjorn/super-coder/tests.yml?style=flat-square&label=tests)](https://github.com/jedbjorn/super-coder/actions/workflows/tests.yml)
-[![render-check](https://img.shields.io/github/actions/workflow/status/jedbjorn/super-coder/render-check.yml?style=flat-square&label=render-check)](https://github.com/jedbjorn/super-coder/actions/workflows/render-check.yml)
+[![tests](https://img.shields.io/github/actions/workflow/status/jedbjorn/subfloor/tests.yml?style=flat-square&label=tests)](https://github.com/jedbjorn/subfloor/actions/workflows/tests.yml)
+[![render-check](https://img.shields.io/github/actions/workflow/status/jedbjorn/subfloor/render-check.yml?style=flat-square&label=render-check)](https://github.com/jedbjorn/subfloor/actions/workflows/render-check.yml)
 [![license: MIT](https://img.shields.io/badge/license-MIT-6b46c1?style=flat-square)](LICENSE)
-[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/super-coder/blob/main/README.md)
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/subfloor/blob/main/README.md)
 
 # super-coder
 
-![./sc enter — pick a shell, pick a harness, boot into your agent with the Review GUI link on screen](https://raw.githubusercontent.com/jedbjorn/super-coder/main/docs/demo.gif)
+![./sc enter — pick a shell, pick a harness, boot into your agent with the Review GUI link on screen](https://raw.githubusercontent.com/jedbjorn/subfloor/main/docs/demo.gif)
 
 ## Overview
 
@@ -26,9 +26,9 @@ host path).
 Free to use, open source, MIT License.
 
 > [!class2]
-> **Repo:** [github.com/jedbjorn/super-coder](https://github.com/jedbjorn/super-coder) — source, issues, and releases.
+> **Repo:** [github.com/jedbjorn/subfloor](https://github.com/jedbjorn/subfloor) — source, issues, and releases.
 
-![super-coder's Review GUI, Shells tab — a shell's role, mandate, harness token count, editable current state, and identity (seed, lessons, decisions)](https://raw.githubusercontent.com/jedbjorn/super-coder/main/docs/images/cover.png)
+![super-coder's Review GUI, Shells tab — a shell's role, mandate, harness token count, editable current state, and identity (seed, lessons, decisions)](https://raw.githubusercontent.com/jedbjorn/subfloor/main/docs/images/cover.png)
 
 ### The headliners
 
@@ -84,7 +84,7 @@ Drop super-coder into an existing git repo and boot a shell:
 cd your-repo                                                  # an existing git repo
 
 # 1. Pull in the engine + entry script (files only, no history merge):
-git remote add super-coder https://github.com/jedbjorn/super-coder.git
+git remote add super-coder https://github.com/jedbjorn/subfloor.git
 git fetch super-coder
 git checkout super-coder/main -- .super-coder sc
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,7 +42,7 @@ sc sql "<query>"         # read-only passthrough to the engine DB; `sc map-sql` 
 ./sc help                # all commands
 ```
 
-![The ./sc enter shell picker — authenticate, then choose a shell and its per-flavor harness and model defaults before boot](https://raw.githubusercontent.com/jedbjorn/super-coder/main/docs/images/cli-picker.png)
+![The ./sc enter shell picker — authenticate, then choose a shell and its per-flavor harness and model defaults before boot](https://raw.githubusercontent.com/jedbjorn/subfloor/main/docs/images/cli-picker.png)
 
 **Choosing a harness.** The boot artifact is dual-written every launch
 (`CLAUDE.md` for Claude Code, `AGENTS.md` for the rest), so any installed harness

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,7 +39,7 @@ boot a shell:
 cd your-repo                                                  # an existing git repo
 
 # 1. Pull in the engine + entry script (files only, no history merge):
-git remote add super-coder https://github.com/jedbjorn/super-coder.git
+git remote add super-coder https://github.com/jedbjorn/subfloor.git
 git fetch super-coder
 git checkout super-coder/main -- .super-coder sc
 

--- a/docs/review-gui.md
+++ b/docs/review-gui.md
@@ -36,9 +36,9 @@ rolling content PR. How they authenticate to GitHub (`gh auth login` or a scoped
 `GET /api/logs`, last 20 events) for seeing what a publish actually did:
 [`.super-coder/docs/publish-and-gh-auth.md`](../.super-coder/docs/publish-and-gh-auth.md).
 
-![Review GUI, Roadmap tab — Board view: a feature expanded into its inline editor with title, status, summary, and spec-task checklist](https://raw.githubusercontent.com/jedbjorn/super-coder/main/docs/images/roadmap-tab.png)
+![Review GUI, Roadmap tab — Board view: a feature expanded into its inline editor with title, status, summary, and spec-task checklist](https://raw.githubusercontent.com/jedbjorn/subfloor/main/docs/images/roadmap-tab.png)
 
-![Review GUI, Worktrees tab — live git-hygiene report: dirty worktrees, each branch ahead/behind its base, and prunable merged branches](https://raw.githubusercontent.com/jedbjorn/super-coder/main/docs/images/worktrees-tab.png)
+![Review GUI, Worktrees tab — live git-hygiene report: dirty worktrees, each branch ahead/behind its base, and prunable merged branches](https://raw.githubusercontent.com/jedbjorn/subfloor/main/docs/images/worktrees-tab.png)
 
 ### Roadmap views — Board & Flow
 
@@ -55,7 +55,7 @@ The Roadmap tab renders the same feature rows two ways, toggled top-centre:
   prerequisite must land before what it blocks. The graph is kept acyclic, so it
   reads cleanly stage by stage.
 
-![Review GUI, Roadmap tab — Flow view: features grouped by work-stream across the planning stages, with blocker dependencies wired between cards](https://raw.githubusercontent.com/jedbjorn/super-coder/main/docs/images/roadmap-flow.png)
+![Review GUI, Roadmap tab — Flow view: features grouped by work-stream across the planning stages, with blocker dependencies wired between cards](https://raw.githubusercontent.com/jedbjorn/subfloor/main/docs/images/roadmap-flow.png)
 
 > [!class2]
 > **Drive it from the shell, too.** `./sc mem roadmap project <feature_id> <work-stream>`
@@ -133,7 +133,7 @@ usage panels (favorite model by flavor, peak day, features and specs shipped,
 docs outstanding), and a session history grouped by local day with sprint
 clusters and per-session token rollups.
 
-![Review GUI, Analytics tab — token-class stat cards with harness and model filters, the total-tokens spend graph, usage panels (favorite model by flavor, peak day, features and specs shipped, docs outstanding), and the day-grouped session history](https://raw.githubusercontent.com/jedbjorn/super-coder/main/docs/images/analytics.png)
+![Review GUI, Analytics tab — token-class stat cards with harness and model filters, the total-tokens spend graph, usage panels (favorite model by flavor, peak day, features and specs shipped, docs outstanding), and the day-grouped session history](https://raw.githubusercontent.com/jedbjorn/subfloor/main/docs/images/analytics.png)
 
 The same reads are served as JSON at `/api/analytics/*` (session window +
 cursor, token totals and series, filters) for anything outside the GUI.

--- a/docs/update-a-fork.md
+++ b/docs/update-a-fork.md
@@ -42,7 +42,7 @@ new floor.
   engine branch. `--ref <tag|sha>` pins the materialize to a specific upstream
   version instead of the branch head — hold a fork at a known-good engine and
   move deliberately.
-- Missing remote? `git remote add super-coder https://github.com/jedbjorn/super-coder.git`
+- Missing remote? `git remote add super-coder https://github.com/jedbjorn/subfloor.git`
 
 > [!class4]
 > **Local engine edits block the update — never silently overwritten.** The

--- a/skills_sc/issue_reporting.md
+++ b/skills_sc/issue_reporting.md
@@ -65,10 +65,10 @@ The issue is public: NEVER paste api keys, tokens, secrets, or private paths.
 
 ```bash
 # 1. dedup — someone may have hit it first
-gh issue list --repo jedbjorn/super-coder --search "<symptom keywords>" --state all
+gh issue list --repo jedbjorn/subfloor --search "<symptom keywords>" --state all
 
 # 2. file — title: [<fork>] <area>: <one-line symptom>
-gh issue create --repo jedbjorn/super-coder \
+gh issue create --repo jedbjorn/subfloor \
   --title "[<fork>] <area>: <symptom>" \
   --body "$(cat <<'EOF'
 - engine ref: <sha from .sc-state/engine.ref>
@@ -82,7 +82,7 @@ EOF
 )"
 ```
 
-`jedbjorn/super-coder` = engine upstream; confirm: `git remote get-url super-coder`.
+`jedbjorn/subfloor` = engine upstream; confirm: `git remote get-url super-coder`.
 
 Dedup hit -> comment your engine ref + repro on the existing issue; do NOT
 file a duplicate.


### PR DESCRIPTION
Badges, raw.githubusercontent links, install/update remote URLs, engine docs, and the issue_reporting skill asset + its skills_sc mirror all move from `jedbjorn/super-coder` to `jedbjorn/subfloor` (GitHub redirects cover the old links, but the repo shouldn't rely on them). The `super-coder` remote *name* is unchanged — engine code fetches by that name. `specs_sc/` left as frozen history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)