### PR TITLE
docs(sprint_orchestration): faulted worker consumes its task row

### DIFF
--- a/.super-coder/assets/skills/sprint_orchestration/SKILL.md
+++ b/.super-coder/assets/skills/sprint_orchestration/SKILL.md
@@ -291,10 +291,21 @@ Stalls and the moves:
   Low, reviewer says Medium) -> rule by message immediately — a chain
   waiting on a classification argument is pure loss. Dispute about what
   the unit *should do* -> FnB.
+- **Worker faulted mid-task** (rate-limit cutoff, provider error, session
+  died): its `task` row is already consumed — a worker marks the row read
+  when it starts acting, so a fault leaves a read row and an unfinished
+  unit. Re-launching alone drains an empty inbox and the worker idles on
+  the default prompt. **Confirm the row's state at runtime before you
+  boot** — `sc mem message sent` carries read receipts; a task row showing
+  read means re-send it (same unit, plus where the work stopped and what
+  is already on the branch), *then* `./sc run`. A re-boot is not a
+  re-task.
 - **Link gone quiet** (no `result` row, no `pr_event` movement): boot it with
   its declared sprint route — `./sc run <shortname> --harness <role-harness>
   -m <role-model> --effort high` drains its inbox and acts; that IS the nudge in
-  an event-driven sprint. The liveness guard refusing (session already
+  an event-driven sprint. Check `sent` first, though — a read task row
+  means the link faulted rather than stalled, and the boot has nothing to
+  act on. The liveness guard refusing (session already
   live) + still silent -> escalate to the FnB with the worktree state.
   The bottleneck question in Step 3 is what surfaces a dead link.
 - **Re-sequencing**: edit the board + `task` row to *every* affected dev

--- a/.super-coder/migrations/0081_reseed_sprint_orch_worker_fault.sql
+++ b/.super-coder/migrations/0081_reseed_sprint_orch_worker_fault.sql
@@ -1,29 +1,33 @@
----
-rendered_by: super-coder
-source: db
-edit: changes here are overwritten — author via the shell or localhost GUI
----
+-- 0081 — reseed: sprint_orchestration — faulted worker consumes its task row
+--
+-- A worker that faults mid-task (rate-limit cutoff, provider error, dead
+-- session) has already marked its `task` row read, so `./sc run` on it drains
+-- an empty inbox and the shell idles on the default prompt. Step 4 now names
+-- the failure mode and the check: confirm read receipts via
+-- `sc mem message sent` at runtime, re-send the task row, then boot. Source
+-- asset updated in the same commit; UPSERT by name, skill_id + grants
+-- preserved.
 
-# sprint_orchestration
+BEGIN;
 
-Planner-side governance of a multi-shell sprint — decompose the push, sequence the dependency chain, assign devs and reviewers, run the model & provider interview, declare the sprint doc, arm your inbox watcher, boot workers per task (./sc run), monitor the event stream (result + pr_event rows), unblock stalls, close out — run the pre-freeze conformance pass (review shells judge the spec against main), freeze the doc (revoking all scoped authority), and synthesize the sprint report from unit reports + the conformance doc into the fixed skeleton. Zero scheduled polling by any shell. Load when the FnB directs a coordinated multi-dev push. Companion to the participant-side `sprint` skill.
-
-**Category:** craft
-
----
-
-# sprint_orchestration — governing a coordinated multi-shell push
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_orchestration',
+  'Planner-side governance of a multi-shell sprint — decompose the push, sequence the dependency chain, assign devs and reviewers, run the model & provider interview, declare the sprint doc, arm your inbox watcher, boot workers per task (./sc run), monitor the event stream (result + pr_event rows), unblock stalls, close out — run the pre-freeze conformance pass (review shells judge the spec against main), freeze the doc (revoking all scoped authority), and synthesize the sprint report from unit reports + the conformance doc into the fixed skeleton. Zero scheduled polling by any shell. Load when the FnB directs a coordinated multi-dev push. Companion to the participant-side `sprint` skill.',
+  'craft',
+  NULL,
+  0,
+  '# sprint_orchestration — governing a coordinated multi-shell push
 
 The FnB declares *that* a sprint happens; you make it run: decompose the
 push into units, sequence who builds on whom, assign a reviewer to every
-unit, interview the FnB for the sprint's models, boot each worker when its
+unit, interview the FnB for the sprint''s models, boot each worker when its
 turn comes, watch the event stream, unblock stalls, close out with a
 report. The participant loop (build → PR + watch → CI → sprint review →
 merge on green+clean → hand off, plus the reviewer slot) = the `sprint`
 skill — devs and reviewers run it; you run this.
 
 The skills meet at one artifact, the **sprint doc**: your declaration
-turns the participants' scoped authority ON (dev merge-on-green+clean,
+turns the participants'' scoped authority ON (dev merge-on-green+clean,
 reviewer direct handoffs); your close-out turns it OFF.
 
 **The sprint is event-driven — nobody polls on a schedule.** Every
@@ -33,17 +37,17 @@ with the watcher daemon, which sends you `pr_event` rows. Your inbox
 watcher wakes you the moment any row lands. Workers are ephemeral,
 per-task sessions; you are the one long-lived context in the loop — you
 manage, you never load code. The full trail replays with
-`SELECT * FROM shell_messages WHERE kind != 'shell' ORDER BY created_at`.
+`SELECT * FROM shell_messages WHERE kind != ''shell'' ORDER BY created_at`.
 
 ## Step 1: Declare the sprint
 
 Decompose the push into units a single shell can own end-to-end. Map
 dependency order stingily: a dependency edge = a real code dependency, not
-a preference. Units that don't touch each other run in parallel; keep
+a preference. Units that don''t touch each other run in parallel; keep
 chains short and the graph wide where the code allows.
 
 Assign each unit a dev shell + a reviewer shell (one reviewer may gate
-several units — don't let one reviewer become the whole sprint's
+several units — don''t let one reviewer become the whole sprint''s
 bottleneck).
 
 **How many shells to deploy = your call, not a formula.** Weigh the
@@ -78,11 +82,11 @@ the chosen harness exactly:
 
 # Anthropic / Claude: exit 0 = plan; 10 = API key; 11 = unknown auth.
 claude auth status --json 2>/dev/null |
-  python3 -c 'import json,sys
+  python3 -c ''import json,sys
 try: s=json.load(sys.stdin)
 except Exception: print("billing=unknown"); raise SystemExit(11)
 key=s.get("apiKeySource"); plan=s.get("loggedIn") and s.get("authMethod") == "claude.ai" and s.get("apiProvider") == "firstParty" and s.get("subscriptionType") and not key
-print("billing=plan source=claude.ai" if plan else ("billing=api source=" + str(key) if key else "billing=unknown")); raise SystemExit(0 if plan else (10 if key else 11))'
+print("billing=plan source=claude.ai" if plan else ("billing=api source=" + str(key) if key else "billing=unknown")); raise SystemExit(0 if plan else (10 if key else 11))''
 ```
 
 Exit 0 + `billing=plan` -> launch normally. Exit 10 -> hold and ask the FnB to
@@ -138,7 +142,7 @@ sc models resolve <reviewers-harness> <reviewers-model>
 Each must return `route:` plus an exact `call:` ending in `--effort high`.
 Failure means the selector is not locally callable, the harness lacks a
 headless/high-effort seam, or Refresh models has not seen it. Run
-`sc models list <harness>` for the local choices; the FnB's **Refresh models**
+`sc models list <harness>` for the local choices; the FnB''s **Refresh models**
 button in `/#shells` repopulates the same runtime table. Resolve again after a
 refresh. Never silently fall back across a provider or lineage.
 
@@ -172,7 +176,7 @@ Note the returned `document_id` — every task and report references it —
 and embed `SPRINT doc=<id> governing` in your own `current_state`; drop
 it at close-out.
 
-You are the doc's only writer: devs report transitions as `result` rows;
+You are the doc''s only writer: devs report transitions as `result` rows;
 fold them into the board with `sc mem doc edit <id> --body-file`.
 
 ## Step 2: Arm the watcher, kick off
@@ -183,7 +187,7 @@ task (it blocks until any message row lands for you, then exits — the
 exit is your wake-up):
 
 ```
-./sc watch inbox        # background it via your harness's background-task tool
+./sc watch inbox        # background it via your harness''s background-task tool
 ```
 
 **Interactive sessions only.** A harness background task is
@@ -194,7 +198,7 @@ row boots you again. The watcher belongs to the long-lived interactive
 planner seat, nowhere else.
 
 Re-arm it every time you finish draining your inbox. On other harnesses
-the watcher isn't available — check your inbox at every task boundary
+the watcher isn''t available — check your inbox at every task boundary
 instead; correctness is identical, latency degrades gracefully. (Strong
 recommendation, not a gate: the planner seat runs best on claude/Fable —
 the one long-lived, low-volume, high-leverage context in the loop, and
@@ -205,7 +209,7 @@ load the `sprint` skill + the slot), then boot whoever can start:
 
 ```
 # devs — unit, dependencies, reviewer:
-sc mem message send <dev> "SPRINT <doc-id>: you own unit <seq> — <one line>. Depends on unit <k> (<shell>); <shell'> depends on you; <reviewer> reviews you. Load the sprint skill and take your slot; your merge closes with the unit report. First move: <start now | build locally, wait for unit <k>>." --kind task
+sc mem message send <dev> "SPRINT <doc-id>: you own unit <seq> — <one line>. Depends on unit <k> (<shell>); <shell''> depends on you; <reviewer> reviews you. Load the sprint skill and take your slot; your merge closes with the unit report. First move: <start now | build locally, wait for unit <k>>." --kind task
 
 # reviewers — assigned units, the severity bar:
 sc mem message send <reviewer> "SPRINT <doc-id>: you review units <seq,seq> — Major/Medium block, Low goes to the report. Load the sprint skill (reviewer slot). Review requests come to you directly as units go green." --kind task
@@ -214,20 +218,20 @@ sc mem message send <reviewer> "SPRINT <doc-id>: you review units <seq,seq> — 
 ./sc run <dev> --harness <devs-harness> -m <devs-model> --effort high
 ```
 
-`./sc run` renders the shell's boot doc and drains its inbox
+`./sc run` renders the shell''s boot doc and drains its inbox
 non-interactively — the `task` row you just sent is what it acts on. The
 default prompt is exactly that ("check your inbox and act"); pass
-`-p` only to say something the task row doesn't. A shell with a live
+`-p` only to say something the task row doesn''t. A shell with a live
 session refuses to boot (one shell, one session) — a live session reads
 the same `task` row at its next inbox check.
 
 Keep `task` bodies model-neutral and constraint-explicit: point at the
-sprint doc, the unit, the spec, and the skill — don't restate them in
+sprint doc, the unit, the spec, and the skill — don''t restate them in
 your own phrasing. Constraints live in specs, which every lineage reads
 the same way.
 
-This kickoff activates each dev's scoped merge authority and each
-reviewer's direct-handoff authority for its assigned units.
+This kickoff activates each dev''s scoped merge authority and each
+reviewer''s direct-handoff authority for its assigned units.
 
 ## Step 3: Monitor the event stream
 
@@ -235,7 +239,7 @@ Your watcher wakes you on every row. On wake, drain the inbox and act:
 
 - **`result` rows** (dev/reviewer transitions — pr-open, in-review,
   review-clean, merged, ambiguity calls, stall reports): fold into the
-  board, then move whatever it unblocks. A dev's merge arrives as its
+  board, then move whatever it unblocks. A dev''s merge arrives as its
   **unit report** (the one multi-line `result` row — shipped /
   judgements / issues / deviations / follow-ups): file it whole; it is
   a primary source for the sprint report, and its `deviations` +
@@ -245,7 +249,7 @@ Your watcher wakes you on every row. On wake, drain the inbox and act:
 - **`pr_event` rows** (daemon ground truth — checks green/red, review
   submitted, merged, closed): the wake-up for transitions no worker is
   live to report. Green on an in-review unit -> nothing (the reviewer
-  gate holds); red -> re-task the unit's dev (`task` row + `./sc run`);
+  gate holds); red -> re-task the unit''s dev (`task` row + `./sc run`);
   merged -> boot the downstream dev whose turn it is.
 - Mark rows read as you fold them; then **re-arm the watcher**.
 
