### PR TITLE
feat(session): add operator status and analytics integration

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -204,6 +204,7 @@ def get_shell(con, sid: int) -> dict | None:
         "SELECT decision_id, decision_date, priority, decision FROM shell_decisions "
         "WHERE shell_id=? AND COALESCE(is_deleted,0)=0 ORDER BY decision_id DESC "
         "LIMIT 25", (sid,)))
+    shell["session_control"] = get_session_control_overview(con, sid)
     return shell
 
 
@@ -487,14 +488,19 @@ def get_analytics_sessions(con, q) -> dict:
         marks = ",".join("?" for _ in aids)
         arch = {a["archive_id"]: dict(a) for a in con.execute(
             f"SELECT a.archive_id, a.session_id, a.sprint_ref, s.shortname, "
-            f"s.display_name, s.flavor FROM shell_memory_archives a "
-            f"JOIN shells s ON s.shell_id=a.shell_id WHERE a.archive_id IN ({marks})",
+            f"s.display_name, s.flavor, b.state AS control_state, "
+            f"b.managed AS control_managed FROM shell_memory_archives a "
+            f"JOIN shells s ON s.shell_id=a.shell_id "
+            f"LEFT JOIN shell_session_bindings b ON b.archive_id=a.archive_id "
+            f"WHERE a.archive_id IN ({marks})",
             aids)}
     for c in cards:
         a = arch.get(c["archive_id"]) or {}
         c["shell"] = a.get("shortname")
         c["shell_session"] = a.get("session_id")
         c["sprint_ref"] = a.get("sprint_ref")
+        c["control_state"] = a.get("control_state")
+        c["control_managed"] = bool(a.get("control_managed"))
         c["status"] = _card_status(c.pop("statuses"), c["archive_id"])
         c["unattributed"] = c["archive_id"] is None
     older = con.execute(
@@ -584,9 +590,24 @@ def get_analytics_usage(con, q) -> dict:
         "SELECT DISTINCT a.sprint_ref, d.title FROM shell_memory_archives a "
         "LEFT JOIN documents d ON CAST(d.document_id AS TEXT) = a.sprint_ref "
         "WHERE a.sprint_ref IS NOT NULL")}
+    controlled_shell_ids = [r[0] for r in con.execute(
+        "SELECT DISTINCT b.shell_id FROM shell_session_bindings b "
+        "JOIN shells s ON s.active_archive_id=b.archive_id "
+        "WHERE COALESCE(s.is_deleted,0)=0 ORDER BY b.shell_id"
+    )]
+    control = []
+    for shell_id in controlled_shell_ids:
+        overview = get_session_control_overview(con, shell_id)
+        if overview is None:
+            continue
+        shell = con.execute(
+            "SELECT shortname FROM shells WHERE shell_id=?", (shell_id,)
+        ).fetchone()
+        control.append({"shortname": shell[0], **overview})
     return {"favorite_models": sorted(fav.values(), key=lambda f: f["flavor"]),
             "features_shipped": features_shipped, "specs_shipped": specs_shipped,
-            "docs_outstanding": docs_outstanding, "sprint_titles": sprint_titles}
+            "docs_outstanding": docs_outstanding, "sprint_titles": sprint_titles,
+            "session_control": control}
 
 
 def get_analytics_filters(con) -> dict:
@@ -1220,6 +1241,14 @@ def get_session_control(con, shell_id: int, binding_id: int | None = None):
             "WHERE binding_id=? GROUP BY state", (binding["binding_id"],)
         )
     }
+    archive = con.execute(
+        "SELECT session_id, harness, provider, model, sprint_ref "
+        "FROM shell_memory_archives WHERE archive_id=?", (binding["archive_id"],)
+    ).fetchone()
+    last_delivery = con.execute(
+        "SELECT MAX(finished_at) FROM session_wake_jobs "
+        "WHERE binding_id=? AND state='done'", (binding["binding_id"],)
+    ).fetchone()[0]
     visible = {
         key: binding[key] for key in (
             "binding_id", "archive_id", "shell_id", "harness",
@@ -1230,8 +1259,49 @@ def get_session_control(con, shell_id: int, binding_id: int | None = None):
             "lease_generation", "last_error", "created_at", "updated_at",
         )
     }
-    return {"binding": visible, "jobs": counts,
-            "dispatcher": dict(beat) if beat else None}
+    owner = "none"
+    owner_pid = None
+    if binding["lease_pid"]:
+        owner, owner_pid = "lease", binding["lease_pid"]
+    elif binding["active_channel_pid"]:
+        owner, owner_pid = "active-channel", binding["active_channel_pid"]
+    errors = counts.get("failed", 0) + int(
+        binding["state"] == "error" or bool(binding["last_error"])
+    )
+    return {
+        "binding": visible,
+        "archive": dict(archive) if archive else None,
+        "jobs": counts,
+        "summary": {
+            "queued": counts.get("queued", 0),
+            "errors": errors,
+            "owner": owner,
+            "owner_pid": owner_pid,
+            "last_delivery": last_delivery,
+        },
+        "dispatcher": dict(beat) if beat else None,
+    }
+
+
+def get_session_control_overview(con, shell_id: int) -> dict | None:
+    """Safe compact status for GUI surfaces; omit endpoints/capabilities/PIDs."""
+    payload = get_session_control(con, shell_id)
+    binding = payload.get("binding")
+    if binding is None:
+        return None
+    archive = payload.get("archive") or {}
+    summary = payload.get("summary") or {}
+    return {
+        "binding_id": binding["binding_id"],
+        "engine_session_id": archive.get("session_id"),
+        "harness": binding["harness"],
+        "model": archive.get("model"),
+        "state": binding["state"],
+        "managed": bool(binding["managed"]),
+        "queued": summary.get("queued", 0),
+        "errors": summary.get("errors", 0),
+        "last_delivery": summary.get("last_delivery"),
+    }
 
 
 def _binding_capabilities(binding) -> dict:
