### PR TITLE
feat(interface): cross-harness lifecycle adapters (sprint 25 seq 7, task #83)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -48,6 +48,7 @@ sys.path.insert(0, str(ENGINE / "scripts"))
 sys.path.insert(0, str(ENGINE / "api"))
 import db_driver  # noqa: E402
 import interface_broker  # noqa: E402
+import interface_hooks  # noqa: E402
 import interface_state  # noqa: E402
 import ports as ports_mod  # noqa: E402
 import shell_liveness  # noqa: E402
@@ -781,16 +782,35 @@ def _reconcile(actor, headers, body):
 def _hook_callback(headers, body):
     """Generation-scoped hook authority: the token calls ONLY this route, for
     its one generation. session_start additionally promotes the reservation
-    (reserved → occupied) after exact identity proof."""
+    (reserved → occupied) after exact identity proof.
+
+    Contract (spec #20 Harness Hooks, seq 7): callbacks carry ONLY event,
+    session, generation, sequence, PID identity, and token — no content.
+    Wrong tokens, stale generations, replayed sequences, unknown events,
+    illegal transitions, and PID mismatches are rejected and audited.
+    `source` distinguishes the entrypoint's pre-exec identity claim from a
+    provider-native hook; only the provider's session_start is readiness."""
     authz = headers.get("Authorization") or ""
     token = authz[7:].strip() if authz[:7].lower() == "bearer " else ""
     shell_id, generation = body.get("shell_id"), body.get("generation")
     hook_seq, event = body.get("hook_seq"), body.get("event")
+    source = body.get("source", "provider")
     if not token or not isinstance(shell_id, int) \
             or not isinstance(generation, int) \
             or not isinstance(hook_seq, int) or not event:
         return _err(422, "validation",
                     "bearer token + shell_id, generation, hook_seq, event")
+    unknown = set(body) - {"shell_id", "generation", "hook_seq", "event",
+                           "source", "pid", "start_ticks", "archive_id",
+                           "cli_version"}
+    if unknown:
+        return _err(422, "validation", f"unknown fields: {sorted(unknown)}")
+    if event not in interface_hooks.EVENTS:
+        _log(f"hook event rejected shell={shell_id} gen={generation} "
+             f"event={event!r}")
+        return _err(422, "validation", f"unknown hook event {event!r}")
+    if source not in interface_hooks.SOURCES:
+        return _err(422, "validation", f"unknown hook source {source!r}")
     con = _db()
     try:
         gen = con.execute(
@@ -811,17 +831,22 @@ def _hook_callback(headers, body):
             return _err(404, "no_such_session", "no live session for generation")
         session_id, occupancy, pane_pid = sess
         try:
+            # Exact identity (spec: PID presence is never authority): a
+            # callback reporting a pid must report the pane's pid — the
+            # exec chain makes harness pid == pane pid, and the emitter
+            # passes $PPID. session_start MUST carry it (entrypoint and
+            # emitter both do); any mismatch fails closed, on any event.
+            if body.get("pid") is None and event == "session_start":
+                return _err(422, "validation",
+                            "session_start requires pid identity")
+            if body.get("pid") is not None and body.get("pid") != pane_pid:
+                _log(f"hook identity mismatch session={session_id} "
+                     f"event={event} pid={body.get('pid')} "
+                     f"pane_pid={pane_pid}")
+                return _err(403, "identity_mismatch",
+                            "reported pid is not the pane's pid")
             if event == "session_start":
-                # Exact identity (spec: PID presence is never authority): the
-                # entrypoint's pid must be the pane's pid — exec-chained all
-                # the way down. Any mismatch fails closed.
-                if body.get("pid") != pane_pid:
-                    _log(f"session_start identity mismatch session="
-                         f"{session_id} pid={body.get('pid')} "
-                         f"pane_pid={pane_pid}")
-                    return _err(403, "identity_mismatch",
-                                "reported pid is not the pane's pid")
-                if occupancy == "reserved":
+                if source == "entrypoint" and occupancy == "reserved":
                     interface_state.transition(
                         con, "occupancy", session_id, "occupied",
                         extra_sets={"occupied_at": _now(con),
@@ -830,15 +855,16 @@ def _hook_callback(headers, body):
                                     "harness_start_ticks":
                                         body.get("start_ticks"),
                                     "cli_version": body.get("cli_version")})
-                result = interface_broker.record_hook(
-                    con, shell_id, generation, hook_seq, event)
-            else:
-                result = interface_broker.record_hook(
-                    con, shell_id, generation, hook_seq, event)
+            result = interface_broker.record_hook(
+                con, shell_id, generation, hook_seq, event, source=source)
             con.commit()
             return _json(200, result)
         except interface_broker.BrokerError as exc:
             return _err(409, "hook_rejected", str(exc))
+        except interface_state.InterfaceTransitionError as exc:
+            _log(f"hook illegal transition session={session_id} "
+                 f"event={event}: {exc}")
+            return _err(409, "hook_rejected", f"illegal transition: {exc}")
     finally:
         con.close()
 

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import hashlib
 
+import interface_hooks
 import interface_state
 
 MAX_INPUT_BYTES = 64 * 1024  # one human frame, per the pinned spike protocol
@@ -30,6 +31,21 @@ DEFAULT_QUIET_S = 3.0  # debounce, never proof of an empty composer
 
 class BrokerError(ValueError):
     """A refused broker operation (stale generation, bad sequence, gate)."""
+
+
+def _begin_immediate(con) -> bool:
+    """Serialize a check-then-act gate (REV2 seq-4 L5 TOCTOU): take the DB
+    write lock BEFORE the gate reads so a concurrent gate on another
+    connection cannot pass on the same pre-commit snapshot. WAL +
+    busy_timeout make the contender wait, then re-read post-commit state.
+    Returns True when THIS call opened the transaction — the caller must
+    then release it (commit or rollback) on every exit path; False when the
+    connection was already in a transaction (serialization is then the
+    caller's own)."""
+    if con.in_transaction:
+        return False
+    con.execute("BEGIN IMMEDIATE")
+    return True
 
 
 def _now(con) -> str:
@@ -136,53 +152,71 @@ def accept_human_input(con, session_id: int, client_seq: int,
     a writer() failure WITHOUT process death takes the same park immediately
     (delivery unknown, writer revoked, alert) since the bytes may have
     landed.
+
+    The gate reads + the phase-1 commit are serialized under BEGIN IMMEDIATE
+    (REV2 seq-4 L5): a wake submission committing its input lock on another
+    connection cannot slip between this frame's lock check and its
+    reservation — whichever commits first wins; the loser re-reads and
+    refuses (lock held) or re-gates (frame pending).
     """
-    if payload_len > MAX_INPUT_BYTES:
-        raise BrokerError(f"payload {payload_len} > {MAX_INPUT_BYTES} bytes")
-    sess = _session(con, session_id)
-    if sess[3] != "occupied":
-        raise BrokerError(f"session {session_id} is {sess[3]}, not occupied")
-    lease = current_writer(con, session_id)
-    if lease is None:
-        raise BrokerError(f"session {session_id} has no writer")
-    istate = con.execute(
-        "SELECT composer, delivery, pending_seq, forwarded_seq "
-        "FROM interface_input_state WHERE session_id=?",
-        (session_id,),
-    ).fetchone()
-    if istate is None:
-        raise BrokerError(f"session {session_id} has no input state row")
-    _, _, pending_seq, forwarded_seq = istate
+    began = _begin_immediate(con)
+    try:
+        if payload_len > MAX_INPUT_BYTES:
+            raise BrokerError(
+                f"payload {payload_len} > {MAX_INPUT_BYTES} bytes")
+        sess = _session(con, session_id)
+        if sess[3] != "occupied":
+            raise BrokerError(
+                f"session {session_id} is {sess[3]}, not occupied")
+        lease = current_writer(con, session_id)
+        if lease is None:
+            raise BrokerError(f"session {session_id} has no writer")
+        istate = con.execute(
+            "SELECT composer, delivery, pending_seq, forwarded_seq "
+            "FROM interface_input_state WHERE session_id=?",
+            (session_id,),
+        ).fetchone()
+        if istate is None:
+            raise BrokerError(f"session {session_id} has no input state row")
+        _, _, pending_seq, forwarded_seq = istate
 
-    if client_seq <= forwarded_seq:
-        # Known-forwarded duplicate: replay the ack, never the bytes.
-        return {"ack": client_seq, "duplicate": True}
-    # The input lock: while a wake batch is submitting, its fixed prompt is
-    # the indivisible input — a human frame is ordered AFTER it (spec #20
-    # Retry Policy), never interleaved inside the submission.
-    locked = con.execute(
-        "SELECT 1 FROM planner_wake_batches "
-        "WHERE shell_id=? AND generation=? AND state='submitting'",
-        (sess[1], sess[2])).fetchone()
-    if locked is not None:
-        raise BrokerError(
-            "a wake submission holds the input lock — this frame is ordered "
-            "after it; retry once the wake is acknowledged")
-    if pending_seq is not None:
-        # One unacknowledged frame per writer — the client buffers locally.
-        raise BrokerError(f"sequence {pending_seq} is pending — wait for its ack")
-    if client_seq != lease[2]:
-        raise BrokerError(
-            f"sequence gap: expected {lease[2]}, got {client_seq} — rejected, "
-            "no bytes forwarded")
+        if client_seq <= forwarded_seq:
+            # Known-forwarded duplicate: replay the ack, never the bytes.
+            if began:
+                con.rollback()
+            return {"ack": client_seq, "duplicate": True}
+        # The input lock: while a wake batch is submitting, its fixed prompt is
+        # the indivisible input — a human frame is ordered AFTER it (spec #20
+        # Retry Policy), never interleaved inside the submission.
+        locked = con.execute(
+            "SELECT 1 FROM planner_wake_batches "
+            "WHERE shell_id=? AND generation=? AND state='submitting'",
+            (sess[1], sess[2])).fetchone()
+        if locked is not None:
+            raise BrokerError(
+                "a wake submission holds the input lock — this frame is "
+                "ordered after it; retry once the wake is acknowledged")
+        if pending_seq is not None:
+            # One unacknowledged frame per writer — the client buffers locally.
+            raise BrokerError(
+                f"sequence {pending_seq} is pending — wait for its ack")
+        if client_seq != lease[2]:
+            raise BrokerError(
+                f"sequence gap: expected {lease[2]}, got {client_seq} — "
+                "rejected, no bytes forwarded")
 
-    # Phase 1 (commit): reserve the sequence, dirty the composer FIRST.
-    interface_state.transition(
-        con, "composer", session_id, "dirty",
-        extra_sets={"pending_seq": client_seq,
-                    "pending_reserved_at": _now(con),
-                    "last_human_input_at": _now(con)})
-    con.commit()
+        # Phase 1 (commit): reserve the sequence, dirty the composer FIRST.
+        interface_state.transition(
+            con, "composer", session_id, "dirty",
+            extra_sets={"pending_seq": client_seq,
+                        "pending_reserved_at": _now(con),
+                        "last_human_input_at": _now(con)})
+        con.commit()
+        began = False
+    except Exception:
+        if began:
+            con.rollback()
+        raise
 
     # Phase 2: forward the exact bytes once. A crash here is the window.
     try:
@@ -256,14 +290,24 @@ def reconcile_input(con, session_id: int, outcome: str) -> None:
 
 
 def record_hook(con, shell_id: int, generation: int, hook_seq: int,
-                event: str) -> dict:
+                event: str, source: str = "provider") -> dict:
     """Record one authenticated harness hook with its durable sequence.
 
-    Rejects replays (hook_seq <= last_hook_seq) and stale generations. The
-    sequence is the crash-window evidence: a batch's submit/stop hook seqs
-    are stamped here, and startup reconciliation trusts only these durable
-    stamps — never the broker's memory of what it sent.
+    Rejects replays (hook_seq <= last_hook_seq), stale generations, and
+    unknown events. The sequence is the crash-window evidence: a batch's
+    submit/stop hook seqs are stamped here, and startup reconciliation
+    trusts only these durable stamps — never the broker's memory of what
+    it sent.
+
+    `source` distinguishes the entrypoint's pre-exec identity claim
+    (reserved → occupied promotion; NOT readiness) from a provider-native
+    hook delivered by the emitter — only the provider's session_start is
+    real start-readiness (sprint 25 seq 7).
     """
+    if event not in interface_hooks.EVENTS:
+        raise BrokerError(f"unknown hook event {event!r} — rejected")
+    if source not in interface_hooks.SOURCES:
+        raise BrokerError(f"unknown hook source {source!r} — rejected")
     gen = con.execute(
         "SELECT last_hook_seq, ended_at FROM interface_generations "
         "WHERE shell_id=? AND generation=?",
@@ -289,9 +333,24 @@ def record_hook(con, shell_id: int, generation: int, hook_seq: int,
     result = {"hook_seq": hook_seq, "event": event}
 
     if event == "session_start":
-        # Ready prompt proven, zero accepted human sequence → idle + clean.
-        interface_state.transition(con, "lifecycle", sess[0], "idle")
-        interface_state.transition(con, "composer", sess[0], "clean")
+        if source == "provider":
+            # Real provider readiness (seq 7): the harness's own start hook,
+            # not the entrypoint's identity claim. starting → idle; composer
+            # unknown → clean ONLY while zero human input has been accepted
+            # (spec: clean requires the ready callback AND no accepted human
+            # sequence). Readiness arriving after human input leaves the
+            # composer as it is — dirty/unknown still need submit/certify.
+            if sess[1] == "starting":
+                interface_state.transition(con, "lifecycle", sess[0], "idle")
+            istate = con.execute(
+                "SELECT composer, pending_seq, forwarded_seq "
+                "FROM interface_input_state WHERE session_id=?",
+                (sess[0],)).fetchone()
+            if istate is not None and istate[1] is None and istate[2] == 0:
+                interface_state.transition(con, "composer", sess[0], "clean")
+            _hook_capability_alerts(con, sess[0])
+        # source='entrypoint': identity/promotion only (the route owns the
+        # reserved → occupied move); readiness waits for the provider hook.
     elif event == "prompt_submit":
         # Fenced submit callback. A prompt_submit hook clears dirty -> clean
         # and promotes a submitting wake batch ONLY when it provably answers
@@ -336,14 +395,8 @@ def record_hook(con, shell_id: int, generation: int, hook_seq: int,
                 result["wake_batch_running"] = batch[0]
         interface_state.transition(con, "lifecycle", sess[0], "busy")
     elif event == "turn_stop":
-        interface_state.transition(con, "lifecycle", sess[0], "idle")
-        batch = con.execute(
-            "SELECT batch_id FROM planner_wake_batches "
-            "WHERE shell_id=? AND generation=? AND state='running'",
-            (shell_id, generation)).fetchone()
-        if batch is not None:
-            _complete_batch(con, batch[0], hook_seq)
-            result["wake_batch_complete"] = batch[0]
+        if _turn_finished(con, sess, shell_id, generation, hook_seq):
+            result["wake_batch_complete"] = True
     elif event == "session_end":
         interface_state.transition(con, "lifecycle", sess[0], "ended")
         # The chat is provably over: end the generation too. Without this the
@@ -354,11 +407,80 @@ def record_hook(con, shell_id: int, generation: int, hook_seq: int,
             "UPDATE interface_generations SET ended_at=datetime('now') "
             "WHERE shell_id=? AND generation=? AND ended_at IS NULL",
             (shell_id, generation))
-    # approval_wait / approval_result / user_input_wait / interrupt map to
-    # plain lifecycle moves — added with the adapters (task #83); the
-    # mandatory four above are the wake-critical contract.
+    elif event == "approval_wait":
+        # Optional (kimi PermissionRequest): busy → approval + alert. A
+        # harness without this event simply stays busy — safe (spec).
+        if sess[1] == "busy":
+            interface_state.transition(con, "lifecycle", sess[0], "approval")
+            _alert(con, severity="warning", reason="approval_wait",
+                   session_id=sess[0])
+    elif event == "approval_result":
+        if sess[1] == "approval":
+            interface_state.transition(con, "lifecycle", sess[0], "busy")
+            con.execute(
+                "UPDATE planner_alerts SET resolved_at=datetime('now') "
+                "WHERE session_id=? AND reason='approval_wait' "
+                "AND resolved_at IS NULL", (sess[0],))
+    elif event == "user_input_wait":
+        if sess[1] == "busy":
+            interface_state.transition(
+                con, "lifecycle", sess[0], "user_input")
+            _alert(con, severity="warning", reason="user_input_wait",
+                   session_id=sess[0])
+    elif event in ("interrupt", "failure"):
+        # The turn is over (user cancel / provider error). kimi's Stop does
+        # not fire on interrupt and claude's Stop does not fire on API
+        # error, so these events ARE that harness's turn-stop: preserve
+        # every queue, record the explicit terminal state, and reconcile a
+        # running batch exactly like turn_stop (spec Harness Hooks).
+        if _turn_finished(con, sess, shell_id, generation, hook_seq):
+            result["wake_batch_complete"] = True
+        if event == "failure":
+            _alert(con, severity="warning", reason="turn_failure",
+                   session_id=sess[0])
+        result["turn_terminal"] = event
     con.commit()
     return result
+
+
+def _turn_finished(con, sess, shell_id: int, generation: int,
+                   stop_hook_seq: int) -> bool:
+    """turn_stop / interrupt / failure: the model turn ended. Lifecycle
+    walks back to idle (through busy from approval/user_input — Stop may
+    arrive while a wait state is up), and a running wake batch reconciles
+    from durable read state. Returns True when a batch was completed."""
+    if sess[1] in ("approval", "user_input"):
+        interface_state.transition(con, "lifecycle", sess[0], "busy")
+        interface_state.transition(con, "lifecycle", sess[0], "idle")
+    else:
+        interface_state.transition(con, "lifecycle", sess[0], "idle")
+    batch = con.execute(
+        "SELECT batch_id FROM planner_wake_batches "
+        "WHERE shell_id=? AND generation=? AND state='running'",
+        (shell_id, generation)).fetchone()
+    if batch is not None:
+        _complete_batch(con, batch[0], stop_hook_seq)
+        return True
+    return False
+
+
+def _hook_capability_alerts(con, session_id: int) -> None:
+    """Spec Harness Hooks: a harness lacking distinct approval/user-input
+    hooks stays busy during those waits (safe) and Interface REPORTS the
+    degradation; a mandatory-hook gap blocks sprint-wake arming — never
+    the ordinary chat. Evaluated once per generation at provider
+    readiness; alerts dedupe while open."""
+    row = con.execute(
+        "SELECT harness, cli_version FROM interface_sessions "
+        "WHERE session_id=?", (session_id,)).fetchone()
+    cap = interface_hooks.capability(row[0] if row else None,
+                                     row[1] if row else None)
+    if not cap["mandatory_ok"]:
+        _alert(con, severity="warning", reason="wake_not_armable",
+               session_id=session_id)
+    elif cap["degraded"]:
+        _alert(con, severity="info", reason="hooks_degraded",
+               session_id=session_id)
 
 
 def _complete_batch(con, batch_id: int, stop_hook_seq: int) -> None:
@@ -492,78 +614,101 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
     sequence the submit hook must answer). A writer failure without process
     death parks the batch as delivery_unknown — the prompt may have landed —
     which also releases the lock.
+
+    The gate reads + the 'submitting' commit are serialized under BEGIN
+    IMMEDIATE (REV2 seq-4 L5 TOCTOU): two concurrent submitters on separate
+    connections can no longer both pass the gate on the same pre-commit
+    snapshot — the second blocks on the write lock, then re-reads state
+    'submitting' and refuses; a human frame racing the gate either commits
+    its pending reservation first (this gate then sees it and cancels the
+    attempt) or loses to the 'submitting' commit and is refused by the lock.
     """
     if quiet_s <= 0:
         raise BrokerError("quiet_s must be > 0 — a zero debounce is forbidden")
-    batch = con.execute(
-        "SELECT binding_id, shell_id, generation, state "
-        "FROM planner_wake_batches WHERE batch_id=?",
-        (batch_id,)).fetchone()
-    if batch is None:
-        raise BrokerError(f"wake batch {batch_id} not found")
-    if batch[3] != "queued":
-        raise BrokerError(f"wake batch {batch_id} is {batch[3]}, not queued")
-    binding_id, shell_id, generation, _ = batch
+    began = _begin_immediate(con)
+    try:
+        batch = con.execute(
+            "SELECT binding_id, shell_id, generation, state "
+            "FROM planner_wake_batches WHERE batch_id=?",
+            (batch_id,)).fetchone()
+        if batch is None:
+            raise BrokerError(f"wake batch {batch_id} not found")
+        if batch[3] != "queued":
+            raise BrokerError(
+                f"wake batch {batch_id} is {batch[3]}, not queued")
+        binding_id, shell_id, generation, _ = batch
 
-    # Revalidate the arming at SUBMIT time: a sprint close or binding release
-    # since form_batch cancels the batch outright (no byte, no retry).
-    binding = con.execute(
-        "SELECT sprint_doc_id, released_at FROM sprint_planner_bindings "
-        "WHERE binding_id=?", (binding_id,)).fetchone()
-    if binding is None or binding[1] is not None:
-        _cancel_batch(con, batch_id)
+        # Revalidate the arming at SUBMIT time: a sprint close or binding
+        # release since form_batch cancels the batch outright (no byte).
+        binding = con.execute(
+            "SELECT sprint_doc_id, released_at FROM sprint_planner_bindings "
+            "WHERE binding_id=?", (binding_id,)).fetchone()
+        if binding is None or binding[1] is not None:
+            _cancel_batch(con, batch_id)
+            con.commit()
+            began = False
+            return {"submitted": False, "cancelled": True,
+                    "reason": "binding released — sprint no longer armed"}
+        if not _sprint_active(con, binding[0]):
+            _cancel_batch(con, batch_id)
+            con.commit()
+            began = False
+            return {"submitted": False, "cancelled": True,
+                    "reason": "sprint doc is not ACTIVE"}
+
+        sess = con.execute(
+            "SELECT session_id, occupancy, lifecycle, occupied_at, created_at "
+            "FROM interface_sessions "
+            "WHERE shell_id=? AND generation=? AND occupancy <> 'ended'",
+            (shell_id, generation)).fetchone()
+        istate = con.execute(
+            "SELECT composer, pending_seq, forwarded_seq, last_human_input_at "
+            "FROM interface_input_state WHERE session_id=?",
+            (sess[0],)).fetchone()
+
+        def gate_fail(reason):
+            if began:
+                con.rollback()
+            return {"submitted": False, "reason": reason}
+
+        if sess[1] != "occupied" or sess[2] != "idle":
+            return gate_fail(
+                f"session not occupied+idle ({sess[1]}/{sess[2]})")
+        if istate[0] != "clean":
+            return gate_fail(f"composer is {istate[0]}")
+        if istate[1] is not None:
+            return gate_fail("a human frame is pending")
+        # Quiet baseline: the last human input if any, else the session's
+        # start — floored at the last service restart (startup_reconcile
+        # revokes every lease with reason 'service_restart'; that stamp is
+        # the restart time).
+        baseline = istate[3] or sess[3] or sess[4]
+        restart_at = con.execute(
+            "SELECT MAX(revoked_at) FROM interface_writer_leases "
+            "WHERE session_id=? AND revoke_reason='service_restart'",
+            (sess[0],)).fetchone()[0]
+        if restart_at is not None and restart_at > baseline:
+            baseline = restart_at
+        quiet = con.execute(
+            "SELECT julianday(?) - julianday(?)", (now_iso, baseline)
+        ).fetchone()[0] * 86400.0
+        if quiet < quiet_s:
+            return gate_fail(f"quiet {quiet:.2f}s < {quiet_s}s")
+
+        fence = istate[2] + 1
+        interface_state.transition(
+            con, "wake_batch", batch_id, "submitting",
+            extra_sets={"input_seq_fence": fence})
+        con.execute(
+            "UPDATE planner_wake_items SET state='submitting' "
+            "WHERE batch_id=? AND state='batched'",
+            (batch_id,))
         con.commit()
-        return {"submitted": False, "cancelled": True,
-                "reason": "binding released — sprint no longer armed"}
-    if not _sprint_active(con, binding[0]):
-        _cancel_batch(con, batch_id)
-        con.commit()
-        return {"submitted": False, "cancelled": True,
-                "reason": "sprint doc is not ACTIVE"}
-
-    sess = con.execute(
-        "SELECT session_id, occupancy, lifecycle, occupied_at, created_at "
-        "FROM interface_sessions "
-        "WHERE shell_id=? AND generation=? AND occupancy <> 'ended'",
-        (shell_id, generation)).fetchone()
-    istate = con.execute(
-        "SELECT composer, pending_seq, forwarded_seq, last_human_input_at "
-        "FROM interface_input_state WHERE session_id=?",
-        (sess[0],)).fetchone()
-
-    if sess[1] != "occupied" or sess[2] != "idle":
-        return {"submitted": False,
-                "reason": f"session not occupied+idle ({sess[1]}/{sess[2]})"}
-    if istate[0] != "clean":
-        return {"submitted": False, "reason": f"composer is {istate[0]}"}
-    if istate[1] is not None:
-        return {"submitted": False, "reason": "a human frame is pending"}
-    # Quiet baseline: the last human input if any, else the session's start —
-    # floored at the last service restart (startup_reconcile revokes every
-    # lease with reason 'service_restart'; that stamp is the restart time).
-    baseline = istate[3] or sess[3] or sess[4]
-    restart_at = con.execute(
-        "SELECT MAX(revoked_at) FROM interface_writer_leases "
-        "WHERE session_id=? AND revoke_reason='service_restart'",
-        (sess[0],)).fetchone()[0]
-    if restart_at is not None and restart_at > baseline:
-        baseline = restart_at
-    quiet = con.execute(
-        "SELECT julianday(?) - julianday(?)", (now_iso, baseline)
-    ).fetchone()[0] * 86400.0
-    if quiet < quiet_s:
-        return {"submitted": False,
-                "reason": f"quiet {quiet:.2f}s < {quiet_s}s"}
-
-    fence = istate[2] + 1
-    interface_state.transition(
-        con, "wake_batch", batch_id, "submitting",
-        extra_sets={"input_seq_fence": fence})
-    con.execute(
-        "UPDATE planner_wake_items SET state='submitting' "
-        "WHERE batch_id=? AND state='batched'",
-        (batch_id,))
-    con.commit()
+        began = False
+    except Exception:
+        if began:
+            con.rollback()
+        raise
 
     try:
         writer(len(WAKE_PROMPT) + 1)  # the fixed prompt + Enter, indivisible

--- a/.super-coder/scripts/interface_exec.py
+++ b/.super-coder/scripts/interface_exec.py
@@ -13,12 +13,17 @@ points a private tmux pane's shell line at this script. This process then:
     3. chdirs into the token's worktree.
     4. prepares the launch through run.py's `prepare_launch` — the NORMAL
        harness/model/effort/permission/worktree/render/boot/archive path
-       (exit 3 on refusal).
-    5. confirms identity to the API with a session_start hook callback,
-       which promotes the reservation reserved→occupied (exit 4 when the
-       API is unreachable or rejects — fail closed: never start an
+       (exit 3 on refusal), then merges the harness's authenticated
+       lifecycle hook config (interface_hooks — never replacing fork/user
+       hooks) and injects the emitter's per-generation credentials into
+       the launch env;
+    5. confirms identity to the API with an entrypoint session_start hook
+       callback, which promotes the reservation reserved→occupied (exit 4
+       when the API is unreachable or rejects — fail closed: never start an
        unmanaged harness; an unpromoted reservation expires into
-       unreconciled for the operator).
+       unreconciled for the operator). This is IDENTITY only: lifecycle
+       idle + composer clean wait for the harness's own provider
+       session_start hook (seq 7 hardening);
     6. execvpe's the harness TUI — this process BECOMES the harness,
        keeping the pane PID (the pane shell line exec's all the way down).
 
@@ -39,8 +44,10 @@ import urllib.request
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
+RUN_DIR = ENGINE / "run" / "interface"  # gitignored runtime home
 sys.path.insert(0, str(ENGINE / "scripts"))
 import run as run_mod  # noqa: E402
+import interface_hooks  # noqa: E402
 
 # Fields the reservation capability must carry (harness/model/effort are
 # optional route hints — prepare_launch resolves their defaults).
@@ -172,11 +179,27 @@ def main(argv: "list[str] | None" = None) -> int:
               f"({type(e).__name__}: {e})", file=sys.stderr)
         return 3
 
+    # Lifecycle hooks (sprint 25 seq 7): merge this harness's authenticated
+    # hook config WITHOUT replacing fork/user hooks, and hand the emitter
+    # its per-generation credentials through the launch env — the token
+    # never touches a config file, argv, or stderr. A harness whose hooks
+    # can't install still launches (ordinary chat unaffected); without the
+    # provider session_start the session simply never becomes wake-armable.
+    hook_install = interface_hooks.install(
+        plan.harness, Path(plan.cwd), run_dir=RUN_DIR,
+        session_id=int(token["session_id"]), cli_version=plan.cli_version)
+    argv = list(plan.argv) + hook_install["argv"]
+    env = dict(plan.env)
+    env["SC_INTERFACE_HOOK_TOKEN"] = token["hook_token"]
+    env["SC_INTERFACE_SHELL_ID"] = str(token["shell_id"])
+    env["SC_INTERFACE_GENERATION"] = str(token["generation"])
+
     body = {
         "shell_id": int(token["shell_id"]),
         "generation": int(token["generation"]),
         "hook_seq": 1,
         "event": "session_start",
+        "source": "entrypoint",
         "archive_id": plan.archive_id,
         "pid": os.getpid(),
         "start_ticks": _start_ticks(),
@@ -193,7 +216,7 @@ def main(argv: "list[str] | None" = None) -> int:
         return 4
 
     os.chdir(plan.cwd)
-    _exec(plan.argv, plan.env)
+    _exec(argv, env)
     return 0  # unreachable: _exec replaces the process
 
 

--- a/.super-coder/scripts/interface_hook.py
+++ b/.super-coder/scripts/interface_hook.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Interface lifecycle hook emitter (spec #20 Harness Hooks, sprint 25
+seq 7, task #83).
+
+Invoked BY the harness (claude/codex/kimi) through the hook config
+interface_hooks.install() merged at launch. It turns one native hook
+firing into one authenticated contract callback:
+
+    {"shell_id", "generation", "hook_seq", "event", "pid",
+     "source": "provider"}
+
+The callback contract DISCARDS content: the native payload arrives on
+stdin (prompt text, tool input, transcripts) and is never read here — the
+registered commands already redirect </dev/null — and nothing but the
+fields above is sent. The bearer token, shell, and generation come from
+the launch env the pane entrypoint injected (SC_INTERFACE_*), never from
+config files or argv.
+
+hook_seq is allocated from a per-generation counter file under the engine
+run dir (flock-serialized — concurrent hooks can't double-issue). The
+entrypoint's pre-exec session_start is always seq 1, so the counter starts
+at 1 and the first harness-side hook issues 2. A crash between allocation
+and POST leaves a gap; the receiver rejects only <= last, so gaps are
+safe (a lost hook is a missed event, never a replay).
+
+The emitter NEVER blocks the harness: several contract events ride awaited
+native hooks (UserPromptSubmit/Stop/SessionEnd), so it posts with a short
+timeout, retries once on transport failure, and exits 0 either way (the
+registered commands also `|| true`). Failures go to stderr only, without
+the token.
+
+Usage (registered by interface_hooks; not a human surface):
+    python3 interface_hook.py --event <contract-event> --pid <harness-pid>
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ENGINE / "scripts"))
+import interface_hooks  # noqa: E402
+
+POST_TIMEOUT_S = 3
+POST_RETRIES = 2  # one retry on transport failure only
+
+
+class EmitError(Exception):
+    """A local refusal (bad env, unknown event) — logged, exit 0 regardless."""
+
+
+def _run_dir() -> Path:
+    override = os.environ.get("SC_INTERFACE_RUN_DIR")
+    return Path(override) if override else ENGINE / "run" / "interface"
+
+
+def next_hook_seq(run_dir: Path, shell_id: int, generation: int) -> int:
+    """Allocate the next durable hook sequence for this generation.
+
+    The counter file starts at 1 (the entrypoint's pre-exec session_start
+    is always seq 1), so the first harness-side hook issues 2. flock makes
+    concurrent native hooks (kimi runs matches in parallel) allocate
+    strictly monotonic sequences."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = run_dir / f"hook-seq-{shell_id}-{generation}.seq"
+    with open(path, "a+") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        fh.seek(0)
+        raw = fh.read().strip()
+        last = int(raw) if raw else 1  # 1 = the entrypoint's session_start
+        nxt = last + 1
+        fh.seek(0)
+        fh.truncate()
+        fh.write(f"{nxt}\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+        fcntl.flock(fh, fcntl.LOCK_UN)
+    return nxt
+
+
+def post_callback(api_base: str, token: str, body: dict,
+                  retries: int = POST_RETRIES,
+                  timeout: float = POST_TIMEOUT_S,
+                  sleep=time.sleep) -> bool:
+    """POST the callback. Retries only on transport failure; an HTTP
+    response — even a rejection — is definitive (a replayed sequence or
+    stale generation will not heal in 300ms). Never logs the token."""
+    url = f"{api_base.rstrip('/')}/api/interface/hook-callbacks"
+    data = json.dumps(body).encode()
+    for attempt in range(1, retries + 1):
+        req = urllib.request.Request(
+            url, data=data, method="POST",
+            headers={"Authorization": f"Bearer {token}",
+                     "Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                ok = 200 <= resp.status < 300
+                if not ok:
+                    print(f"interface-hook: {body['event']} rejected "
+                          f"(HTTP {resp.status})", file=sys.stderr)
+                return ok
+        except urllib.error.HTTPError as e:
+            print(f"interface-hook: {body['event']} rejected (HTTP {e.code})",
+                  file=sys.stderr)
+            return False
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            reason = getattr(e, "reason", e)
+            print(f"interface-hook: {body['event']} attempt "
+                  f"{attempt}/{retries} failed ({reason})", file=sys.stderr)
+            if attempt < retries:
+                sleep(0.3)
+    return False
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--event", required=True)
+    ap.add_argument("--pid", type=int, default=None)
+    args = ap.parse_args(argv)
+
+    # NOTE: stdin (the native hook payload — prompt/tool content) is
+    # deliberately never read. The contract carries no content.
+    try:
+        if args.event not in interface_hooks.EVENTS:
+            raise EmitError(f"unknown contract event {args.event!r}")
+        token = os.environ.get("SC_INTERFACE_HOOK_TOKEN") or ""
+        shell_id = os.environ.get("SC_INTERFACE_SHELL_ID") or ""
+        generation = os.environ.get("SC_INTERFACE_GENERATION") or ""
+        api_base = os.environ.get("SC_API_BASE") or ""
+        if not token or not shell_id or not generation or not api_base:
+            raise EmitError("SC_INTERFACE_HOOK_TOKEN / SC_INTERFACE_SHELL_ID "
+                            "/ SC_INTERFACE_GENERATION / SC_API_BASE unset — "
+                            "not an Interface-managed session")
+        seq = next_hook_seq(_run_dir(), int(shell_id), int(generation))
+        body = {"shell_id": int(shell_id), "generation": int(generation),
+                "hook_seq": seq, "event": args.event, "source": "provider"}
+        if args.pid is not None:
+            body["pid"] = args.pid
+        post_callback(api_base, token, body)
+    except EmitError as e:
+        print(f"interface-hook: {e}", file=sys.stderr)
+    except Exception as e:  # noqa: BLE001 — never break the harness
+        print(f"interface-hook: {type(e).__name__}: {e}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.super-coder/scripts/interface_hooks.py
+++ b/.super-coder/scripts/interface_hooks.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Cross-harness lifecycle hook adapters (spec #20 Harness Hooks, sprint 25
+seq 7, task #83).
+
+One authenticated contract across Claude, Codex, and Kimi: native harness
+hook events are mapped onto the engine's hook vocabulary and POSTed by
+scripts/interface_hook.py (the emitter) with ONLY event, session,
+generation, sequence, PID identity, and token — prompt, tool, transcript,
+and terminal content is discarded at the emitter, never forwarded.
+
+This module owns:
+- the contract event vocabulary (EVENTS) and the mandatory set a harness
+  must support before sprint wake may ARM (MANDATORY — a gap blocks arming,
+  never an ordinary chat, spec #20 Harness Hooks);
+- the per-harness capability table (CAPABILITIES) — which native events each
+  installed CLI generation can actually deliver, the minimum version the
+  mapping was verified against, and the honesty notes about each harness's
+  readiness semantics;
+- the per-harness hook-config installers (install) — hook configuration is
+  MERGED without replacing fork or user hooks: claude rides a per-session
+  `--settings` overlay file (additive by design, zero clobber), codex merges
+  event groups into the emitted project `.codex/hooks.json` (preserving the
+  fork's existing groups), kimi appends a marker-fenced block to the
+  user-level `config.toml` (the only config file kimi 0.27 reads).
+
+Verified against the installed CLIs (2026-07-23):
+- claude 2.1.217/2.1.218: SessionStart (startup|resume; fires DURING
+  startup, pre-prompt — see readiness notes), UserPromptSubmit, Stop,
+  SessionEnd, StopFailure. PermissionRequest exists but has NO result event,
+  and AskUserQuestion has none — per spec a harness lacking distinct
+  approval/user-input hooks stays `busy` during the wait (safe), so those
+  events are deliberately not mapped.
+- codex 0.145.0: hooks feature stable+on; SessionStart (during session
+  init — pre-prompt), UserPromptSubmit, Stop, SessionEnd (present in the
+  binary, undocumented on the hooks page). No approval-result, user-input,
+  interrupt, or failure events.
+- kimi 0.27.0: full 16-event HookEngine; SessionStart is awaited as the
+  FINAL step of session creation (the strongest readiness signal of the
+  three), UserPromptSubmit, Stop, Interrupt, StopFailure, SessionEnd,
+  PermissionRequest + PermissionResult (a real approval pair). No
+  AskUserQuestion hook event.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from pathlib import Path
+
+# ── Contract vocabulary ─────────────────────────────────────────────────────
+
+EVENTS = (
+    "session_start",      # mandatory — provider readiness (see CAPABILITIES)
+    "prompt_submit",      # mandatory
+    "turn_stop",          # mandatory
+    "session_end",        # mandatory
+    "approval_wait",      # optional — absent → harness stays busy (safe)
+    "approval_result",    # optional
+    "user_input_wait",    # optional
+    "interrupt",          # optional — user cancel; the turn is over
+    "failure",            # optional — turn failed; the turn is over
+)
+MANDATORY = ("session_start", "prompt_submit", "turn_stop", "session_end")
+
+# Sources the hook-callback route accepts. `entrypoint` = the pane
+# entrypoint's pre-exec identity claim (interface_exec); it proves PID
+# identity and promotes the reservation but is NOT provider readiness.
+# `provider` = a native harness hook delivered through the emitter; its
+# session_start is the real readiness signal that moves starting→idle.
+SOURCES = ("entrypoint", "provider")
+
+EMITTER = "interface_hook.py"
+
+
+def _emitter_command(event: str) -> str:
+    """The hook command every adapter registers. Reads per-session
+    credentials from the launch env (never baked into config), passes the
+    harness's PID ($PPID — the hook spawns as the harness's child via a
+    shell), and discards the native payload on stdin (</dev/null — prompt
+    and tool content never crosses the contract). `|| true` keeps a dead
+    engine endpoint from ever breaking the harness UX (awaited hooks fail
+    open)."""
+    return (f'python3 "$SC_ENGINE_DIR/scripts/{EMITTER}" '
+            f'--event {event} --pid "$PPID" </dev/null || true')
+
+
+# ── Per-harness capability table ─────────────────────────────────────────────
+# events: contract events the harness can actually deliver.
+# min_version: oldest CLI release this mapping was verified against —
+# anything older is treated as incapable (fail closed for arming, the
+# ordinary chat is unaffected).
+# readiness: how strong the harness's session_start is as a start-READY
+# proof — 'session_created' = fires after session construction completes
+# (kimi: awaited final step of createMain); 'startup_hook' = fires during
+# startup, before the interactive prompt is proven painted (claude/codex).
+# Neither CLI offers a later native prompt-ready signal; the wake gate's
+# quiet debounce + submit-hook fence absorb the residual window.
+
+CAPABILITIES = {
+    "claude": {
+        "min_version": (2, 1, 217),
+        "events": ("session_start", "prompt_submit", "turn_stop",
+                   "session_end", "failure"),
+        "readiness": "startup_hook",
+        "degraded": ("no approval-result or user-input hook events — the "
+                     "session stays busy during those waits (safe); "
+                     "SessionStart fires during startup, pre-prompt"),
+    },
+    "codex": {
+        "min_version": (0, 145, 0),
+        "events": ("session_start", "prompt_submit", "turn_stop",
+                   "session_end"),
+        "readiness": "startup_hook",
+        "degraded": ("no approval, user-input, interrupt, or failure hook "
+                     "events — approval waits stay busy (safe); SessionEnd "
+                     "is undocumented but present in 0.145.0"),
+    },
+    "kimi": {
+        "min_version": (0, 14, 0),
+        "events": ("session_start", "prompt_submit", "turn_stop",
+                   "session_end", "approval_wait", "approval_result",
+                   "interrupt", "failure"),
+        "readiness": "session_created",
+        "degraded": ("no AskUserQuestion hook event — structured input "
+                     "waits stay busy (safe)"),
+    },
+}
+
+
+def _parse_version(text: "str | None") -> "tuple[int, ...] | None":
+    """First dotted numeric triple in a `--version` line (claude prints
+    '2.1.217 (Claude Code)', codex 'codex-cli 0.145.0')."""
+    if not text:
+        return None
+    m = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
+    if m is None:
+        return None
+    return tuple(int(g) for g in m.groups() if g is not None)
+
+
+def capability(harness: "str | None",
+               cli_version: "str | None" = None) -> dict:
+    """What one harness (at one installed version) can deliver against the
+    contract. `mandatory_ok` is the sprint-wake ARMING gate: a harness
+    lacking a mandatory hook — or below the verified version — blocks
+    arming only, never the chat itself."""
+    cap = CAPABILITIES.get(harness or "")
+    if cap is None:
+        return {"harness": harness, "cli_version": cli_version,
+                "mandatory_ok": False, "missing_mandatory": list(MANDATORY),
+                "events": {}, "readiness": "none", "version_ok": False,
+                "degraded": (f"no hook adapter for harness {harness!r}",)}
+    version = _parse_version(cli_version)
+    version_ok = version is not None and version >= cap["min_version"]
+    supported = set(cap["events"])
+    missing = [e for e in MANDATORY if e not in supported]
+    return {"harness": harness, "cli_version": cli_version,
+            "mandatory_ok": version_ok and not missing,
+            "missing_mandatory": missing,
+            "events": {e: (e in supported) for e in EVENTS},
+            "readiness": cap["readiness"], "version_ok": version_ok,
+            "degraded": cap["degraded"]}
+
+
+# ── Hook-config installers (merge, never replace) ───────────────────────────
+
+def _claude_overlay(run_dir: Path, session_id: int) -> Path:
+    """Claude: a per-session `--settings` overlay file. --settings loads
+    ADDITIONAL settings for this session only — user, project, and local
+    hooks stay live alongside ours; nothing is rewritten. The overlay
+    carries no secrets (credentials travel in the launch env)."""
+    def group(event, matcher=None):
+        g = {"hooks": [{"type": "command",
+                        "command": _emitter_command(
+                            {"SessionStart": "session_start",
+                             "UserPromptSubmit": "prompt_submit",
+                             "Stop": "turn_stop",
+                             "StopFailure": "failure",
+                             "SessionEnd": "session_end"}[event]),
+                        "timeout": 5}]}
+        if matcher:
+            g["matcher"] = matcher
+        return g
+
+    overlay = {"hooks": {
+        "SessionStart": [group("SessionStart", "startup|resume")],
+        "UserPromptSubmit": [group("UserPromptSubmit")],
+        "Stop": [group("Stop")],
+        "StopFailure": [group("StopFailure")],
+        "SessionEnd": [group("SessionEnd")],
+    }}
+    path = run_dir / f"claude-hooks-{session_id}.json"
+    path.write_text(json.dumps(overlay, indent=2) + "\n")
+    path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
+    return path
+
+
+_CODEX_EVENTS = (("SessionStart", "session_start", "startup|resume"),
+                 ("UserPromptSubmit", "prompt_submit", None),
+                 ("Stop", "turn_stop", None),
+                 ("SessionEnd", "session_end", None))
+
+
+def _codex_merge(work_dir: Path) -> bool:
+    """Codex: merge our event groups into the project `.codex/hooks.json`
+    the adapter emits each launch (emit runs before this in the launch
+    pipeline). Existing groups — the fork's PreToolUse branch-guard — are
+    preserved; our groups are (re)written by contract-event identity, so
+    re-install is idempotent. An unparseable file is left untouched rather
+    than clobbered. Project-layer hooks load because prepare_launch already
+    trusts the worktree and launches with --dangerously-bypass-hook-trust.
+    """
+    path = work_dir / ".codex" / "hooks.json"
+    cfg: dict = {}
+    if path.exists():
+        try:
+            cfg = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return False
+    hooks = cfg.setdefault("hooks", {})
+    for native, event, matcher in _CODEX_EVENTS:
+        group: dict = {"hooks": [{"type": "command",
+                                  "command": _emitter_command(event),
+                                  "timeout": 10}]}
+        if matcher:
+            group["matcher"] = matcher
+        # Replace only groups that are already ours (same emitter command);
+        # never disturb a group the fork/user wrote for the same event.
+        existing = hooks.get(native) or []
+        kept = [g for g in existing
+                if EMITTER not in json.dumps(g)]
+        kept.append(group)
+        hooks[native] = kept
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(cfg, indent=2) + "\n")
+    os.replace(tmp, path)
+    return True
+
+
+_KIMI_EVENTS = (("SessionStart", "session_start", "startup|resume"),
+                ("UserPromptSubmit", "prompt_submit", None),
+                ("Stop", "turn_stop", None),
+                ("Interrupt", "interrupt", None),
+                ("StopFailure", "failure", None),
+                ("SessionEnd", "session_end", "exit"),
+                ("PermissionRequest", "approval_wait", None),
+                ("PermissionResult", "approval_result", None))
+
+_KIMI_BEGIN = "# >>> super-coder interface hooks (managed — do not edit)"
+_KIMI_END = "# <<< super-coder interface hooks"
+
+
+def _kimi_config_path() -> Path:
+    home = os.environ.get("KIMI_CODE_HOME")
+    return (Path(home) if home else Path.home() / ".kimi-code") / "config.toml"
+
+
+def _kimi_block() -> str:
+    """The managed block: one [[hooks]] table per native event. Kimi 0.27
+    reads ONLY the user-level config.toml (no project config), and its
+    hook schema is strict (event/matcher/command/timeout only). Values
+    travel in the launch env, so one static block serves every session."""
+    lines = [_KIMI_BEGIN]
+    for native, event, matcher in _KIMI_EVENTS:
+        lines.append("[[hooks]]")
+        lines.append(f'event = "{native}"')
+        if matcher:
+            lines.append(f'matcher = "{matcher}"')
+        lines.append(f"command = '{_emitter_command(event)}'")
+        lines.append("timeout = 10")
+    lines.append(_KIMI_END)
+    return "\n".join(lines) + "\n"
+
+
+def _kimi_merge() -> bool:
+    """Kimi: append-or-replace a marker-fenced managed block in the user's
+    config.toml. Everything outside the markers — the user's own hooks and
+    settings — is preserved byte-for-byte; TOML array-of-tables is additive,
+    so our tables never replace existing [[hooks]]."""
+    path = _kimi_config_path()
+    block = _kimi_block()
+    try:
+        cur = path.read_text() if path.exists() else ""
+    except OSError:
+        return False
+    if _KIMI_BEGIN in cur and _KIMI_END in cur:
+        head, rest = cur.split(_KIMI_BEGIN, 1)
+        _, tail = rest.split(_KIMI_END, 1)
+        new = head + block + tail.lstrip("\n")
+        if new == cur:
+            return True
+    else:
+        sep = "" if not cur or cur.endswith("\n") else "\n"
+        new = f"{cur}{sep}\n{block}" if cur else block
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".toml.tmp")
+        tmp.write_text(new)
+        os.replace(tmp, path)
+    except OSError:
+        return False
+    return True
+
+
+def install(harness: "str | None", work_dir: Path, *, run_dir: Path,
+            session_id: int,
+            cli_version: "str | None" = None) -> dict:
+    """Install one session's lifecycle hook config for its harness.
+
+    Returns {"installed": bool, "argv": [...], "capability": capability()}.
+    `argv` carries launch-flag additions (claude's --settings overlay).
+    Installed=False means the harness is unversioned/unknown or the config
+    write failed: the chat still launches, the provider session_start
+    simply never arrives — lifecycle stays `starting`, sprint wake can
+    never arm on it (fail closed, ordinary chat unaffected).
+    """
+    cap = capability(harness, cli_version)
+    result = {"installed": False, "argv": [], "capability": cap}
+    if not cap["mandatory_ok"]:
+        return result
+    if harness == "claude":
+        run_dir.mkdir(parents=True, exist_ok=True)
+        overlay = _claude_overlay(run_dir, session_id)
+        result.update(installed=True, argv=["--settings", str(overlay)])
+    elif harness == "codex":
+        result["installed"] = _codex_merge(work_dir)
+    elif harness == "kimi":
+        result["installed"] = _kimi_merge()
+    return result

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -157,17 +157,25 @@ class InterfaceApiTest(unittest.TestCase):
                          {"shell_id": shell_id, **extra})
 
     def occupy(self, shell_id=1):
-        """Drive a session to occupied+idle+clean via the hook callback."""
+        """Drive a session to occupied+idle+clean: the entrypoint's
+        session_start (identity, promotes reserved→occupied) then the
+        provider's session_start (real readiness → idle+clean)."""
         status, _, body = self.create_session(shell_id)
         assert status == 201, body
         sid = body["session_id"]
-        status, _, _ = self.call(
+        status, _, b = self.call(
             "POST", "/api/interface/hook-callbacks",
             ("Authorization: Bearer " + self.hook_token(sid),),
             {"shell_id": shell_id, "generation": 1, "hook_seq": 1,
-             "event": "session_start", "archive_id": 10, "pid": 4321,
-             "start_ticks": 999})
-        assert status == 200, (sid, status)
+             "event": "session_start", "source": "entrypoint",
+             "archive_id": 10, "pid": 4321, "start_ticks": 999})
+        assert status == 200, (sid, status, b)
+        status, _, b = self.call(
+            "POST", "/api/interface/hook-callbacks",
+            ("Authorization: Bearer " + self.hook_token(sid),),
+            {"shell_id": shell_id, "generation": 1, "hook_seq": 2,
+             "event": "session_start", "source": "provider", "pid": 4321})
+        assert status == 200, (sid, status, b)
         return sid
 
     def hook_token(self, session_id):
@@ -402,18 +410,38 @@ class InterfaceApiTest(unittest.TestCase):
 
     def test_hook_session_start_promotes(self):
         self.create_session()
+        # Phase 1 — the entrypoint's identity claim: promotes reserved →
+        # occupied, but is NOT readiness: lifecycle stays 'starting' and
+        # the composer stays 'unknown' (seq 7 hardening).
         status, _, _ = self.call(
             "POST", "/api/interface/hook-callbacks",
             ("Authorization: Bearer " + self.hook_token(1),),
             {"shell_id": 1, "generation": 1, "hook_seq": 1,
-             "event": "session_start", "archive_id": 10, "pid": 4321,
-             "start_ticks": 999})
+             "event": "session_start", "source": "entrypoint",
+             "archive_id": 10, "pid": 4321, "start_ticks": 999})
         self.assertEqual(status, 200)
         con = sqlite3.connect(self.db_path)
         sess = con.execute(
             "SELECT occupancy, lifecycle, archive_id FROM interface_sessions "
             "WHERE session_id=1").fetchone()
-        self.assertEqual(sess, ("occupied", "idle", 10))
+        self.assertEqual(sess, ("occupied", "starting", 10))
+        composer = con.execute(
+            "SELECT composer FROM interface_input_state WHERE session_id=1"
+        ).fetchone()[0]
+        self.assertEqual(composer, "unknown")
+        con.close()
+        # Phase 2 — the provider's own session_start: real readiness.
+        status, _, _ = self.call(
+            "POST", "/api/interface/hook-callbacks",
+            ("Authorization: Bearer " + self.hook_token(1),),
+            {"shell_id": 1, "generation": 1, "hook_seq": 2,
+             "event": "session_start", "source": "provider", "pid": 4321})
+        self.assertEqual(status, 200)
+        con = sqlite3.connect(self.db_path)
+        sess = con.execute(
+            "SELECT occupancy, lifecycle FROM interface_sessions "
+            "WHERE session_id=1").fetchone()
+        self.assertEqual(sess, ("occupied", "idle"))
         composer = con.execute(
             "SELECT composer FROM interface_input_state WHERE session_id=1"
         ).fetchone()[0]
@@ -424,9 +452,216 @@ class InterfaceApiTest(unittest.TestCase):
             "POST", "/api/interface/hook-callbacks",
             ("Authorization: Bearer " + self.hook_token(1),),
             {"shell_id": 1, "generation": 1, "hook_seq": 1,
-             "event": "session_start", "archive_id": 10, "pid": 4321,
-             "start_ticks": 999})
+             "event": "session_start", "source": "entrypoint",
+             "archive_id": 10, "pid": 4321, "start_ticks": 999})
         self.assertEqual(status, 409)
