### PR TITLE
feat(analytics): map kimi → kimi-for-coding in the model catalog

### DIFF
--- a/.super-coder/api/model_catalog.py
+++ b/.super-coder/api/model_catalog.py
@@ -5,8 +5,9 @@ Layered, best-effort sources. The GUI's model field stays free text, so none
 of this is load-bearing — a source that fails just thins the suggestions:
 
   1. models.dev/api.json — the keyless catalog OpenCode itself consumes.
-     One fetch covers all four harness providers (anthropic / openai /
-     mistral / ollama-cloud), with release dates for newest-first sorting.
+     One fetch covers all five harness providers (anthropic / openai /
+     mistral / ollama-cloud / kimi-for-coding), with release dates for
+     newest-first sorting.
   2. Provider list-models APIs — only when the matching env key is present.
      Harness logins are OAuth, not API keys, so these are usually absent.
   3. `opencode models` CLI — exactly what the local install can resolve.
@@ -42,12 +43,18 @@ TTL_HOURS = 24
 TIMEOUT = 8
 MODELS_DEV_URL = "https://models.dev/api.json"
 
-# harness -> models.dev provider key
+# harness -> models.dev provider key. kimi maps to "kimi-for-coding" (the
+# Kimi Code plan), not the general "moonshotai" API provider: its ids are the
+# ones the CLI actually reports (k3 / kimi-for-coding[-highspeed]), so the GUI
+# datalist suggests what a kimi session can really select. Provider attribution
+# for analytics is NOT sourced here — run.py's session_provider pins kimi to
+# "kimi" to match its native wire.jsonl, regardless of this catalog mapping.
 HARNESS_PROVIDER = {
     "claude": "anthropic",
     "codex": "openai",
     "vibe": "mistral",
     "opencode": "ollama-cloud",
+    "kimi": "kimi-for-coding",
 }
 # opencode model ids are provider-prefixed ("ollama-cloud/<model>") — the
 # format flavor_defaults already stores for that harness.

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -576,9 +576,9 @@ def session_provider(harness: str, model: "str | None") -> "str | None":
     """Boot-time provider for the archive row. opencode model ids are
     provider-prefixed ("ollama-cloud/<model>") — the prefix wins; otherwise the
     harness's home provider (claude→anthropic, codex→openai, vibe→mistral).
-    kimi is absent from model_catalog's map (models.dev has no kimi key) but its
-    wire.jsonl reports provider="kimi" natively — pin the same value here so
-    boot-row and sweep-row providers agree."""
+    model_catalog maps kimi→"kimi-for-coding" for the model datalist, but its
+    wire.jsonl reports provider="kimi" natively — pin that value here (ahead of
+    the map lookup) so boot-row and sweep-row providers agree."""
     if harness in model_catalog.PREFIXED_HARNESSES and model and "/" in model:
         return model.split("/", 1)[0]
     if harness == "kimi":

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Tests for the model-catalog service (api/model_catalog.py).
 
-The catalog is layered and best-effort: models.dev (keyless, all four
+The catalog is layered and best-effort: models.dev (keyless, all five
 harnesses) → provider APIs (only with env keys) → `opencode models` CLI →
 cache → static floor. Payload v2 is family-first: per harness `families`
 (newest-first; claude families with a CLI alias resolve `latest` to the
@@ -41,6 +41,11 @@ MODELS_DEV = {
                                                "family": "devstral"}}},
     "ollama-cloud": {"models": {"deepseek-v4-pro": {"release_date": "2026-02-02",
                                                     "family": "deepseek"}}},
+    "kimi-for-coding": {"models": {
+        "k3": {"name": "Kimi K3", "release_date": "2026-07-16", "family": "kimi-k3"},
+        "kimi-for-coding": {"name": "Kimi K2.7 Code",
+                            "release_date": "2026-06-12", "family": "kimi-k2"},
+    }},
 }
 
 
@@ -77,6 +82,9 @@ class BuildTest(NoCLI):
         self.assertEqual(ids(got["harnesses"]["codex"]), ["gpt-5.5"])
         self.assertEqual(ids(got["harnesses"]["opencode"]),
                          ["ollama-cloud/deepseek-v4-pro"])
+        # kimi maps to the kimi-for-coding provider; ids stay bare (not
+        # provider-prefixed like opencode) — the form the CLI reports.
+        self.assertEqual(ids(got["harnesses"]["kimi"]), ["k3", "kimi-for-coding"])
         self.assertEqual(got["sources"], ["models.dev"])
 
     def test_families_newest_first_alias_latest(self):


### PR DESCRIPTION
Adds kimi to `model_catalog.HARNESS_PROVIDER` (per your call — HARNESS_PROVIDER yes, flavor_defaults no).

## What
- `kimi → "kimi-for-coding"` — the **Kimi Code plan** provider on models.dev, whose ids (`k3`, `kimi-for-coding`, `kimi-for-coding-highspeed`) are exactly what the CLI reports. The demo TUI showed `Model: K3`, and `kimi-for-coding`'s id is literally `k3`. Chosen over the general `moonshotai` API provider precisely so the datalist matches what a kimi session can select.
- Result: the **Default Models** GUI datalist now suggests real Kimi Code models instead of nothing.

## What it does *not* change
- **Analytics provider attribution is untouched.** `run.py`'s `session_provider` already special-cases kimi → `"kimi"` (its native `wire.jsonl` value) *ahead of* the map lookup, so boot-row and sweep-row providers still agree. Correcting my earlier flag (SC-003): attribution was never actually broken. Updated the now-stale comment there that claimed models.dev has no kimi key.
- **No `flavor_defaults` / `STATIC_FLOOR` entry** — kimi ships no flavor default and the field is free text; operators configure it.

## Test
Pins the contract: kimi resolves to **bare** ids (not provider-prefixed like opencode). `test_model_catalog.py` + `test_analytics.py` green; changed files clean under ruff.

## Runtime note
`model_catalog` is read by the API server per request (24h-cached sweep). The datalist picks up kimi after the server refreshes its cache / restarts on the host — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)