### PR TITLE
fix(sprint): require plan billing by default

### DIFF
--- a/.super-coder/assets/skills/sprint_orchestration/SKILL.md
+++ b/.super-coder/assets/skills/sprint_orchestration/SKILL.md
@@ -45,12 +45,45 @@ that exist, reviewer bandwidth, how wide the dependency graph genuinely
 runs — and make the call. More units than shells is fine (units queue
 behind the chain); more shells than parallel work is waste.
 
-**The model & provider interview — exactly two questions to the FnB:**
+**The model & provider interview — two routine routing questions to the FnB:**
 
 1. **Devs** — which harness and model? One answer; every dev in the
    sprint runs it.
 2. **Reviewers** — which harness and model? One answer; every reviewer
    runs it.
+
+**Billing gate — Plan billing only by default.** Do not research provider docs
+during a sprint. Before resolving models, run the chosen harness's preflight
+exactly:
+
+```sh
+# OpenAI / Codex: ignore the per-run API override; persisted auth must be ChatGPT.
+test "$(env -u CODEX_API_KEY codex login status 2>&1)" = "Logged in using ChatGPT"
+
+# Anthropic / Claude: ignore the API override; require first-party plan auth.
+env -u ANTHROPIC_API_KEY claude auth status --json |
+  python3 -c 'import json,sys; s=json.load(sys.stdin); raise SystemExit(0 if s.get("loggedIn") and s.get("authMethod") == "claude.ai" and s.get("apiProvider") == "firstParty" and s.get("subscriptionType") and not s.get("apiKeySource") else 1)'
+```
+
+Exit 0 = auth gate passed. Any other result -> hold the route and ask the FnB
+to correct the login. Keep the API override scrubbed on EVERY launch:
+
+```sh
+env -u CODEX_API_KEY ./sc run <shell> --harness codex -m <model> --effort high
+env -u ANTHROPIC_API_KEY ./sc run <shell> --harness claude -m <model> --effort high
+```
+
+CLI auth cannot see account-side overage controls. The standing FnB setup for
+plan-only sprints is: Anthropic **Settings -> Usage -> Usage Credits disabled**;
+OpenAI **Codex Settings -> Usage -> Auto top-up off and flexible-credit balance
+0**. Once the FnB establishes these account invariants, planners run the gates
+above — they do not research or re-check web settings every sprint. A nonzero
+OpenAI flexible-credit balance, enabled Anthropic Usage Credits, API billing, or
+any exception requires explicit FnB permission recorded with its scope in the
+sprint doc before the affected run. Choosing a harness/model is not permission.
+No standing invariant or recorded exception -> do not launch that route.
+
+`sc models resolve` proves callability, not billing; run it only after this gate.
 
 Flavor-uniform by design: shells of a flavor are interchangeable workers,
 and one answer per flavor keeps the board readable and the review lineage

