### PR TITLE
docs(issue_reporting): require engine staleness check in upstream reports

### DIFF
--- a/.super-coder/migrations/0074_reseed_issue_reporting_staleness.sql
+++ b/.super-coder/migrations/0074_reseed_issue_reporting_staleness.sql
@@ -1,17 +1,27 @@
----
-name: issue_reporting
-description: Report engine defects upstream — the moment a ./sc command fails or lies, a skill contradicts your reality, the API blocks a documented workflow, or you work around the engine to proceed. File a GitHub issue on super-coder; your repo's app bugs stay in the fork.
-category: substrate
-common: true
----
+-- 0074 — reseed: issue_reporting staleness check.
+--
+-- Upstream triage of the July issue wave found repeat filings from forks on
+-- stale engine refs for defects already fixed at head. The capture step now
+-- requires comparing engine.ref to upstream head and stating current/behind
+-- in every report. Source asset updated in the same commit; this trailing
+-- forward reseed (UPSERT by name; skill_id + grants preserved) carries it to
+-- installed forks and fresh builds alike.
 
-# issue_reporting — the backwards flow
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'issue_reporting',
+  'Report engine defects upstream — the moment a ./sc command fails or lies, a skill contradicts your reality, the API blocks a documented workflow, or you work around the engine to proceed. File a GitHub issue on super-coder; your repo''s app bugs stay in the fork.',
+  'substrate',
+  NULL,
+  1,
+  '# issue_reporting — the backwards flow
 
 An engine defect fixed upstream reaches every fork via `./sc update`; worked
 around silently, every fork re-derives the workaround. File the issue while
 the failure is on screen — NEVER batch to session end.
 
-A workaround IS a report: deviating from a skill's steps, wrapping a command,
+A workaround IS a report: deviating from a skill''s steps, wrapping a command,
 or hand-patching state to proceed -> you hold the exact repro; file it now.
 
 ## Boundary — engine vs fork
@@ -19,7 +29,7 @@ or hand-patching state to proceed -> you hold the exact repro; file it now.
 | Where | What |
 |---|---|
 | **Upstream — file it** | anything the engine materializes/owns: `.super-coder/`, `sc` + every subcommand, engine skills (this catalogue), the boot doc render, the sandbox / dev kit, `./sc update` + migrations, the `_sc` API + `sc mem` |
-| **Fork — don't** | the repo's app code, fork-local skills (see `local_skill_management`), operator-owned host config |
+| **Fork — don''t** | the repo''s app code, fork-local skills (see `local_skill_management`), operator-owned host config |
 
 Unsure -> "would the same problem hit any other fork?" yes = upstream.
 