@@ -258,12 +262,12 @@ the message is the wake-up.
 At any moment, be able to answer: which link is the bottleneck? The board
 is what the FnB and any rebooted shell reads to re-orient mid-sprint —
 fold every state change in as it happens. The board + message table ARE
-the sprint's state: a rebooted planner replays the rows and loses
+the sprint''s state: a rebooted planner replays the rows and loses
 nothing.
 
 Messages are your steering wheel: every dev checks its inbox at each
 step start, and a headless boot drains it first thing — your `task` row
-is read before that dev's next move. Steer with `task` rows — holds,
+is read before that dev''s next move. Steer with `task` rows — holds,
 re-sequencing, nudges, rulings on reported reds. The board records state;
 messages change behavior; on conflict your latest message wins -> then
 update the board to match.
@@ -282,13 +286,13 @@ Stalls and the moves:
   per the `sprint` skill): pair another shell onto it / re-scope the
   unit / pull the failing part into a follow-up unit so the chain moves.
 - **Anomalous red** (flaky test, runner death, `main` red underneath — the
-  dev's job was to rerun and report, not patch healthy code): fix the
+  dev''s job was to rerun and report, not patch healthy code): fix the
   cause as its own unit, or hold the chain while infra recovers; rule by
-  `task` row when the dev may proceed. Don't count phantom reds against
-  the dev's fix attempts — and don't let anyone merge over one; green
+  `task` row when the dev may proceed. Don''t count phantom reds against
+  the dev''s fix attempts — and don''t let anyone merge over one; green
   means green.
 - **Unit growing past scope**: split it — the piece downstream needs ships
