### PR TITLE
feat(cli): add colored shell status column

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -525,22 +525,23 @@ def _default_label(defaults: dict, flavor: str | None) -> str:
     return harness + (f" · {model.split('/')[-1]}" if model else "")
 
 
-def _liveness_note(shell, snap: "dict | None") -> str:
-    """Picker row annotation from the liveness snapshot: '(busy)' — a live
-    harness session holds the worktree; '(orphan?)' — the slot is held only by
-    survivors of closed terminals / dead parents; '(Exempt)' — the admin boots
-    at the repo root, outside the worktree signal, so it is never marked or
-    guarded. Empty when dormant or when no snapshot was taken (non-TTY)."""
+def _shell_status(shell, snap: "dict | None") -> str:
+    """Styled, fixed-width picker status derived from the liveness snapshot."""
     if shell["flavor"] == "admin":
-        return style.dim("  (Exempt)")
-    if not snap:
-        return ""
-    state = shell_liveness.session_state(shell["shortname"] or "", snap)
-    if state == "busy":
-        return style.yellow("  (busy)")
-    if state == "orphan":
-        return style.yellow("  (orphan?)")
-    return ""
+        label, paint = "Exempt", style.dim
+    elif not snap or not snap.get("supported"):
+        label, paint = "Unknown", style.dim
+    else:
+        state = shell_liveness.session_state(shell["shortname"] or "", snap)
+        if state == "busy":
+            label, paint = "Busy", style.amber
+        elif state == "orphan":
+            label, paint = "Orphaned", style.red
+        elif snap.get("indeterminate"):
+            label, paint = "Unknown", style.dim
+        else:
+            label, paint = "Available", style.green
+    return f"{paint(label)}{' ' * (12 - len(label))}"
 
 
 def confirm_live(shell, snap: "dict | None") -> bool:
@@ -591,7 +592,7 @@ def pick_shell(shells: list, requested: str | None,
     # it always reads 1, 2, 3… down the screen. shell_id is global and
     # non-contiguous, so showing it here made the numbering jump around within a
     # group; position tracks the display order instead.
-    print(style.dim(f"\n{'#':>3}  {'Name':<16}{'Shortname':<14}"
+    print(style.dim(f"\n{'#':>3}  {'Name':<16}{'Shortname':<14}{'Status':<12}"
                     f"{'Default (harness · model)'}"))
     _sentinel = object()
     cur_flavor: object = _sentinel
@@ -602,9 +603,8 @@ def pick_shell(shells: list, requested: str | None,
         num = style.dim(f"{n:>3}")
         name = style.bold("{:<16}".format(s["display_name"] or ""))
         short = "{:<14}".format(s["shortname"] or "")
-        print(f"{num}  {name}{short}"
-              f"{style.dim(_default_label(defaults, s['flavor']))}"
-              f"{_liveness_note(s, snap)}")
+        print(f"{num}  {name}{short}{_shell_status(s, snap)}"
+              f"{style.dim(_default_label(defaults, s['flavor']))}")
     if snap and snap.get("indeterminate"):
         print(style.dim(f"\n  ⚠ {snap['indeterminate']} harness process(es) "
                         f"with unreadable cwd — liveness markers are partial."))
@@ -793,7 +793,7 @@ def main() -> None:
     user = authenticate(con, interactive=not headless)
     fdefaults = flavor_defaults(con)
     # Liveness snapshot for the interactive picker: one /proc pass (ms) so the
-    # boot list can mark occupied shells — (busy) / (orphan?) / (Exempt) — and
+    # boot list can show shell status — Busy / Orphaned / Available / Exempt — and
     # confirm before booting into a live worktree. Headless keeps its own lazy
     # compute below; non-TTY boots (--first, piped) can't confirm, so no snap.
     snap = (shell_liveness.compute()

--- a/.super-coder/scripts/style.py
+++ b/.super-coder/scripts/style.py
@@ -41,6 +41,8 @@ accent = _c("38;5;135")   # subfloor purple
 cyan = _c("36")
 green = _c("32")
 yellow = _c("33")
+amber = _c("38;5;214")
+red = _c("31")
 
 
 class _Spinner:

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression tests for the launcher's TTY-only spinner."""
+"""Regression tests for launcher styling and its TTY-only spinner."""
 from __future__ import annotations
 
 import io
@@ -67,6 +67,47 @@ class _LabelRecorder:
     def label(self, value: str) -> None:
         self._label = value
         self._labels.append(value)
+
+
+class ShellStatusTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.shell = {"shortname": "DEV1", "flavor": "dev"}
+        self.snap = {"supported": True, "processes": [], "indeterminate": 0}
+
+    def test_status_colors_and_labels(self) -> None:
+        cases = (
+            ("busy", "\x1b[38;5;214mBusy\x1b[0m        "),
+            ("orphan", "\x1b[31mOrphaned\x1b[0m    "),
+            (None, "\x1b[32mAvailable\x1b[0m   "),
+        )
+        with mock.patch.object(style, "ON", True):
+            for state, expected in cases:
+                with self.subTest(state=state), mock.patch.object(
+                        run.shell_liveness, "session_state", return_value=state):
+                    self.assertEqual(expected, run._shell_status(self.shell, self.snap))
+
+    def test_admin_and_indeterminate_states_are_explicit(self) -> None:
+        admin = {"shortname": "ADMIN", "flavor": "admin"}
+        partial = {**self.snap, "indeterminate": 1}
+        unsupported = {"supported": False, "processes": []}
+
+        self.assertEqual("Exempt      ", run._shell_status(admin, self.snap))
+        self.assertEqual("Unknown     ", run._shell_status(self.shell, partial))
+        self.assertEqual("Unknown     ", run._shell_status(self.shell, unsupported))
+
+    def test_picker_has_a_dedicated_status_column(self) -> None:
+        shell = {**self.shell, "display_name": "Dev One"}
+        stdout = _Stdout(tty=False)
+        stdin = _Stdout(tty=True)
+
+        with mock.patch.object(run.sys, "stdout", stdout), \
+             mock.patch.object(run.sys, "stdin", stdin), \
+             mock.patch("builtins.input", return_value="1"):
+            chosen = run.pick_shell([shell], None, False, snap=self.snap)
+
+        self.assertIs(shell, chosen)
+        self.assertIn("Shortname     Status      Default", stdout.getvalue())
+        self.assertIn("DEV1          Available", stdout.getvalue())
 
 
 class SpinnerTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- give shell liveness its own fixed-width Status column in the CLI picker
- render Busy in amber, Available in green, and Orphaned in red
- retain explicit dimmed Exempt and Unknown states when liveness is not applicable or trustworthy
- cover status labels, exact ANSI colors, and picker column placement

## Trade-off
A partial or unsupported liveness snapshot shows Unknown instead of claiming a shell is Available; admin remains Exempt because its repo-root session is outside worktree liveness detection.

## Verification
- `python3 -m py_compile .super-coder/scripts/run.py .super-coder/scripts/style.py tests/test_style_spinner.py`
- `./sc lint .super-coder/scripts/run.py .super-coder/scripts/style.py tests/test_style_spinner.py --ignore E741` (the ignored E741 findings pre-exist in `style.panel`)
- `env -u SC_SANDBOX ./sc test` — 507 passed