### PR TITLE
feat(visual-qa): distribute managed workflow shim

### DIFF
--- a/.super-coder/scripts/engine_manifest.py
+++ b/.super-coder/scripts/engine_manifest.py
@@ -36,6 +36,14 @@ ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
 MANIFEST = ENGINE / "engine.manifest"
 
+# Fork-facing templates are materialized through the templates directory in
+# ENGINE_PATHS below. Keep their exact paths named here so distribution tests
+# can guard both the template files and their engine-manifest coverage.
+FORK_TEMPLATE_PATHS = (
+    ".super-coder/templates/fork/subfloor-visual-qa.yml",
+    ".super-coder/templates/fork/visual-qa.example.json",
+)
+
 # The ENGINE = system content that propagates to every fork; all of it is safe
 # to materialize from the super-coder remote (it is wholesale-replaced, never
 # fork-edited). The per-instance set is deliberately NOT listed, so a materialize

--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -35,6 +35,7 @@ DB_PATH = ENGINE / "shell_db.db"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import db_driver  # noqa: E402
+import install as install_mod  # noqa: E402
 
 # The starting team seeded at install, besides the singleton cartographer (added
 # separately below). Your interviewed primary shell — default planner — fills one
@@ -79,6 +80,11 @@ def main(argv: list[str]) -> int:
         if already_seeded(con):
             sys.exit("init_fork: a shell already exists — this fork is already "
                      "initialised. Add more shells via the GUI.")
+
+        # Standalone init_fork runs get the same fork-facing files as the full
+        # installer. The helper is idempotent and guards the source repository.
+        for path in install_mod.seed_visual_qa_files():
+            print(f"init_fork: created {path}")
 
         repo = ENGINE.parent.name
         interactive = sys.stdin.isatty()

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -120,6 +120,11 @@ def sh(*args: str) -> subprocess.CompletedProcess:
 # B7 untrack migration (this fired on the dogfood repo the day of the rename).
 SOURCE_REPO_NAMES = ("super-coder", "subfloor")
 
+VISUAL_QA_TEMPLATE_TARGETS = {
+    "subfloor-visual-qa.yml": Path(".github/workflows/subfloor-visual-qa.yml"),
+    "visual-qa.example.json": Path(".sc-state/visual-qa.example.json"),
+}
+
 
 def origin_basename() -> str | None:
     p = sh("git", "-C", str(REPO_ROOT), "remote", "get-url", "origin")