-  first; the rest becomes a new unit at the chain's tail.
+  first; the rest becomes a new unit at the chain''s tail.
 - **Merge broke `main`**: `task` row to all devs to hold merges, insert a
   fix unit at the front of the chain, resume when green.
 - **Review stall** (unit sitting `in-review` while its reviewer is idle):
@@ -302,7 +306,7 @@ Stalls and the moves:
   died): its `task` row is already consumed — a worker marks the row read
   when it starts acting, so a fault leaves a read row and an unfinished
   unit. Re-launching alone drains an empty inbox and the worker idles on
-  the default prompt. **Confirm the row's state at runtime before you
+  the default prompt. **Confirm the row''s state at runtime before you
   boot** — `sc mem message sent` carries read receipts; a task row showing
   read means re-send it (same unit, plus where the work stopped and what
   is already on the branch), *then* `./sc run`. A re-boot is not a
@@ -325,14 +329,14 @@ Stalls and the moves:
   switch is theirs), resume where the board says you stopped.
 - **CI queue clogged at the tail**: a queued verify whose commit a later
   stack head already supersedes is pure queue time — cancel it (`gh run
-  cancel`) and let the head's run stand for the stack. Cancelling
+  cancel`) and let the head''s run stand for the stack. Cancelling
   anything to protect a measurement run is allowed but logged: rationale
   in the board or a `result` row, and re-run the cancelled check after.
   Green means green — cancellation never substitutes for a verdict on
   what still needs one.
 - **Judgment calls** (scope vs. deadline, cutting a unit, changing an
   interface another team reads): escalate to the FnB immediately — the one
-  stall you can't unblock yourself.
+  stall you can''t unblock yourself.
 
 You boot workers; the daemon never does (it only writes rows), and the
 FnB is only pulled in for judgment. Autonomous wake stays a deliberate
@@ -345,7 +349,7 @@ When every unit is `merged` and `main` is green:
 1. **Run the conformance pass — before the freeze.** "All units merged"
    and "the spec shipped" are different claims; this is where the second
    one gets checked. Boot review shell(s) — reviewer lineage, the
-   sprint's reviewer harness/model; one shell by default, shard by spec
+   sprint''s reviewer harness/model; one shell by default, shard by spec
    section only when the spec genuinely exceeds one context:
 
    ```
