### PR TITLE
feat(session-control): add binding state foundation

### DIFF
--- a/.super-coder/migrations/0077_session_control_state.sql
+++ b/.super-coder/migrations/0077_session_control_state.sql
@@ -1,0 +1,69 @@
+-- 0077 — provider-neutral planner session-control state.
+--
+-- A managed sprint planner keeps one engine archive bound to one native
+-- harness conversation. shell_session_bindings records that address plus the
+-- locally validated owner/control state; session_wake_jobs is the durable
+-- claim/audit ledger reconstructed from unread shell_messages.
+--
+-- Message read_at remains the delivery acknowledgement. A wake row reaching
+-- done never marks its trigger message read, and a missing wake row can always
+-- be recreated with INSERT OR IGNORE from the unread-message source of truth.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS shell_session_bindings (
+  binding_id          INTEGER PRIMARY KEY,
+  archive_id          INTEGER NOT NULL UNIQUE
+                      REFERENCES shell_memory_archives(archive_id),
+  shell_id            INTEGER NOT NULL REFERENCES shells(shell_id),
+  harness             TEXT NOT NULL,
+  native_session_id   TEXT,
+  control_endpoint    TEXT,
+  control_capabilities TEXT NOT NULL DEFAULT '{}',
+  cli_version         TEXT,
+  state               TEXT NOT NULL CHECK (state IN
+                      ('starting','foreground','idle','dispatching',
+                       'dormant','released','error')),
+  managed             INTEGER NOT NULL DEFAULT 0 CHECK (managed IN (0,1)),
+  lease_pid           INTEGER,
+  lease_start_ticks   INTEGER,
+  active_channel_pid  INTEGER,
+  active_channel_start_ticks INTEGER,
+  active_channel_heartbeat_at TEXT,
+  lease_generation    INTEGER NOT NULL DEFAULT 0,
+  last_error          TEXT,
+  created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (harness, native_session_id)
+);
+
+CREATE TABLE IF NOT EXISTS session_wake_jobs (
+  wake_id             INTEGER PRIMARY KEY,
+  binding_id          INTEGER NOT NULL
+                      REFERENCES shell_session_bindings(binding_id),
+  trigger_message_id  INTEGER NOT NULL REFERENCES shell_messages(message_id),
+  state               TEXT NOT NULL DEFAULT 'queued'
+                      CHECK (state IN ('queued','running','done','failed','cancelled')),
+  attempt_count       INTEGER NOT NULL DEFAULT 0,
+  available_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  started_at          TEXT,
+  finished_at         TEXT,
+  last_error          TEXT,
+  UNIQUE (binding_id, trigger_message_id)
+);
+
+-- One shell may retain historical/released bindings, but autonomous delivery
+-- has exactly one current conversation target.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_session_bindings_managed_shell
+  ON shell_session_bindings(shell_id) WHERE managed = 1;
+
+CREATE INDEX IF NOT EXISTS idx_session_bindings_managed_state
+  ON shell_session_bindings(state) WHERE managed = 1;
+
+CREATE INDEX IF NOT EXISTS idx_session_wake_jobs_ready
+  ON session_wake_jobs(binding_id, state, available_at);
+
+CREATE INDEX IF NOT EXISTS idx_session_wake_jobs_message
+  ON session_wake_jobs(trigger_message_id);
+
+COMMIT;

