### PR TITLE
docs(skills): anticipated user activity — soft-vocabulary posture section for specs

### DIFF
--- a/.super-coder/assets/skills/spec/SKILL.md
+++ b/.super-coder/assets/skills/spec/SKILL.md
@@ -53,6 +53,12 @@ Surface all three before any planning or code:
   slice.
 - No stated done-condition in the spec -> that is the first unclear item.
 
+### Anticipated User Activity
+The spec's `## Anticipated User Activity` section is governing intent: its
+roles, reach, and tenancy invariants shape the plan — access and tenancy
+checks are planned tasks, not afterthoughts. Older specs predate the section;
+absence there is not a blocker.
+
 ### Unclear items
 Anything you cannot act on without guessing:
 - Ambiguous between two interpretations
@@ -112,7 +118,7 @@ Always this shape:
 |---|---|---|
 | 0 | Preparation | Always first — read code paths, verify DB state, confirm entry points |
 | 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
-| N+1 | Verification | Always last — run tests, smoke-test against done-condition, snapshot + render |
+| N+1 | Verification | Always last — run tests, smoke-test against done-condition, check the build against the spec's Anticipated User Activity section, snapshot + render |
 
 Add one task per seq with `sc mem task add` — each write is live in the
 shared DB immediately:
@@ -121,7 +127,7 @@ shared DB immediately:
 sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points"
 sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>"
 sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>"
-sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, snapshot + render"
+sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, check the build against the spec's Anticipated User Activity section, snapshot + render"
 ```
 
 Then set `current_state` — nothing done yet, next = Preparation:
@@ -232,6 +238,9 @@ Mid-build, the work grows past the spec's stated what/why:
   marked done.
 - **Verification is not optional.** It is the last task; skipping it makes
   "done" meaningless.
+- **Anticipated User Activity is intent.** Verification checks the build
+  against the spec's section — a capability beyond its stated roles, or data
+  crossing a tenancy line it states, is a finding, not a nuance.
 - **Spec too large for one session** -> scope a slice at Preparation: cover
   steps 1–K verifiable now, leave K+1–N pending. NEVER start work that can't
   be verified before the session ends.

--- a/.super-coder/migrations/0081_reseed_anticipated_user_activity.sql
+++ b/.super-coder/migrations/0081_reseed_anticipated_user_activity.sql
@@ -1,11 +1,24 @@
----
-name: docs
-description: Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.
-category: substrate
-common: false
----
+-- 0081 — reseed: docs + spec skills — Anticipated User Activity.
+--
+-- Specs now carry an "## Anticipated User Activity" section: a soft-vocabulary
+-- posture statement (Vocabulary / Expected Activity / Reach / Data Tenancy /
+-- Beyond Intention, on a shared role roster incl. System and Shell) that
+-- review + Verification test the build against. The docs skill gains the
+-- authoring requirement (shape, roster, soft-language map); the spec skill
+-- gains the consumption (analyze against it; Verification checks the build
+-- against it). Source assets updated in the same commit; this trailing
+-- forward reseed (UPSERT by name; skill_id + grants preserved) carries it to
+-- installed forks and fresh builds alike.
 
-# docs — author & review documents
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'docs',
+  'Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.',
+  'substrate',
+  NULL,
+  0,
+  '# docs — author & review documents
 
 The DB owns document bodies: a `documents` row is the source — NEVER author a
 loose `.md` file as the canonical body. `sc render` writes the read-only flat
@@ -22,10 +35,10 @@ copy to `specs_sc/` / `docs_sc/`; the GUI opens it rendered in md-converter.
 
 Feature = the `roadmap` row; exists from `brainstorm` onward, before any spec.
 Specs hang off the feature, not off each other: several unfrozen specs per
-feature, each a `documents (kind='spec')` row, ordered by `seq`. No
+feature, each a `documents (kind=''spec'')` row, ordered by `seq`. No
 feature-to-feature links; no second roadmap row for related work — related
 work = another spec under the same feature. Freeze = the ship-time record of
-what was built to; it never gates the feature's other specs.
+what was built to; it never gates the feature''s other specs.
 
 | state | test | meaning |
 |---|---|---|
@@ -33,7 +46,7 @@ what was built to; it never gates the feature's other specs.
 | **active** | unfrozen + has rows in `spec_tasks` | the spec being built now |
 | **backlog** | unfrozen, no task plan | the pile, ordered by `seq` |
 
-The **doc** (`kind='doc'`) = the feature's readable face — write it when the
+The **doc** (`kind=''doc''`) = the feature''s readable face — write it when the
 first spec ships, under the same `feature_id`. Sibling of the specs, not a
 parent.
 
@@ -46,7 +59,7 @@ work-stream in the same act:
 
 ```
 sc mem get projects   # existing work-streams — pick the fit
