### PR TITLE
fix(interface): provision shell worktree at reserve, never assume it (flag #61)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -290,8 +290,38 @@ def _shortname(con, shell_id: int) -> str:
 
 # ------------------------------------------------------------------ sessions
 
-def _worktree_for(shortname: str) -> str:
-    return str(REPO_ROOT / ".sc-worktrees" / shortname.lower())
+def _worktree_for(shortname: str, flavor: "str | None" = None) -> str:
+    """A shell's exec cwd, resolved through the CLI boot's own rule
+    (run.shell_work_dir): admin at the repo root, every other flavor at
+    .sc-worktrees/<shortname>. Lazy import — run.py is the CLI module."""
+    import run as run_mod
+    return str(run_mod.shell_work_dir(shortname, flavor))
+
+
+def _provision_worktree(worktree: str, shortname: str):
+    """Create the shell's git worktree on demand, exactly like the CLI boot
+    (run.ensure_worktree). A shell that was never CLI-booted has no
+    .sc-worktrees/<shortname> yet; the tmux pane's `cd` and the exec both
+    assume it exists, so it must be provisioned BEFORE the reservation is
+    written — never left to fail as a raw 'not a directory'. Returns an
+    error tuple for produce() on failure, None on success/no-op."""
+    path = Path(worktree)
+    if path.is_dir():
+        return None
+    import run as run_mod
+    if path == run_mod.REPO_ROOT:
+        return None  # admin flavor boots at the repo root — nothing to add
+    try:
+        run_mod.ensure_worktree(path, shortname)
+    except SystemExit as e:  # ensure_worktree exits with the git stderr
+        detail = str(e).removeprefix("FATAL: ").strip()
+        return 500, {"error": {
+            "code": "worktree_provision_failed",
+            "message": f"could not provision the shell worktree: {detail} — "
+                       f"fix the repo (`git worktree list`) or create it by "
+                       f"hand (`./sc enter {shortname}`), then retry New chat",
+            "details": {"worktree": worktree, "shortname": shortname}}}
+    return None
 
 
 def _create_session(actor, headers, body):
@@ -314,12 +344,13 @@ def _create_session(actor, headers, body):
     con = _db()
     try:
         shell = con.execute(
-            "SELECT shell_id, shortname FROM shells "
+            "SELECT shell_id, shortname, flavor FROM shells "
             "WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
             (shell_id,)).fetchone()
         if shell is None:
             return _err(404, "no_such_shell", f"shell {shell_id} not found")
         shortname = shell[1]
+        flavor = shell[2]
 
         def produce():
             # These checks live INSIDE produce: the idempotency store is
@@ -348,6 +379,14 @@ def _create_session(actor, headers, body):
                                "chat is blocked as unreconciled until "
                                "absence is proved",
                     "details": {"shortname": shortname}}}
+            # Resolve + provision the shell's exec cwd through the CLI
+            # boot's own rule BEFORE any row or token exists: a shell never
+            # CLI-booted (e.g. a planner woken only through the Interface)
+            # has no worktree yet — create it here, like `./sc enter`.
+            worktree = _worktree_for(shortname, flavor)
+            provision_err = _provision_worktree(worktree, shortname)
+            if provision_err is not None:
+                return provision_err
             gen_no = con.execute(
                 "SELECT COALESCE(MAX(generation),0)+1 FROM "
                 "interface_generations WHERE shell_id=?",
@@ -366,7 +405,7 @@ def _create_session(actor, headers, body):
                 "VALUES (?,?,?,?,?, 'reserved', 'starting', "
                 "        datetime('now', ?))",
                 (shell_id, gen_no, harness, body.get("model"),
-                 _worktree_for(shortname), f"+{RESERVATION_TTL_S} seconds"))
+                 worktree, f"+{RESERVATION_TTL_S} seconds"))
             session_id = cur.lastrowid
             con.execute(
                 "INSERT INTO interface_input_state "
@@ -379,14 +418,14 @@ def _create_session(actor, headers, body):
                 "session_id": session_id, "shell_id": shell_id,
                 "generation": gen_no, "hook_token": hook_token,
                 "api_port": ports_mod.resolve().get("port", 8800),
-                "worktree": _worktree_for(shortname),
+                "worktree": worktree,
                 "harness": harness, "model": body.get("model"),
                 "effort": body.get("effort")}))
             os.chmod(token_path, 0o600)
             try:
                 identity = _runtime.call(_runtime.spawn(
                     session_id=session_id, shell_id=shell_id,
-                    generation=gen_no, worktree=_worktree_for(shortname),
+                    generation=gen_no, worktree=worktree,
                     sc_path=str(REPO_ROOT / "sc"),
                     token_path=str(token_path), rows=rows, cols=cols))
             except Exception as exc:  # noqa: BLE001 — see below

