### PR TITLE
feat: show boot spinner during silent launcher phases

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -226,7 +226,7 @@ def ensure_worktree(work_dir: Path, shortname: str) -> None:
         sys.exit(f"FATAL: could not create worktree at {work_dir}:\n{result.stderr.strip()}")
 
 
-def link_worktree_map(work_dir: Path) -> None:
+def link_worktree_map(work_dir: Path) -> "str | None":
     """Point a shell worktree's .sc-state/map.db at the ROOT's map DB.
 
     The dr_* repo map is a single derived cache at the main repo root (built by
@@ -251,7 +251,7 @@ def link_worktree_map(work_dir: Path) -> None:
         sc_state.mkdir(parents=True, exist_ok=True)
         if link.is_symlink():
             if link.readlink() == target:
-                return
+                return None
             link.unlink()
         elif link.exists():
             link.unlink()  # empty/stale per-worktree shadow — root is canonical
@@ -261,10 +261,11 @@ def link_worktree_map(work_dir: Path) -> None:
                 p.unlink()
         link.symlink_to(target)
     except OSError as e:
-        print(f"→ map link: skipped ({e})")
+        return f"→ map link: skipped ({e})"
+    return None
 
 
-def trust_codex_worktree(work_dir: Path) -> None:
+def trust_codex_worktree(work_dir: Path) -> "str | None":
     """Mark a codex shell's worktree as a trusted project in codex's config, so
     its project-local .codex/hooks.json (the branch-guard) actually LOADS.
 
@@ -286,14 +287,14 @@ def trust_codex_worktree(work_dir: Path) -> None:
     try:
         text = cfg.read_text() if cfg.exists() else ""
         if header in text:
-            return  # already trusted (codex writes exactly this stanza)
+            return None  # already trusted (codex writes exactly this stanza)
         home.mkdir(parents=True, exist_ok=True)
         sep = "" if (not text or text.endswith("\n")) else "\n"
         with cfg.open("a") as f:
             f.write(f'{sep}\n{header}\ntrust_level = "trusted"\n')
-        print(f"→ codex: trusted worktree layer (hooks load) → {cfg}")
+        return f"→ codex: trusted worktree layer (hooks load) → {cfg}"
     except OSError as e:
-        print(f"→ codex trust: skipped ({e})")
+        return f"→ codex trust: skipped ({e})"
 
 
 def _git(work_dir: Path, *args: str, timeout: int = 15) -> "subprocess.CompletedProcess[str]":
@@ -784,96 +785,109 @@ def main() -> None:
                or pick_harness(detect_harnesses(), default_harness, first or headless)
                or default_harness)
 
-    # Now that the harness is known, resolve THIS flavor's model for it (the
-    # (flavor, harness) cell). None when the flavor has no entry for the chosen
-    # harness (e.g. opencode as a manual fallback) — then the harness picks its own.
-    flavor_model = fdef["models"].get(harness) if fdef else None
+    feedback = not headless and not os.environ.get("RENDER_ONLY")
+    map_note = None
+    trust_note = None
+    with style.spinner("sweeping analytics", enabled=feedback) as spinner:
+        # Now that the harness is known, resolve THIS flavor's model for it (the
+        # (flavor, harness) cell). None when the flavor has no entry for the chosen
+        # harness (e.g. opencode as a manual fallback) — then the harness picks its own.
+        flavor_model = fdef["models"].get(harness) if fdef else None
 
-    # Pre-session analytics sweep (doc #11): pull harness-side usage data into
-    # session_token_usage + backfill the PREVIOUS session's ended_at. MUST run
-    # before open_session — the stub-reuse check there relies on the previous
-    # boot's session being attributed to its archive already. Incremental
-    # (mtime-gated), so steady-state cost is near zero; the first-ever sweep of
-    # harness history is the one large pass. Best-effort like the prune — a
-    # broken parser must never block a boot. Skipped under RENDER_ONLY
-    # (headless verify must not mutate).
-    sweep_note = None
-    if not os.environ.get("RENDER_ONLY"):
-        try:
-            import analytics
-            s = analytics.sweep(quiet=True)
-            if s["inserted"] or s["updated"]:
-                sweep_note = (f"{s['inserted']} new, {s['updated']} refreshed "
-                              f"session-usage row(s)")
-        except Exception:
-            sweep_note = None
+        # Pre-session analytics sweep (doc #11): pull harness-side usage data into
+        # session_token_usage + backfill the PREVIOUS session's ended_at. MUST run
+        # before open_session — the stub-reuse check there relies on the previous
+        # boot's session being attributed to its archive already. Incremental
+        # (mtime-gated), so steady-state cost is near zero; the first-ever sweep of
+        # harness history is the one large pass. Best-effort like the prune — a
+        # broken parser must never block a boot. Skipped under RENDER_ONLY
+        # (headless verify must not mutate).
+        sweep_note = None
+        if not os.environ.get("RENDER_ONLY"):
+            try:
+                import analytics
+                s = analytics.sweep(quiet=True)
+                if s["inserted"] or s["updated"]:
+                    sweep_note = (f"{s['inserted']} new, {s['updated']} refreshed "
+                                  f"session-usage row(s)")
+            except Exception:
+                sweep_note = None
 