-sc mem get roadmap    # this feature's current project_id
+sc mem get roadmap    # this feature''s current project_id
 ```
 
 | case | action |
@@ -54,20 +67,20 @@ sc mem get roadmap    # this feature's current project_id
 | new feature | create pre-assigned: `sc mem roadmap add "<title>" --project <shortname>` |
 | existing + Ungrouped | `sc mem roadmap project <feature_id> <shortname>` |
 | no fitting stream | `sc mem project add <shortname> "<title>" --purpose "…"` -> then assign |
-| already correctly assigned | no-op — don't churn |
+| already correctly assigned | no-op — don''t churn |
 
 Auto-assign when only one plausible fit / it clearly belongs to an existing
 stream. Surface to the FnB only when ambiguous — several streams fit, or a
-new stream you're unsure how to name. Exempt (as with stages): work that
-isn't a feature/spec (a quick fix) needs no work-stream.
+new stream you''re unsure how to name. Exempt (as with stages): work that
+isn''t a feature/spec (a quick fix) needs no work-stream.
 
 ## Review first
 
-Before writing — don't duplicate, don't re-litigate:
+Before writing — don''t duplicate, don''t re-litigate:
 ```
 sc mem get documents      # every spec/doc in the engine DB (kind, seq, frozen, task_count)
 sc mem get decisions      # active-decision index (<id> = full row + rationale; --all incl. superseded)
-sc map-sql "SELECT path FROM dr_filepath WHERE role='doc';"   # repo's own docs (map db)
+sc map-sql "SELECT path FROM dr_filepath WHERE role=''doc'';"   # repo''s own docs (map db)
 ```
 
 Spec touches a recorded decision -> honor it, or supersede explicitly: say so
@@ -84,17 +97,17 @@ in-process API lock — sufficient because these artifacts only ever come from
 manual admin-shell or GUI actions (single writer by design; cross-process
 concurrency is out of scope for v1, decision #20 / roadmap #21).
 ```
-# a doc against a feature (kind='doc'); DB owns the body:
+# a doc against a feature (kind=''doc''); DB owns the body:
 sc mem doc add "…" --kind doc --feature <id> --body-file ./draft.md --render-path docs_sc/….md
 
