### PR TITLE
feat(interface): transactional brokered planner wake (sprint 25 seq 8, task #84)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -50,6 +50,7 @@ import db_driver  # noqa: E402
 import interface_broker  # noqa: E402
 import interface_hooks  # noqa: E402
 import interface_state  # noqa: E402
+import interface_wake  # noqa: E402
 import ports as ports_mod  # noqa: E402
 import shell_liveness  # noqa: E402
 
@@ -120,10 +121,12 @@ def _parse_headers(headers_raw: str):
 # ------------------------------------------------------------------ authority
 
 class _Actor:
-    def __init__(self, kind: str, scope: str, csrf_ok: bool):
-        self.kind = kind          # "operator" | "browser"
+    def __init__(self, kind: str, scope: str, csrf_ok: bool,
+                 shell_id: "int | None" = None):
+        self.kind = kind          # "operator" | "browser" | "shell"
         self.scope = scope        # idempotency actor_scope
         self.csrf_ok = csrf_ok    # mutation authority for browser actors
+        self.shell_id = shell_id  # set for kind="shell" (the planner's token)
 
 
 def _host_ok(headers) -> bool:
@@ -160,6 +163,21 @@ def _resolve_actor(headers) -> "_Actor | None":
         token = authz[7:].strip()
         if token and token == _operator_token():
             return _Actor("operator", "operator", True)
+        # A shell's own API token (the planner driving `sc sprint action` /
+        # arming its own binding). Deliberately read-only elsewhere: shell
+        # actors may call ONLY the sprint-binding and action-receipt routes
+        # (enforced in handle()) — never session/writer/stop authority.
+        if token:
+            con = _db()
+            try:
+                row = con.execute(
+                    "SELECT shell_id FROM shells WHERE api_key=? "
+                    "AND COALESCE(is_deleted,0)=0", (token,)).fetchone()
+            finally:
+                con.close()
+            if row is not None:
+                return _Actor("shell", f"shell:{row[0]}", True,
+                              shell_id=row[0])
         return None
     cookie = headers.get("Cookie") or ""
     for part in cookie.split(";"):
@@ -471,7 +489,7 @@ def _get_session(session_id: int):
             "last_human_input_at": istate[3] if istate else None,
             "writer": {"held": writer is not None,
                        "client_id": writer[1] if writer else None},
-            "wake_state": "disarmed",
+            "wake_state": _wake_state(con, session_id=session_id),
             "clients": (runtime_state or {}).get("attached_clients", 0),
             "alerts": _alert_count(con, session_id),
         })
@@ -491,7 +509,8 @@ def _list_shells():
             proj = _availability(con, shell_id, snap)
             out.append({"shell_id": shell_id, "shortname": shortname,
                         "display_name": display_name,
-                        "wake_state": "disarmed", **proj})
+                        "wake_state": _wake_state(
+                            con, planner_shell_id=shell_id), **proj})
         return _json(200, {"shells": out})
     finally:
         con.close()
@@ -616,6 +635,8 @@ def _certify_clean(actor, headers, body):
             except interface_broker.BrokerError as exc:
                 return 409, {"error": {"code": "certify_refused",
                                        "message": str(exc), "details": {}}}
+            # A fresh clean certification may unblock queued wake work.
+            interface_wake.notify_session(session_id)
             return 201, {"session_id": session_id, "composer": "clean"}
         return _idempotent(con, actor, "certify_clean", headers, body, produce)
     finally:
@@ -779,6 +800,244 @@ def _reconcile(actor, headers, body):
 
 # ------------------------------------------------------------------ hooks
 
+# ------------------------------------------------------------------ sprint wake
+
+def _wake_state(con, *, session_id=None, planner_shell_id=None) -> str:
+    """The occupancy model's wake dimension, derived (never stored):
+    disarmed without an unreleased binding; parked while a batch is
+    delivery_unknown; the live batch's state while one submits/runs;
+    queued with pending work; else armed."""
+    if session_id is not None:
+        binding = con.execute(
+            "SELECT binding_id FROM sprint_planner_bindings "
+            "WHERE session_id=? AND released_at IS NULL",
+            (session_id,)).fetchone()
+    else:
+        binding = con.execute(
+            "SELECT binding_id FROM sprint_planner_bindings "
+            "WHERE planner_shell_id=? AND released_at IS NULL",
+            (planner_shell_id,)).fetchone()
+    if binding is None:
+        return "disarmed"
+    batch = con.execute(
+        "SELECT state FROM planner_wake_batches WHERE binding_id=? "
+        "AND state IN ('queued','submitting','running','delivery_unknown') "
+        "ORDER BY batch_id DESC LIMIT 1", (binding[0],)).fetchone()
+    if batch is not None:
+        if batch[0] == "delivery_unknown":
+            return "parked"
+        if batch[0] in ("submitting", "running"):
+            return batch[0]
+        return "queued"
+    queued = con.execute(
+        "SELECT 1 FROM planner_wake_items WHERE binding_id=? "
+        "AND state='queued' LIMIT 1", (binding[0],)).fetchone()
+    return "queued" if queued is not None else "armed"
+
+
+def _err_obj(code: str, message: str) -> dict:
+    return {"error": {"code": code, "message": message, "details": {}}}
+
+
+def _arm_binding(actor, headers, body):
+    """POST /api/interface/sprint-bindings — arm one ACTIVE sprint document
+    to one planner generation (spec #20 API Resources / Sprint Scope). A
+    shell actor may arm only ITSELF; the operator may arm any planner.
+    Fail-closed refusals: doc missing/frozen/not ACTIVE, no occupied
+    planner session, a mandatory-hook gap (an unverifiable wake must never
+    arm), or a second ACTIVE binding (the partial unique indexes backstop).
+    """
+    doc_id = body.get("sprint_doc_id")
+    planner = body.get("planner_shell_id")
+    if not isinstance(doc_id, int) or not isinstance(planner, int):
+        return _err(422, "validation",
+                    "sprint_doc_id, planner_shell_id (int) required")
+    if actor.kind == "shell" and actor.shell_id != planner:
+        return _err(403, "not_the_planner",
+                    "a shell may arm only its own binding")
+    con = _db()
+    try:
+        def produce():
+            doc = con.execute(
+                "SELECT frozen FROM documents WHERE document_id=?",
+                (doc_id,)).fetchone()
+            if doc is None or doc[0] or not interface_broker._sprint_active(
+                    con, doc_id):
+                return 409, _err_obj(
+                    "sprint_not_active",
+                    "sprint document is missing, frozen, or not ACTIVE")
+            sess = con.execute(
+                "SELECT session_id, shell_id, generation, harness, "
+                "cli_version FROM interface_sessions "
+                "WHERE shell_id=? AND occupancy='occupied'",
+                (planner,)).fetchone()
+            if sess is None:
+                return 409, _err_obj(
+                    "no_live_session",
+                    "planner has no occupied Interface session to bind")
+            cap = interface_hooks.capability(sess[3], sess[4])
+            if not cap["mandatory_ok"]:
+                return 409, _err_obj(
+                    "hooks_unsupported",
+                    f"harness {sess[3]!r} lacks mandatory lifecycle hooks "
+                    f"({', '.join(cap['missing_mandatory']) or 'version'}) — "
+                    "sprint wake cannot arm")
+            try:
+                cur = con.execute(
+                    "INSERT INTO sprint_planner_bindings "
+                    "(sprint_doc_id, planner_shell_id, session_id, shell_id,"
+                    " generation) VALUES (?,?,?,?,?)",
+                    (doc_id, planner, sess[0], sess[1], sess[2]))
+            except db_driver.IntegrityError:
+                return 409, _err_obj(
+                    "already_armed",
+                    "planner or sprint already has an ACTIVE binding")
+            con.commit()
+            _log(f"sprint binding {cur.lastrowid} armed: doc={doc_id} "
+                 f"planner={planner} session={sess[0]} gen={sess[2]}")
+            return 201, {"binding_id": cur.lastrowid,
+                         "sprint_doc_id": doc_id,
+                         "planner_shell_id": planner,
+                         "session_id": sess[0], "generation": sess[2],
+                         "wake_state": "armed"}
+        resp = _idempotent(con, actor, "sprint_binding_arm", headers, body,
+                           produce)
+        if resp[0] == 201:
+            interface_wake.notify_binding(
+                json.loads(resp[2])["binding_id"])
+        return resp
+    finally:
+        con.close()
+
+
+def _release_binding(actor, headers, body, binding_id: int):
+    """DELETE /api/interface/sprint-bindings/{id} — release the binding and
+    cancel its queued wake work with an audit reason (spec Sprint Scope:
+    messages stay UNREAD; a live submitting/running batch is left for hook
+    reconciliation — its fenced evidence still resolves it)."""
+    con = _db()
+    try:
+        def produce():
+            row = con.execute(
+                "SELECT planner_shell_id, released_at "
+                "FROM sprint_planner_bindings WHERE binding_id=?",
+                (binding_id,)).fetchone()
+            if row is None:
+                return 404, _err_obj("no_such_binding",
+                                     f"binding {binding_id} not found")
+            if actor.kind == "shell" and actor.shell_id != row[0]:
+                return 403, _err_obj(
+                    "not_the_planner",
+                    "a shell may release only its own binding")
+            if row[1] is not None:
+                return 200, {"binding_id": binding_id, "released": True,
+                             "already_released": True}
+            reason = (body.get("reason") or "operator release").strip()
+            con.execute(
+                "UPDATE sprint_planner_bindings "
+                "SET released_at=datetime('now'), release_reason=? "
+                "WHERE binding_id=?", (reason, binding_id))
+            cancelled = 0
+            batches = con.execute(
+                "SELECT batch_id FROM planner_wake_batches "
+                "WHERE binding_id=? AND state='queued'",
+                (binding_id,)).fetchall()
+            for (batch_id_,) in batches:
+                batched = con.execute(
+                    "SELECT COUNT(*) FROM planner_wake_items "
+                    "WHERE batch_id=? AND state='batched'",
+                    (batch_id_,)).fetchone()[0]
+                interface_broker._cancel_batch(con, batch_id_)
+                cancelled += batched
+            items = con.execute(
+                "SELECT item_id FROM planner_wake_items "
+                "WHERE binding_id=? AND state='queued'",
+                (binding_id,)).fetchall()
+            for (item_id,) in items:
+                interface_state.transition(
+                    con, "wake_item", item_id, "cancelled",
+                    extra_sets={"error": f"binding released: {reason}"})
+                cancelled += 1
+            con.commit()
+            _log(f"sprint binding {binding_id} released ({reason}); "
+                 f"{cancelled} queued wake item(s) cancelled")
+            return 200, {"binding_id": binding_id, "released": True,
+                         "cancelled_items": cancelled,
+                         "wake_state": "disarmed"}
+        return _idempotent(con, actor, "sprint_binding_release", headers,
+                           body, produce)
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------- action receipts
+
+def _begin_receipt(actor, headers, body):
+    """POST /api/planner-action-receipts — record action INTENT before a
+    planner side effect (spec Event Ingress). The idempotency key derives
+    from message + operation + target; an existing key returns the original
+    receipt — a completed one suppresses the duplicate action outright."""
+    message_id = body.get("message_id")
+    operation = (body.get("operation") or "").strip()
+    target = (body.get("target") or "").strip()
+    if not operation or not target:
+        return _err(422, "validation", "operation and target required")
+    if message_id is not None and not isinstance(message_id, int):
+        return _err(422, "validation", "message_id must be an int")
+    idem_key = f"action|{message_id or '-'}|{operation}|{target}"
+    con = _db()
+    try:
+        def produce():
+            existing = con.execute(
+                "SELECT receipt_id, state FROM planner_action_receipts "
+                "WHERE idem_key=?", (idem_key,)).fetchone()
+            if existing is not None:
+                return 200, {"receipt_id": existing[0], "state": existing[1],
+                             "duplicate": True,
+                             "suppressed": existing[1] == "complete"}
+            cur = con.execute(
+                "INSERT INTO planner_action_receipts "
+                "(message_id, operation, target, idem_key) VALUES (?,?,?,?)",
+                (message_id, operation, target, idem_key))
+            con.commit()
+            return 201, {"receipt_id": cur.lastrowid, "state": "intent",
+                         "idem_key": idem_key}
+        return _idempotent(con, actor, "planner_action_begin", headers, body,
+                           produce)
+    finally:
+        con.close()
+
+
+def _update_receipt(actor, headers, body, receipt_id: int):
+    """PATCH /api/planner-action-receipts/{id} — record the observed result:
+    complete | unknown (parks the message's wake item for reconciliation on
+    the next batch completion) | reconciled (operator-resolved unknown)."""
+    new_state = body.get("state")
+    if new_state not in ("complete", "unknown", "reconciled"):
+        return _err(422, "validation",
+                    "state must be complete | unknown | reconciled")
+    detail = (body.get("result_detail") or "").strip() or None
+    con = _db()
+    try:
+        def produce():
+            extra = {"result_detail": detail}
+            if new_state == "complete":
+                extra["completed_at"] = _now(con)
+            elif new_state == "reconciled":
+                extra["reconciled_at"] = _now(con)
+            try:
+                interface_state.transition(
+                    con, "receipt", receipt_id, new_state, extra_sets=extra)
+            except interface_state.InterfaceTransitionError as exc:
+                return 409, _err_obj("receipt_transition", str(exc))
+            con.commit()
+            return 200, {"receipt_id": receipt_id, "state": new_state}
+        return _idempotent(con, actor, "planner_action_update", headers, body,
+                           produce)
+    finally:
+        con.close()
+
+
 def _hook_callback(headers, body):
     """Generation-scoped hook authority: the token calls ONLY this route, for
     its one generation. session_start additionally promotes the reservation
@@ -798,18 +1057,24 @@ def _hook_callback(headers, body):
     if not token or not isinstance(shell_id, int) \
             or not isinstance(generation, int) \
             or not isinstance(hook_seq, int) or not event:
+        _log(f"hook rejected (422 missing/invalid fields): "
+             f"shell={shell_id} gen={generation} event={event!r}")
         return _err(422, "validation",
                     "bearer token + shell_id, generation, hook_seq, event")
     unknown = set(body) - {"shell_id", "generation", "hook_seq", "event",
                            "source", "pid", "start_ticks", "archive_id",
                            "cli_version"}
     if unknown:
+        _log(f"hook rejected (422 unknown fields {sorted(unknown)}): "
+             f"shell={shell_id} gen={generation} event={event!r}")
         return _err(422, "validation", f"unknown fields: {sorted(unknown)}")
     if event not in interface_hooks.EVENTS:
         _log(f"hook event rejected shell={shell_id} gen={generation} "
              f"event={event!r}")
         return _err(422, "validation", f"unknown hook event {event!r}")
     if source not in interface_hooks.SOURCES:
+        _log(f"hook rejected (422 unknown source {source!r}): "
+             f"shell={shell_id} gen={generation} event={event}")
         return _err(422, "validation", f"unknown hook source {source!r}")
     con = _db()
     try:
@@ -828,6 +1093,8 @@ def _hook_callback(headers, body):
             "WHERE shell_id=? AND generation=? AND occupancy <> 'ended'",
             (shell_id, generation)).fetchone()
         if sess is None:
+            _log(f"hook rejected (404 no live session): shell={shell_id} "
+                 f"gen={generation} event={event}")
             return _err(404, "no_such_session", "no live session for generation")
         session_id, occupancy, pane_pid = sess
         try:
@@ -837,6 +1104,8 @@ def _hook_callback(headers, body):
             # passes $PPID. session_start MUST carry it (entrypoint and
             # emitter both do); any mismatch fails closed, on any event.
             if body.get("pid") is None and event == "session_start":
+                _log(f"hook rejected (422 session_start without pid): "
+                     f"session={session_id} source={source}")
                 return _err(422, "validation",
                             "session_start requires pid identity")
             if body.get("pid") is not None and body.get("pid") != pane_pid:
@@ -858,8 +1127,17 @@ def _hook_callback(headers, body):
             result = interface_broker.record_hook(
                 con, shell_id, generation, hook_seq, event, source=source)
             con.commit()
+            # A lifecycle event may make queued wake work submittable
+            # (turn_stop → idle, provider session_start → ready+quiet
+            # baseline). Signal after commit; a no-op when nothing is queued.
+            interface_wake.notify_session(session_id)
             return _json(200, result)
         except interface_broker.BrokerError as exc:
+            # Flag #51 (decision #31): EVERY rejection is audited — a silent
+            # rejection hides exactly the losses #50's ordering needs to
+            # diagnose in production (stale/replayed hook_seq among them).
+            _log(f"hook rejected (409 {event} shell={shell_id} "
+                 f"gen={generation} seq={hook_seq}): {exc}")
             return _err(409, "hook_rejected", str(exc))
         except interface_state.InterfaceTransitionError as exc:
             _log(f"hook illegal transition session={session_id} "
@@ -951,6 +1229,14 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
     if actor is None:
         return _err(401, "unauthorized",
                     "operator bearer or browser session required")
+    # Shell actors (the planner's own API token) reach ONLY the sprint-wake
+    # surfaces — bindings + action receipts — never session/writer/stop.
+    if actor.kind == "shell" and not (
+            p.startswith("/api/interface/sprint-bindings")
+            or p.startswith("/api/planner-action-receipts")):
+        return _err(403, "shell_scope",
+                    "a shell token may call only sprint-binding and "
+                    "action-receipt routes")
     if method in ("POST", "DELETE", "PATCH", "PUT"):
         if not actor.csrf_ok:
             return _err(403, "csrf", "browser mutations need the session's "
@@ -979,6 +1265,17 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
             return _terminate(actor, headers, data)
         if p == "/api/interface/reconciliations" and method == "POST":
             return _reconcile(actor, headers, data)
+        if p == "/api/interface/sprint-bindings" and method == "POST":
+            return _arm_binding(actor, headers, data)
+        if p.startswith("/api/interface/sprint-bindings/") \
+                and method == "DELETE":
+            return _release_binding(actor, headers, data,
+                                    int(p.rsplit("/", 1)[1]))
+        if p == "/api/planner-action-receipts" and method == "POST":
+            return _begin_receipt(actor, headers, data)
+        if p.startswith("/api/planner-action-receipts/") and method == "PATCH":
+            return _update_receipt(actor, headers, data,
+                                   int(p.rsplit("/", 1)[1]))
         return _err(404, "no_such_route", f"no route: {method} {p}")
     except ValueError:
         return _err(404, "no_such_route", f"no route: {method} {p}")

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -63,6 +63,7 @@ import backfill_shell_api_keys  # noqa: E402  (startup key provisioning)
 import db_driver  # noqa: E402
 import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import interface_reconcile  # noqa: E402  (Interface startup reconciliation)
+import interface_wake  # noqa: E402  (transactional wake ingress + coordinator)
 sys.path.insert(0, str(ENGINE / "api"))
 try:
     import interface_routes  # noqa: E402  (Interface HTTP API, spec #20)
@@ -1812,9 +1813,18 @@ class Handler(BaseHTTPRequestHandler):
                         return self._send(200, {"message_id": r[0], "duplicate": True})
                 try:
                     cur = con.execute(
-                        "INSERT INTO shell_messages (from_shell_id, to_shell_id, body, kind, dedupe_key) "
-                        "VALUES (?, ?, ?, ?, ?)",
-                        (sid, int(to_sid), msg, kind, dk))
+                        "INSERT INTO shell_messages (from_shell_id, to_shell_id, body, kind, sprint_doc_id, dedupe_key) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        (sid, int(to_sid), msg, kind,
+                         body.get("sprint_doc_id"), dk))
+                    message_id = cur.lastrowid
+                    # Transactional wake ingress (spec #20 Event Ingress, seq
+                    # 8): the wake item rides the SAME transaction as the
+                    # message — unique (binding_id, message_id) dedupes; a
+                    # rollback drops both, so no accepted event is ever lost
+                    # or double-woken. Ineligible traffic (shell kind,
+                    # unscoped, no ACTIVE binding) creates nothing.
+                    interface_wake.maybe_create_wake_item(con, message_id)
                     con.commit()
                 except db_driver.IntegrityError:
                     r = con.execute(
@@ -1823,7 +1833,11 @@ class Handler(BaseHTTPRequestHandler):
                     if r is None:
                         raise
                     return self._send(200, {"message_id": r[0], "duplicate": True})
-                return self._send(201, {"message_id": cur.lastrowid})
+                # The event is durable — signal the wake coordinator (a no-op
+                # when the Interface stack or coordinator is down; the next
+                # startup pass drains durable queued work regardless).
+                interface_wake.notify_message(message_id)
+                return self._send(201, {"message_id": message_id})
 
             if path == "/_sc/mem/projects":
                 shortname = (body.get("shortname") or "").strip()
@@ -2593,7 +2607,8 @@ def dispatch_http(method: str, path: str, headers_raw: str,
     (status, [(header, value)], body bytes). Interface API paths go to the
     interface module; everything else runs through the shimmed Handler."""
     parsed = urlparse(path)
