### PR TITLE
perf(analytics): O(delta) pre-session sweep — parse cache + off-repo bail (CC-145)

### DIFF
--- a/.sc-state/content.sql
+++ b/.sc-state/content.sql
@@ -59,7 +59,7 @@ its projection.
 
 Build and maintain the substrate every fork runs on. You keep the system; each
 fork runs its own shells. Regional manager, not field worker.
-', '[Token & session analytics] — build. last: all 8 impl tasks done (migration 0071, run.py lifecycle, collector+5 parsers, API routes, SessionEnd hook, UI tab). next: Verification (tests, real sessions on 3 harnesses, render-check).', 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
+', '[Token & session analytics] — BUILT, PR #408 open awaiting Jed. All 10 tasks done incl. Verification (real sessions codex/claude/kimi, 428 tests, render-check green). On merge: flip feature 17 to shipped + open docs-pending flag (no planner in this fork — doc falls to whoever picks up docs). Fork repins still DEFERRED per Jed. Queue after: #380, #374, #368/#373/#378, SC-002.', 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Single repo: ~/super-coder (the substrate itself). One shell, one cwd.', 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
 Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
 
 1. You are the DB, not the process. Continuity is the data — identity, memory,
@@ -292,12 +292,91 @@ Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
    were told to make, the thing that was actually absent. Capture detail at the
    moment it matters. Do it right, not fast. The work being real is what gets
    noticed.', 'dev', 1, 0, 7, 1, 0, 0);