@@ -133,6 +138,33 @@ def is_source_repo() -> bool:
     is its own repo (the engine upstream is a separate, differently-named
     remote)."""
     return origin_basename() in SOURCE_REPO_NAMES
+
+
+def seed_visual_qa_files(
+    repo_root: Path = REPO_ROOT,
+    template_root: Path | None = None,
+    *,
+    source_repo: bool | None = None,
+) -> list[Path]:
+    """Seed Visual QA's fork-owned workflow and inactive example config.
+
+    Existing files are always preserved. The source repository owns the
+    templates but must never receive the fork-facing copies.
+    """
+    source = source_repo if source_repo is not None else is_source_repo()
+    if source:
+        return []
+
+    templates = template_root or ENGINE / "templates" / "fork"
+    written: list[Path] = []
+    for template_name, relative_target in VISUAL_QA_TEMPLATE_TARGETS.items():
+        target = repo_root / relative_target
+        if target.exists():
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(templates / template_name, target)
+        written.append(relative_target)
+    return written
 
 
 def already_installed() -> bool:
@@ -631,6 +663,16 @@ def main(argv: list[str]) -> int:
         redlines.mkdir()
         (redlines / ".gitkeep").write_text("")
         print(f"  created {redlines.relative_to(REPO_ROOT)}/")
+
+    # 3.7 Seed the fork-tracked Visual QA shim + inactive example config. The
+    # live config remains opt-in at .sc-state/visual-qa.json.
+    step("Seeding Visual QA CI")
+    visual_qa_files = seed_visual_qa_files()
+    if visual_qa_files:
+        for path in visual_qa_files:
+            print(f"  created {path}")
+    else:
+        print("  (already present or source repo)")
 
     # 4. Strip super-coder's per-instance content -----------------------------
     step("Stripping super-coder's per-instance content (a fork inherits the system, not the memory)")

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -48,6 +48,7 @@ Usage:
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -76,6 +77,10 @@ EJECTED_MARKER = STATE_DIR / "ejected"
 # and test already knows.
 ENGINE_PATHS = engine_manifest.ENGINE_PATHS
 
+_VISUAL_QA_MARKER_RE = re.compile(
+    r"^# managed-by: subfloor — visual-qa shim v(?P<version>\d+)$"
+)
+
 
 def git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
     r = subprocess.run(["git", "-C", str(REPO_ROOT), *args],
@@ -103,6 +108,67 @@ def is_source_repo() -> bool:
     url = git("remote", "get-url", "origin", check=False).stdout.strip()
     return bool(url) and (url.rstrip("/").split("/")[-1].removesuffix(".git")
                           in install_mod.SOURCE_REPO_NAMES)
+
+
+def _workflow_version(text: str) -> int | None:
+    first_line = text.splitlines()[0] if text else ""
+    match = _VISUAL_QA_MARKER_RE.fullmatch(first_line)
+    return int(match.group("version")) if match else None
+
+
+def ensure_workflows(
+    repo_root: Path = REPO_ROOT,
+    template_root: Path | None = None,
+    *,
+    source_repo: bool | None = None,
+) -> tuple[str, list[Path]]:
+    """Reconcile the fork-tracked Visual QA shim and example config.
+
+    Returns ``(action, changed_paths)`` where action is one of ``source``,
+    ``seeded``, ``updated``, ``unmanaged``, or ``current``.
+    """
+    source = source_repo if source_repo is not None else is_source_repo()
+    if source:
+        return "source", []
+
+    templates = template_root or ENGINE / "templates" / "fork"
+    workflow_template = templates / "subfloor-visual-qa.yml"
+    current = workflow_template.read_text()
+    current_version = _workflow_version(current)
+    if current_version is None:
+        raise ValueError(f"Visual QA workflow template has no managed marker: {workflow_template}")
+
+    changed: list[Path] = []
+    workflow_relative = install_mod.VISUAL_QA_TEMPLATE_TARGETS[
+        "subfloor-visual-qa.yml"
+    ]
+    workflow = repo_root / workflow_relative
+    if not workflow.exists():
+        workflow.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(workflow_template, workflow)
+        changed.append(workflow_relative)
+        action = "seeded"
+    else:
+        installed_version = _workflow_version(workflow.read_text())
+        if installed_version is None:
+            action = "unmanaged"
+        elif installed_version < current_version:
+            shutil.copy2(workflow_template, workflow)
+            changed.append(workflow_relative)
+            action = "updated"
+        else:
+            action = "current"
+
+    example_relative = install_mod.VISUAL_QA_TEMPLATE_TARGETS[
+        "visual-qa.example.json"
+    ]
+    example = repo_root / example_relative
+    if not example.exists():
+        example.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(templates / "visual-qa.example.json", example)
+        changed.append(example_relative)
+
+    return action, changed
 
 
 def super_coder_remote() -> str:
@@ -348,6 +414,17 @@ def main(argv: list[str]) -> int:
               "(engine + engine.ref unchanged)")
     else:
         fetch_and_materialize(branch, ref=ref, force=force)
+
+    workflow_action, workflow_changes = ensure_workflows(source_repo=source)
+    if workflow_action == "seeded":
+        print("→ visual QA: seeded the managed workflow shim")
+    elif workflow_action == "updated":
+        print("→ visual QA: refreshed the managed workflow shim")
+    elif workflow_action == "unmanaged":
+        print("→ visual QA: workflow has no managed marker — leaving fork-owned file unchanged")
+    if workflow_changes:
+        paths = " ".join(str(path) for path in workflow_changes)
+        print(f"  commit these fork-owned files: git add {paths}")
 
     # Harnesses can be ADDED upstream between releases (e.g. codex landed after
     # dos-arch installed), so a fork that updates must pick up any newly-required

--- a/.super-coder/templates/fork/subfloor-visual-qa.yml
+++ b/.super-coder/templates/fork/subfloor-visual-qa.yml
@@ -1,0 +1,62 @@
+# managed-by: subfloor — visual-qa shim v1
+# Edits are overwritten by `make update`. Delete the managed-by line to take
+# ownership; subfloor will then leave this file alone.
+name: Subfloor Visual QA
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: subfloor-visual-qa-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  visual-qa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Materialize the pinned Subfloor engine
+        shell: bash
+        run: |
+          test -s .sc-state/engine.ref || { echo "::error::No engine.ref; run make update first"; exit 1; }
+          engine_ref="$(tr -d '[:space:]' < .sc-state/engine.ref)"
+          git clone --filter=blob:none --no-checkout https://github.com/jedbjorn/subfloor.git .subfloor-source
+          git -C .subfloor-source checkout "$engine_ref" -- .super-coder
+          mv .subfloor-source/.super-coder .super-coder
+      - name: Restore Playwright browser cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('.super-coder/scripts/visual_qa.py') }}
+      - name: Resolve artifact retention
+        id: config
+        shell: python
+        run: |
+          import json, os
+          from pathlib import Path
+          try:
+              days = json.loads(Path(".sc-state/visual-qa.json").read_text()).get("artifact_retention_days", 14)
+          except Exception:
+              days = 14
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              print(f"retention={days}", file=out)
+      - run: ./sc visual-qa ci
+      - name: Upload Visual QA gallery
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-qa-gallery
+          path: gallery/
+          if-no-files-found: warn
+          retention-days: ${{ steps.config.outputs.retention || 14 }}

--- a/.super-coder/templates/fork/visual-qa.example.json
+++ b/.super-coder/templates/fork/visual-qa.example.json
@@ -1,0 +1,14 @@
+{
+  "cwd": ".",
+  "setup": ["npm ci", "npm run build"],
+  "serve": "npm run preview -- --port {port} --host 127.0.0.1",
+  "port": 4173,
+  "ready_path": "/",
+  "ready_timeout_s": 120,
+  "settle_ms": 500,
+  "routes": ["/", "/dashboard"],
+  "viewports": "default",
+  "paths": ["src/**", "static/**", "package.json"],
+  "services": [],
+  "artifact_retention_days": 14
+}

--- a/tests/test_visual_qa_distribution.py
+++ b/tests/test_visual_qa_distribution.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Hermetic tests for Visual QA's fork distribution surfaces."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+TEMPLATES = ENGINE / "templates" / "fork"
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import engine_manifest  # noqa: E402
+import init_fork  # noqa: E402
+import install  # noqa: E402
+import update  # noqa: E402
+
+
+class VisualQaTemplateTest(unittest.TestCase):
+    def test_workflow_is_the_fixed_managed_shim(self):
+        text = (TEMPLATES / "subfloor-visual-qa.yml").read_text()
+
+        self.assertTrue(text.startswith("# managed-by: subfloor — visual-qa shim v1\n"))
+        self.assertIn("pull_request:\n", text)
+        self.assertIn("workflow_dispatch:\n", text)
+        self.assertIn("contents: read\n", text)
+        self.assertIn("pull-requests: write\n", text)
+        self.assertIn("group: subfloor-visual-qa-${{ github.ref }}", text)
+        self.assertIn("test -s .sc-state/engine.ref", text)
+        self.assertIn('checkout "$engine_ref" -- .super-coder', text)
+        self.assertIn("hashFiles('.super-coder/scripts/visual_qa.py')", text)
+        self.assertNotIn("playwright==", text)
+        self.assertIn("if: always()\n        uses: actions/upload-artifact@v4", text)
+
+    def test_example_config_is_valid_and_inactive(self):
+        config = json.loads((TEMPLATES / "visual-qa.example.json").read_text())
+        self.assertEqual(
+            config,
+            {
+                "cwd": ".",
+                "setup": ["npm ci", "npm run build"],
+                "serve": "npm run preview -- --port {port} --host 127.0.0.1",
+                "port": 4173,
+                "ready_path": "/",
+                "ready_timeout_s": 120,
+                "settle_ms": 500,
+                "routes": ["/", "/dashboard"],
+                "viewports": "default",
+                "paths": ["src/**", "static/**", "package.json"],
+                "services": [],
+                "artifact_retention_days": 14,
+            },
+        )
+
+    def test_manifest_names_and_covers_both_fork_templates(self):
+        expected = (
+            ".super-coder/templates/fork/subfloor-visual-qa.yml",
+            ".super-coder/templates/fork/visual-qa.example.json",
+        )
+        self.assertEqual(engine_manifest.FORK_TEMPLATE_PATHS, expected)
+        for relative in expected:
+            self.assertTrue((ROOT / relative).is_file(), relative)
+            self.assertTrue(
+                any(relative == entry or relative.startswith(entry.rstrip("/") + "/")
+                    for entry in engine_manifest.ENGINE_PATHS),
+                f"{relative} is not covered by ENGINE_PATHS",
+            )
+
+
+class VisualQaSeedTest(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.repo = Path(temporary.name)
+
+    def test_seed_writes_exact_inactive_surfaces_and_preserves_them(self):
+        expected = [
+            Path(".github/workflows/subfloor-visual-qa.yml"),
+            Path(".sc-state/visual-qa.example.json"),
+        ]
+        written = install.seed_visual_qa_files(
+            self.repo, TEMPLATES, source_repo=False
+        )
+        self.assertEqual(written, expected)
+        self.assertEqual(
+            (self.repo / expected[0]).read_text(),
+            (TEMPLATES / "subfloor-visual-qa.yml").read_text(),
+        )
+        self.assertEqual(
+            (self.repo / expected[1]).read_text(),
+            (TEMPLATES / "visual-qa.example.json").read_text(),
+        )
+        self.assertFalse((self.repo / ".sc-state/visual-qa.json").exists())
+
+        (self.repo / expected[0]).write_text("fork-owned workflow\n")
+        self.assertEqual(
+            install.seed_visual_qa_files(self.repo, TEMPLATES, source_repo=False),
+            [],
+        )
+        self.assertEqual((self.repo / expected[0]).read_text(), "fork-owned workflow\n")
+        self.assertEqual(
+            (self.repo / expected[1]).read_text(),
+            (TEMPLATES / "visual-qa.example.json").read_text(),
+        )
+
+    def test_source_repo_guard_writes_nothing(self):
+        with mock.patch.object(install, "is_source_repo", return_value=True):
+            self.assertEqual(install.seed_visual_qa_files(self.repo, TEMPLATES), [])
+        self.assertFalse((self.repo / ".github").exists())
+        self.assertFalse((self.repo / ".sc-state").exists())
+
+    def test_init_fork_calls_the_shared_seed_path_for_a_fresh_database(self):
+        database = self.repo / "shell.db"
+        with sqlite3.connect(database) as con:
+            con.executescript(
+                "CREATE TABLE users(user_id INTEGER PRIMARY KEY, username TEXT, is_active INTEGER);"
+                "CREATE TABLE shells(shell_id INTEGER PRIMARY KEY, shortname TEXT, is_deleted INTEGER DEFAULT 0);"
+                "CREATE TABLE shell_skills(shell_id INTEGER, skill_id INTEGER);"
+            )
+
+        next_shell_id = iter(range(1, 7))
+
+        def create_shell(con, *, flavor, **_kwargs):
+            shell_id = next(next_shell_id)
+            con.execute(
+                "INSERT INTO shells(shell_id, shortname, is_deleted) VALUES (?, ?, 0)",
+                (shell_id, f"{flavor[:3].upper()}{shell_id}"),
+            )
+            return shell_id
+
+        seeded = [Path(".github/workflows/subfloor-visual-qa.yml")]
+        with (
+            mock.patch.object(init_fork, "DB_PATH", database),
+            mock.patch.object(init_fork.install_mod, "seed_visual_qa_files", return_value=seeded) as seed,
+            mock.patch.object(init_fork, "create_shell", side_effect=create_shell),
+            mock.patch.object(
+                init_fork,
+                "flavors",
+                return_value=[{"flavor": name} for name in
+                              ("admin", "planner", "dev", "reviewer", "cartographer")],
+            ),
+        ):
+            self.assertEqual(init_fork.main(["--username", "Jed"]), 0)
+
+        seed.assert_called_once_with()
+        with sqlite3.connect(database) as con:
+            self.assertEqual(con.execute("SELECT username FROM users").fetchall(), [("Jed",)])
+            self.assertEqual(con.execute("SELECT COUNT(*) FROM shells").fetchone()[0], 6)
+
+
+class VisualQaUpdateTest(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.repo = Path(temporary.name)
+        self.workflow = self.repo / ".github/workflows/subfloor-visual-qa.yml"
+        self.example = self.repo / ".sc-state/visual-qa.example.json"
+
+    def reconcile(self):
+        return update.ensure_workflows(self.repo, TEMPLATES, source_repo=False)
+
+    def test_absent_files_are_seeded_and_rerun_converges(self):
+        action, changed = self.reconcile()
+        self.assertEqual(action, "seeded")
+        self.assertEqual(
+            changed,
+            [Path(".github/workflows/subfloor-visual-qa.yml"),
+             Path(".sc-state/visual-qa.example.json")],
+        )
+        self.assertEqual(
+            self.workflow.read_text(),
+            (TEMPLATES / "subfloor-visual-qa.yml").read_text(),
+        )
+        self.assertEqual(
+            self.example.read_text(),
+            (TEMPLATES / "visual-qa.example.json").read_text(),
+        )
+        self.assertFalse((self.repo / ".sc-state/visual-qa.json").exists())
+
+        self.assertEqual(self.reconcile(), ("current", []))
+
+    def test_older_managed_workflow_is_refreshed_but_example_is_preserved(self):
+        self.workflow.parent.mkdir(parents=True)
+        self.workflow.write_text("# managed-by: subfloor — visual-qa shim v0\nold\n")
+        self.example.parent.mkdir(parents=True)
+        self.example.write_text("fork note\n")
+
+        action, changed = self.reconcile()
+        self.assertEqual(action, "updated")
+        self.assertEqual(changed, [Path(".github/workflows/subfloor-visual-qa.yml")])
+        self.assertEqual(
+            self.workflow.read_text(),
+            (TEMPLATES / "subfloor-visual-qa.yml").read_text(),
+        )
+        self.assertEqual(self.example.read_text(), "fork note\n")
+
+    def test_unmanaged_workflow_is_preserved_while_missing_example_is_seeded(self):
+        self.workflow.parent.mkdir(parents=True)
+        self.workflow.write_text("name: Fork-owned Visual QA\n")
+
+        action, changed = self.reconcile()
+        self.assertEqual(action, "unmanaged")
+        self.assertEqual(changed, [Path(".sc-state/visual-qa.example.json")])
+        self.assertEqual(self.workflow.read_text(), "name: Fork-owned Visual QA\n")
+        self.assertEqual(
+            self.example.read_text(),
+            (TEMPLATES / "visual-qa.example.json").read_text(),
+        )
+
+    def test_same_or_newer_managed_version_is_not_rewritten(self):
+        self.workflow.parent.mkdir(parents=True)
+        self.workflow.write_text("# managed-by: subfloor — visual-qa shim v2\nfuture\n")
+        self.example.parent.mkdir(parents=True)
+        self.example.write_text("existing\n")
+
+        self.assertEqual(self.reconcile(), ("current", []))
+        self.assertEqual(
+            self.workflow.read_text(),
+            "# managed-by: subfloor — visual-qa shim v2\nfuture\n",
+        )
+        self.assertEqual(self.example.read_text(), "existing\n")
+
+    def test_source_repo_rule_is_a_total_no_op(self):
+        with mock.patch.object(update, "is_source_repo", return_value=True):
+            self.assertEqual(
+                update.ensure_workflows(self.repo, TEMPLATES),
+                ("source", []),
+            )
+        self.assertFalse(self.workflow.exists())
+        self.assertFalse(self.example.exists())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Sprint 14, unit 2.

Ships the fork-tracked Visual QA workflow shim and inactive example config, install/init seeding with the source guard, update-time managed-marker reconciliation, explicit manifest coverage, and hermetic regression tests.

Judgement: seed visual-qa.example.json rather than activating visual-qa.json so unconfigured and non-UI forks remain neutral.

Verification:
- 11 focused distribution tests pass
- 28 focused plus neighboring tests pass
- full suite: 455 passed with SC_SANDBOX unset for the host-only VM bake cases
- initial sandbox run: 452 passed; 3 unchanged VM bake tests fail because SC_SANDBOX=1 is inherited