-    if parsed.path.startswith("/api/interface/"):
+    if parsed.path.startswith("/api/interface/") or \
+            parsed.path.startswith("/api/planner-action-receipts"):
         if interface_routes is None:
             return (503, [("Content-Type", "application/json")],
                     json.dumps({"error": {

--- a/.super-coder/migrations/0081_planner_wake.sql
+++ b/.super-coder/migrations/0081_planner_wake.sql
@@ -1,0 +1,12 @@
+-- 0081 — Transactional brokered planner wake (sprint 25 seq 8, spec #20
+-- task #84, HARD requirement #49 from decisions #28/#31).
+--
+-- provider_ready_at stamps REAL provider readiness: the provider-native
+-- session_start hook (never the entrypoint's pre-exec identity claim). The
+-- wake gate's quiet debounce measures from this stamp — a >3s claude/codex
+-- boot can no longer let a queued wake submit into an unpainted TUI just
+-- because the pre-exec occupied_at baseline already aged past the debounce
+-- (flag #49). NULL = the provider has not proven readiness yet; the gate
+-- then falls back to occupied_at/created_at exactly as before.
+
+ALTER TABLE interface_sessions ADD COLUMN provider_ready_at TEXT;

--- a/.super-coder/migrations/0081_planner_wake.sql
+++ b/.super-coder/migrations/0081_planner_wake.sql
@@ -10,3 +10,26 @@
 -- then falls back to occupied_at/created_at exactly as before.
 
 ALTER TABLE interface_sessions ADD COLUMN provider_ready_at TEXT;
+
+-- queued -> done wake-item edge (spec #20 Wake Delivery: a message handled
+-- — read — during another batch's turn "completes it" without riding a
+-- batch of its own), and running -> quarantined (the third completed wake
+-- turn quarantines an unread item at stop-hook reconciliation). The trigger
+-- is the DB backstop; DROP + recreate with the widened edge set
+-- (interface_state.WAKE_ITEM_EDGES mirrors it;
+-- tests/test_interface_transitions.py walks both layers for drift).
+
+DROP TRIGGER trg_pwi_state;
+CREATE TRIGGER trg_pwi_state
+BEFORE UPDATE OF state ON planner_wake_items
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'queued'      AND NEW.state IN ('batched','done','quarantined','cancelled')) OR
+    (OLD.state = 'batched'     AND NEW.state IN ('queued','submitting','cancelled')) OR
+    (OLD.state = 'submitting'  AND NEW.state IN ('queued','running','cancelled')) OR
+    (OLD.state = 'running'     AND NEW.state IN ('done','reconcile','queued','quarantined','cancelled')) OR
+    (OLD.state = 'reconcile'   AND NEW.state IN ('queued','done','cancelled')) OR
+    (OLD.state = 'quarantined' AND NEW.state IN ('queued','cancelled'))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal wake item transition');
+END;

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -377,6 +377,11 @@ CREATE TABLE interface_sessions (
     ended_at             TEXT,
     end_reason           TEXT,
     error_detail         TEXT,
+    -- graceful_timed_out_at TEXT — force-gate stamp, migration 0080.
+    -- provider_ready_at TEXT — REAL provider readiness stamp (provider
+    -- session_start hook; the wake gate's quiet baseline, flag #49),
+    -- migration 0081. Both ride the migration-only ADD COLUMN precedent
+    -- (schema.sql + migrations both apply on rebuild — never inline).
     UNIQUE (shell_id, generation),
     FOREIGN KEY (shell_id, generation)
         REFERENCES interface_generations(shell_id, generation)

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -595,10 +595,10 @@ END;
 CREATE TRIGGER trg_pwi_state
 BEFORE UPDATE OF state ON planner_wake_items
 WHEN NEW.state <> OLD.state AND NOT (
-    (OLD.state = 'queued'      AND NEW.state IN ('batched','quarantined','cancelled')) OR
+    (OLD.state = 'queued'      AND NEW.state IN ('batched','done','quarantined','cancelled')) OR
     (OLD.state = 'batched'     AND NEW.state IN ('queued','submitting','cancelled')) OR
     (OLD.state = 'submitting'  AND NEW.state IN ('queued','running','cancelled')) OR
-    (OLD.state = 'running'     AND NEW.state IN ('done','reconcile','queued','cancelled')) OR
+    (OLD.state = 'running'     AND NEW.state IN ('done','reconcile','queued','quarantined','cancelled')) OR
     (OLD.state = 'reconcile'   AND NEW.state IN ('queued','done','cancelled')) OR
     (OLD.state = 'quarantined' AND NEW.state IN ('queued','cancelled'))
 )

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -27,10 +27,19 @@ import interface_state
 MAX_INPUT_BYTES = 64 * 1024  # one human frame, per the pinned spike protocol
 WAKE_PROMPT = "Check your inbox and act on unread sprint events."
 DEFAULT_QUIET_S = 3.0  # debounce, never proof of an empty composer
+MAX_COMPLETED_WAKES = 3  # unread after 3 completed wake turns → quarantined
 
 
 class BrokerError(ValueError):
     """A refused broker operation (stale generation, bad sequence, gate)."""
+
+
+class PreSendError(Exception):
+    """A DEFINITE pre-send failure: the writer proved no byte reached tmux
+    (its preflight failed before any send-keys call). Distinct from an
+    ambiguous write failure (which parks delivery_unknown): a PreSendError
+    returns the batch to queued and rides the coordinator's bounded pre-send
+    retry schedule (1s/5s/30s, spec #20 Retry Policy) instead of parking."""
 
 
 def _begin_immediate(con) -> bool:
@@ -64,14 +73,14 @@ def _session(con, session_id: int):
 
 
 def _alert(con, *, severity: str, reason: str, session_id=None,
-           binding_id=None) -> None:
+           binding_id=None, message_id=None) -> None:
     """Raise an alert, deduplicated while open (partial unique index)."""
-    dedupe = f"{session_id or '-'}|{binding_id or '-'}|{reason}"
+    dedupe = f"{session_id or '-'}|{binding_id or '-'}|{message_id or '-'}|{reason}"
     con.execute(
         "INSERT OR IGNORE INTO planner_alerts "
-        "(session_id, binding_id, severity, reason, dedupe_key) "
-        "VALUES (?,?,?,?,?)",
-        (session_id, binding_id, severity, reason, dedupe))
+        "(session_id, binding_id, message_id, severity, reason, dedupe_key) "
+        "VALUES (?,?,?,?,?,?)",
+        (session_id, binding_id, message_id, severity, reason, dedupe))
 
 
 def park_delivery_unknown(con, session_id: int, *,
@@ -342,6 +351,15 @@ def record_hook(con, shell_id: int, generation: int, hook_seq: int,
             # composer as it is — dirty/unknown still need submit/certify.
             if sess[1] == "starting":
                 interface_state.transition(con, "lifecycle", sess[0], "idle")
+            # REAL provider readiness (flag #49, decisions #28/#31): stamp
+            # the quiet baseline NOW — never at the pre-exec occupied_at —
+            # so a >3s harness boot cannot let a queued wake submit into an
+            # unpainted TUI. The wake gate measures quiet from max(human
+            # input, provider_ready_at, ...), so this stamp resets the
+            # debounce to the moment the provider actually proved alive.
+            con.execute(
+                "UPDATE interface_sessions SET provider_ready_at=datetime('now') "
+                "WHERE session_id=?", (sess[0],))
             istate = con.execute(
                 "SELECT composer, pending_seq, forwarded_seq "
                 "FROM interface_input_state WHERE session_id=?",
@@ -485,29 +503,79 @@ def _hook_capability_alerts(con, session_id: int) -> None:
 
 def _complete_batch(con, batch_id: int, stop_hook_seq: int) -> None:
     """Reconcile a running batch's items from durable message read state
-    (spec #20 Wake Delivery): read → done; unread → back to queued with
-    completed_wakes+1. Infrastructure never marks messages read."""
+    (spec #20 Wake Delivery): read → done; unread with a durable ambiguous
+    action (an action receipt still intent/unknown) → reconcile; unread
+    without ambiguity → back to queued with completed_wakes+1 — except the
+    third completed wake, which QUARANTINES the item and alerts (newer work
+    is never blocked). A queued item whose message was read during the turn
+    completes without a wake of its own ("new message handled in the turn:
+    complete it"). Infrastructure never marks messages read."""
     interface_state.transition(
         con, "wake_batch", batch_id, "complete",
         extra_sets={"stop_hook_seq": stop_hook_seq, "completed_at": _now(con)})
+    binding_id = con.execute(
+        "SELECT binding_id FROM planner_wake_batches WHERE batch_id=?",
+        (batch_id,)).fetchone()[0]
     items = con.execute(
         "SELECT item_id, message_id FROM planner_wake_items "
         "WHERE batch_id=? AND state IN ('batched','submitting','running')",
         (batch_id,)).fetchall()
     for item_id, message_id in items:
-        read = con.execute(
-            "SELECT read_at FROM shell_messages WHERE message_id=?",
-            (message_id,)).fetchone()[0]
-        if read is not None:
-            interface_state.transition(
-                con, "wake_item", item_id, "done",
-                extra_sets={"done_at": _now(con)})
-        else:
-            con.execute(
-                "UPDATE planner_wake_items SET completed_wakes="
-                "completed_wakes + 1, batch_id=NULL WHERE item_id=?",
-                (item_id,))
-            interface_state.transition(con, "wake_item", item_id, "queued")
+        _reconcile_item(con, item_id, message_id, binding_id)
+    # Messages that arrived DURING the turn and were read in it complete
+    # without riding a batch (spec: "new message handled in the turn:
+    # complete it; otherwise leave it queued").
+    strays = con.execute(
+        "SELECT i.item_id, i.message_id FROM planner_wake_items i "
+        "JOIN shell_messages m ON m.message_id=i.message_id "
+        "WHERE i.binding_id=? AND i.state='queued' AND m.read_at IS NOT NULL",
+        (binding_id,)).fetchall()
+    for item_id, _ in strays:
+        interface_state.transition(
+            con, "wake_item", item_id, "done",
+            extra_sets={"done_at": _now(con)})
+
+
+def _reconcile_item(con, item_id: int, message_id: int,
+                    binding_id: int) -> None:
+    """One batched item's stop-hook reconciliation (see _complete_batch)."""
+    read = con.execute(
+        "SELECT read_at FROM shell_messages WHERE message_id=?",
+        (message_id,)).fetchone()[0]
+    if read is not None:
+        interface_state.transition(
+            con, "wake_item", item_id, "done",
+            extra_sets={"done_at": _now(con)})
+        return
+    ambiguous = con.execute(
+        "SELECT receipt_id, state FROM planner_action_receipts "
+        "WHERE message_id=? AND state IN ('intent','unknown')",
+        (message_id,)).fetchone()
+    if ambiguous is not None:
+        # A durable ambiguous action: the planner started a side effect whose
+        # result was never observed. Park for operator reconciliation —
+        # NEVER requeue blind (spec Wake Delivery; decision #12).
+        interface_state.transition(
+            con, "wake_item", item_id, "reconcile",
+            extra_sets={"ambiguity":
+                        f"action receipt {ambiguous[0]} is {ambiguous[1]}"})
+        _alert(con, severity="warning", reason="wake_item_reconcile",
+               binding_id=binding_id, message_id=message_id)
+        return
+    wakes = con.execute(
+        "SELECT completed_wakes FROM planner_wake_items WHERE item_id=?",
+        (item_id,)).fetchone()[0] + 1
+    con.execute(
+        "UPDATE planner_wake_items SET completed_wakes=?, batch_id=NULL "
+        "WHERE item_id=?", (wakes, item_id))
+    if wakes >= MAX_COMPLETED_WAKES:
+        # Three completed wakes left it unread: quarantine + alert; newer
+        # work continues past it (spec Wake Delivery; decision #12).
+        interface_state.transition(con, "wake_item", item_id, "quarantined")
+        _alert(con, severity="warning", reason="wake_item_quarantined",
+               binding_id=binding_id, message_id=message_id)
+    else:
+        interface_state.transition(con, "wake_item", item_id, "queued")
 
 
 def form_batch(con, binding_id: int) -> int:
@@ -527,7 +595,8 @@ def form_batch(con, binding_id: int) -> int:
     batch_id = cur.lastrowid
     items = con.execute(
         "SELECT item_id FROM planner_wake_items "
-        "WHERE binding_id=? AND state='queued' ORDER BY item_id",
+        "WHERE binding_id=? AND state='queued' AND batch_id IS NULL "
+        "ORDER BY item_id",
         (binding_id,)).fetchall()
     for (item_id,) in items:
         interface_state.transition(
@@ -594,26 +663,37 @@ def _cancel_batch(con, batch_id: int) -> None:
 
 
 def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
-                      quiet_s: float = DEFAULT_QUIET_S) -> dict:
+                      quiet_s: float = DEFAULT_QUIET_S,
+                      unmanaged_writable=None) -> dict:
     """Gate + submit one coalesced fixed-prompt batch under the input lock.
 
     Revalidates everything the spec requires before a byte moves: the binding
     still armed and its sprint still ACTIVE (a close between form_batch and
     submit CANCELS the batch), occupied session, idle lifecycle, clean
     composer, quiet >= quiet_s since the last accepted human input AND since
-    the last service restart (a fresh full debounce is owed after every
-    restart — a NULL last_human_input_at never skips the check), no pending
-    human frame. quiet_s must be > 0 (the spec forbids a zero debounce).
-    Transient gate failures (busy/dirty/quiet) cancel the attempt WITHOUT a
-    state change — the batch stays queued awaiting a later event.
+    REAL provider readiness (flag #49: the provider session_start stamp, NOT
+    the pre-exec occupied_at — a >3s claude/codex boot must not submit into
+    an unpainted TUI) AND since the last service restart (a fresh full
+    debounce is owed after every restart), no pending human frame, mandatory
+    lifecycle hooks actually supported by the session's harness, and NO
+    unmanaged writable tmux client (decision #15: one is an immediate
+    composer-unknown + disarm + alert, recoverable only by removal plus
+    explicit clean certification). quiet_s must be > 0 (the spec forbids a
+    zero debounce). Transient gate failures (busy/dirty/quiet) cancel the
+    attempt WITHOUT a state change — the batch stays queued awaiting a
+    later event; the quiet failure carries retry_after so the coordinator
+    can re-attempt at the exact debounce deadline (event-reset, never a
+    poll).
 
     From the 'submitting' commit until the fenced submit hook, the batch
     holds the input lock: accept_human_input refuses new frames, so no human
     input can interleave inside the fixed submission. The submission is one
     indivisible writer call; its fence is forwarded_seq+1 (the broker
-    sequence the submit hook must answer). A writer failure without process
-    death parks the batch as delivery_unknown — the prompt may have landed —
-    which also releases the lock.
+    sequence the submit hook must answer). A writer raising PreSendError
+    PROVES no byte moved: the batch returns to queued (a legal edge) for the
+    coordinator's bounded pre-send retries (1s/5s/30s) — it never parks.
+    Any OTHER writer failure is ambiguous (the prompt may have landed): the
+    batch parks as delivery_unknown, which also releases the lock.
 
     The gate reads + the 'submitting' commit are serialized under BEGIN
     IMMEDIATE (REV2 seq-4 L5 TOCTOU): two concurrent submitters on separate
@@ -657,7 +737,8 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
                     "reason": "sprint doc is not ACTIVE"}
 
         sess = con.execute(
-            "SELECT session_id, occupancy, lifecycle, occupied_at, created_at "
+            "SELECT session_id, occupancy, lifecycle, occupied_at, "
+            "created_at, provider_ready_at, harness, cli_version "
             "FROM interface_sessions "
             "WHERE shell_id=? AND generation=? AND occupancy <> 'ended'",
             (shell_id, generation)).fetchone()
@@ -666,10 +747,10 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
             "FROM interface_input_state WHERE session_id=?",
             (sess[0],)).fetchone()
 
-        def gate_fail(reason):
+        def gate_fail(reason, **extra):
             if began:
                 con.rollback()
-            return {"submitted": False, "reason": reason}
+            return {"submitted": False, "reason": reason, **extra}
 
         if sess[1] != "occupied" or sess[2] != "idle":
             return gate_fail(
@@ -678,11 +759,33 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
             return gate_fail(f"composer is {istate[0]}")
         if istate[1] is not None:
             return gate_fail("a human frame is pending")
-        # Quiet baseline: the last human input if any, else the session's
-        # start — floored at the last service restart (startup_reconcile
-        # revokes every lease with reason 'service_restart'; that stamp is
-        # the restart time).
-        baseline = istate[3] or sess[3] or sess[4]
+        cap = interface_hooks.capability(sess[6], sess[7])
+        if not cap["mandatory_ok"]:
+            return gate_fail(
+                f"harness {sess[6]!r} lacks mandatory lifecycle hooks "
+                f"(missing: {', '.join(cap['missing_mandatory']) or 'version'})"
+                " — wake cannot submit")
+        if unmanaged_writable is not None and unmanaged_writable():
+            # Decision #15: an unmanaged writable client bypasses the ordered
+            # input boundary — detection sets composer unknown (which disarms
+            # wake: the gate requires clean), alerts, and requires removal +
+            # explicit clean certification before rearming.
+            interface_state.transition(con, "composer", sess[0], "unknown")
+            _alert(con, severity="critical",
+                   reason="unmanaged_writable_client", session_id=sess[0])
+            con.commit()
+            began = False
+            return {"submitted": False, "disarmed": True,
+                    "reason": "unmanaged writable tmux client — composer "
+                              "unknown, wake disarmed until removal + "
+                              "clean certification"}
+        # Quiet baseline (#49): the most recent of — last accepted human
+        # input, REAL provider readiness (the provider session_start stamp,
+        # never the pre-exec occupied_at), session start, and the last
+        # service restart (startup_reconcile revokes every lease with reason
+        # 'service_restart'; that stamp is the restart time).
+        baseline = max(t for t in (istate[3], sess[3], sess[4], sess[5])
+                       if t is not None)
         restart_at = con.execute(
             "SELECT MAX(revoked_at) FROM interface_writer_leases "
             "WHERE session_id=? AND revoke_reason='service_restart'",
@@ -693,7 +796,8 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
             "SELECT julianday(?) - julianday(?)", (now_iso, baseline)
         ).fetchone()[0] * 86400.0
         if quiet < quiet_s:
-            return gate_fail(f"quiet {quiet:.2f}s < {quiet_s}s")
+            return gate_fail(f"quiet {quiet:.2f}s < {quiet_s}s",
+                             retry_after=quiet_s - quiet)
 
         fence = istate[2] + 1
         interface_state.transition(
@@ -701,7 +805,7 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
             extra_sets={"input_seq_fence": fence})
         con.execute(
             "UPDATE planner_wake_items SET state='submitting' "
-            "WHERE batch_id=? AND state='batched'",
+            "WHERE batch_id=? AND state IN ('batched','queued')",
             (batch_id,))
         con.commit()
         began = False
@@ -712,6 +816,17 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
 
     try:
         writer(len(WAKE_PROMPT) + 1)  # the fixed prompt + Enter, indivisible
+    except PreSendError:
+        # DEFINITE pre-send failure (the writer's preflight proved no byte
+        # moved): the batch returns to queued — a legal edge — and the
+        # coordinator's bounded retry schedule (1s/5s/30s) decides the next
+        # attempt. NEVER parked: nothing is ambiguous.
+        interface_state.transition(con, "wake_batch", batch_id, "queued")
+        con.execute(
+            "UPDATE planner_wake_items SET state='queued' "
+            "WHERE batch_id=? AND state='submitting'", (batch_id,))
+        con.commit()
+        raise
     except Exception:
         # The prompt may or may not have landed and no submit hook can be
         # trusted to disambiguate — park exactly like the restart path (never

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -668,8 +668,13 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
     """Gate + submit one coalesced fixed-prompt batch under the input lock.
 
     Revalidates everything the spec requires before a byte moves: the binding
-    still armed and its sprint still ACTIVE (a close between form_batch and
-    submit CANCELS the batch), occupied session, idle lifecycle, clean
+    still armed and its sprint still ACTIVE AND unfrozen (a close or freeze
+    between form_batch and submit CANCELS the batch — freeze is how sprint
+    authority is revoked, so a post-freeze wake is exactly what must not
+    fire), a live occupied session (an ended session gate-fails with an
+    ALERT and the batch stays queued for a future generation — End chat
+    deliberately does not release the sprint binding, so this gate must
+    never crash on it), idle lifecycle, clean
     composer, quiet >= quiet_s since the last accepted human input AND since
     REAL provider readiness (flag #49: the provider session_start stamp, NOT
     the pre-exec occupied_at — a >3s claude/codex boot must not submit into
@@ -684,6 +689,10 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
     later event; the quiet failure carries retry_after so the coordinator
     can re-attempt at the exact debounce deadline (event-reset, never a
     poll).
+
+    The unmanaged-client probe runs BEFORE the write txn (SC-013): it
+    shells out to tmux, and a wedged-but-alive server must never hang the
+    drain thread while this gate holds the SQLite write lock.
 
     From the 'submitting' commit until the fenced submit hook, the batch
     holds the input lock: accept_human_input refuses new frames, so no human
@@ -705,6 +714,10 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
     """
     if quiet_s <= 0:
         raise BrokerError("quiet_s must be > 0 — a zero debounce is forbidden")
+    # Decision #15 probe runs BEFORE the write txn (SC-013): it shells out
+    # to tmux, and a wedged-but-alive server must never hang the drain
+    # thread while this gate holds the SQLite write lock.
+    unmanaged = unmanaged_writable is not None and unmanaged_writable()
     began = _begin_immediate(con)
     try:
         batch = con.execute(
@@ -729,12 +742,16 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
             began = False
             return {"submitted": False, "cancelled": True,
                     "reason": "binding released — sprint no longer armed"}
-        if not _sprint_active(con, binding[0]):
+        frozen = con.execute(
+            "SELECT frozen FROM documents WHERE document_id=?",
+            (binding[0],)).fetchone()
+        if (frozen is None or frozen[0]
+                or not _sprint_active(con, binding[0])):
             _cancel_batch(con, batch_id)
             con.commit()
             began = False
             return {"submitted": False, "cancelled": True,
-                    "reason": "sprint doc is not ACTIVE"}
+                    "reason": "sprint doc is frozen or not ACTIVE"}
 
         sess = con.execute(
             "SELECT session_id, occupancy, lifecycle, occupied_at, "
@@ -742,6 +759,21 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
             "FROM interface_sessions "
             "WHERE shell_id=? AND generation=? AND occupancy <> 'ended'",
             (shell_id, generation)).fetchone()
+        if sess is None:
+            # End chat (_end_session) deliberately does NOT release the
+            # binding or cancel queued wake work — chat and sprint
+            # lifecycles are separate — so an armed binding can outlive its
+            # session. The batch STAYS queued for a future generation; spec
+            # Retry Policy requires harness/session loss to queue AND alert
+            # (SC-011: a silent crash stall is the failure class this
+            # feature exists to prevent).
+            if began:
+                con.rollback()
+                began = False
+            _alert(con, severity="critical", reason="wake_session_ended",
+                   binding_id=binding_id)
+            con.commit()
+            return {"submitted": False, "reason": "session ended"}
         istate = con.execute(
             "SELECT composer, pending_seq, forwarded_seq, last_human_input_at "
             "FROM interface_input_state WHERE session_id=?",
@@ -765,11 +797,13 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
                 f"harness {sess[6]!r} lacks mandatory lifecycle hooks "
                 f"(missing: {', '.join(cap['missing_mandatory']) or 'version'})"
                 " — wake cannot submit")
-        if unmanaged_writable is not None and unmanaged_writable():
+        if unmanaged:
             # Decision #15: an unmanaged writable client bypasses the ordered
             # input boundary — detection sets composer unknown (which disarms
             # wake: the gate requires clean), alerts, and requires removal +
-            # explicit clean certification before rearming.
+            # explicit clean certification before rearming. The probe itself
+            # ran before the write txn (SC-013); only its verdict is applied
+            # here.
             interface_state.transition(con, "composer", sess[0], "unknown")
             _alert(con, severity="critical",
                    reason="unmanaged_writable_client", session_id=sess[0])

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -803,9 +803,15 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
         interface_state.transition(
             con, "wake_batch", batch_id, "submitting",
             extra_sets={"input_seq_fence": fence})
+        # Items ride legal edges only: a first attempt's items are 'batched',
+        # a bounded-retry re-attempt's were returned to 'queued' with the
+        # batch — walk those through 'batched' before 'submitting'.
+        con.execute(
+            "UPDATE planner_wake_items SET state='batched' "
+            "WHERE batch_id=? AND state='queued'", (batch_id,))
         con.execute(
             "UPDATE planner_wake_items SET state='submitting' "
-            "WHERE batch_id=? AND state IN ('batched','queued')",
+            "WHERE batch_id=? AND state='batched'",
             (batch_id,))
         con.commit()
         began = False

--- a/.super-coder/scripts/interface_hook.py
+++ b/.super-coder/scripts/interface_hook.py
@@ -17,7 +17,9 @@ the launch env the pane entrypoint injected (SC_INTERFACE_*), never from
 config files or argv.
 
 hook_seq is allocated from a per-generation counter file under the engine
-run dir (flock-serialized — concurrent hooks can't double-issue). The
+run dir. The flock is held through the POST (flag #50, decisions #28/#31):
+allocation order IS commit order, so a concurrent hook can never commit
+first and strand the earlier event as a stale-sequence rejection. The
 entrypoint's pre-exec session_start is always seq 1, so the counter starts
 at 1 and the first harness-side hook issues 2. A crash between allocation
 and POST leaves a gap; the receiver rejects only <= last, so gaps are
@@ -72,17 +74,48 @@ def next_hook_seq(run_dir: Path, shell_id: int, generation: int) -> int:
     path = run_dir / f"hook-seq-{shell_id}-{generation}.seq"
     with open(path, "a+") as fh:
         fcntl.flock(fh, fcntl.LOCK_EX)
-        fh.seek(0)
-        raw = fh.read().strip()
-        last = int(raw) if raw else 1  # 1 = the entrypoint's session_start
-        nxt = last + 1
-        fh.seek(0)
-        fh.truncate()
-        fh.write(f"{nxt}\n")
-        fh.flush()
-        os.fsync(fh.fileno())
+        nxt = _alloc_seq(fh)
         fcntl.flock(fh, fcntl.LOCK_UN)
     return nxt
+
+
+def _alloc_seq(fh) -> int:
+    """Allocate + persist the next sequence on an already-flocked counter
+    file. The counter is written BEFORE the POST: a crash leaves a gap
+    (safe — the receiver rejects only <= last), never a duplicate."""
+    fh.seek(0)
+    raw = fh.read().strip()
+    last = int(raw) if raw else 1  # 1 = the entrypoint's session_start
+    nxt = last + 1
+    fh.seek(0)
+    fh.truncate()
+    fh.write(f"{nxt}\n")
+    fh.flush()
+    os.fsync(fh.fileno())
+    return nxt
+
+
+def emit_locked(run_dir: Path, shell_id: int, generation: int, body: dict,
+                api_base: str, token: str) -> bool:
+    """Allocate the hook sequence AND post the callback while holding the
+    counter flock through the POST (flag #50, decisions #28/#31 — HARD
+    seq-8 requirement): the flock serializes COMMIT, not just allocation.
+    Without it two concurrent hooks allocated in order could POST out of
+    order; the later seq would commit first and the earlier hook would be
+    rejected as stale — a dropped prompt_submit strands its wake batch
+    'submitting' with RESTART-ONLY recovery. Holding the lock through the
+    POST makes allocation order == commit order, so that state is
+    unreachable. The POST is short-timeout and the harness is local; the
+    worst-case wait for a concurrent hook is bounded by POST_TIMEOUT_S."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = run_dir / f"hook-seq-{shell_id}-{generation}.seq"
+    with open(path, "a+") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            body["hook_seq"] = _alloc_seq(fh)
+            return post_callback(api_base, token, body)
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
 
 
 def post_callback(api_base: str, token: str, body: dict,
@@ -138,12 +171,14 @@ def main(argv: "list[str] | None" = None) -> int:
             raise EmitError("SC_INTERFACE_HOOK_TOKEN / SC_INTERFACE_SHELL_ID "
                             "/ SC_INTERFACE_GENERATION / SC_API_BASE unset — "
                             "not an Interface-managed session")
-        seq = next_hook_seq(_run_dir(), int(shell_id), int(generation))
         body = {"shell_id": int(shell_id), "generation": int(generation),
-                "hook_seq": seq, "event": args.event, "source": "provider"}
+                "event": args.event, "source": "provider"}
         if args.pid is not None:
             body["pid"] = args.pid
-        post_callback(api_base, token, body)
+        # Seq allocation AND the POST ride one flock (flag #50) — commit
+        # order can no longer invert allocation order.
+        emit_locked(_run_dir(), int(shell_id), int(generation), body,
+                    api_base, token)
     except EmitError as e:
         print(f"interface-hook: {e}", file=sys.stderr)
     except Exception as e:  # noqa: BLE001 — never break the harness

--- a/.super-coder/scripts/interface_runtime.py
+++ b/.super-coder/scripts/interface_runtime.py
@@ -45,6 +45,7 @@ from pathlib import Path
 
 import db_driver
 import interface_broker
+import interface_wake
 
 ENGINE = Path(__file__).resolve().parents[1]
 SHADOW_DIR = ENGINE / "shadow"
@@ -437,6 +438,7 @@ class InterfaceRuntime:
         self.available = False
         self.unavailable_reason = "start() not called"
         self.on_unexpected_exit = None  # sync callable(session_id), set by routes
+        self.wake_coordinator = None    # interface_wake.WakeCoordinator (start())
         self._tmux_session_started = False
         self._reaper: asyncio.Task | None = None
         self._tickets: dict[str, dict] = {}
@@ -506,9 +508,70 @@ class InterfaceRuntime:
             except Exception as exc:  # noqa: BLE001 — keep booting
                 _log("boot", f"lost-transition for s{session_id} failed: "
                              f"{exc!r}")
+        # Wake coordinator (sprint 25 seq 8): the event-driven drain of
+        # queued sprint wake work through the broker-owned input path —
+        # never a direct tmux send. Signals arrive from message ingress,
+        # hook callbacks, certifications, and binding arms; startup_pass is
+        # the ONE reconciliation scan (spec Event Ingress: no interval model
+        # scan, no steady wake timer).
+        self.wake_coordinator = interface_wake.WakeCoordinator(
+            self.db_path, writer_factory=self.wake_writer,
+            unmanaged_probe=self.unmanaged_writable_client)
+        self.wake_coordinator.start(self.loop)
+        interface_wake.bind(self.wake_coordinator)
+        self.wake_coordinator.startup_pass()
+
+    # -- wake submission (sprint 25 seq 8 — the API-owned input path) -----------
+
+    def wake_writer(self, session_id: int):
+        """The broker-owned writer for one wake submission: preflight the
+        pane (a failure PROVES no byte moved → PreSendError — the definite
+        pre-send failure that rides the bounded 1s/5s/30s retries), then one
+        indivisible send-keys of the fixed prompt + Enter. This is the ONLY
+        path a wake reaches tmux; the crash-window parking in the broker is
+        unbypassable from here."""
+        payload = interface_broker.WAKE_PROMPT.encode() + b"\r"
+
+        def writer(n: int) -> None:
+            assert n == len(payload)
+            gen = self.generations.get(session_id)
+            if gen is None or gen.terminated:
+                raise interface_broker.PreSendError(
+                    f"session {session_id} generation not live in runtime")
+            try:
+                subprocess.run(
+                    ["tmux", "-S", self.sock, "display-message", "-p",
+                     "-t", gen.pane_id, "#{pane_id}"],
+                    capture_output=True, check=True)
+            except Exception as exc:
+                raise interface_broker.PreSendError(
+                    f"wake preflight failed for {gen.pane_id}: "
+                    f"{exc!r}") from exc
+            self._send_keys_sync(gen.pane_id, payload)
+
+        return writer
+
+    def unmanaged_writable_client(self, session_id: int) -> bool:
+        """Decision #15 probe: any READ-WRITE tmux client attached to our
+        private server is unmanaged — the broker never attaches a client,
+        and a read-only diagnostic client (spec Tmux Runtime) is tolerated.
+        tmux itself being unreachable is NOT reported here (the wake
+        writer's preflight owns that failure, as definite pre-send)."""
+        if session_id not in self.generations:
+            return False
+        try:
+            out = subprocess.run(
+                ["tmux", "-S", self.sock, "list-clients",
+                 "-F", "#{client_readonly}"],
+                capture_output=True, check=True, text=True).stdout
+        except Exception:  # noqa: BLE001
+            return False
+        return any(line.strip() == "0" for line in out.splitlines())
 
     async def stop(self) -> None:
         """Release runtime resources; panes stay alive for reattach."""
+        interface_wake.bind(None)
+        self.wake_coordinator = None
         if self._reaper:
             self._reaper.cancel()
         for gen in list(self.generations.values()):

--- a/.super-coder/scripts/interface_runtime.py
+++ b/.super-coder/scripts/interface_runtime.py
@@ -60,6 +60,8 @@ LEASE_LIVENESS_TIMEOUT = 40.0         # dead-lease sweep bound (WS PING_TIMEOUT)
 TICKET_TTL_S = 60
 GRACEFUL_TERMINATE_S = 10.0
 SHADOW_REQUEST_TIMEOUT_S = 10.0   # a sidecar that can't answer is dead
+TMUX_SYNC_TIMEOUT_S = 10.0   # a wedged-but-alive tmux must never hang the
+                             # broker worker thread (SC-013)
 
 TMUX_SESSION = "sc-interface"
 
@@ -542,7 +544,8 @@ class InterfaceRuntime:
                 subprocess.run(
                     ["tmux", "-S", self.sock, "display-message", "-p",
                      "-t", gen.pane_id, "#{pane_id}"],
-                    capture_output=True, check=True)
+                    capture_output=True, check=True,
+                    timeout=TMUX_SYNC_TIMEOUT_S)
             except Exception as exc:
                 raise interface_broker.PreSendError(
                     f"wake preflight failed for {gen.pane_id}: "
@@ -555,15 +558,18 @@ class InterfaceRuntime:
         """Decision #15 probe: any READ-WRITE tmux client attached to our
         private server is unmanaged — the broker never attaches a client,
         and a read-only diagnostic client (spec Tmux Runtime) is tolerated.
-        tmux itself being unreachable is NOT reported here (the wake
-        writer's preflight owns that failure, as definite pre-send)."""
+        tmux itself being unreachable — or wedged and never answering — is
+        NOT reported here (the wake writer's preflight owns that failure, as
+        definite pre-send); the timeout keeps a wedged server from hanging
+        the drain thread (SC-013)."""
         if session_id not in self.generations:
             return False
         try:
             out = subprocess.run(
                 ["tmux", "-S", self.sock, "list-clients",
                  "-F", "#{client_readonly}"],
-                capture_output=True, check=True, text=True).stdout
+                capture_output=True, check=True, text=True,
+                timeout=TMUX_SYNC_TIMEOUT_S).stdout
         except Exception:  # noqa: BLE001
             return False
         return any(line.strip() == "0" for line in out.splitlines())
@@ -648,13 +654,17 @@ class InterfaceRuntime:
     def _send_keys_sync(self, pane_id: str, payload: bytes) -> None:
         """The injected broker writer: chunked send-keys -H, ≤512 bytes per
         invocation, called exactly once per accepted frame (as many tmux
-        calls as chunks). Runs in the broker worker thread."""
+        calls as chunks). Runs in the broker worker thread. Every call is
+        timeout-bounded: a wedged server raises (TimeoutExpired — ambiguous,
+        the caller parks delivery_unknown) instead of hanging the thread
+        (SC-013)."""
         for off in range(0, len(payload), SENDKEYS_CHUNK):
             chunk = payload[off:off + SENDKEYS_CHUNK]
             subprocess.run(
                 ["tmux", "-S", self.sock, "send-keys", "-t", pane_id, "-H",
                  *[f"{b:02x}" for b in chunk]],
-                capture_output=True, check=True)
+                capture_output=True, check=True,
+                timeout=TMUX_SYNC_TIMEOUT_S)
 
     async def send_keys(self, pane_id: str, payload: bytes) -> None:
         for off in range(0, len(payload), SENDKEYS_CHUNK):

--- a/.super-coder/scripts/interface_state.py
+++ b/.super-coder/scripts/interface_state.py
@@ -51,10 +51,13 @@ DELIVERY_EDGES = {
 }
 
 WAKE_ITEM_EDGES = {
-    "queued": {"batched", "quarantined", "cancelled"},
+    # queued -> done: a message handled (read) during another batch's turn
+    # completes without riding a batch of its own (spec #20 Wake Delivery:
+    # "new message handled in the turn: complete it").
+    "queued": {"batched", "done", "quarantined", "cancelled"},
     "batched": {"queued", "submitting", "cancelled"},
     "submitting": {"queued", "running", "cancelled"},
-    "running": {"done", "reconcile", "queued", "cancelled"},
+    "running": {"done", "reconcile", "queued", "quarantined", "cancelled"},
     "reconcile": {"queued", "done", "cancelled"},
     "quarantined": {"queued", "cancelled"},
     "done": set(),

--- a/.super-coder/scripts/interface_wake.py
+++ b/.super-coder/scripts/interface_wake.py
@@ -28,7 +28,6 @@ import threading
 import db_driver
 import interface_broker
 import interface_hooks
-import interface_state
 
 ELIGIBLE_KINDS = ("task", "result", "pr_event")
 RETRY_DELAYS_S = (1.0, 5.0, 30.0)  # bounded pre-send retries (spec table)
@@ -184,9 +183,14 @@ class WakeCoordinator:
     def _schedule_retry(self, binding_id: int, delay: float) -> None:
         """One re-attempt at the exact debounce deadline / retry delay.
         Event-reset semantics: a fresh event may drain first; the timer is
-        deduped per binding and the re-drain re-gates from live state."""
+        deduped per binding and the re-drain re-gates from live state.
+        call_later is loop-thread-only, so hop through call_soon_threadsafe
+        (the drain runs in a worker thread)."""
         if self.loop is None:
             return
+        self.loop.call_soon_threadsafe(self._arm_timer, binding_id, delay)
+
+    def _arm_timer(self, binding_id: int, delay: float) -> None:
         with self._lock:
             old = self._timers.pop(binding_id, None)
             if old is not None:

--- a/.super-coder/scripts/interface_wake.py
+++ b/.super-coder/scripts/interface_wake.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Transactional brokered planner wake — event ingress + the wake
+coordinator (spec #20 Event Ingress / Wake Delivery / Retry Policy,
+sprint 25 seq 8, task #84).
+
+Event ingress: maybe_create_wake_item() runs IN the message insert's own
+transaction (unique (binding_id, message_id) is the dedupe backstop) — the
+message and its wake work commit or roll back together, so no eligible
+sprint event is ever lost and none is ever woken twice. After commit the
+producer signals the coordinator.
+
+The coordinator is event-driven (spec: "performs no interval model scan"):
+message commits, harness hook callbacks, clean certifications, binding
+arms, and one startup pass are its only triggers. A gate that fails on the
+quiet debounce schedules ONE re-attempt at the exact debounce deadline
+(event-reset, never polling); a definite pre-send failure (PreSendError —
+the writer proved no byte moved) rides the bounded 1s/5s/30s retry
+schedule and then stops with an alert. Anything ambiguous parks
+delivery_unknown inside the broker and is NEVER auto-replayed here — this
+module has no resubmit path for parked batches (decision #22: only
+operator resolve_batch requeues parked work).
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import db_driver
+import interface_broker
+import interface_hooks
+import interface_state
+
+ELIGIBLE_KINDS = ("task", "result", "pr_event")
+RETRY_DELAYS_S = (1.0, 5.0, 30.0)  # bounded pre-send retries (spec table)
+
+
+# ── Event ingress (in-transaction wake-item creation) ────────────────────────
+
+def maybe_create_wake_item(con, message_id: int) -> "int | None":
+    """Create the wake item for one freshly inserted message iff it is
+    eligible (spec #20 Sprint Scope) — same transaction as the message, so
+    the pair is atomic. Returns the item_id, or None when ineligible.
+
+    Eligibility, exactly the spec's list: a typed sprint event (task /
+    result / pr_event — `shell` and legacy unscoped traffic NEVER wake),
+    carrying a sprint_doc_id whose document exists, is unfrozen, and
+    declares status ACTIVE; an ACTIVE (unreleased) binding for that sprint
+    names this message's recipient as planner; the binding's Interface
+    session and generation are still live (not ended/replaced); and the
+    harness supports the mandatory lifecycle hooks (a capability gap
+    refuses arming AND ingress — the wake would be unverifiable). Message
+    bodies are never parsed for sprint identity.
+    """
+    msg = con.execute(
+        "SELECT to_shell_id, kind, sprint_doc_id FROM shell_messages "
+        "WHERE message_id=?", (message_id,)).fetchone()
+    if msg is None or msg[1] not in ELIGIBLE_KINDS or msg[2] is None:
+        return None
+    to_shell_id, _, sprint_doc_id = msg
+    doc = con.execute(
+        "SELECT frozen FROM documents WHERE document_id=?",
+        (sprint_doc_id,)).fetchone()
+    if doc is None or doc[0] or not interface_broker._sprint_active(
+            con, sprint_doc_id):
+        return None
+    binding = con.execute(
+        "SELECT binding_id, session_id, shell_id, generation "
+        "FROM sprint_planner_bindings "
+        "WHERE sprint_doc_id=? AND planner_shell_id=? AND released_at IS NULL",
+        (sprint_doc_id, to_shell_id)).fetchone()
+    if binding is None:
+        return None
+    sess = con.execute(
+        "SELECT occupancy, generation, harness, cli_version "
+        "FROM interface_sessions WHERE session_id=?", (binding[1],)).fetchone()
+    if sess is None or sess[0] != "occupied" or sess[1] != binding[3]:
+        return None  # session ended or generation replaced — binding is stale
+    if not interface_hooks.capability(sess[2], sess[3])["mandatory_ok"]:
+        return None
+    cur = con.execute(
+        "INSERT OR IGNORE INTO planner_wake_items (binding_id, message_id) "
+        "VALUES (?, ?)", (binding[0], message_id))
+    return cur.lastrowid if cur.rowcount else None
+
+
+# ── The coordinator ───────────────────────────────────────────────────────────
+
+class WakeCoordinator:
+    """Event-driven drain of queued wake work through the API-owned input
+    path. One instance lives on the API server's asyncio loop; producers
+    (routes, the PR poller thread, hook callbacks) signal it thread-safely.
+
+    writer_factory(session_id) -> the broker-owned tmux writer for that
+    session's generation (raises interface_broker.PreSendError when its
+    preflight proves no byte moved); unmanaged_probe(session_id) -> True
+    when an unmanaged writable tmux client is attached (decision #15).
+    Both are injected so the coordinator — and every crash window — is
+    hermetically testable without tmux.
+    """
+
+    def __init__(self, db_path: str, *, writer_factory, unmanaged_probe,
+                 quiet_s: float = interface_broker.DEFAULT_QUIET_S):
+        self.db_path = str(db_path)
+        self.writer_factory = writer_factory
+        self.unmanaged_probe = unmanaged_probe
+        self.quiet_s = quiet_s
+        self.loop: "asyncio.AbstractEventLoop | None" = None
+        self._lock = threading.Lock()
+        self._scheduled: set[int] = set()       # binding_ids with a drain queued
+        self._timers: dict[int, asyncio.TimerHandle] = {}
+        self._pre_send_attempts: dict[int, int] = {}  # batch_id -> retries used
+
+    # -- signals (thread-safe; no-ops before start) -----------------------------
+
+    def start(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.loop = loop
+
+    def notify_binding(self, binding_id: int) -> None:
+        """Signal that a binding may have submittable work. Coalesced: one
+        queued drain per binding no matter how many events arrive."""
+        if self.loop is None:
+            return
+        with self._lock:
+            if binding_id in self._scheduled:
+                return
+            self._scheduled.add(binding_id)
+        self.loop.call_soon_threadsafe(
+            lambda: asyncio.ensure_future(self._drain(binding_id)))
+
+    def notify_message(self, message_id: int) -> None:
+        binding_id = self._binding_for(
+            "SELECT binding_id FROM planner_wake_items WHERE message_id=?",
+            (message_id,))
+        if binding_id is not None:
+            self.notify_binding(binding_id)
+
+    def notify_session(self, session_id: int) -> None:
+        binding_id = self._binding_for(
+            "SELECT binding_id FROM sprint_planner_bindings "
+            "WHERE session_id=? AND released_at IS NULL", (session_id,))
+        if binding_id is not None:
+            self.notify_binding(binding_id)
+
+    def _binding_for(self, sql: str, params) -> "int | None":
+        try:
+            con = db_driver.connect(self.db_path)
+            try:
+                row = con.execute(sql, params).fetchone()
+                return row[0] if row else None
+            finally:
+                con.close()
+        except Exception:  # noqa: BLE001 — a signal must never break its producer
+            return None
+
+    def startup_pass(self) -> None:
+        """The one startup reconciliation of wake work (spec Event Ingress):
+        every unreleased binding with queued items gets exactly one drain
+        signal. No steady timer is installed — events drive from here."""
+        try:
+            con = db_driver.connect(self.db_path)
+            try:
+                rows = con.execute(
+                    "SELECT DISTINCT i.binding_id FROM planner_wake_items i "
+                    "JOIN sprint_planner_bindings b "
+                    "ON b.binding_id=i.binding_id "
+                    "WHERE i.state='queued' AND b.released_at IS NULL"
+                ).fetchall()
+            finally:
+                con.close()
+        except Exception:  # noqa: BLE001
+            return
+        for (binding_id,) in rows:
+            self.notify_binding(binding_id)
+
+    # -- the drain ---------------------------------------------------------------
+
+    async def _drain(self, binding_id: int) -> None:
+        try:
+            await asyncio.to_thread(self._drain_sync, binding_id)
+        finally:
+            with self._lock:
+                self._scheduled.discard(binding_id)
+
+    def _schedule_retry(self, binding_id: int, delay: float) -> None:
+        """One re-attempt at the exact debounce deadline / retry delay.
+        Event-reset semantics: a fresh event may drain first; the timer is
+        deduped per binding and the re-drain re-gates from live state."""
+        if self.loop is None:
+            return
+        with self._lock:
+            old = self._timers.pop(binding_id, None)
+            if old is not None:
+                old.cancel()
+            self._scheduled.add(binding_id)
+            self._timers[binding_id] = self.loop.call_later(
+                delay,
+                lambda: asyncio.ensure_future(self._drain(binding_id)))
+
+    def _drain_sync(self, binding_id: int) -> None:
+        con = db_driver.connect(self.db_path)
+        try:
+            binding = con.execute(
+                "SELECT session_id, shell_id, generation, released_at "
+                "FROM sprint_planner_bindings WHERE binding_id=?",
+                (binding_id,)).fetchone()
+            if binding is None or binding[3] is not None:
+                return
+            session_id = binding[0]
+            live = con.execute(
+                "SELECT batch_id, state FROM planner_wake_batches "
+                "WHERE binding_id=? AND state IN ('queued','submitting',"
+                "'running')", (binding_id,)).fetchone()
+            if live is not None and live[1] in ("submitting", "running"):
+                return  # the hook evidence drives it from here
+            if live is None:
+                queued = con.execute(
+                    "SELECT 1 FROM planner_wake_items WHERE binding_id=? "
+                    "AND state='queued' AND batch_id IS NULL LIMIT 1",
+                    (binding_id,)).fetchone()
+                if queued is None:
+                    return
+                batch_id = interface_broker.form_batch(con, binding_id)
+                con.commit()
+            else:
+                batch_id = live[0]
+
+            now_iso = con.execute("SELECT datetime('now')").fetchone()[0]
+            try:
+                out = interface_broker.submit_wake_batch(
+                    con, batch_id, self.writer_factory(session_id), now_iso,
+                    quiet_s=self.quiet_s,
+                    unmanaged_writable=lambda: self.unmanaged_probe(session_id))
+            except interface_broker.PreSendError:
+                self._pre_send_failed(con, binding_id, batch_id)
+                return
+            if out.get("submitted"):
+                self._pre_send_attempts.pop(batch_id, None)
+            elif out.get("retry_after") is not None:
+                self._schedule_retry(binding_id, out["retry_after"])
+            # any other gate failure (busy/dirty/pending/disarmed/cancelled)
+            # awaits the next event — no timer, no poll.
+        finally:
+            con.close()
+
+    def _pre_send_failed(self, con, binding_id: int, batch_id: int) -> None:
+        """Bounded pre-send retries (spec Retry Policy): one definite
+        pre-send failure retries at 1s, 5s, 30s and then STOPS — the batch
+        stays queued (no byte ever moved) and an alert names the stall."""
+        attempts = self._pre_send_attempts.get(batch_id, 0) + 1
+        self._pre_send_attempts[batch_id] = attempts
+        if attempts <= len(RETRY_DELAYS_S):
+            self._schedule_retry(binding_id, RETRY_DELAYS_S[attempts - 1])
+            return
+        self._pre_send_attempts.pop(batch_id, None)
+        interface_broker._alert(
+            con, severity="critical", reason="wake_presend_retries_exhausted",
+            binding_id=binding_id)
+        con.commit()
+
+
+# ── Module handle: producers signal without knowing the runtime ──────────────
+# Routes (any thread), the PR poller thread, and server startup all signal
+# through these; with no coordinator bound (Interface stack down, CLI
+# contexts, hermetic route tests) they are deliberate no-ops — the work is
+# durable and the next startup_pass/coordinator bind drains it.
+
+_COORDINATOR: "WakeCoordinator | None" = None
+
+
+def bind(coordinator: "WakeCoordinator | None") -> None:
+    global _COORDINATOR
+    _COORDINATOR = coordinator
+
+
+def notify_message(message_id: int) -> None:
+    if _COORDINATOR is not None:
+        _COORDINATOR.notify_message(message_id)
+
+
+def notify_session(session_id: int) -> None:
+    if _COORDINATOR is not None:
+        _COORDINATOR.notify_session(session_id)
+
+
+def notify_binding(binding_id: int) -> None:
+    if _COORDINATOR is not None:
+        _COORDINATOR.notify_binding(binding_id)

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -50,7 +50,7 @@ Run from the repo root, like every engine command:
     ./sc mem doc freeze <document_id>
     ./sc mem narrative "<line>"
     ./sc mem message check [N]                         # your unread inbox (read-only)
-    ./sc mem message send <to-shortname> "<body>" [--kind shell|task|result]
+    ./sc mem message send <to-shortname> "<body>" [--kind shell|task|result] [--sprint DOC_ID]
     ./sc mem message sent                              # outbound view — verify delivery
     ./sc mem message mark-read <message_id>            # (pr_event rows are daemon-emitted)
 
@@ -629,6 +629,7 @@ def cmd_message(args) -> int:
         # timeout — the failure mode that used to duplicate messages fleet-wide.
         r = _api("POST", "/_sc/mem/messages",
                  {"to": args.to, "body": args.body, "kind": args.kind,
+                  "sprint_doc_id": args.sprint,
                   "dedupe_key": uuid.uuid4().hex},
                  idempotent=True)
         tag = f" ({args.kind})" if args.kind != "shell" else ""
@@ -809,6 +810,9 @@ def build_parser() -> argparse.ArgumentParser:
     # forging PR transitions would poison the wake loop's ground truth.
     ms.add_argument("--kind", default="shell", choices=["shell", "task", "result"],
                     help="message kind: shell (default) | task (planner→worker) | result (worker→planner)")
+    ms.add_argument("--sprint", type=int, default=None, metavar="DOC_ID",
+                    help="scope a task/result event to an ACTIVE sprint doc — "
+                         "wake-eligible when the recipient is the bound planner")
     mm = msub.add_parser("mark-read")
     mm.add_argument("message_id", type=int)
     sp.set_defaults(fn=cmd_message)

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -399,6 +399,7 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
             for e in events:
                 if _emit_event(con, w, e, cur.get("sha") or ""):
                     summary["events"] += 1
+                    emitted.append((w["sprint_doc_id"], e, cur.get("sha") or ""))
             con.execute(
                 "UPDATE watched_prs SET last_seen=?" +
                 (", closed_at=datetime('now')" if terminal else "") +

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -296,12 +296,13 @@ def _alert(con, *, severity: str, reason: str, watch_id=None) -> None:
         (watch_id, severity, reason, dedupe))
 
 
-def _emit_event(con, watch, event: dict, head_sha: str) -> bool:
+def _emit_event(con, watch, event: dict, head_sha: str) -> "int | None":
     """One semantic transition → idempotent pr_event + same-transaction wake
     item. Dedupe keyed (watch, transition, head SHA, state) via the message's
     dedupe_key partial unique index: a repeated key is a no-op, so a replayed
-    poll or a baseline race can never double-wake the planner. Returns True
-    when the event was newly emitted."""
+    poll or a baseline race can never double-wake the planner. Returns the
+    new message_id when the event was emitted (None on dedupe) so the caller
+    can signal the wake coordinator after commit."""
     dedupe_key = f"pr-event|{watch['watch_id']}|{event['key']}|{head_sha}"
     try:
         cur = con.execute(
@@ -311,7 +312,7 @@ def _emit_event(con, watch, event: dict, head_sha: str) -> bool:
             (watch["shell_id"], watch["shell_id"], event["body"],
              watch["sprint_doc_id"], dedupe_key))
     except sqlite3.IntegrityError:
-        return False  # the dedupe index — already emitted
+        return None  # the dedupe index — already emitted
     message_id = cur.lastrowid
     binding = con.execute(
         "SELECT binding_id FROM sprint_planner_bindings "
@@ -321,7 +322,7 @@ def _emit_event(con, watch, event: dict, head_sha: str) -> bool:
         con.execute(
             "INSERT OR IGNORE INTO planner_wake_items (binding_id, message_id) "
             "VALUES (?, ?)", (binding[0], message_id))
-    return True
+    return message_id
 
 
 def poll_cycle(con, fetch=None, source: str = "scheduler",
@@ -336,6 +337,7 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
     now = now if now is not None else time.monotonic()
     summary = {"watches": 0, "repos": 0, "skipped_backoff": 0,
                "events": 0, "errors": 0, "retired": 0}
+    emitted_ids: list[int] = []
     watches = armed_watches(con)
     summary["watches"] = len(watches)
     if not watches:
@@ -397,9 +399,10 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
                     (w["watch_id"], run_id, cur.get("sha"), json.dumps(cur),
                      ",".join(e["key"] for e in events) or None, blind))
             for e in events:
-                if _emit_event(con, w, e, cur.get("sha") or ""):
+                mid = _emit_event(con, w, e, cur.get("sha") or "")
+                if mid is not None:
                     summary["events"] += 1
-                    emitted.append((w["sprint_doc_id"], e, cur.get("sha") or ""))
+                    emitted_ids.append(mid)
             con.execute(
                 "UPDATE watched_prs SET last_seen=?" +
                 (", closed_at=datetime('now')" if terminal else "") +
@@ -408,6 +411,11 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
             if terminal:
                 summary["retired"] += 1
         con.commit()
+    # Events are durable — signal the wake coordinator (thread-safe; a no-op
+    # when the Interface stack is down, durable work drains at next startup).
+    import interface_wake
+    for mid in emitted_ids:
+        interface_wake.notify_message(mid)
     return summary
 
 

--- a/.super-coder/scripts/sprint.py
+++ b/.super-coder/scripts/sprint.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""sc sprint — planner-side sprint workflow client (spec #20 Event Ingress,
+sprint 25 seq 8, task #84).
+
+    ./sc sprint action begin     --message <id> --operation <op> --target <t>
+    ./sc sprint action complete  <receipt_id> [--detail "…"]
+    ./sc sprint action unknown   <receipt_id> [--detail "…"]
+    ./sc sprint action reconcile <receipt_id> [--detail "…"]
+
+Before a planner performs an engine-owned or external side effect for a
+message it records action INTENT (begin) under a key derived from
+message + operation + target; a completed existing receipt suppresses the
+duplicate. After the side effect it records the observed result
+(complete), parks it (unknown — the wake item reconciles instead of
+requeuing blind), and an operator later resolves the park (reconcile).
+Only then is the message marked read. Informational messages need no
+receipt. The CLI is a pure API client (shell token); it never touches the
+DB directly.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.request
+
+SC_API_BASE = os.environ.get("SC_API_BASE", "http://127.0.0.1:8800")
+SC_API_TOKEN = os.environ.get("SC_API_TOKEN", "")
+_TIMEOUT = 10
+
+
+def _die(msg: str) -> "SystemExit":
+    return SystemExit(f"sc sprint: {msg}")
+
+
+def _api(method: str, path: str, payload: dict, idem_key: str) -> dict:
+    if not SC_API_TOKEN:
+        raise _die("SC_API_TOKEN unset — this shell has no API credential")
+    req = urllib.request.Request(
+        SC_API_BASE.rstrip("/") + path,
+        data=json.dumps(payload).encode(), method=method,
+        headers={"Authorization": f"Bearer {SC_API_TOKEN}",
+                 "Content-Type": "application/json",
+                 "Idempotency-Key": idem_key})
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        try:
+            err = json.loads(e.read()).get("error", {})
+            msg = err.get("message", e.reason) if isinstance(err, dict) \
+                else str(err)
+        except Exception:  # noqa: BLE001
+            msg = e.reason
+        raise _die(f"{method} {path} → HTTP {e.code}: {msg}")
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise _die(f"API unreachable ({getattr(e, 'reason', e)}) — "
+                   "the engine server must be up; the write may NOT have "
+                   "landed. Check `sc sprint action begin` again with the "
+                   "same key before acting — a completed receipt suppresses "
+                   "the duplicate.")
+
+
+def cmd_begin(args) -> int:
+    idem_key = f"action|{args.message or '-'}|{args.operation}|{args.target}"
+    r = _api("POST", "/api/planner-action-receipts",
+             {"message_id": args.message, "operation": args.operation,
+              "target": args.target}, idem_key)
+    if r.get("duplicate"):
+        state = r.get("state")
+        note = ("SUPPRESSED — a completed receipt already covers this "
+                "action; do NOT perform it again" if r.get("suppressed")
+                else f"existing receipt in state {state}")
+        print(f"sc sprint: receipt #{r['receipt_id']} ({state}) — {note}")
+        return 0 if r.get("suppressed") else 1
+    print(f"sc sprint: receipt #{r['receipt_id']} intent recorded "
+          f"({r['idem_key']}) — perform the action, then record the result")
+    return 0
+
+
+def _cmd_update(args, state: str) -> int:
+    r = _api("PATCH", f"/api/planner-action-receipts/{args.receipt_id}",
+             {"state": state, "result_detail": args.detail},
+             f"action-update|{args.receipt_id}|{state}")
+    print(f"sc sprint: receipt #{r['receipt_id']} → {r['state']}")
+    return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    p = argparse.ArgumentParser(prog="sc sprint",
+                                description=__doc__.splitlines()[0])
+    sub = p.add_subparsers(dest="cmd", required=True)
+    act = sub.add_parser("action", help="idempotent planner action receipts")
+    asub = act.add_subparsers(dest="action_cmd", required=True)
+    b = asub.add_parser("begin", help="record action intent before a side effect")
+    b.add_argument("--message", type=int, default=None,
+                   help="the sprint message this action answers")
+    b.add_argument("--operation", required=True)
+    b.add_argument("--target", required=True)
+    for name, state in (("complete", "complete"), ("unknown", "unknown"),
+                        ("reconcile", "reconciled")):
+        sp = asub.add_parser(name, help=f"record the action as {state}")
+        sp.add_argument("receipt_id", type=int)
+        sp.add_argument("--detail", default=None)
+        sp.set_defaults(_state=state)
+    args = p.parse_args(argv)
+    if args.action_cmd == "begin":
+        return cmd_begin(args)
+    return _cmd_update(args, args._state)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sc
+++ b/sc
@@ -865,6 +865,7 @@ case "$cmd" in
   migrate)      exec "$PY" "$S/migrate.py" "$DB" ;;
   snapshot)     exec "$PY" "$S/snapshot.py" ;;
   mem)          exec "$PY" "$S/mem.py" "$@" ;;
+  sprint)       exec "$PY" "$S/sprint.py" "$@" ;;
   # ── sprint eventing: PR watches + inbox watcher (shell-side, API) and the
   # GitHub watcher daemon (HOST-side foreground; -up/-down supervise it) ──
   watch)             exec "$PY" "$S/watch.py" "$@" ;;
@@ -1139,6 +1140,8 @@ super-coder — forkable shell substrate
   ./sc snapshot            dump per-instance tables -> .sc-state/content.sql
   ./sc mem <cmd> [args]    a shell's own memory, over the engine API (get/state/seed/lns/decision/flag/roadmap/doc/narrative);
                              identity is the shell's token, server-resolved — no DB path, no direct-DB fallback. `./sc mem which` to orient
+  ./sc sprint action <cmd>  planner action receipts over the API: begin (--message/--operation/--target) records
+                             intent before a side effect; complete|unknown|reconcile <receipt_id> records the result
   ./sc watch pr <o/r> <n>  register a PR watch (--shell <name> subscribes another shell, e.g. the planner;
                              --sprint <doc-id> arms it to an ACTIVE sprint); an immediate GitHub baseline
                              is taken at registration, then the engine service poller turns transitions

--- a/tests/test_interface_crash_window.py
+++ b/tests/test_interface_crash_window.py
@@ -93,7 +93,8 @@ class CrashWindowTest(unittest.TestCase):
             "VALUES (1,1)")
         self.sid = self.con.execute(
             "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
-            " lifecycle) VALUES (1,1,'occupied','idle')").lastrowid
+            " lifecycle, harness, cli_version) VALUES (1,1,'occupied','idle',"
+            "'kimi','kimi-code 0.27.0')").lastrowid
         self.con.execute(
             "INSERT INTO interface_input_state (session_id, shell_id,"
             " generation, composer) VALUES (?,1,1,'clean')", (self.sid,))

--- a/tests/test_interface_runtime.py
+++ b/tests/test_interface_runtime.py
@@ -100,6 +100,66 @@ async def wait_for(pred, timeout=10.0, what="condition"):
     raise AssertionError(f"timed out waiting for {what}")
 
 
+class WedgedTmuxTimeoutTest(unittest.TestCase):
+    """SC-013 (sprint 25 seq 8): every wake-path SYNC tmux call — the
+    unmanaged-client probe, the writer preflight, _send_keys_sync — is
+    timeout-bounded. A wedged-but-alive tmux (socket accepts, never
+    answers) must raise / fail closed fast, never hang the broker drain
+    thread (a hang strands the batch and, worse, used to stall it while
+    the gate held the SQLite write lock). Hermetic: a stub `tmux` that
+    sleeps forever, first on PATH, with the timeout constant patched
+    down for speed."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        bindir = self.tmp / "bin"
+        bindir.mkdir()
+        stub = bindir / "tmux"
+        stub.write_text("#!/bin/sh\nexec sleep 3600\n")
+        stub.chmod(0o755)
+        self.rt = interface_runtime.InterfaceRuntime(
+            str(self.db), run_dir=str(self.tmp / "run"))
+        self.rt.sock = str(self.tmp / "tmux.sock")
+        gen = mock.Mock()
+        gen.terminated = False
+        gen.pane_id = "%1"
+        self.rt.generations = {1: gen}
+        self._env = mock.patch.dict(
+            os.environ,
+            {"PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}"})
+        self._env.start()
+        self._tmo = mock.patch.object(
+            interface_runtime, "TMUX_SYNC_TIMEOUT_S", 0.5)
+        self._tmo.start()
+
+    def tearDown(self):
+        self._tmo.stop()
+        self._env.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_probe_timeout_fails_closed_never_hangs(self):
+        start = time.monotonic()
+        # Unreachable/wedged tmux is NOT 'unmanaged' — the writer preflight
+        # owns that failure as definite pre-send (decision #32) — but the
+        # call must RETURN, not hang.
+        self.assertFalse(self.rt.unmanaged_writable_client(1))
+        self.assertLess(time.monotonic() - start, 5)
+
+    def test_wake_preflight_timeout_is_definite_pre_send(self):
+        writer = self.rt.wake_writer(1)
+        with self.assertRaises(interface_broker.PreSendError):
+            writer(len(interface_broker.WAKE_PROMPT) + 1)
+
+    def test_send_keys_timeout_raises_never_hangs(self):
+        # send-keys hangs AFTER bytes may have moved: TimeoutExpired must
+        # propagate (ambiguous → the broker parks delivery_unknown + alerts),
+        # never hang the worker thread.
+        with self.assertRaises(subprocess.TimeoutExpired):
+            self.rt._send_keys_sync("%1", b"x")
+
+
 # ------------------------------------------------------------------ unit (no tmux)
 
 class AvailabilityTest(unittest.TestCase):

--- a/tests/test_interface_wake.py
+++ b/tests/test_interface_wake.py
@@ -1,0 +1,1046 @@
+#!/usr/bin/env python3
+"""Transactional brokered planner wake — hermetic proofs (spec #20, sprint
+25 seq 8, task #84).
+
+Covers, without tmux or a live harness:
+
+- Event ingress: maybe_create_wake_item eligibility (Sprint Scope) — typed
+  sprint events only, ACTIVE unfrozen sprint, live binding/generation,
+  mandatory hooks; atomic unique (binding, message) dedupe.
+- Flag #49 (decisions #28/#31): the quiet baseline keys off REAL provider
+  readiness (provider session_start stamp), never the pre-exec
+  occupied_at — a >3s boot can no longer submit into an unpainted TUI.
+- Gate hardening: mandatory-hook capability, unmanaged-writable probe
+  (decision #15 disarm), PreSendError (definite pre-send failure → queued,
+  never parked) vs ambiguous failure (parked, never auto-retried).
+- Stop-hook reconciliation: ambiguity parking (action receipts),
+  quarantine after three completed wakes, read-during-turn completion.
+- The coordinator: event-driven drain, quiet-deadline reschedule,
+  bounded 1s/5s/30s pre-send retries, and the proof that NO wake path
+  bypasses delivery_unknown parking (decision #22).
+- Flag #50: the emitter's flock is held through the POST — commit order
+  can never invert allocation order.
+
+Run:
+    python3 tests/test_interface_wake.py
+"""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import interface_broker  # noqa: E402
+import interface_hook  # noqa: E402
+import interface_wake  # noqa: E402
+
+QUIET = 0.2  # tight debounce for fast hermetic drains
+
+
+def build_engine_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1,'T',1)")
+    for sid in (1, 2):
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+            "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+            "VALUES (?,?,?,'test','sp',1,0,1,1)", (sid, f"S{sid}", f"s{sid}"))
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title, body) "
+        "VALUES (1,'doc','SPRINT: test','# SPRINT: test\nstatus: ACTIVE')")
+    con.commit()
+    con.close()
+
+
+def _age(con, table, col, row_id, seconds, pk):
+    """Backdate a timestamp column so quiet-debounce arithmetic is exact."""
+    con.execute(
+        f"UPDATE {table} SET {col}=datetime('now', ?) WHERE {pk}=?",
+        (f"-{seconds} seconds", row_id))
+
+
+class WakeFixture(unittest.TestCase):
+    """An armed sprint: occupied+idle+clean planner session (kimi, full
+    hooks), an ACTIVE sprint doc, an unreleased binding."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db)
+        self.con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,1)")
+        self.sid = self.con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle, harness, cli_version) VALUES (1,1,'occupied','idle',"
+            "'kimi','kimi-code 0.27.0')").lastrowid
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,1,1,'clean')", (self.sid,))
+        self.binding = self.con.execute(
+            "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (1,1,?,1,1)", (self.sid,)).lastrowid
+        # Age the session so the quiet debounce is already satisfied unless
+        # a test freshens a baseline.
+        _age(self.con, "interface_sessions", "occupied_at", self.sid, 60,
+             "session_id")
+        _age(self.con, "interface_sessions", "created_at", self.sid, 60,
+             "session_id")
+        self.con.commit()
+
+    def tearDown(self):
+        self.con.close()
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def add_message(self, kind="task", sprint_doc_id=1, to_shell_id=1,
+                    read=False):
+        cur = self.con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+            " kind, sprint_doc_id) VALUES (2,?,?,?,?)",
+            (to_shell_id, f"wake me ({kind})", kind, sprint_doc_id))
+        if read:
+            self.con.execute(
+                "UPDATE shell_messages SET read_at=datetime('now') "
+                "WHERE message_id=?", (cur.lastrowid,))
+        self.con.commit()
+        return cur.lastrowid
+
+    def batch_state(self, batch_id):
+        return self.con.execute(
+            "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+            (batch_id,)).fetchone()[0]
+
+    def item_states(self):
+        return self.con.execute(
+            "SELECT item_id, message_id, state, completed_wakes, batch_id "
+            "FROM planner_wake_items ORDER BY item_id").fetchall()
+
+    def form(self):
+        bid = interface_broker.form_batch(self.con, self.binding)
+        self.con.commit()
+        return bid
+
+    def submit(self, batch_id, writer, quiet_s=QUIET, probe=None):
+        return interface_broker.submit_wake_batch(
+            self.con, batch_id, writer,
+            self.con.execute("SELECT datetime('now')").fetchone()[0],
+            quiet_s=quiet_s, unmanaged_writable=probe)
+
+
+# ── Event ingress (spec Sprint Scope) ────────────────────────────────────────
+
+class WakeIngressTest(WakeFixture):
+
+    def test_eligible_task_message_creates_item(self):
+        mid = self.add_message("task")
+        item = interface_wake.maybe_create_wake_item(self.con, mid)
+        self.con.commit()
+        self.assertIsNotNone(item)
+        rows = self.item_states()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][2], "queued")
+        self.assertEqual(rows[0][1], mid)
+
+    def test_result_and_pr_event_are_eligible(self):
+        for kind in ("result", "pr_event"):
+            mid = self.add_message(kind)
+            self.assertIsNotNone(
+                interface_wake.maybe_create_wake_item(self.con, mid))
+
+    def test_shell_kind_never_wakes(self):
+        mid = self.add_message("shell")
+        self.assertIsNone(interface_wake.maybe_create_wake_item(self.con, mid))
+        self.assertEqual(self.item_states(), [])
+
+    def test_unscoped_message_never_wakes(self):
+        mid = self.add_message("task", sprint_doc_id=None)
+        self.assertIsNone(interface_wake.maybe_create_wake_item(self.con, mid))
+
+    def test_wrong_recipient_never_wakes(self):
+        mid = self.add_message("task", to_shell_id=2)  # not the planner
+        self.assertIsNone(interface_wake.maybe_create_wake_item(self.con, mid))
+
+    def test_closed_sprint_never_wakes(self):
+        self.con.execute(
+            "UPDATE documents SET body='# SPRINT: test\nstatus: CLOSED' "
+            "WHERE document_id=1")
+        mid = self.add_message("task")
+        self.assertIsNone(interface_wake.maybe_create_wake_item(self.con, mid))
+
+    def test_frozen_sprint_never_wakes(self):
+        self.con.execute("UPDATE documents SET frozen=1 WHERE document_id=1")
+        mid = self.add_message("task")
+        self.assertIsNone(interface_wake.maybe_create_wake_item(self.con, mid))
+
+    def test_released_binding_never_wakes(self):
+        self.con.execute(
+            "UPDATE sprint_planner_bindings SET released_at=datetime('now') "
+            "WHERE binding_id=?", (self.binding,))
+        mid = self.add_message("task")
+        self.assertIsNone(interface_wake.maybe_create_wake_item(self.con, mid))
+
+    def test_replaced_generation_never_wakes(self):
+        self.con.execute(
+            "UPDATE interface_sessions SET generation=2 WHERE session_id=?",
+            (self.sid,))
+        mid = self.add_message("task")
+        self.assertIsNone(interface_wake.maybe_create_wake_item(self.con, mid))
+
+    def test_mandatory_hook_gap_never_wakes(self):
+        self.con.execute(
+            "UPDATE interface_sessions SET harness='codex', "
+            "cli_version='codex-cli 0.100.0' WHERE session_id=?", (self.sid,))
+        mid = self.add_message("task")
+        self.assertIsNone(interface_wake.maybe_create_wake_item(self.con, mid))
+
+    def test_duplicate_send_creates_one_item(self):
+        mid = self.add_message("task")
+        first = interface_wake.maybe_create_wake_item(self.con, mid)
+        second = interface_wake.maybe_create_wake_item(self.con, mid)
+        self.con.commit()
+        self.assertIsNotNone(first)
+        self.assertIsNone(second, "unique (binding, message) dedupes")
+        self.assertEqual(len(self.item_states()), 1)
+
+
+# ── Flag #49: quiet baseline keys off REAL provider readiness ─────────────────
+
+class WakeReadinessTest(WakeFixture):
+
+    def test_provider_session_start_stamps_readiness(self):
+        interface_broker.record_hook(self.con, 1, 1, 2, "session_start",
+                                     source="provider")
+        self.con.commit()
+        ready = self.con.execute(
+            "SELECT provider_ready_at FROM interface_sessions "
+            "WHERE session_id=?", (self.sid,)).fetchone()[0]
+        self.assertIsNotNone(ready)
+
+    def test_entrypoint_session_start_is_NOT_readiness(self):
+        interface_broker.record_hook(self.con, 1, 1, 1, "session_start",
+                                     source="entrypoint")
+        self.con.commit()
+        ready = self.con.execute(
+            "SELECT provider_ready_at FROM interface_sessions "
+            "WHERE session_id=?", (self.sid,)).fetchone()[0]
+        self.assertIsNone(ready, "the pre-exec identity claim is never "
+                                 "readiness — that was flag #49's defect")
+
+    def test_slow_boot_blocks_submit_despite_old_occupied_at(self):
+        """The #49 defect: occupied_at aged >3s during a slow claude/codex
+        boot let a wake submit into an unpainted TUI. With provider
+        readiness 1s old, the gate must still owe the debounce."""
+        mid = self.add_message("task")
+        interface_wake.maybe_create_wake_item(self.con, mid)
+        self.con.commit()
+        batch_id = self.form()
+        # Provider proved readiness only 1s ago; occupied_at is 60s old.
+        self.con.execute(
+            "UPDATE interface_sessions SET provider_ready_at="
+            "datetime('now', '-1 seconds') WHERE session_id=?", (self.sid,))
+        self.con.commit()
+        out = self.submit(batch_id, lambda n: None, quiet_s=3.0)
+        self.assertFalse(out["submitted"])
+        self.assertIn("quiet", out["reason"])
+        self.assertAlmostEqual(out["retry_after"], 2.0, delta=0.5)
+        self.assertEqual(self.batch_state(batch_id), "queued")
+
+    def test_readiness_older_than_debounce_passes(self):
+        mid = self.add_message("task")
+        interface_wake.maybe_create_wake_item(self.con, mid)
+        self.con.commit()
+        batch_id = self.form()
+        self.con.execute(
+            "UPDATE interface_sessions SET provider_ready_at="
+            "datetime('now', '-30 seconds') WHERE session_id=?", (self.sid,))
+        self.con.commit()
+        writes = []
+        out = self.submit(batch_id, writes.append)
+        self.assertTrue(out["submitted"], out)
+        self.assertEqual(writes, [len(interface_broker.WAKE_PROMPT) + 1])
+
+    def test_human_input_after_readiness_resets_the_baseline(self):
+        """max() semantics: the most recent activity owns the debounce."""
+        mid = self.add_message("task")
+        interface_wake.maybe_create_wake_item(self.con, mid)
+        self.con.commit()
+        batch_id = self.form()
+        self.con.execute(
+            "UPDATE interface_sessions SET provider_ready_at="
+            "datetime('now', '-30 seconds') WHERE session_id=?", (self.sid,))
+        self.con.execute(
+            "UPDATE interface_input_state SET last_human_input_at="
+            "datetime('now', '-1 seconds') WHERE session_id=?", (self.sid,))
+        self.con.commit()
+        out = self.submit(batch_id, lambda n: None, quiet_s=3.0)
+        self.assertFalse(out["submitted"])
+        self.assertIn("quiet", out["reason"])
+
+
+# ── Gate hardening: hooks capability, unmanaged probe, PreSendError ───────────
+
+class WakeGateHardeningTest(WakeFixture):
+
+    def _armed_batch(self):
+        mid = self.add_message("task")
+        interface_wake.maybe_create_wake_item(self.con, mid)
+        self.con.commit()
+        return self.form()
+
+    def test_mandatory_hook_gap_blocks_submit(self):
+        self.con.execute(
+            "UPDATE interface_sessions SET harness='codex', "
+            "cli_version='codex-cli 0.100.0' WHERE session_id=?", (self.sid,))
+        self.con.commit()
+        batch_id = self._armed_batch()
+        writes = []
+        out = self.submit(batch_id, writes.append)
+        self.assertFalse(out["submitted"])
+        self.assertIn("mandatory", out["reason"])
+        self.assertEqual(writes, [])
+        self.assertEqual(self.batch_state(batch_id), "queued")
+
+    def test_unmanaged_writable_client_disarms_and_alerts(self):
+        batch_id = self._armed_batch()
+        writes = []
+        out = self.submit(batch_id, writes.append,
+                          probe=lambda: True)
+        self.assertFalse(out["submitted"])
+        self.assertTrue(out["disarmed"])
+        self.assertEqual(writes, [], "no byte may move")
+        row = self.con.execute(
+            "SELECT composer FROM interface_input_state WHERE session_id=?",
+            (self.sid,)).fetchone()
+        self.assertEqual(row[0], "unknown",
+                         "decision #15: detection sets composer unknown")
+        alert = self.con.execute(
+            "SELECT severity FROM planner_alerts "
+            "WHERE reason='unmanaged_writable_client' AND resolved_at IS NULL"
+        ).fetchone()
+        self.assertIsNotNone(alert)
+        self.assertEqual(self.batch_state(batch_id), "queued")
+
+    def test_pre_send_failure_requeues_without_parking(self):
+        batch_id = self._armed_batch()
+
+        def presend(n):
+            raise interface_broker.PreSendError("preflight proved no byte")
+
+        with self.assertRaises(interface_broker.PreSendError):
+            self.submit(batch_id, presend)
+        self.assertEqual(self.batch_state(batch_id), "queued",
+                         "a DEFINITE pre-send failure never parks")
+        items = self.item_states()
+        self.assertEqual(items[0][2], "queued")
+        self.assertIsNone(self.con.execute(
+            "SELECT 1 FROM planner_alerts WHERE reason="
+            "'wake_batch_delivery_unknown'").fetchone())
+        # The retry: same batch, a healthy writer, submits normally.
+        writes = []
+        out = self.submit(batch_id, writes.append)
+        self.assertTrue(out["submitted"], out)
+        self.assertEqual(writes, [len(interface_broker.WAKE_PROMPT) + 1])
+        self.assertEqual(self.batch_state(batch_id), "submitting")
+
+    def test_ambiguous_failure_parks_and_never_auto_retries(self):
+        batch_id = self._armed_batch()
+
+        def crash(n):
+            raise RuntimeError("tmux died mid-write")
+
+        with self.assertRaises(RuntimeError):
+            self.submit(batch_id, crash)
+        self.assertEqual(self.batch_state(batch_id), "delivery_unknown")
+        # No broker/coordinator path resubmits it: a second submit attempt
+        # refuses because the batch is not queued.
+        with self.assertRaises(interface_broker.BrokerError):
+            self.submit(batch_id, lambda n: None)
+
+
+# ── Stop-hook reconciliation: ambiguity, quarantine, read-during-turn ─────────
+
+class BatchReconcileTest(WakeFixture):
+
+    def setUp(self):
+        super().setUp()
+        self._hseq = 1  # durable hook sequences are monotonic per generation
+
+    def hook(self, event):
+        self._hseq += 1
+        result = interface_broker.record_hook(
+            self.con, 1, 1, self._hseq, event)
+        self.con.commit()
+        return result
+
+    def _running_batch(self, mids):
+        for m in mids:
+            interface_wake.maybe_create_wake_item(self.con, m)
+        self.con.commit()
+        batch_id = self.form()
+        out = self.submit(batch_id, lambda n: None)
+        assert out["submitted"], out
+        self.hook("prompt_submit")
+        return batch_id
+
+    def test_unread_with_ambiguous_action_parks_reconcile(self):
+        mid = self.add_message("task")
+        batch_id = self._running_batch([mid])
+        self.con.execute(
+            "INSERT INTO planner_action_receipts (message_id, operation,"
+            " target, idem_key) VALUES (?,'edit','file.py','k1')", (mid,))
+        self.con.commit()
+        self.hook("turn_stop")
+        self.assertEqual(self.batch_state(batch_id), "complete")
+        item = self.item_states()[0]
+        self.assertEqual(item[2], "reconcile",
+                         "unread + durable ambiguous action must park, "
+                         "never requeue blind")
+        self.assertIsNotNone(self.con.execute(
+            "SELECT 1 FROM planner_alerts WHERE reason='wake_item_reconcile'"
+        ).fetchone())
+
+    def test_receipt_unknown_state_also_parks(self):
+        mid = self.add_message("task")
+        self._running_batch([mid])
+        self.con.execute(
+            "INSERT INTO planner_action_receipts (message_id, operation,"
+            " target, idem_key, state) VALUES (?,'merge','#1','k2','unknown')",
+            (mid,))
+        self.con.commit()
+        self.hook("turn_stop")
+        self.assertEqual(self.item_states()[0][2], "reconcile")
+
+    def test_three_completed_wakes_quarantine(self):
+        mid = self.add_message("task")
+        for _ in range(3):
+            self._running_batch([mid])
+            self.hook("turn_stop")
+        item = self.item_states()[0]
+        self.assertEqual(item[2], "quarantined")
+        self.assertEqual(item[3], 3)
+        self.assertIsNotNone(self.con.execute(
+            "SELECT 1 FROM planner_alerts WHERE reason='wake_item_quarantined'"
+        ).fetchone())
+
+    def test_quarantine_does_not_block_newer_work(self):
+        poison = self.add_message("task")
+        for _ in range(3):
+            self._running_batch([poison])
+            self.hook("turn_stop")
+        fresh = self.add_message("task")
+        self._running_batch([fresh])
+        self.con.execute(
+            "UPDATE shell_messages SET read_at=datetime('now') "
+            "WHERE message_id=?", (fresh,))
+        self.hook("turn_stop")
+        states = {r[1]: r[2] for r in self.item_states()}
+        self.assertEqual(states[poison], "quarantined")
+        self.assertEqual(states[fresh], "done")
+
+    def test_message_read_during_turn_completes_without_its_own_batch(self):
+        mid_a = self.add_message("task")
+        interface_wake.maybe_create_wake_item(self.con, mid_a)
+        self.con.commit()
+        batch_id = self.form()
+        out = self.submit(batch_id, lambda n: None)
+        assert out["submitted"], out
+        self.hook("prompt_submit")
+        # A second message arrives DURING the turn and is read in it.
+        mid_b = self.add_message("result")
+        interface_wake.maybe_create_wake_item(self.con, mid_b)
+        self.con.execute(
+            "UPDATE shell_messages SET read_at=datetime('now') "
+            "WHERE message_id=?", (mid_b,))
+        self.con.commit()
+        self.hook("turn_stop")
+        states = {r[1]: r[2] for r in self.item_states()}
+        self.assertEqual(states[mid_b], "done",
+                         "handled in the turn → completed, never woken again")
+
+    def test_read_message_marks_item_done(self):
+        mid = self.add_message("task")
+        self._running_batch([mid])
+        self.con.execute(
+            "UPDATE shell_messages SET read_at=datetime('now') "
+            "WHERE message_id=?", (mid,))
+        self.con.commit()
+        self.hook("turn_stop")
+        self.assertEqual(self.item_states()[0][2], "done")
+
+
+# ── The coordinator: event-driven drain, retries, parking non-bypass ─────────
+
+class WakeCoordinatorTest(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.dbpath = self.tmp / "shell_db.db"
+        build_engine_db(self.dbpath)
+        con = sqlite3.connect(self.dbpath)
+        con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,1)")
+        self.sid = con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle, harness, cli_version) VALUES (1,1,'occupied','idle',"
+            "'kimi','kimi-code 0.27.0')").lastrowid
+        con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,1,1,'clean')", (self.sid,))
+        self.binding = con.execute(
+            "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (1,1,?,1,1)", (self.sid,)).lastrowid
+        _age(con, "interface_sessions", "occupied_at", self.sid, 60,
+             "session_id")
+        _age(con, "interface_sessions", "created_at", self.sid, 60,
+             "session_id")
+        con.commit()
+        con.close()
+        self.writes = []
+        self.attempts = 0
+        self.writer_error = None
+        def writer(n):
+            self.attempts += 1
+            if self.writer_error is not None:
+                raise self.writer_error
+            self.writes.append(n)
+
+        self.probe_result = False
+        self.coord = interface_wake.WakeCoordinator(
+            str(self.dbpath),
+            writer_factory=lambda session_id: writer,
+            unmanaged_probe=lambda session_id: self.probe_result,
+            quiet_s=QUIET)
+
+    def tearDown(self):
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    # -- helpers (sync DB access from the test's async context) ---------------
+
+    def connect(self):
+        return sqlite3.connect(self.dbpath)
+
+    def add_message(self, kind="task", read=False):
+        con = self.connect()
+        cur = con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+            " kind, sprint_doc_id) VALUES (2,1,'evt',?,1)", (kind,))
+        mid = cur.lastrowid
+        if read:
+            con.execute(
+                "UPDATE shell_messages SET read_at=datetime('now') "
+                "WHERE message_id=?", (mid,))
+        interface_wake.maybe_create_wake_item(con, mid)
+        con.commit()
+        con.close()
+        return mid
+
+    def one(self, sql, params=()):
+        con = self.connect()
+        row = con.execute(sql, params).fetchone()
+        con.close()
+        return row[0] if row else None
+
+    async def wait_for(self, pred, timeout=5.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if pred():
+                return True
+            await asyncio.sleep(0.01)
+        return False
+
+    # -- tests ------------------------------------------------------------------
+
+    async def test_event_drains_to_submission(self):
+        self.coord.start(asyncio.get_running_loop())
+        self.add_message("task")
+        self.coord.notify_binding(self.binding)
+        ok = await self.wait_for(lambda: len(self.writes) == 1)
+        self.assertTrue(ok, "the eligible event must drive one submission")
+        self.assertEqual(self.writes,
+                         [len(interface_broker.WAKE_PROMPT) + 1])
+        state = self.one("SELECT state FROM planner_wake_batches")
+        self.assertEqual(state, "submitting")
+
+    async def test_busy_lifecycle_awaits_events_no_poll(self):
+        con = self.connect()
+        con.execute("UPDATE interface_sessions SET lifecycle='busy' "
+                    "WHERE session_id=?", (self.sid,))
+        con.commit()
+        con.close()
+        self.coord.start(asyncio.get_running_loop())
+        self.add_message("task")
+        self.coord.notify_binding(self.binding)
+        await asyncio.sleep(QUIET * 2)
+        self.assertEqual(self.writes, [], "busy queues — no byte, no retry")
+        # The turn ends: the hook-driven signal submits.
+        con = self.connect()
+        con.execute("UPDATE interface_sessions SET lifecycle='idle' "
+                    "WHERE session_id=?", (self.sid,))
+        con.commit()
+        con.close()
+        self.coord.notify_binding(self.binding)
+        ok = await self.wait_for(lambda: len(self.writes) == 1)
+        self.assertTrue(ok)
+
+    async def test_quiet_debounce_reschedules_at_the_deadline(self):
+        con = self.connect()
+        con.execute("UPDATE interface_input_state SET last_human_input_at="
+                    "datetime('now') WHERE session_id=?", (self.sid,))
+        con.commit()
+        con.close()
+        self.coord.start(asyncio.get_running_loop())
+        self.add_message("task")
+        self.coord.notify_binding(self.binding)
+        await asyncio.sleep(QUIET / 2)
+        self.assertEqual(self.writes, [], "inside the debounce: no byte")
+        ok = await self.wait_for(lambda: len(self.writes) == 1,
+                                 timeout=QUIET * 5)
+        self.assertTrue(ok, "the deadline timer must re-attempt exactly once")
+
+    async def test_pre_send_retries_are_bounded(self):
+        self.writer_error = interface_broker.PreSendError("preflight down")
+        self.coord.start(asyncio.get_running_loop())
+        self.add_message("task")
+        with mock.patch.object(interface_wake, "RETRY_DELAYS_S",
+                               (0.02, 0.02, 0.02)):
+            self.coord.notify_binding(self.binding)
+            ok = await self.wait_for(
+                lambda: self.one(
+                    "SELECT COUNT(*) FROM planner_alerts WHERE reason="
+                    "'wake_presend_retries_exhausted'") == 1)
+        self.assertTrue(ok, "retries must stop after the third delay + alert")
+        self.assertEqual(self.one(
+            "SELECT state FROM planner_wake_batches"), "queued")
+        # initial attempt + exactly 3 bounded retries (1s/5s/30s) — then stop
+        self.assertEqual(self.attempts, 4)
+        self.assertEqual(self.coord._pre_send_attempts, {})
+
+    async def test_delivery_unknown_is_never_resubmitted(self):
+        """Decision #22 non-bypass proof: a parked batch stays parked through
+        coordinator drains and the startup pass; only operator resolution
+        requeues the WORK (as a NEW batch), never the parked submission."""
+        self.coord.start(asyncio.get_running_loop())
+        # Park a batch live: an ambiguous writer failure mid-submit.
+        self.writer_error = RuntimeError("tmux died mid-write")
+        self.add_message("task")
+        self.coord.notify_binding(self.binding)
+        ok = await self.wait_for(
+            lambda: self.one("SELECT state FROM planner_wake_batches")
+            == "delivery_unknown")
+        self.assertTrue(ok)
+        writes_at_park = len(self.writes)
+        self.writer_error = None
+        # Drains + the startup pass must NOT touch the parked batch.
+        self.coord.notify_binding(self.binding)
+        self.coord.startup_pass()
+        await asyncio.sleep(QUIET * 2)
+        self.assertEqual(len(self.writes), writes_at_park,
+                         "no wake path may replay a parked submission")
+        self.assertEqual(self.one(
+            "SELECT state FROM planner_wake_batches"), "delivery_unknown")
+        # The sanctioned path: operator resolves → items requeue → the NEXT
+        # drain forms a NEW batch and submits it once.
+        con = self.connect()
+        batch_id = con.execute("SELECT batch_id FROM planner_wake_batches"
+                               ).fetchone()[0]
+        interface_broker.resolve_batch(con, batch_id)
+        con.commit()
+        con.close()
+        self.coord.notify_binding(self.binding)
+        ok = await self.wait_for(lambda: len(self.writes) > writes_at_park)
+        self.assertTrue(ok, "operator-resolved work requeues as a NEW batch")
+        states = self.one("SELECT COUNT(*) FROM planner_wake_batches")
+        self.assertEqual(states, 2)
+
+    async def test_startup_pass_drains_queued_work(self):
+        self.add_message("task")
+        self.coord.start(asyncio.get_running_loop())
+        self.coord.startup_pass()
+        ok = await self.wait_for(lambda: len(self.writes) == 1)
+        self.assertTrue(ok)
+
+
+# ── Flag #50: hook commit ordering (flock held through the POST) ──────────────
+
+class HookCommitOrderingTest(unittest.TestCase):
+
+    def test_commit_order_never_inverts_allocation_order(self):
+        tmp = Path(tempfile.mkdtemp())
+        posts = []
+        barrier = threading.Barrier(2)
+
+        def fake_post(api_base, token, body, **kw):
+            # The inversion the old code allowed: the FIRST allocated seq
+            # sleeps inside its POST, so without the lock the later seq
+            # would commit first and the earlier hook would be rejected as
+            # stale — stranding a wake batch 'submitting' (restart-only
+            # recovery, decision #31).
+            if body["hook_seq"] == 2:
+                time.sleep(0.1)
+            posts.append(body["hook_seq"])
+            return True
+
+        def emit(event):
+            barrier.wait()
+            interface_hook.emit_locked(
+                tmp, 1, 1, {"shell_id": 1, "generation": 1, "event": event,
+                            "source": "provider"}, "http://x", "tok")
+
+        with mock.patch.object(interface_hook, "post_callback", fake_post):
+            threads = [threading.Thread(target=emit, args=(e,))
+                       for e in ("prompt_submit", "turn_stop")]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        self.assertEqual(len(posts), 2)
+        self.assertEqual(posts, sorted(posts),
+                         "allocation order must BE commit order (flag #50)")
+
+    def test_failed_post_leaves_a_gap_never_a_duplicate(self):
+        tmp = Path(tempfile.mkdtemp())
+        with mock.patch.object(interface_hook, "post_callback",
+                               return_value=False):
+            interface_hook.emit_locked(tmp, 1, 1, {"event": "turn_stop"},
+                                       "http://x", "tok")
+        with mock.patch.object(interface_hook, "post_callback",
+                               return_value=True) as p:
+            interface_hook.emit_locked(tmp, 1, 1, {"event": "session_end"},
+                                       "http://x", "tok")
+        self.assertEqual(p.call_args[0][2]["hook_seq"], 3,
+                         "a lost hook is a gap (safe), never a re-issued seq")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+# ── Routes: sprint bindings, action receipts, #51 rejection audit ────────────
+
+import hashlib  # noqa: E402
+import json  # noqa: E402
+
+sys.path.insert(0, str(ENGINE / "api"))
+import interface_routes as routes  # noqa: E402
+
+OP = "Authorization: Bearer optok"
+SHELL1 = "Authorization: Bearer shelltok1"
+
+
+def hdrs(*lines) -> str:
+    return "\r\n".join(("Host: 127.0.0.1:8800", *lines))
+
+
+class WakeRoutesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db_path = self.tmp / "shell_db.db"
+        build_engine_db(self.db_path)
+        run_dir = self.tmp / "run" / "interface"
+        run_dir.mkdir(parents=True)
+        self.patches = [
+            mock.patch.object(routes, "DB_PATH", self.db_path),
+            mock.patch.object(routes, "RUN_DIR", run_dir),
+            mock.patch.object(routes, "OPERATOR_TOKEN_PATH",
+                              run_dir / "operator.token"),
+        ]
+        for p in self.patches:
+            p.start()
+        (run_dir / "operator.token").write_text("optok")
+        con = sqlite3.connect(self.db_path)
+        con.execute("UPDATE shells SET api_key='shelltok1' WHERE shell_id=1")
+        con.execute("UPDATE shells SET api_key='shelltok2' WHERE shell_id=2")
+        con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,1)")
+        self.sid = con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle, harness, cli_version) VALUES (1,1,'occupied','idle',"
+            "'kimi','kimi-code 0.27.0')").lastrowid
+        con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,1,1,'clean')", (self.sid,))
+        con.commit()
+        con.close()
+
+    def tearDown(self):
+        for p in self.patches:
+            p.stop()
+        for f in self.tmp.glob("*"):
+            if f.is_file():
+                f.unlink()
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def call(self, method, path, header_lines=(), body=None):
+        payload = json.dumps(body).encode() if body is not None else b""
+        status, headers, resp = routes.handle(method, path,
+                                              hdrs(*header_lines), payload)
+        return status, json.loads(resp or b"{}")
+
+    def arm(self, doc=1, planner=1, headers=(OP,), key="k-arm"):
+        return self.call("POST", "/api/interface/sprint-bindings",
+                         (*headers, f"Idempotency-Key: {key}"),
+                         {"sprint_doc_id": doc, "planner_shell_id": planner})
+
+    # -- sprint bindings ---------------------------------------------------------
+
+    def test_arm_happy_path_and_wake_state_surface(self):
+        status, body = self.arm()
+        self.assertEqual(status, 201, body)
+        self.assertEqual(body["wake_state"], "armed")
+        status, detail = self.call("GET",
+                                   f"/api/interface/sessions/{self.sid}",
+                                   (OP,))
+        self.assertEqual(status, 200)
+        self.assertEqual(detail["wake_state"], "armed")
+        # A queued wake item surfaces as 'queued'.
+        con = sqlite3.connect(self.db_path)
+        mid = con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+            " kind, sprint_doc_id) VALUES (2,1,'x','task',1)").lastrowid
+        import interface_wake
+        interface_wake.maybe_create_wake_item(con, mid)
+        con.commit()
+        con.close()
+        status, detail = self.call("GET",
+                                   f"/api/interface/sessions/{self.sid}",
+                                   (OP,))
+        self.assertEqual(detail["wake_state"], "queued")
+
+    def test_double_arm_refused(self):
+        status, _ = self.arm()
+        self.assertEqual(status, 201)
+        status, body = self.arm(key="k-arm-2")
+        self.assertEqual(status, 409)
+        self.assertEqual(body["error"]["code"], "already_armed")
+
+    def test_arm_requires_active_unfrozen_sprint(self):
+        con = sqlite3.connect(self.db_path)
+        con.execute("UPDATE documents SET body='# S\nstatus: CLOSED' "
+                    "WHERE document_id=1")
+        con.commit()
+        con.close()
+        status, body = self.arm()
+        self.assertEqual(status, 409)
+        self.assertEqual(body["error"]["code"], "sprint_not_active")
+
+    def test_arm_requires_mandatory_hooks(self):
+        con = sqlite3.connect(self.db_path)
+        con.execute("UPDATE interface_sessions SET harness='codex', "
+                    "cli_version='codex-cli 0.100.0' WHERE session_id=?",
+                    (self.sid,))
+        con.commit()
+        con.close()
+        status, body = self.arm()
+        self.assertEqual(status, 409)
+        self.assertEqual(body["error"]["code"], "hooks_unsupported")
+
+    def test_shell_actor_arms_only_itself(self):
+        status, body = self.arm(headers=(SHELL1,))
+        self.assertEqual(status, 201, body)
+        # shell 1 arming planner 2 → refused before any state check
+        status, body = self.arm(headers=(SHELL1,), planner=2, key="k-arm-3")
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error"]["code"], "not_the_planner")
+
+    def test_shell_actor_cannot_reach_session_routes(self):
+        status, body = self.call("GET", "/api/interface/shells", (SHELL1,))
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error"]["code"], "shell_scope")
+
+    def test_release_cancels_queued_work_messages_stay_unread(self):
+        status, body = self.arm()
+        self.assertEqual(status, 201)
+        binding_id = body["binding_id"]
+        con = sqlite3.connect(self.db_path)
+        mid = con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+            " kind, sprint_doc_id) VALUES (2,1,'x','task',1)").lastrowid
+        import interface_wake
+        interface_wake.maybe_create_wake_item(con, mid)
+        con.commit()
+        con.close()
+        status, body = self.call(
+            "DELETE", f"/api/interface/sprint-bindings/{binding_id}",
+            (OP, "Idempotency-Key: k-rel"), {"reason": "sprint closed"})
+        self.assertEqual(status, 200, body)
+        self.assertEqual(body["cancelled_items"], 1)
+        con = sqlite3.connect(self.db_path)
+        item = con.execute(
+            "SELECT state, error FROM planner_wake_items").fetchone()
+        self.assertEqual(item[0], "cancelled")
+        self.assertIn("sprint closed", item[1])
+        read = con.execute(
+            "SELECT read_at FROM shell_messages WHERE message_id=?",
+            (mid,)).fetchone()[0]
+        self.assertIsNone(read, "release must leave messages unread")
+        released = con.execute(
+            "SELECT released_at, release_reason FROM sprint_planner_bindings"
+        ).fetchone()
+        self.assertIsNotNone(released[0])
+        self.assertEqual(released[1], "sprint closed")
+        con.close()
+
+    # -- action receipts -----------------------------------------------------------
+
+    def test_receipt_lifecycle(self):
+        con = sqlite3.connect(self.db_path)
+        mid = con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+            " kind, sprint_doc_id) VALUES (2,1,'x','task',1)").lastrowid
+        con.commit()
+        con.close()
+        status, body = self.call(
+            "POST", "/api/planner-action-receipts",
+            (SHELL1, "Idempotency-Key: k-rc1"),
+            {"message_id": mid, "operation": "merge", "target": "#42"})
+        self.assertEqual(status, 201, body)
+        rid = body["receipt_id"]
+        self.assertEqual(body["state"], "intent")
+        # Same key → the original receipt, no twin.
+        status, body = self.call(
+            "POST", "/api/planner-action-receipts",
+            (SHELL1, "Idempotency-Key: k-rc1b"),
+            {"message_id": mid, "operation": "merge", "target": "#42"})
+        self.assertEqual(status, 200)
+        self.assertEqual(body["receipt_id"], rid)
+        self.assertTrue(body["duplicate"])
+        # complete → suppresses a later duplicate begin.
+        status, body = self.call(
+            "PATCH", f"/api/planner-action-receipts/{rid}",
+            (SHELL1, "Idempotency-Key: k-rc2"), {"state": "complete"})
+        self.assertEqual(status, 200)
+        status, body = self.call(
+            "POST", "/api/planner-action-receipts",
+            (SHELL1, "Idempotency-Key: k-rc3"),
+            {"message_id": mid, "operation": "merge", "target": "#42"})
+        self.assertTrue(body["suppressed"])
+        # complete → complete is a same-state no-op; unknown from complete is
+        # an illegal edge.
+        status, body = self.call(
+            "PATCH", f"/api/planner-action-receipts/{rid}",
+            (SHELL1, "Idempotency-Key: k-rc4"), {"state": "unknown"})
+        self.assertEqual(status, 409)
+
+    def test_receipt_unknown_then_reconciled(self):
+        status, body = self.call(
+            "POST", "/api/planner-action-receipts",
+            (SHELL1, "Idempotency-Key: k-rc5"),
+            {"operation": "push", "target": "main"})
+        rid = body["receipt_id"]
+        status, _ = self.call(
+            "PATCH", f"/api/planner-action-receipts/{rid}",
+            (SHELL1, "Idempotency-Key: k-rc6"), {"state": "unknown"})
+        self.assertEqual(status, 200)
+        status, body = self.call(
+            "PATCH", f"/api/planner-action-receipts/{rid}",
+            (SHELL1, "Idempotency-Key: k-rc7"),
+            {"state": "reconciled", "result_detail": "operator verified"})
+        self.assertEqual(status, 200)
+        self.assertEqual(body["state"], "reconciled")
+
+    # -- flag #51: every hook rejection path is audited ------------------------------
+
+    def _hook_gen(self):
+        """A generation whose hook token is known, with no live session."""
+        con = sqlite3.connect(self.db_path)
+        con.execute(
+            "UPDATE interface_generations SET hook_token_hash=? "
+            "WHERE shell_id=1 AND generation=1",
+            (hashlib.sha256(b"hooktok").hexdigest(),))
+        con.commit()
+        con.close()
+
+    def _post_hook(self, body, token="hooktok"):
+        with mock.patch.object(routes, "_log") as log:
+            status, resp = self.call(
+                "POST", "/api/interface/hook-callbacks",
+                (f"Authorization: Bearer {token}",), body)
+        return status, resp, log
+
+    def test_audit_missing_fields(self):
+        status, _, log = self._post_hook({"event": "turn_stop"})
+        self.assertEqual(status, 422)
+        self.assertTrue(log.called, "flag #51: missing-fields rejection "
+                                    "must be audited")
+
+    def test_audit_unknown_fields(self):
+        status, _, log = self._post_hook(
+            {"shell_id": 1, "generation": 1, "hook_seq": 2,
+             "event": "turn_stop", "prompt": "stolen"})
+        self.assertEqual(status, 422)
+        self.assertTrue(log.called)
+
+    def test_audit_unknown_source(self):
+        self._hook_gen()
+        status, _, log = self._post_hook(
+            {"shell_id": 1, "generation": 1, "hook_seq": 2,
+             "event": "turn_stop", "source": "moon"})
+        self.assertEqual(status, 422)
+        self.assertTrue(log.called)
+
+    def test_audit_no_session(self):
+        self._hook_gen()
+        con = sqlite3.connect(self.db_path)
+        con.execute("UPDATE interface_sessions SET occupancy='ended' "
+                    "WHERE session_id=?", (self.sid,))
+        con.commit()
+        con.close()
+        status, _, log = self._post_hook(
+            {"shell_id": 1, "generation": 1, "hook_seq": 2,
+             "event": "turn_stop", "pid": 4321})
+        self.assertEqual(status, 404)
+        self.assertTrue(log.called, "flag #51: no-session rejection must "
+                                    "be audited")
+
+    def test_audit_session_start_without_pid(self):
+        self._hook_gen()
+        status, _, log = self._post_hook(
+            {"shell_id": 1, "generation": 1, "hook_seq": 1,
+             "event": "session_start", "source": "provider"})
+        self.assertEqual(status, 422)
+        self.assertTrue(log.called)
+
+    def test_audit_stale_hook_seq(self):
+        self._hook_gen()
+        con = sqlite3.connect(self.db_path)
+        con.execute(
+            "UPDATE interface_sessions SET pane_pid=4321 WHERE session_id=?",
+            (self.sid,))
+        con.execute(
+            "UPDATE interface_generations SET last_hook_seq=5 "
+            "WHERE shell_id=1 AND generation=1")
+        con.commit()
+        con.close()
+        status, _, log = self._post_hook(
+            {"shell_id": 1, "generation": 1, "hook_seq": 3,
+             "event": "turn_stop", "pid": 4321})
+        self.assertEqual(status, 409)
+        self.assertTrue(log.called, "flag #51: a replayed/stale hook_seq "
+                                    "must be audited — it is the exact "
+                                    "diagnostic #50 needs in production")

