### PR TITLE
feat(interface): CLI parity + full Interface workflow (sprint 25 seq 6, task #82)

### DIFF
--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -356,6 +356,13 @@ def _read_stdin() -> bytes:
     return os.read(0, 65536)
 
 
+def _ws_connect(ws_url: str):
+    """The WS seam — tests patch this, never a socket. Lazy import: the CLI
+    verbs (and their test env) never need the websockets package."""
+    from websockets.sync.client import connect
+    return connect(ws_url, subprotocols=[SUBPROTOCOL])
+
+
 def run_stream(ws_url: str, role: str, start_seq: int,
                lease: dict | None = None) -> int:
     """The sc-term.v1 terminal loop, production client semantics (spec #20
@@ -373,9 +380,7 @@ def run_stream(ws_url: str, role: str, start_seq: int,
     close/terminated. The writer lease is released on the way out (a
     closing client releases only ITS lease — tmux and the harness
     continue)."""
-    from websockets.sync.client import connect
-
-    ws = connect(ws_url, subprotocols=[SUBPROTOCOL])
+    ws = _ws_connect(ws_url)
     old_attrs = termios.tcgetattr(0) if os.isatty(0) else None
     if old_attrs:
         tty.setraw(0)

--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -24,14 +24,16 @@ supervised-runtime remediation; it never falls back).
                                                    reattach an occupied one
 
 The attach client speaks sc-term.v1 (api/interface_ws.py) — the same session
-stream and writer lease as the browser, ported from the proven spike
-(spikes/interface-stream/cli_client.py). A refresh/reconnect reattaches the
-same generation; it never provider-resumes.
+stream and writer lease as the browser, with the full client-side protocol
+semantics (ack-gated input, read-only flip on lease loss, quiet control
+frames). A refresh/reconnect reattaches the same generation; it never
+provider-resumes.
 """
 from __future__ import annotations
 
 import argparse
 import json
+from collections import deque
 import os
 import select
 import signal
@@ -343,22 +345,83 @@ def cmd_take_control(args) -> int:
     return _attach_writer(shell, _session_of(shell), takeover=True)
 
 
+def _stdin_ready(timeout: float) -> bool:
+    """One stdin poll — the sender's input seam (tests patch this)."""
+    r, _, _ = select.select([sys.stdin.buffer], [], [], timeout)
+    return bool(r)
+
+
+def _read_stdin() -> bytes:
+    """One stdin read — ≤64 KiB, so it always fits MAX_INPUT_PAYLOAD."""
+    return os.read(0, 65536)
+
+
 def run_stream(ws_url: str, role: str, start_seq: int,
                lease: dict | None = None) -> int:
-    """The sc-term.v1 terminal loop (spike port): stdin raw, stdin bytes →
-    0x01|seq:u64be|payload as writer, 0x03 resize on start + SIGWINCH,
-    0x00/0x04 payloads → stdout, JSON control frames dimmed to stderr, 20s
-    writer heartbeat, clean exit on close/terminated. The writer lease is
-    released on the way out (a closing client releases only ITS lease —
-    tmux and the harness continue)."""
+    """The sc-term.v1 terminal loop, production client semantics (spec #20
+    Input Broker): stdin raw; keystrokes are sent ACK-GATED — at most one
+    unacknowledged input frame in flight, later keystrokes buffered locally
+    and drained one frame per input_ack (the same one-unacked rule as the
+    browser, which also bounds what a stalled broker can queue server-side).
+    A writer_revoked/stale_generation reject or a non-active writer control
+    flips the client READ-ONLY with a loud notice — input stops, output
+    continues (the browser's flip for a lost lease). Routine control frames
+    (input_ack, heartbeat acks, unchanged state) are never echoed: raw-mode
+    stderr carries errors and state transitions only, so the attached TUI
+    isn't garbled. 0x00/0x04 payloads → stdout, 0x03 resize on start +
+    SIGWINCH, 20s writer heartbeat (halted on read-only), clean exit on
+    close/terminated. The writer lease is released on the way out (a
+    closing client releases only ITS lease — tmux and the harness
+    continue)."""
     from websockets.sync.client import connect
 
     ws = connect(ws_url, subprotocols=[SUBPROTOCOL])
     old_attrs = termios.tcgetattr(0) if os.isatty(0) else None
     if old_attrs:
         tty.setraw(0)
-    state = {"seq": start_seq, "winch": True, "dead": False}
+    lock = threading.Lock()
+    state: dict = {"seq": start_seq, "winch": True, "dead": False,
+                   "readonly": role != "writer", "inflight": None,
+                   "outbuf": deque(), "writer_state": None, "lifecycle": None}
     signal.signal(signal.SIGWINCH, lambda *_: state.__setitem__("winch", True))
+
+    def notice(text: str) -> None:
+        # Raw-mode-safe: \r\n keeps the line from staircasing the TUI.
+        print(f"\r\n\x1b[1m[sc interface] {text}\x1b[0m\r\n",
+              file=sys.stderr, flush=True)
+
+    def pump() -> None:
+        """Send the next buffered input frame iff nothing is unacknowledged
+        (the one-unacked-frame rule, client side)."""
+        with lock:
+            if (state["dead"] or state["readonly"]
+                    or state["inflight"] is not None or not state["outbuf"]):
+                return
+            data = state["outbuf"].popleft()
+            seq = state["seq"]
+            state["seq"] += 1
+            state["inflight"] = seq
+        ws.send(b"\x01" + seq.to_bytes(8, "big") + data)
+
+    def acked(seq) -> None:
+        """An ack or a non-terminal reject: the inflight frame is settled —
+        release it and drain the local buffer."""
+        with lock:
+            if state["inflight"] == seq:
+                state["inflight"] = None
+        pump()
+
+    def go_readonly(text: str) -> None:
+        """Terminal input loss: flip read-only exactly once (loud), drop
+        pending input, keep streaming output like the browser."""
+        with lock:
+            if state["readonly"]:
+                return
+            state["readonly"] = True
+            state["outbuf"].clear()
+            state["inflight"] = None
+        notice(f"{text} — READ-ONLY from here; `sc interface take-control` "
+               "regains the writer role")
 
     def sender() -> None:
         try:
@@ -368,22 +431,25 @@ def run_stream(ws_url: str, role: str, start_seq: int,
                     rows, cols = _winsize()
                     ws.send(b"\x03" + rows.to_bytes(2, "big")
                             + cols.to_bytes(2, "big"))
-                r, _, _ = select.select([sys.stdin.buffer], [], [], 0.2)
-                if not r:
+                if not _stdin_ready(0.2):
                     continue
-                data = os.read(0, 65536)
+                data = _read_stdin()
                 if not data:
                     state["dead"] = True
                     return
-                if role == "writer":
-                    ws.send(b"\x01" + state["seq"].to_bytes(8, "big") + data)
-                    state["seq"] += 1
+                with lock:
+                    if not state["readonly"]:
+                        state["outbuf"].append(data)
+                pump()
         except Exception:
             state["dead"] = True
 
     def heartbeater() -> None:
         while not state["dead"]:
             time.sleep(HEARTBEAT_S)
+            with lock:
+                if state["readonly"] or state["dead"]:
+                    return  # no lease left to keep alive
             try:
                 ws.send(json.dumps({"type": "heartbeat"}))
             except Exception:
@@ -402,11 +468,42 @@ def run_stream(ws_url: str, role: str, start_seq: int,
                 if message[:1] in (b"\x00", b"\x04"):
                     out.write(message[1:])
                     out.flush()
-            else:
-                msg = json.loads(message)
-                if msg.get("type") == "error" and msg.get("code") == "terminated":
+                continue
+            msg = json.loads(message)
+            mtype = msg.get("type")
+            if mtype == "input_ack":
+                acked(msg.get("seq"))              # routine: silent
+            elif mtype == "input_reject":
+                reason = msg.get("reason", "?")
+                if reason in ("writer_revoked", "stale_generation"):
+                    go_readonly(f"writer lease lost ({reason})")
+                else:
+                    notice(f"input seq {msg.get('seq')} rejected: {reason}")
+                    acked(msg.get("seq"))
+            elif mtype == "writer":
+                new = msg.get("state")
+                with lock:
+                    prev = state["writer_state"]
+                    state["writer_state"] = new
+                if role == "writer" and new != "active":
+                    go_readonly(f"writer lease lost (state: {new})")
+                elif new != prev:
+                    notice(f"writer {new}")
+            elif mtype == "lifecycle":
+                cur = (msg.get("lifecycle"), msg.get("composer"))
+                with lock:
+                    changed = cur != state["lifecycle"]
+                    state["lifecycle"] = cur
+                if changed:
+                    notice(f"lifecycle {cur[0]}"
+                           + (f" · composer {cur[1]}" if cur[1] else ""))
+            elif mtype == "resync":
+                notice(f"resync ({msg.get('reason', '?')})")
+            elif mtype == "error":
+                if msg.get("code") == "terminated":
                     break
-                print(f"\x1b[2m[{message}]\x1b[0m", file=sys.stderr)
+                notice(f"error: {msg.get('code', '?')}")
+            # heartbeat acks: routine, silent
     except Exception as exc:
         print(f"connection closed: {exc!r}", file=sys.stderr)
     finally:

--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""sc interface — CLI parity for the Interface (spec #20, sprint 25 seq 6).
+
+The terminal client half of the Interface: every verb talks to the engine's
+Interface HTTP API (operator bearer, the mode-0600 capability the supervised
+server provisions at boot) and NOTHING else — no direct DB reads of interface
+state, no `tmux attach` (spec #20 CLI Parity: an API outage reports the
+supervised-runtime remediation; it never falls back).
+
+    ./sc interface status [<shell>] [--json]       rail state (+ exact session
+                                                   state for a named shell)
+    ./sc interface start <shell> [--harness H] [--model M] [--effort E] [--json]
+                                                   scriptable New chat
+    ./sc interface view <shell>                    read-only attach
+    ./sc interface attach <shell>                  writer attach (refuses a held
+                                                   lease; never takes over)
+    ./sc interface take-control <shell>            explicit writer transfer
+    ./sc interface stop <shell> [--force] [--json] graceful end; force only
+                                                   after a graceful timeout
+    ./sc interface reconcile <shell> [--close] [--json]
+    ./sc interface enter [<shell>]                 the `sc enter` flow: New chat
+                                                   for an available shell
+                                                   (normal harness picker),
+                                                   reattach an occupied one
+
+The attach client speaks sc-term.v1 (api/interface_ws.py) — the same session
+stream and writer lease as the browser, ported from the proven spike
+(spikes/interface-stream/cli_client.py). A refresh/reconnect reattaches the
+same generation; it never provider-resumes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import select
+import signal
+import sys
+import termios
+import threading
+import time
+import tty
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ENGINE / "scripts"))
+import ports as ports_mod  # noqa: E402
+import style  # noqa: E402
+import run as run_mod  # noqa: E402  — the enter flow reuses its harness picker
+
+RUN_DIR = ENGINE / "run" / "interface"
+OPERATOR_TOKEN_PATH = RUN_DIR / "operator.token"
+API_BASE = f"http://127.0.0.1:{ports_mod.resolve().get('port', 8800)}"
+
+EXIT_REFUSED = 1       # an API refusal (409/4xx) or a precondition failed
+EXIT_USAGE = 2         # bad arguments / unknown shell
+EXIT_API_DOWN = 3      # API unreachable / capability missing — remediation
+
+SUBPROTOCOL = "sc-term.v1"
+HEARTBEAT_S = 20
+OCCUPIED_WAIT_S = 90   # reservation TTL is 60s; a healthy boot is seconds
+
+
+class ApiError(Exception):
+    """An HTTP answer from the Interface API (status + the error envelope)."""
+
+    def __init__(self, status: int, code: str, message: str, details=None):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+        self.details = details or {}
+
+
+def die(msg: str, code: int = EXIT_REFUSED) -> None:
+    print(f"sc interface: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _die_unreachable(reason) -> None:
+    die(f"Interface API unreachable at {API_BASE} ({reason})\n"
+        "  The Interface runtime is host-supervised — restart it via the "
+        "supervisor (`./sc restart`, or `make dos-r` on the host stack).\n"
+        "  There is no direct-DB or tmux fallback (spec #20).",
+        EXIT_API_DOWN)
+
+
+def _operator_token() -> str:
+    try:
+        return OPERATOR_TOKEN_PATH.read_text().strip()
+    except OSError:
+        die(f"operator capability missing at {OPERATOR_TOKEN_PATH} — the "
+            "Interface server provisions it at boot; restart the supervised "
+            "runtime (`./sc restart` / `make dos-r`).", EXIT_API_DOWN)
+
+
+def _http(req):
+    """The one network seam — tests patch this, never the verbs."""
+    return urllib.request.urlopen(req, timeout=15)
+
+
+def api(method: str, path: str, body: dict | None = None) -> dict:
+    """One Interface API call: operator bearer, Idempotency-Key (uuid4) on
+    every mutation exactly as the API requires. An HTTP error answer raises
+    ApiError; a transport failure is the supervised-runtime remediation."""
+    headers = {"Authorization": f"Bearer {_operator_token()}"}
+    data = None
+    if method in ("POST", "DELETE", "PATCH", "PUT"):
+        headers["Idempotency-Key"] = str(uuid.uuid4())
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(API_BASE + path, data=data, headers=headers,
+                                 method=method)
+    try:
+        with _http(req) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        try:
+            err = json.loads(exc.read() or b"{}").get("error") or {}
+        except ValueError:
+            err = {}
+        raise ApiError(exc.code, err.get("code", f"http_{exc.code}"),
+                       err.get("message", exc.reason),
+                       err.get("details")) from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        _die_unreachable(getattr(exc, "reason", exc))
+
+
+# ------------------------------------------------------------------ helpers
+
+def _shells() -> list[dict]:
+    return api("GET", "/api/interface/shells").get("shells", [])
+
+
+def _find_shell(name: str) -> dict:
+    shells = _shells()
+    chosen = next((s for s in shells
+                   if (s.get("shortname") or "").lower() == name.lower()), None)
+    if chosen is None:
+        avail = ", ".join(s.get("shortname") or "?" for s in shells) or "none"
+        die(f"no shell '{name}'. Available: {avail}", EXIT_USAGE)
+    return chosen
+
+
+def _session_of(shell: dict) -> int | None:
+    sid = shell.get("session_id")
+    if sid is None:
+        die(f"{shell.get('shortname')} is {shell.get('availability')} — no "
+            "live Interface session to act on")
+    return sid
+
+
+def _session_detail(session_id: int) -> dict:
+    return api("GET", f"/api/interface/sessions/{session_id}")
+
+
+def _client_id() -> str:
+    return f"cli-{os.getpid()}"
+
+
+def _winsize() -> tuple[int, int]:
+    """Current terminal rows/cols for the pane reservation (24x80 off-TTY)."""
+    try:
+        import fcntl
+        import struct
+        rows, cols, _, _ = struct.unpack(
+            "HHHH", fcntl.ioctl(0, termios.TIOCGWINSZ, b"\0" * 8))
+        return rows or 24, cols or 80
+    except OSError:
+        return 24, 80
+
+
+def _print_json(obj) -> None:
+    print(json.dumps(obj, indent=2, sort_keys=True))
+
+
+def _print_api_error(exc: ApiError) -> None:
+    print(f"sc interface: {exc.code}: {exc.message}", file=sys.stderr)
+
+
+# ------------------------------------------------------------------ status
+
+def _status_line(s: dict) -> str:
+    short = "{:<10}".format(s.get("shortname") or "?")
+    name = "{:<18}".format(s.get("display_name") or "")
+    avail = "{:<13}".format(s.get("availability") or "?")
+    bits = []
+    if s.get("lifecycle"):
+        bits.append(s["lifecycle"])
+    if s.get("harness"):
+        bits.append(s["harness"])
+    if s.get("composer"):
+        bits.append(f"composer:{s['composer']}")
+    if s.get("alerts"):
+        bits.append(f"alerts:{s['alerts']}")
+    return f"{short} {name} {avail} {' · '.join(bits)}".rstrip()
+
+
+def cmd_status(args) -> int:
+    if not args.shell:
+        shells = _shells()
+        if args.json:
+            _print_json({"shells": shells})
+        else:
+            for s in shells:
+                print(_status_line(s))
+        return 0
+    shell = _find_shell(args.shell)
+    detail = (_session_detail(shell["session_id"])
+              if shell.get("session_id") is not None else None)
+    if args.json:
+        _print_json({"shell": shell, "session": detail})
+        return 0
+    print(_status_line(shell))
+    if detail is None:
+        return 0
+    writer = detail.get("writer") or {}
+    held = (f"held by {writer.get('client_id')}" if writer.get("held")
+            else "free")
+    rows = [("session", detail.get("session_id")),
+            ("generation", detail.get("generation")),
+            ("occupancy", detail.get("occupancy")),
+            ("lifecycle", detail.get("lifecycle")),
+            ("harness", detail.get("harness")),
+            ("model", detail.get("model_route")),
+            ("composer", detail.get("composer")),
+            ("writer", held),
+            ("wake", detail.get("wake_state")),
+            ("clients", detail.get("clients")),
+            ("alerts", detail.get("alerts"))]
+    if detail.get("error_detail"):
+        rows.append(("error", detail["error_detail"]))
+    for key, value in rows:
+        print(f"  {key:<11} {value}")
+    return 0
+
+
+# ------------------------------------------------------------------ start
+
+def _start_session(shell: dict, harness=None, model=None, effort=None) -> dict:
+    body = {"shell_id": shell["shell_id"]}
+    rows, cols = _winsize()
+    body["rows"], body["cols"] = rows, cols
+    if harness:
+        body["harness"] = harness
+    if model:
+        body["model"] = model
+    if effort:
+        body["effort"] = effort
+    try:
+        return api("POST", "/api/interface/sessions", body)
+    except ApiError as exc:
+        if exc.status == 409 and exc.code == "shell_occupied":
+            owner = (exc.details or {}).get("session_id")
+            die(f"{shell.get('shortname')} is occupied — session {owner} "
+                "owns it; attach with `sc interface attach "
+                f"{shell.get('shortname')}` (or take-control)")
+        _print_api_error(exc)
+        raise SystemExit(EXIT_REFUSED) from exc
+
+
+def cmd_start(args) -> int:
+    shell = _find_shell(args.shell)
+    resp = _start_session(shell, harness=args.harness, model=args.model,
+                          effort=args.effort)
+    if args.json:
+        _print_json(resp)
+        return 0
+    short = shell.get("shortname")
+    if resp.get("occupancy") in ("unreconciled", "ended"):
+        die(f"session {resp.get('session_id')} could not start "
+            f"({resp.get('error', 'spawn failed')}) — investigate, then "
+            f"`sc interface reconcile {short}`")
+    print(f"→ session {resp['session_id']} reserved for {short} "
+          f"(generation {resp.get('generation')}, starting) — attach with "
+          f"`sc interface attach {short}`")
+    return 0
+
+
+# ------------------------------------------------------------------ attach
+
+def _acquire_lease(session_id: int, takeover: bool) -> dict:
+    return api("POST", "/api/interface/writer-leases",
+               {"session_id": session_id, "client_id": _client_id(),
+                "takeover": takeover})
+
+
+def _writer_holder(session_id: int) -> str:
+    try:
+        writer = (_session_detail(session_id).get("writer") or {})
+    except ApiError:
+        return ""
+    return (f" by {writer.get('client_id')}" if writer.get("held") else "")
+
+
+def _attach(session_id: int, role: str, lease: dict | None = None) -> int:
+    """Mint a single-use ticket and run the terminal stream. Writer tickets
+    ride the current lease token; input seq continues the SESSION's sequence
+    (the lease reseeds from forwarded_seq+1 — starting at 1 would wedge)."""
+    body = {"session_id": session_id, "role": role,
+            "client_id": _client_id()}
+    if lease is not None:
+        body["lease_token"] = lease["lease_token"]
+    ticket = api("POST", "/api/interface/stream-tickets", body)["ticket"]
+    ws_url = (API_BASE.replace("http", "ws", 1)
+              + f"/api/interface/session-streams/{session_id}?ticket={ticket}")
+    start_seq = (lease or {}).get("next_input_seq", 1)
+    return run_stream(ws_url, role, start_seq, lease)
+
+
+def _attach_writer(shell: dict, session_id: int, takeover: bool) -> int:
+    short = shell.get("shortname")
+    try:
+        lease = _acquire_lease(session_id, takeover)
+    except ApiError as exc:
+        if exc.status == 409 and not takeover:
+            die(f"writer lease held{_writer_holder(session_id)} "
+                f"({exc.message}) — not taking over silently; use "
+                f"`sc interface take-control {short}` for an explicit "
+                f"transfer, or `sc interface view {short}` to watch")
+        _print_api_error(exc)
+        raise SystemExit(EXIT_REFUSED) from exc
+    return _attach(session_id, "writer", lease)
+
+
+def cmd_view(args) -> int:
+    shell = _find_shell(args.shell)
+    return _attach(_session_of(shell), "viewer")
+
+
+def cmd_attach(args) -> int:
+    shell = _find_shell(args.shell)
+    return _attach_writer(shell, _session_of(shell), takeover=False)
+
+
+def cmd_take_control(args) -> int:
+    shell = _find_shell(args.shell)
+    return _attach_writer(shell, _session_of(shell), takeover=True)
+
+
+def run_stream(ws_url: str, role: str, start_seq: int,
+               lease: dict | None = None) -> int:
+    """The sc-term.v1 terminal loop (spike port): stdin raw, stdin bytes →
+    0x01|seq:u64be|payload as writer, 0x03 resize on start + SIGWINCH,
+    0x00/0x04 payloads → stdout, JSON control frames dimmed to stderr, 20s
+    writer heartbeat, clean exit on close/terminated. The writer lease is
+    released on the way out (a closing client releases only ITS lease —
+    tmux and the harness continue)."""
+    from websockets.sync.client import connect
+
+    ws = connect(ws_url, subprotocols=[SUBPROTOCOL])
+    old_attrs = termios.tcgetattr(0) if os.isatty(0) else None
+    if old_attrs:
+        tty.setraw(0)
+    state = {"seq": start_seq, "winch": True, "dead": False}
+    signal.signal(signal.SIGWINCH, lambda *_: state.__setitem__("winch", True))
+
+    def sender() -> None:
+        try:
+            while not state["dead"]:
+                if state["winch"]:
+                    state["winch"] = False
+                    rows, cols = _winsize()
+                    ws.send(b"\x03" + rows.to_bytes(2, "big")
+                            + cols.to_bytes(2, "big"))
+                r, _, _ = select.select([sys.stdin.buffer], [], [], 0.2)
+                if not r:
+                    continue
+                data = os.read(0, 65536)
+                if not data:
+                    state["dead"] = True
+                    return
+                if role == "writer":
+                    ws.send(b"\x01" + state["seq"].to_bytes(8, "big") + data)
+                    state["seq"] += 1
+        except Exception:
+            state["dead"] = True
+
+    def heartbeater() -> None:
+        while not state["dead"]:
+            time.sleep(HEARTBEAT_S)
+            try:
+                ws.send(json.dumps({"type": "heartbeat"}))
+            except Exception:
+                return
+
+    threads = [threading.Thread(target=sender, daemon=True)]
+    if role == "writer":
+        threads.append(threading.Thread(target=heartbeater, daemon=True))
+    for t in threads:
+        t.start()
+
+    out = sys.stdout.buffer
+    try:
+        for message in ws:
+            if isinstance(message, bytes):
+                if message[:1] in (b"\x00", b"\x04"):
+                    out.write(message[1:])
+                    out.flush()
+            else:
+                msg = json.loads(message)
+                if msg.get("type") == "error" and msg.get("code") == "terminated":
+                    break
+                print(f"\x1b[2m[{message}]\x1b[0m", file=sys.stderr)
+    except Exception as exc:
+        print(f"connection closed: {exc!r}", file=sys.stderr)
+    finally:
+        state["dead"] = True
+        if old_attrs:
+            termios.tcsetattr(0, termios.TCSADRAIN, old_attrs)
+        if lease:
+            try:
+                api("DELETE",
+                    f"/api/interface/writer-leases/{lease['lease_id']}",
+                    {"lease_token": lease["lease_token"]})
+            except Exception:
+                pass  # session end already revokes; release is best-effort
+    return 0
+
+
+# ------------------------------------------------------------------ stop / reconcile
+
+def cmd_stop(args) -> int:
+    shell = _find_shell(args.shell)
+    session_id = _session_of(shell)
+    try:
+        resp = api("POST", "/api/interface/termination-requests",
+                   {"session_id": session_id, "force": bool(args.force)})
+    except ApiError as exc:
+        _print_api_error(exc)
+        if exc.code == "force_requires_graceful_timeout":
+            print("  run without --force first; force unlocks only after "
+                  "that graceful request times out", file=sys.stderr)
+        raise SystemExit(EXIT_REFUSED) from exc
+    if args.json:
+        _print_json(resp)
+        return 0 if resp.get("terminated") else EXIT_REFUSED
+    if resp.get("terminated"):
+        print(f"→ session {session_id} ended — {shell.get('shortname')} "
+              "offers New chat again")
+        return 0
+    reason = resp.get("reason", "graceful_timeout")
+    print(f"→ session {session_id} not terminated ({reason}, "
+          f"pid {resp.get('pid')}, generation {resp.get('generation')})")
+    if reason == "graceful_timeout":
+        print("  force is now unlocked: `sc interface stop "
+              f"{shell.get('shortname')} --force`")
+    return EXIT_REFUSED
+
+
+def cmd_reconcile(args) -> int:
+    shell = _find_shell(args.shell)
+    session_id = _session_of(shell)
+    action = "close" if args.close else "verify"
+    try:
+        resp = api("POST", "/api/interface/reconciliations",
+                   {"session_id": session_id, "action": action})
+    except ApiError as exc:
+        _print_api_error(exc)
+        raise SystemExit(EXIT_REFUSED) from exc
+    if args.json:
+        _print_json(resp)
+        return 0
+    for line in resp.get("actions", []):
+        print(f"→ {line}")
+    print(f"→ session {session_id}: occupancy {resp.get('occupancy')}")
+    return 0
+
+
+# ------------------------------------------------------------------ enter
+
+def _flavor_harness(shell: dict) -> str | None:
+    """The shell's flavor default harness, read from the engine DB exactly as
+    the boot path does (launch routing data — never interface state, which
+    comes from the API only). Best-effort: any failure degrades to the
+    instance default."""
+    try:
+        con = run_mod.db_driver.connect(str(run_mod.DB_PATH))
+        try:
+            row = con.execute("SELECT flavor FROM shells WHERE shell_id=?",
+                              (shell["shell_id"],)).fetchone()
+            fdef = run_mod.flavor_defaults(con).get(row["flavor"] if row
+                                                    else None)
+        finally:
+            con.close()
+    except Exception:
+        return None
+    return fdef["default_harness"] if fdef else None
+
+
+def _pick_harness(shell: dict, args) -> str | None:
+    """The normal boot picker (run.py's own): an explicit --harness / HARNESS
+    wins silently; else the harnesses on PATH, defaulting to this shell's
+    flavor default → instance.json → 'claude'. Model/effort resolve through
+    the reservation (prepare_launch's flavor_defaults), like the GUI's New
+    chat; explicit --model/--effort flags override."""
+    if args.harness:
+        return args.harness
+    if os.environ.get("HARNESS"):
+        return os.environ["HARNESS"]
+    default = (_flavor_harness(shell) or run_mod._configured_harness()
+               or "claude")
+    picked = run_mod.pick_harness(run_mod.detect_harnesses(), default,
+                                  first=False)
+    return picked or default
+
+
+def _pick_shell(shells: list[dict], requested: str | None) -> dict:
+    """The `sc enter` shell picker, API-backed: the rail's own data (the
+    operator bearer is the auth — no username round-trip)."""
+    if requested:
+        return _find_shell(requested)
+    if not shells:
+        die("no shells")
+    if not sys.stdin.isatty():
+        return shells[0]
+    for n, s in enumerate(shells, 1):
+        print(f"{style.dim(f'{n:>3}')}  {_status_line(s)}")
+    while True:
+        choice = input("\nPick (#): ").strip()
+        if choice.isdigit() and 1 <= int(choice) <= len(shells):
+            return shells[int(choice) - 1]
+        print("  invalid choice")
+
+
+def _wait_occupied(session_id: int, timeout: float = OCCUPIED_WAIT_S) -> dict:
+    """Poll until the reservation promotes to occupied (the session_start
+    hook) or fails. A writer lease requires occupied, so attach waits."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        detail = _session_detail(session_id)
+        if detail.get("occupancy") == "occupied":
+            return detail
+        if detail.get("occupancy") in ("unreconciled", "ended"):
+            die(f"session {session_id} failed to start "
+                f"({detail.get('error_detail') or 'no detail'}) — "
+                "`sc interface reconcile` after investigating")
+        time.sleep(1)
+    die(f"session {session_id} still starting after {int(timeout)}s — "
+        "attach when occupied: `sc interface attach <shell>`")
+
+
+def cmd_enter(args) -> int:
+    """`sc enter`: resolve the Interface API, then New chat for an available
+    shell or reattach the occupied generation. Never provider-resume, never
+    `tmux attach`."""
+    shell = _pick_shell(_shells(), args.shell)
+    short = shell.get("shortname")
+    avail = shell.get("availability")
+    if avail == "available":
+        harness = _pick_harness(shell, args)
+        resp = _start_session(shell, harness=harness, model=args.model,
+                              effort=args.effort)
+        session_id = resp["session_id"]
+        print(f"→ session {session_id} starting for {short} "
+              f"(generation {resp.get('generation')}, harness "
+              f"{resp.get('harness') or harness or 'default'})…")
+        _wait_occupied(session_id)
+        return _attach_writer(shell, session_id, takeover=False)
+    if avail == "occupied":
+        session_id = shell["session_id"]
+        try:
+            lease = _acquire_lease(session_id, takeover=False)
+        except ApiError as exc:
+            if exc.status != 409:
+                _print_api_error(exc)
+                raise SystemExit(EXIT_REFUSED) from exc
+            print(f"→ writer lease held{_writer_holder(session_id)} — "
+                  "attaching READ-ONLY (`sc interface take-control "
+                  f"{short}` to take the writer role)", file=sys.stderr)
+            return _attach(session_id, "viewer")
+        return _attach(session_id, "writer", lease)
+    if avail == "starting":
+        die(f"{short} is starting (a reservation is booting) — retry in a "
+            f"moment, or watch with `sc interface view {short}`")
+    die(f"{short} is {avail} — New chat is blocked. "
+        f"`sc interface status {short}` shows the session; "
+        f"`sc interface reconcile {short}` revalidates it.")
+
+
+# ------------------------------------------------------------------ dispatch
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sc interface",
+        description="CLI parity for the Interface (spec #20) — API only, "
+                    "no direct DB, no tmux attach")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("status", help="rail/session state")
+    sp.add_argument("shell", nargs="?")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(fn=cmd_status)
+
+    sp = sub.add_parser("start", help="scriptable API-backed New chat")
+    sp.add_argument("shell")
+    sp.add_argument("--harness")
+    sp.add_argument("--model")
+    sp.add_argument("--effort")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(fn=cmd_start)
+
+    sp = sub.add_parser("view", help="read-only attach")
+    sp.add_argument("shell")
+    sp.set_defaults(fn=cmd_view)
+
+    sp = sub.add_parser("attach", help="writer attach (never takes over)")
+    sp.add_argument("shell")
+    sp.set_defaults(fn=cmd_attach)
+
+    sp = sub.add_parser("take-control", help="explicit writer transfer")
+    sp.add_argument("shell")
+    sp.set_defaults(fn=cmd_take_control)
+
+    sp = sub.add_parser("stop", help="graceful end; --force after a timeout")
+    sp.add_argument("shell")
+    sp.add_argument("--force", action="store_true")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(fn=cmd_stop)
+
+    sp = sub.add_parser("reconcile", help="revalidate (or --close) a session")
+    sp.add_argument("shell")
+    sp.add_argument("--close", action="store_true",
+                    help="end an unreconciled session after proved absence")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(fn=cmd_reconcile)
+
+    sp = sub.add_parser("enter", help="the `sc enter` flow (in-container)")
+    sp.add_argument("shell", nargs="?")
+    sp.add_argument("--harness")
+    sp.add_argument("--model")
+    sp.add_argument("--effort")
+    sp.set_defaults(fn=cmd_enter)
+    return p
+
+
+def main(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.super-coder/scripts/interface_runtime.py
+++ b/.super-coder/scripts/interface_runtime.py
@@ -10,9 +10,13 @@ thread with the tmux send-keys write injected as `writer`; the output path
 (private tmux server on a mode-0700 socket, FIFO pipe-pane pump, 8 MiB
 bounded bridge, shadow sidecar fed before fanout) is ported unchanged.
 
-The runtime owns processes, tmux, and volatile stream state ONLY — every
+The runtime owns processes, tmux, and volatile stream state; every
 occupancy/lifecycle/composer transition stays in the DB and is the routes
-layer's job. On service restart the tmux server and FIFO files survive
+layer's job. The one DB-write exception is writer-lease liveness (seq 6):
+a writer's heartbeats stamp heartbeat_at, and a detached or heartbeat-silent
+writer's lease row is revoked (revoke_reason='liveness'), fenced by lease
+id/token/generation so a stale detach never clobbers a re-acquired lease.
+On service restart the tmux server and FIFO files survive
 (`.super-coder/run/interface/` is stable), so start() reattaches every
 occupied session whose pane identity still verifies exactly.
 
@@ -51,6 +55,7 @@ SENDKEYS_CHUNK = 512                  # proven tmux -H chunk size
 MAX_INPUT_PAYLOAD = 64 * 1024         # wire protocol limit
 TMUX_MIN_VERSION = (3, 4)
 LEASE_HEARTBEAT_TIMEOUT = 60.0        # 3 missed 20s heartbeats
+LEASE_LIVENESS_TIMEOUT = 40.0         # dead-lease sweep bound (WS PING_TIMEOUT)
 TICKET_TTL_S = 60
 GRACEFUL_TERMINATE_S = 10.0
 SHADOW_REQUEST_TIMEOUT_S = 10.0   # a sidecar that can't answer is dead
@@ -1057,6 +1062,12 @@ class InterfaceRuntime:
         gen = self.generations.get(client.session_id)
         if gen is not None:
             gen.detach(client)
+        if client.role == "writer" and client.lease_id is not None:
+            # A detached writer's DB lease dies with it (seq 6 liveness);
+            # the revoke is fenced so a stale detach never clobbers a lease
+            # the client re-acquired. A viewer detaches nothing.
+            generation = gen.generation if gen is not None else None
+            asyncio.create_task(self._revoke_writer_lease(client, generation))
 
     # -- DB state reads (for controls) ---------------------------------------------
 
@@ -1106,7 +1117,7 @@ class InterfaceRuntime:
             msg["stale"] = True
         return msg
 
-    # -- writer heartbeat (WS layer heartbeats; DB revoke is seq 6+) ---------
+    # -- writer lease liveness (seq 6): the DB lease tracks the client -------
 
     def heartbeat(self, client) -> None:
         gen = self.generations.get(client.session_id)
@@ -1114,17 +1125,122 @@ class InterfaceRuntime:
             return
         was_stale = getattr(client, "hb_stale", False)
         client.last_hb = time.monotonic()
+        if client.lease_id is not None:
+            # Durable heartbeat: the dead-lease sweep reads heartbeat_at.
+            asyncio.create_task(self._touch_writer_lease(client))
         if was_stale:
             client.hb_stale = False
             asyncio.create_task(self._broadcast_writer_state(gen))
+
+    def _touch_lease_sync(self, lease_id, lease_token) -> None:
+        token_hash = hashlib.sha256((lease_token or "").encode()).hexdigest()
+        con = db_driver.connect(self.db_path)
+        try:
+            con.execute(
+                "UPDATE interface_writer_leases SET heartbeat_at=datetime('now')"
+                " WHERE lease_id=? AND token_hash=? AND revoked_at IS NULL",
+                (lease_id, token_hash))
+            con.commit()
+        finally:
+            con.close()
+
+    async def _touch_writer_lease(self, client) -> None:
+        try:
+            await asyncio.to_thread(self._touch_lease_sync, client.lease_id,
+                                    client.lease_token)
+        except Exception as exc:  # noqa: BLE001 — a missed touch is retried
+            _log(f"s{client.session_id}", f"lease heartbeat failed: {exc!r}")
+
+    def _revoke_lease_sync(self, lease_id, lease_token, generation) -> bool:
+        """Liveness revoke, fenced by lease id + token (+ generation when
+        known): a late detach of a dead client must never clobber the lease
+        it re-acquired. True iff this call did the revoking."""
+        token_hash = hashlib.sha256((lease_token or "").encode()).hexdigest()
+        sql = ("UPDATE interface_writer_leases SET revoked_at=datetime('now'),"
+               " revoke_reason='liveness' WHERE lease_id=? AND token_hash=?"
+               " AND revoked_at IS NULL")
+        args: list = [lease_id, token_hash]
+        if generation is not None:
+            sql += " AND generation=?"
+            args.append(generation)
+        con = db_driver.connect(self.db_path)
+        try:
+            cur = con.execute(sql, args)
+            con.commit()
+            return cur.rowcount > 0
+        finally:
+            con.close()
+
+    async def _revoke_writer_lease(self, client, generation) -> None:
+        try:
+            revoked = await asyncio.to_thread(
+                self._revoke_lease_sync, client.lease_id, client.lease_token,
+                generation)
+        except Exception as exc:  # noqa: BLE001 — never break the detach path
+            _log(f"s{client.session_id}", f"lease revoke failed: {exc!r}")
+            return
+        if not revoked:
+            return  # already released / taken over / ended — nothing to say
+        _log(f"s{client.session_id}", f"writer lease {client.lease_id} revoked"
+                                     " (liveness: client detached)")
+        gen = self.generations.get(client.session_id)
+        if gen is not None:
+            await self._broadcast_writer_state(gen)
+
+    def _sweep_dead_leases_sync(self, targets) -> list:
+        """Revoke live leases whose durable heartbeat has gone silent past
+        the liveness bound, scoped to the (session, generation) pairs this
+        runtime owns. Returns the [(session_id, lease_id)] it revoked."""
+        con = db_driver.connect(self.db_path)
+        revoked = []
+        try:
+            for session_id, generation in targets:
+                row = con.execute(
+                    "SELECT lease_id FROM interface_writer_leases "
+                    "WHERE session_id=? AND generation=? AND revoked_at IS NULL"
+                    " AND (heartbeat_at IS NULL OR heartbeat_at < "
+                    "datetime('now', ?))",
+                    (session_id, generation,
+                     f"-{int(LEASE_LIVENESS_TIMEOUT)} seconds")).fetchone()
+                if row is None:
+                    continue
+                cur = con.execute(
+                    "UPDATE interface_writer_leases SET "
+                    "revoked_at=datetime('now'), revoke_reason='liveness' "
+                    "WHERE lease_id=? AND revoked_at IS NULL", (row[0],))
+                if cur.rowcount > 0:
+                    revoked.append((session_id, row[0]))
+            con.commit()
+            return revoked
+        finally:
+            con.close()
+
+    async def _sweep_dead_leases(self) -> None:
+        targets = [(gen.session_id, gen.generation)
+                   for gen in list(self.generations.values())]
+        if not targets:
+            return
+        try:
+            revoked = await asyncio.to_thread(self._sweep_dead_leases_sync,
+                                              targets)
+        except Exception as exc:  # noqa: BLE001 — the reaper must not die
+            _log("sweep", f"stale-lease sweep failed: {exc!r}")
+            return
+        for session_id, lease_id in revoked:
+            _log(f"s{session_id}", f"stale writer lease {lease_id} swept "
+                                   "(liveness: heartbeat silent)")
+            gen = self.generations.get(session_id)
+            if gen is not None:
+                await self._broadcast_writer_state(gen)
 
     async def _broadcast_writer_state(self, gen: Generation) -> None:
         for client in list(gen.clients):
             client.send_control(await self.writer_control(gen, client))
 
     async def _heartbeat_reaper(self) -> None:
-        """Mark heartbeat-silent writers stale and broadcast writer state.
-        The DB lease itself persists until takeover/termination/restart."""
+        """Mark heartbeat-silent writers stale, broadcast writer state, and
+        sweep writer leases whose durable heartbeat has gone silent past the
+        liveness bound — a dead writer's lease must not outlive it."""
         try:
             while True:
                 await asyncio.sleep(5)
@@ -1141,6 +1257,7 @@ class InterfaceRuntime:
                             changed = True
                     if changed:
                         await self._broadcast_writer_state(gen)
+                await self._sweep_dead_leases()
         except asyncio.CancelledError:
             pass
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -16,6 +16,13 @@ Usage:
     python3 .super-coder/scripts/run.py [shortname] [--first]
     RENDER_ONLY=1 python3 .super-coder/scripts/run.py --first   # render, don't exec
 
+Interface gate (spec #20): the INTERACTIVE path of main() is no longer a public
+entry — interactive chats start through the Interface API (`./sc enter`), which
+holds the reservation capability, so a direct interactive launch refuses before
+creating an archive (SC_RAW_BOOT=1 is the tooling escape hatch). Headless and
+RENDER_ONLY are unaffected. The token-carrying engine path (interface_exec)
+calls prepare_launch below, never main().
+
 Headless (`./sc run <shortname> [-p "<prompt>"] [--harness <h>] [-m <model>]
 [--effort <level>]`):
 the same render-then-exec path minus the picker and the TTY. The harness runs
@@ -1094,6 +1101,22 @@ def main() -> None:
     if headless and not requested:
         sys.exit('usage: ./sc run <shortname> [-p "<prompt>"] [--harness <h>] '
                  '[-m <model>] [--effort <level>]')
+
+    # Interface gate (spec #20 Tmux Runtime): a public INTERACTIVE launch holds
+    # no reservation capability. Interactive chats start through the Interface
+    # API (`./sc enter` / `sc interface start`), which reserves the generation
+    # BEFORE any archive exists; the token-carrying exec path (interface-exec)
+    # goes through prepare_launch, never main(). Refuse before open_db/
+    # open_session could create an unmanaged archive. Headless (`sc run`) and
+    # RENDER_ONLY (verify) are not interactive launches and stay on this path;
+    # SC_RAW_BOOT=1 is the tooling escape hatch (same standing as
+    # SC_NO_AUTOPRUNE — process scanning stays the backstop either way).
+    if not headless and not os.environ.get("RENDER_ONLY") \
+            and not os.environ.get("SC_RAW_BOOT"):
+        sys.exit("interactive launches go through the Interface (spec #20) — "
+                 "use `./sc enter <shell>` (or `./sc interface start <shell>`). "
+                 "The raw launch path is reserved for the engine's reservation "
+                 "capability (interface-exec).")
 
     # Wordmark banner — interactive boots only; headless/verify logs stay clean.
     if not headless and not os.environ.get("RENDER_ONLY") and sys.stdin.isatty():

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2131,9 +2131,15 @@ async function ifBootstrap() {
   for (let attempt = 0; attempt < 2; attempt++) {
     const headers = { "Content-Type": "application/json", "Idempotency-Key": crypto.randomUUID() };
     if (ifOpToken) headers["Authorization"] = "Bearer " + ifOpToken;
-    const r = await fetch("/api/interface/browser-sessions", {
-      method: "POST", credentials: "same-origin", headers, body: "{}",
-    });
+    let r;
+    try {
+      r = await fetch("/api/interface/browser-sessions", {
+        method: "POST", credentials: "same-origin", headers, body: "{}",
+      });
+    } catch (e) {
+      ifOpToken = null;   // network failure — never keep a half-used capability
+      throw e;
+    }
     const data = await r.json().catch(() => ({}));
     if (r.ok) { ifCsrf = data.csrf; ifOpToken = null; return; }
     if (r.status === 401 && attempt === 0) {
@@ -2141,13 +2147,14 @@ async function ifBootstrap() {
         "Interface operator capability required — paste the contents of\n" +
         ".super-coder/run/interface/operator.token (mode 0600, operator-only):",
         "");
-      if (!t) throw ifError(r, data);
+      if (!t) { ifOpToken = null; throw ifError(r, data); }
       ifOpToken = t.trim();
       continue;
     }
-    if (r.status === 401) {   // the pasted capability was rejected
-      ifOpToken = null;
-    }
+    // EVERY other non-ok exit (rejected 401 retry, 403, 409, 422, 5xx,
+    // malformed body) drops the capability uniformly — it never survives a
+    // failed exchange, no matter which branch failed.
+    ifOpToken = null;
     throw ifError(r, data);
   }
 }
@@ -2207,18 +2214,33 @@ async function renderInterface(root) {
   }
   const rail = el("div", { className: "if-rail" });
   const pane = el("div", { className: "if-pane" });
-  root.append(el("div", { className: "if-wrap" }, rail, pane));
+  // Mobile shell picker (CSS-hidden on desktop): same selection, same hash.
+  const picker = el("select", { className: "if-picker", title: "shell" });
+  picker.append(el("option", { value: "" }, "select a shell…"));
+  root.append(el("div", { className: "if-wrap" }, picker, rail, pane));
   for (const s of shells) {
+    // Projection happens SERVER-side (_availability): reserved+starting →
+    // starting, occupied+(idle|busy|approval|user_input) → occupied,
+    // unreconciled+(lost|error) → lost|error. The rail renders it verbatim;
+    // New-chat authority below stays keyed on availability === "available".
     const row = el("button", { type: "button",
       className: "if-row" + (s.shortname === ifSelected ? " active" : "") });
-    row.append(
-      el("div", { className: "if-row-head" },
-        el("b", {}, s.display_name || s.shortname),
-        el("span", { className: "pill if-badge " + (IF_BADGE[s.availability] || "") }, s.availability)),
+    const head = el("div", { className: "if-row-head" },
+      el("b", {}, s.display_name || s.shortname),
+      el("span", { className: "pill if-badge " + (IF_BADGE[s.availability] || "") }, s.availability));
+    if (s.alerts > 0)
+      head.append(el("span", { className: "pill if-badge bad",
+        title: s.alerts + " unread alert(s)" }, "⚠ " + s.alerts));
+    row.append(head,
       el("div", { className: "if-row-sub" }, s.shortname + (s.harness ? " · " + s.harness : "")));
     row.onclick = () => { location.hash = "interface/" + s.shortname; };
     rail.append(row);
+    const opt = el("option", { value: s.shortname },
+      `${s.display_name || s.shortname} · ${s.shortname} · ${s.availability}`);
+    if (s.shortname === ifSelected) opt.selected = true;
+    picker.append(opt);
   }
+  picker.onchange = () => { if (picker.value) location.hash = "interface/" + picker.value; };
   if (!shells.length) rail.append(el("div", { className: "muted" }, "No shells."));
   const sel = shells.find((s) => s.shortname === ifSelected);
   if (!sel) {
@@ -2229,68 +2251,190 @@ async function renderInterface(root) {
   if (sel.availability === "available") return ifAvailablePane(pane, sel, root);
   if (sel.availability === "lost" || sel.availability === "error" || sel.availability === "unreconciled") {
     ifDetach();
-    const card = el("div", { className: "card" },
-      el("div", {}, el("b", {}, sel.display_name || sel.shortname), " is ",
-        el("span", { className: "pill if-badge bad" }, sel.availability), "."));
-    if (!sel.session_id) {
-      card.append(el("div", { className: "muted" },
-        "New chat is blocked — this shell runs a legacy or unmanaged harness."));
-    } else {
-      // Spec Interface Layout: a lost/error pane offers reconcile (verify the
-      // process still lives) and close (after absence is proved); a closed
-      // session frees the shell for a fresh generation.
-      const msg = el("div", { className: "muted" },
-        "New chat is blocked until this generation is reconciled or closed.");
-      const recon = el("button", { className: "act", type: "button", textContent: "Reconcile" });
-      const close = el("button", { className: "act", type: "button", textContent: "Close session" });
-      const note = el("div", { className: "if-note" });
-      recon.onclick = async () => {
-        recon.disabled = true; note.textContent = "";
-        try {
-          const r = await apiIf("/interface/reconciliations", "POST",
-            { session_id: sel.session_id, action: "verify" });
-          if (r.verified) return renderInterface(root);
-          note.textContent = "identity could not be verified — close it if the process is gone.";
-        } catch (e) { note.textContent = (e.code ? e.code + ": " : "") + e.message; }
-        recon.disabled = false;
-      };
-      close.onclick = async () => {
-        if (!confirm(`Close session #${sel.session_id}? Allowed only after the process is proved absent. This frees ${sel.display_name || sel.shortname} for a new chat.`)) return;
-        close.disabled = true; note.textContent = "";
-        try {
-          await apiIf("/interface/reconciliations", "POST",
-            { session_id: sel.session_id, action: "close" });
-          return renderInterface(root);
-        } catch (e) {
-          note.textContent = (e.code ? e.code + ": " : "") + e.message;
-          close.disabled = false;
-        }
-      };
-      card.append(msg, el("div", {}, recon, " ", close), note);
-    }
-    pane.append(card);
-    return;
+    return ifRecoveryPane(pane, sel, root);
   }
   return ifSessionPane(pane, sel);   // occupied | starting
 }
 
+// Lost/error/unreconciled pane (spec Interface Layout): diagnostics and
+// queued-work counts come straight from GET /sessions/<id> — occupancy,
+// lifecycle, error_detail, the input pipeline (composer/delivery/forwarded
+// seq), wake and alerts. The API exposes no explicit allowed-actions field,
+// so the action gates mirror the route's own 409 preconditions exactly:
+// verify any time the session isn't ended (this pane never shows ended),
+// close ONLY while occupancy is unreconciled (occupied refuses with
+// not_unreconciled; absence is re-proved server-side on every close). A
+// closed session derives available → New chat IS the fresh-generation action.
+async function ifRecoveryPane(pane, sel, root) {
+  const card = el("div", { className: "card" },
+    el("div", {}, el("b", {}, sel.display_name || sel.shortname), " is ",
+      el("span", { className: "pill if-badge bad" }, sel.availability), "."));
+  pane.append(card);
+  if (!sel.session_id) {
+    card.append(el("div", { className: "muted" },
+      "New chat is blocked — this shell runs a legacy or unmanaged harness. " +
+      "Prove the process absent (or adopt a managed generation) to free it."));
+    return;
+  }
+  let sess;
+  try { sess = await apiIf("/interface/sessions/" + sel.session_id); }
+  catch (e) {
+    card.append(el("div", { className: "muted" },
+      "session state unavailable (" + e.message + ") — reselect the shell to retry. " +
+      "Recovery actions stay hidden while the exact state is unknown."));
+    return;
+  }
+  const diag = el("div", { className: "if-diag" });
+  const drow = (k, v) => diag.append(el("span", { className: "if-stat" }, k + " ", el("b", {}, String(v ?? "—"))));
+  drow("session", "#" + sess.session_id + " · gen " + (sess.generation ?? "—"));
+  drow("occupancy", sess.occupancy);
+  drow("lifecycle", sess.lifecycle);
+  drow("harness", sess.harness || "—");
+  drow("composer", sess.composer);
+  drow("delivery", sess.delivery);
+  drow("forwarded seq", sess.forwarded_seq);
+  drow("wake", sess.wake_state);
+  drow("alerts", sess.alerts ?? 0);
+  card.append(diag);
+  if (sess.error_detail)
+    card.append(el("div", { className: "if-note" }, "diagnostics: " + sess.error_detail));
+  card.append(el("div", { className: "muted" },
+    "New chat is blocked until this generation is reconciled or closed."));
+
+  const note = el("div", { className: "if-note" });
+  const acts = el("div", {});
+  const recon = el("button", { className: "act", type: "button", textContent: "Reconcile",
+    title: "re-verify tmux/process identity — a verified unreconciled session returns to occupied" });
+  recon.onclick = async () => {
+    recon.disabled = true; note.textContent = "";
+    try {
+      const r = await apiIf("/interface/reconciliations", "POST",
+        { session_id: sess.session_id, action: "verify" });
+      if (r.verified) return renderInterface(root);
+      note.textContent = (r.actions || [])[0] ||
+        "identity could not be verified — close it if the process is gone.";
+    } catch (e) { note.textContent = (e.code ? e.code + ": " : "") + e.message; }
+    recon.disabled = false;
+  };
+  acts.append(recon);
+  if (sess.occupancy === "unreconciled") {
+    const close = el("button", { className: "act", type: "button", textContent: "Close session",
+      title: "only after absence is proved (re-checked server-side) — frees the shell for a fresh generation" });
+    close.onclick = async () => {
+      if (!confirm(`Close session #${sess.session_id}? Allowed only after the process is proved absent. This frees ${sel.display_name || sel.shortname} for a new chat.`)) return;
+      close.disabled = true; note.textContent = "";
+      try {
+        await apiIf("/interface/reconciliations", "POST",
+          { session_id: sess.session_id, action: "close" });
+        return renderInterface(root);
+      } catch (e) {
+        note.textContent = (e.code ? e.code + ": " : "") + e.message;
+        close.disabled = false;
+      }
+    };
+    acts.append(" ", close);
+  }
+  card.append(acts, note);
+}
+
+// Available pane: one primary New chat command (spec Interface Layout — no
+// second New-chat control exists for occupied or unreconciled shells). The
+// action opens the normal harness/model/effort choices sourced from the live
+// catalogue (GET /api/models v3, family-first) using the Default Models
+// picker conventions (dmModelPicker). POST /sessions rejects unknown fields
+// and accepts only shell_id/harness/model/effort/rows/cols — there is no
+// permission-mode field on the API, so none is offered here.
 function ifAvailablePane(pane, sel, root) {
   ifDetach();
-  const btn = el("button", { className: "act primary", type: "button", textContent: "New chat" });
-  const msg = el("div", { className: "muted" });
-  btn.onclick = async () => {
-    btn.disabled = true; msg.textContent = "";
+  const card = el("div", { className: "card if-newchat" },
+    el("div", {}, el("b", {}, sel.display_name || sel.shortname), " is available."));
+  const open = el("button", { className: "act primary", type: "button", textContent: "New chat" });
+  open.onclick = () => { open.remove(); ifNewChatForm(card, sel, root); };
+  card.append(open);
+  pane.append(card);
+}
+
+async function ifNewChatForm(card, sel, root) {
+  const msg = el("div", { className: "muted" }, "loading model catalogue…");
+  card.append(msg);
+  let cat = null;
+  try { cat = await api("/models"); } catch { /* typed ids still store as-is */ }
+  if (!card.isConnected) return;   // user navigated away mid-fetch
+  msg.textContent = cat ? "" :
+    "catalogue unreachable — typed ids are stored as-is (advisory).";
+
+  const harnesses = Object.keys((cat && cat.harnesses) || {}).sort();
+  const choice = { harness: harnesses[0] || null, model: "", effort: "" };
+
+  const effortSel = el("select", { className: "if-effort", title: "effort" });
+  const effortRow = el("div", { className: "dm-row", hidden: true },
+    el("span", { className: "dm-harness" }, "effort"), effortSel);
+  effortSel.onchange = () => { choice.effort = effortSel.value; };
+  const paintEffort = () => {
+    const entry = (((cat || {}).harnesses || {})[choice.harness] || { models: [] })
+      .models.find((m) => m.id === choice.model);
+    const efforts = (entry && entry.supported_efforts) || [];
+    choice.effort = "";
+    effortSel.replaceChildren(el("option", { value: "" }, "effort: harness default"));
+    for (const ef of efforts) {
+      const o = el("option", { value: ef }, "effort: " + ef);
+      if (ef === entry.default_effort) { o.selected = true; choice.effort = ef; }
+      effortSel.append(o);
+    }
+    effortRow.hidden = !efforts.length;   // effort is unknown for typed/uncatalogued models
+  };
+
+  // dmModelPicker reads row.model for the current label and calls save(value)
+  // on a pick — `choice` plays the row; save also refreshes the effort list.
+  const pickerZone = el("div");
+  const buildPicker = () => {
+    const picker = dmModelPicker(choice.harness, cat || { harnesses: {} }, choice,
+      async (value) => { choice.model = value || ""; paintEffort(); });
+    pickerZone.replaceChildren(
+      el("div", { className: "dm-row" },
+        el("span", { className: "dm-harness" }, "model"), picker.current, picker.input),
+      picker.results);
+  };
+
+  let harnessCtl;
+  if (harnesses.length) {
+    harnessCtl = el("select", { title: "harness" });
+    for (const h of harnesses) harnessCtl.append(el("option", { value: h }, h));
+    harnessCtl.onchange = () => {
+      choice.harness = harnessCtl.value; choice.model = "";
+      buildPicker(); paintEffort();
+    };
+  } else {
+    harnessCtl = el("input", { type: "text", className: "dm-search",
+      placeholder: "harness (e.g. claude)" });
+    harnessCtl.oninput = () => { choice.harness = harnessCtl.value.trim() || null; };
+  }
+  buildPicker();   // effort select stays hidden until a catalogued model is picked
+
+  const start = el("button", { className: "act primary", type: "button", textContent: "Start chat" });
+  start.onclick = async () => {
+    start.disabled = true; msg.textContent = "";
+    const body = { shell_id: sel.shell_id };
+    if (choice.harness) body.harness = choice.harness;
+    if (choice.model) body.model = choice.model;
+    if (choice.effort) body.effort = choice.effort;
     try {
-      // 201 → the shell flips to occupied; re-render lands on the session pane.
-      await apiIf("/interface/sessions", "POST", { shell_id: sel.shell_id });
+      // 201 → the shell flips to reserved/starting; re-render lands on the
+      // session pane. A 202 (ambiguous spawn) re-renders onto the recovery
+      // pane, which shows the server's error_detail.
+      await apiIf("/interface/sessions", "POST", body);
       await renderInterface(root);
     } catch (e) {   // 409 shell_occupied / unmanaged_harness — show the server's message
       msg.textContent = (e.code ? e.code + ": " : "") + e.message;
-      btn.disabled = false;
+      start.disabled = false;
     }
   };
-  pane.append(el("div", { className: "card if-newchat" },
-    el("div", {}, el("b", {}, sel.display_name || sel.shortname), " is available."), btn, msg));
+  card.append(
+    el("div", { className: "dm-row" },
+      el("span", { className: "dm-harness" }, "harness"), harnessCtl),
+    pickerZone,
+    effortRow,
+    start);
 }
 
 // Occupied/starting pane: header state line + terminal. Attaches writer-first
@@ -2318,10 +2462,14 @@ async function ifSessionPane(pane, sel) {
 
   const st = {
     harness: sess.harness || sel.harness || "—",
+    model: sess.model_route || "harness default",
     lifecycle: sess.lifecycle || "—",
     composer: sess.composer || "unknown",
     writer: sess.writer && sess.writer.held ? "held" : "none",
     clients: sess.clients ?? 0,
+    wake: sess.wake_state || "disarmed",
+    archive: sess.archive_id ?? null,
+    since: sess.occupied_at || sess.created_at || null,
     note: "",
   };
   const headEl = el("div", { className: "if-head" });
@@ -2371,19 +2519,45 @@ function ifReleaseLease(a) {
   a.leaseId = null;
 }
 
+// Session age from a UTC timestamp — SQLite datetime('now') shape
+// ("YYYY-MM-DD HH:MM:SS") or ISO-8601; both parse as UTC here.
+function ifAge(ts) {
+  if (!ts) return "—";
+  const s0 = String(ts);
+  const t = new Date(s0.includes("T") ? s0 : s0.replace(" ", "T") + "Z");
+  if (isNaN(t)) return "—";
+  const s = Math.max(0, (Date.now() - t.getTime()) / 1000);
+  if (s < 90) return Math.floor(s) + "s";
+  if (s < 5400) return Math.floor(s / 60) + "m";
+  if (s < 129600) return Math.floor(s / 3600) + "h";
+  return Math.floor(s / 86400) + "d";
+}
+
 function ifPaintHeader(a, sel, pane) {
   const st = a.st;
+  const stat = (k, v) => el("span", { className: "if-stat" }, k + " ", el("b", {}, String(v)));
+  // Spec Interface Layout header: harness/model, archive/session age, writer
+  // or read-only state, draft (composer) state, sprint wake state, then the
+  // exact recovery actions. idle/busy/approval/user_input stay lifecycle
+  // details HERE — they never replace occupancy in the rail.
   const head = [
-    el("span", { className: "if-stat" }, "harness ", el("b", {}, String(st.harness))),
-    el("span", { className: "if-stat" }, "session ", el("b", {}, "#" + a.sessionId)),
-    el("span", { className: "if-stat" }, "lifecycle ", el("b", {}, String(st.lifecycle))),
-    el("span", { className: "if-stat" }, "composer ", el("b", {}, String(st.composer))),
-    el("span", { className: "if-stat" }, "writer ", el("b", {}, st.writer)),
-    el("span", { className: "if-stat" }, "clients ", el("b", {}, String(st.clients))),
+    stat("harness", st.harness),
+    stat("model", st.model),
+    stat("session", "#" + a.sessionId + (st.archive != null ? " · arc #" + st.archive : "")),
+    stat("age", ifAge(st.since)),
+    stat("lifecycle", st.lifecycle),
+    stat("composer", st.composer),
+    stat("writer", st.writer === "active" ? "you" : st.writer === "held" ? "read-only" : st.writer),
+    stat("clients", st.clients),
+    stat("wake", st.wake),
   ];
   if (st.writer === "held" || st.writer === "revoked") {
-    const take = el("button", { className: "act", type: "button", textContent: "Take-over" });
-    take.onclick = () => ifTakeover(a);
+    const take = el("button", { className: "act", type: "button", textContent: "Take-over",
+      title: "explicitly take the writer lease — the current writer turns read-only" });
+    take.onclick = () => {
+      if (confirm("Take control of this session? The current writer (another tab or CLI) becomes read-only."))
+        ifTakeover(a);
+    };
     head.push(take);
   }
   if (st.composer === "dirty" || st.composer === "unknown") {
@@ -2399,29 +2573,45 @@ function ifPaintHeader(a, sel, pane) {
     };
     head.push(cert);
   }
-  const end = el("button", { className: "act", type: "button", textContent: "End chat" });
-  end.onclick = () => ifEndChat(a, sel, pane);
+  const end = el("button", { className: "act", type: "button", textContent: "End chat",
+    title: "explicit, confirmed — graceful first; force unlocks only after a graceful timeout" });
+  end.onclick = () => ifEndChat(a, sel, pane, end);
   head.push(end);
   if (st.note) head.push(el("span", { className: "if-note" }, st.note));
   a.headEl.replaceChildren(...head);
 }
 
-async function ifEndChat(a, sel, pane) {
+// End chat (spec Workflow 9): explicit + confirmed, graceful first. Force is
+// a SEPARATE action that exists only after the graceful request timed out —
+// the API enforces the same gate (force_requires_graceful_timeout) and the
+// prompt names the exact PID/generation from its response. The shell returns
+// to available only when the API says terminated; identity_mismatch fails
+// closed into unreconciled/lost, so we re-render onto the recovery pane.
+async function ifEndChat(a, sel, pane, btn) {
   if (!confirm(`End chat with ${sel.display_name || sel.shortname}? This terminates session #${a.sessionId}.`)) return;
+  if (btn) btn.disabled = true;
+  const root = pane.closest(".view");
   let r;
   try { r = await apiIf("/interface/termination-requests", "POST", { session_id: a.sessionId, force: false }); }
   catch (e) {
     if (e.status === 409 && e.body && e.body.reason) r = e.body;
     else { a.st.note = "end chat failed: " + e.message; a.paint(); return; }
   }
+  if (!r.terminated && r.reason === "identity_mismatch") {
+    if (root) return renderInterface(root);
+    return;
+  }
   if (!r.terminated && r.reason === "graceful_timeout") {
-    if (!confirm(`Graceful stop timed out. Force-kill PID ${r.pid} (generation ${r.generation})?`)) return;
+    if (!confirm(`Graceful stop timed out. Force-kill PID ${r.pid} (generation ${r.generation})?`)) {
+      a.st.note = "graceful stop timed out — End chat again to retry, or confirm the force kill.";
+      a.paint();
+      return;
+    }
     try { r = await apiIf("/interface/termination-requests", "POST", { session_id: a.sessionId, force: true }); }
     catch (e) { a.st.note = "force kill failed: " + e.message; a.paint(); return; }
   }
   if (r.terminated) {
     ifDetach();
-    const root = pane.closest(".view");
     if (root) renderInterface(root);
   } else { a.st.note = "not terminated: " + (r.reason || "?"); a.paint(); }
 }
@@ -2531,23 +2721,39 @@ function ifSendResize(a, rows, cols) {
   a.ws.send(frame);
 }
 
+// This client's writer lease is gone (taken over elsewhere): flip read-only
+// IMMEDIATELY with a clear notice (spec Workflow 6).
+function ifRevoked(a) {
+  a.role = "viewer"; a.leaseId = null; a.leaseToken = null;
+  a.awaiting = false; a.halted = false; a.outBuf = "";
+  a.st.writer = "held";
+  a.st.note = "control was taken by another client — you are now read-only (Take-over to reclaim)";
+}
+
 function ifControl(a, m) {
   switch (m.type) {
     case "input_ack":   // may carry replayed:true — either way the frame landed
       if (m.seq === a.inflight) { a.awaiting = false; a.lastAck = m.seq; ifFlush(a); }
       break;
-    case "input_reject":   // seqs are session-scoped; stop until the next attach
+    case "input_reject":
       a.awaiting = false;
-      a.halted = true;
-      a.st.note = `input rejected (seq ${m.seq}): ${m.reason || "?"} — reattach to resume`;
+      // writer_revoked = a takeover revoked our lease; the runtime learns of
+      // it at the next keystroke and rejects the frame. Same flip as a
+      // writer-state revoke — not a halt.
+      if (m.reason === "writer_revoked" && a.role === "writer") {
+        ifRevoked(a);
+      } else {   // seqs are session-scoped; stop until the next attach
+        a.halted = true;
+        a.st.note = `input rejected (seq ${m.seq}): ${m.reason || "?"} — reattach to resume`;
+      }
       a.paint();
       break;
     case "writer":
-      a.st.writer = m.state;
-      if (m.state === "revoked" && a.role === "writer") {
-        a.role = "viewer"; a.leaseId = null; a.leaseToken = null; a.halted = false;
-        a.st.note = "writer lease revoked — now read-only";
-      }
+      // Server states (interface_runtime.writer_control): active | held |
+      // none — there is no "revoked" frame. A non-active state while we still
+      // believe we hold the lease IS the revocation signal.
+      if (a.role === "writer" && m.state !== "active") ifRevoked(a);
+      else a.st.writer = m.state;
       a.paint();
       break;
     case "lifecycle":

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -726,3 +726,20 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .if-term .xterm { height: 100%; }
 .if-newchat .act { margin-top: .8rem; }
 .if-newchat .muted { margin-top: .5rem; }
+.if-newchat .dm-row { margin-top: .6rem; grid-template-columns: 100px minmax(10rem, 26rem) 1fr;
+  border-top: none; padding: .4rem 0; }
+.if-newchat select { background: var(--panel); border: 1px solid var(--line);
+  border-radius: var(--r); color: var(--ink); font: inherit; padding: .3rem .5rem; }
+.if-diag { display: flex; flex-wrap: wrap; gap: .4rem 1.2rem; margin: .5rem 0; }
+/* Mobile: the rail collapses into a shell picker above the terminal; the
+   terminal keeps a stable minimum height and the header stays above it. */
+.if-picker { display: none; }
+@media (max-width: 760px) {
+  .if-wrap { flex-direction: column; }
+  .if-rail { display: none; }
+  .if-picker { display: block; width: 100%; background: var(--panel);
+    border: 1px solid var(--line); border-radius: var(--r); color: var(--ink);
+    font: inherit; padding: .45rem .6rem; }
+  .if-pane { width: 100%; }
+  .if-term { height: 55vh; min-height: 240px; }
+}

--- a/sc
+++ b/sc
@@ -25,6 +25,17 @@ DB="$ENGINE/shell_db.db"
 MAPDB="$ROOT/.sc-state/map.db"
 S="$ENGINE/scripts"
 
+# Python for the Interface verbs: the attach client needs `websockets` —
+# baked into the sandbox image's own python (Dockerfile) and pinned in
+# requirements.txt for the ./sc deps .venv. Take the first interpreter that
+# has it; else fail with the fix, like _sc_devtool.
+ifpy() {
+  if "$PY" -c 'import websockets' >/dev/null 2>&1; then printf '%s\n' "$PY"; return 0; fi
+  if [ -x "$here/.venv/bin/python" ] && "$here/.venv/bin/python" -c 'import websockets' >/dev/null 2>&1; then printf '%s\n' "$here/.venv/bin/python"; return 0; fi
+  echo "✗ sc interface: no python with websockets — run ./sc deps (or ./sc build to refresh the sandbox image)" >&2
+  return 1
+}
+
 port() { "$PY" "$S/ports.py" port; }
 devport() { "$PY" "$S/ports.py" devport; }
 
@@ -57,7 +68,7 @@ SC_PG_SHM="${SC_PG_SHM:-1g}"
 dcheck() {
   if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
     echo "✗ docker daemon not reachable — the sandbox needs it." >&2
-    echo "  Setup (one-time):  ./sc doctor      No docker:  ./sc serve + ./sc boot" >&2
+    echo "  Setup (one-time):  ./sc doctor      No docker:  ./sc serve + ./sc interface enter" >&2
     exit 1
   fi
 }
@@ -948,6 +959,10 @@ case "$cmd" in
   # Interface pane entrypoint (internal; spec #20) — consumes the single-use
   # launch token the API wrote, then becomes the shell's harness TUI.
   interface-exec)  exec "$PY" "$S/interface_exec.py" "$@" ;;
+  # Interface CLI parity (spec #20 seq 6) — status/start/view/attach/
+  # take-control/stop/reconcile, and the in-container half of `sc enter`.
+  # API-backed only; the attach client needs websockets (ifpy).
+  interface)    IFPY="$(ifpy)" && exec "$IFPY" "$S/interface_cli.py" "$@" ;;
   # Headless boot (sprint eventing): same render-then-exec path as boot, minus
   # the picker and the TTY. In-container primitive like boot — the planner
   # calls it to stand up an ephemeral worker; also the no-docker host path.
@@ -1066,8 +1081,11 @@ case "$cmd" in
     # no host watch-daemon is started here anymore.
     # Start the PG sidecar when configured — self-skips otherwise.
     sc_pg_up || true ;;
-  enter)        exec docker exec -it "$CNAME" ./sc boot "$@" ;;
-  enter-*)      exec docker exec -it "$CNAME" ./sc boot "${cmd#enter-}" "$@" ;;
+  # Interactive entry goes through the Interface API (spec #20): the in-container
+  # target resolves occupancy, starts a New chat (picker + reservation) for an
+  # available shell, or reattaches the occupied generation. Never a raw boot.
+  enter)        exec docker exec -it "$CNAME" ./sc interface enter "$@" ;;
+  enter-*)      exec docker exec -it "$CNAME" ./sc interface enter "${cmd#enter-}" "$@" ;;
   down)         docker rm -f "$CNAME" >/dev/null 2>&1 && echo "→ sandbox stopped" || echo "→ not running"
                 sc_vm_broker_down
                 sc_ts_broker_down
@@ -1155,10 +1173,15 @@ super-coder — forkable shell substrate
   Sandbox (docker — the default way to run; allow-everything is safe because the
   container only sees this repo + your harness creds):
   ./sc launch              build + start the sandbox container (server + GUI), 127.0.0.1 only
-  ./sc enter               attach an interactive session: auth + pick shell + pick harness + boot
-  ./sc enter-<shortname>   attach + boot that shell directly (skip the shell picker)
+  ./sc enter               enter a shell through the Interface API: pick a shell, then
+                             New chat (harness picker) if available, else reattach the live session
+  ./sc enter-<shortname>   enter that shell directly (skip the shell picker)
                              harness: --harness <name> or HARNESS=<name> forces it; else when
                              >1 harness is on PATH you're prompted (per-launch, not persisted)
+  ./sc interface <verb>    Interface CLI parity (spec #20), API-backed (never direct DB/tmux):
+                             status [shell] [--json] · start <shell> [--harness H] [--model M] [--effort E]
+                             view <shell> (read-only) · attach <shell> (writer) · take-control <shell>
+                             stop <shell> [--force] · reconcile <shell> [--close] — mutations take --json
   ./sc run <shortname>     headless boot: render + exec the harness NON-interactively (claude · codex ·
                              opencode · kimi) to drain the shell's inbox and act; -p "<prompt>" overrides the
                              default prompt · --harness <h> · -m <model> (else flavor_defaults);
@@ -1170,7 +1193,8 @@ super-coder — forkable shell substrate
 
   Primitives (run inside the container; also the no-docker host escape hatch):
   ./sc serve               run the review layer (api + static UI) in the foreground
-  ./sc boot [shortname]    auth + pick shell + pick harness + boot (no container, no GUI)
+  ./sc boot [shortname]    raw interactive launch — REFUSES without the Interface reservation
+                             capability (spec #20); use ./sc enter / ./sc interface instead
   ./sc deps                install this fork's python (.venv) + node (node_modules) deps into the bind-mount
                              (plus an only-if-needed dev kit: pytest httpx coverage ruff mypy datasette)
   ./sc test                run backend (.venv pytest or stdlib unittest) + UI (vitest) suites; non-zero on any failure

--- a/tests/test_interface_cli.py
+++ b/tests/test_interface_cli.py
@@ -481,7 +481,7 @@ class RunStreamTest(unittest.TestCase):
         patches = [
             mock.patch.object(ic, "_stdin_ready", stdin.ready),
             mock.patch.object(ic, "_read_stdin", stdin.read),
-            mock.patch("websockets.sync.client.connect", return_value=ws),
+            mock.patch.object(ic, "_ws_connect", return_value=ws),
             # run_stream installs its SIGWINCH handler unconditionally; off
             # the main thread that raises — the handler is untestable noise.
             mock.patch.object(ic.signal, "signal"),

--- a/tests/test_interface_cli.py
+++ b/tests/test_interface_cli.py
@@ -8,6 +8,10 @@ operator bearer, method, path, and body are all asserted on the REAL api()
 wrapper), and the WS loop (`run_stream`) is a mock — the verbs are tested
 up to the point a socket would open.
 
+The real `run_stream` is covered separately (RunStreamTest) against a
+scripted FakeWS peer + a scripted stdin: ack-gating (one unacknowledged
+input frame), the read-only flip on lease loss, and quiet control frames.
+
 Also covers the run.py raw-launch refusal (spec #20 Tmux Runtime): the
 public interactive entry refuses before an archive exists; the escape
 hatch, headless (`sc run`), and RENDER_ONLY paths pass the gate.
@@ -21,8 +25,11 @@ import contextlib
 import email.message
 import io
 import json
+import queue
 import sys
 import tempfile
+import threading
+import time
 import unittest
 import urllib.error
 from pathlib import Path
@@ -397,6 +404,191 @@ class InterfaceCliTest(unittest.TestCase):
         self.assertIn("reconcile", err)
         self.assertEqual(self.http.find("POST", "/api/interface/sessions"), [])
         self.stream.assert_not_called()
+
+
+class FakeWS:
+    """A scripted sc-term.v1 peer for the REAL run_stream: outbound frames
+    are recorded in `sent`; inbound frames are fed by the test through a
+    queue so the receive loop blocks exactly like a socket would."""
+
+    _END = object()
+
+    def __init__(self):
+        self.sent = []
+        self._q = queue.Queue()
+
+    def send(self, data):
+        self.sent.append(data)
+
+    def feed(self, frame):
+        self._q.put(frame)
+
+    def end(self):
+        self._q.put(self._END)
+
+    def __iter__(self):
+        while True:
+            item = self._q.get()
+            if item is self._END:
+                return
+            yield item
+
+    def input_frames(self):
+        return [f for f in self.sent if f[:1] == b"\x01"]
+
+
+class StdinScript:
+    """A scripted stdin for run_stream's input seams: the test feeds reads;
+    `ready` blocks (like select) until one is pending."""
+
+    def __init__(self):
+        self._cv = threading.Condition()
+        self._reads = []
+
+    def feed(self, data: bytes):
+        with self._cv:
+            self._reads.append(data)
+            self._cv.notify_all()
+
+    def ready(self, timeout: float) -> bool:
+        with self._cv:
+            if not self._reads:
+                self._cv.wait(timeout)
+            return bool(self._reads)
+
+    def read(self) -> bytes:
+        with self._cv:
+            return self._reads.pop(0)
+
+
+def wait_for(cond, timeout=5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if cond():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class RunStreamTest(unittest.TestCase):
+    """The real run_stream against FakeWS + StdinScript: client-side broker
+    protocol semantics (spec #20 Input Broker — review r1 M1)."""
+
+    def run_stream(self, ws, stdin, role="writer", start_seq=5):
+        """Drives run_stream on a thread; returns (thread, stderr StringIO).
+        The caller feeds frames/keystrokes, then `ws.end()` and joins."""
+        err = io.StringIO()
+        patches = [
+            mock.patch.object(ic, "_stdin_ready", stdin.ready),
+            mock.patch.object(ic, "_read_stdin", stdin.read),
+            mock.patch("websockets.sync.client.connect", return_value=ws),
+            # run_stream installs its SIGWINCH handler unconditionally; off
+            # the main thread that raises — the handler is untestable noise.
+            mock.patch.object(ic.signal, "signal"),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        redir = contextlib.redirect_stderr(err)
+        redir.__enter__()
+        self.addCleanup(redir.__exit__, None, None, None)
+        t = threading.Thread(target=ic.run_stream,
+                             args=("ws://x", role, start_seq), daemon=True)
+        t.start()
+        self.addCleanup(t.join, 10)
+        return t, err
+
+    @staticmethod
+    def _seq(frame):
+        return int.from_bytes(frame[1:9], "big")
+
+    def test_input_is_ack_gated_one_unacked_frame(self):
+        ws, stdin = FakeWS(), StdinScript()
+        t, _ = self.run_stream(ws, stdin)
+        # Resize goes out immediately (0x03); keystrokes wait on the gate.
+        self.assertTrue(wait_for(lambda: any(f[:1] == b"\x03"
+                                             for f in ws.sent)))
+        stdin.feed(b"a")
+        self.assertTrue(wait_for(lambda: len(ws.input_frames()) == 1))
+        self.assertEqual(self._seq(ws.input_frames()[0]), 5)
+        # A second keystroke with no ack must NOT hit the wire.
+        stdin.feed(b"b")
+        time.sleep(0.3)
+        self.assertEqual(len(ws.input_frames()), 1,
+                         "one unacknowledged frame — b must buffer locally")
+        # The ack releases exactly the next buffered frame.
+        ws.feed(json.dumps({"type": "input_ack", "seq": 5}))
+        self.assertTrue(wait_for(lambda: len(ws.input_frames()) == 2))
+        self.assertEqual(self._seq(ws.input_frames()[1]), 6)
+        self.assertEqual(ws.input_frames()[1][9:], b"b")
+        # A non-terminal reject also settles the inflight frame (loudly) —
+        # the buffer keeps draining without an ack.
+        ws.feed(json.dumps({"type": "input_reject", "seq": 6,
+                            "reason": "delivery_unknown"}))
+        stdin.feed(b"c")
+        self.assertTrue(wait_for(lambda: len(ws.input_frames()) == 3))
+        self.assertEqual(ws.input_frames()[2][9:], b"c")
+        ws.end()
+        t.join(10)
+        self.assertFalse(t.is_alive())
+
+    def test_writer_revoked_reject_flips_readonly(self):
+        ws, stdin = FakeWS(), StdinScript()
+        t, err = self.run_stream(ws, stdin)
+        stdin.feed(b"a")
+        self.assertTrue(wait_for(lambda: len(ws.input_frames()) == 1))
+        ws.feed(json.dumps({"type": "input_reject", "seq": 5,
+                            "reason": "writer_revoked"}))
+        self.assertTrue(wait_for(lambda: "READ-ONLY" in err.getvalue()))
+        self.assertIn("take-control", err.getvalue())
+        # The displaced writer types into the void no longer: input stops.
+        stdin.feed(b"b")
+        time.sleep(0.3)
+        self.assertEqual(len(ws.input_frames()), 1,
+                         "a revoked writer must stop sending input")
+        ws.end()
+        t.join(10)
+        self.assertFalse(t.is_alive())
+
+    def test_writer_control_non_active_flips_readonly(self):
+        ws, stdin = FakeWS(), StdinScript()
+        t, err = self.run_stream(ws, stdin)
+        ws.feed(json.dumps({"type": "writer", "state": "active"}))
+        self.assertTrue(wait_for(lambda: "writer active" in err.getvalue()))
+        # A takeover broadcast ("held" while we believe we're writer) is the
+        # same signal as a revoke: read-only flip, input halted.
+        ws.feed(json.dumps({"type": "writer", "state": "held"}))
+        self.assertTrue(wait_for(lambda: "READ-ONLY" in err.getvalue()))
+        stdin.feed(b"x")
+        time.sleep(0.3)
+        self.assertEqual(ws.input_frames(), [])
+        ws.end()
+        t.join(10)
+        self.assertFalse(t.is_alive())
+
+    def test_routine_control_frames_are_silent(self):
+        ws, stdin = FakeWS(), StdinScript()
+        t, err = self.run_stream(ws, stdin, role="viewer")
+        ws.feed(json.dumps({"type": "writer", "state": "held"}))
+        ws.feed(json.dumps({"type": "writer", "state": "held"}))   # unchanged
+        ws.feed(json.dumps({"type": "lifecycle", "lifecycle": "running",
+                            "composer": "idle"}))
+        ws.feed(json.dumps({"type": "lifecycle", "lifecycle": "running",
+                            "composer": "idle"}))                    # unchanged
+        ws.feed(json.dumps({"type": "heartbeat"}))                   # hb ack
+        ws.feed(json.dumps({"type": "input_ack", "seq": 1}))
+        ws.feed(json.dumps({"type": "error", "code": "boom"}))
+        ws.feed(json.dumps({"type": "error", "code": "terminated"}))
+        t.join(10)
+        self.assertFalse(t.is_alive(), "terminated ends the stream")
+        text = err.getvalue()
+        self.assertEqual(text.count("writer held"), 1)
+        self.assertEqual(text.count("lifecycle running"), 1)
+        self.assertEqual(text.count("error: boom"), 1)
+        self.assertNotIn("heartbeat", text)
+        self.assertNotIn("input_ack", text)
+        self.assertNotIn("\x1b[2m", text, "no dimmed per-frame echo in raw "
+                                          "mode — transitions/errors only")
 
 
 class RawLaunchRefusalTest(unittest.TestCase):

--- a/tests/test_interface_cli.py
+++ b/tests/test_interface_cli.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Interface CLI — hermetic verb/routing proofs (spec #20, sprint 25 seq 6).
+
+Covers `sc interface` + the `sc enter` routing decision WITHOUT a server,
+a socket, or tmux: the module's one network seam (`_http`) is a fake
+transport that records every urllib Request (so Idempotency-Key, the
+operator bearer, method, path, and body are all asserted on the REAL api()
+wrapper), and the WS loop (`run_stream`) is a mock — the verbs are tested
+up to the point a socket would open.
+
+Also covers the run.py raw-launch refusal (spec #20 Tmux Runtime): the
+public interactive entry refuses before an archive exists; the escape
+hatch, headless (`sc run`), and RENDER_ONLY paths pass the gate.
+
+Run:
+    python3 tests/test_interface_cli.py
+"""
+from __future__ import annotations
+
+import contextlib
+import email.message
+import io
+import json
+import sys
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import interface_cli as ic  # noqa: E402
+import run as run_mod  # noqa: E402
+
+SHELLS = {
+    "shells": [
+        {"shell_id": 1, "shortname": "S1", "display_name": "One",
+         "availability": "available", "session_id": None, "lifecycle": None,
+         "harness": None, "composer": None, "alerts": 0,
+         "wake_state": "disarmed"},
+        {"shell_id": 2, "shortname": "S2", "display_name": "Two",
+         "availability": "occupied", "session_id": 7, "lifecycle": "idle",
+         "harness": "claude", "composer": "clean", "alerts": 0,
+         "wake_state": "disarmed"},
+        {"shell_id": 3, "shortname": "S3", "display_name": "Three",
+         "availability": "lost", "session_id": 9, "lifecycle": "lost",
+         "harness": "claude", "composer": "unknown", "alerts": 1,
+         "wake_state": "disarmed"},
+    ]
+}
+
+SESSION7 = {
+    "session_id": 7, "shell_id": 2, "generation": 1, "archive_id": 20,
+    "harness": "claude", "model_route": None, "worktree": "/x/s2",
+    "occupancy": "occupied", "lifecycle": "idle", "composer": "clean",
+    "delivery": "idle", "forwarded_seq": 4, "last_human_input_at": None,
+    "writer": {"held": True, "client_id": "web-1"},
+    "wake_state": "disarmed", "clients": 1, "alerts": 0,
+    "created_at": "t", "occupied_at": "t", "ended_at": None,
+    "end_reason": None, "error_detail": None,
+}
+
+
+def http_error(status: int, code: str, message: str,
+               details=None) -> urllib.error.HTTPError:
+    body = json.dumps({"error": {"code": code, "message": message,
+                                 "details": details or {}}}).encode()
+    return urllib.error.HTTPError("http://x", status, message,
+                                  email.message.Message(),
+                                  io.BytesIO(body))
+
+
+class FakeResp:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+class FakeHTTP:
+    """The `_http` seam: routes (method, path) → payload or exception."""
+
+    def __init__(self):
+        self.calls = []
+        self.routes = {}
+
+    def add(self, method, path, payload):
+        self.routes[(method, path)] = payload
+
+    def __call__(self, req):
+        path = req.full_url.replace(ic.API_BASE, "")
+        self.calls.append({
+            "method": req.method,
+            "path": path,
+            "headers": {k.lower(): v for k, v in req.header_items()},
+            "body": json.loads(req.data) if req.data else None,
+        })
+        outcome = self.routes[(req.method, path)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return FakeResp(outcome)
+
+    def find(self, method, path):
+        return [c for c in self.calls
+                if c["method"] == method and c["path"] == path]
+
+
+class InterfaceCliTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        token = Path(self.tmp.name) / "operator.token"
+        token.write_text("optok")
+        self.http = FakeHTTP()
+        self.stream = mock.Mock(return_value=0)
+        patches = [
+            mock.patch.object(ic, "OPERATOR_TOKEN_PATH", token),
+            mock.patch.object(ic, "_http", self.http),
+            mock.patch.object(ic, "run_stream", self.stream),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        # Default routes: the shell rail + the occupied session's detail.
+        self.http.add("GET", "/api/interface/shells", SHELLS)
+        self.http.add("GET", "/api/interface/sessions/7", SESSION7)
+        self.http.add("POST", "/api/interface/stream-tickets",
+                      {"ticket": "tk-1", "expires_in": 60})
+        self.http.add("POST", "/api/interface/writer-leases",
+                      {"lease_id": 5, "lease_token": "lt-1",
+                       "next_input_seq": 5})
+
+    # -- helpers -------------------------------------------------------------
+
+    def run_cli(self, argv):
+        """Returns (exit_code, stdout, stderr); SystemExit becomes its code."""
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), \
+                contextlib.redirect_stderr(err):
+            try:
+                rc = ic.main(argv)
+            except SystemExit as exc:
+                rc = exc.code if isinstance(exc.code, int) else 1
+        return rc, out.getvalue(), err.getvalue()
+
+    # -- envelope: bearer + idempotency on the real api() wrapper -------------
+
+    def test_operator_bearer_and_idempotency_key(self):
+        self.run_cli(["status"])
+        call = self.http.find("GET", "/api/interface/shells")[0]
+        self.assertEqual(call["headers"].get("authorization"),
+                         "Bearer optok")
+        self.assertNotIn("idempotency-key", call["headers"])
+        self.http.add("POST", "/api/interface/reconciliations",
+                      {"session_id": 7, "verified": True,
+                       "occupancy": "occupied", "actions": []})
+        self.run_cli(["reconcile", "s2"])
+        call = self.http.find("POST", "/api/interface/reconciliations")[0]
+        key = call["headers"].get("idempotency-key")
+        self.assertTrue(key, "every mutation sends an Idempotency-Key")
+        self.assertEqual(len(key), 36, "uuid4")
+
+    # -- status ---------------------------------------------------------------
+
+    def test_status_rail_json(self):
+        rc, out, _ = self.run_cli(["status", "--json"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertEqual([s["shortname"] for s in payload["shells"]],
+                         ["S1", "S2", "S3"])
+        self.assertEqual(payload["shells"][1]["availability"], "occupied")
+
+    def test_status_named_shell_fetches_session(self):
+        rc, out, _ = self.run_cli(["status", "s2", "--json"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.http.find("GET", "/api/interface/sessions/7"),
+                         self.http.find("GET", "/api/interface/sessions/7"))
+        payload = json.loads(out)
+        self.assertEqual(payload["shell"]["session_id"], 7)
+        self.assertEqual(payload["session"]["occupancy"], "occupied")
+        self.assertEqual(payload["session"]["writer"]["client_id"], "web-1")
+        # Human mode names the writer holder.
+        rc, out, _ = self.run_cli(["status", "s2"])
+        self.assertIn("held by web-1", out)
+
+    def test_status_available_shell_has_no_session_fetch(self):
+        rc, out, _ = self.run_cli(["status", "s1", "--json"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertIsNone(payload["session"])
+        self.assertEqual(self.http.find("GET", "/api/interface/sessions/7"),
+                         [])
+
+    # -- start (New chat) -------------------------------------------------------
+
+    def test_start_posts_session_with_route_hints(self):
+        self.http.add("POST", "/api/interface/sessions",
+                      {"session_id": 11, "shell_id": 1, "generation": 1,
+                       "occupancy": "reserved", "lifecycle": "starting",
+                       "harness": "claude"})
+        rc, out, _ = self.run_cli(
+            ["start", "s1", "--harness", "claude", "--model", "m1",
+             "--effort", "high", "--json"])
+        self.assertEqual(rc, 0)
+        call = self.http.find("POST", "/api/interface/sessions")[0]
+        self.assertEqual(call["body"]["shell_id"], 1)
+        self.assertEqual(call["body"]["harness"], "claude")
+        self.assertEqual(call["body"]["model"], "m1")
+        self.assertEqual(call["body"]["effort"], "high")
+        self.assertIn("rows", call["body"])
+        self.assertIn("cols", call["body"])
+        self.assertEqual(json.loads(out)["session_id"], 11)
+
+    def test_start_occupied_race_reports_existing_session(self):
+        self.http.add("POST", "/api/interface/sessions",
+                      http_error(409, "shell_occupied", "a live generation "
+                                 "already owns this shell",
+                                 {"session_id": 7, "occupancy": "occupied"}))
+        rc, _, err = self.run_cli(["start", "s2"])
+        self.assertEqual(rc, 1)
+        self.assertIn("session 7", err)
+        self.assertIn("attach", err)
+
+    # -- attach verbs ---------------------------------------------------------
+
+    def test_view_mints_viewer_ticket_without_lease(self):
+        rc, _, _ = self.run_cli(["view", "s2"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.http.find("POST", "/api/interface/writer-leases"),
+                         [])
+        call = self.http.find("POST", "/api/interface/stream-tickets")[0]
+        self.assertEqual(call["body"]["role"], "viewer")
+        self.assertEqual(call["body"]["session_id"], 7)
+        self.assertNotIn("lease_token", call["body"])
+        args = self.stream.call_args[0]
+        self.assertTrue(args[0].startswith("ws://127.0.0.1:"))
+        self.assertIn("/api/interface/session-streams/7?ticket=tk-1", args[0])
+        self.assertEqual(args[1], "viewer")
+
+    def test_attach_acquires_lease_then_writer_ticket(self):
+        rc, _, _ = self.run_cli(["attach", "s2"])
+        self.assertEqual(rc, 0)
+        lease = self.http.find("POST", "/api/interface/writer-leases")[0]
+        self.assertFalse(lease["body"]["takeover"])
+        ticket = self.http.find("POST", "/api/interface/stream-tickets")[0]
+        self.assertEqual(ticket["body"]["role"], "writer")
+        self.assertEqual(ticket["body"]["lease_token"], "lt-1")
+        args = self.stream.call_args[0]
+        self.assertEqual(args[1], "writer")
+        # The input seq continues the SESSION's sequence (next_input_seq),
+        # never reset to 1 — a reset would wedge the broker's gap detection.
+        self.assertEqual(args[2], 5)
+
+    def test_attach_held_lease_refuses_without_takeover(self):
+        self.http.add("POST", "/api/interface/writer-leases",
+                      http_error(409, "lease_refused", "session 7 writer "
+                                 "held by web-1 — explicit takeover required"))
+        rc, _, err = self.run_cli(["attach", "s2"])
+        self.assertEqual(rc, 1)
+        self.assertIn("take-control", err)
+        self.assertIn("web-1", err)
+        self.assertEqual(self.http.find("POST", "/api/interface/stream-tickets"),
+                         [], "a refused lease must not mint a ticket")
+        self.stream.assert_not_called()
+
+    def test_take_control_passes_takeover(self):
+        rc, _, _ = self.run_cli(["take-control", "s2"])
+        self.assertEqual(rc, 0)
+        lease = self.http.find("POST", "/api/interface/writer-leases")[0]
+        self.assertTrue(lease["body"]["takeover"])
+        self.assertEqual(self.stream.call_args[0][1], "writer")
+
+    def test_view_without_session_refuses(self):
+        rc, _, err = self.run_cli(["view", "s1"])
+        self.assertEqual(rc, 1)
+        self.assertIn("no live Interface session", err)
+
+    # -- stop / reconcile -----------------------------------------------------
+
+    def test_stop_graceful_then_json(self):
+        self.http.add("POST", "/api/interface/termination-requests",
+                      {"terminated": True})
+        rc, out, _ = self.run_cli(["stop", "s2", "--json"])
+        self.assertEqual(rc, 0)
+        call = self.http.find("POST", "/api/interface/termination-requests")[0]
+        self.assertEqual(call["body"],
+                         {"session_id": 7, "force": False})
+        self.assertTrue(json.loads(out)["terminated"])
+
+    def test_stop_graceful_timeout_names_force_followup(self):
+        self.http.add("POST", "/api/interface/termination-requests",
+                      {"terminated": False, "reason": "graceful_timeout",
+                       "pid": 4321, "generation": 1})
+        rc, out, _ = self.run_cli(["stop", "s2"])
+        self.assertEqual(rc, 1, "not-terminated is a non-zero exit")
+        self.assertIn("--force", out)
+        self.assertIn("4321", out)
+
+    def test_stop_force_gate_error_explains(self):
+        self.http.add("POST", "/api/interface/termination-requests",
+                      http_error(409, "force_requires_graceful_timeout",
+                                 "force is available only after a graceful "
+                                 "termination timed out"))
+        rc, _, err = self.run_cli(["stop", "s2", "--force"])
+        self.assertEqual(rc, 1)
+        self.assertIn("graceful", err)
+        call = self.http.find("POST", "/api/interface/termination-requests")[0]
+        self.assertTrue(call["body"]["force"])
+
+    def test_reconcile_verify_and_close(self):
+        self.http.add("POST", "/api/interface/reconciliations",
+                      {"session_id": 9, "verified": False,
+                       "occupancy": "unreconciled",
+                       "actions": ["identity could not be verified"]})
+        rc, out, _ = self.run_cli(["reconcile", "s3", "--json"])
+        self.assertEqual(rc, 0)
+        call = self.http.find("POST", "/api/interface/reconciliations")[0]
+        self.assertEqual(call["body"], {"session_id": 9, "action": "verify"})
+        self.assertFalse(json.loads(out)["verified"])
+        rc, _, _ = self.run_cli(["reconcile", "s3", "--close"])
+        self.assertEqual(rc, 0)
+        call = self.http.find("POST", "/api/interface/reconciliations")[-1]
+        self.assertEqual(call["body"]["action"], "close")
+
+    # -- API outage ---------------------------------------------------------------
+
+    def test_api_unreachable_reports_supervised_remediation(self):
+        def boom(req):
+            raise urllib.error.URLError("connection refused")
+        with mock.patch.object(ic, "_http", boom):
+            rc, _, err = self.run_cli(["status"])
+        self.assertEqual(rc, 3)
+        self.assertIn("unreachable", err)
+        self.assertIn("supervised", err)
+        self.assertIn("./sc restart", err)
+        self.assertIn("no direct-DB or tmux fallback", err)
+
+    def test_missing_operator_capability_is_api_down(self):
+        with mock.patch.object(ic, "OPERATOR_TOKEN_PATH",
+                               Path(self.tmp.name) / "nope"):
+            rc, _, err = self.run_cli(["status"])
+        self.assertEqual(rc, 3)
+        self.assertIn("operator capability", err)
+
+    # -- enter routing ---------------------------------------------------------
+
+    def test_enter_available_picks_starts_attaches_writer(self):
+        self.http.add("POST", "/api/interface/sessions",
+                      {"session_id": 11, "shell_id": 1, "generation": 1,
+                       "occupancy": "reserved", "lifecycle": "starting",
+                       "harness": "claude"})
+        with mock.patch.object(ic, "_pick_harness", return_value="claude"), \
+                mock.patch.object(ic, "_wait_occupied",
+                                  return_value={"occupancy": "occupied"}):
+            rc, out, _ = self.run_cli(["enter", "s1"])
+        self.assertEqual(rc, 0)
+        # New chat through the reservation BEFORE the writer attach.
+        self.assertEqual(len(self.http.find("POST", "/api/interface/sessions")),
+                         1)
+        lease = self.http.find("POST", "/api/interface/writer-leases")[0]
+        self.assertEqual(lease["body"]["session_id"], 11)
+        self.assertFalse(lease["body"]["takeover"])
+        self.assertEqual(self.stream.call_args[0][1], "writer")
+
+    def test_enter_occupied_lease_free_attaches_writer(self):
+        self.http.add("POST", "/api/interface/writer-leases",
+                      {"lease_id": 6, "lease_token": "lt-2",
+                       "next_input_seq": 5})
+        rc, _, _ = self.run_cli(["enter", "s2"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.http.find("POST", "/api/interface/sessions"), [])
+        self.assertEqual(self.stream.call_args[0][1], "writer")
+
+    def test_enter_occupied_lease_held_falls_back_readonly(self):
+        self.http.add("POST", "/api/interface/writer-leases",
+                      http_error(409, "lease_refused", "writer held by web-1"))
+        rc, _, err = self.run_cli(["enter", "s2"])
+        self.assertEqual(rc, 0)
+        self.assertIn("READ-ONLY", err)
+        self.assertIn("take-control", err)
+        ticket = self.http.find("POST", "/api/interface/stream-tickets")[0]
+        self.assertEqual(ticket["body"]["role"], "viewer")
+        self.assertEqual(self.stream.call_args[0][1], "viewer")
+
+    def test_enter_starting_or_lost_refuses(self):
+        rc, _, err = self.run_cli(["enter", "s3"])
+        self.assertEqual(rc, 1)
+        self.assertIn("lost", err)
+        self.assertIn("reconcile", err)
+        self.assertEqual(self.http.find("POST", "/api/interface/sessions"), [])
+        self.stream.assert_not_called()
+
+
+class RawLaunchRefusalTest(unittest.TestCase):
+    """run.py's public interactive entry refuses without the reservation
+    capability — before open_db/open_session can create an archive."""
+
+    def _main(self, argv, env):
+        with mock.patch.dict(run_mod.os.environ, env, clear=True), \
+                mock.patch.object(run_mod.sys, "argv", argv), \
+                mock.patch.object(run_mod, "open_db",
+                                  side_effect=KeyError("reached boot")):
+            run_mod.main()
+
+    def test_interactive_boot_refuses_before_archive(self):
+        with self.assertRaises(SystemExit) as cm:
+            self._main(["run.py", "dev3"], {})
+        self.assertIn("./sc enter", str(cm.exception.code))
+        self.assertIn("Interface", str(cm.exception.code))
+
+    def test_escape_hatch_passes_the_gate(self):
+        # SC_RAW_BOOT is tooling's explicit opt-in (like SC_NO_AUTOPRUNE);
+        # reaching open_db proves the gate did not fire.
+        with self.assertRaises(KeyError):
+            self._main(["run.py", "dev3"], {"SC_RAW_BOOT": "1"})
+
+    def test_headless_sc_run_passes_the_gate(self):
+        with self.assertRaises(KeyError):
+            self._main(["run.py", "--headless", "dev3"], {})
+
+    def test_render_only_passes_the_gate(self):
+        with self.assertRaises(KeyError):
+            self._main(["run.py", "--first"], {"RENDER_ONLY": "1"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_runtime.py
+++ b/tests/test_interface_runtime.py
@@ -3,7 +3,8 @@
 
 Unit tests run hermetic WITHOUT tmux/node: availability gating, ticket
 mint/consume discipline, reject-reason mapping, PID-reuse identity, the
-reattach-lost callback wiring. The sidecar tests need node only (a dead or
+reattach-lost callback wiring, and writer-lease liveness (seq 6: fenced
+detach revoke, dead-lease sweep, durable heartbeat stamps). The sidecar tests need node only (a dead or
 silent sidecar must fail fast, never hang — sprint 25 flag #45).
 Integration tests are gated on tmux + node + the @xterm/headless module
 (tmux+node alone is NOT sufficient — the sidecar dies on require without
@@ -340,6 +341,231 @@ class RejectReasonTest(unittest.TestCase):
             reason = interface_runtime._reject_reason(
                 interface_broker.BrokerError(msg))
             self.assertEqual(reason, expect, f"mapping of {msg!r}")
+
+
+# ------------------------------------------------------------- lease liveness (seq 6)
+
+class LeaseLivenessTest(unittest.TestCase):
+    """Hermetic (no tmux/node): a dead writer's DB lease must not outlive
+    it — detach revokes fenced by lease id/token/generation, the reaper's
+    sweep revokes heartbeat-silent leases, and neither path can clobber a
+    re-acquired lease."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.rt = interface_runtime.InterfaceRuntime(
+            str(self.db), run_dir=str(self.tmp / "run"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _session(self, shell_id=1, generation=1):
+        """One occupied session + input state + a runtime-owned Generation."""
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (?,?)", (shell_id, generation))
+        sid = con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle) VALUES (?,?,'occupied','idle')",
+            (shell_id, generation)).lastrowid
+        con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,?,?,'clean')",
+            (sid, shell_id, generation))
+        con.commit()
+        con.close()
+        gen = interface_runtime.Generation(self.rt, sid, shell_id, generation,
+                                           24, 80)
+        self.rt.generations[sid] = gen
+        return sid, gen
+
+    def _lease(self, sid, client_id="tab-1", token="tok-1", takeover=False):
+        con = sqlite3.connect(self.db)
+        lease_id = interface_broker.acquire_writer(con, sid, client_id, token,
+                                                   takeover=takeover)
+        con.commit()
+        con.close()
+        return lease_id
+
+    def _lease_row(self, lease_id):
+        con = sqlite3.connect(self.db)
+        row = con.execute(
+            "SELECT revoked_at, revoke_reason FROM interface_writer_leases "
+            "WHERE lease_id=?", (lease_id,)).fetchone()
+        con.close()
+        return row
+
+    def _stale_heartbeat(self, lease_id):
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "UPDATE interface_writer_leases SET "
+            "heartbeat_at=datetime('now','-120 seconds') WHERE lease_id=?",
+            (lease_id,))
+        con.commit()
+        con.close()
+
+    def _heartbeat_fresh(self, lease_id):
+        con = sqlite3.connect(self.db)
+        row = con.execute(
+            "SELECT heartbeat_at > datetime('now','-5 seconds') "
+            "FROM interface_writer_leases WHERE lease_id=?", (lease_id,)
+        ).fetchone()
+        con.close()
+        return row[0] == 1
+
+    def test_writer_detach_revokes_its_lease(self):
+        sid, gen = self._session()
+        lease_id = self._lease(sid)
+        writer = FakeClient(sid, role="writer", client_id="tab-1",
+                            lease_id=lease_id, lease_token="tok-1")
+        viewer = FakeClient(sid, role="viewer", client_id="tab-2")
+        gen.clients.update({writer, viewer})
+
+        async def flow():
+            self.rt.detach(writer)
+            await wait_for(lambda: self._lease_row(lease_id)[0] is not None,
+                           what="liveness revoke")
+        asyncio.run(flow())
+        self.assertEqual(self._lease_row(lease_id)[1], "liveness")
+        # The remaining client is told the writer lease is gone.
+        wstates = viewer.by_type("writer")
+        self.assertTrue(wstates)
+        self.assertEqual(wstates[-1]["state"], "none")
+
+    def test_viewer_detach_revokes_nothing(self):
+        sid, gen = self._session()
+        lease_id = self._lease(sid)
+        viewer = FakeClient(sid, role="viewer", client_id="tab-2")
+        gen.clients.add(viewer)
+
+        async def flow():
+            self.rt.detach(viewer)
+            await asyncio.sleep(0.2)  # any stray revoke task would land
+        asyncio.run(flow())
+        self.assertIsNone(self._lease_row(lease_id)[0])
+
+    def test_late_detach_never_clobbers_reacquired_lease(self):
+        sid, gen = self._session()
+        old_lease = self._lease(sid, token="tok-old")
+        old = FakeClient(sid, role="writer", client_id="tab-1",
+                         lease_id=old_lease, lease_token="tok-old")
+        gen.clients.add(old)
+
+        async def flow():
+            self.rt.detach(old)
+            await wait_for(lambda: self._lease_row(old_lease)[0] is not None,
+                           what="first liveness revoke")
+        asyncio.run(flow())
+
+        # The client re-acquires (new lease id, new token); then the OLD
+        # client object's detach fires again — a late close echo.
+        new_lease = self._lease(sid, token="tok-new")
+        stale = FakeClient(sid, role="writer", client_id="tab-1",
+                           lease_id=old_lease, lease_token="tok-old")
+
+        async def flow2():
+            self.rt.detach(stale)
+            await asyncio.sleep(0.2)
+        asyncio.run(flow2())
+        self.assertIsNone(self._lease_row(new_lease)[0],
+                          "a stale detach must not touch the new lease")
+
+    def test_revoke_fence_requires_token_and_generation(self):
+        sid, _gen = self._session()
+        lease_id = self._lease(sid, token="tok-1")
+        self.assertFalse(self.rt._revoke_lease_sync(lease_id, "wrong", 1))
+        self.assertFalse(self.rt._revoke_lease_sync(lease_id, "tok-1", 2))
+        self.assertIsNone(self._lease_row(lease_id)[0])
+        self.assertTrue(self.rt._revoke_lease_sync(lease_id, "tok-1", 1))
+        self.assertEqual(self._lease_row(lease_id)[1], "liveness")
+        # A double revoke is a no-op (the revoked_at IS NULL fence).
+        self.assertFalse(self.rt._revoke_lease_sync(lease_id, "tok-1", 1))
+
+    def test_sweep_revokes_silent_lease_keeps_fresh_one(self):
+        sid, _gen = self._session()
+        stale_lease = self._lease(sid, client_id="tab-dead", token="tok-d")
+        self._stale_heartbeat(stale_lease)
+
+        async def flow():
+            await self.rt._sweep_dead_leases()
+        asyncio.run(flow())
+        self.assertEqual(self._lease_row(stale_lease)[1], "liveness")
+
+        # A lease with a fresh durable heartbeat survives the sweep.
+        fresh_lease = self._lease(sid, client_id="tab-live", token="tok-l")
+        asyncio.run(flow())
+        self.assertIsNone(self._lease_row(fresh_lease)[0])
+
+    def test_acquire_after_sweep_needs_no_takeover(self):
+        sid, _gen = self._session()
+        dead_lease = self._lease(sid, client_id="tab-dead", token="tok-d")
+        self._stale_heartbeat(dead_lease)
+        # While the dead writer's lease is live, a plain acquire refuses.
+        con = sqlite3.connect(self.db)
+        with self.assertRaises(interface_broker.BrokerError):
+            interface_broker.acquire_writer(con, sid, "tab-2", "tok-2")
+        con.close()
+
+        async def flow():
+            await self.rt._sweep_dead_leases()
+        asyncio.run(flow())
+        # After the sweep the lease is free — no takeover needed.
+        new_lease = self._lease(sid, client_id="tab-2", token="tok-2")
+        self.assertIsNone(self._lease_row(new_lease)[0])
+
+    def test_sweep_scopes_to_owned_generations(self):
+        sid1, _gen1 = self._session(shell_id=1, generation=1)
+        lease1 = self._lease(sid1, client_id="tab-1", token="tok-1")
+        # A second occupied session this runtime does NOT manage.
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (2,1)")
+        sid2 = con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle) VALUES (2,1,'occupied','idle')").lastrowid
+        con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,2,1,'clean')", (sid2,))
+        con.commit()
+        con.close()
+        lease2 = self._lease(sid2, client_id="tab-x", token="tok-x")
+        self._stale_heartbeat(lease1)
+        self._stale_heartbeat(lease2)
+
+        async def flow():
+            await self.rt._sweep_dead_leases()
+        asyncio.run(flow())
+        self.assertEqual(self._lease_row(lease1)[1], "liveness")
+        self.assertIsNone(self._lease_row(lease2)[0],
+                          "the sweep must not touch foreign generations")
+
+    def test_heartbeat_stamps_lease_fenced_by_token(self):
+        sid, _gen = self._session()
+        lease_id = self._lease(sid, token="tok-1")
+        self._stale_heartbeat(lease_id)
+        writer = FakeClient(sid, role="writer", client_id="tab-1",
+                            lease_id=lease_id, lease_token="tok-1")
+
+        async def flow():
+            self.rt.heartbeat(writer)
+            await wait_for(lambda: self._heartbeat_fresh(lease_id),
+                           what="durable heartbeat stamp")
+        asyncio.run(flow())
+
+        # A writer frame with the wrong token stamps nothing.
+        self._stale_heartbeat(lease_id)
+        impostor = FakeClient(sid, role="writer", client_id="tab-9",
+                              lease_id=lease_id, lease_token="nope")
+
+        async def flow2():
+            self.rt.heartbeat(impostor)
+            await asyncio.sleep(0.3)
+        asyncio.run(flow2())
+        self.assertFalse(self._heartbeat_fresh(lease_id))
 
 
 # ------------------------------------------------------------- integration (tmux)

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -302,7 +302,12 @@ class BootPhaseLabelTest(unittest.TestCase):
             self.assertTrue(enabled)
             yield _LabelRecorder(labels, label)
 
-        env = {"SC_NO_AUTOPRUNE": "1"} if no_prune else {}
+        # SC_RAW_BOOT: main()'s interactive entry refuses without the Interface
+        # reservation capability (spec #20); these unit tests drive the raw
+        # boot pipeline itself, so they hold the tooling escape hatch.
+        env = {"SC_RAW_BOOT": "1"}
+        if no_prune:
+            env["SC_NO_AUTOPRUNE"] = "1"
         stdout = _Stdout(tty=False)
         stdin = _Stdout(tty=False)
         sync = mock.Mock(return_value="in sync with origin/main")

--- a/tests/test_vm_bake.py
+++ b/tests/test_vm_bake.py
@@ -15,6 +15,7 @@ Run:
 """
 from __future__ import annotations
 
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -36,6 +37,15 @@ def _virsh_op(argv: list[str]) -> str:
 
 
 class BakeTest(unittest.TestCase):
+    def setUp(self):
+        # The suite itself often runs inside a sandbox (SC_SANDBOX=1 in the
+        # env); clear it so only test_refuses_in_sandbox exercises the
+        # refusal path.
+        patcher = mock.patch.dict("os.environ")
+        patcher.start()
+        os.environ.pop("SC_SANDBOX", None)
+        self.addCleanup(patcher.stop)
+
     def test_refuses_in_sandbox(self):
         with mock.patch.dict("os.environ", {"SC_SANDBOX": "1"}):
             r = vm.do_bake()


### PR DESCRIPTION
## Sprint 25 seq 6 · task #82 · spec #20

Builds on the seq-5 vertical slice (@7e39ce0). Three commits, one per concern.

### 1. CLI parity (`sc interface` + `sc enter`)
- `sc interface status [shell] [--json]` · `start <shell> [--harness --model --effort]` · `view` (read-only) · `attach` (writer, no silent takeover) · `take-control` · `stop [--force]` · `reconcile [--close]` — all through the Interface API (operator bearer + `Idempotency-Key`), stable `--json`.
- Attach client ports the proven spike client onto sc-term.v1: raw stdin → `0x01` frames reseeded from the lease's `next_input_seq`, `0x03` resize on start + SIGWINCH, output/redraw → stdout, 20s writer heartbeat, lease released on exit.
- `sc enter` rerouted: available → harness picker + `POST /sessions` → writer attach; occupied → reattach the same generation (writer if free, else read-only + take-control notice). Never `tmux attach`, never provider resume.
- Raw interactive launch refuses without the reservation capability, before archive creation (`SC_RAW_BOOT=1` escape hatch; headless/`RENDER_ONLY` unaffected).
- API outage → exit 3 with supervised-runtime remediation (`./sc restart` / `make dos-r`); no direct-DB/tmux fallback, ever.

### 2. Full Interface tab workflow
- New chat picker: harness/model/effort from the `/api/models` catalogue (reuses the Default Models picker idiom).
- Rail projects occupancy per spec (`starting`/`occupied`/`lost`/`error`) + unread-alert pills; header shows harness/model, age, writer/read-only, composer, wake state.
- Explicit confirmed takeover; revoked writers flip read-only immediately (writer-state frame ≠ active, or `writer_revoked` input-reject).
- Graceful-first End chat; force only after `graceful_timeout`, naming PID/generation. Lost/error panes: diagnostics + reconcile/close gated on server preconditions.
- Responsive: ≤760px the rail collapses to a picker above a min-height terminal.
- Cleanup (seq-5 r3 Low): `ifOpToken` nulled on **every** non-ok bootstrap exit.

### 3. Writer-lease DB liveness
- Detach revokes the writer's lease (fenced by lease id/token/generation — a stale detach can't clobber a re-acquired lease); heartbeats stamp `heartbeat_at`; a 40s-silent lease is swept (scoped to owned generations). All `revoke_reason='liveness'` + writer-state broadcast. Takeover after a dead writer no longer needs force.

### Verification
- New: `tests/test_interface_cli.py` (25 hermetic: verb HTTP calls, `--json` shapes, 409 occupied-race, held-lease refusal, unreachable → exit 3, enter routing all four ways, raw-launch refusal before `open_db`, escape-hatch/headless/RENDER_ONLY pass).
- `tests/test_interface_runtime.py` +9 liveness tests (detach revoke, fences, sweep, reacquire-without-force).
- Full suite: **692 passed, 4 skipped** (tmux-gated integration). `tests/test_vm_bake.py` 3 reds are **pre-existing/environmental** (ambient `SC_SANDBOX=1` in this container; 6/6 green with it unset — same on base).
- `ruff` clean on all touched files (23 repo-wide errors pre-exist on base); `node --check app.js` ✓; `sh -n sc` ✓. mypy repo-wide is pre-existing red (214 on base); the one new arg-type error was fixed.

### Declared deviations / planner notes
- **Permission picker**: `POST /sessions` accepts exactly `shell_id, harness, model, effort, rows, cols` — no permission-mode field exists, so none was added to the UI (would need an API change; flags for a follow-up if wanted).
- **No server push on HTTP takeover**: takeover revokes the lease in the DB but doesn't broadcast; the old writer flips read-only on its next writer-state frame (liveness broadcast) or its next input's `writer_revoked` reject. Immediate push would need a runtime hook in the takeover path.
- `wake_state` renders but is hardcoded `disarmed` server-side — seq 8 territory.
- `sc enter` no longer prompts for username auth — the operator bearer is the auth.
- Live end-to-end attach not exercised from the sandbox (supervised Interface server not running here); the WS loop is spike-proven code, exercised hermetically up to the socket open.