### PR TITLE
feat(session): dispatch managed planner wakes

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -59,6 +59,8 @@ import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
 import ports as ports_mod  # noqa: E402
 import shell_factory  # noqa: E402
+import session_control  # noqa: E402  (planner wake state + job reconstruction)
+import session_supervisor  # noqa: E402  (active-channel PID fencing)
 import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin rule)
 import model_catalog  # noqa: E402  (live model-id suggestions, sibling module)
 import analytics  # noqa: E402  (token & session analytics sweep — doc #11)
@@ -1181,6 +1183,278 @@ def _land_on_base(out: list, state: dict) -> None:
         out.append(f"↩ back on {BASE_BRANCH}")
 
 
+# ── Token-scoped session control ──────────────────────────────────────────────
+
+SESSION_BINDING_EDITABLE = {
+    "native_session_id", "control_endpoint", "control_capabilities",
+    "cli_version", "state",
+}
+
+
+def _owned_binding(con, shell_id: int, binding_id: int | None = None):
+    if binding_id is not None:
+        return con.execute(
+            "SELECT * FROM shell_session_bindings "
+            "WHERE binding_id=? AND shell_id=?", (binding_id, shell_id)
+        ).fetchone()
+    return con.execute(
+        "SELECT b.* FROM shell_session_bindings b "
+        "JOIN shells s ON s.active_archive_id=b.archive_id "
+        "WHERE s.shell_id=? AND b.shell_id=s.shell_id", (shell_id,)
+    ).fetchone()
+
+
+def get_session_control(con, shell_id: int, binding_id: int | None = None):
+    binding = _owned_binding(con, shell_id, binding_id)
+    beat = con.execute(
+        "SELECT beat_at, interval_s, "
+        "CAST((julianday('now')-julianday(beat_at))*86400 AS INTEGER) AS age_s "
+        "FROM daemon_heartbeats WHERE name='session-dispatcher'"
+    ).fetchone()
+    if binding is None:
+        return {"binding": None, "jobs": {},
+                "dispatcher": dict(beat) if beat else None}
+    counts = {
+        row["state"]: row["n"] for row in con.execute(
+            "SELECT state, COUNT(*) AS n FROM session_wake_jobs "
+            "WHERE binding_id=? GROUP BY state", (binding["binding_id"],)
+        )
+    }
+    visible = {
+        key: binding[key] for key in (
+            "binding_id", "archive_id", "shell_id", "harness",
+            "native_session_id", "control_endpoint", "control_capabilities",
+            "cli_version", "state", "managed", "lease_pid",
+            "lease_start_ticks", "active_channel_pid",
+            "active_channel_start_ticks", "active_channel_heartbeat_at",
+            "lease_generation", "last_error", "created_at", "updated_at",
+        )
+    }
+    return {"binding": visible, "jobs": counts,
+            "dispatcher": dict(beat) if beat else None}
+
+
+def _binding_capabilities(binding) -> dict:
+    try:
+        capabilities = json.loads(binding["control_capabilities"] or "{}")
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return capabilities if isinstance(capabilities, dict) else {}
+
+
+def manage_session_control(con, shell_id: int, binding_id: int | None = None):
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        binding = _owned_binding(con, shell_id, binding_id)
+        if binding is None:
+            con.rollback()
+            return None, "no session binding for this shell"
+        if not binding["native_session_id"]:
+            con.rollback()
+            return None, "native session id is not registered"
+        capabilities = _binding_capabilities(binding)
+        if not any(capabilities.get(name) for name in ("deliver", "resume")):
+            con.rollback()
+            return None, "binding has neither deliver nor resume capability"
+        other = con.execute(
+            "SELECT binding_id FROM shell_session_bindings "
+            "WHERE shell_id=? AND managed=1 AND binding_id!=?",
+            (shell_id, binding["binding_id"]),
+        ).fetchone()
+        if other:
+            con.rollback()
+            return None, f"binding {other['binding_id']} is already managed"
+        if binding["state"] == "dispatching":
+            con.rollback()
+            return None, "cannot manage a binding while dispatching"
+        if binding["state"] in ("released", "error"):
+            session_control.transition_binding(
+                con, binding["binding_id"], expected=binding["state"],
+                target="starting")
+        con.execute(
+            "UPDATE shell_session_bindings SET managed=1, last_error=NULL, "
+            "updated_at=datetime('now') WHERE binding_id=?",
+            (binding["binding_id"],),
+        )
+        # A prior release deliberately cancelled its queued audit rows.  Re-manage
+        # reactivates only rows whose messages are still unread.
+        con.execute(
+            "UPDATE session_wake_jobs SET state='queued', attempt_count=0, "
+            "available_at=datetime('now'), started_at=NULL, finished_at=NULL, "
+            "last_error=NULL WHERE binding_id=? AND state='cancelled' "
+            "AND EXISTS (SELECT 1 FROM shell_messages m "
+            "WHERE m.message_id=session_wake_jobs.trigger_message_id "
+            "AND m.read_at IS NULL)", (binding["binding_id"],)
+        )
+        session_control.reconstruct_wake_jobs(con)
+        con.commit()
+    except Exception:
+        con.rollback()
+        raise
+    return get_session_control(con, shell_id, binding["binding_id"]), None
+
+
+def release_session_control(con, shell_id: int, binding_id: int | None = None):
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        binding = _owned_binding(con, shell_id, binding_id)
+        if binding is None:
+            con.rollback()
+            return None, "no session binding for this shell"
+        if binding["state"] == "dispatching":
+            con.rollback()
+            return None, "binding is dispatching; release after the turn exits"
+        if binding["state"] != "released":
+            session_control.transition_binding(
+                con, binding["binding_id"], expected=binding["state"],
+                target="released")
+        con.execute(
+            "UPDATE shell_session_bindings SET managed=0, last_error=NULL, "
+            "updated_at=datetime('now') WHERE binding_id=?",
+            (binding["binding_id"],),
+        )
+        con.execute(
+            "UPDATE session_wake_jobs SET state='cancelled', "
+            "finished_at=datetime('now'), last_error='binding released' "
+            "WHERE binding_id=? AND state IN ('queued','failed')",
+            (binding["binding_id"],),
+        )
+        con.commit()
+    except Exception:
+        con.rollback()
+        raise
+    return get_session_control(con, shell_id, binding["binding_id"]), None
+
+
+def retry_session_control(con, shell_id: int, binding_id: int | None = None):
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        binding = _owned_binding(con, shell_id, binding_id)
+        if binding is None:
+            con.rollback()
+            return None, "no session binding for this shell"
+        if binding["state"] != "error":
+            con.rollback()
+            return None, "retry requires a binding in error"
+        session_control.transition_binding(
+            con, binding["binding_id"], expected="error", target="starting")
+        con.execute(
+            "UPDATE shell_session_bindings SET last_error=NULL, "
+            "updated_at=datetime('now') WHERE binding_id=?",
+            (binding["binding_id"],),
+        )
+        con.execute(
+            "UPDATE session_wake_jobs SET state='queued', attempt_count=0, "
+            "available_at=datetime('now'), started_at=NULL, finished_at=NULL, "
+            "last_error=NULL WHERE binding_id=? AND state='failed' "
+            "AND EXISTS (SELECT 1 FROM shell_messages m "
+            "WHERE m.message_id=session_wake_jobs.trigger_message_id "
+            "AND m.read_at IS NULL)", (binding["binding_id"],)
+        )
+        con.commit()
+    except Exception:
+        con.rollback()
+        raise
+    return get_session_control(con, shell_id, binding["binding_id"]), None
+
+
+def _local_control_endpoint(value: str) -> bool:
+    if not value:
+        return True
+    if value.startswith("/"):
+        return True
+    parsed = urlparse(value)
+    if parsed.scheme == "unix":
+        return bool(parsed.path and parsed.path.startswith("/"))
+    return (parsed.scheme in ("http", "https")
+            and parsed.hostname in ("127.0.0.1", "localhost", "::1")
+            and parsed.username is None and parsed.password is None)
+
+
+def patch_session_binding(con, shell_id: int, binding_id: int, body: dict):
+    body = dict(body)
+    unknown = set(body) - SESSION_BINDING_EDITABLE
+    if unknown:
+        return None, f"unknown field(s): {', '.join(sorted(unknown))}"
+    if "control_endpoint" in body and not _local_control_endpoint(
+            str(body["control_endpoint"] or "")):
+        return None, "control_endpoint must be a local socket or loopback URL"
+    capabilities = body.get("control_capabilities")
+    if capabilities is not None:
+        if not isinstance(capabilities, dict):
+            return None, "control_capabilities must be an object"
+        body = {**body, "control_capabilities": json.dumps(
+            capabilities, sort_keys=True, separators=(",", ":"))}
+    if "native_session_id" in body and not str(body["native_session_id"] or "").strip():
+        return None, "native_session_id cannot be empty"
+    if "native_session_id" in body:
+        body["native_session_id"] = str(body["native_session_id"]).strip()
+    if body.get("state") in ("dispatching", "released"):
+        return None, "dispatching/released are owned by dispatcher/release operations"
+
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        binding = _owned_binding(con, shell_id, binding_id)
+        if binding is None:
+            con.rollback()
+            return None, "no such session binding"
+        native = body.get("native_session_id")
+        if native is not None and con.execute(
+                "SELECT 1 FROM shell_session_bindings "
+                "WHERE harness=? AND native_session_id=? AND binding_id!=?",
+                (binding["harness"], native, binding_id)).fetchone():
+            con.rollback()
+            return None, "native session id is already bound"
+        state = body.pop("state", None)
+        if state is not None:
+            session_control.transition_binding(
+                con, binding_id, expected=binding["state"], target=state)
+        if body:
+            fields = list(body)
+            con.execute(
+                "UPDATE shell_session_bindings SET "
+                + ", ".join(f"{field}=?" for field in fields)
+                + ", updated_at=datetime('now') WHERE binding_id=?",
+                [body[field] for field in fields] + [binding_id],
+            )
+        con.commit()
+    except Exception:
+        con.rollback()
+        raise
+    return get_session_control(con, shell_id, binding_id), None
+
+
+def update_session_channel(con, shell_id: int, body: dict):
+    try:
+        binding_id = int(body.get("binding_id"))
+    except (TypeError, ValueError):
+        return None, "binding_id required"
+    binding = _owned_binding(con, shell_id, binding_id)
+    if binding is None:
+        return None, "no such session binding"
+    action = body.get("action")
+    try:
+        pid = int(body.get("pid"))
+        ticks = int(body.get("start_ticks")) if body.get("start_ticks") is not None else None
+    except (TypeError, ValueError):
+        return None, "pid/start_ticks must be integers"
+    if action == "register":
+        actual = session_supervisor.register_active_channel(
+            con, binding_id, pid, repo_root=REPO_ROOT)
+        return {"binding_id": binding_id, "pid": pid, "start_ticks": actual}, None
+    if ticks is None:
+        return None, "start_ticks required"
+    if action == "heartbeat":
+        if not session_supervisor.heartbeat_active_channel(con, binding_id, pid, ticks):
+            return None, "active channel identity changed"
+        return {"binding_id": binding_id, "heartbeat": True}, None
+    if action == "clear":
+        if not session_supervisor.clear_active_channel(con, binding_id, pid, ticks):
+            return None, "active channel identity changed"
+        return {"binding_id": binding_id, "cleared": True}, None
+    return None, "action must be register, heartbeat, or clear"
+
+
 # ── HTTP ──────────────────────────────────────────────────────────────────────
 
 class Handler(BaseHTTPRequestHandler):