--- a/.super-coder/scripts/interface_exec.py
+++ b/.super-coder/scripts/interface_exec.py
@@ -10,7 +10,13 @@ points a private tmux pane's shell line at this script. This process then:
        unreadable, unparsable, or missing fields refuses (exit 2) BEFORE
        any archive row exists: no capability, no launch, no session.
     2. deletes the token (single use — a second invocation refuses).
-    3. chdirs into the token's worktree.
+    3. chdirs into the token's worktree when it exists. A missing one is
+       NOT fatal: prepare_launch below resolves the shell's cwd through the
+       CLI boot's own rule (admin → repo root, every other flavor →
+       .sc-worktrees/<shortname>, provisioning the git worktree on demand),
+       and the process chdirs to plan.cwd before exec. (The API already
+       provisions at reserve time; this is the self-heal for a worktree
+       lost between reserve and exec.)
     4. prepares the launch through run.py's `prepare_launch` — the NORMAL
        harness/model/effort/permission/worktree/render/boot/archive path
        (exit 3 on refusal), then merges the harness's authenticated
@@ -159,11 +165,12 @@ def main(argv: "list[str] | None" = None) -> int:
         pass
 
     worktree = Path(token["worktree"])
-    if not worktree.is_dir():
-        print(f"interface-exec: worktree {worktree} is not a directory",
-              file=sys.stderr)
-        return 2
-    os.chdir(worktree)
+    if worktree.is_dir():
+        os.chdir(worktree)
+    # A missing token worktree is not a hard failure: prepare_launch (the
+    # CLI boot's own resolver) provisions the shell's worktree on demand
+    # and hands back the authoritative plan.cwd, which we chdir to before
+    # exec. Never refuse with a bare "not a directory".
 
     try:
         plan = run_mod.prepare_launch(

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -250,6 +250,17 @@ def apply_sandbox(adapter: dict, root: Path = REPO_ROOT) -> list[str]:
     return _merge_json_spec((adapter.get("sandbox") or {}).get("merge_json") or {}, root)
 
 
+def shell_work_dir(shortname: "str | None", flavor: "str | None") -> Path:
+    """The one worktree rule, shared by every boot path (interactive CLI,
+    headless `sc run`, Interface exec): the admin flavor boots at the repo
+    root (it maintains `main` itself); every other shell — dev, planner,
+    reviewer alike — gets an isolated git worktree at
+    `.sc-worktrees/<shortname>` on branch `shell/<shortname>`."""
+    if shortname and flavor != "admin":
+        return REPO_ROOT / ".sc-worktrees" / shortname.lower()
+    return REPO_ROOT
+
+
 def ensure_worktree(work_dir: Path, shortname: str) -> None:
     """Create a git worktree for a shell at work_dir on branch shell/<shortname>.
 
@@ -942,10 +953,9 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
 
     # Worktree: identical rule to main() — every non-admin shell boots in
     # .sc-worktrees/<shortname>; admin boots at the repo root.
-    work_dir = REPO_ROOT
+    work_dir = shell_work_dir(chosen["shortname"], chosen["flavor"])
     sync_note = None
-    if chosen["shortname"] and chosen["flavor"] != "admin":
-        work_dir = REPO_ROOT / ".sc-worktrees" / chosen["shortname"].lower()
+    if work_dir != REPO_ROOT:
         ensure_worktree(work_dir, chosen["shortname"])
         sync_note = sync_worktree(work_dir, chosen["shortname"])
         link_worktree_map(work_dir)
@@ -1269,11 +1279,10 @@ def main() -> None:
         # it maintains `main` itself (engine updates, migrations, applying approved
         # patches), so it boots in the repo root — no worktree, no shell/* branch.
         # The branch-guard exempts it via SC_SHELL_FLAVOR (exported at exec below).
-        work_dir = REPO_ROOT
+        work_dir = shell_work_dir(chosen["shortname"], chosen["flavor"])
         sync_note = None
-        if chosen["shortname"] and chosen["flavor"] != "admin":
+        if work_dir != REPO_ROOT:
             spinner.label = "syncing worktree"
-            work_dir = REPO_ROOT / ".sc-worktrees" / chosen["shortname"].lower()
             ensure_worktree(work_dir, chosen["shortname"])
             sync_note = sync_worktree(work_dir, chosen["shortname"])
             map_note = link_worktree_map(work_dir)

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -38,6 +38,7 @@ MIGRATIONS = ENGINE / "migrations"
 sys.path.insert(0, str(ENGINE / "scripts"))
 sys.path.insert(0, str(ENGINE / "api"))
 import interface_routes as routes  # noqa: E402
+import run as run_mod  # noqa: E402
 
 
 def build_engine_db(path: Path) -> None:
@@ -124,9 +125,15 @@ class InterfaceApiTest(unittest.TestCase):
             mock.patch.object(routes, "RUN_DIR", run_dir),
             mock.patch.object(routes, "OPERATOR_TOKEN_PATH",
                               run_dir / "operator.token"),
+            # New chat provisions a missing shell worktree through the CLI
+            # boot's ensure_worktree (flag #61) — a real git mutation.
+            # Hermetic default: stub it; the provisioning tests below drive
+            # the stub explicitly.
+            mock.patch.object(run_mod, "ensure_worktree"),
         ]
         for p in self.patches:
             p.start()
+        self.ensure_wt = run_mod.ensure_worktree
         routes.ensure_operator_capability()
         (run_dir / "operator.token").write_text("optok")
         self.runtime = FakeRuntime()
@@ -347,6 +354,72 @@ class InterfaceApiTest(unittest.TestCase):
     def test_unknown_fields_rejected(self):
         status, _, body = self.create_session(shell_id=1, bogus=True)
         self.assertEqual(status, 422)
+
+    # -- worktree provisioning (flag #61) --------------------------------------
+
+    def _launch_token(self, session_id):
+        return json.loads(
+            (routes.RUN_DIR / f"launch-{session_id}.json").read_text())
+
+    def test_new_chat_provisions_missing_worktree(self):
+        """A shell never CLI-booted (e.g. a planner woken only through the
+        Interface) has no .sc-worktrees/<shortname>: New chat must provision
+        it through the CLI boot's ensure_worktree BEFORE the reservation —
+        the old failure was a raw 'not a directory' at exec time."""
+        root = Path(self.tmp.name)
+        with mock.patch.object(run_mod, "REPO_ROOT", root):
+            expected = str(root / ".sc-worktrees" / "s1")
+            status, _, body = self.create_session()
+        self.assertEqual(status, 201, body)
+        self.ensure_wt.assert_called_once_with(Path(expected), "s1")
+        self.assertEqual(self._launch_token(body["session_id"])["worktree"],
+                         expected)
+        self.assertEqual(self.runtime.spawned[0]["worktree"], expected)
+
+    def test_new_chat_existing_worktree_not_reprovisioned(self):
+        root = Path(self.tmp.name)
+        (root / ".sc-worktrees" / "s1").mkdir(parents=True)
+        with mock.patch.object(run_mod, "REPO_ROOT", root):
+            status, _, body = self.create_session()
+        self.assertEqual(status, 201, body)
+        self.ensure_wt.assert_not_called()
+
+    def test_new_chat_admin_resolves_repo_root(self):
+        """The admin flavor boots at the repo root (the CLI boot's rule) —
+        the Interface must resolve it there and provision nothing."""
+        con = sqlite3.connect(self.db_path)
+        con.execute("UPDATE shells SET flavor='admin' WHERE shell_id=1")
+        con.commit()
+        con.close()
+        root = Path(self.tmp.name)
+        with mock.patch.object(run_mod, "REPO_ROOT", root):
+            status, _, body = self.create_session()
+        self.assertEqual(status, 201, body)
+        self.ensure_wt.assert_not_called()
+        self.assertEqual(self._launch_token(body["session_id"])["worktree"],
+                         str(root))
+
+    def test_new_chat_provision_failure_is_actionable(self):
+        """A failed provision refuses cleanly: an actionable 500, and no
+        reservation row, token, or pane left behind."""
+        self.ensure_wt.side_effect = SystemExit(
+            "FATAL: could not create worktree at /x:\nfatal: branch conflict")
+        root = Path(self.tmp.name)
+        with mock.patch.object(run_mod, "REPO_ROOT", root):
+            status, _, body = self.create_session()
+        self.assertEqual(status, 500)
+        err = body["error"]
+        self.assertEqual(err["code"], "worktree_provision_failed")
+        self.assertIn("branch conflict", err["message"])
+        self.assertIn("git worktree list", err["message"])
+        self.assertNotIn("FATAL", err["message"])
+        con = sqlite3.connect(self.db_path)
+        count = con.execute("SELECT COUNT(*) FROM interface_sessions"
+                            ).fetchone()[0]
+        con.close()
+        self.assertEqual(count, 0)
+        self.assertEqual(list(routes.RUN_DIR.glob("launch-*.json")), [])
+        self.assertEqual(self.runtime.spawned, [])
 
     # -- reservation + spawn ---------------------------------------------------------------
 

--- a/tests/test_interface_exec.py
+++ b/tests/test_interface_exec.py
@@ -193,12 +193,21 @@ class InterfaceExecTest(unittest.TestCase):
         self.assertEqual(self.plan_calls, [])
         self.assertEqual(self._archive_count(), 0)
 
-    def test_bad_worktree_refuses(self):
+    # ── 1b: a missing worktree self-heals (flag #61) ─────────────────────
+    def test_missing_worktree_self_heals_via_prepare_launch(self):
+        """A token whose worktree was never provisioned (a shell never
+        CLI-booted) must NOT refuse with a bare 'not a directory':
+        prepare_launch — the CLI boot's own resolver — re-resolves and
+        provisions the shell's cwd, and the harness execs from plan.cwd."""
         path = self._write_token(worktree=str(self.tmp / "ghost"))
-        code, _ = self._run(path)
-        self.assertEqual(code, 2)
-        self.assertEqual(self.plan_calls, [])
-        self.assertEqual(self._archive_count(), 0)
+        code, err = self._run(path)
+        self.assertEqual(code, 0)
+        self.assertNotIn("not a directory", err)
+        self.assertEqual(len(self.plan_calls), 1,
+                         "prepare_launch (the shared resolver) must run")
+        self.assertEqual(len(self.exec_calls), 1)
+        self.assertEqual(os.getcwd(), str(self.worktree),
+                         "the final cwd is prepare_launch's plan.cwd")
 
     # ── 2: single use ───────────────────────────────────────────────────
     def test_token_consumed_on_read(self):

--- a/tests/test_worktree_sync.py
+++ b/tests/test_worktree_sync.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Tests for the launcher's worktree drift check (run.sync_worktree).
+"""Tests for the launcher's worktree handling: the drift check
+(run.sync_worktree), the shared boot-cwd resolver (run.shell_work_dir),
+and on-demand worktree provisioning (run.ensure_worktree, flag #61).
 
 Stdlib `unittest`, no pytest — matching the engine's no-dependency style.
 Each test builds a throwaway origin + clone + shell worktree with real git in
@@ -17,11 +19,13 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parents[1] / ".super-coder" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-from run import sync_worktree  # noqa: E402
+import run as run_mod  # noqa: E402
+from run import ensure_worktree, shell_work_dir, sync_worktree  # noqa: E402
 
 GIT_ENV = {
     **os.environ,
@@ -132,6 +136,53 @@ class WorktreeSyncTest(unittest.TestCase):
         note = sync_worktree(self.wt, "DEV1")
         self.assertIn("in sync", note)
         self.assertIn("unmerged local commit", note)
+
+
+class ShellWorkDirTest(unittest.TestCase):
+    """The shared boot-cwd resolver (flag #61): admin boots at the repo
+    root; every other flavor — dev, planner, reviewer — boots in its own
+    .sc-worktrees/<shortname> worktree."""
+
+    def test_role_resolution(self) -> None:
+        root = Path("/repo")
+        with mock.patch.object(run_mod, "REPO_ROOT", root):
+            for flavor in ("dev", "planner", "reviewer", None):
+                with self.subTest(flavor=flavor):
+                    self.assertEqual(
+                        shell_work_dir("PLN1", flavor),
+                        root / ".sc-worktrees" / "pln1")
+            self.assertEqual(shell_work_dir("ADMIN", "admin"), root)
+            self.assertEqual(shell_work_dir("", "dev"), root)
+
+
+class EnsureWorktreeTest(unittest.TestCase):
+    """ensure_worktree is the provisioning the Interface reserve path now
+    shares with the CLI boot (flag #61): it must create a missing shell
+    worktree on branch shell/<shortname>, idempotently."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name) / "fork"
+        self.repo.mkdir()
+        git(self.repo, "init", "-q", "-b", "main")
+        (self.repo / "f.txt").write_text("v1\n")
+        git(self.repo, "add", "f.txt")
+        git(self.repo, "commit", "-qm", "c1")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_provisions_missing_worktree(self) -> None:
+        wt = self.repo / ".sc-worktrees" / "pln1"
+        with mock.patch.object(run_mod, "REPO_ROOT", self.repo):
+            ensure_worktree(wt, "PLN1")
+            self.assertTrue(wt.is_dir())
+            self.assertIn("shell/pln1",
+                          git(self.repo, "branch", "--list", "shell/pln1"))
+            self.assertIn(str(wt), git(self.repo, "worktree", "list"))
+            ensure_worktree(wt, "PLN1")  # second call is a no-op
+        self.assertEqual(git(wt, "symbolic-ref", "--short", "HEAD"),
+                         "shell/pln1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Sprint 25 · seq-11 fix unit · flag #61

**Repro (ami, real fork):** opening the Interface for a shell never CLI-booted errors `interface-exec worktree /home/j3d1/ami/.sc-worktrees/pln1 is not a directory`.

**Root cause (investigated per the task's two candidates):** candidate **(b) missing provision** — candidate (a) role-mismatch is disproved by the engine's own model. `run.py` (interactive boot, headless `sc run`, and `prepare_launch` alike) gives **every non-admin shell** — dev, planner, reviewer — its own `.sc-worktrees/<shortname>` worktree, created on demand by `ensure_worktree` ("planner/reviewer commit their own artifacts there too" — run.py:1274); only **admin** boots at the repo root. The Interface reserve path (`interface_routes._worktree_for`) computed the worktree path for every shell but **never provisioned it**, so the tmux pane's `cd` and the exec's `is_dir` check both failed hard on a shell that had never been CLI-booted.

## Fix — one resolver, shared, no divergence

- **`run.shell_work_dir(shortname, flavor)`** — the single boot-cwd rule (admin → repo root; every other flavor → `.sc-worktrees/<shortname>`), now used by all three boot paths (interactive `main()`, headless `prepare_launch`, Interface).
- **`interface_routes._create_session`** — resolves the exec cwd through `shell_work_dir` and **provisions a missing worktree via `run.ensure_worktree`** (the CLI boot's own worktree-create) *before* any reservation row, token, or pane exists. Provisioning failure returns an actionable 500 `worktree_provision_failed` ("fix the repo (`git worktree list`) or create it by hand (`./sc enter <shell>`), then retry New chat") — never a raw not-a-directory, never a reservation for a dead pane.
- **`interface_exec`** — a missing token worktree no longer exit-2s; `prepare_launch` (the same shared resolver) re-provisions and the harness execs from `plan.cwd`. Self-heal for a worktree lost between reserve and exec.

## Verification (hermetic)

- `test_interface_api` (+4): reserve provisions a missing worktree (ensure_worktree called before reservation; token + spawn carry the resolved path) · existing worktree not re-provisioned · **admin flavor resolves to the repo root, no provision** · provision failure → actionable 500, zero rows/token/pane left behind.
- `test_interface_exec`: missing worktree **self-heals** via prepare_launch and execs from plan.cwd — the old raw not-a-directory refusal is gone (rewrote `test_bad_worktree_refuses`).
- `test_worktree_sync` (+2 classes): `shell_work_dir` role matrix (dev/planner/reviewer/NULL → worktree; admin/empty → root) · `ensure_worktree` real-git provisioning + idempotency.
- Full suite **809 passed, 4 tmux-gated skips**; `render_check.py` (worktree-direct) ✓; `ruff` ✓.

**Not done here (by design):** the end-to-end fork proof (Interface on ami for pln1 + dev1) is the planner's post-merge acceptance test.

Reviewer: REV1 (Kimi) per the seq-11 task.