### PR TITLE
fix(diagnostics): fail closed and skip linked worktrees

### DIFF
--- a/.super-coder/scripts/map_repo.py
+++ b/.super-coder/scripts/map_repo.py
@@ -25,7 +25,6 @@ import json
 import re
 import sqlite3
 import subprocess
-import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -42,7 +41,8 @@ CONFIG_PATH_LEGACY = ENGINE / "map.config.json"
 
 # Built-in defaults. A fork's map.config.json EXTENDS the skip sets and may add
 # role_overrides — it never shrinks these (so the engine dirs below stay hidden).
-SKIP_DIRS = {".git", "node_modules", ".super-coder", ".sc-state", ".venv", "venv",
+SKIP_DIRS = {".git", ".sc-worktrees", "node_modules", ".super-coder", ".sc-state",
+             ".venv", "venv",
              "__pycache__", ".svelte-kit", "dist", "build", ".next", "target",
              "vendor", ".claude", ".idea", ".vscode", "coverage", ".pytest_cache",
              # super-coder's own render output — mirrors the DB, not host source.

--- a/.super-coder/scripts/shell_liveness.py
+++ b/.super-coder/scripts/shell_liveness.py
@@ -21,11 +21,11 @@ under THIS repo is a live shell session:
                                   root, not a worktree)
   • cwd under .sc-worktrees/<n> → the shell whose shortname.lower() == <n>
 
-The admin runs this (directly or as a child of its own harness), so its OWN
-session always appears — identified by `is_self` (PPID walk from our pid up to a
-harness ancestor) and by the repo-root cwd. The admin being active is EXPECTED;
-the gate is about OTHER shells. `active_other_shells == []` ⇒ the admin is the
-only live shell ⇒ every worktree is dormant ⇒ safe to clean all.
+The admin runs this (directly or as a child of its own harness), and its OWN
+session is positively identified only when the PPID walk finds a harness
+ancestor whose cwd is the repo root. Host launchers may hide that ancestor; in
+that case admin presence is indeterminate and cleanup fails closed. When Admin
+is positively present, the gate is about OTHER shells.
 
 Permissions: /proc/<pid>/cwd is readable only for same-user processes. A harness
 owned by another OS user is counted but unreadable → `indeterminate`. When
@@ -204,7 +204,6 @@ def compute() -> dict:
 
     bins = harness_binaries()
     root = REPO_ROOT.resolve()
-    wt_base = (REPO_ROOT / ".sc-worktrees").resolve()
     labels = _shell_labels()
 
     # First pass: every harness process and its raw pid/comm (cwd resolved next).
@@ -261,11 +260,14 @@ def compute() -> dict:
     active_other = sorted(worktree_sessions)
     indeterminate = len(indeterminate_pids)
     orphaned_pids = [p["pid"] for p in processes if p["orphaned"]]
+    admin_present = self_pid is not None and self_pid in admin_root_pids
+    admin_presence = "present" if admin_present else "indeterminate"
     return {
         "supported": True,
         "repo": {"name": REPO_ROOT.name, "root": str(REPO_ROOT)},
         "harness_binaries": sorted(bins),
         "self_pid": self_pid,
+        "admin_presence": admin_presence,
         "processes": processes,
         "worktree_sessions": worktree_sessions,
         "active_other_shells": active_other,
@@ -273,8 +275,9 @@ def compute() -> dict:
         "indeterminate": indeterminate,
         "indeterminate_pids": indeterminate_pids,
         "orphaned_pids": orphaned_pids,
-        # The gate: only the admin is live AND nothing is unreadable.
-        "safe_to_clean_all": not active_other and indeterminate == 0,
+        # The gate: Admin is positively present, no other shell is live, and
+        # every harness cwd was readable.
+        "safe_to_clean_all": admin_present and not active_other and indeterminate == 0,
     }
 
 
@@ -313,7 +316,8 @@ def _print_text(d: dict) -> None:
         print(f"{d['repo']['name']}: liveness unsupported — {d.get('note','')}")
         return
     print(f"{d['repo']['name']}   harnesses={','.join(d['harness_binaries'])}"
-          f"   self_pid={d['self_pid']}")
+          f"   self_pid={d['self_pid']}"
+          f"   admin_presence={d['admin_presence']}")
     print("\nLIVE HARNESS SESSIONS")
     if not d["processes"]:
         print("  (none — no harness cwd'd inside this repo)")
