### PR TITLE
fix(update): source-repo guard survives the subfloor rename

### DIFF
--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -112,6 +112,15 @@ def sh(*args: str) -> subprocess.CompletedProcess:
     return subprocess.run(args, capture_output=True, text=True)
 
 
+# Repo basenames that identify the SOURCE repo (canonical set — update.py and
+# map_repo.py key off this too). Both names stay valid through the
+# super-coder → subfloor rename: GitHub redirects the old URL, so either can
+# appear in a checkout's origin. Getting this wrong is not cosmetic — a source
+# repo misread as a fork gets its tracked engine `git rm --cached`-ed by the
+# B7 untrack migration (this fired on the dogfood repo the day of the rename).
+SOURCE_REPO_NAMES = ("super-coder", "subfloor")
+
+
 def origin_basename() -> str | None:
     p = sh("git", "-C", str(REPO_ROOT), "remote", "get-url", "origin")
     if p.returncode != 0:
@@ -120,9 +129,10 @@ def origin_basename() -> str | None:
 
 
 def is_source_repo() -> bool:
-    """The super-coder source repo's origin is …/super-coder. A fork's origin is
-    its own repo (super-coder is a separate, differently-named remote)."""
-    return origin_basename() == "super-coder"
+    """The source repo's origin is …/super-coder or …/subfloor. A fork's origin
+    is its own repo (the engine upstream is a separate, differently-named
+    remote)."""
+    return origin_basename() in SOURCE_REPO_NAMES
 
 
 def already_installed() -> bool:
@@ -452,16 +462,18 @@ def ensure_gitignore(repo_root: Path = REPO_ROOT) -> bool:
 
 
 def sc_remote() -> str | None:
-    """The remote pointing at super-coder (the bootstrap checkout added it)."""
+    """The remote pointing at the engine upstream (the bootstrap checkout
+    added it) — matched by either name across the super-coder → subfloor
+    rename."""
     named = None
     for line in sh("git", "-C", str(REPO_ROOT), "remote", "-v").stdout.splitlines():
         parts = line.split()
         if len(parts) < 2:
             continue
         name, url = parts[0], parts[1]
-        if "super-coder" in url:
+        if any(n in url for n in SOURCE_REPO_NAMES):
             return name
-        if name == "super-coder":
+        if name in SOURCE_REPO_NAMES:
             named = name
     return named
 

--- a/.super-coder/scripts/map_repo.py
+++ b/.super-coder/scripts/map_repo.py
@@ -132,10 +132,13 @@ def git(*args: str) -> str | None:
 
 
 def is_source_repo() -> bool:
-    """In a fork, .super-coder is infrastructure (skip it). In the super-coder
-    SOURCE repo the engine IS the project, so map it too."""
+    """In a fork, .super-coder is infrastructure (skip it). In the SOURCE repo
+    the engine IS the project, so map it too. Names canonical in
+    install.SOURCE_REPO_NAMES (super-coder → subfloor rename: both valid)."""
+    from install import SOURCE_REPO_NAMES
     url = git("remote", "get-url", "origin")
-    return bool(url) and url.rstrip("/").split("/")[-1].removesuffix(".git") == "super-coder"
+    return bool(url) and (url.rstrip("/").split("/")[-1].removesuffix(".git")
+                          in SOURCE_REPO_NAMES)
 
 
 # ── Dependency parsers (best-effort; each guarded) ───────────────────────────

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -94,30 +94,35 @@ def run_script(name: str) -> None:
 
 
 def is_source_repo() -> bool:
-    """The super-coder SOURCE repo (origin basename == super-coder) tracks the
-    engine as its canonical source — it must NEVER untrack or materialize over
-    it. A fork's origin is its own repo (super-coder is a separate remote)."""
+    """The SOURCE repo (origin basename in install.SOURCE_REPO_NAMES — both
+    names valid across the super-coder → subfloor rename) tracks the engine as
+    its canonical source — it must NEVER untrack or materialize over it. A
+    fork's origin is its own repo (the engine upstream is a separate remote).
+    A miss here is destructive: the fork branch below git-rm-caches the
+    engine — exactly what hit the dogfood repo the day origin was renamed."""
     url = git("remote", "get-url", "origin", check=False).stdout.strip()
-    return bool(url) and url.rstrip("/").split("/")[-1].removesuffix(".git") == "super-coder"
+    return bool(url) and (url.rstrip("/").split("/")[-1].removesuffix(".git")
+                          in install_mod.SOURCE_REPO_NAMES)
 
 
 def super_coder_remote() -> str:
-    """The remote pointing at super-coder. Prefer a URL match (robust to a
-    rename), else a remote literally named 'super-coder'."""
+    """The remote pointing at the engine upstream. Prefer a URL match (either
+    name across the super-coder → subfloor rename), else a remote literally
+    named after it."""
     named = None
     for line in git("remote", "-v", check=False).stdout.splitlines():
         parts = line.split()
         if len(parts) < 2:
             continue
         name, url = parts[0], parts[1]
