### PR TITLE
fix(sandbox): pin tmux 3.5a from source + add @xterm/xterm (spike stack)

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -35,14 +35,29 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # tmux — the Interface process host (spec #20): a DECLARED, version-gated
-# dependency, not ambient host availability. bookworm main ships 3.3a; the
-# Interface stack is proven on 3.5a (spikes/interface-stream/RESULTS.md), which
-# bookworm-backports carries (3.5a-2~bpo12+1). The runtime additionally gates
-# `tmux -V` >= 3.4 at startup and reports Interface unavailable below that.
-RUN echo "deb http://deb.debian.org/debian bookworm-backports main" \
-      > /etc/apt/sources.list.d/bookworm-backports.list \
- && apt-get update \
- && apt-get install -y --no-install-recommends -t bookworm-backports tmux \
+# dependency, not ambient host availability. The fence proofs are tmux-3.5a-
+# specific (alt-screen capture behavior, paste-before-bindings timing —
+# spikes/interface-stream/RESULTS.md "Chosen stack (pinned)"), so build the
+# pinned 3.5a release tarball from source with sha256 verification — NOT a
+# distro apt install (a repo pocket can drift or resolve differently per base
+# release → false green; the bookworm-backports this replaces also assumed a
+# bookworm base, and python:3.12-slim is trixie now). The runtime additionally
+# gates `tmux -V` >= 3.4 at startup and reports Interface unavailable below
+# that.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      build-essential libevent-dev libncurses-dev pkg-config bison \
+ && curl -fsSL -o /tmp/tmux-3.5a.tar.gz \
+      https://github.com/tmux/tmux/releases/download/3.5a/tmux-3.5a.tar.gz \
+ && echo "16216bd0877170dfcc64157085ba9013610b12b082548c7c9542cc0103198951  /tmp/tmux-3.5a.tar.gz" \
+      | sha256sum -c - \
+ && tar -xzf /tmp/tmux-3.5a.tar.gz -C /tmp \
+ && cd /tmp/tmux-3.5a \
+ && ./configure --prefix=/usr/local \
+ && make -j"$(nproc)" \
+ && make install \
+ && cd / \
+ && rm -rf /tmp/tmux-3.5a /tmp/tmux-3.5a.tar.gz \
  && rm -rf /var/lib/apt/lists/*
 
 # Interface stream stack (spec #20; sprint 25 seq 3 pinned these):
@@ -75,11 +90,12 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/*
 
-# @xterm/headless 6.0.0 (MIT) at /opt/sc-shadow — the shadow terminal the
-# Interface runtime mirrors output through for reconnect redraws (spec #20;
-# pinned by the seq-3 spike). The Node sidecar resolves it via NODE_PATH
+# @xterm/headless 6.0.0 + @xterm/xterm 6.0.0 (MIT) at /opt/sc-shadow — the
+# shadow terminal the Interface runtime mirrors output through for reconnect
+# redraws, and the vendored browser terminal source (spec #20; pinned by the
+# seq-3 spike). The Node sidecar resolves them via NODE_PATH
 # (scripts/interface_runtime.py).
-RUN npm install --prefix /opt/sc-shadow "@xterm/headless@6.0.0" \
+RUN npm install --prefix /opt/sc-shadow "@xterm/headless@6.0.0" "@xterm/xterm@6.0.0" \
  && chmod -R a+rX /opt/sc-shadow
 
 # Playwright E2E browser — baked at the IMAGE level on purpose, unlike the per-fork


### PR DESCRIPTION
## What

Corrects the sandbox image's Interface stack bake to the spike-pinned stack (roadmap feature #14, outside-team/host task):

- **tmux**: replaces the seq-5 bookworm-backports apt install (#505) with a **sha256-verified source build of the official 3.5a tarball**. The spike (`spikes/interface-stream/RESULTS.md` → "Chosen stack (pinned)") is explicit: not a distro apt install — the fence proofs are 3.5a-specific (alt-screen capture behavior, paste-before-bindings timing), and a repo pocket can resolve differently per base release → false green. The backports block also assumed a bookworm base; `python:3.12-slim` is trixie now.
- **@xterm/xterm 6.0.0**: added to the `/opt/sc-shadow` npm install — the one missing entry from the pinned shopping list. `websockets==16.1.1` and `@xterm/headless@6.0.0` were already correct and are unchanged.

## Verification

Built and verified live on the host image ahead of this PR (`sc-super-coder` already restarted onto it, WAL-safe DB backup taken pre-restart — no data loss):

```
tmux 3.5a            (/usr/local/bin/tmux, source-built)
websockets 16.1.1    (image python)
require('@xterm/headless') + require('@xterm/xterm') — resolve
```

`interface_runtime.py`'s NODE_PATH chain (`/opt/sc-shadow/node_modules` → repo-local → `$NODE_PATH`) is satisfied by both this layout and the interim live image. Unblocks the @tmux-gated middle verification tier and the seq-11 prerequisite.