### PR TITLE
fix(session): attach managed enter bindings

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -13,7 +13,7 @@ Flow:
     5. exec the harness  (skipped when RENDER_ONLY=1 — used to verify headless)
 
 Usage:
-    python3 .super-coder/scripts/run.py [shortname] [--first]
+    python3 .super-coder/scripts/run.py [shortname] [--first] [--new-session]
     RENDER_ONLY=1 python3 .super-coder/scripts/run.py --first   # render, don't exec
 
 Headless (`./sc run <shortname> [-p "<prompt>"] [--harness <h>] [-m <model>]
@@ -702,11 +702,13 @@ def session_provider(harness: str, model: "str | None") -> "str | None":
 
 def open_session(con, shell_id: int,
                  lifecycle: "dict | None" = None,
-                 reuse_archive_id: "int | None" = None) -> tuple[str, int]:
+                 reuse_archive_id: "int | None" = None,
+                 force_new: bool = False) -> tuple[str, int]:
     """`lifecycle` carries the launch telemetry persisted onto the archive row
     (started_at/harness/provider/model/sprint_ref — migration 0071). ended_at is
     NOT written here: run.py execs the harness, so no code runs at exit; the
-    analytics sweep backfills it from harness session data."""
+    analytics sweep backfills it from harness session data. ``force_new`` skips
+    unused-stub reuse for an explicit operator-requested session boundary."""
     if reuse_archive_id is not None:
         row = con.execute(
             "SELECT archive_id, session_id FROM shell_memory_archives "
@@ -726,9 +728,9 @@ def open_session(con, shell_id: int,
     # opened session 0001, or a prior launch did no work) — avoids phantom empty
     # sessions and the incidental first-snapshot diff. The reused stub becomes
     # THIS launch's session, so its lifecycle is overwritten with this launch's.
-    active = con.execute(
+    active = (None if force_new else con.execute(
         "SELECT active_archive_id FROM shells WHERE shell_id=?", (shell_id,)
-    ).fetchone()[0]
+    ).fetchone()[0])
     if active:
         row = con.execute(
             "SELECT archive_id, session_id, full_narrative FROM shell_memory_archives "
@@ -804,6 +806,7 @@ def main() -> None:
     args = sys.argv[1:]
     first = "--first" in args
     headless = "--headless" in args
+    new_session = "--new-session" in args
     # --harness <name> / --harness=<name> forces the harness and skips the
     # picker; its value must not be mistaken for the shell shortname positional.
     # Headless adds -p/--prompt and -m/--model (value-taking, same rule).
@@ -920,6 +923,21 @@ def main() -> None:
             print(f"→ liveness: {snap['indeterminate']} unreadable harness process(es) — "
                   f"proceeding, but liveness was indeterminate")
 
+    if new_session and flag_binding:
+        sys.exit("session launch refused: --new-session cannot be combined with "
+                 "--session-binding")
+    try:
+        enter_binding = (None if flag_binding else
+                         session_supervisor.binding_for_enter(
+                             con, chosen["shell_id"], new_session=new_session))
+    except ValueError as e:
+        sys.exit(f"session launch refused: {e}")
+    # Headless workers keep their existing ephemeral behavior unless the
+    # dispatcher names a binding explicitly.  Automatic attachment is the
+    # interactive `sc enter` contract only.
+    if headless:
+        enter_binding = None
+
     # This shell's flavor default (advisory): the harness it boots with. The
     # model is resolved AFTER the harness pick — a flavor names a model PER
     # harness, so the model tracks whichever harness the operator lands on. Both
@@ -936,6 +954,7 @@ def main() -> None:
     ensure_harness_path()
     default_harness = flavor_harness or _configured_harness() or "claude"
     harness = (flag_harness or os.environ.get("HARNESS")
+               or (enter_binding or {}).get("harness")
                or pick_harness(detect_harnesses(), default_harness, first or headless)
                or default_harness)
 
@@ -953,11 +972,17 @@ def main() -> None:
         except ValueError as e:
             sys.exit(f"sc run: {e}")
 
-    resume_binding = None
+    resume_binding = enter_binding
     if flag_binding:
         try:
+            resume_binding = {"binding_id": int(flag_binding)}
+        except (TypeError, ValueError) as e:
+            sys.exit(f"session resume refused: {e}")
+    if resume_binding:
+        try:
             resume_binding = session_supervisor.binding_for_resume(
-                con, int(flag_binding), shell_id=chosen["shell_id"], harness=harness)
+                con, resume_binding["binding_id"], shell_id=chosen["shell_id"],
+                harness=harness)
         except (TypeError, ValueError) as e:
             sys.exit(f"session resume refused: {e}")
         pinned_model = resume_binding.get("archive_model")
@@ -1003,7 +1028,8 @@ def main() -> None:
                     "provider": session_provider(harness, session_model),
                     "model": session_model,
                     "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
-                }, reuse_archive_id=(resume_binding or {}).get("archive_id"))
+                }, reuse_archive_id=(resume_binding or {}).get("archive_id"),
+                force_new=new_session)
         except ValueError as e:
             sys.exit(f"session resume refused: {e}")
 

--- a/.super-coder/scripts/session_supervisor.py
+++ b/.super-coder/scripts/session_supervisor.py
@@ -213,13 +213,20 @@ def binding_for_enter(con, shell_id: int, *, new_session: bool = False) -> dict 
     """
     row = con.execute(
         "SELECT b.*, a.session_id, a.model AS archive_model, "
-        "a.provider AS archive_provider FROM shell_session_bindings b "
+        "a.provider AS archive_provider, s.shortname FROM shell_session_bindings b "
         "JOIN shell_memory_archives a ON a.archive_id=b.archive_id "
+        "JOIN shells s ON s.shell_id=b.shell_id "
         "WHERE b.shell_id=? AND b.managed=1",
         (shell_id,),
     ).fetchone()
     if not row:
         return None
+    if row["state"] == "error":
+        raise ValueError(
+            f"managed binding {row['binding_id']} is in error; run "
+            f"./sc session retry {row['shortname']} to recover it, or "
+            f"./sc session release {row['shortname']} before starting a new session"
+        )
     if new_session:
         raise ValueError(
             f"--new-session requires releasing managed binding {row['binding_id']} first"

--- a/.super-coder/scripts/session_supervisor.py
+++ b/.super-coder/scripts/session_supervisor.py
@@ -204,6 +204,29 @@ def binding_for_resume(con, binding_id: int, *, shell_id: int,
     return dict(row)
 
 
+def binding_for_enter(con, shell_id: int, *, new_session: bool = False) -> dict | None:
+    """Return the shell's managed binding for an interactive enter.
+
+    A managed binding owns the planner's conversation until the operator
+    releases it.  Bare ``sc enter`` therefore reuses it, while an explicit new
+    session must fail before a second archive can be opened.
+    """
+    row = con.execute(
+        "SELECT b.*, a.session_id, a.model AS archive_model, "
+        "a.provider AS archive_provider FROM shell_session_bindings b "
+        "JOIN shell_memory_archives a ON a.archive_id=b.archive_id "
+        "WHERE b.shell_id=? AND b.managed=1",
+        (shell_id,),
+    ).fetchone()
+    if not row:
+        return None
+    if new_session:
+        raise ValueError(
+            f"--new-session requires releasing managed binding {row['binding_id']} first"
+        )
+    return dict(row)
+
+
 def register_native_session(con, binding_id: int, native_session_id: str, *,
                             control_endpoint: str | None = None,
                             capabilities: str = "{}",

--- a/sc
+++ b/sc
@@ -1203,8 +1203,8 @@ super-coder — forkable shell substrate
   Sandbox (docker — the default way to run; allow-everything is safe because the
   container only sees this repo + your harness creds):
   ./sc launch              build + start the sandbox container (server + GUI), 127.0.0.1 only
-  ./sc enter               attach an interactive session: auth + pick shell + pick harness + boot
-  ./sc enter-<shortname>   attach + boot that shell directly (skip the shell picker)
+  ./sc enter [--new-session]  attach an interactive session; managed bindings resume by default
+  ./sc enter-<shortname> [--new-session]  attach that shell directly; new session requires release
                              harness: --harness <name> or HARNESS=<name> forces it; else when
                              >1 harness is on PATH you're prompted (per-launch, not persisted)
   ./sc run <shortname>     headless boot: render + exec the harness NON-interactively (claude · codex ·

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -12,6 +12,7 @@ import threading
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
@@ -34,10 +35,15 @@ CREATE TABLE shell_memory_archives (
   archive_id INTEGER PRIMARY KEY,
   shell_id INTEGER NOT NULL,
   session_id TEXT NOT NULL,
+  date TEXT,
+  full_narrative TEXT,
+  started_at TEXT,
   harness TEXT,
   provider TEXT,
-  model TEXT
+  model TEXT,
+  sprint_ref TEXT
 );
+CREATE TABLE session_token_usage (archive_id INTEGER);
 CREATE TABLE shell_session_bindings (
   binding_id INTEGER PRIMARY KEY,
   archive_id INTEGER NOT NULL UNIQUE,
@@ -71,8 +77,12 @@ def make_db(path: str = ":memory:") -> sqlite3.Connection:
     con.executescript(BINDING_SCHEMA)
     con.execute("INSERT INTO shells VALUES (1, 'DEV1', 'planner', NULL)")
     con.execute(
-        "INSERT INTO shell_memory_archives VALUES "
-        "(10, 1, '0007', 'claude', 'anthropic', 'opus')"
+        "INSERT INTO shell_memory_archives "
+        "(archive_id, shell_id, session_id, date, full_narrative, harness, "
+        "provider, model) VALUES "
+        "(10, 1, '0007', '2026-07-21', "
+        "'# 0007\\n[00:00] Session start.\\n[00:01] Work happened.', "
+        "'claude', 'anthropic', 'opus')"
     )
     con.commit()
     return con
@@ -403,6 +413,71 @@ class MigratedStateMachineIntegrationTest(unittest.TestCase):
 
 
 class ArchiveReuseTest(unittest.TestCase):
+    def _managed_binding(self, con):
+        binding = supervisor.ensure_binding(
+            con, archive_id=10, shell_id=1, harness="claude",
+            native_session_id="native-7")
+        con.execute(
+            "UPDATE shell_session_bindings SET state='dormant', managed=1 "
+            "WHERE binding_id=?", (binding["binding_id"],))
+        con.commit()
+        return binding
+
+    def test_bare_enter_selects_dormant_managed_binding_and_exact_archive(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = self._managed_binding(con)
+
+        selected = supervisor.binding_for_enter(con, 1)
+        self.assertEqual(
+            (binding["binding_id"], 10, "0007", "claude", "native-7", "dormant", 1),
+            (selected["binding_id"], selected["archive_id"], selected["session_id"],
+             selected["harness"], selected["native_session_id"], selected["state"],
+             selected["managed"]),
+        )
+        session_id, archive_id = run.open_session(
+            con, 1, reuse_archive_id=selected["archive_id"])
+        self.assertEqual(("0007", 10), (session_id, archive_id))
+        self.assertEqual(1, con.execute(
+            "SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0])
+
+    def test_new_session_is_refused_while_managed_binding_exists(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = self._managed_binding(con)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                rf"--new-session requires releasing managed binding {binding['binding_id']} first"):
+            supervisor.binding_for_enter(con, 1, new_session=True)
+        self.assertEqual(1, con.execute(
+            "SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0])
+        self.assertIsNone(con.execute(
+            "SELECT active_archive_id FROM shells WHERE shell_id=1").fetchone()[0])
+
+    def test_new_session_opens_new_archive_after_binding_release(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = self._managed_binding(con)
+        con.execute(
+            "UPDATE shell_session_bindings SET state='released', managed=0 "
+            "WHERE binding_id=?", (binding["binding_id"],))
+        con.execute("UPDATE shells SET active_archive_id=10 WHERE shell_id=1")
+        con.execute(
+            "UPDATE shell_memory_archives SET full_narrative="
+            "'# 0007\\n[00:00] Session start.' WHERE archive_id=10")
+        con.commit()
+
+        self.assertIsNone(supervisor.binding_for_enter(con, 1, new_session=True))
+        session_id, archive_id = run.open_session(
+            con, 1, lifecycle={"harness": "claude", "provider": "anthropic",
+                               "model": "opus"}, force_new=True)
+        self.assertEqual(("0008", 11), (session_id, archive_id))
+        rows = con.execute(
+            "SELECT archive_id, session_id FROM shell_memory_archives ORDER BY archive_id"
+        ).fetchall()
+        self.assertEqual([(10, "0007"), (11, "0008")], [tuple(row) for row in rows])
+
     def test_resume_reuses_exact_archive_without_creating_or_rewriting_it(self):
         con = make_db()
         self.addCleanup(con.close)
@@ -426,6 +501,94 @@ class ArchiveReuseTest(unittest.TestCase):
             run.open_session(con, 2, reuse_archive_id=10)
         self.assertIsNone(con.execute(
             "SELECT active_archive_id FROM shells WHERE shell_id=2").fetchone()[0])
+
+
+class EnterMainFlowTest(unittest.TestCase):
+    class OpenReached(Exception):
+        def __init__(self, call_args, call_kwargs):
+            super().__init__("open_session reached")
+            self.call_args = call_args
+            self.call_kwargs = call_kwargs
+
+    def _managed_binding(self, con):
+        binding = supervisor.ensure_binding(
+            con, archive_id=10, shell_id=1, harness="claude",
+            native_session_id="native-7")
+        con.execute(
+            "UPDATE shell_session_bindings SET state='dormant', managed=1 "
+            "WHERE binding_id=?", (binding["binding_id"],))
+        con.commit()
+        return binding
+
+    def _run_until_open(self, con, argv):
+        chosen = {"shell_id": 1, "shortname": "DEV1", "flavor": "planner"}
+        defaults = {
+            "planner": {"default_harness": "codex", "models": {
+                "claude": "default-claude", "codex": "default-codex",
+            }}
+        }
+        def capture(*args, **kwargs):
+            raise self.OpenReached(args, kwargs)
+
+        with mock.patch.dict(run.os.environ, {"RENDER_ONLY": "1"}, clear=True), \
+                mock.patch.object(run.sys, "argv", ["run.py", *argv]), \
+                mock.patch.object(run.sys, "stdin", mock.Mock(isatty=lambda: False)), \
+                mock.patch.object(run, "open_db", return_value=con), \
+                mock.patch.object(run, "authenticate", return_value={"user_id": 1}), \
+                mock.patch.object(run, "flavor_defaults", return_value=defaults), \
+                mock.patch.object(run, "list_shells", return_value=[chosen]), \
+                mock.patch.object(run, "ensure_harness_path"), \
+                mock.patch.object(run, "load_adapter", return_value={
+                    "launch": ["claude"], "emit": [], "env": {},
+                    "session_control": {"capabilities": {}},
+                }), \
+                mock.patch.object(run, "open_session", side_effect=capture):
+            run.main()
+
+    def test_bare_enter_routes_main_through_managed_binding_archive(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        self._managed_binding(con)
+
+        with self.assertRaises(self.OpenReached) as reached:
+            self._run_until_open(con, ["DEV1"])
+        self.assertEqual((con, 1), reached.exception.call_args[:2])
+        self.assertEqual(10, reached.exception.call_kwargs["reuse_archive_id"])
+        self.assertFalse(reached.exception.call_kwargs["force_new"])
+        self.assertEqual(
+            {"harness": "claude", "provider": "anthropic", "model": "opus",
+             "sprint_ref": None},
+            reached.exception.call_kwargs["lifecycle"],
+        )
+
+    def test_new_session_flag_is_refused_by_main_before_archive_open(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = self._managed_binding(con)
+
+        with self.assertRaisesRegex(
+                SystemExit,
+                rf"session launch refused: --new-session requires releasing managed binding "
+                rf"{binding['binding_id']} first"):
+            self._run_until_open(con, ["DEV1", "--new-session"])
+        self.assertEqual(1, con.execute(
+            "SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0])
+
+    def test_released_new_session_reaches_open_with_force_new(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = self._managed_binding(con)
+        con.execute(
+            "UPDATE shell_session_bindings SET state='released', managed=0 "
+            "WHERE binding_id=?", (binding["binding_id"],))
+        con.commit()
+
+        with self.assertRaises(self.OpenReached) as reached:
+            self._run_until_open(
+                con, ["DEV1", "--harness", "claude", "--new-session"])
+        self.assertEqual((con, 1), reached.exception.call_args[:2])
+        self.assertIsNone(reached.exception.call_kwargs["reuse_archive_id"])
+        self.assertTrue(reached.exception.call_kwargs["force_new"])
 
 
 class SuperviseTest(unittest.TestCase):

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -574,6 +574,34 @@ class EnterMainFlowTest(unittest.TestCase):
         self.assertEqual(1, con.execute(
             "SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0])
 
+    def test_error_binding_refuses_before_archive_open_with_remedies(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = self._managed_binding(con)
+        con.execute(
+            "UPDATE shell_session_bindings SET state='error', "
+            "last_error='transport failed' WHERE binding_id=?",
+            (binding["binding_id"],),
+        )
+        con.commit()
+
+        with self.assertRaisesRegex(
+                SystemExit,
+                rf"session launch refused: managed binding {binding['binding_id']} is in "
+                rf"error; run \./sc session retry DEV1 to recover it, or "
+                rf"\./sc session release DEV1 before starting a new session"):
+            self._run_until_open(con, ["DEV1"])
+        self.assertEqual(1, con.execute(
+            "SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0])
+        self.assertIsNone(con.execute(
+            "SELECT active_archive_id FROM shells WHERE shell_id=1").fetchone()[0])
+        row = con.execute(
+            "SELECT state, managed, lease_pid, last_error "
+            "FROM shell_session_bindings WHERE binding_id=?",
+            (binding["binding_id"],),
+        ).fetchone()
+        self.assertEqual(("error", 1, None, "transport failed"), tuple(row))
+
     def test_released_new_session_reaches_open_with_force_new(self):
         con = make_db()
         self.addCleanup(con.close)

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -274,6 +274,8 @@ class BootPhaseLabelTest(unittest.TestCase):
                 run.style, "spinner", side_effect=recording_spinner))
             stack.enter_context(mock.patch.object(
                 run, "open_session", return_value=("0001", 1)))
+            stack.enter_context(mock.patch.object(
+                run.session_supervisor, "binding_for_enter", return_value=None))
             stack.enter_context(mock.patch.object(run.ports_mod, "resolve", return_value={}))
             stack.enter_context(mock.patch.object(run, "ensure_worktree"))
             stack.enter_context(mock.patch.object(run, "sync_worktree", sync))


### PR DESCRIPTION
## Summary
- make bare `./sc enter <planner>` select the shell's managed binding before harness resolution and reuse its exact archive
- refuse `--new-session` while a managed binding exists; after release, force a genuinely new archive instead of reusing an empty stub
- document the flag in CLI help and add hermetic main-flow/archive tests

## Tests
- `python3 -m unittest tests.test_session_supervisor tests.test_style_spinner` (36 passed after rebase)
- `SC_SANDBOX= ./sc test` (647 passed)
- `./sc lint .super-coder/scripts/run.py .super-coder/scripts/session_supervisor.py tests/test_session_supervisor.py tests/test_style_spinner.py`
- `bash -n sc`

## Verification note
The first raw sandbox full run exposed two test fixtures that needed the new binding lookup mocked (fixed) and three unrelated `vm-bake` tests inheriting `SC_SANDBOX`; those host-only tests pass with the sandbox gate cleared, as does the full suite.

Sprint 21 unit 10 · closes conformance doc #22 F1.