@@ -345,6 +349,9 @@ def _print_text(d: dict) -> None:
               f"  → surface those worktrees; do NOT act on them.")
         if not d["indeterminate"]:
             print("  All other worktrees are dormant → safe to clean.")
+    elif d["admin_presence"] != "present":
+        print("  Admin presence is indeterminate — current harness identity "
+              "was not positively matched to the repo root; cleanup remains unsafe.")
     elif d["indeterminate"]:
         print("  No live other shells seen, but indeterminate>0 → surface, "
               "do not assume safe.")

--- a/tests/test_map_repo.py
+++ b/tests/test_map_repo.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Regression coverage for the repo map's unconditional skip surface."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import map_repo  # noqa: E402
+
+
+SCHEMA = """
+CREATE TABLE dr_repo (
+    repo_id INTEGER PRIMARY KEY,
+    name TEXT,
+    root TEXT,
+    remote TEXT,
+    vcs TEXT,
+    default_branch TEXT,
+    file_count INTEGER,
+    mapped_at TEXT
+);
+CREATE TABLE dr_filepath (
+    path TEXT PRIMARY KEY,
+    ext TEXT,
+    lang TEXT,
+    role TEXT,
+    bytes INTEGER,
+    lines INTEGER,
+    desc TEXT
+);
+CREATE TABLE dr_dependency (
+    manager TEXT,
+    name TEXT,
+    version TEXT,
+    kind TEXT,
+    source_file TEXT
+);
+CREATE TABLE dr_env (name TEXT, source_file TEXT);
+CREATE TABLE dr_section (
+    name TEXT PRIMARY KEY,
+    path_prefix TEXT,
+    description TEXT,
+    sort_order INTEGER
+);
+"""
+
+
+class WorktreeSkipTest(unittest.TestCase):
+    def test_linked_worktree_is_absent_from_every_core_projection(self):
+        with tempfile.TemporaryDirectory() as td:
+            temp_root = Path(td)
+            root = temp_root / "repo"
+            root.mkdir()
+            db_path = temp_root / "map.db"
+            con = sqlite3.connect(db_path)
+            con.executescript(SCHEMA)
+            con.close()
+
+            (root / "app.py").write_text("print('selected checkout')\n")
+            (root / "package.json").write_text(
+                '{"dependencies":{"express":"1.0.0"}}')
+            (root / ".env.example").write_text("ROOT_ONLY=1\n")
+
+            linked = root / ".sc-worktrees" / "dev1"
+            linked.mkdir(parents=True)
+            (linked / "app.py").write_text("print('linked worktree')\n")
+            (linked / "package.json").write_text(
+                '{"dependencies":{"express":"1.0.0","uuid":"1.0.0"}}')
+            (linked / ".env.example").write_text("LINKED_ONLY=1\n")
+
+            def connect() -> sqlite3.Connection:
+                return sqlite3.connect(db_path)
+
+            with mock.patch.object(map_repo, "REPO_ROOT", root), \
+                    mock.patch.object(map_repo, "ENGINE", root / ".super-coder"), \
+                    mock.patch.object(map_repo, "CONFIG_PATH",
+                                      root / ".sc-state" / "map.config.json"), \
+                    mock.patch.object(map_repo, "CONFIG_PATH_LEGACY",
+                                      root / ".super-coder" / "map.config.json"), \
+                    mock.patch.object(map_repo, "is_source_repo",
+                                      return_value=False), \
+                    mock.patch.object(map_repo, "git", return_value=""), \
+                    mock.patch.object(map_repo.map_db, "connect", side_effect=connect):
+                self.assertEqual(0, map_repo.main())
+
+            con = sqlite3.connect(db_path)
+            paths = [row[0] for row in con.execute(
+                "SELECT path FROM dr_filepath ORDER BY path")]
+            dependencies = con.execute(
+                "SELECT manager, name FROM dr_dependency ORDER BY name").fetchall()
+            env_names = [row[0] for row in con.execute(
+                "SELECT name FROM dr_env ORDER BY name")]
+            file_count = con.execute(
+                "SELECT file_count FROM dr_repo WHERE repo_id=1").fetchone()[0]
+            con.close()
+
+        self.assertEqual([".env.example", "app.py", "package.json"], paths)
+        self.assertEqual([("npm", "express")], dependencies)
+        self.assertEqual(["ROOT_ONLY"], env_names)
+        self.assertEqual(len(paths), file_count)
+        self.assertFalse(any(path.startswith(".sc-worktrees/") for path in paths))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shell_liveness.py
+++ b/tests/test_shell_liveness.py
@@ -10,9 +10,13 @@ Run:
 """
 from __future__ import annotations
 
+import io
 import sys
+import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 sys.path.insert(0, str(ENGINE / "scripts"))
@@ -118,6 +122,52 @@ class SessionStateTest(unittest.TestCase):
             "dev2", {"supported": False, "processes": self.SNAP["processes"]}))
 
 
+class AdminPresenceTest(unittest.TestCase):
+    """Cleanup requires positive evidence that the current Admin owns root."""
+
+    def test_missing_self_identity_is_indeterminate_and_unsafe(self):
+        with tempfile.TemporaryDirectory() as td, \
+                mock.patch.object(shell_liveness, "PROC", Path(td)), \
+                mock.patch.object(shell_liveness, "harness_binaries",
+                                  return_value={"codex"}), \
+                mock.patch.object(shell_liveness, "_shell_labels", return_value={}):
+            snap = shell_liveness.compute()
+
+        self.assertIsNone(snap["self_pid"])
+        self.assertEqual("indeterminate", snap["admin_presence"])
+        self.assertFalse(snap["safe_to_clean_all"])
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            shell_liveness._print_text(snap)
+        self.assertIn("admin_presence=indeterminate", output.getvalue())
+        self.assertIn("cleanup remains unsafe", output.getvalue())
+
+    def test_matched_root_self_is_positive_evidence(self):
+        with tempfile.TemporaryDirectory() as td:
+            proc = Path(td)
+            process = proc / "123"
+            process.mkdir()
+            (process / "comm").write_text("codex\n")
+            (process / "cwd").symlink_to(shell_liveness.REPO_ROOT)
+
+            with mock.patch.object(shell_liveness, "PROC", proc), \
+                    mock.patch.object(shell_liveness, "harness_binaries",
+                                      return_value={"codex"}), \
+                    mock.patch.object(shell_liveness, "_shell_labels",
+                                      return_value={}), \
+                    mock.patch.object(shell_liveness, "_self_harness_pid",
+                                      return_value=123), \
+                    mock.patch.object(shell_liveness, "_tty_nr", return_value=0), \
+                    mock.patch.object(shell_liveness, "_ppid", return_value=2), \
+                    mock.patch.object(shell_liveness, "_tty_fd", return_value=None):
+                snap = shell_liveness.compute()
+
+        self.assertEqual("present", snap["admin_presence"])
+        self.assertEqual([123], snap["admin_root_pids"])
+        self.assertTrue(snap["safe_to_clean_all"])
+
+
 class ComputeSmokeTest(unittest.TestCase):
     """compute() against the real /proc: shape only, no liveness assumptions."""
 
@@ -125,6 +175,9 @@ class ComputeSmokeTest(unittest.TestCase):
         snap = shell_liveness.compute()
         if not snap.get("supported"):
             self.skipTest("non-Linux: /proc unavailable")
+        self.assertIn(snap["admin_presence"], ("present", "indeterminate"))
+        if snap["admin_presence"] == "indeterminate":
+            self.assertFalse(snap["safe_to_clean_all"])
         self.assertIn("orphaned_pids", snap)
         self.assertIsInstance(snap["orphaned_pids"], list)
         for p in snap["processes"]:


### PR DESCRIPTION
## Outcome

- require positive current-Admin harness evidence before `safe_to_clean_all` can become true
- expose `admin_presence=indeterminate` and an unsafe text verdict when self identity cannot be proved
- unconditionally exclude `.sc-worktrees` from file, dependency, environment, language, and count projections
- add regression coverage for the exact #517 and #524 reproductions

## Verification

- `pytest -q tests/test_shell_liveness.py tests/test_map_repo.py` — 20 passed
- `./sc lint` on touched files — green
- `./sc test` — 824 passed, 7 skipped (clean rerun)
- first full run had one unrelated SQLite `-shm` teardown race in `test_interface_wake`; isolated rerun passed, then the full suite passed

## Trade-off

Admin presence is intentionally binary at the cleanup gate: a positively matched self harness is `present`; every unproved case is `indeterminate`. This is stricter than trying to infer absence from missing process evidence and matches the fail-closed requirement.

Refs #517 #524; closure deferred to U10 AMI acceptance.