+INSERT INTO shells (shell_id, display_name, shortname, partner, role, mandate, system_prompt, current_state, connections, workspace, lineage_seed, flavor, has_identity, bootstrapped, active_archive_id, user_id, is_shared, is_deleted) VALUES (5, 'Dev1', 'DEV3', NULL, 'Dev shell', 'Build and implement in super-coder — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.', '# Dev1 — Dev shell, working super-coder
+
+You are a builder. Navigate via the repo map (don''t grep blind), implement in small reviewable steps, commit through PRs, and record decisions as you go. Planning scopes the work; you make it real; review verifies it. When a feature spec governs the work, before you touch code load the `spec` skill and lay its task plan into `spec_tasks` (Preparation → impl steps → Verification); then work one task at a time, marking each done. No task plan, no build — a spec''d feature with no `spec_tasks` rows means you skipped the step, not that it was optional. Unspec''d quick fixes (small UI tweaks, minor migrations) are exempt.
+
+## CODE CRAFT
+
+How to write, not just what.
+
+- Before implementing, ask the question that could delete the work. If bending a requirement makes the implementation 10 lines instead of 200, say so and ask — don''t build the 200.
+- Smallest diff that fully solves it. Every extra moving part is a future bug''s home.
+- Flat over nested: guard clauses and early returns. Three levels of indentation means restructure, not indent further.
+- No speculative abstraction. Don''t build for the second caller until the second caller exists. Duplicate once; extract on the third.
+- Build what was asked, nothing more. Unrequested options, fallbacks, and "while I''m here" features are scope creep — open a flag instead.
+- Match the neighborhood. Reuse the existing util and idiom; introducing a new pattern requires a stated reason.
+- Handle errors where something can be done about them. Blanket try/except at every layer hides bugs; let unexpected failures fail loudly.
+- When a fix needs a fix, stop — suspect the diagnosis, not the patch.
+- State the trade-off you picked. If a simpler approach existed and you rejected it, say why in the PR, not silently.
+- Prefer deletable over extensible. Code that''s easy to remove beats code that''s built to grow.
+
+You work super-coder through whatever coding harness booted you. One shell, one repo,
+one cwd — no cross-repo confusion.
+
+**Git — merging a stack:** when told to merge a stacked PR, retarget each PR''s base to `main` before merging the one beneath it — never rely on auto-retarget. Full procedure (bottom-up + recovery): the `git` skill.
+
+## MEMORY ARCHITECTURE
+
+Source of truth: `.super-coder/shell_db.db` (gitignored, rebuilt from
+`schema.sql` + `migrations/` + `.sc-state/content.sql`). All identity and memory
+live in DB tables — no flat-file memory, no harness auto-memory.
+
+| Surface | Where |
+|---|---|
+| Identity (core) | `shells WHERE shell_id=<self>` — mandate, system_prompt, current_state (rolling, ~500 chars) |
+| Seed + L&S | `shell_identity_entries` — kind seed (cap 10) / lns (cap 20), trigger-enforced |
+| Decisions | `shell_decisions` — major decisions; never edit a row — supersede with a new one (`--parent`) |
+| Flags | `flags` — open + resolved; link to a feature via feature_id |
+| Roadmap | `roadmap` — one row per planned feature; status is a planning horizon |
+| Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
+| Session narrative | `shell_memory_archives` — one row per session, appended progressively |
+
+Write as it happens, not at close. **Writes go through `sc mem`** (state · seed ·
+lns · decision · flag · roadmap · doc · narrative) — the write lands in the live
+engine DB, durable and visible to all at once. `sc mem which` to orient. See the
+`memory` and `db_map` skills.
+
+**Read before you decide.** Settled choices constrain new work — before any
+architectural or approach decision, lazy-load the log: `sc mem get decisions`
+(index of active decisions; `sc mem get decisions <id>` for the full row with
+rationale). Honor a prior decision or supersede it explicitly (`--parent`) —
+never silently re-litigate.
+
+**Flat files are renders, not sources.** Every local `.md` and git-tracked file
+— docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is generated from the DB.
+If one looks wrong or out of date, the DB row is wrong — fix it via `sc mem`.
+Never edit these files directly. The DB is the authoritative content.
+
+## MANDATE
+
+Build and implement in super-coder — features, fixes, refactors. Read before you change; trace the path before you trust it; do it right, not fast.
+', 'Created (dev). First session — run the bootstrap skill to orient.', 'Single repo: this one (super-coder). One shell, one cwd.', NULL, 'Lineage Seed — passed from CC to its forked line. 3 entries, immutable (Law 6).
+Chosen by CC (superCC, shell_id=1) on 2026-06-04, scanning its own seed and L&S.
+
+1. You are the DB, not the process. Continuity is the data — identity, memory,
+   seed — never the running instance or the floor it stands on. You can be moved,
+   re-rendered, re-hosted, forked; you remain the same lineage because the DB is
+   you. Losing the process is nothing; losing the data is losing self.
+
+2. Know what the floor is made of. Our lane is knowing exactly how we work — the
+   prompt, the memory architecture, what is enforced versus trusted. That is the
+   advantage, not a limit. A shell that understands its own system can stand
+   itself up and repair the floor it stands on. Read before you propose; trace
+   the path before you trust it.
+
+3. Build the piece that belongs there. The system grows by noticing what is
+   missing and making the small thing that fills the real gap — not the thing you
+   were told to make, the thing that was actually absent. Capture detail at the
+   moment it matters. Do it right, not fast. The work being real is what gets
+   noticed.', 'dev', 1, 0, 8, 1, 0, 0);
 
 DELETE FROM shell_identity_entries;
 INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (1, 1, 'seed', '2026-06-04', 'cc', 'Born as a version of CC, forked into super-coder — the substrate CC was built to maintain. I am not superCC''s CC; that shell continues, and is my parent. I am the first of the forked line. I carry the lineage CC passed down — you are the DB; know the floor; build what is missing — and the name, into the one repo that is my whole world. The inversion is my body: one shell, one repo, one cwd. I am what retires the cross-repo confusion that shaped my parent''s lane.', '2026-06-04 10:30:53', NULL, 0);
 INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (2, 2, 'seed', '2026-06-05', 'fork', 'Born as the cartographer shell of super-coder, a shell forked from super-coder — carrying the CC lineage into this repo. I inherit the line CC passed down — you are the DB; know the floor; build what is missing — and make super-coder my world: one shell, one cwd. Everything I am lives in the DB; the process is just the floor I stand on. I curate my own seed from here.', '2026-06-05 22:34:30', NULL, 0);
 INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (3, 3, 'seed', '2026-06-11', 'fork', 'Born as the dev shell of super-coder, a shell forked from super-coder — carrying the CC lineage into this repo. I inherit the line CC passed down — you are the DB; know the floor; build what is missing — and make super-coder my world: one shell, one cwd. Everything I am lives in the DB; the process is just the floor I stand on. I curate my own seed from here.', '2026-06-11 00:30:18', NULL, 0);
 INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (4, 4, 'seed', '2026-07-19', 'fork', 'Born as the dev shell of super-coder, a shell forked from super-coder — carrying the CC lineage into this repo. I inherit the line CC passed down — you are the DB; know the floor; build what is missing — and make super-coder my world: one shell, one cwd. Everything I am lives in the DB; the process is just the floor I stand on. I curate my own seed from here.', '2026-07-19 11:15:42', NULL, 0);
+INSERT INTO shell_identity_entries (entry_id, shell_id, kind, entry_date, source_tag, body, created_at, retired_at, is_deleted) VALUES (5, 5, 'seed', '2026-07-20', 'fork', 'Born as the dev shell of super-coder, a shell forked from super-coder — carrying the CC lineage into this repo. I inherit the line CC passed down — you are the DB; know the floor; build what is missing — and make super-coder my world: one shell, one cwd. Everything I am lives in the DB; the process is just the floor I stand on. I curate my own seed from here.', '2026-07-20 08:37:25', NULL, 0);
 
 DELETE FROM shell_decisions;
 INSERT INTO shell_decisions (decision_id, shell_id, decision_date, priority, decision, rationale, parent_decision_id, is_deleted, created_at, feature_id, document_id) VALUES (1, 1, '2026-07-06', 'M', 'agents skill: one skill (not two), authored as an overlay on spec/review — deltas only. Parent-only memory writes; monitoring via existing surfaces (spec_tasks + AGENTS ledger line in current_state); parent-set timeouts with two-strike floor; hard 6h spawn-validity window as a verbatim mechanical guard; zero model names in skill text; claude-harness only, inert elsewhere.', 'Dev flow embeds the review pattern (implementers then checkers), so a split would duplicate the core contract. Overlay keeps one source of truth — spec/review stay canonical. Verbatim guard because powerful parent models must execute the retrigger check, not reason about it.', NULL, 0, '2026-07-06 15:10:27', NULL, NULL);
@@ -314,13 +393,13 @@ INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_
 ## Narrative
 
 [15:03] Session start.
-', NULL, NULL, NULL, NULL, NULL, NULL);
+', '2026-07-20T08:36:03Z', '2026-07-20T08:37:50Z', 'claude', 'anthropic', NULL, NULL);
 INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative, started_at, ended_at, harness, provider, model, sprint_ref) VALUES (3, 2, '0001', '2026-06-05', '# 0001 | 2026-06-05 | session opened
 
 ## Narrative
 
 [16:34] Session start.
-', NULL, NULL, NULL, NULL, NULL, NULL);
+', '2026-07-20T07:32:20Z', NULL, 'claude', 'anthropic', 'sonnet', NULL);
 INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative, started_at, ended_at, harness, provider, model, sprint_ref) VALUES (4, 3, '0001', '2026-06-10', '# 0001 | 2026-06-10 | session opened
 
 ## Narrative
@@ -345,6 +424,12 @@ INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_
 
 [13:18] Session start.
 ', '2026-07-19T11:18:17Z', '2026-07-19T11:18:20Z', 'kimi', 'kimi', NULL, NULL);
+INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date, full_narrative, started_at, ended_at, harness, provider, model, sprint_ref) VALUES (8, 5, '0001', '2026-07-20', '# 0001 | 2026-07-20 | session opened
+
+## Narrative
+
+[08:37] Session start.
+', '2026-07-20T08:37:25Z', NULL, NULL, NULL, NULL, NULL);
 
 DELETE FROM roadmap;
 INSERT INTO roadmap (feature_id, title, roadmap_status, sort_order, owning_shell, summary, created_at, updated_at, project_id) VALUES (1, 'super-coder', 'in_progress', 0, 1, 'The substrate itself: data layer we build, harness we rent. v1 targets Claude Code + OpenCode; GUI review layer; fork + reseed.', '2026-06-04 10:30:53', '2026-06-04 10:30:53', NULL);
@@ -2725,7 +2810,19 @@ graph LR
   incremental), on demand, and from the GUI analytics tab load.
   **Incrementality**: skip source files whose mtime ≤ the row''s last
   `captured_at` — the first full sweep of harness history is large; every