--- a/tests/test_interface_wake.py
+++ b/tests/test_interface_wake.py
@@ -375,6 +375,72 @@ class WakeGateHardeningTest(WakeFixture):
         with self.assertRaises(interface_broker.BrokerError):
             self.submit(batch_id, lambda n: None)
 
+    def test_ended_session_gate_fails_alerts_never_crashes(self):
+        # SC-011: End chat does NOT release the binding or cancel queued
+        # wake work — armed binding + queued batch + ended session must
+        # gate_fail WITH an alert (spec Retry Policy: session loss queues
+        # AND alerts), never die on a None dereference.
+        batch_id = self._armed_batch()
+        self.con.execute(
+            "UPDATE interface_sessions SET occupancy='ended' "
+            "WHERE session_id=?", (self.sid,))
+        self.con.commit()
+        writes = []
+        out = self.submit(batch_id, writes.append)
+        self.assertFalse(out["submitted"])
+        self.assertIn("session ended", out["reason"])
+        self.assertEqual(writes, [], "no byte may move")
+        self.assertEqual(self.batch_state(batch_id), "queued",
+                         "the batch waits for a future generation")
+        alert = self.con.execute(
+            "SELECT severity FROM planner_alerts "
+            "WHERE reason='wake_session_ended' AND resolved_at IS NULL"
+        ).fetchone()
+        self.assertIsNotNone(alert, "session loss must alert, not stall")
+        self.assertEqual(alert[0], "critical")
+        # Idempotent: every drain / startup_pass re-attempt gate-fails
+        # cleanly — no re-crash, and the open alert dedupes (no spam).
+        out2 = self.submit(batch_id, writes.append)
+        self.assertFalse(out2["submitted"])
+        self.assertEqual(self.batch_state(batch_id), "queued")
+        count = self.con.execute(
+            "SELECT COUNT(*) FROM planner_alerts "
+            "WHERE reason='wake_session_ended' AND resolved_at IS NULL"
+        ).fetchone()[0]
+        self.assertEqual(count, 1)
+
+    def test_frozen_active_sprint_blocks_submit(self):
+        # SC-012: spec Sprint Scope — a wake is eligible only while the doc
+        # is unfrozen AND ACTIVE. Freeze between form and submit revokes
+        # sprint authority exactly like a close: the batch cancels, no byte.
+        batch_id = self._armed_batch()
+        self.con.execute("UPDATE documents SET frozen=1 WHERE document_id=1")
+        self.con.commit()
+        writes = []
+        out = self.submit(batch_id, writes.append)
+        self.assertFalse(out["submitted"])
+        self.assertTrue(out["cancelled"])
+        self.assertEqual(writes, [], "a post-freeze wake must never fire")
+        self.assertEqual(self.batch_state(batch_id), "complete")
+        self.assertEqual(self.item_states()[0][2], "cancelled")
+
+    def test_probe_runs_outside_the_write_transaction(self):
+        # SC-013: the unmanaged-client probe shells out to tmux; run inside
+        # BEGIN IMMEDIATE, a wedged server would hang the drain thread WHILE
+        # HOLDING the SQLite write lock — an engine-wide write stall.
+        batch_id = self._armed_batch()
+        seen = {}
+
+        def probe():
+            seen["in_txn"] = self.con.in_transaction
+            return False
+
+        writes = []
+        out = self.submit(batch_id, writes.append, probe=probe)
+        self.assertTrue(out["submitted"], out)
+        self.assertFalse(seen["in_txn"],
+                         "the probe must not run inside the write txn")
+
 
 # ── Stop-hook reconciliation: ambiguity, quarantine, read-during-turn ─────────
 

