### PR TITLE
feat(interface): session schema + state machines (sprint 25 seq 4, task #80)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -56,6 +56,7 @@ sys.path.insert(0, str(ENGINE / "scripts"))
 import backfill_shell_api_keys  # noqa: E402  (startup key provisioning)
 import db_driver  # noqa: E402
 import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
+import interface_reconcile  # noqa: E402  (Interface startup reconciliation)
 import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
 import ports as ports_mod  # noqa: E402
 import shell_factory  # noqa: E402
@@ -2466,6 +2467,18 @@ def main(argv):
     # auth path resolves against; a `make launch/restart` thus self-heals keys
     # (no separate `./sc update` step). New shells are still keyed at creation.
     backfill_shell_api_keys.backfill(str(DB_PATH))
+    # Interface startup reconciliation (spec #20): idempotent, once per boot —
+    # parks any crash-window pending input as delivery_unknown (never
+    # replays), recovers wake batches from durable hook-sequence evidence,
+    # repairs expired reservations, revokes stale writer leases. No-ops on a
+    # pre-0078 DB.
+    con = db_driver.connect(DB_PATH)
+    try:
+        recon = interface_reconcile.startup_reconcile(con)
+    finally:
+        con.close()
+    if recon.get("parks") or recon.get("batches_delivery_unknown"):
+        print(f"server: interface reconcile {recon}")
     # Bind 127.0.0.1 by default (the host stance: localhost-only, operator owns
     # network controls). In the container set SC_BIND=0.0.0.0 so docker can
     # publish the port — the jail is the `-p 127.0.0.1:PORT:PORT` mapping, which

--- a/.super-coder/migrations/0078_interface_sessions.sql
+++ b/.super-coder/migrations/0078_interface_sessions.sql
@@ -1,0 +1,406 @@
+-- 0078 — Interface session schema + state machines (sprint 25 seq 4, spec #20
+-- task #80). The Interface tab's durable state: one API brokered interactive
+-- chat generation per shell, writer leases, metadata-only input state, HTTP
+-- idempotency keys, sprint planner bindings, wake items/batches, planner
+-- action receipts, PR poll audit, and alerts — plus transition triggers for
+-- every state machine (the DB backstop; interface_state.py mirrors the edge
+-- maps for friendly app-level errors) and the uniqueness constraints the
+-- spec's occupancy model requires (one non-ended session per shell, one live
+-- generation, one current writer, one live batch, one unreleased binding per
+-- planner and per sprint, unique (binding, message) wake work).
+--
+-- Crash-window contract (decision #22): interface_input_state.pending_seq is
+-- the durable reservation for a human frame that was accepted but not yet
+-- acknowledged; a broker restart with pending_seq set cannot distinguish
+-- pre-write from post-write, so startup reconciliation parks composer AND
+-- delivery as unknown, revokes the writer, and never replays (see
+-- interface_reconcile.startup_reconcile + tests/test_interface_crash_window.py).
+--
+-- Snapshot stance: volatile runtime tables (interface_writer_leases,
+-- interface_input_state, pr_poll_runs) are deliberately absent from
+-- snapshot.py's PER_INSTANCE_TABLES (the 0075 precedent); durable audit tables
+-- are snapshotted with row filters (live rows excluded — rebuild/update refuse
+-- while any of them exist anyway) and volatile columns (tmux socket,
+-- PIDs/start ticks, hook token hash) ride SENSITIVE_COLUMNS.
+
+BEGIN;
+
+-- ── Generations: the per-shell monotonic fence ──────────────────────────────
+-- Every interactive chat is one generation; callbacks, leases, leases' input
+-- sequences, and wake batches are all fenced by (shell_id, generation) so a
+-- stale generation can never act. hook_token_hash + last_hook_seq are the
+-- generation-scoped hook credential and replay fence (spec puts them on the
+-- binding; they live here because ordinary chats authenticate hooks too, with
+-- no binding). last_hook_seq is DURABLE — it is the crash-window evidence.
+
+CREATE TABLE IF NOT EXISTS interface_generations (
+    shell_id        INTEGER NOT NULL REFERENCES shells(shell_id),
+    generation      INTEGER NOT NULL CHECK (generation > 0),
+    hook_token_hash TEXT,                      -- volatile hash; snapshot-excluded
+    last_hook_seq   INTEGER NOT NULL DEFAULT 0,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    ended_at        TEXT,
+    PRIMARY KEY (shell_id, generation)
+);
+-- One live (non-ended) generation per shell.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_interface_generations_live
+    ON interface_generations(shell_id) WHERE ended_at IS NULL;
+
+-- ── Sessions: one row per interactive chat ──────────────────────────────────
+-- occupancy walks reserved → occupied → ended (unreconciled = uncertain);
+-- lifecycle is the harness TUI's own state. PID/start-ticks/tmux-socket are
+-- exact-identity fencing, never authority by presence alone — and volatile,
+-- so snapshot-excluded (ended rows keep only the audit trail).
+
+CREATE TABLE IF NOT EXISTS interface_sessions (
+    session_id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    shell_id             INTEGER NOT NULL REFERENCES shells(shell_id),
+    generation           INTEGER NOT NULL CHECK (generation > 0),
+    archive_id           INTEGER REFERENCES shell_memory_archives(archive_id),
+    harness              TEXT,               -- claude/codex/kimi
+    model_route          TEXT,
+    cli_version          TEXT,
+    worktree             TEXT,
+    tmux_socket          TEXT,               -- volatile; snapshot-excluded
+    tmux_session         TEXT,
+    tmux_window          TEXT,
+    tmux_pane_id         TEXT,               -- immutable tmux pane id
+    pane_pid             INTEGER,            -- volatile; snapshot-excluded
+    pane_start_ticks    INTEGER,            -- volatile; snapshot-excluded
+    harness_pid          INTEGER,            -- volatile; snapshot-excluded
+    harness_start_ticks INTEGER,            -- volatile; snapshot-excluded
+    occupancy            TEXT NOT NULL DEFAULT 'reserved'
+                         CHECK (occupancy IN
+                             ('reserved','occupied','unreconciled','ended')),
+    lifecycle            TEXT NOT NULL DEFAULT 'starting'
+                         CHECK (lifecycle IN
+                             ('starting','idle','busy','approval','user_input',
+                              'stopping','lost','error','ended')),
+    reservation_expires_at TEXT,
+    created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+    occupied_at          TEXT,
+    ended_at             TEXT,
+    end_reason           TEXT,
+    error_detail         TEXT,
+    UNIQUE (shell_id, generation),
+    FOREIGN KEY (shell_id, generation)
+        REFERENCES interface_generations(shell_id, generation)
+);
+-- One partial uniqueness constraint: one non-ended Interface session per shell.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_interface_sessions_live
+    ON interface_sessions(shell_id) WHERE occupancy <> 'ended';
+
+-- ── Writer leases: one current writer per session ───────────────────────────
+-- VOLATILE — excluded from snapshot (live leases, token hashes, heartbeats).
+
+CREATE TABLE IF NOT EXISTS interface_writer_leases (
+    lease_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id     INTEGER NOT NULL REFERENCES interface_sessions(session_id),
+    shell_id       INTEGER NOT NULL,
+    generation     INTEGER NOT NULL,
+    client_id      TEXT NOT NULL,            -- browser tab / CLI instance id
+    token_hash     TEXT NOT NULL,            -- volatile credential hash
+    next_input_seq INTEGER NOT NULL DEFAULT 1, -- expected monotonic client seq
+    heartbeat_at   TEXT,                     -- volatile
+    acquired_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    revoked_at     TEXT,
+    revoke_reason  TEXT,
+    FOREIGN KEY (shell_id, generation)
+        REFERENCES interface_generations(shell_id, generation)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_interface_writer_leases_current
+    ON interface_writer_leases(session_id) WHERE revoked_at IS NULL;
+
+-- ── Input state: metadata only, never bytes ─────────────────────────────────
+-- VOLATILE — excluded from snapshot (pending-input metadata). One row per
+-- session. pending_seq is the crash-window reservation: set before the tmux
+-- write, cleared only by the forward commit AFTER the write. last_submit_seq
+-- is the fenced submit-callback proof that lets dirty → clean.
+
+CREATE TABLE IF NOT EXISTS interface_input_state (
+    session_id          INTEGER PRIMARY KEY
+                        REFERENCES interface_sessions(session_id),
+    shell_id            INTEGER NOT NULL,
+    generation          INTEGER NOT NULL,
+    composer            TEXT NOT NULL DEFAULT 'unknown'
+                        CHECK (composer IN ('clean','dirty','unknown')),
+    delivery            TEXT NOT NULL DEFAULT 'normal'
+                        CHECK (delivery IN ('normal','delivery_unknown')),
+    pending_seq         INTEGER,          -- reserved, not yet acked (no bytes)
+    pending_reserved_at TEXT,
+    forwarded_seq       INTEGER NOT NULL DEFAULT 0, -- highest forwarded seq
+    last_human_input_at TEXT,
+    last_submit_seq     INTEGER,          -- seq proven by fenced submit callback
+    certified_by        TEXT,             -- client_id of certifying writer
+    certified_seq       INTEGER,
+    certified_at        TEXT,
+    updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (shell_id, generation)
+        REFERENCES interface_generations(shell_id, generation)
+);
+
+-- ── HTTP idempotency keys (all Interface mutations) ─────────────────────────
+-- Durable across rebuild — an exact retry must still find its original result.
+
+CREATE TABLE IF NOT EXISTS interface_idempotency_keys (
+    actor_scope       TEXT NOT NULL,     -- operator / browser:<session> / cli
+    operation         TEXT NOT NULL,
+    idem_key          TEXT NOT NULL,
+    request_hash      TEXT NOT NULL,     -- reuse with a different body → 409
+    response_status   INTEGER,
+    response_resource TEXT,
+    created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at        TEXT NOT NULL,
+    PRIMARY KEY (actor_scope, operation, idem_key)
+);
+CREATE INDEX IF NOT EXISTS idx_interface_idem_expiry
+    ON interface_idempotency_keys(expires_at);
+
+-- ── Sprint planner bindings ─────────────────────────────────────────────────
+-- Arms one ACTIVE sprint document to one planner generation. Snapshot keeps
+-- released rows only (closed-binding audit).
+
+CREATE TABLE IF NOT EXISTS sprint_planner_bindings (
+    binding_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_doc_id    INTEGER NOT NULL REFERENCES documents(document_id),
+    planner_shell_id INTEGER NOT NULL REFERENCES shells(shell_id),
+    session_id       INTEGER NOT NULL REFERENCES interface_sessions(session_id),
+    shell_id         INTEGER NOT NULL,   -- = planner_shell_id (generation FK)
+    generation       INTEGER NOT NULL,
+    armed_at         TEXT NOT NULL DEFAULT (datetime('now')),
+    released_at      TEXT,
+    release_reason   TEXT,
+    FOREIGN KEY (shell_id, generation)
+        REFERENCES interface_generations(shell_id, generation)
+);
+-- A planner owns at most one ACTIVE binding; a sprint names only one planner.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_spb_live_planner
+    ON sprint_planner_bindings(planner_shell_id) WHERE released_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_spb_live_sprint
+    ON sprint_planner_bindings(sprint_doc_id) WHERE released_at IS NULL;
+
+-- ── Wake batches: one coalesced fixed-prompt submission ─────────────────────
+-- input_seq_fence is the broker sequence the wake submitted at;
+-- submit/stop_hook_seq are the durable hook-sequence evidence that decides
+-- restart recovery: submitting/running → delivery_unknown UNLESS the hook
+-- evidence proves the transition (decision #22).
+
+CREATE TABLE IF NOT EXISTS planner_wake_batches (
+    batch_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id      INTEGER NOT NULL REFERENCES sprint_planner_bindings(binding_id),
+    shell_id        INTEGER NOT NULL,
+    generation      INTEGER NOT NULL,
+    state           TEXT NOT NULL DEFAULT 'queued'
+                    CHECK (state IN
+                        ('queued','submitting','running','complete',
+                         'delivery_unknown')),
+    input_seq_fence INTEGER,
+    submit_hook_seq INTEGER,
+    stop_hook_seq   INTEGER,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    submitted_at    TEXT,
+    completed_at    TEXT,
+    FOREIGN KEY (shell_id, generation)
+        REFERENCES interface_generations(shell_id, generation)
+);
+-- Only one live batch per binding.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pwb_live
+    ON planner_wake_batches(binding_id)
+    WHERE state IN ('queued','submitting','running');
+
+-- ── Wake items: one per unread eligible message ─────────────────────────────
+
+CREATE TABLE IF NOT EXISTS planner_wake_items (
+    item_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id      INTEGER NOT NULL REFERENCES sprint_planner_bindings(binding_id),
+    message_id      INTEGER NOT NULL REFERENCES shell_messages(message_id),
+    batch_id        INTEGER REFERENCES planner_wake_batches(batch_id),
+    state           TEXT NOT NULL DEFAULT 'queued'
+                    CHECK (state IN
+                        ('queued','batched','submitting','running','done',
+                         'reconcile','quarantined','cancelled')),
+    completed_wakes INTEGER NOT NULL DEFAULT 0,
+    ambiguity       TEXT,
+    error           TEXT,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    done_at         TEXT,
+    UNIQUE (binding_id, message_id)
+);
+CREATE INDEX IF NOT EXISTS idx_pwi_binding_state
+    ON planner_wake_items(binding_id, state);
+CREATE INDEX IF NOT EXISTS idx_pwi_batch ON planner_wake_items(batch_id);
+
+-- ── Planner action receipts: idempotent side-effect guard ───────────────────
+
+CREATE TABLE IF NOT EXISTS planner_action_receipts (
+    receipt_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id     INTEGER REFERENCES shell_messages(message_id),
+    operation      TEXT NOT NULL,
+    target         TEXT NOT NULL,
+    idem_key       TEXT NOT NULL UNIQUE, -- derived from message+operation+target
+    state          TEXT NOT NULL DEFAULT 'intent'
+                   CHECK (state IN ('intent','complete','unknown','reconciled')),
+    result_detail  TEXT,
+    created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at   TEXT,
+    reconciled_at  TEXT
+);
+
+-- ── PR poll audit ───────────────────────────────────────────────────────────
+-- pr_poll_runs is VOLATILE (successful no-transition runs are noise) and
+-- excluded from snapshot. observations are durable only when they carry a
+-- semantic transition or a blind-window marker (snapshot row filter), so its
+-- run_id linkage is audit-only (no REFERENCES — the run row may not survive).
+
+CREATE TABLE IF NOT EXISTS pr_poll_runs (
+    run_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo        TEXT,
+    source      TEXT NOT NULL,           -- scheduler / startup / reconcile
+    watch_count INTEGER NOT NULL DEFAULT 0,
+    started_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    finished_at TEXT,
+    status      TEXT NOT NULL DEFAULT 'running'
+                CHECK (status IN ('running','ok','error','rate_limited')),
+    error       TEXT                     -- sanitized
+);
+
+CREATE TABLE IF NOT EXISTS pr_poll_observations (
+    observation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    watch_id    INTEGER NOT NULL REFERENCES watched_prs(watch_id),
+    run_id      INTEGER,                 -- audit linkage only (runs are volatile)
+    head_sha    TEXT,
+    fingerprint TEXT,                    -- normalized JSON; never raw payloads
+    transition  TEXT,                    -- semantic transition key; NULL = none
+    blind_window INTEGER NOT NULL DEFAULT 0,
+    observed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ppo_watch
+    ON pr_poll_observations(watch_id, observed_at);
+
+-- ── Alerts: deduplicated while open ─────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS planner_alerts (
+    alert_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  INTEGER REFERENCES interface_sessions(session_id),
+    binding_id  INTEGER REFERENCES sprint_planner_bindings(binding_id),
+    message_id  INTEGER REFERENCES shell_messages(message_id),
+    watch_id    INTEGER REFERENCES watched_prs(watch_id),
+    severity    TEXT NOT NULL CHECK (severity IN ('info','warning','critical')),
+    reason      TEXT NOT NULL,
+    dedupe_key  TEXT NOT NULL,           -- app-computed: refs + reason
+    opened_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    resolved_at TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_planner_alerts_open
+    ON planner_alerts(dedupe_key) WHERE resolved_at IS NULL;
+
+-- ── Sprint scoping columns on existing tables ───────────────────────────────
+-- Nullable; existing rows stay valid and unwoken (migration-only ADD COLUMN —
+-- the 0047/0059/0062 precedent; schema.sql carries pointer comments). The
+-- watched_prs uniqueness rebuild into one active watch per binding/repo/PR is
+-- the polling cutover's job (task #85), not this unit's.
+
+ALTER TABLE shell_messages ADD COLUMN sprint_doc_id INTEGER
+    REFERENCES documents(document_id);
+ALTER TABLE watched_prs ADD COLUMN sprint_doc_id INTEGER
+    REFERENCES documents(document_id);
+CREATE INDEX IF NOT EXISTS idx_shell_messages_sprint
+    ON shell_messages(to_shell_id, sprint_doc_id)
+    WHERE sprint_doc_id IS NOT NULL;
+
+-- ── Transition validators (DB backstop — RAISE(ABORT) style) ────────────────
+-- The app-level mirror lives in scripts/interface_state.py; keep the edge
+-- sets in sync (tests/test_interface_transitions.py walks every pair against
+-- BOTH, so drift fails the suite).
+
+CREATE TRIGGER IF NOT EXISTS trg_interface_sessions_occupancy
+BEFORE UPDATE OF occupancy ON interface_sessions
+WHEN NEW.occupancy <> OLD.occupancy AND NOT (
+    (OLD.occupancy = 'reserved'     AND NEW.occupancy IN ('occupied','unreconciled','ended')) OR
+    (OLD.occupancy = 'occupied'     AND NEW.occupancy IN ('unreconciled','ended')) OR
+    (OLD.occupancy = 'unreconciled' AND NEW.occupancy IN ('occupied','ended'))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal interface occupancy transition');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_interface_sessions_lifecycle
+BEFORE UPDATE OF lifecycle ON interface_sessions
+WHEN NEW.lifecycle <> OLD.lifecycle AND NOT (
+    (OLD.lifecycle = 'starting'   AND NEW.lifecycle IN ('idle','stopping','lost','error','ended')) OR
+    (OLD.lifecycle = 'idle'       AND NEW.lifecycle IN ('busy','stopping','lost')) OR
+    (OLD.lifecycle = 'busy'       AND NEW.lifecycle IN ('idle','approval','user_input','error','stopping','lost')) OR
+    (OLD.lifecycle = 'approval'   AND NEW.lifecycle IN ('busy','error','stopping','lost')) OR
+    (OLD.lifecycle = 'user_input' AND NEW.lifecycle IN ('busy','error','stopping','lost')) OR
+    (OLD.lifecycle = 'stopping'   AND NEW.lifecycle IN ('ended','lost','error')) OR
+    -- unexpected verified exit/close after proof: lost/error → ended
+    (OLD.lifecycle = 'lost'       AND NEW.lifecycle IN ('ended','stopping')) OR
+    (OLD.lifecycle = 'error'      AND NEW.lifecycle IN ('ended','stopping'))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal interface lifecycle transition');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_interface_input_composer
+BEFORE UPDATE OF composer ON interface_input_state
+WHEN NEW.composer <> OLD.composer AND NOT (
+    (OLD.composer = 'unknown' AND NEW.composer IN ('clean','dirty')) OR
+    (OLD.composer = 'clean'   AND NEW.composer IN ('dirty','unknown')) OR
+    (OLD.composer = 'dirty'   AND NEW.composer IN ('clean','unknown'))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal composer transition');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_interface_input_delivery
+BEFORE UPDATE OF delivery ON interface_input_state
+WHEN NEW.delivery <> OLD.delivery AND NOT (
+    (OLD.delivery = 'normal'           AND NEW.delivery = 'delivery_unknown') OR
+    (OLD.delivery = 'delivery_unknown' AND NEW.delivery = 'normal')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal delivery transition');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_pwi_state
+BEFORE UPDATE OF state ON planner_wake_items
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'queued'      AND NEW.state IN ('batched','quarantined','cancelled')) OR
+    (OLD.state = 'batched'     AND NEW.state IN ('queued','submitting','cancelled')) OR
+    (OLD.state = 'submitting'  AND NEW.state IN ('queued','running','cancelled')) OR
+    (OLD.state = 'running'     AND NEW.state IN ('done','reconcile','queued','cancelled')) OR
+    (OLD.state = 'reconcile'   AND NEW.state IN ('queued','done','cancelled')) OR
+    (OLD.state = 'quarantined' AND NEW.state IN ('queued','cancelled'))
+    -- done and cancelled are terminal
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal wake item transition');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_pwb_state
+BEFORE UPDATE OF state ON planner_wake_batches
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'queued'           AND NEW.state IN ('submitting','complete')) OR
+    (OLD.state = 'submitting'       AND NEW.state IN ('queued','running','delivery_unknown')) OR
+    (OLD.state = 'running'          AND NEW.state IN ('complete','delivery_unknown')) OR
+    -- operator reconciliation closes a parked batch; items are re-queued anew
+    (OLD.state = 'delivery_unknown' AND NEW.state = 'complete')
+    -- complete is terminal
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal wake batch transition');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_par_state
+BEFORE UPDATE OF state ON planner_action_receipts
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'intent'  AND NEW.state IN ('complete','unknown')) OR
+    (OLD.state = 'unknown' AND NEW.state = 'reconciled')
+    -- complete and reconciled are terminal
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal action receipt transition');
+END;
+
+COMMIT;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -281,6 +281,8 @@ CREATE TABLE shell_messages (
     -- dedupe_key TEXT — idempotent send (#333), added by migration 0062
     -- (same migration-only precedent; unique partial index
     -- idx_shell_messages_dedupe rides in the migration).
+    -- sprint_doc_id INTEGER REFERENCES documents(document_id) — sprint scoping
+    -- for wake-eligible traffic, added by migration 0078 (same precedent).
 );
 
 -- ── Watched PRs (sprint eventing — subscription registry + daemon state) ────
@@ -301,6 +303,10 @@ CREATE TABLE watched_prs (
     created_at     TEXT    NOT NULL DEFAULT (datetime('now')),
     closed_at      TEXT,                      -- set on merge/close; NULL = live
     UNIQUE (repo, pr_number, shell_id)
+    -- sprint_doc_id INTEGER REFERENCES documents(document_id) — sprint scoping,
+    -- added by migration 0078 (same migration-only ADD COLUMN precedent as
+    -- shell_messages.kind above). The uniqueness rebuild into one active watch
+    -- per binding/repo/PR is the polling cutover's migration (spec #20 task 36).
 );
 
 -- Daemon liveness (#359): the watcher daemon UPSERTs its row once per poll
@@ -314,6 +320,304 @@ CREATE TABLE daemon_heartbeats (
     beat_at     TEXT    NOT NULL,              -- datetime('now') at last poll cycle
     interval_s  INTEGER NOT NULL               -- the daemon's configured poll interval
 );
+
+-- ── Interface (spec #20: Interface-backed planner wake) ─────────────────────
+-- Durable state for the API-brokered interactive chat surface: one generation
+-- per shell, exact-identity sessions, writer leases, metadata-only input
+-- state, idempotency keys, sprint planner bindings, wake items/batches,
+-- action receipts, PR poll audit, and alerts. Volatile runtime tables
+-- (interface_writer_leases, interface_input_state, pr_poll_runs) are
+-- deliberately NOT in snapshot.py's PER_INSTANCE_TABLES; volatile columns
+-- (tmux socket, PIDs/start ticks, hook token hash) ride SENSITIVE_COLUMNS.
+-- See migrations/0078_interface_sessions.sql (convergent — carries an
+-- existing fork) and scripts/interface_state.py (app-level edge maps — keep
+-- in sync with the transition triggers below).
+
+CREATE TABLE interface_generations (
+    shell_id        INTEGER NOT NULL REFERENCES shells(shell_id),
+    generation      INTEGER NOT NULL CHECK (generation > 0),
+    hook_token_hash TEXT,                      -- volatile hash; snapshot-excluded
+    last_hook_seq   INTEGER NOT NULL DEFAULT 0,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    ended_at        TEXT,
+    PRIMARY KEY (shell_id, generation)
+);
+
+CREATE TABLE interface_sessions (
+    session_id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    shell_id             INTEGER NOT NULL REFERENCES shells(shell_id),
+    generation           INTEGER NOT NULL CHECK (generation > 0),
+    archive_id           INTEGER REFERENCES shell_memory_archives(archive_id),
+    harness              TEXT,               -- claude/codex/kimi
+    model_route          TEXT,
+    cli_version          TEXT,
+    worktree             TEXT,
+    tmux_socket          TEXT,               -- volatile; snapshot-excluded
+    tmux_session         TEXT,
+    tmux_window          TEXT,
+    tmux_pane_id         TEXT,               -- immutable tmux pane id
+    pane_pid             INTEGER,            -- volatile; snapshot-excluded
+    pane_start_ticks    INTEGER,            -- volatile; snapshot-excluded
+    harness_pid          INTEGER,            -- volatile; snapshot-excluded
+    harness_start_ticks INTEGER,            -- volatile; snapshot-excluded
+    occupancy            TEXT NOT NULL DEFAULT 'reserved'
+                         CHECK (occupancy IN
+                             ('reserved','occupied','unreconciled','ended')),
+    lifecycle            TEXT NOT NULL DEFAULT 'starting'
+                         CHECK (lifecycle IN
+                             ('starting','idle','busy','approval','user_input',
+                              'stopping','lost','error','ended')),
+    reservation_expires_at TEXT,
+    created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+    occupied_at          TEXT,
+    ended_at             TEXT,
+    end_reason           TEXT,
+    error_detail         TEXT,
+    UNIQUE (shell_id, generation),
+    FOREIGN KEY (shell_id, generation)
+        REFERENCES interface_generations(shell_id, generation)
+);
+
+CREATE TABLE interface_writer_leases (
+    lease_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id     INTEGER NOT NULL REFERENCES interface_sessions(session_id),
+    shell_id       INTEGER NOT NULL,
+    generation     INTEGER NOT NULL,
+    client_id      TEXT NOT NULL,            -- browser tab / CLI instance id
+    token_hash     TEXT NOT NULL,            -- volatile credential hash
+    next_input_seq INTEGER NOT NULL DEFAULT 1, -- expected monotonic client seq
+    heartbeat_at   TEXT,                     -- volatile
+    acquired_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    revoked_at     TEXT,
+    revoke_reason  TEXT,
+    FOREIGN KEY (shell_id, generation)
+        REFERENCES interface_generations(shell_id, generation)
+);
+
+CREATE TABLE interface_input_state (
+    session_id          INTEGER PRIMARY KEY
+                        REFERENCES interface_sessions(session_id),
+    shell_id            INTEGER NOT NULL,
+    generation          INTEGER NOT NULL,
+    composer            TEXT NOT NULL DEFAULT 'unknown'
+                        CHECK (composer IN ('clean','dirty','unknown')),
+    delivery            TEXT NOT NULL DEFAULT 'normal'
+                        CHECK (delivery IN ('normal','delivery_unknown')),
+    pending_seq         INTEGER,          -- reserved, not yet acked (no bytes)
+    pending_reserved_at TEXT,
+    forwarded_seq       INTEGER NOT NULL DEFAULT 0, -- highest forwarded seq
+    last_human_input_at TEXT,
+    last_submit_seq     INTEGER,          -- seq proven by fenced submit callback
+    certified_by        TEXT,             -- client_id of certifying writer
+    certified_seq       INTEGER,
+    certified_at        TEXT,
+    updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (shell_id, generation)
+        REFERENCES interface_generations(shell_id, generation)
+);
+
+CREATE TABLE interface_idempotency_keys (
+    actor_scope       TEXT NOT NULL,     -- operator / browser:<session> / cli
+    operation         TEXT NOT NULL,
+    idem_key          TEXT NOT NULL,
+    request_hash      TEXT NOT NULL,     -- reuse with a different body → 409
+    response_status   INTEGER,
+    response_resource TEXT,
+    created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at        TEXT NOT NULL,
+    PRIMARY KEY (actor_scope, operation, idem_key)
+);
+
+CREATE TABLE sprint_planner_bindings (
+    binding_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_doc_id    INTEGER NOT NULL REFERENCES documents(document_id),
+    planner_shell_id INTEGER NOT NULL REFERENCES shells(shell_id),
+    session_id       INTEGER NOT NULL REFERENCES interface_sessions(session_id),
+    shell_id         INTEGER NOT NULL,   -- = planner_shell_id (generation FK)
+    generation       INTEGER NOT NULL,
+    armed_at         TEXT NOT NULL DEFAULT (datetime('now')),
+    released_at      TEXT,
+    release_reason   TEXT,
+    FOREIGN KEY (shell_id, generation)
+        REFERENCES interface_generations(shell_id, generation)
+);
+
+CREATE TABLE planner_wake_batches (
+    batch_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id      INTEGER NOT NULL REFERENCES sprint_planner_bindings(binding_id),
+    shell_id        INTEGER NOT NULL,
+    generation      INTEGER NOT NULL,
+    state           TEXT NOT NULL DEFAULT 'queued'
+                    CHECK (state IN
+                        ('queued','submitting','running','complete',
+                         'delivery_unknown')),
+    input_seq_fence INTEGER,
+    submit_hook_seq INTEGER,
+    stop_hook_seq   INTEGER,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    submitted_at    TEXT,
+    completed_at    TEXT,
+    FOREIGN KEY (shell_id, generation)
+        REFERENCES interface_generations(shell_id, generation)
+);
+
+CREATE TABLE planner_wake_items (
+    item_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id      INTEGER NOT NULL REFERENCES sprint_planner_bindings(binding_id),
+    message_id      INTEGER NOT NULL REFERENCES shell_messages(message_id),
+    batch_id        INTEGER REFERENCES planner_wake_batches(batch_id),
+    state           TEXT NOT NULL DEFAULT 'queued'
+                    CHECK (state IN
+                        ('queued','batched','submitting','running','done',
+                         'reconcile','quarantined','cancelled')),
+    completed_wakes INTEGER NOT NULL DEFAULT 0,
+    ambiguity       TEXT,
+    error           TEXT,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    done_at         TEXT,
+    UNIQUE (binding_id, message_id)
+);
+
+CREATE TABLE planner_action_receipts (
+    receipt_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id     INTEGER REFERENCES shell_messages(message_id),
+    operation      TEXT NOT NULL,
+    target         TEXT NOT NULL,
+    idem_key       TEXT NOT NULL UNIQUE, -- derived from message+operation+target
+    state          TEXT NOT NULL DEFAULT 'intent'
+                   CHECK (state IN ('intent','complete','unknown','reconciled')),
+    result_detail  TEXT,
+    created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at   TEXT,
+    reconciled_at  TEXT
+);
+
+-- pr_poll_observations.run_id is deliberately NOT a REFERENCES: runs are
+-- volatile (excluded from snapshot) while transition/blind-window observations
+-- are durable audit — the linkage outlives its target.
+CREATE TABLE pr_poll_runs (
+    run_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo        TEXT,
+    source      TEXT NOT NULL,           -- scheduler / startup / reconcile
+    watch_count INTEGER NOT NULL DEFAULT 0,
+    started_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    finished_at TEXT,
+    status      TEXT NOT NULL DEFAULT 'running'
+                CHECK (status IN ('running','ok','error','rate_limited')),
+    error       TEXT                     -- sanitized
+);
+
+CREATE TABLE pr_poll_observations (
+    observation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    watch_id    INTEGER NOT NULL REFERENCES watched_prs(watch_id),
+    run_id      INTEGER,                 -- audit linkage only (runs are volatile)
+    head_sha    TEXT,
+    fingerprint TEXT,                    -- normalized JSON; never raw payloads
+    transition  TEXT,                    -- semantic transition key; NULL = none
+    blind_window INTEGER NOT NULL DEFAULT 0,
+    observed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE planner_alerts (
+    alert_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  INTEGER REFERENCES interface_sessions(session_id),
+    binding_id  INTEGER REFERENCES sprint_planner_bindings(binding_id),
+    message_id  INTEGER REFERENCES shell_messages(message_id),
+    watch_id    INTEGER REFERENCES watched_prs(watch_id),
+    severity    TEXT NOT NULL CHECK (severity IN ('info','warning','critical')),
+    reason      TEXT NOT NULL,
+    dedupe_key  TEXT NOT NULL,           -- app-computed: refs + reason
+    opened_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    resolved_at TEXT
+);
+
+-- Transition validators — the DB backstop (app pre-checks for friendly
+-- errors via scripts/interface_state.py; keep the edge sets in sync).
+
+CREATE TRIGGER trg_interface_sessions_occupancy
+BEFORE UPDATE OF occupancy ON interface_sessions
+WHEN NEW.occupancy <> OLD.occupancy AND NOT (
+    (OLD.occupancy = 'reserved'     AND NEW.occupancy IN ('occupied','unreconciled','ended')) OR
+    (OLD.occupancy = 'occupied'     AND NEW.occupancy IN ('unreconciled','ended')) OR
+    (OLD.occupancy = 'unreconciled' AND NEW.occupancy IN ('occupied','ended'))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal interface occupancy transition');
+END;
+
+CREATE TRIGGER trg_interface_sessions_lifecycle
+BEFORE UPDATE OF lifecycle ON interface_sessions
+WHEN NEW.lifecycle <> OLD.lifecycle AND NOT (
+    (OLD.lifecycle = 'starting'   AND NEW.lifecycle IN ('idle','stopping','lost','error','ended')) OR
+    (OLD.lifecycle = 'idle'       AND NEW.lifecycle IN ('busy','stopping','lost')) OR
+    (OLD.lifecycle = 'busy'       AND NEW.lifecycle IN ('idle','approval','user_input','error','stopping','lost')) OR
+    (OLD.lifecycle = 'approval'   AND NEW.lifecycle IN ('busy','error','stopping','lost')) OR
+    (OLD.lifecycle = 'user_input' AND NEW.lifecycle IN ('busy','error','stopping','lost')) OR
+    (OLD.lifecycle = 'stopping'   AND NEW.lifecycle IN ('ended','lost','error')) OR
+    (OLD.lifecycle = 'lost'       AND NEW.lifecycle IN ('ended','stopping')) OR
+    (OLD.lifecycle = 'error'      AND NEW.lifecycle IN ('ended','stopping'))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal interface lifecycle transition');
+END;
+
+CREATE TRIGGER trg_interface_input_composer
+BEFORE UPDATE OF composer ON interface_input_state
+WHEN NEW.composer <> OLD.composer AND NOT (
+    (OLD.composer = 'unknown' AND NEW.composer IN ('clean','dirty')) OR
+    (OLD.composer = 'clean'   AND NEW.composer IN ('dirty','unknown')) OR
+    (OLD.composer = 'dirty'   AND NEW.composer IN ('clean','unknown'))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal composer transition');
+END;
+
+CREATE TRIGGER trg_interface_input_delivery
+BEFORE UPDATE OF delivery ON interface_input_state
+WHEN NEW.delivery <> OLD.delivery AND NOT (
+    (OLD.delivery = 'normal'           AND NEW.delivery = 'delivery_unknown') OR
+    (OLD.delivery = 'delivery_unknown' AND NEW.delivery = 'normal')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal delivery transition');
+END;
+
+CREATE TRIGGER trg_pwi_state
+BEFORE UPDATE OF state ON planner_wake_items
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'queued'      AND NEW.state IN ('batched','quarantined','cancelled')) OR
+    (OLD.state = 'batched'     AND NEW.state IN ('queued','submitting','cancelled')) OR
+    (OLD.state = 'submitting'  AND NEW.state IN ('queued','running','cancelled')) OR
+    (OLD.state = 'running'     AND NEW.state IN ('done','reconcile','queued','cancelled')) OR
+    (OLD.state = 'reconcile'   AND NEW.state IN ('queued','done','cancelled')) OR
+    (OLD.state = 'quarantined' AND NEW.state IN ('queued','cancelled'))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal wake item transition');
+END;
+
+CREATE TRIGGER trg_pwb_state
+BEFORE UPDATE OF state ON planner_wake_batches
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'queued'           AND NEW.state IN ('submitting','complete')) OR
+    (OLD.state = 'submitting'       AND NEW.state IN ('queued','running','delivery_unknown')) OR
+    (OLD.state = 'running'          AND NEW.state IN ('complete','delivery_unknown')) OR
+    (OLD.state = 'delivery_unknown' AND NEW.state = 'complete')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal wake batch transition');
+END;
+
+CREATE TRIGGER trg_par_state
+BEFORE UPDATE OF state ON planner_action_receipts
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'intent'  AND NEW.state IN ('complete','unknown')) OR
+    (OLD.state = 'unknown' AND NEW.state = 'reconciled')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal action receipt transition');
+END;
 
 -- ── Skills (system content — seeded from assets/, propagates) ────────────────
 
@@ -434,3 +738,28 @@ CREATE INDEX idx_watched_prs_live ON watched_prs(closed_at) WHERE closed_at IS N
 CREATE INDEX idx_dr_filepath_role ON dr_filepath(role);
 CREATE INDEX idx_dr_filepath_lang ON dr_filepath(lang);
 CREATE INDEX idx_dr_dependency_mgr ON dr_dependency(manager);
+
+-- Interface (0078; the migration-only idx_shell_messages_sprint rides 0078
+-- because its column does)
+CREATE UNIQUE INDEX idx_interface_generations_live
+    ON interface_generations(shell_id) WHERE ended_at IS NULL;
+CREATE UNIQUE INDEX idx_interface_sessions_live
+    ON interface_sessions(shell_id) WHERE occupancy <> 'ended';
+CREATE UNIQUE INDEX idx_interface_writer_leases_current
+    ON interface_writer_leases(session_id) WHERE revoked_at IS NULL;
+CREATE INDEX idx_interface_idem_expiry
+    ON interface_idempotency_keys(expires_at);
+CREATE UNIQUE INDEX idx_spb_live_planner
+    ON sprint_planner_bindings(planner_shell_id) WHERE released_at IS NULL;
+CREATE UNIQUE INDEX idx_spb_live_sprint
+    ON sprint_planner_bindings(sprint_doc_id) WHERE released_at IS NULL;
+CREATE UNIQUE INDEX idx_pwb_live
+    ON planner_wake_batches(binding_id)
+    WHERE state IN ('queued','submitting','running');
+CREATE INDEX idx_pwi_binding_state
+    ON planner_wake_items(binding_id, state);
+CREATE INDEX idx_pwi_batch ON planner_wake_items(batch_id);
+CREATE INDEX idx_ppo_watch
+    ON pr_poll_observations(watch_id, observed_at);
+CREATE UNIQUE INDEX idx_planner_alerts_open
+    ON planner_alerts(dedupe_key) WHERE resolved_at IS NULL;

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Interface input broker — durable two-phase input path (spec #20, task #80).
+
+This is the DB-side half of the broker: the ordered, fenced, metadata-only
+commit protocol every accepted human frame and wake submission walks. The
+byte transport (tmux send-keys) is INJECTED as `writer` so the crash windows
+are hermetically provable — a writer that records then raises simulates
+"crash after the tmux write"; one that raises first simulates "crash before".
+
+The crash window (decision #22): accept_human_input commits a `pending`
+reservation BEFORE calling writer() and commits `forwarded` only AFTER it
+returns. A broker death in between leaves pending_seq set; the next startup's
+reconcile (interface_reconcile.startup_reconcile) cannot distinguish
+pre-write from post-write, so it parks composer AND delivery as unknown,
+revokes the writer, and never replays. This module has no replay path —
+there is deliberately no "resend pending" function.
+
+No input bytes are ever stored: only sequence numbers, lengths, and times.
+"""
+from __future__ import annotations
+
+import hashlib
+
+import interface_state
+
+MAX_INPUT_BYTES = 64 * 1024  # one human frame, per the pinned spike protocol
+WAKE_PROMPT = "Check your inbox and act on unread sprint events."
+DEFAULT_QUIET_S = 3.0  # debounce, never proof of an empty composer
+
+
+class BrokerError(ValueError):
+    """A refused broker operation (stale generation, bad sequence, gate)."""
+
+
+def _now(con) -> str:
+    return con.execute("SELECT datetime('now')").fetchone()[0]
+
+
+def _session(con, session_id: int):
+    row = con.execute(
+        "SELECT session_id, shell_id, generation, occupancy, lifecycle "
+        "FROM interface_sessions WHERE session_id=?",
+        (session_id,),
+    ).fetchone()
+    if row is None:
+        raise BrokerError(f"interface session {session_id} not found")
+    return row
+
+
+def current_writer(con, session_id: int):
+    return con.execute(
+        "SELECT lease_id, client_id, next_input_seq FROM interface_writer_leases "
+        "WHERE session_id=? AND revoked_at IS NULL",
+        (session_id,),
+    ).fetchone()
+
+
+def acquire_writer(con, session_id: int, client_id: str, token: str,
+                   takeover: bool = False) -> int:
+    """Take the session's writer lease. With takeover=True an existing lease
+    is atomically revoked first (the old client's frames are rejected from
+    that commit on); without it, a held lease refuses."""
+    sess = _session(con, session_id)
+    if sess[3] != "occupied":
+        raise BrokerError(f"session {session_id} is {sess[3]}, not occupied")
+    held = current_writer(con, session_id)
+    if held is not None:
+        if not takeover:
+            raise BrokerError(
+                f"session {session_id} writer held by {held[1]} — explicit "
+                "takeover required")
+        con.execute(
+            "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
+            "revoke_reason='takeover' WHERE lease_id=?",
+            (held[0],),
+        )
+    cur = con.execute(
+        "INSERT INTO interface_writer_leases "
+        "(session_id, shell_id, generation, client_id, token_hash, "
+        " heartbeat_at) VALUES (?,?,?,?,?,datetime('now'))",
+        (session_id, sess[1], sess[2], client_id,
+         hashlib.sha256(token.encode()).hexdigest()),
+    )
+    return cur.lastrowid
+
+
+def accept_human_input(con, session_id: int, client_seq: int,
+                       payload_len: int, writer) -> dict:
+    """The ordered two-phase human-input path (spec #20 Input Broker 1–5).
+
+    1. occupied session + current writer lease + monotonic sequence;
+    2. bounded payload (length only — bytes stay client-side);
+    3. COMMIT a metadata-only pending reservation + composer dirty;
+    4. writer(payload_len) — the injected tmux write, exactly once;
+    5. COMMIT forwarded, then the caller acks the client.
+
+    An exact duplicate of a known-forwarded sequence returns its prior ack
+    and forwards nothing; a gap rejects before any state change. A crash
+    between the commits leaves pending_seq for startup reconciliation.
+    """
+    if payload_len > MAX_INPUT_BYTES:
+        raise BrokerError(f"payload {payload_len} > {MAX_INPUT_BYTES} bytes")
+    sess = _session(con, session_id)
+    if sess[3] != "occupied":
+        raise BrokerError(f"session {session_id} is {sess[3]}, not occupied")
+    lease = current_writer(con, session_id)
+    if lease is None:
+        raise BrokerError(f"session {session_id} has no writer")
+    istate = con.execute(
+        "SELECT composer, delivery, pending_seq, forwarded_seq "
+        "FROM interface_input_state WHERE session_id=?",
+        (session_id,),
+    ).fetchone()
+    if istate is None:
+        raise BrokerError(f"session {session_id} has no input state row")
+    _, _, pending_seq, forwarded_seq = istate
+
+    if client_seq <= forwarded_seq:
+        # Known-forwarded duplicate: replay the ack, never the bytes.
+        return {"ack": client_seq, "duplicate": True}
+    if pending_seq is not None:
+        # One unacknowledged frame per writer — the client buffers locally.
+        raise BrokerError(f"sequence {pending_seq} is pending — wait for its ack")
+    if client_seq != lease[2]:
+        raise BrokerError(
+            f"sequence gap: expected {lease[2]}, got {client_seq} — rejected, "
+            "no bytes forwarded")
+
+    # Phase 1 (commit): reserve the sequence, dirty the composer FIRST.
+    interface_state.transition(
+        con, "composer", session_id, "dirty",
+        extra_sets={"pending_seq": client_seq,
+                    "pending_reserved_at": _now(con),
+                    "last_human_input_at": _now(con)})
+    con.commit()
+
+    # Phase 2: forward the exact bytes once. A crash here is the window.
+    writer(payload_len)
+
+    # Phase 3 (commit): mark forwarded, clear the reservation, bump the lease.
+    con.execute(
+        "UPDATE interface_input_state SET forwarded_seq=?, pending_seq=NULL, "
+        "pending_reserved_at=NULL, updated_at=datetime('now') "
+        "WHERE session_id=?",
+        (client_seq, session_id))
+    con.execute(
+        "UPDATE interface_writer_leases SET next_input_seq=? WHERE lease_id=?",
+        (client_seq + 1, lease[0]))
+    con.commit()
+    return {"ack": client_seq, "duplicate": False}
+
+
+def certify_clean(con, session_id: int, client_id: str, client_seq: int) -> None:
+    """Writer certification of an empty composer — the only non-hook path
+    dirty|unknown → clean. Records the certifying writer and sequence."""
+    interface_state.transition(
+        con, "composer", session_id, "clean",
+        extra_sets={"certified_by": client_id, "certified_seq": client_seq,
+                    "certified_at": _now(con)})
+
+
+def reconcile_input(con, session_id: int, outcome: str) -> None:
+    """Explicit operator reconciliation of a delivery_unknown park.
+
+    outcome='delivered' — operator confirmed the frame reached the pane: the
+    pending sequence is folded into forwarded_seq (never re-sent).
+    outcome='not_delivered' — operator confirmed it never landed: the
+    reservation is dropped; the client resends from its own buffer.
+    Either way delivery returns to normal; composer goes to unknown→certify
+    or stays as reconciled evidence demands (certification is a separate,
+    deliberate act)."""
+    if outcome not in ("delivered", "not_delivered"):
+        raise BrokerError(f"unknown reconcile outcome {outcome!r}")
+    row = con.execute(
+        "SELECT pending_seq, forwarded_seq, delivery "
+        "FROM interface_input_state WHERE session_id=?",
+        (session_id,),
+    ).fetchone()
+    if row is None:
+        raise BrokerError(f"session {session_id} has no input state row")
+    pending_seq, forwarded_seq, delivery = row
+    if delivery != "delivery_unknown":
+        raise BrokerError(
+            f"session {session_id} delivery is {delivery}, not delivery_unknown")
+    new_forwarded = forwarded_seq
+    if outcome == "delivered" and pending_seq is not None:
+        new_forwarded = max(forwarded_seq, pending_seq)
+    interface_state.transition(
+        con, "delivery", session_id, "normal",
+        extra_sets={"pending_seq": None, "pending_reserved_at": None,
+                    "forwarded_seq": new_forwarded})
+
+
+def record_hook(con, shell_id: int, generation: int, hook_seq: int,
+                event: str) -> dict:
+    """Record one authenticated harness hook with its durable sequence.
+
+    Rejects replays (hook_seq <= last_hook_seq) and stale generations. The
+    sequence is the crash-window evidence: a batch's submit/stop hook seqs
+    are stamped here, and startup reconciliation trusts only these durable
+    stamps — never the broker's memory of what it sent.
+    """
+    gen = con.execute(
+        "SELECT last_hook_seq, ended_at FROM interface_generations "
+        "WHERE shell_id=? AND generation=?",
+        (shell_id, generation),
+    ).fetchone()
+    if gen is None:
+        raise BrokerError(f"unknown generation {shell_id}/{generation}")
+    if gen[1] is not None:
+        raise BrokerError(f"generation {shell_id}/{generation} has ended")
+    if hook_seq <= gen[0]:
+        raise BrokerError(
+            f"stale hook sequence {hook_seq} (last {gen[0]}) — rejected")
+    con.execute(
+        "UPDATE interface_generations SET last_hook_seq=? "
+        "WHERE shell_id=? AND generation=?",
+        (hook_seq, shell_id, generation))
+
+    sess = con.execute(
+        "SELECT session_id, lifecycle FROM interface_sessions "
+        "WHERE shell_id=? AND generation=? AND occupancy <> 'ended'",
+        (shell_id, generation),
+    ).fetchone()
+    result = {"hook_seq": hook_seq, "event": event}
+
+    if event == "session_start":
+        # Ready prompt proven, zero accepted human sequence → idle + clean.
+        interface_state.transition(con, "lifecycle", sess[0], "idle")
+        interface_state.transition(con, "composer", sess[0], "clean")
+    elif event == "prompt_submit":
+        # Fenced submit: clears dirty, moves to busy, acknowledges a
+        # submitting wake batch whose fence this hook answers.
+        input_seq = con.execute(
+            "SELECT forwarded_seq FROM interface_input_state WHERE session_id=?",
+            (sess[0],)).fetchone()[0]
+        interface_state.transition(
+            con, "composer", sess[0], "clean",
+            extra_sets={"last_submit_seq": input_seq})
+        interface_state.transition(con, "lifecycle", sess[0], "busy")
+        batch = con.execute(
+            "SELECT batch_id FROM planner_wake_batches "
+            "WHERE shell_id=? AND generation=? AND state='submitting'",
+            (shell_id, generation)).fetchone()
+        if batch is not None:
+            interface_state.transition(
+                con, "wake_batch", batch[0], "running",
+                extra_sets={"submit_hook_seq": hook_seq,
+                            "submitted_at": _now(con)})
+            con.execute(
+                "UPDATE planner_wake_items SET state='running' "
+                "WHERE batch_id=? AND state='submitting'",
+                (batch[0],))
+            result["wake_batch_running"] = batch[0]
+    elif event == "turn_stop":
+        interface_state.transition(con, "lifecycle", sess[0], "idle")
+        batch = con.execute(
+            "SELECT batch_id FROM planner_wake_batches "
+            "WHERE shell_id=? AND generation=? AND state='running'",
+            (shell_id, generation)).fetchone()
+        if batch is not None:
+            _complete_batch(con, batch[0], hook_seq)
+            result["wake_batch_complete"] = batch[0]
+    elif event == "session_end":
+        interface_state.transition(con, "lifecycle", sess[0], "ended")
+    # approval_wait / approval_result / user_input_wait / interrupt map to
+    # plain lifecycle moves — added with the adapters (task #83); the
+    # mandatory four above are the wake-critical contract.
+    con.commit()
+    return result
+
+
+def _complete_batch(con, batch_id: int, stop_hook_seq: int) -> None:
+    """Reconcile a running batch's items from durable message read state
+    (spec #20 Wake Delivery): read → done; unread → back to queued with
+    completed_wakes+1. Infrastructure never marks messages read."""
+    interface_state.transition(
+        con, "wake_batch", batch_id, "complete",
+        extra_sets={"stop_hook_seq": stop_hook_seq, "completed_at": _now(con)})
+    items = con.execute(
+        "SELECT item_id, message_id FROM planner_wake_items "
+        "WHERE batch_id=? AND state IN ('batched','submitting','running')",
+        (batch_id,)).fetchall()
+    for item_id, message_id in items:
+        read = con.execute(
+            "SELECT read_at FROM shell_messages WHERE message_id=?",
+            (message_id,)).fetchone()[0]
+        if read is not None:
+            interface_state.transition(
+                con, "wake_item", item_id, "done",
+                extra_sets={"done_at": _now(con)})
+        else:
+            con.execute(
+                "UPDATE planner_wake_items SET completed_wakes="
+                "completed_wakes + 1, batch_id=NULL WHERE item_id=?",
+                (item_id,))
+            interface_state.transition(con, "wake_item", item_id, "queued")
+
+
+def form_batch(con, binding_id: int) -> int:
+    """Coalesce a binding's currently queued items into one batch (the
+    fixed-prompt submission unit). The partial unique index backstops the
+    one-live-batch invariant; items join oldest first."""
+    binding = con.execute(
+        "SELECT shell_id, generation FROM sprint_planner_bindings "
+        "WHERE binding_id=? AND released_at IS NULL",
+        (binding_id,)).fetchone()
+    if binding is None:
+        raise BrokerError(f"binding {binding_id} not found or released")
+    cur = con.execute(
+        "INSERT INTO planner_wake_batches (binding_id, shell_id, generation) "
+        "VALUES (?,?,?)",
+        (binding_id, binding[0], binding[1]))
+    batch_id = cur.lastrowid
+    items = con.execute(
+        "SELECT item_id FROM planner_wake_items "
+        "WHERE binding_id=? AND state='queued' ORDER BY item_id",
+        (binding_id,)).fetchall()
+    for (item_id,) in items:
+        interface_state.transition(
+            con, "wake_item", item_id, "batched",
+            extra_sets={"batch_id": batch_id})
+    return batch_id
+
+
+def resolve_batch(con, batch_id: int) -> None:
+    """Operator resolution of a delivery_unknown batch: the batch closes as
+    audit (delivery_unknown → complete) and its still-in-flight items return
+    to queued — never blindly resubmitted inside the parked batch; a NEW
+    batch forms only after the input park itself is reconciled."""
+    batch = con.execute(
+        "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+        (batch_id,)).fetchone()
+    if batch is None:
+        raise BrokerError(f"wake batch {batch_id} not found")
+    if batch[0] != "delivery_unknown":
+        raise BrokerError(f"wake batch {batch_id} is {batch[0]}, "
+                          "not delivery_unknown")
+    items = con.execute(
+        "SELECT item_id FROM planner_wake_items "
+        "WHERE batch_id=? AND state IN ('batched','submitting','running')",
+        (batch_id,)).fetchall()
+    for (item_id,) in items:
+        con.execute(
+            "UPDATE planner_wake_items SET batch_id=NULL WHERE item_id=?",
+            (item_id,))
+        interface_state.transition(con, "wake_item", item_id, "queued")
+    interface_state.transition(
+        con, "wake_batch", batch_id, "complete",
+        extra_sets={"completed_at": _now(con)})
+    con.commit()
+
+
+def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
+                      quiet_s: float = DEFAULT_QUIET_S) -> dict:
+    """Gate + submit one coalesced fixed-prompt batch under the input lock.
+
+    Revalidates everything the spec requires before a byte moves: occupied
+    session, idle lifecycle, clean composer, quiet >= quiet_s since the last
+    accepted human input, no pending human frame, current generation. Any
+    uncertainty cancels the attempt WITHOUT a state change (the batch stays
+    queued awaiting a later event) and without sending a byte. The
+    submission is one indivisible writer call; its fence is forwarded_seq+1
+    (the broker sequence the submit hook must answer).
+    """
+    batch = con.execute(
+        "SELECT binding_id, shell_id, generation, state "
+        "FROM planner_wake_batches WHERE batch_id=?",
+        (batch_id,)).fetchone()
+    if batch is None:
+        raise BrokerError(f"wake batch {batch_id} not found")
+    if batch[3] != "queued":
+        raise BrokerError(f"wake batch {batch_id} is {batch[3]}, not queued")
+    _, shell_id, generation, _ = batch
+    sess = con.execute(
+        "SELECT session_id, occupancy, lifecycle FROM interface_sessions "
+        "WHERE shell_id=? AND generation=? AND occupancy <> 'ended'",
+        (shell_id, generation)).fetchone()
+    istate = con.execute(
+        "SELECT composer, pending_seq, forwarded_seq, last_human_input_at "
+        "FROM interface_input_state WHERE session_id=?",
+        (sess[0],)).fetchone()
+
+    if sess[1] != "occupied" or sess[2] != "idle":
+        return {"submitted": False,
+                "reason": f"session not occupied+idle ({sess[1]}/{sess[2]})"}
+    if istate[0] != "clean":
+        return {"submitted": False, "reason": f"composer is {istate[0]}"}
+    if istate[1] is not None:
+        return {"submitted": False, "reason": "a human frame is pending"}
+    if istate[3] is not None:
+        quiet = con.execute(
+            "SELECT julianday(?) - julianday(?)", (now_iso, istate[3])
+        ).fetchone()[0] * 86400.0
+        if quiet < quiet_s:
+            return {"submitted": False,
+                    "reason": f"quiet {quiet:.2f}s < {quiet_s}s"}
+
+    fence = istate[2] + 1
+    interface_state.transition(
+        con, "wake_batch", batch_id, "submitting",
+        extra_sets={"input_seq_fence": fence})
+    con.execute(
+        "UPDATE planner_wake_items SET state='submitting' "
+        "WHERE batch_id=? AND state='batched'",
+        (batch_id,))
+    con.commit()
+
+    writer(len(WAKE_PROMPT) + 1)  # the fixed prompt + Enter, indivisible
+    # The submit hook (record_hook 'prompt_submit') moves the batch to
+    # running with durable evidence. No hook → on restart the batch parks
+    # as delivery_unknown and is never blindly resubmitted.
+    return {"submitted": True, "input_seq_fence": fence}

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -47,6 +47,29 @@ def _session(con, session_id: int):
     return row
 
 
+def _alert(con, *, severity: str, reason: str, session_id=None,
+           binding_id=None) -> None:
+    """Raise an alert, deduplicated while open (partial unique index)."""
+    dedupe = f"{session_id or '-'}|{binding_id or '-'}|{reason}"
+    con.execute(
+        "INSERT OR IGNORE INTO planner_alerts "
+        "(session_id, binding_id, severity, reason, dedupe_key) "
+        "VALUES (?,?,?,?,?)",
+        (session_id, binding_id, severity, reason, dedupe))
+
+
+def park_delivery_unknown(con, session_id: int, *,
+                          reason: str = "crash_window_delivery_unknown",
+                          severity: str = "critical") -> None:
+    """Park input delivery as unknown — the crash-window stance (decision
+    #22): composer unknown, delivery delivery_unknown, alert raised.
+    pending_seq is KEPT as evidence; only reconcile_input() clears the park.
+    There is no replay path."""
+    interface_state.transition(con, "composer", session_id, "unknown")
+    interface_state.transition(con, "delivery", session_id, "delivery_unknown")
+    _alert(con, severity=severity, reason=reason, session_id=session_id)
+
+
 def current_writer(con, session_id: int):
     return con.execute(
         "SELECT lease_id, client_id, next_input_seq FROM interface_writer_leases "
@@ -59,10 +82,21 @@ def acquire_writer(con, session_id: int, client_id: str, token: str,
                    takeover: bool = False) -> int:
     """Take the session's writer lease. With takeover=True an existing lease
     is atomically revoked first (the old client's frames are rejected from
-    that commit on); without it, a held lease refuses."""
+    that commit on); without it, a held lease refuses.
+
+    The new lease's expected sequence is reseeded from the SESSION's
+    forwarded_seq+1, not reset to 1: duplicate detection is session-scoped,
+    so a fresh lease (takeover/reconnect/post-park resend) must continue the
+    session's sequence — reseeding to 1 would either gap-wedge the client's
+    legitimate next frame or false-duplicate-ack new bytes (silent loss)."""
     sess = _session(con, session_id)
     if sess[3] != "occupied":
         raise BrokerError(f"session {session_id} is {sess[3]}, not occupied")
+    istate = con.execute(
+        "SELECT forwarded_seq FROM interface_input_state WHERE session_id=?",
+        (session_id,)).fetchone()
+    if istate is None:
+        raise BrokerError(f"session {session_id} has no input state row")
     held = current_writer(con, session_id)
     if held is not None:
         if not takeover:
@@ -77,9 +111,9 @@ def acquire_writer(con, session_id: int, client_id: str, token: str,
     cur = con.execute(
         "INSERT INTO interface_writer_leases "
         "(session_id, shell_id, generation, client_id, token_hash, "
-        " heartbeat_at) VALUES (?,?,?,?,?,datetime('now'))",
+        " next_input_seq, heartbeat_at) VALUES (?,?,?,?,?,?,datetime('now'))",
         (session_id, sess[1], sess[2], client_id,
-         hashlib.sha256(token.encode()).hexdigest()),
+         hashlib.sha256(token.encode()).hexdigest(), istate[0] + 1),
     )
     return cur.lastrowid
 
@@ -95,8 +129,13 @@ def accept_human_input(con, session_id: int, client_seq: int,
     5. COMMIT forwarded, then the caller acks the client.
 
     An exact duplicate of a known-forwarded sequence returns its prior ack
-    and forwards nothing; a gap rejects before any state change. A crash
-    between the commits leaves pending_seq for startup reconciliation.
+    and forwards nothing; a gap rejects before any state change. While a
+    wake batch holds the input lock (state 'submitting') every new frame is
+    refused — later input is ordered after the indivisible submission. A
+    crash between the commits leaves pending_seq for startup reconciliation;
+    a writer() failure WITHOUT process death takes the same park immediately
+    (delivery unknown, writer revoked, alert) since the bytes may have
+    landed.
     """
     if payload_len > MAX_INPUT_BYTES:
         raise BrokerError(f"payload {payload_len} > {MAX_INPUT_BYTES} bytes")
@@ -118,6 +157,17 @@ def accept_human_input(con, session_id: int, client_seq: int,
     if client_seq <= forwarded_seq:
         # Known-forwarded duplicate: replay the ack, never the bytes.
         return {"ack": client_seq, "duplicate": True}
+    # The input lock: while a wake batch is submitting, its fixed prompt is
+    # the indivisible input — a human frame is ordered AFTER it (spec #20
+    # Retry Policy), never interleaved inside the submission.
+    locked = con.execute(
+        "SELECT 1 FROM planner_wake_batches "
+        "WHERE shell_id=? AND generation=? AND state='submitting'",
+        (sess[1], sess[2])).fetchone()
+    if locked is not None:
+        raise BrokerError(
+            "a wake submission holds the input lock — this frame is ordered "
+            "after it; retry once the wake is acknowledged")
     if pending_seq is not None:
         # One unacknowledged frame per writer — the client buffers locally.
         raise BrokerError(f"sequence {pending_seq} is pending — wait for its ack")
@@ -135,7 +185,21 @@ def accept_human_input(con, session_id: int, client_seq: int,
     con.commit()
 
     # Phase 2: forward the exact bytes once. A crash here is the window.
-    writer(payload_len)
+    try:
+        writer(payload_len)
+    except Exception:
+        # The write failed WITHOUT process death (e.g. tmux error): the frame
+        # may or may not have landed — exactly the crash-window ambiguity, so
+        # take the same stance live: park delivery unknown, revoke the writer,
+        # alert, keep pending_seq as evidence, never replay. reconcile_input()
+        # is the only way out.
+        park_delivery_unknown(con, session_id)
+        con.execute(
+            "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
+            "revoke_reason='write_failure' WHERE lease_id=?",
+            (lease[0],))
+        con.commit()
+        raise
 
     # Phase 3 (commit): mark forwarded, clear the reservation, bump the lease.
     con.execute(
@@ -229,29 +293,48 @@ def record_hook(con, shell_id: int, generation: int, hook_seq: int,
         interface_state.transition(con, "lifecycle", sess[0], "idle")
         interface_state.transition(con, "composer", sess[0], "clean")
     elif event == "prompt_submit":
-        # Fenced submit: clears dirty, moves to busy, acknowledges a
-        # submitting wake batch whose fence this hook answers.
-        input_seq = con.execute(
-            "SELECT forwarded_seq FROM interface_input_state WHERE session_id=?",
-            (sess[0],)).fetchone()[0]
-        interface_state.transition(
-            con, "composer", sess[0], "clean",
-            extra_sets={"last_submit_seq": input_seq})
-        interface_state.transition(con, "lifecycle", sess[0], "busy")
+        # Fenced submit callback. A prompt_submit hook clears dirty -> clean
+        # and promotes a submitting wake batch ONLY when it provably answers
+        # that batch's submission: no human input sequence may have been
+        # accepted after the batch's input_seq_fence (spec: "clean only if no
+        # later human input sequence was accepted"). Without the fence a
+        # human's own Enter would manufacture the durable hook evidence
+        # decision #22 recovery trusts. A fence violation parks the batch as
+        # delivery_unknown — the wake may or may not have been consumed.
+        composer, forwarded_seq = con.execute(
+            "SELECT composer, forwarded_seq FROM interface_input_state "
+            "WHERE session_id=?", (sess[0],)).fetchone()
         batch = con.execute(
-            "SELECT batch_id FROM planner_wake_batches "
+            "SELECT batch_id, binding_id, input_seq_fence "
+            "FROM planner_wake_batches "
             "WHERE shell_id=? AND generation=? AND state='submitting'",
             (shell_id, generation)).fetchone()
-        if batch is not None:
-            interface_state.transition(
-                con, "wake_batch", batch[0], "running",
-                extra_sets={"submit_hook_seq": hook_seq,
-                            "submitted_at": _now(con)})
-            con.execute(
-                "UPDATE planner_wake_items SET state='running' "
-                "WHERE batch_id=? AND state='submitting'",
-                (batch[0],))
-            result["wake_batch_running"] = batch[0]
+        fenced = batch is None or (
+            batch[2] is not None and forwarded_seq < batch[2])
+        if not fenced:
+            interface_state.transition(con, "wake_batch", batch[0],
+                                       "delivery_unknown")
+            _alert(con, severity="critical",
+                   reason="wake_batch_delivery_unknown", binding_id=batch[1])
+            result["wake_batch_delivery_unknown"] = batch[0]
+        else:
+            # 'unknown' is never cleared by a hook — only exact recovery plus
+            # certification clears an ambiguity (spec #20 Composer).
+            if composer in ("clean", "dirty"):
+                interface_state.transition(
+                    con, "composer", sess[0], "clean",
+                    extra_sets={"last_submit_seq": forwarded_seq})
+            if batch is not None:
+                interface_state.transition(
+                    con, "wake_batch", batch[0], "running",
+                    extra_sets={"submit_hook_seq": hook_seq,
+                                "submitted_at": _now(con)})
+                con.execute(
+                    "UPDATE planner_wake_items SET state='running' "
+                    "WHERE batch_id=? AND state='submitting'",
+                    (batch[0],))
+                result["wake_batch_running"] = batch[0]
+        interface_state.transition(con, "lifecycle", sess[0], "busy")
     elif event == "turn_stop":
         interface_state.transition(con, "lifecycle", sess[0], "idle")
         batch = con.execute(
@@ -263,6 +346,14 @@ def record_hook(con, shell_id: int, generation: int, hook_seq: int,
             result["wake_batch_complete"] = batch[0]
     elif event == "session_end":
         interface_state.transition(con, "lifecycle", sess[0], "ended")
+        # The chat is provably over: end the generation too. Without this the
+        # one-live-generation index keeps the shell occupied forever — and a
+        # snapshot/rebuild cycle would resurrect a "live" generation that
+        # bricks the shell's next New chat.
+        con.execute(
+            "UPDATE interface_generations SET ended_at=datetime('now') "
+            "WHERE shell_id=? AND generation=? AND ended_at IS NULL",
+            (shell_id, generation))
     # approval_wait / approval_result / user_input_wait / interrupt map to
     # plain lifecycle moves — added with the adapters (task #83); the
     # mandatory four above are the wake-critical contract.
@@ -351,18 +442,59 @@ def resolve_batch(con, batch_id: int) -> None:
     con.commit()
 
 
+def _sprint_active(con, sprint_doc_id: int) -> bool:
+    """The sprint doc's body contract carries a `status: ACTIVE|CLOSED` line
+    (the planner is its only writer); a wake may submit only while ACTIVE."""
+    row = con.execute(
+        "SELECT body FROM documents WHERE document_id=?",
+        (sprint_doc_id,)).fetchone()
+    if row is None or row[0] is None:
+        return False
+    for line in row[0].splitlines():
+        if line.startswith("status:"):
+            return line.split(":", 1)[1].strip() == "ACTIVE"
+    return False
+
+
+def _cancel_batch(con, batch_id: int) -> None:
+    """Close a still-queued batch without sending a byte (the binding was
+    released or the sprint left ACTIVE between form and submit): the batch
+    completes empty and its batched items are cancelled — a wake must never
+    fire for a sprint that is no longer armed."""
+    interface_state.transition(
+        con, "wake_batch", batch_id, "complete",
+        extra_sets={"completed_at": _now(con)})
+    items = con.execute(
+        "SELECT item_id FROM planner_wake_items "
+        "WHERE batch_id=? AND state='batched'", (batch_id,)).fetchall()
+    for (item_id,) in items:
+        interface_state.transition(con, "wake_item", item_id, "cancelled")
+
+
 def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
                       quiet_s: float = DEFAULT_QUIET_S) -> dict:
     """Gate + submit one coalesced fixed-prompt batch under the input lock.
 
-    Revalidates everything the spec requires before a byte moves: occupied
-    session, idle lifecycle, clean composer, quiet >= quiet_s since the last
-    accepted human input, no pending human frame, current generation. Any
-    uncertainty cancels the attempt WITHOUT a state change (the batch stays
-    queued awaiting a later event) and without sending a byte. The
-    submission is one indivisible writer call; its fence is forwarded_seq+1
-    (the broker sequence the submit hook must answer).
+    Revalidates everything the spec requires before a byte moves: the binding
+    still armed and its sprint still ACTIVE (a close between form_batch and
+    submit CANCELS the batch), occupied session, idle lifecycle, clean
+    composer, quiet >= quiet_s since the last accepted human input AND since
+    the last service restart (a fresh full debounce is owed after every
+    restart — a NULL last_human_input_at never skips the check), no pending
+    human frame. quiet_s must be > 0 (the spec forbids a zero debounce).
+    Transient gate failures (busy/dirty/quiet) cancel the attempt WITHOUT a
+    state change — the batch stays queued awaiting a later event.
+
+    From the 'submitting' commit until the fenced submit hook, the batch
+    holds the input lock: accept_human_input refuses new frames, so no human
+    input can interleave inside the fixed submission. The submission is one
+    indivisible writer call; its fence is forwarded_seq+1 (the broker
+    sequence the submit hook must answer). A writer failure without process
+    death parks the batch as delivery_unknown — the prompt may have landed —
+    which also releases the lock.
     """
+    if quiet_s <= 0:
+        raise BrokerError("quiet_s must be > 0 — a zero debounce is forbidden")
     batch = con.execute(
         "SELECT binding_id, shell_id, generation, state "
         "FROM planner_wake_batches WHERE batch_id=?",
@@ -371,9 +503,27 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
         raise BrokerError(f"wake batch {batch_id} not found")
     if batch[3] != "queued":
         raise BrokerError(f"wake batch {batch_id} is {batch[3]}, not queued")
-    _, shell_id, generation, _ = batch
+    binding_id, shell_id, generation, _ = batch
+
+    # Revalidate the arming at SUBMIT time: a sprint close or binding release
+    # since form_batch cancels the batch outright (no byte, no retry).
+    binding = con.execute(
+        "SELECT sprint_doc_id, released_at FROM sprint_planner_bindings "
+        "WHERE binding_id=?", (binding_id,)).fetchone()
+    if binding is None or binding[1] is not None:
+        _cancel_batch(con, batch_id)
+        con.commit()
+        return {"submitted": False, "cancelled": True,
+                "reason": "binding released — sprint no longer armed"}
+    if not _sprint_active(con, binding[0]):
+        _cancel_batch(con, batch_id)
+        con.commit()
+        return {"submitted": False, "cancelled": True,
+                "reason": "sprint doc is not ACTIVE"}
+
     sess = con.execute(
-        "SELECT session_id, occupancy, lifecycle FROM interface_sessions "
+        "SELECT session_id, occupancy, lifecycle, occupied_at, created_at "
+        "FROM interface_sessions "
         "WHERE shell_id=? AND generation=? AND occupancy <> 'ended'",
         (shell_id, generation)).fetchone()
     istate = con.execute(
@@ -388,13 +538,22 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
         return {"submitted": False, "reason": f"composer is {istate[0]}"}
     if istate[1] is not None:
         return {"submitted": False, "reason": "a human frame is pending"}
-    if istate[3] is not None:
-        quiet = con.execute(
-            "SELECT julianday(?) - julianday(?)", (now_iso, istate[3])
-        ).fetchone()[0] * 86400.0
-        if quiet < quiet_s:
-            return {"submitted": False,
-                    "reason": f"quiet {quiet:.2f}s < {quiet_s}s"}
+    # Quiet baseline: the last human input if any, else the session's start —
+    # floored at the last service restart (startup_reconcile revokes every
+    # lease with reason 'service_restart'; that stamp is the restart time).
+    baseline = istate[3] or sess[3] or sess[4]
+    restart_at = con.execute(
+        "SELECT MAX(revoked_at) FROM interface_writer_leases "
+        "WHERE session_id=? AND revoke_reason='service_restart'",
+        (sess[0],)).fetchone()[0]
+    if restart_at is not None and restart_at > baseline:
+        baseline = restart_at
+    quiet = con.execute(
+        "SELECT julianday(?) - julianday(?)", (now_iso, baseline)
+    ).fetchone()[0] * 86400.0
+    if quiet < quiet_s:
+        return {"submitted": False,
+                "reason": f"quiet {quiet:.2f}s < {quiet_s}s"}
 
     fence = istate[2] + 1
     interface_state.transition(
@@ -406,7 +565,18 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
         (batch_id,))
     con.commit()
 
-    writer(len(WAKE_PROMPT) + 1)  # the fixed prompt + Enter, indivisible
+    try:
+        writer(len(WAKE_PROMPT) + 1)  # the fixed prompt + Enter, indivisible
+    except Exception:
+        # The prompt may or may not have landed and no submit hook can be
+        # trusted to disambiguate — park exactly like the restart path (never
+        # auto-retry; resolve_batch requeues after operator inspection).
+        interface_state.transition(con, "wake_batch", batch_id,
+                                   "delivery_unknown")
+        _alert(con, severity="critical", reason="wake_batch_delivery_unknown",
+               binding_id=binding_id)
+        con.commit()
+        raise
     # The submit hook (record_hook 'prompt_submit') moves the batch to
     # running with durable evidence. No hook → on restart the batch parks
     # as delivery_unknown and is never blindly resubmitted.

--- a/.super-coder/scripts/interface_reconcile.py
+++ b/.super-coder/scripts/interface_reconcile.py
@@ -42,15 +42,10 @@ def _has_table(con, name: str) -> bool:
     ).fetchone() is not None
 
 
-def _alert(con, *, severity: str, reason: str, session_id=None,
-           binding_id=None) -> None:
-    """Raise an alert, deduplicated while open (partial unique index)."""
-    dedupe = f"{session_id or '-'}|{binding_id or '-'}|{reason}"
-    con.execute(
-        "INSERT OR IGNORE INTO planner_alerts "
-        "(session_id, binding_id, severity, reason, dedupe_key) "
-        "VALUES (?,?,?,?,?)",
-        (session_id, binding_id, severity, reason, dedupe))
+def _alert(con, **kw) -> None:
+    """Raise an alert, deduplicated while open — interface_broker owns the
+    helper (it parks live too); kept here as a thin alias for readability."""
+    interface_broker._alert(con, **kw)
 
 
 def startup_reconcile(con) -> dict:
@@ -67,11 +62,7 @@ def startup_reconcile(con) -> dict:
         "SELECT session_id FROM interface_input_state WHERE pending_seq IS NOT NULL"
     ).fetchall()
     for (session_id,) in parked:
-        interface_state.transition(con, "composer", session_id, "unknown")
-        interface_state.transition(con, "delivery", session_id,
-                                   "delivery_unknown")
-        _alert(con, severity="critical", reason="crash_window_delivery_unknown",
-               session_id=session_id)
+        interface_broker.park_delivery_unknown(con, session_id)
         counts["parks"] += 1
 
     # 2. Batch recovery — durable hook-sequence evidence or park.
@@ -138,6 +129,14 @@ def live_refusal_reasons(db_path) -> list[str]:
         if not _has_table(con, "interface_sessions"):
             return []
         reasons = []
+        rows = con.execute(
+            "SELECT shell_id, generation FROM interface_generations "
+            "WHERE ended_at IS NULL").fetchall()
+        for shell_id, generation in rows:
+            reasons.append(
+                f"generation {shell_id}/{generation} is live — end it first "
+                "(a rebuilt live generation bricks that shell's next New "
+                "chat)")
         rows = con.execute(
             "SELECT session_id, shell_id, occupancy FROM interface_sessions "
             "WHERE occupancy <> 'ended'").fetchall()

--- a/.super-coder/scripts/interface_reconcile.py
+++ b/.super-coder/scripts/interface_reconcile.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Interface startup reconciliation + rebuild/update live-guard (spec #20).
+
+startup_reconcile() is the DB-durable half of "ordinary service restart
+reconciles the live DB": it runs once at API boot (server.main, next to the
+api-key backfill) and repairs exactly what a broker/service death can leave
+behind:
+
+1. Crash-window parking (decision #22 — THE proof point): any input_state
+   with a pending (accepted, unacknowledged) human frame cannot tell
+   pre-write from post-write. It parks: composer=unknown,
+   delivery=delivery_unknown, writer revoked, alert raised. pending_seq is
+   KEPT as evidence. There is no replay — no code path re-forwards it;
+   only reconcile_input() (operator inspection) clears the park.
+2. Batch recovery from durable hook-sequence evidence only: submitting
+   without a submit hook stamp → delivery_unknown; submitting with one →
+   running (the submit is proven, the stop hook will complete it); running
+   with a stop stamp → complete with items reconciled from message read
+   state; running without new evidence stays running — the live harness's
+   hooks re-drive it after the API is back.
+3. Reservation repair: a reserved session past its lease expiry is
+   unreconciled (fail closed — we cannot prove the spawn never happened).
+4. Lease hygiene: every still-current writer lease is revoked (a restart
+   dropped every client); composer/draft state is preserved.
+
+live_refusal_reasons() is the rebuild/update/materialize guard: it names
+every live Interface state that must be drained first. Tolerates a pre-0078
+DB (no Interface tables → no reasons).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import db_driver
+import interface_broker
+import interface_state
+
+
+def _has_table(con, name: str) -> bool:
+    return con.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone() is not None
+
+
+def _alert(con, *, severity: str, reason: str, session_id=None,
+           binding_id=None) -> None:
+    """Raise an alert, deduplicated while open (partial unique index)."""
+    dedupe = f"{session_id or '-'}|{binding_id or '-'}|{reason}"
+    con.execute(
+        "INSERT OR IGNORE INTO planner_alerts "
+        "(session_id, binding_id, severity, reason, dedupe_key) "
+        "VALUES (?,?,?,?,?)",
+        (session_id, binding_id, severity, reason, dedupe))
+
+
+def startup_reconcile(con) -> dict:
+    """Idempotent post-restart repair. Returns a counts summary for the log."""
+    if not _has_table(con, "interface_sessions"):
+        return {"skipped": "pre-0078 DB"}
+
+    counts = {"reservations_unreconciled": 0, "parks": 0,
+              "batches_delivery_unknown": 0, "batches_proven_running": 0,
+              "batches_completed": 0, "leases_revoked": 0}
+
+    # 1. Crash-window parking — pending human frame at restart.
+    parked = con.execute(
+        "SELECT session_id FROM interface_input_state WHERE pending_seq IS NOT NULL"
+    ).fetchall()
+    for (session_id,) in parked:
+        interface_state.transition(con, "composer", session_id, "unknown")
+        interface_state.transition(con, "delivery", session_id,
+                                   "delivery_unknown")
+        _alert(con, severity="critical", reason="crash_window_delivery_unknown",
+               session_id=session_id)
+        counts["parks"] += 1
+
+    # 2. Batch recovery — durable hook-sequence evidence or park.
+    live_batches = con.execute(
+        "SELECT batch_id, state, submit_hook_seq, stop_hook_seq "
+        "FROM planner_wake_batches WHERE state IN ('submitting','running')"
+    ).fetchall()
+    for batch_id, state, submit_seq, stop_seq in live_batches:
+        if stop_seq is not None:
+            # The full submit+stop cycle is proven — reconcile items from
+            # durable message read state, exactly like a live turn_stop.
+            interface_broker._complete_batch(con, batch_id, stop_seq)
+            counts["batches_completed"] += 1
+        elif submit_seq is not None:
+            # Submit proven, stop not yet seen — the batch legitimately runs;
+            # the live harness's stop hook completes it.
+            if state == "submitting":
+                interface_state.transition(con, "wake_batch", batch_id, "running")
+            counts["batches_proven_running"] += 1
+        else:
+            interface_state.transition(con, "wake_batch", batch_id,
+                                       "delivery_unknown")
+            binding = con.execute(
+                "SELECT binding_id FROM planner_wake_batches WHERE batch_id=?",
+                (batch_id,)).fetchone()[0]
+            _alert(con, severity="critical",
+                   reason="wake_batch_delivery_unknown", binding_id=binding)
+            counts["batches_delivery_unknown"] += 1
+
+    # 3. Expired reservations fail closed — ambiguous spawn ⇒ unreconciled.
+    expired = con.execute(
+        "SELECT session_id FROM interface_sessions "
+        "WHERE occupancy='reserved' AND reservation_expires_at IS NOT NULL "
+        "AND reservation_expires_at < datetime('now')"
+    ).fetchall()
+    for (session_id,) in expired:
+        interface_state.transition(con, "occupancy", session_id, "unreconciled",
+                                   extra_sets={"error_detail":
+                                               "reservation expired at restart"})
+        _alert(con, severity="warning", reason="reservation_expired",
+               session_id=session_id)
+        counts["reservations_unreconciled"] += 1
+
+    # 4. A restart dropped every client — revoke all current writer leases.
+    #    Composer/dirty state is preserved (spec: dirty survives disconnect).
+    cur = con.execute(
+        "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
+        "revoke_reason='service_restart' WHERE revoked_at IS NULL")
+    counts["leases_revoked"] = cur.rowcount
+
+    con.commit()
+    return counts
+
+
+def live_refusal_reasons(db_path) -> list[str]:
+    """Why a rebuild/update/materialize must refuse right now (spec #20:
+    'rebuild/update refuses while any non-ended session, unreleased binding,
+    nonterminal wake batch, or input ambiguity exists'). Empty list = safe.
+    A pre-0078 DB has no Interface state → no reasons."""
+    if not Path(str(db_path)).exists():
+        return []
+    con = db_driver.connect(str(db_path))
+    try:
+        if not _has_table(con, "interface_sessions"):
+            return []
+        reasons = []
+        rows = con.execute(
+            "SELECT session_id, shell_id, occupancy FROM interface_sessions "
+            "WHERE occupancy <> 'ended'").fetchall()
+        for session_id, shell_id, occupancy in rows:
+            reasons.append(
+                f"interface session {session_id} (shell {shell_id}) is "
+                f"{occupancy} — end/reconcile it first")
+        rows = con.execute(
+            "SELECT binding_id, sprint_doc_id FROM sprint_planner_bindings "
+            "WHERE released_at IS NULL").fetchall()
+        for binding_id, doc_id in rows:
+            reasons.append(
+                f"sprint binding {binding_id} (doc {doc_id}) is armed — "
+                "release it first")
+        rows = con.execute(
+            "SELECT batch_id, state FROM planner_wake_batches "
+            "WHERE state <> 'complete'").fetchall()
+        for batch_id, state in rows:
+            reasons.append(
+                f"wake batch {batch_id} is {state} — drain or reconcile it "
+                "first")
+        rows = con.execute(
+            "SELECT session_id FROM interface_input_state "
+            "WHERE composer='unknown' OR delivery='delivery_unknown' "
+            "OR pending_seq IS NOT NULL").fetchall()
+        for (session_id,) in rows:
+            reasons.append(
+                f"session {session_id} has input ambiguity — inspect the live "
+                "TUI and reconcile first")
+        return reasons
+    finally:
+        con.close()

--- a/.super-coder/scripts/interface_state.py
+++ b/.super-coder/scripts/interface_state.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Interface state machines — app-level transition validation (spec #20).
+
+The DB triggers in migrations/0078_interface_sessions.sql are the backstop
+(RAISE(ABORT)); these maps mirror them so the API/broker can pre-check and
+fail with a friendly error instead of an IntegrityError. KEEP THE TWO IN
+SYNC — tests/test_interface_transitions.py walks every (old, new) pair of
+every machine against BOTH layers and fails on any drift.
+
+Edge rationales trace to spec #20's Occupancy Model / Input Broker / Wake
+Delivery sections. Two deliberate readings of the spec's edge lists:
+- lifecycle lost|error → ended: the spec lists no such edge, but an
+  unreconciled generation must be closable after exact process absence is
+  proved ("the operator closes or replaces it") — occupancy walks
+  unreconciled → ended and lifecycle must be able to follow.
+- lifecycle starting → ended: "definite pre-spawn failure closes it" — the
+  reservation fails before any process exists, so ended is provable.
+"""
+from __future__ import annotations
+
+# ── Edge maps (mirror the 0078 triggers exactly) ─────────────────────────────
+
+OCCUPANCY_EDGES = {
+    "reserved": {"occupied", "unreconciled", "ended"},
+    "occupied": {"unreconciled", "ended"},
+    "unreconciled": {"occupied", "ended"},
+    "ended": set(),
+}
+
+LIFECYCLE_EDGES = {
+    "starting": {"idle", "stopping", "lost", "error", "ended"},
+    "idle": {"busy", "stopping", "lost"},
+    "busy": {"idle", "approval", "user_input", "error", "stopping", "lost"},
+    "approval": {"busy", "error", "stopping", "lost"},
+    "user_input": {"busy", "error", "stopping", "lost"},
+    "stopping": {"ended", "lost", "error"},
+    "lost": {"ended", "stopping"},
+    "error": {"ended", "stopping"},
+    "ended": set(),
+}
+
+COMPOSER_EDGES = {
+    "unknown": {"clean", "dirty"},
+    "clean": {"dirty", "unknown"},
+    "dirty": {"clean", "unknown"},
+}
+
+DELIVERY_EDGES = {
+    "normal": {"delivery_unknown"},
+    "delivery_unknown": {"normal"},
+}
+
+WAKE_ITEM_EDGES = {
+    "queued": {"batched", "quarantined", "cancelled"},
+    "batched": {"queued", "submitting", "cancelled"},
+    "submitting": {"queued", "running", "cancelled"},
+    "running": {"done", "reconcile", "queued", "cancelled"},
+    "reconcile": {"queued", "done", "cancelled"},
+    "quarantined": {"queued", "cancelled"},
+    "done": set(),
+    "cancelled": set(),
+}
+
+WAKE_BATCH_EDGES = {
+    "queued": {"submitting", "complete"},
+    "submitting": {"queued", "running", "delivery_unknown"},
+    "running": {"complete", "delivery_unknown"},
+    "delivery_unknown": {"complete"},
+    "complete": set(),
+}
+
+RECEIPT_EDGES = {
+    "intent": {"complete", "unknown"},
+    "unknown": {"reconciled"},
+    "complete": set(),
+    "reconciled": set(),
+}
+
+# (table, pk column, state column, edge map) — one entry per machine.
+MACHINES = {
+    "occupancy": ("interface_sessions", "session_id", "occupancy", OCCUPANCY_EDGES),
+    "lifecycle": ("interface_sessions", "session_id", "lifecycle", LIFECYCLE_EDGES),
+    "composer": ("interface_input_state", "session_id", "composer", COMPOSER_EDGES),
+    "delivery": ("interface_input_state", "session_id", "delivery", DELIVERY_EDGES),
+    "wake_item": ("planner_wake_items", "item_id", "state", WAKE_ITEM_EDGES),
+    "wake_batch": ("planner_wake_batches", "batch_id", "state", WAKE_BATCH_EDGES),
+    "receipt": ("planner_action_receipts", "receipt_id", "state", RECEIPT_EDGES),
+}
+
+# State tables carrying an updated_at column, touched on every transition.
+_UPDATED_AT_TABLES = {"interface_input_state", "planner_wake_items"}
+
+
+class InterfaceTransitionError(ValueError):
+    """An illegal state-machine edge, caught before the DB backstop fires."""
+
+
+def check(edges: dict, old: str, new: str) -> None:
+    """Raise InterfaceTransitionError unless old -> new is a legal edge
+    (a same-state no-op is always legal — the triggers agree)."""
+    if new == old:
+        return
+    if new not in edges.get(old, ()):  # unknown old state → empty set → raise
+        raise InterfaceTransitionError(f"illegal transition: {old} -> {new}")
+
+
+def transition(con, machine: str, row_id: int, new_state: str,
+               extra_sets: dict | None = None) -> str:
+    """Validated state move for one row. Returns the prior state.
+
+    Reads the current state, checks the edge (friendly error), then UPDATEs;
+    the DB trigger backstops any caller that skips this helper. extra_sets
+    are additional column=value pairs written in the same UPDATE (timestamps,
+    reasons) — column names are internal constants, never user input.
+    """
+    table, pk, col, edges = MACHINES[machine]
+    row = con.execute(
+        f"SELECT {col} FROM {table} WHERE {pk}=?", (row_id,)
+    ).fetchone()
+    if row is None:
+        raise InterfaceTransitionError(f"{table} row {row_id} not found")
+    old = row[0]
+    check(edges, old, new_state)
+    sets = {col: new_state, **(extra_sets or {})}
+    clause = ", ".join(f"{c}=?" for c in sets)
+    if table in _UPDATED_AT_TABLES:
+        clause += ", updated_at=datetime('now')"
+    con.execute(
+        f"UPDATE {table} SET {clause} WHERE {pk}=?",
+        (*sets.values(), row_id),
+    )
+    return old

--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -37,6 +37,7 @@ import db_driver    # noqa: E402
 import migrate as migrate_mod  # noqa: E402
 import map_repo     # noqa: E402
 import backfill_shell_api_keys  # noqa: E402  (re-provision api_keys post-rebuild)
+import interface_reconcile  # noqa: E402  (live-Interface refusal guard)
 import seed_skills  # noqa: E402  (re-assert the fork retire list post-seed)
 
 
@@ -158,6 +159,16 @@ def main(argv: list[str]) -> int:
     if "--no-backup" not in argv:
         backup_existing()
     keys = read_existing_keys()
+    # Spec #20: a rebuild destroys the live DB, so it refuses while any live
+    # Interface state would be lost — non-ended session, unreleased binding,
+    # nonterminal wake batch, or input ambiguity. Same fail-closed shape as
+    # read_existing_keys (#279): abort while the outgoing DB still exists.
+    reasons = interface_reconcile.live_refusal_reasons(DB_PATH)
+    if reasons:
+        sys.exit(
+            "rebuild: refusing — live Interface state exists; the clean "
+            "operator drain path is required first:\n  - "
+            + "\n  - ".join(reasons))
     for suffix in ("", "-wal", "-shm"):
         p = Path(str(DB_PATH) + suffix)
         if p.exists():

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -103,6 +103,7 @@ PER_INSTANCE_TABLES = [
 # run while a chat is live). The dump still DELETEs the whole table on load;
 # rows outside the filter simply never existed as far as the rebuild knows.
 SNAPSHOT_ROW_FILTERS = {
+    "interface_generations": "WHERE ended_at IS NOT NULL",
     "interface_sessions": "WHERE occupancy = 'ended'",
     "sprint_planner_bindings": "WHERE released_at IS NOT NULL",
     "planner_wake_batches": "WHERE state IN ('complete','delivery_unknown')",

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -76,10 +76,41 @@ PER_INSTANCE_TABLES = [
     # the engine's baseline; content.sql loads AFTER migrations on rebuild, so
     # the fork's edits win — without this the GUI's changes vanish on rebuild.
     "flavor_defaults",
+    # ── Interface (spec #20, 0078) — durable audit only. Live rows are
+    # row-filtered OUT (SNAPSHOT_ROW_FILTERS below): snapshot may run while a
+    # chat is live, and rebuild/update refuse while any live state exists, so
+    # content.sql only ever carries closed/terminal rows. Volatile columns
+    # (tmux socket, PIDs/start ticks, hook token hash) ride SENSITIVE_COLUMNS.
+    # Fully volatile tables (interface_writer_leases, interface_input_state,
+    # pr_poll_runs) are NOT in this list — a rebuild rederives them empty.
+    "interface_generations",
+    "interface_sessions",
+    "interface_idempotency_keys",
+    "sprint_planner_bindings",
+    "planner_wake_batches",
+    "planner_wake_items",
+    "planner_action_receipts",
+    "pr_poll_observations",
+    "planner_alerts",
     # NOTE: dr_section is authored navigation but lives in the MAP DB now
     # (.sc-state/map.db), not shell_db.db — it is serialized separately to
     # .sc-state/map_content.sql by snapshot_map() below, not here.
 ]
+
+# Row-level projection for tables whose LIVE rows must not reach content.sql
+# (spec #20: snapshot preserves closed session/binding audit, terminal/
+# quarantined wake audit, and transition/blind-window observations — and may
+# run while a chat is live). The dump still DELETEs the whole table on load;
+# rows outside the filter simply never existed as far as the rebuild knows.
+SNAPSHOT_ROW_FILTERS = {
+    "interface_sessions": "WHERE occupancy = 'ended'",
+    "sprint_planner_bindings": "WHERE released_at IS NOT NULL",
+    "planner_wake_batches": "WHERE state IN ('complete','delivery_unknown')",
+    "planner_wake_items":
+        "WHERE state IN ('done','reconcile','quarantined','cancelled')",
+    "pr_poll_observations":
+        "WHERE transition IS NOT NULL OR blind_window <> 0",
+}
 
 
 def quote(v) -> str:
@@ -189,6 +220,11 @@ def dump_local_skills(con) -> list[str]:
 SENSITIVE_COLUMNS = {
     "shells": {"api_key", "api_key_rotated_at"},
     "users": {"password_hash", "password_salt"},
+    # Interface (0078): exact-identity fencing + credential hashes are
+    # volatile runtime state — never serialized even on ended audit rows.
+    "interface_generations": {"hook_token_hash"},
+    "interface_sessions": {"tmux_socket", "pane_pid", "pane_start_ticks",
+                           "harness_pid", "harness_start_ticks"},
 }
 
 
@@ -202,7 +238,9 @@ def dump_table(con, table: str) -> list[str]:
     if not cols:
         return []
     collist = ", ".join(cols)
-    rows = con.execute(f"SELECT {collist} FROM {table} ORDER BY rowid").fetchall()
+    where = SNAPSHOT_ROW_FILTERS.get(table, "")
+    rows = con.execute(
+        f"SELECT {collist} FROM {table} {where} ORDER BY rowid").fetchall()
     lines = [f"DELETE FROM {table};"]
     for row in rows:
         vals = ", ".join(quote(v) for v in row)

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -66,6 +66,7 @@ sys.path.insert(0, str(ENGINE / "scripts"))
 import db_driver  # noqa: E402
 import engine_manifest  # noqa: E402
 import install as install_mod  # noqa: E402  (ensure_harnesses)
+import interface_reconcile  # noqa: E402  (live-Interface refusal guard)
 import migrate as migrate_mod  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402
 import seed_skills  # noqa: E402
@@ -320,6 +321,14 @@ def migrate_or_rebuild() -> None:
         print("→ no live DB (fresh fork) — building from text")
         rebuild_mod.main([])
         return
+    # Spec #20: update/materialize refuses while live Interface state exists
+    # (non-ended session, unreleased binding, nonterminal batch, input
+    # ambiguity) — same guard as rebuild, before any structural change.
+    reasons = interface_reconcile.live_refusal_reasons(DB_PATH)
+    if reasons:
+        sys.exit(
+            "update: refusing — live Interface state exists; drain/reconcile "
+            "it first:\n  - " + "\n  - ".join(reasons))
     rebuild_mod.backup_existing()  # restore point before any structural change
     print("→ migrate in place (pending migrations → the live DB; data preserved)")
     migrate_mod.migrate(str(DB_PATH))

--- a/tests/test_interface_crash_window.py
+++ b/tests/test_interface_crash_window.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Crash-window / delivery_unknown parking proofs (decision #22, spec #20).
+
+The seq-3 gate spike DEFERRED this proof to seq 4 with a hard condition: no
+wake/retry unit may ship until parking is implemented AND proven. These are
+those proofs, hermetic against a real engine DB (schema.sql + all migrations)
+with the byte transport injected as a recording fake:
+
+1. Broker crash BEFORE the tmux write with a pending unacknowledged human
+   sequence → composer unknown, delivery delivery_unknown, writer revoked,
+   alert raised, ZERO bytes ever written, and no auto-replay — the pending
+   frame is never re-forwarded by any recovery path.
+2. Broker crash AFTER the tmux write (bytes landed, forward-commit lost) →
+   indistinguishable from (1): identical park, and the write count stays 1
+   across every reconciliation — never replayed.
+3. Operator reconciliation is the only way out: 'delivered' folds the
+   pending sequence into forwarded (no resend), 'not_delivered' drops the
+   reservation so the client can resend under a fresh lease.
+4. A submitting/running wake batch at restart → delivery_unknown UNLESS
+   durable hook-sequence evidence proves the transition (submit stamp →
+   running; stop stamp → complete with items reconciled from message read
+   state). A parked batch is never blindly resubmitted; resolve_batch
+   requeues its items without sending anything.
+
+Run:
+    python3 tests/test_interface_crash_window.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import interface_broker  # noqa: E402
+import interface_reconcile  # noqa: E402
+
+
+class Crash(Exception):
+    """Simulated broker process death at an exact point."""
+
+
+class Recorder:
+    """The injected tmux write. `mode` decides where the process dies."""
+
+    def __init__(self, mode="ok"):
+        self.mode = mode
+        self.writes = []
+
+    def __call__(self, payload_len: int) -> None:
+        if self.mode == "crash_before_write":
+            raise Crash("died before the tmux write")
+        self.writes.append(payload_len)
+        if self.mode == "crash_after_write":
+            raise Crash("died after the tmux write, before forward-commit")
+
+
+def build_engine_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1,'T',1)")
+    for sid in (1, 2):
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+            "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+            "VALUES (?,?,?,'test','sp',1,0,1,1)", (sid, f"S{sid}", f"s{sid}"))
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title) "
+        "VALUES (1,'doc','SPRINT: test')")
+    con.commit()
+    con.close()
+
+
+class CrashWindowTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db)
+        # One occupied shell-1 session (generation 1), clean composer,
+        # writer lease held by client 'tab-1'.
+        self.con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,1)")
+        self.sid = self.con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle) VALUES (1,1,'occupied','idle')").lastrowid
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,1,1,'clean')", (self.sid,))
+        interface_broker.acquire_writer(self.con, self.sid, "tab-1", "tok-1")
+        self.con.commit()
+
+    def tearDown(self):
+        self.con.close()
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def _reconnect(self):
+        """Simulate process death + service restart: drop the connection."""
+        self.con.close()
+        self.con = sqlite3.connect(self.db)
+
+    def _input(self):
+        cols = ("composer", "delivery", "pending_seq", "forwarded_seq")
+        row = self.con.execute(
+            f"SELECT {', '.join(cols)} FROM interface_input_state "
+            "WHERE session_id=?", (self.sid,)).fetchone()
+        return dict(zip(cols, row))
+
+    def _assert_parked(self, writes):
+        ist = self._input()
+        self.assertEqual(ist["composer"], "unknown")
+        self.assertEqual(ist["delivery"], "delivery_unknown")
+        self.assertEqual(ist["pending_seq"], 1, "evidence must survive")
+        self.assertEqual(ist["forwarded_seq"], 0)
+        lease = self.con.execute(
+            "SELECT revoked_at, revoke_reason FROM interface_writer_leases "
+            "WHERE session_id=?", (self.sid,)).fetchone()
+        self.assertIsNotNone(lease[0], "writer must be revoked")
+        alert = self.con.execute(
+            "SELECT severity FROM planner_alerts "
+            "WHERE reason='crash_window_delivery_unknown' AND resolved_at IS "
+            "NULL").fetchone()
+        self.assertIsNotNone(alert, "park must alert")
+
+    # ── 1 & 2: crash before vs after the tmux write ─────────────────────
+    def _crash_case(self, mode, expect_writes):
+        rec = Recorder(mode)
+        with self.assertRaises(Crash):
+            interface_broker.accept_human_input(
+                self.con, self.sid, client_seq=1, payload_len=10, writer=rec)
+        self.assertEqual(rec.writes, expect_writes)
+        # The pending reservation committed before the crash.
+        self.assertEqual(self._input()["pending_seq"], 1)
+
+        self._reconnect()
+        interface_reconcile.startup_reconcile(self.con)
+        self._assert_parked(rec.writes)
+
+        # Reconciliation is idempotent and NEVER replays: run it twice more.
+        interface_reconcile.startup_reconcile(self.con)
+        interface_reconcile.startup_reconcile(self.con)
+        self.assertEqual(rec.writes, expect_writes,
+                         "recovery must never re-forward the pending frame")
+        self.assertEqual(self._input()["pending_seq"], 1)
+        return rec
+
+    def test_crash_before_write_parks_without_replay(self):
+        self._crash_case("crash_before_write", [])
+
+    def test_crash_after_write_parks_without_replay(self):
+        self._crash_case("crash_after_write", [10])
+
+    # ── 3: operator reconciliation paths ────────────────────────────────
+    def test_reconcile_delivered_folds_sequence_no_resend(self):
+        rec = Recorder("crash_after_write")
+        with self.assertRaises(Crash):
+            interface_broker.accept_human_input(
+                self.con, self.sid, 1, 10, writer=rec)
+        self._reconnect()
+        interface_reconcile.startup_reconcile(self.con)
+        interface_broker.reconcile_input(self.con, self.sid, "delivered")
+        self.con.commit()
+        ist = self._input()
+        self.assertEqual(ist["delivery"], "normal")
+        self.assertIsNone(ist["pending_seq"])
+        self.assertEqual(ist["forwarded_seq"], 1,
+                         "proven-delivered frame folds into forwarded_seq")
+        self.assertEqual(rec.writes, [10], "folding must not resend")
+
+    def test_reconcile_not_delivered_allows_client_resend(self):
+        rec = Recorder("crash_before_write")
+        with self.assertRaises(Crash):
+            interface_broker.accept_human_input(
+                self.con, self.sid, 1, 10, writer=rec)
+        self._reconnect()
+        interface_reconcile.startup_reconcile(self.con)
+        interface_broker.reconcile_input(self.con, self.sid, "not_delivered")
+        self.con.commit()
+        self.assertEqual(self._input()["forwarded_seq"], 0)
+        # The operator certifies the composer; the client re-acquires the
+        # writer and resends sequence 1 — accepted exactly once.
+        interface_broker.certify_clean(self.con, self.sid, "op", 0)
+        lease = interface_broker.acquire_writer(
+            self.con, self.sid, "tab-2", "tok-2")
+        self.assertIsNotNone(lease)
+        rec2 = Recorder("ok")
+        ack = interface_broker.accept_human_input(
+            self.con, self.sid, 1, 10, writer=rec2)
+        self.assertEqual(ack, {"ack": 1, "duplicate": False})
+        self.assertEqual(rec2.writes, [10])
+        self.assertEqual(self._input()["forwarded_seq"], 1)
+
+    # ── duplicate / gap discipline (no double-forward, no out-of-order) ──
+    def test_duplicate_seq_replays_ack_never_bytes(self):
+        rec = Recorder("ok")
+        interface_broker.accept_human_input(
+            self.con, self.sid, 1, 10, writer=rec)
+        dup = interface_broker.accept_human_input(
+            self.con, self.sid, 1, 10, writer=rec)
+        self.assertEqual(dup, {"ack": 1, "duplicate": True})
+        self.assertEqual(rec.writes, [10], "duplicate must not re-forward")
+
+    def test_sequence_gap_rejected_before_any_write(self):
+        rec = Recorder("ok")
+        with self.assertRaises(interface_broker.BrokerError):
+            interface_broker.accept_human_input(
+                self.con, self.sid, 5, 10, writer=rec)
+        self.assertEqual(rec.writes, [])
+        self.assertEqual(self._input()["composer"], "clean")
+
+    # ── 4: wake-batch restart recovery from hook-sequence evidence ───────
+    def _arm_and_submit(self):
+        """A binding, one wake item, a submitted batch. Returns batch_id."""
+        self.con.execute(
+            "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (1,1,?,1,1)", (self.sid,))
+        bid = self.con.execute("SELECT last_insert_rowid()").fetchone()[0]
+        self.con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+            " kind, sprint_doc_id) VALUES (2,1,'wake','task',1)")
+        mid = self.con.execute("SELECT last_insert_rowid()").fetchone()[0]
+        self.con.execute(
+            "INSERT INTO planner_wake_items (binding_id, message_id) "
+            "VALUES (?,?)", (bid, mid))
+        batch = interface_broker.form_batch(self.con, bid)
+        self.con.commit()
+        rec = Recorder("ok")
+        out = interface_broker.submit_wake_batch(
+            self.con, batch, writer=rec, now_iso="2030-01-01 00:00:10")
+        self.assertTrue(out["submitted"], "gates were clean+idle+quiet")
+        self.assertEqual(len(rec.writes), 1)
+        self.con.commit()
+        return batch, rec
+
+    def test_submitting_batch_without_hook_evidence_parks(self):
+        batch, rec = self._arm_and_submit()
+        # Broker dies before the submit hook lands — no durable evidence.
+        self._reconnect()
+        interface_reconcile.startup_reconcile(self.con)
+        state = self.con.execute(
+            "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+            (batch,)).fetchone()[0]
+        self.assertEqual(state, "delivery_unknown")
+        alert = self.con.execute(
+            "SELECT 1 FROM planner_alerts "
+            "WHERE reason='wake_batch_delivery_unknown' AND resolved_at IS "
+            "NULL").fetchone()
+        self.assertIsNotNone(alert)
+        # Never blindly resubmitted: the only byte-write was the original.
+        self.assertEqual(len(rec.writes), 1)
+        # Operator resolution requeues the item WITHOUT sending anything.
+        interface_broker.resolve_batch(self.con, batch)
+        item = self.con.execute(
+            "SELECT state, batch_id FROM planner_wake_items").fetchone()
+        self.assertEqual(item, ("queued", None))
+        bstate = self.con.execute(
+            "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+            (batch,)).fetchone()[0]
+        self.assertEqual(bstate, "complete")
+
+    def test_submitting_batch_with_submit_hook_proven_running(self):
+        batch, _ = self._arm_and_submit()
+        # The submit hook landed durably before the crash.
+        interface_broker.record_hook(self.con, 1, 1, 1, "prompt_submit")
+        self._reconnect()
+        counts = interface_reconcile.startup_reconcile(self.con)
+        state = self.con.execute(
+            "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+            (batch,)).fetchone()[0]
+        self.assertEqual(state, "running",
+                         "durable submit evidence proves the transition")
+        self.assertEqual(counts["batches_delivery_unknown"], 0)
+
+    def test_running_batch_with_stop_evidence_completes(self):
+        batch, _ = self._arm_and_submit()
+        interface_broker.record_hook(self.con, 1, 1, 1, "prompt_submit")
+        # Crash between recording the stop hook and finishing the batch:
+        # stop evidence exists but the batch is still 'running'.
+        self.con.execute(
+            "UPDATE interface_generations SET last_hook_seq=2 "
+            "WHERE shell_id=1 AND generation=1")
+        self.con.execute(
+            "UPDATE planner_wake_batches SET stop_hook_seq=2 WHERE batch_id=?",
+            (batch,))
+        # The planner read the message during the turn (durable read state).
+        self.con.execute(
+            "UPDATE shell_messages SET read_at=datetime('now')")
+        self.con.commit()
+        self._reconnect()
+        interface_reconcile.startup_reconcile(self.con)
+        bstate = self.con.execute(
+            "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+            (batch,)).fetchone()[0]
+        self.assertEqual(bstate, "complete")
+        istate = self.con.execute(
+            "SELECT state FROM planner_wake_items").fetchone()[0]
+        self.assertEqual(istate, "done",
+                         "read message → item done on proven stop")
+
+    def test_running_batch_unread_item_requeues_with_wake_count(self):
+        batch, _ = self._arm_and_submit()
+        interface_broker.record_hook(self.con, 1, 1, 1, "prompt_submit")
+        self.con.execute(
+            "UPDATE planner_wake_batches SET stop_hook_seq=2 WHERE batch_id=?",
+            (batch,))
+        self.con.commit()
+        self._reconnect()
+        interface_reconcile.startup_reconcile(self.con)
+        item = self.con.execute(
+            "SELECT state, completed_wakes, batch_id FROM planner_wake_items"
+        ).fetchone()
+        self.assertEqual(item, ("queued", 1, None),
+                         "unread without ambiguity → queued, wake count +1")
+
+    def test_stale_hook_sequence_rejected(self):
+        self._arm_and_submit()
+        interface_broker.record_hook(self.con, 1, 1, 1, "prompt_submit")
+        with self.assertRaises(interface_broker.BrokerError):
+            interface_broker.record_hook(self.con, 1, 1, 1, "turn_stop")
+        with self.assertRaises(interface_broker.BrokerError):
+            interface_broker.record_hook(self.con, 1, 1, 0, "turn_stop")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_crash_window.py
+++ b/tests/test_interface_crash_window.py
@@ -74,8 +74,8 @@ def build_engine_db(path: Path) -> None:
             "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
             "VALUES (?,?,?,'test','sp',1,0,1,1)", (sid, f"S{sid}", f"s{sid}"))
     con.execute(
-        "INSERT INTO documents (document_id, kind, title) "
-        "VALUES (1,'doc','SPRINT: test')")
+        "INSERT INTO documents (document_id, kind, title, body) "
+        "VALUES (1,'doc','SPRINT: test','# SPRINT: test\nstatus: ACTIVE')")
     con.commit()
     con.close()
 
@@ -332,6 +332,168 @@ class CrashWindowTest(unittest.TestCase):
             interface_broker.record_hook(self.con, 1, 1, 1, "turn_stop")
         with self.assertRaises(interface_broker.BrokerError):
             interface_broker.record_hook(self.con, 1, 1, 0, "turn_stop")
+
+    # ── fresh-lease sequence continuity (flag #34) ──────────────────────
+    def test_fresh_lease_continues_session_sequence(self):
+        rec = Recorder("ok")
+        interface_broker.accept_human_input(self.con, self.sid, 1, 10, writer=rec)
+        interface_broker.accept_human_input(self.con, self.sid, 2, 10, writer=rec)
+        # Service restart: the lease dies, the session's forwarded_seq is 2.
+        self._reconnect()
+        interface_reconcile.startup_reconcile(self.con)
+        lease = interface_broker.acquire_writer(self.con, self.sid, "tab-2", "tok-2")
+        next_seq = self.con.execute(
+            "SELECT next_input_seq FROM interface_writer_leases WHERE lease_id=?",
+            (lease,)).fetchone()[0]
+        self.assertEqual(next_seq, 3,
+                         "a fresh lease must continue the session sequence, "
+                         "not reseed to 1")
+        rec2 = Recorder("ok")
+        # The client's legitimate next frame is accepted (no gap-wedge)...
+        ack = interface_broker.accept_human_input(
+            self.con, self.sid, 3, 10, writer=rec2)
+        self.assertEqual(ack, {"ack": 3, "duplicate": False})
+        self.assertEqual(rec2.writes, [10])
+        # ...and an already-forwarded sequence is a duplicate ack, never a
+        # false acceptance of new bytes.
+        dup = interface_broker.accept_human_input(
+            self.con, self.sid, 2, 10, writer=rec2)
+        self.assertEqual(dup, {"ack": 2, "duplicate": True})
+        self.assertEqual(rec2.writes, [10])
+
+    def test_not_delivered_resend_with_forwarded_seq_nonzero(self):
+        # forwarded_seq=1 when the crash wedges seq 2: the not_delivered
+        # resend path must work past the degenerate forwarded_seq=0 case.
+        rec = Recorder("ok")
+        interface_broker.accept_human_input(self.con, self.sid, 1, 10, writer=rec)
+        crash = Recorder("crash_before_write")
+        with self.assertRaises(Crash):
+            interface_broker.accept_human_input(
+                self.con, self.sid, 2, 20, writer=crash)
+        self._reconnect()
+        interface_reconcile.startup_reconcile(self.con)
+        interface_broker.reconcile_input(self.con, self.sid, "not_delivered")
+        self.con.commit()
+        self.assertEqual(self._input()["forwarded_seq"], 1)
+        interface_broker.certify_clean(self.con, self.sid, "op", 1)
+        interface_broker.acquire_writer(self.con, self.sid, "tab-2", "tok-2")
+        rec2 = Recorder("ok")
+        ack = interface_broker.accept_human_input(
+            self.con, self.sid, 2, 20, writer=rec2)
+        self.assertEqual(ack, {"ack": 2, "duplicate": False})
+        self.assertEqual(rec2.writes, [20], "the resent frame forwards once")
+        self.assertEqual(self._input()["forwarded_seq"], 2)
+
+    # ── live park on write failure without process death (flag #35) ─────
+    def test_write_failure_without_crash_parks_live(self):
+        class TmuxError(Exception):
+            pass
+
+        def failing_writer(_len):
+            raise TmuxError("tmux send-keys failed")
+
+        with self.assertRaises(TmuxError):
+            interface_broker.accept_human_input(
+                self.con, self.sid, 1, 10, writer=failing_writer)
+        # No restart, no reconciliation yet — the park is immediate.
+        ist = self._input()
+        self.assertEqual(ist["composer"], "unknown")
+        self.assertEqual(ist["delivery"], "delivery_unknown")
+        self.assertEqual(ist["pending_seq"], 1, "evidence must survive")
+        lease = self.con.execute(
+            "SELECT revoked_at, revoke_reason FROM interface_writer_leases "
+            "WHERE session_id=?", (self.sid,)).fetchone()
+        self.assertIsNotNone(lease[0], "writer must be revoked live")
+        self.assertEqual(lease[1], "write_failure")
+        alert = self.con.execute(
+            "SELECT 1 FROM planner_alerts "
+            "WHERE reason='crash_window_delivery_unknown' AND resolved_at IS "
+            "NULL").fetchone()
+        self.assertIsNotNone(alert, "a live write failure must alert")
+        # The way out is the same operator reconciliation as the crash window.
+        interface_broker.reconcile_input(self.con, self.sid, "not_delivered")
+        self.con.commit()
+        interface_broker.certify_clean(self.con, self.sid, "op", 0)
+        interface_broker.acquire_writer(self.con, self.sid, "tab-2", "tok-2")
+        rec = Recorder("ok")
+        ack = interface_broker.accept_human_input(
+            self.con, self.sid, 1, 10, writer=rec)
+        self.assertEqual(ack, {"ack": 1, "duplicate": False})
+
+    # ── fenced submit hook + input lock (flag #33) ──────────────────────
+    def test_input_lock_rejects_human_frame_during_submit(self):
+        self._arm_and_submit()
+        rec = Recorder("ok")
+        with self.assertRaises(interface_broker.BrokerError):
+            interface_broker.accept_human_input(
+                self.con, self.sid, 1, 10, writer=rec)
+        self.assertEqual(rec.writes, [], "locked frame must never be written")
+        ist = self._input()
+        self.assertIsNone(ist["pending_seq"])
+        self.assertEqual(ist["composer"], "clean")
+
+    def test_submit_hook_fenced_against_later_human_input(self):
+        batch, _ = self._arm_and_submit()  # fence = forwarded_seq+1 = 1
+        # A human frame slipped in before the lock engaged (the race the
+        # fence exists for): seq 1 was accepted after the wake submitted.
+        self.con.execute(
+            "UPDATE interface_input_state SET forwarded_seq=1, composer='dirty'"
+            " WHERE session_id=?", (self.sid,))
+        self.con.commit()
+        # The Enter that fires this hook is the human's — it must NOT
+        # manufacture the batch's durable submit evidence.
+        interface_broker.record_hook(self.con, 1, 1, 1, "prompt_submit")
+        row = self.con.execute(
+            "SELECT state, submit_hook_seq FROM planner_wake_batches "
+            "WHERE batch_id=?", (batch,)).fetchone()
+        self.assertEqual(row[0], "delivery_unknown",
+                         "an unfenced hook parks the batch, never promotes it")
+        self.assertIsNone(row[1], "no submit evidence may be stamped")
+        self.assertEqual(self._input()["composer"], "dirty",
+                         "a later human sequence keeps the composer dirty")
+        alert = self.con.execute(
+            "SELECT 1 FROM planner_alerts "
+            "WHERE reason='wake_batch_delivery_unknown' AND resolved_at IS "
+            "NULL").fetchone()
+        self.assertIsNotNone(alert)
+        # Decision #22 re-proof under the fixed fence: recovery finds no
+        # manufactured evidence and keeps the park — never a blind resubmit.
+        self._reconnect()
+        interface_reconcile.startup_reconcile(self.con)
+        state = self.con.execute(
+            "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+            (batch,)).fetchone()[0]
+        self.assertEqual(state, "delivery_unknown")
+
+    def test_unfenced_hook_cannot_clear_unknown_composer(self):
+        self._arm_and_submit()
+        self.con.execute(
+            "UPDATE interface_input_state SET composer='unknown' "
+            "WHERE session_id=?", (self.sid,))
+        self.con.commit()
+        interface_broker.record_hook(self.con, 1, 1, 1, "prompt_submit")
+        self.assertEqual(self._input()["composer"], "unknown",
+                         "only exact recovery + certification clears unknown")
+
+    def test_session_end_hook_ends_generation(self):
+        self._arm_and_submit()
+        interface_broker.record_hook(self.con, 1, 1, 1, "prompt_submit")
+        interface_broker.record_hook(self.con, 1, 1, 2, "turn_stop")
+        # lifecycle walks busy -> idle -> stopping before the end hook.
+        self.con.execute(
+            "UPDATE interface_sessions SET lifecycle='stopping' "
+            "WHERE session_id=?", (self.sid,))
+        self.con.commit()
+        interface_broker.record_hook(self.con, 1, 1, 3, "session_end")
+        ended = self.con.execute(
+            "SELECT ended_at FROM interface_generations "
+            "WHERE shell_id=1 AND generation=1").fetchone()[0]
+        self.assertIsNotNone(ended,
+                             "a proven session end must end the generation — "
+                             "else a rebuild resurrects it and bricks New chat")
+        # Hooks for the ended generation are rejected from here on.
+        with self.assertRaises(interface_broker.BrokerError):
+            interface_broker.record_hook(self.con, 1, 1, 4, "prompt_submit")
 
 
 if __name__ == "__main__":

--- a/tests/test_interface_reconcile_guard.py
+++ b/tests/test_interface_reconcile_guard.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Interface startup reconciliation + rebuild/update refusal tests (spec #20).
+
+Covers the non-crash-window halves of interface_reconcile: expired
+reservation repair, writer-lease hygiene on restart (dirty state preserved),
+the rebuild/update live-guard (live_refusal_reasons) across every blocking
+shape and the fully-drained case, and the rebuild.py/update.py integration
+that turns those reasons into a refusal.
+
+Run:
+    python3 tests/test_interface_reconcile_guard.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import interface_reconcile  # noqa: E402
+import rebuild  # noqa: E402
+import update  # noqa: E402
+
+
+def build_engine_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1,'T',1)")
+    for sid in (1, 2):
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+            "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+            "VALUES (?,?,?,'test','sp',1,0,1,1)", (sid, f"S{sid}", f"s{sid}"))
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title) "
+        "VALUES (1,'doc','SPRINT: test')")
+    con.commit()
+    con.close()
+
+
+class StartupReconcileTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db)
+
+    def tearDown(self):
+        self.con.close()
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def _session(self, shell_id=1, generation=1, occupancy="occupied",
+                 reservation_expires_at=None):
+        self.con.execute(
+            "INSERT OR IGNORE INTO interface_generations (shell_id, generation)"
+            " VALUES (?,?)", (shell_id, generation))
+        sid = self.con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " reservation_expires_at) VALUES (?,?,?,?)",
+            (shell_id, generation, occupancy, reservation_expires_at)
+        ).lastrowid
+        self.con.commit()
+        return sid
+
+    def test_expired_reservation_fails_closed(self):
+        sid = self._session(occupancy="reserved",
+                            reservation_expires_at="2020-01-01 00:00:00")
+        counts = interface_reconcile.startup_reconcile(self.con)
+        occ, detail = self.con.execute(
+            "SELECT occupancy, error_detail FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(occ, "unreconciled",
+                         "ambiguous spawn must fail closed, never auto-end")
+        self.assertEqual(detail, "reservation expired at restart")
+        self.assertEqual(counts["reservations_unreconciled"], 1)
+        alert = self.con.execute(
+            "SELECT 1 FROM planner_alerts WHERE reason='reservation_expired'"
+        ).fetchone()
+        self.assertIsNotNone(alert)
+
+    def test_fresh_reservation_untouched(self):
+        sid = self._session(occupancy="reserved",
+                            reservation_expires_at="2999-01-01 00:00:00")
+        interface_reconcile.startup_reconcile(self.con)
+        occ = self.con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE session_id=?",
+            (sid,)).fetchone()[0]
+        self.assertEqual(occ, "reserved")
+
+    def test_restart_revokes_writers_preserves_dirty(self):
+        sid = self._session()
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,1,1,'dirty')", (sid,))
+        self.con.execute(
+            "INSERT INTO interface_writer_leases (session_id, shell_id,"
+            " generation, client_id, token_hash) VALUES (?,1,1,'c','h')",
+            (sid,))
+        self.con.commit()
+        counts = interface_reconcile.startup_reconcile(self.con)
+        self.assertEqual(counts["leases_revoked"], 1)
+        reason = self.con.execute(
+            "SELECT revoke_reason FROM interface_writer_leases "
+            "WHERE session_id=?", (sid,)).fetchone()[0]
+        self.assertEqual(reason, "service_restart")
+        composer = self.con.execute(
+            "SELECT composer FROM interface_input_state WHERE session_id=?",
+            (sid,)).fetchone()[0]
+        self.assertEqual(composer, "dirty",
+                         "dirty state survives disconnect per spec")
+        # Idempotent: a second run revokes nothing.
+        counts = interface_reconcile.startup_reconcile(self.con)
+        self.assertEqual(counts["leases_revoked"], 0)
+
+    def test_pre_0078_db_is_a_noop(self):
+        bare = self.tmp / "bare.db"
+        con = sqlite3.connect(bare)
+        con.execute("CREATE TABLE t (x INTEGER)")
+        con.commit()
+        out = interface_reconcile.startup_reconcile(con)
+        self.assertEqual(out, {"skipped": "pre-0078 DB"})
+        con.close()
+        self.assertEqual(interface_reconcile.live_refusal_reasons(bare), [])
+
+
+class LiveRefusalGuardTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db)
+
+    def tearDown(self):
+        self.con.close()
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def _occupied_session(self):
+        self.con.execute(
+            "INSERT OR IGNORE INTO interface_generations (shell_id, generation)"
+            " VALUES (1,1)")
+        sid = self.con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy)"
+            " VALUES (1,1,'occupied')").lastrowid
+        self.con.commit()
+        return sid
+
+    def test_clean_db_has_no_reasons(self):
+        self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
+        self.assertEqual(
+            interface_reconcile.live_refusal_reasons(self.tmp / "nope.db"),
+            [])
+
+    def test_live_session_blocks(self):
+        self._occupied_session()
+        reasons = interface_reconcile.live_refusal_reasons(self.db)
+        self.assertEqual(len(reasons), 1)
+        self.assertIn("occupied", reasons[0])
+
+    def test_armed_binding_blocks(self):
+        sid = self._occupied_session()
+        self.con.execute(
+            "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (1,2,?,2,1)", (sid,))
+        self.con.commit()
+        reasons = interface_reconcile.live_refusal_reasons(self.db)
+        self.assertTrue(any("binding" in r for r in reasons))
+
+    def test_nonterminal_batch_blocks(self):
+        sid = self._occupied_session()
+        self.con.execute(
+            "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (1,2,?,2,1)", (sid,))
+        bid = self.con.execute("SELECT last_insert_rowid()").fetchone()[0]
+        for state in ("queued", "submitting", "running", "delivery_unknown"):
+            self.con.execute("DELETE FROM planner_wake_batches")
+            self.con.execute(
+                "INSERT INTO planner_wake_batches (binding_id, shell_id,"
+                " generation, state) VALUES (?,2,1,?)", (bid, state))
+            self.con.commit()
+            reasons = interface_reconcile.live_refusal_reasons(self.db)
+            self.assertTrue(
+                any("batch" in r and state in r for r in reasons),
+                f"batch state {state} must block: {reasons}")
+        self.con.execute(
+            "UPDATE planner_wake_batches SET state='complete'")
+        self.con.execute(
+            "UPDATE sprint_planner_bindings SET released_at=datetime('now')")
+        self.con.execute(
+            "UPDATE interface_sessions SET occupancy='ended'")
+        self.con.commit()
+        self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
+
+    def test_input_ambiguity_blocks(self):
+        sid = self._occupied_session()
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,1,1,'unknown')", (sid,))
+        self.con.commit()
+        reasons = interface_reconcile.live_refusal_reasons(self.db)
+        self.assertTrue(any("ambiguity" in r for r in reasons))
+
+    def test_fully_drained_passes(self):
+        sid = self._occupied_session()
+        self.con.execute(
+            "UPDATE interface_sessions SET occupancy='ended', lifecycle="
+            "'ended', ended_at=datetime('now') WHERE session_id=?", (sid,))
+        self.con.execute(
+            "UPDATE interface_generations SET ended_at=datetime('now')")
+        self.con.commit()
+        self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
+
+
+class RefusalIntegrationTest(unittest.TestCase):
+    """rebuild.main and update.migrate_or_rebuild turn reasons into refusal."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,1)")
+        con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy)"
+            " VALUES (1,1,'occupied')")
+        con.commit()
+        con.close()
+
+    def tearDown(self):
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def test_rebuild_refuses_with_live_session(self):
+        with mock.patch.object(rebuild, "DB_PATH", self.db), \
+             mock.patch.object(rebuild, "backup_existing"):
+            with self.assertRaises(SystemExit) as ctx:
+                rebuild.main(["--no-backup"])
+        self.assertIn("refusing", str(ctx.exception))
+
+    def test_update_refuses_with_live_session(self):
+        with mock.patch.object(update, "DB_PATH", self.db):
+            with self.assertRaises(SystemExit) as ctx:
+                update.migrate_or_rebuild()
+        self.assertIn("refusing", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_reconcile_guard.py
+++ b/tests/test_interface_reconcile_guard.py
@@ -167,8 +167,19 @@ class LiveRefusalGuardTest(unittest.TestCase):
     def test_live_session_blocks(self):
         self._occupied_session()
         reasons = interface_reconcile.live_refusal_reasons(self.db)
+        self.assertTrue(any("occupied" in r for r in reasons))
+        self.assertTrue(any("generation" in r for r in reasons),
+                        "a live generation is itself live state")
+
+    def test_live_generation_blocks_with_all_sessions_ended(self):
+        sid = self._occupied_session()
+        self.con.execute(
+            "UPDATE interface_sessions SET occupancy='ended', lifecycle="
+            "'ended', ended_at=datetime('now') WHERE session_id=?", (sid,))
+        self.con.commit()
+        reasons = interface_reconcile.live_refusal_reasons(self.db)
         self.assertEqual(len(reasons), 1)
-        self.assertIn("occupied", reasons[0])
+        self.assertIn("generation 1/1 is live", reasons[0])
 
     def test_armed_binding_blocks(self):
         sid = self._occupied_session()
@@ -203,6 +214,8 @@ class LiveRefusalGuardTest(unittest.TestCase):
             "UPDATE sprint_planner_bindings SET released_at=datetime('now')")
         self.con.execute(
             "UPDATE interface_sessions SET occupancy='ended'")
+        self.con.execute(
+            "UPDATE interface_generations SET ended_at=datetime('now')")
         self.con.commit()
         self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
 

--- a/tests/test_interface_schema.py
+++ b/tests/test_interface_schema.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Interface schema tests (sprint 25 seq 4, spec #20 task #80).
+
+Builds a throwaway engine DB from the real schema.sql + the full migration
+chain and asserts the 0078 surface: every Interface table exists with its key
+columns, the sprint_doc_id columns landed, and the uniqueness invariants the
+occupancy model requires actually hold at the DB layer:
+
+- one non-ended Interface session per shell (ended rows free the slot)
+- one live generation per shell
+- one current writer lease per session
+- one live wake batch per binding
+- one unreleased binding per planner, and per sprint
+- unique (binding, message) wake work
+- idempotency keys unique per (actor, operation, key)
+
+Run:
+    python3 tests/test_interface_schema.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+TABLES = [
+    "interface_generations", "interface_sessions", "interface_writer_leases",
+    "interface_input_state", "interface_idempotency_keys",
+    "sprint_planner_bindings", "planner_wake_items", "planner_wake_batches",
+    "planner_action_receipts", "pr_poll_runs", "pr_poll_observations",
+    "planner_alerts",
+]
+
+
+def build_engine_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1,'T',1)")
+    for sid in (1, 2):
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+            "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+            "VALUES (?,?,?,'test','sp',1,0,1,1)", (sid, f"S{sid}", f"s{sid}"))
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title) "
+        "VALUES (1,'doc','SPRINT: test')")
+    con.commit()
+    con.close()
+
+
+class InterfaceSchemaTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db)
+
+    def tearDown(self):
+        self.con.close()
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def _session(self, shell_id=1, generation=1, occupancy="reserved"):
+        self.con.execute(
+            "INSERT OR IGNORE INTO interface_generations (shell_id, generation) "
+            "VALUES (?,?)", (shell_id, generation))
+        cur = self.con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy) "
+            "VALUES (?,?,?)", (shell_id, generation, occupancy))
+        return cur.lastrowid
+
+    def _binding(self, planner=2, doc=1, released=False):
+        sid = self._session(shell_id=planner, generation=10 + planner,
+                            occupancy="occupied")
+        cur = self.con.execute(
+            "INSERT INTO sprint_planner_bindings "
+            "(sprint_doc_id, planner_shell_id, session_id, shell_id, "
+            " generation, released_at) VALUES (?,?,?,?,?,?)",
+            (doc, planner, sid, planner, 10 + planner,
+             "2026-01-01" if released else None))
+        return cur.lastrowid
+
+    def test_tables_and_columns_exist(self):
+        for table in TABLES:
+            row = self.con.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+                (table,)).fetchone()
+            self.assertIsNotNone(row, f"missing table {table}")
+        msg_cols = {r[1] for r in self.con.execute(
+            "PRAGMA table_info(shell_messages)")}
+        self.assertIn("sprint_doc_id", msg_cols)
+        wp_cols = {r[1] for r in self.con.execute(
+            "PRAGMA table_info(watched_prs)")}
+        self.assertIn("sprint_doc_id", wp_cols)
+
+    def test_one_non_ended_session_per_shell(self):
+        self._session(shell_id=1, generation=1, occupancy="occupied")
+        self.con.commit()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self._session(shell_id=1, generation=2, occupancy="reserved")
+        self.con.rollback()
+        # Ending the live session frees the slot.
+        self.con.execute(
+            "UPDATE interface_sessions SET occupancy='ended', ended_at="
+            "datetime('now') WHERE shell_id=1 AND generation=1")
+        self._session(shell_id=1, generation=2, occupancy="reserved")
+
+    def test_one_live_generation_per_shell(self):
+        self.con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,1)")
+        self.con.commit()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO interface_generations (shell_id, generation) "
+                "VALUES (1,2)")
+        self.con.rollback()
+        self.con.execute(
+            "UPDATE interface_generations SET ended_at=datetime('now') "
+            "WHERE shell_id=1 AND generation=1")
+        self.con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,2)")
+
+    def test_one_current_writer_per_session(self):
+        sid = self._session(occupancy="occupied")
+        self.con.execute(
+            "INSERT INTO interface_writer_leases "
+            "(session_id, shell_id, generation, client_id, token_hash) "
+            "VALUES (?,1,1,'c1','h1')", (sid,))
+        self.con.commit()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO interface_writer_leases "
+                "(session_id, shell_id, generation, client_id, token_hash) "
+                "VALUES (?,1,1,'c2','h2')", (sid,))
+        self.con.rollback()
+        # Revoking frees the writer slot (takeover).
+        self.con.execute(
+            "UPDATE interface_writer_leases SET revoked_at=datetime('now') "
+            "WHERE session_id=?", (sid,))
+        self.con.execute(
+            "INSERT INTO interface_writer_leases "
+            "(session_id, shell_id, generation, client_id, token_hash) "
+            "VALUES (?,1,1,'c2','h2')", (sid,))
+
+    def test_one_live_batch_per_binding(self):
+        bid = self._binding()
+        self.con.execute(
+            "INSERT INTO planner_wake_batches (binding_id, shell_id, "
+            "generation) VALUES (?,2,12)", (bid,))
+        self.con.commit()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO planner_wake_batches (binding_id, shell_id, "
+                "generation) VALUES (?,2,12)", (bid,))
+        self.con.rollback()
+        self.con.execute(
+            "UPDATE planner_wake_batches SET state='complete' "
+            "WHERE binding_id=?", (bid,))
+        self.con.execute(
+            "INSERT INTO planner_wake_batches (binding_id, shell_id, "
+            "generation) VALUES (?,2,12)", (bid,))
+
+    def test_one_unreleased_binding_per_planner_and_sprint(self):
+        bid = self._binding(planner=2, doc=1)
+        sess, gen = self.con.execute(
+            "SELECT session_id, generation FROM sprint_planner_bindings "
+            "WHERE binding_id=?", (bid,)).fetchone()
+        self.con.commit()
+        # Same planner, same live session, second armed binding → planner slot.
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO sprint_planner_bindings "
+                "(sprint_doc_id, planner_shell_id, session_id, shell_id, "
+                " generation) VALUES (1,2,?,?,?)", (sess, 2, gen))
+        self.con.rollback()
+        # A different planner arming the SAME sprint doc → sprint slot.
+        other = self._session(shell_id=1, generation=11, occupancy="occupied")
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO sprint_planner_bindings "
+                "(sprint_doc_id, planner_shell_id, session_id, shell_id, "
+                " generation) VALUES (1,1,?,1,11)", (other,))
+        self.con.rollback()
+        # Released bindings free both slots.
+        self.con.execute(
+            "UPDATE sprint_planner_bindings SET released_at=datetime('now')")
+        self.con.execute(
+            "INSERT INTO sprint_planner_bindings "
+            "(sprint_doc_id, planner_shell_id, session_id, shell_id, "
+            " generation) VALUES (1,2,?,?,?)", (sess, 2, gen))
+
+    def test_wake_item_unique_per_binding_message(self):
+        bid = self._binding()
+        self.con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body, "
+            "kind, sprint_doc_id) VALUES (1,2,'wake','task',1)")
+        mid = self.con.execute("SELECT last_insert_rowid()").fetchone()[0]
+        self.con.execute(
+            "INSERT INTO planner_wake_items (binding_id, message_id) "
+            "VALUES (?,?)", (bid, mid))
+        self.con.commit()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO planner_wake_items (binding_id, message_id) "
+                "VALUES (?,?)", (bid, mid))
+        self.con.rollback()
+
+    def test_idempotency_key_scope_unique(self):
+        self.con.execute(
+            "INSERT INTO interface_idempotency_keys "
+            "(actor_scope, operation, idem_key, request_hash, expires_at) "
+            "VALUES ('operator','sessions.create','k1','h','2030-01-01')")
+        self.con.commit()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO interface_idempotency_keys "
+                "(actor_scope, operation, idem_key, request_hash, expires_at) "
+                "VALUES ('operator','sessions.create','k1','h2','2030-01-01')")
+        self.con.rollback()
+        # Same key under a different operation is a different slot.
+        self.con.execute(
+            "INSERT INTO interface_idempotency_keys "
+            "(actor_scope, operation, idem_key, request_hash, expires_at) "
+            "VALUES ('operator','sessions.stop','k1','h','2030-01-01')")
+
+    def test_alert_dedupe_while_open(self):
+        self.con.execute(
+            "INSERT INTO planner_alerts (severity, reason, dedupe_key) "
+            "VALUES ('critical','crash','-|1|crash')")
+        self.con.commit()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO planner_alerts (severity, reason, dedupe_key) "
+                "VALUES ('critical','crash','-|1|crash')")
+        self.con.rollback()
+        self.con.execute("UPDATE planner_alerts SET resolved_at=datetime('now')")
+        self.con.execute(
+            "INSERT INTO planner_alerts (severity, reason, dedupe_key) "
+            "VALUES ('critical','crash','-|1|crash')")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_snapshot.py
+++ b/tests/test_interface_snapshot.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Interface snapshot-projection tests (spec #20 task #80).
+
+The snapshot contract: it may run while a chat is live because it omits all
+volatile state, and rebuild/update refuse while live state exists — so
+content.sql carries only durable audit. These tests pin:
+
+- volatile tables (interface_writer_leases, interface_input_state,
+  pr_poll_runs) are NOT in PER_INSTANCE_TABLES;
+- volatile columns (tmux socket, PIDs/start ticks, hook token hash) never
+  appear in a dump even on preserved rows;
+- row filters keep live rows out: non-ended sessions, armed bindings,
+  nonterminal batches/items, and no-transition observations are excluded
+  while their terminal counterparts are preserved;
+- durable guard tables (action receipts, idempotency keys, alerts) dump
+  whole.
+
+Run:
+    python3 tests/test_interface_snapshot.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import snapshot  # noqa: E402
+
+SECRET_SOCKET = "/run/sc/SECRET-tmux-socket-0700"
+SECRET_HOOK_HASH = "hookhash_SECRET_must_not_ship_to_git_00000000"
+
+
+def build_engine_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1,'T',1)")
+    for sid in (1, 2):
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+            "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+            "VALUES (?,?,?,'test','sp',1,0,1,1)", (sid, f"S{sid}", f"s{sid}"))
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title) "
+        "VALUES (1,'doc','SPRINT: test')")
+    con.commit()
+    con.close()
+
+
+class InterfaceSnapshotTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db)
+        # Generations: gen 1 live (secret hook hash), gen 2 ended.
+        self.con.execute(
+            "INSERT INTO interface_generations (shell_id, generation,"
+            " hook_token_hash) VALUES (1,1,?)", (SECRET_HOOK_HASH,))
+        self.con.execute(
+            "INSERT INTO interface_generations (shell_id, generation,"
+            " ended_at) VALUES (1,2,datetime('now'))")
+        # Sessions: one live with volatile identity, one ended audit row.
+        self.con.execute(
+            "INSERT INTO interface_sessions (session_id, shell_id,"
+            " generation, occupancy, tmux_socket, tmux_session, tmux_pane_id,"
+            " pane_pid, pane_start_ticks, harness_pid, harness_start_ticks) "
+            "VALUES (1,1,1,'occupied',?, 's','%1',111,222,333,444)",
+            (SECRET_SOCKET,))
+        self.con.execute(
+            "INSERT INTO interface_sessions (session_id, shell_id,"
+            " generation, occupancy, lifecycle, ended_at, end_reason,"
+            " tmux_socket, pane_pid) "
+            "VALUES (2,1,2,'ended','ended',datetime('now'),'operator_end',"
+            " ?, 999)", (SECRET_SOCKET,))
+        # Bindings: one armed, one released.
+        self.con.execute(
+            "INSERT INTO sprint_planner_bindings (binding_id, sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (1,1,2,1,2,1)")
+        self.con.execute(
+            "INSERT INTO sprint_planner_bindings (binding_id, sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation,"
+            " released_at, release_reason) "
+            "VALUES (2,1,2,2,2,2,datetime('now'),'sprint_closed')")
+        # Batches: complete (audit) + queued (live).
+        self.con.execute(
+            "INSERT INTO planner_wake_batches (batch_id, binding_id,"
+            " shell_id, generation, state) VALUES (1,2,2,2,'complete')")
+        self.con.execute(
+            "INSERT INTO planner_wake_batches (batch_id, binding_id,"
+            " shell_id, generation, state) VALUES (2,1,2,1,'queued')")
+        # Items: done (audit) + queued (live).
+        self.con.execute(
+            "INSERT INTO shell_messages (message_id, from_shell_id,"
+            " to_shell_id, body) VALUES (1,1,2,'a')")
+        self.con.execute(
+            "INSERT INTO shell_messages (message_id, from_shell_id,"
+            " to_shell_id, body) VALUES (2,1,2,'b')")
+        self.con.execute(
+            "INSERT INTO planner_wake_items (item_id, binding_id, message_id,"
+            " batch_id, state) VALUES (1,2,1,1,'done')")
+        self.con.execute(
+            "INSERT INTO planner_wake_items (item_id, binding_id, message_id,"
+            " state) VALUES (2,1,2,'queued')")
+        # Observations: transition + blind-window (audit), plain (noise).
+        self.con.execute(
+            "INSERT INTO watched_prs (watch_id, repo, pr_number, shell_id) "
+            "VALUES (1,'o/r',5,2)")
+        self.con.execute(
+            "INSERT INTO pr_poll_observations (observation_id, watch_id,"
+            " transition) VALUES (1,1,'checks_green')")
+        self.con.execute(
+            "INSERT INTO pr_poll_observations (observation_id, watch_id,"
+            " blind_window) VALUES (2,1,1)")
+        self.con.execute(
+            "INSERT INTO pr_poll_observations (observation_id, watch_id)"
+            " VALUES (3,1)")
+        # Durable guard tables.
+        self.con.execute(
+            "INSERT INTO planner_action_receipts (operation, target,"
+            " idem_key) VALUES ('op','tgt','k1')")
+        self.con.execute(
+            "INSERT INTO interface_idempotency_keys (actor_scope, operation,"
+            " idem_key, request_hash, expires_at) "
+            "VALUES ('operator','sessions.create','k','h','2030-01-01')")
+        self.con.execute(
+            "INSERT INTO planner_alerts (severity, reason, dedupe_key) "
+            "VALUES ('critical','crash','-|-|crash')")
+        self.con.commit()
+
+    def tearDown(self):
+        self.con.close()
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def _dump(self, table):
+        return "\n".join(snapshot.dump_table(self.con, table))
+
+    def test_volatile_tables_not_snapshotted(self):
+        for table in ("interface_writer_leases", "interface_input_state",
+                      "pr_poll_runs"):
+            self.assertNotIn(table, snapshot.PER_INSTANCE_TABLES,
+                             f"{table} must never reach content.sql")
+
+    def test_session_rows_filtered_and_redacted(self):
+        out = self._dump("interface_sessions")
+        self.assertIn("session_id", out)
+        self.assertNotIn("'occupied'", out, "live session leaked")
+        self.assertIn("'ended'", out, "closed-session audit must survive")
+        self.assertIn("'operator_end'", out)
+        for col in ("tmux_socket", "pane_pid", "pane_start_ticks",
+                    "harness_pid", "harness_start_ticks"):
+            self.assertNotIn(col, out, f"volatile column {col} leaked")
+        self.assertNotIn(SECRET_SOCKET, out)
+        self.assertNotIn("999", out, "volatile PID value leaked")
+
+    def test_generation_hook_hash_redacted(self):
+        out = self._dump("interface_generations")
+        self.assertNotIn(SECRET_HOOK_HASH, out)
+        self.assertNotIn("hook_token_hash", out)
+
+    def test_bindings_keep_released_only(self):
+        out = self._dump("sprint_planner_bindings")
+        self.assertIn("'sprint_closed'", out)
+        # binding 1 (armed) must not appear; binding 2 (released) must.
+        self.assertNotIn("VALUES (1,", out)
+        self.assertIn("VALUES (2,", out)
+
+    def test_wake_batches_keep_terminal_only(self):
+        out = self._dump("planner_wake_batches")
+        self.assertIn("'complete'", out)
+        self.assertNotIn("'queued'", out)
+
+    def test_wake_items_keep_terminal_only(self):
+        out = self._dump("planner_wake_items")
+        self.assertIn("'done'", out)
+        self.assertNotIn("'queued'", out)
+
+    def test_observations_keep_transitions_and_blind_windows(self):
+        out = self._dump("pr_poll_observations")
+        self.assertIn("'checks_green'", out)
+        self.assertIn("VALUES (2,", out, "blind-window observation dropped")
+        self.assertNotIn("VALUES (3,", out, "no-transition observation kept")
+
+    def test_durable_guard_tables_dump_whole(self):
+        self.assertIn("'k1'", self._dump("planner_action_receipts"))
+        self.assertIn("'operator'", self._dump("interface_idempotency_keys"))
+        self.assertIn("'crash'", self._dump("planner_alerts"))
+
+    def test_row_filters_reference_live_columns(self):
+        # Drift guard: each filter must parse and execute against the live
+        # schema — a renamed column would otherwise silently turn the filter
+        # into a SQL error (or worse, get "fixed" by dropping the filter and
+        # widening the dump to all rows).
+        for table, filt in snapshot.SNAPSHOT_ROW_FILTERS.items():
+            try:
+                self.con.execute(
+                    f"SELECT 1 FROM {table} {filt} LIMIT 1").fetchall()
+            except sqlite3.OperationalError as e:
+                self.fail(f"{table}: row filter broken against schema "
+                          f"({filt!r}): {e}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_snapshot.py
+++ b/tests/test_interface_snapshot.py
@@ -170,6 +170,14 @@ class InterfaceSnapshotTest(unittest.TestCase):
         self.assertNotIn(SECRET_HOOK_HASH, out)
         self.assertNotIn("hook_token_hash", out)
 
+    def test_generations_keep_ended_only(self):
+        # A LIVE generation must never serialize: a rebuild would restore it
+        # and idx_interface_generations_live would brick that shell's next
+        # New chat (flag #36). Ended generations are durable audit.
+        out = self._dump("interface_generations")
+        self.assertNotIn("VALUES (1, 1,", out, "live generation leaked")
+        self.assertIn("VALUES (1, 2,", out, "ended generation audit dropped")
+
     def test_bindings_keep_released_only(self):
         out = self._dump("sprint_planner_bindings")
         self.assertIn("'sprint_closed'", out)

--- a/tests/test_interface_transitions.py
+++ b/tests/test_interface_transitions.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Interface transition-validator tests (spec #20 task #80).
+
+Drift guard between the two enforcement layers: the SQL triggers in
+migrations/0078_interface_sessions.sql (backstop) and the app-level edge
+maps in scripts/interface_state.py (friendly errors). For EVERY state
+machine this walks every (old, new) pair and asserts:
+
+- the DB trigger allows exactly the pairs interface_state calls legal
+  (a same-state no-op is legal in both layers), and
+- interface_state.transition raises InterfaceTransitionError on illegal
+  pairs and never on legal ones.
+
+Any drift between the SQL and the Python fails this file.
+
+Run:
+    python3 tests/test_interface_transitions.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import interface_state  # noqa: E402
+
+
+def build_engine_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1,'T',1)")
+    for sid in (1, 2):
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+            "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+            "VALUES (?,?,?,'test','sp',1,0,1,1)", (sid, f"S{sid}", f"s{sid}"))
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title) "
+        "VALUES (1,'doc','SPRINT: test')")
+    con.commit()
+    con.close()
+
+
+class TransitionMatrixTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db)
+
+    def tearDown(self):
+        self.con.close()
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    # ── row factories: INSERT bypasses the UPDATE triggers, so any state ──
+    def _session_row(self, occupancy, lifecycle):
+        self.con.execute("DELETE FROM interface_sessions")
+        self.con.execute(
+            "INSERT OR IGNORE INTO interface_generations (shell_id, generation)"
+            " VALUES (1,1)")
+        cur = self.con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle) VALUES (1,1,?,?)", (occupancy, lifecycle))
+        self.con.commit()
+        return cur.lastrowid
+
+    def _input_row(self, composer, delivery):
+        self.con.execute("DELETE FROM interface_input_state")
+        self.con.execute("DELETE FROM interface_sessions")
+        self.con.execute(
+            "INSERT OR IGNORE INTO interface_generations (shell_id, generation)"
+            " VALUES (1,1)")
+        sid = self.con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy)"
+            " VALUES (1,1,'occupied')").lastrowid
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer, delivery) VALUES (?,1,1,?,?)",
+            (sid, composer, delivery))
+        self.con.commit()
+        return sid
+
+    def _item_row(self, state):
+        self.con.execute("DELETE FROM planner_wake_items")
+        self.con.execute(
+            "INSERT OR IGNORE INTO interface_generations (shell_id, generation)"
+            " VALUES (2,1)")
+        self.con.execute(
+            "INSERT OR IGNORE INTO interface_sessions (session_id, shell_id,"
+            " generation, occupancy) VALUES (1,2,1,'occupied')")
+        self.con.execute(
+            "INSERT OR IGNORE INTO sprint_planner_bindings (binding_id,"
+            " sprint_doc_id, planner_shell_id, session_id, shell_id,"
+            " generation) VALUES (1,1,2,1,2,1)")
+        self.con.execute(
+            "INSERT OR IGNORE INTO shell_messages (message_id, from_shell_id,"
+            " to_shell_id, body) VALUES (1,1,2,'wake')")
+        cur = self.con.execute(
+            "INSERT INTO planner_wake_items (binding_id, message_id, state)"
+            " VALUES (1,1,?)", (state,))
+        self.con.commit()
+        return cur.lastrowid
+
+    def _batch_row(self, state):
+        self.con.execute("DELETE FROM planner_wake_batches")
+        self.con.execute(
+            "INSERT OR IGNORE INTO interface_generations (shell_id, generation)"
+            " VALUES (2,1)")
+        self.con.execute(
+            "INSERT OR IGNORE INTO interface_sessions (session_id, shell_id,"
+            " generation, occupancy) VALUES (1,2,1,'occupied')")
+        self.con.execute(
+            "INSERT OR IGNORE INTO sprint_planner_bindings (binding_id,"
+            " sprint_doc_id, planner_shell_id, session_id, shell_id,"
+            " generation) VALUES (1,1,2,1,2,1)")
+        cur = self.con.execute(
+            "INSERT INTO planner_wake_batches (binding_id, shell_id,"
+            " generation, state) VALUES (1,2,1,?)", (state,))
+        self.con.commit()
+        return cur.lastrowid
+
+    def _receipt_row(self, state, n):
+        self.con.execute("DELETE FROM planner_action_receipts")
+        cur = self.con.execute(
+            "INSERT INTO planner_action_receipts (operation, target, idem_key,"
+            " state) VALUES ('op','tgt',?,?)", (f"k{n}", state))
+        self.con.commit()
+        return cur.lastrowid
+
+    # ── the matrix walker ────────────────────────────────────────────────
+    def _walk(self, machine, row_factory):
+        table, pk, col, edges = interface_state.MACHINES[machine]
+        states = set(edges) | {s for targets in edges.values() for s in targets}
+        for old in sorted(states):
+            for new in sorted(states):
+                row_id = row_factory(old, new)
+                legal = (new == old) or (new in edges.get(old, ()))
+                # app layer
+                if legal:
+                    prior = interface_state.transition(
+                        self.con, machine, row_id, new)
+                    self.assertEqual(prior, old, f"{machine}: {old}->{new}")
+                    self.con.commit()
+                else:
+                    with self.assertRaises(
+                            interface_state.InterfaceTransitionError,
+                            msg=f"{machine}: {old}->{new} must refuse"):
+                        interface_state.transition(
+                            self.con, machine, row_id, new)
+                # DB layer: replay the same pair on a fresh row and ask the
+                # trigger directly (bypassing the app pre-check).
+                row_id = row_factory(old, new)
+                try:
+                    self.con.execute(
+                        f"UPDATE {table} SET {col}=? WHERE {pk}=?",
+                        (new, row_id))
+                    self.con.commit()
+                    db_allowed = True
+                except sqlite3.IntegrityError:
+                    self.con.rollback()
+                    db_allowed = False
+                self.assertEqual(
+                    db_allowed, legal,
+                    f"{machine}: trigger/app drift on {old}->{new}")
+
+    def test_occupancy_machine(self):
+        self._walk("occupancy",
+                   lambda old, _n: self._session_row(old, "idle"))
+
+    def test_lifecycle_machine(self):
+        self._walk("lifecycle",
+                   lambda old, _n: self._session_row("occupied", old))
+
+    def test_composer_machine(self):
+        self._walk("composer",
+                   lambda old, _n: self._input_row(old, "normal"))
+
+    def test_delivery_machine(self):
+        self._walk("delivery",
+                   lambda old, _n: self._input_row("clean", old))
+
+    def test_wake_item_machine(self):
+        self._walk("wake_item", lambda old, _n: self._item_row(old))
+
+    def test_wake_batch_machine(self):
+        self._walk("wake_batch", lambda old, _n: self._batch_row(old))
+
+    def test_receipt_machine(self):
+        n = [0]
+
+        def factory(old, _new):
+            n[0] += 1
+            return self._receipt_row(old, n[0])
+
+        self._walk("receipt", factory)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_wake_submit.py
+++ b/tests/test_interface_wake_submit.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Wake-submission gate tests (spec #20 Wake Delivery, flags #33/#37).
+
+submit_wake_batch is the last checkpoint before a byte moves: it must
+revalidate everything at SUBMIT time, not trust what form_batch saw:
+
+- binding still armed + sprint doc still ACTIVE — a sprint close between
+  form_batch and submit CANCELS the batch (no byte, no blind retry);
+- a fresh full debounce after every service restart — a NULL
+  last_human_input_at never skips the quiet check, and the restart stamp
+  (service_restart lease revocation) floors the quiet baseline;
+- quiet_s=0 is forbidden outright;
+- a writer failure without process death parks the batch delivery_unknown
+  (the prompt may have landed) and releases the input lock.
+
+Run:
+    python3 tests/test_interface_wake_submit.py
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import interface_broker  # noqa: E402
+
+ACTIVE_BODY = "# SPRINT: live\nstatus: ACTIVE"
+CLOSED_BODY = "# SPRINT: done\nstatus: CLOSED"
+
+
+def build_engine_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute("INSERT INTO users (user_id, username, is_active) VALUES (1,'T',1)")
+    for sid in (1, 2):
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+            "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+            "VALUES (?,?,?,'test','sp',1,0,1,1)",
+            (sid, f"S{sid}", f"s{sid}"),
+        )
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title, body) "
+        "VALUES (1,'doc','SPRINT: live',?)",
+        (ACTIVE_BODY,),
+    )
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title, body) "
+        "VALUES (2,'doc','SPRINT: done',?)",
+        (CLOSED_BODY,),
+    )
+    con.commit()
+    con.close()
+
+
+def parse(ts: str) -> datetime:
+    return datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
+
+
+class WakeSubmitGateTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db)
+
+    def tearDown(self):
+        self.con.close()
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def _arm(self, doc_id=1, shell_id=1):
+        """Occupied+idle session, clean composer, binding, one wake item,
+        one formed batch. Returns (session_id, binding_id, batch_id)."""
+        self.con.execute(
+            "INSERT OR IGNORE INTO interface_generations (shell_id, generation)"
+            " VALUES (?,1)",
+            (shell_id,),
+        )
+        sid = self.con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle) VALUES (?,1,'occupied','idle')",
+            (shell_id,),
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,?,1,'clean')",
+            (sid, shell_id),
+        )
+        bid = self.con.execute(
+            "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (?,?,?,?,1)",
+            (doc_id, shell_id, sid, shell_id),
+        ).lastrowid
+        mid = self.con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+            " kind, sprint_doc_id) VALUES (2,?,'wake','task',?)",
+            (shell_id, doc_id),
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO planner_wake_items (binding_id, message_id) VALUES (?,?)",
+            (bid, mid),
+        )
+        self.con.commit()
+        batch = interface_broker.form_batch(self.con, bid)
+        self.con.commit()
+        return sid, bid, batch
+
+    def _submit(self, batch, now_iso, **kw):
+        writes = []
+
+        def rec(_len):
+            writes.append(_len)
+
+        out = interface_broker.submit_wake_batch(
+            self.con, batch, writer=rec, now_iso=now_iso, **kw
+        )
+        return out, writes
+
+    def _batch_state(self, batch):
+        return self.con.execute(
+            "SELECT state FROM planner_wake_batches WHERE batch_id=?", (batch,)
+        ).fetchone()[0]
+
+    # ── happy path ──────────────────────────────────────────────────────
+    def test_clean_gates_submit(self):
+        _, _, batch = self._arm()
+        out, writes = self._submit(batch, "2030-01-01 00:00:10")
+        self.assertTrue(out["submitted"])
+        self.assertEqual(out["input_seq_fence"], 1)
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(self._batch_state(batch), "submitting")
+
+    # ── armed/ACTIVE revalidation at submit (flag #37) ──────────────────
+    def test_binding_released_after_form_cancels_batch(self):
+        _, bid, batch = self._arm()
+        self.con.execute(
+            "UPDATE sprint_planner_bindings SET released_at=datetime('now')"
+            " WHERE binding_id=?",
+            (bid,),
+        )
+        self.con.commit()
+        out, writes = self._submit(batch, "2030-01-01 00:00:10")
+        self.assertFalse(out["submitted"])
+        self.assertTrue(out["cancelled"])
+        self.assertEqual(writes, [], "a cancelled batch never sends a byte")
+        self.assertEqual(self._batch_state(batch), "complete")
+        item = self.con.execute("SELECT state FROM planner_wake_items").fetchone()[0]
+        self.assertEqual(item, "cancelled", "items must not fire for a disarmed sprint")
+
+    def test_closed_sprint_cancels_batch(self):
+        _, _, batch = self._arm(doc_id=2, shell_id=2)
+        out, writes = self._submit(batch, "2030-01-01 00:00:10")
+        self.assertFalse(out["submitted"])
+        self.assertTrue(out["cancelled"])
+        self.assertEqual(writes, [])
+        self.assertEqual(self._batch_state(batch), "complete")
+
+    # ── post-restart debounce (flag #37) ────────────────────────────────
+    def test_null_last_human_input_still_owes_full_debounce(self):
+        sid, _, batch = self._arm()
+        created = self.con.execute(
+            "SELECT created_at FROM interface_sessions WHERE session_id=?", (sid,)
+        ).fetchone()[0]
+        # NULL last_human_input_at must NOT skip the quiet check: 1s after
+        # the session started is inside the debounce.
+        soon = (parse(created) + timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+        out, writes = self._submit(batch, soon)
+        self.assertFalse(out["submitted"])
+        self.assertIn("quiet", out["reason"])
+        self.assertEqual(writes, [])
+        self.assertEqual(
+            self._batch_state(batch),
+            "queued",
+            "a quiet refusal awaits a later event, no state change",
+        )
+        later = (parse(created) + timedelta(seconds=10)).strftime("%Y-%m-%d %H:%M:%S")
+        out, writes = self._submit(batch, later)
+        self.assertTrue(out["submitted"])
+        self.assertEqual(len(writes), 1)
+
+    def test_restart_floors_the_quiet_baseline(self):
+        sid, _, batch = self._arm()
+        # Human input long ago — would pass the old check — but a service
+        # restart (lease revocation stamp) is 1s before NOW: a fresh full
+        # debounce is owed.
+        self.con.execute(
+            "UPDATE interface_input_state SET last_human_input_at="
+            "'2020-01-01 00:00:00' WHERE session_id=?",
+            (sid,),
+        )
+        self.con.execute(
+            "INSERT INTO interface_writer_leases (session_id, shell_id,"
+            " generation, client_id, token_hash, revoked_at, revoke_reason) "
+            "VALUES (?,1,1,'c','h','2030-01-01 00:00:00','service_restart')",
+            (sid,),
+        )
+        self.con.commit()
+        out, writes = self._submit(batch, "2030-01-01 00:00:01")
+        self.assertFalse(out["submitted"])
+        self.assertIn("quiet", out["reason"])
+        self.assertEqual(writes, [])
+        out, writes = self._submit(batch, "2030-01-01 00:00:10")
+        self.assertTrue(out["submitted"])
+        self.assertEqual(len(writes), 1)
+
+    # ── zero debounce forbidden (flag #37) ──────────────────────────────
+    def test_zero_quiet_s_rejected(self):
+        _, _, batch = self._arm()
+        with self.assertRaises(interface_broker.BrokerError):
+            self._submit(batch, "2030-01-01 00:00:10", quiet_s=0)
+        with self.assertRaises(interface_broker.BrokerError):
+            self._submit(batch, "2030-01-01 00:00:10", quiet_s=-1)
+        self.assertEqual(self._batch_state(batch), "queued")
+
+    # ── writer failure parks the batch live (lock release, flag #33) ────
+    def test_writer_failure_parks_batch_and_alerts(self):
+        _, bid, batch = self._arm()
+
+        class TmuxError(Exception):
+            pass
+
+        def failing_writer(_len):
+            raise TmuxError("tmux send-keys failed")
+
+        with self.assertRaises(TmuxError):
+            interface_broker.submit_wake_batch(
+                self.con, batch, writer=failing_writer, now_iso="2030-01-01 00:00:10"
+            )
+        row = self.con.execute(
+            "SELECT state, submit_hook_seq FROM planner_wake_batches WHERE batch_id=?",
+            (batch,),
+        ).fetchone()
+        self.assertEqual(
+            row,
+            ("delivery_unknown", None),
+            "ambiguous delivery parks; no evidence may be stamped",
+        )
+        alert = self.con.execute(
+            "SELECT 1 FROM planner_alerts "
+            "WHERE reason='wake_batch_delivery_unknown' AND resolved_at IS "
+            "NULL"
+        ).fetchone()
+        self.assertIsNotNone(alert)
+        # The park releases the input lock: human input flows again.
+        self.con.execute(
+            "INSERT INTO interface_writer_leases (session_id, shell_id,"
+            " generation, client_id, token_hash) "
+            "SELECT session_id, shell_id, generation, 'tab', 'h' "
+            "FROM interface_sessions"
+        )
+        self.con.commit()
+        sid = self.con.execute("SELECT session_id FROM interface_sessions").fetchone()[
+            0
+        ]
+        writes = []
+        ack = interface_broker.accept_human_input(
+            self.con, sid, 1, 10, writer=lambda n: writes.append(n)
+        )
+        self.assertEqual(ack, {"ack": 1, "duplicate": False})
+        self.assertEqual(writes, [10])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sprint 25 seq 4 (the SPINE) — spec #20 task #80. Builds on the seq-3 gate spike stack/state model (@81756b1). Reviewer: REV1.

## What ships

- **Migration 0078 + convergent schema.sql**: `interface_generations`, `interface_sessions`, `interface_writer_leases`, `interface_input_state`, `interface_idempotency_keys`, `sprint_planner_bindings`, `planner_wake_items`, `planner_wake_batches`, `planner_action_receipts`, `pr_poll_runs`, `pr_poll_observations`, `planner_alerts`; nullable `sprint_doc_id` on `shell_messages` + `watched_prs` (migration-only ADD COLUMN precedent). Uniqueness: one non-ended session/shell, one live generation/shell, one current writer/session, one live batch/binding, one unreleased binding per planner and per sprint, unique (binding,message), idempotency (actor,operation,key).
- **Transition validators, two layers**: SQL `RAISE(ABORT)` triggers (backstop) + `scripts/interface_state.py` edge maps (friendly errors) for occupancy, lifecycle, composer, delivery, wake item, wake batch, receipt. `test_interface_transitions.py` walks EVERY (old,new) pair against BOTH layers — drift fails the suite.
- **`scripts/interface_broker.py`**: the durable two-phase input path (pending commit → injected tmux write → forwarded commit), duplicate-ack replay (never re-forward), gap rejection, writer lease acquire/takeover, certify-clean, hook-sequence recording with replay rejection, batch form/submit gates (idle+clean+quiet≥3s+no pending+generation-current), stop-hook item reconciliation.
- **`scripts/interface_reconcile.py`**: startup reconstruction (crash-window parking, hook-evidence batch recovery, expired-reservation fail-closed, lease revocation preserving dirty state) wired into `server.main`; `live_refusal_reasons` wired into `rebuild.main` and `update.migrate_or_rebuild` — refuse while any non-ended session, unreleased binding, nonterminal batch, or input ambiguity exists.
- **Snapshot projection**: volatile tables (writer leases, input state, poll runs) excluded; volatile columns (tmux socket, PIDs/start ticks, hook token hash) redacted via SENSITIVE_COLUMNS; new SNAPSHOT_ROW_FILTERS keep live rows (non-ended sessions, armed bindings, nonterminal batches/items, no-transition observations) out of content.sql.

## Decision #22 — crash-window parking, implemented AND proven

`tests/test_interface_crash_window.py` (11 proofs, hermetic, real schema+migrations, injected recording transport):

- broker crash **before** the tmux write with a pending unacknowledged human sequence → composer unknown, delivery `delivery_unknown`, writer revoked, critical alert, zero bytes written, pending_seq kept as evidence;
- crash **after** the tmux write → indistinguishable, identical park, and the write count stays 1 across repeated reconciliations — **no auto-replay** (there is deliberately no resend code path);
- operator `reconcile_input` is the only exit: `delivered` folds the seq into forwarded (no resend), `not_delivered` drops the reservation so the client resends under a fresh lease;
- submitting/running batch at restart → `delivery_unknown` unless durable hook-sequence evidence proves the transition (submit stamp → running; stop stamp → complete with items reconciled from message read state); parked batch never blindly resubmitted — `resolve_batch` requeues items byte-free.

## Ambiguity calls (sprint-scoped, for REV1's gate)

- spec's Data Model lists hook token hash + sequence on `sprint_planner_bindings`; they live on **`interface_generations`** — ordinary chats authenticate hooks with no binding.
- lifecycle edges `lost|error → ended` and `starting → ended` added beyond the spec's literal list — operator close after proven absence / definite pre-spawn failure require them.
- `watched_prs` uniqueness rebuild into one-active-watch-per-binding is left to the polling cutover (#85) where the spec places it; this unit adds only the nullable `sprint_doc_id` columns.
- `pr_poll_observations.run_id` is deliberately NOT a REFERENCES — runs are snapshot-volatile, observations durable; the linkage outlives its target.

## Verification

- 41 new hermetic tests across 5 files, all green.
- Full suite: 569 passed + 3 `test_vm_bake` failures that are sandbox-env anomalies (they read the live `SC_SANDBOX` env var; all 6 pass with it unset — unrelated to this diff, green on CI's runner).
- `ruff` clean on all touched files; `mypy` clean on the three new modules; `./sc verify` (rebuild + render + headless boot) green with 0078 in the chain.