### PR TITLE
feat(boot): source-aware PROJECT vs ENGINE block

### DIFF
--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -32,6 +32,35 @@ MAP_DISCREPANCY_BLOCK = (
     "from what the map *does* show — healing it is the cartographer's job, on its "
     "next boot."
 )
+# PROJECT vs ENGINE renders by repo position (`{{project_vs_engine}}` slot).
+# A fork consumes the engine as a gitignored dependency; the SOURCE repo
+# (origin basename in install.SOURCE_REPO_NAMES — the dogfood repo whose
+# shells build subfloor itself) IS the engine and has no upstream. Same
+# pipeline, described from each end — so source shells stop hunting for an
+# upstream that is them, and fork shells keep the never-edit-engine rule.
+PROJECT_VS_ENGINE_FORK = (
+    "**Your project is this repo** — everything except `.super-coder/`.\n"
+    "`.super-coder/` is the **engine** you run on (your memory + identity\n"
+    "substrate), a gitignored dependency — do not treat it as the project or edit\n"
+    "it. Engine changes are authored upstream in subfloor (formerly super-coder)\n"
+    "and delivered here by `./sc update` — never authored here."
+)
+PROJECT_VS_ENGINE_SOURCE = (
+    "**This repo IS the engine source — you are upstream.** `.super-coder/` is\n"
+    "tracked here and is your work surface: engine changes are authored in this\n"
+    "repo, land via branch → PR → merge, and reach every fork through *their*\n"
+    "`./sc update`. There is no upstream above you to receive fixes from or file\n"
+    "issues to — you are where engine fixes come from.\n"
+    "\n"
+    "Getting your own updates: after an engine change merges, sync with main and\n"
+    "run `./sc update` — in this repo it skips fetch/materialize (the engine is\n"
+    "already here) and reconciles in place: migrations, skills catalogue, repo\n"
+    "map, snapshot. Restart your session to boot onto the new floor.\n"
+    "\n"
+    "Engine skills speak fork-language. Where a skill says \"never edit\n"
+    "`.super-coder/`\" or \"report/file it upstream\", that guidance is for forks —\n"
+    "here you author the fix directly instead."
+)
 # The repo catalogue (dr_*) lives in its OWN db, separate from shell_db.db.
 MAP_DB_PATH = ENGINE.parent / ".sc-state" / "map.db"
 
@@ -213,7 +242,8 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
                  archive_id: int, work_dir: "Path | None" = None,
                  sync_note: "str | None" = None,
                  api_key: "str | None" = None,
-                 api_port: "int | None" = None) -> str:
+                 api_port: "int | None" = None,
+                 source_mode: bool = False) -> str:
     """Assemble the full boot markdown for `shell`, driven by `user`.
 
     work_dir, when set, is the shell's effective working directory (dev-shell
@@ -221,9 +251,14 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
     operates from a worktree rather than the repo root. sync_note is the
     launcher's worktree-drift status (run.sync_worktree) — surfaced alongside
     so a stale or divergent worktree is ambient knowledge, not something the
-    shell must remember to check.
+    shell must remember to check. source_mode flips PROJECT vs ENGINE to the
+    source-repo variant (caller decides via install.is_source_repo() — compose
+    stays a pure render, no git).
     """
     template = TEMPLATE_PATH.read_text().rstrip()
+    template = template.replace(
+        "{{project_vs_engine}}",
+        PROJECT_VS_ENGINE_SOURCE if source_mode else PROJECT_VS_ENGINE_FORK)
     shell_id = shell["shell_id"]
     counts = fetch_counts(con, shell_id)
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -871,6 +871,7 @@ def main() -> None:
         content = compose_boot(con, full, user, session_id, archive_id,
                                work_dir=work_dir if work_dir != REPO_ROOT else None,
                                sync_note=sync_note,
+                               source_mode=install.is_source_repo(),
                                api_key=full["api_key"],
                                api_port=api_port)
 

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -22,10 +22,7 @@ One memory system, not two. Auto-memory is disabled by design.
 
 ## PROJECT vs ENGINE
 
-**Your project is this repo** — everything except `.super-coder/`.
-`.super-coder/` is the **engine** you run on (your memory + identity
-substrate), a gitignored dependency — do not treat it as the project or edit
-it. Engine changes are authored upstream in super-coder, never here.
+{{project_vs_engine}}
 
 ---
 