-        if "super-coder" in url:
+        if any(n in url for n in install_mod.SOURCE_REPO_NAMES):
             return name
-        if name == "super-coder":
+        if name in install_mod.SOURCE_REPO_NAMES:
             named = name
     if named:
         return named
-    sys.exit("update: no super-coder remote found. Add it:\n"
-             "  git remote add super-coder https://github.com/jedbjorn/super-coder.git")
+    sys.exit("update: no engine upstream remote found. Add it:\n"
+             "  git remote add super-coder https://github.com/jedbjorn/subfloor.git")
 
 
 def _engine_paths_at(ref: str) -> list[str]:

--- a/tests/test_source_repo_guard.py
+++ b/tests/test_source_repo_guard.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""The source-repo guard must survive the super-coder → subfloor rename.
+
+is_source_repo() is the ONLY thing standing between the source repo and the
+fork-flavored B7 engine untrack (`git rm -r --cached .super-coder`) plus the
+fork gitignore block. The day origin was renamed to subfloor, the
+basename == "super-coder" check silently flipped to False and the untrack
+fired on the dogfood repo. Three modules carry the check (install, update,
+map_repo); all must key off install.SOURCE_REPO_NAMES and accept BOTH names.
+
+Run:
+    python3 tests/test_source_repo_guard.py
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import install  # noqa: E402
+import map_repo  # noqa: E402
+import update  # noqa: E402
+
+
+class SourceRepoGuardTest(unittest.TestCase):
+    def test_canonical_names(self):
+        self.assertIn("super-coder", install.SOURCE_REPO_NAMES)
+        self.assertIn("subfloor", install.SOURCE_REPO_NAMES)
+
+    def test_install_accepts_both_names(self):
+        orig = install.origin_basename
+        try:
+            for base, want in [("super-coder", True), ("subfloor", True),
+                               ("my-fork", False), (None, False)]:
+                install.origin_basename = lambda b=base: b
+                self.assertEqual(install.is_source_repo(), want, base)
+        finally:
+            install.origin_basename = orig
+
+    def test_update_accepts_both_names(self):
+        orig = update.git
+        try:
+            for url, want in [("https://github.com/jedbjorn/subfloor.git", True),
+                              ("https://github.com/jedbjorn/super-coder.git", True),
+                              ("git@github.com:me/my-fork.git", False)]:
+                update.git = lambda *a, u=url, **k: SimpleNamespace(stdout=u + "\n",
+                                                                    returncode=0)
+                self.assertEqual(update.is_source_repo(), want, url)
+        finally:
+            update.git = orig
+
+    def test_map_repo_accepts_both_names(self):
+        orig = map_repo.git
+        try:
+            for url, want in [("https://github.com/jedbjorn/subfloor", True),
+                              ("https://github.com/jedbjorn/super-coder", True),
+                              ("https://github.com/me/other", False)]:
+                map_repo.git = lambda *a, u=url: u
+                self.assertEqual(map_repo.is_source_repo(), want, url)
+        finally:
+            map_repo.git = orig
+
+    def test_update_remote_matcher_accepts_renamed_url(self):
+        orig = update.git
+        try:
+            update.git = lambda *a, **k: SimpleNamespace(
+                stdout="origin\tgit@github.com:me/my-fork.git (fetch)\n"
+                       "engine\thttps://github.com/jedbjorn/subfloor.git (fetch)\n",
+                returncode=0)
+            self.assertEqual(update.super_coder_remote(), "engine")
+        finally:
+            update.git = orig
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**High-priority rename fallout.** `is_source_repo()` keyed on origin basename == `"super-coder"` in three places (`install.py`, `update.py`, `map_repo.py`). After origin flipped to `jedbjorn/subfloor`, the source repo self-identified as a **fork** — and a run through update's fork branch executed the B7 engine untrack against dogfood: `git rm -r --cached .super-coder` (staged deletion of the entire tracked engine) + the fork gitignore block (`/.super-coder/`, `/CLAUDE.md`, …). Caught before any commit and reverted; discovered while working CC-145 (#421).

Fix: `install.SOURCE_REPO_NAMES = ("super-coder", "subfloor")` becomes the canonical set; all three guards key off it, and the remote matchers (`update.super_coder_remote`, `install.sc_remote`) accept either name in a URL (GitHub redirects the old one, so both stay live in the wild). `map_repo`'s check also gates whether the engine dir gets mapped — dogfood's repo map had silently dropped the engine too.

**This should land before any `./sc update` runs on the dogfood tree** — until then, every update run re-stages the engine deletion.

**Test plan**
- [x] `tests/test_source_repo_guard.py` — all three guards × both names × a fork URL, plus the remote matcher on a renamed URL
- [x] live check on dogfood: `install/update/map_repo.is_source_repo()` all `True` again
- [x] neighbor suites green (update_materialize, eject, gitignore_sync, engine_manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)