-    # The model this launch will actually route (headless resolves via flags →
-    # flavor default; interactive routes the flavor default). None = the harness
-    # picks its own — recorded as NULL, honest about what we know at boot.
-    session_model = (resolve_headless_model(flag_model, fdef, harness)
-                     if headless else flavor_model)
-    session_id, archive_id = open_session(con, chosen["shell_id"], lifecycle={
-        "harness": harness,
-        "provider": session_provider(harness, session_model),
-        "model": session_model,
-        "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
-    })
+        spinner.label = "opening session"
+        # The model this launch will actually route (headless resolves via flags →
+        # flavor default; interactive routes the flavor default). None = the harness
+        # picks its own — recorded as NULL, honest about what we know at boot.
+        session_model = (resolve_headless_model(flag_model, fdef, harness)
+                         if headless else flavor_model)
+        session_id, archive_id = open_session(con, chosen["shell_id"], lifecycle={
+            "harness": harness,
+            "provider": session_provider(harness, session_model),
+            "model": session_model,
+            "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
+        })
 
-    full = con.execute(
-        "SELECT shell_id, display_name, shortname, partner, role, mandate, "
-        "current_state, system_prompt, connections, flavor, api_key FROM shells WHERE shell_id=?",
-        (chosen["shell_id"],),
-    ).fetchone()
-    api_port = ports_mod.resolve().get("port")
+        full = con.execute(
+            "SELECT shell_id, display_name, shortname, partner, role, mandate, "
+            "current_state, system_prompt, connections, flavor, api_key FROM shells WHERE shell_id=?",
+            (chosen["shell_id"],),
+        ).fetchone()
+        api_port = ports_mod.resolve().get("port")
 
-    # Every shell gets an isolated git worktree so parallel shells can work on
-    # separate branches without clobbering each other — planner/reviewer commit
-    # their own artifacts (specs, snapshots, state) there too. All artifacts
-    # (CLAUDE.md, AGENTS.md, skills, harness config) land in the worktree root;
-    # the harness is exec'd from there. The ONE exception is the admin flavor:
-    # it maintains `main` itself (engine updates, migrations, applying approved
-    # patches), so it boots in the repo root — no worktree, no shell/* branch.
-    # The branch-guard exempts it via SC_SHELL_FLAVOR (exported at exec below).
-    work_dir = REPO_ROOT
-    sync_note = None
-    if chosen["shortname"] and chosen["flavor"] != "admin":
-        work_dir = REPO_ROOT / ".sc-worktrees" / chosen["shortname"].lower()
-        ensure_worktree(work_dir, chosen["shortname"])
-        sync_note = sync_worktree(work_dir, chosen["shortname"])
-        link_worktree_map(work_dir)  # .sc-state/map.db -> root's map DB (heals shadows)
-        if harness == "codex":
-            trust_codex_worktree(work_dir)  # so codex loads the worktree's branch-guard hook
+        spinner.label = "syncing worktree"
+        # Every shell gets an isolated git worktree so parallel shells can work on
+        # separate branches without clobbering each other — planner/reviewer commit
+        # their own artifacts (specs, snapshots, state) there too. All artifacts
+        # (CLAUDE.md, AGENTS.md, skills, harness config) land in the worktree root;
+        # the harness is exec'd from there. The ONE exception is the admin flavor:
+        # it maintains `main` itself (engine updates, migrations, applying approved
+        # patches), so it boots in the repo root — no worktree, no shell/* branch.
+        # The branch-guard exempts it via SC_SHELL_FLAVOR (exported at exec below).
+        work_dir = REPO_ROOT
+        sync_note = None
+        if chosen["shortname"] and chosen["flavor"] != "admin":
+            work_dir = REPO_ROOT / ".sc-worktrees" / chosen["shortname"].lower()
+            ensure_worktree(work_dir, chosen["shortname"])
+            sync_note = sync_worktree(work_dir, chosen["shortname"])
+            map_note = link_worktree_map(work_dir)
+            if harness == "codex":
+                trust_note = trust_codex_worktree(work_dir)
 
