### PR TITLE
docs(readme): demo GIF features Kimi Code (K3) — tape updated, host re-record needed

### DIFF
--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,14 +1,16 @@
 # Records docs/demo.gif — the README demo of `./sc enter`.
 #
 # Re-record from the repo root:  vhs docs/demo.tape
-# Needs: vhs + ttyd + ffmpeg on PATH, the fork's sandbox container up,
+# Needs: vhs + ttyd + ffmpeg on PATH, the fork's sandbox container up on an
+# image built since the kimi bake (`./sc build`, then relaunch) so all five
+# harnesses detect, host ~/.kimi-code logged in (bind-mounted for creds),
 # and a warm analytics sweep (run any boot once first) so the hidden
 # wait below covers the pre-session sweep comfortably.
 Output "docs/demo.gif"
 Set Shell "bash"
 Set FontSize 16
 Set Width 1000
-Set Height 650
+Set Height 780
 Set Padding 16
 Set Theme "Catppuccin Mocha"
 Set TypingSpeed 60ms
@@ -22,13 +24,13 @@ Type "Jed"
 Enter
 Sleep 3s
 
-# Shell picker — Cartographer
+# Shell picker — Cartographer (flavored shells sort first, cartographer at #1)
 Type "1"
 Enter
 Sleep 2.5s
 
-# Harness picker — claude
-Type "1"
+# Harness picker — kimi (adapter-dir order: claude, codex, kimi, opencode, vibe)
+Type "3"
 Enter
 Sleep 1s
 


### PR DESCRIPTION
## What

Updates `docs/demo.tape` so the README demo boots **Kimi Code** instead of claude, and sizes the frame for the grown shell roster.

- Harness pick `1` → `3` (adapter-dir order: claude, codex, **kimi**, opencode, vibe)
- `Height` 650 → 780 — seven shells + five harnesses no longer risk scrolling the banner off
- Tape header now documents the full re-record prereqs (image rebuilt with the kimi bake, `~/.kimi-code` logged in, warm sweep)

## Why the GIF currently lacks kimi

`./sc enter` runs the picker inside the sandbox container; `detect_harnesses()` only offers CLIs it can exec. The kimi adapter + Dockerfile bake landed in #404 (July 19), but the fork's sandbox image was built before that — `/usr/local/bin/kimi` is absent in the live container — so the picker silently dropped it at recording time.

## What this PR does NOT do

`docs/demo.gif` is **not** re-recorded here — vhs/ttyd/ffmpeg and the docker rebuild are host-side, outside the sandbox. Host runbook:

1. `./sc build` then relaunch the container (bakes kimi into the image)
2. Ensure kimi is logged in on the host (`~/.kimi-code` is bind-mounted for creds)
3. Boot any shell once to warm the analytics sweep
4. `vhs docs/demo.tape` from the repo root, eyeball the GIF, commit it to this branch

Note: no `flavor_defaults` rows exist for kimi, so the boot line shows no flavor-default model — the kimi CLI picks its own (K3). Seeding a (flavor, kimi) model column is a separate, optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)