+
+    def test_hook_contract_validation(self):
+        self.create_session()
+        tok = "Authorization: Bearer " + self.hook_token(1)
+        # Unknown event → 422, audited (nothing recorded).
+        status, _, body = self.call(
+            "POST", "/api/interface/hook-callbacks", (tok,),
+            {"shell_id": 1, "generation": 1, "hook_seq": 1,
+             "event": "screenshot", "pid": 4321})
+        self.assertEqual(status, 422)
+        # Unknown source → 422.
+        status, _, _ = self.call(
+            "POST", "/api/interface/hook-callbacks", (tok,),
+            {"shell_id": 1, "generation": 1, "hook_seq": 1,
+             "event": "session_start", "source": "moon", "pid": 4321})
+        self.assertEqual(status, 422)
+        # Unknown payload fields → 422 (spec: unknown fields are rejected).
+        status, _, _ = self.call(
+            "POST", "/api/interface/hook-callbacks", (tok,),
+            {"shell_id": 1, "generation": 1, "hook_seq": 1,
+             "event": "turn_stop", "prompt": "never content"})
+        self.assertEqual(status, 422)
+        # session_start without pid identity → 422.
+        status, _, _ = self.call(
+            "POST", "/api/interface/hook-callbacks", (tok,),
+            {"shell_id": 1, "generation": 1, "hook_seq": 1,
+             "event": "session_start", "source": "entrypoint"})
+        self.assertEqual(status, 422)
+
+    def test_hook_pid_fence_on_every_event(self):
+        sid = self.occupy()
+        # A pid on ANY event must be the pane's pid (exec-chain identity).
+        status, _, _ = self.call(
+            "POST", "/api/interface/hook-callbacks",
+            ("Authorization: Bearer " + self.hook_token(sid),),
+            {"shell_id": 1, "generation": 1, "hook_seq": 3,
+             "event": "turn_stop", "pid": 9999})
+        self.assertEqual(status, 403)
+
+    def test_hook_approval_and_user_input_lifecycle(self):
+        sid = self.occupy()
+        tok = "Authorization: Bearer " + self.hook_token(sid)
+
+        def hook(seq, event):
+            status, _, body = self.call(
+                "POST", "/api/interface/hook-callbacks", (tok,),
+                {"shell_id": 1, "generation": 1, "hook_seq": seq,
+                 "event": event, "pid": 4321})
+            assert status == 200, (event, status, body)
+
+        def lifecycle():
+            con = sqlite3.connect(self.db_path)
+            row = con.execute("SELECT lifecycle FROM interface_sessions "
+                              "WHERE session_id=?", (sid,)).fetchone()[0]
+            con.close()
+            return row
+
+        hook(3, "prompt_submit")
+        self.assertEqual(lifecycle(), "busy")
+        hook(4, "approval_wait")
+        self.assertEqual(lifecycle(), "approval")
+        # The wait raised an alert; the result resolves it.
+        con = sqlite3.connect(self.db_path)
+        alert = con.execute(
+            "SELECT 1 FROM planner_alerts WHERE session_id=? AND "
+            "reason='approval_wait' AND resolved_at IS NULL",
+            (sid,)).fetchone()
+        con.close()
+        self.assertIsNotNone(alert)
+        hook(5, "approval_result")
+        self.assertEqual(lifecycle(), "busy")
+        con = sqlite3.connect(self.db_path)
+        alert = con.execute(
+            "SELECT 1 FROM planner_alerts WHERE session_id=? AND "
+            "reason='approval_wait' AND resolved_at IS NULL",
+            (sid,)).fetchone()
+        con.close()
+        self.assertIsNone(alert)
+        hook(6, "user_input_wait")
+        self.assertEqual(lifecycle(), "user_input")
+        # turn_stop from a wait state walks back through busy to idle.
+        hook(7, "turn_stop")
+        self.assertEqual(lifecycle(), "idle")
+
+    def test_hook_interrupt_and_failure_end_the_turn(self):
+        sid = self.occupy()
+        tok = "Authorization: Bearer " + self.hook_token(sid)
+
+        def hook(seq, event):
+            status, _, body = self.call(
+                "POST", "/api/interface/hook-callbacks", (tok,),
+                {"shell_id": 1, "generation": 1, "hook_seq": seq,
+                 "event": event, "pid": 4321})
+            assert status == 200, (event, status, body)
+
+        def lifecycle():
+            con = sqlite3.connect(self.db_path)
+            row = con.execute("SELECT lifecycle FROM interface_sessions "
+                              "WHERE session_id=?", (sid,)).fetchone()[0]
+            con.close()
+            return row
+
+        hook(3, "prompt_submit")
+        hook(4, "interrupt")  # kimi Interrupt: Stop never fires on cancel
+        self.assertEqual(lifecycle(), "idle")
+        hook(5, "prompt_submit")
+        hook(6, "failure")  # claude StopFailure: Stop never fires on error
+        self.assertEqual(lifecycle(), "idle")
+        con = sqlite3.connect(self.db_path)
+        alert = con.execute(
+            "SELECT 1 FROM planner_alerts WHERE session_id=? AND "
+            "reason='turn_failure'", (sid,)).fetchone()
+        con.close()
+        self.assertIsNotNone(alert)
+
+    def test_hook_capability_alerts_at_readiness(self):
+        # claude (no approval-result/user-input events) → degraded info
+        # alert; the chat itself is unaffected.
+        status, _, body = self.create_session(1, harness="claude")
+        assert status == 201, body
+        sid = body["session_id"]
+        tok = "Authorization: Bearer " + self.hook_token(sid)
+        status, _, b = self.call(
+            "POST", "/api/interface/hook-callbacks", (tok,),
+            {"shell_id": 1, "generation": 1, "hook_seq": 1,
+             "event": "session_start", "source": "entrypoint",
+             "archive_id": 10, "pid": 4321, "start_ticks": 999,
+             "cli_version": "2.1.217 (Claude Code)"})
+        assert status == 200, b
+        status, _, b = self.call(
+            "POST", "/api/interface/hook-callbacks", (tok,),
+            {"shell_id": 1, "generation": 1, "hook_seq": 2,
+             "event": "session_start", "source": "provider", "pid": 4321})
+        assert status == 200, b
+        con = sqlite3.connect(self.db_path)
+        alert = con.execute(
+            "SELECT severity FROM planner_alerts WHERE session_id=? AND "
+            "reason='hooks_degraded'", (sid,)).fetchone()
+        con.close()
+        self.assertIsNotNone(alert)
+        self.assertEqual(alert[0], "info")
+
+    def test_hook_mandatory_gap_alerts_not_armable(self):
+        # An unknown harness (no adapter) can chat, but provider readiness
+        # flags the mandatory-hook gap: wake can never arm on it.
+        status, _, body = self.create_session(1, harness="ed")
+        assert status == 201, body
+        sid = body["session_id"]
+        tok = "Authorization: Bearer " + self.hook_token(sid)
+        self.call("POST", "/api/interface/hook-callbacks", (tok,),
+                  {"shell_id": 1, "generation": 1, "hook_seq": 1,
+                   "event": "session_start", "source": "entrypoint",
+                   "archive_id": 10, "pid": 4321, "start_ticks": 999})
+        status, _, b = self.call(
+            "POST", "/api/interface/hook-callbacks", (tok,),
+            {"shell_id": 1, "generation": 1, "hook_seq": 2,
+             "event": "session_start", "source": "provider", "pid": 4321})
+        assert status == 200, b
+        con = sqlite3.connect(self.db_path)
+        alert = con.execute(
+            "SELECT severity FROM planner_alerts WHERE session_id=? AND "
+            "reason='wake_not_armable'", (sid,)).fetchone()
+        con.close()
+        self.assertIsNotNone(alert)
+        self.assertEqual(alert[0], "warning")
+
+    def test_provider_readiness_never_cleans_after_human_input(self):
+        sid = self.occupy()
+        # A human frame is accepted (composer dirty), THEN a second provider
+        # session_start arrives (e.g. a resume): it must NOT manufacture
+        # clean — only submit/certify can.
+        status, _, body = self.acquire_lease(sid)
+        assert status == 201, body
+        con = sqlite3.connect(self.db_path)
+        con.execute("UPDATE interface_input_state SET composer='dirty', "
+                    "forwarded_seq=1 WHERE session_id=?", (sid,))
+        con.commit()
+        con.close()
+        status, _, _ = self.call(
+            "POST", "/api/interface/hook-callbacks",
+            ("Authorization: Bearer " + self.hook_token(sid),),
+            {"shell_id": 1, "generation": 1, "hook_seq": 3,
+             "event": "session_start", "source": "provider", "pid": 4321})
+        self.assertEqual(status, 200)
+        con = sqlite3.connect(self.db_path)
+        composer = con.execute(
+            "SELECT composer FROM interface_input_state WHERE session_id=?",
+            (sid,)).fetchone()[0]
+        con.close()
+        self.assertEqual(composer, "dirty")
+
+    def test_hook_illegal_transition_rejected(self):
+        self.create_session()
+        # prompt_submit from lifecycle 'starting' is an illegal edge
+        # (starting → busy) — rejected + audited, no state churn.
+        status, _, body = self.call(
+            "POST", "/api/interface/hook-callbacks",
+            ("Authorization: Bearer " + self.hook_token(1),),
+            {"shell_id": 1, "generation": 1, "hook_seq": 1,
+             "event": "prompt_submit", "pid": 4321})
+        self.assertEqual(status, 409)
+        con = sqlite3.connect(self.db_path)
+        lifecycle = con.execute(
+            "SELECT lifecycle FROM interface_sessions WHERE session_id=1"
+        ).fetchone()[0]
+        con.close()
+        self.assertEqual(lifecycle, "starting")
 
     # -- leases + tickets + certification ---------------------------------------------------------------
 

