### PR TITLE
fix(interface): real-tmux runtime defects + seq-11 wake e2e (sprint 25 seq 11)

### DIFF
--- a/.super-coder/scripts/interface_runtime.py
+++ b/.super-coder/scripts/interface_runtime.py
@@ -269,6 +269,7 @@ class Generation:
         self.pane_start_ticks = 0
         self.dbg_pump_bytes = 0
         self.dbg_fanout_bytes = 0
+        self._fifo_keep_fd = -1
         self._pump_fd = -1
         self._pump_thread: threading.Thread | None = None
         self._tasks: list[asyncio.Task] = []
@@ -305,10 +306,15 @@ class Generation:
                 return  # loop closed (service shutting down)
 
     def _notify_exit(self, loop) -> None:
+        # run_coroutine_threadsafe, not call_soon_threadsafe: the latter
+        # would CALL the async def and drop the coroutine un-awaited —
+        # the pump's pane-death signal never fired (real-tmux finding,
+        # sprint 25 seq 11).
+        coro = self.runtime._on_pump_exit(self)
         try:
-            loop.call_soon_threadsafe(self.runtime._on_pump_exit, self)
+            asyncio.run_coroutine_threadsafe(coro, loop)
         except RuntimeError:
-            pass  # loop closed
+            coro.close()  # loop closed before it could be scheduled
 
     def _on_pump_bytes(self, chunk: bytes) -> None:
         if self.continuity_broken:
@@ -410,6 +416,7 @@ class Generation:
             except OSError:
                 pass
             self._pump_fd = -1
+        self.runtime._close_fifo_keep(self)
 
 
 # ---------------------------------------------------------------- runtime
@@ -673,7 +680,16 @@ class InterfaceRuntime:
                             *[f"{b:02x}" for b in chunk])
 
     async def capture_pane(self, pane_id: str) -> bytes:
-        return await self.tmux("capture-pane", "-epN", "-t", pane_id)
+        """Screen text for a shadow rebuild. tmux 3.5a emits a trailing
+        newline after the last row; replayed as a stream into a same-sized
+        zero-scrollback shadow terminal that extra newline scrolls the top
+        row off the grid (real-tmux finding, sprint 25 seq 11 — a pane whose
+        content sat on row 1 rebuilt as a blank screen). Strip exactly one
+        trailing newline: 24 rows replay into 24 rows with no scroll."""
+        out = await self.tmux("capture-pane", "-epN", "-t", pane_id)
+        if out.endswith(b"\n"):
+            out = out[:-1]
+        return out
 
     # -- spawn -----------------------------------------------------------------
 
@@ -685,15 +701,49 @@ class InterfaceRuntime:
 
     def _open_fifo(self, gen: Generation) -> None:
         """Open the blocking pump reader. A FIFO O_RDONLY open blocks until a
-        writer exists, so pre-open RDWR|NONBLOCK as the stand-in writer —
-        then CLOSE it immediately. A held write end would make the pump's
-        read never return EOF when the pane dies and tmux's `cat` writer
-        exits, and that EOF is the pump's pane-death signal."""
-        keep_fd = os.open(
+        writer exists, so pre-open RDWR|NONBLOCK as the stand-in writer. The
+        stand-in is held until _pipe_pane PROVES tmux's writer attached (the
+        pump thread starts immediately after; a closed stand-in plus a
+        still-starting `cat` reads as an instant false EOF — the pane-death
+        signal — before any byte could flow, real-tmux finding seq 11). A
+        stand-in held FOREVER would be just as wrong: the pump's read must
+        return EOF when the pane dies and tmux's `cat` writer exits, and
+        that EOF is the pump's pane-death signal."""
+        gen._fifo_keep_fd = os.open(  # noqa: SLF001
             self._fifo_path(gen.session_id), os.O_RDWR | os.O_NONBLOCK)
         gen._pump_fd = os.open(  # noqa: SLF001
             self._fifo_path(gen.session_id), os.O_RDONLY)