-    # Repo-global branch hygiene: delete local branches whose PR is provably
-    # merged (git_hygiene's `stale` set — gh-confirmed MERGED, never a base or a
-    # checked-out branch). The unattended subset of the git_cleanup skill, run
-    # once per boot from whichever shell launches next. Best-effort and silent:
-    # soft-fails so it never blocks a launch, and surfaces a line only when it
-    # actually removed something. Skipped under RENDER_ONLY (headless verify must
-    # not mutate) and opt-out-able per fork via SC_NO_AUTOPRUNE=1.
-    prune_note = None
-    if not os.environ.get("SC_NO_AUTOPRUNE") and not os.environ.get("RENDER_ONLY"):
-        try:
-            prune_note = git_prune.status_line(git_prune.prune(fetch=False))
-        except Exception:
-            prune_note = None
+        spinner.label = "pruning merged branches"
+        # Repo-global branch hygiene: delete local branches whose PR is provably
+        # merged (git_hygiene's `stale` set — gh-confirmed MERGED, never a base or a
+        # checked-out branch). The unattended subset of the git_cleanup skill, run
+        # once per boot from whichever shell launches next. Best-effort and silent:
+        # soft-fails so it never blocks a launch, and surfaces a line only when it
+        # actually removed something. Skipped under RENDER_ONLY (headless verify must
+        # not mutate) and opt-out-able per fork via SC_NO_AUTOPRUNE=1.
+        prune_note = None
+        if not os.environ.get("SC_NO_AUTOPRUNE") and not os.environ.get("RENDER_ONLY"):
+            try:
+                prune_note = git_prune.status_line(git_prune.prune(fetch=False))
+            except Exception:
+                prune_note = None
 
-    content = compose_boot(con, full, user, session_id, archive_id,
-                           work_dir=work_dir if work_dir != REPO_ROOT else None,
-                           sync_note=sync_note,
-                           api_key=full["api_key"],
-                           api_port=api_port)
+        spinner.label = "rendering boot doc + skills"
+        content = compose_boot(con, full, user, session_id, archive_id,
+                               work_dir=work_dir if work_dir != REPO_ROOT else None,
+                               sync_note=sync_note,
+                               api_key=full["api_key"],
+                               api_port=api_port)
 
-    # Render this shell's granted skills to .claude/skills/<name>/SKILL.md —
-    # harness-consumed, gitignored, rebuilt per boot (like the boot artifact).
-    skills = flat.render_skill_md(con, full["shell_id"], work_dir)
-    con.close()
+        # Render this shell's granted skills to .claude/skills/<name>/SKILL.md —
+        # harness-consumed, gitignored, rebuilt per boot (like the boot artifact).
+        skills = flat.render_skill_md(con, full["shell_id"], work_dir)
+        con.close()
 
-    # One compose, two outputs — Claude Code reads CLAUDE.md, the AGENTS.md
-    # harnesses read AGENTS.md. Both at the working directory root.
-    for name in ("CLAUDE.md", "AGENTS.md"):
-        atomic_write(work_dir / name, content)
+        # One compose, two outputs — Claude Code reads CLAUDE.md, the AGENTS.md
+        # harnesses read AGENTS.md. Both at the working directory root.
+        for name in ("CLAUDE.md", "AGENTS.md"):
+            atomic_write(work_dir / name, content)
+
+    if map_note:
+        print(map_note)
+    if trust_note:
+        print(trust_note)
 
     print(f"\n→ booted {style.bold(full['display_name'])} "
           f"(shell_id={full['shell_id']}, session={session_id})")

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -833,7 +833,6 @@ def main() -> None:
         ).fetchone()
         api_port = ports_mod.resolve().get("port")
 