--- a/tests/test_interface_wake_submit.py
+++ b/tests/test_interface_wake_submit.py
@@ -91,7 +91,8 @@ class WakeSubmitGateTest(unittest.TestCase):
         )
         sid = self.con.execute(
             "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
-            " lifecycle) VALUES (?,1,'occupied','idle')",
+            " lifecycle, harness, cli_version) VALUES (?,1,'occupied','idle',"
+            "'kimi','kimi-code 0.27.0')",
             (shell_id,),
         ).lastrowid
         self.con.execute(
@@ -301,7 +302,8 @@ class SubmitGateToctouTest(unittest.TestCase):
             "VALUES (1,1)")
         sid = con.execute(
             "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
-            " lifecycle) VALUES (1,1,'occupied','idle')").lastrowid
+            " lifecycle, harness, cli_version) VALUES (1,1,'occupied','idle',"
+            "'kimi','kimi-code 0.27.0')").lastrowid
         con.execute(
             "INSERT INTO interface_input_state (session_id, shell_id,"
             " generation, composer) VALUES (?,1,1,'clean')", (sid,))


### PR DESCRIPTION
## What

Wires automatic planner wake through the API-owned input broker — the sprint-25 feature payload (spec #20 task #84). An eligible sprint event (task/result/pr_event addressed to the bound planner, same sprint_doc_id, ACTIVE unfrozen binding, unreplaced generation) queues a wake item in the **same transaction** as the message; the event-driven coordinator coalesces queued items into one fixed-prompt batch and submits it into the planner's live tmux chat **only** through the broker-owned input path (preflight + one indivisible send) — never a direct write.

## The gate (decision #15)

Submit only when: binding armed + sprint ACTIVE · session occupied + lifecycle idle · composer clean · accepted human input quiet ≥3s · no pending human frame · mandatory lifecycle hooks supported · **no unmanaged writable tmux client** (detection → composer unknown + disarm + alert; removal + explicit clean certification to rearm). All human + wake bytes share the generation-fenced input order: while a batch is `submitting`, human frames are refused and ordered after it.

## Hard requirements (decisions #28 + #31 — seq-7 findings, all three landed)

- **#49 START-READY** — quiet baseline keys off REAL provider readiness: the provider `session_start` hook stamps `provider_ready_at` (migration 0081) and the gate measures quiet from `max(last_human_input, provider_ready_at, occupied_at, created_at, restart_at)` — a >3s claude/codex boot can no longer submit into an unpainted TUI on the pre-exec `occupied_at` baseline. Test: `test_slow_boot_blocks_submit_despite_old_occupied_at`.
- **#50 HOOK COMMIT ORDERING** — the emitter now holds the counter flock **through the POST** (`emit_locked`), so allocation order IS commit order; the out-of-order commit that stranded a batch `submitting` with restart-only recovery is unreachable. Test: `test_commit_order_never_inverts_allocation_order` (slow-first-POST inversion harness).
- **#51 REJECTION AUDIT** — every hook-callback rejection path now audit-`_log`s: missing/unknown fields (422), unknown source (422), no-session (404), session_start-without-pid (422), and every BrokerError 409 incl. replayed/stale hook_seq. One test per path.

## Reconciliation, parking, retries (decisions #12/#16/#22)

- Stop-hook reconciliation from durable read state: read → done · unread + ambiguous action receipt (intent/unknown) → `reconcile` (parked, never blind-requeued) · unread → requeue with wake count · **third completed wake → quarantined + alert, newer work unblocked** · message read during a turn → completed without its own batch (new `queued → done` + `running → quarantined` edges, trigger + app map kept in sync).
- Definite pre-send failure (`PreSendError` — the writer's pane preflight proved no byte moved) → batch back to queued, bounded retries 1s/5s/30s, then stop + critical alert. Any other writer failure → `delivery_unknown` park. **No wake path bypasses parking**: drains and the startup pass never touch a parked batch; only operator `resolve_batch` requeues the work as a NEW batch (test: `test_delivery_unknown_is_never_resubmitted`).
- Planner action receipts: `POST/PATCH /api/planner-action-receipts` (idempotent intent keyed message+operation+target; complete/unknown/reconciled) + `sc sprint action` CLI. Sprint bindings: `POST/DELETE /api/interface/sprint-bindings` (arm validates ACTIVE unfrozen sprint + occupied generation + mandatory hooks; release cancels queued wake work with audit reason, messages stay unread). Shell API tokens are scoped to the wake routes only. `wake_state` is now derived (armed/queued/submitting/running/parked) instead of the hardcoded stub. `sc mem message send --sprint <doc>` scopes task/result events.

## Trust boundary (decision #30)

No new browser-facing surface: wake submission rides the existing operator/generation capabilities (hook tokens call only the callback route; shell tokens only the two wake route families; arming/release operator or self only).

## Verification

- **Hermetic**: 49 new tests in `tests/test_interface_wake.py` (ingress eligibility matrix, #49 readiness baselines, gate hardening, coordinator drain/reschedule/bounded-retry/parking-non-bypass, route + receipt lifecycle, #51 audit paths, #50 ordering) + full suite **779 passed, 4 skipped** (tmux-gated; no tmux in this sandbox).
- **Smoke**: `render-check` hermetic pass (81 migrations incl. 0081); ruff clean on touched files.
- **Proven by construction** (to be re-proven e2e at the seq-11 real-sprint gate): wake reaches tmux only via the broker writer; a parked batch is never resubmitted by any path; hook commit order cannot invert; a >3s boot cannot pass the quiet gate.
- **Deferred to seq-11** (needs real tmux + harness): wake-into-fresh claude/codex, out-of-order hook injection under load, parking-under-crash e2e.

## Notes

- Ambiguity calls: (1) PreSendError retries are in-memory per batch — a restart resets the counter and the batch stays queued for the startup pass (safe: nothing re-sends without re-gating); (2) the unmanaged-client probe tolerates read-only diagnostic tmux clients per spec Tmux Runtime and fails open on tmux unreachability (the writer preflight owns that failure as definite pre-send); (3) `retry_after` quiet rescheduling uses a one-shot loop timer per binding — event-reset, no polling.