@@ -1242,7 +1312,8 @@ def _binding_capabilities(binding) -> dict:
     return capabilities if isinstance(capabilities, dict) else {}
 
 
-def manage_session_control(con, shell_id: int, binding_id: int | None = None):
+def manage_session_control(con, shell_id: int, binding_id: int | None = None,
+                           sprint_ref: str | None = None):
     con.execute("BEGIN IMMEDIATE")
     try:
         binding = _owned_binding(con, shell_id, binding_id)
@@ -1272,6 +1343,16 @@ def manage_session_control(con, shell_id: int, binding_id: int | None = None):
         if binding["state"] == "dispatching":
             con.rollback()
             return None, "cannot manage a binding while dispatching"
+        if sprint_ref is not None:
+            sprint_ref = str(sprint_ref).strip()
+            if not sprint_ref:
+                con.rollback()
+                return None, "sprint reference is required"
+            if not sprint_ref.isdigit() or con.execute(
+                    "SELECT 1 FROM documents WHERE document_id=?",
+                    (int(sprint_ref),)).fetchone() is None:
+                con.rollback()
+                return None, f"unknown sprint document {sprint_ref!r}"
         if binding["state"] in ("released", "error"):
             session_control.transition_binding(
                 con, binding["binding_id"], expected=binding["state"],
@@ -1281,6 +1362,11 @@ def manage_session_control(con, shell_id: int, binding_id: int | None = None):
             "updated_at=datetime('now') WHERE binding_id=?",
             (binding["binding_id"],),
         )