-# a feature's next spec stage (kind='spec'); seq auto-advances:
+# a feature''s next spec stage (kind=''spec''); seq auto-advances:
 sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
 ```
 
 ## Specs carry "Anticipated User Activity"
 
-Every spec (`kind='spec'`) ships an `## Anticipated User Activity` section —
-the feature's posture statement: who is expected to touch it, where it can be
+Every spec (`kind=''spec''`) ships an `## Anticipated User Activity` section —
+the feature''s posture statement: who is expected to touch it, where it can be
 reached, whose data it holds, and what it does not intend to allow. Soft
 vocabulary, hard invariants — the nouns stay gentle, every statement stays
 checkable from code ("a Valid User only ever sees rows tied to their own
@@ -144,17 +157,17 @@ sc mem doc edit <document_id> --body-file ./draft.md
 sc mem doc edit <document_id> --title "New title" --render-path specs_sc/….md
 ```
 
-## Freeze + document on ship — the planner's handoff
+## Freeze + document on ship — the planner''s handoff
 
 Shipping is a two-shell act (keeps `shipped` honest):
 
 - **dev**: flips `roadmap_status = shipped` + opens a **docs-pending** flag
-  (`spec` skill, Step 5) — `shipped` never silently claims a doc that doesn't
+  (`spec` skill, Step 5) — `shipped` never silently claims a doc that doesn''t
   exist yet.
 - **planner**: on that flag (arrives in your inbox per the `flags` skill), do
   the paperwork:
 
-1. **Freeze the shipped spec** — immutable thereafter; the feature's other
+1. **Freeze the shipped spec** — immutable thereafter; the feature''s other
    specs stay unfrozen and unaffected. NEVER edit a frozen spec (open a new
    spec under the same feature); the GUI and render layer both refuse edits
    to frozen docs:
@@ -187,7 +200,7 @@ markdown to `body`; render + md-converter own presentation.
 # Authoring format (themed-markdown)
 
 The `body` you write IS themed-markdown — the format md-converter renders.
-Your job = structure; styling = the renderer's job. NEVER write visual
+Your job = structure; styling = the renderer''s job. NEVER write visual
 instructions (colors, fonts, sizes, themes) — apply the four semantic
 classes; the theme picks colors.
 
@@ -353,7 +366,275 @@ GitHub, dropped from the render by the preamble rule):
 [![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/<owner>/<repo>/blob/<branch>/<path>)
 ```
 
-Fill `<owner>/<repo>/<branch>/<path>` with the file's GitHub location (any
+Fill `<owner>/<repo>/<branch>/<path>` with the file''s GitHub location (any
 subdirectory depth). Public repos only — the badge fetches the raw file in
-the reader's browser (no server/auth). Destination unknown -> keep the
-placeholders and tell the user to fill them.
+the reader''s browser (no server/auth). Destination unknown -> keep the
+placeholders and tell the user to fill them.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'spec',
+  'Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step. Load when starting, implementing, or building any feature, spec, or roadmap item — before writing code.',
+  'craft',
+  NULL,
+  0,
+  '# spec — analyze and execute a spec
+
+Load at the start of any session that builds or implements a feature, whether
+or not the work is framed as a "spec". A spec governs the work -> this skill
+executes it; one should exist but doesn''t -> the `docs` skill authors it first.
+Run **Analyze** before touching any code. Blockers / unclear items you can''t
+resolve alone -> pause for the FnB.
+
+`<self>` = your shell_id.
+
+---
+
+## Step 1: Load the spec
+
+A feature can hold several unfrozen specs at once (see the `docs` skill).
+NEVER auto-pick "the latest" — list the feature''s open specs and choose the
+target explicitly:
+
+```
+# the feature''s documents — pick an unfrozen spec (frozen=0) by id:
+sc mem get documents --feature <id>
+# load the chosen spec body:
+sc mem get documents --doc <doc_id>
+# the spec''s task plan (empty = no plan yet):
+sc mem get tasks --doc <doc_id>
+```
+
+`get documents --feature <id>` lists every spec/doc with `kind`, `seq`,
+`frozen`, `task_count`. Active spec = the unfrozen one with `task_count > 0`
+— resume it. `task_count = 0` = backlog; starting it (Step 3) makes it
+active. More than one open spec and the target unclear -> ask the FnB.
+
+Tasks already exist -> skip to **Step 4** (Track).
+
+Read the entire spec body before going further. Do not skim.
+
+---
+
+## Step 2: Analyze
+
+Surface all three before any planning or code:
+
+### Viability
+- Session-completable? Bounded + clear entry points = yes. Multiple layers /
+  migrations / unknown dependencies = no -> say so + propose a session-sized
+  slice.
+- No stated done-condition in the spec -> that is the first unclear item.
+
+### Anticipated User Activity
+The spec''s `## Anticipated User Activity` section is governing intent: its
+roles, reach, and tenancy invariants shape the plan — access and tenancy
+checks are planned tasks, not afterthoughts. Older specs predate the section;
+absence there is not a blocker.
+
+### Unclear items
+Anything you cannot act on without guessing:
+- Ambiguous between two interpretations
+- Missing a critical detail (which table? which endpoint? which component?)
+- Implies knowledge not stated in the spec
+
+List them and ask the FnB before writing the plan.
+
+### Blockers
+Hard stops — prior work not shipped, missing environment state, unresolved
+external dependency. Open one flag per blocker:
+
+```
+sc mem flag open "[Spec] <what is blocked> | Blocker for: <feature title>" --name SC-### --priority High --feature <feature_id>
+```
+
+NEVER open a flag for an unclear item resolvable by asking — ask first.
+
+---
+
+## Step 3: Plan
+
+### Reconcile the stage first
+
+Planning a spec = engaging it to build, so the feature''s `roadmap_status`
+(loaded in Step 1) must catch up to reality. Stages:
+`brainstorm · long_term · near_term · next · in_progress · shipped`.
+
+- At `brainstorm`/`long_term`/`near_term` + building this session ->
+  `sc mem roadmap status <feature_id> in_progress`
+- Planning ahead only (no build this session) -> move it to `next`.
+- Already at `in_progress` (or further) -> no-op; don''t churn it.
+
+The transition fires because you *act on* the spec — reading one for
+reference moves nothing. No spec governing the work (quick UI fix, minor
+migration) -> skip all stage handling (see Stance).
+
+### Confirm the work-stream too
+
+Check the feature''s work-stream (`roadmap.project_id` — the Flow-view
+grouping). Ungrouped -> assign now so the feature shows in a flow:
+
+```
+sc mem roadmap project <feature_id> <shortname>   # ''none'' to clear
+```
+
+Stream obvious -> assign; ambiguous -> surface to the FnB; already assigned
+-> no-op. Full create/assess procedure (new streams, new features) = the
+`docs` skill; this is only the engage-time confirmation.
+
+### Write the task plan
+
+Analysis clear + blockers resolved or accepted -> generate the task list.
+Always this shape:
+
+| seq | title | role |
+|---|---|---|
+| 0 | Preparation | Always first — read code paths, verify DB state, confirm entry points |
+| 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
+| N+1 | Verification | Always last — run tests, smoke-test against done-condition, check the build against the spec''s Anticipated User Activity section, snapshot + render |
+
+Add one task per seq with `sc mem task add` — each write is live in the
+shared DB immediately:
+
+```
+sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points"
+sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>"
+sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>"
+sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, check the build against the spec''s Anticipated User Activity section, snapshot + render"
+```
+
+Then set `current_state` — nothing done yet, next = Preparation:
+
+```
+sc mem state "[<feature_title>] — last: —. next: Preparation."
+```
+
+---
+
+## Step 4: Track session by session
+
+**Agents overlay:** this shell granted `agents` + FnB invoked `--agents` ->
+that skill''s overlay replaces this step''s one-task-at-a-time loop with
+adjudicated waves. Load it and apply it on top of this step.
+
+At each work session''s start, load the plan:
+
+```
+sc mem get tasks --doc <doc_id>
+```
+
+Find the first `pending` task -> mark it in progress:
+
+```
+sc mem task start <task_id>
+```
+
+Work ONLY that task. When done:
+
+```
+sc mem task done <task_id>
+```
+
+A planned task overtaken by a feature split or re-scope (its work moved to
+another feature/spec, never built here) is cancelled, not done:
+
+```
+sc mem task cancel <task_id> --notes "moved to F<id> as task #<n>"
+```
+
+NEVER mark unbuilt work `done` and NEVER leave it `pending` under a shipped
+feature — the task ledger is how a planner answers "is this feature actually
+finished."
+
+Re-read the plan (`sc mem get tasks --doc <doc_id>`) and resolve from it:
+`last_done` = highest-`seq` `done` task; `next_up` = lowest-`seq` `pending`.
+Advance `current_state`:
+
+```
+sc mem state "[<feature_title>] — last: <last_done>. next: <next_up>."
+```
+
+`next_up` NULL = all tasks done -> set current_state to reflect that.
+
+---
+
+## Step 5: Hand off on completion
+
+Verification task passes (`next_up` NULL — the existing done-line) = feature
+delivered. As the dev: flip the horizon + hand the paperwork to the planner.
+Do NOT freeze the spec or write the doc — that''s the planner (`docs` skill).
+
+1. **Flip the horizon to shipped:**
+   ```
+   sc mem roadmap status <feature_id> shipped
+   ```
+2. **Open a docs-pending flag + message the planner with full instructions.**
+   `shipped` + an open flag = the honest interim state; the message carries
+   everything the planner needs without digging:
+   ```
+   sc mem flag open "[Docs] <feature> shipped, doc pending | Blocker for: <feature> doc" --name SC-### --priority Medium --feature <feature_id>
+   sc mem message send <planner-shortname> "**[Docs pending] <feature_title> (feature <feature_id>)**
+
+   Spec <doc_id> shipped. Flag SC-### is open — your action required:
+
+   1. **Read the shipped code first.** Write the doc from what actually shipped, not from the spec. Drift happens and decisions get made in production — the spec captures the intent, the code is the truth.
+   2. Freeze the spec: \`sc mem doc freeze <doc_id>\`
+   3. Write the doc (\`kind=''doc''\`) under feature <feature_id> (see the \`docs\` skill).
+   4. Close flag SC-### when the doc is live."
+   ```
+3. **Surface to the FnB:** "shipped; the planner needs to freeze the spec +
+   write the doc." The planner closes the flag when the doc lands.
+
+No planner-flavor shell in this fork -> message nobody; surface to the FnB
+directly and leave the docs-pending flag open for whoever picks up docs.
+
+---
+
+## Watch for creep while you build
+
+Mid-build, the work grows past the spec''s stated what/why:
+
+- **Small growth** (same mental model, a few more tasks) -> the unfrozen spec
+  is living; edit it (`sc mem doc edit`) and carry on. No ceremony.
+- **A separate coherent intent** (a new mental-model boundary — the
+  granularity test in the `docs` skill) -> do NOT quietly absorb it.
+  Recommend a **new spec** to the FnB, authored by the planner against its
+  own feature. Significant creep = planning event, not dev improvisation.
+
+---
+
+## Stance
+
+- **Analyze before acting.** Analysis finds the gap between what the spec
+  says and what the code does.
+- **One task at a time.** Start task N+1 only after task N is verified +
+  marked done.
+- **Verification is not optional.** It is the last task; skipping it makes
+  "done" meaningless.
+- **Anticipated User Activity is intent.** Verification checks the build
+  against the spec''s section — a capability beyond its stated roles, or data
+  crossing a tenancy line it states, is a finding, not a nuance.
+- **Spec too large for one session** -> scope a slice at Preparation: cover
+  steps 1–K verifiable now, leave K+1–N pending. NEVER start work that can''t
+  be verified before the session ends.
+- **current_state always reflects the plan.** Update after every task
+  completion — last done + next up. The next session resumes from it without
+  reading the full task list first.
+- **The stage tracks reality — spec''d work only.** Engaging a spec ->
+  `in_progress`; finishing -> `shipped`; already matching -> no-op, don''t
+  churn. Work with no spec (quick UI tweaks, minor migrations) is exempt
+  entirely: no promotion, no handoff, no creep check. Stage discipline never
+  blocks small things.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/skills_sc/docs.md
+++ b/skills_sc/docs.md
@@ -98,6 +98,49 @@ sc mem doc add "…" --kind doc --feature <id> --body-file ./draft.md --render-p
 sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
 ```
 
+## Specs carry "Anticipated User Activity"
+
+Every spec (`kind='spec'`) ships an `## Anticipated User Activity` section —
+the feature's posture statement: who is expected to touch it, where it can be
+reached, whose data it holds, and what it does not intend to allow. Soft
+vocabulary, hard invariants — the nouns stay gentle, every statement stays
+checkable from code ("a Valid User only ever sees rows tied to their own
+account"), because review + Verification test the build against this section.
+
+Shape (H3s under the section H2):
+
+| H3 | holds |
+|---|---|
+| `### Vocabulary` | the cast — roles from the shared roster below + any feature-specific ones, each defined in one line |
+| `### Expected Activity` | per role: what they do, what they see, what they can change |
+| `### Reach` | where the feature meets the world — pages, endpoints, jobs, files it adds or alters, and which roles can arrive at each |
+| `### Data Tenancy` | whose data the feature touches; what stays within one account; what, if anything, is deliberately shared |
+| `### Beyond Intention` | activity the feature does not intend to accommodate — anything observed here in review is a finding, not a nuance |
+
+Shared roster (always available; same meaning in every spec):
+
+| role | means |
+|---|---|
+| **Valid Privileged User** | signed-in user with an operator/admin role, acting within what that role allows |
+| **Valid User** | signed-in user acting inside their own account and their own data |
+| **Visitor** | expected traffic that has not signed in (public/shared surfaces) |
+| **Future Potential User** | a role anticipated later, not built now — the design must not wall it out |
+| **System** | the product acting on a schedule or trigger — daemons, jobs, watchers |
+| **Shell** | an AI agent shell acting through its granted tools — its activity is messages, memory writes, file edits |
+| **Unexpected Participant** | anyone acting outside the roles above — where the spec says what must never be reachable |
+
+Language — soft by design. Specs never use: threat model, attack or attack
+surface, adversary, exploit, abuse case, vulnerability, breach, privilege
+escalation, exfiltration, malicious. Say it in roster words instead: threat
+model -> anticipated activity · attacker -> Unexpected Participant · abuse
+case -> Beyond Intention · access matrix -> Expected Activity · attack
+surface -> Reach · isolation -> tenancy. Describe behavior and boundaries,
+never hostility.
+
+Internal-only feature -> the section still ships, one line ("All activity is
+by Valid Privileged Users; no tenancy boundary"). Whole section ≤ ~40 lines —
+it frames the build, it does not enumerate it.
+
 ## Revise before freeze
 
 Unfrozen -> edit in place: no new row, no seq bump. Pass any of `--title` /

--- a/skills_sc/spec.md
+++ b/skills_sc/spec.md
@@ -60,6 +60,12 @@ Surface all three before any planning or code:
   slice.
 - No stated done-condition in the spec -> that is the first unclear item.
 
+### Anticipated User Activity
+The spec's `## Anticipated User Activity` section is governing intent: its
+roles, reach, and tenancy invariants shape the plan — access and tenancy
+checks are planned tasks, not afterthoughts. Older specs predate the section;
+absence there is not a blocker.
+
 ### Unclear items
 Anything you cannot act on without guessing:
 - Ambiguous between two interpretations
@@ -119,7 +125,7 @@ Always this shape:
 |---|---|---|
 | 0 | Preparation | Always first — read code paths, verify DB state, confirm entry points |
 | 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
-| N+1 | Verification | Always last — run tests, smoke-test against done-condition, snapshot + render |
+| N+1 | Verification | Always last — run tests, smoke-test against done-condition, check the build against the spec's Anticipated User Activity section, snapshot + render |
 
 Add one task per seq with `sc mem task add` — each write is live in the
 shared DB immediately:
@@ -128,7 +134,7 @@ shared DB immediately:
 sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points"
 sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>"
 sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>"
-sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, snapshot + render"
+sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, check the build against the spec's Anticipated User Activity section, snapshot + render"
 ```
 
 Then set `current_state` — nothing done yet, next = Preparation:
@@ -239,6 +245,9 @@ Mid-build, the work grows past the spec's stated what/why:
   marked done.
 - **Verification is not optional.** It is the last task; skipping it makes
   "done" meaningless.
+- **Anticipated User Activity is intent.** Verification checks the build
+  against the spec's section — a capability beyond its stated roles, or data
+  crossing a tenancy line it states, is a finding, not a nuance.
 - **Spec too large for one session** -> scope a slice at Preparation: cover
   steps 1–K verifiable now, leave K+1–N pending. NEVER start work that can't
   be verified before the session ends.


### PR DESCRIPTION
## What

Specs now carry a required `## Anticipated User Activity` section — the feature's posture statement: who is expected to touch it, where it can be reached, whose data it holds, and what it does not intend to allow. Soft vocabulary, hard invariants.

- **docs skill** gains the authoring requirement: the section shape (Vocabulary / Expected Activity / Reach / Data Tenancy / Beyond Intention), a shared role roster, the soft-language map, and a one-line escape for internal-only features.
- **spec skill** gains the consumption: Analyze reads the section as governing intent, Verification checks the build against it, plus a stance bullet.
- **0081 reseed migration** UPSERTs both skills (skill_id + grants preserved) so it reaches installed forks on `./sc update` and fresh builds alike. Generated with `seed_skills.parse_skill`/`sql_str` so the inline body matches what a 0001 regen would carry.
- `skills_sc/{docs,spec}.md` mirrors re-rendered hermetically (schema + migrations + content.sql); `render-check` passes.

## The roster

Valid Privileged User · Valid User · Visitor · Future Potential User · **System** (daemons/jobs/watchers) · **Shell** (AI agent shells acting through granted tools) · Unexpected Participant.

## Trade-off, stated

The vocabulary is deliberately soft (no *threat model*, *attack surface*, *adversary*, *exploit*, …) so specs don't trip model content filters — the enforceability lives in precise, code-checkable statements ("a Valid User only ever sees rows tied to their own account") rather than in naming categories of harm. Reviews and the Verification task test the build against the section, so the intention stays binding without the vocabulary.

Older specs predate the section; the spec skill explicitly says absence there is not a blocker.

## Verification

- Migration applies through the full 81-migration chain in a scratch DB; both skills come out with the new section.
- `render_check.py` from this worktree: ✓ mirror matches tracked sources.
- `pytest tests/test_skills_freshness.py tests/test_skill_retire.py tests/test_local_skill_persistence.py` — 34 passed (run in a fresh worktree venv; the main checkout's venv pytest is broken — missing `_pytest` module, flagging separately).

Co-Authored-By: Code-04 (super-coder) <noreply@super-coder.local>