### PR TITLE
Rebrand review UI header to subfloor

### DIFF
--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>super-coder — review</title>
+  <title>subfloor — review</title>
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <header>
-    <h1>super-coder<span id="repo"></span></h1>
+    <h1>subfloor<span id="repo"></span></h1>
     <nav>
       <button data-tab="shells" class="active">Shells</button>
       <button data-tab="skills">Skills</button>


### PR DESCRIPTION
## Summary
- change the top-left review UI brand from `super-coder` to `subfloor`
- update the browser title to match

## Verification
- `git diff --check`
- `./sc test`: 645 passed; 3 unrelated sandbox-only `test_vm_bake.py` failures tracked in #478

## Trade-off
This stays a direct literal update because the no-build UI has one fixed product brand; adding runtime configuration would add machinery without another caller.