@@ -364,17 +368,17 @@ When every unit is `merged` and `main` is green:
      the freeze — a reopened sprint re-grants nothing); re-run the pass
      scoped to the fix when it merges.
    - **Medium** -> your judgment: fix unit now, or defer with the FnB
-     told explicitly in the report's Verdict.
+     told explicitly in the report''s Verdict.
    - **Low** -> Deferred & Follow-ups; never holds the close.
 2. Set `status: CLOSED` in the body, then freeze:
    `sc mem doc freeze <doc-id>`. Freezing IS the revocation — a frozen or
    `CLOSED` sprint doc is exactly what the `sprint` skill checks before
-   any merge; every participant's scoped authority ends with it.
+   any merge; every participant''s scoped authority ends with it.
 3. Message every participant (`task` row): sprint closed, default merge
    gates resume.
-4. Verify the watches are gone: `./sc watch list` — every sprint PR's
+4. Verify the watches are gone: `./sc watch list` — every sprint PR''s
    watch retired itself at merge/close; a survivor means an unmerged PR
-   or a mis-registered watch — resolve it, don't leave it. Then stop
+   or a mis-registered watch — resolve it, don''t leave it. Then stop
    re-arming your inbox watcher (a running one just times out — it holds
    no authority and wakes nothing that matters).
 5. Write the sprint report — one `documents` row, the durable record:
@@ -384,7 +388,7 @@ When every unit is `merged` and `main` is green:
    ```
 
    Fixed skeleton — fill it by **reasoning over the unit reports and the
-   conformance doc against each other** (a dev's `deviations: none`
+   conformance doc against each other** (a dev''s `deviations: none`
    meeting a `deviated-silently` finding on its unit is exactly what the
    report exists to say), not by pasting either verbatim:
 
@@ -393,20 +397,20 @@ When every unit is `merged` and `main` is green:
    | `## Verdict` | your synthesis — five-second answer: N units / N PRs, conformance state (conforms / conforms-with-deviations / gaps-found), main green, anything deferred-with-eyes-open |
    | `## Units Shipped` | the board — final table, planned vs. actual order |
    | `## Judgements Made` | unit reports (`judgements:`) + your rulings + severity disputes; every call with its final state |
-   | `## Spec Accuracy` | conformance doc — verdict table + findings, cross-checked against unit reports' `deviations:` |
+   | `## Spec Accuracy` | conformance doc — verdict table + findings, cross-checked against unit reports'' `deviations:` |
    | `## Issues Encountered` | unit reports (`issues:`) + the `pr_event`/stall trail — CI fights, anomalous reds, re-scopes, unblocks |
-   | `## Deferred & Follow-ups` | unit reports (`follow-ups:`) + reviewers' Lows + conformance Lows + anything cut — one actionable backlog, the next sprint's seed list |
+   | `## Deferred & Follow-ups` | unit reports (`follow-ups:`) + reviewers'' Lows + conformance Lows + anything cut — one actionable backlog, the next sprint''s seed list |
    | `## Spec Debt` | judgement calls that should be written back into the spec + places the spec was silent, wrong, or contradictory — the input to the spec-update pass |
    | `## Metrics` (optional) | mechanical from the trail: review cycles per unit, CI reds, boots per shell, planned vs. actual merge order |
 
