### PR TITLE
feat(launcher): mark occupied shells in the boot picker + confirm guard

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -525,8 +525,54 @@ def _default_label(defaults: dict, flavor: str | None) -> str:
     return harness + (f" · {model.split('/')[-1]}" if model else "")
 
 
+def _liveness_note(shell, snap: "dict | None") -> str:
+    """Picker row annotation from the liveness snapshot: '(busy)' — a live
+    harness session holds the worktree; '(orphan?)' — the slot is held only by
+    survivors of closed terminals / dead parents; '(Exempt)' — the admin boots
+    at the repo root, outside the worktree signal, so it is never marked or
+    guarded. Empty when dormant or when no snapshot was taken (non-TTY)."""
+    if shell["flavor"] == "admin":
+        return style.dim("  (Exempt)")
+    if not snap:
+        return ""
+    state = shell_liveness.session_state(shell["shortname"] or "", snap)
+    if state == "busy":
+        return style.yellow("  (busy)")
+    if state == "orphan":
+        return style.yellow("  (orphan?)")
+    return ""
+
+
+def confirm_live(shell, snap: "dict | None") -> bool:
+    """Interactive twin of the headless liveness refusal: booting a shell whose
+    worktree already hosts a live session runs two sessions against one tree +
+    one memory row set, so warn and put the call to the operator. True → boot
+    (dormant, admin-exempt, no snapshot, or the operator said yes)."""
+    if not snap or shell["flavor"] == "admin" or not shell["shortname"]:
+        return True
+    state = shell_liveness.session_state(shell["shortname"], snap)
+    if state is None:
+        return True
+    pids, orphans = shell_liveness.orphan_split(shell["shortname"], snap)
+    if state == "orphan":
+        print(style.yellow(
+            f"\n  ⚠ {shell['shortname']} slot is held by an ORPHANED session "
+            f"(pid {', '.join(map(str, orphans))} — terminal closed / parent "
+            f"gone)."))
+        print(style.dim(
+            f"    Verify it is idle (`ps -o etime=,stat= -p {orphans[0]}`; no "
+            f"busy children), `kill` it, then boot. An orphan can still be "
+            f"mid-work — never kill unverified."))
+    else:
+        print(style.yellow(
+            f"\n  ⚠ {shell['shortname']} already has a live session "
+            f"(pid {', '.join(map(str, pids))}) — one shell, one session."))
+    return input("  Boot anyway? [y/N]: ").strip().lower() in ("y", "yes")
+
+
 def pick_shell(shells: list, requested: str | None,
-               first: bool, defaults: dict | None = None):
+               first: bool, defaults: dict | None = None,
+               snap: "dict | None" = None):
     defaults = defaults or {}
     if not shells:
         sys.exit("FATAL: no shells available to this user.")
@@ -557,11 +603,18 @@ def pick_shell(shells: list, requested: str | None,
         name = style.bold("{:<16}".format(s["display_name"] or ""))
         short = "{:<14}".format(s["shortname"] or "")
         print(f"{num}  {name}{short}"
-              f"{style.dim(_default_label(defaults, s['flavor']))}")
+              f"{style.dim(_default_label(defaults, s['flavor']))}"
+              f"{_liveness_note(s, snap)}")
+    if snap and snap.get("indeterminate"):
+        print(style.dim(f"\n  ⚠ {snap['indeterminate']} harness process(es) "
+                        f"with unreadable cwd — liveness markers are partial."))
     while True:
         choice = input("\nPick (#): ").strip()
         if choice.isdigit() and 1 <= int(choice) <= len(shells):
-            return shells[int(choice) - 1]
+            chosen = shells[int(choice) - 1]
+            if not confirm_live(chosen, snap):
+                continue          # operator declined — back to the picker
+            return chosen
         print("  invalid choice")
 
 
@@ -739,12 +792,24 @@ def main() -> None:
 
     user = authenticate(con, interactive=not headless)
     fdefaults = flavor_defaults(con)
-    chosen = pick_shell(list_shells(con, user["user_id"]), requested, first, fdefaults)
+    # Liveness snapshot for the interactive picker: one /proc pass (ms) so the
+    # boot list can mark occupied shells — (busy) / (orphan?) / (Exempt) — and
+    # confirm before booting into a live worktree. Headless keeps its own lazy
+    # compute below; non-TTY boots (--first, piped) can't confirm, so no snap.
+    snap = (shell_liveness.compute()
+            if not headless and sys.stdin.isatty() else None)
+    chosen = pick_shell(list_shells(con, user["user_id"]), requested, first,
+                        fdefaults, snap)
+    # Direct interactive boots (`./sc enter dev3`) skip the picker and its
+    # confirm — run the same guard here. Picker path already confirmed.
+    if requested and not headless and not confirm_live(chosen, snap):
+        sys.exit(f"aborted — shell '{chosen['shortname']}' has a live session "
+                 f"(one shell, one session; see shell_liveness)")
 
-    # Liveness guard (headless only): one shell, one session. A headless boot
+    # Liveness guard (headless): one shell, one session. A headless boot
     # into a worktree that already hosts a live harness would run two sessions
     # of the same shell against one tree + one memory row set. Interactive
