### PR TITLE
fix(cli): ignore closed sprint reservations

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -535,13 +535,28 @@ def authenticate(con, interactive: bool = True):
 # ── Shell selection ─────────────────────────────────────────────────────────
 
 def list_shells(con, user_id: int) -> list:
-    return con.execute(
+    shells = [dict(row) for row in con.execute(
         "SELECT shell_id, display_name, shortname, mandate, is_shared, flavor, "
         "current_state FROM shells "
         "WHERE (user_id=? OR is_shared=1) AND COALESCE(is_deleted,0)=0 "
         "ORDER BY flavor IS NULL, flavor, shell_id",
         (user_id,),
-    ).fetchall()
+    ).fetchall()]
+    refs_by_shell = [_sprint_doc_refs(shell) for shell in shells]
+    referenced = set().union(*refs_by_shell)
+    active = set()
+    if referenced:
+        placeholders = ",".join("?" for _ in referenced)
+        docs = con.execute(
+            f"SELECT document_id, frozen, body FROM documents "
+            f"WHERE kind='doc' AND document_id IN ({placeholders})",
+            tuple(sorted(referenced)),
+        ).fetchall()
+        active = {doc["document_id"] for doc in docs
+                  if _sprint_doc_is_active(doc)}
+    for shell, refs in zip(shells, refs_by_shell):
+        shell["sprint_reserved"] = bool(refs & active)
+    return shells
 
 
 def flavor_defaults(con) -> dict:
@@ -576,11 +591,36 @@ def _default_label(defaults: dict, flavor: str | None) -> str:
     return harness + (f" · {model.split('/')[-1]}" if model else "")
 
 
-def _is_sprint_reserved(shell) -> bool:
-    """True while the sprint skill's reservation marker is in current_state."""
+def _sprint_doc_refs(shell) -> set[int]:
+    """Tracker document ids named by current_state's sprint marker lines."""
     current_state = dict(shell).get("current_state") or ""
-    return any(line.strip().startswith("SPRINT doc=")
-               for line in current_state.splitlines())
+    refs = set()
+    prefix = "SPRINT doc="
+    for line in current_state.splitlines():
+        marker = line.strip()
+        if not marker.startswith(prefix):
+            continue
+        value = marker[len(prefix):].split(maxsplit=1)[0]
+        if value.isdigit():
+            refs.add(int(value))
+    return refs
+
+
+def _sprint_doc_is_active(doc) -> bool:
+    """The tracker contract says ACTIVE, and freeze has not revoked authority."""
+    if doc["frozen"]:
+        return False
+    for line in (doc["body"] or "").splitlines():
+        field, separator, value = line.strip().partition(":")
+        if field == "status" and separator:
+            status = value.strip().split(maxsplit=1)
+            return bool(status) and status[0] == "ACTIVE"
+    return False
+
+
+def _is_sprint_reserved(shell) -> bool:
+    """Picker-only annotation computed by list_shells; never a boot gate."""
+    return bool(dict(shell).get("sprint_reserved"))
 
 
 def _shell_status(shell, snap: "dict | None") -> str:

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import sqlite3
 import sys
 import threading
 import time
@@ -99,6 +100,7 @@ class ShellStatusTest(unittest.TestCase):
         sprint_shell = {
             **self.shell,
             "current_state": "working notes\nSPRINT doc=21 unit=4 status=waiting",
+            "sprint_reserved": True,
         }
         with mock.patch.object(style, "ON", True), mock.patch.object(
                 run.shell_liveness, "session_state", return_value=None):
@@ -115,6 +117,63 @@ class ShellStatusTest(unittest.TestCase):
         with mock.patch.object(run.shell_liveness, "session_state", return_value=None):
             self.assertEqual("Unknown",
                              run._shell_status(sprint_shell, partial).strip())
+
+    def test_only_active_unfrozen_sprint_docs_reserve_shells(self) -> None:
+        con = sqlite3.connect(":memory:")
+        self.addCleanup(con.close)
+        con.row_factory = sqlite3.Row
+        con.executescript("""
+            CREATE TABLE shells (
+                shell_id INTEGER PRIMARY KEY,
+                display_name TEXT,
+                shortname TEXT,
+                mandate TEXT,
+                is_shared INTEGER NOT NULL DEFAULT 0,
+                flavor TEXT,
+                current_state TEXT,
+                user_id INTEGER,
+                is_deleted INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE documents (
+                document_id INTEGER PRIMARY KEY,
+                kind TEXT NOT NULL,
+                frozen INTEGER NOT NULL DEFAULT 0,
+                body TEXT
+            );
+            INSERT INTO documents VALUES
+                (21, 'doc', 0, '# SPRINT: active\nstatus: ACTIVE'),
+                (22, 'doc', 0, '# SPRINT: closed\nstatus: CLOSED'),
+                (23, 'doc', 1, '# SPRINT: frozen\nstatus: ACTIVE'),
+                (24, 'doc', 0, '# SPRINT: malformed\nstatus:');
+            INSERT INTO shells VALUES
+                (1, 'Active', 'DEV1', '', 0, 'dev', 'SPRINT doc=21 unit=1', 1, 0),
+                (2, 'Closed', 'DEV2', '', 0, 'dev', 'SPRINT doc=22 unit=2', 1, 0),
+                (3, 'Frozen', 'REV1', '', 0, 'reviewer', 'SPRINT doc=23 reviewing=2', 1, 0),
+                (4, 'Missing', 'DEV3', '', 0, 'dev', 'SPRINT doc=999 unit=3', 1, 0),
+                (5, 'Bad marker', 'DEV4', '', 0, 'dev', 'SPRINT doc=oops unit=4', 1, 0),
+                (6, 'Bad tracker', 'DEV5', '', 0, 'dev', 'SPRINT doc=24 unit=5', 1, 0);
+        """)
+
+        shells = {shell["shortname"]: shell
+                  for shell in run.list_shells(con, user_id=1)}
+
+        self.assertEqual(
+            {"DEV1": True, "DEV2": False, "REV1": False,
+             "DEV3": False, "DEV4": False, "DEV5": False},
+            {name: shell["sprint_reserved"] for name, shell in shells.items()},
+        )
+        with mock.patch.object(
+                run.shell_liveness, "session_state", return_value=None):
+            self.assertEqual(
+                "Sprint", run._shell_status(shells["DEV1"], self.snap).strip())
+            self.assertEqual(
+                "Available", run._shell_status(shells["DEV2"], self.snap).strip())
+
+    def test_sprint_annotation_never_blocks_boot(self) -> None:
+        sprint_shell = {**self.shell, "sprint_reserved": True}
+        with mock.patch.object(
+                run.shell_liveness, "session_state", return_value=None):
+            self.assertTrue(run.confirm_live(sprint_shell, self.snap))
 
     def test_picker_has_a_dedicated_status_column(self) -> None:
         shell = {**self.shell, "display_name": "Dev One"}


### PR DESCRIPTION
## Summary
- validate `SPRINT doc=` markers against their tracker document before annotating a shell
- show `Sprint` only for ACTIVE, unfrozen sprint trackers
- keep sprint state picker-only; boot confirmation remains based solely on process liveness

## Verification
- `python3 tests/test_style_spinner.py` — 15 passed
- `./sc lint .super-coder/scripts/run.py tests/test_style_spinner.py` — clean
- `./sc test` — 647 passed; 3 existing sandbox-only `test_vm_bake.py` failures (host-only bake guard, unrelated)
