### PR TITLE
fix: handle Visual QA gallery collisions

### DIFF
--- a/.super-coder/scripts/visual_qa.py
+++ b/.super-coder/scripts/visual_qa.py
@@ -1137,6 +1137,30 @@ def cmd_ci(
     if config is not None:
         gallery = repo / Path(str(config["output"]))
     write_workflow_output("output", gallery.relative_to(repo).as_posix(), environ=env)
+
+    if config is None:
+        summary = result_summary(
+            gallery,
+            "neutral",
+            reason="Visual QA is not configured — run `./sc visual-qa init`.",
+            write=False,
+        )
+        publish_result(summary, environ=env)
+        print("visual-qa: not configured — neutral pass")
+        return 0
+
+    changed = changed_paths(repo, environ=env)
+    if should_skip(config["paths"], changed):
+        summary = result_summary(
+            gallery,
+            "neutral",
+            reason="No configured app paths changed.",
+            write=False,
+        )
+        publish_result(summary, environ=env)
+        print("visual-qa: no app paths changed — neutral pass")
+        return 0
+
     try:
         prepare_gallery(gallery)
     except Exception as exc:
@@ -1147,25 +1171,6 @@ def cmd_ci(
         publish_result(summary, environ=env)
         print(f"visual-qa: {error}", file=sys.stderr)
         return 1
-
-    if config is None:
-        summary = result_summary(
-            gallery,
-            "neutral",
-            reason="Visual QA is not configured — run `./sc visual-qa init`.",
-        )
-        publish_result(summary, environ=env)
-        print("visual-qa: not configured — neutral pass")
-        return 0
-
-    changed = changed_paths(repo, environ=env)
-    if should_skip(config["paths"], changed):
-        summary = result_summary(
-            gallery, "neutral", reason="No configured app paths changed."
-        )
-        publish_result(summary, environ=env)
-        print("visual-qa: no app paths changed — neutral pass")
-        return 0
 
     boot_log = gallery / "boot.log"
     try:

--- a/.super-coder/scripts/visual_qa.py
+++ b/.super-coder/scripts/visual_qa.py
@@ -69,6 +69,21 @@ def _string_list(value: object, key: str, *, allow_empty: bool = True) -> list[s
     return list(value)
 
 
+def _relative_output(value: object, key: str = "output") -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or any(character in value for character in ("\0", "\r", "\n"))
+    ):
+        raise VisualQaError(f"config key '{key}' must be a non-empty string")
+    output = Path(value.strip())
+    if output.is_absolute() or ".." in output.parts or output == Path("."):
+        raise VisualQaError(
+            f"config key '{key}' must be a non-root path within the fork checkout"
+        )
+    return output.as_posix()
+
+
 def _validate_viewports(value: object) -> list[dict[str, object]]:
     if value == "default":
         return [dict(viewport) for viewport in DEFAULT_VIEWPORTS]
@@ -131,6 +146,7 @@ def validate_config(raw: object) -> dict[str, object]:
         "paths",
         "services",
         "artifact_retention_days",
+        "output",
     }
     unknown = set(raw) - known
     if unknown:
@@ -190,6 +206,7 @@ def validate_config(raw: object) -> dict[str, object]:
             minimum=1,
             maximum=90,
         ),
+        "output": _relative_output(raw.get("output", DEFAULT_GALLERY.as_posix())),
     }
 
 