--- a/.super-coder/migrations/0078_reseed_sprint_plan_billing.sql
+++ b/.super-coder/migrations/0078_reseed_sprint_plan_billing.sql
@@ -1,0 +1,59 @@
+-- 0078 — require plan billing for sprint worker launches by default.
+--
+-- The sprint planner must not treat a callable model route as permission to
+-- incur API or Extra Usage charges. The source asset is authoritative; this
+-- idempotent replacement carries the policy to existing installs while fresh
+-- builds converge with the same asset.
+
+BEGIN;
+
+UPDATE skills SET content = replace(content,
+'**The model & provider interview — exactly two questions to the FnB:**',
+'**The model & provider interview — two routine routing questions to the FnB:**')
+WHERE name='sprint_orchestration';
+
+UPDATE skills SET content = replace(content,
+'2. **Reviewers** — which harness and model? One answer; every reviewer
+   runs it.
+
+Flavor-uniform by design:',
+'2. **Reviewers** — which harness and model? One answer; every reviewer
+   runs it.
+
+**Billing gate — Plan billing only by default.** Do not research provider docs
+during a sprint. Before resolving models, run the chosen harness''s preflight
+exactly:
+
+```sh
+# OpenAI / Codex: ignore the per-run API override; persisted auth must be ChatGPT.
+test "$(env -u CODEX_API_KEY codex login status 2>&1)" = "Logged in using ChatGPT"
+
+# Anthropic / Claude: ignore the API override; require first-party plan auth.
+env -u ANTHROPIC_API_KEY claude auth status --json |
+  python3 -c ''import json,sys; s=json.load(sys.stdin); raise SystemExit(0 if s.get("loggedIn") and s.get("authMethod") == "claude.ai" and s.get("apiProvider") == "firstParty" and s.get("subscriptionType") and not s.get("apiKeySource") else 1)''
+```
+
+Exit 0 = auth gate passed. Any other result -> hold the route and ask the FnB
+to correct the login. Keep the API override scrubbed on EVERY launch:
+
+```sh
+env -u CODEX_API_KEY ./sc run <shell> --harness codex -m <model> --effort high
+env -u ANTHROPIC_API_KEY ./sc run <shell> --harness claude -m <model> --effort high
+```
+
+CLI auth cannot see account-side overage controls. The standing FnB setup for
+plan-only sprints is: Anthropic **Settings -> Usage -> Usage Credits disabled**;
+OpenAI **Codex Settings -> Usage -> Auto top-up off and flexible-credit balance
+0**. Once the FnB establishes these account invariants, planners run the gates
+above — they do not research or re-check web settings every sprint. A nonzero
+OpenAI flexible-credit balance, enabled Anthropic Usage Credits, API billing, or
+any exception requires explicit FnB permission recorded with its scope in the
+sprint doc before the affected run. Choosing a harness/model is not permission.
+No standing invariant or recorded exception -> do not launch that route.
+
+`sc models resolve` proves callability, not billing; run it only after this gate.
+
+Flavor-uniform by design:')
+WHERE name='sprint_orchestration';
+
+COMMIT;

--- a/skills_sc/sprint_orchestration.md
+++ b/skills_sc/sprint_orchestration.md
@@ -52,12 +52,45 @@ that exist, reviewer bandwidth, how wide the dependency graph genuinely
 runs — and make the call. More units than shells is fine (units queue
 behind the chain); more shells than parallel work is waste.
 
-**The model & provider interview — exactly two questions to the FnB:**
+**The model & provider interview — two routine routing questions to the FnB:**
 
 1. **Devs** — which harness and model? One answer; every dev in the
    sprint runs it.
 2. **Reviewers** — which harness and model? One answer; every reviewer
    runs it.
+
+**Billing gate — Plan billing only by default.** Do not research provider docs
+during a sprint. Before resolving models, run the chosen harness's preflight
+exactly:
+
+```sh
+# OpenAI / Codex: ignore the per-run API override; persisted auth must be ChatGPT.
+test "$(env -u CODEX_API_KEY codex login status 2>&1)" = "Logged in using ChatGPT"
+
+# Anthropic / Claude: ignore the API override; require first-party plan auth.
+env -u ANTHROPIC_API_KEY claude auth status --json |
+  python3 -c 'import json,sys; s=json.load(sys.stdin); raise SystemExit(0 if s.get("loggedIn") and s.get("authMethod") == "claude.ai" and s.get("apiProvider") == "firstParty" and s.get("subscriptionType") and not s.get("apiKeySource") else 1)'
+```
+
+Exit 0 = auth gate passed. Any other result -> hold the route and ask the FnB
+to correct the login. Keep the API override scrubbed on EVERY launch:
+
+```sh
+env -u CODEX_API_KEY ./sc run <shell> --harness codex -m <model> --effort high
+env -u ANTHROPIC_API_KEY ./sc run <shell> --harness claude -m <model> --effort high
+```
+
+CLI auth cannot see account-side overage controls. The standing FnB setup for
+plan-only sprints is: Anthropic **Settings -> Usage -> Usage Credits disabled**;
+OpenAI **Codex Settings -> Usage -> Auto top-up off and flexible-credit balance
+0**. Once the FnB establishes these account invariants, planners run the gates
+above — they do not research or re-check web settings every sprint. A nonzero
+OpenAI flexible-credit balance, enabled Anthropic Usage Credits, API billing, or
+any exception requires explicit FnB permission recorded with its scope in the
+sprint doc before the affected run. Choosing a harness/model is not permission.
+No standing invariant or recorded exception -> do not launch that route.
+
+`sc models resolve` proves callability, not billing; run it only after this gate.
 
 Flavor-uniform by design: shells of a flavor are interchangeable workers,
 and one answer per flavor keeps the board readable and the review lineage

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -112,6 +112,20 @@ class SchemaTest(unittest.TestCase):
             "SELECT content FROM skills WHERE name='sprint_orchestration'").fetchone()[0]
         self.assertEqual(body, asset)
 