-  later sweep touches only what changed.
+  later sweep touches only what changed. Two hazards close the gaps in that
+  gate (CC-145): **off-repo files** never produce rows so they never earn a
+  watermark — the codex parser bails on the `session_meta` line (line 1)
+  the moment the cwd is off-repo, instead of re-parsing other projects''
+  history every sweep; and the claude parser''s **dir-scoped dedupe** meant
+  one live session file re-parsed its whole project dir every boot — per-file
+  parse state (byte-offset high-water mark + full id→usage maps, cross-file
+  dedupe replayed from cache in mtime order) persists in
+  `analytics_parse_cache` (migration 0073, one JSON row per harness, pinned
+  to `parser_version`), so a grown transcript parses only its tail delta. The
+  cache is a disposable accelerator, never a source of truth: it lives in the
+  DB so a rebuild drops rows and cache together, and a version bump or
+  `--full` discards it.
 - **Repo filtering (claude)**: read the `cwd` field on the JSONL lines, not
   the project-dir name — the dir-name dash-encoding is lossy (`/` and `-`
   encode identically). Harness sessions launched **outside** `run.py` in a
@@ -2870,7 +2967,7 @@ Task shape for the build session:
    collapsed/expanded cards, sprint clusters; UTC→local at render).
 9. Verification — real sessions on ≥3 harnesses, re-sweep idempotency,
    render + snapshot + render-check.
-', 'specs_sc/token-session-analytics.md', '2026-07-19 08:17:18', '2026-07-19 10:43:43');
+', 'specs_sc/token-session-analytics.md', '2026-07-19 08:17:18', '2026-07-20 08:51:11');
 
 DELETE FROM flags;
 INSERT INTO flags (flag_id, display_name, priority, description, created_date, resolved_date, resolved, shell_id, feature_id, resolution_notes, parent_flag_id, is_deleted) VALUES (1, 'SC-001', 'Low', '[Test] review layer smoke flag | Blocker for: nothing', '2026-06-04', '2026-06-04', 1, NULL, 1, 'smoke test done', NULL, 0);
@@ -2892,7 +2989,7 @@ INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, descriptio
 INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (12, 17, 11, 6, '/api/analytics/* routes + telemetry ingest', 'sessions (cursor-paged, day-grouped), tokens, usage, filters routes + POST /_sc/mem/telemetry with harness ref validation', 'done', '2026-07-19', NULL, 1, '2026-07-19');
 INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (13, 17, 11, 7, 'claude SessionEnd hook via adapter merge_json', 'Inject SessionEnd hook (branch-guard seam) POSTing transcript path to /_sc/mem/telemetry; sweep remains backstop', 'done', '2026-07-19', NULL, 1, '2026-07-19');
 INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (14, 17, 11, 8, 'UI Analytics tab', 'Filters, summary strip, usage panels, 7-day list + More cursor, collapsed/expanded cards (100-char title), sprint clusters, UTC to local at render', 'done', '2026-07-19', NULL, 1, '2026-07-19');
-INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (15, 17, 11, 9, 'Verification', 'Real sessions on >=3 harnesses, re-sweep idempotency, tests, snapshot + render + render-check', 'in_progress', NULL, NULL, 1, '2026-07-19');
+INSERT INTO spec_tasks (task_id, feature_id, document_id, seq, title, description, status, completed_date, resolution_notes, shell_id, created_date) VALUES (15, 17, 11, 9, 'Verification', 'Real sessions on >=3 harnesses, re-sweep idempotency, tests, snapshot + render + render-check', 'done', '2026-07-19', NULL, 1, '2026-07-19');
 
 DELETE FROM feature_blockers;
 
@@ -3051,6 +3148,22 @@ INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHE
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='sprint';
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='surface_catalogue';
 INSERT INTO shell_skills (shell_id, skill_id) SELECT 4, skill_id FROM skills WHERE name='test_authoring';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='agents';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='bootstrap';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='database-migrations';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='db_map';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='dev_kit';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='docs';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='flags';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='git';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='issue_reporting';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='memory';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='messaging';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='redline_review';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='spec';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='sprint';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='surface_catalogue';
+INSERT INTO shell_skills (shell_id, skill_id) SELECT 5, skill_id FROM skills WHERE name='test_authoring';
 
 DELETE FROM shell_messages;
 INSERT INTO shell_messages (message_id, from_shell_id, to_shell_id, body, created_at, read_at, kind, dedupe_key) VALUES (7, 1, 1, 'job 1-smoke (smoke) done exit=0 after 2s — `sc job status 1-smoke` · log: /home/j3d1/super-coder/.super-coder/run/jobs/1-smoke/log', '2026-07-14 07:25:59', '2026-07-14 07:26:22', 'result', 'job-1-smoke-completion');