@@ -453,7 +470,7 @@ def ci_app(
             service.stop(log)
 
 
-def prepare_gallery(gallery: Path) -> None:
+def prepare_gallery(gallery: Path, *, output_hint: str = "config key 'output'") -> None:
     if not gallery.exists():
         gallery.mkdir(parents=True)
         return
@@ -477,7 +494,7 @@ def prepare_gallery(gallery: Path) -> None:
     if not isinstance(summary, dict) or not required_keys.issubset(summary):
         raise VisualQaError(
             f"gallery directory exists and isn't visual-QA output: {gallery}; "
-            "move it or choose another --output directory"
+            f"move it or choose another {output_hint}"
         )
 
     shutil.rmtree(gallery)
@@ -711,7 +728,12 @@ article{{background:#1d1d1d;padding:1rem;border-radius:.5rem}}img{{width:100%;he
 
 
 def result_summary(
-    gallery: Path, outcome: str, *, reason: str | None = None, error: str | None = None
+    gallery: Path,
+    outcome: str,
+    *,
+    reason: str | None = None,
+    error: str | None = None,
+    write: bool = True,
 ) -> dict[str, object]:
     summary: dict[str, object] = {
         "generated_at": _utc_now(),
@@ -724,7 +746,8 @@ def result_summary(
         summary["reason"] = reason
     if error:
         summary["error"] = error
-    write_gallery(gallery, summary)
+    if write:
+        write_gallery(gallery, summary)
     return summary
 
 
@@ -906,6 +929,20 @@ def write_step_summary(body: str, *, environ: dict[str, str] | None = None) -> N
         print(f"visual-qa: could not write GITHUB_STEP_SUMMARY: {exc}", file=sys.stderr)
 
 
+def write_workflow_output(
+    name: str, value: str, *, environ: dict[str, str] | None = None
+) -> None:
+    env = dict(os.environ) if environ is None else environ
+    target = env.get("GITHUB_OUTPUT")
+    if not target:
+        return
+    try:
+        with Path(target).open("a") as output:
+            print(f"{name}={value}", file=output)
+    except OSError as exc:
+        print(f"visual-qa: could not write GITHUB_OUTPUT: {exc}", file=sys.stderr)
+
+
 def publish_result(
     summary: dict[str, object], *, environ: dict[str, str] | None = None
 ) -> str:
@@ -1049,7 +1086,7 @@ def cmd_run(
     if output.is_absolute() or ".." in output.parts or output in (Path("."), Path("")):
         raise VisualQaError("--output must be a non-root path within the fork checkout")
     gallery = repo / output
-    prepare_gallery(gallery)
+    prepare_gallery(gallery, output_hint="--output directory")
     summary = capture_gallery(
         config, base_url, gallery, capture_factory=capture_factory
     )
@@ -1081,13 +1118,34 @@ def cmd_ci(
 ) -> int:
     env = dict(os.environ) if environ is None else environ
     gallery = repo / DEFAULT_GALLERY
-    prepare_gallery(gallery)
     try:
         config = load_config(repo)
     except VisualQaError as exc:
-        summary = result_summary(gallery, "failed", error=str(exc))
+        write_workflow_output("output", DEFAULT_GALLERY.as_posix(), environ=env)
+        try:
+            prepare_gallery(gallery)
+            write_summary = True
+            error = str(exc)
+        except Exception as prepare_exc:
+            write_summary = False
+            error = f"{exc}; gallery preparation also failed: {prepare_exc}"
+        summary = result_summary(gallery, "failed", error=error, write=write_summary)
         publish_result(summary, environ=env)
-        print(f"visual-qa: {exc}", file=sys.stderr)
+        print(f"visual-qa: {error}", file=sys.stderr)
+        return 1
+
+    if config is not None:
+        gallery = repo / Path(str(config["output"]))
+    write_workflow_output("output", gallery.relative_to(repo).as_posix(), environ=env)
+    try:
+        prepare_gallery(gallery)
+    except Exception as exc:
+        error = (
+            str(exc) if isinstance(exc, VisualQaError) else f"unexpected error: {exc}"
+        )
+        summary = result_summary(gallery, "failed", error=error, write=False)
+        publish_result(summary, environ=env)
+        print(f"visual-qa: {error}", file=sys.stderr)
         return 1
 
     if config is None:

--- a/.super-coder/templates/fork/subfloor-visual-qa.yml
+++ b/.super-coder/templates/fork/subfloor-visual-qa.yml
@@ -1,4 +1,4 @@
-# managed-by: subfloor — visual-qa shim v2
+# managed-by: subfloor — visual-qa shim v3
 # Edits are overwritten by `make update`. Delete the managed-by line to take
 # ownership; subfloor will then leave this file alone.
 name: Subfloor Visual QA
@@ -51,7 +51,8 @@ jobs:
               days = 14
           with open(os.environ["GITHUB_OUTPUT"], "a") as out:
               print(f"retention={days}", file=out)
-      - run: ./sc visual-qa ci
+      - id: visual_qa
+        run: ./sc visual-qa ci
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Upload Visual QA gallery
@@ -59,6 +60,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: visual-qa-gallery
-          path: gallery/
+          path: ${{ steps.visual_qa.outputs.output || 'gallery' }}/
           if-no-files-found: warn
           retention-days: ${{ steps.config.outputs.retention || 14 }}

--- a/.super-coder/templates/fork/visual-qa.example.json
+++ b/.super-coder/templates/fork/visual-qa.example.json
@@ -10,5 +10,6 @@
   "viewports": "default",
   "paths": ["src/**", "static/**", "package.json"],
   "services": [],
+  "output": "gallery",
   "artifact_retention_days": 14
 }

--- a/tests/test_visual_qa.py
+++ b/tests/test_visual_qa.py
@@ -571,10 +571,43 @@ class ModeTest(unittest.TestCase):
             summary["reason"],
             "Visual QA is not configured — run `./sc visual-qa init`.",
         )
+        self.assertFalse((self.repo / "gallery").exists())
+
+    def test_ci_without_config_ignores_tracked_gallery_and_publishes_neutral(self):
+        tracked = self.repo / "gallery" / "tracked-app-file.txt"
+        tracked.parent.mkdir()
+        tracked.write_bytes(b"keep me")
+        step_summary = self.repo / "step-summary.md"
+        github_output = self.repo / "github-output"
+        installer = mock.Mock(side_effect=AssertionError("installer called"))
+        app = mock.Mock(side_effect=AssertionError("app called"))
+
+        with mock.patch.object(visual_qa, "post_sticky_comment") as post:
+            code = visual_qa.cmd_ci(
+                argparse.Namespace(),
+                repo=self.repo,
+                environ={
+                    "GITHUB_OUTPUT": str(github_output),
+                    "GITHUB_STEP_SUMMARY": str(step_summary),
+                },
+                installer=installer,
+                app_context=app,
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(installer.call_count, 0)
+        self.assertEqual(app.call_count, 0)
+        self.assertEqual(tracked.read_bytes(), b"keep me")
         self.assertEqual(
-            json.loads((self.repo / "gallery" / "summary.json").read_text())["outcome"],
-            "neutral",
+            [path.name for path in tracked.parent.iterdir()], [tracked.name]
         )
+        body = post.call_args.args[0]
+        self.assertIn("### ◻ Visual QA skipped", body)
+        self.assertIn("Visual QA is not configured", body)
+        written_summary = step_summary.read_text()
+        self.assertIn("### ◻ Visual QA skipped", written_summary)
+        self.assertIn("Visual QA is not configured", written_summary)
+        self.assertEqual(github_output.read_text(), "output=gallery\n")
 
     def test_ci_path_skip_is_neutral_and_does_not_cross_capture_boundaries(self):
         self.write_config(paths=["src/**"])

--- a/tests/test_visual_qa.py
+++ b/tests/test_visual_qa.py
@@ -96,6 +96,7 @@ class ConfigTest(unittest.TestCase):
         self.assertIsNone(config["paths"])
         self.assertEqual(config["services"], [])
         self.assertEqual(config["artifact_retention_days"], 14)
+        self.assertEqual(config["output"], "gallery")
 
     def test_invalid_contract_branches_are_rejected_with_specific_errors(self):
         cases = (
@@ -114,6 +115,14 @@ class ConfigTest(unittest.TestCase):
             (
                 {"serve": "x", "routes": ["/"], "port": True},
                 "'port' must be an integer",
+            ),
+            (
+                {"serve": "x", "routes": ["/"], "output": "../gallery"},
+                "'output' must be a non-root path within the fork checkout",
+            ),
+            (
+                {"serve": "x", "routes": ["/"], "output": "bad\npath"},
+                "'output' must be a non-empty string",
             ),
             (
                 {
@@ -588,6 +597,80 @@ class ModeTest(unittest.TestCase):
         self.assertEqual(
             publish.call_args.args[0]["reason"], "No configured app paths changed."
         )
+
+    def test_ci_uses_validated_config_output_instead_of_tracked_gallery(self):
+        self.write_config(
+            output="artifacts/visual-qa",
+            viewports=[{"name": "phone", "width": 375, "height": 812}],
+        )
+        tracked = self.repo / "gallery" / "app-image.png"
+        tracked.parent.mkdir()
+        tracked.write_bytes(b"fork-owned")
+
+        @contextmanager
+        def app(_config, _repo, log):
+            log.write("ready\n")
+            yield "http://app", {}
+
+        github_output = self.repo / "github-output"
+        code = visual_qa.cmd_ci(
+            argparse.Namespace(),
+            repo=self.repo,
+            environ={"GITHUB_OUTPUT": str(github_output)},
+            changed_paths=lambda *_args, **_kwargs: None,
+            installer=lambda: None,
+            app_context=app,
+            capture_factory=capture_factory({"default": OK}, []),
+        )
+
+        output = self.repo / "artifacts" / "visual-qa"
+        self.assertEqual(code, 0)
+        self.assertEqual(tracked.read_bytes(), b"fork-owned")
+        self.assertEqual(
+            [path.name for path in tracked.parent.iterdir()], [tracked.name]
+        )
+        self.assertTrue((output / "root" / "phone.png").is_file())
+        self.assertEqual(
+            json.loads((output / "summary.json").read_text())["outcome"], "passed"
+        )
+        self.assertEqual(github_output.read_text(), "output=artifacts/visual-qa\n")
+
+    def test_ci_gallery_collision_publishes_failure_without_touching_fork_files(self):
+        self.write_config()
+        tracked = self.repo / "gallery" / "tracked-app-file.txt"
+        tracked.parent.mkdir()
+        tracked.write_bytes(b"keep me")
+        step_summary = self.repo / "step-summary.md"
+        github_output = self.repo / "github-output"
+        installer = mock.Mock(side_effect=AssertionError("installer called"))
+        app = mock.Mock(side_effect=AssertionError("app called"))
+
+        with mock.patch.object(visual_qa, "post_sticky_comment") as post:
+            code = visual_qa.cmd_ci(
+                argparse.Namespace(),
+                repo=self.repo,
+                environ={
+                    "GITHUB_OUTPUT": str(github_output),
+                    "GITHUB_STEP_SUMMARY": str(step_summary),
+                },
+                installer=installer,
+                app_context=app,
+            )
+
+        self.assertEqual(code, 1)
+        self.assertEqual(installer.call_count, 0)
+        self.assertEqual(app.call_count, 0)
+        self.assertEqual(tracked.read_bytes(), b"keep me")
+        self.assertEqual(
+            [path.name for path in tracked.parent.iterdir()], [tracked.name]
+        )
+        body = post.call_args.args[0]
+        self.assertIn("### ✗ Visual QA could not run", body)
+        self.assertIn("choose another config key 'output'", body)
+        written_summary = step_summary.read_text()
+        self.assertIn("### ✗ Visual QA could not run", written_summary)
+        self.assertIn("choose another config key 'output'", written_summary)
+        self.assertEqual(github_output.read_text(), "output=gallery\n")
 
     def test_ci_runs_mock_capture_and_fails_only_when_all_routes_fail(self):
         self.write_config(

--- a/tests/test_visual_qa_distribution.py
+++ b/tests/test_visual_qa_distribution.py
@@ -25,7 +25,7 @@ class VisualQaTemplateTest(unittest.TestCase):
     def test_workflow_is_the_fixed_managed_shim(self):
         text = (TEMPLATES / "subfloor-visual-qa.yml").read_text()
 
-        self.assertTrue(text.startswith("# managed-by: subfloor — visual-qa shim v2\n"))
+        self.assertTrue(text.startswith("# managed-by: subfloor — visual-qa shim v3\n"))
         self.assertIn("pull_request:\n", text)
         self.assertIn("workflow_dispatch:\n", text)
         self.assertIn("contents: read\n", text)
@@ -37,6 +37,8 @@ class VisualQaTemplateTest(unittest.TestCase):
         self.assertNotIn("playwright==", text)
         self.assertIn("GITHUB_TOKEN: ${{ github.token }}", text)
         self.assertIn("if: always()\n        uses: actions/upload-artifact@v4", text)
+        self.assertIn("id: visual_qa\n        run: ./sc visual-qa ci", text)
+        self.assertIn("path: ${{ steps.visual_qa.outputs.output || 'gallery' }}/", text)
 
     def test_example_config_is_valid_and_inactive(self):
         config = json.loads((TEMPLATES / "visual-qa.example.json").read_text())
@@ -54,6 +56,7 @@ class VisualQaTemplateTest(unittest.TestCase):
                 "viewports": "default",
                 "paths": ["src/**", "static/**", "package.json"],
                 "services": [],
+                "output": "gallery",
                 "artifact_retention_days": 14,
             },
         )
@@ -187,7 +190,7 @@ class VisualQaUpdateTest(unittest.TestCase):
 
     def test_older_managed_workflow_is_refreshed_but_example_is_preserved(self):
         self.workflow.parent.mkdir(parents=True)
-        self.workflow.write_text("# managed-by: subfloor — visual-qa shim v1\nold\n")
+        self.workflow.write_text("# managed-by: subfloor — visual-qa shim v2\nold\n")
         self.example.parent.mkdir(parents=True)
         self.example.write_text("fork note\n")
 
@@ -215,14 +218,14 @@ class VisualQaUpdateTest(unittest.TestCase):
 
     def test_same_or_newer_managed_version_is_not_rewritten(self):
         self.workflow.parent.mkdir(parents=True)
-        self.workflow.write_text("# managed-by: subfloor — visual-qa shim v2\nfuture\n")
+        self.workflow.write_text("# managed-by: subfloor — visual-qa shim v3\nfuture\n")
         self.example.parent.mkdir(parents=True)
         self.example.write_text("existing\n")
 
         self.assertEqual(self.reconcile(), ("current", []))
         self.assertEqual(
             self.workflow.read_text(),
-            "# managed-by: subfloor — visual-qa shim v2\nfuture\n",
+            "# managed-by: subfloor — visual-qa shim v3\nfuture\n",
         )
         self.assertEqual(self.example.read_text(), "existing\n")
 


### PR DESCRIPTION
## Summary
- add validated optional `output` config with `gallery` default
- report gallery preparation failures through sticky comment and step summary without modifying fork-owned contents
- route artifact uploads through the runner-selected output and refresh managed shims to v3

## Tests
- `.venv/bin/pytest -q tests/test_visual_qa.py tests/test_visual_qa_distribution.py` (40 passed, 10 subtests)
- `env -u SC_SANDBOX .venv/bin/pytest -q` (503 passed, 10 subtests)
- Ruff, py_compile, shell syntax, and diff checks

## Sprint 14 unit 3
Ambiguity call: a runner-only output key would leave the artifact uploader pinned to `gallery/`; this PR emits the validated runner path as a step output and bumps the managed shim v2→v3 so existing forks receive the complete escape.