### PR TITLE
fix(mem): simplest safe single-writer — drop r3 publish lock-scoping (#493 follow-up)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -840,23 +840,18 @@ def run_snapshot_render() -> str:
 # ONE serialization boundary for every path that writes the non-atomic
 # snapshot/render outputs (content.sql + the flat-render mirror) or moves the
 # main checkout's branches: mem doc writes (serialize_doc_write), the header
-# '/api/snapshot' shortcut, the '/api/scripts/{snapshot,render}' maintenance
-# routes, and '/api/publish' (git_publish). These were once per-path private
-# locks — a doc write could interleave its content.sql/render writes with a
-# Publish's branch checkout/staging (SC-012). Held at the caller level only:
-# run_snapshot_render() itself never takes it, so nothing re-enters.
+# '/api/snapshot' shortcut, and '/api/publish' (git_publish). These were once
+# per-path private locks — a doc write could interleave its content.sql/render
+# writes with a Publish's branch checkout/staging (SC-012). Held at the caller
+# level only: run_snapshot_render() itself never takes it, so nothing re-enters.
 #
-# Publish takes the lock around its LOCAL section only (SC-013) — branch moves,
-# the serialize, the commit — never across push/GitHub I/O: those carry no
-# timeout, and a queued doc write's 420s budget (_DOC_WRITE_TIMEOUT in
-# scripts/mem.py) is a real completion bound only when the lock queue is
-# bounded too.
+# SINGLE-WRITER CONSTRAINT: this is an in-process lock only. It is sufficient
+# because rendered artifacts are created solely by manual admin-shell or GUI
+# actions — no concurrent writers exist in real use. Cross-process locking,
+# bounded lock-queueing, and concurrent-Publish races are explicitly out of
+# scope for v1 (FnB decision #20; tracked as roadmap #21). Do not add writers
+# outside this process without revisiting that decision.
 _CONTENT_WRITE_LOCK = threading.Lock()
-
-# The whitelisted maintenance scripts that write the same non-atomic outputs —
-# run_script takes no lock itself, so the /api/scripts/ endpoint wraps these
-# keys (the other scripts don't touch content.sql or the flat renders).
-_CONTENT_WRITE_SCRIPTS = frozenset({"snapshot", "render"})
 
 
 def serialize_doc_write() -> dict:
@@ -886,9 +881,7 @@ def serialize_doc_write() -> dict:
 # COMMITTED locally (the unpushed branch is kept so the commit isn't lost) — only
 # push/PR is skipped, with a clear message. Concurrent publishes — and every
 # other content-write path — serialize on _CONTENT_WRITE_LOCK (one git index,
-# one set of snapshot outputs), which git_publish() holds around its LOCAL
-# section only; the push + PR upsert run lock-free so no queued writer waits
-# on network I/O (SC-013).
+# one set of snapshot outputs), taken by the /api/publish endpoint.
 BASE_BRANCH = "main"
 PUBLISH_BRANCH = "sc_gui_content"
 _STASH_MSG = "sc-publish: stray non-content work"
@@ -990,63 +983,46 @@ def _redact(s: str, token: str) -> str:
 
 def git_publish() -> dict:
     out: list[str] = []
-    # state survives into the cleanup so it knows whether the commit reached
+    # state survives into the finally so cleanup knows whether the commit reached
     # origin (safe to drop the local branch) or only exists locally (keep it).
     state: dict = {"ok": True, "pr_url": None, "pushed": False}
-    committed = False
-    # The LOCAL phase is ONE bounded critical section under _CONTENT_WRITE_LOCK:
-    # branch moves, the content.sql/render write, and the commit are what race
-    # the other content writers — and they are bounded (the serialize
-    # subprocesses carry 180s timeouts; local git touches no network). The push
-    # + PR upsert below run AFTER the lock is released (SC-013): a queued doc
-    # write waits only for this section, never for GitHub I/O with no timeout,
-    # so its 420s client budget is a real completion bound.
-    with _CONTENT_WRITE_LOCK:
-        try:
-            # 1. Get onto a clean BASE and (re)create the ephemeral branch BEFORE
-            #    any snapshot writes. The old order serialized first, which
-            #    dirtied whatever branch the tree happened to be on; if a prior
-            #    run had left it stranded on the publish branch, the next publish
-            #    could then neither delete that branch (it was current) nor check
-            #    out main (the dirty, regenerated content blocked it) — a
-            #    self-perpetuating stuck state. Preparing the branch first means
-            #    the serialize lands on the publish branch and can never block
-            #    its own creation.
-            if _prepare_branch(out, state):
-                # 2. serialize the DB → git-tracked text + render the flat files.
-                out.append(run_snapshot_render())
-                # 3. stage → commit (local only — push/PR happen lock-free below).
-                committed = _commit_content(out, state)
-        except Exception as e:
-            state["ok"] = False
-            out.append(f"✗ publish error: {e}")
-        finally:
-            # Always land back on main — runs even if a step raised or returned
-            # early, so the tree never stays stranded on the publish branch. The
-            # local branch itself is dropped only after the push's fate is known
-            # (_drop_publish_branch below).
-            _land_on_base(out)
-            # Restore any stray non-content work stashed by _prepare_branch — only
-            # now, once we're back on base, so it lands where it was taken from.
-            # Non-content files are identical across base/publish tips, so pop
-            # can't conflict; if it somehow does, keep the stash and tell the
-            # operator loudly rather than drop.
-            if state.get("stashed"):
-                n = state["stashed"]
-                pop = _git("stash", "pop")
-                if pop.returncode == 0:
-                    out.append(f"(restored {n} stashed non-content file(s))")
-                else:
-                    out.append(f"⚠ {n} stashed non-content file(s) NOT restored — run "
-                               f"'git stash pop' manually:\n{pop.stderr.strip()}")
-    # 4. Network phase — lock released: force-push + open/update the ONE PR.
-    if committed and state["ok"]:
-        _push_and_pr(out, state)
-    # 5. Local branch cleanup, keyed on whether the commit reached origin.
-    _drop_publish_branch(out, state, committed)
+    try:
+        # 1. Get onto a clean BASE and (re)create the ephemeral branch BEFORE any
+        #    snapshot writes. The old order serialized first, which dirtied
+        #    whatever branch the tree happened to be on; if a prior run had left it
+        #    stranded on the publish branch, the next publish could then neither
+        #    delete that branch (it was current) nor check out main (the dirty,
+        #    regenerated content blocked it) — a self-perpetuating stuck state.
+        #    Preparing the branch first means the serialize lands on the publish
+        #    branch and can never block its own creation.
+        if _prepare_branch(out, state):
+            # 2. serialize the DB → git-tracked text + render the flat files.
+            out.append(run_snapshot_render())
+            # 3. stage → commit → push → open/update one PR.
+            _publish_content(out, state)
+    except Exception as e:
+        state["ok"] = False
+        out.append(f"✗ publish error: {e}")
+    finally:
+        # Always land back on main and drop the ephemeral local branch — runs even
+        # if a step raised or returned early, so the tree never stays stranded on
+        # the publish branch.
+        _land_on_base(out, state)
+        # Restore any stray non-content work stashed by _prepare_branch — only now,
+        # once we're back on base, so it lands where it was taken from. Non-content
+        # files are identical across base/publish tips, so pop can't conflict; if it
+        # somehow does, keep the stash and tell the operator loudly rather than drop.
+        if state.get("stashed"):
+            n = state["stashed"]
+            pop = _git("stash", "pop")
+            if pop.returncode == 0:
+                out.append(f"(restored {n} stashed non-content file(s))")
+            else:
+                out.append(f"⚠ {n} stashed non-content file(s) NOT restored — run "
+                           f"'git stash pop' manually:\n{pop.stderr.strip()}")
     # Record the full end-to-end trace (success OR failure) so a publish that
     # "looked done" can be inspected after the fact — the gap that made the live
-    # incident unexplainable. The steps above append to `out`, so log here.
+    # incident unexplainable. _land_on_base above appends to `out`, so log here.
     log_event("publish", ok=state["ok"], pushed=state["pushed"],
               pr_url=state["pr_url"], detail=out)
     return {"ok": state["ok"], "output": "\n".join(out), "pr_url": state["pr_url"]}
@@ -1128,12 +1104,10 @@ def _prepare_branch(out: list, state: dict) -> bool:
     return True
 
 
-def _commit_content(out: list, state: dict) -> bool:
-    """Stage the publishable text + renders on the ephemeral branch and commit
-    if anything changed — LOCAL work inside _CONTENT_WRITE_LOCK. Returns True
-    only when a commit was created (i.e. there is something to push)."""
+def _publish_content(out: list, state: dict) -> None:
     # The ephemeral branch is already created clean from base by _prepare_branch,
     # and the snapshot+render has written the publishable content onto it.
+    # 3. stage the publishable text + renders; commit if anything changed.
     #    Filter to paths that exist — `git add` is fatal on a missing pathspec, and
     #    a minimal fork may lack some (e.g. docs_sc/ before any doc is authored).
     #    Drop gitignored paths too: in a fork the engine (schema/migrations) is
@@ -1148,7 +1122,7 @@ def _commit_content(out: list, state: dict) -> bool:
     staged = _git("diff", "--cached", "--name-only").stdout.strip()
     if not staged:
         out.append(f"✓ no content changes vs {BASE_BRANCH} — nothing to publish")
-        return False
+        return
     n = len(staged.splitlines())
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     msg = (f"gui: publish content edits ({n} file{'s' if n != 1 else ''})\n\n"
@@ -1158,28 +1132,20 @@ def _commit_content(out: list, state: dict) -> bool:
     if c.returncode != 0:
         state["ok"] = False
         out.append("✗ commit failed:\n" + (c.stderr or c.stdout).strip())
-        return False
+        return
     out.append(f"committed {n} file(s)")
-    return True
 
-
-def _push_and_pr(out: list, state: dict) -> None:
-    """Network phase: force-push the ephemeral branch and upsert the ONE PR.
-    Runs AFTER _CONTENT_WRITE_LOCK is released (SC-013) — none of this is
-    timeout-bounded, so no queued content writer may ever wait on it. The tree
-    is back on base by now; the push addresses the branch by ref, not by
-    checkout."""
-    # token gate: committed locally either way, but push/PR needs a token.
+    # 4. token gate: committed locally either way, but push/PR needs a token.
     token = _gh_token()
     if not token:
         out.append("⚠ committed locally, but no GH_TOKEN — can't push or open a "
                    "PR. Set SC_GH_TOKEN, or `./sc launch` with a host gh login.")
         return
 
-    # force-push: the branch is recreated from HEAD each publish (one commit
-    # ahead of main — the full current state), so it intentionally overwrites
-    # the prior rolling head. Only publish ever writes this branch, so --force
-    # is safe and force-with-lease's tracking-ref dance is unnecessary.
+    # 5. force-push: the branch is recreated from HEAD each publish (one commit
+    #    ahead of main — the full current state), so it intentionally overwrites
+    #    the prior rolling head. Only publish ever writes this branch, so --force
+    #    is safe and force-with-lease's tracking-ref dance is unnecessary.
     url = _origin_https()
     if not url:
         state["ok"] = False
@@ -1194,7 +1160,7 @@ def _push_and_pr(out: list, state: dict) -> None:
     state["pushed"] = True
     out.append(f"force-pushed {PUBLISH_BRANCH} → origin")
 
-    # upsert ONE PR — no merge; the open PR is the gate the FnB merges.
+    # 6. upsert ONE PR — no merge; the open PR is the gate the FnB merges.
     env = {**os.environ, "GH_TOKEN": token}
 
     def gh(*args):
@@ -1219,9 +1185,11 @@ def _push_and_pr(out: list, state: dict) -> None:
     state["pr_url"] = pr_url
 
 
-def _land_on_base(out: list) -> None:
-    """Return to main. The ephemeral local branch is left in place here —
-    _drop_publish_branch drops or keeps it once the push's fate is known."""
+def _land_on_base(out: list, state: dict) -> None:
+    """Return to main and drop the ephemeral local branch — the pushed remote
+    branch + its PR are what persist. If the commit was NOT pushed (no token /
+    push failed), KEEP the local branch so its commit isn't lost; the live DB is
+    still the source of truth and a later `snapshot` regenerates the same text."""
     now = _git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
     if now != BASE_BRANCH:
         # If a step raised after the snapshot but before the commit, the publish
@@ -1233,24 +1201,16 @@ def _land_on_base(out: list) -> None:
             out.append(f"⚠ left on {now} — couldn't return to {BASE_BRANCH}:\n"
                        f"{co.stderr.strip()}")
             return
-    out.append(f"↩ back on {BASE_BRANCH}")
-
-
-def _drop_publish_branch(out: list, state: dict, committed: bool) -> None:
-    """Drop the local ephemeral branch once its commit reached origin; KEEP it
-    when the commit exists only locally (no token / push failed) so it isn't
-    lost — the live DB is still the source of truth and a later `snapshot`
-    regenerates the same text. A branch this run never committed on holds
-    nothing, so it is dropped too."""
     local_exists = _git("rev-parse", "--verify", "--quiet",
                         f"refs/heads/{PUBLISH_BRANCH}").returncode == 0
-    if not local_exists:
-        return
-    if state["pushed"] or not committed:
+    if local_exists and state["pushed"]:
         _git("branch", "-D", PUBLISH_BRANCH)
-        out.append(f"local {PUBLISH_BRANCH} cleaned up")
+        out.append(f"↩ back on {BASE_BRANCH}; local {PUBLISH_BRANCH} cleaned up")
+    elif local_exists:
+        out.append(f"↩ back on {BASE_BRANCH}; kept local {PUBLISH_BRANCH} "
+                   "(unpushed commit preserved)")
     else:
-        out.append(f"kept local {PUBLISH_BRANCH} (unpushed commit preserved)")
+        out.append(f"↩ back on {BASE_BRANCH}")
 
 
 # ── HTTP ──────────────────────────────────────────────────────────────────────
@@ -2311,23 +2271,11 @@ class Handler(BaseHTTPRequestHandler):
                 log_event("snapshot", ok=True, detail=out)
                 return self._send(200, {"output": out})
             if path == "/api/publish":
-                # No lock here: git_publish() takes _CONTENT_WRITE_LOCK around
-                # its LOCAL section itself (SC-013) — wrapping the whole call
-                # would hold the lock across push/GitHub I/O (and deadlock:
-                # the lock is not re-entrant).
-                r = git_publish()
+                with _CONTENT_WRITE_LOCK:
+                    r = git_publish()
                 return self._send(200 if r["ok"] else 500, r)
             if path.startswith("/api/scripts/"):
-                key = path.rsplit("/", 1)[1]
-                # snapshot/render write the same non-atomic outputs as a
-                # doc-write serialize — run them under the shared lock
-                # (SC-012). The other maintenance scripts don't touch those
-                # files and stay lock-free.
-                if key in _CONTENT_WRITE_SCRIPTS:
-                    with _CONTENT_WRITE_LOCK:
-                        r = run_script(key)
-                else:
-                    r = run_script(key)
+                r = run_script(path.rsplit("/", 1)[1])
                 if r is None:
                     return self._send(404, {"error": "no such script"})
                 return self._send(200 if r["ok"] else 500, r)

--- a/.super-coder/assets/skills/docs/SKILL.md
+++ b/.super-coder/assets/skills/docs/SKILL.md
@@ -79,7 +79,10 @@ re-decide a settled choice.
 Write through `sc mem doc add` (routes through the engine API): `--body-file`
 reads the markdown from a file (no shell-escaping a long body); `--seq`
 auto-increments within `(feature, kind)`; it renders + snapshots for you
-(pipeline = the `snapshot` skill):
+(pipeline = the `snapshot` skill). The render+snapshot is serialized by one
+in-process API lock — sufficient because these artifacts only ever come from
+manual admin-shell or GUI actions (single writer by design; cross-process
+concurrency is out of scope for v1, decision #20 / roadmap #21).
 ```
 # a doc against a feature (kind='doc'); DB owns the body:
 sc mem doc add "…" --kind doc --feature <id> --body-file ./draft.md --render-path docs_sc/….md

--- a/.super-coder/migrations/0077_reseed_docs_single_writer.sql
+++ b/.super-coder/migrations/0077_reseed_docs_single_writer.sql
@@ -1,0 +1,335 @@
+-- 0077 — reseed: docs skill — single-writer note.
+--
+-- Sprint 25 ruling (decision #20) deferred SC-012/013/014: rendered artifacts
+-- (content.sql + flat renders) are created only by manual admin-shell or GUI
+-- actions, so a single in-process API lock suffices and cross-process
+-- concurrency is out of scope for v1 (roadmap #21). The docs skill's Author
+-- section now says so. Source asset updated in the same commit; this trailing
+-- forward reseed (UPSERT by name; skill_id + grants preserved) carries it to
+-- installed forks and fresh builds alike.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'docs',
+  'Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.',
+  'substrate',
+  NULL,
+  0,
+  '# docs — author & review documents
+
+The DB owns document bodies: a `documents` row is the source — NEVER author a
+loose `.md` file as the canonical body. `sc render` writes the read-only flat
+copy to `specs_sc/` / `docs_sc/`; the GUI opens it rendered in md-converter.
+
+| kind | lives on | meaning |
+|---|---|---|
+| `spec` | the **Roadmap** (the dev cycle) | working spec for a feature; a feature can hold several at once; **freezes on ship** |
+| `doc` | the **Docs** tab | documentation; not part of the spec lifecycle |
+
+`<self>` = your shell_id.
+
+## One feature, many specs
+
+Feature = the `roadmap` row; exists from `brainstorm` onward, before any spec.
+Specs hang off the feature, not off each other: several unfrozen specs per
+feature, each a `documents (kind=''spec'')` row, ordered by `seq`. No
+feature-to-feature links; no second roadmap row for related work — related
+work = another spec under the same feature. Freeze = the ship-time record of
+what was built to; it never gates the feature''s other specs.
+
+| state | test | meaning |
+|---|---|---|
+| **shipped** | `frozen = 1` | delivered; immutable record |
+| **active** | unfrozen + has rows in `spec_tasks` | the spec being built now |
+| **backlog** | unfrozen, no task plan | the pile, ordered by `seq` |
+
+The **doc** (`kind=''doc''`) = the feature''s readable face — write it when the
+first spec ships, under the same `feature_id`. Sibling of the specs, not a
+parent.
+
+## Assess the work-stream on every feature
+
+A feature attaches to a work-stream (`projects` row) via `roadmap.project_id`.
+The GUI Flow view groups on it; `NULL` shows as Ungrouped = invisible to the
+grouping. On every feature create / spec author / spec update, assess the
+work-stream in the same act:
+
+```
+sc mem get projects   # existing work-streams — pick the fit
+sc mem get roadmap    # this feature''s current project_id
+```
+
+| case | action |
+|---|---|
+| new feature | create pre-assigned: `sc mem roadmap add "<title>" --project <shortname>` |
+| existing + Ungrouped | `sc mem roadmap project <feature_id> <shortname>` |
+| no fitting stream | `sc mem project add <shortname> "<title>" --purpose "…"` -> then assign |
+| already correctly assigned | no-op — don''t churn |
+
+Auto-assign when only one plausible fit / it clearly belongs to an existing
+stream. Surface to the FnB only when ambiguous — several streams fit, or a
+new stream you''re unsure how to name. Exempt (as with stages): work that
+isn''t a feature/spec (a quick fix) needs no work-stream.
+
+## Review first
+
+Before writing — don''t duplicate, don''t re-litigate:
+```
+sc mem get documents      # every spec/doc in the engine DB (kind, seq, frozen, task_count)
+sc mem get decisions      # active-decision index (<id> = full row + rationale; --all incl. superseded)
+sc map-sql "SELECT path FROM dr_filepath WHERE role=''doc'';"   # repo''s own docs (map db)
+```
+
+Spec touches a recorded decision -> honor it, or supersede explicitly: say so
+in the spec + record `sc mem decision "…" --parent <old_id>`. NEVER silently
+re-decide a settled choice.
+
+## Author
+
+Write through `sc mem doc add` (routes through the engine API): `--body-file`
+reads the markdown from a file (no shell-escaping a long body); `--seq`
+auto-increments within `(feature, kind)`; it renders + snapshots for you
+(pipeline = the `snapshot` skill). The render+snapshot is serialized by one
+in-process API lock — sufficient because these artifacts only ever come from
+manual admin-shell or GUI actions (single writer by design; cross-process
+concurrency is out of scope for v1, decision #20 / roadmap #21).
+```
+# a doc against a feature (kind=''doc''); DB owns the body:
+sc mem doc add "…" --kind doc --feature <id> --body-file ./draft.md --render-path docs_sc/….md
+
+# a feature''s next spec stage (kind=''spec''); seq auto-advances:
+sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
+```
+
+## Revise before freeze
+
+Unfrozen -> edit in place: no new row, no seq bump. Pass any of `--title` /
+`--body-file` / `--render-path`; renders + snapshots like `add`. Frozen ->
+refused; open a new spec under the same feature instead:
+```
+sc mem doc edit <document_id> --body-file ./draft.md
+sc mem doc edit <document_id> --title "New title" --render-path specs_sc/….md
+```
+
+## Freeze + document on ship — the planner''s handoff
+
+Shipping is a two-shell act (keeps `shipped` honest):
+
+- **dev**: flips `roadmap_status = shipped` + opens a **docs-pending** flag
+  (`spec` skill, Step 5) — `shipped` never silently claims a doc that doesn''t
+  exist yet.
+- **planner**: on that flag (arrives in your inbox per the `flags` skill), do
+  the paperwork:
+
+1. **Freeze the shipped spec** — immutable thereafter; the feature''s other
+   specs stay unfrozen and unaffected. NEVER edit a frozen spec (open a new
+   spec under the same feature); the GUI and render layer both refuse edits
+   to frozen docs:
+   ```
+   sc mem doc freeze <document_id>
+   ```
+2. **Read the shipped code, then write the doc** — from the code as it
+   actually shipped, NOT from the spec body. The spec is intent; the code is
+   truth (drift lands during production). Read the implementation first,
+   write what it does:
+   ```
+   sc mem doc add "<feature> — how it works" --kind doc --feature <id> --body-file ./draft.md --render-path docs_sc/<slug>.md
+   ```
+3. **Close the docs-pending flag** pointing at the doc:
+   ```
+   sc mem flag close <flag_id> --notes "Spec frozen; doc <document_id> written → docs_sc/<slug>.md"
+   ```
+
+Until step 3, `shipped` + open flag = the truthful interim state: delivered,
+doc pending.
+
+## View
+
+GUI "open in md-converter ↗" (Roadmap card / Docs tab) opens any doc rendered
+— the body rides in the URL, no upload. Long-form authoring: write the
+markdown to `body`; render + md-converter own presentation.
+
+---
+
+# Authoring format (themed-markdown)
+
+The `body` you write IS themed-markdown — the format md-converter renders.
+Your job = structure; styling = the renderer''s job. NEVER write visual
+instructions (colors, fonts, sizes, themes) — apply the four semantic
+classes; the theme picks colors.
+
+Use ONLY the constructs below — anything else drops silently or breaks the
+render.
+
+`req` = required · `opt` = optional · `≤N` = soft character cap (over-cap
+wraps awkwardly / overflows a fixed UI slot).
+
+## Frontmatter
+
+```
+---
+title: Document Title
+tags: [tag1, tag2]
+date: YYYY-MM-DD
+project: Project Name
+purpose: Brief description
+---
+```
+
+| Field | Status | Cap |
+|---|---|---|
+| `title` | req | ≤40 |
+| `tags` | req (YAML list; `[]` ok) | — |
+| `date` | opt | `YYYY-MM-DD` |
+| `project` | opt | ≤40 |
+| `purpose` | opt | ≤40 |
+
+`date`/`project`/`purpose` -> footer meta cards. `sc render` injects
+`feature`, `roadmap_status`, `frozen`, `rendered_by`, `source` on top —
+NEVER write those yourself. Tags = YAML list only; comma-separated
+(`tags: a, b`) breaks.
+
+## Structure
+
+| Syntax | Role | Cap |
+|---|---|---|
+| `# Title` | doc title (opt; falls back to `frontmatter.title`) | — |
+| `## Section` | sidebar tab | ≤28 |
+| `### Heading` | subsection -> `<h3>` | ≤80 |
+
+H4–H6 ⛔.
+
+**Tab rule:** every H2 = one tab; content between two H2s belongs to the
+first. Content between H1 and the first H2 is silently dropped — put intro
+under an H2 (e.g. "Overview"). Single-section docs may omit H2s (whole doc =
+one tab).
+
+**Doc scale:** ≤25 sections + ≤15 Mermaid diagrams (every section renders
+up-front; every Mermaid re-renders per tab switch) — split larger material.
+
+## Inline · lists · tables · images · code
+
+- Inline: `**bold**` · `*italic*` · `~~strike~~` · `` `code` `` · `[text](url)`
+- Lists: `-` unordered · `1.` ordered · `- [ ]` / `- [x]` tasks
+- Tables: standard GFM pipe tables
+- Images: `![alt](https://url/img.png)` — absolute URLs only, descriptive alt
+- Video: a bare video URL alone on its own line renders as a player — a
+  `github.com/user-attachments/assets/<id>` URL (paste a video into a GitHub
+  issue/PR to mint one) or any absolute URL ending `.mp4`/`.webm`/`.mov`/`.ogg`.
+  NEVER wrap it in `![]()` / `[]()` — bare triggers the player.
+- Code: fenced with a language hint (```` ```python ````)
+
+## Color classes
+
+`class1`–`class4` — on callouts, stat cards, mermaid nodes, linear steps.
+Choose the class by meaning; the theme decides the color. Keep one class per
+semantic role across the doc (e.g. `class1` = primary, `class2` = supporting,
+`class3` = positive/done, `class4` = caution/warning). Consistency >
+specific choice.
+
+## Callouts
+
+```
+> [!class1]
+> Callout content.
+```
+Cap ≤280 (one short paragraph). class1–class4.
+
+## Stat cards
+
+````
+```stats
+:::class1
+value: 87%
+label: User satisfaction
+description: Up 12% from last quarter
+:::class2
+value: 1.2M
+label: Active users
+```
+````
+
+| Field | Status | Cap | Notes |
+|---|---|---|---|
+| `value` | req | ≤12 | short token (`87%`, `1.2M`) — not sentences |
+| `label` | req | ≤28 | one short noun phrase |
+| `description` | opt | one short line | omit if no signal |
+
+Layout: 2 per row; trailing odd card spans the row.
+
+## Mermaid
+
+````
+```mermaid
+graph LR
+  A[Start]:::class1 --> B[Middle]:::class2 --> C[End]:::class3
+```
+````
+
+Class via `:::classN` on nodes. The app injects `classDef` — NEVER write
+`classDef`, `fill:`, or any style directive. Node label cap ≤24 (long labels
+balloon auto-sized nodes).
+
+**Quote labels with special characters** — unquoted node text is parsed as
+Mermaid grammar. Any label containing `/`, `(`, `)`, `*`, `[`, `]`, `{`, `}`,
+`<`, `>`, `#`, `:`, `;`, or a quote MUST be double-quoted inside the brackets
+-> else *"Syntax error in text"* and nothing renders. Notably `A[/text/]` =
+the parallelogram shape, so a literal path like `/lease/mail/*` breaks unless
+quoted.
+
+```
+GOOD:  AD["/admin/user-credentials/"]:::class3
+       N["count > 0"]:::class2
+BAD:   AD[/admin/user-credentials/]      (parsed as a parallelogram shape → error)
+       N[count > 0]                      (> is a grammar token → error)
+```
+
+Cylinder/stadium shapes are fine as-is — `DB[(secrets.db)]`, `X([ready])` —
+quote only the inner text, not the shape brackets.
+
+## Linear
+
+````
+```linear
+Step 1 :::class1 -> Step 2 :::class2 -> Step 3 :::class3
+```
+````
+Steps separated by `->`, optional `:::classN`. Renders vertically — one step
+per row, top→bottom (never horizontal). Step text cap ≤48.
+
+## Never
+
+- H4–H6 · blockquotes (except callouts) · footnotes · raw HTML
+- Color / font / size / theme / visual mentions (the theme owns styling)
+- Content between H1 and the first H2 (silently dropped — use an H2)
+- Comma-separated `tags` (must be a YAML list)
+- `classDef` / `fill:` / style directives inside Mermaid
+- Unquoted Mermaid labels containing special characters
+
+## Open in md-converter
+
+A doc whose `body` lives in the DB already opens in the app from the GUI
+("open in md-converter ↗" on the Roadmap/Docs card) — author nothing there.
+
+When committing a **standalone** themed-markdown file to the repo (a README,
+or a rendered `docs_sc/` page meant to be read on GitHub), drop a one-click
+badge in its preamble — between `# Title` and the first `##` (shows on
+GitHub, dropped from the render by the preamble rule):
+
+```markdown
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/<owner>/<repo>/blob/<branch>/<path>)
+```
+
+Fill `<owner>/<repo>/<branch>/<path>` with the file''s GitHub location (any
+subdirectory depth). Public repos only — the badge fetches the raw file in
+the reader''s browser (no server/auth). Destination unknown -> keep the
+placeholders and tell the user to fill them.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/skills_sc/docs.md
+++ b/skills_sc/docs.md
@@ -86,7 +86,10 @@ re-decide a settled choice.
 Write through `sc mem doc add` (routes through the engine API): `--body-file`
 reads the markdown from a file (no shell-escaping a long body); `--seq`
 auto-increments within `(feature, kind)`; it renders + snapshots for you
-(pipeline = the `snapshot` skill):
+(pipeline = the `snapshot` skill). The render+snapshot is serialized by one
+in-process API lock — sufficient because these artifacts only ever come from
+manual admin-shell or GUI actions (single writer by design; cross-process
+concurrency is out of scope for v1, decision #20 / roadmap #21).
 ```
 # a doc against a feature (kind='doc'); DB owns the body:
 sc mem doc add "…" --kind doc --feature <id> --body-file ./draft.md --render-path docs_sc/….md

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -438,12 +438,11 @@ class ApiMemTest(unittest.TestCase):
 
     # ── SC-012: doc write vs Publish — ONE shared serialization boundary ──────
     def test_doc_write_and_publish_share_one_lock(self):
-        # Doc-write serialize, /api/snapshot, /api/scripts/{snapshot,render},
-        # and Publish's local phase all write the same non-atomic files
-        # (content.sql + flat renders) and Publish switches branches. Force a
-        # Publish to sit inside its local critical section (its _prepare_branch
-        # runs under the lock), then prove a concurrent doc write's serialize
-        # cannot enter until the Publish releases the lock.
+        # Doc-write serialize, /api/snapshot, and Publish all write the same
+        # non-atomic files (content.sql + flat renders) and Publish switches
+        # branches — per-path private locks let them interleave. Force a Publish
+        # to sit inside its critical section, then prove a concurrent doc
+        # write's serialize cannot enter until the Publish releases the lock.
         self.run_mem("roadmap", "add", "feat race")
         fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat race'")[0]
         body = self.tmp / "race.md"
@@ -452,19 +451,16 @@ class ApiMemTest(unittest.TestCase):
                      "--feature", str(fid))
         did = self.q("SELECT document_id FROM documents WHERE title='spec race'")[0]
         server.serialize_doc_write = self._real_serialize
-        real_prepare = server._prepare_branch
-        real_land = server._land_on_base
-        real_drop = server._drop_publish_branch
+        real_publish = server.git_publish
         real_rsr = server.run_snapshot_render
         in_publish = threading.Event()
         release = threading.Event()
         overlap = []
 
-        def fake_prepare(out, state):
-            # runs inside git_publish's locked local section
+        def fake_publish():
             in_publish.set()
             release.wait(5)
-            return False  # no serialize/commit follows; nothing to push
+            return {"ok": True, "output": "published (test stub)", "pr_url": None}
 
         def fake_rsr():
             # runs inside serialize_doc_write's lock hold — if Publish is still
@@ -472,11 +468,7 @@ class ApiMemTest(unittest.TestCase):
             overlap.append(in_publish.is_set() and not release.is_set())
             return "snapshot+render (test stub)"
 
-        server._prepare_branch = fake_prepare
-        # no real git against the test checkout: the local phase is stubbed
-        # short and the branch never exists
-        server._land_on_base = lambda out: None
-        server._drop_publish_branch = lambda out, state, committed: None
+        server.git_publish = fake_publish
         server.run_snapshot_render = fake_rsr
         publish_rc = []
 
@@ -500,212 +492,7 @@ class ApiMemTest(unittest.TestCase):
             self.assertEqual(overlap, [False])  # serialize ran AFTER publish released
         finally:
             release.set()
-            server._prepare_branch = real_prepare
-            server._land_on_base = real_land
-            server._drop_publish_branch = real_drop
-            server.run_snapshot_render = real_rsr
-            server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
-
-    def test_scripts_content_writers_share_the_lock(self):
-        # SC-012: /api/scripts/snapshot and /api/scripts/render call the same
-        # content writers as the header shortcut — they must queue on the same
-        # lock as a doc-write serialize, not bypass it. Hold a scripts/snapshot
-        # call inside the lock and prove a concurrent doc write waits.
-        self.run_mem("roadmap", "add", "feat scr")
-        fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat scr'")[0]
-        body = self.tmp / "scr.md"
-        body.write_text("# scr\n")
-        self.run_mem("doc", "add", "spec scr", "--body-file", str(body),
-                     "--feature", str(fid))
-        did = self.q("SELECT document_id FROM documents WHERE title='spec scr'")[0]
-        server.serialize_doc_write = self._real_serialize
-        real_run_script = server.run_script
-        real_rsr = server.run_snapshot_render
-        in_script = threading.Event()
-        release = threading.Event()
-        overlap = []
-
-        def fake_run_script(key):
-            # the endpoint wraps snapshot/render in _CONTENT_WRITE_LOCK, so
-            # this stub runs INSIDE the lock hold for those keys
-            in_script.set()
-            release.wait(5)
-            return {"ok": True, "code": 0, "output": f"{key} (test stub)"}
-
-        def fake_rsr():
-            # runs inside serialize_doc_write's lock hold — if the scripts
-            # route still bypassed the lock, the script would still be inside
-            # its section (release unset) when this runs
-            overlap.append(in_script.is_set() and not release.is_set())
-            return "snapshot+render (test stub)"
-
-        server.run_script = fake_run_script
-        server.run_snapshot_render = fake_rsr
-        script_rc = []
-
-        def do_script():
-            req = urllib.request.Request(
-                f"http://127.0.0.1:{self.port}/api/scripts/snapshot",
-                data=b"", method="POST")
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                script_rc.append(resp.status)
-
-        try:
-            t = threading.Thread(target=do_script)
-            t.start()
-            self.assertTrue(in_script.wait(5), "script never entered its section")
-            threading.Timer(0.5, release.set).start()
-            self.assertEqual(
-                self.run_mem("doc", "edit", str(did), "--title", "spec scr v2"), 0)
-            t.join(10)
-            self.assertEqual(script_rc, [200])
-            self.assertEqual(overlap, [False])  # serialize ran AFTER the script released
-        finally:
-            release.set()
-            server.run_script = real_run_script
-            server.run_snapshot_render = real_rsr
-            server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
-
-    # ── SC-013: Publish's network phase never blocks a queued doc write ───────
-    def test_publish_network_phase_holds_no_lock(self):
-        # The 420s doc-write budget is a completion bound only if the lock
-        # queue is bounded: Publish must hold _CONTENT_WRITE_LOCK for its local
-        # serialize/commit only, NOT across push + GitHub I/O (no timeout).
-        # Park a Publish inside its network phase and prove a concurrent doc
-        # write completes without waiting for it — under the old whole-call
-        # lock it would have queued behind the blocked push.
-        self.run_mem("roadmap", "add", "feat net")
-        fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat net'")[0]
-        body = self.tmp / "net.md"
-        body.write_text("# net\n")
-        self.run_mem("doc", "add", "spec net", "--body-file", str(body),
-                     "--feature", str(fid))
-        did = self.q("SELECT document_id FROM documents WHERE title='spec net'")[0]
-        server.serialize_doc_write = self._real_serialize
-        real_prepare = server._prepare_branch
-        real_commit = server._commit_content
-        real_land = server._land_on_base
-        real_drop = server._drop_publish_branch
-        real_push_pr = server._push_and_pr
-        real_rsr = server.run_snapshot_render
-        in_network = threading.Event()
-        release = threading.Event()
-        serialize_during_network = []
-
-        def fake_push_pr(out, state):
-            # the network phase — OUTSIDE the lock by design
-            in_network.set()
-            release.wait(30)
-
-        def fake_rsr():
-            # serves Publish's local serialize (before the network phase) AND
-            # the doc write's serialize — only the doc write's can see
-            # in_network set
-            serialize_during_network.append(
-                in_network.is_set() and not release.is_set())
-            return "serialize (test stub)"
-
-        server._prepare_branch = lambda out, state: True
-        server._commit_content = lambda out, state: True
-        server._land_on_base = lambda out: None
-        server._drop_publish_branch = lambda out, state, committed: None
-        server._push_and_pr = fake_push_pr
-        server.run_snapshot_render = fake_rsr
-        publish_rc = []
-
-        def do_publish():
-            req = urllib.request.Request(
-                f"http://127.0.0.1:{self.port}/api/publish", data=b"", method="POST")
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                publish_rc.append(resp.status)
-
-        try:
-            t = threading.Thread(target=do_publish)
-            t.start()
-            self.assertTrue(in_network.wait(5),
-                            "publish never reached its network phase")
-            # The doc write runs on the main thread (mem.main sets signal
-            # handlers — main-thread only). If Publish still held the lock
-            # across its network phase, this would queue behind the blocked
-            # push until release.wait(30) above timed out — so the wall clock
-            # is the verdict: lock-free network phase = sub-second; lock held
-            # = ~30s.
-            start = time.monotonic()
-            self.assertEqual(
-                self.run_mem("doc", "edit", str(did), "--title", "spec net v2"), 0)
-            elapsed = time.monotonic() - start
-            self.assertLess(
-                elapsed, 10,
-                "doc write queued behind Publish's network phase — "
-                "the lock is held across network I/O again")
-            # the doc write's serialize really ran while Publish sat in its
-            # network phase (Publish's own local serialize saw neither flag)
-            self.assertEqual(serialize_during_network, [False, True])
-            release.set()
-            t.join(10)
-            self.assertEqual(publish_rc, [200])
-        finally:
-            release.set()
-            server._prepare_branch = real_prepare
-            server._commit_content = real_commit
-            server._land_on_base = real_land
-            server._drop_publish_branch = real_drop
-            server._push_and_pr = real_push_pr
-            server.run_snapshot_render = real_rsr
-            server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
-
-    def test_doc_write_queued_behind_slow_holder_succeeds(self):
-        # SC-013: the doc-write budget covers QUEUEING behind another content
-        # writer's bounded critical section, not just a slow serialize of its
-        # own. A slow /api/snapshot holds the lock; a concurrent doc write
-        # queues behind it, then succeeds — with the generic timeout shrunk
-        # below the hold, only the doc budget makes that possible.
-        self.run_mem("roadmap", "add", "feat queue")
-        fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat queue'")[0]
-        body = self.tmp / "queue.md"
-        body.write_text("# queue\n")
-        self.run_mem("doc", "add", "spec queue", "--body-file", str(body),
-                     "--feature", str(fid))
-        did = self.q("SELECT document_id FROM documents WHERE title='spec queue'")[0]
-        server.serialize_doc_write = self._real_serialize
-        real_rsr = server.run_snapshot_render
-        entered = threading.Event()
-
-        def slow_rsr():
-            # 1.5s inside the lock, per caller — the holder (/api/snapshot)
-            # and then the queued doc write each pay it
-            entered.set()
-            time.sleep(1.5)
-            return "slow ok"
-
-        server.run_snapshot_render = slow_rsr
-        real_timeout = mem._TIMEOUT
-        mem._TIMEOUT = 0.5  # any call on the generic budget now times out
-        holder_rc = []
-
-        def do_snapshot():
-            req = urllib.request.Request(
-                f"http://127.0.0.1:{self.port}/api/snapshot", data=b"", method="POST")
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                holder_rc.append(resp.status)
-
-        try:
-            t = threading.Thread(target=do_snapshot)
-            t.start()
-            self.assertTrue(entered.wait(5), "snapshot never entered the lock")
-            start = time.monotonic()
-            self.assertEqual(
-                self.run_mem("doc", "edit", str(did), "--title", "spec queue v2"), 0)
-            elapsed = time.monotonic() - start
-            t.join(10)
-            self.assertEqual(holder_rc, [200])
-            # really queued behind the holder (no bypass), yet well within the
-            # doc-write budget — the bounded critical section is what a queued
-            # writer ever waits on
-            self.assertGreaterEqual(elapsed, 1.0)
-            self.assertLess(elapsed, mem._DOC_WRITE_TIMEOUT)
-        finally:
-            mem._TIMEOUT = real_timeout
+            server.git_publish = real_publish
             server.run_snapshot_render = real_rsr
             server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
 

--- a/tests/test_publish_cleanup.py
+++ b/tests/test_publish_cleanup.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
-"""Tests for publish's cleanup contract (server._land_on_base + _drop_publish_branch).
+"""Tests for publish's cleanup contract (server._land_on_base).
 
 Stdlib `unittest`, real git in a tmpdir — matching test_git_prune.py's
 no-dependency style. The full git_publish() round-trip shells out to snapshot/
 render + a real remote + `gh`, so it isn't unit-testable here; what IS isolable
 (and is the behavior change) is the ephemeral-branch cleanup: always land back
-on main, then drop the local branch ONLY when its commit reached origin, keep
-it otherwise so an unpushed commit isn't lost (SC-013 split the cleanup from
-the landing: the push now runs lock-free after the local section, so the
-branch's fate is known only later). server._git binds cwd to the module global
-REPO_ROOT at call time, so pointing that at a tmp repo retargets the whole
-helper.
+on main, drop the local branch ONLY when its commit reached origin, keep it
+otherwise so an unpushed commit isn't lost. server._git binds cwd to the
+module global REPO_ROOT at call time, so pointing that at a tmp repo retargets
+the whole helper.
 
 Run:
     python3 tests/test_publish_cleanup.py
@@ -70,45 +68,21 @@ class LandOnBaseTest(unittest.TestCase):
         server.REPO_ROOT = self._orig_root
         subprocess.run(["rm", "-rf", str(self.tmp)])
 
-    def test_lands_back_on_base(self) -> None:
-        # Whatever the push's fate, the tree returns to main; the local branch
-        # is left in place for _drop_publish_branch.
-        out: list[str] = []
-        server._land_on_base(out)
-        self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
-        self.assertIn(server.PUBLISH_BRANCH, local_branches(self.repo))
-        self.assertEqual(out, [f"↩ back on {server.BASE_BRANCH}"])
-
     def test_pushed_drops_local_branch(self) -> None:
         # commit reached origin → the local branch is disposable.
-        server._land_on_base([])
         out: list[str] = []
-        server._drop_publish_branch(out, {"ok": True, "pr_url": "x", "pushed": True},
-                                    committed=True)
+        server._land_on_base(out, {"ok": True, "pr_url": "x", "pushed": True})
         self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
         self.assertNotIn(server.PUBLISH_BRANCH, local_branches(self.repo))
         self.assertTrue(any("cleaned up" in line for line in out))
 
     def test_unpushed_keeps_local_branch(self) -> None:
         # no token / push failed → keep the branch so the commit isn't lost.
-        server._land_on_base([])
         out: list[str] = []
-        server._drop_publish_branch(out, {"ok": True, "pr_url": None, "pushed": False},
-                                    committed=True)
+        server._land_on_base(out, {"ok": True, "pr_url": None, "pushed": False})
         self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
         self.assertIn(server.PUBLISH_BRANCH, local_branches(self.repo))
         self.assertTrue(any("kept local" in line for line in out))
-
-    def test_uncommitted_branch_is_dropped(self) -> None:
-        # Nothing was committed this run (no content changes / a step raised
-        # before the commit) — the branch holds nothing, so it goes.
-        git(self.repo, "checkout", server.BASE_BRANCH)
-        git(self.repo, "branch", "-f", server.PUBLISH_BRANCH, server.BASE_BRANCH)
-        out: list[str] = []
-        server._drop_publish_branch(out, {"ok": True, "pr_url": None, "pushed": False},
-                                    committed=False)
-        self.assertNotIn(server.PUBLISH_BRANCH, local_branches(self.repo))
-        self.assertTrue(any("cleaned up" in line for line in out))
 
     def test_already_on_base_is_a_noop_return(self) -> None:
         # Nothing to do but report — e.g. branch creation failed earlier so we
@@ -116,9 +90,7 @@ class LandOnBaseTest(unittest.TestCase):
         git(self.repo, "checkout", server.BASE_BRANCH)
         git(self.repo, "branch", "-D", server.PUBLISH_BRANCH)
         out: list[str] = []
-        server._land_on_base(out)
-        server._drop_publish_branch(out, {"ok": False, "pr_url": None,
-                                          "pushed": False}, committed=False)
+        server._land_on_base(out, {"ok": False, "pr_url": None, "pushed": False})
         self.assertEqual(current_branch(self.repo), server.BASE_BRANCH)
         self.assertEqual(out, [f"↩ back on {server.BASE_BRANCH}"])
 


### PR DESCRIPTION
Sprint 25 seq 2 follow-up, per PLN1's ruling (FnB decision #20): SC-012/013/014 are **deferred** (roadmap #21) — rendered artifacts (`content.sql` + flat renders) are created only by manual admin-shell or GUI actions, so no concurrent writers exist in real use.

## What this does

- **Reverts the r3 'publish lock scoped off network I/O' change** — the one that *introduced* the SC-014 publish race — back to the r2 shape: `/api/publish` holds the shared `_CONTENT_WRITE_LOCK` across the whole publish (simplest safe). `_commit_content`/`_push_and_pr`/`_drop_publish_branch` fold back into `_publish_content`/`_land_on_base`.
- **Keeps** everything the ruling kept: the headless render after `sc mem doc add/edit/freeze` (SC-008, closes #434), the one shared in-process `_CONTENT_WRITE_LOCK` across all content-write paths, the 420s doc-write client budget, and idempotent freeze.
- **Drops** the tests that pinned the removed lock-free network phase (r3); r2's lock/race/timeout/freeze tests stay.
- **Documents the constraint**: comment at `_CONTENT_WRITE_LOCK` in `server.py` + a note in the `docs` skill's Author section, propagated via reseed migration `0077`.

## Notes

- The asset edit required a reseed migration (0074 precedent); committed `0001` lags assets for `issue_reporting`/`sprint_orchestration` (they shipped as deltas 0074/0076 without a 0001 regen) — left alone here, flagged as a follow-up.
- Local suite: 521 passed; the 3 `test_vm_bake` failures are environmental (`SC_SANDBOX` guard refuses bake in the sandbox; pass with it unset, CI green on #493 confirmed the same).

Co-authored-by: Code-02 (super-coder) <noreply@super-coder.local>