### PR TITLE
fix(session-control): always-fresh enter + support-latest adapter probes

### DIFF
--- a/.super-coder/adapters/claude/claude_cli.py
+++ b/.super-coder/adapters/claude/claude_cli.py
@@ -8,7 +8,10 @@ import subprocess
 from collections.abc import Callable
 
 
-TESTED_VERSIONS = frozenset({(2, 1)})
+# Validated version floor — newer CLIs are accepted on feature-probe evidence
+# (the flag detection below), older ones fail closed. Support-latest policy:
+# a version bump alone never disables session control.
+MIN_TESTED_VERSION = (2, 1)
 
 
 def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -42,7 +45,7 @@ def probe_claude(
     match = re.search(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?!\d)", version_text)
     version = tuple(map(int, match.groups())) if match else None
     help_text = _output(help_result)
-    known = bool(version and version[:2] in TESTED_VERSIONS)
+    known = bool(version and version[:2] >= MIN_TESTED_VERSION)
     create = (
         known
         and help_result.returncode == 0

--- a/.super-coder/adapters/codex/codex-session.py
+++ b/.super-coder/adapters/codex/codex-session.py
@@ -19,7 +19,9 @@ sys.path.insert(0, str(ENGINE / "scripts"))
 
 import db_driver  # type: ignore[import-not-found]  # noqa: E402
 import session_supervisor  # type: ignore[import-not-found]  # noqa: E402
-from codex_rpc import AppServerClient, probe_codex  # noqa: E402
+from codex_rpc import (  # noqa: E402
+    MIN_SUPPORTED_MAJOR, MIN_SUPPORTED_MINOR, AppServerClient, probe_codex,
+)
 
 
 def socket_path(binding_id: int) -> Path:
@@ -56,7 +58,8 @@ def main() -> int:
     if not probe["create"]:
         raise SystemExit(
             f"Codex {probe.get('cli_version') or 'unknown'} is not validated for "
-            f"app-server session control (expected 0.144.x)"
+            f"app-server session control "
+            f"(requires codex-cli >= {MIN_SUPPORTED_MAJOR}.{MIN_SUPPORTED_MINOR})"
         )
 
     RUN_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)

--- a/.super-coder/adapters/codex/codex_rpc.py
+++ b/.super-coder/adapters/codex/codex_rpc.py
@@ -27,12 +27,16 @@ class CodexRpcError(RuntimeError):
     """The app-server returned a JSON-RPC error."""
 
 
-SUPPORTED_MAJOR = 0
-SUPPORTED_MINOR = 144
+# Validated version floor. Newer CLIs are accepted on feature-probe evidence
+# (the --help detection below is the real capability gate); older ones fail
+# closed. Support-latest policy: a version bump alone must never wedge a
+# launch (#483) — protocol drift in a future CLI fails loudly at RPC time.
+MIN_SUPPORTED_MAJOR = 0
+MIN_SUPPORTED_MINOR = 144
 
 
 def probe_codex(run: Callable[..., subprocess.CompletedProcess] = subprocess.run) -> dict:
-    """Probe the installed CLI and fail active control closed on unknown versions."""
+    """Probe the installed CLI; versions below the floor fail active control closed."""
     version_call = run(
         ["codex", "--version"], capture_output=True, text=True, timeout=5, check=False
     )
@@ -50,8 +54,8 @@ def probe_codex(run: Callable[..., subprocess.CompletedProcess] = subprocess.run
     app_text = (app_help.stdout or "") + (app_help.stderr or "")
     resume_text = (resume_help.stdout or "") + (resume_help.stderr or "")
     known_version = bool(
-        match and int(match.group(1)) == SUPPORTED_MAJOR
-        and int(match.group(2)) == SUPPORTED_MINOR
+        match and (int(match.group(1)), int(match.group(2)))
+        >= (MIN_SUPPORTED_MAJOR, MIN_SUPPORTED_MINOR)
     )
     unix_transport = app_help.returncode == 0 and "unix://" in app_text and "--listen" in app_text
     resume = resume_help.returncode == 0 and "SESSION_ID" in resume_text

--- a/.super-coder/adapters/kimi/kimi_http.py
+++ b/.super-coder/adapters/kimi/kimi_http.py
@@ -13,7 +13,10 @@ from pathlib import Path
 from typing import IO
 
 
-TESTED_SERVER_VERSIONS = frozenset({(0, 27), (0, 28)})
+# Validated version floor — newer CLIs are accepted on feature-probe evidence
+# (the command-tree detection below), older ones fail closed. Support-latest
+# policy: a version bump alone never disables session control.
+MIN_TESTED_SERVER_VERSION = (0, 27)
 DEFAULT_TURN_TIMEOUT = 4 * 60 * 60
 _SECRET_PATTERNS = (
     re.compile(r"(?i)(bearer\s+)[^\s,;]+"),
@@ -84,7 +87,7 @@ def probe_kimi(
 
     version_text = _output(version_result).strip()
     version = _version_tuple(version_text)
-    known_server = bool(version and version[:2] in TESTED_SERVER_VERSIONS)
+    known_server = bool(version and version[:2] >= MIN_TESTED_SERVER_VERSION)
     root_help = _output(root_result)
     server_help = _output(server_result)
     web_help = _output(web_result)

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -966,17 +966,20 @@ def main() -> None:
     if new_session and flag_binding:
         sys.exit("session launch refused: --new-session cannot be combined with "
                  "--session-binding")
-    try:
-        enter_binding = (None if flag_binding else
-                         session_supervisor.binding_for_enter(
-                             con, chosen["shell_id"], new_session=new_session))
-    except ValueError as e:
-        sys.exit(f"session launch refused: {e}")
-    # Headless workers keep their existing ephemeral behavior unless the
-    # dispatcher names a binding explicitly.  Automatic attachment is the
-    # interactive `sc enter` contract only.
-    if headless:
-        enter_binding = None
+    # Interactive enter ALWAYS starts a fresh session — a native harness
+    # conversation is never resumed here (dormant resume is the dispatcher's
+    # headless path, and a stale binding must never wedge `sc enter`: #483/#484).
+    # Any binding that would otherwise be resumed — the shell's managed binding,
+    # or one parked on the active archive — is superseded now (released, audit
+    # kept) and rebound fresh below.  Headless workers keep their existing
+    # ephemeral behavior unless the dispatcher names a binding explicitly.
+    superseded = None
+    if not flag_binding and not headless and not os.environ.get("RENDER_ONLY"):
+        try:
+            superseded = session_supervisor.supersede_for_enter(
+                con, chosen["shell_id"], repo_root=REPO_ROOT)
+        except ValueError as e:
+            sys.exit(f"session launch refused: {e}")
 
     # This shell's flavor default (advisory): the harness it boots with. The
     # model is resolved AFTER the harness pick — a flavor names a model PER
@@ -994,7 +997,7 @@ def main() -> None:
     ensure_harness_path()
     default_harness = flavor_harness or _configured_harness() or "claude"
     harness = (flag_harness or os.environ.get("HARNESS")
-               or (enter_binding or {}).get("harness")
+               or (superseded or {}).get("harness")
                or pick_harness(detect_harnesses(), default_harness, first or headless)
                or default_harness)
 
@@ -1012,7 +1015,7 @@ def main() -> None:
         except ValueError as e:
             sys.exit(f"sc run: {e}")
 
-    resume_binding = enter_binding
+    resume_binding = None
     if flag_binding:
         try:
             resume_binding = {"binding_id": int(flag_binding)}
@@ -1069,12 +1072,17 @@ def main() -> None:
                     "model": session_model,
                     "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
                 }, reuse_archive_id=(resume_binding or {}).get("archive_id"),
-                force_new=new_session)
+                force_new=new_session or superseded is not None)
         except ValueError as e:
             sys.exit(f"session resume refused: {e}")
 
         binding = resume_binding
-        if (not binding and chosen["flavor"] == "planner"
+        # Fresh binding for the fresh session: always after a supersede (any
+        # flavor — the superseded binding's managed flag carries over), plus the
+        # standing planner-first-boot case.  Native id starts NULL so the
+        # controlled launcher opens a NEW provider conversation.
+        if (not binding
+                and (superseded is not None or chosen["flavor"] == "planner")
                 and adapter.get("session_control")
                 and not os.environ.get("RENDER_ONLY")):
             binding = session_supervisor.ensure_binding(
@@ -1084,6 +1092,7 @@ def main() -> None:
                 capabilities=json.dumps(
                     (adapter.get("session_control") or {}).get("capabilities") or {},
                     sort_keys=True),
+                managed=bool(superseded and superseded.get("managed")),
             )
 
         full = con.execute(
@@ -1155,6 +1164,13 @@ def main() -> None:
     if binding:
         native = binding.get("native_session_id") or "pending"
         print(f"→ session binding: {binding['binding_id']} · {harness}={native}")
+    if superseded is not None:
+        print(f"→ superseded binding {superseded['binding_id']} "
+              f"({superseded['harness']}) — released; fresh session started")
+        if superseded.get("managed") and not binding:
+            print(f"→ warning: managed wake inactive until "
+                  f"./sc session manage {chosen['shortname']} "
+                  f"(harness '{harness}' has no session control)")
     if work_dir != REPO_ROOT:
         print(f"→ worktree: {work_dir}")
         print(f"→ sync: {sync_note}")

--- a/.super-coder/scripts/session_supervisor.py
+++ b/.super-coder/scripts/session_supervisor.py
@@ -230,52 +230,72 @@ def supersede_for_enter(con, shell_id: int, *, repo_root: Path,
     supersede.  Raises while a validated owner (or its orphaned group) still
     holds a binding — never release under a live session.
     """
-    rows = con.execute(
-        "SELECT b.*, a.session_id, a.model AS archive_model, "
-        "a.provider AS archive_provider, s.shortname, s.flavor "
-        "FROM shell_session_bindings b "
-        "JOIN shell_memory_archives a ON a.archive_id=b.archive_id "
-        "JOIN shells s ON s.shell_id=b.shell_id "
-        "WHERE b.shell_id=? AND (b.managed=1 OR b.archive_id="
-        "(SELECT active_archive_id FROM shells WHERE shell_id=?))",
-        (shell_id, shell_id),
-    ).fetchall()
-    if not rows:
-        return None
-    # Fence first, write second: reconcile commits/rolls back internally, so it
-    # must run before any mutation on this connection.
-    for row in rows:
-        status = reconcile_binding(con, row["binding_id"], repo_root=repo_root,
-                                   proc_root=proc_root)
-        if status not in ("vacant", "stale-cleared"):
-            raise ValueError(
-                f"session binding {row['binding_id']} is held by a live owner "
-                f"({status}) — attach to the running session, or "
-                f"./sc session release {row['shortname']} first"
+    # The ownership fence and release are one write transaction. Otherwise a
+    # dispatcher can claim the binding after reconciliation and before the
+    # release, leaving a live lease on a row we just marked released (#485).
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        rows = con.execute(
+            "SELECT b.*, a.session_id, a.model AS archive_model, "
+            "a.provider AS archive_provider, s.shortname, s.flavor "
+            "FROM shell_session_bindings b "
+            "JOIN shell_memory_archives a ON a.archive_id=b.archive_id "
+            "JOIN shells s ON s.shell_id=b.shell_id "
+            "WHERE b.shell_id=? AND (b.managed=1 OR b.archive_id="
+            "(SELECT active_archive_id FROM shells WHERE shell_id=?))",
+            (shell_id, shell_id),
+        ).fetchall()
+        if not rows:
+            con.rollback()
+            return None
+
+        for row in rows:
+            status = _reconcile_binding_locked(
+                con, row["binding_id"], repo_root=repo_root,
+                proc_root=proc_root)
+            current = _binding_context(con, row["binding_id"])
+            if status not in ("vacant", "stale-cleared"):
+                raise ValueError(
+                    f"session binding {row['binding_id']} is held by a live owner "
+                    f"({status}) — attach to the running session, or "
+                    f"./sc session release {row['shortname']} first"
+                )
+            # claim_batch moves to dispatching before the resume child can
+            # register its lease. No PID in that window does not mean vacant;
+            # releasing here could start a fresh interactive writer alongside
+            # a headless turn that has already been claimed.
+            if current["state"] == "dispatching":
+                raise ValueError(
+                    f"session binding {row['binding_id']} has a dispatch in progress; "
+                    "wait for it to finish before starting a fresh session"
+                )
+
+        primary = None
+        for row in rows:
+            current = _binding_context(con, row["binding_id"])
+            if current["state"] != "released":
+                session_control.transition_binding(
+                    con, row["binding_id"], expected=current["state"],
+                    target="released")
+            con.execute(
+                "UPDATE shell_session_bindings SET managed=0, "
+                "updated_at=datetime('now') WHERE binding_id=?",
+                (row["binding_id"],),
             )
-    primary = None
-    for row in rows:
-        current = _binding_context(con, row["binding_id"])
-        if current["state"] != "released":
-            session_control.transition_binding(
-                con, row["binding_id"], expected=current["state"],
-                target="released")
-        con.execute(
-            "UPDATE shell_session_bindings SET managed=0, "
-            "updated_at=datetime('now') WHERE binding_id=?",
-            (row["binding_id"],),
-        )
-        con.execute(
-            "UPDATE session_wake_jobs SET state='cancelled', "
-            "finished_at=datetime('now'), "
-            "last_error='superseded by interactive enter' "
-            "WHERE binding_id=? AND state IN ('queued','failed')",
-            (row["binding_id"],),
-        )
-        if primary is None or row["managed"]:
-            primary = row
-    con.commit()
-    return dict(primary)
+            con.execute(
+                "UPDATE session_wake_jobs SET state='cancelled', "
+                "finished_at=datetime('now'), "
+                "last_error='superseded by interactive enter' "
+                "WHERE binding_id=? AND state IN ('queued','failed')",
+                (row["binding_id"],),
+            )
+            if primary is None or row["managed"]:
+                primary = row
+        con.commit()
+        return dict(primary)
+    except Exception:
+        con.rollback()
+        raise
 
 
 def register_native_session(con, binding_id: int, native_session_id: str, *,
@@ -513,52 +533,54 @@ def _reconcile_active_channel(con, row: dict, *, repo_root: Path,
     return True
 
 
+def _reconcile_binding_locked(con, binding_id: int, *, repo_root: Path,
+                              proc_root: Path = PROC) -> str:
+    """Validate ownership inside the caller's active write transaction."""
+    row = _binding_context(con, binding_id)
+    _reconcile_active_channel(con, row, repo_root=repo_root, proc_root=proc_root)
+    status, pids = _recorded_owner_status(
+        row, repo_root=repo_root, proc_root=proc_root)
+    if status in ("vacant", "live", "cleanup"):
+        return status
+    if status == "orphan-group":
+        target = "released" if row["state"] == "released" else "error"
+        session_control.transition_binding(
+            con, binding_id, expected=row["state"], target=target)
+        con.execute(
+            "UPDATE shell_session_bindings SET last_error=?, "
+            "updated_at=datetime('now') WHERE binding_id=?",
+            ("recorded owner exited but process group survives: "
+             + ",".join(map(str, pids)), binding_id),
+        )
+        return status
+
+    if row["state"] in ("released", "error"):
+        target = row["state"]
+    else:
+        target = "dormant" if row.get("native_session_id") else "error"
+    error = (None if row.get("native_session_id")
+             else "stale owner and no native session id")
+    session_control.transition_binding(
+        con, binding_id, expected=row["state"], target=target)
+    con.execute(
+        "UPDATE shell_session_bindings SET lease_pid=NULL, lease_start_ticks=NULL, "
+        "supervisor_pid=NULL, supervisor_start_ticks=NULL, last_error=?, "
+        "updated_at=datetime('now') WHERE binding_id=? "
+        "AND lease_pid=? AND lease_start_ticks=?",
+        (error, binding_id, row["lease_pid"], row["lease_start_ticks"]),
+    )
+    return "stale-cleared"
+
+
 def reconcile_binding(con, binding_id: int, *, repo_root: Path,
                       proc_root: Path = PROC) -> str:
     """Validate recorded ownership before a claim or dispatcher decision."""
     con.execute("BEGIN IMMEDIATE")
     try:
-        row = _binding_context(con, binding_id)
-        channel_cleared = _reconcile_active_channel(
-            con, row, repo_root=repo_root, proc_root=proc_root)
-        status, pids = _recorded_owner_status(
-            row, repo_root=repo_root, proc_root=proc_root)
-        if status in ("vacant", "live", "cleanup"):
-            if channel_cleared:
-                con.commit()
-            else:
-                con.rollback()
-            return status
-        if status == "orphan-group":
-            target = "released" if row["state"] == "released" else "error"
-            session_control.transition_binding(
-                con, binding_id, expected=row["state"], target=target)
-            con.execute(
-                "UPDATE shell_session_bindings SET last_error=?, "
-                "updated_at=datetime('now') WHERE binding_id=?",
-                ("recorded owner exited but process group survives: "
-                 + ",".join(map(str, pids)), binding_id),
-            )
-            con.commit()
-            return status
-
-        if row["state"] in ("released", "error"):
-            target = row["state"]
-        else:
-            target = "dormant" if row.get("native_session_id") else "error"
-        error = (None if row.get("native_session_id")
-                 else "stale owner and no native session id")
-        session_control.transition_binding(
-            con, binding_id, expected=row["state"], target=target)
-        con.execute(
-            "UPDATE shell_session_bindings SET lease_pid=NULL, lease_start_ticks=NULL, "
-            "supervisor_pid=NULL, supervisor_start_ticks=NULL, last_error=?, "
-            "updated_at=datetime('now') WHERE binding_id=? "
-            "AND lease_pid=? AND lease_start_ticks=?",
-            (error, binding_id, row["lease_pid"], row["lease_start_ticks"]),
-        )
+        status = _reconcile_binding_locked(
+            con, binding_id, repo_root=repo_root, proc_root=proc_root)
         con.commit()
-        return "stale-cleared"
+        return status
     except Exception:
         con.rollback()
         raise

--- a/.super-coder/scripts/session_supervisor.py
+++ b/.super-coder/scripts/session_supervisor.py
@@ -145,8 +145,14 @@ def expected_worktree(repo_root: Path, shortname: str | None,
 def ensure_binding(con, *, archive_id: int, shell_id: int, harness: str,
                    native_session_id: str | None = None,
                    control_endpoint: str | None = None,
-                   capabilities: str = "{}", cli_version: str | None = None) -> dict:
-    """Create the binding for an archive, or verify/reuse that exact binding."""
+                   capabilities: str = "{}", cli_version: str | None = None,
+                   managed: bool = False) -> dict:
+    """Create the binding for an archive, or verify/reuse that exact binding.
+
+    ``managed`` applies only at INSERT — an existing row is returned as-is.
+    The caller must have cleared any prior managed row for the shell first
+    (the partial unique index allows exactly one)."""
+
     row = con.execute(
         "SELECT * FROM shell_session_bindings WHERE archive_id=?", (archive_id,)
     ).fetchone()
@@ -175,10 +181,10 @@ def ensure_binding(con, *, archive_id: int, shell_id: int, harness: str,
     cur = con.execute(
         "INSERT INTO shell_session_bindings "
         "(archive_id, shell_id, harness, native_session_id, control_endpoint, "
-        "control_capabilities, cli_version, state) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, 'starting')",
+        "control_capabilities, cli_version, managed, state) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'starting')",
         (archive_id, shell_id, harness, native_session_id, control_endpoint,
-         capabilities, cli_version),
+         capabilities, cli_version, 1 if managed else 0),
     )
     con.commit()
     return dict(con.execute(
@@ -204,34 +210,72 @@ def binding_for_resume(con, binding_id: int, *, shell_id: int,
     return dict(row)
 
 
-def binding_for_enter(con, shell_id: int, *, new_session: bool = False) -> dict | None:
-    """Return the shell's managed binding for an interactive enter.
+def supersede_for_enter(con, shell_id: int, *, repo_root: Path,
+                        proc_root: Path = PROC) -> dict | None:
+    """Release the shell's resumable bindings so an interactive enter starts fresh.
 
-    A managed binding owns the planner's conversation until the operator
-    releases it.  Bare ``sc enter`` therefore reuses it, while an explicit new
-    session must fail before a second archive can be opened.
+    Interactive enter never resumes a native harness conversation — dormant
+    resume is the dispatcher's headless path, and a stale binding must never
+    wedge ``sc enter`` (#483/#484).  Any binding that would otherwise be
+    resumed — the shell's managed binding, or one parked on the shell's active
+    archive (the unused-stub shape that resurrected an errored row, #484) — is
+    released here: state -> released, ``managed`` cleared, queued/failed wake
+    jobs cancelled.  ``last_error`` is deliberately kept: the original adapter
+    error must stay visible after recovery.  Provider credential/socket files
+    are per-binding-id, so the stale ones are inert once a fresh binding (new
+    id) exists — no cleanup needed here.
+
+    Returns the superseded row (the managed one when several matched — its
+    harness still hints the picker), or None when there is nothing to
+    supersede.  Raises while a validated owner (or its orphaned group) still
+    holds a binding — never release under a live session.
     """
-    row = con.execute(
+    rows = con.execute(
         "SELECT b.*, a.session_id, a.model AS archive_model, "
-        "a.provider AS archive_provider, s.shortname FROM shell_session_bindings b "
+        "a.provider AS archive_provider, s.shortname, s.flavor "
+        "FROM shell_session_bindings b "
         "JOIN shell_memory_archives a ON a.archive_id=b.archive_id "
         "JOIN shells s ON s.shell_id=b.shell_id "
-        "WHERE b.shell_id=? AND b.managed=1",
-        (shell_id,),
-    ).fetchone()
-    if not row:
+        "WHERE b.shell_id=? AND (b.managed=1 OR b.archive_id="
+        "(SELECT active_archive_id FROM shells WHERE shell_id=?))",
+        (shell_id, shell_id),
+    ).fetchall()
+    if not rows:
         return None
-    if row["state"] == "error":
-        raise ValueError(
-            f"managed binding {row['binding_id']} is in error; run "
-            f"./sc session retry {row['shortname']} to recover it, or "
-            f"./sc session release {row['shortname']} before starting a new session"
+    # Fence first, write second: reconcile commits/rolls back internally, so it
+    # must run before any mutation on this connection.
+    for row in rows:
+        status = reconcile_binding(con, row["binding_id"], repo_root=repo_root,
+                                   proc_root=proc_root)
+        if status not in ("vacant", "stale-cleared"):
+            raise ValueError(
+                f"session binding {row['binding_id']} is held by a live owner "
+                f"({status}) — attach to the running session, or "
+                f"./sc session release {row['shortname']} first"
+            )
+    primary = None
+    for row in rows:
+        current = _binding_context(con, row["binding_id"])
+        if current["state"] != "released":
+            session_control.transition_binding(
+                con, row["binding_id"], expected=current["state"],
+                target="released")
+        con.execute(
+            "UPDATE shell_session_bindings SET managed=0, "
+            "updated_at=datetime('now') WHERE binding_id=?",
+            (row["binding_id"],),
         )
-    if new_session:
-        raise ValueError(
-            f"--new-session requires releasing managed binding {row['binding_id']} first"
+        con.execute(
+            "UPDATE session_wake_jobs SET state='cancelled', "
+            "finished_at=datetime('now'), "
+            "last_error='superseded by interactive enter' "
+            "WHERE binding_id=? AND state IN ('queued','failed')",
+            (row["binding_id"],),
         )
-    return dict(row)
+        if primary is None or row["managed"]:
+            primary = row
+    con.commit()
+    return dict(primary)
 
 
 def register_native_session(con, binding_id: int, native_session_id: str, *,

--- a/sc
+++ b/sc
@@ -1203,8 +1203,9 @@ super-coder — forkable shell substrate
   Sandbox (docker — the default way to run; allow-everything is safe because the
   container only sees this repo + your harness creds):
   ./sc launch              build + start the sandbox container (server + GUI), 127.0.0.1 only
-  ./sc enter [--new-session]  attach an interactive session; managed bindings resume by default
-  ./sc enter-<shortname> [--new-session]  attach that shell directly; new session requires release
+  ./sc enter [--new-session]  attach an interactive session — always starts a FRESH session;
+                             a managed binding is superseded (released + rebound), never resumed
+  ./sc enter-<shortname> [--new-session]  attach that shell directly (same fresh-session rule)
                              harness: --harness <name> or HARNESS=<name> forces it; else when
                              >1 harness is on PATH you're prompted (per-launch, not persisted)
   ./sc run <shortname>     headless boot: render + exec the harness NON-interactively (claude · codex ·

--- a/tests/test_claude_session_control.py
+++ b/tests/test_claude_session_control.py
@@ -109,8 +109,14 @@ class ProbeTest(unittest.TestCase):
             (True, True, True),
         )
 
-    def test_unknown_version_fails_active_closed_but_keeps_flag_tested_resume(self):
+    def test_newer_version_is_accepted_on_feature_probe_evidence(self):
         probe = probe_claude(self.runner("2.2.0 (Claude Code)"))
+        self.assertTrue(probe["create"])
+        self.assertTrue(probe["active_delivery"])
+        self.assertTrue(probe["resume"])
+
+    def test_older_version_fails_active_closed_but_keeps_flag_tested_resume(self):
+        probe = probe_claude(self.runner("2.0.9 (Claude Code)"))
         self.assertFalse(probe["create"])
         self.assertFalse(probe["active_delivery"])
         self.assertTrue(probe["resume"])

--- a/tests/test_codex_session_control.py
+++ b/tests/test_codex_session_control.py
@@ -154,8 +154,15 @@ class VersionProbeTest(unittest.TestCase):
         self.assertTrue(result["resume"])
         self.assertFalse(result["normal_steer"])
 
-    def test_unknown_version_fails_active_closed_but_keeps_smoke_tested_resume(self):
+    def test_newer_version_is_accepted_on_feature_probe_evidence(self):
         result = codex_rpc.probe_codex(self.runner_for("0.145.0"))
+        self.assertEqual(result["cli_version"], "0.145.0")
+        self.assertTrue(result["create"])
+        self.assertTrue(result["active_delivery"])
+        self.assertTrue(result["resume"])
+
+    def test_older_version_fails_active_closed_but_keeps_smoke_tested_resume(self):
+        result = codex_rpc.probe_codex(self.runner_for("0.143.9"))
         self.assertFalse(result["create"])
         self.assertFalse(result["active_delivery"])
         self.assertTrue(result["resume"])

--- a/tests/test_kimi_session_control.py
+++ b/tests/test_kimi_session_control.py
@@ -110,8 +110,20 @@ class ProbeTest(unittest.TestCase):
         self.assertNotIn("--dangerous-bypass-auth", probe["server_command"])
         self.assertTrue(probe["active_delivery"])
 
-    def test_unknown_version_fails_closed_for_server_but_retains_tested_resume(self):
+    def test_newer_version_is_accepted_on_feature_probe_evidence(self):
         probe = kimi_http.probe_kimi(self.runner("0.29.0", web=True))
+        self.assertEqual(
+            probe["server_command"],
+            ["kimi", "web", "--port", "0", "--foreground", "--no-open"],
+        )
+        self.assertEqual(
+            (probe["create"], probe["deliver"], probe["active_delivery"]),
+            (True, True, True),
+        )
+        self.assertTrue(probe["resume"])
+
+    def test_older_version_fails_closed_for_server_but_retains_tested_resume(self):
+        probe = kimi_http.probe_kimi(self.runner("0.26.3", web=True))
         self.assertEqual(
             (probe["create"], probe["deliver"], probe["active_delivery"]),
             (False, False, False),

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -560,6 +560,85 @@ class SupersedeForEnterTest(unittest.TestCase):
             "WHERE binding_id=?", (binding["binding_id"],)).fetchone()
         self.assertEqual(("foreground", 1, 501), tuple(row))
 
+    def test_dispatch_claim_before_lease_refuses_without_cancelling_work(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = self._managed_binding(con)
+        con.execute(
+            "UPDATE shell_session_bindings SET state='dispatching' "
+            "WHERE binding_id=?", (binding["binding_id"],))
+        con.execute(
+            "INSERT INTO session_wake_jobs "
+            "(binding_id, trigger_message_id, state, attempt_count) "
+            "VALUES (?, 1, 'running', 1)", (binding["binding_id"],))
+        con.commit()
+
+        with self.assertRaisesRegex(ValueError, "dispatch in progress"):
+            supervisor.supersede_for_enter(con, 1, repo_root=Path("/none"))
+
+        row = con.execute(
+            "SELECT state, managed, lease_pid, lease_start_ticks "
+            "FROM shell_session_bindings WHERE binding_id=?",
+            (binding["binding_id"],)).fetchone()
+        self.assertEqual(("dispatching", 1, None, None), tuple(row))
+        job = con.execute(
+            "SELECT state, attempt_count, finished_at, last_error "
+            "FROM session_wake_jobs WHERE binding_id=?",
+            (binding["binding_id"],)).fetchone()
+        self.assertEqual(("running", 1, None, None), tuple(job))
+
+    def test_reconcile_and_release_hold_one_write_lock(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = str(Path(tmp.name) / "supersede.db")
+        con = make_db(path)
+        self.addCleanup(con.close)
+        binding = supervisor.ensure_binding(
+            con, archive_id=10, shell_id=1, harness="claude",
+            native_session_id="native-7", managed=True)
+        con.execute(
+            "UPDATE shell_session_bindings SET state='dormant' "
+            "WHERE binding_id=?", (binding["binding_id"],))
+        con.commit()
+        proc = FakeProc(self)
+        repo = proc.root / "repo"
+        worktree = repo / ".sc-worktrees" / "dev1"
+        proc.add(502, ticks=52, command=("claude",), cwd=worktree)
+        original = supervisor._reconcile_binding_locked
+
+        def competing_claim(*args, **kwargs):
+            contender = sqlite3.connect(path, timeout=0)
+            contender.row_factory = sqlite3.Row
+            try:
+                with self.assertRaisesRegex(sqlite3.OperationalError, "locked"):
+                    supervisor.claim_lease(
+                        contender, binding["binding_id"], 502,
+                        repo_root=repo, state="foreground", proc_root=proc.root)
+            finally:
+                contender.close()
+            return original(*args, **kwargs)
+
+        with mock.patch.object(
+                supervisor, "_reconcile_binding_locked",
+                side_effect=competing_claim):
+            superseded = supervisor.supersede_for_enter(
+                con, 1, repo_root=repo, proc_root=proc.root)
+
+        self.assertEqual(binding["binding_id"], superseded["binding_id"])
+        row = con.execute(
+            "SELECT state, managed, lease_pid, lease_start_ticks "
+            "FROM shell_session_bindings WHERE binding_id=?",
+            (binding["binding_id"],)).fetchone()
+        self.assertEqual(("released", 0, None, None), tuple(row))
+
+        contender = sqlite3.connect(path, timeout=0)
+        contender.row_factory = sqlite3.Row
+        self.addCleanup(contender.close)
+        with self.assertRaises(session_control.InvalidStateTransition):
+            supervisor.claim_lease(
+                contender, binding["binding_id"], 502,
+                repo_root=repo, state="foreground", proc_root=proc.root)
+
     def test_resume_reuses_exact_archive_without_creating_or_rewriting_it(self):
         con = make_db()
         self.addCleanup(con.close)

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -68,6 +68,17 @@ CREATE TABLE shell_session_bindings (
   updated_at TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE (harness, native_session_id)
 );
+CREATE TABLE session_wake_jobs (
+  wake_id INTEGER PRIMARY KEY,
+  binding_id INTEGER NOT NULL,
+  trigger_message_id INTEGER NOT NULL,
+  state TEXT NOT NULL DEFAULT 'queued',
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  available_at TEXT,
+  started_at TEXT,
+  finished_at TEXT,
+  last_error TEXT
+);
 """
 
 
@@ -412,7 +423,7 @@ class MigratedStateMachineIntegrationTest(unittest.TestCase):
         self.assertEqual(("error", None, generation), tuple(row))
 
 
-class ArchiveReuseTest(unittest.TestCase):
+class SupersedeForEnterTest(unittest.TestCase):
     def _managed_binding(self, con):
         binding = supervisor.ensure_binding(
             con, archive_id=10, shell_id=1, harness="claude",
@@ -423,60 +434,131 @@ class ArchiveReuseTest(unittest.TestCase):
         con.commit()
         return binding
 
-    def test_bare_enter_selects_dormant_managed_binding_and_exact_archive(self):
-        con = make_db()
-        self.addCleanup(con.close)
-        binding = self._managed_binding(con)
+    def _binding_row(self, con, binding_id):
+        return con.execute(
+            "SELECT state, managed, last_error, native_session_id "
+            "FROM shell_session_bindings WHERE binding_id=?",
+            (binding_id,)).fetchone()
 
-        selected = supervisor.binding_for_enter(con, 1)
-        self.assertEqual(
-            (binding["binding_id"], 10, "0007", "claude", "native-7", "dormant", 1),
-            (selected["binding_id"], selected["archive_id"], selected["session_id"],
-             selected["harness"], selected["native_session_id"], selected["state"],
-             selected["managed"]),
-        )
-        session_id, archive_id = run.open_session(
-            con, 1, reuse_archive_id=selected["archive_id"])
-        self.assertEqual(("0007", 10), (session_id, archive_id))
-        self.assertEqual(1, con.execute(
-            "SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0])
-
-    def test_new_session_is_refused_while_managed_binding_exists(self):
-        con = make_db()
-        self.addCleanup(con.close)
-        binding = self._managed_binding(con)
-
-        with self.assertRaisesRegex(
-                ValueError,
-                rf"--new-session requires releasing managed binding {binding['binding_id']} first"):
-            supervisor.binding_for_enter(con, 1, new_session=True)
-        self.assertEqual(1, con.execute(
-            "SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0])
-        self.assertIsNone(con.execute(
-            "SELECT active_archive_id FROM shells WHERE shell_id=1").fetchone()[0])
-
-    def test_new_session_opens_new_archive_after_binding_release(self):
+    def test_bare_enter_supersedes_dormant_managed_binding(self):
         con = make_db()
         self.addCleanup(con.close)
         binding = self._managed_binding(con)
         con.execute(
-            "UPDATE shell_session_bindings SET state='released', managed=0 "
-            "WHERE binding_id=?", (binding["binding_id"],))
-        con.execute("UPDATE shells SET active_archive_id=10 WHERE shell_id=1")
-        con.execute(
-            "UPDATE shell_memory_archives SET full_narrative="
-            "'# 0007\\n[00:00] Session start.' WHERE archive_id=10")
+            "INSERT INTO session_wake_jobs (binding_id, trigger_message_id, state) "
+            "VALUES (?, 1, 'queued'), (?, 2, 'failed'), (?, 3, 'done')",
+            (binding["binding_id"],) * 3)
         con.commit()
 
-        self.assertIsNone(supervisor.binding_for_enter(con, 1, new_session=True))
+        superseded = supervisor.supersede_for_enter(con, 1, repo_root=Path("/none"))
+        self.assertEqual(
+            (binding["binding_id"], 10, "0007", "claude", "native-7", "dormant", 1),
+            (superseded["binding_id"], superseded["archive_id"],
+             superseded["session_id"], superseded["harness"],
+             superseded["native_session_id"], superseded["state"],
+             superseded["managed"]),
+        )
+        self.assertEqual(("released", 0, None, "native-7"),
+                         tuple(self._binding_row(con, binding["binding_id"])))
+        jobs = con.execute(
+            "SELECT state, last_error FROM session_wake_jobs "
+            "WHERE binding_id=? ORDER BY trigger_message_id",
+            (binding["binding_id"],)).fetchall()
+        self.assertEqual(
+            [("cancelled", "superseded by interactive enter"),
+             ("cancelled", "superseded by interactive enter"),
+             ("done", None)],
+            [tuple(job) for job in jobs])
+
+        # The fresh session opens a NEW archive and rebinds managed=1 on it.
         session_id, archive_id = run.open_session(
             con, 1, lifecycle={"harness": "claude", "provider": "anthropic",
                                "model": "opus"}, force_new=True)
         self.assertEqual(("0008", 11), (session_id, archive_id))
-        rows = con.execute(
-            "SELECT archive_id, session_id FROM shell_memory_archives ORDER BY archive_id"
-        ).fetchall()
-        self.assertEqual([(10, "0007"), (11, "0008")], [tuple(row) for row in rows])
+        fresh = supervisor.ensure_binding(
+            con, archive_id=archive_id, shell_id=1, harness="claude", managed=True)
+        managed = con.execute(
+            "SELECT binding_id, archive_id, state FROM shell_session_bindings "
+            "WHERE managed=1").fetchall()
+        self.assertEqual([(fresh["binding_id"], 11, "starting")],
+                         [tuple(row) for row in managed])
+
+    def test_error_binding_is_superseded_with_error_preserved(self):
+        # #484 regression: a failed bootstrap must never wedge the next enter.
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = self._managed_binding(con)
+        con.execute(
+            "UPDATE shell_session_bindings SET state='error', "
+            "last_error='Codex 0.145.0 is not validated' WHERE binding_id=?",
+            (binding["binding_id"],))
+        con.commit()
+
+        superseded = supervisor.supersede_for_enter(con, 1, repo_root=Path("/none"))
+        self.assertEqual(binding["binding_id"], superseded["binding_id"])
+        self.assertEqual(
+            ("released", 0, "Codex 0.145.0 is not validated", "native-7"),
+            tuple(self._binding_row(con, binding["binding_id"])))
+
+    def test_unmanaged_binding_on_active_archive_is_superseded(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = supervisor.ensure_binding(
+            con, archive_id=10, shell_id=1, harness="claude",
+            native_session_id="native-7")
+        con.execute(
+            "UPDATE shell_session_bindings SET state='dormant' WHERE binding_id=?",
+            (binding["binding_id"],))
+        con.execute("UPDATE shells SET active_archive_id=10 WHERE shell_id=1")
+        con.commit()
+
+        superseded = supervisor.supersede_for_enter(con, 1, repo_root=Path("/none"))
+        self.assertEqual(binding["binding_id"], superseded["binding_id"])
+        self.assertEqual(("released", 0, None, "native-7"),
+                         tuple(self._binding_row(con, binding["binding_id"])))
+
+    def test_unmanaged_binding_off_active_archive_is_left_alone(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        supervisor.ensure_binding(
+            con, archive_id=10, shell_id=1, harness="claude",
+            native_session_id="native-7")
+        con.commit()
+        self.assertIsNone(
+            supervisor.supersede_for_enter(con, 1, repo_root=Path("/none")))
+        row = con.execute(
+            "SELECT state, managed FROM shell_session_bindings").fetchone()
+        self.assertEqual(("starting", 0), tuple(row))
+
+    def test_no_binding_returns_none_and_writes_nothing(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        self.assertIsNone(
+            supervisor.supersede_for_enter(con, 1, repo_root=Path("/none")))
+        self.assertEqual(0, con.execute(
+            "SELECT COUNT(*) FROM shell_session_bindings").fetchone()[0])
+
+    def test_live_owner_refuses_supersede_without_touching_the_binding(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = self._managed_binding(con)
+        proc = FakeProc(self)
+        repo = proc.root / "repo"
+        worktree = repo / ".sc-worktrees" / "dev1"
+        proc.add(501, ticks=51, command=("claude",), cwd=worktree)
+        con.execute(
+            "UPDATE shell_session_bindings SET lease_pid=501, "
+            "lease_start_ticks=51, state='foreground' WHERE binding_id=?",
+            (binding["binding_id"],))
+        con.commit()
+
+        with self.assertRaisesRegex(ValueError, "live owner"):
+            supervisor.supersede_for_enter(
+                con, 1, repo_root=repo, proc_root=proc.root)
+        row = con.execute(
+            "SELECT state, managed, lease_pid FROM shell_session_bindings "
+            "WHERE binding_id=?", (binding["binding_id"],)).fetchone()
+        self.assertEqual(("foreground", 1, 501), tuple(row))
 
     def test_resume_reuses_exact_archive_without_creating_or_rewriting_it(self):
         con = make_db()
@@ -520,7 +602,7 @@ class EnterMainFlowTest(unittest.TestCase):
         con.commit()
         return binding
 
-    def _run_until_open(self, con, argv):
+    def _run_until_open(self, con, argv, *, render_only=False):
         chosen = {"shell_id": 1, "shortname": "DEV1", "flavor": "planner"}
         defaults = {
             "planner": {"default_harness": "codex", "models": {
@@ -530,7 +612,8 @@ class EnterMainFlowTest(unittest.TestCase):
         def capture(*args, **kwargs):
             raise self.OpenReached(args, kwargs)
 
-        with mock.patch.dict(run.os.environ, {"RENDER_ONLY": "1"}, clear=True), \
+        env = {"RENDER_ONLY": "1"} if render_only else {}
+        with mock.patch.dict(run.os.environ, env, clear=True), \
                 mock.patch.object(run.sys, "argv", ["run.py", *argv]), \
                 mock.patch.object(run.sys, "stdin", mock.Mock(isatty=lambda: False)), \
                 mock.patch.object(run, "open_db", return_value=con), \
@@ -538,6 +621,10 @@ class EnterMainFlowTest(unittest.TestCase):
                 mock.patch.object(run, "flavor_defaults", return_value=defaults), \
                 mock.patch.object(run, "list_shells", return_value=[chosen]), \
                 mock.patch.object(run, "ensure_harness_path"), \
+                mock.patch.object(run.seed_skills, "sync_engine_skills",
+                                  return_value=[]), \
+                mock.patch("analytics.sweep",
+                          return_value={"inserted": 0, "updated": 0}), \
                 mock.patch.object(run, "load_adapter", return_value={
                     "launch": ["claude"], "emit": [], "env": {},
                     "session_control": {"capabilities": {}},
@@ -545,36 +632,36 @@ class EnterMainFlowTest(unittest.TestCase):
                 mock.patch.object(run, "open_session", side_effect=capture):
             run.main()
 
-    def test_bare_enter_routes_main_through_managed_binding_archive(self):
-        con = make_db()
-        self.addCleanup(con.close)
-        self._managed_binding(con)
-
-        with self.assertRaises(self.OpenReached) as reached:
-            self._run_until_open(con, ["DEV1"])
-        self.assertEqual((con, 1), reached.exception.call_args[:2])
-        self.assertEqual(10, reached.exception.call_kwargs["reuse_archive_id"])
-        self.assertFalse(reached.exception.call_kwargs["force_new"])
-        self.assertEqual(
-            {"harness": "claude", "provider": "anthropic", "model": "opus",
-             "sprint_ref": None},
-            reached.exception.call_kwargs["lifecycle"],
-        )
-
-    def test_new_session_flag_is_refused_by_main_before_archive_open(self):
+    def test_bare_enter_supersedes_and_opens_fresh_archive(self):
         con = make_db()
         self.addCleanup(con.close)
         binding = self._managed_binding(con)
 
-        with self.assertRaisesRegex(
-                SystemExit,
-                rf"session launch refused: --new-session requires releasing managed binding "
-                rf"{binding['binding_id']} first"):
-            self._run_until_open(con, ["DEV1", "--new-session"])
-        self.assertEqual(1, con.execute(
-            "SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0])
+        with self.assertRaises(self.OpenReached) as reached:
+            self._run_until_open(con, ["DEV1"])
+        self.assertEqual((con, 1), reached.exception.call_args[:2])
+        self.assertIsNone(reached.exception.call_kwargs["reuse_archive_id"])
+        self.assertTrue(reached.exception.call_kwargs["force_new"])
+        row = con.execute(
+            "SELECT state, managed FROM shell_session_bindings WHERE binding_id=?",
+            (binding["binding_id"],)).fetchone()
+        self.assertEqual(("released", 0), tuple(row))
 
-    def test_error_binding_refuses_before_archive_open_with_remedies(self):
+    def test_new_session_flag_supersedes_instead_of_refusing(self):
+        con = make_db()
+        self.addCleanup(con.close)
+        binding = self._managed_binding(con)
+
+        with self.assertRaises(self.OpenReached) as reached:
+            self._run_until_open(con, ["DEV1", "--new-session"])
+        self.assertTrue(reached.exception.call_kwargs["force_new"])
+        row = con.execute(
+            "SELECT state, managed FROM shell_session_bindings WHERE binding_id=?",
+            (binding["binding_id"],)).fetchone()
+        self.assertEqual(("released", 0), tuple(row))
+
+    def test_error_binding_is_superseded_not_refused(self):
+        # #484 regression at the main() level: the next enter starts fresh.
         con = make_db()
         self.addCleanup(con.close)
         binding = self._managed_binding(con)
@@ -585,38 +672,40 @@ class EnterMainFlowTest(unittest.TestCase):
         )
         con.commit()
 
-        with self.assertRaisesRegex(
-                SystemExit,
-                rf"session launch refused: managed binding {binding['binding_id']} is in "
-                rf"error; run \./sc session retry DEV1 to recover it, or "
-                rf"\./sc session release DEV1 before starting a new session"):
+        with self.assertRaises(self.OpenReached) as reached:
             self._run_until_open(con, ["DEV1"])
-        self.assertEqual(1, con.execute(
-            "SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0])
-        self.assertIsNone(con.execute(
-            "SELECT active_archive_id FROM shells WHERE shell_id=1").fetchone()[0])
+        self.assertIsNone(reached.exception.call_kwargs["reuse_archive_id"])
+        self.assertTrue(reached.exception.call_kwargs["force_new"])
         row = con.execute(
             "SELECT state, managed, lease_pid, last_error "
             "FROM shell_session_bindings WHERE binding_id=?",
             (binding["binding_id"],),
         ).fetchone()
-        self.assertEqual(("error", 1, None, "transport failed"), tuple(row))
+        self.assertEqual(("released", 0, None, "transport failed"), tuple(row))
 
-    def test_released_new_session_reaches_open_with_force_new(self):
+    def test_render_only_never_supersedes(self):
+        # Headless verify must not mutate: the binding survives untouched.
         con = make_db()
         self.addCleanup(con.close)
         binding = self._managed_binding(con)
-        con.execute(
-            "UPDATE shell_session_bindings SET state='released', managed=0 "
-            "WHERE binding_id=?", (binding["binding_id"],))
-        con.commit()
 
         with self.assertRaises(self.OpenReached) as reached:
-            self._run_until_open(
-                con, ["DEV1", "--harness", "claude", "--new-session"])
-        self.assertEqual((con, 1), reached.exception.call_args[:2])
+            self._run_until_open(con, ["DEV1"], render_only=True)
         self.assertIsNone(reached.exception.call_kwargs["reuse_archive_id"])
-        self.assertTrue(reached.exception.call_kwargs["force_new"])
+        self.assertFalse(reached.exception.call_kwargs["force_new"])
+        row = con.execute(
+            "SELECT state, managed FROM shell_session_bindings WHERE binding_id=?",
+            (binding["binding_id"],)).fetchone()
+        self.assertEqual(("dormant", 1), tuple(row))
+
+    def test_no_binding_enter_opens_without_supersede(self):
+        con = make_db()
+        self.addCleanup(con.close)
+
+        with self.assertRaises(self.OpenReached) as reached:
+            self._run_until_open(con, ["DEV1", "--harness", "claude"])
+        self.assertIsNone(reached.exception.call_kwargs["reuse_archive_id"])
+        self.assertFalse(reached.exception.call_kwargs["force_new"])
 
 
 class SuperviseTest(unittest.TestCase):

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -334,7 +334,7 @@ class BootPhaseLabelTest(unittest.TestCase):
             stack.enter_context(mock.patch.object(
                 run, "open_session", return_value=("0001", 1)))
             stack.enter_context(mock.patch.object(
-                run.session_supervisor, "binding_for_enter", return_value=None))
+                run.session_supervisor, "supersede_for_enter", return_value=None))
             stack.enter_context(mock.patch.object(run.ports_mod, "resolve", return_value={}))
             stack.enter_context(mock.patch.object(run, "ensure_worktree"))
             stack.enter_context(mock.patch.object(run, "sync_worktree", sync))


### PR DESCRIPTION
## Root cause

Two stacked session-control defects, plus the RST-C launch crash:

1. **#483 — version pins reject current CLIs.** `probe_codex()` hard-coded `SUPPORTED_MINOR = 144`, so codex-cli 0.145.0 got `create=false` and the controlled launcher exited "not validated". Same pin shape in the claude (`TESTED_VERSIONS = {(2,1)}`) and kimi (`TESTED_SERVER_VERSIONS = {(0,27),(0,28)}`) probes.
2. **#484 + RST-C — enter resumed the managed binding's native thread**, so any stale/poisoned binding wedged or crashed `make dos-e`: an errored binding rode the unused-stub archive reuse into `claim_lease` (`error -> foreground` invalid transition), and a binding whose rollout no longer exists crashed the codex TUI bootstrap (`thread/resume: no rollout found for thread id`).

## Fix

**Interactive enter always starts a fresh session.** `binding_for_enter` → `supersede_for_enter`: the shell's managed binding (or one parked on the active archive) is released — wake jobs cancelled, `last_error` preserved for audit — a fresh archive is opened (`force_new`), and a fresh binding is created with the managed flag carried over. The launcher then opens a NEW provider conversation instead of resuming. A live/orphaned owner still refuses the enter (one shell, one session).

**Headless sprint orchestration is untouched**: the dispatcher's `--session-binding` resume/deliver path, lease fencing, and `./sc session manage|release|retry` all behave as before. Wake jobs rebuild from unread messages on the new managed binding, and the dispatcher safely idles until the new native id registers.

**Version policy: floor, not pin.** codex >= 0.144, claude >= 2.1, kimi >= 0.27 — newer CLIs are accepted on the existing `--help` feature probes (the real capability gate); older/unparsable versions still fail closed. Trade-off, stated: protocol drift in a future CLI now fails loudly at RPC time instead of refusing at boot — that is the intended `support Latest` behavior.

## Testing

- New/rewritten: `SupersedeForEnterTest` (dormant/error/live-owner/unmanaged/no-binding + wake-job cancellation + managed rebind), `EnterMainFlowTest` (supersede-not-refuse at `main()`, RENDER_ONLY never mutates), probe floor tests for all three adapters (newer accepted, older closed).
- Targeted: 104 passed. Full `./sc test`: 654 passed; the 3 `test_vm_bake.py` failures are the documented sandbox-environment baseline (they pass with `SC_SANDBOX` unset; unrelated to this change). Ruff clean. Real-CLI probe smoke: codex 0.144.6 validates, 0.145.0 now accepted by the floor.

## Follow-ups (not in this diff)

- Spec #20 body (DB-owned) still documents "managed bindings resume by default" + SC-466 retry-first — needs a `sc mem doc` update or PLN1 pass; conformance render follows the DB.
- `./sc update-harnesses` on forks pulls the fixed probes; kcsos/RST-C recover via `./sc update` then `make dos-e` (the errored binding is superseded automatically).

Closes #483
Closes #484