-        spinner.label = "syncing worktree"
         # Every shell gets an isolated git worktree so parallel shells can work on
         # separate branches without clobbering each other — planner/reviewer commit
         # their own artifacts (specs, snapshots, state) there too. All artifacts
@@ -845,6 +844,7 @@ def main() -> None:
         work_dir = REPO_ROOT
         sync_note = None
         if chosen["shortname"] and chosen["flavor"] != "admin":
+            spinner.label = "syncing worktree"
             work_dir = REPO_ROOT / ".sc-worktrees" / chosen["shortname"].lower()
             ensure_worktree(work_dir, chosen["shortname"])
             sync_note = sync_worktree(work_dir, chosen["shortname"])
@@ -852,7 +852,6 @@ def main() -> None:
             if harness == "codex":
                 trust_note = trust_codex_worktree(work_dir)
 
-        spinner.label = "pruning merged branches"
         # Repo-global branch hygiene: delete local branches whose PR is provably
         # merged (git_hygiene's `stale` set — gh-confirmed MERGED, never a base or a
         # checked-out branch). The unattended subset of the git_cleanup skill, run
@@ -862,6 +861,7 @@ def main() -> None:
         # not mutate) and opt-out-able per fork via SC_NO_AUTOPRUNE=1.
         prune_note = None
         if not os.environ.get("SC_NO_AUTOPRUNE") and not os.environ.get("RENDER_ONLY"):
+            spinner.label = "pruning merged branches"
             try:
                 prune_note = git_prune.status_line(git_prune.prune(fetch=False))
             except Exception:

--- a/.super-coder/scripts/style.py
+++ b/.super-coder/scripts/style.py
@@ -59,14 +59,18 @@ class _Spinner:
         if not self._active:
             return
         self._thread = threading.Thread(target=self._spin, daemon=True)
-        self._thread.start()
+        try:
+            self._thread.start()
+        except RuntimeError:
+            self._thread = None
+            self._active = False
 
     def stop(self) -> None:
         if self._thread is None or self._stopped:
             return
         self._stopped = True
         self._stop.set()
-        self._thread.join(timeout=0.2)
+        self._thread.join()
         sys.stdout.write("\r\x1b[2K")
         sys.stdout.flush()
 

