### PR TITLE
feat(session): supervise harness ownership leases

### DIFF
--- a/.super-coder/migrations/0078_session_supervisor_identity.sql
+++ b/.super-coder/migrations/0078_session_supervisor_identity.sql
@@ -1,0 +1,13 @@
+-- 0078 — distinguish live supervisor cleanup from an orphaned harness group.
+--
+-- The harness process remains the fenced conversation owner and process-group
+-- leader.  These nullable identity fields record the engine supervisor that
+-- is responsible for reaping that group after the leader exits, so the
+-- dispatcher does not misclassify a healthy shutdown as a #439 orphan race.
+
+BEGIN;
+
+ALTER TABLE shell_session_bindings ADD COLUMN supervisor_pid INTEGER;
+ALTER TABLE shell_session_bindings ADD COLUMN supervisor_start_ticks INTEGER;
+
+COMMIT;

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -1237,6 +1237,16 @@ def main() -> None:
 
     lease: dict[str, int] = {}
 
+    def lease_preflight() -> None:
+        if not binding:
+            return
+        lease_con = open_db()
+        try:
+            session_supervisor.preflight_lease(
+                lease_con, binding["binding_id"], repo_root=REPO_ROOT)
+        finally:
+            lease_con.close()
+
     def lease_started(pid: int) -> None:
         if not binding:
             return
@@ -1244,7 +1254,8 @@ def main() -> None:
         try:
             generation = session_supervisor.claim_lease(
                 lease_con, binding["binding_id"], pid, repo_root=REPO_ROOT,
-                state="dispatching" if headless else "foreground")
+                state="dispatching" if headless else "foreground",
+                supervisor_pid=os.getpid())
             identity = session_supervisor.read_process(pid)
             if not identity:  # claim_lease already validated it; fail closed on a race.
                 raise RuntimeError("harness process vanished while recording its lease")
@@ -1270,7 +1281,8 @@ def main() -> None:
 
     try:
         rc = session_supervisor.supervise(
-            cmd, cwd=work_dir, env=env, on_started=lease_started,
+            cmd, cwd=work_dir, env=env, on_pre_spawn=lease_preflight,
+            on_started=lease_started,
             on_exited=lease_exited)
     except (OSError, RuntimeError, session_supervisor.LeaseConflict) as e:
         sys.exit(f"session launch refused: {e}")

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import signal
 import socket
 import subprocess
 import sys
@@ -54,6 +55,7 @@ import ports as ports_mod  # noqa: E402  — derive the per-fork API base URL
 import style  # noqa: E402  — launcher ANSI; degrades to plain text off-TTY
 import seed_skills  # noqa: E402  — boot-time self-heal of stale engine skills
 import shell_liveness  # noqa: E402  — headless boot's one-shell-one-session guard
+import session_supervisor  # noqa: E402  — process groups + fenced planner ownership
 
 sys.path.insert(0, str(ENGINE / "api"))
 import model_catalog  # noqa: E402  — HARNESS_PROVIDER: one source for harness → provider
@@ -680,11 +682,24 @@ def session_provider(harness: str, model: "str | None") -> "str | None":
 
 
 def open_session(con, shell_id: int,
-                 lifecycle: "dict | None" = None) -> tuple[str, int]:
+                 lifecycle: "dict | None" = None,
+                 reuse_archive_id: "int | None" = None) -> tuple[str, int]:
     """`lifecycle` carries the launch telemetry persisted onto the archive row
     (started_at/harness/provider/model/sprint_ref — migration 0071). ended_at is
     NOT written here: run.py execs the harness, so no code runs at exit; the
     analytics sweep backfills it from harness session data."""