-    # boots keep the operator's judgment; `sc run` is scripted, so it refuses.
+    # boots warn + confirm (above); `sc run` is scripted, so it refuses.
     # Admin boots at the repo root (no worktree signal), so it isn't guarded.
     if headless and chosen["shortname"] and chosen["flavor"] != "admin":
         snap = shell_liveness.compute()

--- a/.super-coder/scripts/shell_liveness.py
+++ b/.super-coder/scripts/shell_liveness.py
@@ -294,6 +294,20 @@ def orphan_split(shortname: str, snap: dict) -> "tuple[list[int], list[int]]":
             [p["pid"] for p in procs if p.get("orphaned")])
 
 
+def session_state(shortname: str, snap: dict) -> "str | None":
+    """One shell's slot verdict, the shape the picker annotation needs:
+    'busy' (a working session holds the worktree), 'orphan' (EVERY session pid
+    is an orphan — closed terminal / dead parent still holding the slot), or
+    None (dormant, or liveness unsupported). A single live session among
+    orphans wins: someone is working there → 'busy'."""
+    if not snap.get("supported"):
+        return None
+    pids, orphans = orphan_split(shortname, snap)
+    if not pids:
+        return None
+    return "orphan" if len(orphans) == len(pids) else "busy"
+
+
 def _print_text(d: dict) -> None:
     if not d.get("supported"):
         print(f"{d['repo']['name']}: liveness unsupported — {d.get('note','')}")

--- a/tests/test_shell_liveness.py
+++ b/tests/test_shell_liveness.py
@@ -86,6 +86,38 @@ class OrphanSplitTest(unittest.TestCase):
         self.assertEqual(([], []), shell_liveness.orphan_split("ghost", self.SNAP))
 
 
+class SessionStateTest(unittest.TestCase):
+    """session_state shapes the picker annotation: 'busy' / 'orphan' / None."""
+
+    SNAP = {
+        "supported": True,
+        "processes": [
+            {"pid": 100, "shortname": "dev1", "orphaned": "tty-gone"},
+            {"pid": 101, "shortname": "dev1", "orphaned": None},
+            {"pid": 200, "shortname": "dev2", "orphaned": "detached"},
+            {"pid": 300, "shortname": None, "orphaned": None},  # admin root
+        ],
+    }
+
+    def test_live_session_wins_over_orphan_sibling(self):
+        # One working session among orphans → someone is there → busy.
+        self.assertEqual("busy", shell_liveness.session_state("dev1", self.SNAP))
+
+    def test_all_orphaned_is_orphan(self):
+        self.assertEqual("orphan", shell_liveness.session_state("dev2", self.SNAP))
+
+    def test_dormant_shell_is_none(self):
+        self.assertIsNone(shell_liveness.session_state("ghost", self.SNAP))
+
+    def test_case_insensitive_shortname(self):
+        self.assertEqual("orphan", shell_liveness.session_state("DEV2", self.SNAP))
+
+    def test_unsupported_snapshot_is_none(self):
+        # Non-Linux: no /proc → no verdicts, the picker degrades to unmarked.
+        self.assertIsNone(shell_liveness.session_state(
+            "dev2", {"supported": False, "processes": self.SNAP["processes"]}))
+
+
 class ComputeSmokeTest(unittest.TestCase):
     """compute() against the real /proc: shape only, no liveness assumptions."""
 


### PR DESCRIPTION
## What

The interactive boot list (`./sc enter`) now shows which shells are occupied, and guards against booting into a live one:

- **`(busy)`** — a live harness session's cwd sits in that shell's worktree
- **`(orphan?)`** — the slot is held only by orphaned sessions (terminal closed / parent gone); likely a stale pid to verify and kill
- **`(Exempt)`** — the admin shell boots at the repo root, outside the worktree cwd signal, so it is never marked or guarded (matches the existing headless exemption)

Picking a live shell in the picker — or direct-booting one with `./sc enter <name>` — now warns with the holding pid(s) and asks `Boot anyway? [y/N]` (default No). The picker returns to the list on decline; the direct path aborts. This is the interactive twin of the existing headless `sc run` refusal, which is unchanged.

## How

One `shell_liveness.compute()` pass (a /proc scan, milliseconds) taken only for interactive TTY boots. New pure helper `shell_liveness.session_state()` carries the verdict (`busy` / `orphan` / `None`; one working session among orphans wins → busy), sitting next to `is_active` / `orphan_split`.

Degradations: non-TTY boots (`--first`, piped) take no snapshot and behave exactly as before; non-Linux (`supported=False`) renders an unmarked list; unreadable foreign-user processes print a dim "markers are partial" footer.

## Testing

- `python3 tests/test_shell_liveness.py` — 17 pass (5 new `session_state` cases: busy-wins-over-orphan-sibling, all-orphaned, dormant, case-insensitivity, unsupported-snapshot)
- Smoke-tested marker rendering and the confirm guard (y / n / bare-Enter-defaults-No) against a fabricated snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)