### PR TITLE
fix(engine): materialize .super-coder/shadow to forks (sprint 25 seq-11 fix, flag #59)

### DIFF
--- a/.super-coder/scripts/engine_manifest.py
+++ b/.super-coder/scripts/engine_manifest.py
@@ -70,6 +70,7 @@ ENGINE_PATHS = [
     ".super-coder/ui",
     ".super-coder/assets/skills",
     ".super-coder/hooks",
+    ".super-coder/shadow",
 ]
 
 # Never hashed: bytecode + caches that churn without a source edit.

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python3
-"""Guard: every top-level engine file is materialized to forks on `./sc update`.
+"""Guard: every tracked engine file is materialized to forks on `./sc update`.
 
-The bug this prevents: a new top-level file under `.super-coder/` (e.g.
-map_schema.sql, added with the map split) that isn't in update.py's ENGINE_PATHS
-allowlist never reaches an updating fork — the fork gets the new code but not the
-file, and breaks. Subdirs (scripts/, templates/, …) are materialized whole, so
-files inside them are covered; only NEW TOP-LEVEL files are at risk. This asserts
-each one is in the allowlist (or is a deliberate per-instance exclusion).
+The bugs this prevents: a new top-level file under `.super-coder/` (e.g.
+map_schema.sql, added with the map split) or a new tracked SUBDIRECTORY (e.g.
+shadow/, added with the Interface runtime) that isn't in update.py's
+ENGINE_PATHS allowlist never reaches an updating fork — the fork gets the new
+code but not the files, and breaks (shadow/: 'interface_unavailable: shadow
+sidecar exited' on every fresh fork; flag #59). Known subdirs (scripts/,
+templates/, …) are materialized whole, so files inside them are covered; only
+NEW top-level files and NEW subdirs are at risk. The file-level test asserts
+every git-tracked engine file is covered by the allowlist (or is a deliberate
+per-instance / super-coder-only exclusion); the dir-level one keeps the cheap
+top-level signal.
 
 Run:
     python3 tests/test_update_materialize.py
 """
 from __future__ import annotations
 
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -28,6 +34,18 @@ PER_INSTANCE = {
     "instance.json", "shell_db.db", "shell_db.db-wal", "shell_db.db-shm", "map.db",
     "engine.manifest",  # derived hash baseline — rewritten by each materialize
 }
+
+# Tracked upstream, deliberately NOT materialized to forks (file or dir
+# prefix): assets/seed/ is super-coder-only (stripped on install) — see the
+# ENGINE_PATHS comment in engine_manifest.py.
+NOT_MATERIALIZED = (".super-coder/assets/seed/",)
+
+
+def _covered(rel: str) -> bool:
+    """True when an ENGINE_PATHS entry archives `rel` (exact file or dir
+    prefix — git archive emits whole trees for directory pathspecs)."""
+    return any(rel == entry or rel.startswith(entry.rstrip("/") + "/")
+               for entry in update.ENGINE_PATHS)
 
 
 class EnginePathsCoverageTest(unittest.TestCase):
@@ -50,6 +68,28 @@ class EnginePathsCoverageTest(unittest.TestCase):
     def test_map_schema_specifically_present(self):
         # The file whose omission caused the dos-arch update failure.
         self.assertIn(".super-coder/map_schema.sql", update.ENGINE_PATHS)
+
+    def test_shadow_specifically_present(self):
+        # The dir whose omission broke the Interface on every fresh fork (#59).
+        self.assertIn(".super-coder/shadow", update.ENGINE_PATHS)
+
+    def test_every_tracked_engine_file_is_materialized(self):
+        """The recurrence guard for the class: any git-tracked file under
+        .super-coder/ — including one inside a NEW subdirectory — must be
+        covered by ENGINE_PATHS, or explicitly opted out in NOT_MATERIALIZED.
+        git ls-files lists exactly the upstream-owned set a fork can receive,
+        so a new engine dir can't silently miss materialization."""
+        tracked = subprocess.run(
+            ["git", "-C", str(ROOT), "ls-files", "--", ".super-coder"],
+            capture_output=True, text=True, check=True).stdout.splitlines()
+        missing = [rel for rel in tracked
+                   if not _covered(rel)
+                   and not any(rel.startswith(prefix) for prefix in NOT_MATERIALIZED)]
+        self.assertEqual(
+            missing, [],
+            f"tracked engine file(s) absent from update.ENGINE_PATHS — forks "
+            f"won't receive them on `./sc update` (add the path to ENGINE_PATHS "
+            f"or opt out in NOT_MATERIALIZED): {missing}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Seq-11 real-fork gate (flag #59) found the Interface runtime broken on **every fresh materialized fork**: `interface_runtime.py` boots its shadow sidecar from `.super-coder/shadow/sidecar.js` (`interface_runtime.py:51,438`), the four shadow files are git-tracked at origin/main, but the dir was never added to the materialize set — `ENGINE_PATHS` in `engine_manifest.py` drives the `git archive <ref> -- <paths>` pathspec (`update.py:_engine_paths_at`), so forks never receive `shadow/`. Symptom on ami: `interface_unavailable: shadow sidecar exited` / `Cannot find module '.super-coder/shadow/sidecar.js'`. The source-run sandbox hid the gap (shadow/ is present there as ordinary tracked files).

## What

- **`engine_manifest.py`**: add `.super-coder/shadow` to `ENGINE_PATHS`. The same list drives the hash-manifest (`_iter_files` walks dir entries), so a locally-modified shadow file now blocks `./sc update` like any other engine file.
- **`tests/test_update_materialize.py`**: recurrence guard for the class, not just this dir — the coverage test now asserts **every git-tracked file under `.super-coder/`** is covered by `ENGINE_PATHS` (previously: top-level files only, which is how a whole new subdir slipped through). Deliberate exclusions are named (`assets/seed/` super-coder-only, per-instance files). Plus a shadow-specific assertion alongside the existing map_schema one.

Verified: the new guard goes **red** against the unfixed manifest (flags exactly the four shadow files) and **green** after.

## Verification (hermetic)

- `_engine_paths_at(HEAD)` includes `.super-coder/shadow`
- `git archive HEAD -- <engine_paths>` listing shows all four shadow files
- `_iter_files(ENGINE_PATHS)` covers all four for the local-edit hash guard
- `interface_runtime.py`'s expected path (`ENGINE/shadow/sidecar.js`) matches where materialize writes — no path drift
- Full suite: **803 passed, 4 skipped** (tmux-gated); `ruff check` clean; render-check clean (run via worktree script per flag #47)

## Not in scope

The end-to-end fork proof — re-materialize ami, Interface tab boots with a live sidecar — is the planner/FnB acceptance test post-merge (task #542).

Sprint 25 seq-11 fix unit · reviewer REV1 · gates the real-fork gate.