@@ -1287,6 +1561,72 @@ class Handler(BaseHTTPRequestHandler):
             self._send(401, {"error": "Authorization: Bearer <token> required"})
             return None
         return shell_id
+
+    # -- /_sc/session-control token-scoped binding + wake controls --
+
+    def _session_get(self):
+        sid = self._require_shell_auth()
+        if sid is None:
+            return
+        q = parse_qs(urlparse(self.path).query)
+        raw_binding = q.get("binding", [None])[0]
+        try:
+            binding_id = int(raw_binding) if raw_binding is not None else None
+            con = db()
+            try:
+                return self._send(200, get_session_control(con, sid, binding_id))
+            finally:
+                con.close()
+        except ValueError:
+            return self._send(400, {"error": "invalid binding id"})
+        except Exception as exc:
+            return self._fail(exc)
+
+    def _session_post(self, path: str, body: dict):
+        sid = self._require_shell_auth()
+        if sid is None:
+            return
+        con = db()
+        try:
+            raw_binding = body.get("binding_id")
+            binding_id = int(raw_binding) if raw_binding is not None else None
+            if path == "/_sc/session-control/manage":
+                payload, error = manage_session_control(con, sid, binding_id)
+            elif path == "/_sc/session-control/release":
+                payload, error = release_session_control(con, sid, binding_id)
+            elif path == "/_sc/session-control/retry":
+                payload, error = retry_session_control(con, sid, binding_id)
+            elif path == "/_sc/session-control/channel":
+                payload, error = update_session_channel(con, sid, body)
+            else:
+                return self._send(404, {"error": "not found"})
+            return self._send(409 if error else 200,
+                              {"error": error} if error else payload)
+        except (TypeError, ValueError):
+            return self._send(400, {"error": "invalid binding id"})
+        except Exception as exc:
+            return self._fail(exc)
+        finally:
+            con.close()
+
+    def _session_patch(self, path: str, body: dict):
+        sid = self._require_shell_auth()
+        if sid is None:
+            return
+        parts = path.strip("/").split("/")
+        if len(parts) != 4 or parts[:3] != ["_sc", "session-control", "bindings"]:
+            return self._send(404, {"error": "not found"})
+        con = db()
+        try:
+            payload, error = patch_session_binding(con, sid, int(parts[3]), body)
+            return self._send(400 if error else 200,
+                              {"error": error} if error else payload)
+        except ValueError:
+            return self._send(400, {"error": "invalid binding id or state"})
+        except Exception as exc:
+            return self._fail(exc)
+        finally:
+            con.close()
 
     # -- /mem/* token-scoped shell memory endpoints --
 
@@ -2053,6 +2393,8 @@ class Handler(BaseHTTPRequestHandler):
             return self._send(200, f.read_text(), ctype)
         if path.startswith("/_sc/mem/"):
             return self._mem_get(path)
+        if path == "/_sc/session-control":
+            return self._session_get()
         if path == "/_sc/watches":
             return self._watches_get()
         if not path.startswith("/api/"):
@@ -2181,6 +2523,8 @@ class Handler(BaseHTTPRequestHandler):
         path = urlparse(self.path).path
         if path.startswith("/_sc/mem/"):
             return self._mem_post(path, self._body())
+        if path.startswith("/_sc/session-control/"):
+            return self._session_post(path, self._body())
         if path == "/_sc/watches":
             return self._watches_post(self._body())
         con = db()
@@ -2308,6 +2652,8 @@ class Handler(BaseHTTPRequestHandler):
         path = urlparse(self.path).path
         if path.startswith("/_sc/mem/"):
             return self._mem_patch(path)
+        if path.startswith("/_sc/session-control/"):
+            return self._session_patch(path, self._body())
         body = self._body()
         con = db()
         try:

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1398,6 +1398,9 @@ def patch_session_binding(con, shell_id: int, binding_id: int, body: dict):
         if binding is None:
             con.rollback()
             return None, "no such session binding"
