### PR TITLE
feat(session): add Claude session control

### DIFF
--- a/.super-coder/adapters/claude/README.md
+++ b/.super-coder/adapters/claude/README.md
@@ -13,9 +13,23 @@ the launch command. No extra config file to emit at v1.
 | `emit` | files in this dir copied to the repo root at launch (none for Claude) |
 | `env` | extra env merged into the launch environment |
 | `model` | `{ "flag": "--model" }` — run.py appends `--model <id>` for the flavor's claude model (alias: `sonnet`/`haiku`/`opus`) |
+| `session_control` | controlled planner launcher + background inbox-watcher transport |
 | `headless.effort` | `{ "flag": "--effort" }` — sprint workers default to `--effort high` |
 | `merge_json` | always-on: project-scoped JSON deep-merged every launch (preserves fork keys). Installs the branch-guard hook into `.claude/settings.local.json`. |
 | `sandbox` | `merge_json`: project-scoped config patched in-sandbox only (allow-all permissions) |
+
+## Managed planner session control
+
+The controlled launcher supplies a UUID with `--session-id`, records the exact
+model, effort, cwd, and Claude-native permission posture, then keeps that UUID
+for every planner turn. `./sc watch inbox` registers and heartbeats its exact
+PID/start-ticks as Claude's active channel; without a fresh watcher, a live
+foreground session stays queued instead of being treated as deliverable.
+
+When the foreground process is gone, the dispatcher uses a lease-fenced
+`claude --resume <uuid> ... -p <prompt>` turn with the recorded route and
+permissions. It never resumes while a validated foreground owner is live, and
+delivery is complete only after the planner marks the inbox message read.
 
 ## Branch-guard hook
 

--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -6,6 +6,14 @@
   "env": {},
   "model": { "flag": "--model" },
   "name": { "flag": "--name" },
+  "session_control": {
+    "launch": ["python3", "{adapter_dir}/claude-session.py"],
+    "capabilities": {
+      "provider": "claude",
+      "transport": "background-task-inbox-v1",
+      "normal_steer": false
+    }
+  },
   "headless": {
     "launch": ["claude"],
     "prompt_flag": "-p",

--- a/.super-coder/adapters/claude/claude-session.py
+++ b/.super-coder/adapters/claude/claude-session.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Launch one Claude planner with an engine-supplied native session UUID."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Callable
+
+ADAPTER_DIR = Path(__file__).resolve().parent
+ENGINE = ADAPTER_DIR.parents[1]
+DB_PATH = ENGINE / "shell_db.db"
+sys.path.insert(0, str(ADAPTER_DIR))
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import db_driver  # type: ignore[import-not-found]  # noqa: E402
+import session_control as common_session_control  # type: ignore[import-not-found]  # noqa: E402
+import session_supervisor  # type: ignore[import-not-found]  # noqa: E402
+from claude_cli import probe_claude  # noqa: E402
+
+
+def _capabilities(value: object) -> dict:
+    try:
+        parsed = json.loads(value or "{}") if isinstance(value, str) else value
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def launch_plan(
+    binding: dict,
+    probe: dict,
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    native_id_factory: Callable[[], uuid.UUID] = uuid.uuid4,
+) -> tuple[str, list[str], dict]:
+    """Return the supplied/resumed ID, exact argv, and recorded capabilities."""
+    stored = _capabilities(binding.get("control_capabilities"))
+    value = stored.get("settings") or {}
+    settings = dict(value) if isinstance(value, dict) else {}
+    model = settings.get("model") or env.get("SC_SESSION_MODEL") or None
+    effort = settings.get("effort") or env.get("SC_SESSION_EFFORT") or None
+    permission = settings.get("permission_mode")
+    if not permission:
+        permission = "bypassPermissions" if env.get("SC_SANDBOX") else "auto"
+    settings = {
+        "model": model,
+        "cwd": str(cwd),
+        "effort": effort,
+        "permission_mode": permission,
+    }
+    common_session_control.validate_managed_wake_posture(  # type: ignore[attr-defined]
+        {"settings": settings}
+    )
+
+    existing = binding.get("native_session_id")
+    native_id = str(existing or native_id_factory())
+    command = ["claude"]
+    command.extend(["--resume", native_id] if existing else ["--session-id", native_id])
+    if binding.get("display_name"):
+        command.extend(["--name", str(binding["display_name"])])
+    if model:
+        command.extend(["--model", str(model)])
+    if effort:
+        command.extend(["--effort", str(effort)])
+    if permission == "bypassPermissions":
+        command.append("--dangerously-skip-permissions")
+    else:
+        command.extend(["--permission-mode", str(permission)])
+
+    capabilities = {
+        **stored,
+        **probe,
+        "provider": "claude",
+        "transport": "background-task-inbox-v1",
+        "normal_steer": False,
+        "settings": settings,
+    }
+    return native_id, command, capabilities
+
+
+def main() -> int:
+    try:
+        binding_id = int(os.environ["SC_SESSION_BINDING_ID"])
+    except (KeyError, ValueError):
+        raise SystemExit("Claude controlled launch requires SC_SESSION_BINDING_ID")
+
+    probe = probe_claude()
+    if not probe.get("create"):
+        raise SystemExit(
+            f"Claude {probe.get('cli_version') or 'unknown'} is not validated for "
+            "managed inbox-watcher session control"
+        )
+
+    con = db_driver.connect(DB_PATH)
+    try:
+        row = con.execute(
+            "SELECT b.*, s.display_name FROM shell_session_bindings b "
+            "JOIN shells s ON s.shell_id=b.shell_id WHERE b.binding_id=?",
+            (binding_id,),
+        ).fetchone()
+    finally:
+        con.close()
+    if not row:
+        raise SystemExit(f"unknown Claude session binding {binding_id}")
+
+    native_id, command, capabilities = launch_plan(
+        dict(row), probe, cwd=Path.cwd().resolve(), env=dict(os.environ)
+    )
+    con = db_driver.connect(DB_PATH)
+    try:
+        session_supervisor.register_native_session(
+            con,
+            binding_id,
+            native_id,
+            capabilities=json.dumps(capabilities, sort_keys=True),
+            cli_version=probe.get("cli_version"),
+        )
+    finally:
+        con.close()
+
+    env = dict(os.environ)
+    env["SC_SESSION_ACTIVE_CHANNEL"] = "claude-inbox"
+    os.execvpe(command[0], command, env)
+    return 127
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.super-coder/adapters/claude/claude_cli.py
+++ b/.super-coder/adapters/claude/claude_cli.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Claude Code capability probe used by the launcher and dormant adapter."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections.abc import Callable
+
+
+TESTED_VERSIONS = frozenset({(2, 1)})
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command, capture_output=True, text=True, timeout=5, check=False
+    )
+
+
+def _output(result: subprocess.CompletedProcess[str]) -> str:
+    return "\n".join(part for part in (result.stdout, result.stderr) if part)
+
+
+def probe_claude(
+    runner: Callable[[list[str]], subprocess.CompletedProcess[str]] = _run,
+) -> dict:
+    """Probe real CLI flags; unknown versions fail active delivery closed."""
+    try:
+        version_result = runner(["claude", "--version"])
+        help_result = runner(["claude", "--help"])
+    except (OSError, subprocess.SubprocessError):
+        return {
+            "cli_version": None,
+            "create": False,
+            "deliver": False,
+            "resume": False,
+            "active_delivery": False,
+            "normal_steer": False,
+        }
+
+    version_text = _output(version_result).strip()
+    match = re.search(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?!\d)", version_text)
+    version = tuple(map(int, match.groups())) if match else None
+    help_text = _output(help_result)
+    known = bool(version and version[:2] in TESTED_VERSIONS)
+    create = (
+        known
+        and help_result.returncode == 0
+        and "--session-id" in help_text
+        and "--permission-mode" in help_text
+    )
+    resume = (
+        version_result.returncode == 0
+        and help_result.returncode == 0
+        and "--resume" in help_text
+        and "--print" in help_text
+        and "--model" in help_text
+        and "--effort" in help_text
+    )
+    return {
+        "cli_version": ".".join(map(str, version)) if version else None,
+        "create": create,
+        "deliver": create,
+        "resume": resume,
+        "active_delivery": create,
+        "normal_steer": False,
+    }