--- a/.super-coder/scripts/session_control.py
+++ b/.super-coder/scripts/session_control.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Pure binding-state rules and wake-ledger reconstruction.
+
+Provider adapters own transport. This module owns only the common state
+contract: which lifecycle moves are valid, a compare-and-set DB transition,
+and reconstruction of missing wake jobs from managed bindings plus unread
+messages. Callers own transactions and commits.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Mapping
+
+
+BINDING_STATES = frozenset(
+    {"starting", "foreground", "idle", "dispatching", "dormant", "released", "error"}
+)
+
+# Recovery is deliberately explicit: released/error bindings cannot dispatch
+# directly. Re-manage/retry moves them through starting so capability and owner
+# reconciliation happens before a transport is authorized.
+_NEXT_STATES: Mapping[str, frozenset[str]] = {
+    "starting": frozenset({"foreground", "idle", "dormant", "released", "error"}),
+    "foreground": frozenset({"idle", "dispatching", "dormant", "released", "error"}),
+    "idle": frozenset({"foreground", "dispatching", "dormant", "released", "error"}),
+    "dispatching": frozenset({"foreground", "idle", "dormant", "released", "error"}),
+    "dormant": frozenset(
+        {"starting", "foreground", "idle", "dispatching", "released", "error"}
+    ),
+    "released": frozenset({"starting"}),
+    "error": frozenset({"starting", "released"}),
+}
+
+
+class SessionControlError(RuntimeError):
+    """Base error for session-control state operations."""
+
+
+class UnknownBindingState(SessionControlError, ValueError):
+    """A caller supplied a state outside the provider-neutral contract."""
+
+
+class InvalidStateTransition(SessionControlError, ValueError):
+    """The requested lifecycle edge is not allowed."""
+
+
+class BindingNotFound(SessionControlError):
+    """The requested binding row does not exist."""
+
+
+class StaleBindingState(SessionControlError):
+    """Another owner changed the row before this transition could commit."""
+
+    def __init__(self, binding_id: int, expected: str, actual: str):
+        self.binding_id = binding_id
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"binding {binding_id} state changed: expected {expected!r}, found {actual!r}"
+        )
+
+
+def _require_state(state: str) -> None:
+    if state not in BINDING_STATES:
+        raise UnknownBindingState(f"unknown session binding state: {state!r}")
+
+
+def is_transition_allowed(current: str, target: str) -> bool:
+    """Return whether ``current -> target`` is a valid lifecycle edge.
+
+    A same-state refresh is valid so a reconciler can atomically refresh
+    metadata without inventing a lifecycle transition.
+    """
+    _require_state(current)
+    _require_state(target)
+    return current == target or target in _NEXT_STATES[current]
+
+
+def validate_transition(current: str, target: str) -> None:
+    """Raise a precise error when a lifecycle edge is invalid."""
+    if not is_transition_allowed(current, target):
+        raise InvalidStateTransition(
+            f"invalid session binding transition: {current} -> {target}"
+        )
+
+
+def transition_binding(
+    con: sqlite3.Connection,
+    binding_id: int,
+    *,
+    expected: str,
+    target: str,
+) -> None:
+    """Compare-and-set one binding state, leaving commit control to caller."""
+    validate_transition(expected, target)
+    cur = con.execute(
+        "UPDATE shell_session_bindings "
+        "SET state = ?, updated_at = datetime('now') "
+        "WHERE binding_id = ? AND state = ?",
+        (target, binding_id, expected),
+    )
+    if cur.rowcount == 1:
+        return
+
+    row = con.execute(
+        "SELECT state FROM shell_session_bindings WHERE binding_id = ?", (binding_id,)
+    ).fetchone()
+    if row is None:
+        raise BindingNotFound(f"session binding {binding_id} not found")
+    raise StaleBindingState(binding_id, expected, row[0])
+
+
+def reconstruct_wake_jobs(con: sqlite3.Connection) -> int:
+    """Insert missing wake jobs for every unread managed-binding message.
+
+    Existing jobs retain their state/attempt history. The returned count is
+    exact for this call, including zero on an idempotent rescan. The caller
+    owns commit/rollback.
+    """
+    before = con.total_changes
+    con.execute(
+        "INSERT OR IGNORE INTO session_wake_jobs (binding_id, trigger_message_id) "
+        "SELECT b.binding_id, m.message_id "
+        "FROM shell_session_bindings AS b "
+        "JOIN shell_messages AS m ON m.to_shell_id = b.shell_id "
+        "WHERE b.managed = 1 AND m.read_at IS NULL"
+    )
+    return con.total_changes - before