+        if sprint_ref is not None:
+            con.execute(
+                "UPDATE shell_memory_archives SET sprint_ref=? WHERE archive_id=?",
+                (sprint_ref, binding["archive_id"]),
+            )
         # A prior release deliberately cancelled its queued audit rows.  Re-manage
         # reactivates only rows whose messages are still unread.
         con.execute(
@@ -1299,6 +1385,42 @@ def manage_session_control(con, shell_id: int, binding_id: int | None = None):
     return get_session_control(con, shell_id, binding["binding_id"]), None
 
 
+SESSION_CREDENTIAL_DIR = ENGINE / "run" / "session-control"
+
+
+def _binding_credential_paths(binding) -> list[Path]:
+    """Return provider-declared ephemeral credentials after strict path checks."""
+    capabilities = _binding_capabilities(binding)
+    declared: list[object] = []
+    if capabilities.get("token_file"):
+        declared.append(capabilities["token_file"])
+    extra = capabilities.get("credential_files") or []
+    if isinstance(extra, list):
+        declared.extend(extra)
+    root = SESSION_CREDENTIAL_DIR.resolve()
+    prefix = f"{binding['harness']}-{binding['binding_id']}."
+    paths: list[Path] = []
+    for raw in declared:
+        path = Path(str(raw)).resolve()
+        if path.parent != root or not path.name.startswith(prefix):
+            raise session_control.SessionControlError(
+                "provider credential path is outside the binding runtime scope"
+            )
+        if path not in paths:
+            paths.append(path)
+    return paths
+
+
+def _remove_binding_credentials(binding) -> None:
+    for path in _binding_credential_paths(binding):
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise session_control.SessionControlError(
+                f"could not remove provider runtime credential {path.name}: {exc}"
+            ) from exc
+
+
 def release_session_control(con, shell_id: int, binding_id: int | None = None):
     con.execute("BEGIN IMMEDIATE")
     try:
@@ -1309,6 +1431,11 @@ def release_session_control(con, shell_id: int, binding_id: int | None = None):
         if binding["state"] == "dispatching":
             con.rollback()
             return None, "binding is dispatching; release after the turn exits"
+        try:
+            _remove_binding_credentials(binding)
+        except session_control.SessionControlError as exc:
+            con.rollback()
+            return None, str(exc)
         if binding["state"] != "released":
             session_control.transition_binding(
                 con, binding["binding_id"], expected=binding["state"],
@@ -1361,6 +1488,33 @@ def retry_session_control(con, shell_id: int, binding_id: int | None = None):
         con.rollback()
         raise
     return get_session_control(con, shell_id, binding["binding_id"]), None
+
+
+def _shell_id_for_shortname(con, shortname: str) -> int | None:
+    row = con.execute(
+        "SELECT shell_id FROM shells WHERE lower(shortname)=lower(?) "
+        "AND COALESCE(is_deleted,0)=0", (shortname.strip(),)
+    ).fetchone()
+    return int(row[0]) if row else None
+
+
+def operator_session_control(con, shortname: str, action: str = "status",
+                             *, sprint_ref: str | None = None):
+    """Local operator surface used by ``sc session`` and the review GUI."""
+    shell_id = _shell_id_for_shortname(con, shortname)
+    if shell_id is None:
+        return None, f"unknown shell {shortname!r}"
+    if action == "status":
+        return get_session_control(con, shell_id), None
+    if action == "manage":
+        if sprint_ref is None:
+            return None, "sprint reference is required"
+        return manage_session_control(con, shell_id, sprint_ref=sprint_ref)
+    if action == "release":
+        return release_session_control(con, shell_id)
+    if action == "retry":
+        return retry_session_control(con, shell_id)
+    return None, f"unknown session action {action!r}"
 
 
 def _local_control_endpoint(value: str) -> bool:
@@ -2444,6 +2598,11 @@ class Handler(BaseHTTPRequestHandler):
                 cfg = ports_mod.resolve()
                 return self._send(200, {"ok": True, "repo": cfg.get("repo"),
                                         "port": cfg.get("port")})
+            if path.startswith("/api/session-control/status/"):
+                shortname = path.rsplit("/", 1)[1]
+                payload, error = operator_session_control(con, shortname)
+                return self._send(404 if error else 200,
+                                  {"error": error} if error else payload)
             if path == "/api/shells":
                 return self._send(200, {"shells": get_shells(con)})
             if path == "/api/shell-templates":
@@ -2551,6 +2710,17 @@ class Handler(BaseHTTPRequestHandler):
             return self._watches_post(self._body())
         con = db()
         try:
+            if path.startswith("/api/session-control/"):
+                parts = path.strip("/").split("/")
+                if len(parts) != 4 or parts[:2] != ["api", "session-control"]:
+                    return self._send(404, {"error": "not found"})
+                action, shortname = parts[2], parts[3]
+                body = self._body()
+                payload, error = operator_session_control(
+                    con, shortname, action, sprint_ref=body.get("sprint_ref")
+                )
+                return self._send(409 if error else 200,
+                                  {"error": error} if error else payload)
             if path == "/api/flags":
                 fid, err = create_flag(con, self._body())
                 return self._send(400 if err else 201,

--- a/.super-coder/scripts/analytics.py
+++ b/.super-coder/scripts/analytics.py
@@ -13,7 +13,8 @@ upsert is a manual UPDATE-then-INSERT rather than ON CONFLICT because
 distinct in UNIQUE indexes — ON CONFLICT would re-insert those rows on
 every sweep. Updates never touch archive_id/shell_id (attribution owns them).
 
-Attribution: harness session → archive by (cwd → shell, time-window). A
+Attribution: harness session → archive by exact native binding first, then
+(cwd → shell, time-window). A
 shell's window runs from an archive's started_at to the same shell's next
 started_at (open-ended for the latest). Worktree cwds map to the shell whose
 shortname names the worktree; the repo root maps to admin-flavor shells.
@@ -192,6 +193,22 @@ def _attribute(con, batch: list[dict], log) -> "tuple[int, int]":
     windows = _windows(con)
     attributed = shell_only = 0
     for r in batch:
+        native_id = r.get("native_session_id")
+        if native_id:
+            exact = con.execute(
+                "SELECT archive_id, shell_id FROM shell_session_bindings "
+                "WHERE harness=? AND native_session_id=?",
+                (r["harness"], native_id),
+            ).fetchone()
+            if exact:
+                cur = con.execute(
+                    "UPDATE session_token_usage SET archive_id=?, shell_id=? "
+                    "WHERE harness=? AND harness_session_ref=? AND model IS ?",
+                    (exact["archive_id"], exact["shell_id"], r["harness"],
+                     r["harness_session_ref"], r["model"]),
+                )
+                attributed += cur.rowcount
+                continue
         if not r.get("cwd"):
             continue
         sids = _shell_for_cwd(r["cwd"], by_wt, admins)

--- a/.super-coder/scripts/session_cli.py
+++ b/.super-coder/scripts/session_cli.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python3
-"""Internal token-scoped client for provider session-control adapters.
-
-The public operator surface (``sc session`` plus GUI status) lands in sprint
-unit 7.  This lower-level client exists now so provider adapters never write
-binding rows directly.
-"""
+"""Session-control CLI: public operator commands plus adapter-only internals."""
 from __future__ import annotations
 
 import argparse
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import NoReturn
 
 
-API_BASE = os.environ.get("SC_API_BASE", "")
+ENGINE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ENGINE / "scripts"))
+import ports as ports_mod  # noqa: E402
+
+API_BASE = os.environ.get("SC_API_BASE", "") or (
+    f"http://127.0.0.1:{ports_mod.resolve().get('port')}"
+)
 API_TOKEN = os.environ.get("SC_API_TOKEN", "")
 
 
@@ -25,11 +28,12 @@ def die(message: str) -> NoReturn:
     sys.exit(f"session-control: {message}")
 
 
-def api(method: str, path: str, payload: dict | None = None) -> dict:
-    if not API_BASE or not API_TOKEN:
+def api(method: str, path: str, payload: dict | None = None,
+        *, token_required: bool = True) -> dict:
+    if not API_BASE or (token_required and not API_TOKEN):
         die("SC_API_BASE + SC_API_TOKEN are required; boot through ./sc enter")
     data = json.dumps(payload).encode() if payload is not None else None
-    headers = {"Authorization": f"Bearer {API_TOKEN}"}
+    headers = ({"Authorization": f"Bearer {API_TOKEN}"} if API_TOKEN else {})
     if data is not None:
         headers["Content-Type"] = "application/json"
     request = urllib.request.Request(
@@ -59,12 +63,21 @@ def print_status(payload: dict) -> None:
         return
     native = binding.get("native_session_id") or "pending"
     managed = "managed" if binding.get("managed") else "manual"
-    jobs = payload.get("jobs") or {}
-    queued = jobs.get("queued", 0)
+    archive = payload.get("archive") or {}
+    summary = payload.get("summary") or {}
+    queued = summary.get("queued", (payload.get("jobs") or {}).get("queued", 0))
+    errors = summary.get("errors", (payload.get("jobs") or {}).get("failed", 0))
+    engine_session = archive.get("session_id") or "pending"
+    model = archive.get("model") or "harness default"
+    owner = summary.get("owner") or "none"
     print(
-        f"binding {binding['binding_id']} · {binding['harness']}={native} · "
-        f"{binding['state']} · {managed} · queued={queued}"
+        f"binding {binding['binding_id']} · engine={engine_session} · "
+        f"{binding['harness']}={native} · model={model} · "
+        f"{binding['state']} · {managed} · owner={owner} · "
+        f"queued={queued} · errors={errors}"
     )
+    if summary.get("last_delivery"):
+        print(f"  last delivery: {summary['last_delivery']}")
     if binding.get("last_error"):
         print(f"  error: {binding['last_error']}")
 
@@ -124,6 +137,52 @@ def cmd_channel(args) -> int:
     return 0
 
 
+def operator_api(method: str, action: str, shortname: str,
+                 payload: dict | None = None) -> dict:
+    target = urllib.parse.quote(shortname, safe="")
+    return api(
+        method, f"/api/session-control/{action}/{target}", payload,
+        token_required=False,
+    )
+
+
+def cmd_operator_status(args) -> int:
+    if args.shortname:
+        print_status(operator_api("GET", "status", args.shortname))
+        return 0
+    print_status(api("GET", "/_sc/session-control"))
+    return 0
+
+
+def cmd_operator_manage(args) -> int:
+    print_status(operator_api(
+        "POST", "manage", args.shortname, {"sprint_ref": args.sprint}
+    ))
+    return 0
+
+
+def cmd_operator_action(args) -> int:
+    if args.action == "release":
+        while True:
+            status = operator_api("GET", "status", args.shortname)
+            if status.get("binding", {}).get("state") == "dispatching":
+                if not args.after_turn:
+                    die("binding is dispatching; pass --after-turn to wait for release")
+                time.sleep(1)
+                continue
+            try:
+                result = operator_api("POST", "release", args.shortname, {})
+                break
+            except SystemExit as exc:
+                if not args.after_turn or "dispatching" not in str(exc):
+                    raise
+                time.sleep(1)
+        print_status(result)
+        return 0
+    print_status(operator_api("POST", args.action, args.shortname, {}))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="sc session-control")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -158,8 +217,35 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def build_operator_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="sc session")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    status = sub.add_parser("status")
+    status.add_argument("shortname", nargs="?")
+    status.set_defaults(fn=cmd_operator_status)
+
+    manage = sub.add_parser("manage")
+    manage.add_argument("shortname")
+    manage.add_argument("--sprint", required=True)
+    manage.set_defaults(fn=cmd_operator_manage)
+
+    release = sub.add_parser("release")
+    release.add_argument("shortname")
+    release.add_argument("--after-turn", action="store_true")
+    release.set_defaults(fn=cmd_operator_action, action="release")
+
+    retry = sub.add_parser("retry")
+    retry.add_argument("shortname")
+    retry.set_defaults(fn=cmd_operator_action, action="retry", after_turn=False)
+    return parser
+
+
 def main(argv: list[str]) -> int:
-    args = build_parser().parse_args(argv)
+    operator = bool(argv and argv[0] == "--operator")
+    if operator:
+        argv = argv[1:]
+    args = (build_operator_parser() if operator else build_parser()).parse_args(argv)
     return args.fn(args)
 
 

--- a/.super-coder/scripts/session_cli.py
+++ b/.super-coder/scripts/session_cli.py
@@ -165,7 +165,7 @@ def cmd_operator_action(args) -> int:
     if args.action == "release":
         while True:
             status = operator_api("GET", "status", args.shortname)
-            if status.get("binding", {}).get("state") == "dispatching":
+            if (status.get("binding") or {}).get("state") == "dispatching":
                 if not args.after_turn:
                     die("binding is dispatching; pass --after-turn to wait for release")
                 time.sleep(1)

--- a/.super-coder/scripts/token_parsers/__init__.py
+++ b/.super-coder/scripts/token_parsers/__init__.py
@@ -27,7 +27,7 @@ Contract — every module exposes:
                cache={}. Only claude uses it today (per-file byte-offset
                tail parsing, CC-145).
 
-Row keys: harness, harness_session_ref, provider, model, title, started_at,
+Row keys: harness, harness_session_ref, native_session_id (transient), provider, model, title, started_at,
 ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
 reasoning_tokens, status ('ok'|'partial'|'no_usage'), parser_version, cwd
 (transient). Token-class rule: NULL means "not exposed by this harness",
@@ -84,7 +84,7 @@ def row(*, harness: str, ref: str, parser_version: str, provider=None,
         model=None, title=None, started_at=None, ended_at=None,
         input_tokens=None, output_tokens=None, cache_read_tokens=None,
         cache_write_tokens=None, reasoning_tokens=None, status="ok",
-        cwd=None) -> dict:
+        cwd=None, native_session_id=None) -> dict:
     return {
         "harness": harness, "harness_session_ref": ref,
         "parser_version": parser_version, "provider": provider,
@@ -95,4 +95,5 @@ def row(*, harness: str, ref: str, parser_version: str, provider=None,
         "cache_write_tokens": cache_write_tokens,
         "reasoning_tokens": reasoning_tokens,
         "status": status, "cwd": cwd,
+        "native_session_id": native_session_id,
     }

--- a/.super-coder/scripts/token_parsers/claude.py
+++ b/.super-coder/scripts/token_parsers/claude.py
@@ -240,7 +240,8 @@ def sweep(repo_root, since_epoch, log, cache=None) -> list[dict]:
             common = dict(harness=HARNESS, parser_version=PARSER_VERSION,
                           provider="anthropic", title=agg["title"],
                           started_at=agg["started_at"],
-                          ended_at=agg["ended_at"], cwd=agg["cwd"])
+                          ended_at=agg["ended_at"], cwd=agg["cwd"],
+                          native_session_id=Path(ref).stem)
             if not agg["per_model"]:
                 rows.append(row(ref=ref, model=None, status="no_usage", **common))
                 continue

--- a/.super-coder/scripts/token_parsers/codex.py
+++ b/.super-coder/scripts/token_parsers/codex.py
@@ -105,7 +105,7 @@ def sweep(repo_root, since_epoch, log, cache=None) -> list[dict]:
                       provider=parsed["meta"].get("model_provider"),
                       model=parsed["model"], title=parsed["title"],
                       started_at=parsed["started_at"], ended_at=parsed["ended_at"],
-                      cwd=cwd)
+                      cwd=cwd, native_session_id=parsed["meta"].get("id"))
         total = (parsed["last_tc"] or {}).get("total_token_usage")
         if not total:
             rows.append(row(status="no_usage", **common))