--- a/.super-coder/adapters/claude/session_control.py
+++ b/.super-coder/adapters/claude/session_control.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Claude inbox-watcher and dormant-resume session-control transport."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+ADAPTER_DIR = Path(__file__).resolve().parent
+ENGINE = ADAPTER_DIR.parents[1]
+REPO_ROOT = ENGINE.parent
+DB_PATH = ENGINE / "shell_db.db"
+sys.path.insert(0, str(ADAPTER_DIR))
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import db_driver  # type: ignore[import-not-found]  # noqa: E402
+import session_control as common_session_control  # type: ignore[import-not-found]  # noqa: E402
+import session_supervisor  # type: ignore[import-not-found]  # noqa: E402
+from claude_cli import probe_claude  # noqa: E402
+
+
+CHANNEL_HEARTBEAT_MAX_AGE = 90
+ACK_TIMEOUT = 4 * 60 * 60
+
+
+def _capabilities(binding: dict) -> dict:
+    value = binding.get("control_capabilities") or "{}"
+    try:
+        parsed = json.loads(value) if isinstance(value, str) else value
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _settings(binding: dict) -> dict:
+    value = _capabilities(binding).get("settings") or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def active_channel_ready(binding: dict, *, now: datetime | None = None) -> bool:
+    if binding.get("active_channel_pid") is None:
+        return False
+    if binding.get("active_channel_start_ticks") is None:
+        return False
+    heartbeat = _timestamp(binding.get("active_channel_heartbeat_at"))
+    if heartbeat is None:
+        return False
+    now = now or datetime.now(timezone.utc)
+    age = (now - heartbeat).total_seconds()
+    return -5 <= age <= CHANNEL_HEARTBEAT_MAX_AGE
+
+
+def resume_command(binding: dict, prompt: str) -> list[str]:
+    native_id = binding.get("native_session_id")
+    if not native_id:
+        raise RuntimeError("Claude native session ID is unavailable")
+    settings = _settings(binding)
+    command = ["claude", "--resume", str(native_id)]
+    model = settings.get("model") or binding.get("archive_model")
+    if model:
+        command.extend(["--model", str(model)])
+    if settings.get("effort"):
+        command.extend(["--effort", str(settings["effort"])])
+    permission = settings.get("permission_mode")
+    if permission == "bypassPermissions":
+        command.append("--dangerously-skip-permissions")
+    elif permission:
+        command.extend(["--permission-mode", str(permission)])
+    command.extend(["-p", prompt])
+    return command
+
+
+def resume_environment(binding: dict) -> dict[str, str]:
+    env = dict(os.environ)
+    if _settings(binding).get("permission_mode") == "bypassPermissions":
+        env["IS_SANDBOX"] = "1"
+    return env
+
+
+def _run_fenced_resume(binding: dict, command: list[str], cwd: Path) -> None:
+    lease: dict[str, int] = {}
+
+    def preflight() -> None:
+        con = db_driver.connect(DB_PATH)
+        try:
+            session_supervisor.preflight_lease(
+                con, binding["binding_id"], repo_root=REPO_ROOT
+            )
+        finally:
+            con.close()
+
+    def started(pid: int) -> None:
+        con = db_driver.connect(DB_PATH)
+        try:
+            generation = session_supervisor.claim_lease(
+                con,
+                binding["binding_id"],
+                pid,
+                repo_root=REPO_ROOT,
+                state="dispatching",
+            )
+        finally:
+            con.close()
+        identity = session_supervisor.read_process(pid)
+        if not identity:
+            raise RuntimeError("Claude resume vanished while recording its lease")
+        lease.update(pid=pid, start_ticks=identity.start_ticks, generation=generation)
+
+    def exited(_pid: int, returncode: int) -> None:
+        if not lease:
+            return
+        con = db_driver.connect(DB_PATH)
+        try:
+            session_supervisor.release_lease(
+                con,
+                binding["binding_id"],
+                lease["pid"],
+                lease["start_ticks"],
+                lease["generation"],
+                error=f"Claude resume exited {returncode}" if returncode else None,
+            )
+        finally:
+            con.close()
+
+    rc = session_supervisor.supervise(
+        command,
+        cwd=cwd,
+        env=resume_environment(binding),
+        on_pre_spawn=preflight,
+        on_started=started,
+        on_exited=exited,
+    )
+    if rc:
+        raise RuntimeError(f"Claude resume exited {rc}")
+
+
+def _running_unread(binding: dict) -> int:
+    con = db_driver.connect(DB_PATH)
+    try:
+        return int(
+            con.execute(
+                "SELECT COUNT(*) FROM session_wake_jobs j "
+                "JOIN shell_messages m ON m.message_id=j.trigger_message_id "
+                "WHERE j.binding_id=? AND j.state='running' AND m.read_at IS NULL",
+                (binding["binding_id"],),
+            ).fetchone()[0]
+        )
+    finally:
+        con.close()
+
+
+def _wait_for_ack(
+    binding: dict,
+    *,
+    unread: Callable[[dict], int] = _running_unread,
+    sleeper: Callable[[float], None] = time.sleep,
+    clock: Callable[[], float] = time.monotonic,
+) -> None:
+    deadline = clock() + ACK_TIMEOUT
+    while unread(binding):
+        if clock() >= deadline:
+            raise TimeoutError("Claude inbox wake was not acknowledged before timeout")
+        sleeper(0.2)
+
+
+class ClaudeAdapter:
+    def __init__(
+        self,
+        *,
+        ack_waiter: Callable[[dict], None] = _wait_for_ack,
+        unread: Callable[[dict], int] = _running_unread,
+        resume_runner: Callable[[dict, list[str], Path], None] = _run_fenced_resume,
+        resume_probe: Callable[[], dict] = probe_claude,
+        now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+    ):
+        self.ack_waiter = ack_waiter
+        self.unread = unread
+        self.resume_runner = resume_runner
+        self.resume_probe = resume_probe
+        self.now = now
+
+    def status(self, binding: dict) -> str:
+        if not binding.get("native_session_id"):
+            return "starting"
+        if binding.get("lease_pid") is None or binding.get("lease_start_ticks") is None:
+            return "dormant"
+        if not _capabilities(binding).get("active_delivery"):
+            return "error"
+        if active_channel_ready(binding, now=self.now()):
+            return "idle"
+        return "active"
+
+    def deliver(self, binding: dict, _prompt: str) -> None:
+        capabilities = _capabilities(binding)
+        common_session_control.validate_managed_wake_posture(  # type: ignore[attr-defined]
+            capabilities
+        )
+        if not capabilities.get("active_delivery"):
+            raise RuntimeError("Claude inbox-watcher delivery is unsupported")
+        if not self.unread(binding):
+            return
+        if not active_channel_ready(binding, now=self.now()):
+            raise common_session_control.ProviderBusy(  # type: ignore[attr-defined]
+                "Claude inbox watcher fired before dispatcher delivery"
+            )
+        self.ack_waiter(binding)
+
+    def resume(self, binding: dict, prompt: str) -> None:
+        capabilities = _capabilities(binding)
+        common_session_control.validate_managed_wake_posture(  # type: ignore[attr-defined]
+            capabilities
+        )
+        if not capabilities.get("resume"):
+            raise RuntimeError("Claude CLI resume capability is unavailable")
+        if not self.resume_probe().get("resume"):
+            raise RuntimeError(
+                "installed Claude CLI failed the resume capability probe"
+            )
+        settings = _settings(binding)
+        cwd = Path(
+            settings.get("cwd")
+            or session_supervisor.expected_worktree(
+                REPO_ROOT, binding.get("shortname"), binding.get("flavor")
+            )
+        )
+        self.resume_runner(binding, resume_command(binding, prompt), cwd)
+
+
+def create_adapter() -> ClaudeAdapter:
+    return ClaudeAdapter()