--- a/tests/test_session_control.py
+++ b/tests/test_session_control.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Hermetic schema and state-machine tests for planner session control."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import session_control  # noqa: E402
+
+
+def build_db() -> sqlite3.Connection:
+    """Build a fresh engine DB from the baseline plus every migration."""
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+def build_pre_session_control_db() -> sqlite3.Connection:
+    """Build the dirty upgrade shape immediately before migration 0077."""
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        if migration.name >= "0077_session_control_state.sql":
+            break
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+def seed_shell(con: sqlite3.Connection, shell_id: int, shortname: str) -> int:
+    con.execute(
+        "INSERT OR IGNORE INTO users (user_id, username, is_active) VALUES (1, 'T', 1)"
+    )
+    con.execute(
+        "INSERT INTO shells "
+        "(shell_id, display_name, shortname, system_prompt, user_id) "
+        "VALUES (?, ?, ?, 'test', 1)",
+        (shell_id, shortname.upper(), shortname),
+    )
+    cur = con.execute(
+        "INSERT INTO shell_memory_archives (shell_id, session_id, date) "
+        "VALUES (?, ?, '2026-07-21')",
+        (shell_id, f"session-{shell_id}"),
+    )
+    return cur.lastrowid
+
+
+def insert_binding(
+    con: sqlite3.Connection,
+    *,
+    archive_id: int,
+    shell_id: int,
+    harness: str = "codex",
+    native_session_id: str | None = None,
+    state: str = "idle",
+    managed: int = 1,
+) -> int:
+    cur = con.execute(
+        "INSERT INTO shell_session_bindings "
+        "(archive_id, shell_id, harness, native_session_id, state, managed) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (archive_id, shell_id, harness, native_session_id, state, managed),
+    )
+    return cur.lastrowid
+
+
+class SessionControlSchemaTest(unittest.TestCase):
+    def setUp(self):
+        self.con = build_db()
+        self.archive_id = seed_shell(self.con, 1, "plan1")
+
+    def tearDown(self):
+        self.con.close()
+
+    def test_binding_defaults_and_foreign_keys(self):
+        binding_id = insert_binding(
+            self.con, archive_id=self.archive_id, shell_id=1, managed=0
+        )
+        row = self.con.execute(
+            "SELECT * FROM shell_session_bindings WHERE binding_id = ?", (binding_id,)
+        ).fetchone()
+        self.assertEqual(row["archive_id"], self.archive_id)
+        self.assertEqual(row["shell_id"], 1)
+        self.assertEqual(row["harness"], "codex")
+        self.assertIsNone(row["native_session_id"])
+        self.assertEqual(row["control_capabilities"], "{}")
+        self.assertEqual(row["state"], "idle")
+        self.assertEqual(row["managed"], 0)
+        self.assertEqual(row["lease_generation"], 0)
+
+        with self.assertRaises(sqlite3.IntegrityError):
+            insert_binding(self.con, archive_id=999, shell_id=1, managed=0)
+        with self.assertRaises(sqlite3.IntegrityError):
+            insert_binding(
+                self.con, archive_id=self.archive_id, shell_id=999, managed=0
+            )
+
+    def test_binding_uniqueness_and_state_constraints(self):
+        insert_binding(
+            self.con,
+            archive_id=self.archive_id,
+            shell_id=1,
+            native_session_id="thread-1",
+        )
+        archive_2 = seed_shell(self.con, 2, "plan2")
+        with self.assertRaises(sqlite3.IntegrityError):
+            insert_binding(
+                self.con,
+                archive_id=archive_2,
+                shell_id=2,
+                native_session_id="thread-1",
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            insert_binding(
+                self.con,
+                archive_id=archive_2,
+                shell_id=2,
+                state="lost",
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "UPDATE shell_session_bindings SET managed = 2 WHERE binding_id = 1"
+            )
+
+    def test_only_one_managed_binding_per_shell(self):
+        insert_binding(self.con, archive_id=self.archive_id, shell_id=1)
+        self.con.execute(
+            "INSERT INTO shell_memory_archives (shell_id, session_id, date) "
+            "VALUES (1, 'later-session', '2026-07-21')"
+        )
+        archive_2 = self.con.execute(
+            "SELECT MAX(archive_id) FROM shell_memory_archives"
+        ).fetchone()[0]
+        with self.assertRaises(sqlite3.IntegrityError):
+            insert_binding(
+                self.con,
+                archive_id=archive_2,
+                shell_id=1,
+                native_session_id="thread-2",
+            )
+        # Historical/released rows remain valid when they are unmanaged.
+        insert_binding(
+            self.con,
+            archive_id=archive_2,
+            shell_id=1,
+            native_session_id="thread-2",
+            state="released",
+            managed=0,
+        )
+        rows = self.con.execute(
+            "SELECT state, managed FROM shell_session_bindings ORDER BY binding_id"
+        ).fetchall()
+        self.assertEqual(
+            [(r["state"], r["managed"]) for r in rows], [("idle", 1), ("released", 0)]
+        )
+
+    def test_wake_job_defaults_uniqueness_and_foreign_keys(self):
+        binding_id = insert_binding(self.con, archive_id=self.archive_id, shell_id=1)
+        message_id = self.con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body) "
+            "VALUES (1, 1, 'wake')"
+        ).lastrowid
+        wake_id = self.con.execute(
+            "INSERT INTO session_wake_jobs (binding_id, trigger_message_id) VALUES (?, ?)",
+            (binding_id, message_id),
+        ).lastrowid
+        row = self.con.execute(
+            "SELECT * FROM session_wake_jobs WHERE wake_id = ?", (wake_id,)
+        ).fetchone()
+        self.assertEqual(row["binding_id"], binding_id)
+        self.assertEqual(row["trigger_message_id"], message_id)
+        self.assertEqual(row["state"], "queued")
+        self.assertEqual(row["attempt_count"], 0)
+        self.assertIsNone(row["started_at"])
+        self.assertIsNone(row["finished_at"])
+        self.assertIsNone(row["last_error"])
+
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO session_wake_jobs (binding_id, trigger_message_id) VALUES (?, ?)",
+                (binding_id, message_id),
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO session_wake_jobs (binding_id, trigger_message_id) VALUES (999, ?)",
+                (message_id,),
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO session_wake_jobs (binding_id, trigger_message_id) VALUES (?, 999)",
+                (binding_id,),
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "UPDATE session_wake_jobs SET state = 'lost' WHERE wake_id = ?",
+                (wake_id,),
+            )
+
+    def test_dispatch_indexes_exist(self):
+        names = {
+            row["name"]
+            for row in self.con.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index'"
+            )
+        }
+        self.assertTrue(
+            {
+                "idx_session_bindings_managed_shell",
+                "idx_session_bindings_managed_state",
+                "idx_session_wake_jobs_ready",
+                "idx_session_wake_jobs_message",
+            }.issubset(names)
+        )
+
+
+class SessionControlMigrationTest(unittest.TestCase):
+    def test_dirty_pre_0077_database_upgrades_without_losing_messages(self):
+        con = build_pre_session_control_db()
+        self.addCleanup(con.close)
+        archive_id = seed_shell(con, 1, "plan1")
+        message_id = con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body) "
+            "VALUES (1, 1, 'already unread before upgrade')"
+        ).lastrowid
+        con.commit()
+
+        migration = MIGRATIONS / "0077_session_control_state.sql"
+        con.executescript(migration.read_text())
+        binding_id = insert_binding(
+            con, archive_id=archive_id, shell_id=1, state="starting", managed=1
+        )
+
+        self.assertEqual(session_control.reconstruct_wake_jobs(con), 1)
+        row = con.execute(
+            "SELECT binding_id, trigger_message_id, state FROM session_wake_jobs"
+        ).fetchone()
+        self.assertEqual(tuple(row), (binding_id, message_id, "queued"))
+        preserved = con.execute(
+            "SELECT body, read_at FROM shell_messages WHERE message_id = ?",
+            (message_id,),
+        ).fetchone()
+        self.assertEqual(tuple(preserved), ("already unread before upgrade", None))
+
+
+class BindingStateMachineTest(unittest.TestCase):
+    ALLOWED = {
+        "starting": {"starting", "foreground", "idle", "dormant", "released", "error"},
+        "foreground": {
+            "foreground",
+            "idle",
+            "dispatching",
+            "dormant",
+            "released",
+            "error",
+        },
+        "idle": {"idle", "foreground", "dispatching", "dormant", "released", "error"},
+        "dispatching": {
+            "dispatching",
+            "foreground",
+            "idle",
+            "dormant",
+            "released",
+            "error",
+        },
+        "dormant": {
+            "dormant",
+            "starting",
+            "foreground",
+            "idle",
+            "dispatching",
+            "released",
+            "error",
+        },
+        "released": {"released", "starting"},
+        "error": {"error", "starting", "released"},
+    }
+
+    def test_every_allowed_and_forbidden_transition(self):
+        self.assertEqual(set(self.ALLOWED), set(session_control.BINDING_STATES))
+        for current in session_control.BINDING_STATES:
+            for target in session_control.BINDING_STATES:
+                expected = target in self.ALLOWED[current]
+                self.assertEqual(
+                    session_control.is_transition_allowed(current, target),
+                    expected,
+                    f"unexpected policy for {current} -> {target}",
+                )
+                if expected:
+                    session_control.validate_transition(current, target)
+                else:
+                    with self.assertRaises(session_control.InvalidStateTransition):
+                        session_control.validate_transition(current, target)
+
+    def test_unknown_states_fail_closed(self):
+        for current, target in (("lost", "idle"), ("idle", "lost")):
+            with self.assertRaises(session_control.UnknownBindingState):
+                session_control.is_transition_allowed(current, target)
+
+    def test_compare_and_set_transition_and_stale_owner(self):
+        con = build_db()
+        try:
+            archive_id = seed_shell(con, 1, "plan1")
+            binding_id = insert_binding(
+                con, archive_id=archive_id, shell_id=1, state="idle"
+            )
+            session_control.transition_binding(
+                con, binding_id, expected="idle", target="dispatching"
+            )
+            row = con.execute(
+                "SELECT state FROM shell_session_bindings WHERE binding_id = ?",
+                (binding_id,),
+            ).fetchone()
+            self.assertEqual(row["state"], "dispatching")
+            with self.assertRaises(session_control.StaleBindingState) as caught:
+                session_control.transition_binding(
+                    con, binding_id, expected="idle", target="dormant"
+                )
+            self.assertEqual(caught.exception.actual, "dispatching")
+            self.assertEqual(
+                con.execute(
+                    "SELECT state FROM shell_session_bindings WHERE binding_id = ?",
+                    (binding_id,),
+                ).fetchone()["state"],
+                "dispatching",
+            )
+        finally:
+            con.close()
+
+    def test_invalid_transition_and_missing_binding_do_not_write(self):
+        con = build_db()
+        try:
+            archive_id = seed_shell(con, 1, "plan1")
+            binding_id = insert_binding(
+                con, archive_id=archive_id, shell_id=1, state="released", managed=0
+            )
+            with self.assertRaises(session_control.InvalidStateTransition):
+                session_control.transition_binding(
+                    con, binding_id, expected="released", target="dispatching"
+                )
+            self.assertEqual(
+                con.execute(
+                    "SELECT state FROM shell_session_bindings WHERE binding_id = ?",
+                    (binding_id,),
+                ).fetchone()["state"],
+                "released",
+            )
+            with self.assertRaises(session_control.BindingNotFound):
+                session_control.transition_binding(
+                    con, 999, expected="starting", target="idle"
+                )
+        finally:
+            con.close()
+
+
+class WakeReconstructionTest(unittest.TestCase):
+    def setUp(self):
+        self.con = build_db()
+        archive_1 = seed_shell(self.con, 1, "plan1")
+        archive_2 = seed_shell(self.con, 2, "plan2")
+        self.binding_1 = insert_binding(
+            self.con, archive_id=archive_1, shell_id=1, managed=1
+        )
+        self.binding_2 = insert_binding(
+            self.con, archive_id=archive_2, shell_id=2, managed=0
+        )
+
+    def tearDown(self):
+        self.con.close()
+
+    def _message(self, to_shell_id: int, body: str, *, read: bool = False) -> int:
+        cur = self.con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body, read_at) "
+            "VALUES (1, ?, ?, ?)",
+            (to_shell_id, body, "2026-07-21 19:00:00" if read else None),
+        )
+        return cur.lastrowid
+
+    def test_reconstructs_only_unread_managed_messages_and_is_idempotent(self):
+        unread_managed = self._message(1, "managed unread")
+        self._message(1, "managed read", read=True)
+        self._message(2, "unmanaged unread")
+
+        self.assertEqual(session_control.reconstruct_wake_jobs(self.con), 1)
+        rows = self.con.execute(
+            "SELECT binding_id, trigger_message_id, state, attempt_count "
+            "FROM session_wake_jobs"
+        ).fetchall()
+        self.assertEqual(
+            [tuple(row) for row in rows],
+            [(self.binding_1, unread_managed, "queued", 0)],
+        )
+        self.assertEqual(session_control.reconstruct_wake_jobs(self.con), 0)
+        self.assertEqual(
+            self.con.execute("SELECT COUNT(*) FROM session_wake_jobs").fetchone()[0], 1
+        )
+
+    def test_rescan_adds_new_messages_without_resetting_existing_job(self):
+        first = self._message(1, "first")
+        self.assertEqual(session_control.reconstruct_wake_jobs(self.con), 1)
+        self.con.execute(
+            "UPDATE session_wake_jobs SET state = 'failed', attempt_count = 3, "
+            "last_error = 'provider down' WHERE trigger_message_id = ?",
+            (first,),
+        )
+        second = self._message(1, "second")
+
+        self.assertEqual(session_control.reconstruct_wake_jobs(self.con), 1)
+        rows = self.con.execute(
+            "SELECT trigger_message_id, state, attempt_count, last_error "
+            "FROM session_wake_jobs ORDER BY trigger_message_id"
+        ).fetchall()
+        self.assertEqual(
+            [tuple(row) for row in rows],
+            [
+                (first, "failed", 3, "provider down"),
+                (second, "queued", 0, None),
+            ],
+        )
+
+    def test_enabling_management_makes_existing_unread_message_reconstructible(self):
+        message_id = self._message(2, "waiting before manage")
+        self.assertEqual(session_control.reconstruct_wake_jobs(self.con), 0)
+        self.con.execute(
+            "UPDATE shell_session_bindings SET managed = 1 WHERE binding_id = ?",
+            (self.binding_2,),
+        )
+        self.assertEqual(session_control.reconstruct_wake_jobs(self.con), 1)
+        row = self.con.execute(
+            "SELECT binding_id, trigger_message_id FROM session_wake_jobs"
+        ).fetchone()
+        self.assertEqual(tuple(row), (self.binding_2, message_id))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add migration 0077 with session bindings, wake-job ledger, constraints, and dispatcher indexes
- add the provider-neutral binding state machine with compare-and-set transitions
- reconstruct missing wake jobs idempotently from managed bindings and unread messages

## Judgement

The spec names states but not transition edges. This unit uses a conservative graph: same-state metadata refreshes are valid; active/dormant states may dispatch; released/error states must recover through starting before delivery. This keeps capability and ownership reconciliation explicit.

## Verification

- 13 focused session-control tests
- 4 migration-runner tests
- fresh migration chain + render-check
- Ruff + py_compile
- full host-mode suite: 528 passed, 13 subtests
- sandbox suite: same pass set plus the known unrelated vm-bake #435 guard trio

Sprint 21 unit 1 · spec #20 · task #50.