--- a/tests/test_interface_exec.py
+++ b/tests/test_interface_exec.py
@@ -227,11 +227,42 @@ class InterfaceExecTest(unittest.TestCase):
         self.assertEqual(body["archive_id"], 4242,
                          "the archive id comes from prepare_launch")
         self.assertEqual(body["pid"], os.getpid())
+        self.assertEqual(body["source"], "entrypoint",
+                         "the pre-exec claim is identity, not readiness")
         self.assertIsInstance(body["start_ticks"], int)
         self.assertEqual(body["cli_version"], "test-cli 1.0")
         self.assertEqual(self.exec_calls[0][0], ["/bin/true"])
         self.assertEqual(self.plan_calls[0]["shell_id"], 1)
         self.assertEqual(self.plan_calls[0]["harness"], "claude")
+
+    def test_hook_credentials_reach_the_exec_env_only(self):
+        """The emitter's per-generation credentials travel in the launch
+        env (SC_INTERFACE_*) — never in argv, never on stderr; and the
+        harness's hook config is installed for the session (mocked here at
+        the capability-gated version in _fake_prepare: 'test-cli 1.0' is
+        below claude's floor, so install must refuse and add no argv)."""
+        code, err = self._run(self._write_token())
+        self.assertEqual(code, 0)
+        argv, env = self.exec_calls[0]
+        self.assertEqual(env["SC_INTERFACE_HOOK_TOKEN"], HOOK_TOKEN)
+        self.assertEqual(env["SC_INTERFACE_SHELL_ID"], "1")
+        self.assertEqual(env["SC_INTERFACE_GENERATION"], "3")
+        self.assertNotIn(HOOK_TOKEN, " ".join(argv))
+        self.assertNotIn(HOOK_TOKEN, err)
+        self.assertEqual(argv, ["/bin/true"],
+                         "unversioned harness → no hook config, chat "
+                         "still launches (ordinary chat unaffected)")
+
+    def test_hook_install_argv_is_appended(self):
+        with mock.patch.object(interface_exec.interface_hooks, "install",
+                               return_value={"installed": True,
+                                             "argv": ["--settings", "/x.json"],
+                                             "capability": {}}) as inst:
+            code, _ = self._run(self._write_token())
+        self.assertEqual(code, 0)
+        self.assertEqual(self.exec_calls[0][0],
+                         ["/bin/true", "--settings", "/x.json"])
+        self.assertEqual(inst.call_args[0][0], "claude")
 
     # ── 4: fail closed ──────────────────────────────────────────────────
     def test_rejected_hook_never_execs(self):

