### PR TITLE
feat(sprints): self-heal model routes

### DIFF
--- a/.super-coder/adapters/claude/README.md
+++ b/.super-coder/adapters/claude/README.md
@@ -13,6 +13,7 @@ the launch command. No extra config file to emit at v1.
 | `emit` | files in this dir copied to the repo root at launch (none for Claude) |
 | `env` | extra env merged into the launch environment |
 | `model` | `{ "flag": "--model" }` — run.py appends `--model <id>` for the flavor's claude model (alias: `sonnet`/`haiku`/`opus`) |
+| `headless.effort` | `{ "flag": "--effort" }` — sprint workers default to `--effort high` |
 | `merge_json` | always-on: project-scoped JSON deep-merged every launch (preserves fork keys). Installs the branch-guard hook into `.claude/settings.local.json`. |
 | `sandbox` | `merge_json`: project-scoped config patched in-sandbox only (allow-all permissions) |
 

--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -6,7 +6,12 @@
   "env": {},
   "model": { "flag": "--model" },
   "name": { "flag": "--name" },
-  "headless": { "launch": ["claude", "-p"], "model_flag": "--model" },
+  "headless": {
+    "launch": ["claude"],
+    "prompt_flag": "-p",
+    "model_flag": "--model",
+    "effort": { "flag": "--effort" }
+  },
   "merge_json": {
     ".claude/settings.local.json": {
       "hooks": {

--- a/.super-coder/adapters/codex/README.md
+++ b/.super-coder/adapters/codex/README.md
@@ -20,6 +20,7 @@ billing. opencode stays as the universal metered catch-all.
 | `emit` | files copied to the repo root at launch (`.codex/hooks.json` — the branch-guard hook) |
 | `env` | extra env merged into the launch environment |
 | `model` | `{ "flag": "--model" }` — run.py appends `--model <id>` for the flavor's codex model |
+| `headless.effort` | maps sprint `high` to `-c model_reasoning_effort="high"` |
 | `sandbox.launch_flags` | flags appended ONLY inside the docker sandbox (`SC_SANDBOX`) |
 
 ## Branch-guard hook

--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -5,7 +5,11 @@
   "emit": [".codex/hooks.json"],
   "env": {},
   "model": { "flag": "--model" },
-  "headless": { "launch": ["codex", "exec"], "model_flag": "-m" },
+  "headless": {
+    "launch": ["codex", "exec"],
+    "model_flag": "-m",
+    "effort": { "config_flag": "-c", "config_key": "model_reasoning_effort" }
+  },
   "sandbox": {
     "launch_flags": ["--dangerously-bypass-approvals-and-sandbox"],
     "headless_flags": ["--dangerously-bypass-approvals-and-sandbox"]

--- a/.super-coder/adapters/kimi/README.md
+++ b/.super-coder/adapters/kimi/README.md
@@ -18,7 +18,10 @@ catch-all; kimi is the native Moonshot path.
 | `launch` | argv exec'd to start the harness (`kimi` — cwd is the workspace; no dir flag exists) |
 | `boot_artifact` | the context file this harness reads (`AGENTS.md`, informational) |
 | `emit` | files copied to the repo root at launch (none — kimi reads `~/.kimi-code` + `AGENTS.md`) |
-| `headless.launch` | non-interactive argv (`kimi -p` — the prompt is `-p`'s option value, appended last) |
+| `headless.launch` | non-interactive base argv (`kimi`) |
+| `headless.prompt_flag` | `-p`; run.py emits it immediately before the prompt value |
+| `headless.model_flag` | `-m`; the selector must be an alias discovered from `~/.kimi-code/config.toml` |
+| `headless.effort.env` | `KIMI_MODEL_THINKING_EFFORT`; sprint headless boots set it to `high` |
 | `sandbox.launch_flags` | flags appended ONLY inside the docker sandbox, interactive launches only (`--yolo`) |
 
 **`--yolo` (sandbox, interactive only):** auto-approves all actions inside the
@@ -32,12 +35,13 @@ flag at all. This adapter is why the sandbox seam splits `launch_flags`
 other. On the no-docker host path (`./sc boot`), kimi keeps its normal
 per-action approval prompts.
 
-**No `model` field:** kimi takes no model from the launch seam. Its `-m` flag
-selects a model *alias* defined in `~/.kimi-code/config.toml` (`[models."…"]`) —
-user-local names, not portable provider ids — so routing a flavor-default model
-here would be meaningless; kimi uses its configured `default_model` (or
-`/model` in-session). For the same reason the headless block declares no
-`model_flag` and kimi has no `flavor_defaults` seeds or model-catalog entry.
+**No interactive `model` field:** Kimi's `-m` selects a user-local alias from
+`~/.kimi-code/config.toml`, not a portable provider id, so an interactive flavor
+default remains unsafe. Headless sprint boots are different: Refresh models
+discovers the exact local aliases (for example `kimi-code/k3`), the resolver
+accepts only a locally available high-effort route, and the adapter emits
+`kimi -m <alias> -p <prompt>`. A requested selector that cannot be applied fails
+before the worker session opens.
 
 **Skills:** kimi does not read `.claude/skills/` (its discovery dirs are
 `.kimi-code/skills/` + `.agents/skills/`), so like codex/vibe it loads skills

--- a/.super-coder/adapters/kimi/adapter.json
+++ b/.super-coder/adapters/kimi/adapter.json
@@ -4,6 +4,11 @@
   "boot_artifact": "AGENTS.md",
   "emit": [],
   "env": {},
-  "headless": { "launch": ["kimi", "-p"] },
+  "headless": {
+    "launch": ["kimi"],
+    "prompt_flag": "-p",
+    "model_flag": "-m",
+    "effort": { "env": "KIMI_MODEL_THINKING_EFFORT" }
+  },
   "sandbox": { "launch_flags": ["--yolo"] }
 }

--- a/.super-coder/api/model_catalog.py
+++ b/.super-coder/api/model_catalog.py
@@ -19,13 +19,13 @@ Fetched server-side (no CORS), cached under the gitignored .super-coder/logs/
 dirty the tree and trip the publish guard) with a TTL; a failed refresh serves
 the stale cache and says so.
 
-Payload (v2) is family-first, matching the picker: per harness, `families`
+Payload (v3) is family-first, matching the picker: per harness, `families`
 ([{family, latest, release_date, n}], newest-first — "pick opus / sonnet /
 fable / deepseek and track its latest") plus the flat `models` list for
 sub-version search. For claude, a family with a CLI alias (opus / sonnet /
-haiku) resolves `latest` to the alias — an alias floats to the newest model
-in its family, so the stored value never goes stale; families without one
-(the fable case) resolve to the newest concrete id.
+haiku / fable) resolves `latest` to the alias — an alias floats to the newest
+model in its family, so the stored value never goes stale. Entries also carry
+their route source, local availability, CLI version, and effort support.
 """
 from __future__ import annotations
 
@@ -33,12 +33,14 @@ import json
 import os
 import shutil
 import subprocess
+import tomllib
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
 CACHE = ENGINE / "logs" / "model_catalog.json"
+ADAPTERS = ENGINE / "adapters"
 TTL_HOURS = 24
 TIMEOUT = 8
 MODELS_DEV_URL = "https://models.dev/api.json"
@@ -65,7 +67,7 @@ CLAUDE_ALIASES = ["fable", "opus", "sonnet", "haiku"]
 # Bump when the response/cache shape changes — a cached payload from another
 # version is ignored (treated as no cache) instead of being served to a
 # client that expects the new shape.
-PAYLOAD_VERSION = 2
+PAYLOAD_VERSION = 3
 
 # provider APIs, keyed by harness: (env var, url, header builder). Responses
 # are the OpenAI-style {"data": [{"id": ...}, ...]} shape on all three.
@@ -98,9 +100,18 @@ def _http_json(url: str, headers: dict | None = None) -> dict:
 
 
 def _entry(mid: str, release_date: str = "", name: str = "",
-           family: str | None = None) -> dict:
+           family: str | None = None, *, source: str = "models.dev",
+           availability: str = "advisory", provider: str | None = None,
+           provider_model: str | None = None,
+           supported_efforts: list[str] | None = None,
+           default_effort: str | None = None,
+           cli_version: str | None = None) -> dict:
     return {"id": mid, "release_date": release_date, "name": name or mid,
-            "family": family}
+            "family": family, "source": source,
+            "availability": availability, "provider": provider,
+            "provider_model": provider_model or mid,
+            "supported_efforts": supported_efforts or [],
+            "default_effort": default_effort, "cli_version": cli_version}
 
 
 def _from_models_dev(fetch) -> dict[str, list[dict]]:
@@ -111,8 +122,9 @@ def _from_models_dev(fetch) -> dict[str, list[dict]]:
         entries = []
         for mid, m in models.items():
             full = f"{provider}/{mid}" if harness in PREFIXED_HARNESSES else mid
-            entries.append(_entry(full, m.get("release_date") or "",
-                                  m.get("name") or mid, m.get("family")))
+            entries.append(_entry(
+                full, m.get("release_date") or "", m.get("name") or mid,
+                m.get("family"), provider=provider, provider_model=mid))
         entries.sort(key=lambda e: e["release_date"], reverse=True)
         out[harness] = entries
     return out
@@ -154,7 +166,9 @@ def _from_provider_apis(fetch, env) -> dict[str, list[dict]]:
             continue  # opportunistic — a bad key never degrades the catalog
         ids = [m.get("id") for m in data.get("data") or [] if m.get("id")]
         if ids:
-            out[harness] = [_entry(i) for i in ids]
+            out[harness] = [
+                _entry(i, source=f"{HARNESS_PROVIDER[harness]}-api",
+                       provider=HARNESS_PROVIDER[harness]) for i in ids]
     return out
 
 
@@ -176,12 +190,105 @@ def _from_opencode_cli(run) -> list[dict]:
     ids = sorted({line.strip() for line in r.stdout.splitlines()
                   if "/" in line.strip() and " " not in line.strip()},
                  key=lambda i: (not i.startswith("ollama-cloud/"), i))
-    return [_entry(i) for i in ids]
+    return [_entry(i, source="opencode-cli", availability="available",
+                   provider=i.split("/", 1)[0]) for i in ids]
+
+
+def _cli_version(binary: str, run) -> str | None:
+    try:
+        r = run([binary, "--version"], capture_output=True, text=True,
+                timeout=5)
+    except Exception:
+        return None
+    if r.returncode != 0:
+        return None
+    return (r.stdout or r.stderr).strip().splitlines()[0] or None
+
+
+def _from_claude_cli(run) -> list[dict]:
+    """Claude's aliases are the portable local launch selectors.
+
+    Claude Code does not expose an account-scoped list-models command, so the
+    installed CLI proves selector syntax while models.dev supplies concrete
+    family members for advisory browsing.
+    """
+    if not shutil.which("claude"):
+        return []
+    version = _cli_version("claude", run)
+    return [
+        _entry(alias, name=f"Claude {alias.title()} (alias)",
+               family=f"claude-{alias}", source="claude-cli",
+               availability="available", provider="anthropic",
+               supported_efforts=["low", "medium", "high", "max"],
+               default_effort="high", cli_version=version)
+        for alias in CLAUDE_ALIASES
+    ]
+
+
+def _from_codex_cache(env, run) -> list[dict]:
+    """Read the signed-in Codex CLI's own model cache.
+
+    This is stronger evidence than the public OpenAI model list: it describes
+    what this installed ChatGPT-backed CLI was actually offered, including its
+    supported reasoning-effort levels.
+    """
+    if not shutil.which("codex"):
+        return []
+    root = Path(env.get("CODEX_HOME") or (Path.home() / ".codex"))
+    try:
+        data = json.loads((root / "models_cache.json").read_text())
+    except Exception:  # noqa: BLE001  (missing/corrupt = no local evidence)
+        return []
+    version = _cli_version("codex", run)
+    entries = []
+    for m in data.get("models") or []:
+        mid = m.get("slug")
+        if not mid or m.get("visibility") == "hide":
+            continue
+        efforts = [e.get("effort") for e in m.get("supported_reasoning_levels") or []
+                   if e.get("effort")]
+        entries.append(_entry(
+            mid, name=m.get("display_name") or mid, family=m.get("family"),
+            source="codex-cache", availability="available", provider="openai",
+            supported_efforts=efforts,
+            default_effort=m.get("default_reasoning_level"), cli_version=version))
+    return entries
+
+
+def _from_kimi_config(env, run) -> list[dict]:
+    """Read Kimi's exact user-defined aliases without touching credentials."""
+    if not shutil.which("kimi"):
+        return []
+    root = Path(env.get("KIMI_CODE_HOME") or (Path.home() / ".kimi-code"))
+    try:
+        data = tomllib.loads((root / "config.toml").read_text())
+    except Exception:  # noqa: BLE001
+        return []
+    version = _cli_version("kimi", run)
+    entries = []
+    for alias, cfg in (data.get("models") or {}).items():
+        if not isinstance(cfg, dict) or not cfg.get("model"):
+            continue
+        effective = {**cfg, **(cfg.get("overrides") or {})}
+        entries.append(_entry(
+            alias, name=effective.get("display_name") or cfg["model"],
+            family=f"kimi-{cfg['model']}", source="kimi-config",
+            availability="available", provider=cfg.get("provider"),
+            provider_model=cfg["model"],
+            supported_efforts=effective.get("support_efforts") or [],
+            default_effort=effective.get("default_effort"),
+            cli_version=version))
+    return entries
 
 
 def _merge(base: list[dict], extra: list[dict]) -> list[dict]:
     seen = {e["id"] for e in base}
     return base + [e for e in extra if e["id"] not in seen]
+
+
+def _prefer(preferred: list[dict], advisory: list[dict]) -> list[dict]:
+    """Put locally authoritative entries first and replace duplicate ids."""
+    return _merge(preferred, advisory)
 
 
 def build(fetch=_http_json, env=os.environ, run=subprocess.run) -> dict:
@@ -200,8 +307,18 @@ def build(fetch=_http_json, env=os.environ, run=subprocess.run) -> dict:
         sources.append(f"{HARNESS_PROVIDER[harness]}-api")
     oc = _from_opencode_cli(run)
     if oc:
-        harnesses["opencode"] = _merge(harnesses.get("opencode", []), oc)
+        harnesses["opencode"] = _prefer(oc, harnesses.get("opencode", []))
         sources.append("opencode-cli")
+    local = {
+        "claude": _from_claude_cli(run),
+        "codex": _from_codex_cache(env, run),
+        "kimi": _from_kimi_config(env, run),
+    }
+    for harness, entries in local.items():
+        if not entries:
+            continue
+        harnesses[harness] = _prefer(entries, harnesses.get(harness, []))
+        sources.append(entries[0]["source"])
     if not sources:
         raise RuntimeError("; ".join(errors) or "no catalog sources available")
     return {"v": PAYLOAD_VERSION,
@@ -237,13 +354,72 @@ _FLOOR_FAMILY = {"fable": "claude-fable", "opus": "claude-opus",
 def _floor() -> dict[str, dict]:
     out = {}
     for h, ids in STATIC_FLOOR.items():
-        entries = [_entry(i, family=_FLOOR_FAMILY.get(i)) for i in ids]
+        entries = [_entry(i, family=_FLOOR_FAMILY.get(i), source="static",
+                          availability="fallback") for i in ids]
         out[h] = {"families": _families(h, entries), "models": entries}
     return out
 
 
+def _headless_supported(harness: str) -> bool:
+    try:
+        cfg = json.loads((ADAPTERS / harness / "adapter.json").read_text())
+    except Exception:  # noqa: BLE001
+        return False
+    return bool((cfg.get("headless") or {}).get("launch"))
+
+
+def persist_routes(con, payload: dict) -> None:
+    """Upsert a refresh payload into the disposable runtime route table.
+
+    A failed refresh marks carried-forward rows stale but never deletes them.
+    Older DBs mid-update simply lack the table; the advisory picker continues
+    to work from the JSON payload until migrations land.
+    """
+    try:
+        con.execute("UPDATE model_routes SET stale=1, last_error=?",
+                    (payload.get("error"),))
+    except Exception:
+        return
+    seen_at = payload.get("fetched_at") or datetime.now(timezone.utc).isoformat()
+    stale = int(bool(payload.get("stale")))
+    for harness, block in (payload.get("harnesses") or {}).items():
+        headless = int(_headless_supported(harness))
+        for entry in block.get("models") or []:
+            efforts = entry.get("supported_efforts") or []
+            con.execute(
+                "INSERT INTO model_routes ("
+                "harness, selector, provider, provider_model, display_name, family, "
+                "source, availability, headless_supported, high_effort_supported, "
+                "default_effort, supported_efforts, cli_version, last_seen_at, stale, "
+                "last_error) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(harness, selector) DO UPDATE SET "
+                "provider=excluded.provider, provider_model=excluded.provider_model, "
+                "display_name=excluded.display_name, family=excluded.family, "
+                "source=excluded.source, availability=excluded.availability, "
+                "headless_supported=excluded.headless_supported, "
+                "high_effort_supported=excluded.high_effort_supported, "
+                "default_effort=excluded.default_effort, "
+                "supported_efforts=excluded.supported_efforts, "
+                "cli_version=excluded.cli_version, last_seen_at=excluded.last_seen_at, "
+                "stale=excluded.stale, last_error=excluded.last_error",
+                (harness, entry["id"], entry.get("provider"),
+                 entry.get("provider_model"), entry.get("name"), entry.get("family"),
+                 entry.get("source") or "unknown",
+                 entry.get("availability") or "advisory", headless,
+                 int("high" in efforts), entry.get("default_effort"),
+                 json.dumps(efforts), entry.get("cli_version"), seen_at, stale,
+                 payload.get("error")))
+    con.commit()
+
+
+def _served(payload: dict, con=None) -> dict:
+    if con is not None:
+        persist_routes(con, payload)
+    return payload
+
+
 def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
-            run=subprocess.run) -> dict:
+            run=subprocess.run, con=None) -> dict:
     """The cached-with-fallbacks entry point the API serves.
 
     fresh cache → serve it; miss/stale/refresh → live sweep, cache the result;
@@ -251,15 +427,15 @@ def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
     carries `stale` + `fetched_at` so the GUI can say how current it is."""
     cached = _load_cache()
     if cached and not refresh and _fresh(cached):
-        return {**cached, "stale": False}
+        return _served({**cached, "stale": False}, con)
     try:
         fresh = build(fetch, env, run)
     except Exception as e:  # noqa: BLE001
         if cached:
-            return {**cached, "stale": True, "error": str(e)}
-        return {"v": PAYLOAD_VERSION, "fetched_at": None,
-                "sources": ["static"], "stale": True,
-                "error": str(e), "harnesses": _floor()}
+            return _served({**cached, "stale": True, "error": str(e)}, con)
+        return _served({"v": PAYLOAD_VERSION, "fetched_at": None,
+                        "sources": ["static"], "stale": True,
+                        "error": str(e), "harnesses": _floor()}, con)
     CACHE.parent.mkdir(parents=True, exist_ok=True)
     CACHE.write_text(json.dumps(fresh, indent=1) + "\n")
-    return {**fresh, "stale": False}
+    return _served({**fresh, "stale": False}, con)

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2089,7 +2089,8 @@ class Handler(BaseHTTPRequestHandler):
             if path == "/api/models":
                 q = parse_qs(urlparse(self.path).query)
                 return self._send(200, model_catalog.catalog(
-                    refresh=q.get("refresh", ["0"])[0] in ("1", "true")))
+                    refresh=q.get("refresh", ["0"])[0] in ("1", "true"),
+                    con=con))
             if path.startswith("/api/shells/"):
                 sid = int(path.rsplit("/", 1)[1])
                 shell = get_shell(con, sid)

--- a/.super-coder/assets/skills/sprint_orchestration/SKILL.md
+++ b/.super-coder/assets/skills/sprint_orchestration/SKILL.md
@@ -56,9 +56,30 @@ Flavor-uniform by design: shells of a flavor are interchangeable workers,
 and one answer per flavor keeps the board readable and the review lineage
 coherent — reviewers stay a different lineage from the code they gate,
 chosen per sprint instead of per boot. No answer -> `flavor_defaults`,
-unchanged (omit the `models:` line). The answers parameterize every
-`./sc run` you issue for this sprint. Per-unit model mixing is out of
-scope — the interview covers the real need, provider choice per role.
+unchanged (omit the `models:` line). Every sprint worker still runs at high
+effort. Per-unit model mixing is out of scope — the interview covers the real
+need, provider choice per role.
+
+**Resolve each answered route before declaring it.** Lazy-load only the two
+choices the FnB made — never trust a display name or translate a provider id by
+hand:
+
+```
+sc models resolve <devs-harness> <devs-model>
+sc models resolve <reviewers-harness> <reviewers-model>
+```
+
+Each must return `route:` plus an exact `call:` ending in `--effort high`.
+Failure means the selector is not locally callable, the harness lacks a
+headless/high-effort seam, or Refresh models has not seen it. Run
+`sc models list <harness>` for the local choices; the FnB's **Refresh models**
+button in `/#shells` repopulates the same runtime table. Resolve again after a
+refresh. Never silently fall back across a provider or lineage.
+
+Common exact selectors: Claude aliases (`fable`, `opus`) and Codex ids
+(`gpt-5.6-sol`, `gpt-5.6-terra`) pass directly. Kimi takes the configured alias
+shown by `sc models list kimi` (for example `kimi-code/k3`), never the bare
+provider model `k3`.
 
 Write the board as a `documents` row:
 
@@ -123,8 +144,8 @@ sc mem message send <dev> "SPRINT <doc-id>: you own unit <seq> — <one line>. D
 # reviewers — assigned units, the severity bar:
 sc mem message send <reviewer> "SPRINT <doc-id>: you review units <seq,seq> — Major/Medium block, Low goes to the report. Load the sprint skill (reviewer slot). Review requests come to you directly as units go green." --kind task
 
-# boot each first-in-chain dev headless, with the sprint's models:
-./sc run <dev> --harness <devs-harness> -m <devs-model>
+# boot each first-in-chain dev with the RESOLVED selector; high is invariant:
+./sc run <dev> --harness <devs-harness> -m <devs-model> --effort high
 ```
 
 `./sc run` renders the shell's boot doc and drains its inbox
@@ -206,13 +227,14 @@ Stalls and the moves:
   fix unit at the front of the chain, resume when green.
 - **Review stall** (unit sitting `in-review` while its reviewer is idle):
   boot the reviewer — `./sc run <reviewer> --harness <reviewers-harness>
-  -m <reviewers-model>`; its inbox holds the review request. Still stuck
+  -m <reviewers-model> --effort high`; its inbox holds the review request. Still stuck
   -> reassign the unit to another reviewer. Severity dispute (dev says
   Low, reviewer says Medium) -> rule by message immediately — a chain
   waiting on a classification argument is pure loss. Dispute about what
   the unit *should do* -> FnB.
-- **Link gone quiet** (no `result` row, no `pr_event` movement): boot it —
-  `./sc run <shortname>` drains its inbox and acts; that IS the nudge in
+- **Link gone quiet** (no `result` row, no `pr_event` movement): boot it with
+  its declared sprint route — `./sc run <shortname> --harness <role-harness>
+  -m <role-model> --effort high` drains its inbox and acts; that IS the nudge in
   an event-driven sprint. The liveness guard refusing (session already
   live) + still silent -> escalate to the FnB with the worktree state.
   The bottleneck question in Step 3 is what surfaces a dead link.
@@ -251,7 +273,7 @@ When every unit is `merged` and `main` is green:
 
    ```
    sc mem message send <reviewer> "SPRINT <doc-id>: conformance pass — spec doc <spec-id>, main @ <merge-sha><, sections <scope> if sharded>. Ratified judgement calls: <list — the only narrative input>. Load the sprint skill (conformance slot)." --kind task
-   ./sc run <reviewer> --harness <reviewers-harness> -m <reviewers-model>
+   ./sc run <reviewer> --harness <reviewers-harness> -m <reviewers-model> --effort high
    ```
 
    The shell judges the spec against the code on `main` — never the

--- a/.super-coder/migrations/0075_model_routes.sql
+++ b/.super-coder/migrations/0075_model_routes.sql
@@ -1,0 +1,37 @@
+-- 0075 — runtime model-route catalogue.
+--
+-- Model availability is host/account state, not fork memory: Refresh models
+-- rebuilds these rows from locally authoritative CLI/config caches plus
+-- advisory public catalogues. The table is deliberately absent from
+-- snapshot.py's PER_INSTANCE_TABLES, so a rebuild starts empty and self-heals
+-- on the next refresh instead of carrying one machine's entitlements forward.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS model_routes (
+    harness               TEXT NOT NULL,
+    selector              TEXT NOT NULL,
+    provider              TEXT,
+    provider_model        TEXT,
+    display_name          TEXT,
+    family                TEXT,
+    source                TEXT NOT NULL,
+    availability          TEXT NOT NULL CHECK (
+        availability IN ('available', 'advisory', 'fallback')
+    ),
+    headless_supported     INTEGER NOT NULL DEFAULT 0,
+    high_effort_supported  INTEGER NOT NULL DEFAULT 0,
+    default_effort         TEXT,
+    supported_efforts      TEXT,
+    cli_version            TEXT,
+    last_seen_at           TEXT NOT NULL,
+    stale                  INTEGER NOT NULL DEFAULT 0,
+    last_error             TEXT,
+    PRIMARY KEY (harness, selector)
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_routes_runnable
+    ON model_routes(harness, availability, headless_supported,
+                    high_effort_supported, stale);
+
+COMMIT;

--- a/.super-coder/migrations/0076_reseed_sprint_model_routes.sql
+++ b/.super-coder/migrations/0076_reseed_sprint_model_routes.sql
@@ -1,0 +1,73 @@
+-- 0076 — reseed sprint_orchestration with model-route resolution.
+--
+-- The source asset is authoritative. These exact, idempotent replacements
+-- carry the delta across a fresh rebuild (0001's older seed) and existing
+-- forks; update.py's skill sync converges any already-divergent live row from
+-- the same asset.
+
+BEGIN;
+
+UPDATE skills SET content = replace(content,
+'coherent — reviewers stay a different lineage from the code they gate,
+chosen per sprint instead of per boot. No answer -> `flavor_defaults`,
+unchanged (omit the `models:` line). The answers parameterize every
+`./sc run` you issue for this sprint. Per-unit model mixing is out of
+scope — the interview covers the real need, provider choice per role.',
+'coherent — reviewers stay a different lineage from the code they gate,
+chosen per sprint instead of per boot. No answer -> `flavor_defaults`,
+unchanged (omit the `models:` line). Every sprint worker still runs at high
+effort. Per-unit model mixing is out of scope — the interview covers the real
+need, provider choice per role.
+
+**Resolve each answered route before declaring it.** Lazy-load only the two
+choices the FnB made — never trust a display name or translate a provider id by
+hand:
+
+```
+sc models resolve <devs-harness> <devs-model>
+sc models resolve <reviewers-harness> <reviewers-model>
+```
+
+Each must return `route:` plus an exact `call:` ending in `--effort high`.
+Failure means the selector is not locally callable, the harness lacks a
+headless/high-effort seam, or Refresh models has not seen it. Run
+`sc models list <harness>` for the local choices; the FnB''s **Refresh models**
+button in `/#shells` repopulates the same runtime table. Resolve again after a
+refresh. Never silently fall back across a provider or lineage.
+
+Common exact selectors: Claude aliases (`fable`, `opus`) and Codex ids
+(`gpt-5.6-sol`, `gpt-5.6-terra`) pass directly. Kimi takes the configured alias
+shown by `sc models list kimi` (for example `kimi-code/k3`), never the bare
+provider model `k3`.')
+WHERE name='sprint_orchestration';
+
+UPDATE skills SET content = replace(content,
+'# boot each first-in-chain dev headless, with the sprint''s models:
+./sc run <dev> --harness <devs-harness> -m <devs-model>',
+'# boot each first-in-chain dev with the RESOLVED selector; high is invariant:
+./sc run <dev> --harness <devs-harness> -m <devs-model> --effort high')
+WHERE name='sprint_orchestration';
+
+UPDATE skills SET content = replace(content,
+'- **Review stall** (unit sitting `in-review` while its reviewer is idle):
+  boot the reviewer — `./sc run <reviewer> --harness <reviewers-harness>
+  -m <reviewers-model>`; its inbox holds the review request. Still stuck',
+'- **Review stall** (unit sitting `in-review` while its reviewer is idle):
+  boot the reviewer — `./sc run <reviewer> --harness <reviewers-harness>
+  -m <reviewers-model> --effort high`; its inbox holds the review request. Still stuck')
+WHERE name='sprint_orchestration';
+
+UPDATE skills SET content = replace(content,
+'- **Link gone quiet** (no `result` row, no `pr_event` movement): boot it —
+  `./sc run <shortname>` drains its inbox and acts; that IS the nudge in',
+'- **Link gone quiet** (no `result` row, no `pr_event` movement): boot it with
+  its declared sprint route — `./sc run <shortname> --harness <role-harness>
+  -m <role-model> --effort high` drains its inbox and acts; that IS the nudge in')
+WHERE name='sprint_orchestration';
+
+UPDATE skills SET content = replace(content,
+'   ./sc run <reviewer> --harness <reviewers-harness> -m <reviewers-model>',
+'   ./sc run <reviewer> --harness <reviewers-harness> -m <reviewers-model> --effort high')
+WHERE name='sprint_orchestration';
+
+COMMIT;

--- a/.super-coder/scripts/models.py
+++ b/.super-coder/scripts/models.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Inspect and resolve locally callable model routes.
+
+`sc models refresh` is the CLI twin of Shells → Default Models → Refresh.
+`sc models resolve <harness> <selector>` is the sprint skill's lazy-load seam:
+it returns one exact, high-effort `sc run` call or fails with the reason that
+route cannot be honored on this machine.
+"""
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+DB_PATH = ENGINE / "shell_db.db"
+
+sys.path.insert(0, str(ENGINE / "api"))
+sys.path.insert(0, str(ENGINE / "scripts"))
+import model_catalog  # noqa: E402
+import db_driver  # noqa: E402
+
+
+def _open_db():
+    if not DB_PATH.exists():
+        raise SystemExit(f"models: no DB at {DB_PATH} — run `sc rebuild`")
+    return db_driver.connect(DB_PATH)
+
+
+def _route(con, harness: str, selector: str):
+    try:
+        row = con.execute(
+            "SELECT * FROM model_routes WHERE harness=? AND selector=?",
+            (harness, selector)).fetchone()
+    except db_driver.OperationalError:
+        raise SystemExit("models: model_routes unavailable — run `sc rebuild` to migrate")
+    if row is None:
+        model_catalog.catalog(con=con)
+        row = con.execute(
+            "SELECT * FROM model_routes WHERE harness=? AND selector=?",
+            (harness, selector)).fetchone()
+    return dict(row) if row else None
+
+
+def _command(harness: str, selector: str, shell: str, effort: str) -> list[str]:
+    return ["./sc", "run", shell, "--harness", harness, "-m", selector,
+            "--effort", effort]
+
+
+def resolve(con, harness: str, selector: str, *, shell: str = "<shell>",
+            effort: str = "high") -> dict:
+    row = _route(con, harness, selector)
+    if row is None:
+        return {"ok": False, "error": f"no route for {harness}/{selector}; refresh models"}
+    failures = []
+    if row["availability"] != "available":
+        failures.append(f"source is {row['availability']} ({row['source']}), not local")
+    if not row["headless_supported"]:
+        failures.append("harness has no headless launch seam")
+    if effort == "high" and not row["high_effort_supported"]:
+        failures.append("model has no locally verified high-effort route")
+    command = _command(harness, selector, shell, effort)
+    return {"ok": not failures, "harness": harness, "selector": selector,
+            "source": row["source"], "availability": row["availability"],
+            "stale": bool(row["stale"]), "cli_version": row["cli_version"],
+            "supported_efforts": json.loads(row["supported_efforts"] or "[]"),
+            "command": command, "error": "; ".join(failures) or None}
+
+
+def _print_resolved(data: dict, as_json: bool) -> int:
+    if as_json:
+        print(json.dumps(data, indent=2))
+    elif not data["ok"]:
+        print(f"models: {data['error']}", file=sys.stderr)
+    else:
+        suffix = " · stale last-known-good" if data["stale"] else ""
+        print(f"route: {data['harness']}/{data['selector']} · {data['source']}{suffix}")
+        print(f"call:  {shlex.join(data['command'])}")
+    return 0 if data["ok"] else 2
+
+
+def _list(con, harness: str | None) -> int:
+    sql = ("SELECT harness, selector, source, availability, stale, "
+           "headless_supported, high_effort_supported FROM model_routes")
+    params: tuple = ()
+    if harness:
+        sql += " WHERE harness=?"
+        params = (harness,)
+    sql += " ORDER BY harness, availability='available' DESC, selector"
+    try:
+        rows = con.execute(sql, params).fetchall()
+    except db_driver.OperationalError:
+        raise SystemExit("models: model_routes unavailable — run `sc rebuild` to migrate")
+    if not rows:
+        model_catalog.catalog(con=con)
+        rows = con.execute(sql, params).fetchall()
+    for r in rows:
+        runnable = (r["availability"] == "available" and r["headless_supported"]
+                    and r["high_effort_supported"])
+        state = "runnable" if runnable else r["availability"]
+        if r["stale"]:
+            state += "/stale"
+        print(f"{r['harness']}/{r['selector']}\t{state}\t{r['source']}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args or args[0] in ("-h", "--help"):
+        print("usage: sc models refresh | list [harness] | "
+              "resolve <harness> <selector> [--shell <shortname>] [--json]")
+        return 0
+    con = _open_db()
+    try:
+        if args[0] == "refresh":
+            payload = model_catalog.catalog(refresh=True, con=con)
+            print("models: " + ("stale — " + payload.get("error", "refresh failed")
+                                if payload.get("stale") else
+                                "refreshed from " + ", ".join(payload.get("sources") or [])))
+            return 2 if payload.get("stale") else 0
+        if args[0] == "list":
+            return _list(con, args[1] if len(args) > 1 else None)
+        if args[0] != "resolve" or len(args) < 3:
+            raise SystemExit("models: expected refresh, list, or resolve <harness> <selector>")
+        shell = "<shell>"
+        if "--shell" in args:
+            i = args.index("--shell")
+            shell = args[i + 1] if i + 1 < len(args) else ""
+            if not shell:
+                raise SystemExit("models: --shell requires a shortname")
+        data = resolve(con, args[1], args[2], shell=shell)
+        return _print_resolved(data, "--json" in args)
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -16,7 +16,8 @@ Usage:
     python3 .super-coder/scripts/run.py [shortname] [--first]
     RENDER_ONLY=1 python3 .super-coder/scripts/run.py --first   # render, don't exec
 
-Headless (`./sc run <shortname> [-p "<prompt>"] [--harness <h>] [-m <model>]`):
+Headless (`./sc run <shortname> [-p "<prompt>"] [--harness <h>] [-m <model>]
+[--effort <level>]`):
 the same render-then-exec path minus the picker and the TTY. The harness runs
 non-interactively via its adapter's `headless` block (claude -p · codex exec ·
 opencode run), streams a final message, and exits — the ephemeral-worker
@@ -71,8 +72,41 @@ def resolve_headless_model(flag_model: "str | None", fdef: "dict | None",
     return fdef["models"].get(harness) if fdef else None
 
 
+def _headless_effort_args(hcfg: dict, effort: "str | None",
+                          harness: str = "?") -> list[str]:
+    if not effort:
+        return []
+    ecfg = hcfg.get("effort") or {}
+    if ecfg.get("flag"):
+        return [ecfg["flag"], effort]
+    if ecfg.get("config_flag") and ecfg.get("config_key"):
+        return [ecfg["config_flag"], f'{ecfg["config_key"]}="{effort}"']
+    if ecfg.get("env"):
+        return []
+    raise ValueError(
+        f"harness '{harness}' cannot apply effort '{effort}'")
+
+
+def headless_effort_env(adapter: dict, effort: "str | None") -> dict[str, str]:
+    ecfg = ((adapter.get("headless") or {}).get("effort") or {})
+    return {ecfg["env"]: effort} if effort and ecfg.get("env") else {}
+
+
+def validate_headless_request(adapter: dict, model: "str | None",
+                              effort: "str | None") -> None:
+    hcfg = adapter.get("headless") or {}
+    harness = adapter.get("harness", "?")
+    if not hcfg.get("launch"):
+        raise ValueError(f"harness '{harness}' has no headless adapter")
+    if model and not hcfg.get("model_flag"):
+        raise ValueError(
+            f"harness '{harness}' cannot apply requested model '{model}'")
+    _headless_effort_args(hcfg, effort, harness)
+
+
 def headless_command(adapter: dict, prompt: str, model: "str | None" = None,
-                     sandbox_flags: "list[str] | None" = None) -> "list[str] | None":
+                     sandbox_flags: "list[str] | None" = None,
+                     effort: "str | None" = None) -> "list[str] | None":
     """The non-interactive exec argv from the adapter's `headless` block —
     launch prefix + model flag + sandbox flags + the prompt as the final
     positional. None when the harness declares no headless block (e.g. vibe,
@@ -80,11 +114,16 @@ def headless_command(adapter: dict, prompt: str, model: "str | None" = None,
     hcfg = adapter.get("headless")
     if not hcfg or not hcfg.get("launch"):
         return None
+    validate_headless_request(adapter, model, effort)
     cmd = list(hcfg["launch"])
-    if model and hcfg.get("model_flag"):
+    if model:
         cmd += [hcfg["model_flag"], model]
+    cmd += _headless_effort_args(hcfg, effort, adapter.get("harness", "?"))
     cmd += list(sandbox_flags or [])
-    cmd.append(prompt)
+    if hcfg.get("prompt_flag"):
+        cmd += [hcfg["prompt_flag"], prompt]
+    else:
+        cmd.append(prompt)
     return cmd
 
 
@@ -736,6 +775,7 @@ def main() -> None:
     # Headless adds -p/--prompt and -m/--model (value-taking, same rule).
     flag_harness = None
     flag_model = None
+    flag_effort = None
     prompt = None
     positional = []
     i = 0
@@ -749,6 +789,10 @@ def main() -> None:
             flag_model = args[i + 1] if i + 1 < len(args) else None
             i += 2
             continue
+        if a == "--effort":
+            flag_effort = args[i + 1] if i + 1 < len(args) else None
+            i += 2
+            continue
         if a in ("-p", "--prompt"):
             prompt = args[i + 1] if i + 1 < len(args) else None
             i += 2
@@ -757,6 +801,8 @@ def main() -> None:
             flag_harness = a.split("=", 1)[1]
         elif a.startswith("--model="):
             flag_model = a.split("=", 1)[1]
+        elif a.startswith("--effort="):
+            flag_effort = a.split("=", 1)[1]
         elif a.startswith("--prompt="):
             prompt = a.split("=", 1)[1]
         elif not a.startswith("-"):
@@ -764,7 +810,8 @@ def main() -> None:
         i += 1
     requested = positional[0] if positional else None
     if headless and not requested:
-        sys.exit('usage: ./sc run <shortname> [-p "<prompt>"] [--harness <h>] [-m <model>]')
+        sys.exit('usage: ./sc run <shortname> [-p "<prompt>"] [--harness <h>] '
+                 '[-m <model>] [--effort <level>]')
 
     # Wordmark banner — interactive boots only; headless/verify logs stay clean.
     if not headless and not os.environ.get("RENDER_ONLY") and sys.stdin.isatty():
@@ -850,6 +897,20 @@ def main() -> None:
                or pick_harness(detect_harnesses(), default_harness, first or headless)
                or default_harness)
 
+    # Resolve + validate the complete headless route before opening a session.
+    # `sc run` is the sprint-worker primitive, so high effort is its default;
+    # the orchestration skill passes it explicitly as well for auditability.
+    flavor_model = fdef["models"].get(harness) if fdef else None
+    session_model = (resolve_headless_model(flag_model, fdef, harness)
+                     if headless else flavor_model)
+    session_effort = flag_effort or ("high" if headless else None)
+    adapter = load_adapter(harness)
+    if headless:
+        try:
+            validate_headless_request(adapter, session_model, session_effort)
+        except ValueError as e:
+            sys.exit(f"sc run: {e}")
+
     feedback = not headless and not os.environ.get("RENDER_ONLY")
     map_note = None
     trust_note = None
@@ -857,8 +918,6 @@ def main() -> None:
         # Now that the harness is known, resolve THIS flavor's model for it (the
         # (flavor, harness) cell). None when the flavor has no entry for the chosen
         # harness (e.g. opencode as a manual fallback) — then the harness picks its own.
-        flavor_model = fdef["models"].get(harness) if fdef else None
-
         # Pre-session analytics sweep (doc #11): pull harness-side usage data into
         # session_token_usage + backfill the PREVIOUS session's ended_at. MUST run
         # before open_session — the stub-reuse check there relies on the previous
@@ -882,8 +941,6 @@ def main() -> None:
         # The model this launch will actually route (headless resolves via flags →
         # flavor default; interactive routes the flavor default). None = the harness
         # picks its own — recorded as NULL, honest about what we know at boot.
-        session_model = (resolve_headless_model(flag_model, fdef, harness)
-                         if headless else flavor_model)
         session_id, archive_id = open_session(con, chosen["shell_id"], lifecycle={
             "harness": harness,
             "provider": session_provider(harness, session_model),
@@ -977,7 +1034,6 @@ def main() -> None:
 
     # Harness was resolved up front (override / picker / default); the adapter
     # seam owns the launch command + any harness-specific config to emit.
-    adapter = load_adapter(harness)
     emitted = emit_adapter(adapter, work_dir)
     resolve_opencode_plugins(work_dir)  # engine-relative plugin path → absolute (loads in worktrees)
     print(f"→ harness: {style.bold(harness)} "
@@ -1047,13 +1103,15 @@ def main() -> None:
     if headless:
         hmodel = session_model  # resolved up front (persisted on the archive row)
         headless_cmd = headless_command(
-            adapter, prompt or DEFAULT_HEADLESS_PROMPT, hmodel, sandbox_flags)
+            adapter, prompt or DEFAULT_HEADLESS_PROMPT, hmodel, sandbox_flags,
+            session_effort)
         if headless_cmd is None:
             sys.exit(f"sc run: harness '{harness}' has no headless adapter — "
                      f"use claude, codex, opencode, or kimi")
         if hmodel:
             src = "explicit -m" if flag_model else f"flavor default for {chosen['flavor']}"
             print(f"→ model: {hmodel} ({src})")
+        print(f"→ effort: {session_effort}")
         print(f"→ headless prompt: {(prompt or DEFAULT_HEADLESS_PROMPT)[:120]}")
 
     # Close the boot summary with the review GUI — the link lives in a different
@@ -1077,7 +1135,9 @@ def main() -> None:
 
     cmd = (headless_cmd if headless else
            (adapter.get("launch") or [harness]) + name_args + model_args + sandbox_flags)
-    env = {**os.environ, **{k: str(v) for k, v in adapter.get("env", {}).items()}, **sandbox_env}
+    effort_env = headless_effort_env(adapter, session_effort) if headless else {}
+    env = {**os.environ, **{k: str(v) for k, v in adapter.get("env", {}).items()},
+           **sandbox_env, **effort_env}
     # The booted shell's flavor, inherited by everything the harness spawns.
     # branch-guard.sh reads it to exempt the admin shell (which works on main
     # by mandate); like SC_PROTECTED_BRANCHES it's a guardrail, not a boundary.

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -324,13 +324,19 @@ async function renderShells(root) {
 // list appears once a family is active or a query is typed, "all" + Enter
 // browses everything, Enter stores any typed id as-is, Escape / outside
 // click / a pick collapses. Catalog: /api/models v2 — advisory, never a
-// constraint.
+// constraint. Payload v3 adds local route authority + effort capability: a
+// public suggestion remains typeable, but only a locally available model with
+// verified high effort is sprint-runnable through `sc models resolve`.
 const DM_MODEL_CAP = 60;   // rendered cards per view — "all" on opencode is huge
 
 function dmModelPicker(harness, cat, row, save) {
   const data = cat.harnesses?.[harness] || { families: [], models: [] };
+  const currentRoute = (data.models || []).find((m) => m.id === row.model);
   const current = el("span", { className: "dm-current" + (row.model ? "" : " dm-unset"),
-                               textContent: row.model || "harness default" });
+                               textContent: row.model || "harness default",
+                               title: currentRoute
+                                 ? `${currentRoute.availability || "advisory"} · ${currentRoute.source || "unknown source"}`
+                                 : (row.model ? "not present in the latest catalogue" : "") });
   const input = el("input", { className: "dm-search",
                               placeholder: "search · click a family to filter · “all” ⏎" });
   const results = el("div", { className: "dm-results", hidden: true });
@@ -361,6 +367,13 @@ function dmModelPicker(harness, cat, row, save) {
     c.append(el("b", {}, id), el("span", { className: "dm-mcard-sub" }, sub || ""));
     c.onclick = () => pick(id);
     return c;
+  };
+  const routeSub = (m) => {
+    const efforts = m.supported_efforts || [];
+    const route = m.availability === "available"
+      ? (efforts.includes("high") ? "local · high-effort route" : "local · no verified high effort")
+      : (m.availability || "advisory");
+    return [route, m.source, m.release_date].filter(Boolean).join(" · ");
   };
 
   const paint = () => {
@@ -400,7 +413,7 @@ function dmModelPicker(harness, cat, row, save) {
       if (famMeta && !models.some((m) => m.id === famMeta.latest) && hit(famMeta.latest))
         list.append(mcard(famMeta.latest, "alias — tracks this family's latest", "dm-alias"));
       for (const m of models.slice(0, DM_MODEL_CAP))
-        list.append(mcard(m.id, m.release_date));
+        list.append(mcard(m.id, routeSub(m)));
       if (q && !allMode)
         list.append(mcard(input.value.trim(), "use as typed", "dm-raw"));
       results.append(list);
@@ -491,7 +504,7 @@ async function renderDefaultModels(root, s) {
     root.append(panel);
   }
   root.append(el("div", { className: "dm-note" },
-    "★ = default harness at launch. Family chip = track that line's latest. Suggestions are unfiltered — an open-model licence gate (e.g. MIT/Apache-only) stays operator policy."));
+    "★ = default harness at launch. Local + high-effort = sprint-runnable. Advisory entries remain free-text suggestions. Family chip = track that line's latest."));
 }
 
 // Harness — the shell's surfaces as grouped accordions: Operational

--- a/sc
+++ b/sc
@@ -933,6 +933,7 @@ case "$cmd" in
   # Token & session analytics — sweep each harness's on-disk usage data for
   # THIS repo into session_token_usage (incremental, idempotent; doc #11).
   analytics)    exec "$PY" "$S/analytics.py" "$@" ;;
+  models)       exec "$PY" "$S/models.py" "$@" ;;
   seed-skills)  exec "$PY" "$S/seed_skills.py" ;;
   # Skill catalogue write surface — grants/retirement by name, loud on a miss
   # (the raw-SQL grant's silent no-op class). Snapshot is still the persist step.
@@ -1168,6 +1169,9 @@ super-coder — forkable shell substrate
                              (--label <slug> names it, --timeout <s> kills the wedged process group)
   ./sc job wait <id>       bounded foreground wait, ≤550s slice — exit 0 done · 2 still running
                              (drain your inbox between slices); list/status/tail/kill complete the set
+  ./sc models refresh      refresh local model routes (same action as Shells → Refresh models)
+  ./sc models resolve <h> <model> [--shell <shortname>]
+                             print one exact, locally runnable high-effort sprint call; list [harness] shows routes
   ./sc visual-qa <mode>    viewport screenshot QA: ci boots/captures · run captures a local app · init scaffolds config
   sc sql "<query>"         read-only passthrough to the engine DB (schema/skills/flags) — absolute path, cwd-independent (no `cd` to root)
   sc map-sql "<query>"     read-only passthrough to the repo-map DB (dr_* catalogue) — absolute path, cwd-independent
@@ -1191,9 +1195,9 @@ super-coder — forkable shell substrate
                              harness: --harness <name> or HARNESS=<name> forces it; else when
                              >1 harness is on PATH you're prompted (per-launch, not persisted)
   ./sc run <shortname>     headless boot: render + exec the harness NON-interactively (claude · codex ·
-                             opencode) to drain the shell's inbox and act; -p "<prompt>" overrides the
+                             opencode · kimi) to drain the shell's inbox and act; -p "<prompt>" overrides the
                              default prompt · --harness <h> · -m <model> (else flavor_defaults);
-                             refuses a shell that already has a live session
+                             --effort defaults to high; refuses a shell that already has a live session
   ./sc down                stop + remove the sandbox container
   ./sc restart             confirm (YES) + DB backup, then down + launch — recreate fresh (--yes skips the prompt)
   ./sc build               (re)build the sandbox image

--- a/skills_sc/sprint_orchestration.md
+++ b/skills_sc/sprint_orchestration.md
@@ -63,9 +63,30 @@ Flavor-uniform by design: shells of a flavor are interchangeable workers,
 and one answer per flavor keeps the board readable and the review lineage
 coherent — reviewers stay a different lineage from the code they gate,
 chosen per sprint instead of per boot. No answer -> `flavor_defaults`,
-unchanged (omit the `models:` line). The answers parameterize every
-`./sc run` you issue for this sprint. Per-unit model mixing is out of
-scope — the interview covers the real need, provider choice per role.
+unchanged (omit the `models:` line). Every sprint worker still runs at high
+effort. Per-unit model mixing is out of scope — the interview covers the real
+need, provider choice per role.
+
+**Resolve each answered route before declaring it.** Lazy-load only the two
+choices the FnB made — never trust a display name or translate a provider id by
+hand:
+
+```
+sc models resolve <devs-harness> <devs-model>
+sc models resolve <reviewers-harness> <reviewers-model>
+```
+
+Each must return `route:` plus an exact `call:` ending in `--effort high`.
+Failure means the selector is not locally callable, the harness lacks a
+headless/high-effort seam, or Refresh models has not seen it. Run
+`sc models list <harness>` for the local choices; the FnB's **Refresh models**
+button in `/#shells` repopulates the same runtime table. Resolve again after a
+refresh. Never silently fall back across a provider or lineage.
+
+Common exact selectors: Claude aliases (`fable`, `opus`) and Codex ids
+(`gpt-5.6-sol`, `gpt-5.6-terra`) pass directly. Kimi takes the configured alias
+shown by `sc models list kimi` (for example `kimi-code/k3`), never the bare
+provider model `k3`.
 
 Write the board as a `documents` row:
 
@@ -130,8 +151,8 @@ sc mem message send <dev> "SPRINT <doc-id>: you own unit <seq> — <one line>. D
 # reviewers — assigned units, the severity bar:
 sc mem message send <reviewer> "SPRINT <doc-id>: you review units <seq,seq> — Major/Medium block, Low goes to the report. Load the sprint skill (reviewer slot). Review requests come to you directly as units go green." --kind task
 
-# boot each first-in-chain dev headless, with the sprint's models:
-./sc run <dev> --harness <devs-harness> -m <devs-model>
+# boot each first-in-chain dev with the RESOLVED selector; high is invariant:
+./sc run <dev> --harness <devs-harness> -m <devs-model> --effort high
 ```
 
 `./sc run` renders the shell's boot doc and drains its inbox
@@ -213,13 +234,14 @@ Stalls and the moves:
   fix unit at the front of the chain, resume when green.
 - **Review stall** (unit sitting `in-review` while its reviewer is idle):
   boot the reviewer — `./sc run <reviewer> --harness <reviewers-harness>
-  -m <reviewers-model>`; its inbox holds the review request. Still stuck
+  -m <reviewers-model> --effort high`; its inbox holds the review request. Still stuck
   -> reassign the unit to another reviewer. Severity dispute (dev says
   Low, reviewer says Medium) -> rule by message immediately — a chain
   waiting on a classification argument is pure loss. Dispute about what
   the unit *should do* -> FnB.
-- **Link gone quiet** (no `result` row, no `pr_event` movement): boot it —
-  `./sc run <shortname>` drains its inbox and acts; that IS the nudge in
+- **Link gone quiet** (no `result` row, no `pr_event` movement): boot it with
+  its declared sprint route — `./sc run <shortname> --harness <role-harness>
+  -m <role-model> --effort high` drains its inbox and acts; that IS the nudge in
   an event-driven sprint. The liveness guard refusing (session already
   live) + still silent -> escalate to the FnB with the worktree state.
   The bottleneck question in Step 3 is what surfaces a dead link.
@@ -258,7 +280,7 @@ When every unit is `merged` and `main` is green:
 
    ```
    sc mem message send <reviewer> "SPRINT <doc-id>: conformance pass — spec doc <spec-id>, main @ <merge-sha><, sections <scope> if sharded>. Ratified judgement calls: <list — the only narrative input>. Load the sprint skill (conformance slot)." --kind task
-   ./sc run <reviewer> --harness <reviewers-harness> -m <reviewers-model>
+   ./sc run <reviewer> --harness <reviewers-harness> -m <reviewers-model> --effort high
    ```
 
    The shell judges the spec against the code on `main` — never the

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -17,6 +17,7 @@ Run:
 from __future__ import annotations
 
 import json
+import sqlite3
 import sys
 import tempfile
 import unittest
@@ -25,7 +26,9 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / ".super-coder" / "api"))
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
 import model_catalog as mc  # noqa: E402
+import models as routes_cli  # noqa: E402
 
 MODELS_DEV = {
     "anthropic": {"models": {
@@ -125,13 +128,115 @@ class BuildTest(NoCLI):
                                         "not a model line\n")
             got = mc.build(fetch=fetch_ok, env={}, run=run)
         self.assertEqual(ids(got["harnesses"]["opencode"]),
-                         ["ollama-cloud/deepseek-v4-pro", "ollama-cloud/glm-5.1",
-                          "zprovider/zeta"])
+                         ["ollama-cloud/glm-5.1", "zprovider/zeta",
+                          "ollama-cloud/deepseek-v4-pro"])
         self.assertIn("opencode-cli", got["sources"])
 
     def test_all_sources_down_raises(self):
         with self.assertRaises(RuntimeError):
             mc.build(fetch=fetch_down, env={}, run=None)
+
+
+class LocalRouteDiscoveryTest(unittest.TestCase):
+    def test_codex_cache_is_locally_available_with_efforts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "models_cache.json").write_text(json.dumps({"models": [{
+                "slug": "gpt-local", "display_name": "GPT Local",
+                "visibility": "list", "default_reasoning_level": "medium",
+                "supported_reasoning_levels": [
+                    {"effort": "medium"}, {"effort": "high"}],
+            }]}))
+            run = mock.Mock(return_value=mock.Mock(
+                returncode=0, stdout="codex-cli 9.9\n", stderr=""))
+            with mock.patch.object(
+                    mc.shutil, "which",
+                    side_effect=lambda name: "/bin/codex" if name == "codex" else None):
+                got = mc.build(fetch=fetch_down, env={"CODEX_HOME": tmp}, run=run)
+        model = got["harnesses"]["codex"]["models"][0]
+        self.assertEqual(model["id"], "gpt-local")
+        self.assertEqual(model["availability"], "available")
+        self.assertEqual(model["source"], "codex-cache")
+        self.assertIn("high", model["supported_efforts"])
+
+    def test_kimi_config_selector_is_alias_not_provider_model(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "config.toml").write_text(
+                'default_model = "kimi-code/k3"\n'
+                '[models."kimi-code/k3"]\n'
+                'provider = "managed:kimi-code"\nmodel = "k3"\n'
+                'display_name = "K3"\nsupport_efforts = ["low", "high"]\n'
+                'default_effort = "high"\n')
+            run = mock.Mock(return_value=mock.Mock(
+                returncode=0, stdout="0.27.0\n", stderr=""))
+            with mock.patch.object(
+                    mc.shutil, "which",
+                    side_effect=lambda name: "/bin/kimi" if name == "kimi" else None):
+                got = mc.build(fetch=fetch_down, env={"KIMI_CODE_HOME": tmp}, run=run)
+        model = got["harnesses"]["kimi"]["models"][0]
+        self.assertEqual(model["id"], "kimi-code/k3")
+        self.assertEqual(model["provider_model"], "k3")
+        self.assertEqual(model["availability"], "available")
+
+
+class RoutePersistenceTest(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite3.connect(":memory:")
+        self.con.row_factory = sqlite3.Row
+        migration = ROOT / ".super-coder" / "migrations" / "0075_model_routes.sql"
+        self.con.executescript(migration.read_text())
+
+    def tearDown(self):
+        self.con.close()
+
+    def test_persist_marks_exact_high_effort_route_runnable(self):
+        payload = {
+            "fetched_at": "2026-07-21T00:00:00+00:00", "stale": False,
+            "harnesses": {"kimi": {"models": [mc._entry(
+                "kimi-code/k3", source="kimi-config", availability="available",
+                provider="managed:kimi-code", provider_model="k3",
+                supported_efforts=["low", "high"])]}},
+        }
+        mc.persist_routes(self.con, payload)
+        row = self.con.execute(
+            "SELECT selector, availability, headless_supported, "
+            "high_effort_supported, stale FROM model_routes").fetchone()
+        self.assertEqual(tuple(row), ("kimi-code/k3", "available", 1, 1, 0))
+
+    def test_failed_refresh_keeps_route_and_marks_it_stale(self):
+        fresh = {"fetched_at": "2026-07-21T00:00:00+00:00", "stale": False,
+                 "harnesses": {"claude": {"models": [mc._entry(
+                     "fable", source="claude-cli", availability="available",
+                     supported_efforts=["high"])]}}}
+        mc.persist_routes(self.con, fresh)
+        mc.persist_routes(self.con, {"fetched_at": None, "stale": True,
+                                     "error": "network down", "harnesses": {}})
+        row = self.con.execute(
+            "SELECT stale, last_error FROM model_routes WHERE selector='fable'").fetchone()
+        self.assertEqual(tuple(row), (1, "network down"))
+
+    def test_resolver_returns_exact_high_effort_sc_run_call(self):
+        fresh = {"fetched_at": "2026-07-21T00:00:00+00:00", "stale": False,
+                 "harnesses": {"codex": {"models": [mc._entry(
+                     "gpt-5.6-sol", source="codex-cache",
+                     availability="available", supported_efforts=["high"])]}}}
+        mc.persist_routes(self.con, fresh)
+        got = routes_cli.resolve(
+            self.con, "codex", "gpt-5.6-sol", shell="DEV3")
+        self.assertTrue(got["ok"])
+        self.assertEqual(
+            got["command"],
+            ["./sc", "run", "DEV3", "--harness", "codex", "-m",
+             "gpt-5.6-sol", "--effort", "high"])
+
+    def test_resolver_rejects_unverified_high_effort(self):
+        fresh = {"fetched_at": "2026-07-21T00:00:00+00:00", "stale": False,
+                 "harnesses": {"kimi": {"models": [mc._entry(
+                     "kimi-code/legacy", source="kimi-config",
+                     availability="available", supported_efforts=[])]}}}
+        mc.persist_routes(self.con, fresh)
+        got = routes_cli.resolve(self.con, "kimi", "kimi-code/legacy")
+        self.assertFalse(got["ok"])
+        self.assertIn("high-effort", got["error"])
 
 
 class CatalogCacheTest(NoCLI):

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -100,6 +100,18 @@ class SchemaTest(unittest.TestCase):
         ).fetchone()
         self.assertIsNotNone(idx, "live-watch partial index missing")
 
+    def test_model_routes_runtime_table_is_migrated(self):
+        cols = {r[1] for r in self.con.execute("PRAGMA table_info(model_routes)")}
+        self.assertTrue({"harness", "selector", "availability",
+                         "high_effort_supported", "stale"}.issubset(cols))
+
+    def test_sprint_orchestration_seed_matches_source_asset(self):
+        asset = (ENGINE / "assets" / "skills" / "sprint_orchestration" /
+                 "SKILL.md").read_text().split("---", 2)[2].strip()
+        body = self.con.execute(
+            "SELECT content FROM skills WHERE name='sprint_orchestration'").fetchone()[0]
+        self.assertEqual(body, asset)
+
 
 # ── daemon core: diff_events (pure) ──────────────────────────────────────────
 
@@ -558,13 +570,17 @@ class HeadlessTest(unittest.TestCase):
             None, {"default_harness": None, "models": {}}, "claude"))
 
     def test_claude_headless_argv(self):