--- a/.super-coder/scripts/token_parsers/kimi.py
+++ b/.super-coder/scripts/token_parsers/kimi.py
@@ -84,7 +84,8 @@ def sweep(repo_root, since_epoch, log, cache=None) -> list[dict]:
         common = dict(harness=HARNESS, ref=str(sess_dir), parser_version=PARSER_VERSION,
                       provider=provider or "kimi", title=state.get("title"),
                       started_at=norm_iso(state.get("createdAt")),
-                      ended_at=norm_iso(state.get("updatedAt")), cwd=cwd)
+                      ended_at=norm_iso(state.get("updatedAt")), cwd=cwd,
+                      native_session_id=state.get("id"))
         if not per_model:
             rows.append(row(model=None, status="no_usage", **common))
             continue

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -514,6 +514,11 @@ async function renderDefaultModels(root, s) {
 function renderHarness(root, s) {
   const groups = [{ title: "Operational", items: [
     { label: "CURRENT STATE", text: s.current_state || "", editable: true },
+    ...(s.session_control ? [{
+      label: "SESSION CONTROL",
+      text: `${s.session_control.state} · queued=${s.session_control.queued} · errors=${s.session_control.errors}`,
+      node: sessionControlStatus(s.session_control),
+    }] : []),
     ...(s.system_prompt ? [{ label: "SYSTEM PROMPT", text: s.system_prompt }] : []),
   ] }];
 
@@ -550,6 +555,22 @@ function renderHarness(root, s) {
     for (const sec of g.items) panel.append(accordion(sec, s));
   }
   root.append(panel);
+}
+
+function sessionControlStatus(c, { shortname = null } = {}) {
+  const box = el("div", { className: "session-control-status" });
+  const stateClass = c.state === "error" || c.errors ? " warn" : (c.managed ? " ok" : "");
+  box.append(el("div", { className: "session-control-line" },
+    ...(shortname ? [el("b", { className: "mono" }, shortname)] : []),
+    el("span", { className: "pill" + stateClass }, c.state),
+    el("span", { className: "pill" }, c.managed ? "managed" : "manual"),
+    el("span", { className: "pill" + (c.queued ? " warn" : "") }, `queued ${c.queued || 0}`),
+    el("span", { className: "pill" + (c.errors ? " warn" : "") }, `errors ${c.errors || 0}`)));
+  box.append(el("div", { className: "muted" },
+    [c.harness, c.model, c.engine_session_id ? `engine ${c.engine_session_id}` : null,
+     c.last_delivery ? `last ${localTime(c.last_delivery)}` : null]
+      .filter(Boolean).join(" · ")));
+  return box;
 }
 
 function entryList(entries) {
@@ -1900,6 +1921,9 @@ function anSessionCard(c, sprintTitles) {
   head.append(el("span", { className: "pill" + (c.unattributed ? " warn" : "") },
     c.unattributed ? "unattributed" : c.shell || "?"));
   head.append(el("span", { className: "pill" }, c.harness));
+  if (c.control_state) head.append(el("span", {
+    className: "pill" + (c.control_state === "error" ? " warn" : ""),
+  }, c.control_managed ? c.control_state : `${c.control_state} · manual`));
   if (c.models) head.append(el("span", { className: "sess-model" }, c.models));
   const title = c.title || "";
   head.append(el("span", { className: "sess-title" },
@@ -1920,7 +1944,6 @@ function anSessionCard(c, sprintTitles) {
   if (c.sprint_ref) meta.push(["sprint", sprintTitles[c.sprint_ref] || "#" + c.sprint_ref]);
   if (c.status !== "ok") meta.push(["status", c.status]);
   if (meta.length) body.append(statRow(meta));
-  body.append(el("code", { className: "sess-ref" }, c.harness_session_ref));
   row.append(body);
   return row;
 }
@@ -1964,6 +1987,14 @@ async function renderAnalytics(root) {
     anSelect("Harness", "harness", filters.harnesses, reset("harness")),
     anSelect("Model", "model", filters.models, reset("model")),
     rangeSeg));
+
+  if (usage.session_control?.length) {
+    const control = el("div", { className: "card session-control-card" },
+      microlabel("Planner sessions"));
+    for (const c of usage.session_control)
+      control.append(sessionControlStatus(c, { shortname: c.shortname }));
+    root.append(control);
+  }
 
   // stat cards, then the graph in ITS OWN card: no card selected = the
   // combined total is graphed; clicking a card graphs that class, clicking it

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -97,6 +97,12 @@ main { padding: 1.2rem; }
 .pill.ok { color: var(--ok); }
 .pill.retired { color: var(--dim); opacity: .6; text-decoration: line-through; }
 .pill.warn { color: var(--warn); border-color: var(--warn); }
+
+.session-control-card { margin-top: 14px; }
+.session-control-status { display: grid; gap: 6px; padding: 9px 0; }
+.session-control-status + .session-control-status { border-top: 1px solid var(--line); }
+.session-control-line { display: flex; align-items: center; flex-wrap: wrap; gap: 7px; }
+.session-control-line > b { margin-right: 4px; }
 .grid2 { display: grid; grid-template-columns: 180px 1fr; gap: .4rem 1rem; align-items: start; }
 .grid2 > .k { color: var(--dim); }
 label.k { color: var(--dim); display: block; margin: .6rem 0 .2rem; font-size: .85rem; }

--- a/sc
+++ b/sc
@@ -901,9 +901,9 @@ case "$cmd" in
   watch-daemon-down) sc_watch_daemon_down ;;
   watch-daemon-install)   sc_watch_daemon_install ;;
   watch-daemon-uninstall) sc_watch_daemon_uninstall ;;
-  # Provider-neutral planner wake control. `session-control` is the internal,
-  # token-scoped adapter client; the public operator `session` surface lands
-  # with the sprint's status/analytics unit.
+  # Provider-neutral planner wake control. `session-control` stays the internal,
+  # token-scoped adapter client; `session` is the public shortname-based surface.
+  session)            exec "$PY" "$S/session_cli.py" --operator "$@" ;;
   session-control)    exec "$PY" "$S/session_cli.py" "$@" ;;
   session-dispatcher) exec "$PY" "$S/session_dispatcher.py" "$@" ;;
   # ── persist (HOST-side): reboot-proof all applicable daemons via systemd ──