--- a/tests/test_boot_project_vs_engine.py
+++ b/tests/test_boot_project_vs_engine.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Tests for the source-aware PROJECT vs ENGINE boot block (render/compose.py).
+
+The contract: templates/boot.md carries exactly one `{{project_vs_engine}}`
+slot; compose substitutes the fork block by default and the source block when
+source_mode is set. A fork boot must keep the never-edit-engine rule and name
+its upstream; a source boot must say the opposite — you are upstream, the
+engine is your work surface — and defuse the fork-language in engine skills.
+Losing the slot (a template edit) or a constant would silently drop the whole
+section from every boot doc; this pins both.
+
+Run:
+    python3 tests/test_boot_project_vs_engine.py
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "render"))
+import compose  # noqa: E402
+
+SLOT = "{{project_vs_engine}}"
+
+
+class ProjectVsEngineTest(unittest.TestCase):
+    def setUp(self):
+        self.template = compose.TEMPLATE_PATH.read_text()
+
+    def test_template_carries_slot_exactly_once(self):
+        self.assertEqual(self.template.count(SLOT), 1)
+
+    def test_template_has_no_hardcoded_variant(self):
+        # The block must come from the slot — a hardcoded copy in the template
+        # would render alongside (or instead of) the mode-picked constant.
+        self.assertNotIn("authored upstream", self.template)
+        self.assertNotIn("you are upstream", self.template)
+
+    def test_fork_block_keeps_the_dependency_stance(self):
+        fork = compose.PROJECT_VS_ENGINE_FORK
+        self.assertIn("do not treat it as the project or edit", fork)
+        self.assertIn("authored upstream in subfloor", fork)
+        self.assertIn("`./sc update`", fork)
+        self.assertNotIn("you are upstream", fork)
+
+    def test_source_block_inverts_it(self):
+        source = compose.PROJECT_VS_ENGINE_SOURCE
+        self.assertIn("you are upstream", source)
+        self.assertIn("There is no upstream above you", source)
+        self.assertIn("`./sc update`", source)  # the self-update loop
+        self.assertIn("fork-language", source)  # the skills caveat
+        self.assertNotIn("do not treat it as the project", source)
+
+    def test_substitution_resolves_per_mode(self):
+        fork_render = self.template.replace(SLOT, compose.PROJECT_VS_ENGINE_FORK)
+        source_render = self.template.replace(SLOT, compose.PROJECT_VS_ENGINE_SOURCE)
+        for render in (fork_render, source_render):
+            self.assertNotIn(SLOT, render)
+        self.assertIn("gitignored dependency", fork_render)
+        self.assertIn("you are upstream", source_render)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The dogfood repo's own shells boot the same PROJECT vs ENGINE block forks get — "engine changes are authored upstream, never here" — so they keep hunting for an upstream that is *them*. The update mechanics were already source-aware (`update.py` skips fetch/materialize in the source repo and reconciles in place); this makes the boot narrative match, telling each audience where it sits in the same pipeline:

- **Source shells** now boot: you are upstream, `.super-coder/` is your work surface, your update loop is merge → sync → `./sc update` (in-place reconcile) → restart — plus a caveat that engine skills speak fork-language ("never edit `.super-coder/`", "file it upstream") which doesn't apply here.
- **Fork shells** keep the exact stance they had, renamed to subfloor and now naming the delivery mechanism ("delivered here by `./sc update`").

Mechanically: the block moves to a `{{project_vs_engine}}` slot in `templates/boot.md` (same pattern as `{{map_discrepancy}}`), mode-picked in `compose.py`; `run.py` passes `install.is_source_repo()` so compose stays a pure render. No fork can trip into source mode — the branch keys off origin basename ∈ `SOURCE_REPO_NAMES`.

Test plan:
- [x] `tests/test_boot_project_vs_engine.py` — slot present exactly once, no hardcoded variant left in the template, both constants pin their key clauses, substitution resolves per mode
- [x] `compose_boot` exercised end-to-end read-only against the live DB in both modes (slot resolved; source text in, fork text out, and vice versa)
- [x] `is_source_repo()` confirmed True in this repo; `test_source_repo_guard.py` + `test_update_materialize.py` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)