### PR TITLE
feat(polling): watched-PR polling + daemon cutover (sprint 25 seq 9, task #85)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -58,6 +58,7 @@ import db_driver  # noqa: E402
 import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import interface_reconcile  # noqa: E402  (Interface startup reconciliation)
 import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
+import pr_poller  # noqa: E402  (watched-PR polling — the service scheduler)
 import ports as ports_mod  # noqa: E402
 import shell_factory  # noqa: E402
 import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin rule)
@@ -1997,12 +1998,15 @@ class Handler(BaseHTTPRequestHandler):
     # `shell` names another subscriber (the sprint skill registers the planner
     # at PR open — the recipient-naming precedent of `message send`). The list
     # is a shared read like /roadmap: single-operator fork, the planner needs
-    # the whole board. The daemon never calls these — it owns the DB side
-    # (last_seen, closed_at) directly.
+    # the whole board. Since the polling cutover (spec #20 task #85, decision
+    # #19) the service's own scheduler is the sole poller and DB writer:
+    # registration takes an immediate GitHub baseline (no baseline, no armed
+    # watch), `--sprint` scopes a watch to an ACTIVE sprint document, and
+    # /_sc/watches/reconcile is the operator's explicit one-shot poll.
 
     def _daemon_state(self, con) -> "dict | None":
-        """Watcher-daemon liveness (#359): the heartbeat row → age + verdict.
-        Stale = beat older than 3× the daemon's own poll interval (one slow gh
+        """Poller liveness (#359): the heartbeat row → age + verdict.
+        Stale = beat older than 3× the poller's own interval (one slow gh
         call + the sleep fit comfortably inside). None = never run (or a
         pre-0068 DB with no heartbeat table yet) — the client renders both
         None and stale as "watches are NOT being polled"."""
@@ -2026,13 +2030,19 @@ class Handler(BaseHTTPRequestHandler):
         try:
             q = parse_qs(urlparse(self.path).query)
             include_closed = q.get("all", ["0"])[0] in ("1", "true", "yes")
+            active = pr_poller.active_sprint_doc_ids(con)
             sql = ("SELECT w.watch_id, w.repo, w.pr_number, w.shell_id, "
-                   "s.shortname, w.created_at, w.closed_at FROM watched_prs w "
+                   "s.shortname, w.created_at, w.closed_at, w.sprint_doc_id "
+                   "FROM watched_prs w "
                    "JOIN shells s ON s.shell_id = w.shell_id")
             if not include_closed:
                 sql += " WHERE w.closed_at IS NULL"
             sql += " ORDER BY w.repo, w.pr_number, w.watch_id"
-            return self._send(200, {"watches": rows(con.execute(sql)),
+            ws = rows(con.execute(sql))
+            for w in ws:
+                w["armed"] = (w.get("closed_at") is None
+                              and w.get("sprint_doc_id") in active)
+            return self._send(200, {"watches": ws,
                                     "daemon": self._daemon_state(con)})
         except Exception as e:
             return self._fail(e)
@@ -2052,6 +2062,16 @@ class Handler(BaseHTTPRequestHandler):
                 pr = None
             if not repo or repo.count("/") != 1 or pr is None:
                 return self._send(400, {"error": "repo (owner/name) and pr_number (int) required"})
+            sprint_doc_id = body.get("sprint_doc_id")
+            if sprint_doc_id is not None:
+                try:
+                    sprint_doc_id = int(sprint_doc_id)
+                except (TypeError, ValueError):
+                    return self._send(400, {"error": "sprint_doc_id must be an int"})
+                if not pr_poller.is_active_sprint(con, sprint_doc_id):
+                    return self._send(409, {"error":
+                        f"document {sprint_doc_id} is not an ACTIVE, unfrozen "
+                        "SPRINT doc — watches arm only to active sprints"})
             target = sid
             if body.get("shell"):
                 r = con.execute(
@@ -2060,32 +2080,67 @@ class Handler(BaseHTTPRequestHandler):
                 if r is None:
                     return self._send(404, {"error": f"shell '{body['shell']}' unknown"})
                 target = r[0]
-            # Idempotent by (repo, pr, shell): a live duplicate returns the
-            # existing watch; a retired one re-arms (fresh baseline — last_seen
-            # cleared so the first poll re-fingerprints, not diffs stale state).
+            # Idempotent by (repo, pr, shell, scope): a live duplicate in the
+            # SAME scope returns the existing watch. A live UNSCOPED watch
+            # registered with --sprint is rebound (explicit re-arm — legacy
+            # dormant watches become polled only this way). A retired watch is
+            # NOT reopened: registration inserts a new row so closed history
+            # is retained (0080 cutover).
             existing = con.execute(
-                "SELECT watch_id, closed_at FROM watched_prs "
-                "WHERE repo=? AND pr_number=? AND shell_id=?",
-                (repo, pr, target)).fetchone()
-            # daemon liveness rides every registration response (#359): a
-            # watch registered while nobody is polling must say so up front.
+                "SELECT watch_id, sprint_doc_id FROM watched_prs "
+                "WHERE repo=? AND pr_number=? AND shell_id=? AND closed_at IS NULL "
+                "AND COALESCE(sprint_doc_id, 0) = COALESCE(?, 0)",
+                (repo, pr, target, sprint_doc_id)).fetchone()
             daemon = self._daemon_state(con)
             if existing is not None:
-                if existing["closed_at"] is None:
-                    return self._send(200, {"watch_id": existing["watch_id"],
-                                            "existing": True, "daemon": daemon})
+                return self._send(200, {"watch_id": existing["watch_id"],
+                                        "existing": True, "daemon": daemon})
+            unscoped = None
+            if sprint_doc_id is not None:
+                unscoped = con.execute(
+                    "SELECT watch_id FROM watched_prs "
+                    "WHERE repo=? AND pr_number=? AND shell_id=? "
+                    "AND closed_at IS NULL AND sprint_doc_id IS NULL",
+                    (repo, pr, target)).fetchone()
+            # Registration baseline (spec: an immediate GitHub read, normalized
+            # and stored BEFORE arming; a failed baseline creates no armed
+            # watch and returns a retryable sanitized error). The gh call
+            # happens before the INSERT so a failure leaves no row at all.
+            fp, err = pr_poller.baseline_read(repo, pr)
+            if fp is None:
+                return self._send(502, {"error":
+                    f"baseline read failed (retryable): {err}",
+                    "retryable": True, "daemon": daemon})
+            if unscoped is not None:
                 con.execute(
-                    "UPDATE watched_prs SET closed_at=NULL, last_seen=NULL, "
-                    "created_at=datetime('now') WHERE watch_id=?",
-                    (existing["watch_id"],))
+                    "UPDATE watched_prs SET sprint_doc_id=?, last_seen=? "
+                    "WHERE watch_id=?",
+                    (sprint_doc_id, json.dumps(fp), unscoped["watch_id"]))
                 con.commit()
-                return self._send(201, {"watch_id": existing["watch_id"],
-                                        "reopened": True, "daemon": daemon})
+                return self._send(200, {"watch_id": unscoped["watch_id"],
+                                        "rebound": True, "daemon": daemon})
             cur = con.execute(
-                "INSERT INTO watched_prs (repo, pr_number, shell_id) VALUES (?, ?, ?)",
-                (repo, pr, target))
+                "INSERT INTO watched_prs (repo, pr_number, shell_id, last_seen, "
+                "sprint_doc_id) VALUES (?, ?, ?, ?, ?)",
+                (repo, pr, target, json.dumps(fp), sprint_doc_id))
             con.commit()
             return self._send(201, {"watch_id": cur.lastrowid, "daemon": daemon})
+        except Exception as e:
+            return self._fail(e)
+        finally:
+            con.close()
+
+    def _watches_reconcile(self):
+        """Operator's explicit one-shot poll (spec: startup + explicit
+        reconciliation are the two non-interval triggers). Synchronous —
+        the response IS the cycle's summary."""
+        sid = self._require_shell_auth()
+        if sid is None:
+            return
+        con = db()
+        try:
+            summary = pr_poller.poll_cycle(con, source="reconcile")
+            return self._send(200, summary)
         except Exception as e:
             return self._fail(e)
         finally:
@@ -2231,6 +2286,8 @@ class Handler(BaseHTTPRequestHandler):
             return self._mem_post(path, self._body())
         if path == "/_sc/watches":
             return self._watches_post(self._body())
+        if path == "/_sc/watches/reconcile":
+            return self._watches_reconcile()
         con = db()
         try:
             if path == "/api/flags":
@@ -2479,6 +2536,13 @@ def main(argv):
         con.close()
     if recon.get("parks") or recon.get("batches_delivery_unknown"):
         print(f"server: interface reconcile {recon}")
+    # Watched-PR poller (spec #20 task #85, decision #19): this service is the
+    # fork's SOLE GitHub poller — the legacy host `sc watch daemon` (direct-DB
+    # writer) is retired by the same commit that enables this scheduler, which
+    # is the cutover gate: no second writer can be started by any supervised
+    # path. Bounded interval only while ACTIVE sprint watches exist, plus the
+    # startup pass inside the thread; self-disables when gh is absent.
+    pr_poller.Poller(DB_PATH).start()
     # Bind 127.0.0.1 by default (the host stance: localhost-only, operator owns
     # network controls). In the container set SC_BIND=0.0.0.0 so docker can
     # publish the port — the jail is the `-p 127.0.0.1:PORT:PORT` mapping, which

