### PR TITLE
Fix repository map scope

### DIFF
--- a/.sc-state/map.config.json
+++ b/.sc-state/map.config.json
@@ -1,0 +1,14 @@
+{
+  "skip_dirs": [
+    ".codex",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".sc-worktrees",
+    "db_backups",
+    "logs",
+    "run"
+  ],
+  "skip_files": [
+    "shell_db.db"
+  ]
+}


### PR DESCRIPTION
## Summary
- Exclude sibling worktrees, local harness/cache directories, runtime logs, and the engine DB cache from the repository map.
- Preserve only canonical source files for future hook and hourly remaps.

## Verification
- Validated map configuration as JSON.
- Live catalogue curated to 270 canonical files with zero worktree paths, zero undescribed leaves, and zero unsectioned leaves.
- Verified core.hooksPath plus the post-checkout, post-merge, and post-rewrite hooks.