+    def test_sprint_orchestration_requires_plan_billing_by_default(self):
+        body = self.con.execute(
+            "SELECT content FROM skills WHERE name='sprint_orchestration'").fetchone()[0]
+        self.assertIn("two routine routing questions to the FnB", body)
+        self.assertIn("Billing gate — Plan billing only by default.", body)
+        self.assertIn("env -u CODEX_API_KEY codex login status", body)
+        self.assertIn("env -u ANTHROPIC_API_KEY claude auth status --json", body)
+        self.assertIn("env -u CODEX_API_KEY ./sc run", body)
+        self.assertIn("env -u ANTHROPIC_API_KEY ./sc run", body)
+        self.assertIn("Usage Credits disabled", body)
+        self.assertIn("Auto top-up off and flexible-credit balance\n0", body)
+        self.assertIn("Choosing a harness/model is not permission", body)
+        self.assertIn("No standing invariant or recorded exception -> do not launch", body)
+
 
 # ── daemon core: diff_events (pure) ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- make Plan billing mandatory by default for every sprint worker launch
- add copy-paste OpenAI/Codex and Anthropic/Claude auth preflights
- scrub `CODEX_API_KEY` / `ANTHROPIC_API_KEY` on every launch so environment overrides cannot silently switch billing
- define standing FnB account controls for overages: Anthropic Usage Credits disabled; OpenAI Auto top-up off with zero flexible-credit balance
- require explicit, scoped FnB authorization for API billing, Extra Usage, or any nonzero flexible-credit route
- reseed existing installs with migration 0078 and regenerate the tracked skill mirror

## Verification

- exact Codex plan-auth preflight — passed
- exact Claude plan-auth preflight — passed
- `python3 tests/test_skills_freshness.py` — 8 passed
- `python3 tests/test_sprint_eventing.py` — 70 passed
- `.venv/bin/python .super-coder/scripts/render_check.py` — passed against branch sources
- `git diff --check` — passed
- `./sc test` — baseline blocked by unrelated known VM failure (#459), cross-suite `server` import collision (#497), and missing `tmux` for spike tests (#498)

## Provider basis

- OpenAI documents that ChatGPT auth uses plan access, API-key auth uses API billing, and flexible credits are consumed after included limits: https://help.openai.com/en/articles/12642688
- Anthropic documents that `ANTHROPIC_API_KEY` overrides subscription auth and that Usage Credits switch to standard API-rate billing after included limits: https://support.claude.com/en/articles/12304248-manage-api-key-environment-variables-in-claude-code and https://support.claude.com/en/articles/12429409-manage-usage-credits-for-paid-claude-plans

## Trade-off

The CLIs expose authentication source but not account-side overage toggles. The skill therefore makes those web settings standing FnB-owned invariants; planners run deterministic CLI gates and do not research provider billing each sprint.