### PR TITLE
fix(mem): serialize doc writes headlessly (sprint 25 seq 2, SC-008, #434)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -840,11 +840,23 @@ def run_snapshot_render() -> str:
 # ONE serialization boundary for every path that writes the non-atomic
 # snapshot/render outputs (content.sql + the flat-render mirror) or moves the
 # main checkout's branches: mem doc writes (serialize_doc_write), the header
-# '/api/snapshot' shortcut, and '/api/publish' (git_publish). These were once
-# per-path private locks — a doc write could interleave its content.sql/render
-# writes with a Publish's branch checkout/staging (SC-012). Held at the caller
-# level only: run_snapshot_render() itself never takes it, so nothing re-enters.
+# '/api/snapshot' shortcut, the '/api/scripts/{snapshot,render}' maintenance
+# routes, and '/api/publish' (git_publish). These were once per-path private
+# locks — a doc write could interleave its content.sql/render writes with a
+# Publish's branch checkout/staging (SC-012). Held at the caller level only:
+# run_snapshot_render() itself never takes it, so nothing re-enters.
+#
+# Publish takes the lock around its LOCAL section only (SC-013) — branch moves,
+# the serialize, the commit — never across push/GitHub I/O: those carry no
+# timeout, and a queued doc write's 420s budget (_DOC_WRITE_TIMEOUT in
+# scripts/mem.py) is a real completion bound only when the lock queue is
+# bounded too.
 _CONTENT_WRITE_LOCK = threading.Lock()
+
+# The whitelisted maintenance scripts that write the same non-atomic outputs —
+# run_script takes no lock itself, so the /api/scripts/ endpoint wraps these
+# keys (the other scripts don't touch content.sql or the flat renders).
+_CONTENT_WRITE_SCRIPTS = frozenset({"snapshot", "render"})
 
 
 def serialize_doc_write() -> dict:
@@ -874,7 +886,9 @@ def serialize_doc_write() -> dict:
 # COMMITTED locally (the unpushed branch is kept so the commit isn't lost) — only
 # push/PR is skipped, with a clear message. Concurrent publishes — and every
 # other content-write path — serialize on _CONTENT_WRITE_LOCK (one git index,
-# one set of snapshot outputs), taken by the /api/publish endpoint.
+# one set of snapshot outputs), which git_publish() holds around its LOCAL
+# section only; the push + PR upsert run lock-free so no queued writer waits
+# on network I/O (SC-013).
 BASE_BRANCH = "main"
 PUBLISH_BRANCH = "sc_gui_content"
 _STASH_MSG = "sc-publish: stray non-content work"
@@ -976,46 +990,63 @@ def _redact(s: str, token: str) -> str:
 
 def git_publish() -> dict:
     out: list[str] = []
-    # state survives into the finally so cleanup knows whether the commit reached
+    # state survives into the cleanup so it knows whether the commit reached
     # origin (safe to drop the local branch) or only exists locally (keep it).
     state: dict = {"ok": True, "pr_url": None, "pushed": False}
-    try:
-        # 1. Get onto a clean BASE and (re)create the ephemeral branch BEFORE any
-        #    snapshot writes. The old order serialized first, which dirtied
-        #    whatever branch the tree happened to be on; if a prior run had left it
-        #    stranded on the publish branch, the next publish could then neither
-        #    delete that branch (it was current) nor check out main (the dirty,
-        #    regenerated content blocked it) — a self-perpetuating stuck state.
-        #    Preparing the branch first means the serialize lands on the publish
-        #    branch and can never block its own creation.
-        if _prepare_branch(out, state):
-            # 2. serialize the DB → git-tracked text + render the flat files.
-            out.append(run_snapshot_render())
-            # 3. stage → commit → push → open/update one PR.
-            _publish_content(out, state)
-    except Exception as e:
-        state["ok"] = False
-        out.append(f"✗ publish error: {e}")
-    finally:
-        # Always land back on main and drop the ephemeral local branch — runs even
-        # if a step raised or returned early, so the tree never stays stranded on
-        # the publish branch.
-        _land_on_base(out, state)
-        # Restore any stray non-content work stashed by _prepare_branch — only now,
-        # once we're back on base, so it lands where it was taken from. Non-content
-        # files are identical across base/publish tips, so pop can't conflict; if it
-        # somehow does, keep the stash and tell the operator loudly rather than drop.
-        if state.get("stashed"):
-            n = state["stashed"]
-            pop = _git("stash", "pop")
-            if pop.returncode == 0:
-                out.append(f"(restored {n} stashed non-content file(s))")
-            else:
-                out.append(f"⚠ {n} stashed non-content file(s) NOT restored — run "
-                           f"'git stash pop' manually:\n{pop.stderr.strip()}")
+    committed = False
+    # The LOCAL phase is ONE bounded critical section under _CONTENT_WRITE_LOCK:
+    # branch moves, the content.sql/render write, and the commit are what race
+    # the other content writers — and they are bounded (the serialize
+    # subprocesses carry 180s timeouts; local git touches no network). The push
+    # + PR upsert below run AFTER the lock is released (SC-013): a queued doc
+    # write waits only for this section, never for GitHub I/O with no timeout,
+    # so its 420s client budget is a real completion bound.
+    with _CONTENT_WRITE_LOCK:
+        try:
+            # 1. Get onto a clean BASE and (re)create the ephemeral branch BEFORE
+            #    any snapshot writes. The old order serialized first, which
+            #    dirtied whatever branch the tree happened to be on; if a prior
+            #    run had left it stranded on the publish branch, the next publish
+            #    could then neither delete that branch (it was current) nor check
+            #    out main (the dirty, regenerated content blocked it) — a
+            #    self-perpetuating stuck state. Preparing the branch first means
+            #    the serialize lands on the publish branch and can never block
+            #    its own creation.
+            if _prepare_branch(out, state):
+                # 2. serialize the DB → git-tracked text + render the flat files.
+                out.append(run_snapshot_render())
+                # 3. stage → commit (local only — push/PR happen lock-free below).
+                committed = _commit_content(out, state)
+        except Exception as e:
+            state["ok"] = False
+            out.append(f"✗ publish error: {e}")
+        finally:
+            # Always land back on main — runs even if a step raised or returned
+            # early, so the tree never stays stranded on the publish branch. The
+            # local branch itself is dropped only after the push's fate is known
+            # (_drop_publish_branch below).
+            _land_on_base(out)
+            # Restore any stray non-content work stashed by _prepare_branch — only
+            # now, once we're back on base, so it lands where it was taken from.
+            # Non-content files are identical across base/publish tips, so pop
+            # can't conflict; if it somehow does, keep the stash and tell the
+            # operator loudly rather than drop.
+            if state.get("stashed"):
+                n = state["stashed"]
+                pop = _git("stash", "pop")
+                if pop.returncode == 0:
+                    out.append(f"(restored {n} stashed non-content file(s))")
+                else:
+                    out.append(f"⚠ {n} stashed non-content file(s) NOT restored — run "
+                               f"'git stash pop' manually:\n{pop.stderr.strip()}")
+    # 4. Network phase — lock released: force-push + open/update the ONE PR.
+    if committed and state["ok"]:
+        _push_and_pr(out, state)
+    # 5. Local branch cleanup, keyed on whether the commit reached origin.
+    _drop_publish_branch(out, state, committed)
     # Record the full end-to-end trace (success OR failure) so a publish that
     # "looked done" can be inspected after the fact — the gap that made the live
-    # incident unexplainable. _land_on_base above appends to `out`, so log here.
+    # incident unexplainable. The steps above append to `out`, so log here.
     log_event("publish", ok=state["ok"], pushed=state["pushed"],
               pr_url=state["pr_url"], detail=out)
     return {"ok": state["ok"], "output": "\n".join(out), "pr_url": state["pr_url"]}
@@ -1097,10 +1128,12 @@ def _prepare_branch(out: list, state: dict) -> bool:
     return True
 
 
-def _publish_content(out: list, state: dict) -> None:
+def _commit_content(out: list, state: dict) -> bool:
+    """Stage the publishable text + renders on the ephemeral branch and commit
+    if anything changed — LOCAL work inside _CONTENT_WRITE_LOCK. Returns True
+    only when a commit was created (i.e. there is something to push)."""
     # The ephemeral branch is already created clean from base by _prepare_branch,
     # and the snapshot+render has written the publishable content onto it.
-    # 3. stage the publishable text + renders; commit if anything changed.
     #    Filter to paths that exist — `git add` is fatal on a missing pathspec, and
     #    a minimal fork may lack some (e.g. docs_sc/ before any doc is authored).
     #    Drop gitignored paths too: in a fork the engine (schema/migrations) is
@@ -1115,7 +1148,7 @@ def _publish_content(out: list, state: dict) -> None:
     staged = _git("diff", "--cached", "--name-only").stdout.strip()
     if not staged:
         out.append(f"✓ no content changes vs {BASE_BRANCH} — nothing to publish")
-        return
+        return False
     n = len(staged.splitlines())
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     msg = (f"gui: publish content edits ({n} file{'s' if n != 1 else ''})\n\n"
@@ -1125,20 +1158,28 @@ def _publish_content(out: list, state: dict) -> None:
     if c.returncode != 0:
         state["ok"] = False
         out.append("✗ commit failed:\n" + (c.stderr or c.stdout).strip())
-        return
+        return False
     out.append(f"committed {n} file(s)")
+    return True
 
-    # 4. token gate: committed locally either way, but push/PR needs a token.
+
+def _push_and_pr(out: list, state: dict) -> None:
+    """Network phase: force-push the ephemeral branch and upsert the ONE PR.
+    Runs AFTER _CONTENT_WRITE_LOCK is released (SC-013) — none of this is
+    timeout-bounded, so no queued content writer may ever wait on it. The tree
+    is back on base by now; the push addresses the branch by ref, not by
+    checkout."""
+    # token gate: committed locally either way, but push/PR needs a token.
     token = _gh_token()
     if not token:
         out.append("⚠ committed locally, but no GH_TOKEN — can't push or open a "
                    "PR. Set SC_GH_TOKEN, or `./sc launch` with a host gh login.")
         return
 
-    # 5. force-push: the branch is recreated from HEAD each publish (one commit
-    #    ahead of main — the full current state), so it intentionally overwrites
-    #    the prior rolling head. Only publish ever writes this branch, so --force
-    #    is safe and force-with-lease's tracking-ref dance is unnecessary.
+    # force-push: the branch is recreated from HEAD each publish (one commit
+    # ahead of main — the full current state), so it intentionally overwrites
+    # the prior rolling head. Only publish ever writes this branch, so --force
+    # is safe and force-with-lease's tracking-ref dance is unnecessary.
     url = _origin_https()
     if not url:
         state["ok"] = False
@@ -1153,7 +1194,7 @@ def _publish_content(out: list, state: dict) -> None:
     state["pushed"] = True
     out.append(f"force-pushed {PUBLISH_BRANCH} → origin")
 
-    # 6. upsert ONE PR — no merge; the open PR is the gate the FnB merges.
+    # upsert ONE PR — no merge; the open PR is the gate the FnB merges.
     env = {**os.environ, "GH_TOKEN": token}
 
     def gh(*args):
@@ -1178,11 +1219,9 @@ def _publish_content(out: list, state: dict) -> None:
     state["pr_url"] = pr_url
 
 
-def _land_on_base(out: list, state: dict) -> None:
-    """Return to main and drop the ephemeral local branch — the pushed remote
-    branch + its PR are what persist. If the commit was NOT pushed (no token /
-    push failed), KEEP the local branch so its commit isn't lost; the live DB is
-    still the source of truth and a later `snapshot` regenerates the same text."""
+def _land_on_base(out: list) -> None:
+    """Return to main. The ephemeral local branch is left in place here —
+    _drop_publish_branch drops or keeps it once the push's fate is known."""
     now = _git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
     if now != BASE_BRANCH:
         # If a step raised after the snapshot but before the commit, the publish
@@ -1194,16 +1233,24 @@ def _land_on_base(out: list, state: dict) -> None:
             out.append(f"⚠ left on {now} — couldn't return to {BASE_BRANCH}:\n"
                        f"{co.stderr.strip()}")
             return
+    out.append(f"↩ back on {BASE_BRANCH}")
+
+
+def _drop_publish_branch(out: list, state: dict, committed: bool) -> None:
+    """Drop the local ephemeral branch once its commit reached origin; KEEP it
+    when the commit exists only locally (no token / push failed) so it isn't
+    lost — the live DB is still the source of truth and a later `snapshot`
+    regenerates the same text. A branch this run never committed on holds
+    nothing, so it is dropped too."""
     local_exists = _git("rev-parse", "--verify", "--quiet",
                         f"refs/heads/{PUBLISH_BRANCH}").returncode == 0
-    if local_exists and state["pushed"]:
+    if not local_exists:
+        return
+    if state["pushed"] or not committed:
         _git("branch", "-D", PUBLISH_BRANCH)
-        out.append(f"↩ back on {BASE_BRANCH}; local {PUBLISH_BRANCH} cleaned up")
-    elif local_exists:
-        out.append(f"↩ back on {BASE_BRANCH}; kept local {PUBLISH_BRANCH} "
-                   "(unpushed commit preserved)")
+        out.append(f"local {PUBLISH_BRANCH} cleaned up")
     else:
-        out.append(f"↩ back on {BASE_BRANCH}")
+        out.append(f"kept local {PUBLISH_BRANCH} (unpushed commit preserved)")
 
 
 # ── HTTP ──────────────────────────────────────────────────────────────────────
@@ -2264,11 +2311,23 @@ class Handler(BaseHTTPRequestHandler):
                 log_event("snapshot", ok=True, detail=out)
                 return self._send(200, {"output": out})
             if path == "/api/publish":
-                with _CONTENT_WRITE_LOCK:
-                    r = git_publish()
+                # No lock here: git_publish() takes _CONTENT_WRITE_LOCK around
+                # its LOCAL section itself (SC-013) — wrapping the whole call
+                # would hold the lock across push/GitHub I/O (and deadlock:
+                # the lock is not re-entrant).
+                r = git_publish()
                 return self._send(200 if r["ok"] else 500, r)
             if path.startswith("/api/scripts/"):
-                r = run_script(path.rsplit("/", 1)[1])
+                key = path.rsplit("/", 1)[1]
+                # snapshot/render write the same non-atomic outputs as a
+                # doc-write serialize — run them under the shared lock
+                # (SC-012). The other maintenance scripts don't touch those
+                # files and stay lock-free.
+                if key in _CONTENT_WRITE_SCRIPTS:
+                    with _CONTENT_WRITE_LOCK:
+                        r = run_script(key)
+                else:
+                    r = run_script(key)
                 if r is None:
                     return self._send(404, {"error": "no such script"})
                 return self._send(200 if r["ok"] else 500, r)

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -837,9 +837,14 @@ def run_snapshot_render() -> str:
     return (snap["output"] + "\n" + rend["output"]).strip()
 
 
-# Serializes two snapshot/render subprocesses against each other — concurrent
-# mem doc writes would otherwise interleave writes to content.sql / the mirror.
-_serialize_lock = threading.Lock()
+# ONE serialization boundary for every path that writes the non-atomic
+# snapshot/render outputs (content.sql + the flat-render mirror) or moves the
+# main checkout's branches: mem doc writes (serialize_doc_write), the header
+# '/api/snapshot' shortcut, and '/api/publish' (git_publish). These were once
+# per-path private locks — a doc write could interleave its content.sql/render
+# writes with a Publish's branch checkout/staging (SC-012). Held at the caller
+# level only: run_snapshot_render() itself never takes it, so nothing re-enters.
+_CONTENT_WRITE_LOCK = threading.Lock()
 
 
 def serialize_doc_write() -> dict:
@@ -850,7 +855,7 @@ def serialize_doc_write() -> dict:
     is rare enough that the synchronous pair costs nothing that matters.
     Never raises: the DB write is already committed, so a serialize failure
     comes back as {"ok": False, ...} for the caller to surface instead."""
-    with _serialize_lock:
+    with _CONTENT_WRITE_LOCK:
         try:
             return {"ok": True, "output": run_snapshot_render()}
         except RuntimeError as e:
@@ -867,12 +872,12 @@ def serialize_doc_write() -> dict:
 # accumulate. Push + PR need a GitHub token (SC_GH_TOKEN / GH_TOKEN); `./sc
 # launch` forwards it into the sandbox. Without a token the change is still
 # COMMITTED locally (the unpushed branch is kept so the commit isn't lost) — only
-# push/PR is skipped, with a clear message. A module lock serializes concurrent
-# publishes (one git index).
+# push/PR is skipped, with a clear message. Concurrent publishes — and every
+# other content-write path — serialize on _CONTENT_WRITE_LOCK (one git index,
+# one set of snapshot outputs), taken by the /api/publish endpoint.
 BASE_BRANCH = "main"
 PUBLISH_BRANCH = "sc_gui_content"
 _STASH_MSG = "sc-publish: stray non-content work"
-_PUBLISH_LOCK = threading.Lock()
 # The git-tracked text the DB rebuilds from + the flat renders. NOT the .db
 # (gitignored). schema.sql + migrations are engine paths: TRACKED in the source
 # repo, GITIGNORED in a fork (B7) — git_publish() filters ignored paths so the
@@ -1931,7 +1936,12 @@ class Handler(BaseHTTPRequestHandler):
                 if r is None:
                     return self._send(404, {"error": "no such document"})
                 if r[0]:
-                    return self._send(409, {"error": "document is already frozen"})
+                    # Idempotent (SC-013): a retry after an ambiguous timeout —
+                    # the freeze committed but the response was lost — must read
+                    # as the success it was, not a 409. The re-serialize also
+                    # heals any drift a lost post-freeze serialize left behind.
+                    return self._send(200, {"ok": True, "already_frozen": True,
+                                            "serialize": serialize_doc_write()})
                 con.execute(
                     "UPDATE documents SET frozen=1, frozen_date=date('now') WHERE document_id=?",
                     (did,))
@@ -2244,7 +2254,8 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, analytics.sweep(quiet=True))
             if path == "/api/snapshot":
                 try:
-                    out = run_snapshot_render()
+                    with _CONTENT_WRITE_LOCK:
+                        out = run_snapshot_render()
                 except Exception as e:
                     # run_snapshot_render raises on a failed serialize/render; log
                     # the failure before re-raising so it's in the rolling log too.
@@ -2253,7 +2264,7 @@ class Handler(BaseHTTPRequestHandler):
                 log_event("snapshot", ok=True, detail=out)
                 return self._send(200, {"output": out})
             if path == "/api/publish":
-                with _PUBLISH_LOCK:
+                with _CONTENT_WRITE_LOCK:
                     r = git_publish()
                 return self._send(200 if r["ok"] else 500, r)
             if path.startswith("/api/scripts/"):

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -837,6 +837,26 @@ def run_snapshot_render() -> str:
     return (snap["output"] + "\n" + rend["output"]).strip()
 
 
+# Serializes two snapshot/render subprocesses against each other — concurrent
+# mem doc writes would otherwise interleave writes to content.sql / the mirror.
+_serialize_lock = threading.Lock()
+
+
+def serialize_doc_write() -> dict:
+    """Re-snapshot + re-render after a mem doc write, so `sc mem doc add/edit/
+    freeze` lands on disk headlessly — the git-tracked flat render and
+    .sc-state/content.sql move with the write, no GUI Publish (subfloor#434).
+    The API is the admin surface (run_script sets SC_ADMIN), and a doc write
+    is rare enough that the synchronous pair costs nothing that matters.
+    Never raises: the DB write is already committed, so a serialize failure
+    comes back as {"ok": False, ...} for the caller to surface instead."""
+    with _serialize_lock:
+        try:
+            return {"ok": True, "output": run_snapshot_render()}
+        except RuntimeError as e:
+            return {"ok": False, "output": str(e)}
+
+
 # ── Publish: serialize → render → commit → push → open/update one PR ──────────
 # Ephemeral-branch model: each publish (re)creates the local branch from HEAD,
 # commits the serialized content + renders onto it, force-pushes, opens/updates
@@ -1683,7 +1703,8 @@ class Handler(BaseHTTPRequestHandler):
                      body.get("body") or None,
                      body.get("render_path") or None))
                 con.commit()
-                return self._send(201, {"document_id": cur.lastrowid})
+                return self._send(201, {"document_id": cur.lastrowid,
+                                        "serialize": serialize_doc_write()})
 
             if path == "/_sc/mem/narrative":
                 text = (body.get("text") or "").strip()
@@ -1915,7 +1936,8 @@ class Handler(BaseHTTPRequestHandler):
                     "UPDATE documents SET frozen=1, frozen_date=date('now') WHERE document_id=?",
                     (did,))
                 con.commit()
-                return self._send(200, {"ok": True})
+                return self._send(200, {"ok": True,
+                                        "serialize": serialize_doc_write()})
 
             # PATCH /_sc/mem/docs/{id}
             if len(parts) == 4 and parts[2] == "docs":
@@ -1925,7 +1947,10 @@ class Handler(BaseHTTPRequestHandler):
                         (did,)).fetchone():
                     return self._send(404, {"error": "no such document"})
                 ok, err = patch_document(con, did, body)
-                return self._send(200 if ok else 400, {"ok": ok, "error": err})
+                if not ok:
+                    return self._send(400, {"ok": ok, "error": err})
+                return self._send(200, {"ok": ok,
+                                        "serialize": serialize_doc_write()})
 
             # PATCH /_sc/mem/messages/{id}/read
             if len(parts) == 5 and parts[2] == "messages" and parts[4] == "read":

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -97,10 +97,18 @@ def _require_api() -> None:
 
 _RETRIES = 3          # extra attempts beyond the first
 _RETRY_PAUSE = 2.0    # seconds between attempts (503 may override via Retry-After)
+_TIMEOUT = 10         # default per-request HTTP timeout (seconds)
+# Doc add/edit/freeze commit fast but then SYNCHRONOUSLY run snapshot+render
+# server-side (each subprocess capped at 180s — up to ~360s, plus queueing on
+# the shared content-write lock behind another serialize or a Publish). With
+# the generic timeout a slow success surfaced as "API unreachable" and a PATCH
+# retry re-ran the whole serialize (SC-013). Doc writes carry their own budget.
+_DOC_WRITE_TIMEOUT = 420
 
 
 def _api(method: str, path: str, payload: "dict | None" = None,
-         idempotent: "bool | None" = None) -> dict:
+         idempotent: "bool | None" = None,
+         timeout: "float | None" = None) -> dict:
     """POST/PATCH/GET to the engine API; die loud on any error.
 
     Retries (#331 — multi-shell write contention on the engine DB):
@@ -115,6 +123,8 @@ def _api(method: str, path: str, payload: "dict | None" = None,
     """
     if idempotent is None:
         idempotent = method in ("GET", "PATCH")
+    if timeout is None:
+        timeout = _TIMEOUT
     url = SC_API_BASE.rstrip("/") + path
     data = json.dumps(payload).encode() if payload is not None else None
     headers: dict = {"Authorization": f"Bearer {SC_API_TOKEN}"}
@@ -124,7 +134,7 @@ def _api(method: str, path: str, payload: "dict | None" = None,
     for attempt in range(1 + _RETRIES):
         last = attempt == _RETRIES
         try:
-            with urllib.request.urlopen(req, timeout=10) as resp:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
                 return json.loads(resp.read())
         except urllib.error.HTTPError as e:
             if e.code == 503 and not last:
@@ -519,7 +529,11 @@ def cmd_oriented(args) -> int:
 
 def cmd_doc(args) -> int:
     if args.doc_cmd == "freeze":
-        r = _api("PATCH", f"/_sc/mem/docs/{args.document_id}/freeze")
+        r = _api("PATCH", f"/_sc/mem/docs/{args.document_id}/freeze",
+                 timeout=_DOC_WRITE_TIMEOUT)
+        if r.get("already_frozen"):
+            print(f"mem: document #{args.document_id} was already frozen "
+                  f"(freeze is idempotent)")
         rc = _finish_api(f"mem: document #{args.document_id} frozen")
         return _note_serialize(r) or rc
     if args.doc_cmd == "edit":
@@ -532,7 +546,8 @@ def cmd_doc(args) -> int:
             payload["render_path"] = args.render_path
         if not payload:
             die("nothing to edit — pass at least one of --title / --body-file / --render-path")
-        r = _api("PATCH", f"/_sc/mem/docs/{args.document_id}", payload)
+        r = _api("PATCH", f"/_sc/mem/docs/{args.document_id}", payload,
+                 timeout=_DOC_WRITE_TIMEOUT)
         rc = _finish_api(f"mem: document #{args.document_id} edited")
         return _note_serialize(r) or rc
     body_text = Path(args.body_file).read_text()
@@ -542,7 +557,8 @@ def cmd_doc(args) -> int:
               "seq": args.seq,
               "title": args.title,
               "body": body_text,
-              "render_path": args.render_path})
+              "render_path": args.render_path},
+             timeout=_DOC_WRITE_TIMEOUT)
     rc = _finish_api(f"mem: {args.kind} document #{r.get('document_id', '')} added"
                      f" ('{args.title}', {len(body_text)} chars)")
     return _note_serialize(r) or rc

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -519,8 +519,9 @@ def cmd_oriented(args) -> int:
 
 def cmd_doc(args) -> int:
     if args.doc_cmd == "freeze":
-        _api("PATCH", f"/_sc/mem/docs/{args.document_id}/freeze")
-        return _finish_api(f"mem: document #{args.document_id} frozen")
+        r = _api("PATCH", f"/_sc/mem/docs/{args.document_id}/freeze")
+        rc = _finish_api(f"mem: document #{args.document_id} frozen")
+        return _note_serialize(r) or rc
     if args.doc_cmd == "edit":
         payload: dict = {}
         if args.title is not None:
@@ -531,8 +532,9 @@ def cmd_doc(args) -> int:
             payload["render_path"] = args.render_path
         if not payload:
             die("nothing to edit — pass at least one of --title / --body-file / --render-path")
-        _api("PATCH", f"/_sc/mem/docs/{args.document_id}", payload)
-        return _finish_api(f"mem: document #{args.document_id} edited")
+        r = _api("PATCH", f"/_sc/mem/docs/{args.document_id}", payload)
+        rc = _finish_api(f"mem: document #{args.document_id} edited")
+        return _note_serialize(r) or rc
     body_text = Path(args.body_file).read_text()
     r = _api("POST", "/_sc/mem/docs",
              {"feature_id": args.feature,
@@ -541,8 +543,25 @@ def cmd_doc(args) -> int:
               "title": args.title,
               "body": body_text,
               "render_path": args.render_path})
-    return _finish_api(f"mem: {args.kind} document #{r.get('document_id', '')} added"
-                       f" ('{args.title}', {len(body_text)} chars)")
+    rc = _finish_api(f"mem: {args.kind} document #{r.get('document_id', '')} added"
+                     f" ('{args.title}', {len(body_text)} chars)")
+    return _note_serialize(r) or rc
+
+
+def _note_serialize(r: dict) -> int:
+    """Surface the server-side snapshot+render that follows a doc write
+    (subfloor#434): the flat file + content.sql refresh headlessly on the main
+    checkout. A failed serialize never fails the write — it prints a warning
+    and exits nonzero so the drift is visible, not silent."""
+    s = r.get("serialize") if isinstance(r, dict) else None
+    if not s:
+        return 0
+    if s.get("ok"):
+        print("  (snapshot + flat render refreshed on the main checkout)")
+        return 0
+    print(f"  WARNING: post-write snapshot/render failed — the DB row is live "
+          f"but the flat file + content.sql did not refresh:\n{s.get('output')}")
+    return 1
 
 
 def cmd_narrative(args) -> int:

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -438,11 +438,12 @@ class ApiMemTest(unittest.TestCase):
 
     # ── SC-012: doc write vs Publish — ONE shared serialization boundary ──────
     def test_doc_write_and_publish_share_one_lock(self):
-        # Doc-write serialize, /api/snapshot, and Publish all write the same
-        # non-atomic files (content.sql + flat renders) and Publish switches
-        # branches — per-path private locks let them interleave. Force a Publish
-        # to sit inside its critical section, then prove a concurrent doc
-        # write's serialize cannot enter until the Publish releases the lock.
+        # Doc-write serialize, /api/snapshot, /api/scripts/{snapshot,render},
+        # and Publish's local phase all write the same non-atomic files
+        # (content.sql + flat renders) and Publish switches branches. Force a
+        # Publish to sit inside its local critical section (its _prepare_branch
+        # runs under the lock), then prove a concurrent doc write's serialize
+        # cannot enter until the Publish releases the lock.
         self.run_mem("roadmap", "add", "feat race")
         fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat race'")[0]
         body = self.tmp / "race.md"
@@ -451,16 +452,19 @@ class ApiMemTest(unittest.TestCase):
                      "--feature", str(fid))
         did = self.q("SELECT document_id FROM documents WHERE title='spec race'")[0]
         server.serialize_doc_write = self._real_serialize
-        real_publish = server.git_publish
+        real_prepare = server._prepare_branch
+        real_land = server._land_on_base
+        real_drop = server._drop_publish_branch
         real_rsr = server.run_snapshot_render
         in_publish = threading.Event()
         release = threading.Event()
         overlap = []
 
-        def fake_publish():
+        def fake_prepare(out, state):
+            # runs inside git_publish's locked local section
             in_publish.set()
             release.wait(5)
-            return {"ok": True, "output": "published (test stub)", "pr_url": None}
+            return False  # no serialize/commit follows; nothing to push
 
         def fake_rsr():
             # runs inside serialize_doc_write's lock hold — if Publish is still
@@ -468,7 +472,11 @@ class ApiMemTest(unittest.TestCase):
             overlap.append(in_publish.is_set() and not release.is_set())
             return "snapshot+render (test stub)"
 
-        server.git_publish = fake_publish
+        server._prepare_branch = fake_prepare
+        # no real git against the test checkout: the local phase is stubbed
+        # short and the branch never exists
+        server._land_on_base = lambda out: None
+        server._drop_publish_branch = lambda out, state, committed: None
         server.run_snapshot_render = fake_rsr
         publish_rc = []
 
@@ -492,7 +500,212 @@ class ApiMemTest(unittest.TestCase):
             self.assertEqual(overlap, [False])  # serialize ran AFTER publish released
         finally:
             release.set()
-            server.git_publish = real_publish
+            server._prepare_branch = real_prepare
+            server._land_on_base = real_land
+            server._drop_publish_branch = real_drop
+            server.run_snapshot_render = real_rsr
+            server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
+
+    def test_scripts_content_writers_share_the_lock(self):
+        # SC-012: /api/scripts/snapshot and /api/scripts/render call the same
+        # content writers as the header shortcut — they must queue on the same
+        # lock as a doc-write serialize, not bypass it. Hold a scripts/snapshot
+        # call inside the lock and prove a concurrent doc write waits.
+        self.run_mem("roadmap", "add", "feat scr")
+        fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat scr'")[0]
+        body = self.tmp / "scr.md"
+        body.write_text("# scr\n")
+        self.run_mem("doc", "add", "spec scr", "--body-file", str(body),
+                     "--feature", str(fid))
+        did = self.q("SELECT document_id FROM documents WHERE title='spec scr'")[0]
+        server.serialize_doc_write = self._real_serialize
+        real_run_script = server.run_script
+        real_rsr = server.run_snapshot_render
+        in_script = threading.Event()
+        release = threading.Event()
+        overlap = []
+
+        def fake_run_script(key):
+            # the endpoint wraps snapshot/render in _CONTENT_WRITE_LOCK, so
+            # this stub runs INSIDE the lock hold for those keys
+            in_script.set()
+            release.wait(5)
+            return {"ok": True, "code": 0, "output": f"{key} (test stub)"}
+
+        def fake_rsr():
+            # runs inside serialize_doc_write's lock hold — if the scripts
+            # route still bypassed the lock, the script would still be inside
+            # its section (release unset) when this runs
+            overlap.append(in_script.is_set() and not release.is_set())
+            return "snapshot+render (test stub)"
+
+        server.run_script = fake_run_script
+        server.run_snapshot_render = fake_rsr
+        script_rc = []
+
+        def do_script():
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{self.port}/api/scripts/snapshot",
+                data=b"", method="POST")
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                script_rc.append(resp.status)
+
+        try:
+            t = threading.Thread(target=do_script)
+            t.start()
+            self.assertTrue(in_script.wait(5), "script never entered its section")
+            threading.Timer(0.5, release.set).start()
+            self.assertEqual(
+                self.run_mem("doc", "edit", str(did), "--title", "spec scr v2"), 0)
+            t.join(10)
+            self.assertEqual(script_rc, [200])
+            self.assertEqual(overlap, [False])  # serialize ran AFTER the script released
+        finally:
+            release.set()
+            server.run_script = real_run_script
+            server.run_snapshot_render = real_rsr
+            server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
+
+    # ── SC-013: Publish's network phase never blocks a queued doc write ───────
+    def test_publish_network_phase_holds_no_lock(self):
+        # The 420s doc-write budget is a completion bound only if the lock
+        # queue is bounded: Publish must hold _CONTENT_WRITE_LOCK for its local
+        # serialize/commit only, NOT across push + GitHub I/O (no timeout).
+        # Park a Publish inside its network phase and prove a concurrent doc
+        # write completes without waiting for it — under the old whole-call
+        # lock it would have queued behind the blocked push.
+        self.run_mem("roadmap", "add", "feat net")
+        fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat net'")[0]
+        body = self.tmp / "net.md"
+        body.write_text("# net\n")
+        self.run_mem("doc", "add", "spec net", "--body-file", str(body),
+                     "--feature", str(fid))
+        did = self.q("SELECT document_id FROM documents WHERE title='spec net'")[0]
+        server.serialize_doc_write = self._real_serialize
+        real_prepare = server._prepare_branch
+        real_commit = server._commit_content
+        real_land = server._land_on_base
+        real_drop = server._drop_publish_branch
+        real_push_pr = server._push_and_pr
+        real_rsr = server.run_snapshot_render
+        in_network = threading.Event()
+        release = threading.Event()
+        serialize_during_network = []
+
+        def fake_push_pr(out, state):
+            # the network phase — OUTSIDE the lock by design
+            in_network.set()
+            release.wait(30)
+
+        def fake_rsr():
+            # serves Publish's local serialize (before the network phase) AND
+            # the doc write's serialize — only the doc write's can see
+            # in_network set
+            serialize_during_network.append(
+                in_network.is_set() and not release.is_set())
+            return "serialize (test stub)"
+
+        server._prepare_branch = lambda out, state: True
+        server._commit_content = lambda out, state: True
+        server._land_on_base = lambda out: None
+        server._drop_publish_branch = lambda out, state, committed: None
+        server._push_and_pr = fake_push_pr
+        server.run_snapshot_render = fake_rsr
+        publish_rc = []
+
+        def do_publish():
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{self.port}/api/publish", data=b"", method="POST")
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                publish_rc.append(resp.status)
+
+        try:
+            t = threading.Thread(target=do_publish)
+            t.start()
+            self.assertTrue(in_network.wait(5),
+                            "publish never reached its network phase")
+            # The doc write runs on the main thread (mem.main sets signal
+            # handlers — main-thread only). If Publish still held the lock
+            # across its network phase, this would queue behind the blocked
+            # push until release.wait(30) above timed out — so the wall clock
+            # is the verdict: lock-free network phase = sub-second; lock held
+            # = ~30s.
+            start = time.monotonic()
+            self.assertEqual(
+                self.run_mem("doc", "edit", str(did), "--title", "spec net v2"), 0)
+            elapsed = time.monotonic() - start
+            self.assertLess(
+                elapsed, 10,
+                "doc write queued behind Publish's network phase — "
+                "the lock is held across network I/O again")
+            # the doc write's serialize really ran while Publish sat in its
+            # network phase (Publish's own local serialize saw neither flag)
+            self.assertEqual(serialize_during_network, [False, True])
+            release.set()
+            t.join(10)
+            self.assertEqual(publish_rc, [200])
+        finally:
+            release.set()
+            server._prepare_branch = real_prepare
+            server._commit_content = real_commit
+            server._land_on_base = real_land
+            server._drop_publish_branch = real_drop
+            server._push_and_pr = real_push_pr
+            server.run_snapshot_render = real_rsr
+            server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
+
+    def test_doc_write_queued_behind_slow_holder_succeeds(self):
+        # SC-013: the doc-write budget covers QUEUEING behind another content
+        # writer's bounded critical section, not just a slow serialize of its
+        # own. A slow /api/snapshot holds the lock; a concurrent doc write
+        # queues behind it, then succeeds — with the generic timeout shrunk
+        # below the hold, only the doc budget makes that possible.
+        self.run_mem("roadmap", "add", "feat queue")
+        fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat queue'")[0]
+        body = self.tmp / "queue.md"
+        body.write_text("# queue\n")
+        self.run_mem("doc", "add", "spec queue", "--body-file", str(body),
+                     "--feature", str(fid))
+        did = self.q("SELECT document_id FROM documents WHERE title='spec queue'")[0]
+        server.serialize_doc_write = self._real_serialize
+        real_rsr = server.run_snapshot_render
+        entered = threading.Event()
+
+        def slow_rsr():
+            # 1.5s inside the lock, per caller — the holder (/api/snapshot)
+            # and then the queued doc write each pay it
+            entered.set()
+            time.sleep(1.5)
+            return "slow ok"
+
+        server.run_snapshot_render = slow_rsr
+        real_timeout = mem._TIMEOUT
+        mem._TIMEOUT = 0.5  # any call on the generic budget now times out
+        holder_rc = []
+
+        def do_snapshot():
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{self.port}/api/snapshot", data=b"", method="POST")
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                holder_rc.append(resp.status)
+
+        try:
+            t = threading.Thread(target=do_snapshot)
+            t.start()
+            self.assertTrue(entered.wait(5), "snapshot never entered the lock")
+            start = time.monotonic()
+            self.assertEqual(
+                self.run_mem("doc", "edit", str(did), "--title", "spec queue v2"), 0)
+            elapsed = time.monotonic() - start
+            t.join(10)
+            self.assertEqual(holder_rc, [200])
+            # really queued behind the holder (no bypass), yet well within the
+            # doc-write budget — the bounded critical section is what a queued
+            # writer ever waits on
+            self.assertGreaterEqual(elapsed, 1.0)
+            self.assertLess(elapsed, mem._DOC_WRITE_TIMEOUT)
+        finally:
+            mem._TIMEOUT = real_timeout
             server.run_snapshot_render = real_rsr
             server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
 

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -75,9 +75,17 @@ class ApiMemTest(unittest.TestCase):
         # mem reads these into module globals at import — set them directly.
         mem.SC_API_BASE = f"http://127.0.0.1:{cls.port}"
         mem.SC_API_TOKEN = TOKEN
+        # Doc writes trigger a server-side snapshot+render against REPO_ROOT
+        # (subfloor#434) — stub it class-wide so tests never touch the real
+        # main tree; the hook itself is covered by test_doc_write_serializes.
+        # staticmethod: a plain function stored on the class would come back
+        # bound via self._real_serialize and eat an unwanted `self`.
+        cls._real_serialize = staticmethod(server.serialize_doc_write)
+        server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
 
     @classmethod
     def tearDownClass(cls):
+        server.serialize_doc_write = cls._real_serialize
         cls.httpd.shutdown()
         cls.httpd.server_close()
 
@@ -388,6 +396,43 @@ class ApiMemTest(unittest.TestCase):
         tid = self.q("SELECT task_id FROM spec_tasks WHERE title='task C'")[0]
         self.run_mem("task", "done", str(tid))
         self.assertEqual(self.q("SELECT status FROM spec_tasks WHERE task_id=?", tid)[0], "done")
+
+    # ── doc writes serialize headlessly (subfloor#434) ───────────────────────
+    def test_doc_write_serializes(self):
+        # Real hook, fake subprocess pair: assert the wiring, not the scripts.
+        server.serialize_doc_write = self._real_serialize
+        calls = []
+        real_rsr = server.run_snapshot_render
+        server.run_snapshot_render = lambda: calls.append(1) or "snapshot+render ok"
+        try:
+            self.run_mem("roadmap", "add", "feat ser")
+            fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat ser'")[0]
+            body = self.tmp / "ser.md"
+            body.write_text("# ser\nbody\n")
+            self.assertEqual(
+                self.run_mem("doc", "add", "spec ser", "--body-file", str(body),
+                             "--feature", str(fid)), 0)
+            did = self.q("SELECT document_id FROM documents WHERE title='spec ser'")[0]
+            self.assertEqual(
+                self.run_mem("doc", "edit", str(did), "--title", "spec ser v2"), 0)
+            self.assertEqual(self.run_mem("doc", "freeze", str(did)), 0)
+            self.assertEqual(len(calls), 3)  # add + edit + freeze each serialize once
+            # a failed serialize never fails the write — the row commits, the
+            # CLI warns and exits nonzero so the drift is visible
+            def boom():
+                raise RuntimeError("snapshot failed:\nbroken")
+            server.run_snapshot_render = boom
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = self.run_mem("doc", "add", "spec ser2", "--body-file",
+                                  str(body), "--feature", str(fid))
+            self.assertEqual(rc, 1)
+            self.assertIn("WARNING", buf.getvalue())
+            self.assertIsNotNone(
+                self.q("SELECT document_id FROM documents WHERE title='spec ser2'"))
+        finally:
+            server.run_snapshot_render = real_rsr
+            server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
 
     # ── task cancel: honest terminal state after a feature split (#342) ───────
     def test_task_cancel_with_notes(self):

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -20,7 +20,9 @@ import sqlite3
 import sys
 import tempfile
 import threading
+import time
 import unittest
+import urllib.request
 from http.server import ThreadingHTTPServer
 from pathlib import Path
 
@@ -431,6 +433,119 @@ class ApiMemTest(unittest.TestCase):
             self.assertIsNotNone(
                 self.q("SELECT document_id FROM documents WHERE title='spec ser2'"))
         finally:
+            server.run_snapshot_render = real_rsr
+            server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
+
+    # ── SC-012: doc write vs Publish — ONE shared serialization boundary ──────
+    def test_doc_write_and_publish_share_one_lock(self):
+        # Doc-write serialize, /api/snapshot, and Publish all write the same
+        # non-atomic files (content.sql + flat renders) and Publish switches
+        # branches — per-path private locks let them interleave. Force a Publish
+        # to sit inside its critical section, then prove a concurrent doc
+        # write's serialize cannot enter until the Publish releases the lock.
+        self.run_mem("roadmap", "add", "feat race")
+        fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat race'")[0]
+        body = self.tmp / "race.md"
+        body.write_text("# race\n")
+        self.run_mem("doc", "add", "spec race", "--body-file", str(body),
+                     "--feature", str(fid))
+        did = self.q("SELECT document_id FROM documents WHERE title='spec race'")[0]
+        server.serialize_doc_write = self._real_serialize
+        real_publish = server.git_publish
+        real_rsr = server.run_snapshot_render
+        in_publish = threading.Event()
+        release = threading.Event()
+        overlap = []
+
+        def fake_publish():
+            in_publish.set()
+            release.wait(5)
+            return {"ok": True, "output": "published (test stub)", "pr_url": None}
+
+        def fake_rsr():
+            # runs inside serialize_doc_write's lock hold — if Publish is still
+            # inside ITS section (release unset), the two paths interleaved
+            overlap.append(in_publish.is_set() and not release.is_set())
+            return "snapshot+render (test stub)"
+
+        server.git_publish = fake_publish
+        server.run_snapshot_render = fake_rsr
+        publish_rc = []
+
+        def do_publish():
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{self.port}/api/publish", data=b"", method="POST")
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                publish_rc.append(resp.status)
+
+        try:
+            t = threading.Thread(target=do_publish)
+            t.start()
+            self.assertTrue(in_publish.wait(5), "publish never entered its section")
+            # hold the Publish inside its section while the doc write arrives;
+            # the timer releases it well after an unshared lock would overlap
+            threading.Timer(0.5, release.set).start()
+            self.assertEqual(
+                self.run_mem("doc", "edit", str(did), "--title", "spec race v2"), 0)
+            t.join(10)
+            self.assertEqual(publish_rc, [200])
+            self.assertEqual(overlap, [False])  # serialize ran AFTER publish released
+        finally:
+            release.set()
+            server.git_publish = real_publish
+            server.run_snapshot_render = real_rsr
+            server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
+
+    # ── SC-013: a slow successful serialize is still a successful write ────────
+    def test_doc_write_slow_serializer_succeeds(self):
+        # The post-write snapshot+render can legitimately run for minutes; the
+        # generic client timeout turned that slow SUCCESS into "API unreachable"
+        # and a PATCH retry re-ran the serialize. Doc writes carry their own
+        # budget — shrink the generic timeout below the serializer's runtime and
+        # prove add/edit/freeze still succeed; freeze is idempotent on retry.
+        # A urlopen spy pins the wiring: doc writes must USE the doc budget,
+        # everything else the generic one (without it a slow-enough-to-pass
+        # stub could let a hardcoded timeout slip through).
+        server.serialize_doc_write = self._real_serialize
+        real_rsr = server.run_snapshot_render
+        server.run_snapshot_render = lambda: (time.sleep(1.0), "slow ok")[1]
+        real_timeout = mem._TIMEOUT
+        mem._TIMEOUT = 0.5  # any call on the generic budget now times out
+        timeouts = []
+        real_urlopen = mem.urllib.request.urlopen
+
+        def spy(req, timeout=None):
+            timeouts.append(timeout)
+            return real_urlopen(req, timeout=timeout)
+
+        mem.urllib.request.urlopen = spy
+        try:
+            self.run_mem("roadmap", "add", "feat slow")
+            fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat slow'")[0]
+            body = self.tmp / "slow.md"
+            body.write_text("# slow\n")
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                self.assertEqual(
+                    self.run_mem("doc", "add", "spec slow", "--body-file", str(body),
+                                 "--feature", str(fid)), 0)
+                did = self.q(
+                    "SELECT document_id FROM documents WHERE title='spec slow'")[0]
+                self.assertEqual(
+                    self.run_mem("doc", "edit", str(did), "--title", "spec slow v2"), 0)
+                self.assertEqual(self.run_mem("doc", "freeze", str(did)), 0)
+                # retry of a committed freeze (the ambiguous-timeout case):
+                # success again, flagged already_frozen — not a 409
+                self.assertEqual(self.run_mem("doc", "freeze", str(did)), 0)
+            out = buf.getvalue()
+            self.assertIn("already frozen", out)
+            self.assertNotIn("WARNING", out)
+            self.assertEqual(
+                self.q("SELECT frozen FROM documents WHERE document_id=?", did)[0], 1)
+            self.assertEqual(timeouts, [0.5] + [mem._DOC_WRITE_TIMEOUT] * 4)
+        finally:
+            mem.urllib.request.urlopen = real_urlopen
+            mem._TIMEOUT = real_timeout
             server.run_snapshot_render = real_rsr
             server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
 

--- a/tests/test_publish_cleanup.py
+++ b/tests/test_publish_cleanup.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
-"""Tests for publish's cleanup contract (server._land_on_base).
+"""Tests for publish's cleanup contract (server._land_on_base + _drop_publish_branch).
 
 Stdlib `unittest`, real git in a tmpdir — matching test_git_prune.py's
 no-dependency style. The full git_publish() round-trip shells out to snapshot/
 render + a real remote + `gh`, so it isn't unit-testable here; what IS isolable
 (and is the behavior change) is the ephemeral-branch cleanup: always land back
-on main, drop the local branch ONLY when its commit reached origin, keep it
-otherwise so an unpushed commit isn't lost. server._git binds cwd to the
-module global REPO_ROOT at call time, so pointing that at a tmp repo retargets
-the whole helper.
+on main, then drop the local branch ONLY when its commit reached origin, keep
+it otherwise so an unpushed commit isn't lost (SC-013 split the cleanup from
+the landing: the push now runs lock-free after the local section, so the
+branch's fate is known only later). server._git binds cwd to the module global
+REPO_ROOT at call time, so pointing that at a tmp repo retargets the whole
+helper.
 
 Run:
     python3 tests/test_publish_cleanup.py
@@ -68,21 +70,45 @@ class LandOnBaseTest(unittest.TestCase):
         server.REPO_ROOT = self._orig_root
         subprocess.run(["rm", "-rf", str(self.tmp)])
 
+    def test_lands_back_on_base(self) -> None:
+        # Whatever the push's fate, the tree returns to main; the local branch
+        # is left in place for _drop_publish_branch.
+        out: list[str] = []
+        server._land_on_base(out)
+        self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
+        self.assertIn(server.PUBLISH_BRANCH, local_branches(self.repo))
+        self.assertEqual(out, [f"↩ back on {server.BASE_BRANCH}"])
+
     def test_pushed_drops_local_branch(self) -> None:
         # commit reached origin → the local branch is disposable.
+        server._land_on_base([])
         out: list[str] = []
-        server._land_on_base(out, {"ok": True, "pr_url": "x", "pushed": True})
+        server._drop_publish_branch(out, {"ok": True, "pr_url": "x", "pushed": True},
+                                    committed=True)
         self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
         self.assertNotIn(server.PUBLISH_BRANCH, local_branches(self.repo))
         self.assertTrue(any("cleaned up" in line for line in out))
 
     def test_unpushed_keeps_local_branch(self) -> None:
         # no token / push failed → keep the branch so the commit isn't lost.
+        server._land_on_base([])
         out: list[str] = []
-        server._land_on_base(out, {"ok": True, "pr_url": None, "pushed": False})
+        server._drop_publish_branch(out, {"ok": True, "pr_url": None, "pushed": False},
+                                    committed=True)
         self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
         self.assertIn(server.PUBLISH_BRANCH, local_branches(self.repo))
         self.assertTrue(any("kept local" in line for line in out))
+
+    def test_uncommitted_branch_is_dropped(self) -> None:
+        # Nothing was committed this run (no content changes / a step raised
+        # before the commit) — the branch holds nothing, so it goes.
+        git(self.repo, "checkout", server.BASE_BRANCH)
+        git(self.repo, "branch", "-f", server.PUBLISH_BRANCH, server.BASE_BRANCH)
+        out: list[str] = []
+        server._drop_publish_branch(out, {"ok": True, "pr_url": None, "pushed": False},
+                                    committed=False)
+        self.assertNotIn(server.PUBLISH_BRANCH, local_branches(self.repo))
+        self.assertTrue(any("cleaned up" in line for line in out))
 
     def test_already_on_base_is_a_noop_return(self) -> None:
         # Nothing to do but report — e.g. branch creation failed earlier so we
@@ -90,7 +116,9 @@ class LandOnBaseTest(unittest.TestCase):
         git(self.repo, "checkout", server.BASE_BRANCH)
         git(self.repo, "branch", "-D", server.PUBLISH_BRANCH)
         out: list[str] = []
-        server._land_on_base(out, {"ok": False, "pr_url": None, "pushed": False})
+        server._land_on_base(out)
+        server._drop_publish_branch(out, {"ok": False, "pr_url": None,
+                                          "pushed": False}, committed=False)
         self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
         self.assertEqual(out, [f"↩ back on {server.BASE_BRANCH}"])
 


### PR DESCRIPTION
Sprint 25 (doc #25) seq 2 — phase-0 tooling. Resolves flag SC-008, closes #434. **Stacked on #492** (seq 1; shared files `mem.py`/`test_mem.py`) — retarget to `main` after #492 merges.

**Problem:** `sc mem doc add/edit/freeze` committed the `documents` row but the git-tracked flat render + `.sc-state/content.sql` only moved on a FnB GUI Publish — contradicting the docs skill's "renders + snapshots for you". A headless shell's doc never reached disk.

**Fix:** the API is already the admin surface (`run_script` sets `SC_ADMIN=1`), so after a successful mem doc write (add / edit / freeze — all three change what the mirror renders, incl. the `frozen:` header line) the server runs the same snapshot→render pair Publish uses, synchronously, behind a lock. The result rides the response JSON; a failed serialize never fails the committed write — it returns `serialize.ok=false`, which the CLI prints as a WARNING and exits nonzero on.

**Tests:** `test_doc_write_serializes` — add/edit/freeze each trigger exactly one serialize; a raising serialize still commits the row, CLI warns + exits 1. Class-wide stub keeps the rest of the suite off the real main tree. Full file green (36 passed).

**Live verification (worktree copy of the live DB, live DB untouched):** `PATCH /_sc/mem/docs/20` → 200 → snapshot wrote `.sc-state/content.sql` + render refreshed `specs_sc/interface-backed-planner-wake.md` (45,398 bytes) — no GUI step. Hermetic `render-check` matches for doc #20.

**Known pre-existing issue (not absorbed, reported):** live-DB doc #21 has `render_path=NULL` while committed `content.sql` still carries its old `specs_sc/sprint-planner-session-control.md` — the next Publish will surface that orphan as render-check drift. Owner: Publish flow / planner.

Reviewer: REV1 · planner: PLN1