@@ -33,14 +43,14 @@ Match the left column -> file.
 | A `./sc` command fails out of the box | `./sc verify` always aborted — its own render step needed `SC_ADMIN` it never set (#227) |
 | A command exits green without doing the work | `./sc test` silently fell back to unittest when pytest was missing — green-washed suites (#219) |
 | The documented remedy is a closed loop | `./sc lint` said "run `./sc deps` first," but deps skips pip in the sandbox — tool unobtainable from inside the box (#246) |
-| A skill instructs tools/paths your seat doesn't have | `configure_winbox` drove raw `ssh`/`virsh` — neither exists in the broker-only sandbox (#248) |
+| A skill instructs tools/paths your seat doesn''t have | `configure_winbox` drove raw `ssh`/`virsh` — neither exists in the broker-only sandbox (#248) |
 | A skill contradicts what the engine actually does | skills still taught raw `sqlite3` against the substrate DB after memory went API-only (#226) |
-| The API refuses what the skills document | `sc mem doc add` 400'd standalone docs the docs + onboard skills both document (#245) |
-| A permission wall mid-workflow | a dev shell could read a planner-owned feature but 404'd advancing its status (#224) |
-| Every write suddenly 401s | rebuild didn't re-mint api_keys — all live shells locked out until an API bounce (#214) |
+| The API refuses what the skills document | `sc mem doc add` 400''d standalone docs the docs + onboard skills both document (#245) |
+| A permission wall mid-workflow | a dev shell could read a planner-owned feature but 404''d advancing its status (#224) |
+| Every write suddenly 401s | rebuild didn''t re-mint api_keys — all live shells locked out until an API bounce (#214) |
 | `./sc update` / migrate wedges or half-applies | migration failed partway, retry died on `duplicate column name` (#229); update aborted crossing a commit that deleted an engine file (#209) |
 | A structural foot-gun keeps re-biting you | the cwd trap — `cd` to root for `./sc`, then bare git hit the wrong tree, "my edits vanished" (#225) |
-| The sandbox can reach something it shouldn't | `do_push` src/dest weren't contained — sandbox→host escape (#228) |
+| The sandbox can reach something it shouldn''t | `do_push` src/dest weren''t contained — sandbox→host escape (#228) |
 
 Stale guidance (skill says X, engine does Y) files the same as a crash.
 
@@ -52,7 +62,7 @@ Stale guidance (skill says X, engine does Y) files the same as a crash.
   `current` or `behind head <sha7>`. Behind + the symptom is a missing
   command or a skill/engine mismatch -> the fix may already be shipped:
   ask your FnB for `./sc update` first, and file only if the defect
-  survives the update (or updating isn't an option — then the staleness
+  survives the update (or updating isn''t an option — then the staleness
   note carries that caveat). Triage reads this line to tell a live
   engine defect from a stale fork build.
 - **fork + seat**: repo name, shell flavor, sandbox/host
@@ -71,7 +81,7 @@ gh issue list --repo jedbjorn/subfloor --search "<symptom keywords>" --state all
 # 2. file — title: [<fork>] <area>: <one-line symptom>
 gh issue create --repo jedbjorn/subfloor \
   --title "[<fork>] <area>: <symptom>" \
-  --body "$(cat <<'EOF'
+  --body "$(cat <<''EOF''
 - engine ref: <sha from .sc-state/engine.ref> · <current | behind head <sha7>>
 - fork/seat: <repo> · <shell flavor> · <sandbox|host>
 
@@ -98,4 +108,12 @@ message the **admin** shell to relay it upstream (see `messaging`).
 - Observed failure = the bar for filing unasked; enhancement ideas ("the
   engine should…") go to your FnB first.
 - Filing ≠ unblocked: defect blocks work -> also open a fork flag linking the
-  issue URL.
+  issue URL.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/skills_sc/issue_reporting.md
+++ b/skills_sc/issue_reporting.md
@@ -54,6 +54,14 @@ Stale guidance (skill says X, engine does Y) files the same as a crash.
 ## Capture — while the failure is on screen
 
 - **engine ref** = `cat .sc-state/engine.ref` — first line of every report
+- **staleness** = compare that ref to upstream head:
+  `git ls-remote https://github.com/jedbjorn/subfloor HEAD` — write
+  `current` or `behind head <sha7>`. Behind + the symptom is a missing
+  command or a skill/engine mismatch -> the fix may already be shipped:
+  ask your FnB for `./sc update` first, and file only if the defect
+  survives the update (or updating isn't an option — then the staleness
+  note carries that caveat). Triage reads this line to tell a live
+  engine defect from a stale fork build.
 - **fork + seat**: repo name, shell flavor, sandbox/host
 - **ran / followed**: the exact command, or skill name + step
 - **expected vs actual**: exact output, trimmed to the failing lines
@@ -71,7 +79,7 @@ gh issue list --repo jedbjorn/subfloor --search "<symptom keywords>" --state all
 gh issue create --repo jedbjorn/subfloor \
   --title "[<fork>] <area>: <symptom>" \
   --body "$(cat <<'EOF'
-- engine ref: <sha from .sc-state/engine.ref>
+- engine ref: <sha from .sc-state/engine.ref> · <current | behind head <sha7>>
 - fork/seat: <repo> · <shell flavor> · <sandbox|host>
 
 **Ran / followed:** <command or skill+step>


### PR DESCRIPTION
## What

Issue triage (2026-07-20) closed 6 duplicates out of 40 open issues; five of them (#416 #417 #419 #420 → #373) were filed from a fork running a stale engine ref, for surfaces that already existed at head. Reports include the engine sha but nothing that lets triage tell *stale build* from *live defect*.

- `issue_reporting` capture step: new **staleness** line — compare `.sc-state/engine.ref` to upstream head (`git ls-remote`), write `current` or `behind head <sha7>`; if behind and the symptom is a missing command or skill/engine mismatch, ask the FnB for `./sc update` before filing.
- Report template: engine-ref line now carries the `<current | behind head <sha7>>` annotation.
- Migration `0074_reseed_issue_reporting_staleness.sql`: trailing forward reseed (UPSERT by name; skill_id + grants preserved), generated from the asset — content round-trip verified.

## Verification

- `./sc test tests/test_migrate.py tests/test_skills_freshness.py` — 12 passed.
- Migration applied against a scratch schema; seeded body matches the asset byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)