### PR TITLE
feat(session): add Kimi K3 session control

### DIFF
--- a/.super-coder/adapters/kimi/README.md
+++ b/.super-coder/adapters/kimi/README.md
@@ -2,8 +2,9 @@
 
 Kimi Code (`kimi`, Moonshot AI's coding CLI — repo `MoonshotAI/kimi-code`, the
 TypeScript successor to the legacy Python `kimi-cli`) reads the boot artifact
-(`AGENTS.md`) natively — already emitted by the render chain — so the adapter
-carries only the launch command, a headless block, and a sandbox approval flag.
+(`AGENTS.md`) natively — already emitted by the render chain. Managed planner
+sessions additionally run through Kimi's authenticated loopback web server;
+workers and unmanaged shells keep the terminal CLI.
 
 **Why it exists:** the Kimi-models sibling of the claude/codex/vibe harnesses —
 a first-party CLI billed against a Kimi membership (Moderato / Allegretto /
@@ -23,6 +24,20 @@ catch-all; kimi is the native Moonshot path.
 | `headless.model_flag` | `-m`; the selector must be an alias discovered from `~/.kimi-code/config.toml` |
 | `headless.effort.env` | `KIMI_MODEL_THINKING_EFFORT`; sprint headless boots set it to `high` |
 | `sandbox.launch_flags` | flags appended ONLY inside the docker sandbox, interactive launches only (`--yolo`) |
+
+### Managed planner session control
+
+The controlled launcher probes the installed command tree because Kimi 0.27
+uses `kimi server run` while 0.28 uses `kimi web`. It binds an OS-selected
+loopback port, keeps bearer auth enabled, stores the token only in a mode-0600
+runtime file, creates or resumes the binding's native session, and opens the
+web client. The binding records the effective `kimi-code/k3` route, thinking
+effort, cwd, and Kimi-native `permission_mode=auto` posture.
+
+Wake delivery reads the session's busy state before submitting a normal prompt.
+It never calls Kimi's steer endpoint. When the local server is gone, the
+dispatcher can run a fenced `kimi --session <id> --model kimi-code/k3 --prompt
+<prompt>` turn with the recorded thinking effort.
 
 **`--yolo` (sandbox, interactive only):** auto-approves all actions inside the
 container, where the container itself is the safety boundary (matches how

--- a/.super-coder/adapters/kimi/adapter.json
+++ b/.super-coder/adapters/kimi/adapter.json
@@ -4,6 +4,14 @@
   "boot_artifact": "AGENTS.md",
   "emit": [],
   "env": {},
+  "session_control": {
+    "launch": ["python3", "{adapter_dir}/kimi-session.py"],
+    "capabilities": {
+      "provider": "kimi",
+      "transport": "authenticated-loopback-rest-v1",
+      "normal_steer": false
+    }
+  },
   "headless": {
     "launch": ["kimi"],
     "prompt_flag": "-p",

--- a/.super-coder/adapters/kimi/kimi-session.py
+++ b/.super-coder/adapters/kimi/kimi-session.py
@@ -235,6 +235,7 @@ def main() -> int:
                 server.wait()
         if drain is not None:
             drain.join(timeout=1)
+        token_path(binding_id).unlink(missing_ok=True)
         log.close()
 
 

--- a/.super-coder/adapters/kimi/kimi-session.py
+++ b/.super-coder/adapters/kimi/kimi-session.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Own one authenticated Kimi web server and its managed planner session."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import select
+import signal
+import subprocess
+import sys
+import threading
+import time
+import webbrowser
+from pathlib import Path
+from typing import TextIO
+from urllib.parse import quote
+
+ADAPTER_DIR = Path(__file__).resolve().parent
+ENGINE = ADAPTER_DIR.parents[1]
+DB_PATH = ENGINE / "shell_db.db"
+RUN_DIR = ENGINE / "run" / "session-control"
+sys.path.insert(0, str(ADAPTER_DIR))
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import db_driver  # type: ignore[import-not-found]  # noqa: E402
+import session_supervisor  # type: ignore[import-not-found]  # noqa: E402
+from kimi_http import KimiClient, probe_kimi  # noqa: E402
+
+
+_URL_PATTERN = re.compile(r"(http://(?:127\.0\.0\.1|localhost):\d+)/#token=([^\s]+)")
+_TOKEN_PATTERN = re.compile(r"(?i)(token(?:=|:\s*))[^\s]+")
+
+
+def _capabilities(value: object) -> dict:
+    try:
+        parsed = json.loads(value or "{}") if isinstance(value, str) else value
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def token_path(binding_id: int) -> Path:
+    return RUN_DIR / f"kimi-{binding_id}.token"
+
+
+def write_private(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.parent.chmod(0o700)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(descriptor, "w") as handle:
+        handle.write(value)
+        handle.write("\n")
+    path.chmod(0o600)
+
+
+def wait_for_server(
+    process: subprocess.Popen[str], log: TextIO, *, timeout: float = 15
+) -> tuple[str, str]:
+    """Read the provider banner without persisting or echoing its bearer token."""
+    if process.stdout is None:
+        raise RuntimeError("Kimi server output is unavailable")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"Kimi session server exited {process.returncode}")
+        ready, _, _ = select.select([process.stdout], [], [], 0.1)
+        if not ready:
+            continue
+        line = process.stdout.readline()
+        if not line:
+            continue
+        match = _URL_PATTERN.search(line)
+        log.write(_TOKEN_PATTERN.sub(r"\1[REDACTED]", line))
+        log.flush()
+        if match:
+            return match.group(1), match.group(2)
+    raise RuntimeError("Kimi session server did not become ready")
+
+
+def drain_server_output(stream: TextIO, log: TextIO) -> None:
+    for line in stream:
+        log.write(_TOKEN_PATTERN.sub(r"\1[REDACTED]", line))
+        log.flush()
+
+
+def configure_session(
+    client: KimiClient,
+    binding: dict,
+    *,
+    cwd: Path,
+    model: str,
+    effort: str | None,
+) -> tuple[str, dict]:
+    native_id = binding.get("native_session_id")
+    if native_id:
+        session_id = str(native_id)
+        client.get_session(session_id)
+    else:
+        created = client.create_session(cwd)
+        session_id = str(created.get("id") or "")
+        if not session_id:
+            raise RuntimeError("Kimi session create returned no native ID")
+
+    agent_config = {"model": model, "permission_mode": "auto"}
+    if effort:
+        agent_config["thinking"] = effort
+    client.update_profile(session_id, agent_config)
+    status = client.get_status(session_id)
+    effective_model = status.get("model")
+    effective_effort = status.get("thinking_level")
+    permission = status.get("permission")
+    if effective_model != model:
+        raise RuntimeError(
+            f"Kimi route drifted at launch: requested {model}, got {effective_model or 'none'}"
+        )
+    if effort and effective_effort != effort:
+        raise RuntimeError(
+            f"Kimi effort drifted at launch: requested {effort}, got {effective_effort or 'none'}"
+        )
+    if permission != "auto":
+        raise RuntimeError(
+            f"Kimi managed session is not approval-safe (permission={permission or 'none'})"
+        )
+    return session_id, {
+        "model": effective_model,
+        "cwd": str(cwd),
+        "effort": effective_effort,
+        "permission_mode": permission,
+    }
+
+
+def main() -> int:
+    try:
+        binding_id = int(os.environ["SC_SESSION_BINDING_ID"])
+    except (KeyError, ValueError):
+        raise SystemExit("Kimi controlled launch requires SC_SESSION_BINDING_ID")
+
+    probe = probe_kimi()
+    command = probe.get("server_command")
+    if not probe.get("create") or not isinstance(command, list):
+        raise SystemExit(
+            f"Kimi {probe.get('cli_version') or 'unknown'} is not validated for "
+            "authenticated session-server control"
+        )
+
+    cwd = Path.cwd().resolve()
+    con = db_driver.connect(DB_PATH)
+    try:
+        row = con.execute(
+            "SELECT * FROM shell_session_bindings WHERE binding_id=?", (binding_id,)
+        ).fetchone()
+    finally:
+        con.close()
+    if not row:
+        raise SystemExit(f"unknown Kimi session binding {binding_id}")
+    binding = dict(row)
+    stored_settings = _capabilities(binding.get("control_capabilities")).get("settings")
+    stored_settings = stored_settings if isinstance(stored_settings, dict) else {}
+    model = stored_settings.get("model") or os.environ.get("SC_SESSION_MODEL")
+    if model != "kimi-code/k3":
+        raise SystemExit("Kimi managed planners require the pinned kimi-code/k3 route")
+    effort = (
+        stored_settings.get("effort")
+        or os.environ.get("SC_SESSION_EFFORT")
+        or os.environ.get("KIMI_MODEL_THINKING_EFFORT")
+        or None
+    )
+
+    RUN_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+    log_path = RUN_DIR / f"kimi-{binding_id}.log"
+    log_fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    log = os.fdopen(log_fd, "a")
+    server: subprocess.Popen[str] | None = None
+    drain: threading.Thread | None = None
+
+    def stop(signum: int, _frame: object) -> None:
+        raise SystemExit(128 + signum)
+
+    for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT):
+        signal.signal(sig, stop)
+
+    try:
+        server = subprocess.Popen(
+            [str(value) for value in command],
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        endpoint, token = wait_for_server(server, log)
+        if server.stdout is not None:
+            drain = threading.Thread(
+                target=drain_server_output,
+                args=(server.stdout, log),
+                name=f"kimi-{binding_id}-log-drain",
+                daemon=True,
+            )
+            drain.start()
+        runtime_token = token_path(binding_id)
+        write_private(runtime_token, token)
+        client = KimiClient(endpoint, token)
+        session_id, settings = configure_session(
+            client, binding, cwd=cwd, model=str(model), effort=effort
+        )
+        capabilities = {
+            **probe,
+            "token_file": str(runtime_token),
+            "settings": settings,
+        }
+        con = db_driver.connect(DB_PATH)
+        try:
+            session_supervisor.register_native_session(
+                con,
+                binding_id,
+                session_id,
+                control_endpoint=endpoint,
+                capabilities=json.dumps(capabilities, sort_keys=True),
+                cli_version=probe.get("cli_version"),
+            )
+        finally:
+            con.close()
+
+        url = f"{endpoint}/sessions/{quote(session_id, safe='')}#token={token}"
+        print(f"→ Kimi managed web session: {url}", flush=True)
+        webbrowser.open(url)
+        return server.wait()
+    finally:
+        if server is not None and server.poll() is None:
+            server.terminate()
+            try:
+                server.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                server.kill()
+                server.wait()
+        if drain is not None:
+            drain.join(timeout=1)
+        log.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.super-coder/adapters/kimi/kimi_http.py
+++ b/.super-coder/adapters/kimi/kimi_http.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Authenticated Kimi session-server client and capability probe."""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+from typing import IO
+
+
+TESTED_SERVER_VERSIONS = frozenset({(0, 27), (0, 28)})
+DEFAULT_TURN_TIMEOUT = 4 * 60 * 60
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)(bearer\s+)[^\s,;]+"),
+    re.compile(r"(?i)((?:token|authorization)\s*[=:]\s*)[^\s,;]+"),
+)
+
+
+def _sanitize(value: object) -> str:
+    text = " ".join(str(value).replace("\x00", "").split())
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(r"\1[REDACTED]", text)
+    return text[:500] or "request failed"
+
+
+class KimiProtocolError(RuntimeError):
+    """The local server returned a response outside its documented contract."""
+
+
+class KimiApiError(RuntimeError):
+    """The local server returned a structured non-zero API result."""
+
+    def __init__(self, code: int | None, message: str):
+        self.code = code
+        super().__init__(
+            f"Kimi API error {code if code is not None else 'unknown'}: {_sanitize(message)}"
+        )
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command, capture_output=True, text=True, timeout=5, check=False
+    )
+
+
+def _output(result: subprocess.CompletedProcess[str]) -> str:
+    return "\n".join(part for part in (result.stdout, result.stderr) if part)
+
+
+def _version_tuple(value: str) -> tuple[int, int, int] | None:
+    match = re.search(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?!\d)", value)
+    if not match:
+        return None
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch)
+
+
+def probe_kimi(
+    runner: Callable[[list[str]], subprocess.CompletedProcess[str]] = _run,
+) -> dict:
+    """Probe real CLI surfaces; unknown versions fail closed for live delivery."""
+    try:
+        version_result = runner(["kimi", "--version"])
+        root_result = runner(["kimi", "--help"])
+        server_result = runner(["kimi", "server", "run", "--help"])
+        web_result = runner(["kimi", "web", "--help"])
+        acp_result = runner(["kimi", "acp", "--help"])
+    except (OSError, subprocess.SubprocessError):
+        return {
+            "cli_version": None,
+            "create": False,
+            "deliver": False,
+            "resume": False,
+            "active_delivery": False,
+            "acp": False,
+            "normal_steer": False,
+            "server_command": None,
+        }
+
+    version_text = _output(version_result).strip()
+    version = _version_tuple(version_text)
+    known_server = bool(version and version[:2] in TESTED_SERVER_VERSIONS)
+    root_help = _output(root_result)
+    server_help = _output(server_result)
+    web_help = _output(web_result)
+    acp_help = _output(acp_result)
+
+    command: list[str] | None = None
+    if known_server and "--foreground" in web_help and "--no-open" in web_help:
+        command = ["kimi", "web", "--port", "0", "--foreground", "--no-open"]
+    elif known_server and "--foreground" in server_help:
+        command = ["kimi", "server", "run", "--port", "0", "--foreground"]
+
+    resume = (
+        version_result.returncode == 0
+        and root_result.returncode == 0
+        and "--session" in root_help
+        and "--prompt" in root_help
+        and "--model" in root_help
+    )
+    active = command is not None
+    return {
+        "cli_version": ".".join(map(str, version)) if version else None,
+        "create": active,
+        "deliver": active,
+        "resume": resume,
+        "active_delivery": active,
+        "acp": acp_result.returncode == 0 and "ACP" in acp_help,
+        "normal_steer": False,
+        "server_command": command,
+    }
+
+
+class KimiClient:
+    """Small blocking client for the stable ``/api/v1`` Kimi web contract."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        token: str,
+        *,
+        opener: Callable[..., IO[bytes]] = urllib.request.urlopen,
+        timeout: float = 10,
+        sleeper: Callable[[float], None] = time.sleep,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self.endpoint = endpoint.rstrip("/")
+        self.token = token
+        self.opener = opener
+        self.timeout = timeout
+        self.sleeper = sleeper
+        self.clock = clock
+
+    def request(self, method: str, path: str, body: dict | None = None) -> object:
+        payload = None if body is None else json.dumps(body).encode()
+        request = urllib.request.Request(
+            self.endpoint + "/api/v1/" + path.lstrip("/"),
+            data=payload,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with self.opener(request, timeout=self.timeout) as response:
+                envelope = json.loads(response.read())
+        except urllib.error.HTTPError as exc:
+            raise KimiApiError(exc.code, exc.reason or "HTTP request failed") from exc
+        except json.JSONDecodeError as exc:
+            raise KimiProtocolError("Kimi server returned invalid JSON") from exc
+        if not isinstance(envelope, dict):
+            raise KimiProtocolError("Kimi server returned a non-object envelope")
+        code = envelope.get("code")
+        if code != 0:
+            message = str(envelope.get("msg") or "request failed")
+            raise KimiApiError(code if isinstance(code, int) else None, message)
+        if "data" not in envelope:
+            raise KimiProtocolError("Kimi server response omitted data")
+        return envelope["data"]
+
+    @staticmethod
+    def _object(value: object, operation: str) -> dict:
+        if not isinstance(value, dict):
+            raise KimiProtocolError(f"Kimi {operation} returned non-object data")
+        return value
+
+    def create_session(self, cwd: Path) -> dict:
+        return self._object(
+            self.request("POST", "sessions", {"metadata": {"cwd": str(cwd)}}),
+            "session create",
+        )
+
+    def get_session(self, session_id: str) -> dict:
+        return self._object(self.request("GET", f"sessions/{session_id}"), "session read")
+
+    def update_profile(self, session_id: str, agent_config: dict) -> dict:
+        return self._object(
+            self.request(
+                "POST",
+                f"sessions/{session_id}/profile",
+                {"agent_config": agent_config},
+            ),
+            "profile update",
+        )
+
+    def get_status(self, session_id: str) -> dict:
+        return self._object(
+            self.request("GET", f"sessions/{session_id}/status"), "status read"
+        )
+
+    def submit_prompt(
+        self,
+        session_id: str,
+        prompt: str,
+        *,
+        model: str,
+        effort: str | None,
+        permission_mode: str,
+    ) -> str:
+        body: dict[str, object] = {
+            "content": [{"type": "text", "text": prompt}],
+            "model": model,
+            "permission_mode": permission_mode,
+        }
+        if effort:
+            body["thinking"] = effort
+        data = self._object(
+            self.request(
+                "POST",
+                f"sessions/{session_id}/prompts",
+                body,
+            ),
+            "prompt submit",
+        )
+        prompt_id = data.get("prompt_id")
+        if not isinstance(prompt_id, str) or not prompt_id:
+            raise KimiProtocolError("Kimi prompt response omitted prompt_id")
+        return prompt_id
+
+    def list_prompts(self, session_id: str) -> dict:
+        return self._object(
+            self.request("GET", f"sessions/{session_id}/prompts"), "prompt list"
+        )
+
+    def wait_prompt(
+        self, session_id: str, prompt_id: str, *, timeout: float = DEFAULT_TURN_TIMEOUT
+    ) -> None:
+        deadline = self.clock() + timeout
+        while self.clock() < deadline:
+            prompts = self.list_prompts(session_id)
+            active = prompts.get("active")
+            queued = prompts.get("queued") or []
+            active_id = active.get("prompt_id") if isinstance(active, dict) else None
+            queued_ids = {
+                item.get("prompt_id")
+                for item in queued
+                if isinstance(item, dict)
+            }
+            session = self.get_session(session_id)
+            pending = session.get("pending_interaction", "none")
+            if pending != "none":
+                raise RuntimeError(
+                    f"Kimi managed turn requires interactive {pending}; refusing to wedge"
+                )
+            if active_id != prompt_id and prompt_id not in queued_ids:
+                if session.get("busy") or session.get("main_turn_active"):
+                    self.sleeper(0.2)
+                    continue
+                if session.get("last_turn_reason") == "failed":
+                    raise RuntimeError("Kimi managed turn failed")
+                return
+            self.sleeper(0.2)
+        raise TimeoutError("Kimi managed turn did not become idle before timeout")
+
+    def deliver(
+        self,
+        session_id: str,
+        prompt: str,
+        *,
+        model: str,
+        effort: str | None,
+        permission_mode: str,
+    ) -> None:
+        prompt_id = self.submit_prompt(
+            session_id,
+            prompt,
+            model=model,
+            effort=effort,
+            permission_mode=permission_mode,
+        )
+        self.wait_prompt(session_id, prompt_id)
+
+
+def read_token(path: Path) -> str:
+    try:
+        mode = path.stat().st_mode & 0o777
+        token = path.read_text().strip()
+    except OSError as exc:
+        raise RuntimeError("Kimi session-control token is unavailable") from exc
+    if mode & 0o077:
+        raise RuntimeError("Kimi session-control token file permissions are unsafe")
+    if not token:
+        raise RuntimeError("Kimi session-control token is empty")
+    return token

--- a/.super-coder/adapters/kimi/session_control.py
+++ b/.super-coder/adapters/kimi/session_control.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Kimi K3 transport for provider-neutral managed session control."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+from pathlib import Path
+from typing import Callable
+from urllib.parse import urlparse
+
+ADAPTER_DIR = Path(__file__).resolve().parent
+ENGINE = ADAPTER_DIR.parents[1]
+REPO_ROOT = ENGINE.parent
+DB_PATH = ENGINE / "shell_db.db"
+CONTROL_DIR = ENGINE / "run" / "session-control"
+sys.path.insert(0, str(ADAPTER_DIR))
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import db_driver  # type: ignore[import-not-found]  # noqa: E402
+import session_control as common_session_control  # type: ignore[import-not-found]  # noqa: E402
+import session_supervisor  # type: ignore[import-not-found]  # noqa: E402
+from kimi_http import KimiApiError, KimiClient, probe_kimi, read_token  # noqa: E402
+
+
+def _capabilities(binding: dict) -> dict:
+    value = binding.get("control_capabilities") or "{}"
+    try:
+        parsed = json.loads(value) if isinstance(value, str) else value
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _settings(binding: dict) -> dict:
+    value = _capabilities(binding).get("settings") or {}
+    return value if isinstance(value, dict) else {}
+
+
+def token_path(binding_id: int) -> Path:
+    return CONTROL_DIR / f"kimi-{binding_id}.token"
+
+
+def _validated_endpoint(binding: dict) -> tuple[str, Path]:
+    endpoint = str(binding.get("control_endpoint") or "")
+    parsed = urlparse(endpoint)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in ("", "/")
+        or parsed.port is None
+    ):
+        raise ValueError("Kimi control endpoint must be an authenticated loopback URL")
+    return endpoint.rstrip("/"), token_path(int(binding["binding_id"]))
+
+
+def resume_command(binding: dict, prompt: str) -> list[str]:
+    native_id = binding.get("native_session_id")
+    if not native_id:
+        raise RuntimeError("Kimi native session ID is unavailable")
+    settings = _settings(binding)
+    model = settings.get("model") or binding.get("archive_model")
+    if model != "kimi-code/k3":
+        raise RuntimeError("Kimi managed resume requires pinned kimi-code/k3 route")
+    command = ["kimi", "--session", str(native_id), "--model", str(model)]
+    command.extend(["--prompt", prompt])
+    return command
+
+
+def resume_environment(binding: dict, base: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(os.environ if base is None else base)
+    effort = _settings(binding).get("effort")
+    if effort:
+        env["KIMI_MODEL_THINKING_EFFORT"] = str(effort)
+    return env
+
+
+def _run_fenced_resume(binding: dict, command: list[str], cwd: Path) -> None:
+    lease: dict[str, int] = {}
+
+    def preflight() -> None:
+        con = db_driver.connect(DB_PATH)
+        try:
+            session_supervisor.preflight_lease(
+                con, binding["binding_id"], repo_root=REPO_ROOT
+            )
+        finally:
+            con.close()
+
+    def started(pid: int) -> None:
+        con = db_driver.connect(DB_PATH)
+        try:
+            generation = session_supervisor.claim_lease(
+                con,
+                binding["binding_id"],
+                pid,
+                repo_root=REPO_ROOT,
+                state="dispatching",
+            )
+        finally:
+            con.close()
+        identity = session_supervisor.read_process(pid)
+        if not identity:
+            raise RuntimeError("Kimi resume vanished while recording its lease")
+        lease.update(pid=pid, start_ticks=identity.start_ticks, generation=generation)
+
+    def exited(_pid: int, returncode: int) -> None:
+        if not lease:
+            return
+        con = db_driver.connect(DB_PATH)
+        try:
+            session_supervisor.release_lease(
+                con,
+                binding["binding_id"],
+                lease["pid"],
+                lease["start_ticks"],
+                lease["generation"],
+                error=f"Kimi resume exited {returncode}" if returncode else None,
+            )
+        finally:
+            con.close()
+
+    rc = session_supervisor.supervise(
+        command,
+        cwd=cwd,
+        env=resume_environment(binding),
+        on_pre_spawn=preflight,
+        on_started=started,
+        on_exited=exited,
+    )
+    if rc:
+        raise RuntimeError(f"Kimi resume exited {rc}")
+
+
+class KimiAdapter:
+    def __init__(
+        self,
+        *,
+        client_factory: Callable[[str, str], KimiClient] = KimiClient,
+        resume_runner: Callable[[dict, list[str], Path], None] = _run_fenced_resume,
+        resume_probe: Callable[[], dict] = probe_kimi,
+    ):
+        self.client_factory = client_factory
+        self.resume_runner = resume_runner
+        self.resume_probe = resume_probe
+
+    def _client(self, binding: dict) -> KimiClient:
+        endpoint, path = _validated_endpoint(binding)
+        return self.client_factory(endpoint, read_token(path))
+
+    def status(self, binding: dict) -> str:
+        if not binding.get("native_session_id"):
+            return "starting"
+        try:
+            client = self._client(binding)
+            session = client.get_session(str(binding["native_session_id"]))
+        except (ConnectionRefusedError, FileNotFoundError, urllib.error.URLError):
+            return "dormant"
+        except (KimiApiError, OSError, RuntimeError, ValueError):
+            return "error"
+        if session.get("pending_interaction", "none") != "none":
+            return "error"
+        if session.get("busy") or session.get("main_turn_active"):
+            return "active"
+        return "idle"
+
+    def deliver(self, binding: dict, prompt: str) -> None:
+        capabilities = _capabilities(binding)
+        common_session_control.validate_managed_wake_posture(  # type: ignore[attr-defined]
+            capabilities
+        )
+        if not capabilities.get("active_delivery"):
+            raise RuntimeError("Kimi active delivery is unsupported by this CLI version")
+        client = self._client(binding)
+        session_id = str(binding["native_session_id"])
+        session = client.get_session(session_id)
+        if session.get("busy") or session.get("main_turn_active"):
+            raise common_session_control.ProviderBusy(  # type: ignore[attr-defined]
+                "Kimi session became active before wake delivery"
+            )
+        pending = session.get("pending_interaction", "none")
+        if pending != "none":
+            raise RuntimeError(f"Kimi session is waiting for interactive {pending}")
+        settings = _settings(binding)
+        client.deliver(
+            session_id,
+            prompt,
+            model=str(settings.get("model") or binding.get("archive_model") or ""),
+            effort=str(settings["effort"]) if settings.get("effort") else None,
+            permission_mode=str(settings.get("permission_mode") or ""),
+        )
+
+    def resume(self, binding: dict, prompt: str) -> None:
+        common_session_control.validate_managed_wake_posture(  # type: ignore[attr-defined]
+            _capabilities(binding)
+        )
+        if not _capabilities(binding).get("resume"):
+            raise RuntimeError("Kimi CLI resume capability is unavailable")
+        if not self.resume_probe().get("resume"):
+            raise RuntimeError("installed Kimi CLI failed the resume capability probe")
+        settings = _settings(binding)
+        cwd = Path(
+            settings.get("cwd")
+            or session_supervisor.expected_worktree(
+                REPO_ROOT, binding.get("shortname"), binding.get("flavor")
+            )
+        )
+        self.resume_runner(binding, resume_command(binding, prompt), cwd)
+
+
+def create_adapter() -> KimiAdapter:
+    return KimiAdapter()

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -1229,6 +1229,7 @@ def main() -> None:
     if binding:
         env["SC_SESSION_BINDING_ID"] = str(binding["binding_id"])
         env["SC_SESSION_MODEL"] = str(session_model or flavor_model or "")
+        env["SC_SESSION_EFFORT"] = str(session_effort or "")
     # The shell's HOME worktree — the dir we exec the harness from (below). The
     # branch-guard reads it to judge "outside your worktree" against the assigned
     # tree, not the live cwd: a shell whose cwd has drifted to the repo root (to

--- a/.super-coder/scripts/session_control.py
+++ b/.super-coder/scripts/session_control.py
@@ -76,6 +76,14 @@ def validate_managed_wake_posture(capabilities: Mapping[str, object]) -> None:
     settings = capabilities.get("settings")
     if not isinstance(settings, Mapping):
         return
+    if (
+        "permission_mode" in settings
+        and settings.get("permission_mode") not in ("auto", "yolo")
+    ):
+        raise SessionControlError(
+            "managed wake requires permission_mode='auto' or 'yolo' "
+            "so an injected turn cannot request approval"
+        )
     if "approval_policy" not in settings and "sandbox" not in settings:
         return
     if (

--- a/tests/test_kimi_session_control.py
+++ b/tests/test_kimi_session_control.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Hermetic Kimi authenticated-server and fallback-resume fixtures."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+ADAPTER = ENGINE / "adapters" / "kimi"
+EXPECTED_ENDPOINT = "http://127.0.0.1:43223"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import run  # noqa: E402
+import session_control as common_session_control  # noqa: E402
+
+sys.path.insert(0, str(ADAPTER))
+import kimi_http  # noqa: E402
+
+
+def load_file(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+adapter_module = load_file("kimi_session_control_adapter", ADAPTER / "session_control.py")
+launcher_module = load_file("kimi_session_launcher", ADAPTER / "kimi-session.py")
+
+
+def completed(command: list[str], output: str, returncode: int = 0):
+    return subprocess.CompletedProcess(command, returncode, output, "")
+
+
+def binding(*, permission: str = "auto", endpoint: str = EXPECTED_ENDPOINT) -> dict:
+    capabilities = {
+        "active_delivery": True,
+        "deliver": True,
+        "resume": True,
+        "normal_steer": False,
+        "settings": {
+            "model": "kimi-code/k3",
+            "cwd": "/repo/.sc-worktrees/pln1",
+            "effort": "high",
+            "permission_mode": permission,
+        },
+    }
+    return {
+        "binding_id": 8,
+        "native_session_id": "session-native-1",
+        "control_endpoint": endpoint,
+        "control_capabilities": json.dumps(capabilities),
+        "archive_model": "kimi-code/k3",
+        "shortname": "PLN1",
+        "flavor": "planner",
+        "state": "idle",
+    }
+
+
+class ProbeTest(unittest.TestCase):
+    @staticmethod
+    def runner(version: str, *, web: bool, server: bool = True):
+        def run(command: list[str]):
+            if command == ["kimi", "--version"]:
+                return completed(command, version)
+            if command == ["kimi", "--help"]:
+                return completed(command, "--session --prompt --model")
+            if command == ["kimi", "web", "--help"]:
+                text = "--foreground --no-open" if web else "web unavailable"
+                return completed(command, text, 0 if web else 1)
+            if command == ["kimi", "server", "run", "--help"]:
+                text = "--foreground" if server else "server unavailable"
+                return completed(command, text, 0 if server else 1)
+            if command == ["kimi", "acp", "--help"]:
+                return completed(command, "Agent Client Protocol (ACP)")
+            raise AssertionError(command)
+
+        return run
+
+    def test_installed_027_uses_legacy_authenticated_server_tree(self):
+        probe = kimi_http.probe_kimi(self.runner("0.27.0", web=False))
+        self.assertEqual(probe["cli_version"], "0.27.0")
+        self.assertEqual(
+            probe["server_command"],
+            ["kimi", "server", "run", "--port", "0", "--foreground"],
+        )
+        self.assertEqual(
+            (probe["create"], probe["deliver"], probe["resume"], probe["acp"]),
+            (True, True, True, True),
+        )
+        self.assertFalse(probe["normal_steer"])
+
+    def test_current_028_prefers_web_and_keeps_auth_enabled(self):
+        probe = kimi_http.probe_kimi(self.runner("0.28.1", web=True))
+        self.assertEqual(
+            probe["server_command"],
+            ["kimi", "web", "--port", "0", "--foreground", "--no-open"],
+        )
+        self.assertNotIn("--dangerous-bypass-auth", probe["server_command"])
+        self.assertTrue(probe["active_delivery"])
+
+    def test_unknown_version_fails_closed_for_server_but_retains_tested_resume(self):
+        probe = kimi_http.probe_kimi(self.runner("0.29.0", web=True))
+        self.assertEqual(
+            (probe["create"], probe["deliver"], probe["active_delivery"]),
+            (False, False, False),
+        )
+        self.assertIsNone(probe["server_command"])
+        self.assertTrue(probe["resume"])
+
+
+class JsonResponse:
+    def __init__(self, payload: dict):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        return None
+
+    def read(self) -> bytes:
+        return self.payload
+
+
+class HttpClientTest(unittest.TestCase):
+    def test_delivery_uses_normal_prompt_endpoint_and_waits_for_idle(self):
+        requests: list[tuple[str, str, dict | None, str | None]] = []
+        responses = iter(
+            [
+                {"code": 0, "data": {"prompt_id": "msg-7"}},
+                {"code": 0, "data": {"active": None, "queued": []}},
+                {
+                    "code": 0,
+                    "data": {
+                        "busy": False,
+                        "main_turn_active": False,
+                        "pending_interaction": "none",
+                        "last_turn_reason": "completed",
+                    },
+                },
+            ]
+        )
+
+        def opener(request, *, timeout):
+            body = json.loads(request.data) if request.data else None
+            requests.append(
+                (
+                    request.method,
+                    request.full_url,
+                    body,
+                    request.get_header("Authorization"),
+                )
+            )
+            self.assertEqual(timeout, 10)
+            return JsonResponse(next(responses))
+
+        client = kimi_http.KimiClient(
+            EXPECTED_ENDPOINT, "secret-token", opener=opener, sleeper=lambda _n: None
+        )
+        client.deliver(
+            "session-native-1",
+            "check inbox",
+            model="kimi-code/k3",
+            effort="high",
+            permission_mode="auto",
+        )
+
+        self.assertEqual(
+            [(method, url) for method, url, _body, _auth in requests],
+            [
+                ("POST", EXPECTED_ENDPOINT + "/api/v1/sessions/session-native-1/prompts"),
+                ("GET", EXPECTED_ENDPOINT + "/api/v1/sessions/session-native-1/prompts"),
+                ("GET", EXPECTED_ENDPOINT + "/api/v1/sessions/session-native-1"),
+            ],
+        )
+        self.assertEqual(
+            requests[0][2], {
+                "content": [{"type": "text", "text": "check inbox"}],
+                "model": "kimi-code/k3",
+                "thinking": "high",
+                "permission_mode": "auto",
+            }
+        )
+        self.assertEqual({request[3] for request in requests}, {"Bearer secret-token"})
+        self.assertFalse(any(":steer" in request[1] for request in requests))
+
+    def test_structured_error_never_echoes_bearer_token(self):
+        token = "sensitive-bearer-value"
+
+        def opener(_request, *, timeout):
+            self.assertEqual(timeout, 10)
+            return JsonResponse(
+                {"code": 40101, "msg": f"Authorization: Bearer {token}", "data": None}
+            )
+
+        client = kimi_http.KimiClient(EXPECTED_ENDPOINT, token, opener=opener)
+        with self.assertRaises(kimi_http.KimiApiError) as caught:
+            client.get_session("session-native-1")
+        self.assertNotIn(token, str(caught.exception))
+        self.assertIn("[REDACTED]", str(caught.exception))
+
+    def test_pending_approval_fails_instead_of_marking_delivery_complete(self):
+        responses = iter(
+            [
+                {"code": 0, "data": {"prompt_id": "msg-7"}},
+                {
+                    "code": 0,
+                    "data": {"active": {"prompt_id": "msg-7"}, "queued": []},
+                },
+                {
+                    "code": 0,
+                    "data": {"busy": True, "pending_interaction": "approval"},
+                },
+            ]
+        )
+        client = kimi_http.KimiClient(
+            EXPECTED_ENDPOINT,
+            "token",
+            opener=lambda _request, timeout: JsonResponse(next(responses)),
+            sleeper=lambda _n: None,
+        )
+        with self.assertRaisesRegex(RuntimeError, "interactive approval"):
+            client.deliver(
+                "session-native-1",
+                "check inbox",
+                model="kimi-code/k3",
+                effort="high",
+                permission_mode="auto",
+            )
+
+
+class FakeClient:
+    def __init__(self, session: dict | None = None):
+        self.session = session or {
+            "busy": False,
+            "main_turn_active": False,
+            "pending_interaction": "none",
+        }
+        self.deliveries: list[tuple[str, str, dict]] = []
+
+    def get_session(self, _session_id: str) -> dict:
+        return dict(self.session)
+
+    def deliver(self, session_id: str, prompt: str, **settings) -> None:
+        self.deliveries.append((session_id, prompt, settings))
+
+
+class AdapterTest(unittest.TestCase):
+    def adapter(self, client: FakeClient, **kwargs):
+        return adapter_module.KimiAdapter(
+            client_factory=lambda endpoint, token: (
+                self.assertEqual((endpoint, token), (EXPECTED_ENDPOINT, "runtime-token"))
+                or client
+            ),
+            **kwargs,
+        )
+
+    def test_status_maps_idle_busy_and_missing_server_without_guessing(self):
+        with mock.patch.object(adapter_module, "read_token", return_value="runtime-token"):
+            self.assertEqual(self.adapter(FakeClient()).status(binding()), "idle")
+            busy = FakeClient({
+                "busy": True,
+                "main_turn_active": True,
+                "pending_interaction": "none",
+            })
+            self.assertEqual(self.adapter(busy).status(binding()), "active")
+
+            def unavailable(_endpoint, _token):
+                raise urllib.error.URLError("connection refused")
+
+            dormant = adapter_module.KimiAdapter(client_factory=unavailable)
+            self.assertEqual(dormant.status(binding()), "dormant")
+
+    def test_busy_race_queues_without_prompt_or_steer(self):
+        client = FakeClient({
+            "busy": True,
+            "main_turn_active": True,
+            "pending_interaction": "none",
+        })
+        adapter = self.adapter(client)
+        with mock.patch.object(adapter_module, "read_token", return_value="runtime-token"):
+            with self.assertRaises(common_session_control.ProviderBusy):
+                adapter.deliver(binding(), "check inbox")
+        self.assertEqual(client.deliveries, [])
+
+    def test_manual_permission_posture_refuses_before_auth_or_transport(self):
+        clients: list[bool] = []
+        adapter = adapter_module.KimiAdapter(
+            client_factory=lambda _endpoint, _token: clients.append(True)
+        )
+        with self.assertRaisesRegex(RuntimeError, "permission_mode='auto'"):
+            adapter.deliver(binding(permission="manual"), "check inbox")
+        self.assertEqual(clients, [])
+
+    def test_idle_delivery_uses_bound_native_session(self):
+        client = FakeClient()
+        adapter = self.adapter(client)
+        with mock.patch.object(adapter_module, "read_token", return_value="runtime-token"):
+            adapter.deliver(binding(), "check inbox")
+        self.assertEqual(client.deliveries, [(
+            "session-native-1",
+            "check inbox",
+            {
+                "model": "kimi-code/k3",
+                "effort": "high",
+                "permission_mode": "auto",
+            },
+        )])
+
+    def test_resume_pins_native_id_k3_route_effort_and_worktree(self):
+        calls: list[tuple[dict, list[str], Path]] = []
+        adapter = adapter_module.KimiAdapter(
+            resume_runner=lambda row, command, cwd: calls.append((row, command, cwd)),
+            resume_probe=lambda: {"resume": True},
+        )
+        row = binding()
+        adapter.resume(row, "check inbox")
+        self.assertEqual(
+            calls,
+            [
+                (
+                    row,
+                    [
+                        "kimi",
+                        "--session",
+                        "session-native-1",
+                        "--model",
+                        "kimi-code/k3",
+                        "--prompt",
+                        "check inbox",
+                    ],
+                    Path("/repo/.sc-worktrees/pln1"),
+                )
+            ],
+        )
+        self.assertEqual(
+            adapter_module.resume_environment(row, {"PATH": "/bin"}),
+            {"PATH": "/bin", "KIMI_MODEL_THINKING_EFFORT": "high"},
+        )
+
+    def test_non_loopback_or_credentialed_endpoint_fails_before_auth_read(self):
+        adapter = adapter_module.KimiAdapter()
+        with mock.patch.object(adapter_module, "read_token") as token_read:
+            with self.assertRaisesRegex(ValueError, "loopback"):
+                adapter.deliver(
+                    binding(endpoint="http://user:pw@example.test:43223"), "check inbox"
+                )
+        token_read.assert_not_called()
+
+
+class LauncherTest(unittest.TestCase):
+    def test_controlled_launcher_is_declared(self):
+        adapter = run.load_adapter("kimi")
+        self.assertEqual(
+            run.session_control_launch(adapter),
+            ["python3", str(ADAPTER / "kimi-session.py")],
+        )
+
+    def test_runtime_token_file_is_mode_0600_and_exact(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "kimi-8.token"
+            launcher_module.write_private(path, "runtime-secret")
+            self.assertEqual(path.read_text(), "runtime-secret\n")
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+    def test_new_session_pins_k3_effort_and_auto_permission(self):
+        class Client:
+            def __init__(self):
+                self.created: list[Path] = []
+                self.profile: list[tuple[str, dict]] = []
+
+            def create_session(self, cwd):
+                self.created.append(cwd)
+                return {"id": "session-created"}
+
+            def update_profile(self, session_id, config):
+                self.profile.append((session_id, config))
+                return {}
+
+            def get_status(self, session_id):
+                self.status_id = session_id
+                return {
+                    "model": "kimi-code/k3",
+                    "thinking_level": "high",
+                    "permission": "auto",
+                }
+
+        client = Client()
+        session_id, settings = launcher_module.configure_session(
+            client,
+            {"native_session_id": None},
+            cwd=Path("/repo/.sc-worktrees/pln1"),
+            model="kimi-code/k3",
+            effort="high",
+        )
+        self.assertEqual(session_id, "session-created")
+        self.assertEqual(client.created, [Path("/repo/.sc-worktrees/pln1")])
+        self.assertEqual(
+            client.profile,
+            [
+                (
+                    "session-created",
+                    {
+                        "model": "kimi-code/k3",
+                        "thinking": "high",
+                        "permission_mode": "auto",
+                    },
+                )
+            ],
+        )
+        self.assertEqual(
+            settings,
+            {
+                "model": "kimi-code/k3",
+                "cwd": "/repo/.sc-worktrees/pln1",
+                "effort": "high",
+                "permission_mode": "auto",
+            },
+        )
+        self.assertNotIn("approval_policy", settings)
+        self.assertNotIn("sandbox", settings)
+
+    def test_existing_binding_resumes_exact_session_without_creating_another(self):
+        class Client:
+            def __init__(self):
+                self.reads: list[str] = []
+
+            def get_session(self, session_id):
+                self.reads.append(session_id)
+                return {"id": session_id}
+
+            def create_session(self, _cwd):
+                raise AssertionError("must not replace a missing/known native session")
+
+            def update_profile(self, _session_id, _config):
+                return {}
+
+            def get_status(self, _session_id):
+                return {
+                    "model": "kimi-code/k3",
+                    "thinking_level": "high",
+                    "permission": "auto",
+                }
+
+        client = Client()
+        session_id, _settings = launcher_module.configure_session(
+            client,
+            {"native_session_id": "session-existing"},
+            cwd=Path("/repo/.sc-worktrees/pln1"),
+            model="kimi-code/k3",
+            effort="high",
+        )
+        self.assertEqual(session_id, "session-existing")
+        self.assertEqual(client.reads, ["session-existing"])
+
+    def test_effective_route_drift_fails_before_binding_registration(self):
+        class Client:
+            def create_session(self, _cwd):
+                return {"id": "session-created"}
+
+            def update_profile(self, _session_id, _config):
+                return {}
+
+            def get_status(self, _session_id):
+                return {
+                    "model": "kimi-code/k2",
+                    "thinking_level": "high",
+                    "permission": "auto",
+                }
+
+        with self.assertRaisesRegex(RuntimeError, "route drifted"):
+            launcher_module.configure_session(
+                Client(),
+                {"native_session_id": None},
+                cwd=Path("/repo/.sc-worktrees/pln1"),
+                model="kimi-code/k3",
+                effort="high",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kimi_session_control.py
+++ b/tests/test_kimi_session_control.py
@@ -375,6 +375,83 @@ class LauncherTest(unittest.TestCase):
             self.assertEqual(path.read_text(), "runtime-secret\n")
             self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
 
+    def test_runtime_token_file_is_removed_when_server_exits(self):
+        class Connection:
+            def execute(self, _query, _params):
+                return self
+
+            def fetchone(self):
+                return {
+                    "binding_id": 8,
+                    "native_session_id": None,
+                    "control_capabilities": json.dumps({
+                        "settings": {"model": "kimi-code/k3", "effort": "high"}
+                    }),
+                }
+
+            def close(self):
+                return None
+
+        server = mock.Mock(stdout=None, returncode=0)
+        server.wait.return_value = 0
+        server.poll.return_value = 0
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp)
+            runtime_token = run_dir / "kimi-8.token"
+
+            def client(endpoint, token):
+                self.assertEqual((endpoint, token), (EXPECTED_ENDPOINT, "runtime-secret"))
+                self.assertEqual(runtime_token.read_text(), "runtime-secret\n")
+                return mock.Mock()
+
+            with (
+                mock.patch.dict(
+                    "os.environ", {"SC_SESSION_BINDING_ID": "8"}, clear=False
+                ),
+                mock.patch.object(launcher_module, "RUN_DIR", run_dir),
+                mock.patch.object(
+                    launcher_module,
+                    "probe_kimi",
+                    return_value={
+                        "create": True,
+                        "server_command": ["kimi", "server", "run"],
+                        "cli_version": "0.27.0",
+                    },
+                ),
+                mock.patch.object(
+                    launcher_module.db_driver,
+                    "connect",
+                    side_effect=[Connection(), Connection()],
+                ),
+                mock.patch.object(launcher_module.subprocess, "Popen", return_value=server),
+                mock.patch.object(
+                    launcher_module,
+                    "wait_for_server",
+                    return_value=(EXPECTED_ENDPOINT, "runtime-secret"),
+                ),
+                mock.patch.object(launcher_module, "KimiClient", side_effect=client),
+                mock.patch.object(
+                    launcher_module,
+                    "configure_session",
+                    return_value=(
+                        "session-native-1",
+                        {
+                            "model": "kimi-code/k3",
+                            "cwd": str(ROOT),
+                            "effort": "high",
+                            "permission_mode": "auto",
+                        },
+                    ),
+                ),
+                mock.patch.object(
+                    launcher_module.session_supervisor, "register_native_session"
+                ),
+                mock.patch.object(launcher_module.webbrowser, "open"),
+            ):
+                self.assertEqual(launcher_module.main(), 0)
+
+            self.assertFalse(runtime_token.exists())
+
     def test_new_session_pins_k3_effort_and_auto_permission(self):
         class Client:
             def __init__(self):

--- a/tests/test_session_control_api.py
+++ b/tests/test_session_control_api.py
@@ -143,6 +143,46 @@ class ControlMutationTest(unittest.TestCase):
             )],
         )
 
+    def test_manage_rejects_kimi_manual_permission_without_mutation(self):
+        message_id = add_message(self.con)
+        self.con.execute(
+            "UPDATE shell_session_bindings SET harness='kimi', "
+            "control_capabilities=? WHERE binding_id=20",
+            (json.dumps({
+                "deliver": True,
+                "resume": True,
+                "settings": {
+                    "model": "kimi-code/k3",
+                    "effort": "high",
+                    "permission_mode": "manual",
+                },
+            }),),
+        )
+        self.con.commit()
+
+        payload, error = server.manage_session_control(self.con, 1, 20)
+
+        self.assertIsNone(payload)
+        self.assertEqual(
+            "managed wake requires permission_mode='auto' or 'yolo' "
+            "so an injected turn cannot request approval",
+            error,
+        )
+        self.assertEqual(
+            ("dormant", 0, None),
+            tuple(self.con.execute(
+                "SELECT state, managed, last_error FROM shell_session_bindings "
+                "WHERE binding_id=20"
+            ).fetchone()),
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM session_wake_jobs WHERE trigger_message_id=?",
+                (message_id,),
+            ).fetchone()[0],
+        )
+
     def test_release_cancels_queue_but_keeps_message_unread(self):
         message_id = add_message(self.con)
         server.manage_session_control(self.con, 1, 20)


### PR DESCRIPTION
## Summary
- launch managed Kimi planners through the authenticated loopback web/session server and capture the native session ID
- deliver only to idle sessions through the normal prompt endpoint; never use steer
- preserve `kimi-code/k3`, effective thinking effort, cwd, and auto-permission posture across live delivery and fenced CLI resume
- probe installed `server`/`web`/ACP capabilities and fail closed for unvalidated active transports

## Verification
- 58 focused session-control tests pass
- ruff and mypy pass on changed Python surfaces
- real Kimi 0.27.0 web-server smoke passed with auth enabled and OS-assigned loopback port
- full suite: 606 passed; only 3 pre-existing VM-bake tests failed because the suite ran with `SC_SANDBOX=1`; those 6 VM tests pass with the sandbox marker removed

## Judgements
- Applied the ratified config-effective-at-launch reading: the launcher records the server-reported effective route/effort and every injected prompt reasserts them.
- Kimi records its native `permission_mode` vocabulary; the provider-generic arming validator accepts only `auto`/`yolo`, without inventing Codex approval/sandbox keys.
- Active delivery is validated for Kimi 0.27/0.28 command trees; unknown versions retain smoke-probed CLI resume only.