-        cmd = run.headless_command(self.adapter("claude"), "do the task", "opus")
-        self.assertEqual(cmd, ["claude", "-p", "--model", "opus", "do the task"])
+        cmd = run.headless_command(
+            self.adapter("claude"), "do the task", "opus", effort="high")
+        self.assertEqual(cmd, ["claude", "--model", "opus", "--effort", "high",
+                               "-p", "do the task"])
 
     def test_codex_headless_argv(self):
         cmd = run.headless_command(self.adapter("codex"), "do it", "gpt-5.4",
-                                   ["--dangerously-bypass-approvals-and-sandbox"])
+                                   ["--dangerously-bypass-approvals-and-sandbox"],
+                                   effort="high")
         self.assertEqual(cmd, ["codex", "exec", "-m", "gpt-5.4",
+                               "-c", 'model_reasoning_effort="high"',
                                "--dangerously-bypass-approvals-and-sandbox", "do it"])
 
     def test_opencode_headless_argv(self):
@@ -579,15 +595,23 @@ class HeadlessTest(unittest.TestCase):
         self.assertIsNone(run.headless_command(self.adapter("vibe"), "p"))
 
     def test_kimi_headless_argv(self):
-        cmd = run.headless_command(self.adapter("kimi"), "do it")
-        self.assertEqual(cmd, ["kimi", "-p", "do it"])
+        cmd = run.headless_command(
+            self.adapter("kimi"), "do it", "kimi-code/k3", effort="high")
+        self.assertEqual(cmd, ["kimi", "-m", "kimi-code/k3", "-p", "do it"])
+        self.assertEqual(
+            run.headless_effort_env(self.adapter("kimi"), "high"),
+            {"KIMI_MODEL_THINKING_EFFORT": "high"})
 