--- a/.super-coder/scripts/style.py
+++ b/.super-coder/scripts/style.py
@@ -10,9 +10,12 @@ skews a border.
 """
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 import os
 import re
 import sys
+import threading
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -38,6 +41,53 @@ accent = _c("38;5;135")   # subfloor purple
 cyan = _c("36")
 green = _c("32")
 yellow = _c("33")
+
+
+class _Spinner:
+    """Small stdout spinner whose lifecycle is owned by a context manager."""
+
+    _FRAMES = "|/-\\"
+
+    def __init__(self, label: str, *, enabled: bool = True) -> None:
+        self.label = label
+        self._active = enabled and sys.stdout.isatty()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._stopped = False
+
+    def start(self) -> None:
+        if not self._active:
+            return
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._thread is None or self._stopped:
+            return
+        self._stopped = True
+        self._stop.set()
+        self._thread.join(timeout=0.2)
+        sys.stdout.write("\r\x1b[2K")
+        sys.stdout.flush()
+
+    def _spin(self) -> None:
+        frame = 0
+        while not self._stop.is_set():
+            sys.stdout.write(f"\r{self._FRAMES[frame]} {self.label}…")
+            sys.stdout.flush()
+            frame = (frame + 1) % len(self._FRAMES)
+            self._stop.wait(0.1)
+
+
+@contextmanager
+def spinner(label: str, *, enabled: bool = True) -> Iterator[_Spinner]:
+    """Show liveness on a TTY and always clear the line before returning."""
+    state = _Spinner(label, enabled=enabled)
+    state.start()
+    try:
+        yield state
+    finally:
+        state.stop()
 
 
 def visible_len(s: str) -> int:

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Regression tests for the launcher's TTY-only spinner."""
+from __future__ import annotations
+
+import io
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS = Path(__file__).resolve().parents[1] / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import style  # noqa: E402
+
+
+class _Stdout(io.StringIO):
+    def __init__(self, tty: bool) -> None:
+        super().__init__()
+        self.tty = tty
+
+    def isatty(self) -> bool:
+        return self.tty
+
+
+def _wait_for(stream: _Stdout, text: str) -> None:
+    deadline = time.monotonic() + 0.5
+    while text not in stream.getvalue() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if text not in stream.getvalue():
+        raise AssertionError(f"spinner never wrote {text!r}: {stream.getvalue()!r}")
+
+
+class SpinnerTest(unittest.TestCase):
+    def test_non_tty_is_a_structural_noop(self) -> None:
+        stdout = _Stdout(tty=False)
+
+        with mock.patch.object(style.sys, "stdout", stdout):
+            with style.spinner("sweeping analytics") as spinner:
+                spinner.label = "syncing worktree"
+
+        self.assertEqual("", stdout.getvalue())
+        self.assertIsNone(spinner._thread)
+
+    def test_disabled_spinner_is_a_noop_even_on_tty(self) -> None:
+        stdout = _Stdout(tty=True)
+
+        with mock.patch.object(style.sys, "stdout", stdout):
+            with style.spinner("headless boot", enabled=False) as spinner:
+                spinner.label = "rendering boot doc + skills"
+
+        self.assertEqual("", stdout.getvalue())
+        self.assertIsNone(spinner._thread)
+
+    def test_tty_spins_updates_label_and_stays_stopped(self) -> None:
+        stdout = _Stdout(tty=True)
+
+        with mock.patch.object(style.sys, "stdout", stdout):
+            with style.spinner("sweeping analytics") as spinner:
+                _wait_for(stdout, "sweeping analytics")
+                spinner.label = "syncing worktree"
+                _wait_for(stdout, "syncing worktree")
+
+            stopped = stdout.getvalue()
+            time.sleep(0.15)
+
+        self.assertTrue(spinner._thread.daemon)
+        self.assertFalse(spinner._thread.is_alive())
+        self.assertIn("\r| sweeping analytics…", stopped)
+        self.assertIn("syncing worktree…", stopped)
+        self.assertTrue(stopped.endswith("\r\x1b[2K"))
+        self.assertEqual(stopped, stdout.getvalue())
+
+    def test_keyboard_interrupt_clears_before_propagating(self) -> None:
+        stdout = _Stdout(tty=True)
+
+        with mock.patch.object(style.sys, "stdout", stdout):
+            with self.assertRaises(KeyboardInterrupt):
+                with style.spinner("syncing worktree") as spinner:
+                    _wait_for(stdout, "syncing worktree")
+                    raise KeyboardInterrupt
+            stopped = stdout.getvalue()
+            time.sleep(0.15)
+
+        self.assertFalse(spinner._thread.is_alive())
+        self.assertTrue(stopped.endswith("\r\x1b[2K"))
+        self.assertEqual(stopped, stdout.getvalue())
+
+    def test_explicit_stop_is_idempotent_at_context_exit(self) -> None:
+        stdout = _Stdout(tty=True)
+
+        with mock.patch.object(style.sys, "stdout", stdout):
+            with style.spinner("syncing worktree") as spinner:
+                _wait_for(stdout, "syncing worktree")
+                spinner.stop()
+
+        self.assertEqual(1, stdout.getvalue().count("\r\x1b[2K"))
+        self.assertFalse(spinner._thread.is_alive())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import io
 import sys
+import threading
 import time
 import unittest
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from unittest import mock
 
@@ -13,6 +15,7 @@ SCRIPTS = Path(__file__).resolve().parents[1] / ".super-coder" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import style  # noqa: E402
+import run  # noqa: E402
 
 
 class _Stdout(io.StringIO):
@@ -24,12 +27,46 @@ class _Stdout(io.StringIO):
         return self.tty
 
 
+class _DelayedStdout(_Stdout):
+    def __init__(self) -> None:
+        super().__init__(tty=True)
+        self.frame_started = threading.Event()
+        self._delayed = False
+
+    def write(self, text: str) -> int:
+        if text.startswith("\r|") and not self._delayed:
+            self._delayed = True
+            self.frame_started.set()
+            time.sleep(0.3)
+        return super().write(text)
+
+
 def _wait_for(stream: _Stdout, text: str) -> None:
     deadline = time.monotonic() + 0.5
     while text not in stream.getvalue() and time.monotonic() < deadline:
         time.sleep(0.01)
     if text not in stream.getvalue():
         raise AssertionError(f"spinner never wrote {text!r}: {stream.getvalue()!r}")