--- a/.super-coder/adapters/claude/session_control.py
+++ b/.super-coder/adapters/claude/session_control.py
@@ -26,6 +26,8 @@ from claude_cli import probe_claude  # noqa: E402
 
 CHANNEL_HEARTBEAT_MAX_AGE = 90
 ACK_TIMEOUT = 4 * 60 * 60
+ACK_POLL_INTERVAL = 1.5
+BINDING_RECHECK_INTERVAL = 5.0
 
 
 def _capabilities(binding: dict) -> dict:
@@ -166,18 +168,55 @@ def _running_unread(binding: dict) -> int:
         con.close()
 
 
+def _current_delivery_binding(binding: dict) -> dict:
+    con = db_driver.connect(DB_PATH)
+    try:
+        row = con.execute(
+            "SELECT lease_pid, lease_start_ticks, active_channel_pid, "
+            "active_channel_start_ticks, active_channel_heartbeat_at "
+            "FROM shell_session_bindings WHERE binding_id=?",
+            (binding["binding_id"],),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("Claude session binding disappeared during delivery")
+        return dict(row)
+    finally:
+        con.close()
+
+
+def _delivery_owner_lost(binding: dict, *, now: datetime) -> bool:
+    lease_vacant = (
+        binding.get("lease_pid") is None
+        or binding.get("lease_start_ticks") is None
+    )
+    return lease_vacant and not active_channel_ready(binding, now=now)
+
+
 def _wait_for_ack(
     binding: dict,
     *,
     unread: Callable[[dict], int] = _running_unread,
+    binding_reader: Callable[[dict], dict] = _current_delivery_binding,
     sleeper: Callable[[float], None] = time.sleep,
     clock: Callable[[], float] = time.monotonic,
+    now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
 ) -> None:
-    deadline = clock() + ACK_TIMEOUT
+    started = clock()
+    deadline = started + ACK_TIMEOUT
+    next_binding_check = started + BINDING_RECHECK_INTERVAL
     while unread(binding):
-        if clock() >= deadline:
+        current = clock()
+        if current >= deadline:
             raise TimeoutError("Claude inbox wake was not acknowledged before timeout")
-        sleeper(0.2)
+        if current >= next_binding_check:
+            current_binding = binding_reader(binding)
+            if _delivery_owner_lost(current_binding, now=now()):
+                raise RuntimeError(
+                    "Claude delivery owner and inbox watcher disappeared before "
+                    "acknowledgement"
+                )
+            next_binding_check = current + BINDING_RECHECK_INTERVAL
+        sleeper(ACK_POLL_INTERVAL)
 
 
 class ClaudeAdapter:

--- a/.super-coder/scripts/session_control.py
+++ b/.super-coder/scripts/session_control.py
@@ -78,10 +78,12 @@ def validate_managed_wake_posture(capabilities: Mapping[str, object]) -> None:
         return
     if (
         "permission_mode" in settings
-        and settings.get("permission_mode") not in ("auto", "yolo")
+        and settings.get("permission_mode")
+        not in ("auto", "yolo", "bypassPermissions")
     ):
         raise SessionControlError(
-            "managed wake requires permission_mode='auto' or 'yolo' "
+            "managed wake requires permission_mode='auto', 'yolo', or "
+            "'bypassPermissions' "
             "so an injected turn cannot request approval"
         )
     if "approval_policy" not in settings and "sandbox" not in settings:

--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -175,40 +175,92 @@ def cmd_inbox(args) -> int:
     _require_api()
     deadline = time.monotonic() + args.timeout if args.timeout else None
     failures = 0
-    while True:
+    channel = None
+    if os.environ.get("SC_SESSION_ACTIVE_CHANNEL") == "claude-inbox":
         try:
-            r = _api_soft("GET", "/_sc/mem/messages")
-            failures = 0
-            unread = [m for m in r.get("messages", []) if not m.get("read_at")]
-            if unread:
-                print(f"watch: {len(unread)} unread message(s) — inbox watcher fired:")
-                for m in unread[:10]:
-                    kind = m.get("kind") or "shell"
-                    first = (m.get("body") or "").splitlines()[0][:120]
-                    print(f"  [#{m['message_id']}] {kind} · {first}")
-                print("  → `sc mem message check`, act, mark-read, then re-arm the watcher.")
-                return 0
-        except _ApiDown as e:
-            failures += 1
-            if failures >= 10:
-                print(f"watch: inbox watcher giving up — API unreachable ({e})", file=sys.stderr)
-                return 3
-        if deadline and time.monotonic() >= deadline:
-            print("watch: inbox watcher timed out with no unread messages — re-arm to keep watching.")
-            return 2
-        time.sleep(args.interval)
+            binding_id = int(os.environ["SC_SESSION_BINDING_ID"])
+        except (KeyError, ValueError):
+            die("Claude inbox channel requires SC_SESSION_BINDING_ID")
+        channel = _api(
+            "POST",
+            "/_sc/session-control/channel",
+            {"binding_id": binding_id, "action": "register", "pid": os.getpid()},
+        )
+
+    try:
+        while True:
+            try:
+                if channel:
+                    _api_soft(
+                        "POST",
+                        "/_sc/session-control/channel",
+                        {
+                            "binding_id": channel["binding_id"],
+                            "action": "heartbeat",
+                            "pid": channel["pid"],
+                            "start_ticks": channel["start_ticks"],
+                        },
+                    )
+                r = _api_soft("GET", "/_sc/mem/messages")
+                failures = 0
+                unread = [m for m in r.get("messages", []) if not m.get("read_at")]
+                if unread:
+                    print(f"watch: {len(unread)} unread message(s) — inbox watcher fired:")
+                    for m in unread[:10]:
+                        kind = m.get("kind") or "shell"
+                        first = (m.get("body") or "").splitlines()[0][:120]
+                        print(f"  [#{m['message_id']}] {kind} · {first}")
+                    print("  → `sc mem message check`, act, mark-read, then re-arm the watcher.")
+                    return 0
+            except _ApiDown as e:
+                failures += 1
+                if failures >= 10:
+                    print(
+                        f"watch: inbox watcher giving up — API unreachable ({e})",
+                        file=sys.stderr,
+                    )
+                    return 3
+            if deadline and time.monotonic() >= deadline:
+                print(
+                    "watch: inbox watcher timed out with no unread messages — "
+                    "re-arm to keep watching."
+                )
+                return 2
+            time.sleep(args.interval)
+    finally:
+        if channel:
+            try:
+                _api_soft(
+                    "POST",
+                    "/_sc/session-control/channel",
+                    {
+                        "binding_id": channel["binding_id"],
+                        "action": "clear",
+                        "pid": channel["pid"],
+                        "start_ticks": channel["start_ticks"],
+                    },
+                )
+            except _ApiDown:
+                pass
 
 
 class _ApiDown(Exception):
     pass
 
 
-def _api_soft(method: str, path: str) -> dict:
+def _api_soft(
+    method: str, path: str, payload: "dict | None" = None
+) -> dict:
     """Like _api but raises _ApiDown instead of exiting — the inbox watcher
     rides out server restarts (e.g. an `./sc launch` bounce) instead of dying."""
     url = SC_API_BASE.rstrip("/") + path
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers = {"Authorization": f"Bearer {SC_API_TOKEN}"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
     req = urllib.request.Request(
-        url, method=method, headers={"Authorization": f"Bearer {SC_API_TOKEN}"})
+        url, data=data, method=method, headers=headers
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             return json.loads(resp.read())

--- a/tests/test_claude_session_control.py
+++ b/tests/test_claude_session_control.py
@@ -300,7 +300,38 @@ class AdapterTest(unittest.TestCase):
             sleeper=sleeps.append,
             clock=lambda: next(clocks),
         )
-        self.assertEqual(sleeps, [0.2])
+        self.assertEqual(sleeps, [adapter_module.ACK_POLL_INTERVAL])
+
+    def test_ack_waiter_aborts_when_owner_and_watcher_are_gone(self):
+        clocks = iter([0.0, adapter_module.BINDING_RECHECK_INTERVAL])
+        with self.assertRaisesRegex(RuntimeError, "owner and inbox watcher"):
+            adapter_module._wait_for_ack(
+                binding(),
+                unread=lambda _row: 1,
+                binding_reader=lambda _row: binding(owner=False, watcher=False),
+                sleeper=lambda _seconds: self.fail("lost delivery slept again"),
+                clock=lambda: next(clocks),
+                now=lambda: NOW,
+            )
+
+    def test_ack_waiter_keeps_waiting_while_owner_or_watcher_is_live(self):
+        for current_binding in (
+            binding(owner=True, watcher=False),
+            binding(owner=False, watcher=True),
+        ):
+            with self.subTest(current_binding=current_binding):
+                unread = iter([1, 0])
+                clocks = iter([0.0, adapter_module.BINDING_RECHECK_INTERVAL])
+                sleeps: list[float] = []
+                adapter_module._wait_for_ack(
+                    binding(),
+                    unread=lambda _row: next(unread),
+                    binding_reader=lambda _row: current_binding,
+                    sleeper=sleeps.append,
+                    clock=lambda: next(clocks),
+                    now=lambda: NOW,
+                )
+                self.assertEqual(sleeps, [adapter_module.ACK_POLL_INTERVAL])
 
     def test_missing_watcher_queues_without_assuming_foreground_delivery(self):
         adapter = self.adapter(unread=lambda _row: 1)

--- a/tests/test_claude_session_control.py
+++ b/tests/test_claude_session_control.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Hermetic Claude UUID, inbox-watcher, and dormant-resume fixtures."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+ADAPTER = ENGINE / "adapters" / "claude"
+sys.path.insert(0, str(ADAPTER))
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import run  # noqa: E402
+import session_control as common_session_control  # noqa: E402
+import watch  # noqa: E402
+from claude_cli import probe_claude  # noqa: E402
+
+
+def load_file(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+adapter_module = load_file(
+    "claude_session_control_adapter", ADAPTER / "session_control.py"
+)
+launcher_module = load_file("claude_session_launcher", ADAPTER / "claude-session.py")
+
+NOW = datetime(2026, 7, 22, 4, 0, tzinfo=timezone.utc)
+NATIVE_ID = "12345678-1234-4234-8234-123456789abc"
+
+
+def binding(
+    *,
+    native_id: str | None = NATIVE_ID,
+    owner: bool = True,
+    watcher: bool = True,
+    permission: str = "auto",
+) -> dict:
+    capabilities = {
+        "active_delivery": True,
+        "deliver": True,
+        "resume": True,
+        "normal_steer": False,
+        "settings": {
+            "model": "claude-fable-5",
+            "cwd": "/repo/.sc-worktrees/pln1",
+            "effort": "high",
+            "permission_mode": permission,
+        },
+    }
+    return {
+        "binding_id": 8,
+        "native_session_id": native_id,
+        "control_capabilities": json.dumps(capabilities),
+        "archive_model": "claude-fable-5",
+        "shortname": "PLN1",
+        "flavor": "planner",
+        "lease_pid": 41 if owner else None,
+        "lease_start_ticks": 900 if owner else None,
+        "active_channel_pid": 52 if watcher else None,
+        "active_channel_start_ticks": 901 if watcher else None,
+        "active_channel_heartbeat_at": "2026-07-22 03:59:30" if watcher else None,
+    }
+
+
+def completed(command: list[str], output: str, returncode: int = 0):
+    return subprocess.CompletedProcess(command, returncode, output, "")
+
+
+class ProbeTest(unittest.TestCase):
+    @staticmethod
+    def runner(version: str, help_text: str | None = None):
+        flags = (
+            "--session-id --resume --print --model --effort --permission-mode"
+            if help_text is None
+            else help_text
+        )
+
+        def run(command: list[str]):
+            if command == ["claude", "--version"]:
+                return completed(command, version)
+            if command == ["claude", "--help"]:
+                return completed(command, flags)
+            raise AssertionError(command)
+
+        return run
+
+    def test_tested_cli_enables_uuid_launch_watcher_delivery_and_resume(self):
+        probe = probe_claude(self.runner("2.1.216 (Claude Code)"))
+        self.assertEqual(probe["cli_version"], "2.1.216")
+        self.assertEqual(
+            (probe["create"], probe["deliver"], probe["resume"]),
+            (True, True, True),
+        )
+
+    def test_unknown_version_fails_active_closed_but_keeps_flag_tested_resume(self):
+        probe = probe_claude(self.runner("2.2.0 (Claude Code)"))
+        self.assertFalse(probe["create"])
+        self.assertFalse(probe["active_delivery"])
+        self.assertTrue(probe["resume"])
+
+
+class LauncherTest(unittest.TestCase):
+    def test_controlled_launcher_is_declared(self):
+        adapter = run.load_adapter("claude")
+        self.assertEqual(
+            run.session_control_launch(adapter),
+            ["python3", str(ADAPTER / "claude-session.py")],
+        )
+
+    def test_fresh_launch_supplies_uuid_and_applies_effective_route_and_effort(self):
+        row = {
+            "native_session_id": None,
+            "display_name": "Plan-01",
+            "control_capabilities": "{}",
+        }
+        native_id, command, capabilities = launcher_module.launch_plan(
+            row,
+            {"cli_version": "2.1.216", "create": True, "resume": True},
+            cwd=Path("/repo/.sc-worktrees/pln1"),
+            env={"SC_SESSION_MODEL": "claude-fable-5", "SC_SESSION_EFFORT": "high"},
+            native_id_factory=lambda: uuid.UUID(NATIVE_ID),
+        )
+        self.assertEqual(native_id, NATIVE_ID)
+        self.assertEqual(
+            command,
+            [
+                "claude",
+                "--session-id",
+                NATIVE_ID,
+                "--name",
+                "Plan-01",
+                "--model",
+                "claude-fable-5",
+                "--effort",
+                "high",
+                "--permission-mode",
+                "auto",
+            ],
+        )
+        self.assertEqual(
+            capabilities["settings"],
+            {
+                "model": "claude-fable-5",
+                "cwd": "/repo/.sc-worktrees/pln1",
+                "effort": "high",
+                "permission_mode": "auto",
+            },
+        )
+
+    def test_sandbox_launch_records_and_applies_bypass_posture(self):
+        native_id, command, capabilities = launcher_module.launch_plan(
+            {
+                "native_session_id": None,
+                "display_name": None,
+                "control_capabilities": "{}",
+            },
+            {"create": True, "resume": True},
+            cwd=Path("/repo/.sc-worktrees/pln1"),
+            env={"SC_SANDBOX": "1"},
+            native_id_factory=lambda: uuid.UUID(NATIVE_ID),
+        )
+        self.assertEqual(native_id, NATIVE_ID)
+        self.assertEqual(
+            command,
+            ["claude", "--session-id", NATIVE_ID, "--dangerously-skip-permissions"],
+        )
+        self.assertEqual(
+            capabilities["settings"]["permission_mode"], "bypassPermissions"
+        )
+
+    def test_existing_binding_resumes_exact_uuid_with_stored_settings(self):
+        row = binding()
+        row["display_name"] = "Plan-01"
+        native_id, command, _capabilities = launcher_module.launch_plan(
+            row,
+            {"create": True, "resume": True},
+            cwd=Path("/repo/.sc-worktrees/pln1"),
+            env={"SC_SESSION_MODEL": "wrong", "SC_SESSION_EFFORT": "low"},
+        )
+        self.assertEqual(native_id, NATIVE_ID)
+        self.assertEqual(
+            command,
+            [
+                "claude",
+                "--resume",
+                NATIVE_ID,
+                "--name",
+                "Plan-01",
+                "--model",
+                "claude-fable-5",
+                "--effort",
+                "high",
+                "--permission-mode",
+                "auto",
+            ],
+        )
+
+    def test_main_registers_the_same_uuid_it_supplies_to_claude(self):
+        class Connection:
+            def execute(self, _query, _params):
+                return self
+
+            def fetchone(self):
+                return {
+                    "binding_id": 8,
+                    "native_session_id": None,
+                    "display_name": "Plan-01",
+                    "control_capabilities": "{}",
+                }
+
+            def close(self):
+                return None
+
+        probe = {
+            "cli_version": "2.1.216",
+            "create": True,
+            "deliver": True,
+            "resume": True,
+            "active_delivery": True,
+        }
+        with (
+            mock.patch.dict(
+                "os.environ",
+                {
+                    "SC_SESSION_BINDING_ID": "8",
+                    "SC_SESSION_MODEL": "claude-fable-5",
+                },
+                clear=False,
+            ),
+            mock.patch.object(
+                launcher_module.db_driver, "connect", return_value=Connection()
+            ),
+            mock.patch.object(launcher_module, "probe_claude", return_value=probe),
+            mock.patch.object(
+                launcher_module.session_supervisor, "register_native_session"
+            ) as register,
+            mock.patch.object(
+                launcher_module.os, "execvpe", side_effect=RuntimeError("exec stopped")
+            ) as execute,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "exec stopped"):
+                launcher_module.main()
+
+        registered_id = register.call_args.args[2]
+        command = execute.call_args.args[1]
+        launch_env = execute.call_args.args[2]
+        self.assertEqual(command[0:3], ["claude", "--session-id", registered_id])
+        self.assertEqual(launch_env["SC_SESSION_ACTIVE_CHANNEL"], "claude-inbox")
+        self.assertEqual(register.call_args.args[1], 8)
+
+
+class AdapterTest(unittest.TestCase):
+    def adapter(self, **kwargs):
+        return adapter_module.ClaudeAdapter(now=lambda: NOW, **kwargs)
+
+    def test_status_requires_id_owner_and_fresh_watcher(self):
+        adapter = self.adapter()
+        self.assertEqual(adapter.status(binding(native_id=None)), "starting")
+        self.assertEqual(adapter.status(binding(owner=False, watcher=False)), "dormant")
+        self.assertEqual(adapter.status(binding(watcher=False)), "active")
+        self.assertEqual(adapter.status(binding()), "idle")
+
+        stale = binding()
+        stale["active_channel_heartbeat_at"] = "2026-07-22 03:57:00"
+        self.assertEqual(adapter.status(stale), "active")
+
+    def test_active_delivery_waits_for_read_at_acknowledgement(self):
+        waited: list[int] = []
+        adapter = self.adapter(
+            unread=lambda _row: 1,
+            ack_waiter=lambda row: waited.append(row["binding_id"]),
+        )
+        adapter.deliver(binding(), "ignored transport prompt")
+        self.assertEqual(waited, [8])
+
+    def test_default_ack_waiter_polls_until_running_messages_are_read(self):
+        unread = iter([1, 0])
+        sleeps: list[float] = []
+        clocks = iter([0.0, 1.0])
+        adapter_module._wait_for_ack(
+            binding(),
+            unread=lambda _row: next(unread),
+            sleeper=sleeps.append,
+            clock=lambda: next(clocks),
+        )
+        self.assertEqual(sleeps, [0.2])
+
+    def test_missing_watcher_queues_without_assuming_foreground_delivery(self):
+        adapter = self.adapter(unread=lambda _row: 1)
+        with self.assertRaises(common_session_control.ProviderBusy):
+            adapter.deliver(binding(watcher=False), "check inbox")
+
+    def test_already_acknowledged_race_finishes_without_a_rearmed_watcher(self):
+        waited: list[bool] = []
+        adapter = self.adapter(
+            unread=lambda _row: 0,
+            ack_waiter=lambda _row: waited.append(True),
+        )
+        adapter.deliver(binding(watcher=False), "check inbox")
+        self.assertEqual(waited, [])
+
+    def test_manual_permission_posture_refuses_before_delivery_wait(self):
+        waited: list[bool] = []
+        adapter = self.adapter(
+            unread=lambda _row: 1,
+            ack_waiter=lambda _row: waited.append(True),
+        )
+        with self.assertRaisesRegex(RuntimeError, "managed wake requires"):
+            adapter.deliver(binding(permission="manual"), "check inbox")
+        self.assertEqual(waited, [])
+
+    def test_dormant_resume_pins_uuid_route_effort_permission_and_worktree(self):
+        calls: list[tuple[dict, list[str], Path]] = []
+        adapter = self.adapter(
+            resume_runner=lambda row, command, cwd: calls.append((row, command, cwd)),
+            resume_probe=lambda: {"resume": True},
+        )
+        row = binding(owner=False, watcher=False)
+        adapter.resume(row, "check inbox")
+        self.assertEqual(
+            calls,
+            [
+                (
+                    row,
+                    [
+                        "claude",
+                        "--resume",
+                        NATIVE_ID,
+                        "--model",
+                        "claude-fable-5",
+                        "--effort",
+                        "high",
+                        "--permission-mode",
+                        "auto",
+                        "-p",
+                        "check inbox",
+                    ],
+                    Path("/repo/.sc-worktrees/pln1"),
+                )
+            ],
+        )
+
+    def test_resume_reprobes_before_spawning(self):
+        calls: list[bool] = []
+        adapter = self.adapter(
+            resume_runner=lambda _row, _command, _cwd: calls.append(True),
+            resume_probe=lambda: {"resume": False},
+        )
+        with self.assertRaisesRegex(RuntimeError, "failed the resume capability probe"):
+            adapter.resume(binding(owner=False, watcher=False), "check inbox")
+        self.assertEqual(calls, [])
+
+    def test_fenced_runner_refuses_before_spawn_when_an_owner_is_live(self):
+        class Connection:
+            def close(self):
+                return None
+
+        spawned: list[bool] = []
+
+        def supervise(_command, **kwargs):
+            kwargs["on_pre_spawn"]()
+            spawned.append(True)
+            return 0
+
+        with (
+            mock.patch.object(
+                adapter_module.db_driver, "connect", return_value=Connection()
+            ),
+            mock.patch.object(
+                adapter_module.session_supervisor,
+                "preflight_lease",
+                side_effect=RuntimeError("validated owner is live"),
+            ),
+            mock.patch.object(
+                adapter_module.session_supervisor, "supervise", side_effect=supervise
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "validated owner is live"):
+                adapter_module._run_fenced_resume(
+                    binding(owner=False, watcher=False),
+                    ["claude", "--resume", NATIVE_ID, "-p", "check inbox"],
+                    Path("/repo/.sc-worktrees/pln1"),
+                )
+        self.assertEqual(spawned, [])
+
+
+class InboxWatcherTest(unittest.TestCase):
+    def test_claude_watcher_registers_heartbeats_and_clears_exact_identity(self):
+        calls: list[tuple[str, str, dict | None]] = []
+
+        def register(method: str, path: str, payload: dict | None = None):
+            calls.append((method, path, payload))
+            return {"binding_id": 8, "pid": 77, "start_ticks": 901}
+
+        def soft(method: str, path: str, payload: dict | None = None):
+            calls.append((method, path, payload))
+            if path == "/_sc/mem/messages":
+                return {
+                    "messages": [
+                        {"message_id": 9, "kind": "result", "body": "unit ready"}
+                    ]
+                }
+            return {"ok": True}
+
+        with (
+            mock.patch.dict(
+                "os.environ",
+                {
+                    "SC_SESSION_ACTIVE_CHANNEL": "claude-inbox",
+                    "SC_SESSION_BINDING_ID": "8",
+                },
+                clear=False,
+            ),
+            mock.patch.object(watch, "_require_api"),
+            mock.patch.object(watch, "_api", side_effect=register),
+            mock.patch.object(watch, "_api_soft", side_effect=soft),
+            mock.patch.object(watch.os, "getpid", return_value=77),
+        ):
+            result = watch.cmd_inbox(SimpleNamespace(timeout=1, interval=0))
+
+        self.assertEqual(result, 0)
+        actions = [
+            payload.get("action")
+            for _method, path, payload in calls
+            if path == "/_sc/session-control/channel" and payload
+        ]
+        self.assertEqual(actions, ["register", "heartbeat", "clear"])
+        for _method, path, payload in calls:
+            if path == "/_sc/session-control/channel" and payload:
+                self.assertEqual(payload["pid"], 77)
+
+
+class ManagedPostureTest(unittest.TestCase):
+    def test_claude_bypass_permission_vocabulary_is_approval_safe(self):
+        common_session_control.validate_managed_wake_posture(
+            {"settings": {"permission_mode": "bypassPermissions"}}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_control_api.py
+++ b/tests/test_session_control_api.py
@@ -164,7 +164,8 @@ class ControlMutationTest(unittest.TestCase):
 
         self.assertIsNone(payload)
         self.assertEqual(
-            "managed wake requires permission_mode='auto' or 'yolo' "
+            "managed wake requires permission_mode='auto', 'yolo', or "
+            "'bypassPermissions' "
             "so an injected turn cannot request approval",
             error,
         )


### PR DESCRIPTION
## Summary
- launch managed Claude planners with a supplied native session UUID and effective model, effort, cwd, and permission settings
- register and heartbeat the Claude inbox watcher as the live channel; queue safely when it is missing
- resume dormant Claude conversations through the shared ownership lease fence and finish only on inbox read acknowledgement

## Verification
- 108 provider/session-control tests pass
- full suite: 628 passed in host-equivalent mode
- lint and source type checks pass

Sprint 21 unit 4 · spec doc #20 · task #53