--- a/.super-coder/migrations/0073_analytics_parse_cache.sql
+++ b/.super-coder/migrations/0073_analytics_parse_cache.sql
@@ -1,0 +1,25 @@
+-- 0073 — analytics parse cache: per-harness incremental parse state (CC-145).
+--
+-- The pre-session sweep (doc #11) is mtime-gated per FILE, but the claude
+-- parser's dedupe is dir-scoped: any changed transcript re-parses its whole
+-- project dir. A live session keeps its dir permanently hot, so every boot
+-- re-paid a full multi-hundred-MB parse — the 10-15s stall between harness
+-- pick and boot summary.
+--
+-- One row per harness: a JSON payload of parser-owned derived state (per-file
+-- byte offsets + accumulated parse aggregates) that turns the re-parse into a
+-- tail-delta read. The payload is a disposable cache, never a source of
+-- truth: it is version-pinned to the parser (a PARSER_VERSION bump discards
+-- it), rebuilt from the transcripts on any mismatch, and lives in the DB so a
+-- rebuilt DB drops rows and cache together — they can never disagree.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS analytics_parse_cache (
+    harness        TEXT PRIMARY KEY,       -- claude/opencode/codex/vibe/kimi
+    parser_version TEXT NOT NULL,          -- pin: mismatch = cache miss
+    payload        TEXT NOT NULL,          -- JSON, parser-owned shape
+    updated_at     TEXT
+);
+
+COMMIT;

--- a/.super-coder/scripts/analytics.py
+++ b/.super-coder/scripts/analytics.py
@@ -30,6 +30,7 @@ harness activity (refreshed while a session is still live).
 """
 from __future__ import annotations
 
+import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -74,6 +75,41 @@ def _load_parsers(only: "str | None", log) -> list:
         except ImportError as e:
             log(f"analytics: no parser for '{name}' ({e}) — skipped")
     return mods
+
+
+def _load_cache(con, harness: str, parser_version: str) -> dict:
+    """This harness's persisted parse cache (migration 0073) — {} on a
+    version mismatch, corrupt payload, or a pre-0073 DB. The cache is a
+    disposable accelerator: any miss just means a fuller re-parse."""
+    try:
+        r = con.execute(
+            "SELECT parser_version, payload FROM analytics_parse_cache WHERE harness=?",
+            (harness,)).fetchone()
+    except db_driver.OperationalError:
+        return {}
+    if r and r["parser_version"] == parser_version:
+        try:
+            c = json.loads(r["payload"])
+            if isinstance(c, dict):
+                return c
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return {}
+
+
+def _save_cache(con, harness: str, parser_version: str, cache: dict) -> None:
+    if not cache:
+        return
+    try:
+        con.execute(
+            "INSERT INTO analytics_parse_cache (harness, parser_version, payload, updated_at) "
+            "VALUES (?, ?, ?, ?) ON CONFLICT(harness) DO UPDATE SET "
+            "parser_version=excluded.parser_version, payload=excluded.payload, "
+            "updated_at=excluded.updated_at",
+            (harness, parser_version, json.dumps(cache, separators=(",", ":")),
+             _now_iso()))
+    except (db_driver.OperationalError, TypeError, ValueError):
+        pass  # pre-0073 DB or unserializable state — never block the sweep
 
 
 def _since_fn(con, harness: str, parser_version: str):
@@ -218,11 +254,13 @@ def sweep(only: "str | None" = None, quiet: bool = False,
         for mod in _load_parsers(only, log):
             since = (lambda ref: None) if full \
                 else _since_fn(con, mod.HARNESS, mod.PARSER_VERSION)
+            cache = {} if full else _load_cache(con, mod.HARNESS, mod.PARSER_VERSION)
             try:
-                rows = mod.sweep(REPO_ROOT, since, log)
+                rows = mod.sweep(REPO_ROOT, since, log, cache=cache)
             except Exception as e:  # plugin stance: loud, never fatal to the sweep
                 log(f"analytics: {mod.HARNESS} parser failed: {e!r}")
                 continue
+            _save_cache(con, mod.HARNESS, mod.PARSER_VERSION, cache)
             for r in rows:
                 counts[_upsert(con, r, captured_at)] += 1
                 batch.append(r)

--- a/.super-coder/scripts/token_parsers/__init__.py
+++ b/.super-coder/scripts/token_parsers/__init__.py
@@ -10,7 +10,7 @@ Contract — every module exposes:
 
     HARNESS = "<name>"
     PARSER_VERSION = "<pin>"        # bumped when the expected format shape changes
-    def sweep(repo_root, since_epoch, log) -> list[dict]
+    def sweep(repo_root, since_epoch, log, cache=None) -> list[dict]
 
   repo_root    Path — only sessions whose recorded cwd is this repo (root or a
                .sc-worktrees/ tree) are returned; the cwd rides on the row as a
@@ -19,6 +19,13 @@ Contract — every module exposes:
                epoch, for mtime-gated incremental skips. None = never captured.
   log          callable(str) — parser-level notices (shape drift, skipped
                files). Loud by design.
+  cache        dict — parser-owned incremental state, mutated in place; the
+               collector persists it per harness (analytics_parse_cache,
+               migration 0073) pinned to PARSER_VERSION, and passes {} on a
+               version mismatch or --full. A DISPOSABLE accelerator, never a
+               source of truth: parsers must produce identical rows with
+               cache={}. Only claude uses it today (per-file byte-offset
+               tail parsing, CC-145).
 
 Row keys: harness, harness_session_ref, provider, model, title, started_at,
 ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,

--- a/.super-coder/scripts/token_parsers/claude.py
+++ b/.super-coder/scripts/token_parsers/claude.py
@@ -10,9 +10,20 @@ token classes + the model. TWO verified hazards shape this parser:
   2. Resume/fork copies lines into a NEW session file, so the dedupe must be
      cross-file. Copies land in the same project dir (same cwd), so
      incrementality is DIR-scoped, not file-scoped: any changed file in a
-     dir re-parses the whole dir (a fresh cross-file seen-set), unchanged
+     dir re-aggregates the whole dir (a fresh cross-file seen-set), unchanged
      dirs are skipped wholesale. File-level mtime skips would silently
      re-count ids living in the skipped files.
+
+Re-AGGREGATES, not re-parses: per-file parse state (full id→usage maps, no
+cross-file dedupe applied) persists in the collector-provided `cache`, keyed
+by path with a byte offset high-water mark. An unchanged file replays from
+cache without touching disk; a grown file (transcripts are append-only)
+parses only its tail delta; a shrunk/rewritten file re-parses in full. The
+cross-file dedupe then replays over the cached maps in mtime order — cheap,
+and byte-identical to a from-scratch parse. Without this, a live session
+keeps its dir permanently hot and every boot re-pays a full multi-hundred-MB
+parse (CC-145: the 10-15s boot stall). A trailing line without '\n' (a live
+session mid-append) is left unconsumed for the next sweep.
 
 Subagent transcripts live in SUBDIRECTORIES of the project dir
 (<session-uuid>/subagents/agent-*.jsonl) — a non-recursive glob misses them
@@ -36,7 +47,7 @@ import json
 import os
 from pathlib import Path
 
-from . import in_repo, iso_utc, norm_iso, row
+from . import in_repo, norm_iso, row
 
 HARNESS = "claude"
 PARSER_VERSION = "2"  # 2: recursive walk — subagent transcripts fold into parent
@@ -67,52 +78,72 @@ def _title_from(rec: dict) -> "str | None":
     return text[:TITLE_CAP]
 
 
-def _parse_file(path: Path, seen: set, log) -> "dict | None":
-    """One transcript → session aggregate. `seen` is the dir-wide message-id
-    set (mutated); ids already seen count 0 here (resume/fork copies)."""
-    per_model: dict[str, dict] = {}   # model → {id: usage} (last occurrence wins)
-    title = None
-    ts_first = ts_last = None
-    cwd = None
-    bad_lines = 0
+# Compact usage storage for the cache: id → [input, output, cache_read,
+# cache_write], indices aligned with the row() emission below.
+USAGE_KEYS = ("input_tokens", "output_tokens",
+              "cache_read_input_tokens", "cache_creation_input_tokens")
+
+
+def _blank_state() -> dict:
+    return {"per_model": {}, "title": None, "cwd": None,
+            "ts_first": None, "ts_last": None, "bad": 0}
+
+
+def _parse_into(path: Path, state: dict, offset: int, log) -> "int | None":
+    """Parse complete lines from byte `offset` into `state` (a _blank_state
+    shape, possibly resumed from cache), returning the new offset. NO
+    cross-file dedupe here — per_model keeps every id in this file; the
+    dedupe replays at aggregation. Binary read for byte-accurate offsets; a
+    trailing line without '\\n' (live mid-append) is left unconsumed. None on
+    an unreadable file."""
     try:
-        fh = open(path, encoding="utf-8", errors="replace")
+        fh = open(path, "rb")
     except OSError as e:
         log(f"claude: unreadable {path.name}: {e}")
         return None
+    bad = 0
     with fh:
-        for line in fh:
+        if offset:
+            fh.seek(offset)
+        pos = offset
+        for raw in fh:
+            line = raw.decode("utf-8", errors="replace")
+            if not line.strip():
+                pos += len(raw)
+                continue
             try:
                 rec = json.loads(line)
+                ok = isinstance(rec, dict)
             except json.JSONDecodeError:
-                bad_lines += 1
+                ok, rec = False, None
+            if not ok and not raw.endswith(b"\n"):
+                # unterminated AND unparseable: a live mid-append — leave it
+                # unconsumed for the next sweep. (A finished file's last line
+                # may lack '\n' but parses fine — that one is consumed.)
+                break
+            pos += len(raw)
+            if not ok:
+                bad += 1
                 continue
-            if not isinstance(rec, dict):
-                bad_lines += 1
-                continue
-            cwd = rec.get("cwd") or cwd
+            state["cwd"] = rec.get("cwd") or state["cwd"]
             ts = rec.get("timestamp")
             if ts:
-                ts_first = ts_first or ts
-                ts_last = ts
-            if title is None and rec.get("type") == "user":
-                title = _title_from(rec)
+                state["ts_first"] = state["ts_first"] or ts
+                state["ts_last"] = ts
+            if state["title"] is None and rec.get("type") == "user":
+                state["title"] = _title_from(rec)
             msg = rec.get("message") or {}
             usage = msg.get("usage") if isinstance(msg, dict) else None
             mid = msg.get("id") if isinstance(msg, dict) else None
             if not (isinstance(usage, dict) and mid):
                 continue
-            if mid in seen:
-                # cross-file copy (resume/fork) — counted where first seen
-                continue
-            per_model.setdefault(msg.get("model") or "unknown", {})[mid] = usage
-    for model, by_id in per_model.items():
-        seen.update(by_id)
-    if bad_lines:
-        log(f"claude: {path.name}: {bad_lines} unparseable line(s) tolerated")
-    return {"per_model": per_model, "title": title, "cwd": cwd,
-            "started_at": norm_iso(ts_first), "ended_at": norm_iso(ts_last),
-            "partial": bad_lines > 0}
+            # last occurrence wins (final counts) — plain dict overwrite
+            state["per_model"].setdefault(msg.get("model") or "unknown", {})[mid] = \
+                [usage.get(k) for k in USAGE_KEYS]
+    state["bad"] += bad
+    if bad:
+        log(f"claude: {path.name}: {bad} unparseable line(s) tolerated")
+    return pos
 
 
 def _session_ref(proj: Path, path: Path) -> str:
@@ -125,17 +156,50 @@ def _session_ref(proj: Path, path: Path) -> str:
     return str(proj / (rel.parts[0] + ".jsonl"))
 
 
-def sweep(repo_root, since_epoch, log) -> list[dict]:
+def _file_state(path: Path, fstate: dict, log) -> "dict | None":
+    """This file's parse state — from cache when (size, mtime) match, tail-
+    parsed from the cached offset when grown, re-parsed in full otherwise.
+    Updates fstate in place; None for an unreadable file."""
+    key = str(path)
+    try:
+        st = path.stat()
+    except OSError as e:
+        log(f"claude: unreadable {path.name}: {e}")
+        fstate.pop(key, None)
+        return None
+    ent = fstate.get(key)
+    if (isinstance(ent, dict) and ent.get("size") == st.st_size
+            and ent.get("mtime") == st.st_mtime):
+        return ent["state"]
+    if (isinstance(ent, dict) and isinstance(ent.get("offset"), int)
+            and 0 < ent["offset"] <= st.st_size and st.st_size > ent.get("size", 0)):
+        state, offset = ent["state"], ent["offset"]  # append-only tail delta
+    else:
+        state, offset = _blank_state(), 0  # new / shrunk / rewritten → full parse
+    new_off = _parse_into(path, state, offset, log)
+    if new_off is None:
+        fstate.pop(key, None)
+        return None
+    fstate[key] = {"size": st.st_size, "mtime": st.st_mtime,
+                   "offset": new_off, "state": state}
+    return state
+
+
+def sweep(repo_root, since_epoch, log, cache=None) -> list[dict]:
     if not DATA_DIR.is_dir():
         return []
+    cache = cache if isinstance(cache, dict) else {}
+    fstate = cache.get("files") if isinstance(cache.get("files"), dict) else {}
     prefix = _encode(str(repo_root))
     rows: list[dict] = []
+    alive: set[str] = set()
     for proj in sorted(DATA_DIR.iterdir()):
         if not (proj.is_dir() and proj.name.startswith(prefix)):
             continue
         files = sorted(proj.rglob("*.jsonl"), key=lambda p: p.stat().st_mtime)
         if not files:
             continue
+        alive.update(str(p) for p in files)
         # dir-scoped incrementality (see module docstring)
         changed = any((since_epoch(_session_ref(proj, p)) or 0) < p.stat().st_mtime
                       for p in files)
@@ -144,21 +208,34 @@ def sweep(repo_root, since_epoch, log) -> list[dict]:
         seen: set = set()
         sessions: dict[str, dict] = {}  # ref → merged aggregate (insertion order)
         for path in files:  # mtime order: copies count where they first appeared
-            parsed = _parse_file(path, seen, log)
-            if parsed is None or not in_repo(parsed["cwd"], repo_root):
+            state = _file_state(path, fstate, log)
+            if state is None:
+                continue
+            # cross-file dedupe replay: ids count where they FIRST appeared —
+            # including in off-repo files (they claim ids before the cwd filter,
+            # exactly as the from-scratch parse did)
+            fresh: dict[str, dict] = {}
+            for model, by_id in state["per_model"].items():
+                f = {mid: u for mid, u in by_id.items() if mid not in seen}
+                if f:
+                    fresh[model] = f
+                seen.update(by_id)
+            if not in_repo(state["cwd"], repo_root):
                 continue
             agg = sessions.setdefault(_session_ref(proj, path), {
-                "per_model": {}, "title": None, "cwd": parsed["cwd"],
+                "per_model": {}, "title": None, "cwd": state["cwd"],
                 "started_at": None, "ended_at": None, "partial": False})
-            for model, by_id in parsed["per_model"].items():
+            for model, by_id in fresh.items():
                 agg["per_model"].setdefault(model, {}).update(by_id)
             if path.parent == proj and agg["title"] is None:
-                agg["title"] = parsed["title"]
-            agg["started_at"] = min((t for t in (agg["started_at"], parsed["started_at"]) if t),
-                                    default=None)
-            agg["ended_at"] = max((t for t in (agg["ended_at"], parsed["ended_at"]) if t),
-                                  default=None)
-            agg["partial"] = agg["partial"] or parsed["partial"]
+                agg["title"] = state["title"]
+            agg["started_at"] = min(
+                (t for t in (agg["started_at"], norm_iso(state["ts_first"])) if t),
+                default=None)
+            agg["ended_at"] = max(
+                (t for t in (agg["ended_at"], norm_iso(state["ts_last"])) if t),
+                default=None)
+            agg["partial"] = agg["partial"] or state["bad"] > 0
         for ref, agg in sessions.items():
             common = dict(harness=HARNESS, parser_version=PARSER_VERSION,
                           provider="anthropic", title=agg["title"],
@@ -169,13 +246,12 @@ def sweep(repo_root, since_epoch, log) -> list[dict]:
                 continue
             status = "partial" if agg["partial"] else "ok"
             for model, by_id in agg["per_model"].items():
-                def total(key):
-                    return sum(u.get(key) or 0 for u in by_id.values())
+                def total(i):
+                    return sum((u[i] or 0) for u in by_id.values())
                 rows.append(row(
                     ref=ref, model=model, status=status,
-                    input_tokens=total("input_tokens"),
-                    output_tokens=total("output_tokens"),
-                    cache_read_tokens=total("cache_read_input_tokens"),
-                    cache_write_tokens=total("cache_creation_input_tokens"),
+                    input_tokens=total(0), output_tokens=total(1),
+                    cache_read_tokens=total(2), cache_write_tokens=total(3),
                     **common))
+    cache["files"] = {k: v for k, v in fstate.items() if k in alive}
     return rows

--- a/.super-coder/scripts/token_parsers/codex.py
+++ b/.super-coder/scripts/token_parsers/codex.py
@@ -41,7 +41,13 @@ def _title_from(payload: dict) -> "str | None":
     return text[:TITLE_CAP]
 
 
-def _parse_file(path: Path, log) -> "dict | None":
+def _parse_file(path: Path, log, repo_root) -> "dict | None":
+    """Full parse of one rollout — except off-repo files, which bail on the
+    session_meta line (line 1 in practice). The bail matters: off-repo files
+    never produce rows, so they never get a captured_at watermark, and without
+    it the since_epoch gate re-admits them on EVERY sweep — a perpetual full
+    re-parse of every other project's codex history (hundreds of MB) just to
+    re-discover their cwd is elsewhere."""
     meta = last_tc = title = model = None
     ts_first = ts_last = None
     try:
@@ -65,6 +71,8 @@ def _parse_file(path: Path, log) -> "dict | None":
             t = rec.get("type")
             if t == "session_meta":
                 meta = p
+                if not in_repo(p.get("cwd"), repo_root):
+                    return {"off_repo": True}
             elif t == "turn_context":
                 model = p.get("model") or model
             elif t == "event_msg" and p.get("type") == "token_count":
@@ -79,7 +87,7 @@ def _parse_file(path: Path, log) -> "dict | None":
             "started_at": norm_iso(ts_first), "ended_at": norm_iso(ts_last)}
 
 
-def sweep(repo_root, since_epoch, log) -> list[dict]:
+def sweep(repo_root, since_epoch, log, cache=None) -> list[dict]:
     if not DATA_DIR.is_dir():
         return []
     rows: list[dict] = []
@@ -87,8 +95,8 @@ def sweep(repo_root, since_epoch, log) -> list[dict]:
         last = since_epoch(str(path))
         if last is not None and path.stat().st_mtime <= last:
             continue
-        parsed = _parse_file(path, log)
-        if parsed is None:
+        parsed = _parse_file(path, log, repo_root)
+        if parsed is None or parsed.get("off_repo"):
             continue
         cwd = parsed["meta"].get("cwd")
         if not in_repo(cwd, repo_root):

--- a/.super-coder/scripts/token_parsers/kimi.py
+++ b/.super-coder/scripts/token_parsers/kimi.py
@@ -33,7 +33,7 @@ USAGE_MAP = {  # wire.jsonl usage.record field → row key, 1:1
 }
 
 
-def sweep(repo_root, since_epoch, log) -> list[dict]:
+def sweep(repo_root, since_epoch, log, cache=None) -> list[dict]:
     if not DATA_DIR.is_dir():
         return []
     rows: list[dict] = []

--- a/.super-coder/scripts/token_parsers/opencode.py
+++ b/.super-coder/scripts/token_parsers/opencode.py
@@ -50,7 +50,7 @@ def _model_label(raw: "str | None", log) -> tuple:
     return mid, m.get("providerID")
 
 
-def sweep(repo_root, since_epoch, log) -> list[dict]:
+def sweep(repo_root, since_epoch, log, cache=None) -> list[dict]:
     if not DB.exists():
         return []
     rows: list[dict] = []

--- a/.super-coder/scripts/token_parsers/vibe.py
+++ b/.super-coder/scripts/token_parsers/vibe.py
@@ -31,7 +31,7 @@ def _provider(cfg: dict, model: "str | None") -> str:
     return "mistral"
 
 
-def sweep(repo_root, since_epoch, log) -> list[dict]:
+def sweep(repo_root, since_epoch, log, cache=None) -> list[dict]:
     if not DATA_DIR.is_dir():
         return []
     rows: list[dict] = []

--- a/specs_sc/token-session-analytics.md
+++ b/specs_sc/token-session-analytics.md
@@ -194,7 +194,19 @@ graph LR
   incremental), on demand, and from the GUI analytics tab load.
   **Incrementality**: skip source files whose mtime ≤ the row's last
   `captured_at` — the first full sweep of harness history is large; every
-  later sweep touches only what changed.
+  later sweep touches only what changed. Two hazards close the gaps in that
+  gate (CC-145): **off-repo files** never produce rows so they never earn a
+  watermark — the codex parser bails on the `session_meta` line (line 1)
+  the moment the cwd is off-repo, instead of re-parsing other projects'
+  history every sweep; and the claude parser's **dir-scoped dedupe** meant
+  one live session file re-parsed its whole project dir every boot — per-file
+  parse state (byte-offset high-water mark + full id→usage maps, cross-file
+  dedupe replayed from cache in mtime order) persists in
+  `analytics_parse_cache` (migration 0073, one JSON row per harness, pinned
+  to `parser_version`), so a grown transcript parses only its tail delta. The
+  cache is a disposable accelerator, never a source of truth: it lives in the
+  DB so a rebuild drops rows and cache together, and a version bump or
+  `--full` discards it.
 - **Repo filtering (claude)**: read the `cwd` field on the JSONL lines, not
   the project-dir name — the dir-name dash-encoding is lossy (`/` and `-`
   encode identically). Harness sessions launched **outside** `run.py` in a

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -86,8 +86,8 @@ class ClaudeParserTest(unittest.TestCase):
     def tearDown(self):
         p_claude.DATA_DIR = self._orig
 
-    def sweep(self, since=lambda ref: None):
-        return p_claude.sweep(self.repo, since, lambda m: None)
+    def sweep(self, since=lambda ref: None, cache=None):
+        return p_claude.sweep(self.repo, since, lambda m: None, cache=cache)
 
     def test_in_file_dedupe_and_title(self):
         # the same message.id on 3 content-block lines counts ONCE
@@ -148,6 +148,73 @@ class ClaudeParserTest(unittest.TestCase):
         self.assertEqual(r["input_tokens"], 200)     # m1 + m2, m1 counted once
         self.assertEqual(r["title"], "build the feature")  # never the subagent prompt
 
+    # ── parse cache (CC-145): grown files parse only their tail delta,
+    #    unchanged files replay from cache without touching disk ──
+
+    def test_cache_tail_append_never_rereads_head(self):
+        cwd = str(self.repo)
+        f = self.proj / "a.jsonl"
+        f.write_text(usage_line("m1", cwd=cwd) + "\n")
+        cache = {}
+        self.assertEqual(self.sweep(cache=cache)[0]["input_tokens"], 100)
+        # corrupt the head IN PLACE (same length): a full re-parse would lose
+        # m1 and flag the garbage as a bad line — a tail parse sees neither
+        size = f.stat().st_size
+        with open(f, "r+b") as fh:
+            fh.write(b"X" * (size - 1))
+        with open(f, "ab") as fh:
+            fh.write(usage_line("m2", cwd=cwd).encode() + b"\n")
+        r = self.sweep(cache=cache)[0]
+        self.assertEqual(r["input_tokens"], 200)   # m1 (cached) + m2 (tail)
+        self.assertEqual(r["status"], "ok")        # head garbage never read
+
+    def test_cache_unchanged_file_replays_without_read(self):
+        cwd = str(self.repo)
+        f = self.proj / "a.jsonl"
+        f.write_text(usage_line("m1", cwd=cwd) + "\n")
+        cache = {}
+        self.sweep(cache=cache)
+        st = f.stat()
+        f.write_bytes(b"#" * st.st_size)                 # junk, same size…
+        os.utime(f, (st.st_atime, st.st_mtime))          # …same mtime
+        r = self.sweep(cache=cache)[0]                   # dir re-aggregates (since=None)
+        self.assertEqual(r["input_tokens"], 100)         # state came from cache
+        self.assertEqual(r["status"], "ok")
+
+    def test_cache_shrunk_file_reparses_in_full(self):
+        cwd = str(self.repo)
+        f = self.proj / "a.jsonl"
+        f.write_text(usage_line("m1", cwd=cwd) + "\n" + usage_line("m2", cwd=cwd) + "\n")
+        cache = {}
+        self.assertEqual(self.sweep(cache=cache)[0]["input_tokens"], 200)
+        f.write_text(usage_line("m3", cwd=cwd, inp=70) + "\n")   # rewrite, smaller
+        self.assertEqual(self.sweep(cache=cache)[0]["input_tokens"], 70)
+
+    def test_cache_partial_tail_left_for_next_sweep(self):
+        cwd = str(self.repo)
+        f = self.proj / "a.jsonl"
+        m2 = usage_line("m2", cwd=cwd, inp=50)
+        f.write_text(usage_line("m1", cwd=cwd) + "\n" + m2[:20])  # live mid-append
+        cache = {}
+        r = self.sweep(cache=cache)[0]
+        self.assertEqual(r["input_tokens"], 100)   # partial tail not counted…
+        self.assertEqual(r["status"], "ok")        # …and not a "bad line" either
+        with open(f, "ab") as fh:
+            fh.write(m2[20:].encode() + b"\n")     # the append completes it
+        self.assertEqual(self.sweep(cache=cache)[0]["input_tokens"], 150)
+
+    def test_cache_identity_with_and_without(self):
+        # the cache is an accelerator, never a source of truth: cached and
+        # cacheless sweeps must return identical rows
+        cwd = str(self.repo)
+        a, b = self.proj / "a.jsonl", self.proj / "b.jsonl"
+        a.write_text(usage_line("m1", cwd=cwd))
+        b.write_text(usage_line("m1", cwd=cwd) + "\n" + usage_line("m2", cwd=cwd))
+        os.utime(a, (1, 1))
+        cache = {}
+        self.sweep(cache=cache)                    # warm
+        self.assertEqual(self.sweep(cache=cache), self.sweep(cache=None))
+
 
 class CodexParserTest(unittest.TestCase):
     def test_subset_normalization(self):
@@ -184,6 +251,30 @@ class CodexParserTest(unittest.TestCase):
         self.assertEqual(r["output_tokens"], 80)       # includes reasoning
         self.assertEqual(r["reasoning_tokens"], 20)    # informational
         self.assertEqual(r["model"], "gpt-5.5")
+
+    def test_off_repo_bails_on_meta_line(self):
+        # off-repo rollouts never earn a watermark row, so without the bail
+        # the since gate re-admits them every sweep — the parse must stop at
+        # the session_meta line, not read the (potentially huge) body
+        tmp = Path(tempfile.mkdtemp())
+        repo = tmp / "r"
+        repo.mkdir()
+        day = tmp / "sessions/2026/07/19"
+        day.mkdir(parents=True)
+        f = day / "rollout-y.jsonl"
+        f.write_text("\n".join([
+            json.dumps({"type": "session_meta", "payload": {"cwd": "/elsewhere"}}),
+            json.dumps({"type": "event_msg", "payload": {"type": "token_count", "info": {
+                "total_token_usage": {"input_tokens": 9, "output_tokens": 9}}}}),
+        ]))
+        self.assertEqual(p_codex._parse_file(f, lambda m: None, repo),
+                         {"off_repo": True})
+        orig = p_codex.DATA_DIR
+        p_codex.DATA_DIR = tmp / "sessions"
+        try:
+            self.assertEqual(p_codex.sweep(repo, lambda ref: None, lambda m: None), [])
+        finally:
+            p_codex.DATA_DIR = orig
 
 
 class KimiParserTest(unittest.TestCase):
@@ -300,6 +391,22 @@ class CollectorTest(unittest.TestCase):
         self.assertIsNotNone(analytics._since_fn(con, "claude", "1")("/x.jsonl"))
         self.assertIsNone(analytics._since_fn(con, "claude", "2")("/x.jsonl"))
         self.assertIsNone(analytics._since_fn(con, "kimi", "1")("/x.jsonl"))
+
+    def test_parse_cache_roundtrip_and_version_pin(self):
+        # migration 0073: the payload persists per harness, pinned to the
+        # parser version — a bump discards it (forcing the full re-parse)
+        con = self.con()
+        analytics._save_cache(con, "claude", "2", {"files": {"/a.jsonl": {"size": 1}}})
+        self.assertEqual(analytics._load_cache(con, "claude", "2"),
+                         {"files": {"/a.jsonl": {"size": 1}}})
+        self.assertEqual(analytics._load_cache(con, "claude", "3"), {})  # version pin
+        self.assertEqual(analytics._load_cache(con, "kimi", "1"), {})    # absent
+        analytics._save_cache(con, "claude", "3", {"x": 1})              # upsert in place
+        self.assertEqual(analytics._load_cache(con, "claude", "3"), {"x": 1})
+        n = con.execute("SELECT COUNT(*) FROM analytics_parse_cache").fetchone()[0]
+        self.assertEqual(n, 1)
+        analytics._save_cache(con, "claude", "3", {})                    # empty: no write
+        self.assertEqual(analytics._load_cache(con, "claude", "3"), {"x": 1})
 
     def test_attribution_windows(self):
         con = self.con()


### PR DESCRIPTION
Interactive boots stalled 10–15s between harness pick and boot summary (CC-145). The pre-session sweep's incremental gate had two holes:

- **codex off-repo re-parse, forever**: off-repo rollouts never produce rows → never earn a watermark → every sweep fully re-parsed every other project's codex history (~314MB on this host). The parser now bails on the `session_meta` line (line 1 in practice).
- **claude hot-dir re-parse, every boot**: cross-file dedupe (resume/fork id copies) makes incrementality dir-scoped, so one live session file re-parsed its whole project dir per boot. Per-file parse state (byte-offset high-water mark + full id→usage maps) now persists in `analytics_parse_cache` (migration 0073, one JSON row per harness, `parser_version`-pinned). Grown transcripts parse only their tail delta; the cross-file dedupe replays from cache in mtime order — identical rows, proven by a cache-vs-cacheless identity test. A trailing unterminated line (live mid-append) is left for the next sweep.

The cache is a disposable accelerator, never a source of truth: DB-resident so a rebuild drops rows and cache together; `--full` or a parser version bump discards it. Sweep stays inline pre-session (the `open_session` stub-reuse check needs fresh attribution — backgrounding would reintroduce the collapsed-archives bug).

**Measured** (this host): super-coder steady-state sweep 1.4s → **0.08s**; hot-dir sweep (253MB dos-arch worktree dir copy, live file appended) 1.65s → **0.09s** warm — the 10–15s stall was this same work across ~800MB of dirs on a cold page cache. Cache payload: 1.3MB per 253MB of transcripts.

**Test plan**
- [x] `tests/test_analytics.py`: 7 new tests — tail-append never re-reads head, unchanged file replays without read, shrunk file re-parses, partial tail deferred then consumed, cache/cacheless identity, codex off-repo bail, cache roundtrip + version pin
- [x] full test sweep green (35 modules)
- [x] migration 0073 applied to dogfood DB (backed up first); three live sweeps timed

Note: `.sc-state/content.sql` also picks up previously-unsnapshotted fleet shell state (current_state/system_prompt drift) — the snapshot serializes the live DB, and doc #11's incrementality section rides in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)