-    def test_kimi_takes_no_model_from_the_seam(self):
-        # kimi declares no model_flag (its -m wants a config.toml alias, not a
-        # portable id) — a resolved model must NOT leak into the argv, where it
-        # would land between -p and its prompt value.
-        cmd = run.headless_command(self.adapter("kimi"), "p", "k3")
-        self.assertEqual(cmd, ["kimi", "-p", "p"])
+    def test_unroutable_model_fails_instead_of_silent_drop(self):
+        adapter = self.adapter("kimi")
+        del adapter["headless"]["model_flag"]
+        with self.assertRaisesRegex(ValueError, "cannot apply requested model"):
+            run.headless_command(adapter, "p", "kimi-code/k3", effort="high")
+
+    def test_harness_without_effort_control_fails_high_effort(self):
+        with self.assertRaisesRegex(ValueError, "cannot apply effort"):
+            run.headless_command(
+                self.adapter("opencode"), "p", "zai/glm", effort="high")
 
     def test_prompt_is_the_final_positional(self):
         cmd = run.headless_command(self.adapter("claude"), "trailing prompt", "opus",


### PR DESCRIPTION
## Outcome
- persist locally authoritative model routes from Refresh models
- resolve exact high-effort sprint launch commands through new `sc models`
- route Kimi config aliases correctly and reject silent model/effort drops
- teach sprint orchestration to lazy-resolve dev/reviewer selections

## Verification
- `SC_SANDBOX= ./sc test` — 516 passed
- sandbox suite — 513 passed; only known VM-bake sandbox guards failed
- Ruff, Node syntax, py_compile, diff check green
- fresh schema + all migrations and skill asset/reseed equality covered

## Trade-off
OpenCode and Vibe remain visible as advisory models but are not sprint-runnable under the high-effort invariant until they expose a verified high-effort headless seam. No cross-provider fallback is automatic.