-        os.close(keep_fd)
+
+    def _close_fifo_keep(self, gen: Generation) -> None:
+        if gen._fifo_keep_fd >= 0:  # noqa: SLF001
+            try:
+                os.close(gen._fifo_keep_fd)  # noqa: SLF001
+            except OSError:
+                pass
+            gen._fifo_keep_fd = -1  # noqa: SLF001
+
+    async def _pipe_pane(self, gen: Generation) -> None:
+        """Attach the pane's output pipe and drop the stand-in writer only
+        once the pipe writer is PROVEN attached: the pipe command holds its
+        own write fd (9) across the marker touch, so the marker means a real
+        writer owns the FIFO. Without this handshake the pump's first read
+        races tmux's fork of `cat` and loses (EOF with zero bytes read)."""
+        fifo = self._fifo_path(gen.session_id)
+        marker = fifo + ".pipeup"
+        if os.path.exists(marker):
+            os.unlink(marker)
+        await self.tmux(
+            "pipe-pane", "-t", gen.pane_id,
+            f"exec 9>{shlex.quote(fifo)} && touch {shlex.quote(marker)} "
+            f"&& exec cat >&9")
+        deadline = time.monotonic() + TMUX_SYNC_TIMEOUT_S
+        while not os.path.exists(marker):
+            if time.monotonic() > deadline:
+                raise RuntimeError(
+                    f"pipe-pane writer never attached for {fifo}")
+            await asyncio.sleep(0.02)
+        os.unlink(marker)
+        self._close_fifo_keep(gen)
 
     def _start_consumers(self, gen: Generation) -> None:
         gen._pump_thread = threading.Thread(  # noqa: SLF001
@@ -762,8 +812,7 @@ class InterfaceRuntime:
             _read_start_ticks, gen.pane_pid)
 
         self.shadow.create(gen.sid, rows, cols)
-        await self.tmux("pipe-pane", "-t", pane_id,
-                        f"cat > {shlex.quote(fifo)}")
+        await self._pipe_pane(gen)
         # boot the harness only now: zero lost boot bytes
         open(sentinel, "w").close()
 
@@ -839,10 +888,14 @@ class InterfaceRuntime:
                 # (the old pipe-pane died with its writer).
                 os.mkfifo(fifo)
                 self._open_fifo(gen)
-                await self.tmux("pipe-pane", "-t", pane_id,
-                                f"cat > {shlex.quote(fifo)}")
+                await self._pipe_pane(gen)
             else:
                 self._open_fifo(gen)
+                # No new pipe is issued here: the surviving `cat` is already
+                # the writer (or it died with the old service — then the
+                # pump's instant EOF is exactly the stale-pipe signal the
+                # exit path turns into an alert / lost transition).
+                self._close_fifo_keep(gen)
             # The shadow is volatile: rebuild from the visible pane.
             self.shadow.create(gen.sid, rows, cols)
             capture = await self.capture_pane(pane_id)

--- a/spikes/interface-stream/shadow/package.json
+++ b/spikes/interface-stream/shadow/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/spikes/interface-stream/tests/conftest.py
+++ b/spikes/interface-stream/tests/conftest.py
@@ -16,7 +16,22 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from helpers import Api, WSClient, tmux  # noqa: E402
-from server import Server  # noqa: E402
+
+# The engine API (.super-coder/api/server.py) is also imported as plain
+# `server` by the tests/ suite in the same pytest process. Importing the
+# spike's server under that top-level name poisons sys.modules for every
+# later `import server` (sprint 25 seq 11: with the Interface stack baked,
+# this conftest loads and 65 engine tests errored on
+# `module 'server' has no attribute 'Handler'`). Load it namespaced.
+import importlib.util as _ilu  # noqa: E402
+
+_spec = _ilu.spec_from_file_location(
+    "spike_server",
+    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                 "server.py"))
+_mod = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+Server = _mod.Server
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_interface_runtime.py
+++ b/tests/test_interface_runtime.py
@@ -687,8 +687,17 @@ class TmuxIntegrationTest(unittest.TestCase):
             session_id=self.sid, shell_id=1, generation=1,
             worktree=str(self.tmp), sc_path="/bin/sc",
             token_path="/tmp/tok", rows=24, cols=80,
-            command=["/bin/sh", "-c", "stty -echo; cat"])
+            # raw: the spike-proven mode (reader.py setraw). Plain
+            # `stty -echo` leaves canonical mode on — a newline-free frame
+            # never reaches cat, so no echo can ever come back. The READY
+            # marker is the pane's first output: it proves stty already ran,
+            # so no input can land while tty echo is still on (which would
+            # double the echo).
+            command=["/bin/sh", "-c", "stty raw -echo; printf READY; cat"])
         self._persist_identity(info)
+        gen = self.rt.generations[self.sid]
+        await wait_for(lambda: gen.dbg_fanout_bytes >= 5,
+                       what="pane raw-mode READY marker")
         return info
 
     def test_input_echo_redraw_terminate(self):