+    if reuse_archive_id is not None:
+        row = con.execute(
+            "SELECT archive_id, session_id FROM shell_memory_archives "
+            "WHERE archive_id=? AND shell_id=?", (reuse_archive_id, shell_id),
+        ).fetchone()
+        if not row:
+            raise ValueError("resume archive does not belong to the selected shell")
+        con.execute("UPDATE shells SET active_archive_id=? WHERE shell_id=?",
+                    (row["archive_id"], shell_id))
+        con.commit()
+        return row["session_id"], row["archive_id"]
+
     life = {"started_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             **(lifecycle or {})}
     life_cols = ["started_at", "harness", "provider", "model", "sprint_ref"]
@@ -776,6 +791,7 @@ def main() -> None:
     flag_harness = None
     flag_model = None
     flag_effort = None
+    flag_binding = None
     prompt = None
     positional = []
     i = 0
@@ -793,6 +809,10 @@ def main() -> None:
             flag_effort = args[i + 1] if i + 1 < len(args) else None
             i += 2
             continue
+        if a == "--session-binding":
+            flag_binding = args[i + 1] if i + 1 < len(args) else None
+            i += 2
+            continue
         if a in ("-p", "--prompt"):
             prompt = args[i + 1] if i + 1 < len(args) else None
             i += 2
@@ -803,6 +823,8 @@ def main() -> None:
             flag_model = a.split("=", 1)[1]
         elif a.startswith("--effort="):
             flag_effort = a.split("=", 1)[1]
+        elif a.startswith("--session-binding="):
+            flag_binding = a.split("=", 1)[1]
         elif a.startswith("--prompt="):
             prompt = a.split("=", 1)[1]
         elif not a.startswith("-"):
@@ -911,6 +933,19 @@ def main() -> None:
         except ValueError as e:
             sys.exit(f"sc run: {e}")
 
+    resume_binding = None
+    if flag_binding:
+        try:
+            resume_binding = session_supervisor.binding_for_resume(
+                con, int(flag_binding), shell_id=chosen["shell_id"], harness=harness)
+        except (TypeError, ValueError) as e:
+            sys.exit(f"session resume refused: {e}")
+        pinned_model = resume_binding.get("archive_model")
+        if flag_model and pinned_model and flag_model != pinned_model:
+            sys.exit("session resume refused: requested model differs from the "
+                     "binding's pinned archive model")
+        session_model = pinned_model or session_model
+
     feedback = not headless and not os.environ.get("RENDER_ONLY")
     map_note = None
     trust_note = None
@@ -941,12 +976,28 @@ def main() -> None:
         # The model this launch will actually route (headless resolves via flags →
         # flavor default; interactive routes the flavor default). None = the harness
         # picks its own — recorded as NULL, honest about what we know at boot.
-        session_id, archive_id = open_session(con, chosen["shell_id"], lifecycle={
-            "harness": harness,
-            "provider": session_provider(harness, session_model),
-            "model": session_model,
-            "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
-        })
+        try:
+            session_id, archive_id = open_session(
+                con, chosen["shell_id"], lifecycle={
+                    "harness": harness,
+                    "provider": session_provider(harness, session_model),
+                    "model": session_model,
+                    "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
+                }, reuse_archive_id=(resume_binding or {}).get("archive_id"))
+        except ValueError as e:
+            sys.exit(f"session resume refused: {e}")
+
+        binding = resume_binding
+        if (not binding and adapter.get("session_control")
+                and not os.environ.get("RENDER_ONLY")):
+            binding = session_supervisor.ensure_binding(
+                con, archive_id=archive_id, shell_id=chosen["shell_id"],
+                harness=harness,
+                native_session_id=os.environ.get("SC_NATIVE_SESSION_ID") or None,
+                capabilities=json.dumps(
+                    (adapter.get("session_control") or {}).get("capabilities") or {},
+                    sort_keys=True),
+            )
 
         full = con.execute(
             "SELECT shell_id, display_name, shortname, partner, role, mandate, "
@@ -1014,6 +1065,9 @@ def main() -> None:
 
     print(f"\n→ booted {style.bold(full['display_name'])} "
           f"(shell_id={full['shell_id']}, session={session_id})")
+    if binding:
+        native = binding.get("native_session_id") or "pending"
+        print(f"→ session binding: {binding['binding_id']} · {harness}={native}")
     if work_dir != REPO_ROOT:
         print(f"→ worktree: {work_dir}")
         print(f"→ sync: {sync_note}")
@@ -1179,8 +1233,48 @@ def main() -> None:
     if not headless:
         set_terminal_tab_title(full["display_name"])
     os.chdir(work_dir)
-    print(f"→ exec {' '.join(cmd)}\n")
-    os.execvpe(cmd[0], cmd, env)
+    print(f"→ supervise {' '.join(cmd)}\n")
+
+    lease: dict[str, int] = {}
+
+    def lease_started(pid: int) -> None:
+        if not binding:
+            return
+        lease_con = open_db()
+        try:
+            generation = session_supervisor.claim_lease(
+                lease_con, binding["binding_id"], pid, repo_root=REPO_ROOT,
+                state="dispatching" if headless else "foreground")
+            identity = session_supervisor.read_process(pid)
+            if not identity:  # claim_lease already validated it; fail closed on a race.
+                raise RuntimeError("harness process vanished while recording its lease")
+            lease.update(pid=pid, start_ticks=identity.start_ticks,
+                         generation=generation)
+        finally:
+            lease_con.close()
+
+    def lease_exited(_pid: int, returncode: int) -> None:
+        if not binding or not lease:
+            return
+        lease_con = open_db()
+        try:
+            session_supervisor.release_lease(
+                lease_con, binding["binding_id"], lease["pid"],
+                lease["start_ticks"], lease["generation"],
+                error=(f"harness exited {returncode}" if returncode not in (0, -signal.SIGINT,
+                                                                           -signal.SIGTERM)
+                       else None),
+            )
+        finally:
+            lease_con.close()
+
+    try:
+        rc = session_supervisor.supervise(
+            cmd, cwd=work_dir, env=env, on_started=lease_started,
+            on_exited=lease_exited)
+    except (OSError, RuntimeError, session_supervisor.LeaseConflict) as e:
+        sys.exit(f"session launch refused: {e}")
+    raise SystemExit(rc)
 
 
 def set_terminal_tab_title(name: str) -> None:

--- a/.super-coder/scripts/session_supervisor.py
+++ b/.super-coder/scripts/session_supervisor.py
@@ -247,6 +247,13 @@ def _recorded_owner_status(row: dict, *, repo_root: Path,
     if process_matches(pid, ticks, expected_command=row["harness"],
                        expected_worktree=worktree, proc_root=proc_root):
         return "live", [pid]
+    supervisor_pid = row.get("supervisor_pid")
+    supervisor_ticks = row.get("supervisor_start_ticks")
+    if (supervisor_pid is not None and supervisor_ticks is not None
+            and process_matches(
+                supervisor_pid, supervisor_ticks, expected_command="run.py",
+                expected_worktree=worktree, proc_root=proc_root)):
+        return "cleanup", [supervisor_pid]
     survivors = process_group_members(
         pid, expected_worktree=worktree, expected_command=row["harness"],
         proc_root=proc_root)
@@ -256,7 +263,8 @@ def _recorded_owner_status(row: dict, *, repo_root: Path,
 
 
 def claim_lease(con, binding_id: int, pid: int, *, repo_root: Path,
-                state: str, proc_root: Path = PROC) -> int:
+                state: str, supervisor_pid: int | None = None,
+                proc_root: Path = PROC) -> int:
     """Atomically fence one validated process as the binding owner."""
     if state not in ("foreground", "dispatching"):
         raise ValueError(f"invalid owner state {state!r}")
@@ -269,6 +277,14 @@ def claim_lease(con, binding_id: int, pid: int, *, repo_root: Path,
             raise ValueError("new lease PID does not match the binding harness")
         if not _within(identity.cwd, worktree):
             raise ValueError("new lease PID is outside the binding worktree")
+        supervisor_identity = None
+        if supervisor_pid is not None:
+            supervisor_identity = read_process(supervisor_pid, proc_root)
+            if (not supervisor_identity
+                    or not command_matches(supervisor_identity.command, "run.py")):
+                raise ValueError("supervisor PID does not match run.py")
+            if not _within(supervisor_identity.cwd, worktree):
+                raise ValueError("supervisor PID is outside the binding worktree")
 
         owner_status, owner_pids = _recorded_owner_status(
             row, repo_root=repo_root, proc_root=proc_root)
@@ -283,15 +299,23 @@ def claim_lease(con, binding_id: int, pid: int, *, repo_root: Path,
             raise LeaseConflict(
                 f"binding {binding_id} has surviving process-group members "
                 f"{','.join(map(str, owner_pids))}")
+        if owner_status == "cleanup":
+            raise LeaseConflict(
+                f"binding {binding_id} is being cleaned by supervisor pid "
+                f"{owner_pids[0]}")
 
         generation = row["lease_generation"] + 1
         session_control.transition_binding(
             con, binding_id, expected=row["state"], target=state)
         cur = con.execute(
             "UPDATE shell_session_bindings SET lease_pid=?, lease_start_ticks=?, "
-            "lease_generation=?, last_error=NULL, updated_at=datetime('now') "
+            "supervisor_pid=?, supervisor_start_ticks=?, lease_generation=?, "
+            "last_error=NULL, updated_at=datetime('now') "
             "WHERE binding_id=? AND lease_generation=?",
-            (pid, identity.start_ticks, generation, binding_id,
+            (pid, identity.start_ticks,
+             supervisor_identity.pid if supervisor_identity else None,
+             supervisor_identity.start_ticks if supervisor_identity else None,
+             generation, binding_id,
              row["lease_generation"]),
         )
         if cur.rowcount != 1:
@@ -303,13 +327,24 @@ def claim_lease(con, binding_id: int, pid: int, *, repo_root: Path,
         raise
 
 
+def preflight_lease(con, binding_id: int, *, repo_root: Path,
+                    proc_root: Path = PROC) -> None:
+    """Refuse a known owner before spawning; the post-spawn claim stays atomic."""
+    status = reconcile_binding(
+        con, binding_id, repo_root=repo_root, proc_root=proc_root)
+    if status not in ("vacant", "stale-cleared"):
+        raise LeaseConflict(
+            f"binding {binding_id} owner is not vacant ({status})")
+
+
 def release_lease(con, binding_id: int, pid: int, start_ticks: int,
                   generation: int, *, error: str | None = None) -> bool:
     """Release only the exact generation this supervisor acquired."""
     con.execute("BEGIN IMMEDIATE")
     try:
         row = con.execute(
-            "SELECT state, native_session_id FROM shell_session_bindings "
+            "SELECT state, native_session_id, last_error "
+            "FROM shell_session_bindings "
             "WHERE binding_id=? AND lease_pid=? AND lease_start_ticks=? "
             "AND lease_generation=?",
             (binding_id, pid, start_ticks, generation),
@@ -317,17 +352,19 @@ def release_lease(con, binding_id: int, pid: int, start_ticks: int,
         if not row:
             con.rollback()
             return False
-        if row["state"] == "released":
-            target = "released"
+        if row["state"] in ("error", "released"):
+            target = row["state"]
+            last_error = row["last_error"]
         else:
             target = "error" if error or not row["native_session_id"] else "dormant"
-        last_error = error or (None if row["native_session_id"]
-                               else "native session id unavailable when owner exited")
+            last_error = error or (None if row["native_session_id"]
+                                   else "native session id unavailable when owner exited")
         session_control.transition_binding(
             con, binding_id, expected=row["state"], target=target)
         cur = con.execute(
             "UPDATE shell_session_bindings SET lease_pid=NULL, lease_start_ticks=NULL, "
-            "last_error=?, updated_at=datetime('now') WHERE binding_id=? "
+            "supervisor_pid=NULL, supervisor_start_ticks=NULL, last_error=?, "
+            "updated_at=datetime('now') WHERE binding_id=? "
             "AND lease_pid=? AND lease_start_ticks=? AND lease_generation=?",
             (last_error, binding_id, pid, start_ticks, generation),
         )
@@ -412,7 +449,7 @@ def reconcile_binding(con, binding_id: int, *, repo_root: Path,
             con, row, repo_root=repo_root, proc_root=proc_root)
         status, pids = _recorded_owner_status(
             row, repo_root=repo_root, proc_root=proc_root)
-        if status in ("vacant", "live"):
+        if status in ("vacant", "live", "cleanup"):
             if channel_cleared:
                 con.commit()
             else:
@@ -441,7 +478,8 @@ def reconcile_binding(con, binding_id: int, *, repo_root: Path,
             con, binding_id, expected=row["state"], target=target)
         con.execute(
             "UPDATE shell_session_bindings SET lease_pid=NULL, lease_start_ticks=NULL, "
-            "last_error=?, updated_at=datetime('now') WHERE binding_id=? "
+            "supervisor_pid=NULL, supervisor_start_ticks=NULL, last_error=?, "
+            "updated_at=datetime('now') WHERE binding_id=? "
             "AND lease_pid=? AND lease_start_ticks=?",
             (error, binding_id, row["lease_pid"], row["lease_start_ticks"]),
         )
@@ -479,6 +517,7 @@ def terminate_group(process_group: int, *, grace: float = 5.0,
 
 
 def supervise(cmd: list[str], *, cwd: Path, env: dict[str, str],
+              on_pre_spawn: Callable[[], None] | None = None,
               on_started: Callable[[int], None] | None = None,
               on_exited: Callable[[int, int], None] | None = None,
               popen: Callable[..., subprocess.Popen] = subprocess.Popen,
@@ -507,6 +546,8 @@ def supervise(cmd: list[str], *, cwd: Path, env: dict[str, str],
             signal.signal(sig, forward)
         if forwarded is not None:
             return _normalize_returncode(0, forwarded)
+        if on_pre_spawn:
+            on_pre_spawn()
         child = popen(cmd, cwd=str(cwd), env=env, start_new_session=True)
         if forwarded is not None:
             forward(forwarded, None)

--- a/.super-coder/scripts/session_supervisor.py
+++ b/.super-coder/scripts/session_supervisor.py
@@ -22,9 +22,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable
 
+import session_control
+
 
 PROC = Path("/proc")
-FORWARDED_SIGNALS = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT)
+EXIT_SIGNALS = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT)
+FORWARDED_SIGNALS = EXIT_SIGNALS + (signal.SIGWINCH,)
 
 
 class LeaseConflict(RuntimeError):
@@ -282,11 +285,13 @@ def claim_lease(con, binding_id: int, pid: int, *, repo_root: Path,
                 f"{','.join(map(str, owner_pids))}")
 
         generation = row["lease_generation"] + 1
+        session_control.transition_binding(
+            con, binding_id, expected=row["state"], target=state)
         cur = con.execute(
             "UPDATE shell_session_bindings SET lease_pid=?, lease_start_ticks=?, "
-            "lease_generation=?, state=?, last_error=NULL, updated_at=datetime('now') "
+            "lease_generation=?, last_error=NULL, updated_at=datetime('now') "
             "WHERE binding_id=? AND lease_generation=?",
-            (pid, identity.start_ticks, generation, state, binding_id,
+            (pid, identity.start_ticks, generation, binding_id,
              row["lease_generation"]),
         )
         if cur.rowcount != 1:
@@ -301,24 +306,38 @@ def claim_lease(con, binding_id: int, pid: int, *, repo_root: Path,
 def release_lease(con, binding_id: int, pid: int, start_ticks: int,
                   generation: int, *, error: str | None = None) -> bool:
     """Release only the exact generation this supervisor acquired."""
-    row = con.execute(
-        "SELECT native_session_id FROM shell_session_bindings WHERE binding_id=?",
-        (binding_id,),
-    ).fetchone()
-    if not row:
-        return False
-    target = "error" if error or not row["native_session_id"] else "dormant"
-    last_error = error or (None if row["native_session_id"]
-                           else "native session id unavailable when owner exited")
-    cur = con.execute(
-        "UPDATE shell_session_bindings SET lease_pid=NULL, lease_start_ticks=NULL, "
-        "state=?, last_error=?, updated_at=datetime('now') "
-        "WHERE binding_id=? AND lease_pid=? AND lease_start_ticks=? "
-        "AND lease_generation=?",
-        (target, last_error, binding_id, pid, start_ticks, generation),
-    )
-    con.commit()
-    return cur.rowcount == 1
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        row = con.execute(
+            "SELECT state, native_session_id FROM shell_session_bindings "
+            "WHERE binding_id=? AND lease_pid=? AND lease_start_ticks=? "
+            "AND lease_generation=?",
+            (binding_id, pid, start_ticks, generation),
+        ).fetchone()
+        if not row:
+            con.rollback()
+            return False
+        if row["state"] == "released":
+            target = "released"
+        else:
+            target = "error" if error or not row["native_session_id"] else "dormant"
+        last_error = error or (None if row["native_session_id"]
+                               else "native session id unavailable when owner exited")
+        session_control.transition_binding(
+            con, binding_id, expected=row["state"], target=target)
+        cur = con.execute(
+            "UPDATE shell_session_bindings SET lease_pid=NULL, lease_start_ticks=NULL, "
+            "last_error=?, updated_at=datetime('now') WHERE binding_id=? "
+            "AND lease_pid=? AND lease_start_ticks=? AND lease_generation=?",
+            (last_error, binding_id, pid, start_ticks, generation),
+        )
+        if cur.rowcount != 1:
+            raise LeaseConflict(f"binding {binding_id} lease changed concurrently")
+        con.commit()
+        return True
+    except Exception:
+        con.rollback()
+        raise
 
 
 def register_active_channel(con, binding_id: int, pid: int, *,
@@ -386,36 +405,51 @@ def _reconcile_active_channel(con, row: dict, *, repo_root: Path,
 def reconcile_binding(con, binding_id: int, *, repo_root: Path,
                       proc_root: Path = PROC) -> str:
     """Validate recorded ownership before a claim or dispatcher decision."""
-    row = _binding_context(con, binding_id)
-    channel_cleared = _reconcile_active_channel(
-        con, row, repo_root=repo_root, proc_root=proc_root)
-    status, pids = _recorded_owner_status(
-        row, repo_root=repo_root, proc_root=proc_root)
-    if status in ("vacant", "live"):
-        if channel_cleared:
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        row = _binding_context(con, binding_id)
+        channel_cleared = _reconcile_active_channel(
+            con, row, repo_root=repo_root, proc_root=proc_root)
+        status, pids = _recorded_owner_status(
+            row, repo_root=repo_root, proc_root=proc_root)
+        if status in ("vacant", "live"):
+            if channel_cleared:
+                con.commit()
+            else:
+                con.rollback()
+            return status
+        if status == "orphan-group":
+            target = "released" if row["state"] == "released" else "error"
+            session_control.transition_binding(
+                con, binding_id, expected=row["state"], target=target)
+            con.execute(
+                "UPDATE shell_session_bindings SET last_error=?, "
+                "updated_at=datetime('now') WHERE binding_id=?",
+                ("recorded owner exited but process group survives: "
+                 + ",".join(map(str, pids)), binding_id),
+            )
             con.commit()
-        return status
-    if status == "orphan-group":
+            return status
+
+        if row["state"] in ("released", "error"):
+            target = row["state"]
+        else:
+            target = "dormant" if row.get("native_session_id") else "error"
+        error = (None if row.get("native_session_id")
+                 else "stale owner and no native session id")
+        session_control.transition_binding(
+            con, binding_id, expected=row["state"], target=target)
         con.execute(
-            "UPDATE shell_session_bindings SET state='error', last_error=?, "
-            "updated_at=datetime('now') WHERE binding_id=?",
-            ("recorded owner exited but process group survives: "
-             + ",".join(map(str, pids)), binding_id),
+            "UPDATE shell_session_bindings SET lease_pid=NULL, lease_start_ticks=NULL, "
+            "last_error=?, updated_at=datetime('now') WHERE binding_id=? "
+            "AND lease_pid=? AND lease_start_ticks=?",
+            (error, binding_id, row["lease_pid"], row["lease_start_ticks"]),
         )
         con.commit()
-        return status
-
-    target = "dormant" if row.get("native_session_id") else "error"
-    error = (None if row.get("native_session_id")
-             else "stale owner and no native session id")
-    con.execute(
-        "UPDATE shell_session_bindings SET lease_pid=NULL, lease_start_ticks=NULL, "
-        "state=?, last_error=?, updated_at=datetime('now') "
-        "WHERE binding_id=? AND lease_pid=? AND lease_start_ticks=?",
-        (target, error, binding_id, row["lease_pid"], row["lease_start_ticks"]),
-    )
-    con.commit()
-    return "stale-cleared"
+        return "stale-cleared"
+    except Exception:
+        con.rollback()
+        raise
 
 
 def _normalize_returncode(returncode: int, forwarded_signal: int | None) -> int:
@@ -448,47 +482,57 @@ def supervise(cmd: list[str], *, cwd: Path, env: dict[str, str],
               on_started: Callable[[int], None] | None = None,
               on_exited: Callable[[int, int], None] | None = None,
               popen: Callable[..., subprocess.Popen] = subprocess.Popen,
-              killpg: Callable[[int, int], None] = os.killpg) -> int:
+              killpg: Callable[[int, int], None] = os.killpg,
+              group_grace: float = 2.0) -> int:
     """Run one harness process group and forward cancellation to all children."""
-    child = popen(cmd, cwd=str(cwd), env=env, start_new_session=True)
+    child: subprocess.Popen | None = None
     forwarded: int | None = None
     previous: dict[int, object] = {}
 
     def forward(signum, _frame) -> None:
         nonlocal forwarded
-        forwarded = forwarded or signum
-        if child.poll() is None:
+        if signum in EXIT_SIGNALS:
+            forwarded = forwarded or signum
+        if child is not None and child.poll() is None:
             try:
                 killpg(child.pid, signum)
             except (ProcessLookupError, PermissionError):
                 pass
 
     try:
+        # Install before Popen: cancellation in the fork/exec window is held in
+        # ``forwarded`` and relayed immediately once the child PID is known.
         for sig in FORWARDED_SIGNALS:
             previous[sig] = signal.getsignal(sig)
             signal.signal(sig, forward)
+        if forwarded is not None:
+            return _normalize_returncode(0, forwarded)
+        child = popen(cmd, cwd=str(cwd), env=env, start_new_session=True)
+        if forwarded is not None:
+            forward(forwarded, None)
         if on_started:
             on_started(child.pid)
         returncode = child.wait()
         # If the leader exits but a daemonized descendant remains in its group,
         # do not recreate #439 under a different PID.
-        terminate_group(child.pid, grace=0, killpg=killpg)
+        terminate_group(child.pid, grace=group_grace, killpg=killpg)
         return _normalize_returncode(returncode, forwarded)
     except BaseException:
-        try:
-            killpg(child.pid, signal.SIGTERM)
-        except (ProcessLookupError, PermissionError):
-            pass
-        try:
-            child.wait(timeout=5)
-        except (subprocess.TimeoutExpired, ProcessLookupError):
+        if child is not None:
             try:
-                killpg(child.pid, signal.SIGKILL)
+                killpg(child.pid, signal.SIGTERM)
             except (ProcessLookupError, PermissionError):
                 pass
+            try:
+                child.wait(timeout=5)
+            except (subprocess.TimeoutExpired, ProcessLookupError):
+                try:
+                    killpg(child.pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    pass
         raise
     finally:
         for sig, handler in previous.items():
             signal.signal(sig, handler)
-        if on_exited:
+        if child is not None and on_exited:
             on_exited(child.pid, child.returncode if child.returncode is not None else -1)

--- a/.super-coder/scripts/session_supervisor.py
+++ b/.super-coder/scripts/session_supervisor.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Harness process supervision and fenced session ownership.
+
+The launcher used to ``exec`` a harness directly.  That left no engine-owned
+parent able to forward a wrapper cancellation to descendants, and a detached
+child could outlive the process that the caller stopped (#439).  This module
+keeps a small supervisor in place, launches the harness in its own process
+group, and records an exact ``(pid, Linux start ticks, generation)`` lease for
+managed planner bindings.
+
+Provider adapters own native-session creation and transport.  This module owns
+only the provider-neutral floor: archive/binding identity, one writer, process
+validation, signal forwarding, and crash reconciliation.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+
+PROC = Path("/proc")
+FORWARDED_SIGNALS = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT)
+
+
+class LeaseConflict(RuntimeError):
+    """A validated owner (or its orphaned process group) still holds a binding."""
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    pid: int
+    start_ticks: int
+    process_group: int
+    command: tuple[str, ...]
+    cwd: Path
+
+
+def _stat_fields(pid: int, proc_root: Path = PROC) -> list[str]:
+    """Return Linux ``/proc/<pid>/stat`` fields 3 onward.
+
+    ``comm`` (field 2) may contain spaces or parentheses, so splitting the
+    whole line is incorrect.  The final right parenthesis is the stable seam.
+    """
+    try:
+        data = (proc_root / str(pid) / "stat").read_text()
+    except (OSError, UnicodeDecodeError):
+        return []
+    end = data.rfind(")")
+    return data[end + 2:].split() if end >= 0 else []
+
+
+def read_process(pid: int, proc_root: Path = PROC) -> ProcessIdentity | None:
+    fields = _stat_fields(pid, proc_root)
+    try:
+        # fields[0] is state (kernel field 3), fields[2] pgrp (field 5), and
+        # fields[19] process start time in clock ticks (field 22).
+        process_group = int(fields[2])
+        start_ticks = int(fields[19])
+        raw_cmd = (proc_root / str(pid) / "cmdline").read_bytes()
+        cwd = Path(os.readlink(proc_root / str(pid) / "cwd")).resolve()
+    except (IndexError, ValueError, OSError):
+        return None
+    command = tuple(p.decode(errors="replace") for p in raw_cmd.split(b"\0") if p)
+    if not command:
+        return None
+    return ProcessIdentity(pid, start_ticks, process_group, command, cwd)
+
+
+def _within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def command_matches(command: Iterable[str], expected: str) -> bool:
+    """Match an adapter command without trusting presentation text.
+
+    Script entry points commonly become ``python .../kimi`` or
+    ``node .../claude/...`` after ``execve``.  Match path components from the
+    kernel cmdline, not terminal output, while keeping the harness name exact.
+    """
+    wanted = Path(expected).name
+    for token in command:
+        for part in Path(token).parts:
+            if part == wanted or part.startswith(wanted + "-"):
+                return True
+    return False
+
+
+def process_matches(pid: int, start_ticks: int, *, expected_command: str,
+                    expected_worktree: Path, proc_root: Path = PROC) -> bool:
+    identity = read_process(pid, proc_root)
+    return bool(
+        identity
+        and identity.start_ticks == start_ticks
+        and command_matches(identity.command, expected_command)
+        and _within(identity.cwd, expected_worktree)
+    )
+
+
+def process_group_members(process_group: int, *, expected_worktree: Path,
+                          expected_command: str | None = None,
+                          proc_root: Path = PROC) -> list[ProcessIdentity]:
+    """Validated members of a recorded harness group, including descendants.
+
+    A dead group leader with live members is the dangerous #439 shape.  The
+    original start ticks can no longer be read, so reconciliation must not
+    silently transfer ownership; the surviving group keeps the binding fenced
+    until an operator verifies and removes it.
+    """
+    try:
+        entries = list(proc_root.iterdir())
+    except OSError:
+        return []
+    members: list[ProcessIdentity] = []
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        identity = read_process(int(entry.name), proc_root)
+        if (identity and identity.process_group == process_group
+                and _within(identity.cwd, expected_worktree)
+                and not (identity.pid == process_group and expected_command
+                         and not command_matches(identity.command, expected_command))):
+            members.append(identity)
+    return sorted(members, key=lambda p: p.pid)
+
+
+def expected_worktree(repo_root: Path, shortname: str | None,
+                      flavor: str | None) -> Path:
+    if flavor == "admin" or not shortname:
+        return repo_root.resolve()
+    return (repo_root / ".sc-worktrees" / shortname.lower()).resolve()
+
+
+def ensure_binding(con, *, archive_id: int, shell_id: int, harness: str,
+                   native_session_id: str | None = None,
+                   control_endpoint: str | None = None,
+                   capabilities: str = "{}", cli_version: str | None = None) -> dict:
+    """Create the binding for an archive, or verify/reuse that exact binding."""
+    row = con.execute(
+        "SELECT * FROM shell_session_bindings WHERE archive_id=?", (archive_id,)
+    ).fetchone()
+    if row:
+        if row["shell_id"] != shell_id or row["harness"] != harness:
+            raise ValueError("archive binding belongs to a different shell or harness")
+        if (native_session_id and row["native_session_id"]
+                and row["native_session_id"] != native_session_id):
+            raise ValueError("archive binding already names a different native session")
+        if native_session_id and not row["native_session_id"]:
+            con.execute(
+                "UPDATE shell_session_bindings SET native_session_id=?, "
+                "control_endpoint=COALESCE(?, control_endpoint), "
+                "control_capabilities=?, cli_version=COALESCE(?, cli_version), "
+                "updated_at=datetime('now') WHERE binding_id=?",
+                (native_session_id, control_endpoint, capabilities, cli_version,
+                 row["binding_id"]),
+            )
+            con.commit()
+            row = con.execute(
+                "SELECT * FROM shell_session_bindings WHERE binding_id=?",
+                (row["binding_id"],),
+            ).fetchone()
+        return dict(row)
+
+    cur = con.execute(
+        "INSERT INTO shell_session_bindings "
+        "(archive_id, shell_id, harness, native_session_id, control_endpoint, "
+        "control_capabilities, cli_version, state) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, 'starting')",
+        (archive_id, shell_id, harness, native_session_id, control_endpoint,
+         capabilities, cli_version),
+    )
+    con.commit()
+    return dict(con.execute(
+        "SELECT * FROM shell_session_bindings WHERE binding_id=?",
+        (cur.lastrowid,),
+    ).fetchone())
+
+
+def binding_for_resume(con, binding_id: int, *, shell_id: int,
+                       harness: str) -> dict:
+    row = con.execute(
+        "SELECT b.*, a.session_id, a.model AS archive_model, "
+        "a.provider AS archive_provider FROM shell_session_bindings b "
+        "JOIN shell_memory_archives a ON a.archive_id=b.archive_id "
+        "WHERE b.binding_id=?", (binding_id,),
+    ).fetchone()
+    if not row:
+        raise ValueError(f"unknown session binding {binding_id}")
+    if row["shell_id"] != shell_id or row["harness"] != harness:
+        raise ValueError("session binding belongs to a different shell or harness")
+    if row["state"] == "released":
+        raise ValueError("session binding is released")
+    return dict(row)
+
+
+def register_native_session(con, binding_id: int, native_session_id: str, *,
+                            control_endpoint: str | None = None,
+                            capabilities: str = "{}",
+                            cli_version: str | None = None) -> None:
+    """Persist an ID returned by a provider API/launcher contract, never a TTY scrape."""
+    row = con.execute(
+        "SELECT native_session_id FROM shell_session_bindings WHERE binding_id=?",
+        (binding_id,),
+    ).fetchone()
+    if not row:
+        raise ValueError(f"unknown session binding {binding_id}")
+    if row["native_session_id"] and row["native_session_id"] != native_session_id:
+        raise ValueError("binding already names a different native session")
+    con.execute(
+        "UPDATE shell_session_bindings SET native_session_id=?, "
+        "control_endpoint=COALESCE(?, control_endpoint), control_capabilities=?, "
+        "cli_version=COALESCE(?, cli_version), updated_at=datetime('now') "
+        "WHERE binding_id=?",
+        (native_session_id, control_endpoint, capabilities, cli_version, binding_id),
+    )
+    con.commit()
+
+
+def _binding_context(con, binding_id: int) -> dict:
+    row = con.execute(
+        "SELECT b.*, s.shortname, s.flavor FROM shell_session_bindings b "
+        "JOIN shells s ON s.shell_id=b.shell_id WHERE b.binding_id=?",
+        (binding_id,),
+    ).fetchone()
+    if not row:
+        raise ValueError(f"unknown session binding {binding_id}")
+    return dict(row)
+
+
+def _recorded_owner_status(row: dict, *, repo_root: Path,
+                           proc_root: Path = PROC) -> tuple[str, list[int]]:
+    pid, ticks = row.get("lease_pid"), row.get("lease_start_ticks")
+    if pid is None or ticks is None:
+        return "vacant", []
+    worktree = expected_worktree(repo_root, row.get("shortname"), row.get("flavor"))
+    if process_matches(pid, ticks, expected_command=row["harness"],
+                       expected_worktree=worktree, proc_root=proc_root):
+        return "live", [pid]
+    survivors = process_group_members(
+        pid, expected_worktree=worktree, expected_command=row["harness"],
+        proc_root=proc_root)
+    if survivors:
+        return "orphan-group", [p.pid for p in survivors]
+    return "stale", []
+
+
+def claim_lease(con, binding_id: int, pid: int, *, repo_root: Path,
+                state: str, proc_root: Path = PROC) -> int:
+    """Atomically fence one validated process as the binding owner."""
+    if state not in ("foreground", "dispatching"):
+        raise ValueError(f"invalid owner state {state!r}")
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        row = _binding_context(con, binding_id)
+        worktree = expected_worktree(repo_root, row.get("shortname"), row.get("flavor"))
+        identity = read_process(pid, proc_root)
+        if not identity or not command_matches(identity.command, row["harness"]):
+            raise ValueError("new lease PID does not match the binding harness")
+        if not _within(identity.cwd, worktree):
+            raise ValueError("new lease PID is outside the binding worktree")
+
+        owner_status, owner_pids = _recorded_owner_status(
+            row, repo_root=repo_root, proc_root=proc_root)
+        if owner_status == "live":
+            if (row["lease_pid"] == pid
+                    and row["lease_start_ticks"] == identity.start_ticks):
+                con.rollback()
+                return row["lease_generation"]
+            raise LeaseConflict(
+                f"binding {binding_id} already has live owner pid {owner_pids[0]}")
+        if owner_status == "orphan-group":
+            raise LeaseConflict(
+                f"binding {binding_id} has surviving process-group members "
+                f"{','.join(map(str, owner_pids))}")
+
+        generation = row["lease_generation"] + 1
+        cur = con.execute(
+            "UPDATE shell_session_bindings SET lease_pid=?, lease_start_ticks=?, "
+            "lease_generation=?, state=?, last_error=NULL, updated_at=datetime('now') "
+            "WHERE binding_id=? AND lease_generation=?",
+            (pid, identity.start_ticks, generation, state, binding_id,
+             row["lease_generation"]),
+        )
+        if cur.rowcount != 1:
+            raise LeaseConflict(f"binding {binding_id} lease changed concurrently")
+        con.commit()
+        return generation
+    except Exception:
+        con.rollback()
+        raise
+
+
+def release_lease(con, binding_id: int, pid: int, start_ticks: int,
+                  generation: int, *, error: str | None = None) -> bool:
+    """Release only the exact generation this supervisor acquired."""
+    row = con.execute(
+        "SELECT native_session_id FROM shell_session_bindings WHERE binding_id=?",
+        (binding_id,),
+    ).fetchone()
+    if not row:
+        return False
+    target = "error" if error or not row["native_session_id"] else "dormant"
+    last_error = error or (None if row["native_session_id"]
+                           else "native session id unavailable when owner exited")
+    cur = con.execute(
+        "UPDATE shell_session_bindings SET lease_pid=NULL, lease_start_ticks=NULL, "
+        "state=?, last_error=?, updated_at=datetime('now') "
+        "WHERE binding_id=? AND lease_pid=? AND lease_start_ticks=? "
+        "AND lease_generation=?",
+        (target, last_error, binding_id, pid, start_ticks, generation),
+    )
+    con.commit()
+    return cur.rowcount == 1
+
+
+def register_active_channel(con, binding_id: int, pid: int, *,
+                            repo_root: Path, proc_root: Path = PROC) -> int:
+    """Register a provider-local live delivery channel with an exact identity."""
+    row = _binding_context(con, binding_id)
+    worktree = expected_worktree(repo_root, row.get("shortname"), row.get("flavor"))
+    identity = read_process(pid, proc_root)
+    if not identity or not _within(identity.cwd, worktree):
+        raise ValueError("active channel PID is outside the binding worktree")
+    con.execute(
+        "UPDATE shell_session_bindings SET active_channel_pid=?, "
+        "active_channel_start_ticks=?, active_channel_heartbeat_at=datetime('now'), "
+        "updated_at=datetime('now') WHERE binding_id=?",
+        (pid, identity.start_ticks, binding_id),
+    )
+    con.commit()
+    return identity.start_ticks
+
+
+def heartbeat_active_channel(con, binding_id: int, pid: int,
+                             start_ticks: int) -> bool:
+    cur = con.execute(
+        "UPDATE shell_session_bindings SET active_channel_heartbeat_at=datetime('now'), "
+        "updated_at=datetime('now') WHERE binding_id=? AND active_channel_pid=? "
+        "AND active_channel_start_ticks=?",
+        (binding_id, pid, start_ticks),
+    )
+    con.commit()
+    return cur.rowcount == 1
+
+
+def clear_active_channel(con, binding_id: int, pid: int,
+                         start_ticks: int) -> bool:
+    cur = con.execute(
+        "UPDATE shell_session_bindings SET active_channel_pid=NULL, "
+        "active_channel_start_ticks=NULL, active_channel_heartbeat_at=NULL, "
+        "updated_at=datetime('now') WHERE binding_id=? AND active_channel_pid=? "
+        "AND active_channel_start_ticks=?",
+        (binding_id, pid, start_ticks),
+    )
+    con.commit()
+    return cur.rowcount == 1
+
+
+def _reconcile_active_channel(con, row: dict, *, repo_root: Path,
+                              proc_root: Path) -> bool:
+    pid, ticks = row.get("active_channel_pid"), row.get("active_channel_start_ticks")
+    if pid is None or ticks is None:
+        return False
+    worktree = expected_worktree(repo_root, row.get("shortname"), row.get("flavor"))
+    identity = read_process(pid, proc_root)
+    if identity and identity.start_ticks == ticks and _within(identity.cwd, worktree):
+        return False
+    con.execute(
+        "UPDATE shell_session_bindings SET active_channel_pid=NULL, "
+        "active_channel_start_ticks=NULL, active_channel_heartbeat_at=NULL, "
+        "updated_at=datetime('now') WHERE binding_id=? AND active_channel_pid=? "
+        "AND active_channel_start_ticks=?",
+        (row["binding_id"], pid, ticks),
+    )
+    return True
+
+
+def reconcile_binding(con, binding_id: int, *, repo_root: Path,
+                      proc_root: Path = PROC) -> str:
+    """Validate recorded ownership before a claim or dispatcher decision."""
+    row = _binding_context(con, binding_id)
+    channel_cleared = _reconcile_active_channel(
+        con, row, repo_root=repo_root, proc_root=proc_root)
+    status, pids = _recorded_owner_status(
+        row, repo_root=repo_root, proc_root=proc_root)
+    if status in ("vacant", "live"):
+        if channel_cleared:
+            con.commit()
+        return status
+    if status == "orphan-group":
+        con.execute(
+            "UPDATE shell_session_bindings SET state='error', last_error=?, "
+            "updated_at=datetime('now') WHERE binding_id=?",
+            ("recorded owner exited but process group survives: "
+             + ",".join(map(str, pids)), binding_id),
+        )
+        con.commit()
+        return status
+
+    target = "dormant" if row.get("native_session_id") else "error"
+    error = (None if row.get("native_session_id")
+             else "stale owner and no native session id")
+    con.execute(
+        "UPDATE shell_session_bindings SET lease_pid=NULL, lease_start_ticks=NULL, "
+        "state=?, last_error=?, updated_at=datetime('now') "
+        "WHERE binding_id=? AND lease_pid=? AND lease_start_ticks=?",
+        (target, error, binding_id, row["lease_pid"], row["lease_start_ticks"]),
+    )
+    con.commit()
+    return "stale-cleared"
+
+
+def _normalize_returncode(returncode: int, forwarded_signal: int | None) -> int:
+    if forwarded_signal is not None:
+        return 128 + forwarded_signal
+    return 128 - returncode if returncode < 0 else returncode
+
+
+def terminate_group(process_group: int, *, grace: float = 5.0,
+                    killpg: Callable[[int, int], None] = os.killpg) -> None:
+    """Remove descendants left behind after the group leader exits."""
+    try:
+        killpg(process_group, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        return
+    deadline = time.monotonic() + max(0.0, grace)
+    while time.monotonic() < deadline:
+        try:
+            killpg(process_group, 0)
+        except (ProcessLookupError, PermissionError):
+            return
+        time.sleep(0.05)
+    try:
+        killpg(process_group, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+def supervise(cmd: list[str], *, cwd: Path, env: dict[str, str],
+              on_started: Callable[[int], None] | None = None,
+              on_exited: Callable[[int, int], None] | None = None,
+              popen: Callable[..., subprocess.Popen] = subprocess.Popen,
+              killpg: Callable[[int, int], None] = os.killpg) -> int:
+    """Run one harness process group and forward cancellation to all children."""
+    child = popen(cmd, cwd=str(cwd), env=env, start_new_session=True)
+    forwarded: int | None = None
+    previous: dict[int, object] = {}
+
+    def forward(signum, _frame) -> None:
+        nonlocal forwarded
+        forwarded = forwarded or signum
+        if child.poll() is None:
+            try:
+                killpg(child.pid, signum)
+            except (ProcessLookupError, PermissionError):
+                pass
+
+    try:
+        for sig in FORWARDED_SIGNALS:
+            previous[sig] = signal.getsignal(sig)
+            signal.signal(sig, forward)
+        if on_started:
+            on_started(child.pid)
+        returncode = child.wait()
+        # If the leader exits but a daemonized descendant remains in its group,
+        # do not recreate #439 under a different PID.
+        terminate_group(child.pid, grace=0, killpg=killpg)
+        return _normalize_returncode(returncode, forwarded)
+    except BaseException:
+        try:
+            killpg(child.pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+        try:
+            child.wait(timeout=5)
+        except (subprocess.TimeoutExpired, ProcessLookupError):
+            try:
+                killpg(child.pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+        raise
+    finally:
+        for sig, handler in previous.items():
+            signal.signal(sig, handler)
+        if on_exited:
+            on_exited(child.pid, child.returncode if child.returncode is not None else -1)

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -15,8 +15,11 @@ from pathlib import Path
 
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
 sys.path.insert(0, str(ENGINE / "scripts"))
 import run  # noqa: E402
+import session_control  # noqa: E402
 import session_supervisor as supervisor  # noqa: E402
 
 
@@ -284,6 +287,63 @@ class ConcurrentLeaseTest(unittest.TestCase):
         self.assertEqual("foreground", row["state"])
 
 
+class MigratedStateMachineIntegrationTest(unittest.TestCase):
+    def test_lease_edges_use_migrated_compare_and_set_state_machine(self):
+        con = sqlite3.connect(":memory:")
+        con.row_factory = sqlite3.Row
+        self.addCleanup(con.close)
+        con.executescript(SCHEMA.read_text())
+        for migration in sorted(MIGRATIONS.glob("*.sql")):
+            con.executescript(migration.read_text())
+        con.executescript(
+            "INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1);"
+            "INSERT INTO shells (shell_id, display_name, shortname, flavor, "
+            "system_prompt, user_id) VALUES (1, 'Planner', 'DEV1', 'planner', 'x', 1);"
+            "INSERT INTO shell_memory_archives "
+            "(archive_id, shell_id, session_id, date, harness, provider, model) "
+            "VALUES (10, 1, '0007', '2026-07-21', 'claude', 'anthropic', 'opus');"
+        )
+        binding = supervisor.ensure_binding(
+            con, archive_id=10, shell_id=1, harness="claude")
+        proc = FakeProc(self)
+        repo = proc.root / "repo"
+        worktree = repo / ".sc-worktrees" / "dev1"
+        proc.add(401, ticks=41, command=("claude",), cwd=worktree)
+
+        generation = supervisor.claim_lease(
+            con, binding["binding_id"], 401, repo_root=repo,
+            state="foreground", proc_root=proc.root)
+        row = con.execute(
+            "SELECT state, lease_pid, lease_start_ticks, lease_generation "
+            "FROM shell_session_bindings WHERE binding_id=?",
+            (binding["binding_id"],),
+        ).fetchone()
+        self.assertEqual(("foreground", 401, 41, generation), tuple(row))
+
+        self.assertTrue(supervisor.release_lease(
+            con, binding["binding_id"], 401, 41, generation))
+        row = con.execute(
+            "SELECT state, lease_pid, lease_start_ticks, last_error "
+            "FROM shell_session_bindings WHERE binding_id=?",
+            (binding["binding_id"],),
+        ).fetchone()
+        self.assertEqual(
+            ("error", None, None, "native session id unavailable when owner exited"),
+            tuple(row),
+        )
+
+        proc.add(402, ticks=42, command=("claude",), cwd=worktree)
+        with self.assertRaises(session_control.InvalidStateTransition):
+            supervisor.claim_lease(
+                con, binding["binding_id"], 402, repo_root=repo,
+                state="foreground", proc_root=proc.root)
+        row = con.execute(
+            "SELECT state, lease_pid, lease_generation FROM shell_session_bindings "
+            "WHERE binding_id=?", (binding["binding_id"],),
+        ).fetchone()
+        self.assertEqual(("error", None, generation), tuple(row))
+
+
 class ArchiveReuseTest(unittest.TestCase):
     def test_resume_reuses_exact_archive_without_creating_or_rewriting_it(self):
         con = make_db()
@@ -333,11 +393,36 @@ class SuperviseTest(unittest.TestCase):
             ["claude"], cwd=Path.cwd(), env=dict(os.environ),
             on_started=started, on_exited=lambda pid, code: exited.append((pid, code)),
             popen=lambda *args, **kwargs: Child(),
-            killpg=lambda pid, sig: calls.append((pid, sig)))
+            killpg=lambda pid, sig: calls.append((pid, sig)), group_grace=0)
         self.assertEqual(128 + signal.SIGTERM, rc)
         self.assertEqual((4321, signal.SIGTERM), calls[0])
         self.assertIn((4321, signal.SIGKILL), calls)
         self.assertEqual([(4321, 0)], exited)
+
+    def test_signal_arriving_inside_spawn_window_is_relayed_after_pid_capture(self):
+        calls: list[tuple[int, int]] = []
+
+        class Child:
+            pid = 5432
+            returncode = None
+
+            def poll(self):
+                return self.returncode
+
+            def wait(self, timeout=None):
+                self.returncode = -signal.SIGTERM
+                return self.returncode
+
+        def spawning(*args, **kwargs):
+            os.kill(os.getpid(), signal.SIGTERM)
+            return Child()
+
+        rc = supervisor.supervise(
+            ["claude"], cwd=Path.cwd(), env=dict(os.environ), popen=spawning,
+            killpg=lambda pid, sig: calls.append((pid, sig)), group_grace=0)
+        self.assertEqual(128 + signal.SIGTERM, rc)
+        self.assertEqual((5432, signal.SIGTERM), calls[0])
+        self.assertNotIn((os.getpid(), signal.SIGTERM), calls)
 
     def test_cancelling_supervisor_terminates_real_descendant_group(self):
         tmp = tempfile.TemporaryDirectory()

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -51,6 +51,8 @@ CREATE TABLE shell_session_bindings (
   managed INTEGER NOT NULL DEFAULT 0,
   lease_pid INTEGER,
   lease_start_ticks INTEGER,
+  supervisor_pid INTEGER,
+  supervisor_start_ticks INTEGER,
   active_channel_pid INTEGER,
   active_channel_start_ticks INTEGER,
   active_channel_heartbeat_at TEXT,
@@ -169,6 +171,10 @@ class BindingTest(unittest.TestCase):
         generation = supervisor.claim_lease(
             self.con, self.binding["binding_id"], 100, repo_root=self.repo,
             state="foreground", proc_root=self.proc.root)
+        with self.assertRaisesRegex(supervisor.LeaseConflict, r"not vacant \(live\)"):
+            supervisor.preflight_lease(
+                self.con, self.binding["binding_id"], repo_root=self.repo,
+                proc_root=self.proc.root)
         with self.assertRaisesRegex(supervisor.LeaseConflict, "live owner pid 100"):
             supervisor.claim_lease(
                 self.con, self.binding["binding_id"], 101, repo_root=self.repo,
@@ -218,6 +224,58 @@ class BindingTest(unittest.TestCase):
                          (row["lease_pid"], row["lease_start_ticks"], row["state"]))
         self.assertEqual("recorded owner exited but process group survives: 101",
                          row["last_error"])
+        self.assertTrue(supervisor.release_lease(
+            self.con, self.binding["binding_id"], 100, 10,
+            row["lease_generation"]))
+        row = self.row()
+        self.assertEqual((None, None, "error",
+                          "recorded owner exited but process group survives: 101"),
+                         (row["lease_pid"], row["lease_start_ticks"], row["state"],
+                          row["last_error"]))
+
+    def test_live_supervisor_authorizes_cleanup_after_leader_exit(self):
+        self.proc.add(90, ticks=9, command=("python", "/engine/run.py"),
+                      cwd=self.worktree)
+        self.proc.add(100, ticks=10, command=("claude",), cwd=self.worktree)
+        supervisor.register_native_session(
+            self.con, self.binding["binding_id"], "native-a")
+        generation = supervisor.claim_lease(
+            self.con, self.binding["binding_id"], 100, repo_root=self.repo,
+            state="foreground", supervisor_pid=90, proc_root=self.proc.root)
+        self.proc.remove(100)
+        self.proc.add(101, ticks=11, pgrp=100, command=("python", "worker.py"),
+                      cwd=self.worktree)
+
+        self.assertEqual("cleanup", supervisor.reconcile_binding(
+            self.con, self.binding["binding_id"], repo_root=self.repo,
+            proc_root=self.proc.root))
+        row = self.row()
+        self.assertEqual(("foreground", 100, 90),
+                         (row["state"], row["lease_pid"], row["supervisor_pid"]))
+        self.assertTrue(supervisor.release_lease(
+            self.con, self.binding["binding_id"], 100, 10, generation))
+        row = self.row()
+        self.assertEqual(("dormant", None, None, None),
+                         (row["state"], row["lease_pid"], row["supervisor_pid"],
+                          row["last_error"]))
+
+    def test_release_clears_lease_without_leaving_released_state(self):
+        self.proc.add(100, ticks=10, command=("claude",), cwd=self.worktree)
+        generation = supervisor.claim_lease(
+            self.con, self.binding["binding_id"], 100, repo_root=self.repo,
+            state="foreground", proc_root=self.proc.root)
+        session_control.transition_binding(
+            self.con, self.binding["binding_id"], expected="foreground",
+            target="released")
+        self.con.commit()
+
+        self.assertTrue(supervisor.release_lease(
+            self.con, self.binding["binding_id"], 100, 10, generation,
+            error="ignored terminal error"))
+        row = self.row()
+        self.assertEqual(("released", None, None, None),
+                         (row["state"], row["lease_pid"], row["lease_start_ticks"],
+                          row["last_error"]))
 
     def test_active_channel_pid_reuse_is_cleared_not_heartbeated(self):
         self.proc.add(200, ticks=20, command=("python", "watcher.py"),
@@ -371,6 +429,23 @@ class ArchiveReuseTest(unittest.TestCase):
 
 
 class SuperviseTest(unittest.TestCase):
+    def test_preflight_refuses_before_popen(self):
+        spawned = False
+
+        def refuse() -> None:
+            raise supervisor.LeaseConflict("live owner")
+
+        def popen(*args, **kwargs):
+            nonlocal spawned
+            spawned = True
+            raise AssertionError("Popen must not run after a failed preflight")
+
+        with self.assertRaisesRegex(supervisor.LeaseConflict, "live owner"):
+            supervisor.supervise(
+                ["claude"], cwd=Path.cwd(), env=dict(os.environ),
+                on_pre_spawn=refuse, popen=popen)
+        self.assertFalse(spawned)
+
     def test_forwarded_signal_targets_process_group_and_controls_exit_status(self):
         calls: list[tuple[int, int]] = []
         exited: list[tuple[int, int]] = []

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Tests for harness supervision and exact session-ownership leases."""
+from __future__ import annotations
+
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import run  # noqa: E402
+import session_supervisor as supervisor  # noqa: E402
+
+
+BINDING_SCHEMA = """
+CREATE TABLE shells (
+  shell_id INTEGER PRIMARY KEY,
+  shortname TEXT,
+  flavor TEXT,
+  active_archive_id INTEGER
+);
+CREATE TABLE shell_memory_archives (
+  archive_id INTEGER PRIMARY KEY,
+  shell_id INTEGER NOT NULL,
+  session_id TEXT NOT NULL,
+  harness TEXT,
+  provider TEXT,
+  model TEXT
+);
+CREATE TABLE shell_session_bindings (
+  binding_id INTEGER PRIMARY KEY,
+  archive_id INTEGER NOT NULL UNIQUE,
+  shell_id INTEGER NOT NULL,
+  harness TEXT NOT NULL,
+  native_session_id TEXT,
+  control_endpoint TEXT,
+  control_capabilities TEXT NOT NULL DEFAULT '{}',
+  cli_version TEXT,
+  state TEXT NOT NULL,
+  managed INTEGER NOT NULL DEFAULT 0,
+  lease_pid INTEGER,
+  lease_start_ticks INTEGER,
+  active_channel_pid INTEGER,
+  active_channel_start_ticks INTEGER,
+  active_channel_heartbeat_at TEXT,
+  lease_generation INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (harness, native_session_id)
+);
+"""
+
+
+def make_db(path: str = ":memory:") -> sqlite3.Connection:
+    con = sqlite3.connect(path, timeout=5)
+    con.row_factory = sqlite3.Row
+    con.executescript(BINDING_SCHEMA)
+    con.execute("INSERT INTO shells VALUES (1, 'DEV1', 'planner', NULL)")
+    con.execute(
+        "INSERT INTO shell_memory_archives VALUES "
+        "(10, 1, '0007', 'claude', 'anthropic', 'opus')"
+    )
+    con.commit()
+    return con
+
+
+class FakeProc:
+    def __init__(self, case: unittest.TestCase):
+        self.tmp = tempfile.TemporaryDirectory()
+        case.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def add(self, pid: int, *, ticks: int, pgrp: int | None = None,
+            command: tuple[str, ...] = ("claude",), cwd: Path) -> None:
+        proc = self.root / str(pid)
+        proc.mkdir(exist_ok=True)
+        fields = ["S", "1", str(pgrp if pgrp is not None else pid)]
+        fields += ["0"] * 16
+        fields.append(str(ticks))
+        (proc / "stat").write_text(f"{pid} (harness worker) " + " ".join(fields))
+        (proc / "cmdline").write_bytes(b"\0".join(p.encode() for p in command) + b"\0")
+        cwd.mkdir(parents=True, exist_ok=True)
+        (proc / "cwd").symlink_to(cwd, target_is_directory=True)
+
+    def remove(self, pid: int) -> None:
+        proc = self.root / str(pid)
+        for child in proc.iterdir():
+            child.unlink()
+        proc.rmdir()
+
+
+class ProcessIdentityTest(unittest.TestCase):
+    def setUp(self):
+        self.proc = FakeProc(self)
+        self.worktree = self.proc.root / "repo" / ".sc-worktrees" / "dev1"
+
+    def test_exact_identity_requires_ticks_command_and_worktree(self):
+        self.proc.add(100, ticks=44, command=("node", "/opt/claude/cli.js"),
+                      cwd=self.worktree / "src")
+        self.assertTrue(supervisor.process_matches(
+            100, 44, expected_command="claude", expected_worktree=self.worktree,
+            proc_root=self.proc.root))
+        self.assertFalse(supervisor.process_matches(
+            100, 45, expected_command="claude", expected_worktree=self.worktree,
+            proc_root=self.proc.root), "PID reuse must invalidate old start ticks")
+        self.assertFalse(supervisor.process_matches(
+            100, 44, expected_command="kimi", expected_worktree=self.worktree,
+            proc_root=self.proc.root))
+        self.assertFalse(supervisor.process_matches(
+            100, 44, expected_command="claude",
+            expected_worktree=self.proc.root / "other", proc_root=self.proc.root))
+
+    def test_dead_leader_with_live_descendant_retains_group_evidence(self):
+        self.proc.add(101, ticks=45, pgrp=100, command=("python", "helper.py"),
+                      cwd=self.worktree)
+        members = supervisor.process_group_members(
+            100, expected_worktree=self.worktree, expected_command="claude",
+            proc_root=self.proc.root)
+        self.assertEqual([101], [p.pid for p in members])
+        self.assertEqual(100, members[0].process_group)
+
+
+class BindingTest(unittest.TestCase):
+    def setUp(self):
+        self.con = make_db()
+        self.addCleanup(self.con.close)
+        self.proc = FakeProc(self)
+        self.repo = self.proc.root / "repo"
+        self.worktree = self.repo / ".sc-worktrees" / "dev1"
+        self.binding = supervisor.ensure_binding(
+            self.con, archive_id=10, shell_id=1, harness="claude")
+
+    def row(self) -> sqlite3.Row:
+        return self.con.execute(
+            "SELECT * FROM shell_session_bindings WHERE binding_id=?",
+            (self.binding["binding_id"],),
+        ).fetchone()
+
+    def test_native_id_registration_is_idempotent_but_never_rebinds(self):
+        supervisor.register_native_session(
+            self.con, self.binding["binding_id"], "native-a",
+            control_endpoint="/run/claude.sock", capabilities='{"resume":true}')
+        supervisor.register_native_session(
+            self.con, self.binding["binding_id"], "native-a")
+        with self.assertRaisesRegex(ValueError, "different native session"):
+            supervisor.register_native_session(
+                self.con, self.binding["binding_id"], "native-b")
+        row = self.row()
+        self.assertEqual("native-a", row["native_session_id"])
+        self.assertEqual("/run/claude.sock", row["control_endpoint"])
+        self.assertEqual(1, self.con.execute(
+            "SELECT COUNT(*) FROM shell_session_bindings").fetchone()[0])
+
+    def test_live_owner_blocks_a_second_claim(self):
+        self.proc.add(100, ticks=10, command=("claude",), cwd=self.worktree)
+        self.proc.add(101, ticks=11, command=("claude",), cwd=self.worktree)
+        generation = supervisor.claim_lease(
+            self.con, self.binding["binding_id"], 100, repo_root=self.repo,
+            state="foreground", proc_root=self.proc.root)
+        with self.assertRaisesRegex(supervisor.LeaseConflict, "live owner pid 100"):
+            supervisor.claim_lease(
+                self.con, self.binding["binding_id"], 101, repo_root=self.repo,
+                state="dispatching", proc_root=self.proc.root)
+        row = self.row()
+        self.assertEqual((100, 10, generation, "foreground"),
+                         (row["lease_pid"], row["lease_start_ticks"],
+                          row["lease_generation"], row["state"]))
+
+    def test_pid_reuse_is_stale_and_old_generation_cannot_release_new_owner(self):
+        self.proc.add(100, ticks=10, command=("claude",), cwd=self.worktree)
+        first = supervisor.claim_lease(
+            self.con, self.binding["binding_id"], 100, repo_root=self.repo,
+            state="foreground", proc_root=self.proc.root)
+        self.proc.remove(100)
+        self.proc.add(100, ticks=99, command=("sleep", "999"), cwd=self.worktree)
+        self.proc.add(101, ticks=11, command=("claude",), cwd=self.worktree)
+        second = supervisor.claim_lease(
+            self.con, self.binding["binding_id"], 101, repo_root=self.repo,
+            state="dispatching", proc_root=self.proc.root)
+        self.assertEqual(first + 1, second)
+        self.assertFalse(supervisor.release_lease(
+            self.con, self.binding["binding_id"], 100, 10, first))
+        row = self.row()
+        self.assertEqual((101, 11, second, "dispatching"),
+                         (row["lease_pid"], row["lease_start_ticks"],
+                          row["lease_generation"], row["state"]))
+
+    def test_orphaned_process_group_fails_closed(self):
+        self.proc.add(100, ticks=10, command=("claude",), cwd=self.worktree)
+        supervisor.claim_lease(
+            self.con, self.binding["binding_id"], 100, repo_root=self.repo,
+            state="foreground", proc_root=self.proc.root)
+        self.proc.remove(100)
+        self.proc.add(101, ticks=11, pgrp=100, command=("python", "worker.py"),
+                      cwd=self.worktree)
+        self.proc.add(102, ticks=12, command=("claude",), cwd=self.worktree)
+        self.assertEqual("orphan-group", supervisor.reconcile_binding(
+            self.con, self.binding["binding_id"], repo_root=self.repo,
+            proc_root=self.proc.root))
+        with self.assertRaisesRegex(supervisor.LeaseConflict, "surviving"):
+            supervisor.claim_lease(
+                self.con, self.binding["binding_id"], 102, repo_root=self.repo,
+                state="dispatching", proc_root=self.proc.root)
+        row = self.row()
+        self.assertEqual((100, 10, "error"),
+                         (row["lease_pid"], row["lease_start_ticks"], row["state"]))
+        self.assertEqual("recorded owner exited but process group survives: 101",
+                         row["last_error"])
+
+    def test_active_channel_pid_reuse_is_cleared_not_heartbeated(self):
+        self.proc.add(200, ticks=20, command=("python", "watcher.py"),
+                      cwd=self.worktree)
+        ticks = supervisor.register_active_channel(
+            self.con, self.binding["binding_id"], 200, repo_root=self.repo,
+            proc_root=self.proc.root)
+        self.proc.remove(200)
+        self.proc.add(200, ticks=21, command=("python", "other.py"),
+                      cwd=self.worktree)
+        self.assertFalse(supervisor.heartbeat_active_channel(
+            self.con, self.binding["binding_id"], 200, ticks + 1))
+        self.assertEqual("vacant", supervisor.reconcile_binding(
+            self.con, self.binding["binding_id"], repo_root=self.repo,
+            proc_root=self.proc.root))
+        row = self.row()
+        self.assertEqual((None, None, None),
+                         (row["active_channel_pid"],
+                          row["active_channel_start_ticks"],
+                          row["active_channel_heartbeat_at"]))
+
+
+class ConcurrentLeaseTest(unittest.TestCase):
+    def test_only_one_concurrent_claim_wins(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = str(Path(tmp.name) / "leases.db")
+        seed = make_db(path)
+        binding = supervisor.ensure_binding(
+            seed, archive_id=10, shell_id=1, harness="claude")
+        seed.close()
+        proc = FakeProc(self)
+        repo = proc.root / "repo"
+        worktree = repo / ".sc-worktrees" / "dev1"
+        proc.add(301, ticks=31, command=("claude",), cwd=worktree)
+        proc.add(302, ticks=32, command=("claude",), cwd=worktree)
+        barrier = threading.Barrier(2)
+        results: list[tuple[str, int]] = []
+
+        def claim(pid: int) -> None:
+            con = sqlite3.connect(path, timeout=5)
+            con.row_factory = sqlite3.Row
+            try:
+                barrier.wait(timeout=5)
+                generation = supervisor.claim_lease(
+                    con, binding["binding_id"], pid, repo_root=repo,
+                    state="foreground", proc_root=proc.root)
+                results.append(("won", generation))
+            except supervisor.LeaseConflict:
+                results.append(("blocked", pid))
+            finally:
+                con.close()
+
+        threads = [threading.Thread(target=claim, args=(pid,)) for pid in (301, 302)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(["blocked", "won"], sorted(kind for kind, _ in results))
+        con = sqlite3.connect(path)
+        con.row_factory = sqlite3.Row
+        self.addCleanup(con.close)
+        row = con.execute("SELECT * FROM shell_session_bindings").fetchone()
+        self.assertIn(row["lease_pid"], (301, 302))
+        self.assertEqual(1, row["lease_generation"])
+        self.assertEqual("foreground", row["state"])
+
+
+class ArchiveReuseTest(unittest.TestCase):
+    def test_resume_reuses_exact_archive_without_creating_or_rewriting_it(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        session_id, archive_id = run.open_session(
+            con, 1, lifecycle={"model": "different"}, reuse_archive_id=10)
+        self.assertEqual(("0007", 10), (session_id, archive_id))
+        self.assertEqual(1, con.execute(
+            "SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0])
+        row = con.execute(
+            "SELECT model FROM shell_memory_archives WHERE archive_id=10").fetchone()
+        self.assertEqual("opus", row["model"])
+        self.assertEqual(10, con.execute(
+            "SELECT active_archive_id FROM shells WHERE shell_id=1").fetchone()[0])
+
+    def test_resume_rejects_another_shells_archive_without_changing_active(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        con.execute("INSERT INTO shells VALUES (2, 'DEV2', 'planner', NULL)")
+        con.commit()
+        with self.assertRaisesRegex(ValueError, "selected shell"):
+            run.open_session(con, 2, reuse_archive_id=10)
+        self.assertIsNone(con.execute(
+            "SELECT active_archive_id FROM shells WHERE shell_id=2").fetchone()[0])
+
+
+class SuperviseTest(unittest.TestCase):
+    def test_forwarded_signal_targets_process_group_and_controls_exit_status(self):
+        calls: list[tuple[int, int]] = []
+        exited: list[tuple[int, int]] = []
+
+        class Child:
+            pid = 4321
+            returncode = None
+
+            def poll(self):
+                return self.returncode
+
+            def wait(self, timeout=None):
+                self.returncode = 0
+                return 0
+
+        def started(_pid: int) -> None:
+            os.kill(os.getpid(), signal.SIGTERM)
+
+        rc = supervisor.supervise(
+            ["claude"], cwd=Path.cwd(), env=dict(os.environ),
+            on_started=started, on_exited=lambda pid, code: exited.append((pid, code)),
+            popen=lambda *args, **kwargs: Child(),
+            killpg=lambda pid, sig: calls.append((pid, sig)))
+        self.assertEqual(128 + signal.SIGTERM, rc)
+        self.assertEqual((4321, signal.SIGTERM), calls[0])
+        self.assertIn((4321, signal.SIGKILL), calls)
+        self.assertEqual([(4321, 0)], exited)
+
+    def test_cancelling_supervisor_terminates_real_descendant_group(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        pidfile = Path(tmp.name) / "pids"
+        child_code = (
+            "import os,subprocess,sys,time; "
+            "g=subprocess.Popen([sys.executable,'-c','import time; time.sleep(60)']); "
+            f"open({str(pidfile)!r},'w').write(f'{{os.getpid()}} {{g.pid}}'); "
+            "time.sleep(60)"
+        )
+        supervisor_code = (
+            f"import os,sys; sys.path.insert(0,{str(ENGINE / 'scripts')!r}); "
+            "import session_supervisor as s; "
+            f"raise SystemExit(s.supervise([{sys.executable!r},'-c',{child_code!r}], "
+            f"cwd=s.Path({tmp.name!r}), env=dict(os.environ)))"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", supervisor_code], start_new_session=True)
+
+        def cleanup() -> None:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+            if pidfile.exists():
+                child_pid = int(pidfile.read_text().split()[0])
+                try:
+                    os.killpg(child_pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+        self.addCleanup(cleanup)
+        deadline = time.monotonic() + 5
+        while not pidfile.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        self.assertTrue(pidfile.exists(), "harness descendant never started")
+        child_pid, grandchild_pid = map(int, pidfile.read_text().split())
+
+        proc.terminate()
+        self.assertEqual(128 + signal.SIGTERM, proc.wait(timeout=5))
+
+        def still_running(pid: int) -> bool:
+            try:
+                stat = Path(f"/proc/{pid}/stat").read_text()
+            except OSError:
+                return False
+            end = stat.rfind(")")
+            state = stat[end + 2:].split()[0] if end >= 0 else "?"
+            return state != "Z"
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and (
+                still_running(child_pid) or still_running(grandchild_pid)):
+            time.sleep(0.02)
+        self.assertFalse(still_running(child_pid))
+        self.assertFalse(still_running(grandchild_pid),
+                         "signal reached only the harness leader, recreating #439")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -273,7 +273,7 @@ class BootPhaseLabelTest(unittest.TestCase):
             stack.enter_context(mock.patch.object(run, "set_terminal_tab_title"))
             stack.enter_context(mock.patch.object(run.os, "chdir"))
             stack.enter_context(mock.patch.object(
-                run.os, "execvpe", side_effect=_ExecReached))
+                run.session_supervisor, "supervise", side_effect=_ExecReached))
             with self.assertRaises(_ExecReached):
                 run.main()
 


### PR DESCRIPTION
## Summary

- replace exec-only harness launch with a signal-forwarding supervisor and isolated process group
- fence managed planner ownership with exact PID/start ticks, generation, command identity, and worktree validation
- fail closed on surviving orphan groups and PID reuse; expose exact active-channel registration/heartbeat/clear helpers
- reuse the bound engine archive for attach/resume and accept native IDs only through adapter/API contracts, never terminal scraping
- route every binding lifecycle edge through unit 1's compare-and-set state machine

Closes #439. Advances #454 (Sprint 21 unit 2 / spec task #51).

## Verification

- `env -u SC_SANDBOX ./sc test` — 543 passed
- `.venv/bin/pytest -q tests/test_session_control.py tests/test_session_supervisor.py tests/test_style_spinner.py` — 39 passed, 3 subtests passed after rebase on main
- `./sc lint .super-coder/scripts/session_supervisor.py .super-coder/scripts/run.py tests/test_session_supervisor.py tests/test_style_spinner.py`
- `git diff --check origin/main...HEAD`

## Trade-off

Ownership validation deliberately depends on Linux `/proc`, matching the engine's existing liveness substrate. A missing or ambiguous identity fails closed; provider-specific session creation/delivery remains in later sprint adapter units.