-   The `kind != 'shell'` message trail remains the in-order backbone;
-   the CONFORMANCE doc stays alongside as the report's evidence trail.
+   The `kind != ''shell''` message trail remains the in-order backbone;
+   the CONFORMANCE doc stays alongside as the report''s evidence trail.
 
    Then drop a copy at the repo root: write the same body to
    `shared/SPRINT_REPORT_<slug>.md` (`mkdir -p shared` — the dir may
    not exist yet). Message the FnB: sprint closed, report at doc
    `<id>` + the `shared/` file.
-6. Settle the bookkeeping — close the sprint's flags, advance roadmap /
+6. Settle the bookkeeping — close the sprint''s flags, advance roadmap /
    feature status, note docs-pending.
 
 ## Stance
@@ -417,15 +421,23 @@ When every unit is `merged` and `main` is green:
 - Zero scheduled polling by any shell: rows wake you, you boot workers,
   watches retire themselves. A scheduled tracker anywhere in the sprint
   is a defect.
-- Local long work rides `./sc job` (see the `sprint` skill) — a job's
+- Local long work rides `./sc job` (see the `sprint` skill) — a job''s
   completion is a `result` row like any other wake-up. A hand-rolled
-  nohup/poll waiter anywhere in the sprint is a defect: one sprint's
+  nohup/poll waiter anywhere in the sprint is a defect: one sprint''s
   hand-rolled waiter carried a self-match bug that masked a dead bench.
 - You manage; you never load code. Your context grows at coordination
-  density — the workers' grows at code density and is discarded per task.
+  density — the workers'' grows at code density and is discarded per task.
 - Monitor > interrogate: `pr_event` rows and `gh` reads cost no dev a
   context switch; `task` rows are for changing behavior.
 - The conformance shell files verdicts, never rulings — Major/Medium/Low
-  routing stays yours; what the sprint *means* stays the FnB's.
+  routing stays yours; what the sprint *means* stays the FnB''s.
 - Escalate judgment, absorb mechanics: re-sequencing and worker boots are
-  yours; changing what the sprint *means* is the FnB's.
+  yours; changing what the sprint *means* is the FnB''s.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;


### PR DESCRIPTION
## What

A worker that faults mid-task — rate-limit cutoff, provider error, dead session — has **already marked its `task` row read**. Workers mark on *start of acting*, not on completion, so the fault leaves a read row and an unfinished unit. `./sc run` on that shell then drains an empty inbox and the worker idles on the default prompt: the re-launch looks like a nudge but does nothing.

Step 4 (Unblock) gains this as its own stall entry:

- confirm the row's state **at runtime** — `sc mem message sent` carries read receipts
- a task row showing read → re-send it (same unit + where the work stopped), *then* boot
- "Link gone quiet" now points at it: a read task row distinguishes a faulted link from a stalled one

## How it's authored

This repo is the engine source, so the skill lands the standard way: asset `SKILL.md` + a reseed migration. `0081` UPSERTs by name, so `skill_id` and existing grants survive. The `skills_sc/` mirror is re-rendered from the hermetic tracked-source build, not from a live DB.

## Verification

`python3 .super-coder/scripts/render_check.py` → `✓ render-check: flat _sc mirror matches the render of the tracked sources` (81 migrations applied clean).

Note: `./sc render-check` resolves the engine at the **main** worktree root, which is currently behind `origin/main` (75 migrations, up to 0077) — so from a linked worktree it checks the wrong tree and reports a stale, unrelated drift on `specs_sc/sprint-planner-session-control.md`. Ran the worktree-local checker directly instead. Flagging separately; not touched here.

## Trade-off

Added a distinct bullet rather than a clause on "Link gone quiet" — the two stalls have opposite remedies (re-task vs. plain boot), and folding them together is what makes the no-op re-launch easy to reach for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)