### PR TITLE
fix(enter): avoid stranded skill-sync transaction

### DIFF
--- a/.super-coder/scripts/seed_skills.py
+++ b/.super-coder/scripts/seed_skills.py
@@ -164,11 +164,13 @@ def apply_retired(con) -> list[str]:
     flipped: list[str] = []
     for name in sorted(engine):
         want = 1 if name in retired else 0
-        cur = con.execute(
-            "UPDATE skills SET is_deleted=? WHERE name=? AND is_deleted<>?",
-            (want, name, want))
-        if cur.rowcount:
-            flipped.append(name)
+        row = con.execute(
+            "SELECT is_deleted FROM skills WHERE name=?", (name,)).fetchone()
+        if row is None or row[0] == want:
+            continue
+        con.execute(
+            "UPDATE skills SET is_deleted=? WHERE name=?", (want, name))
+        flipped.append(name)
     if flipped:
         con.commit()
     return flipped

--- a/tests/test_skills_freshness.py
+++ b/tests/test_skills_freshness.py
@@ -98,6 +98,10 @@ class SkillsFreshnessTest(unittest.TestCase):
 
     def test_sync_engine_skills_is_noop_when_fresh(self):
         self.assertEqual(seed_skills.sync_engine_skills(self.con), [])
+        self.assertFalse(
+            self.con.in_transaction,
+            "a no-op boot heal must not strand an implicit transaction",
+        )
 
     def test_sync_engine_skills_heals_stale(self):
         self.con.execute(


### PR DESCRIPTION
## Outcome

Fixes the post-#485 `make dos-e` crash in forks where normal boot-time skill retirement convergence leaves SQLite inside an implicit transaction.

## Change

- read `is_deleted` before updating and write only actual retirement flips
- preserve the `BEGIN IMMEDIATE` dispatcher ownership fence in `supersede_for_enter`
- assert a fresh no-op skill sync leaves the connection outside a transaction

## Verification

- focused: 54 passed (`test_skills_freshness`, `test_skill_retire`, `test_session_supervisor`)
- lint: clean
- full suite: 656 passed; 3 known sandbox-only `test_vm_bake` baseline failures

Closes #486