--- a/.super-coder/migrations/0080_pr_polling_cutover.sql
+++ b/.super-coder/migrations/0080_pr_polling_cutover.sql
@@ -1,0 +1,51 @@
+-- 0080 — watched-PR polling cutover (spec #20 task #85): rebuild the legacy
+-- UNIQUE(repo, pr_number, shell_id) table constraint into one ACTIVE watch per
+-- (repo, PR, subscriber, sprint scope). Closed rows are retained as history —
+-- re-arming a retired watch now inserts a NEW row instead of reopening the old
+-- one, which the old constraint made impossible.
+--
+-- The rebuild dance (create v2 / copy / drop / rename) is the only way to drop
+-- a table-level UNIQUE in SQLite. FK stays ON (migrate.py wraps every file in
+-- one transaction, where PRAGMA foreign_keys is a no-op): the implicit
+-- DELETE FROM that DROP TABLE performs is safe because pr_poll_observations —
+-- the only child table — has no production writers before this unit lands.
+-- watch_id values are preserved; the old UNIQUE guarantees at most one row per
+-- (repo, pr, shell), so the new partial index cannot be violated by the copy.
+
+BEGIN;
+
+CREATE TABLE watched_prs_v2 (
+    watch_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo           TEXT    NOT NULL,          -- owner/name
+    pr_number      INTEGER NOT NULL,
+    shell_id       INTEGER NOT NULL REFERENCES shells(shell_id),
+    last_seen      TEXT,                      -- JSON: normalized fingerprint
+    created_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+    closed_at      TEXT,                      -- set on merge/close; NULL = live
+    sprint_doc_id  INTEGER REFERENCES documents(document_id)
+);
+
+INSERT INTO watched_prs_v2
+    (watch_id, repo, pr_number, shell_id, last_seen, created_at, closed_at,
+     sprint_doc_id)
+SELECT watch_id, repo, pr_number, shell_id, last_seen, created_at, closed_at,
+       sprint_doc_id
+FROM watched_prs;
+
+DROP TABLE watched_prs;
+ALTER TABLE watched_prs_v2 RENAME TO watched_prs;
+
+-- The 0059 live-filter index rode the dropped table; recreate it.
+CREATE INDEX IF NOT EXISTS idx_watched_prs_live
+    ON watched_prs(closed_at) WHERE closed_at IS NULL;
+
+-- One ACTIVE watch per (repo, PR, subscriber, sprint scope) — the cutover's
+-- uniqueness contract. COALESCE folds unscoped (NULL sprint_doc_id) watches
+-- into the same key space: an unscoped live watch and a sprint-scoped live
+-- watch for the same PR can coexist (the unscoped one is dormant until
+-- rebound); two live watches in the SAME scope cannot.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_watched_prs_active
+    ON watched_prs(repo, pr_number, shell_id, COALESCE(sprint_doc_id, 0))
+    WHERE closed_at IS NULL;
+
+COMMIT;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -285,40 +285,44 @@ CREATE TABLE shell_messages (
     -- for wake-eligible traffic, added by migration 0078 (same precedent).
 );
 
--- ── Watched PRs (sprint eventing — subscription registry + daemon state) ────
--- One row per (repo, PR, subscriber shell). `./sc watch pr` registers; the
--- GitHub watcher daemon (`./sc watch daemon`, supervised by launch/down) polls
--- every live watch on one batched query, diffs against last_seen, and writes a
--- `pr_event` message row to the owning shell on each transition. On merge or
--- close it emits the final event and sets closed_at — the watch retires
--- itself. See migrations/0059_sprint_eventing.sql (convergent — carries an
--- existing fork).
+-- ── Watched PRs (sprint eventing — subscription registry + poller state) ────
+-- One ACTIVE watch per (repo, PR, subscriber shell, sprint scope); closed rows
+-- are retained as history. `./sc watch pr` registers (with an immediate GitHub
+-- baseline); the supervised engine service is the sole poller (spec #20,
+-- decision #19 — the legacy host `sc watch daemon` is retired): it polls every
+-- live sprint-scoped watch on batched queries, diffs against last_seen, and
+-- writes an idempotent `pr_event` message row to the owning shell on each
+-- semantic transition. On merge or close it emits the final event and sets
+-- closed_at — the watch retires itself. Unscoped (sprint_doc_id NULL) watches
+-- stay readable but dormant until rebound to an ACTIVE sprint.
+-- See migrations/0059_sprint_eventing.sql (convergent — carries an existing
+-- fork) and 0080_pr_polling_cutover.sql (uniqueness rebuild + active index).
 
 CREATE TABLE watched_prs (
     watch_id       INTEGER PRIMARY KEY AUTOINCREMENT,
     repo           TEXT    NOT NULL,          -- owner/name
     pr_number      INTEGER NOT NULL,
     shell_id       INTEGER NOT NULL REFERENCES shells(shell_id),
-    last_seen      TEXT,                      -- JSON: checks/review/state fingerprint
+    last_seen      TEXT,                      -- JSON: normalized fingerprint
     created_at     TEXT    NOT NULL DEFAULT (datetime('now')),
-    closed_at      TEXT,                      -- set on merge/close; NULL = live
-    UNIQUE (repo, pr_number, shell_id)
+    closed_at      TEXT                       -- set on merge/close; NULL = live
     -- sprint_doc_id INTEGER REFERENCES documents(document_id) — sprint scoping,
     -- added by migration 0078 (same migration-only ADD COLUMN precedent as
-    -- shell_messages.kind above). The uniqueness rebuild into one active watch
-    -- per binding/repo/PR is the polling cutover's migration (spec #20 task 36).
+    -- shell_messages.kind above). The one-active-watch-per-scope uniqueness
+    -- (idx_watched_prs_active, partial on closed_at IS NULL with
+    -- COALESCE(sprint_doc_id, 0)) rides in migration 0080's table rebuild.
 );
 
--- Daemon liveness (#359): the watcher daemon UPSERTs its row once per poll
--- cycle; the /_sc/watches API turns beat age into a live/stale/never verdict
--- so `./sc watch list` can't report watches "live" with nobody polling.
--- See migrations/0068_watch_daemon_heartbeat.sql (convergent — carries an
--- existing fork).
+-- Poller liveness (#359): the engine service's PR poller UPSERTs its row once
+-- per poll cycle; the /_sc/watches API turns beat age into a live/stale/never
+-- verdict so `./sc watch list` can't report watches "live" with nobody
+-- polling. See migrations/0068_watch_daemon_heartbeat.sql (convergent —
+-- carries an existing fork).
 
 CREATE TABLE daemon_heartbeats (
-    name        TEXT PRIMARY KEY,              -- 'watch' — one row per daemon
+    name        TEXT PRIMARY KEY,              -- 'watch' — one row per poller
     beat_at     TEXT    NOT NULL,              -- datetime('now') at last poll cycle
-    interval_s  INTEGER NOT NULL               -- the daemon's configured poll interval
+    interval_s  INTEGER NOT NULL               -- the poller's configured poll interval
 );
 
 -- ── Interface (spec #20: Interface-backed planner wake) ─────────────────────

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -437,7 +437,7 @@ class Poller(threading.Thread):
         import db_driver
         return db_driver.connect(self._db_path)
 
-    def run(self) -> None:  # pragma: no cover — exercised via poll_cycle tests
+    def run(self) -> None:  # pragma: no cover — thread loop; scheduler tests drive it
         if self._fetch is None and shutil.which("gh") is None:
             print("pr-poller: gh CLI not found — PR polling disabled "
                   "(install gh + login to enable)", flush=True)
@@ -447,7 +447,14 @@ class Poller(threading.Thread):
             try:
                 con = self._db()
                 try:
-                    beat(con, self._interval)
+                    try:
+                        beat(con, self._interval)
+                    except Exception as e:
+                        # The beat is ancillary liveness; polling is the
+                        # mission (#359). A beat raising into the cycle's
+                        # except would turn a working poller into a
+                        # dead-with-noise one — log and keep polling.
+                        print(f"pr-poller: heartbeat error ({e})", flush=True)
                     # The DB read is cheap and local; the bounded GitHub poll
                     # happens only while ACTIVE sprint watches exist.
                     if armed_watches(con):

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""pr_poller — the engine service's watched-PR poller (spec #20 task #85,
+decision #19: the supervised service is the SOLE poller and engine-DB writer;
+the legacy host `sc watch daemon` is retired).
+
+What lives here:
+
+- The normalized GitHub surface: one batched GraphQL query per repo, collapsed
+  to a fingerprint of head SHA, PR state, check rollup, and review decision.
+  Never prose, logs, commit messages, raw payloads, or tokens.
+- `transitions()` — the semantic diff: (watch, transition, head SHA, state)
+  keyed events with the same one-line `pr_event` bodies the sprint skills
+  already teach. Merge is terminal only once no checks are still PENDING
+  (#375); close-without-merge retires immediately.
+- `baseline_read()` — registration's immediate GitHub read: no normalized
+  baseline stored, no armed watch (the caller fails retryable).
+- `poll_cycle()` — one bounded pass over ARMED watches only (live rows whose
+  sprint_doc_id names an ACTIVE, unfrozen SPRINT document; unscoped legacy
+  watches stay dormant until rebound). Per cycle: a `pr_poll_runs` audit row
+  per repo, durable `pr_poll_observations` for transitions and blind windows,
+  idempotent `pr_event` messages (dedupe_key) plus same-transaction wake items
+  when a live binding owns the (sprint, planner) pair, fingerprint persistence,
+  and terminal retirement. Per-repo failures back off capped without blocking
+  other repos; a repo recovering from failure marks its next observations as
+  blind windows (GitHub may have moved unobserved — convergence, not history).
+- `Poller` — the service's scheduler thread: 30s default interval with jitter,
+  only while ACTIVE sprint watches exist, plus one startup pass; explicit
+  reconcile rides `poll_cycle(source='reconcile')` through the API. It beats
+  the 'watch' heartbeat so `sc watch list` liveness keeps telling the truth.
+
+It never injects terminal input, never marks a message read, never acts on a
+PR — polling may create an event, nothing more.
+"""
+from __future__ import annotations
+
+import json
+import os
+import random
+import re
+import shutil
+import sqlite3
+import subprocess
+import threading
+import time
+
+CONCLUDED = {"SUCCESS", "FAILURE", "ERROR"}   # statusCheckRollup terminal states
+
+DEFAULT_INTERVAL = int(os.environ.get("SC_PR_POLL_INTERVAL", "30"))
+JITTER_FRACTION = 0.25          # sleep interval + uniform(0, 25%) — herd spread
+BACKOFF_CAP_S = 900             # per-repo failure backoff ceiling (15 min)
+
+_STATUS_ACTIVE = re.compile(r"^status:\s*ACTIVE\s*$", re.MULTILINE)
+
+
+# ── GitHub read (the only network seam — injectable for tests) ───────────────
+
+class GhResult:
+    """One GitHub read: `data` (GraphQL data object) or a sanitized failure."""
+    __slots__ = ("data", "error", "rate_limited")
+
+    def __init__(self, data=None, error=None, rate_limited=False):
+        self.data = data
+        self.error = error            # sanitized one-liner; None on success
+        self.rate_limited = rate_limited
+
+    @property
+    def ok(self) -> bool:
+        return self.data is not None
+
+
+def _sanitize_err(text: str) -> str:
+    """One line, bounded — gh stderr carries no tokens, but the poller's
+    error column is durable, so it gets the normalized-only discipline anyway."""
+    return (text or "").strip().splitlines()[0][:200] if text else "unknown"
+
+
+def gh_fetch(query: str) -> GhResult:
+    """Run the batched query through the sandbox's authenticated `gh`. gh exits
+    non-zero on partial GraphQL errors but still prints data — use it if
+    parseable (one bad watch must not blind the rest)."""
+    try:
+        out = subprocess.run(
+            ["gh", "api", "graphql", "-f", f"query={query}"],
+            capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return GhResult(error=_sanitize_err(f"gh unavailable: {e}"))
+    rate_limited = "rate limit" in (out.stderr or "").lower()
+    try:
+        data = json.loads(out.stdout).get("data")
+    except Exception:
+        data = None
+    if out.returncode != 0 and data is None:
+        return GhResult(error=_sanitize_err(out.stderr), rate_limited=rate_limited)
+    return GhResult(data=data, rate_limited=rate_limited)
+
+
+# ── Normalized fingerprint + semantic transitions (pure — the tested core) ───
+
+def build_query(prs: "list[tuple[str, int]]") -> str:
+    """One batched GraphQL query over every (repo, pr) pair. Aliases are
+    positional (r0, r1, …) so the response maps back by index regardless of
+    characters in repo names."""
+    parts = []
+    for i, (repo, number) in enumerate(prs):
+        owner, name = repo.split("/", 1)
+        parts.append(
+            f'r{i}: repository(owner: "{owner}", name: "{name}") {{'
+            f' pullRequest(number: {number}) {{'
+            f' state headRefOid'
+            f' reviews(last: 1) {{ totalCount nodes {{ state }} }}'
+            f' commits(last: 1) {{ nodes {{ commit {{ statusCheckRollup {{ state }} }} }} }}'
+            f' }} }}')
+    return "query { " + " ".join(parts) + " }"
+
+
+def fingerprint(node: "dict | None") -> "dict | None":
+    """Collapse a GraphQL pullRequest node to the compared surface. None when
+    the PR was unreadable this poll (deleted repo, bad number, partial error)."""
+    if not node:
+        return None
+    commits = (node.get("commits") or {}).get("nodes") or []
+    rollup = (commits[0].get("commit") or {}).get("statusCheckRollup") if commits else None
+    reviews = node.get("reviews") or {}
+    review_nodes = reviews.get("nodes") or []
+    return {
+        "state": node.get("state"),                       # OPEN | MERGED | CLOSED
+        "sha": node.get("headRefOid"),
+        "checks": (rollup or {}).get("state"),            # SUCCESS/FAILURE/ERROR/PENDING/None
+        "reviews": reviews.get("totalCount") or 0,
+        "review_state": review_nodes[0].get("state") if review_nodes else None,
+    }
+
+
+def baseline_read(repo: str, pr_number: int, fetch=None) -> "tuple[dict | None, str | None]":
+    """Registration's immediate GitHub read: (normalized fingerprint, None) or
+    (None, sanitized retryable error). No baseline, no armed watch — a watch
+    armed without one would either replay history or drop its first event."""
+    fetch = fetch or gh_fetch
+    r = fetch(build_query([(repo, pr_number)]))
+    if not r.ok:
+        return None, r.error or "baseline read failed"
+    fp = fingerprint((r.data.get("r0") or {}).get("pullRequest"))
+    if fp is None:
+        return None, "PR unreadable (bad repo/number or no access)"
+    return fp, None
+
+
+def transitions(prev: "dict | None", cur: dict, repo: str, number: int) -> "tuple[list[dict], bool]":
+    """The poller's core: (events, terminal?) for one PR transition.
+
+    Each event is {"key", "body"}: key is the semantic transition key
+    (kind:state — with watch id and head SHA it forms the dedupe identity),
+    body the one-line pr_event text. Detail lives in `gh`; the message is the
+    wake-up, not the payload.
+
+    prev None = first poll of a fresh watch: baseline silently, EXCEPT states
+    that are already conclusive (checks concluded, merged, closed) — a watch
+    registered moments after the transition must still wake its shell, or the
+    event-driven loop drops its first link. Review history is never replayed
+    from a baseline (stale reviews aren't a wake-up).
+
+    A head-SHA change resets the checks comparison implicitly: the fingerprint
+    compares (sha, checks) together, so a new push going green is a fresh
+    transition even if the old head was green too.
+
+    Merge is terminal ONLY once no checks are still running (#375): a PR
+    merged while its rollup is PENDING keeps its watch — the merge event
+    fires now, the checks conclusion fires (and retires the watch) when the
+    already-running workflows finish. Retiring at merge dropped that verdict
+    on the floor and silently stalled the planner's sprint gate. Close
+    without merge retires immediately regardless — its pending checks get
+    cancelled, no conclusion is coming."""
+    events: list[dict] = []
+    sha7 = (cur.get("sha") or "")[:7]
+    tag = f"{repo}#{number}"
+
+    merged = cur.get("state") == "MERGED"
+    checks = cur.get("checks")
+    checks_pending = checks is not None and checks not in CONCLUDED  # PENDING/EXPECTED
+    terminal = cur.get("state") == "CLOSED" or (merged and not checks_pending)
+
+    checks_changed = prev is None or (prev.get("checks"), prev.get("sha")) != (checks, cur.get("sha"))
+    if checks in CONCLUDED and checks_changed:
+        word = "green" if checks == "SUCCESS" else "red"
+        # On a retained post-merge watch this conclusion is the retiring event.
+        tail = " — watch retired" if merged and prev is not None and prev.get("state") == "MERGED" else ""
+        events.append({"key": f"checks:{checks}",
+                       "body": f"pr_event {tag}: checks {word} ({checks}) @ {sha7}{tail}"})
+
+    if prev is not None and (cur.get("reviews") or 0) > (prev.get("reviews") or 0):
+        state = cur.get("review_state") or "REVIEW"
+        events.append({"key": f"review:{state}",
+                       "body": f"pr_event {tag}: review submitted ({state}) @ {sha7}"})
+
+    if merged and (prev is None or prev.get("state") != "MERGED"):
+        if checks_pending:
+            body = f"pr_event {tag}: merged @ {sha7} — checks still pending, watch retained"
+        else:
+            body = f"pr_event {tag}: merged @ {sha7} — watch retired"
+        events.append({"key": "merged:MERGED", "body": body})
+    elif cur.get("state") == "CLOSED" and (prev is None or prev.get("state") != "CLOSED"):
+        events.append({"key": "closed:CLOSED",
+                       "body": f"pr_event {tag}: closed without merge — watch retired"})
+    return events, terminal
+
+
+# ── Sprint scoping ────────────────────────────────────────────────────────────
+
+def active_sprint_doc_ids(con) -> "set[int]":
+    """The unfrozen SPRINT documents declaring `status: ACTIVE` — the only
+    scopes whose watches the poller arms (spec: GitHub polling is limited to
+    active sprint watches)."""
+    ids: set[int] = set()
+    rows = con.execute(
+        "SELECT document_id, body FROM documents "
+        "WHERE kind='doc' AND frozen=0 AND title LIKE 'SPRINT:%'").fetchall()
+    for doc_id, body in rows:
+        if body and _STATUS_ACTIVE.search(body):
+            ids.add(doc_id)
+    return ids
+
+
+def is_active_sprint(con, doc_id: int) -> bool:
+    r = con.execute(
+        "SELECT body FROM documents WHERE document_id=? AND kind='doc' "
+        "AND frozen=0 AND title LIKE 'SPRINT:%'", (doc_id,)).fetchone()
+    return bool(r and r[0] and _STATUS_ACTIVE.search(r[0]))
+
+
+def armed_watches(con) -> list:
+    """Live watches scoped to an ACTIVE sprint — the poller's whole world.
+    Unscoped legacy watches stay dormant until explicitly rebound."""
+    active = active_sprint_doc_ids(con)
+    if not active:
+        return []
+    marks = ",".join("?" for _ in active)
+    return con.execute(
+        "SELECT watch_id, repo, pr_number, shell_id, last_seen, sprint_doc_id "
+        f"FROM watched_prs WHERE closed_at IS NULL AND sprint_doc_id IN ({marks}) "
+        "ORDER BY repo, pr_number, watch_id", tuple(sorted(active))).fetchall()
+
+
+# ── Per-repo backoff + blind windows ─────────────────────────────────────────
+
+class PollerState:
+    """Volatile per-repo poll health (a service restart resets it — the
+    durable half is the run/observation audit). `failures` drives a capped
+    exponential skip; any failure since the last success makes the next
+    successful cycle's observations blind windows."""
+
+    def __init__(self):
+        self._repos: dict[str, dict] = {}
+
+    def _r(self, repo: str) -> dict:
+        return self._repos.setdefault(repo, {"failures": 0, "skip_until": 0.0})
+
+    def due(self, repo: str, now: float) -> bool:
+        return now >= self._r(repo)["skip_until"]
+
+    def record_failure(self, repo: str, now: float, interval: int) -> int:
+        r = self._r(repo)
+        r["failures"] += 1
+        r["skip_until"] = now + min(interval * (2 ** r["failures"]), BACKOFF_CAP_S)
+        return r["failures"]
+
+    def record_success(self, repo: str) -> bool:
+        """True when this success follows ≥1 failure — a blind window: GitHub
+        may have moved while polls were failing/skipped."""
+        r = self._r(repo)
+        blind = r["failures"] > 0
+        r["failures"] = 0
+        r["skip_until"] = 0.0
+        return blind
+
+
+# ── Heartbeat (#359 — same row the legacy daemon beat; liveness UI unchanged) ─
+
+def beat(con, interval: int) -> None:
+    con.execute(
+        "INSERT INTO daemon_heartbeats (name, beat_at, interval_s) "
+        "VALUES ('watch', datetime('now'), ?) "
+        "ON CONFLICT(name) DO UPDATE SET beat_at=excluded.beat_at, "
+        "interval_s=excluded.interval_s", (interval,))
+    con.commit()
+
+
+# ── The poll cycle ────────────────────────────────────────────────────────────
+
+def _alert(con, *, severity: str, reason: str, watch_id=None) -> None:
+    """Raise an alert, deduplicated while open (partial unique index). Local
+    helper — interface_broker._alert predates watch-scoped alerts."""
+    dedupe = f"-|-|{watch_id or '-'}|-|{reason}"
+    con.execute(
+        "INSERT OR IGNORE INTO planner_alerts "
+        "(watch_id, severity, reason, dedupe_key) VALUES (?,?,?,?)",
+        (watch_id, severity, reason, dedupe))
+
+
+def _emit_event(con, watch, event: dict, head_sha: str) -> bool:
+    """One semantic transition → idempotent pr_event + same-transaction wake
+    item. Dedupe keyed (watch, transition, head SHA, state) via the message's
+    dedupe_key partial unique index: a repeated key is a no-op, so a replayed
+    poll or a baseline race can never double-wake the planner. Returns True
+    when the event was newly emitted."""
+    dedupe_key = f"pr-event|{watch['watch_id']}|{event['key']}|{head_sha}"
+    try:
+        cur = con.execute(
+            "INSERT INTO shell_messages "
+            "(from_shell_id, to_shell_id, body, kind, sprint_doc_id, dedupe_key) "
+            "VALUES (?, ?, ?, 'pr_event', ?, ?)",
+            (watch["shell_id"], watch["shell_id"], event["body"],
+             watch["sprint_doc_id"], dedupe_key))
+    except sqlite3.IntegrityError:
+        return False  # the dedupe index — already emitted
+    message_id = cur.lastrowid
+    binding = con.execute(
+        "SELECT binding_id FROM sprint_planner_bindings "
+        "WHERE sprint_doc_id=? AND planner_shell_id=? AND released_at IS NULL",
+        (watch["sprint_doc_id"], watch["shell_id"])).fetchone()
+    if binding is not None:
+        con.execute(
+            "INSERT OR IGNORE INTO planner_wake_items (binding_id, message_id) "
+            "VALUES (?, ?)", (binding[0], message_id))
+    return True
+
+
+def poll_cycle(con, fetch=None, source: str = "scheduler",
+               state: "PollerState | None" = None,
+               interval: int = DEFAULT_INTERVAL, now: "float | None" = None) -> dict:
+    """One bounded pass over armed watches. Per repo: one batched read, one
+    pr_poll_runs audit row, transition/blind-window observations, idempotent
+    events, fingerprint persistence, terminal retirement. A failed repo backs
+    off (capped) without blocking the others. Returns a counts summary."""
+    fetch = fetch or gh_fetch
+    state = state if state is not None else PollerState()
+    now = now if now is not None else time.monotonic()
+    summary = {"watches": 0, "repos": 0, "skipped_backoff": 0,
+               "events": 0, "errors": 0, "retired": 0}
+    watches = armed_watches(con)
+    summary["watches"] = len(watches)
+    if not watches:
+        return summary
+
+    by_repo: dict[str, list] = {}
+    for w in watches:
+        by_repo.setdefault(w["repo"], []).append(w)
+
+    for repo in sorted(by_repo):
+        repo_watches = by_repo[repo]
+        if not state.due(repo, now):
+            summary["skipped_backoff"] += 1
+            continue
+        summary["repos"] += 1
+        run_id = con.execute(
+            "INSERT INTO pr_poll_runs (repo, source, watch_count) VALUES (?,?,?)",
+            (repo, source, len(repo_watches))).lastrowid
+        con.commit()
+
+        prs = sorted({(w["repo"], w["pr_number"]) for w in repo_watches})
+        r = fetch(build_query(prs))
+        if not r.ok:
+            failures = state.record_failure(repo, now, interval)
+            con.execute(
+                "UPDATE pr_poll_runs SET finished_at=datetime('now'), status=?, "
+                "error=? WHERE run_id=?",
+                ("rate_limited" if r.rate_limited else "error", r.error, run_id))
+            _alert(con, severity="warning", reason="pr_poll_failure",
+                   watch_id=repo_watches[0]["watch_id"])
+            con.commit()
+            summary["errors"] += 1
+            if failures >= 3:
+                _alert(con, severity="critical",
+                       reason="pr_poll_backoff_escalated",
+                       watch_id=repo_watches[0]["watch_id"])
+                con.commit()
+            continue
+
+        blind = 1 if state.record_success(repo) else 0
+        con.execute(
+            "UPDATE pr_poll_runs SET finished_at=datetime('now'), status='ok' "
+            "WHERE run_id=?", (run_id,))
+        snaps = {pr: fingerprint((r.data.get(f"r{i}") or {}).get("pullRequest"))
+                 for i, pr in enumerate(prs)}
+        for w in repo_watches:
+            cur = snaps.get((w["repo"], w["pr_number"]))
+            if cur is None:
+                continue  # unreadable this poll — keep the watch, try next cycle
+            prev = json.loads(w["last_seen"]) if w["last_seen"] else None
+            events, terminal = transitions(prev, cur, w["repo"], w["pr_number"])
+            # Durable only with a transition or a blind-window marker (the
+            # snapshot row filter); a quiet successful poll is noise.
+            if events or blind:
+                con.execute(
+                    "INSERT INTO pr_poll_observations "
+                    "(watch_id, run_id, head_sha, fingerprint, transition, "
+                    " blind_window) VALUES (?,?,?,?,?,?)",
+                    (w["watch_id"], run_id, cur.get("sha"), json.dumps(cur),
+                     ",".join(e["key"] for e in events) or None, blind))
+            for e in events:
+                if _emit_event(con, w, e, cur.get("sha") or ""):
+                    summary["events"] += 1
+            con.execute(
+                "UPDATE watched_prs SET last_seen=?" +
+                (", closed_at=datetime('now')" if terminal else "") +
+                " WHERE watch_id=?",
+                (json.dumps(cur), w["watch_id"]))
+            if terminal:
+                summary["retired"] += 1
+        con.commit()
+    return summary
+
+
+# ── The service scheduler ─────────────────────────────────────────────────────
+
+class Poller(threading.Thread):
+    """The service's bounded PR-poll scheduler: 30s + jitter, only while
+    ACTIVE sprint watches exist, plus one startup pass. It polls GitHub and
+    writes the engine DB — it never touches a model, a terminal, or git.
+    A fork without `gh` disables itself exactly like the legacy daemon did."""
+
+    def __init__(self, db_path, interval: int = DEFAULT_INTERVAL, fetch=None,
+                 connect=None):
+        super().__init__(name="pr-poller", daemon=True)
+        self._db_path = str(db_path)
+        self._interval = interval
+        self._fetch = fetch
+        self._connect = connect
+        self._stop_event = threading.Event()
+        self.state = PollerState()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def _db(self):
+        if self._connect is not None:
+            return self._connect()
+        import db_driver
+        return db_driver.connect(self._db_path)
+
+    def run(self) -> None:  # pragma: no cover — exercised via poll_cycle tests
+        if self._fetch is None and shutil.which("gh") is None:
+            print("pr-poller: gh CLI not found — PR polling disabled "
+                  "(install gh + login to enable)", flush=True)
+            return
+        source = "startup"
+        while not self._stop_event.is_set():
+            try:
+                con = self._db()
+                try:
+                    beat(con, self._interval)
+                    # The DB read is cheap and local; the bounded GitHub poll
+                    # happens only while ACTIVE sprint watches exist.
+                    if armed_watches(con):
+                        n = poll_cycle(con, fetch=self._fetch, source=source,
+                                       state=self.state, interval=self._interval)
+                        if n["events"] or n["errors"]:
+                            print(f"pr-poller: {n}", flush=True)
+                finally:
+                    con.close()
+            except Exception as e:
+                # Never die on a cycle: a dead poller silently reverts the
+                # fork to the polling world. Log and keep the loop.
+                print(f"pr-poller: cycle error ({e})", flush=True)
+            source = "scheduler"
+            self._stop_event.wait(self._interval +
+                            random.uniform(0, self._interval * JITTER_FRACTION))

--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -1,38 +1,40 @@
 #!/usr/bin/env python3
-"""sc watch — the sprint-eventing surface: PR watches, the GitHub watcher
-daemon, and the zero-token inbox watcher.
+"""sc watch — the sprint-eventing surface: PR watches and the zero-token
+inbox watcher.
 
-Spec: specs_sc/sprint-eventing.md. Four verbs, two vantages:
+Spec: specs_sc/sprint-eventing.md + spec #20 (polling cutover). Three verbs,
+one vantage — everything shell-side rides the engine API (token identity,
+the `sc mem` doctrine):
 
-Shell-side (over the engine API, token identity — the `sc mem` doctrine):
-    ./sc watch pr <owner/repo> <n> [--shell <shortname>]   register a watch
+    ./sc watch pr <owner/repo> <n> [--shell <shortname>] [--sprint <doc-id>]
+                                                           register a watch
                                                            (defaults to the
-                                                           calling shell)
+                                                           calling shell;
+                                                           --sprint arms it
+                                                           to an ACTIVE sprint)
     ./sc watch list [--all]                                live watches
     ./sc watch inbox [--interval 30] [--timeout 21600]     block until this
                                                            shell has unread
                                                            messages, then exit
+    ./sc watch reconcile                                   explicit one-shot
+                                                           poll (operator)
 
-Host-side (direct DB — engine code, like run.py; never run by a shell):
-    ./sc watch daemon [--interval 75] [--once]             the fork's ONE
-                                                           GitHub poller
-
-The daemon is the fork's single GitHub subscriber: every live `watched_prs`
-row is folded into ONE batched GraphQL query per poll (~1% of an authenticated
-rate limit at 60–90s), each PR is diffed against its stored `last_seen`
-fingerprint, and every transition becomes a `pr_event` row in shell_messages
-addressed to the watch's shell. Events: checks concluded (green or red),
-review submitted, merged, closed. On close — and on merge with no checks
-still running — the final event is emitted and `closed_at` set: the watch
-retires itself. A merge with checks still PENDING retains the watch (#375):
-the merge event is emitted immediately, the watch stays live until the
-rollup concludes, then the green/red event retires it — an early merge must
-not swallow the terminal CI verdict the planner is waiting on. The daemon
-only ever writes message rows + its own registry state: it never boots
-shells, never marks anything read, never touches git. Each cycle it also beats a heartbeat row
-(daemon_heartbeats) so `list`/`pr` can say whether anybody is actually
-polling (#359) — a dead daemon otherwise leaves watches reporting "live"
-with no eventing behind them.
+Polling: the supervised engine service is the fork's SOLE GitHub poller
+(spec #20 task #85, decision #19) — the legacy host `sc watch daemon` (a
+direct-DB writer) is RETIRED: the `daemon` verb here now prints the retirement
+notice and exits clean so legacy nohup/systemd supervision stops instead of
+racing the service. Registration performs an immediate GitHub read and stores
+the normalized baseline before arming; the service then polls armed watches
+(live, scoped to an ACTIVE sprint) on a bounded interval, and every semantic
+transition becomes an idempotent `pr_event` row (+ wake item when a binding is
+armed) addressed to the watch's shell. Events: checks concluded (green or
+red), review submitted, merged, closed. On close — and on merge with no
+checks still running — the final event is emitted and `closed_at` set: the
+watch retires itself. A merge with checks still PENDING retains the watch
+(#375). Unscoped legacy watches stay readable but dormant until rebound to an
+ACTIVE sprint. The poller only ever writes message rows + its own registry
+state: it never boots shells, never marks anything read, never touches git,
+never injects terminal input.
 
 A `pr_event` body is one line — repo, PR, what changed, head SHA. Detail
 lives in `gh`; the message is the wake-up, not the payload.
@@ -41,9 +43,6 @@ lives in `gh`; the message is the wake-up, not the payload.
 cheap local API read (zero harness turns, zero tokens) and exits the moment
 the shell has unread mail — armed as a background task, its exit is the
 wake-up. Re-arm after draining the inbox.
-
-Supervision (daemon): `./sc launch` brings it up, `./sc down` stops it —
-the broker model (nohup + pidfile via the sc dispatcher).
 """
 from __future__ import annotations
 
@@ -51,7 +50,6 @@ import argparse
 import json
 import os
 import signal
-import subprocess
 import sys
 import time
 import urllib.error
@@ -59,16 +57,27 @@ import urllib.request
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
-DB_PATH = ENGINE / "shell_db.db"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
-import db_driver  # noqa: E402
+import pr_poller  # noqa: E402
 
 # API proxy — run.py injects these at boot (token = the shell's api_key).
 SC_API_TOKEN = os.environ.get("SC_API_TOKEN", "")
 SC_API_BASE = os.environ.get("SC_API_BASE", "")
 
-CONCLUDED = {"SUCCESS", "FAILURE", "ERROR"}   # statusCheckRollup terminal states
+# The normalized-GitHub core moved to pr_poller with the polling cutover
+# (spec #20 task #85); re-exported here for the suites that import it from
+# watch (the pure diff behavior is unchanged).
+CONCLUDED = pr_poller.CONCLUDED
+build_query = pr_poller.build_query
+fingerprint = pr_poller.fingerprint
+beat = pr_poller.beat
+
+
+def diff_events(prev, cur, repo, number):
+    """Compat adapter over pr_poller.transitions: (event bodies, terminal?)."""
+    events, terminal = pr_poller.transitions(prev, cur, repo, number)
+    return [e["body"] for e in events], terminal
 
 
 def die(msg: str) -> "NoReturn":  # noqa: F821
@@ -118,14 +127,15 @@ def _age_str(seconds: int) -> str:
 def daemon_line(d: "dict | None") -> str:
     """Render the /_sc/watches `daemon` block as the liveness line (#359):
     a watch is only as live as its poller, and `list` saying "live" while the
-    daemon is dead was the lying half of the dos-arch incident."""
-    dead = "watches are NOT being polled (host: ./sc watch-daemon-up)"
+    poller is dead was the lying half of the dos-arch incident. The poller is
+    the engine service's scheduler thread since the cutover (decision #19)."""
+    dead = "watches are NOT being polled (engine service poller down — restart: ./sc restart)"
     if not d or not d.get("beat_at"):
-        return f"  daemon: never run — {dead}"
+        return f"  poller: never run — {dead}"
     age = _age_str(int(d.get("age_s") or 0))
     if d.get("stale"):
-        return f"  daemon: STALE — last poll {age} ago ({d['beat_at']}Z); {dead}"
-    return f"  daemon: live — last poll {age} ago (interval {d.get('interval_s')}s)"
+        return f"  poller: STALE — last poll {age} ago ({d['beat_at']}Z); {dead}"
+    return f"  poller: live — last poll {age} ago (interval {d.get('interval_s')}s)"
 
 
 def cmd_pr(args) -> int:
@@ -136,17 +146,31 @@ def cmd_pr(args) -> int:
     payload: dict = {"repo": repo, "pr_number": args.number}
     if args.shell:
         payload["shell"] = args.shell
+    if args.sprint:
+        payload["sprint_doc_id"] = args.sprint
     r = _api("POST", "/_sc/watches", payload)
     who = args.shell or "you"
     if r.get("existing"):
         print(f"watch: {repo}#{args.number} already watched for {who} (watch #{r['watch_id']})")
+    elif r.get("rebound"):
+        print(f"watch: {repo}#{args.number} rebound to sprint doc {args.sprint} for {who} "
+              f"(watch #{r['watch_id']}, baseline armed)")
     else:
-        state = "re-armed" if r.get("reopened") else "registered"
-        print(f"watch: {repo}#{args.number} {state} for {who} (watch #{r['watch_id']})")
-        print("  (pr_event rows land in the shell's inbox as the daemon sees transitions)")
+        print(f"watch: {repo}#{args.number} registered for {who} (watch #{r['watch_id']}, baseline armed)")
+        print("  (pr_event rows land in the shell's inbox as the service poller sees transitions)")
     d = r.get("daemon")
     if not d or not d.get("beat_at") or d.get("stale"):
         print(daemon_line(d))
+    return 0
+
+
+def cmd_reconcile(args) -> int:
+    """Explicit one-shot poll of every armed watch (operator recovery)."""
+    _require_api()
+    r = _api("POST", "/_sc/watches/reconcile")
+    print(f"watch: reconcile — {r.get('watches', 0)} armed watch(es), "
+          f"{r.get('repos', 0)} repo(s) polled, {r.get('events', 0)} event(s), "
+          f"{r.get('errors', 0)} error(s), {r.get('skipped_backoff', 0)} in backoff")
     return 0
 
 
@@ -160,6 +184,12 @@ def cmd_list(args) -> int:
         return 0
     for w in ws:
         state = f"closed {w['closed_at']}" if w.get("closed_at") else "live"
+        if not w.get("closed_at"):
+            if w.get("sprint_doc_id"):
+                state += f", sprint #{w['sprint_doc_id']}"
+                state += " (armed)" if w.get("armed") else " (dormant — sprint not ACTIVE)"
+            else:
+                state += ", dormant (unscoped — rebind with `sc watch pr … --sprint <doc>`)"
         print(f"  #{w['watch_id']} {w['repo']}#{w['pr_number']} → {w['shortname']} "
               f"({state}, since {w['created_at']})")
     return 0
@@ -216,219 +246,43 @@ def _api_soft(method: str, path: str) -> dict:
         raise _ApiDown(str(exc)) from exc
 
 
-# ── Daemon: fingerprint + diff (pure — the tested core) ──────────────────────
-
-def build_query(prs: "list[tuple[str, int]]") -> str:
-    """One batched GraphQL query over every (repo, pr) pair. Aliases are
-    positional (r0, r1, …) so the response maps back by index regardless of
-    characters in repo names."""
-    parts = []
-    for i, (repo, number) in enumerate(prs):
-        owner, name = repo.split("/", 1)
-        parts.append(
-            f'r{i}: repository(owner: "{owner}", name: "{name}") {{'
-            f' pullRequest(number: {number}) {{'
-            f' state headRefOid'
-            f' reviews(last: 1) {{ totalCount nodes {{ state }} }}'
-            f' commits(last: 1) {{ nodes {{ commit {{ statusCheckRollup {{ state }} }} }} }}'
-            f' }} }}')
-    return "query { " + " ".join(parts) + " }"
-
-
-def fingerprint(node: "dict | None") -> "dict | None":
-    """Collapse a GraphQL pullRequest node to the compared surface. None when
-    the PR was unreadable this poll (deleted repo, bad number, partial error)."""
-    if not node:
-        return None
-    commits = (node.get("commits") or {}).get("nodes") or []
-    rollup = (commits[0].get("commit") or {}).get("statusCheckRollup") if commits else None
-    reviews = node.get("reviews") or {}
-    review_nodes = reviews.get("nodes") or []
-    return {
-        "state": node.get("state"),                       # OPEN | MERGED | CLOSED
-        "sha": node.get("headRefOid"),
-        "checks": (rollup or {}).get("state"),            # SUCCESS/FAILURE/ERROR/PENDING/None
-        "reviews": reviews.get("totalCount") or 0,
-        "review_state": review_nodes[0].get("state") if review_nodes else None,
-    }
-
-
-def diff_events(prev: "dict | None", cur: dict, repo: str, number: int) -> "tuple[list[str], bool]":
-    """The daemon's core: (event bodies, terminal?) for one PR transition.
-
-    prev None = first poll of a fresh watch: baseline silently, EXCEPT states
-    that are already conclusive (checks concluded, merged, closed) — a watch
-    registered moments after the transition must still wake its shell, or the
-    event-driven loop drops its first link. Review history is never replayed
-    from a baseline (stale reviews aren't a wake-up).
-
-    A head-SHA change resets the checks comparison implicitly: the fingerprint
-    compares (sha, checks) together, so a new push going green is a fresh
-    transition even if the old head was green too.
-
-    Merge is terminal ONLY once no checks are still running (#375): a PR
-    merged while its rollup is PENDING keeps its watch — the merge event
-    fires now, the checks conclusion fires (and retires the watch) when the
-    already-running workflows finish. Retiring at merge dropped that verdict
-    on the floor and silently stalled the planner's sprint gate. Close
-    without merge retires immediately regardless — its pending checks get
-    cancelled, no conclusion is coming."""
-    events: list[str] = []
-    sha7 = (cur.get("sha") or "")[:7]
-    tag = f"{repo}#{number}"
-
-    merged = cur.get("state") == "MERGED"
-    checks = cur.get("checks")
-    checks_pending = checks is not None and checks not in CONCLUDED  # PENDING/EXPECTED
-    terminal = cur.get("state") == "CLOSED" or (merged and not checks_pending)
-
-    checks_changed = prev is None or (prev.get("checks"), prev.get("sha")) != (checks, cur.get("sha"))
-    if checks in CONCLUDED and checks_changed:
-        word = "green" if checks == "SUCCESS" else "red"
-        # On a retained post-merge watch this conclusion is the retiring event.
-        tail = " — watch retired" if merged and prev is not None and prev.get("state") == "MERGED" else ""
-        events.append(f"pr_event {tag}: checks {word} ({checks}) @ {sha7}{tail}")
-
-    if prev is not None and (cur.get("reviews") or 0) > (prev.get("reviews") or 0):
-        state = cur.get("review_state") or "REVIEW"
-        events.append(f"pr_event {tag}: review submitted ({state}) @ {sha7}")
-
-    if merged and (prev is None or prev.get("state") != "MERGED"):
-        if checks_pending:
-            events.append(f"pr_event {tag}: merged @ {sha7} — checks still pending, watch retained")
-        else:
-            events.append(f"pr_event {tag}: merged @ {sha7} — watch retired")
-    elif cur.get("state") == "CLOSED" and (prev is None or prev.get("state") != "CLOSED"):
-        events.append(f"pr_event {tag}: closed without merge — watch retired")
-    return events, terminal
-
-
-# ── Daemon: poll loop (host-side, direct DB + gh) ─────────────────────────────
-
-def _gh_graphql(query: str) -> "dict | None":
-    """Run the batched query through the host's authenticated `gh`. Returns the
-    `data` object, or None on any failure (logged; the loop just tries again —
-    a missed poll is a delayed event, never a lost one)."""
-    try:
-        out = subprocess.run(
-            ["gh", "api", "graphql", "-f", f"query={query}"],
-            capture_output=True, text=True, timeout=60)
-    except (OSError, subprocess.TimeoutExpired) as e:
-        print(f"watch daemon: gh unavailable ({e})", flush=True)
-        return None
-    if out.returncode != 0:
-        # gh exits non-zero on partial GraphQL errors but still prints data —
-        # use it if parseable (one bad watch must not blind the rest).
-        try:
-            return json.loads(out.stdout).get("data")
-        except Exception:
-            print(f"watch daemon: gh api graphql failed: {out.stderr.strip()[:300]}", flush=True)
-            return None
-    try:
-        return json.loads(out.stdout).get("data")
-    except Exception as e:
-        print(f"watch daemon: unparseable gh output ({e})", flush=True)
-        return None
-
-
-def poll_once(con, fetch=_gh_graphql) -> int:
-    """One daemon cycle: read live watches, one batched fetch, diff each PR,
-    emit pr_event rows, persist fingerprints, retire terminal watches.
-    Returns the number of events emitted. `fetch` is injectable for tests."""
-    watches = con.execute(
-        "SELECT watch_id, repo, pr_number, shell_id, last_seen "
-        "FROM watched_prs WHERE closed_at IS NULL "
-        "ORDER BY repo, pr_number, watch_id").fetchall()
-    if not watches:
-        return 0
-    # One query node per distinct (repo, pr); a PR watched by several shells
-    # fans its events out to each subscriber from the same fetch.
-    prs = sorted({(w["repo"], w["pr_number"]) for w in watches})
-    data = fetch(build_query(prs))
-    if data is None:
-        return 0
-    snaps = {pr: fingerprint((data.get(f"r{i}") or {}).get("pullRequest"))
-             for i, pr in enumerate(prs)}
-    emitted = 0
-    for w in watches:
-        cur = snaps.get((w["repo"], w["pr_number"]))
-        if cur is None:
-            continue  # unreadable this poll — keep the watch, try next cycle
-        prev = json.loads(w["last_seen"]) if w["last_seen"] else None
-        events, terminal = diff_events(prev, cur, w["repo"], w["pr_number"])
-        for body in events:
-            con.execute(
-                "INSERT INTO shell_messages (from_shell_id, to_shell_id, body, kind) "
-                "VALUES (?, ?, ?, 'pr_event')",
-                (w["shell_id"], w["shell_id"], body))
-            emitted += 1
-        con.execute(
-            "UPDATE watched_prs SET last_seen=?" +
-            (", closed_at=datetime('now')" if terminal else "") +
-            " WHERE watch_id=?",
-            (json.dumps(cur), w["watch_id"]))
-    con.commit()
-    return emitted
-
-
-def beat(con, interval: int) -> None:
-    """Heartbeat (#359): one UPSERT per poll cycle — idle cycles included —
-    so the watch surface can tell "no transition yet" from "nobody watching"."""
-    con.execute(
-        "INSERT INTO daemon_heartbeats (name, beat_at, interval_s) "
-        "VALUES ('watch', datetime('now'), ?) "
-        "ON CONFLICT(name) DO UPDATE SET beat_at=excluded.beat_at, "
-        "interval_s=excluded.interval_s", (interval,))
-    con.commit()
-
+# ── Retired daemon verb (spec #20 task #85, decision #19) ────────────────────
 
 def cmd_daemon(args) -> int:
-    if not DB_PATH.exists() or DB_PATH.stat().st_size == 0:
-        die(f"no usable DB at {DB_PATH} — rebuild with ./sc rebuild")
-    interval = args.interval or int(os.environ.get("SC_WATCH_INTERVAL", "75"))
-    print(f"watch daemon: polling every {interval}s · db {DB_PATH}", flush=True)
-    while True:
-        con = db_driver.connect(DB_PATH)
-        try:
-            # The beat must never block the poll: on a pre-0068 DB (code newer
-            # than schema — a dev tree between migrate runs) the table is
-            # missing, and a beat raising into the poll's except would turn a
-            # working daemon into a dead-with-noise one. Liveness degrades to
-            # "never run"; eventing keeps flowing.
-            try:
-                beat(con, interval)
-            except Exception as e:
-                print(f"watch daemon: heartbeat error ({e})", flush=True)
-            n = poll_once(con)
-            if n:
-                print(f"watch daemon: {n} pr_event(s) emitted", flush=True)
-        except Exception as e:
-            # Never die on a poll: a daemon crash silently reverts the fork to
-            # the polling world. Log and keep the loop.
-            print(f"watch daemon: poll error ({e})", flush=True)
-        finally:
-            con.close()
-        if args.once:
-            return 0
-        time.sleep(interval)
+    """RETIRED — the host watch daemon (a direct-DB writer) is cut over: the
+    supervised engine service is the fork's sole GitHub poller. Exit CLEAN (0)
+    so legacy nohup/systemd supervision (Restart=on-failure) stops instead of
+    crash-looping against the new single-poller world."""
+    print("watch daemon: RETIRED (spec #20, decision #19) — the engine service "
+          "is now the sole PR poller.\n"
+          "  nothing to run; polling lives in the supervised API service "
+          "(starts with ./sc launch).\n"
+          "  remove legacy supervision: ./sc watch-daemon-down · "
+          "./sc watch-daemon-uninstall", flush=True)
+    return 0
 
 
 # ── arg parsing ───────────────────────────────────────────────────────────────
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="sc watch",
-                                description="PR watches, inbox watcher, GitHub watcher daemon")
+                                description="PR watches, inbox watcher, explicit reconcile")
     sub = p.add_subparsers(dest="cmd", required=True)
 
     sp = sub.add_parser("pr", help="register a PR watch (defaults to the calling shell)")
     sp.add_argument("repo", help="owner/name")
     sp.add_argument("number", type=int, help="PR number")
     sp.add_argument("--shell", help="subscribe another shell (e.g. the planner) instead of you")
+    sp.add_argument("--sprint", type=int, default=0, metavar="DOC_ID",
+                    help="arm the watch to an ACTIVE sprint document (polls only while it stays ACTIVE)")
     sp.set_defaults(fn=cmd_pr)
 
     sp = sub.add_parser("list", help="live watches (--all includes retired)")
     sp.add_argument("--all", action="store_true")
     sp.set_defaults(fn=cmd_list)
+
+    sp = sub.add_parser("reconcile", help="explicit one-shot poll of every armed watch (operator)")
+    sp.set_defaults(fn=cmd_reconcile)
 
     sp = sub.add_parser("inbox", help="block until this shell has unread messages, then exit (arm as a background task)")
     sp.add_argument("--interval", type=int, default=30, help="poll seconds (default 30)")
@@ -436,10 +290,9 @@ def build_parser() -> argparse.ArgumentParser:
                     help="give up after N seconds (default 21600 = 6h; 0 = never)")
     sp.set_defaults(fn=cmd_inbox)
 
-    sp = sub.add_parser("daemon", help="HOST-side: the fork's one GitHub poller (launch/down supervise it)")
-    sp.add_argument("--interval", type=int, default=0,
-                    help="poll seconds (default $SC_WATCH_INTERVAL or 75)")
-    sp.add_argument("--once", action="store_true", help="single poll cycle, then exit")
+    sp = sub.add_parser("daemon", help="RETIRED (decision #19) — prints the cutover notice and exits clean")
+    sp.add_argument("--interval", type=int, default=0, help=argparse.SUPPRESS)
+    sp.add_argument("--once", action="store_true", help=argparse.SUPPRESS)
     sp.set_defaults(fn=cmd_daemon)
     return p
 

--- a/sc
+++ b/sc
@@ -743,16 +743,13 @@ print('-> pg: added to $f')
 }
 
 
-# ── GitHub watcher daemon (HOST-side; the fork's ONE PR poller) ───────────────
-# Sprint eventing (specs_sc/sprint-eventing.md): one poller for the whole fork
-# watches every registered PR (watched_prs) and turns transitions into
-# `pr_event` message rows. Runs HOST-side like the brokers — the host owns the
-# gh login — with the same supervision: `launch` brings it up, `down` stops it.
-# No socket, so aliveness is the pidfile, not a health curl. Self-skips when gh
-# is absent (the fork degrades to task-boundary inbox checks, never breaks).
-# `watch-daemon-install` writes a systemd --user unit for reboot-survival
-# (#359: a host reboot killed the nohup'd daemon while the sandbox
-# auto-restarted); `up`/`down` defer to systemd when the unit is active.
+# ── GitHub PR polling cutover (spec #20 task #85, decision #19) ──────────────
+# The supervised engine service is the fork's SOLE PR poller — it starts with
+# the sandbox (`launch`) and polls only watches armed to an ACTIVE sprint. The
+# legacy HOST watch daemon (a second, direct-DB writer) is RETIRED: `up` and
+# `install` refuse so no legacy supervision can be (re)created, while `down`
+# and `uninstall` stay fully functional — they ARE the cutover's stop+disable
+# for forks that still have the old nohup/systemd supervision lying around.
 WATCH_DAEMON_PID="$ENGINE/run/watch-daemon.pid"
 WATCH_DAEMON_UNIT="sc-watch-daemon-$(basename "$here").service"
 
@@ -761,73 +758,37 @@ sc_watch_daemon_unit_active() {
 }
 sc_watch_daemon_alive() {
   # pid exists AND is actually the daemon — a stale pidfile surviving a host
-  # reboot can point at a reused pid, and a bare kill -0 would false-skip the
-  # relaunch (#359: reboot killed the daemon; the sandbox auto-restarted, so
-  # nothing else looked wrong).
+  # reboot can point at a reused pid, and a bare kill -0 would false-report it.
   [ -f "$WATCH_DAEMON_PID" ] || return 1
   pid="$(cat "$WATCH_DAEMON_PID" 2>/dev/null)"
   [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null || return 1
   ps -p "$pid" -o args= 2>/dev/null | grep -q "watch\.py daemon"
 }
 sc_watch_daemon_up() {
-  if ! command -v gh >/dev/null 2>&1; then
-    echo "→ watch-daemon: gh CLI not found on the host — PR eventing disabled (install gh + login to enable)"; return 0
-  fi
-  if sc_watch_daemon_unit_active; then
-    echo "→ watch-daemon systemd-managed ($WATCH_DAEMON_UNIT) — already running"; return 0
-  fi
-  if sc_watch_daemon_alive; then
-    echo "→ watch-daemon already running (pid $(cat "$WATCH_DAEMON_PID"))"; return 0
-  fi
-  mkdir -p "$ENGINE/run"
-  nohup "$PY" "$S/watch.py" daemon >"$ENGINE/run/watch-daemon.log" 2>&1 &
-  echo $! > "$WATCH_DAEMON_PID"
-  echo "→ watch-daemon up (pid $!) · log $ENGINE/run/watch-daemon.log"
+  echo "→ watch-daemon: RETIRED (spec #20, decision #19) — the engine service is the sole PR poller; nothing started"
+  return 0
 }
 sc_watch_daemon_down() {
   if sc_watch_daemon_alive; then
-    kill "$(cat "$WATCH_DAEMON_PID")" && echo "→ watch-daemon stopped"
+    kill "$(cat "$WATCH_DAEMON_PID")" && echo "→ legacy watch-daemon stopped"
   elif sc_watch_daemon_unit_active; then
-    echo "→ watch-daemon is systemd-managed ($WATCH_DAEMON_UNIT) — leaving it; use watch-daemon-uninstall"
+    echo "→ legacy watch-daemon is systemd-managed ($WATCH_DAEMON_UNIT) — leaving it; use watch-daemon-uninstall"
   else
     echo "→ watch-daemon not running"
   fi
   rm -f "$WATCH_DAEMON_PID"
 }
 sc_watch_daemon_install() {
-  command -v systemctl >/dev/null 2>&1 || { echo "✗ watch-daemon-install: systemd (systemctl) not found on this host" >&2; return 1; }
-  command -v gh >/dev/null 2>&1 || { echo "✗ watch-daemon-install: gh CLI not found — nothing to poll GitHub with (install gh + login first)" >&2; return 1; }
-  unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
-  mkdir -p "$unit_dir"
-  cat > "$unit_dir/$WATCH_DAEMON_UNIT" <<UNIT
-[Unit]
-Description=super-coder watch-daemon ($(basename "$here")) — GitHub PR watcher (sprint eventing)
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-ExecStart=$PY $S/watch.py daemon
-Restart=on-failure
-RestartSec=2
-
-[Install]
-WantedBy=default.target
-UNIT
-  systemctl --user daemon-reload
-  loginctl enable-linger "$(id -un)" >/dev/null 2>&1 || true
-  # A pidfile-managed daemon would double-poll and double-emit pr_events;
-  # stop it so systemd owns the one poller.
-  sc_watch_daemon_down >/dev/null 2>&1 || true
-  systemctl --user enable --now "$WATCH_DAEMON_UNIT"
-  echo "→ watch-daemon installed as systemd --user unit: $WATCH_DAEMON_UNIT (enabled, started, linger on)"
-  echo "  status: systemctl --user status $WATCH_DAEMON_UNIT   ·   logs: journalctl --user -u $WATCH_DAEMON_UNIT"
+  echo "✗ watch-daemon-install: RETIRED (spec #20, decision #19) — the engine service is the sole PR poller." >&2
+  echo "  To remove a legacy unit: ./sc watch-daemon-uninstall" >&2
+  return 1
 }
 sc_watch_daemon_uninstall() {
   command -v systemctl >/dev/null 2>&1 || { echo "✗ watch-daemon-uninstall: systemd not found" >&2; return 1; }
   systemctl --user disable --now "$WATCH_DAEMON_UNIT" 2>/dev/null || true
   rm -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/$WATCH_DAEMON_UNIT"
   systemctl --user daemon-reload
-  echo "→ watch-daemon systemd unit removed ($WATCH_DAEMON_UNIT)"
+  echo "→ legacy watch-daemon systemd unit removed ($WATCH_DAEMON_UNIT)"
 }
 
 # ── persist: reboot-proof every applicable host-side daemon in one verb ───────
@@ -839,11 +800,10 @@ sc_watch_daemon_uninstall() {
 sc_persist() {
   command -v systemctl >/dev/null 2>&1 || {
     echo "✗ persist: systemd (systemctl) not found — nohup + \`./sc launch\` is the only supervision on this host" >&2; return 1; }
-  if command -v gh >/dev/null 2>&1; then
-    sc_watch_daemon_install
-  else
-    echo "→ persist: gh CLI not found — watch-daemon skipped (PR eventing disabled)"
-  fi
+  # The retired watch-daemon is not installed (the engine service is the sole
+  # PR poller — decision #19); a legacy unit, if one exists, is removed by
+  # ./sc watch-daemon-uninstall.
+  echo "→ persist: watch-daemon skipped (retired — the engine service polls)"
   if "$PY" "$S/vm.py" configured;  then sc_vm_broker_install;  else echo "→ persist: no VM linked — vm-broker skipped"; fi
   if "$PY" "$S/ts.py" configured;  then sc_ts_broker_install;  else echo "→ persist: no tailnet linked — ts-broker skipped"; fi
   if "$PY" "$S/pm2.py" configured; then sc_pm2_broker_install; else echo "→ persist: no pm2 stack linked — pm2-broker skipped"; fi
@@ -1099,9 +1059,8 @@ case "$cmd" in
     sc_ts_broker_up || true
     # Same for the pm2 broker — self-skips when no `pm2` block is linked.
     sc_pm2_broker_up || true
-    # GitHub watcher daemon — the fork's one PR poller (sprint eventing).
-    # Self-skips when gh is absent; idles cheaply when no watches are live.
-    sc_watch_daemon_up || true
+    # PR polling rides the engine service itself (spec #20, decision #19) —
+    # no host watch-daemon is started here anymore.
     # Start the PG sidecar when configured — self-skips otherwise.
     sc_pg_up || true ;;
   enter)        exec docker exec -it "$CNAME" ./sc boot "$@" ;;
@@ -1159,9 +1118,12 @@ super-coder — forkable shell substrate
   ./sc snapshot            dump per-instance tables -> .sc-state/content.sql
   ./sc mem <cmd> [args]    a shell's own memory, over the engine API (get/state/seed/lns/decision/flag/roadmap/doc/narrative);
                              identity is the shell's token, server-resolved — no DB path, no direct-DB fallback. `./sc mem which` to orient
-  ./sc watch pr <o/r> <n>  register a PR watch (--shell <name> subscribes another shell, e.g. the planner);
-                             the watcher daemon turns its transitions into pr_event inbox rows
+  ./sc watch pr <o/r> <n>  register a PR watch (--shell <name> subscribes another shell, e.g. the planner;
+                             --sprint <doc-id> arms it to an ACTIVE sprint); an immediate GitHub baseline
+                             is taken at registration, then the engine service poller turns transitions
+                             into pr_event inbox rows
   ./sc watch list          live PR watches (--all includes retired)
+  ./sc watch reconcile     explicit one-shot poll of every armed watch (operator)
   ./sc watch inbox         block until this shell has unread messages, then exit — the zero-token
                              inbox watcher; arm as a background task and its exit is your wake-up
   ./sc job start -- <cmd>  run a long local command (suite/bench/build) detached + supervised — it
@@ -1261,20 +1223,18 @@ super-coder — forkable shell substrate
   ./sc db-broker-install   supervise via a systemd --user unit (survives logout/reboot)
   ./sc db-broker-uninstall remove the systemd unit
 
-  GitHub watcher daemon (HOST-side — the fork's ONE PR poller, sprint eventing:
-  diffs every registered watch on one batched GraphQL query and writes pr_event
-  message rows; watches retire themselves on merge/close). `launch` brings it
-  up when gh is present; `down` stops it:
-  ./sc watch daemon        run the daemon in the foreground (--once = single cycle)
-  ./sc watch-daemon-up     start it in the background (nohup + pidfile); self-skips if gh missing/already up
-  ./sc watch-daemon-down   stop the backgrounded daemon
-  ./sc watch-daemon-install   supervise via a systemd --user unit (survives logout/reboot)
-  ./sc watch-daemon-uninstall remove the systemd unit
+  GitHub PR polling (RETIRED host daemon — spec #20 task #85, decision #19):
+  the supervised engine service is now the fork's SOLE PR poller; it starts
+  with `launch` and polls only watches armed to an ACTIVE sprint. The legacy
+  direct-DB host daemon is retired — `sc watch daemon` prints the cutover
+  notice and exits clean. These verbs remain to REMOVE legacy supervision:
+  ./sc watch-daemon-down   stop a still-running legacy background daemon
+  ./sc watch-daemon-uninstall remove a legacy systemd --user unit
 
   Persist (HOST-side — reboot-proof the fork in one verb; #359): installs the
-  systemd --user unit for every daemon that applies here (watch-daemon when gh
-  is present; vm/ts/pm2/db brokers when linked), enables linger, skips the
-  rest with a reason. Idempotent — re-run any time:
+  systemd --user unit for every daemon that applies here (vm/ts/pm2/db brokers
+  when linked — the retired watch-daemon is no longer installed; the engine
+  service polls), enables linger, skips the rest with a reason. Idempotent:
   ./sc persist             install + enable --now every applicable unit
 
   Postgres sidecar (app-only; docker container on SC_NET, data in a named volume).

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -484,6 +484,38 @@ class CutoverTest(unittest.TestCase):
         finally:
             con.close()
 
+    def test_beat_failure_never_blocks_the_poll(self):
+        # Pre-0068 DB (code newer than schema): the beat raises, the poll must
+        # still run — heartbeat error, not cycle error, and never a crash.
+        import contextlib
+        import io
+        tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
+        con = build_db(tmp)
+        seed_shells(con)
+        seed_sprint_doc(con, 100)
+        con.execute("INSERT INTO watched_prs (repo, pr_number, shell_id, "
+                    "sprint_doc_id) VALUES ('o/r', 1, 1, 100)")
+        con.execute("DROP TABLE daemon_heartbeats")
+        con.commit()
+        con.close()
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            poller = pr_poller.Poller(tmp, interval=30,
+                                      fetch=fetch_ok(gh_node(checks="PENDING")))
+            poller.start()
+            time.sleep(0.5)     # the first iteration runs before the first wait
+            poller.stop()
+            poller.join(timeout=5)
+        self.assertIn("heartbeat error", out.getvalue())
+        self.assertNotIn("cycle error", out.getvalue())
+        con = sqlite3.connect(tmp)
+        con.row_factory = sqlite3.Row
+        try:
+            self.assertIsNotNone(con.execute(
+                "SELECT last_seen FROM watched_prs").fetchone()["last_seen"])
+        finally:
+            con.close()
+
     def test_scheduler_self_disables_without_gh(self):
         import shutil
         old = shutil.which

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Tests for the watched-PR polling cutover (spec #20 task #85, decision
+#19): pr_poller's sprint scoping, registration baselines, bounded poll cycle
+(runs/observations/dedupe/backoff/blind windows), wake-item creation, the
+watched_prs uniqueness rebuild (migration 0080), and the service scheduler.
+
+Stdlib `unittest`, matching the sibling suites. The GitHub seam is injectable
+(`poll_cycle(con, fetch=...)` / `baseline_read(..., fetch=...)`), so every
+transition is exercised hermetically — no network, no gh.
+
+Run:
+    python3 tests/test_pr_poller.py
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import pr_poller  # noqa: E402
+import watch  # noqa: E402  (retired daemon verb)
+
+
+def build_db(path: "Path | None" = None, skip: "set[str] | None" = None) -> sqlite3.Connection:
+    """Fresh DB the way the engine ships it: schema.sql + every migration
+    (optionally minus the named ones — the 0080 migration test)."""
+    con = sqlite3.connect(path if path else ":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        if skip and p.name in skip:
+            continue
+        con.executescript(p.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+def seed_shells(con: sqlite3.Connection) -> None:
+    con.executescript(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1);"
+        "INSERT INTO shells (shell_id, display_name, shortname, system_prompt, user_id, api_key) "
+        "VALUES (1, 'Planner', 'plan1', 'x', 1, 'tok'), (2, 'Dev', 'dev1', 'x', 1, NULL);")
+    con.commit()
+
+
+def seed_sprint_doc(con, doc_id: int, status: str = "ACTIVE", frozen: int = 0,
+                    title: str = "SPRINT: T", kind: str = "doc") -> None:
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title, body, frozen) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (doc_id, kind, title, f"# {title}\nstatus: {status}\ndeclared: today\n", frozen))
+    con.commit()
+
+
+def gh_node(state="OPEN", sha="abc1234def", checks=None, reviews=0, review_state=None):
+    return {"state": state, "headRefOid": sha,
+            "reviews": {"totalCount": reviews,
+                        "nodes": ([{"state": review_state}] if review_state else [])},
+            "commits": {"nodes": [{"commit": {"statusCheckRollup":
+                                              ({"state": checks} if checks else None)}}]}}
+
+
+def fetch_ok(*prs):
+    """A gh_fetch stand-in: r0, r1, … map to the sorted (repo, pr) pairs."""
+    return lambda q: pr_poller.GhResult(
+        data={f"r{i}": {"pullRequest": p} for i, p in enumerate(prs)})
+
+
+def fetch_err(error="boom", rate_limited=False):
+    return lambda q: pr_poller.GhResult(error=error, rate_limited=rate_limited)
+
+
+def watch_row(con, watch_id):
+    return con.execute("SELECT * FROM watched_prs WHERE watch_id=?",
+                       (watch_id,)).fetchone()
+
+
+# ── sprint scoping ────────────────────────────────────────────────────────────
+
+class SprintScopingTest(unittest.TestCase):
+    def setUp(self):
+        self.con = build_db()
+
+    def tearDown(self):
+        self.con.close()
+
+    def test_only_active_unfrozen_sprint_docs_count(self):
+        seed_sprint_doc(self.con, 100)                                # ACTIVE
+        seed_sprint_doc(self.con, 101, status="CLOSED")               # closed
+        seed_sprint_doc(self.con, 102, frozen=1)                      # frozen
+        seed_sprint_doc(self.con, 103, title="SPRINT REPORT: T")      # not a board
+        seed_sprint_doc(self.con, 104, kind="spec")                   # not a doc
+        seed_sprint_doc(self.con, 105, status="active")               # case matters
+        self.assertEqual(pr_poller.active_sprint_doc_ids(self.con), {100})
+
+    def test_is_active_sprint(self):
+        seed_sprint_doc(self.con, 100)
+        seed_sprint_doc(self.con, 101, status="CLOSED")
+        self.assertTrue(pr_poller.is_active_sprint(self.con, 100))
+        self.assertFalse(pr_poller.is_active_sprint(self.con, 101))
+        self.assertFalse(pr_poller.is_active_sprint(self.con, 999))
+
+    def test_armed_watches_excludes_unscoped_and_inactive(self):
+        seed_shells(self.con)
+        seed_sprint_doc(self.con, 100)
+        seed_sprint_doc(self.con, 101, status="CLOSED")
+        self.con.executescript(
+            "INSERT INTO watched_prs (repo, pr_number, shell_id, sprint_doc_id) VALUES "
+            "('o/r', 1, 1, 100),"     # armed
+            "('o/r', 2, 1, NULL),"    # unscoped → dormant
+            "('o/r', 3, 1, 101);"     # closed sprint → dormant
+            "UPDATE watched_prs SET closed_at=datetime('now') WHERE pr_number=3;")
+        self.con.execute(
+            "INSERT INTO watched_prs (repo, pr_number, shell_id, sprint_doc_id, closed_at) "
+            "VALUES ('o/r', 4, 1, 100, datetime('now'))")   # retired
+        self.con.commit()
+        armed = pr_poller.armed_watches(self.con)
+        self.assertEqual([(w["repo"], w["pr_number"]) for w in armed], [("o/r", 1)])
+
+
+# ── registration baselines ────────────────────────────────────────────────────
+
+class BaselineReadTest(unittest.TestCase):
+    def test_ok_returns_normalized_fingerprint(self):
+        fp, err = pr_poller.baseline_read("o/r", 7, fetch_ok(gh_node(checks="PENDING")))
+        self.assertIsNone(err)
+        self.assertEqual(fp["state"], "OPEN")
+        self.assertEqual(fp["checks"], "PENDING")
+        self.assertEqual(fp["sha"], "abc1234def")
+        # normalized only — nothing else rides along
+        self.assertEqual(set(fp), {"state", "sha", "checks", "reviews", "review_state"})
+
+    def test_gh_failure_is_a_retryable_error_not_a_watch(self):
+        fp, err = pr_poller.baseline_read("o/r", 7, fetch_err("API rate limit exceeded"))
+        self.assertIsNone(fp)
+        self.assertIn("rate limit", err)
+
+    def test_unreadable_pr_is_an_error(self):
+        fp, err = pr_poller.baseline_read("o/r", 7, fetch_ok(None))
+        self.assertIsNone(fp)
+        self.assertIn("unreadable", err)
+
+
+# ── per-repo backoff + blind windows ──────────────────────────────────────────
+
+class PollerStateTest(unittest.TestCase):
+    def test_failure_escalates_and_caps(self):
+        s = pr_poller.PollerState()
+        now = 1000.0
+        s.record_failure("o/r", now, 30)
+        self.assertFalse(s.due("o/r", now + 59))
+        self.assertTrue(s.due("o/r", now + 61))          # 30 * 2^1
+        s.record_failure("o/r", now + 61, 30)
+        self.assertFalse(s.due("o/r", now + 61 + 119))   # 30 * 2^2
+        for i in range(20):
+            s.record_failure("o/r", now + 100000 + i, 30)
+        r = s._r("o/r")
+        self.assertLessEqual(r["skip_until"] - (now + 100000 + 19),
+                             pr_poller.BACKOFF_CAP_S)
+
+    def test_success_after_failure_is_a_blind_window(self):
+        s = pr_poller.PollerState()
+        self.assertFalse(s.record_success("o/r"))        # clean history
+        s.record_failure("o/r", 0.0, 30)
+        self.assertTrue(s.record_success("o/r"))         # blind
+        self.assertFalse(s.record_success("o/r"))        # converged again
+
+    def test_other_repos_stay_due(self):
+        s = pr_poller.PollerState()
+        s.record_failure("o/r", 0.0, 30)
+        self.assertTrue(s.due("other/repo", 1.0))
+
+
+# ── the poll cycle ────────────────────────────────────────────────────────────
+
+class PollCycleTest(unittest.TestCase):
+    def setUp(self):
+        self.con = build_db()
+        seed_shells(self.con)
+        seed_sprint_doc(self.con, 100)
+        # PR 1 watched by BOTH shells (fan-out); PR 2 by shell 1;
+        # PR 3 unscoped (dormant) — all under one repo.
+        self.con.executescript(
+            "INSERT INTO watched_prs (repo, pr_number, shell_id, sprint_doc_id) VALUES "
+            "('o/r', 1, 1, 100), ('o/r', 1, 2, 100), ('o/r', 2, 1, 100),"
+            "('o/r', 3, 1, NULL);")
+        self.con.commit()
+
+    def tearDown(self):
+        self.con.close()
+
+    def messages(self):
+        return self.con.execute(
+            "SELECT from_shell_id, to_shell_id, kind, body, sprint_doc_id, dedupe_key "
+            "FROM shell_messages ORDER BY message_id").fetchall()
+
+    def test_first_cycle_baselines_armed_watches_only(self):
+        n = pr_poller.poll_cycle(self.con, fetch_ok(
+            gh_node(checks="PENDING"), gh_node(checks="PENDING")))
+        self.assertEqual(n["events"], 0)
+        seen = {r["pr_number"]: r["last_seen"] for r in self.con.execute(
+            "SELECT pr_number, last_seen FROM watched_prs")}
+        self.assertTrue(seen[1] and seen[2])         # armed → baselined
+        self.assertIsNone(seen[3])                   # dormant → untouched
+
+    def test_dormant_watch_is_never_fetched(self):
+        def fetch(q):
+            self.assertNotIn("number: 3", q)
+            return pr_poller.GhResult(data={
+                "r0": {"pullRequest": gh_node(checks="PENDING")},
+                "r1": {"pullRequest": gh_node(checks="PENDING")}})
+        pr_poller.poll_cycle(self.con, fetch)
+
+    def test_transition_fans_out_scoped_and_idempotent(self):
+        pr_poller.poll_cycle(self.con, fetch_ok(
+            gh_node(checks="PENDING"), gh_node(checks="PENDING")))
+        n = pr_poller.poll_cycle(self.con, fetch_ok(
+            gh_node(checks="SUCCESS"), gh_node(checks="PENDING")))
+        self.assertEqual(n["events"], 2)             # one per subscriber
+        msgs = self.messages()
+        self.assertEqual({m["to_shell_id"] for m in msgs}, {1, 2})
+        for m in msgs:
+            self.assertEqual(m["kind"], "pr_event")
+            self.assertEqual(m["sprint_doc_id"], 100)
+            self.assertIn("checks green", m["body"])
+            self.assertTrue(m["dedupe_key"].startswith("pr-event|"))
+        # The transition is durable as an observation riding its run.
+        obs = self.con.execute(
+            "SELECT watch_id, run_id, head_sha, transition, blind_window "
+            "FROM pr_poll_observations").fetchall()
+        self.assertEqual(len(obs), 2)
+        for o in obs:
+            self.assertEqual(o["transition"], "checks:SUCCESS")
+            self.assertEqual(o["head_sha"], "abc1234def")
+            self.assertEqual(o["blind_window"], 0)
+            self.assertIsNotNone(o["run_id"])
+
+    def test_semantic_dedupe_survives_a_replayed_transition(self):
+        pr_poller.poll_cycle(self.con, fetch_ok(gh_node(checks="PENDING"),
+                                                gh_node(checks="PENDING")))
+        pr_poller.poll_cycle(self.con, fetch_ok(gh_node(checks="SUCCESS"),
+                                                gh_node(checks="PENDING")))
+        self.assertEqual(len(self.messages()), 2)
+        # A replay (state store rewound — restart with a stale snapshot, a
+        # double-fire) re-detects the transition but the dedupe key suppresses
+        # the duplicate pr_event: no double wake, ever.
+        self.con.execute(
+            "UPDATE watched_prs SET last_seen=? WHERE pr_number=1",
+            (json.dumps({"state": "OPEN", "sha": "abc1234def", "checks": "PENDING",
+                         "reviews": 0, "review_state": None}),))
+        self.con.commit()
+        n = pr_poller.poll_cycle(self.con, fetch_ok(gh_node(checks="SUCCESS"),
+                                                    gh_node(checks="PENDING")))
+        self.assertEqual(n["events"], 0)
+        self.assertEqual(len(self.messages()), 2)
+
+    def test_quiet_successful_poll_writes_no_observation(self):
+        pr_poller.poll_cycle(self.con, fetch_ok(gh_node(checks="PENDING"),
+                                                gh_node(checks="PENDING")))
+        pr_poller.poll_cycle(self.con, fetch_ok(gh_node(checks="PENDING"),
+                                                gh_node(checks="PENDING")))
+        self.assertEqual(self.con.execute(
+            "SELECT COUNT(*) FROM pr_poll_observations").fetchone()[0], 0)
+
+    def test_merge_retires_and_early_merge_waits_for_checks(self):
+        # #375 end to end on the new cycle: merge with PENDING checks retains,
+        # the deferred conclusion retires.
+        pr_poller.poll_cycle(self.con, fetch_ok(gh_node(checks="PENDING"),
+                                                gh_node(checks="PENDING")))
+        n = pr_poller.poll_cycle(self.con, fetch_ok(
+            gh_node(checks="PENDING"), gh_node(state="MERGED", checks="PENDING")))
+        self.assertEqual(n["events"], 1)             # merge event, PR 2's one subscriber
+        live = {r["pr_number"] for r in self.con.execute(
+            "SELECT pr_number FROM watched_prs WHERE closed_at IS NULL")}
+        self.assertEqual(live, {1, 2, 3})            # PR 2 retained
+        n = pr_poller.poll_cycle(self.con, fetch_ok(
+            gh_node(checks="PENDING"), gh_node(state="MERGED", checks="SUCCESS")))
+        self.assertEqual(n["events"], 1)             # the deferred conclusion
+        live = {r["pr_number"] for r in self.con.execute(
+            "SELECT pr_number FROM watched_prs WHERE closed_at IS NULL")}
+        self.assertEqual(live, {1, 3})               # now retired
+
+    def test_failed_fetch_audits_backs_off_then_marks_blind_window(self):
+        state = pr_poller.PollerState()
+        pr_poller.poll_cycle(self.con, state=state, fetch=fetch_ok(
+            gh_node(checks="PENDING"), gh_node(checks="PENDING")))
+        t = time.monotonic()
+        n = pr_poller.poll_cycle(self.con, state=state, now=t,
+                                 fetch=fetch_err("connect timeout"))
+        self.assertEqual(n["errors"], 1)
+        run = self.con.execute(
+            "SELECT status, error, finished_at FROM pr_poll_runs "
+            "ORDER BY run_id DESC").fetchone()
+        self.assertEqual(run["status"], "error")
+        self.assertEqual(run["error"], "connect timeout")
+        self.assertIsNotNone(run["finished_at"])
+        # Alert raised, deduplicated while open.
+        self.assertEqual(self.con.execute(
+            "SELECT COUNT(*) FROM planner_alerts WHERE reason='pr_poll_failure' "
+            "AND resolved_at IS NULL").fetchone()[0], 1)
+        # In backoff: the next cycle skips the repo without fetching.
+        n = pr_poller.poll_cycle(self.con, state=state, now=t + 5,
+                                 fetch=lambda q: self.fail("fetched during backoff"))
+        self.assertEqual(n["skipped_backoff"], 1)
+        # Recovery after the backoff: success marks the blind window — GitHub
+        # may have moved while polls failed.
+        n = pr_poller.poll_cycle(self.con, state=state, now=t + 120,
+                                 fetch=fetch_ok(gh_node(checks="SUCCESS"),
+                                                gh_node(checks="PENDING")))
+        self.assertEqual(n["events"], 2)
+        obs = self.con.execute(
+            "SELECT blind_window FROM pr_poll_observations").fetchall()
+        self.assertTrue(all(o["blind_window"] == 1 for o in obs))
+
+    def test_rate_limited_run_status(self):
+        n = pr_poller.poll_cycle(self.con, fetch=fetch_err(
+            "API rate limit exceeded for user", rate_limited=True))
+        self.assertEqual(n["errors"], 1)
+        self.assertEqual(self.con.execute(
+            "SELECT status FROM pr_poll_runs").fetchone()["status"], "rate_limited")
+
+    def test_one_repo_backing_off_does_not_block_another(self):
+        self.con.execute(
+            "INSERT INTO watched_prs (repo, pr_number, shell_id, sprint_doc_id) "
+            "VALUES ('other/repo', 9, 1, 100)")
+        self.con.commit()
+        state = pr_poller.PollerState()
+        state.record_failure("o/r", time.monotonic(), 30)
+        n = pr_poller.poll_cycle(self.con, state=state, fetch=fetch_ok(
+            gh_node(checks="PENDING")))
+        self.assertEqual(n["skipped_backoff"], 1)
+        self.assertEqual(n["repos"], 1)              # only other/repo polled
+        self.assertIsNotNone(self.con.execute(
+            "SELECT last_seen FROM watched_prs WHERE repo='other/repo'").fetchone()[0])
+
+    def test_no_armed_watches_skips_the_fetch(self):
+        self.con.execute("UPDATE watched_prs SET closed_at=datetime('now')")
+        self.con.commit()
+        n = pr_poller.poll_cycle(
+            self.con, fetch=lambda q: self.fail("fetched with no armed watches"))
+        self.assertEqual(n["watches"], 0)
+        self.assertEqual(self.con.execute(
+            "SELECT COUNT(*) FROM pr_poll_runs").fetchone()[0], 0)
+
+    def test_run_audit_carries_source_and_watch_count(self):
+        pr_poller.poll_cycle(self.con, source="reconcile", fetch=fetch_ok(
+            gh_node(checks="PENDING"), gh_node(checks="PENDING")))
+        run = self.con.execute("SELECT * FROM pr_poll_runs").fetchone()
+        self.assertEqual(run["repo"], "o/r")
+        self.assertEqual(run["source"], "reconcile")
+        self.assertEqual(run["watch_count"], 3)      # the dormant one excluded
+        self.assertEqual(run["status"], "ok")
+
+    def test_wake_item_created_when_binding_is_armed(self):
+        # A live (sprint, planner) binding turns the pr_event into scoped wake
+        # work in the same transaction — unique (binding_id, message_id).
+        self.con.executescript(
+            "INSERT INTO interface_generations (shell_id, generation) VALUES (1, 1);"
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy, lifecycle) "
+            "VALUES (1, 1, 'occupied', 'idle');"
+            "INSERT INTO sprint_planner_bindings "
+            "(sprint_doc_id, planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (100, 1, 1, 1, 1);")
+        self.con.commit()
+        pr_poller.poll_cycle(self.con, fetch_ok(gh_node(checks="PENDING"),
+                                                gh_node(checks="PENDING")))
+        pr_poller.poll_cycle(self.con, fetch_ok(gh_node(checks="SUCCESS"),
+                                                gh_node(checks="PENDING")))
+        items = self.con.execute(
+            "SELECT i.binding_id, i.state, m.kind, m.sprint_doc_id "
+            "FROM planner_wake_items i JOIN shell_messages m "
+            "ON m.message_id = i.message_id").fetchall()
+        self.assertEqual(len(items), 1)              # planner's watch only — not dev1's
+        self.assertEqual(items[0]["binding_id"], 1)
+        self.assertEqual(items[0]["state"], "queued")
+        self.assertEqual(items[0]["kind"], "pr_event")
+        self.assertEqual(items[0]["sprint_doc_id"], 100)
+
+
+# ── migration 0080: the uniqueness rebuild ────────────────────────────────────
+
+class MigrationCutoverTest(unittest.TestCase):
+    def test_active_watch_uniqueness_and_history_retention(self):
+        con = build_db()
+        seed_shells(con)
+        seed_sprint_doc(con, 100)
+        try:
+            # One ACTIVE watch per (repo, pr, shell, scope) — the new contract.
+            con.execute("INSERT INTO watched_prs (repo, pr_number, shell_id) "
+                        "VALUES ('o/r', 7, 1)")
+            with self.assertRaises(sqlite3.IntegrityError):
+                con.execute("INSERT INTO watched_prs (repo, pr_number, shell_id) "
+                            "VALUES ('o/r', 7, 1)")
+            # …but a sprint-scoped live watch for the same PR coexists with
+            # the unscoped one (different scope, different key).
+            con.execute("INSERT INTO watched_prs (repo, pr_number, shell_id, "
+                        "sprint_doc_id) VALUES ('o/r', 7, 1, 100)")
+            # Closing frees the key: re-registration is a NEW row, history kept.
+            con.execute("UPDATE watched_prs SET closed_at=datetime('now') "
+                        "WHERE sprint_doc_id IS NULL")
+            con.execute("INSERT INTO watched_prs (repo, pr_number, shell_id) "
+                        "VALUES ('o/r', 7, 1)")
+            rows = con.execute(
+                "SELECT closed_at, sprint_doc_id FROM watched_prs "
+                "ORDER BY watch_id").fetchall()
+            self.assertEqual(len(rows), 3)
+            idx = con.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND name='idx_watched_prs_active'").fetchone()
+            self.assertIsNotNone(idx)
+        finally:
+            con.close()
+
+    def test_rebuild_preserves_rows_and_ids(self):
+        # A pre-0080 DB (all migrations except the cutover) carrying a live and
+        # a retired watch: 0080 must rebuild the table without losing either.
+        con = build_db(skip={"0080_pr_polling_cutover.sql"})
+        seed_shells(con)
+        con.executescript(
+            "INSERT INTO watched_prs (watch_id, repo, pr_number, shell_id) "
+            "VALUES (1, 'o/r', 7, 1), (2, 'o/r', 8, 1);"
+            "UPDATE watched_prs SET closed_at=datetime('now') WHERE watch_id=2;")
+        con.commit()
+        con.executescript((MIGRATIONS / "0080_pr_polling_cutover.sql").read_text())
+        rows = con.execute(
+            "SELECT watch_id, pr_number, closed_at FROM watched_prs "
+            "ORDER BY watch_id").fetchall()
+        self.assertEqual([(r["watch_id"], r["pr_number"]) for r in rows],
+                         [(1, 7), (2, 8)])
+        self.assertIsNone(rows[0]["closed_at"])
+        self.assertIsNotNone(rows[1]["closed_at"])
+        con.close()
+
+
+# ── the retired daemon verb + the service scheduler ───────────────────────────
+
+class CutoverTest(unittest.TestCase):
+    def test_daemon_verb_is_retired_and_exits_clean(self):
+        import contextlib
+        import io
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            # Exit 0 — legacy systemd Restart=on-failure units stop cleanly.
+            self.assertEqual(watch.main(["daemon"]), 0)
+            self.assertEqual(watch.main(["daemon", "--once"]), 0)
+        self.assertIn("RETIRED", out.getvalue())
+        self.assertIn("sole PR poller", out.getvalue())
+
+    def test_scheduler_beats_and_polls_armed_watches(self):
+        tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
+        con = build_db(tmp)
+        seed_shells(con)
+        seed_sprint_doc(con, 100)
+        con.execute("INSERT INTO watched_prs (repo, pr_number, shell_id, "
+                    "sprint_doc_id) VALUES ('o/r', 1, 1, 100)")
+        con.commit()
+        con.close()
+        poller = pr_poller.Poller(tmp, interval=30,
+                                  fetch=fetch_ok(gh_node(checks="PENDING")))
+        poller.start()
+        time.sleep(0.5)     # the first iteration runs before the first wait
+        poller.stop()
+        poller.join(timeout=5)
+        con = sqlite3.connect(tmp)
+        con.row_factory = sqlite3.Row
+        try:
+            self.assertEqual(con.execute(
+                "SELECT COUNT(*) FROM daemon_heartbeats WHERE name='watch'"
+            ).fetchone()[0], 1)
+            self.assertIsNotNone(con.execute(
+                "SELECT last_seen FROM watched_prs").fetchone()["last_seen"])
+            run = con.execute("SELECT source, status FROM pr_poll_runs").fetchone()
+            self.assertEqual(run["source"], "startup")
+            self.assertEqual(run["status"], "ok")
+        finally:
+            con.close()
+
+    def test_scheduler_self_disables_without_gh(self):
+        import shutil
+        old = shutil.which
+        shutil.which = lambda name: None
+        tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
+        build_db(tmp).close()
+        try:
+            poller = pr_poller.Poller(tmp, interval=30)   # no injected fetch
+            poller.start()
+            poller.join(timeout=5)
+        finally:
+            shutil.which = old
+        self.assertFalse(poller.is_alive())
+        con = sqlite3.connect(tmp)
+        try:
+            self.assertEqual(con.execute(
+                "SELECT COUNT(*) FROM daemon_heartbeats").fetchone()[0], 0)
+        finally:
+            con.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -31,11 +31,21 @@ ADAPTERS = ENGINE / "adapters"
 sys.path.insert(0, str(ENGINE / "scripts"))
 sys.path.insert(0, str(ENGINE / "api"))
 import mem  # noqa: E402
+import pr_poller  # noqa: E402
 import run  # noqa: E402
 import server  # noqa: E402
 import watch  # noqa: E402
 
 TOKEN = "test-token-cafebabe"
+
+
+def _baseline_node():
+    """The fake immediate GitHub read behind registration (PENDING = the
+    watch arms mid-flight, exactly like the real baseline path)."""
+    return {"state": "OPEN", "headRefOid": "abc1234def",
+            "reviews": {"totalCount": 0, "nodes": []},
+            "commits": {"nodes": [{"commit": {"statusCheckRollup":
+                                              {"state": "PENDING"}}}]}}
 
 
 def build_db(path: "Path | None" = None) -> sqlite3.Connection:
@@ -284,127 +294,10 @@ class DiffEventsTest(unittest.TestCase):
         self.assertIn("abc1234", events[0])
 
 
-# ── daemon core: poll_once against a real DB, injectable fetch ───────────────
-
-class PollOnceTest(unittest.TestCase):
-    def setUp(self):
-        self.con = build_db()
-        seed_shells(self.con)
-        # PR 1 watched by BOTH shells (fan-out from one fetch); PR 2 by shell 1.
-        self.con.executescript(
-            "INSERT INTO watched_prs (repo, pr_number, shell_id) VALUES "
-            "('o/r', 1, 1), ('o/r', 1, 2), ('o/r', 2, 1);")
-        self.con.commit()
-
-    def tearDown(self):
-        self.con.close()
-
-    @staticmethod
-    def gh_node(state="OPEN", sha="abc1234def", checks=None, reviews=0):
-        return {"state": state, "headRefOid": sha,
-                "reviews": {"totalCount": reviews, "nodes": []},
-                "commits": {"nodes": [{"commit": {"statusCheckRollup":
-                                                  ({"state": checks} if checks else None)}}]}}
-
-    def fetch_returning(self, pr1, pr2):
-        # prs are sorted → r0 = ('o/r', 1), r1 = ('o/r', 2)
-        return lambda q: {"r0": {"pullRequest": pr1}, "r1": {"pullRequest": pr2}}
-
-    def messages(self):
-        return self.con.execute(
-            "SELECT from_shell_id, to_shell_id, kind, body FROM shell_messages "
-            "ORDER BY message_id").fetchall()
-
-    def test_first_poll_baselines_silently(self):
-        n = watch.poll_once(self.con, self.fetch_returning(
-            self.gh_node(checks="PENDING"), self.gh_node(checks="PENDING")))
-        self.assertEqual(n, 0)
-        seen = self.con.execute(
-            "SELECT last_seen FROM watched_prs WHERE closed_at IS NULL").fetchall()
-        self.assertEqual(len(seen), 3)
-        self.assertTrue(all(r["last_seen"] for r in seen))
-
-    def test_transition_fans_out_to_every_subscriber(self):
-        watch.poll_once(self.con, self.fetch_returning(
-            self.gh_node(checks="PENDING"), self.gh_node(checks="PENDING")))
-        n = watch.poll_once(self.con, self.fetch_returning(
-            self.gh_node(checks="SUCCESS"), self.gh_node(checks="PENDING")))
-        self.assertEqual(n, 2)  # PR 1 green → one pr_event per subscriber
-        msgs = self.messages()
-        self.assertEqual({m["to_shell_id"] for m in msgs}, {1, 2})
-        for m in msgs:
-            self.assertEqual(m["kind"], "pr_event")
-            self.assertEqual(m["from_shell_id"], m["to_shell_id"])  # self-addressed wake-up
-            self.assertIn("checks green", m["body"])
-
-    def test_merge_emits_final_event_and_retires_the_watch(self):
-        watch.poll_once(self.con, self.fetch_returning(
-            self.gh_node(checks="PENDING"), self.gh_node(checks="PENDING")))
-        watch.poll_once(self.con, self.fetch_returning(
-            self.gh_node(checks="PENDING"), self.gh_node(state="MERGED", checks="SUCCESS")))
-        live = self.con.execute(
-            "SELECT repo, pr_number FROM watched_prs WHERE closed_at IS NULL").fetchall()
-        self.assertEqual({(r["repo"], r["pr_number"]) for r in live}, {("o/r", 1)})
-        bodies = [m["body"] for m in self.messages()]
-        self.assertTrue(any("merged" in b for b in bodies))
-        # retired watch is not polled again — next cycle only queries PR 1
-        n = watch.poll_once(self.con, lambda q: (self.assertNotIn("number: 2", q)
-                                                 or {"r0": {"pullRequest": self.gh_node(checks="PENDING")}}))
-        self.assertEqual(n, 0)
-
-    def test_early_merge_keeps_watch_until_checks_conclude(self):
-        # The #375 incident, end to end: merge lands while checks are PENDING
-        # → merge event now, watch stays live, conclusion event + retirement
-        # when the already-running workflows finish.
-        watch.poll_once(self.con, self.fetch_returning(
-            self.gh_node(checks="PENDING"), self.gh_node(checks="PENDING")))
-        n = watch.poll_once(self.con, self.fetch_returning(
-            self.gh_node(checks="PENDING"),
-            self.gh_node(state="MERGED", checks="PENDING")))
-        self.assertEqual(n, 1)                    # merge event only, PR 2's single subscriber
-        live = self.con.execute(
-            "SELECT pr_number FROM watched_prs WHERE closed_at IS NULL").fetchall()
-        self.assertEqual({r["pr_number"] for r in live}, {1, 2})  # PR 2 retained
-        n = watch.poll_once(self.con, self.fetch_returning(
-            self.gh_node(checks="PENDING"),
-            self.gh_node(state="MERGED", checks="SUCCESS")))
-        self.assertEqual(n, 1)                    # the deferred conclusion
-        bodies = [m["body"] for m in self.messages() if "#2" in m["body"]]
-        self.assertEqual(len(bodies), 2)          # merge + conclusion, nothing else
-        self.assertIn("checks still pending, watch retained", bodies[0])
-        self.assertIn("checks green", bodies[1])
-        self.assertIn("watch retired", bodies[1])
-        live = self.con.execute(
-            "SELECT pr_number FROM watched_prs WHERE closed_at IS NULL").fetchall()
-        self.assertEqual({r["pr_number"] for r in live}, {1})     # now retired
-
-    def test_failed_fetch_changes_nothing(self):
-        n = watch.poll_once(self.con, lambda q: None)
-        self.assertEqual(n, 0)
-        self.assertTrue(all(r["last_seen"] is None for r in self.con.execute(
-            "SELECT last_seen FROM watched_prs").fetchall()))
-
-    def test_unreadable_pr_keeps_its_watch(self):
-        watch.poll_once(self.con, self.fetch_returning(None, self.gh_node(checks="PENDING")))
-        rows = self.con.execute(
-            "SELECT pr_number, last_seen FROM watched_prs WHERE closed_at IS NULL").fetchall()
-        self.assertEqual(len(rows), 3)
-        self.assertTrue(all(r["last_seen"] is None for r in rows if r["pr_number"] == 1))
-
-    def test_no_live_watches_skips_the_fetch(self):
-        self.con.execute("UPDATE watched_prs SET closed_at=datetime('now')")
-        self.con.commit()
-        n = watch.poll_once(self.con, lambda q: self.fail("fetched with no live watches"))
-        self.assertEqual(n, 0)
-
-    def test_build_query_batches_and_aliases(self):
-        q = watch.build_query([("o/r", 1), ("other/repo", 22)])
-        self.assertIn('r0: repository(owner: "o", name: "r")', q)
-        self.assertIn('r1: repository(owner: "other", name: "repo")', q)
-        self.assertIn("pullRequest(number: 22)", q)
-
-
 # ── daemon heartbeat (#359): beat upsert + liveness rendering ────────────────
+# The poll-cycle coverage that used to ride this file's PollOnceTest moved to
+# tests/test_pr_poller.py with the polling cutover (spec #20 task #85): the
+# retired daemon verb's exit-clean contract is covered there too.
 
 class HeartbeatTest(unittest.TestCase):
     def setUp(self):
@@ -425,43 +318,13 @@ class HeartbeatTest(unittest.TestCase):
         rows = self.beat_rows()
         self.assertEqual([(r["name"], r["interval_s"]) for r in rows], [("watch", 30)])
 
-    def test_daemon_once_beats_even_with_no_watches(self):
-        tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
-        build_db(tmp).close()
-        old = watch.DB_PATH
-        watch.DB_PATH = tmp
-        try:
-            self.assertEqual(watch.main(["daemon", "--once"]), 0)
-        finally:
-            watch.DB_PATH = old
-        con = sqlite3.connect(tmp)
-        try:
-            self.assertEqual(con.execute(
-                "SELECT COUNT(*) FROM daemon_heartbeats WHERE name='watch'"
-            ).fetchone()[0], 1)
-        finally:
-            con.close()
 
-    def test_beat_failure_never_blocks_the_poll(self):
-        # Pre-0068 DB (code newer than schema): the beat raises, the poll must
-        # still run — heartbeat error, not poll error, and never a crash.
-        import contextlib
-        import io
-        tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
-        con = build_db(tmp)
-        con.execute("DROP TABLE daemon_heartbeats")
-        con.commit()
-        con.close()
-        old = watch.DB_PATH
-        watch.DB_PATH = tmp
-        out = io.StringIO()
-        try:
-            with contextlib.redirect_stdout(out):
-                self.assertEqual(watch.main(["daemon", "--once"]), 0)
-        finally:
-            watch.DB_PATH = old
-        self.assertIn("heartbeat error", out.getvalue())
-        self.assertNotIn("poll error", out.getvalue())
+class BuildQueryTest(unittest.TestCase):
+    def test_build_query_batches_and_aliases(self):
+        q = watch.build_query([("o/r", 1), ("other/repo", 22)])
+        self.assertIn('r0: repository(owner: "o", name: "r")', q)
+        self.assertIn('r1: repository(owner: "other", name: "repo")', q)
+        self.assertIn("pullRequest(number: 22)", q)
 
 
 class DaemonLineTest(unittest.TestCase):
@@ -502,9 +365,16 @@ class ApiTest(unittest.TestCase):
         for mod in (mem, watch):
             mod.SC_API_BASE = f"http://127.0.0.1:{cls.port}"
             mod.SC_API_TOKEN = TOKEN
+        # Registration takes an immediate GitHub baseline (spec #20 task #85)
+        # — hermetic suite, so the gh seam is faked at the module global the
+        # server resolves at call time.
+        cls._real_fetch = pr_poller.gh_fetch
+        pr_poller.gh_fetch = lambda q: pr_poller.GhResult(
+            data={"r0": {"pullRequest": _baseline_node()}})
 
     @classmethod
     def tearDownClass(cls):
+        pr_poller.gh_fetch = cls._real_fetch
         cls.httpd.shutdown()
         cls.httpd.server_close()
 
@@ -542,7 +412,7 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(len(self.q(
             "SELECT 1 FROM watched_prs WHERE pr_number=15")), 1)
 
-    def test_retired_watch_rearms_with_fresh_baseline(self):
+    def test_retired_watch_reregisters_as_new_row_keeping_history(self):
         watch.main(["pr", "own/repo", "16"])
         con = sqlite3.connect(self.db)
         con.execute("UPDATE watched_prs SET closed_at=datetime('now'), "
@@ -550,9 +420,31 @@ class ApiTest(unittest.TestCase):
         con.commit()
         con.close()
         watch.main(["pr", "own/repo", "16"])
-        row = self.q("SELECT closed_at, last_seen FROM watched_prs WHERE pr_number=16")[0]
-        self.assertIsNone(row["closed_at"])
-        self.assertIsNone(row["last_seen"])
+        rows = self.q("SELECT closed_at, last_seen FROM watched_prs "
+                      "WHERE pr_number=16 ORDER BY watch_id")
+        # The 0080 cutover: the closed row is RETAINED (with its fingerprint)
+        # and re-registration inserts a fresh row holding the new baseline.
+        self.assertEqual(len(rows), 2)
+        self.assertIsNotNone(rows[0]["closed_at"])
+        self.assertEqual(rows[0]["last_seen"], '{"state":"MERGED"}')
+        self.assertIsNone(rows[1]["closed_at"])
+        self.assertIn('"checks": "PENDING"', rows[1]["last_seen"])
+
+    def test_failed_baseline_creates_no_watch(self):
+        real = pr_poller.gh_fetch
+        pr_poller.gh_fetch = lambda q: pr_poller.GhResult(error="connect timeout")
+        try:
+            with self.assertRaises(SystemExit):   # _api dies on the 502
+                watch.main(["pr", "own/repo", "18"])
+        finally:
+            pr_poller.gh_fetch = real
+        self.assertEqual(self.q("SELECT 1 FROM watched_prs WHERE pr_number=18"), [])
+
+    def test_registration_stores_the_baseline(self):
+        watch.main(["pr", "own/repo", "19"])
+        row = self.q("SELECT last_seen FROM watched_prs WHERE pr_number=19")[0]
+        self.assertIn('"state": "OPEN"', row["last_seen"])
+        self.assertIn('"sha": "abc1234def"', row["last_seen"])
 
     def test_list_shows_live_watches(self):
         watch.main(["pr", "own/repo", "17"])
@@ -684,9 +576,13 @@ class DaemonLivenessApiTest(unittest.TestCase):
         cls.thread.start()
         watch.SC_API_BASE = f"http://127.0.0.1:{cls.port}"
         watch.SC_API_TOKEN = TOKEN
+        cls._real_fetch = pr_poller.gh_fetch
+        pr_poller.gh_fetch = lambda q: pr_poller.GhResult(
+            data={"r0": {"pullRequest": _baseline_node()}})
 
     @classmethod
     def tearDownClass(cls):
+        pr_poller.gh_fetch = cls._real_fetch
         cls.httpd.shutdown()
         cls.httpd.server_close()
 


### PR DESCRIPTION
## What

The supervised engine service becomes the fork's **sole** GitHub poller and engine-DB writer (spec #20 §GitHub Polling, decision #19); the legacy host `sc watch daemon` — a second, direct-DB writer — is retired in the same commit that enables the service scheduler (the cutover gate: no supervised path can start a second writer).

Depends on seq 4 (#80 / PR #500, merged) — builds on `pr_poll_runs` / `pr_poll_observations` and the `sprint_doc_id` scoping columns.

## Changes

- **`.super-coder/scripts/pr_poller.py` (new)** — the service poller:
  - `Poller` scheduler thread started by the API service: 30s default interval + jitter, **only while ACTIVE sprint watches exist**, plus one startup pass; self-disables when `gh` is absent (same posture as the old daemon).
  - `poll_cycle()`: one batched GraphQL read per repo; `pr_poll_runs` audit per repo (`scheduler`/`startup`/`reconcile` source, ok/error/rate_limited); **normalized fingerprints only** (head SHA, PR state, check rollup, review decision — never prose/logs/commit messages/payloads/tokens).
  - Semantic transition dedupe keyed **(watch, transition, head SHA, state)** via message `dedupe_key` → idempotent `pr_event` rows (replay-safe); same-transaction `planner_wake_items` when a live binding owns the (sprint, planner) pair; durable transition + blind-window `pr_poll_observations`; capped per-repo backoff (15 min ceiling) that never blocks other repos; terminal retirement with #375 merge-with-pending-checks semantics preserved.
  - Never injects terminal input, never marks messages read, never touches git or a model.
- **Registration baselines** — `POST /_sc/watches` performs an immediate GitHub read and stores the normalized baseline **before** arming; a failed baseline creates no watch and returns a retryable sanitized 502. New `--sprint <doc-id>` scoping (validated ACTIVE + unfrozen SPRINT doc); explicit rebind of dormant unscoped watches; `POST /_sc/watches/reconcile` operator one-shot.
- **Migration 0080** — `watched_prs` table rebuild: legacy `UNIQUE(repo, pr, shell)` → one ACTIVE watch per (repo, PR, shell, sprint scope) via partial index; closed rows retained; re-registration inserts new history rows.
- **Cutover** — `sc watch daemon` prints the retirement notice and exits **0** (legacy systemd `Restart=on-failure` units stop cleanly); `watch-daemon-up`/`install` refuse; `down`/`uninstall` remain as the stop+disable path; `launch`/`persist` no longer start the host daemon. Liveness heartbeat row (`daemon_heartbeats` 'watch') is now beaten by the service scheduler, so `sc watch list` truth-telling (#359) is unchanged.
- **`sc watch list`** shows armed/dormant scope per watch; `daemon_line` renders poller (service) liveness.

## Ambiguity calls (sprint-scoped, reported to PLN1)

1. **"One active watch per binding/repo/PR"** → implemented as one active watch per (repo, PR, subscriber shell, sprint scope): bindings can't exist yet (seq 5/8 pending), and the watch's `shell_id` + `sprint_doc_id` is exactly the pair a binding binds. When seq 8 lands bindings, wake-item creation already keys off the live (sprint, planner) binding.
2. **Cutover gate** is code-atomic (retire verb + enable scheduler in one commit) rather than a runtime cross-container check — the in-sandbox service cannot see host processes. Legacy supervision exits cleanly on its own.
3. **Heartbeat continuity**: the scheduler beats the existing 'watch' heartbeat so the #359 liveness surface is unchanged, rather than inventing a new row.

## Verification

- New `tests/test_pr_poller.py` — 26 tests: sprint scoping (ACTIVE/CLOSED/frozen/unscoped), baseline success/failure/unreadable, fan-out + scoped messages, dedupe replay, quiet-poll no-observation, #375 early-merge end-to-end, failure → audit → backoff → skip → blind-window recovery, rate-limit status, per-repo backoff isolation, wake-item creation with armed binding, migration invariants + row/id preservation, retired daemon verb exit-clean, scheduler thread beat+startup poll, gh-absent self-disable.
- `tests/test_sprint_eventing.py` updated to the new registration contract (baseline stored, failed baseline → no watch, re-arm = new row + retained history).
- `python3 tests/test_pr_poller.py` 26/26 · `python3 tests/test_sprint_eventing.py` 64/64 · full suite `pytest tests/` **606 passed** (3 `test_vm_bake` failures are the pre-existing `SC_SANDBOX=1` environment posture — no vm files touched) · `migrate.py` end-to-end applies 0080 on a fresh baseline · ruff clean on all touched files (23 pre-existing errors elsewhere) · mypy clean on touched engine files (205 pre-existing errors elsewhere).

Reviewer: REV2. May land dark — no bindings exist yet, so the wake-item path is built but inert until seq 8.