+
+
+class _ExecReached(Exception):
+    pass
+
+
+class _LabelRecorder:
+    def __init__(self, labels: list[str], initial: str) -> None:
+        self._labels = labels
+        self._label = initial
+        labels.append(initial)
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @label.setter
+    def label(self, value: str) -> None:
+        self._label = value
+        self._labels.append(value)
 
 
 class SpinnerTest(unittest.TestCase):
@@ -43,6 +80,7 @@ class SpinnerTest(unittest.TestCase):
         self.assertEqual("", stdout.getvalue())
         self.assertIsNone(spinner._thread)
 
+
     def test_disabled_spinner_is_a_noop_even_on_tty(self) -> None:
         stdout = _Stdout(tty=True)
 
@@ -52,6 +90,7 @@ class SpinnerTest(unittest.TestCase):
 
         self.assertEqual("", stdout.getvalue())
         self.assertIsNone(spinner._thread)
+
 
     def test_tty_spins_updates_label_and_stays_stopped(self) -> None:
         stdout = _Stdout(tty=True)
@@ -97,6 +136,131 @@ class SpinnerTest(unittest.TestCase):
 
         self.assertEqual(1, stdout.getvalue().count("\r\x1b[2K"))
         self.assertFalse(spinner._thread.is_alive())
+
+    def test_slow_frame_finishes_before_line_is_cleared(self) -> None:
+        stdout = _DelayedStdout()
+
+        with mock.patch.object(style.sys, "stdout", stdout):
+            with style.spinner("slow terminal") as spinner:
+                self.assertTrue(stdout.frame_started.wait(0.5))
+
+            spinner._thread.join(timeout=1)
+            stopped = stdout.getvalue()
+
+        self.assertFalse(spinner._thread.is_alive())
+        self.assertIn("\r| slow terminal…", stopped)
+        self.assertTrue(stopped.endswith("\r\x1b[2K"))
+
+    def test_thread_start_failure_falls_back_to_silent_noop(self) -> None:
+        stdout = _Stdout(tty=True)
+        entered = False
+
+        with mock.patch.object(style.sys, "stdout", stdout), \
+             mock.patch.object(style.threading.Thread, "start",
+                               side_effect=RuntimeError("cannot start thread")):
+            with style.spinner("booting") as spinner:
+                entered = True
+                spinner.label = "rendering boot doc + skills"
+
+        self.assertTrue(entered)
+        self.assertEqual("", stdout.getvalue())
+        self.assertIsNone(spinner._thread)
+
+
+class BootPhaseLabelTest(unittest.TestCase):
+    def _run_main(self, *, admin: bool, no_prune: bool) -> tuple[list[str], int, int]:
+        flavor = "admin" if admin else "dev"
+        chosen = {"shell_id": 1, "shortname": "DEV1", "flavor": flavor}
+        full = {"shell_id": 1, "display_name": "Dev One", "api_key": None}
+        con = mock.Mock()
+        con.execute.return_value.fetchone.return_value = full
+        labels: list[str] = []
+
+        @contextmanager
+        def recording_spinner(label: str, *, enabled: bool = True):
+            self.assertTrue(enabled)
+            yield _LabelRecorder(labels, label)
+
+        env = {"SC_NO_AUTOPRUNE": "1"} if no_prune else {}
+        stdout = _Stdout(tty=False)
+        stdin = _Stdout(tty=False)
+        sync = mock.Mock(return_value="in sync with origin/main")
+        prune = mock.Mock(return_value={})
+        analytics = mock.Mock()
+        analytics.sweep.return_value = {"inserted": 0, "updated": 0}
+        fdefaults = {flavor: {"default_harness": "claude", "models": {"claude": None}}}
+        adapter = {"launch": ["claude"], "emit": [], "env": {}}
+
+        with ExitStack() as stack:
+            stack.enter_context(mock.patch.dict(run.os.environ, env, clear=True))
+            stack.enter_context(mock.patch.dict(sys.modules, {"analytics": analytics}))
+            stack.enter_context(mock.patch.object(
+                run.sys, "argv", ["run.py", "--first", "--harness", "claude"]))
+            stack.enter_context(mock.patch.object(run.sys, "stdin", stdin))
+            stack.enter_context(mock.patch.object(run.sys, "stdout", stdout))
+            stack.enter_context(mock.patch.object(run, "open_db", return_value=con))
+            stack.enter_context(mock.patch.object(
+                run.seed_skills, "sync_engine_skills", return_value=[]))
+            stack.enter_context(mock.patch.object(
+                run, "authenticate", return_value={"user_id": 1}))
+            stack.enter_context(mock.patch.object(
+                run, "flavor_defaults", return_value=fdefaults))
+            stack.enter_context(mock.patch.object(run, "list_shells", return_value=[chosen]))
+            stack.enter_context(mock.patch.object(run, "pick_shell", return_value=chosen))
+            stack.enter_context(mock.patch.object(run, "ensure_harness_path"))
+            stack.enter_context(mock.patch.object(
+                run.style, "spinner", side_effect=recording_spinner))
+            stack.enter_context(mock.patch.object(
+                run, "open_session", return_value=("0001", 1)))
+            stack.enter_context(mock.patch.object(run.ports_mod, "resolve", return_value={}))
+            stack.enter_context(mock.patch.object(run, "ensure_worktree"))
+            stack.enter_context(mock.patch.object(run, "sync_worktree", sync))
+            stack.enter_context(mock.patch.object(
+                run, "link_worktree_map", return_value=None))
+            stack.enter_context(mock.patch.object(run.git_prune, "prune", prune))
+            stack.enter_context(mock.patch.object(
+                run.git_prune, "status_line", return_value=None))
+            stack.enter_context(mock.patch.object(run, "compose_boot", return_value="boot"))
+            stack.enter_context(mock.patch.object(
+                run.flat, "render_skill_md", return_value={"written": [], "skipped": []}))
+            stack.enter_context(mock.patch.object(run, "atomic_write"))
+            stack.enter_context(mock.patch.object(run, "load_adapter", return_value=adapter))
+            stack.enter_context(mock.patch.object(run, "emit_adapter", return_value=[]))
+            stack.enter_context(mock.patch.object(run, "resolve_opencode_plugins"))
+            stack.enter_context(mock.patch.object(run, "apply_merge_json", return_value=[]))
+            stack.enter_context(mock.patch.object(run, "apply_sandbox", return_value=[]))
+            stack.enter_context(mock.patch.object(run, "set_terminal_tab_title"))
+            stack.enter_context(mock.patch.object(run.os, "chdir"))
+            stack.enter_context(mock.patch.object(
+                run.os, "execvpe", side_effect=_ExecReached))
+            with self.assertRaises(_ExecReached):
+                run.main()
+
+        return labels, sync.call_count, prune.call_count
+
+    def test_admin_boot_with_prune_disabled_skips_both_phase_labels(self) -> None:
+        labels, sync_calls, prune_calls = self._run_main(admin=True, no_prune=True)
+
+        self.assertEqual([
+            "sweeping analytics",
+            "opening session",
+            "rendering boot doc + skills",
+        ], labels)
+        self.assertEqual(0, sync_calls)
+        self.assertEqual(0, prune_calls)
+
+    def test_worktree_boot_with_prune_enabled_reports_every_phase(self) -> None:
+        labels, sync_calls, prune_calls = self._run_main(admin=False, no_prune=False)
+
+        self.assertEqual([
+            "sweeping analytics",
+            "opening session",
+            "syncing worktree",
+            "pruning merged branches",
+            "rendering boot doc + skills",
+        ], labels)
+        self.assertEqual(1, sync_calls)
+        self.assertEqual(1, prune_calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements roadmap feature #18 / spec doc #12.

## What changed

- add a TTY-only `| / - \\` spinner context manager in `style.py`
- cover the silent post-harness boot region with the five specified phase labels
- stop and clear before all launcher output, exceptions, and Ctrl-C propagation
- keep map-link/Codex-trust notes outside the spinner without changing transcript order
- add focused lifecycle, no-op, label-update, idempotency, and Ctrl-C tests

This deliberately leaves fetch/prune sequencing unchanged; boot feedback is the scope, not boot speed.

## Verification

- `20 passed` — spinner + worktree-sync + git-prune focused suites
- changed-file Ruff passes (excluding two pre-existing E741 findings in untouched `panel()` code)
- isolated `RENDER_ONLY` transcript: byte-identical before/after
- isolated headless transcript: byte-identical before/after
- PTY boot completes with a clean summary line after an offline fetch
- Ctrl-C during delayed sync clears the spinner before the traceback

Full suite: 445 passed, 3 unrelated `test_vm_bake.py` failures caused by the sandbox guard. Tracked in #435.