--- a/tests/test_interface_hooks.py
+++ b/tests/test_interface_hooks.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Cross-harness lifecycle adapter proofs (spec #20 Harness Hooks, sprint
+25 seq 7, task #83).
+
+Hermetic coverage of the adapter layer — no harness binary runs here:
+
+1. Capability table: claude/codex/kimi at verified versions satisfy the
+   mandatory hook set; unknown harnesses and below-minimum versions fail
+   closed (arming blocked, ordinary chat unaffected).
+2. Installers MERGE without replacing fork/user hooks: claude rides a
+   per-session --settings overlay (nothing rewritten), codex preserves the
+   fork's PreToolUse group, kimi preserves user config outside its markers.
+   No credential is ever baked into a config file.
+3. The emitter: per-generation hook sequences are flock-serialized and
+   monotonic from 2 (the entrypoint owns 1); the callback carries ONLY the
+   contract fields — stdin prompt content is never read or forwarded; a
+   missing Interface env is a local no-op, never a harness-breaking error.
+
+Run:
+    python3 tests/test_interface_hooks.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import interface_hook  # noqa: E402
+import interface_hooks  # noqa: E402
+
+
+class CapabilityTest(unittest.TestCase):
+    def test_verified_versions_satisfy_mandatory(self):
+        for harness, version in (("claude", "2.1.217 (Claude Code)"),
+                                 ("codex", "codex-cli 0.145.0"),
+                                 ("kimi", "0.27.0")):
+            with self.subTest(harness=harness):
+                cap = interface_hooks.capability(harness, version)
+                self.assertTrue(cap["mandatory_ok"], cap)
+                self.assertEqual(cap["missing_mandatory"], [])
+                for event in interface_hooks.MANDATORY:
+                    self.assertTrue(cap["events"][event],
+                                    f"{harness} must deliver {event}")
+
+    def test_optional_event_honesty(self):
+        kimi = interface_hooks.capability("kimi", "0.27.0")
+        self.assertTrue(kimi["events"]["approval_wait"])
+        self.assertTrue(kimi["events"]["approval_result"])
+        self.assertTrue(kimi["events"]["interrupt"])
+        self.assertFalse(kimi["events"]["user_input_wait"])
+        claude = interface_hooks.capability("claude", "2.1.217")
+        self.assertFalse(claude["events"]["approval_wait"],
+                         "no approval-result event → stays busy (safe)")
+        self.assertTrue(claude["events"]["failure"])
+        codex = interface_hooks.capability("codex", "0.145.0")
+        self.assertFalse(codex["events"]["interrupt"])
+        self.assertFalse(codex["events"]["failure"])
+
+    def test_below_minimum_version_fails_closed(self):
+        cap = interface_hooks.capability("claude", "2.0.0 (Claude Code)")
+        self.assertFalse(cap["mandatory_ok"])
+        self.assertFalse(cap["version_ok"])
+        cap = interface_hooks.capability("codex", "codex-cli 0.128.0")
+        self.assertFalse(cap["mandatory_ok"])
+
+    def test_unknown_harness_and_version_fail_closed(self):
+        self.assertFalse(interface_hooks.capability("vim", "1.0")
+                         ["mandatory_ok"])
+        self.assertFalse(interface_hooks.capability(None, None)
+                         ["mandatory_ok"])
+        self.assertFalse(interface_hooks.capability("kimi", "unparseable")
+                         ["mandatory_ok"])
+
+
+class InstallerTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.run_dir = self.tmp / "run"
+        self.work = self.tmp / "wt"
+        self.work.mkdir()
+
+    def test_claude_overlay_is_additive_and_secret_free(self):
+        out = interface_hooks.install("claude", self.work,
+                                      run_dir=self.run_dir, session_id=7,
+                                      cli_version="2.1.217")
+        self.assertTrue(out["installed"])
+        self.assertEqual(out["argv"][0], "--settings")
+        overlay = Path(out["argv"][1])
+        self.assertTrue(overlay.exists())
+        mode = stat.S_IMODE(overlay.stat().st_mode)
+        self.assertEqual(mode, 0o600)
+        cfg = json.loads(overlay.read_text())
+        self.assertEqual(set(cfg["hooks"]),
+                         {"SessionStart", "UserPromptSubmit", "Stop",
+                          "StopFailure", "SessionEnd"})
+        raw = overlay.read_text()
+        self.assertIn("interface_hook.py", raw)
+        self.assertNotIn("hook_token", raw,
+                         "credentials travel in the env, never in config")
+        ss = cfg["hooks"]["SessionStart"][0]
+        self.assertEqual(ss["matcher"], "startup|resume")
+
+    def test_codex_merge_preserves_fork_hooks(self):
+        hooks_file = self.work / ".codex" / "hooks.json"
+        hooks_file.parent.mkdir(parents=True)
+        fork_group = {"matcher": "^apply_patch$",
+                      "hooks": [{"type": "command",
+                                 "command": "bash branch-guard.sh"}]}
+        hooks_file.write_text(json.dumps(
+            {"hooks": {"PreToolUse": [fork_group]}}))
+        out = interface_hooks.install("codex", self.work,
+                                      run_dir=self.run_dir, session_id=7,
+                                      cli_version="codex-cli 0.145.0")
+        self.assertTrue(out["installed"])
+        self.assertEqual(out["argv"], [])
+        cfg = json.loads(hooks_file.read_text())
+        self.assertEqual(cfg["hooks"]["PreToolUse"], [fork_group],
+                         "the fork's branch-guard group is untouched")
+        for native in ("SessionStart", "UserPromptSubmit", "Stop",
+                       "SessionEnd"):
+            self.assertIn(native, cfg["hooks"], native)
+            self.assertIn("interface_hook.py",
+                          json.dumps(cfg["hooks"][native]))
+        # Idempotent: a second install replaces our groups, never duplicates.
+        interface_hooks.install("codex", self.work, run_dir=self.run_dir,
+                                session_id=7, cli_version="codex-cli 0.145.0")
+        cfg2 = json.loads(hooks_file.read_text())
+        self.assertEqual(len(cfg2["hooks"]["Stop"]), 1)
+
+    def test_codex_merge_never_clobbers_unparseable(self):
+        hooks_file = self.work / ".codex" / "hooks.json"
+        hooks_file.parent.mkdir(parents=True)
+        hooks_file.write_text("{not json")
+        out = interface_hooks.install("codex", self.work,
+                                      run_dir=self.run_dir, session_id=7,
+                                      cli_version="codex-cli 0.145.0")
+        self.assertFalse(out["installed"])
+        self.assertEqual(hooks_file.read_text(), "{not json")
+
+    def test_kimi_merge_preserves_user_config(self):
+        kimi_home = self.tmp / "kimi-home"
+        kimi_home.mkdir()
+        cfg_path = kimi_home / "config.toml"
+        cfg_path.write_text('model = "k3"\n\n[[hooks]]\nevent = "PreToolUse"\n'
+                            'command = "my-own-hook"\n')
+        with mock.patch.dict(os.environ, {"KIMI_CODE_HOME": str(kimi_home)}):
+            out = interface_hooks.install("kimi", self.work,
+                                          run_dir=self.run_dir, session_id=7,
+                                          cli_version="0.27.0")
+        self.assertTrue(out["installed"])
+        text = cfg_path.read_text()
+        self.assertIn('command = "my-own-hook"', text,
+                      "the user's own hooks are preserved")
+        self.assertIn(interface_hooks._KIMI_BEGIN, text)
+        for native in ("SessionStart", "UserPromptSubmit", "Stop",
+                       "Interrupt", "StopFailure", "SessionEnd",
+                       "PermissionRequest", "PermissionResult"):
+            self.assertIn(f'event = "{native}"', text, native)
+        self.assertNotIn("hook_token", text)
+        # Idempotent: re-install replaces the managed block, no growth.
+        with mock.patch.dict(os.environ, {"KIMI_CODE_HOME": str(kimi_home)}):
+            interface_hooks.install("kimi", self.work, run_dir=self.run_dir,
+                                    session_id=8, cli_version="0.27.0")
+        self.assertEqual(cfg_path.read_text().count(
+            interface_hooks._KIMI_BEGIN), 1)
+
+    def test_install_gates_on_capability(self):
+        out = interface_hooks.install("claude", self.work,
+                                      run_dir=self.run_dir, session_id=7,
+                                      cli_version="2.0.0")
+        self.assertFalse(out["installed"])
+        self.assertEqual(out["argv"], [])
+        self.assertFalse((self.run_dir / "claude-hooks-7.json").exists())
+        out = interface_hooks.install("unknown-cli", self.work,
+                                      run_dir=self.run_dir, session_id=7,
+                                      cli_version="1.0")
+        self.assertFalse(out["installed"])
+
+
+class EmitterSeqTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def test_sequence_starts_after_entrypoint(self):
+        seq = interface_hook.next_hook_seq(self.tmp, 1, 1)
+        self.assertEqual(seq, 2, "the entrypoint's session_start owns seq 1")
+        self.assertEqual(interface_hook.next_hook_seq(self.tmp, 1, 1), 3)
+        self.assertEqual(interface_hook.next_hook_seq(self.tmp, 1, 1), 4)
+
+    def test_sequence_is_per_generation(self):
+        self.assertEqual(interface_hook.next_hook_seq(self.tmp, 1, 1), 2)
+        self.assertEqual(interface_hook.next_hook_seq(self.tmp, 1, 2), 2)
+        self.assertEqual(interface_hook.next_hook_seq(self.tmp, 2, 1), 2)
+
+    def test_concurrent_allocation_is_unique(self):
+        issued = []
+        lock = threading.Lock()
+
+        def alloc():
+            seq = interface_hook.next_hook_seq(self.tmp, 1, 1)
+            with lock:
+                issued.append(seq)
+
+        threads = [threading.Thread(target=alloc) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(sorted(issued), list(range(2, 22)),
+                         "flock serialization forbids double-issue")
+
+
+class EmitterPostTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.env = {"SC_INTERFACE_HOOK_TOKEN": "tok-x",
+                    "SC_INTERFACE_SHELL_ID": "1",
+                    "SC_INTERFACE_GENERATION": "3",
+                    "SC_API_BASE": "http://127.0.0.1:9999",
+                    "SC_INTERFACE_RUN_DIR": str(self.tmp)}
+
+    def _run(self, argv, urlopen):
+        with mock.patch.dict(os.environ, self.env, clear=False), \
+             mock.patch.object(interface_hook.urllib.request,
+                               "urlopen", urlopen):
+            return interface_hook.main(argv)
+
+    def test_callback_carries_only_contract_fields(self):
+        posts = []
+
+        class Resp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def urlopen(req, timeout=None):
+            posts.append(req)
+            return Resp()
+
+        code = self._run(["--event", "turn_stop", "--pid", "4321"], urlopen)
+        self.assertEqual(code, 0)
+        self.assertEqual(len(posts), 1)
+        req = posts[0]
+        self.assertEqual(req.full_url,
+                         "http://127.0.0.1:9999/api/interface/hook-callbacks")
+        self.assertEqual(req.headers["Authorization"], "Bearer tok-x")
+        body = json.loads(req.data)
+        self.assertEqual(body, {"shell_id": 1, "generation": 3,
+                                "hook_seq": 2, "event": "turn_stop",
+                                "source": "provider", "pid": 4321},
+                         "ONLY event/session/generation/sequence/pid/token "
+                         "cross the contract — no content fields")
+
+    def test_stdin_content_is_never_forwarded(self):
+        posts = []
+
+        class Resp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def urlopen(req, timeout=None):
+            posts.append(req)
+            return Resp()
+
+        secret = "the user's secret draft prompt"
+        with mock.patch("sys.stdin") as fake_stdin:
+            fake_stdin.read.return_value = json.dumps({"prompt": secret})
+            self._run(["--event", "prompt_submit", "--pid", "1"], urlopen)
+        body = json.loads(posts[0].data)
+        self.assertNotIn(secret, json.dumps(body))
+        fake_stdin.read.assert_not_called()
+
+    def test_missing_env_is_a_quiet_noop(self):
+        posts = []
+
+        def urlopen(req, timeout=None):
+            posts.append(req)
+            raise AssertionError("must not POST without the Interface env")
+
+        env = {k: v for k, v in self.env.items()
+               if k != "SC_INTERFACE_HOOK_TOKEN"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(interface_hook.urllib.request,
+                               "urlopen", urlopen):
+            code = interface_hook.main(["--event", "turn_stop", "--pid", "1"])
+        self.assertEqual(code, 0, "an unmanaged session's hook never "
+                                 "breaks the harness")
+        self.assertEqual(posts, [])
+
+    def test_unknown_event_refused_locally(self):
+        posts = []
+
+        def urlopen(req, timeout=None):
+            posts.append(req)
+
+        code = self._run(["--event", "bogus", "--pid", "1"], urlopen)
+        self.assertEqual(code, 0)
+        self.assertEqual(posts, [])
+
+    def test_rejection_is_definitive_no_retry(self):
+        calls = []
+
+        def urlopen(req, timeout=None):
+            calls.append(req)
+            raise urllib.error.HTTPError(req.full_url, 409, "conflict",
+                                         None, None)
+
+        code = self._run(["--event", "turn_stop", "--pid", "1"], urlopen)
+        self.assertEqual(code, 0)
+        self.assertEqual(len(calls), 1, "a 4xx is a definitive answer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_wake_submit.py
+++ b/tests/test_interface_wake_submit.py
@@ -274,5 +274,148 @@ class WakeSubmitGateTest(unittest.TestCase):
         self.assertEqual(writes, [10])
 
 
+class SubmitGateToctouTest(unittest.TestCase):
+    """REV2 seq-4 L5: the submit gate's check-then-commit must be
+    serialized. Two connections racing the gate can no longer both pass on
+    the same pre-commit snapshot — the write lock is taken BEFORE the gate
+    reads (BEGIN IMMEDIATE), so the loser re-reads and refuses."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db, timeout=5)
+        self.con.execute("PRAGMA journal_mode=WAL")
+        self.con.execute("PRAGMA busy_timeout=5000")
+
+    def tearDown(self):
+        self.con.close()
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def _arm(self):
+        con = self.con
+        con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,1)")
+        sid = con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle) VALUES (1,1,'occupied','idle')").lastrowid
+        con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,1,1,'clean')", (sid,))
+        bid = con.execute(
+            "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (1,1,?,1,1)", (sid,)).lastrowid
+        mid = con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+            " kind, sprint_doc_id) VALUES (2,1,'wake','task',1)").lastrowid
+        con.execute(
+            "INSERT INTO planner_wake_items (binding_id, message_id) "
+            "VALUES (?,?)", (bid, mid))
+        con.commit()
+        batch = interface_broker.form_batch(con, bid)
+        con.commit()
+        return sid, bid, batch
+
+    def _other_con(self, busy_timeout=200):
+        con = sqlite3.connect(self.db, timeout=1)
+        con.execute("PRAGMA journal_mode=WAL")
+        con.execute(f"PRAGMA busy_timeout={busy_timeout}")
+        return con
+
+    def test_second_submitter_refuses_after_first_commits(self):
+        _, _, batch = self._arm()
+        writes = []
+        out = interface_broker.submit_wake_batch(
+            self.con, batch, writer=lambda n: writes.append(n),
+            now_iso="2030-01-01 00:00:10")
+        self.assertTrue(out["submitted"])
+        other = self._other_con()
+        try:
+            with self.assertRaises(interface_broker.BrokerError) as ctx:
+                interface_broker.submit_wake_batch(
+                    other, batch, writer=lambda n: None,
+                    now_iso="2030-01-01 00:00:10")
+            self.assertIn("not queued", str(ctx.exception))
+        finally:
+            other.close()
+        self.assertEqual(len(writes), 1, "exactly one submission ever fires")
+
+    def test_gate_reads_cannot_observe_a_pre_commit_snapshot(self):
+        """A connection holding the write lock blocks a racing gate at
+        BEGIN IMMEDIATE — it never reads the gate on stale state."""
+        _, _, batch = self._arm()
+        holder = self._other_con()
+        holder.execute("BEGIN IMMEDIATE")
+        try:
+            racer = sqlite3.connect(self.db, timeout=1)
+            racer.execute("PRAGMA busy_timeout=200")
+            try:
+                with self.assertRaises(sqlite3.OperationalError):
+                    interface_broker.submit_wake_batch(
+                        racer, batch, writer=lambda n: None,
+                        now_iso="2030-01-01 00:00:10")
+                # The racer never touched the batch.
+                state = self.con.execute(
+                    "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+                    (batch,)).fetchone()[0]
+                self.assertEqual(state, "queued")
+            finally:
+                racer.close()
+        finally:
+            holder.rollback()
+            holder.close()
+        # With the lock released the same submit succeeds — the refusal was
+        # the serialization, not a gate failure.
+        out = interface_broker.submit_wake_batch(
+            self.con, batch, writer=lambda n: None,
+            now_iso="2030-01-01 00:00:10")
+        self.assertTrue(out["submitted"])
+
+    def test_human_frame_committed_first_cancels_the_gate(self):
+        """The race that mattered: a human frame reserving its sequence
+        BEFORE the submitting commit makes the gate see pending input —
+        the wake attempt cancels, no byte is sent."""
+        sid, _, batch = self._arm()
+        interface_broker.acquire_writer(self.con, sid, "tab-1", "tok")
+        self.con.commit()
+        ack = interface_broker.accept_human_input(
+            self.con, sid, 1, 5, writer=lambda n: None)
+        self.assertEqual(ack, {"ack": 1, "duplicate": False})
+        out = interface_broker.submit_wake_batch(
+            self.con, batch, writer=lambda n: None,
+            now_iso="2030-01-01 00:00:10")
+        self.assertFalse(out["submitted"])
+        self.assertEqual(self._batch_state(batch), "queued")
+
+    def _batch_state(self, batch):
+        return self.con.execute(
+            "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+            (batch,)).fetchone()[0]
+
+    def test_submitting_commit_first_refuses_the_frame(self):
+        """The other ordering: once 'submitting' is committed, the input
+        lock refuses the human frame — no interleave inside the prompt."""
+        sid, _, batch = self._arm()
+        interface_broker.acquire_writer(self.con, sid, "tab-1", "tok")
+        self.con.commit()
+        out = interface_broker.submit_wake_batch(
+            self.con, batch, writer=lambda n: None,
+            now_iso="2030-01-01 00:00:10")
+        self.assertTrue(out["submitted"])
+        with self.assertRaises(interface_broker.BrokerError) as ctx:
+            interface_broker.accept_human_input(
+                self.con, sid, 1, 5, writer=lambda n: None)
+        self.assertIn("input lock", str(ctx.exception))
+        # The refused frame left no residue: no pending reservation.
+        row = self.con.execute(
+            "SELECT pending_seq, composer FROM interface_input_state "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(row, (None, "clean"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Sprint 25 (doc #25) unit seq 7, task #83. Reviewer: REV2. Depends on seq 4 (#500) + seq 5 (#505), both merged — branched off clean origin/main @7e39ce0.

## What ships

Authenticated lifecycle hooks for installed **Claude 2.1.217, Codex 0.145.0, Kimi 0.27.0** mapped into the ONE authenticated hook contract (`session_start / prompt_submit / turn_stop / session_end / approval_wait / approval_result / user_input_wait / interrupt / failure`). Callbacks **discard content**: the emitter never reads stdin; only event, session, generation, sequence, PID identity, and token cross the wire.

- `scripts/interface_hooks.py` — contract vocabulary, per-harness capability table (verified against the installed binaries, version-gated), and installers that **merge without replacing fork/user hooks**: claude = per-session `--settings` overlay (additive by design); codex = event groups merged into the emitted project `.codex/hooks.json` (fork's PreToolUse branch-guard preserved); kimi = marker-fenced block in the user `config.toml` (the only config kimi 0.27 reads; user's own hooks preserved byte-for-byte).
- `scripts/interface_hook.py` — the emitter. flock-serialized per-generation hook sequences from 2 (entrypoint owns 1); short timeout + one transport retry; never breaks the harness; credentials via launch env only.
- **Provider-readiness hardening** (seq-5's entrypoint-identity `session_start` → real provider readiness): `source=entrypoint` is identity-only (promotes reserved→occupied); `idle`+`clean` wait for the harness's own provider `session_start`, and clean is never manufactured after accepted human input.
- `record_hook`: approval/user-input events map to lifecycle + alerts; **interrupt/failure end the turn** (Stop never fires on kimi cancel or claude API error) and reconcile a running batch exactly like turn_stop; unknown events rejected.
- **REV2 seq-4 L5 (submit-gate TOCTOU)**: `submit_wake_batch`'s gate reads + `submitting` commit, and `accept_human_input`'s lock check + pending reservation, are serialized under `BEGIN IMMEDIATE`. A racing gate can no longer pass on a pre-commit snapshot; whichever side commits first wins, the loser re-reads and refuses.
- Hook route: unknown events/sources/fields → 422, illegal transitions → 409, PID fence on **every** event, all rejections audited.
- Mandatory-hook gap (unknown/below-floor harness) blocks sprint-wake **arming**, never ordinary chats; degraded optional hooks (claude/codex approval+user-input, kimi user-input) alert `info` at readiness per spec.

## Ambiguity calls (sprint protocol — reviewer please gate against these)

1. **Start-ready semantics**: kimi's `SessionStart` (awaited final step of session creation) is accepted as start-ready directly; claude/codex `SessionStart` fires during startup (pre-prompt) and neither CLI offers a later native readiness signal. A strict spec reading would bar claude+codex from arming at all; I accepted their startup hooks as readiness and recorded the semantics per-harness in the capability table — the wake gate's quiet debounce + submit-hook fence absorb the residual window.
2. **claude/codex approval_wait not mapped**: both have `PermissionRequest` but NO approval-resolved event — per spec's "lacking distinct approval hooks → stays busy (safe)", the events are deliberately unmapped rather than half-paired.
3. **codex `SessionEnd` used though undocumented** on the hooks page — present in the 0.145.0 binary (`hooks/src/events/session_end.rs`); tmux pane-death remains the backstop.
4. Entrypoint `session_start` no longer sets idle/clean — contract change; seq-5 fixtures updated to the two-phase start.

## Verification

- 43 new/updated hermetic tests: emitter contract + sequence concurrency (20-thread flock proof), stdin-content non-forwarding, all three installers (merge/idempotency/no-clobber), two-phase readiness, approval/user-input/interrupt/failure lifecycle + alert raise/resolve, capability gating, TOCTOU serialization (lock-holder, second-submitter, human-first/wake-first orderings).
- Full suite: **644 passed, 4 skipped**; sole failure `tests/test_vm_bake.py` (pre-existing sandbox bake guard — reproduced on clean `origin/main`, unrelated).
- Ruff clean on all changed files.