@@ -1171,6 +1171,10 @@ super-coder — forkable shell substrate
                              inbox watcher; arm as a background task and its exit is your wake-up
   ./sc session-control …  internal token-scoped binding client for provider adapters
                              (status/manage/release/retry/bind/channel)
+  ./sc session status [shortname]
+  ./sc session manage <shortname> --sprint <ref>
+  ./sc session release <shortname> [--after-turn] · retry <shortname>
+                             inspect and manage provider-neutral planner wake
   ./sc session-dispatcher  run the provider-neutral wake dispatcher in the foreground
                              (`./sc serve` supervises it automatically)
   ./sc job start -- <cmd>  run a long local command (suite/bench/build) detached + supervised — it

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -100,6 +100,7 @@ class ClaudeParserTest(unittest.TestCase):
         self.assertEqual(rows[0]["cache_write_tokens"], 5)
         self.assertEqual(rows[0]["title"], "fix the bug")
         self.assertEqual(rows[0]["provider"], "anthropic")
+        self.assertEqual(rows[0]["native_session_id"], "a")
 
     def test_cross_file_dedupe(self):
         # fork copies m1's line into b.jsonl; only b's fresh m2 may count there
@@ -226,7 +227,8 @@ class CodexParserTest(unittest.TestCase):
         f = day / "rollout-x.jsonl"
         lines = [
             json.dumps({"type": "session_meta", "timestamp": "2026-07-19T10:00:00Z",
-                        "payload": {"cwd": str(repo), "model_provider": "openai"}}),
+                        "payload": {"id": "thread-x", "cwd": str(repo),
+                                    "model_provider": "openai"}}),
             json.dumps({"type": "turn_context", "payload": {"model": "gpt-5.5"}}),
             # cumulative totals — the LAST event wins, never the sum
             json.dumps({"type": "event_msg", "payload": {"type": "token_count", "info": {
@@ -251,6 +253,7 @@ class CodexParserTest(unittest.TestCase):
         self.assertEqual(r["output_tokens"], 80)       # includes reasoning
         self.assertEqual(r["reasoning_tokens"], 20)    # informational
         self.assertEqual(r["model"], "gpt-5.5")
+        self.assertEqual(r["native_session_id"], "thread-x")
 
     def test_off_repo_bails_on_meta_line(self):
         # off-repo rollouts never earn a watermark row, so without the bail
@@ -287,7 +290,7 @@ class KimiParserTest(unittest.TestCase):
             (sess / "agents" / agent).mkdir(parents=True)
         (sess / "state.json").write_text(json.dumps({
             "createdAt": "2026-07-19T10:00:00Z", "updatedAt": "2026-07-19T10:30:00Z",
-            "title": "swarm run", "workDir": str(repo)}))
+            "id": "session-1", "title": "swarm run", "workDir": str(repo)}))
         rec = {"type": "usage.record", "model": "kimi-code/k3",
                "usage": {"inputOther": 10, "output": 5, "inputCacheRead": 7,
                          "inputCacheCreation": 0}}
@@ -308,6 +311,7 @@ class KimiParserTest(unittest.TestCase):
         self.assertEqual(r["cache_write_tokens"], 0)   # measured zero, not NULL
         self.assertEqual(r["provider"], "kimi")
         self.assertEqual(r["title"], "swarm run")
+        self.assertEqual(r["native_session_id"], "session-1")
 
 
 class OpencodeParserTest(unittest.TestCase):
@@ -454,6 +458,48 @@ class CollectorTest(unittest.TestCase):
         self.assertEqual(con.execute("SELECT ended_at FROM shell_memory_archives "
                                      "WHERE archive_id=10").fetchone()[0],
                          "2026-07-19T10:30:00Z")
+
+    def test_native_binding_attribution_precedes_fallback_without_duplicate_rows(self):
+        con = self.con()
+        con.execute(
+            "INSERT INTO shell_memory_archives "
+            "(archive_id, shell_id, session_id, date, started_at, harness) "
+            "VALUES (30, 2, '0009', '2026-07-19', '2026-07-19T11:00:00Z', 'codex')"
+        )
+        con.execute(
+            "INSERT INTO shell_session_bindings "
+            "(binding_id, archive_id, shell_id, harness, native_session_id, "
+            "state, managed) VALUES (40, 30, 2, 'codex', 'thread-exact', "
+            "'dormant', 1)"
+        )
+        base = {
+            "harness": "codex", "harness_session_ref": "/rollout.jsonl",
+            "native_session_id": "thread-exact", "provider": "openai",
+            "title": None, "started_at": "2020-01-01T00:00:00Z",
+            "ended_at": None, "input_tokens": 2, "output_tokens": 3,
+            "cache_read_tokens": None, "cache_write_tokens": None,
+            "reasoning_tokens": None, "status": "ok", "parser_version": "1",
+            "cwd": "/outside/the/repo",
+        }
+        batch = [{**base, "model": "m1"}, {**base, "model": "m2"}]
+        for row in batch:
+            analytics._upsert(con, row, "2026-07-19T13:00:00Z")
+        con.commit()
+
+        attributed, shell_only = analytics._attribute(con, batch, lambda _m: None)
+        con.commit()
+
+        self.assertEqual((2, 0), (attributed, shell_only))
+        got = [tuple(row) for row in con.execute(
+            "SELECT model, archive_id, shell_id, input_tokens, output_tokens "
+            "FROM session_token_usage ORDER BY model"
+        )]
+        self.assertEqual([
+            ("m1", 30, 2, 2, 3), ("m2", 30, 2, 2, 3),
+        ], got)
+        self.assertEqual(2, con.execute(
+            "SELECT COUNT(*) FROM session_token_usage"
+        ).fetchone()[0])
 
     def test_shell_only_attribution(self):
         """Rows predating lifecycle archives still get shell_id from cwd alone;

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Public ``sc session`` command contract."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SPEC = importlib.util.spec_from_file_location(
+    "session_cli_public", ENGINE / "scripts" / "session_cli.py"
+)
+session_cli = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = session_cli
+SPEC.loader.exec_module(session_cli)
+
+
+def payload(state: str = "idle") -> dict:
+    return {
+        "binding": {
+            "binding_id": 7, "harness": "codex", "native_session_id": "thread-7",
+            "state": state, "managed": 1, "last_error": None,
+        },
+        "archive": {"session_id": "0007", "model": "gpt-test"},
+        "jobs": {},
+        "summary": {"queued": 0, "errors": 0, "owner": "none"},
+    }
+
+
+class PublicSessionCliTest(unittest.TestCase):
+    def test_manage_requires_sprint_and_targets_shortname(self):
+        parser = session_cli.build_operator_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["manage", "PLN1"])
+        args = parser.parse_args(["manage", "PLN1", "--sprint", "21"])
+        with mock.patch.object(
+            session_cli, "operator_api", return_value=payload()
+        ) as request, mock.patch.object(session_cli, "print_status"):
+            self.assertEqual(0, args.fn(args))
+        request.assert_called_once_with(
+            "POST", "manage", "PLN1", {"sprint_ref": "21"}
+        )
+
+    def test_release_refuses_dispatch_without_after_turn(self):
+        args = session_cli.build_operator_parser().parse_args(["release", "PLN1"])
+        with mock.patch.object(
+            session_cli, "operator_api", return_value=payload("dispatching")
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                args.fn(args)
+        self.assertIn("pass --after-turn", str(caught.exception))
+
+    def test_release_after_turn_waits_then_releases(self):
+        args = session_cli.build_operator_parser().parse_args(
+            ["release", "PLN1", "--after-turn"]
+        )
+        with mock.patch.object(
+            session_cli, "operator_api",
+            side_effect=[payload("dispatching"), payload("idle"), payload("released")],
+        ) as request, mock.patch.object(session_cli.time, "sleep") as sleep, \
+                mock.patch.object(session_cli, "print_status"):
+            self.assertEqual(0, args.fn(args))
+        sleep.assert_called_once_with(1)
+        self.assertEqual([
+            mock.call("GET", "status", "PLN1"),
+            mock.call("GET", "status", "PLN1"),
+            mock.call("POST", "release", "PLN1", {}),
+        ], request.call_args_list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -69,6 +69,29 @@ class PublicSessionCliTest(unittest.TestCase):
             mock.call("POST", "release", "PLN1", {}),
         ], request.call_args_list)
 
+    def test_release_without_binding_reaches_server_for_both_wait_modes(self):
+        released = {"binding": None, "released": False}
+        for flags in ([], ["--after-turn"]):
+            with self.subTest(flags=flags):
+                args = session_cli.build_operator_parser().parse_args(
+                    ["release", "DEV3", *flags]
+                )
+                with mock.patch.object(
+                    session_cli, "operator_api",
+                    side_effect=[{"binding": None}, released],
+                ) as request, mock.patch.object(
+                    session_cli.time, "sleep"
+                ) as sleep, mock.patch.object(
+                    session_cli, "print_status"
+                ) as print_status:
+                    self.assertEqual(0, args.fn(args))
+                self.assertEqual([
+                    mock.call("GET", "status", "DEV3"),
+                    mock.call("POST", "release", "DEV3", {}),
+                ], request.call_args_list)
+                print_status.assert_called_once_with(released)
+                sleep.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session_control_api.py
+++ b/tests/test_session_control_api.py
@@ -104,6 +104,90 @@ class ControlMutationTest(unittest.TestCase):
             "SELECT COUNT(*) FROM session_wake_jobs"
         ).fetchone()[0])
 
+    def test_status_contract_includes_archive_owner_delivery_and_counts(self):
+        message_id = add_message(self.con)
+        self.con.execute(
+            "UPDATE shell_memory_archives SET model='model-x', sprint_ref='21' "
+            "WHERE archive_id=10"
+        )
+        self.con.execute(
+            "INSERT INTO session_wake_jobs "
+            "(binding_id, trigger_message_id, state, finished_at) "
+            "VALUES (20, ?, 'done', '2026-07-22 05:00:00')", (message_id,)
+        )
+        self.con.execute(
+            "UPDATE shell_session_bindings SET lease_pid=88 WHERE binding_id=20"
+        )
+        self.con.commit()
+
+        payload = server.get_session_control(self.con, 1, 20)
+
+        self.assertEqual(("0001", "model-x", "21"), (
+            payload["archive"]["session_id"], payload["archive"]["model"],
+            payload["archive"]["sprint_ref"],
+        ))
+        self.assertEqual(("lease", 88, 0, 0, "2026-07-22 05:00:00"), (
+            payload["summary"]["owner"], payload["summary"]["owner_pid"],
+            payload["summary"]["queued"], payload["summary"]["errors"],
+            payload["summary"]["last_delivery"],
+        ))
+
+    def test_gui_overviews_are_compact_and_credential_free(self):
+        self.con.execute(
+            "UPDATE shell_session_bindings SET control_endpoint='unix:///secret.sock', "
+            "control_capabilities=? WHERE binding_id=20",
+            (json.dumps({
+                "deliver": True,
+                "token_file": "/runtime/fake-20.token",
+            }),),
+        )
+        self.con.commit()
+
+        shell_status = server.get_shell(self.con, 1)["session_control"]
+        analytics_status = server.get_analytics_usage(
+            self.con, {}
+        )["session_control"][0]
+
+        expected = {
+            "binding_id", "engine_session_id", "harness", "model", "state",
+            "managed", "queued", "errors", "last_delivery",
+        }
+        self.assertEqual(expected, set(shell_status))
+        self.assertEqual(expected | {"shortname"}, set(analytics_status))
+        self.assertNotIn("token", json.dumps([shell_status, analytics_status]))
+        self.assertNotIn("endpoint", json.dumps([shell_status, analytics_status]))
+
+    def test_manage_records_valid_sprint_and_rejects_unknown_one(self):
+        self.con.execute(
+            "INSERT INTO roadmap (feature_id, title, roadmap_status) "
+            "VALUES (1, 'f', 'in_progress')"
+        )
+        self.con.execute(
+            "INSERT INTO documents (document_id, title, kind, body, feature_id) "
+            "VALUES (21, 'SPRINT: x', 'doc', 'status: ACTIVE', 1)"
+        )
+        self.con.commit()
+
+        payload, error = server.manage_session_control(
+            self.con, 1, 20, sprint_ref="21"
+        )
+        self.assertIsNone(error)
+        self.assertEqual("21", payload["archive"]["sprint_ref"])
+        again, again_error = server.manage_session_control(
+            self.con, 1, 20, sprint_ref="21"
+        )
+        self.assertIsNone(again_error)
+        self.assertEqual(20, again["binding"]["binding_id"])
+
+        denied, denied_error = server.manage_session_control(
+            self.con, 1, 20, sprint_ref="999"
+        )
+        self.assertIsNone(denied)
+        self.assertEqual("unknown sprint document '999'", denied_error)
+        self.assertEqual("21", self.con.execute(
+            "SELECT sprint_ref FROM shell_memory_archives WHERE archive_id=10"
+        ).fetchone()[0])
+
     def test_manage_rejects_approval_prompting_posture_without_mutation(self):
         message_id = add_message(self.con)
         self.con.execute(
@@ -199,6 +283,46 @@ class ControlMutationTest(unittest.TestCase):
         self.assertIsNone(self.con.execute(
             "SELECT read_at FROM shell_messages WHERE message_id=?", (message_id,)
         ).fetchone()[0])
+
+    def test_release_removes_provider_declared_runtime_credentials(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = Path(tmp)
+            token = runtime / "fake-20.token"
+            token.write_text("secret")
+            self.con.execute(
+                "UPDATE shell_session_bindings SET control_capabilities=? "
+                "WHERE binding_id=20",
+                (json.dumps({"deliver": True, "token_file": str(token)}),),
+            )
+            self.con.commit()
+            with mock.patch.object(server, "SESSION_CREDENTIAL_DIR", runtime):
+                payload, error = server.release_session_control(self.con, 1, 20)
+            self.assertIsNone(error)
+            self.assertEqual("released", payload["binding"]["state"])
+            self.assertFalse(token.exists())
+
+    def test_release_rejects_credential_path_outside_binding_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = Path(tmp) / "runtime"
+            runtime.mkdir()
+            outside = Path(tmp) / "do-not-delete.token"
+            outside.write_text("secret")
+            self.con.execute(
+                "UPDATE shell_session_bindings SET control_capabilities=? "
+                "WHERE binding_id=20",
+                (json.dumps({"deliver": True, "token_file": str(outside)}),),
+            )
+            self.con.commit()
+            with mock.patch.object(server, "SESSION_CREDENTIAL_DIR", runtime):
+                payload, error = server.release_session_control(self.con, 1, 20)
+            self.assertIsNone(payload)
+            self.assertEqual(
+                "provider credential path is outside the binding runtime scope", error
+            )
+            self.assertTrue(outside.exists())
+            self.assertEqual("dormant", self.con.execute(
+                "SELECT state FROM shell_session_bindings WHERE binding_id=20"
+            ).fetchone()[0])
 
     def test_release_refuses_running_dispatch_without_mutation(self):
         self.con.execute(
@@ -426,6 +550,38 @@ class TokenScopeHttpTest(unittest.TestCase):
                 "ORDER BY binding_id"
             ).fetchall()
         self.assertEqual([(20, 1), (21, 0)], rows)
+
+    def test_public_operator_routes_target_shortname_and_require_valid_sprint(self):
+        status, payload = self.request(
+            "GET", "/api/session-control/status/PLN2"
+        )
+        self.assertEqual((200, 21, "0001", "native-2"), (
+            status, payload["binding"]["binding_id"],
+            payload["archive"]["session_id"],
+            payload["binding"]["native_session_id"],
+        ))
+
+        status, payload = self.request(
+            "POST", "/api/session-control/manage/PLN2",
+            body={"sprint_ref": "404"},
+        )
+        self.assertEqual((409, "unknown sprint document '404'"),
+                         (status, payload["error"]))
+
+        with sqlite3.connect(self.db_path) as con:
+            con.execute(
+                "INSERT INTO documents (document_id, title, kind, body) "
+                "VALUES (21, 'SPRINT: x', 'doc', 'status: ACTIVE')"
+            )
+            con.commit()
+        status, payload = self.request(
+            "POST", "/api/session-control/manage/PLN2",
+            body={"sprint_ref": "21"},
+        )
+        self.assertEqual((200, 21, 1, "21"), (
+            status, payload["binding"]["binding_id"],
+            payload["binding"]["managed"], payload["archive"]["sprint_ref"],
+        ))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add public `sc session status/manage/release/retry` commands with shortname targeting, capability validation, and dispatch-safe `--after-turn` release
- delete provider-declared runtime credentials through one validated generic release path
- show compact managed state plus queued/error counts in Shells and Analytics without raw control/transcript paths
- attribute usage by native session binding before cwd/time fallback without changing the idempotent usage key

## Verification
- `python3 -m unittest -v` across session state/API/dispatcher/supervisor, Claude, Codex, Kimi, CLI, and analytics: 140 passed
- focused latest contracts: 40 passed
- full suite: 639 passed (`env -u SC_SANDBOX ./sc test`; VM bake is host-only)
- ruff, Python compile, JS syntax, shell syntax, and `git diff --check`: clean

## Trade-off
`--after-turn` waits in the operator process and retries the atomic release once the binding is idle. This avoids adding a second persisted release-pending state to the already-landed session schema while preserving the required no-release-during-dispatch rule.