### PR TITLE
feat(session): add Codex app-server control

### DIFF
--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -5,6 +5,14 @@
   "emit": [".codex/hooks.json"],
   "env": {},
   "model": { "flag": "--model" },
+  "session_control": {
+    "launch": ["python3", "{adapter_dir}/codex-session.py"],
+    "capabilities": {
+      "provider": "codex",
+      "transport": "unix-websocket-v2",
+      "normal_steer": false
+    }
+  },
   "headless": {
     "launch": ["codex", "exec"],
     "model_flag": "-m",

--- a/.super-coder/adapters/codex/codex-session.py
+++ b/.super-coder/adapters/codex/codex-session.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Own one Codex app-server and attach the interactive TUI to its thread."""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ADAPTER_DIR = Path(__file__).resolve().parent
+ENGINE = ADAPTER_DIR.parents[1]
+DB_PATH = ENGINE / "shell_db.db"
+RUN_DIR = ENGINE / "run" / "session-control"
+sys.path.insert(0, str(ADAPTER_DIR))
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import db_driver  # type: ignore[import-not-found]  # noqa: E402
+import session_supervisor  # type: ignore[import-not-found]  # noqa: E402
+from codex_rpc import AppServerClient, probe_codex  # noqa: E402
+
+
+def socket_path(binding_id: int) -> Path:
+    return RUN_DIR / f"codex-{binding_id}.sock"
+
+
+def cleanup_socket(path: Path, *, root: Path | None = None) -> None:
+    root = root or RUN_DIR
+    try:
+        path.resolve(strict=False).relative_to(root.resolve())
+    except ValueError as exc:
+        raise ValueError("refusing to clean a Codex socket outside the runtime dir") from exc
+    path.unlink(missing_ok=True)
+
+
+def _thread_params(model: str | None, cwd: Path, sandboxed: bool) -> dict:
+    params: dict = {"cwd": str(cwd)}
+    if model:
+        params["model"] = model
+    if sandboxed:
+        params.update(sandbox="danger-full-access", approvalPolicy="never")
+    return params
+
+
+def main() -> int:
+    try:
+        binding_id = int(os.environ["SC_SESSION_BINDING_ID"])
+    except (KeyError, ValueError):
+        raise SystemExit("Codex controlled launch requires SC_SESSION_BINDING_ID")
+    model = os.environ.get("SC_SESSION_MODEL") or None
+    sandboxed = bool(os.environ.get("SC_SANDBOX"))
+    cwd = Path.cwd().resolve()
+    probe = probe_codex()
+    if not probe["create"]:
+        raise SystemExit(
+            f"Codex {probe.get('cli_version') or 'unknown'} is not validated for "
+            f"app-server session control (expected 0.144.x)"
+        )
+
+    RUN_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+    RUN_DIR.chmod(0o700)
+    path = socket_path(binding_id)
+    cleanup_socket(path)
+    endpoint = f"unix://{path}"
+    log_path = RUN_DIR / f"codex-{binding_id}.log"
+    log_fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    log = os.fdopen(log_fd, "a")
+    server: subprocess.Popen | None = None
+    tui: subprocess.Popen | None = None
+
+    def stop(signum, _frame) -> None:
+        raise SystemExit(128 + signum)
+
+    for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT):
+        signal.signal(sig, stop)
+
+    try:
+        server = subprocess.Popen(
+            ["codex", "--dangerously-bypass-hook-trust", "app-server",
+             "--listen", endpoint],
+            cwd=str(cwd), stdout=log, stderr=log,
+        )
+        deadline = time.monotonic() + 10
+        client = None
+        while time.monotonic() < deadline:
+            if server.poll() is not None:
+                raise RuntimeError(f"Codex app-server exited {server.returncode}")
+            candidate = AppServerClient(endpoint)
+            try:
+                candidate.__enter__()
+                client = candidate
+                break
+            except (FileNotFoundError, ConnectionRefusedError, TimeoutError, OSError):
+                candidate.__exit__(None, None, None)
+                time.sleep(0.05)
+        if client is None:
+            raise RuntimeError("Codex app-server socket did not become ready")
+        try:
+            con = db_driver.connect(DB_PATH)
+            try:
+                binding = con.execute(
+                    "SELECT native_session_id FROM shell_session_bindings "
+                    "WHERE binding_id=?", (binding_id,),
+                ).fetchone()
+            finally:
+                con.close()
+            if not binding:
+                raise RuntimeError(f"unknown Codex session binding {binding_id}")
+            config_result = client.request(
+                "config/read", {"cwd": str(cwd), "includeLayers": False}
+            )
+            config = config_result.get("config") or {}
+            effective_model = model or config.get("model")
+            effective_sandbox = (
+                "danger-full-access" if sandboxed else config.get("sandbox_mode")
+            )
+            effective_approval = "never" if sandboxed else config.get("approval_policy")
+            effective_effort = config.get("model_reasoning_effort")
+            params = _thread_params(effective_model, cwd, sandboxed)
+            if not sandboxed and effective_sandbox:
+                params["sandbox"] = effective_sandbox
+            if not sandboxed and effective_approval:
+                params["approvalPolicy"] = effective_approval
+            native_id = binding["native_session_id"]
+            if native_id:
+                result = client.request(
+                    "thread/resume", {"threadId": native_id, **params}
+                )
+            else:
+                result = client.request("thread/start", params)
+            thread_id = (result.get("thread") or {}).get("id")
+            if not thread_id:
+                raise RuntimeError("Codex app-server did not return a thread ID")
+        finally:
+            client.__exit__(None, None, None)
+
+        capabilities = {
+            **probe,
+            "settings": {
+                "model": effective_model,
+                "cwd": str(cwd),
+                "sandbox": effective_sandbox,
+                "approval_policy": effective_approval,
+                "effort": effective_effort,
+            },
+        }
+        con = db_driver.connect(DB_PATH)
+        try:
+            session_supervisor.register_native_session(
+                con, binding_id, str(thread_id), control_endpoint=endpoint,
+                capabilities=json.dumps(capabilities, sort_keys=True),
+                cli_version=probe.get("cli_version"),
+            )
+        finally:
+            con.close()
+
+        command = ["codex", "--dangerously-bypass-hook-trust", "--remote", endpoint]
+        if sandboxed:
+            command.append("--dangerously-bypass-approvals-and-sandbox")
+        command.extend(["resume", str(thread_id)])
+        tui = subprocess.Popen(command, cwd=str(cwd))
+        return tui.wait()
+    finally:
+        for process in (tui, server):
+            if process is not None and process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+        log.close()
+        cleanup_socket(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.super-coder/adapters/codex/codex_rpc.py
+++ b/.super-coder/adapters/codex/codex_rpc.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Minimal JSON-RPC client for Codex app-server Unix sockets.
+
+Codex speaks WebSocket frames over the Unix socket, not newline JSON.  Keeping
+this client in the adapter avoids adding an engine dependency for one provider.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import socket
+import struct
+import subprocess
+import time
+from pathlib import Path
+from typing import Callable
+
+
+class CodexProtocolError(RuntimeError):
+    """The app-server transport or JSON-RPC response violated its contract."""
+
+
+class CodexRpcError(RuntimeError):
+    """The app-server returned a JSON-RPC error."""
+
+
+SUPPORTED_MAJOR = 0
+SUPPORTED_MINOR = 144
+
+
+def probe_codex(run: Callable[..., subprocess.CompletedProcess] = subprocess.run) -> dict:
+    """Probe the installed CLI and fail active control closed on unknown versions."""
+    version_call = run(
+        ["codex", "--version"], capture_output=True, text=True, timeout=5, check=False
+    )
+    version_text = (version_call.stdout or version_call.stderr or "").strip()
+    match = re.search(r"(?:codex-cli\s+)?(\d+)\.(\d+)\.(\d+)", version_text)
+    version = match.group(0).removeprefix("codex-cli ") if match else None
+    app_help = run(
+        ["codex", "app-server", "--help"], capture_output=True, text=True,
+        timeout=5, check=False,
+    )
+    resume_help = run(
+        ["codex", "exec", "resume", "--help"], capture_output=True, text=True,
+        timeout=5, check=False,
+    )
+    app_text = (app_help.stdout or "") + (app_help.stderr or "")
+    resume_text = (resume_help.stdout or "") + (resume_help.stderr or "")
+    known_version = bool(
+        match and int(match.group(1)) == SUPPORTED_MAJOR
+        and int(match.group(2)) == SUPPORTED_MINOR
+    )
+    unix_transport = app_help.returncode == 0 and "unix://" in app_text and "--listen" in app_text
+    resume = resume_help.returncode == 0 and "SESSION_ID" in resume_text
+    return {
+        "cli_version": version,
+        "active_delivery": bool(known_version and unix_transport),
+        "create": bool(known_version and unix_transport),
+        "deliver": bool(known_version and unix_transport),
+        "resume": resume,
+        "status": bool(known_version and unix_transport),
+        "transport": "unix-websocket-v2" if unix_transport else None,
+        "normal_steer": False,
+    }
+
+
+def unix_socket_path(endpoint: str) -> Path:
+    if not endpoint.startswith("unix://"):
+        raise ValueError("Codex control endpoint must use unix://")
+    path = Path(endpoint[len("unix://"):])
+    if not path.is_absolute():
+        raise ValueError("Codex control socket path must be absolute")
+    return path
+
+
+def encode_frame(payload: bytes, *, opcode: int = 1, mask: bytes | None = None) -> bytes:
+    """Encode one client WebSocket frame; client frames are always masked."""
+    mask = mask or os.urandom(4)
+    if len(mask) != 4:
+        raise ValueError("WebSocket mask must contain four bytes")
+    length = len(payload)
+    if length < 126:
+        header = bytes((0x80 | opcode, 0x80 | length))
+    elif length <= 0xFFFF:
+        header = bytes((0x80 | opcode, 0x80 | 126)) + struct.pack("!H", length)
+    else:
+        header = bytes((0x80 | opcode, 0x80 | 127)) + struct.pack("!Q", length)
+    masked = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    return header + mask + masked
+
+
+def _recv_exact(sock: socket.socket, size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            raise CodexProtocolError("Codex app-server closed the control socket")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def decode_frame(sock: socket.socket) -> tuple[bool, int, bytes]:
+    """Decode one WebSocket frame and return ``(final, opcode, payload)``."""
+    first, second = _recv_exact(sock, 2)
+    final = bool(first & 0x80)
+    opcode = first & 0x0F
+    masked = bool(second & 0x80)
+    length = second & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", _recv_exact(sock, 2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", _recv_exact(sock, 8))[0]
+    mask = _recv_exact(sock, 4) if masked else b""
+    payload = _recv_exact(sock, length)
+    if masked:
+        payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    return final, opcode, payload
+
+
+class AppServerClient:
+    """Synchronous initialized app-server connection over a Unix socket."""
+
+    def __init__(self, endpoint: str, *, timeout: float = 5.0,
+                 socket_factory: Callable[..., socket.socket] = socket.socket):
+        self.endpoint = endpoint
+        self.timeout = timeout
+        self.socket_factory = socket_factory
+        self.sock: socket.socket | None = None
+        self.next_id = 1
+        self.notifications: list[dict] = []
+
+    def __enter__(self) -> "AppServerClient":
+        path = unix_socket_path(self.endpoint)
+        sock = self.socket_factory(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+        sock.connect(str(path))
+        self.sock = sock
+        self._handshake()
+        self.request("initialize", {
+            "clientInfo": {
+                "name": "super_coder",
+                "title": "super-coder session dispatcher",
+                "version": "1",
+            }
+        })
+        self.notify("initialized", {})
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb) -> None:
+        if self.sock is None:
+            return
+        try:
+            self.sock.sendall(encode_frame(b"", opcode=8))
+        except OSError:
+            pass
+        self.sock.close()
+        self.sock = None
+
+    def _handshake(self) -> None:
+        assert self.sock is not None
+        key = base64.b64encode(os.urandom(16)).decode()
+        request = (
+            "GET / HTTP/1.1\r\n"
+            "Host: localhost\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\n"
+            "Sec-WebSocket-Version: 13\r\n\r\n"
+        ).encode()
+        self.sock.sendall(request)
+        response = bytearray()
+        while b"\r\n\r\n" not in response:
+            chunk = self.sock.recv(4096)
+            if not chunk or len(response) + len(chunk) > 65536:
+                raise CodexProtocolError("invalid Codex WebSocket handshake")
+            response.extend(chunk)
+        header = bytes(response).split(b"\r\n\r\n", 1)[0]
+        lines = header.split(b"\r\n")
+        if not lines or b" 101 " not in lines[0] + b" ":
+            raise CodexProtocolError("Codex app-server refused WebSocket upgrade")
+        headers = {}
+        for line in lines[1:]:
+            if b":" in line:
+                name, value = line.split(b":", 1)
+                headers[name.strip().lower()] = value.strip()
+        expected = base64.b64encode(hashlib.sha1(
+            (key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()
+        ).digest())
+        if headers.get(b"sec-websocket-accept") != expected:
+            raise CodexProtocolError("Codex WebSocket accept key did not match")
+
+    def _send_json(self, payload: dict) -> None:
+        if self.sock is None:
+            raise CodexProtocolError("Codex app-server client is not connected")
+        self.sock.sendall(encode_frame(
+            json.dumps(payload, separators=(",", ":")).encode()
+        ))
+
+    def _recv_json(self) -> dict:
+        if self.sock is None:
+            raise CodexProtocolError("Codex app-server client is not connected")
+        fragments: list[bytes] = []
+        text_started = False
+        while True:
+            final, opcode, payload = decode_frame(self.sock)
+            if opcode == 8:
+                raise CodexProtocolError("Codex app-server closed the control socket")
+            if opcode == 9:
+                self.sock.sendall(encode_frame(payload, opcode=10))
+                continue
+            if opcode == 1:
+                fragments = [payload]
+                text_started = True
+            elif opcode == 0 and text_started:
+                fragments.append(payload)
+            else:
+                continue
+            if not final:
+                continue
+            try:
+                message = json.loads(b"".join(fragments))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise CodexProtocolError("Codex app-server sent invalid JSON") from exc
+            if not isinstance(message, dict):
+                raise CodexProtocolError("Codex app-server message is not an object")
+            return message
+
+    def notify(self, method: str, params: dict) -> None:
+        self._send_json({"method": method, "params": params})
+
+    def request(self, method: str, params: dict) -> dict:
+        request_id = self.next_id
+        self.next_id += 1
+        self._send_json({"method": method, "id": request_id, "params": params})
+        while True:
+            message = self._recv_json()
+            if "id" not in message:
+                self.notifications.append(message)
+                continue
+            if message.get("id") != request_id:
+                method_name = message.get("method") or "unknown"
+                raise CodexProtocolError(
+                    f"unsupported Codex server request while awaiting {method}: "
+                    f"{method_name}"
+                )
+            if "error" in message:
+                error = message["error"]
+                detail = error.get("message") if isinstance(error, dict) else str(error)
+                raise CodexRpcError(f"Codex {method} failed: {detail}")
+            result = message.get("result")
+            if not isinstance(result, dict):
+                raise CodexProtocolError(f"Codex {method} returned no result object")
+            return result
+
+    def wait_notification(self, method: str, predicate: Callable[[dict], bool],
+                          *, timeout: float = 3600.0) -> dict:
+        if self.sock is None:
+            raise CodexProtocolError("Codex app-server client is not connected")
+        deadline = time.monotonic() + timeout
+        while True:
+            for index, message in enumerate(self.notifications):
+                if message.get("method") == method and predicate(message):
+                    return self.notifications.pop(index)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"timed out waiting for Codex {method}")
+            self.sock.settimeout(remaining)
+            message = self._recv_json()
+            if "id" in message:
+                raise CodexProtocolError(
+                    "unsupported Codex server request during wake turn: "
+                    f"{message.get('method') or 'unknown'}"
+                )
+            if message.get("method") == method and predicate(message):
+                return message
+            self.notifications.append(message)

--- a/.super-coder/adapters/codex/session_control.py
+++ b/.super-coder/adapters/codex/session_control.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Codex app-server transport for provider-neutral session control."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from typing import Callable
+
+ADAPTER_DIR = Path(__file__).resolve().parent
+ENGINE = ADAPTER_DIR.parents[1]
+REPO_ROOT = ENGINE.parent
+DB_PATH = ENGINE / "shell_db.db"
+sys.path.insert(0, str(ADAPTER_DIR))
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import db_driver  # type: ignore[import-not-found]  # noqa: E402
+import session_control as common_session_control  # type: ignore[import-not-found]  # noqa: E402
+import session_supervisor  # type: ignore[import-not-found]  # noqa: E402
+from codex_rpc import (  # noqa: E402
+    AppServerClient, CodexProtocolError, CodexRpcError, probe_codex,
+    unix_socket_path,
+)
+
+CONTROL_DIR = ENGINE / "run" / "session-control"
+
+
+def _capabilities(binding: dict) -> dict:
+    value = binding.get("control_capabilities") or "{}"
+    try:
+        parsed = json.loads(value) if isinstance(value, str) else value
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _settings(binding: dict) -> dict:
+    value = _capabilities(binding).get("settings") or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _thread_status(result: dict) -> str:
+    thread = result.get("thread") or {}
+    status = thread.get("status") or {}
+    if isinstance(status, str):
+        return status
+    if isinstance(status, dict):
+        return str(status.get("type") or "")
+    return ""
+
+
+def resume_command(binding: dict, prompt: str) -> list[str]:
+    settings = _settings(binding)
+    native_id = binding.get("native_session_id")
+    if not native_id:
+        raise RuntimeError("Codex native thread ID is unavailable")
+    command = ["codex", "exec", "resume"]
+    model = settings.get("model") or binding.get("archive_model")
+    if model:
+        command.extend(["-m", str(model)])
+    if settings.get("sandbox") == "danger-full-access":
+        command.append("--dangerously-bypass-approvals-and-sandbox")
+    else:
+        sandbox = settings.get("sandbox")
+        approval = settings.get("approval_policy")
+        effort = settings.get("effort")
+        if sandbox:
+            command.extend(["-c", f"sandbox_mode={json.dumps(str(sandbox))}"])
+        if approval:
+            if not isinstance(approval, str):
+                raise RuntimeError("Codex granular approval posture cannot be resumed safely")
+            command.extend(["-c", f"approval_policy={json.dumps(approval)}"])
+        if effort:
+            command.extend(["-c", f"model_reasoning_effort={json.dumps(str(effort))}"])
+    command.extend(["--dangerously-bypass-hook-trust", str(native_id), prompt])
+    return command
+
+
+def _run_fenced_resume(binding: dict, command: list[str], cwd: Path) -> None:
+    lease: dict[str, int] = {}
+
+    def preflight() -> None:
+        con = db_driver.connect(DB_PATH)
+        try:
+            session_supervisor.preflight_lease(
+                con, binding["binding_id"], repo_root=REPO_ROOT
+            )
+        finally:
+            con.close()
+
+    def started(pid: int) -> None:
+        con = db_driver.connect(DB_PATH)
+        try:
+            generation = session_supervisor.claim_lease(
+                con, binding["binding_id"], pid, repo_root=REPO_ROOT,
+                state="dispatching",
+            )
+        finally:
+            con.close()
+        identity = session_supervisor.read_process(pid)
+        if not identity:
+            raise RuntimeError("Codex resume vanished while recording its lease")
+        lease.update(pid=pid, start_ticks=identity.start_ticks, generation=generation)
+
+    def exited(_pid: int, returncode: int) -> None:
+        if not lease:
+            return
+        con = db_driver.connect(DB_PATH)
+        try:
+            session_supervisor.release_lease(
+                con, binding["binding_id"], lease["pid"], lease["start_ticks"],
+                lease["generation"],
+                error=f"Codex resume exited {returncode}" if returncode else None,
+            )
+        finally:
+            con.close()
+
+    rc = session_supervisor.supervise(
+        command, cwd=cwd, env=dict(os.environ),
+        on_pre_spawn=preflight, on_started=started, on_exited=exited,
+    )
+    if rc:
+        raise RuntimeError(f"Codex resume exited {rc}")
+
+
+class CodexAdapter:
+    def __init__(self, *, client_factory: Callable[..., AppServerClient] = AppServerClient,
+                 endpoint_available: Callable[[Path], bool] | None = None,
+                 resume_runner: Callable[[dict, list[str], Path], None] = _run_fenced_resume,
+                 resume_probe: Callable[[], dict] = probe_codex):
+        self.client_factory = client_factory
+        self.endpoint_available = endpoint_available or self._is_socket
+        self.resume_runner = resume_runner
+        self.resume_probe = resume_probe
+
+    @staticmethod
+    def _is_socket(path: Path) -> bool:
+        try:
+            return stat.S_ISSOCK(path.lstat().st_mode)
+        except OSError:
+            return False
+
+    def _endpoint(self, binding: dict) -> tuple[str, Path]:
+        endpoint = str(binding.get("control_endpoint") or "")
+        path = unix_socket_path(endpoint)
+        expected = CONTROL_DIR / f"codex-{int(binding['binding_id'])}.sock"
+        if path != expected:
+            raise ValueError("Codex control endpoint does not match its binding socket")
+        return endpoint, path
+
+    def status(self, binding: dict) -> str:
+        if not binding.get("native_session_id"):
+            return "starting"
+        try:
+            endpoint, path = self._endpoint(binding)
+        except ValueError:
+            return "error"
+        if not self.endpoint_available(path):
+            return "dormant"
+        if not _capabilities(binding).get("active_delivery"):
+            return "error"
+        try:
+            with self.client_factory(endpoint) as client:
+                state = _thread_status(client.request(
+                    "thread/read", {"threadId": binding["native_session_id"],
+                                    "includeTurns": False}
+                ))
+        except (FileNotFoundError, ConnectionRefusedError):
+            return "dormant"
+        except (OSError, CodexProtocolError, CodexRpcError, TimeoutError):
+            return "error"
+        if state in ("idle", "notLoaded"):
+            return "idle"
+        if state == "active":
+            return "active"
+        return "error"
+
+    def deliver(self, binding: dict, prompt: str) -> None:
+        if not _capabilities(binding).get("active_delivery"):
+            raise RuntimeError("Codex active delivery is unsupported by this CLI version")
+        endpoint, _path = self._endpoint(binding)
+        thread_id = str(binding["native_session_id"])
+        settings = _settings(binding)
+        with self.client_factory(endpoint) as client:
+            current = client.request(
+                "thread/read", {"threadId": thread_id, "includeTurns": False}
+            )
+            state = _thread_status(current)
+            if state == "active":
+                raise common_session_control.ProviderBusy(  # type: ignore[attr-defined]
+                    "Codex thread became active before wake delivery"
+                )
+            if state == "notLoaded":
+                params = {"threadId": thread_id, "cwd": settings.get("cwd")}
+                if settings.get("model"):
+                    params["model"] = settings["model"]
+                if settings.get("sandbox"):
+                    params["sandbox"] = settings["sandbox"]
+                if settings.get("approval_policy"):
+                    params["approvalPolicy"] = settings["approval_policy"]
+                client.request("thread/resume", params)
+            elif state != "idle":
+                raise RuntimeError(f"Codex thread is not deliverable ({state or 'unknown'})")
+            result = client.request("turn/start", {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": prompt}],
+            })
+            turn = result.get("turn") or {}
+            turn_id = turn.get("id")
+            if not turn_id:
+                raise CodexProtocolError("Codex turn/start returned no turn ID")
+            completed = client.wait_notification(
+                "turn/completed",
+                lambda message: (message.get("params") or {}).get("turn", {}).get("id") == turn_id,
+            )
+            final = (completed.get("params") or {}).get("turn") or {}
+            if final.get("status") != "completed":
+                raise RuntimeError(f"Codex wake turn ended {final.get('status') or 'unknown'}")
+
+    def resume(self, binding: dict, prompt: str) -> None:
+        if not _capabilities(binding).get("resume"):
+            raise RuntimeError("Codex CLI resume capability is unavailable")
+        if not self.resume_probe().get("resume"):
+            raise RuntimeError("installed Codex CLI failed the resume capability probe")
+        settings = _settings(binding)
+        cwd = Path(settings.get("cwd") or session_supervisor.expected_worktree(
+            REPO_ROOT, binding.get("shortname"), binding.get("flavor")
+        ))
+        self.resume_runner(binding, resume_command(binding, prompt), cwd)
+
+
+def create_adapter() -> CodexAdapter:
+    return CodexAdapter()

--- a/.super-coder/adapters/codex/session_control.py
+++ b/.super-coder/adapters/codex/session_control.py
@@ -178,6 +178,7 @@ class CodexAdapter:
         return "error"
 
     def deliver(self, binding: dict, prompt: str) -> None:
+        common_session_control.validate_managed_wake_posture(_capabilities(binding))
         if not _capabilities(binding).get("active_delivery"):
             raise RuntimeError("Codex active delivery is unsupported by this CLI version")
         endpoint, _path = self._endpoint(binding)
@@ -220,6 +221,7 @@ class CodexAdapter:
                 raise RuntimeError(f"Codex wake turn ended {final.get('status') or 'unknown'}")
 
     def resume(self, binding: dict, prompt: str) -> None:
+        common_session_control.validate_managed_wake_posture(_capabilities(binding))
         if not _capabilities(binding).get("resume"):
             raise RuntimeError("Codex CLI resume capability is unavailable")
         if not self.resume_probe().get("resume"):

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1256,6 +1256,11 @@ def manage_session_control(con, shell_id: int, binding_id: int | None = None):
         if not any(capabilities.get(name) for name in ("deliver", "resume")):
             con.rollback()
             return None, "binding has neither deliver nor resume capability"
+        try:
+            session_control.validate_managed_wake_posture(capabilities)
+        except session_control.SessionControlError as exc:
+            con.rollback()
+            return None, str(exc)
         other = con.execute(
             "SELECT binding_id FROM shell_session_bindings "
             "WHERE shell_id=? AND managed=1 AND binding_id!=?",

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -140,6 +140,15 @@ def load_adapter(harness: str) -> dict:
             "emit": [], "env": {}}
 
 
+def session_control_launch(adapter: dict) -> list[str] | None:
+    """Resolve an adapter's controlled interactive launcher, if declared."""
+    launch = ((adapter.get("session_control") or {}).get("launch") or [])
+    if not launch:
+        return None
+    adapter_dir = ADAPTERS / adapter["harness"]
+    return [str(value).replace("{adapter_dir}", str(adapter_dir)) for value in launch]
+
+
 def emit_adapter(adapter: dict, root: Path = REPO_ROOT) -> list[str]:
     """Copy the adapter's harness-specific config files (e.g. opencode.json) to
     `root` (the working directory). These are emitted artifacts (gitignored),
@@ -999,7 +1008,8 @@ def main() -> None:
             sys.exit(f"session resume refused: {e}")
 
         binding = resume_binding
-        if (not binding and adapter.get("session_control")
+        if (not binding and chosen["flavor"] == "planner"
+                and adapter.get("session_control")
                 and not os.environ.get("RENDER_ONLY")):
             binding = session_supervisor.ensure_binding(
                 con, archive_id=archive_id, shell_id=chosen["shell_id"],
@@ -1198,7 +1208,8 @@ def main() -> None:
     if not headless and ncfg.get("flag") and full["display_name"]:
         name_args = [ncfg["flag"], full["display_name"]]
 
-    cmd = (headless_cmd if headless else
+    controlled_cmd = session_control_launch(adapter) if binding and not headless else None
+    cmd = (headless_cmd if headless else controlled_cmd or
            (adapter.get("launch") or [harness]) + name_args + model_args + sandbox_flags)
     effort_env = headless_effort_env(adapter, session_effort) if headless else {}
     env = {**os.environ, **{k: str(v) for k, v in adapter.get("env", {}).items()},
@@ -1215,6 +1226,9 @@ def main() -> None:
     # so it is absent from worktrees; a worktree-relative path failed open). This
     # just saves a subshell per edit on the normal launch path.
     env["SC_ENGINE_DIR"] = str(ENGINE)
+    if binding:
+        env["SC_SESSION_BINDING_ID"] = str(binding["binding_id"])
+        env["SC_SESSION_MODEL"] = str(session_model or flavor_model or "")
     # The shell's HOME worktree — the dir we exec the harness from (below). The
     # branch-guard reads it to judge "outside your worktree" against the assigned
     # tree, not the live cwd: a shell whose cwd has drifted to the repo root (to

--- a/.super-coder/scripts/session_control.py
+++ b/.super-coder/scripts/session_control.py
@@ -65,6 +65,26 @@ class ProviderBusy(SessionControlError):
     """The provider became active after its status probe; defer without retry cost."""
 
 
+MANAGED_WAKE_POSTURE_ERROR = (
+    "managed wake requires approval_policy='never' or "
+    "sandbox='danger-full-access' so a headless turn cannot request approval"
+)
+
+
+def validate_managed_wake_posture(capabilities: Mapping[str, object]) -> None:
+    """Reject recorded settings that can prompt without an interactive client."""
+    settings = capabilities.get("settings")
+    if not isinstance(settings, Mapping):
+        return
+    if "approval_policy" not in settings and "sandbox" not in settings:
+        return
+    if (
+        settings.get("approval_policy") != "never"
+        and settings.get("sandbox") != "danger-full-access"
+    ):
+        raise SessionControlError(MANAGED_WAKE_POSTURE_ERROR)
+
+
 def _require_state(state: str) -> None:
     if state not in BINDING_STATES:
         raise UnknownBindingState(f"unknown session binding state: {state!r}")

--- a/.super-coder/scripts/session_control.py
+++ b/.super-coder/scripts/session_control.py
@@ -61,6 +61,10 @@ class StaleBindingState(SessionControlError):
         )
 
 
+class ProviderBusy(SessionControlError):
+    """The provider became active after its status probe; defer without retry cost."""
+
+
 def _require_state(state: str) -> None:
     if state not in BINDING_STATES:
         raise UnknownBindingState(f"unknown session binding state: {state!r}")

--- a/.super-coder/scripts/session_dispatcher.py
+++ b/.super-coder/scripts/session_dispatcher.py
@@ -127,8 +127,10 @@ class AttemptLog:
 
 def binding_row(con: sqlite3.Connection, binding_id: int) -> dict | None:
     row = con.execute(
-        "SELECT b.*, s.shortname, s.flavor, s.api_key "
+        "SELECT b.*, s.shortname, s.flavor, s.api_key, "
+        "a.model AS archive_model, a.provider AS archive_provider "
         "FROM shell_session_bindings b JOIN shells s ON s.shell_id=b.shell_id "
+        "JOIN shell_memory_archives a ON a.archive_id=b.archive_id "
         "WHERE b.binding_id=?",
         (binding_id,),
     ).fetchone()
@@ -298,6 +300,29 @@ def finish_batch(
         ).fetchone()[0]
         con.commit()
         return BatchResult(acknowledged, queued, failed)
+    except Exception:
+        con.rollback()
+        raise
+
+
+def defer_busy_batch(con: sqlite3.Connection, batch: WakeBatch,
+                     *, return_state: str = "idle") -> BatchResult:
+    """Undo a claim when the provider became busy before transport started."""
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        marks = ",".join("?" for _ in batch.wake_ids)
+        cur = con.execute(
+            f"UPDATE session_wake_jobs SET state='queued', "
+            f"attempt_count=attempt_count-1, available_at=datetime('now'), "
+            f"started_at=NULL, finished_at=NULL, last_error=NULL "
+            f"WHERE wake_id IN ({marks}) AND state='running'",
+            batch.wake_ids,
+        )
+        if cur.rowcount != len(batch.wake_ids):
+            raise RuntimeError("wake batch changed while deferring busy provider")
+        _return_binding_state(con, batch.binding_id, return_state, None)
+        con.commit()
+        return BatchResult(acknowledged=0, queued=len(batch.wake_ids), failed=0)
     except Exception:
         con.rollback()
         raise
@@ -511,6 +536,15 @@ def poll_once(
                     adapter.deliver(binding, WAKE_PROMPT)
                     return_state = "idle"
                 result = finish_batch(con, batch, return_state=return_state)
+            except session_control.ProviderBusy as exc:
+                result = defer_busy_batch(
+                    con, batch,
+                    return_state="dormant" if status == "dormant" else "idle",
+                )
+                attempt_log.write(
+                    binding_id, "provider-busy", queued=result.queued, error=exc
+                )
+                continue
             except Exception as exc:
                 result = finish_batch(
                     con, batch,

--- a/tests/test_codex_session_control.py
+++ b/tests/test_codex_session_control.py
@@ -214,6 +214,24 @@ class AdapterTest(unittest.TestCase):
         self.assertEqual(rpc.waits, ["turn/completed"])
         self.assertNotIn("turn/steer", [method for method, _params in rpc.requests])
 
+    def test_approval_prompting_delivery_refuses_before_opening_transport(self):
+        row = binding()
+        capabilities = json.loads(row["control_capabilities"])
+        capabilities["settings"].update(
+            sandbox="workspace-write", approval_policy="on-request"
+        )
+        row["control_capabilities"] = json.dumps(capabilities)
+        opened: list[str] = []
+        adapter = adapter_module.CodexAdapter(
+            client_factory=lambda endpoint: opened.append(endpoint),
+            endpoint_available=lambda _path: True,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "managed wake requires"):
+            adapter.deliver(row, "check inbox")
+
+        self.assertEqual(opened, [])
+
     def test_active_race_refuses_turn_start_and_never_steers(self):
         rpc = RpcFixture("active")
         adapter = adapter_module.CodexAdapter(
@@ -267,6 +285,26 @@ class AdapterTest(unittest.TestCase):
         )
         with self.assertRaisesRegex(RuntimeError, "failed the resume capability probe"):
             adapter.resume(binding(), "check inbox")
+        self.assertEqual(calls, [])
+
+    def test_approval_prompting_resume_refuses_before_probe_or_spawn(self):
+        row = binding()
+        capabilities = json.loads(row["control_capabilities"])
+        capabilities["settings"].update(
+            sandbox="workspace-write", approval_policy="on-request"
+        )
+        row["control_capabilities"] = json.dumps(capabilities)
+        probes: list[bool] = []
+        calls: list[list[str]] = []
+        adapter = adapter_module.CodexAdapter(
+            resume_runner=lambda _row, command, _cwd: calls.append(command),
+            resume_probe=lambda: probes.append(True),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "managed wake requires"):
+            adapter.resume(row, "check inbox")
+
+        self.assertEqual(probes, [])
         self.assertEqual(calls, [])
 
     def test_host_resume_pins_effective_sandbox_approval_and_effort(self):

--- a/tests/test_codex_session_control.py
+++ b/tests/test_codex_session_control.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Hermetic Codex app-server adapter and protocol fixtures."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+ADAPTER = ENGINE / "adapters" / "codex"
+EXPECTED_ENDPOINT = f"unix://{ENGINE / 'run' / 'session-control' / 'codex-8.sock'}"
+sys.path.insert(0, str(ADAPTER))
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import codex_rpc  # noqa: E402
+import run  # noqa: E402
+
+
+def load_file(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+adapter_module = load_file("codex_session_control_adapter", ADAPTER / "session_control.py")
+launcher_module = load_file("codex_session_launcher", ADAPTER / "codex-session.py")
+
+
+class BytesSocket:
+    def __init__(self, payload: bytes):
+        self.payload = bytearray(payload)
+
+    def recv(self, size: int) -> bytes:
+        chunk = bytes(self.payload[:size])
+        del self.payload[:size]
+        return chunk
+
+
+class RpcFixture:
+    def __init__(self, state: str = "idle"):
+        self.state = state
+        self.requests: list[tuple[str, dict]] = []
+        self.waits: list[str] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        return None
+
+    def request(self, method: str, params: dict) -> dict:
+        self.requests.append((method, params))
+        if method == "thread/read":
+            return {"thread": {"id": params["threadId"],
+                               "status": {"type": self.state}}}
+        if method == "thread/resume":
+            self.state = "idle"
+            return {"thread": {"id": params["threadId"],
+                               "status": {"type": "idle"}}}
+        if method == "turn/start":
+            return {"turn": {"id": "turn-7", "status": "inProgress"}}
+        raise AssertionError(f"unexpected RPC method {method}")
+
+    def wait_notification(self, method: str, predicate, *, timeout: float = 3600):
+        self.waits.append(method)
+        message = {"method": "turn/completed", "params": {
+            "turn": {"id": "turn-7", "status": "completed"}
+        }}
+        if not predicate(message):
+            raise AssertionError("completion predicate rejected the target turn")
+        return message
+
+
+def binding(*, state: str = "idle", endpoint: str = EXPECTED_ENDPOINT) -> dict:
+    capabilities = {
+        "active_delivery": True,
+        "resume": True,
+        "normal_steer": False,
+        "settings": {
+            "model": "gpt-5.6-sol",
+            "cwd": "/repo/.sc-worktrees/pln1",
+            "sandbox": "danger-full-access",
+            "approval_policy": "never",
+        },
+    }
+    return {
+        "binding_id": 8,
+        "native_session_id": "019-native-thread",
+        "control_endpoint": endpoint,
+        "control_capabilities": json.dumps(capabilities),
+        "archive_model": "gpt-5.6-sol",
+        "shortname": "PLN1",
+        "flavor": "planner",
+        "state": state,
+    }
+
+
+class ProtocolFrameTest(unittest.TestCase):
+    def test_client_frames_round_trip_masked_across_all_length_encodings(self):
+        for payload in (b"hello", b"x" * 126, b"y" * 65536):
+            with self.subTest(size=len(payload)):
+                frame = codex_rpc.encode_frame(payload, mask=b"mask")
+                final, opcode, decoded = codex_rpc.decode_frame(BytesSocket(frame))
+                self.assertEqual((final, opcode, decoded), (True, 1, payload))
+                self.assertTrue(frame[1] & 0x80, "client frame must be masked")
+
+    def test_unix_endpoint_rejects_tcp_and_relative_paths(self):
+        with self.assertRaisesRegex(ValueError, "unix"):
+            codex_rpc.unix_socket_path("ws://127.0.0.1:4500")
+        with self.assertRaisesRegex(ValueError, "absolute"):
+            codex_rpc.unix_socket_path("unix://relative.sock")
+
+    def test_unexpected_server_request_fails_closed_instead_of_hanging(self):
+        client = codex_rpc.AppServerClient(EXPECTED_ENDPOINT)
+        client.sock = object()
+        client._send_json = lambda _payload: None
+        client._recv_json = lambda: {
+            "id": 91, "method": "item/commandExecution/requestApproval", "params": {}
+        }
+        with self.assertRaisesRegex(codex_rpc.CodexProtocolError,
+                                    "unsupported Codex server request"):
+            client.request("turn/start", {})
+
+
+class VersionProbeTest(unittest.TestCase):
+    @staticmethod
+    def runner_for(version: str):
+        def run(command, **_kwargs):
+            if command == ["codex", "--version"]:
+                return subprocess.CompletedProcess(command, 0, f"codex-cli {version}\n", "")
+            if command == ["codex", "app-server", "--help"]:
+                return subprocess.CompletedProcess(command, 0, "--listen unix://PATH", "")
+            if command == ["codex", "exec", "resume", "--help"]:
+                return subprocess.CompletedProcess(command, 0, "SESSION_ID PROMPT", "")
+            raise AssertionError(command)
+        return run
+
+    def test_validated_version_enables_active_delivery_and_resume(self):
+        result = codex_rpc.probe_codex(self.runner_for("0.144.6"))
+        self.assertEqual(result["cli_version"], "0.144.6")
+        self.assertEqual(result["transport"], "unix-websocket-v2")
+        self.assertTrue(result["active_delivery"])
+        self.assertTrue(result["resume"])
+        self.assertFalse(result["normal_steer"])
+
+    def test_unknown_version_fails_active_closed_but_keeps_smoke_tested_resume(self):
+        result = codex_rpc.probe_codex(self.runner_for("0.145.0"))
+        self.assertFalse(result["create"])
+        self.assertFalse(result["active_delivery"])
+        self.assertTrue(result["resume"])
+
+
+class AdapterTest(unittest.TestCase):
+    def test_idle_status_reads_exact_bound_thread(self):
+        rpc = RpcFixture("idle")
+        adapter = adapter_module.CodexAdapter(
+            client_factory=lambda _endpoint: rpc,
+            endpoint_available=lambda _path: True,
+        )
+        self.assertEqual(adapter.status(binding()), "idle")
+        self.assertEqual(rpc.requests, [(
+            "thread/read", {"threadId": "019-native-thread", "includeTurns": False}
+        )])
+
+    def test_active_status_keeps_delivery_queued(self):
+        rpc = RpcFixture("active")
+        adapter = adapter_module.CodexAdapter(
+            client_factory=lambda _endpoint: rpc,
+            endpoint_available=lambda _path: True,
+        )
+        self.assertEqual(adapter.status(binding()), "active")
+        self.assertEqual([method for method, _params in rpc.requests], ["thread/read"])
+
+    def test_missing_server_is_dormant_without_opening_a_client(self):
+        opened: list[str] = []
+        adapter = adapter_module.CodexAdapter(
+            client_factory=lambda endpoint: opened.append(endpoint),
+            endpoint_available=lambda _path: False,
+        )
+        self.assertEqual(adapter.status(binding()), "dormant")
+        self.assertEqual(opened, [])
+
+    def test_binding_cannot_redirect_control_to_another_unix_socket(self):
+        adapter = adapter_module.CodexAdapter(endpoint_available=lambda _path: True)
+        self.assertEqual(
+            adapter.status(binding(endpoint="unix:///tmp/unrelated.sock")), "error"
+        )
+
+    def test_idle_delivery_starts_one_turn_waits_and_never_steers(self):
+        rpc = RpcFixture("idle")
+        adapter = adapter_module.CodexAdapter(
+            client_factory=lambda _endpoint: rpc,
+            endpoint_available=lambda _path: True,
+        )
+        adapter.deliver(binding(), "check inbox")
+        self.assertEqual(rpc.requests, [
+            ("thread/read", {"threadId": "019-native-thread", "includeTurns": False}),
+            ("turn/start", {
+                "threadId": "019-native-thread",
+                "input": [{"type": "text", "text": "check inbox"}],
+            }),
+        ])
+        self.assertEqual(rpc.waits, ["turn/completed"])
+        self.assertNotIn("turn/steer", [method for method, _params in rpc.requests])
+
+    def test_active_race_refuses_turn_start_and_never_steers(self):
+        rpc = RpcFixture("active")
+        adapter = adapter_module.CodexAdapter(
+            client_factory=lambda _endpoint: rpc,
+            endpoint_available=lambda _path: True,
+        )
+        with self.assertRaisesRegex(RuntimeError, "became active"):
+            adapter.deliver(binding(), "check inbox")
+        self.assertEqual([method for method, _params in rpc.requests], ["thread/read"])
+        self.assertNotIn("turn/steer", [method for method, _params in rpc.requests])
+
+    def test_unloaded_thread_resumes_with_pinned_settings_before_turn(self):
+        rpc = RpcFixture("notLoaded")
+        adapter = adapter_module.CodexAdapter(
+            client_factory=lambda _endpoint: rpc,
+            endpoint_available=lambda _path: True,
+        )
+        adapter.deliver(binding(), "check inbox")
+        self.assertEqual(rpc.requests[1], (
+            "thread/resume", {
+                "threadId": "019-native-thread",
+                "cwd": "/repo/.sc-worktrees/pln1",
+                "model": "gpt-5.6-sol",
+                "sandbox": "danger-full-access",
+                "approvalPolicy": "never",
+            }
+        ))
+        self.assertEqual(rpc.requests[2][0], "turn/start")
+
+    def test_resume_uses_native_id_pinned_route_and_injected_fenced_runner(self):
+        calls: list[tuple[dict, list[str], Path]] = []
+        adapter = adapter_module.CodexAdapter(
+            resume_runner=lambda row, command, cwd: calls.append((row, command, cwd)),
+            resume_probe=lambda: {"resume": True},
+        )
+        row = binding()
+        adapter.resume(row, "check inbox")
+        self.assertEqual(calls, [(
+            row,
+            ["codex", "exec", "resume", "-m", "gpt-5.6-sol",
+             "--dangerously-bypass-approvals-and-sandbox",
+             "--dangerously-bypass-hook-trust", "019-native-thread", "check inbox"],
+            Path("/repo/.sc-worktrees/pln1"),
+        )])
+
+    def test_resume_reprobes_current_cli_before_spawning(self):
+        calls: list[list[str]] = []
+        adapter = adapter_module.CodexAdapter(
+            resume_runner=lambda _row, command, _cwd: calls.append(command),
+            resume_probe=lambda: {"resume": False},
+        )
+        with self.assertRaisesRegex(RuntimeError, "failed the resume capability probe"):
+            adapter.resume(binding(), "check inbox")
+        self.assertEqual(calls, [])
+
+    def test_host_resume_pins_effective_sandbox_approval_and_effort(self):
+        row = binding()
+        capabilities = json.loads(row["control_capabilities"])
+        capabilities["settings"].update(
+            sandbox="workspace-write", approval_policy="on-request", effort="high"
+        )
+        row["control_capabilities"] = json.dumps(capabilities)
+        command = adapter_module.resume_command(row, "check inbox")
+        self.assertEqual(command, [
+            "codex", "exec", "resume", "-m", "gpt-5.6-sol",
+            "-c", 'sandbox_mode="workspace-write"',
+            "-c", 'approval_policy="on-request"',
+            "-c", 'model_reasoning_effort="high"',
+            "--dangerously-bypass-hook-trust", "019-native-thread", "check inbox",
+        ])
+
+
+class LaunchIntegrationTest(unittest.TestCase):
+    def test_adapter_declares_controlled_launcher(self):
+        adapter = run.load_adapter("codex")
+        self.assertEqual(run.session_control_launch(adapter), [
+            "python3", str(ADAPTER / "codex-session.py")
+        ])
+
+    def test_socket_cleanup_is_scoped_and_removes_stale_runtime_socket(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "run"
+            root.mkdir()
+            stale = root / "codex-8.sock"
+            stale.write_text("stale")
+            launcher_module.cleanup_socket(stale, root=root)
+            self.assertFalse(stale.exists())
+
+            outside = Path(tmp) / "outside.sock"
+            outside.write_text("preserve")
+            with self.assertRaisesRegex(ValueError, "outside"):
+                launcher_module.cleanup_socket(outside, root=root)
+            self.assertEqual(outside.read_text(), "preserve")
+
+    def test_controlled_launch_captures_thread_and_attaches_remote_tui(self):
+        class FakeConnection:
+            def execute(self, sql, params):
+                self.assert_query = (sql, params)
+                return self
+
+            def fetchone(self):
+                return {"native_session_id": None}
+
+            def close(self):
+                return None
+
+        class FakeProcess:
+            def __init__(self, command):
+                self.command = command
+                self.returncode = None
+
+            def poll(self):
+                return self.returncode
+
+            def wait(self, timeout=None):
+                self.returncode = 0
+                return 0
+
+            def terminate(self):
+                self.returncode = 0
+
+            def kill(self):
+                self.returncode = -9
+
+        class FakeClient:
+            requests: list[tuple[str, dict]] = []
+
+            def __init__(self, endpoint):
+                self.endpoint = endpoint
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, _exc_type, _exc, _tb):
+                return None
+
+            def request(self, method, params):
+                self.requests.append((method, params))
+                if method == "config/read":
+                    return {"config": {
+                        "model": "config-model",
+                        "sandbox_mode": "workspace-write",
+                        "approval_policy": "on-request",
+                        "model_reasoning_effort": "high",
+                    }}
+                return {"thread": {"id": "019-captured"}}
+
+        processes: list[FakeProcess] = []
+        registrations: list[tuple] = []
+
+        def popen(command, **_kwargs):
+            process = FakeProcess(command)
+            processes.append(process)
+            return process
+
+        def register(_con, binding_id, native_id, **kwargs):
+            registrations.append((binding_id, native_id, kwargs))
+
+        with tempfile.TemporaryDirectory() as tmp, \
+             mock.patch.object(launcher_module, "RUN_DIR", Path(tmp)), \
+             mock.patch.object(launcher_module, "AppServerClient", FakeClient), \
+             mock.patch.object(launcher_module, "probe_codex", return_value={
+                 "cli_version": "0.144.6", "create": True,
+                 "active_delivery": True, "resume": True,
+             }), \
+             mock.patch.object(launcher_module.db_driver, "connect",
+                               return_value=FakeConnection()), \
+             mock.patch.object(launcher_module.session_supervisor,
+                               "register_native_session", side_effect=register), \
+             mock.patch.object(launcher_module.subprocess, "Popen", side_effect=popen), \
+             mock.patch.object(launcher_module.signal, "signal"), \
+             mock.patch.dict(os.environ, {
+                 "SC_SESSION_BINDING_ID": "8",
+                 "SC_SESSION_MODEL": "gpt-5.6-sol",
+                 "SC_SANDBOX": "1",
+             }):
+            self.assertEqual(launcher_module.main(), 0)
+
+        endpoint = f"unix://{Path(tmp) / 'codex-8.sock'}"
+        self.assertEqual(processes[0].command, [
+            "codex", "--dangerously-bypass-hook-trust", "app-server",
+            "--listen", endpoint,
+        ])
+        self.assertEqual(FakeClient.requests, [(
+            "config/read", {
+                "cwd": str(Path.cwd().resolve()), "includeLayers": False,
+            }
+        ), (
+            "thread/start", {
+                "cwd": str(Path.cwd().resolve()),
+                "model": "gpt-5.6-sol",
+                "sandbox": "danger-full-access",
+                "approvalPolicy": "never",
+            }
+        )])
+        self.assertEqual(registrations[0][0:2], (8, "019-captured"))
+        self.assertEqual(registrations[0][2]["control_endpoint"], endpoint)
+        recorded = json.loads(registrations[0][2]["capabilities"])
+        self.assertEqual(recorded["settings"]["model"], "gpt-5.6-sol")
+        self.assertEqual(recorded["settings"]["sandbox"], "danger-full-access")
+        self.assertEqual(recorded["settings"]["approval_policy"], "never")
+        self.assertEqual(recorded["settings"]["effort"], "high")
+        self.assertEqual(processes[1].command, [
+            "codex", "--dangerously-bypass-hook-trust", "--remote", endpoint,
+            "--dangerously-bypass-approvals-and-sandbox", "resume", "019-captured",
+        ])

--- a/tests/test_session_control_api.py
+++ b/tests/test_session_control_api.py
@@ -104,6 +104,45 @@ class ControlMutationTest(unittest.TestCase):
             "SELECT COUNT(*) FROM session_wake_jobs"
         ).fetchone()[0])
 
+    def test_manage_rejects_approval_prompting_posture_without_mutation(self):
+        message_id = add_message(self.con)
+        self.con.execute(
+            "UPDATE shell_session_bindings SET control_capabilities=? "
+            "WHERE binding_id=20",
+            (json.dumps({
+                "deliver": True,
+                "resume": True,
+                "settings": {
+                    "sandbox": "workspace-write",
+                    "approval_policy": "on-request",
+                },
+            }),),
+        )
+        self.con.commit()
+
+        payload, error = server.manage_session_control(self.con, 1, 20)
+
+        self.assertIsNone(payload)
+        self.assertEqual(
+            "managed wake requires approval_policy='never' or "
+            "sandbox='danger-full-access' so a headless turn cannot request approval",
+            error,
+        )
+        self.assertEqual(
+            ("dormant", 0, None),
+            tuple(self.con.execute(
+                "SELECT state, managed, last_error FROM shell_session_bindings "
+                "WHERE binding_id=20"
+            ).fetchone()),
+        )
+        self.assertEqual(
+            [],
+            [tuple(row) for row in self.con.execute(
+                "SELECT binding_id, trigger_message_id FROM session_wake_jobs "
+                "WHERE trigger_message_id=?", (message_id,)
+            )],
+        )
+
     def test_release_cancels_queue_but_keeps_message_unread(self):
         message_id = add_message(self.con)
         server.manage_session_control(self.con, 1, 20)

--- a/tests/test_session_dispatcher.py
+++ b/tests/test_session_dispatcher.py
@@ -162,6 +162,32 @@ class DispatchTest(unittest.TestCase):
             tuple(binding),
         )
 
+    def test_active_provider_turn_keeps_job_queued_without_attempt_or_steer(self):
+        message_id = add_message(self.con)
+        adapter = FakeAdapter(state="active")
+        self.assertEqual(0, self.poll(adapter))
+        self.assertEqual((0, 0), (adapter.deliveries, adapter.resumes))
+        self.assertEqual([(message_id, "queued", 0, None)], self.jobs())
+        state = self.con.execute(
+            "SELECT state FROM shell_session_bindings WHERE binding_id=20"
+        ).fetchone()[0]
+        self.assertEqual(state, "idle")
+
+    def test_provider_busy_race_undoes_claim_without_burning_retry(self):
+        message_id = add_message(self.con)
+
+        def became_busy(_binding, _prompt):
+            raise session_control.ProviderBusy("turn raced active")
+
+        adapter = FakeAdapter(deliver=became_busy)
+        self.assertEqual(1, self.poll(adapter))
+        self.assertEqual((1, 0), (adapter.deliveries, adapter.resumes))
+        self.assertEqual([(message_id, "queued", 0, None)], self.jobs())
+        state = self.con.execute(
+            "SELECT state FROM shell_session_bindings WHERE binding_id=20"
+        ).fetchone()[0]
+        self.assertEqual(state, "idle")
+
     def test_dormant_probe_cannot_resume_over_a_validated_live_owner(self):
         message_id = add_message(self.con)
         adapter = FakeAdapter(state="dormant")


### PR DESCRIPTION
## Summary

- launch planner Codex through a per-binding Unix-socket app-server wrapper and attach the remote TUI to the captured native thread
- add a version-gated JSON-RPC/WebSocket adapter for idle status, `turn/start` delivery, completion waiting, and lease-fenced `codex exec resume`
- pin effective model, effort, sandbox, approval policy, cwd, and native thread across active and dormant delivery; busy races requeue without steering or retry cost

## Verification

- `env -u SC_SANDBOX ./sc test` — 588 passed
- targeted Codex/session suites — 44 passed
- `./sc lint ...` — clean
- `./sc typecheck ...` — clean
- live Codex 0.144.6 Unix-socket handshake, `thread/list`, and `config/read` probe — passed

## Notes

- Active control fails closed outside validated Codex 0.144.x; dormant resume is separately smoke-probed against the installed CLI.
- The adapter uses a small stdlib WebSocket client to avoid adding an engine-wide dependency for one provider.
- Plain `./sc test` inside the sandbox exposes three pre-existing host-only `vm-bake` failures; unsetting only `SC_SANDBOX` makes the complete suite green.

Sprint 21 · unit 5 · task #54 · spec #20