+        if "state" in body and binding["state"] == "dispatching":
+            con.rollback()
+            return None, "dispatching is owned by the dispatcher"
         native = body.get("native_session_id")
         if native is not None and con.execute(
                 "SELECT 1 FROM shell_session_bindings "

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1409,13 +1409,27 @@ def patch_session_binding(con, shell_id: int, binding_id: int, body: dict):
         if state is not None:
             session_control.transition_binding(
                 con, binding_id, expected=binding["state"], target=state)
-        if body:
-            fields = list(body)
+        for field in (
+                "native_session_id", "control_endpoint", "control_capabilities",
+                "cli_version"):
+            if field not in body:
+                continue
+            # Keep the SQL text literal per field.  The field roster is tiny and
+            # security tooling should not need to infer the whitelist above.
+            if field == "native_session_id":
+                sql = ("UPDATE shell_session_bindings SET native_session_id=?, "
+                       "updated_at=datetime('now') WHERE binding_id=?")
+            elif field == "control_endpoint":
+                sql = ("UPDATE shell_session_bindings SET control_endpoint=?, "
+                       "updated_at=datetime('now') WHERE binding_id=?")
+            elif field == "control_capabilities":
+                sql = ("UPDATE shell_session_bindings SET control_capabilities=?, "
+                       "updated_at=datetime('now') WHERE binding_id=?")
+            else:
+                sql = ("UPDATE shell_session_bindings SET cli_version=?, "
+                       "updated_at=datetime('now') WHERE binding_id=?")
             con.execute(
-                "UPDATE shell_session_bindings SET "
-                + ", ".join(f"{field}=?" for field in fields)
-                + ", updated_at=datetime('now') WHERE binding_id=?",
-                [body[field] for field in fields] + [binding_id],
+                sql, (body[field], binding_id),
             )
         con.commit()
     except Exception:

--- a/.super-coder/scripts/service_supervisor.py
+++ b/.super-coder/scripts/service_supervisor.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Supervise the review API and session dispatcher as one launch service."""
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ENGINE / "scripts"))
+import ports  # noqa: E402
+
+
+def commands(port: int) -> tuple[list[str], list[str]]:
+    python = os.environ.get("SC_PYTHON", sys.executable)
+    api = [python, str(ENGINE / "api" / "server.py"), "--port", str(port)]
+    dispatcher = [
+        python, str(ENGINE / "scripts" / "session_dispatcher.py"),
+        "--api-base", f"http://127.0.0.1:{port}",
+    ]
+    return api, dispatcher
+
+
+def terminate(child: subprocess.Popen | None, sig: int = signal.SIGTERM) -> None:
+    if child is None or child.poll() is not None:
+        return
+    try:
+        os.killpg(child.pid, sig)
+    except (ProcessLookupError, PermissionError):
+        return
+
+
+def wait_or_kill(child: subprocess.Popen | None, timeout: float = 5.0) -> None:
+    if child is None:
+        return
+    try:
+        child.wait(timeout=timeout)
+        return
+    except subprocess.TimeoutExpired:
+        terminate(child, signal.SIGKILL)
+    try:
+        child.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def supervise(port: int, *, popen=subprocess.Popen) -> int:
+    api_command, dispatcher_command = commands(port)
+    stopping = False
+    forwarded_signal: int | None = None
+    api: subprocess.Popen | None = None
+    dispatcher: subprocess.Popen | None = None
+    previous: dict[signal.Signals, object] = {}
+
+    def forward(signum, _frame) -> None:
+        nonlocal stopping, forwarded_signal
+        stopping = True
+        forwarded_signal = forwarded_signal or signum
+        terminate(dispatcher, signum)
+        terminate(api, signum)
+
+    try:
+        for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+            previous[sig] = signal.getsignal(sig)
+            signal.signal(sig, forward)
+        api = popen(api_command, cwd=str(Path.cwd()), start_new_session=True)
+        dispatcher = popen(
+            dispatcher_command, cwd=str(Path.cwd()), start_new_session=True
+        )
+        while not stopping:
+            api_code = api.poll()
+            if api_code is not None:
+                stopping = True
+                terminate(dispatcher)
+                return api_code
+            dispatcher_code = dispatcher.poll()
+            if dispatcher_code is not None:
+                # The API is the root service.  A dispatcher crash must not take
+                # the UI/memory API down; restart the failed child in place.
+                print(
+                    f"service supervisor: session dispatcher exited "
+                    f"{dispatcher_code}; restarting in 1s",
+                    file=sys.stderr, flush=True,
+                )
+                deadline = time.monotonic() + 1
+                while not stopping and time.monotonic() < deadline:
+                    time.sleep(min(0.1, deadline - time.monotonic()))
+                if stopping:
+                    break
+                dispatcher = popen(
+                    dispatcher_command, cwd=str(Path.cwd()), start_new_session=True
+                )
+            time.sleep(0.1)
+        return 128 + forwarded_signal if forwarded_signal else 0
+    finally:
+        terminate(dispatcher)
+        terminate(api)
+        wait_or_kill(dispatcher)
+        wait_or_kill(api)
+        for sig, handler in previous.items():
+            signal.signal(sig, handler)  # type: ignore[arg-type]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="sc serve")
+    parser.add_argument("--port", type=int)
+    args = parser.parse_args(argv)
+    return supervise(args.port or int(ports.resolve().get("port", 8800)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/session_cli.py
+++ b/.super-coder/scripts/session_cli.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Internal token-scoped client for provider session-control adapters.
+
+The public operator surface (``sc session`` plus GUI status) lands in sprint
+unit 7.  This lower-level client exists now so provider adapters never write
+binding rows directly.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import NoReturn
+
+
+API_BASE = os.environ.get("SC_API_BASE", "")
+API_TOKEN = os.environ.get("SC_API_TOKEN", "")
+
+
+def die(message: str) -> NoReturn:
+    sys.exit(f"session-control: {message}")
+
+
+def api(method: str, path: str, payload: dict | None = None) -> dict:
+    if not API_BASE or not API_TOKEN:
+        die("SC_API_BASE + SC_API_TOKEN are required; boot through ./sc enter")
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers = {"Authorization": f"Bearer {API_TOKEN}"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(
+        API_BASE.rstrip("/") + path, data=data, method=method, headers=headers
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        try:
+            error = json.loads(exc.read()).get("error", exc.reason)
+        except Exception:
+            error = exc.reason
+        die(f"API {method} {path} -> HTTP {exc.code}: {error}")
+    except Exception as exc:
+        die(f"API unreachable ({API_BASE}): {exc}")
+
+
+def binding_arg(binding_id: int | None) -> dict:
+    return {"binding_id": binding_id} if binding_id is not None else {}
+
+
+def print_status(payload: dict) -> None:
+    binding = payload.get("binding")
+    if not binding:
+        print("session-control: no binding for this shell")
+        return
+    native = binding.get("native_session_id") or "pending"
+    managed = "managed" if binding.get("managed") else "manual"
+    jobs = payload.get("jobs") or {}
+    queued = jobs.get("queued", 0)
+    print(
+        f"binding {binding['binding_id']} · {binding['harness']}={native} · "
+        f"{binding['state']} · {managed} · queued={queued}"
+    )
+    if binding.get("last_error"):
+        print(f"  error: {binding['last_error']}")
+
+
+def cmd_status(args) -> int:
+    query = ("?binding=" + urllib.parse.quote(str(args.binding_id))) \
+        if args.binding_id is not None else ""
+    print_status(api("GET", "/_sc/session-control" + query))
+    return 0
+
+
+def cmd_action(args) -> int:
+    result = api(
+        "POST", f"/_sc/session-control/{args.action}", binding_arg(args.binding_id)
+    )
+    print_status(result)
+    return 0
+
+
+def cmd_bind(args) -> int:
+    payload: dict = {}
+    if args.native_id is not None:
+        payload["native_session_id"] = args.native_id
+    if args.endpoint is not None:
+        payload["control_endpoint"] = args.endpoint
+    if args.cli_version is not None:
+        payload["cli_version"] = args.cli_version
+    if args.state is not None:
+        payload["state"] = args.state
+    if args.capability:
+        capabilities: dict[str, bool] = {}
+        for item in args.capability:
+            name, sep, raw = item.partition("=")
+            if not sep or raw.lower() not in ("true", "false"):
+                die("--capability must be name=true|false")
+            capabilities[name] = raw.lower() == "true"
+        payload["control_capabilities"] = capabilities
+    if not payload:
+        die("bind needs at least one update flag")
+    result = api(
+        "PATCH", f"/_sc/session-control/bindings/{args.binding_id}", payload
+    )
+    print_status(result)
+    return 0
+
+
+def cmd_channel(args) -> int:
+    payload = {
+        "binding_id": args.binding_id,
+        "action": args.channel_action,
+        "pid": args.pid,
+    }
+    if args.start_ticks is not None:
+        payload["start_ticks"] = args.start_ticks
+    result = api("POST", "/_sc/session-control/channel", payload)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="sc session-control")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    status = sub.add_parser("status")
+    status.add_argument("binding_id", nargs="?", type=int)
+    status.set_defaults(fn=cmd_status)
+
+    for action in ("manage", "release", "retry"):
+        command = sub.add_parser(action)
+        command.add_argument("binding_id", nargs="?", type=int)
+        command.set_defaults(fn=cmd_action, action=action)
+
+    bind = sub.add_parser("bind")
+    bind.add_argument("binding_id", type=int)
+    bind.add_argument("--native-id")
+    bind.add_argument("--endpoint")
+    bind.add_argument("--cli-version")
+    bind.add_argument("--state", choices=(
+        "starting", "foreground", "idle", "dispatching", "dormant",
+        "released", "error",
+    ))
+    bind.add_argument("--capability", action="append")
+    bind.set_defaults(fn=cmd_bind)
+
+    channel = sub.add_parser("channel")
+    channel.add_argument("channel_action", choices=("register", "heartbeat", "clear"))
+    channel.add_argument("binding_id", type=int)
+    channel.add_argument("--pid", type=int, required=True)
+    channel.add_argument("--start-ticks", type=int)
+    channel.set_defaults(fn=cmd_channel)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/session_dispatcher.py
+++ b/.super-coder/scripts/session_dispatcher.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Provider-neutral wake dispatcher for managed planner conversations.
+
+The dispatcher owns durable wake-job claims and acknowledgement.  Provider
+modules own transport.  A provider module lives at
+``adapters/<harness>/session_control.py`` and exposes ``create_adapter()`` with
+three blocking operations::
+
+    status(binding) -> "starting" | "idle" | "active" | "dormant" | "error"
+    deliver(binding, prompt) -> None
+    resume(binding, prompt) -> None
+
+``deliver`` and ``resume`` return only after the injected turn exits.  Resume
+implementations must use :mod:`session_supervisor` to fence their child process;
+the common dispatcher never treats a native session ID as a lock.
+
+Message bodies never cross the transport boundary.  Every turn receives the
+same fixed prompt and the planner reads its token-scoped inbox through the API.
+``shell_messages.read_at`` is the only delivery acknowledgement.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import signal
+import sqlite3
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Protocol
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+DB_PATH = ENGINE / "shell_db.db"
+RUN_DIR = ENGINE / "run" / "session-dispatcher"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import db_driver  # noqa: E402
+import session_control  # noqa: E402
+import session_supervisor  # noqa: E402
+
+
+WAKE_PROMPT = (
+    "Check your unread sprint inbox, act on every message, and mark each "
+    "handled message read."
+)
+ADAPTER_STATES = frozenset({"starting", "idle", "active", "dormant", "error"})
+RETRY_DELAYS = (15, 60, 300)
+MAX_ATTEMPTS = len(RETRY_DELAYS) + 1
+MAX_ERROR_CHARS = 500
+LOG_LINES = 200
+
+
+class Adapter(Protocol):
+    def status(self, binding: dict) -> str: ...
+    def deliver(self, binding: dict, prompt: str) -> None: ...
+    def resume(self, binding: dict, prompt: str) -> None: ...
+
+
+@dataclass(frozen=True)
+class WakeBatch:
+    binding_id: int
+    shell_id: int
+    wake_ids: tuple[int, ...]
+    message_ids: tuple[int, ...]
+    message_watermark: int
+
+
+@dataclass(frozen=True)
+class BatchResult:
+    acknowledged: int
+    queued: int
+    failed: int
+
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)(bearer\s+)[^\s,;]+"),
+    re.compile(r"(?i)((?:api[_-]?key|token|password|authorization)\s*[=:]\s*)[^\s,;]+"),
+    re.compile(r"(?i)(https?://[^/@:\s]+:)[^/@\s]+@"),
+)
+
+
+def sanitize_error(error: object) -> str:
+    """Return a bounded single-line error safe for DB rows and runtime logs."""
+    text = " ".join(str(error).replace("\x00", "").split())
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(r"\1[REDACTED]", text)
+    return text[:MAX_ERROR_CHARS] or "unknown session-control failure"
+
+
+class AttemptLog:
+    """Small mode-0600 JSONL audit, one file per binding and bounded in size."""
+
+    def __init__(self, root: Path = RUN_DIR):
+        self.root = root
+
+    def write(self, binding_id: int, event: str, **fields: object) -> None:
+        try:
+            self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+            path = self.root / f"binding-{binding_id}.jsonl"
+            line = json.dumps(
+                {"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                 "event": event,
+                 **{key: sanitize_error(value) if key == "error" else value
+                    for key, value in fields.items()}},
+                sort_keys=True,
+            )
+            previous = path.read_text().splitlines() if path.exists() else []
+            content = "\n".join((previous + [line])[-LOG_LINES:]) + "\n"
+            descriptor = os.open(
+                path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+            )
+            with os.fdopen(descriptor, "w") as handle:
+                handle.write(content)
+            path.chmod(0o600)
+        except OSError:
+            # The DB ledger remains authoritative; a runtime-log failure must not
+            # change dispatch correctness.
+            return
+
+
+def binding_row(con: sqlite3.Connection, binding_id: int) -> dict | None:
+    row = con.execute(
+        "SELECT b.*, s.shortname, s.flavor, s.api_key "
+        "FROM shell_session_bindings b JOIN shells s ON s.shell_id=b.shell_id "
+        "WHERE b.binding_id=?",
+        (binding_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def claim_batch(con: sqlite3.Connection, binding_id: int) -> WakeBatch | None:
+    """Atomically claim every ready wake for one binding.
+
+    ``BEGIN IMMEDIATE`` plus the binding state transition makes the binding the
+    lock.  Two dispatcher processes may race, but only one can move the ready
+    rows to ``running``.
+    """
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        binding = con.execute(
+            "SELECT binding_id, shell_id, state, managed "
+            "FROM shell_session_bindings WHERE binding_id=?",
+            (binding_id,),
+        ).fetchone()
+        if not binding or not binding["managed"] or binding["state"] not in (
+            "foreground", "idle", "dormant"
+        ):
+            con.rollback()
+            return None
+        jobs = con.execute(
+            "SELECT wake_id, trigger_message_id FROM session_wake_jobs "
+            "WHERE binding_id=? AND state='queued' "
+            "AND available_at <= datetime('now') ORDER BY wake_id",
+            (binding_id,),
+        ).fetchall()
+        if not jobs:
+            con.rollback()
+            return None
+
+        watermark = con.execute(
+            "SELECT COALESCE(MAX(message_id),0) FROM shell_messages "
+            "WHERE to_shell_id=?", (binding["shell_id"],)
+        ).fetchone()[0]
+        session_control.transition_binding(
+            con, binding_id, expected=binding["state"], target="dispatching"
+        )
+        wake_ids = tuple(row["wake_id"] for row in jobs)
+        marks = ",".join("?" for _ in wake_ids)
+        cur = con.execute(
+            f"UPDATE session_wake_jobs SET state='running', "
+            f"attempt_count=attempt_count+1, started_at=datetime('now'), "
+            f"finished_at=NULL, last_error=NULL WHERE wake_id IN ({marks}) "
+            "AND state='queued'",
+            wake_ids,
+        )
+        if cur.rowcount != len(wake_ids):
+            raise RuntimeError("wake batch changed during transactional claim")
+        con.commit()
+        return WakeBatch(
+            binding_id=binding_id,
+            shell_id=binding["shell_id"],
+            wake_ids=wake_ids,
+            message_ids=tuple(row["trigger_message_id"] for row in jobs),
+            message_watermark=watermark,
+        )
+    except Exception:
+        con.rollback()
+        raise
+
+
+def _return_binding_state(
+    con: sqlite3.Connection, binding_id: int, target: str, error: str | None
+) -> None:
+    row = con.execute(
+        "SELECT state FROM shell_session_bindings WHERE binding_id=?", (binding_id,)
+    ).fetchone()
+    if not row:
+        return
+    # Release/error may have been requested while the transport was returning.
+    # Never overwrite that terminal state with a stale dispatcher result.
+    if row["state"] == "dispatching":
+        session_control.transition_binding(
+            con, binding_id, expected="dispatching", target=target
+        )
+    con.execute(
+        "UPDATE shell_session_bindings SET last_error=?, updated_at=datetime('now') "
+        "WHERE binding_id=?",
+        (error, binding_id),
+    )
+
+
+def _reconstruct_turn_arrivals(con: sqlite3.Connection, batch: WakeBatch) -> None:
+    """Ledger messages that arrived during the turn, including already-read rows."""
+    con.execute(
+        "INSERT OR IGNORE INTO session_wake_jobs (binding_id, trigger_message_id) "
+        "SELECT ?, message_id FROM shell_messages "
+        "WHERE to_shell_id=? AND message_id>?",
+        (batch.binding_id, batch.shell_id, batch.message_watermark),
+    )
+
+
+def finish_batch(
+    con: sqlite3.Connection,
+    batch: WakeBatch,
+    *,
+    return_state: str,
+    error: object | None = None,
+) -> BatchResult:
+    """Apply ``read_at`` acknowledgement and retry only unread running jobs."""
+    if return_state not in ("idle", "dormant", "foreground"):
+        raise ValueError(f"invalid post-dispatch state {return_state!r}")
+    clean_error = sanitize_error(error) if error is not None else None
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        _reconstruct_turn_arrivals(con, batch)
+        # A message delivered during the turn can be acknowledged before its
+        # wake row is reconstructed.  Mark all such rows done in the same txn.
+        con.execute(
+            "UPDATE session_wake_jobs SET state='done', finished_at=datetime('now'), "
+            "last_error=NULL WHERE binding_id=? AND state!='cancelled' "
+            "AND EXISTS (SELECT 1 FROM shell_messages m "
+            "WHERE m.message_id=session_wake_jobs.trigger_message_id "
+            "AND m.read_at IS NOT NULL)",
+            (batch.binding_id,),
+        )
+
+        marks = ",".join("?" for _ in batch.wake_ids)
+        unread = con.execute(
+            f"SELECT wake_id, attempt_count FROM session_wake_jobs "
+            f"WHERE wake_id IN ({marks}) AND state='running' ORDER BY wake_id",
+            batch.wake_ids,
+        ).fetchall()
+        terminal = any(row["attempt_count"] >= MAX_ATTEMPTS for row in unread)
+        for row in unread:
+            if terminal or row["attempt_count"] >= MAX_ATTEMPTS:
+                con.execute(
+                    "UPDATE session_wake_jobs SET state='failed', "
+                    "finished_at=datetime('now'), last_error=? WHERE wake_id=?",
+                    (clean_error or "turn exited before inbox acknowledgement", row["wake_id"]),
+                )
+                continue
+            delay = RETRY_DELAYS[row["attempt_count"] - 1]
+            con.execute(
+                "UPDATE session_wake_jobs SET state='queued', "
+                "available_at=datetime('now', ?), finished_at=datetime('now'), "
+                "last_error=? WHERE wake_id=?",
+                (f"+{delay} seconds",
+                 clean_error or "turn exited before inbox acknowledgement",
+                 row["wake_id"]),
+            )
+
+        if terminal:
+            _return_binding_state(
+                con, batch.binding_id, "error",
+                clean_error or "session wake retry budget exhausted",
+            )
+        else:
+            _return_binding_state(con, batch.binding_id, return_state, clean_error)
+
+        acknowledged = con.execute(
+            f"SELECT COUNT(*) FROM session_wake_jobs WHERE wake_id IN ({marks}) "
+            "AND state='done'", batch.wake_ids
+        ).fetchone()[0]
+        queued = con.execute(
+            f"SELECT COUNT(*) FROM session_wake_jobs WHERE wake_id IN ({marks}) "
+            "AND state='queued'", batch.wake_ids
+        ).fetchone()[0]
+        failed = con.execute(
+            f"SELECT COUNT(*) FROM session_wake_jobs WHERE wake_id IN ({marks}) "
+            "AND state='failed'", batch.wake_ids
+        ).fetchone()[0]
+        con.commit()
+        return BatchResult(acknowledged, queued, failed)
+    except Exception:
+        con.rollback()
+        raise
+
+
+def recover_interrupted(con: sqlite3.Connection, binding_id: int) -> BatchResult | None:
+    """Requeue a crash-left running batch after ownership is known vacant."""
+    jobs = con.execute(
+        "SELECT wake_id, trigger_message_id FROM session_wake_jobs "
+        "WHERE binding_id=? AND state='running' ORDER BY wake_id",
+        (binding_id,),
+    ).fetchall()
+    if not jobs:
+        return None
+    binding = con.execute(
+        "SELECT shell_id FROM shell_session_bindings WHERE binding_id=?", (binding_id,)
+    ).fetchone()
+    if not binding:
+        return None
+    watermark = con.execute(
+        "SELECT COALESCE(MAX(message_id),0) FROM shell_messages WHERE to_shell_id=?",
+        (binding["shell_id"],),
+    ).fetchone()[0]
+    return finish_batch(
+        con,
+        WakeBatch(
+            binding_id,
+            binding["shell_id"],
+            tuple(row["wake_id"] for row in jobs),
+            tuple(row["trigger_message_id"] for row in jobs),
+            watermark,
+        ),
+        return_state="dormant",
+        error="dispatcher restarted before inbox acknowledgement",
+    )
+
+
+def set_binding_error(con: sqlite3.Connection, binding_id: int, error: object) -> None:
+    clean = sanitize_error(error)
+    row = con.execute(
+        "SELECT state FROM shell_session_bindings WHERE binding_id=?", (binding_id,)
+    ).fetchone()
+    if not row:
+        return
+    target = "error"
+    if row["state"] != target:
+        session_control.transition_binding(
+            con, binding_id, expected=row["state"], target=target
+        )
+    con.execute(
+        "UPDATE shell_session_bindings SET last_error=?, updated_at=datetime('now') "
+        "WHERE binding_id=?", (clean, binding_id)
+    )
+    con.commit()
+
+
+def load_adapter(binding: dict) -> Adapter:
+    harness = binding["harness"]
+    path = ENGINE / "adapters" / harness / "session_control.py"
+    if not path.is_file():
+        raise RuntimeError(f"session-control adapter unavailable for {harness}")
+    spec = importlib.util.spec_from_file_location(
+        f"sc_session_adapter_{harness.replace('-', '_')}", path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load session-control adapter for {harness}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    factory = getattr(module, "create_adapter", None)
+    if not callable(factory):
+        raise RuntimeError(f"session-control adapter for {harness} has no create_adapter()")
+    adapter = factory()
+    if not all(callable(getattr(adapter, name, None))
+               for name in ("status", "deliver", "resume")):
+        raise RuntimeError(f"session-control adapter for {harness} is incomplete")
+    return adapter
+
+
+def api_ready(binding: dict, api_base: str) -> bool:
+    """Prove the target planner can read its authenticated inbox before a turn."""
+    token = binding.get("api_key") or ""
+    if not api_base or not token:
+        return False
+    req = urllib.request.Request(
+        api_base.rstrip("/") + "/_sc/mem/whoami",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=2) as response:
+            payload = json.loads(response.read())
+        return int(payload.get("shell_id", -1)) == binding["shell_id"]
+    except (OSError, ValueError, urllib.error.URLError, json.JSONDecodeError):
+        return False
+
+
+def beat(con: sqlite3.Connection, interval: int) -> None:
+    con.execute(
+        "INSERT INTO daemon_heartbeats (name, beat_at, interval_s) "
+        "VALUES ('session-dispatcher', datetime('now'), ?) "
+        "ON CONFLICT(name) DO UPDATE SET beat_at=excluded.beat_at, "
+        "interval_s=excluded.interval_s", (interval,)
+    )
+    con.commit()
+
+
+def poll_once(
+    con: sqlite3.Connection,
+    *,
+    repo_root: Path = REPO_ROOT,
+    api_base: str = "",
+    adapter_factory: Callable[[dict], Adapter] = load_adapter,
+    api_probe: Callable[[dict, str], bool] = api_ready,
+    reconcile: Callable[..., str] = session_supervisor.reconcile_binding,
+    lease_preflight: Callable[..., None] = session_supervisor.preflight_lease,
+    attempt_log: AttemptLog | None = None,
+) -> int:
+    """Run one reconstruction/dispatch cycle and return attempted binding count."""
+    attempt_log = attempt_log or AttemptLog()
+    session_control.reconstruct_wake_jobs(con)
+    con.commit()
+    ids = [row[0] for row in con.execute(
+        "SELECT DISTINCT b.binding_id FROM shell_session_bindings b "
+        "JOIN session_wake_jobs j ON j.binding_id=b.binding_id "
+        "WHERE b.managed=1 AND j.state IN ('queued','running') "
+        "ORDER BY b.binding_id"
+    )]
+    attempted = 0
+    for binding_id in ids:
+        binding = binding_row(con, binding_id)
+        if not binding or binding["state"] in ("released", "error"):
+            continue
+        try:
+            owner = reconcile(con, binding_id, repo_root=repo_root)
+            binding = binding_row(con, binding_id)
+            if not binding or binding["state"] in ("released", "error"):
+                continue
+            adapter = adapter_factory(binding)
+            status = adapter.status(binding)
+            if status not in ADAPTER_STATES:
+                raise RuntimeError(f"adapter returned invalid status {status!r}")
+
+            running = con.execute(
+                "SELECT COUNT(*) FROM session_wake_jobs "
+                "WHERE binding_id=? AND state='running'", (binding_id,)
+            ).fetchone()[0]
+            if running:
+                if owner in ("live", "cleanup") or status == "active":
+                    continue
+                result = recover_interrupted(con, binding_id)
+                attempt_log.write(
+                    binding_id, "recovered", queued=result.queued if result else 0,
+                    failed=result.failed if result else 0,
+                )
+                binding = binding_row(con, binding_id)
+                if binding is None:
+                    continue
+
+            if status in ("starting", "active"):
+                continue
+            if status == "error":
+                set_binding_error(con, binding_id, "provider status probe failed")
+                continue
+            if status == "dormant" and owner not in ("vacant", "stale-cleared"):
+                # A provider probe cannot overrule exact process evidence.  This
+                # is the final generic guard before a resume command exists.
+                attempt_log.write(
+                    binding_id, "resume-fenced",
+                    error=f"recorded owner status is {owner}",
+                )
+                continue
+            if not api_probe(binding, api_base):
+                # API downtime is a local readiness condition, not a delivery
+                # attempt.  Preserve queued rows and retry on the next 1s cycle.
+                clean = "engine API unavailable for authenticated inbox read"
+                con.execute(
+                    "UPDATE shell_session_bindings SET last_error=?, "
+                    "updated_at=datetime('now') WHERE binding_id=?",
+                    (clean, binding_id),
+                )
+                con.commit()
+                continue
+
+            batch = claim_batch(con, binding_id)
+            if batch is None:
+                continue
+            attempted += 1
+            attempt_log.write(
+                binding_id, "claimed", wake_ids=list(batch.wake_ids),
+                message_count=len(batch.message_ids), transport=status,
+            )
+            try:
+                if status == "dormant":
+                    lease_preflight(con, binding_id, repo_root=repo_root)
+                    adapter.resume(binding, WAKE_PROMPT)
+                    return_state = "dormant"
+                else:
+                    adapter.deliver(binding, WAKE_PROMPT)
+                    return_state = "idle"
+                result = finish_batch(con, batch, return_state=return_state)
+            except Exception as exc:
+                result = finish_batch(
+                    con, batch,
+                    return_state="dormant" if status == "dormant" else "idle",
+                    error=exc,
+                )
+            attempt_log.write(
+                binding_id, "finished", acknowledged=result.acknowledged,
+                queued=result.queued, failed=result.failed,
+            )
+        except session_supervisor.LeaseConflict as exc:
+            # A live or orphan-fenced owner is expected contention.  Keep the
+            # job queued; reconciliation already records dangerous orphan state.
+            attempt_log.write(binding_id, "owner-busy", error=exc)
+        except Exception as exc:
+            clean = sanitize_error(exc)
+            con.execute(
+                "UPDATE shell_session_bindings SET last_error=?, "
+                "updated_at=datetime('now') WHERE binding_id=?",
+                (clean, binding_id),
+            )
+            con.commit()
+            attempt_log.write(binding_id, "dispatch-error", error=clean)
+    return attempted
+
+
+def cmd_daemon(args: argparse.Namespace) -> int:
+    if not DB_PATH.exists() or DB_PATH.stat().st_size == 0:
+        sys.exit(f"session dispatcher: no usable DB at {DB_PATH} — run ./sc rebuild")
+    interval = args.interval or int(os.environ.get("SC_SESSION_DISPATCH_INTERVAL", "1"))
+    api_base = args.api_base or os.environ.get("SC_API_BASE", "")
+    stopped = False
+
+    def stop(_signum, _frame) -> None:
+        nonlocal stopped
+        stopped = True
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, stop)
+    print(
+        f"session dispatcher: every {interval}s · api {api_base or 'unavailable'}",
+        flush=True,
+    )
+    while not stopped:
+        con = db_driver.connect(DB_PATH)
+        try:
+            beat(con, interval)
+            poll_once(con, api_base=api_base)
+        except Exception as exc:
+            print(f"session dispatcher: cycle error ({sanitize_error(exc)})", flush=True)
+        finally:
+            con.close()
+        if args.once:
+            return 0
+        deadline = time.monotonic() + interval
+        while not stopped and time.monotonic() < deadline:
+            time.sleep(min(0.1, deadline - time.monotonic()))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="sc session-dispatcher")
+    parser.add_argument("--interval", type=int, default=0)
+    parser.add_argument("--api-base", default="")
+    parser.add_argument("--once", action="store_true")
+    parser.set_defaults(fn=cmd_daemon)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/session_dispatcher.py
+++ b/.super-coder/scripts/session_dispatcher.py
@@ -439,6 +439,20 @@ def poll_once(
             if status not in ADAPTER_STATES:
                 raise RuntimeError(f"adapter returned invalid status {status!r}")
 
+            if (
+                binding["state"] == "starting"
+                and status == "dormant"
+                and owner in ("vacant", "stale-cleared")
+                and binding["native_session_id"]
+            ):
+                session_control.transition_binding(
+                    con, binding_id, expected="starting", target="dormant"
+                )
+                con.commit()
+                binding = binding_row(con, binding_id)
+                if binding is None:
+                    continue
+
             running = con.execute(
                 "SELECT COUNT(*) FROM session_wake_jobs "
                 "WHERE binding_id=? AND state='running'", (binding_id,)

--- a/.super-coder/scripts/session_supervisor.py
+++ b/.super-coder/scripts/session_supervisor.py
@@ -526,7 +526,7 @@ def supervise(cmd: list[str], *, cwd: Path, env: dict[str, str],
     """Run one harness process group and forward cancellation to all children."""
     child: subprocess.Popen | None = None
     forwarded: int | None = None
-    previous: dict[int, object] = {}
+    previous: dict[signal.Signals, object] = {}
 
     def forward(signum, _frame) -> None:
         nonlocal forwarded
@@ -574,6 +574,6 @@ def supervise(cmd: list[str], *, cwd: Path, env: dict[str, str],
         raise
     finally:
         for sig, handler in previous.items():
-            signal.signal(sig, handler)
+            signal.signal(sig, handler)  # type: ignore[arg-type]
         if child is not None and on_exited:
             on_exited(child.pid, child.returncode if child.returncode is not None else -1)

--- a/sc
+++ b/sc
@@ -901,6 +901,11 @@ case "$cmd" in
   watch-daemon-down) sc_watch_daemon_down ;;
   watch-daemon-install)   sc_watch_daemon_install ;;
   watch-daemon-uninstall) sc_watch_daemon_uninstall ;;
+  # Provider-neutral planner wake control. `session-control` is the internal,
+  # token-scoped adapter client; the public operator `session` surface lands
+  # with the sprint's status/analytics unit.
+  session-control)    exec "$PY" "$S/session_cli.py" "$@" ;;
+  session-dispatcher) exec "$PY" "$S/session_dispatcher.py" "$@" ;;
   # ── persist (HOST-side): reboot-proof all applicable daemons via systemd ──
   persist)           sc_persist ;;
   # ── session-surviving local jobs: detached supervised one-shots whose
@@ -941,7 +946,7 @@ case "$cmd" in
   ports)        exec "$PY" "$S/ports.py" show ;;
   preview)      exec "$PY" "$S/preview.py" "$@" ;;
   # ── in-container primitives (no docker; also the host escape hatch) ──
-  serve)        exec "$PY" "$ENGINE/api/server.py" "$@" ;;
+  serve)        exec "$PY" "$S/service_supervisor.py" "$@" ;;
   # ── Windows VM broker (HOST-side primitive — runs where virsh + the key live) ──
   vm-broker)         exec "$PY" "$ENGINE/api/vm_broker.py" "$@" ;;
   # Bake/re-bake the clean snapshot — HOST-side, deliberately NOT a broker verb:
@@ -1164,6 +1169,10 @@ super-coder — forkable shell substrate
   ./sc watch list          live PR watches (--all includes retired)
   ./sc watch inbox         block until this shell has unread messages, then exit — the zero-token
                              inbox watcher; arm as a background task and its exit is your wake-up
+  ./sc session-control …  internal token-scoped binding client for provider adapters
+                             (status/manage/release/retry/bind/channel)
+  ./sc session-dispatcher  run the provider-neutral wake dispatcher in the foreground
+                             (`./sc serve` supervises it automatically)
   ./sc job start -- <cmd>  run a long local command (suite/bench/build) detached + supervised — it
                              survives your session; completion lands in YOUR inbox as a result row
                              (--label <slug> names it, --timeout <s> kills the wedged process group)

--- a/tests/test_service_supervisor.py
+++ b/tests/test_service_supervisor.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Launch wiring for the API + provider-neutral session dispatcher."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import service_supervisor  # noqa: E402
+
+
+class CommandTest(unittest.TestCase):
+    def test_serve_starts_api_and_dispatcher_on_the_same_loopback_port(self):
+        with mock.patch.dict(os.environ, {"SC_PYTHON": "/test/python"}):
+            api, dispatcher = service_supervisor.commands(9123)
+        self.assertEqual(
+            ["/test/python", str(ENGINE / "api" / "server.py"),
+             "--port", "9123"],
+            api,
+        )
+        self.assertEqual(
+            ["/test/python", str(ENGINE / "scripts" / "session_dispatcher.py"),
+             "--api-base", "http://127.0.0.1:9123"],
+            dispatcher,
+        )
+        self.assertNotIn("0.0.0.0", dispatcher)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_control_api.py
+++ b/tests/test_session_control_api.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Session-control API state changes and token scope."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+sys.path.insert(0, str(ENGINE / "api"))
+import server  # noqa: E402
+
+
+def build_db(path: str = ":memory:") -> sqlite3.Connection:
+    con = sqlite3.connect(path, timeout=5, check_same_thread=False)
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    con.executescript(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1);"
+        "INSERT INTO shells (shell_id, display_name, shortname, flavor, "
+        "system_prompt, user_id, api_key, active_archive_id) "
+        "VALUES (1, 'Planner 1', 'PLN1', 'planner', 'x', 1, 'token-1', NULL);"
+        "INSERT INTO shells (shell_id, display_name, shortname, flavor, "
+        "system_prompt, user_id, api_key, active_archive_id) "
+        "VALUES (2, 'Planner 2', 'PLN2', 'planner', 'x', 1, 'token-2', NULL);"
+        "INSERT INTO shell_memory_archives "
+        "(archive_id, shell_id, session_id, date, harness, provider, model) "
+        "VALUES (10, 1, '0001', '2026-07-21', 'fake', 'test', 'm');"
+        "INSERT INTO shell_memory_archives "
+        "(archive_id, shell_id, session_id, date, harness, provider, model) "
+        "VALUES (11, 2, '0001', '2026-07-21', 'fake', 'test', 'm');"
+        "UPDATE shells SET active_archive_id=10 WHERE shell_id=1;"
+        "UPDATE shells SET active_archive_id=11 WHERE shell_id=2;"
+        "INSERT INTO shell_session_bindings "
+        "(binding_id, archive_id, shell_id, harness, native_session_id, "
+        "control_capabilities, state, managed) "
+        "VALUES (20, 10, 1, 'fake', 'native-1', "
+        "'{\"deliver\":true,\"resume\":true}', 'dormant', 0);"
+        "INSERT INTO shell_session_bindings "
+        "(binding_id, archive_id, shell_id, harness, native_session_id, "
+        "control_capabilities, state, managed) "
+        "VALUES (21, 11, 2, 'fake', 'native-2', "
+        "'{\"deliver\":true}', 'idle', 0);"
+    )
+    con.commit()
+    return con
+
+
+def add_message(con: sqlite3.Connection, shell_id: int = 1) -> int:
+    mid = con.execute(
+        "INSERT INTO shell_messages (from_shell_id, to_shell_id, body, kind) "
+        "VALUES (?, ?, 'wake', 'task')", (shell_id, shell_id)
+    ).lastrowid
+    con.commit()
+    return mid
+
+
+class ControlMutationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = build_db()
+        self.addCleanup(self.con.close)
+
+    def test_manage_reconstructs_exact_unread_work_and_is_idempotent(self):
+        unread = add_message(self.con)
+        read = add_message(self.con)
+        self.con.execute(
+            "UPDATE shell_messages SET read_at=datetime('now') WHERE message_id=?",
+            (read,),
+        )
+        self.con.commit()
+
+        payload, error = server.manage_session_control(self.con, 1, 20)
+        self.assertIsNone(error)
+        self.assertEqual((20, 1, "dormant"), (
+            payload["binding"]["binding_id"], payload["binding"]["managed"],
+            payload["binding"]["state"],
+        ))
+        self.assertEqual({"queued": 1}, payload["jobs"])
+        self.assertEqual(
+            [(20, unread, "queued", 0)],
+            [tuple(row) for row in self.con.execute(
+                "SELECT binding_id, trigger_message_id, state, attempt_count "
+                "FROM session_wake_jobs")],
+        )
+        # Run the actual second call and prove it did not duplicate the ledger.
+        again, second_error = server.manage_session_control(self.con, 1, 20)
+        self.assertIsNone(second_error)
+        self.assertEqual({"queued": 1}, again["jobs"])
+        self.assertEqual(1, self.con.execute(
+            "SELECT COUNT(*) FROM session_wake_jobs"
+        ).fetchone()[0])
+
+    def test_release_cancels_queue_but_keeps_message_unread(self):
+        message_id = add_message(self.con)
+        server.manage_session_control(self.con, 1, 20)
+        payload, error = server.release_session_control(self.con, 1, 20)
+        self.assertIsNone(error)
+        self.assertEqual(("released", 0), (
+            payload["binding"]["state"], payload["binding"]["managed"]
+        ))
+        row = self.con.execute(
+            "SELECT state, last_error FROM session_wake_jobs"
+        ).fetchone()
+        self.assertEqual(("cancelled", "binding released"), tuple(row))
+        self.assertIsNone(self.con.execute(
+            "SELECT read_at FROM shell_messages WHERE message_id=?", (message_id,)
+        ).fetchone()[0])
+
+    def test_release_refuses_running_dispatch_without_mutation(self):
+        self.con.execute(
+            "UPDATE shell_session_bindings SET managed=1, state='dispatching' "
+            "WHERE binding_id=20"
+        )
+        self.con.commit()
+        payload, error = server.release_session_control(self.con, 1, 20)
+        self.assertIsNone(payload)
+        self.assertEqual("binding is dispatching; release after the turn exits", error)
+        row = self.con.execute(
+            "SELECT state, managed FROM shell_session_bindings WHERE binding_id=20"
+        ).fetchone()
+        self.assertEqual(("dispatching", 1), tuple(row))
+
+    def test_retry_resets_only_failed_unread_jobs(self):
+        failed = add_message(self.con)
+        done = add_message(self.con)
+        self.con.execute(
+            "INSERT INTO session_wake_jobs "
+            "(binding_id, trigger_message_id, state, attempt_count, last_error) "
+            "VALUES (20, ?, 'failed', 4, 'old')", (failed,)
+        )
+        self.con.execute(
+            "INSERT INTO session_wake_jobs "
+            "(binding_id, trigger_message_id, state, attempt_count) "
+            "VALUES (20, ?, 'done', 1)", (done,)
+        )
+        self.con.execute(
+            "UPDATE shell_session_bindings SET state='error', managed=1, "
+            "last_error='old' WHERE binding_id=20"
+        )
+        self.con.commit()
+
+        payload, error = server.retry_session_control(self.con, 1, 20)
+        self.assertIsNone(error)
+        self.assertEqual(("starting", None), (
+            payload["binding"]["state"], payload["binding"]["last_error"]
+        ))
+        self.assertEqual(
+            [(failed, "queued", 0, None), (done, "done", 1, None)],
+            [tuple(row) for row in self.con.execute(
+                "SELECT trigger_message_id, state, attempt_count, last_error "
+                "FROM session_wake_jobs ORDER BY trigger_message_id")],
+        )
+
+    def test_binding_patch_rejects_remote_endpoint_without_partial_write(self):
+        payload, error = server.patch_session_binding(
+            self.con, 1, 20,
+            {"control_endpoint": "https://user:pw@example.test/control",
+             "cli_version": "should-not-land"},
+        )
+        self.assertIsNone(payload)
+        self.assertEqual(
+            "control_endpoint must be a local socket or loopback URL", error
+        )
+        row = self.con.execute(
+            "SELECT control_endpoint, cli_version FROM shell_session_bindings "
+            "WHERE binding_id=20"
+        ).fetchone()
+        self.assertEqual((None, None), tuple(row))
+
+    def test_binding_patch_canonicalizes_capabilities_and_cannot_cross_shells(self):
+        payload, error = server.patch_session_binding(
+            self.con, 1, 20,
+            {"control_endpoint": "unix:///tmp/fake.sock",
+             "control_capabilities": {"resume": True, "deliver": False},
+             "cli_version": "1.2.3", "state": "idle"},
+        )
+        self.assertIsNone(error)
+        self.assertEqual(("idle", "unix:///tmp/fake.sock", "1.2.3"), (
+            payload["binding"]["state"], payload["binding"]["control_endpoint"],
+            payload["binding"]["cli_version"],
+        ))
+        self.assertEqual(
+            '{"deliver":false,"resume":true}',
+            payload["binding"]["control_capabilities"],
+        )
+        denied, denied_error = server.patch_session_binding(
+            self.con, 1, 21, {"cli_version": "stolen"}
+        )
+        self.assertIsNone(denied)
+        self.assertEqual("no such session binding", denied_error)
+        self.assertIsNone(self.con.execute(
+            "SELECT cli_version FROM shell_session_bindings WHERE binding_id=21"
+        ).fetchone()[0])
+
+    def test_binding_patch_cannot_bypass_dispatch_or_release_operations(self):
+        for forbidden in ("dispatching", "released"):
+            payload, error = server.patch_session_binding(
+                self.con, 1, 20, {"state": forbidden}
+            )
+            self.assertIsNone(payload)
+            self.assertEqual(
+                "dispatching/released are owned by dispatcher/release operations",
+                error,
+            )
+        row = self.con.execute(
+            "SELECT state, managed FROM shell_session_bindings WHERE binding_id=20"
+        ).fetchone()
+        self.assertEqual(("dormant", 0), tuple(row))
+
+    def test_channel_registration_uses_fenced_supervisor_and_stays_scoped(self):
+        with mock.patch.object(
+            server.session_supervisor, "register_active_channel", return_value=88
+        ) as register:
+            payload, error = server.update_session_channel(
+                self.con, 1,
+                {"binding_id": 20, "action": "register", "pid": 123},
+            )
+        self.assertIsNone(error)
+        self.assertEqual({"binding_id": 20, "pid": 123, "start_ticks": 88}, payload)
+        register.assert_called_once_with(
+            self.con, 20, 123, repo_root=server.REPO_ROOT
+        )
+        denied, denied_error = server.update_session_channel(
+            self.con, 1,
+            {"binding_id": 21, "action": "register", "pid": 123},
+        )
+        self.assertIsNone(denied)
+        self.assertEqual("no such session binding", denied_error)
+
+
+class TokenScopeHttpTest(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.db_path = Path(tmp.name) / "api.db"
+        con = build_db(str(self.db_path))
+        con.close()
+        self.db_patch = mock.patch.object(server, "DB_PATH", self.db_path)
+        self.db_patch.start()
+        self.addCleanup(self.db_patch.stop)
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+        self.addCleanup(self._stop)
+        self.base = f"http://127.0.0.1:{self.httpd.server_port}"
+
+    def _stop(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+        self.thread.join(timeout=5)
+
+    def request(self, method: str, path: str, *, token: str | None = None,
+                body: dict | None = None) -> tuple[int, dict]:
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        req = urllib.request.Request(
+            self.base + path, data=data, method=method, headers=headers
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=5) as response:
+                return response.status, json.loads(response.read())
+        except urllib.error.HTTPError as exc:
+            return exc.code, json.loads(exc.read())
+
+    def test_auth_is_required_and_token_cannot_mutate_another_binding(self):
+        status, payload = self.request("GET", "/_sc/session-control")
+        self.assertEqual((401, "Authorization: Bearer <token> required"),
+                         (status, payload["error"]))
+        status, payload = self.request(
+            "POST", "/_sc/session-control/manage", token="token-1",
+            body={"binding_id": 21},
+        )
+        self.assertEqual((409, "no session binding for this shell"),
+                         (status, payload["error"]))
+        status, payload = self.request(
+            "POST", "/_sc/session-control/manage", token="token-1",
+            body={"binding_id": 20},
+        )
+        self.assertEqual((200, 20, 1),
+                         (status, payload["binding"]["binding_id"],
+                          payload["binding"]["managed"]))
+        with sqlite3.connect(self.db_path) as con:
+            rows = con.execute(
+                "SELECT binding_id, managed FROM shell_session_bindings "
+                "ORDER BY binding_id"
+            ).fetchall()
+        self.assertEqual([(20, 1), (21, 0)], rows)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_control_api.py
+++ b/tests/test_session_control_api.py
@@ -19,6 +19,7 @@ SCHEMA = ENGINE / "schema.sql"
 MIGRATIONS = ENGINE / "migrations"
 sys.path.insert(0, str(ENGINE / "api"))
 import server  # noqa: E402
+import session_dispatcher as dispatcher  # noqa: E402
 
 
 def build_db(path: str = ":memory:") -> sqlite3.Connection:
@@ -133,7 +134,7 @@ class ControlMutationTest(unittest.TestCase):
         ).fetchone()
         self.assertEqual(("dispatching", 1), tuple(row))
 
-    def test_retry_resets_only_failed_unread_jobs(self):
+    def test_retry_resets_failed_unread_jobs_and_dispatches_again(self):
         failed = add_message(self.con)
         done = add_message(self.con)
         self.con.execute(
@@ -163,6 +164,37 @@ class ControlMutationTest(unittest.TestCase):
                 "SELECT trigger_message_id, state, attempt_count, last_error "
                 "FROM session_wake_jobs ORDER BY trigger_message_id")],
         )
+
+        adapter = mock.Mock()
+        adapter.status.return_value = "dormant"
+
+        def acknowledge(_binding, _prompt):
+            self.con.execute(
+                "UPDATE shell_messages SET read_at=datetime('now') "
+                "WHERE message_id=?", (failed,)
+            )
+            self.con.commit()
+
+        adapter.resume.side_effect = acknowledge
+        attempted = dispatcher.poll_once(
+            self.con,
+            adapter_factory=lambda _binding: adapter,
+            api_probe=lambda _binding, _base: True,
+            reconcile=lambda _con, _binding_id, **_kwargs: "vacant",
+            lease_preflight=lambda _con, _binding_id, **_kwargs: None,
+            attempt_log=mock.Mock(),
+        )
+        self.assertEqual(1, attempted)
+        adapter.resume.assert_called_once()
+        self.assertEqual(
+            [(failed, "done", 1, None), (done, "done", 1, None)],
+            [tuple(row) for row in self.con.execute(
+                "SELECT trigger_message_id, state, attempt_count, last_error "
+                "FROM session_wake_jobs ORDER BY trigger_message_id")],
+        )
+        self.assertEqual("dormant", self.con.execute(
+            "SELECT state FROM shell_session_bindings WHERE binding_id=20"
+        ).fetchone()[0])
 
     def test_binding_patch_rejects_remote_endpoint_without_partial_write(self):
         payload, error = server.patch_session_binding(
@@ -219,6 +251,20 @@ class ControlMutationTest(unittest.TestCase):
             "SELECT state, managed FROM shell_session_bindings WHERE binding_id=20"
         ).fetchone()
         self.assertEqual(("dormant", 0), tuple(row))
+
+        self.con.execute(
+            "UPDATE shell_session_bindings SET state='dispatching' "
+            "WHERE binding_id=20"
+        )
+        self.con.commit()
+        payload, error = server.patch_session_binding(
+            self.con, 1, 20, {"state": "idle"}
+        )
+        self.assertIsNone(payload)
+        self.assertEqual("dispatching is owned by the dispatcher", error)
+        self.assertEqual("dispatching", self.con.execute(
+            "SELECT state FROM shell_session_bindings WHERE binding_id=20"
+        ).fetchone()[0])
 
     def test_channel_registration_uses_fenced_supervisor_and_stays_scoped(self):
         with mock.patch.object(

--- a/tests/test_session_dispatcher.py
+++ b/tests/test_session_dispatcher.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Hermetic wake-dispatch tests with fake provider adapters."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import session_control  # noqa: E402
+import session_dispatcher as dispatcher  # noqa: E402
+
+
+def make_db(path: str = ":memory:") -> sqlite3.Connection:
+    con = sqlite3.connect(path, timeout=5, check_same_thread=False)
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    con.executescript(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1);"
+        "INSERT INTO shells (shell_id, display_name, shortname, flavor, "
+        "system_prompt, user_id, api_key) "
+        "VALUES (1, 'Planner', 'PLN1', 'planner', 'x', 1, 'planner-token');"
+        "INSERT INTO shell_memory_archives "
+        "(archive_id, shell_id, session_id, date, harness, provider, model) "
+        "VALUES (10, 1, '0007', '2026-07-21', 'fake', 'test', 'model');"
+        "INSERT INTO shell_session_bindings "
+        "(binding_id, archive_id, shell_id, harness, native_session_id, "
+        "state, managed) VALUES (20, 10, 1, 'fake', 'native-1', 'idle', 1);"
+    )
+    con.commit()
+    return con
+
+
+def add_message(con: sqlite3.Connection, body: str = "secret event body") -> int:
+    mid = con.execute(
+        "INSERT INTO shell_messages (from_shell_id, to_shell_id, body, kind) "
+        "VALUES (1, 1, ?, 'result')", (body,)
+    ).lastrowid
+    con.commit()
+    return mid
+
+
+class FakeAdapter:
+    def __init__(self, *, state: str = "idle", deliver=None, resume=None):
+        self.state = state
+        self.deliver_fn = deliver or (lambda _binding, _prompt: None)
+        self.resume_fn = resume or (lambda _binding, _prompt: None)
+        self.prompts: list[str] = []
+        self.deliveries = 0
+        self.resumes = 0
+
+    def status(self, _binding: dict) -> str:
+        return self.state
+
+    def deliver(self, binding: dict, prompt: str) -> None:
+        self.deliveries += 1
+        self.prompts.append(prompt)
+        self.deliver_fn(binding, prompt)
+
+    def resume(self, binding: dict, prompt: str) -> None:
+        self.resumes += 1
+        self.prompts.append(prompt)
+        self.resume_fn(binding, prompt)
+
+
+def no_owner(_con, _binding_id, **_kwargs) -> str:
+    return "vacant"
+
+
+class DispatchTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = make_db()
+        self.addCleanup(self.con.close)
+        logs = tempfile.TemporaryDirectory()
+        self.addCleanup(logs.cleanup)
+        self.attempt_log = dispatcher.AttemptLog(Path(logs.name))
+
+    def poll(self, adapter: FakeAdapter, *, api=True) -> int:
+        return dispatcher.poll_once(
+            self.con,
+            adapter_factory=lambda _binding: adapter,
+            api_probe=lambda _binding, _base: api,
+            reconcile=no_owner,
+            lease_preflight=lambda _con, _binding_id, **_kwargs: None,
+            attempt_log=self.attempt_log,
+        )
+
+    def jobs(self) -> list[tuple]:
+        return [tuple(row) for row in self.con.execute(
+            "SELECT trigger_message_id, state, attempt_count, last_error "
+            "FROM session_wake_jobs ORDER BY trigger_message_id"
+        )]
+
+    def test_coalesces_messages_and_acknowledges_only_through_read_at(self):
+        first = add_message(self.con, "event A private body")
+        second = add_message(self.con, "event B private body")
+
+        def acknowledge(_binding, prompt):
+            self.assertEqual(dispatcher.WAKE_PROMPT, prompt)
+            self.assertNotIn("event A", prompt)
+            self.assertNotIn("event B", prompt)
+            self.con.execute(
+                "UPDATE shell_messages SET read_at=datetime('now') "
+                "WHERE message_id IN (?, ?)", (first, second)
+            )
+            self.con.commit()
+
+        adapter = FakeAdapter(deliver=acknowledge)
+        self.assertEqual(1, self.poll(adapter))
+        self.assertEqual((1, 0), (adapter.deliveries, adapter.resumes))
+        self.assertEqual(
+            [(first, "done", 1, None), (second, "done", 1, None)],
+            self.jobs(),
+        )
+        binding = self.con.execute(
+            "SELECT state, last_error FROM shell_session_bindings WHERE binding_id=20"
+        ).fetchone()
+        self.assertEqual(("idle", None), tuple(binding))
+
+    def test_message_arriving_during_turn_gets_an_audit_row(self):
+        first = add_message(self.con, "event A")
+        arrived: list[int] = []
+
+        def acknowledge_with_arrival(_binding, _prompt):
+            arrived.append(add_message(self.con, "event B during turn"))
+            self.con.execute(
+                "UPDATE shell_messages SET read_at=datetime('now') "
+                "WHERE message_id IN (?, ?)", (first, arrived[0])
+            )
+            self.con.commit()
+
+        self.assertEqual(1, self.poll(FakeAdapter(deliver=acknowledge_with_arrival)))
+        self.assertEqual(
+            [(first, "done", 1, None), (arrived[0], "done", 0, None)],
+            self.jobs(),
+        )
+        self.assertEqual(2, self.con.execute(
+            "SELECT COUNT(*) FROM session_wake_jobs"
+        ).fetchone()[0])
+
+    def test_api_down_never_starts_or_consumes_an_attempt(self):
+        message_id = add_message(self.con)
+        adapter = FakeAdapter()
+        self.assertEqual(0, self.poll(adapter, api=False))
+        self.assertEqual((0, 0), (adapter.deliveries, adapter.resumes))
+        self.assertEqual([(message_id, "queued", 0, None)], self.jobs())
+        binding = self.con.execute(
+            "SELECT state, last_error FROM shell_session_bindings WHERE binding_id=20"
+        ).fetchone()
+        self.assertEqual(
+            ("idle", "engine API unavailable for authenticated inbox read"),
+            tuple(binding),
+        )
+
+    def test_dormant_probe_cannot_resume_over_a_validated_live_owner(self):
+        message_id = add_message(self.con)
+        adapter = FakeAdapter(state="dormant")
+        attempted = dispatcher.poll_once(
+            self.con,
+            adapter_factory=lambda _binding: adapter,
+            api_probe=lambda _binding, _base: True,
+            reconcile=lambda _con, _binding_id, **_kwargs: "live",
+            lease_preflight=lambda *_args, **_kwargs: self.fail(
+                "preflight must not run over a validated live owner"),
+            attempt_log=self.attempt_log,
+        )
+        self.assertEqual(0, attempted)
+        self.assertEqual((0, 0), (adapter.deliveries, adapter.resumes))
+        self.assertEqual([(message_id, "queued", 0, None)], self.jobs())
+
+    def test_dormant_resume_runs_lease_preflight_before_adapter(self):
+        message_id = add_message(self.con)
+        calls: list[str] = []
+
+        def resume(_binding, _prompt):
+            calls.append("resume")
+            self.con.execute(
+                "UPDATE shell_messages SET read_at=datetime('now') "
+                "WHERE message_id=?", (message_id,)
+            )
+            self.con.commit()
+
+        adapter = FakeAdapter(state="dormant", resume=resume)
+
+        def preflight(_con, _binding_id, **_kwargs):
+            calls.append("preflight")
+
+        attempted = dispatcher.poll_once(
+            self.con,
+            adapter_factory=lambda _binding: adapter,
+            api_probe=lambda _binding, _base: True,
+            reconcile=no_owner,
+            lease_preflight=preflight,
+            attempt_log=self.attempt_log,
+        )
+        self.assertEqual(1, attempted)
+        self.assertEqual(["preflight", "resume"], calls)
+        self.assertEqual((0, 1), (adapter.deliveries, adapter.resumes))
+        self.assertEqual([(message_id, "done", 1, None)], self.jobs())
+
+    def test_unacknowledged_failures_retry_then_enter_error_without_reading_message(self):
+        message_id = add_message(self.con)
+
+        def fail(_binding, _prompt):
+            raise RuntimeError("Bearer super-secret token=also-secret transport down")
+
+        adapter = FakeAdapter(deliver=fail)
+        for attempt in range(1, dispatcher.MAX_ATTEMPTS + 1):
+            self.assertEqual(1, self.poll(adapter))
+            row = self.con.execute(
+                "SELECT state, attempt_count, last_error FROM session_wake_jobs "
+                "WHERE trigger_message_id=?", (message_id,)
+            ).fetchone()
+            self.assertEqual(attempt, row["attempt_count"])
+            self.assertNotIn("super-secret", row["last_error"])
+            self.assertNotIn("also-secret", row["last_error"])
+            if attempt < dispatcher.MAX_ATTEMPTS:
+                self.assertEqual("queued", row["state"])
+                delay = self.con.execute(
+                    "SELECT CAST(strftime('%s', available_at) AS INTEGER) - "
+                    "CAST(strftime('%s', 'now') AS INTEGER) "
+                    "FROM session_wake_jobs WHERE trigger_message_id=?",
+                    (message_id,),
+                ).fetchone()[0]
+                expected = dispatcher.RETRY_DELAYS[attempt - 1]
+                self.assertGreaterEqual(delay, expected - 1)
+                self.assertLessEqual(delay, expected)
+                self.con.execute(
+                    "UPDATE session_wake_jobs SET available_at=datetime('now','-1 second') "
+                    "WHERE trigger_message_id=?", (message_id,)
+                )
+                self.con.commit()
+            else:
+                self.assertEqual("failed", row["state"])
+
+        binding = self.con.execute(
+            "SELECT state, last_error FROM shell_session_bindings WHERE binding_id=20"
+        ).fetchone()
+        self.assertEqual("error", binding["state"])
+        self.assertNotIn("super-secret", binding["last_error"])
+        self.assertIsNone(self.con.execute(
+            "SELECT read_at FROM shell_messages WHERE message_id=?", (message_id,)
+        ).fetchone()[0])
+        self.assertEqual(dispatcher.MAX_ATTEMPTS, adapter.deliveries)
+
+    def test_crash_left_running_job_is_requeued_without_starting_a_second_writer(self):
+        message_id = add_message(self.con)
+        session_control.reconstruct_wake_jobs(self.con)
+        self.con.commit()
+        batch = dispatcher.claim_batch(self.con, 20)
+        self.assertEqual((message_id,), batch.message_ids)
+        adapter = FakeAdapter(state="dormant")
+
+        self.assertEqual(0, self.poll(adapter))
+        self.assertEqual((0, 0), (adapter.deliveries, adapter.resumes))
+        row = self.con.execute(
+            "SELECT state, attempt_count, last_error FROM session_wake_jobs"
+        ).fetchone()
+        self.assertEqual(
+            ("queued", 1, "dispatcher restarted before inbox acknowledgement"),
+            tuple(row),
+        )
+        self.assertEqual("dormant", self.con.execute(
+            "SELECT state FROM shell_session_bindings WHERE binding_id=20"
+        ).fetchone()[0])
+
+
+class ConcurrentClaimTest(unittest.TestCase):
+    def test_two_dispatchers_claim_exactly_one_batch(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = str(Path(tmp.name) / "dispatcher.db")
+        seed = make_db(path)
+        add_message(seed)
+        session_control.reconstruct_wake_jobs(seed)
+        seed.commit()
+        seed.close()
+        barrier = threading.Barrier(2)
+        claims: list[dispatcher.WakeBatch | None] = []
+
+        def claim() -> None:
+            con = sqlite3.connect(path, timeout=5)
+            con.row_factory = sqlite3.Row
+            try:
+                barrier.wait(timeout=5)
+                claims.append(dispatcher.claim_batch(con, 20))
+            finally:
+                con.close()
+
+        threads = [threading.Thread(target=claim) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(1, sum(batch is not None for batch in claims))
+
+        with sqlite3.connect(path) as con:
+            row = con.execute(
+                "SELECT state, attempt_count FROM session_wake_jobs"
+            ).fetchone()
+            binding_state = con.execute(
+                "SELECT state FROM shell_session_bindings WHERE binding_id=20"
+            ).fetchone()[0]
+        self.assertEqual(("running", 1), row)
+        self.assertEqual("dispatching", binding_state)
+
+
+class SanitizationTest(unittest.TestCase):
+    def test_sanitizes_common_secret_shapes_and_bounds_length(self):
+        error = dispatcher.sanitize_error(
+            "Authorization=abc token:xyz https://user:pass@example.test/ " + "x" * 900
+        )
+        self.assertNotIn("abc", error)
+        self.assertNotIn("xyz", error)
+        self.assertNotIn("pass", error)
+        self.assertIn("[REDACTED]", error)
+        self.assertEqual(dispatcher.MAX_ERROR_CHARS, len(error))
+
+    def test_heartbeat_upserts_one_named_dispatcher_row(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        dispatcher.beat(con, 1)
+        dispatcher.beat(con, 3)
+        rows = [tuple(row) for row in con.execute(
+            "SELECT name, interval_s FROM daemon_heartbeats ORDER BY name"
+        )]
+        self.assertEqual([("session-dispatcher", 3)], rows)
+
+    def test_attempt_log_is_private_bounded_and_redacted(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        log = dispatcher.AttemptLog(Path(tmp.name))
+        for index in range(dispatcher.LOG_LINES + 3):
+            log.write(7, "failed", index=index, error="Bearer secret-value")
+        path = Path(tmp.name) / "binding-7.jsonl"
+        lines = path.read_text().splitlines()
+        self.assertEqual(dispatcher.LOG_LINES, len(lines))
+        self.assertNotIn("secret-value", "\n".join(lines))
+        self.assertIn("[REDACTED]", lines[-1])
+        self.assertEqual(0o600, path.stat().st_mode & 0o777)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the provider-neutral session dispatcher with transactional coalesced claims, mid-turn message reconstruction, read_at-only acknowledgement, crash recovery, bounded retries, heartbeat, and sanitized per-binding logs
- add token-scoped binding manage/release/retry/update/channel endpoints plus the internal `sc session-control` adapter client
- supervise the API and dispatcher together under `sc serve`, dynamically loading provider transports supplied by units 4-6
- cover claim races, API-down gating, live-owner fencing, dormant resume preflight, retries, release, token scope, and launch wiring with hermetic fake adapters

## Judgements / trade-offs

- The retry schedule `15s, 60s, then 5m` is implemented as one initial attempt plus three retries; the fourth unacknowledged completion exhausts the budget. This preserves every stated delay while keeping retries bounded.
- This unit exposes internal `sc session-control ...`; the public operator `sc session ...` surface remains assigned to sprint unit 7.
- Provider adapters implement a minimal blocking `status/deliver/resume` contract. The common layer owns correctness and calls the existing lease preflight before dormant resume; provider-specific process claims remain in the adapter via `session_supervisor`.

## Verification

- `env -u SC_SANDBOX ./sc test` — 567 passed
- `./sc lint <changed Python/tests>` — clean
- `./sc typecheck session_dispatcher.py session_cli.py service_supervisor.py` — clean

Plain `./sc test` currently exposes an unrelated sandbox-environment test isolation defect; reported as #459.