### PR TITLE
feat(cli): mark sprint-reserved shells

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -527,7 +527,8 @@ def authenticate(con, interactive: bool = True):
 
 def list_shells(con, user_id: int) -> list:
     return con.execute(
-        "SELECT shell_id, display_name, shortname, mandate, is_shared, flavor FROM shells "
+        "SELECT shell_id, display_name, shortname, mandate, is_shared, flavor, "
+        "current_state FROM shells "
         "WHERE (user_id=? OR is_shared=1) AND COALESCE(is_deleted,0)=0 "
         "ORDER BY flavor IS NULL, flavor, shell_id",
         (user_id,),
@@ -566,8 +567,15 @@ def _default_label(defaults: dict, flavor: str | None) -> str:
     return harness + (f" · {model.split('/')[-1]}" if model else "")
 
 
+def _is_sprint_reserved(shell) -> bool:
+    """True while the sprint skill's reservation marker is in current_state."""
+    current_state = dict(shell).get("current_state") or ""
+    return any(line.strip().startswith("SPRINT doc=")
+               for line in current_state.splitlines())
+
+
 def _shell_status(shell, snap: "dict | None") -> str:
-    """Styled, fixed-width picker status derived from the liveness snapshot."""
+    """Styled picker status derived from liveness plus sprint reservation."""
     if shell["flavor"] == "admin":
         label, paint = "Exempt", style.dim
     elif not snap or not snap.get("supported"):
@@ -580,6 +588,8 @@ def _shell_status(shell, snap: "dict | None") -> str:
             label, paint = "Orphaned", style.red
         elif snap.get("indeterminate"):
             label, paint = "Unknown", style.dim
+        elif _is_sprint_reserved(shell):
+            label, paint = "Sprint", style.amber
         else:
             label, paint = "Available", style.green
     return f"{paint(label)}{' ' * (12 - len(label))}"
@@ -862,7 +872,8 @@ def main() -> None:
     user = authenticate(con, interactive=not headless)
     fdefaults = flavor_defaults(con)
     # Liveness snapshot for the interactive picker: one /proc pass (ms) so the
-    # boot list can show shell status — Busy / Orphaned / Available / Exempt — and
+    # boot list can show shell status — Busy / Orphaned / Sprint / Available /
+    # Exempt — and
     # confirm before booting into a live worktree. Headless keeps its own lazy
     # compute below; non-TTY boots (--first, piped) can't confirm, so no snap.
     snap = (shell_liveness.compute()

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -71,7 +71,7 @@ class _LabelRecorder:
 
 class ShellStatusTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.shell = {"shortname": "DEV1", "flavor": "dev"}
+        self.shell = {"shortname": "DEV1", "flavor": "dev", "current_state": ""}
         self.snap = {"supported": True, "processes": [], "indeterminate": 0}
 
     def test_status_colors_and_labels(self) -> None:
@@ -94,6 +94,27 @@ class ShellStatusTest(unittest.TestCase):
         self.assertEqual("Exempt      ", run._shell_status(admin, self.snap))
         self.assertEqual("Unknown     ", run._shell_status(self.shell, partial))
         self.assertEqual("Unknown     ", run._shell_status(self.shell, unsupported))
+
+    def test_sprint_reservation_replaces_only_available(self) -> None:
+        sprint_shell = {
+            **self.shell,
+            "current_state": "working notes\nSPRINT doc=21 unit=4 status=waiting",
+        }
+        with mock.patch.object(style, "ON", True), mock.patch.object(
+                run.shell_liveness, "session_state", return_value=None):
+            self.assertEqual("\x1b[38;5;214mSprint\x1b[0m      ",
+                             run._shell_status(sprint_shell, self.snap))
+
+        for state, expected in (("busy", "Busy"), ("orphan", "Orphaned")):
+            with self.subTest(state=state), mock.patch.object(
+                    run.shell_liveness, "session_state", return_value=state):
+                self.assertEqual(expected,
+                                 run._shell_status(sprint_shell, self.snap).strip())
+
+        partial = {**self.snap, "indeterminate": 1}
+        with mock.patch.object(run.shell_liveness, "session_state", return_value=None):
+            self.assertEqual("Unknown",
+                             run._shell_status(sprint_shell, partial).strip())
 
     def test_picker_has_a_dedicated_status_column(self) -> None:
         shell = {**self.shell, "display_name": "Dev One"}


### PR DESCRIPTION
## Summary
- include shell current state in launcher picker rows
- render amber Sprint when the sprint workflow reservation marker is present
- preserve Exempt, Unknown, Busy, and Orphaned precedence

## Verification
- .venv/bin/pytest -q tests/test_style_spinner.py tests/test_shell_liveness.py (30 passed, 5 subtests passed)
- ./sc lint .super-coder/scripts/run.py tests/test_style_spinner.py
- ./sc test (544 passed; 3 unrelated sandbox-only VM bake failures tracked in #457)