--- a/tests/test_interface_wake_tmux.py
+++ b/tests/test_interface_wake_tmux.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Interface wake e2e on REAL tmux (sprint 25 seq 11, task #87) — the three
+integration paths earlier units deferred to the real-tmux gate:
+
+- wake-into-fresh: a >3s-boot harness receives its wake only after REAL
+  provider readiness + the quiet debounce, never at the pre-exec
+  occupied_at (flag #49 end-to-end: the bytes land, exactly once, in a
+  live pane — on the runtime's real writer path through private tmux).
+- out-of-order hook injection under input load: hook sequence fencing
+  holds (out-of-order and replayed seqs rejected, last_hook_seq monotonic)
+  while ordered input streams through real tmux — no lost frames, no
+  interleaved bytes.
+- parking-under-crash: a broker crash mid-write (the private tmux server
+  dies between the wake preflight and send-keys) parks the batch
+  delivery_unknown with an alert, and no drain, startup pass, or notify
+  ever replays it (decision #22 on the real writer path, not a stub).
+
+Gated on the shadow stack (tmux + node + @xterm/headless), like
+TmuxIntegrationTest. Hermetic coverage of the same invariants lives in
+test_interface_wake.py and test_interface_crash_window.py.
+
+Run:
+    python3 tests/test_interface_wake_tmux.py
+"""
+from __future__ import annotations
+
+import asyncio
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+TESTS = Path(__file__).resolve().parent
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(TESTS))
+import interface_broker  # noqa: E402
+import interface_runtime  # noqa: E402
+import interface_wake  # noqa: E402
+from test_interface_crash_window import build_engine_db  # noqa: E402
+from test_interface_runtime import (  # noqa: E402
+    HAS_SHADOW_STACK, FakeClient, wait_for)
+
+
+@unittest.skipUnless(HAS_SHADOW_STACK,
+                     "needs tmux + node + @xterm/headless (shadow sidecar)")
+class WakeTmuxE2ETest(unittest.TestCase):
+    """One armed sprint binding over a real private-tmux generation."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,1)")
+        self.sid = con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle, harness, cli_version) VALUES (1,1,'occupied','idle',"
+            "'kimi','kimi-code 0.27.0')").lastrowid
+        con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,1,1,'clean')", (self.sid,))
+        self.binding = con.execute(
+            "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (1,1,?,1,1)", (self.sid,)).lastrowid
+        con.commit()
+        con.close()
+        self.rt = interface_runtime.InterfaceRuntime(
+            str(self.db), run_dir=str(self.tmp / "run"))
+
+    def tearDown(self):
+        subprocess.run(
+            ["tmux", "-S", str(self.tmp / "run" / "tmux.sock"),
+             "kill-server"], capture_output=True)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _one(self, sql, params=()):
+        con = sqlite3.connect(self.db)
+        row = con.execute(sql, params).fetchone()
+        con.close()
+        return row[0] if row else None
+
+    def _age(self, col, seconds):
+        con = sqlite3.connect(self.db)
+        con.execute(
+            f"UPDATE interface_sessions SET {col}=datetime('now', ?) "
+            f"WHERE session_id=?", (f"-{seconds} seconds", self.sid))
+        con.commit()
+        con.close()
+
+    def _record_hook(self, seq, event):
+        con = sqlite3.connect(self.db)
+        interface_broker.record_hook(con, 1, 1, seq, event)
+        con.commit()
+        con.close()
+
+    def _add_message(self):
+        con = sqlite3.connect(self.db)
+        mid = con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+            " kind, sprint_doc_id) VALUES (2,1,'evt','task',1)").lastrowid
+        interface_wake.maybe_create_wake_item(con, mid)
+        con.commit()
+        con.close()
+        return mid
+
+    def _batch_state(self):
+        return self._one(
+            "SELECT state FROM planner_wake_batches WHERE binding_id=? "
+            "ORDER BY batch_id DESC LIMIT 1", (self.binding,))
+
+    def _capture(self, info):
+        return subprocess.run(
+            ["tmux", "-S", info["tmux_socket"], "capture-pane", "-epN",
+             "-t", info["pane_id"]], capture_output=True).stdout
+
+    def _acquire_writer(self):
+        con = sqlite3.connect(self.db)
+        lease_id = interface_broker.acquire_writer(con, self.sid, "tab-1",
+                                                   "tok-1")
+        con.commit()
+        con.close()
+        return lease_id
+
+    async def _spawn(self, command):
+        await self.rt.start()
+        self.assertTrue(self.rt.available, self.rt.unavailable_reason)
+        info = await self.rt.spawn(
+            session_id=self.sid, shell_id=1, generation=1,
+            worktree=str(self.tmp), sc_path="/bin/sc",
+            token_path="/tmp/tok", rows=24, cols=80, command=command)
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "UPDATE interface_sessions SET tmux_socket=?, tmux_session=?, "
+            "tmux_window=?, tmux_pane_id=?, pane_pid=?, pane_start_ticks=? "
+            "WHERE session_id=?",
+            (info["tmux_socket"], info["tmux_session"], info["tmux_window"],
+             info["pane_id"], info["pane_pid"], info["pane_start_ticks"],
+             self.sid))
+        con.commit()
+        con.close()
+        gen = self.rt.generations[self.sid]
+        await wait_for(lambda: gen.dbg_fanout_bytes >= 5, timeout=15,
+                       what="pane READY marker")
+        return info
+
+    # -- e2e 1: wake-into-fresh -------------------------------------------------
+
+    def test_wake_into_fresh_waits_for_real_readiness(self):
+        asyncio.run(self._flow_wake_into_fresh())
+
+    async def _flow_wake_into_fresh(self):
+        # A >3s boot: the pane is unpainted for 4s, then becomes ready —
+        # and readiness arrives as the provider session_start hook AFTER
+        # the boot, exactly like a real slow harness (flag #49's shape).
+        info = await self._spawn(
+            ["/bin/sh", "-c", "sleep 4; stty raw -echo; printf READY; cat"])
+        # The session row claims occupation long ago (the defect shape):
+        # without the readiness stamp the gate would fire immediately.
+        self._age("occupied_at", 60)
+        self._age("created_at", 60)
+        self._record_hook(1, "session_start")   # real readiness, stamped now
+        hook_at = time.monotonic()
+        self._add_message()
+        self.rt.wake_coordinator.notify_binding(self.binding)
+
+        quiet = interface_broker.DEFAULT_QUIET_S
+        # The debounce is owed from REAL readiness: no byte may move first.
+        await asyncio.sleep(quiet * 0.6)
+        self.assertNotEqual(self._batch_state(), "submitting")
+        self.assertNotIn(interface_broker.WAKE_PROMPT.encode(),
+                         self._capture(info))
+        # Then exactly one submission lands in the live pane.
+        await wait_for(lambda: self._batch_state() == "submitting",
+                       timeout=quiet * 4,
+                       what="wake submission after readiness + quiet")
+        self.assertGreaterEqual(time.monotonic() - hook_at, quiet * 0.8,
+                                "submission came before the readiness "
+                                "debounce was owed")
+        prompt = interface_broker.WAKE_PROMPT.encode()
+        await wait_for(lambda: prompt in self._capture(info),
+                       what="wake prompt visible in pane")
+        await asyncio.sleep(0.5)  # let any stray duplicate land
+        self.assertEqual(self._capture(info).count(prompt), 1,
+                         "the wake must land exactly once")
+        self.assertEqual(
+            self._one("SELECT COUNT(*) FROM planner_wake_batches"), 1)
+        await self.rt.stop()
+
+    # -- e2e 2: out-of-order hook injection under input load ---------------------
+
+    def test_out_of_order_hooks_under_input_load(self):
+        asyncio.run(self._flow_hooks_under_load())
+
+    async def _flow_hooks_under_load(self):
+        await self._spawn(["/bin/sh", "-c",
+                           "stty raw -echo; printf READY; cat"])
+        self._age("occupied_at", 60)
+        self._age("created_at", 60)
+        lease_id = self._acquire_writer()
+        writer = FakeClient(self.sid, role="writer", client_id="tab-1",
+                            lease_id=lease_id, lease_token="tok-1")
+        await self.rt.attach(writer)
+
+        # Hooks arrive OUT OF ORDER from a second thread while input
+        # streams: seqs 2 and 4 arrive after higher seqs committed and
+        # must be fenced as stale; replays must be rejected outright.
+        rejected = []
+        surprises = []
+
+        def hook_worker():
+            con = sqlite3.connect(self.db)
+            try:
+                for seq, event in [(1, "session_start"), (3, "turn_stop"),
+                                   (2, "prompt_submit"), (5, "turn_stop"),
+                                   (4, "prompt_submit")]:
+                    try:
+                        interface_broker.record_hook(con, 1, 1, seq, event)
+                        con.commit()
+                    except interface_broker.BrokerError:
+                        con.rollback()
+                        rejected.append(seq)
+                for replay in (3, 5):
+                    try:
+                        interface_broker.record_hook(con, 1, 1, replay,
+                                                     "turn_stop")
+                        con.commit()
+                        surprises.append(f"replay {replay} ACCEPTED")
+                    except interface_broker.BrokerError:
+                        con.rollback()
+            finally:
+                con.close()
+
+        worker = threading.Thread(target=hook_worker)
+        worker.start()
+
+        frames = [f"frame-{i:02d}".encode() for i in range(1, 21)]
+        for i, payload in enumerate(frames, 1):
+            self.rt.enqueue_input(writer, i, payload)
+            await wait_for(
+                lambda i=i: any(a.get("seq") == i and not a.get("replayed")
+                                for a in writer.by_type("input_ack")),
+                what=f"input_ack seq={i}")
+        worker.join(5)
+
+        # Fencing: the out-of-order seqs were fenced, the replays rejected,
+        # and the durable sequence only ever moved forward.
+        self.assertEqual(surprises, [])
+        self.assertEqual(sorted(rejected), [2, 4],
+                         "out-of-order seqs must be fenced as stale")
+        self.assertEqual(
+            self._one("SELECT last_hook_seq FROM interface_generations "
+                      "WHERE shell_id=1 AND generation=1"), 5)
+        self.assertEqual(
+            self._one("SELECT lifecycle FROM interface_sessions "
+                      "WHERE session_id=?", (self.sid,)), "idle")
+        # No lost frames, no interleaved bytes: the echo stream IS the
+        # frame stream, in order, byte-exact.
+        await wait_for(lambda: b"".join(frames) in b"".join(writer.outputs),
+                       what="full echo stream")
+        await asyncio.sleep(0.3)
+        self.assertEqual(b"".join(writer.outputs), b"".join(frames))
+        self.assertFalse(
+            self.rt.runtime_state(self.sid)["continuity_broken"])
+        await self.rt.stop()
+
+    # -- e2e 3: parking under a mid-write broker crash ----------------------------
+
+    def test_broker_crash_mid_write_parks_delivery_unknown(self):
+        asyncio.run(self._flow_parking_under_crash())
+
+    async def _flow_parking_under_crash(self):
+        await self._spawn(["/bin/sh", "-c",
+                           "stty raw -echo; printf READY; cat"])
+        self._age("occupied_at", 60)
+        self._age("created_at", 60)
+
+        attempts = {"n": 0}
+        original = self.rt._send_keys_sync
+
+        def crashing_write(pane_id, payload):
+            attempts["n"] += 1
+            # The broker's tmux dies MID-WRITE: the preflight already
+            # passed, so whether any byte moved is unprovable — the crash
+            # window decision #22 parks for.
+            subprocess.run(["tmux", "-S", self.rt.sock, "kill-server"],
+                           capture_output=True)
+            original(pane_id, payload)  # raises: the server is gone
+
+        self.rt._send_keys_sync = crashing_write
+        self._add_message()
+        self.rt.wake_coordinator.notify_binding(self.binding)
+
+        await wait_for(lambda: self._batch_state() == "delivery_unknown",
+                       timeout=10, what="batch parked delivery_unknown")
+        self.assertEqual(attempts["n"], 1, "exactly one write attempt")
+        self.assertEqual(
+            self._one("SELECT reason FROM planner_alerts "
+                      "WHERE reason='wake_batch_delivery_unknown'"),
+            "wake_batch_delivery_unknown")
+
+        # No wake path may replay the parked submission: not a fresh
+        # notify, not the startup reconciliation pass.
+        self.rt.wake_coordinator.notify_binding(self.binding)
+        self.rt.wake_coordinator.startup_pass()
+        await asyncio.sleep(2.0)
+        self.assertEqual(attempts["n"], 1,
+                         "a parked batch must never be auto-replayed")
+        self.assertEqual(self._batch_state(), "delivery_unknown")
+        # The tmux server is already gone; stop() only releases runtime
+        # resources (it never touches a dead server).
+        await self.rt.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sprint 25 seq 11 part B (task #87): the @tmux-gated integration tier's first run on the baked tmux 3.5a stack. Evidence for the conformance pass.

## Previously-skipped tests now running

- `tests/test_interface_runtime.py::TmuxIntegrationTest` — 4 tests, gated on `HAS_SHADOW_STACK`, skipped all sprint. First real-tmux run: **1 passed, 3 failed** — the failures were three genuine runtime defects the hermetic tier structurally cannot see (below). After the fixes: **4/4 pass**.
- New `tests/test_interface_wake_tmux.py` — 3 e2e tests for the paths seq 8/5 deferred to this gate: **3/3 pass**.
- Spike suite (`spikes/interface-stream/tests`) — 12 tests, now executes in-sandbox: **12/12 pass** standalone. See "Known flake" below.
- Full engine suite `pytest tests/`: **808 passed, 0 skipped**.

## Real-tmux-only defects found and fixed (conformance-relevant)

1. **Pump FIFO startup race** (`interface_runtime.py`): the stand-in writer was closed before tmux's `pipe-pane` writer attached, so the pump thread's first read hit an instant false EOF — the pane-death signal — before any byte could flow. The stand-in is now held until the pipe writer is *proven* attached (fd-9 + marker handshake in `_pipe_pane`); EOF-as-death-signal semantics preserved.
2. **Pane-death chain never fired**: `_on_pump_exit` was scheduled via `loop.call_soon_threadsafe(async_fn, gen)` — the coroutine was created and dropped un-awaited. Now `asyncio.run_coroutine_threadsafe`.
3. **Shadow rebuild scrolled row 1 off**: tmux 3.5a's `capture-pane` emits a trailing newline after the last row; replayed as a stream into a same-sized zero-scrollback shadow terminal it scrolls the top row off the grid (reattach rebuilt a blank screen). `capture_pane` strips exactly one trailing newline; all three rebuild paths (attach fallback, reattach, resync) share it.

## The three deferred e2e paths (new: `tests/test_interface_wake_tmux.py`)

- **wake-into-fresh**: a >3s-boot harness receives its wake only after REAL provider readiness + the quiet debounce — never at the pre-exec `occupied_at` (flag #49 end-to-end: bytes land, exactly once, in the live pane).
- **out-of-order hook injection under input load**: 20 frames stream through real tmux while hooks arrive out of order from a second thread — seqs 2/4 fenced stale, replays rejected, `last_hook_seq` monotonic, echo stream byte-exact (no interleaved bytes).
- **parking-under-crash**: the private tmux server is killed between the wake preflight and send-keys — batch parks `delivery_unknown` + alert, and no drain/startup-pass/notify replays it (decision #22 on the real writer path).

## Matrix coverage (task #87) on real tmux

session ✓ (spawn/attach/identity) · stream ✓ (byte-exact echo) · draft ✓ (composer dirty/clean) · input-race ✓ (seq gap/dup + hooks-under-load; TOCTOU gate races stay hermetic) · lifecycle ✓ (terminate, identity-mismatch, hook lifecycle) · loss ✓ (pane death → lost/unreconciled) · restart ✓ (reattach) · dedupe ✓ (dup seq ack replay; hook replays rejected) · ambiguity ✓ (mid-write crash parking) · poison — remains hermetic route-level coverage (malformed audit fields rejected; e2e 2 covers replay injection) · polling — structural invariant (event-driven drain, no steady timer; e2e 1 asserts no byte moves before readiness+quiet).

## Tooling fixes (same root cause tier)

- Spike conftest's top-level `import server` poisoned `sys.modules` for the engine API tests in a bare `./sc test` (65 errors) — now a namespaced load. Pre-existing, unmasked by the bake.
- Spike `shadow/package.json`'s scaffolded default `"test"` script failed the `./sc test` npm leg — removed.

## Known flake (reported, not absorbed)

`spikes/.../test_bounded_buffers.py` is timing-calibrated to the host: in-sandbox it fails intermittently with two timing races (good-client delivery slows under parallel suite load; the 1011 slow-consumer close lands at 40–50s vs the test's 30s read window). Passed 12/12 in a standalone spike run; engine gate (`pytest tests/`, what CI runs) is unaffected. Spike code is untouched by this branch.

## Environment gap (flag #60)

The bake installed `@xterm/*` at the npm global root `/usr/lib/node_modules`; the runtime expects `/opt/sc-shadow/node_modules` (or `.super-coder/shadow/node_modules`). Real-tmux tier in-sandbox currently needs a symlink workaround (used here, not committed). Flag #60 filed for the image/engine path fix.