### PR TITLE
fix(supervision): harden restricted-seat restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,10 +50,14 @@
 /.sc-state/map.db
 /.sc-state/map.db-wal
 /.sc-state/map.db-shm
+/.sc-state/db_backups/
 
 # Python / tooling
 __pycache__/
 *.pyc
 .venv/
+# Source-repo shadow uses a symlink to the image's shared node toolchain; the
+# directory-only rule below does not match a symlink.
+/.super-coder/shadow/node_modules
 node_modules/
 .svelte-kit/

--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -38,9 +38,9 @@ SC := ./sc
 # Hot commands — long form, with a one-letter alias delegating to it.
 dos-enter:            ; $(SC) $(if $(s),enter-$(s),enter)
 dos-e: dos-enter
-dos-launch:           ; $(SC) launch
+dos-launch:           ; $(SC) launch $(ARGS)
 dos-l: dos-launch
-dos-restart:          ; $(SC) restart
+dos-restart:          ; $(SC) restart $(ARGS)
 dos-r: dos-restart
 dos-down:             ; $(SC) down
 dos-d: dos-down

--- a/.super-coder/scripts/db_backup.py
+++ b/.super-coder/scripts/db_backup.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Select and create WAL-safe engine DB backups.
+
+Selection is ordered and fail-closed:
+
+1. ``SC_DB_BACKUP_DIR`` when set and writable.
+2. ``~/db_backups/<repo>`` when writable.
+3. The gitignored repo-local ``.sc-state/db_backups`` directory.
+
+Every candidate is created and write-probed before it is returned.  Callers
+that are about to stop supervised processes can therefore resolve the
+destination first and know a predictable permission failure cannot strand the
+fork offline.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Mapping
+
+KEEP_BACKUPS = 5
+
+
+class BackupDestinationError(RuntimeError):
+    """No configured backup destination can be written."""
+
+
+def preferred_home_dir(
+    repo_root: Path, environ: Mapping[str, str] | None = None
+) -> Path:
+    env = os.environ if environ is None else environ
+    home = Path(env.get("HOME") or Path.home()).expanduser()
+    return home / "db_backups" / repo_root.name
+
+
+def candidate_dirs(
+    repo_root: Path, environ: Mapping[str, str] | None = None
+) -> list[Path]:
+    env = os.environ if environ is None else environ
+    candidates: list[Path] = []
+    override = env.get("SC_DB_BACKUP_DIR", "").strip()
+    if override:
+        candidates.append(Path(override).expanduser())
+    candidates.extend(
+        [
+            preferred_home_dir(repo_root, env),
+            repo_root / ".sc-state" / "db_backups",
+        ]
+    )
+    # An override may intentionally name the normal home or local directory.
+    # Probe it once and preserve the documented priority.
+    return list(dict.fromkeys(candidates))
+
+
+def _probe_writable(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    probe = directory / f".sc-write-probe-{os.getpid()}-{time.time_ns()}"
+    fd: int | None = None
+    try:
+        fd = os.open(probe, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        os.write(fd, b"ok")
+    finally:
+        if fd is not None:
+            os.close(fd)
+        probe.unlink(missing_ok=True)
+
+
+def select_backup_dir(
+    repo_root: Path, environ: Mapping[str, str] | None = None
+) -> Path:
+    failures: list[str] = []
+    for candidate in candidate_dirs(repo_root, environ):
+        try:
+            _probe_writable(candidate)
+        except OSError as exc:
+            failures.append(f"{candidate}: {exc.strerror or exc}")
+            continue
+        return candidate
+    detail = "\n  - ".join(failures)
+    raise BackupDestinationError(
+        "no writable DB backup destination; tried:\n  - "
+        f"{detail}\nSet SC_DB_BACKUP_DIR to a writable directory and retry."
+    )
+
+
+def latest_backup(
+    repo_root: Path,
+    pattern: str,
+    environ: Mapping[str, str] | None = None,
+) -> Path | None:
+    """Find the newest matching backup across every configured candidate.
+
+    The writable destination may change between update and rollback (for
+    example, a restricted seat adds ``SC_DB_BACKUP_DIR`` later, or home becomes
+    read-only). Discovery therefore reads all candidate directories instead of
+    hiding an existing restore point behind the currently selected writer.
+    """
+    matches: list[Path] = []
+    for directory in candidate_dirs(repo_root, environ):
+        try:
+            matches.extend(directory.glob(pattern))
+        except OSError:
+            continue
+    if not matches:
+        return None
+    return max(matches, key=lambda path: (path.stat().st_mtime_ns, path.name))
+
+
+def backup_database(
+    src: Path,
+    directory: Path,
+    prefix: str,
+    *,
+    keep: int = KEEP_BACKUPS,
+) -> Path | None:
+    """Create a WAL-safe SQLite online backup and prune old same-prefix files."""
+    if not src.exists():
+        return None
+    _probe_writable(directory)
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+    dst = directory / f"shell_db.{prefix}.{stamp}.db"
+    src_con = sqlite3.connect(src)
+    dst_con = sqlite3.connect(dst)
+    try:
+        with dst_con:
+            src_con.backup(dst_con)
+    finally:
+        dst_con.close()
+        src_con.close()
+    for old in sorted(directory.glob(f"shell_db.{prefix}.*.db"))[:-keep]:
+        old.unlink(missing_ok=True)
+    return dst
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2 or argv[0] not in {"select", "backup"}:
+        print(
+            "usage: db_backup.py select <repo-root> | "
+            "backup <db> <repo-root> <prefix> [destination]",
+            file=sys.stderr,
+        )
+        return 2
+    command = argv[0]
+    try:
+        if command == "select" and len(argv) == 2:
+            print(select_backup_dir(Path(argv[1]).resolve()))
+            return 0
+        if command == "backup" and len(argv) in {4, 5}:
+            src = Path(argv[1])
+            repo_root = Path(argv[2]).resolve()
+            destination = (
+                Path(argv[4]) if len(argv) == 5 else select_backup_dir(repo_root)
+            )
+            result = backup_database(src, destination, argv[3])
+            if result is None:
+                print("→ no DB yet — nothing to back up")
+            else:
+                print(f"→ DB backed up -> {result}")
+            return 0
+    except (BackupDestinationError, OSError, sqlite3.Error) as exc:
+        print(f"backup: {exc}", file=sys.stderr)
+        return 1
+    print("db_backup.py: invalid arguments", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -449,14 +449,15 @@ _GITIGNORE_BLOCK = f"""
 /.codex/hooks.json
 # Shell worktrees — one per shell, linked inside the repo root.
 /.sc-worktrees/
-# .sc-state/ is TRACKED (content.sql + engine.ref). Only the ephemeral
-# pre-update restore pointer and the derived map cache are ignored.
+# .sc-state/ is TRACKED (content.sql + engine.ref). Only ephemeral/derived
+# state is ignored: the pre-update pointer, map cache, and local DB backups.
 /.sc-state/engine.ref.prev
 # Map DB — derived cache of the repo (dr_*), rebuilt by `./sc map`. Its authored
 # layer (sections) is tracked in .sc-state/map_content.sql.
 /.sc-state/map.db
 /.sc-state/map.db-wal
 /.sc-state/map.db-shm
+/.sc-state/db_backups/
 """
 
 

--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -24,21 +24,19 @@ DB_PATH = ENGINE / "shell_db.db"
 SCHEMA_SQLITE = ENGINE / "schema.sql"
 SNAPSHOT       = REPO_ROOT / ".sc-state" / "content.sql"
 SNAPSHOT_LEGACY = ENGINE / "snapshot" / "content.sql"
-# PER-FORK backup dir, keyed by the host repo's dir name. This was a fixed
-# "super-coder" for every fork, which pooled all forks' pre-update dumps in one
-# dir — and rollback restores the MOST RECENT dump, so a multi-fork update
-# sweep could roll one fork back onto ANOTHER FORK'S DB. In the source repo the
-# name IS super-coder, so its path is unchanged. Old pooled dumps stay where
-# they are: they cannot be attributed to a fork after the fact.
-BACKUP_DIR = Path.home() / "db_backups" / REPO_ROOT.name
-
 sys.path.insert(0, str(ENGINE / "scripts"))
+import db_backup as db_backup_mod  # noqa: E402
 import db_driver    # noqa: E402
 import migrate as migrate_mod  # noqa: E402
 import map_repo     # noqa: E402
 import backfill_shell_api_keys  # noqa: E402  (re-provision api_keys post-rebuild)
 import interface_reconcile  # noqa: E402  (live-Interface refusal guard)
 import seed_skills  # noqa: E402  (re-assert the fork retire list post-seed)
+
+# Compatibility/readability constant: the historical preferred location.
+# Writes resolve dynamically through backup_dir() so a restricted host seat can
+# fall through to SC_DB_BACKUP_DIR or the repo-local gitignored destination.
+BACKUP_DIR = db_backup_mod.preferred_home_dir(REPO_ROOT)
 
 
 def snapshot_path() -> Path:
@@ -119,8 +117,13 @@ def restore_keys(keys: dict) -> int:
 KEEP_BACKUPS = 5
 
 
-def prune_backups(prefix: str) -> None:
-    backups = sorted(BACKUP_DIR.glob(f"{prefix}.*.db"))
+def backup_dir() -> Path:
+    return db_backup_mod.select_backup_dir(REPO_ROOT)
+
+
+def prune_backups(prefix: str, directory: Path | None = None) -> None:
+    target = directory or backup_dir()
+    backups = sorted(target.glob(f"{prefix}.*.db"))
     for old in backups[:-KEEP_BACKUPS]:
         old.unlink(missing_ok=True)
 
@@ -143,11 +146,11 @@ def backup_db(dst: Path, src: Path = DB_PATH) -> None:
 def backup_existing() -> None:
     if not DB_PATH.exists():
         return
-    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    target = backup_dir()
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    dst = BACKUP_DIR / f"shell_db.prerebuild.{ts}.db"
+    dst = target / f"shell_db.prerebuild.{ts}.db"
     backup_db(dst)
-    prune_backups("shell_db.prerebuild")
+    prune_backups("shell_db.prerebuild", target)
     print(f"rebuild: backed up existing DB -> {dst}")
 
 

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -36,19 +36,21 @@ ENGINE_REF = STATE_DIR / "engine.ref"
 ENGINE_REF_PREV = STATE_DIR / "engine.ref.prev"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+import db_backup as db_backup_mod  # noqa: E402
 import engine_manifest  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402  (BACKUP_DIR, backup_db, prune_backups, KEEP_BACKUPS)
 import update as update_mod    # noqa: E402  (materialize_engine, super_coder_remote, git)
 
-# One source of truth with rebuild.py — the PER-FORK dir. A restore point must
-# come from THIS fork's backups: a private copy of the path is exactly how the
-# pooled-dir hazard happened (rollback restoring another fork's dump).
+# Compatibility alias for callers that inspect the preferred location. Runtime
+# reads/writes use rebuild_mod.backup_dir() so restricted seats share the same
+# fallback selection as rebuild and restart.
 BACKUP_DIR = rebuild_mod.BACKUP_DIR
 
 
 def latest_db_restore_point() -> Path | None:
-    backups = sorted(BACKUP_DIR.glob("shell_db.prerebuild.*.db"))
-    return backups[-1] if backups else None
+    return db_backup_mod.latest_backup(
+        REPO_ROOT, "shell_db.prerebuild.*.db"
+    )
 
 
 def backup_current_db() -> None:
@@ -56,11 +58,11 @@ def backup_current_db() -> None:
     never mistaken for a pre-update restore point on a later rollback."""
     if not DB_PATH.exists():
         return
-    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    target = rebuild_mod.backup_dir()
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    dst = BACKUP_DIR / f"shell_db.prerollback.{ts}.db"
+    dst = target / f"shell_db.prerollback.{ts}.db"
     rebuild_mod.backup_db(dst)
-    rebuild_mod.prune_backups("shell_db.prerollback")
+    rebuild_mod.prune_backups("shell_db.prerollback", target)
     print(f"→ backed up current DB -> {dst}")
 
 
@@ -99,7 +101,7 @@ def main() -> int:
     src = latest_db_restore_point()
     if src is None:
         sys.exit("rollback: no shell_db.prerebuild.*.db restore point found in "
-                 f"{BACKUP_DIR} — nothing to roll back to.")
+                 f"{rebuild_mod.backup_dir()} — nothing to roll back to.")
     prev_sha = ENGINE_REF_PREV.read_text().strip() if ENGINE_REF_PREV.exists() else ""
 
     print("→ rolling back the last update (DB + engine pair-restore)")

--- a/sc
+++ b/sc
@@ -116,6 +116,15 @@ dbuild() {
     "$here"
 }
 
+dimage_preflight() {
+  if docker image inspect "$IMG" >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "✗ --no-build: sandbox image '$IMG:latest' is missing; nothing was stopped." >&2
+  echo "  Run ./sc build, then retry with --no-build." >&2
+  return 1
+}
+
 # ── dev kit (deps + test) — in-container primitives, like serve/boot ──────────
 # A shell runs these from INSIDE the sandbox, where pip/npm act directly on the
 # bind-mounted repo: the .venv / node_modules they create live in the mount and so
@@ -825,29 +834,139 @@ sc_persist() {
 }
 
 
-# WAL-safe DB backup via sqlite3's online-backup API — a plain file copy of a
-# live WAL database misses un-checkpointed pages (they live in the -wal
-# sidecar). Same dir + naming + keep-5 pruning as rebuild.py/rollback.py.
+# Resolve + write-probe the destination before a restart changes any runtime
+# state. db_backup.py is also used by rebuild/rollback, keeping one deterministic
+# override → home → repo-local fallback contract across every engine backup.
+sc_db_backup_preflight() {
+  "$PY" "$S/db_backup.py" select "$ROOT"
+}
 sc_db_backup() {
-  "$PY" - "$DB" "$(basename "$ROOT")" "${1:-manual}" <<'EOF'
-import sqlite3, sys, time
-from pathlib import Path
-db, repo, prefix = sys.argv[1:4]
-if not Path(db).exists():
-    print("→ no DB yet — nothing to back up"); raise SystemExit(0)
-bdir = Path.home() / "db_backups" / repo
-bdir.mkdir(parents=True, exist_ok=True)
-dst = bdir / f"shell_db.{prefix}.{time.strftime('%Y%m%d_%H%M%S')}.db"
-src = sqlite3.connect(db); out = sqlite3.connect(dst)
-try:
-    with out:
-        src.backup(out)
-finally:
-    out.close(); src.close()
-for old in sorted(bdir.glob(f"shell_db.{prefix}.*.db"))[:-5]:
-    old.unlink()
-print(f"→ DB backed up -> {dst}")
-EOF
+  prefix="${1:-manual}"
+  destination="${2:-}"
+  if [ -n "$destination" ]; then
+    "$PY" "$S/db_backup.py" backup "$DB" "$ROOT" "$prefix" "$destination"
+  else
+    "$PY" "$S/db_backup.py" backup "$DB" "$ROOT" "$prefix"
+  fi
+}
+
+sc_systemd_unit_loaded() {
+  command -v systemctl >/dev/null 2>&1 || return 1
+  [ "$(systemctl --user show "$1" -p LoadState --value 2>/dev/null)" = "loaded" ]
+}
+
+sc_wait_until() {
+  check="$1"
+  attempts=0
+  while [ "$attempts" -lt 20 ]; do
+    "$check" && return 0
+    attempts=$((attempts + 1))
+    sleep 0.25
+  done
+  return 1
+}
+
+sc_sandbox_alive() {
+  docker inspect --format '{{.State.Running}}' "$CNAME" 2>/dev/null | grep -q true \
+    && curl -fsS "http://127.0.0.1:$(port)/api/health" >/dev/null 2>&1
+}
+
+sc_pg_healthy() {
+  sc_pg_alive && docker exec "$PGNAME" pg_isready -U sc -d sc >/dev/null 2>&1
+}
+
+sc_vm_broker_configured() { "$PY" "$S/vm.py" configured; }
+sc_ts_broker_configured() { "$PY" "$S/ts.py" configured; }
+sc_pm2_broker_configured() { "$PY" "$S/pm2.py" configured; }
+sc_db_broker_configured() { "$PY" "$S/dbq.py" configured; }
+
+# Restart one configured broker through its actual supervisor. launch has
+# already recreated pidfile-managed brokers; systemd-managed brokers remain
+# alive across down by design, so restart them explicitly to load current code.
+sc_restart_broker() {
+  label="$1"
+  configured="$2"
+  alive="$3"
+  up="$4"
+  down="$5"
+  pidfile="$6"
+  unit="$7"
+  if ! "$configured"; then
+    echo "  $label: skipped (unconfigured)"
+    return 0
+  fi
+  supervisor="pidfile"
+  if sc_systemd_unit_loaded "$unit"; then
+    supervisor="systemd"
+    # A loaded-but-previously-inactive unit may have let launch create a
+    # pidfile process. Remove that exact process before handing ownership back
+    # to systemd; an already-active systemd process is deliberately left alone
+    # by the broker's down helper and then restarted by its supervisor.
+    "$down" >/dev/null 2>&1 || true
+    if ! systemctl --user restart "$unit"; then
+      echo "  $label: failed (systemd restart)"
+      SC_RESTART_FAILED=1
+      return 0
+    fi
+  elif ! "$up"; then
+    echo "  $label: failed (start)"
+    SC_RESTART_FAILED=1
+    return 0
+  elif [ ! -f "$pidfile" ]; then
+    echo "  $label: failed (live broker has no recognized supervisor)"
+    SC_RESTART_FAILED=1
+    return 0
+  fi
+  if sc_wait_until "$alive"; then
+    echo "  $label: restarted ($supervisor)"
+  else
+    echo "  $label: failed (unhealthy after $supervisor restart)"
+    SC_RESTART_FAILED=1
+  fi
+}
+
+sc_restart_health_summary() {
+  launch_rc="$1"
+  SC_RESTART_FAILED=0
+  echo "→ restart health"
+  if [ "$launch_rc" -eq 0 ] && sc_wait_until sc_sandbox_alive; then
+    echo "  sandbox: restarted"
+  else
+    echo "  sandbox: failed (launch or health)"
+    SC_RESTART_FAILED=1
+  fi
+  sc_restart_broker "vm-broker" \
+    sc_vm_broker_configured sc_vm_broker_alive sc_vm_broker_up \
+    sc_vm_broker_down "$VM_BROKER_PID" "$VM_BROKER_UNIT"
+  sc_restart_broker "ts-broker" \
+    sc_ts_broker_configured sc_ts_broker_alive sc_ts_broker_up \
+    sc_ts_broker_down "$TS_BROKER_PID" "$TS_BROKER_UNIT"
+  sc_restart_broker "pm2-broker" \
+    sc_pm2_broker_configured sc_pm2_broker_alive sc_pm2_broker_up \
+    sc_pm2_broker_down "$PM2_BROKER_PID" "$PM2_BROKER_UNIT"
+  sc_restart_broker "db-broker" \
+    sc_db_broker_configured sc_db_broker_alive sc_db_broker_up \
+    sc_db_broker_down "$DB_BROKER_PID" "$DB_BROKER_UNIT"
+  if sc_pg_configured; then
+    if sc_wait_until sc_pg_healthy; then
+      echo "  postgres: restarted"
+    else
+      echo "  postgres: failed (unhealthy after restart)"
+      SC_RESTART_FAILED=1
+    fi
+  else
+    echo "  postgres: skipped (unconfigured)"
+  fi
+  if sc_watch_daemon_unit_active; then
+    systemctl --user stop "$WATCH_DAEMON_UNIT" >/dev/null 2>&1 || true
+  fi
+  if sc_watch_daemon_alive || sc_watch_daemon_unit_active; then
+    echo "  legacy-watch-daemon: failed (retired service still running)"
+    SC_RESTART_FAILED=1
+  else
+    echo "  legacy-watch-daemon: skipped (retired; confirmed stopped)"
+  fi
+  [ "$SC_RESTART_FAILED" -eq 0 ]
 }
 
 
@@ -977,12 +1096,26 @@ case "$cmd" in
   typecheck)    sc_typecheck "$@" ;;
   # ── docker sandbox (host-side; the default way to run) ──
   launch)
+    no_build=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --no-build) no_build=1 ;;
+        -h|--help)
+          echo "usage: ./sc launch [--no-build]"
+          echo "  --no-build  reuse the existing $IMG:latest image; refuse if absent"
+          exit 0 ;;
+        *)
+          echo "sc launch: unknown argument '$1' (usage: ./sc launch [--no-build])" >&2
+          exit 2 ;;
+      esac
+      shift
+    done
     dcheck
+    if [ -n "$no_build" ]; then dimage_preflight; else dbuild; fi
     dcreds
     "$PY" "$S/ports.py" ensure >/dev/null
     p="$(port)"
     dp="$(devport)"
-    dbuild
     dnet
     # Forward GitHub auth for the in-container push/PR path (GUI publish + shells
     # opening their own PRs). Prefer a repo-scoped SC_GH_TOKEN; else reuse the
@@ -1081,6 +1214,9 @@ case "$cmd" in
     sc_ts_broker_up || true
     # Same for the pm2 broker — self-skips when no `pm2` block is linked.
     sc_pm2_broker_up || true
+    # Same for the read-only DB broker — it was previously omitted from the
+    # sandbox lifecycle, so a restart could leave configured diagnostics down.
+    sc_db_broker_up || true
     # PR polling rides the engine service itself (spec #20, decision #19) —
     # no host watch-daemon is started here anymore.
     # Start the PG sidecar when configured — self-skips otherwise.
@@ -1094,6 +1230,7 @@ case "$cmd" in
                 sc_vm_broker_down
                 sc_ts_broker_down
                 sc_pm2_broker_down
+                sc_db_broker_down
                 sc_watch_daemon_down
                 sc_pg_down ;;
   # restart is a hard bounce — down runs `docker rm -f`, which SIGKILLs every
@@ -1102,20 +1239,43 @@ case "$cmd" in
   # dos-e), so: typed confirmation (only YES / Yes / yes proceed — anything
   # else, including a closed stdin, aborts) + a WAL-safe DB backup BEFORE
   # anything is torn down. --yes/-y skips the prompt for scripted callers.
+  # --no-build validates the existing image before down; the default path
+  # likewise completes its build before down, so a known preflight failure
+  # cannot strand a healthy fork offline.
   restart)
-    case "${1:-}" in
-      -y|--yes) shift ;;
-      *)
-        echo "restart recreates the sandbox — live sessions inside it are killed."
-        printf "ARE YOU SURE YOU WANT TO RESTART? (YES/no): "
-        ans=""; read -r ans || true
-        case "$ans" in
-          YES|Yes|yes) ;;
-          *) echo "→ restart aborted (nothing touched)"; exit 1 ;;
-        esac ;;
-    esac
-    sc_db_backup prerestart
-    "$0" down; exec "$0" launch "$@" ;;
+    assume_yes=""
+    no_build=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -y|--yes) assume_yes=1 ;;
+        --no-build) no_build=1 ;;
+        -h|--help)
+          echo "usage: ./sc restart [-y|--yes] [--no-build]"
+          echo "  --no-build  reuse the existing $IMG:latest image; preflight before down"
+          exit 0 ;;
+        *)
+          echo "sc restart: unknown argument '$1' (usage: ./sc restart [-y|--yes] [--no-build])" >&2
+          exit 2 ;;
+      esac
+      shift
+    done
+    if [ -z "$assume_yes" ]; then
+      echo "restart recreates the sandbox — live sessions inside it are killed."
+      printf "ARE YOU SURE YOU WANT TO RESTART? (YES/no): "
+      ans=""; read -r ans || true
+      case "$ans" in
+        YES|Yes|yes) ;;
+        *) echo "→ restart aborted (nothing touched)"; exit 1 ;;
+      esac
+    fi
+    dcheck
+    if [ -n "$no_build" ]; then dimage_preflight; else dbuild; fi
+    backup_dir="$(sc_db_backup_preflight)"
+    sc_db_backup prerestart "$backup_dir"
+    "$0" down
+    launch_rc=0
+    "$0" launch --no-build || launch_rc=$?
+    sc_restart_health_summary "$launch_rc" ;;
   build)        dcheck; dbuild ;;
   logs)         exec docker logs -f "$CNAME" ;;
   verify)
@@ -1186,6 +1346,7 @@ super-coder — forkable shell substrate
   Sandbox (docker — the default way to run; allow-everything is safe because the
   container only sees this repo + your harness creds):
   ./sc launch              build + start the sandbox container (server + GUI), 127.0.0.1 only
+                             --no-build reuses the existing image and refuses before runtime changes when absent
   ./sc enter               enter a shell through the Interface API: pick a shell, then
                              New chat (harness picker) if available, else reattach the live session
   ./sc enter-<shortname>   enter that shell directly (skip the shell picker)
@@ -1200,7 +1361,8 @@ super-coder — forkable shell substrate
                              default prompt · --harness <h> · -m <model> (else flavor_defaults);
                              --effort defaults to high; refuses a shell that already has a live session
   ./sc down                stop + remove the sandbox container
-  ./sc restart             confirm (YES) + DB backup, then down + launch — recreate fresh (--yes skips the prompt)
+  ./sc restart             confirm + WAL-safe backup, fully bounce, then health-check managed services
+                             --yes skips the prompt · --no-build preflights/reuses the existing image
   ./sc build               (re)build the sandbox image
   ./sc logs                tail the sandbox server logs
 

--- a/sc
+++ b/sc
@@ -721,6 +721,10 @@ sc_pg_configured() {
 sc_pg_alive() {
   docker inspect --format '{{.State.Running}}' "$PGNAME" 2>/dev/null | grep -q true
 }
+sc_pg_absent() {
+  names="$(docker ps -a --filter "name=^/${PGNAME}$" --format '{{.Names}}')" || return 1
+  [ -z "$names" ]
+}
 sc_pg_up() {
   if ! sc_pg_configured; then
     echo "→ pg: no \`pg\` key in instance.json — skipping (run: ./sc pg-init)"; return 0
@@ -739,9 +743,17 @@ sc_pg_up() {
   echo "→ pg 17 up ($PGNAME on $SC_NET) · DATABASE_URL=postgresql://sc:sc@$PGNAME:5432/sc"
 }
 sc_pg_down() {
-  if docker inspect "$PGNAME" >/dev/null 2>&1; then
-    docker rm -f "$PGNAME" >/dev/null 2>&1 && echo "→ pg stopped (volume $PGVOL retained)" || true
+  remove_rc=0
+  docker rm -f "$PGNAME" >/dev/null 2>&1 || remove_rc=$?
+  if sc_pg_absent; then
+    if [ "$remove_rc" -eq 0 ]; then
+      echo "→ pg stopped (volume $PGVOL retained)"
+    fi
+    return 0
   fi
+  echo "✗ postgres teardown could not verify removal of '$PGNAME'." >&2
+  echo "  Fix Docker access, run ./sc pg-down, then retry ./sc restart." >&2
+  return 1
 }
 sc_pg_init() {
   f="$ENGINE/instance.json"
@@ -1272,7 +1284,10 @@ case "$cmd" in
     if [ -n "$no_build" ]; then dimage_preflight; else dbuild; fi
     backup_dir="$(sc_db_backup_preflight)"
     sc_db_backup prerestart "$backup_dir"
-    "$0" down
+    if ! "$0" down; then
+      echo "✗ restart stopped: teardown did not complete; no replacement services were launched." >&2
+      exit 1
+    fi
     launch_rc=0
     "$0" launch --no-build || launch_rc=$?
     sc_restart_health_summary "$launch_rc" ;;

--- a/tests/test_backup_dir.py
+++ b/tests/test_backup_dir.py
@@ -23,9 +23,11 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+import db_backup  # noqa: E402
 import rebuild  # noqa: E402
 import rollback  # noqa: E402
 
@@ -47,6 +49,75 @@ class BackupDirTest(unittest.TestCase):
             src = (ROOT / ".super-coder" / "scripts" / script).read_text()
             self.assertNotIn('"db_backups" / "super-coder"', src,
                              f"{script}: the fixed-name path is the bug")
+
+    def test_explicit_writable_override_wins_without_touching_fallbacks(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            override = base / "explicit"
+            selected = db_backup.select_backup_dir(
+                base / "repo",
+                {"HOME": str(base / "home"),
+                 "SC_DB_BACKUP_DIR": str(override)},
+            )
+            self.assertEqual(selected, override)
+            self.assertTrue(override.is_dir())
+            self.assertFalse((base / "home" / "db_backups").exists())
+
+    def test_unwritable_override_and_home_fall_through_to_repo_local(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td) / "repo"
+            override = Path(td) / "override"
+            home = Path(td) / "home" / "db_backups" / repo.name
+            local = repo / ".sc-state" / "db_backups"
+            probed: list[Path] = []
+
+            def probe(path: Path) -> None:
+                probed.append(path)
+                if path != local:
+                    raise PermissionError("read-only fixture")
+                path.mkdir(parents=True)
+
+            with mock.patch.object(db_backup, "_probe_writable",
+                                   side_effect=probe):
+                selected = db_backup.select_backup_dir(
+                    repo,
+                    {"HOME": str(Path(td) / "home"),
+                     "SC_DB_BACKUP_DIR": str(override)},
+                )
+            self.assertEqual(selected, local)
+            self.assertEqual(probed, [override, home, local])
+
+    def test_no_writable_destination_names_the_supported_override(self):
+        with tempfile.TemporaryDirectory() as td, \
+             mock.patch.object(
+                 db_backup, "_probe_writable",
+                 side_effect=PermissionError("read-only fixture")
+             ):
+            with self.assertRaises(db_backup.BackupDestinationError) as caught:
+                db_backup.select_backup_dir(
+                    Path(td) / "repo", {"HOME": str(Path(td) / "home")}
+                )
+            self.assertIn("Set SC_DB_BACKUP_DIR", str(caught.exception))
+
+    def test_restore_discovery_keeps_prior_home_backup_visible_after_override(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            repo = base / "repo"
+            home_backup = base / "home" / "db_backups" / repo.name
+            override = base / "new-override"
+            home_backup.mkdir(parents=True)
+            override.mkdir()
+            expected = home_backup / "shell_db.prerebuild.20300101_000000.db"
+            expected.touch()
+
+            found = db_backup.latest_backup(
+                repo,
+                "shell_db.prerebuild.*.db",
+                {"HOME": str(base / "home"),
+                 "SC_DB_BACKUP_DIR": str(override)},
+            )
+
+            self.assertEqual(found, expected)
 
 
 class WalSafeBackupTest(unittest.TestCase):
@@ -78,6 +149,34 @@ class WalSafeBackupTest(unittest.TestCase):
             self.assertNotIn("shutil.copy2(DB_PATH", src,
                              f"{script}: backing up the live WAL DB with a "
                              "file copy drops un-checkpointed writes")
+
+    def test_shared_backup_keeps_five_and_preserves_the_live_row(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            live = base / "live.db"
+            out = base / "backups"
+            out.mkdir()
+            with sqlite3.connect(live) as con:
+                con.execute("PRAGMA journal_mode=WAL")
+                con.execute("CREATE TABLE t (x)")
+                con.execute("INSERT INTO t VALUES (42)")
+            for i in range(5):
+                (out / f"shell_db.prerestart.20000101_00000{i}.db").touch()
+
+            written = db_backup.backup_database(
+                live, out, "prerestart", keep=5
+            )
+
+            self.assertIsNotNone(written)
+            backups = sorted(out.glob("shell_db.prerestart.*.db"))
+            self.assertEqual(len(backups), 5)
+            self.assertNotIn(out / "shell_db.prerestart.20000101_000000.db",
+                             backups)
+            with sqlite3.connect(written) as con:
+                self.assertEqual(
+                    con.execute("SELECT x FROM t").fetchall(),
+                    [(42,)],
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_gitignore_sync.py
+++ b/tests/test_gitignore_sync.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".super-coder" / "s
 import install  # noqa: E402
 
 MAP_DB = "/.sc-state/map.db"
+DB_BACKUPS = "/.sc-state/db_backups/"
 
 
 class EnsureGitignoreTest(unittest.TestCase):
@@ -36,6 +37,7 @@ class EnsureGitignoreTest(unittest.TestCase):
         self.assertIn(install._GITIGNORE_MARKER, text)
         for pat in install._required_ignores():
             self.assertIn(pat, text)
+        self.assertIn(DB_BACKUPS, text)
 
     def test_idempotent(self):
         install.ensure_gitignore(self.root)
@@ -53,6 +55,7 @@ class EnsureGitignoreTest(unittest.TestCase):
         self.assertTrue(changed)
         text = self.gi.read_text()
         self.assertIn(MAP_DB, text)
+        self.assertIn(DB_BACKUPS, text)
         # existing lines are not duplicated
         self.assertEqual(text.count("/.super-coder/"), 1)
         # and a second run is a no-op

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -25,10 +25,12 @@ class SupervisionFixture:
         self.fakebin = Path(self._tmp.name) / "bin"
         self.home = Path(self._tmp.name) / "home"
         self.log = Path(self._tmp.name) / "calls.log"
+        self.docker_state = Path(self._tmp.name) / "docker-state"
         self.root.mkdir()
         self.scripts.mkdir(parents=True)
         self.fakebin.mkdir()
         self.home.mkdir()
+        self.docker_state.mkdir()
         shutil.copy2(ROOT / "sc", self.root / "sc")
         shutil.copy2(
             ROOT / ".super-coder" / "scripts" / "db_backup.py",
@@ -59,6 +61,8 @@ class SupervisionFixture:
                 "SC_PYTHON": sys.executable,
                 "SC_TEST_LOG": str(self.log),
                 "SC_TEST_IMAGE": "present",
+                "SC_TEST_DOCKER_STATE": str(self.docker_state),
+                "SC_TEST_PG_NAME": f"sc-pg-{self.root.name}",
                 "NO_COLOR": "1",
             }
         )
@@ -110,6 +114,7 @@ class SupervisionFixture:
             printf 'docker' >> "$SC_TEST_LOG"
             printf ' %s' "$@" >> "$SC_TEST_LOG"
             printf '\\n' >> "$SC_TEST_LOG"
+            state_dir="$SC_TEST_DOCKER_STATE"
             if [ "$1" = info ]; then exit 0; fi
             if [ "$1" = image ] && [ "$2" = inspect ]; then
               [ "$SC_TEST_IMAGE" = present ]
@@ -118,14 +123,59 @@ class SupervisionFixture:
             if [ "$1" = network ] && [ "$2" = inspect ]; then exit 0; fi
             if [ "$1" = network ] && [ "$2" = create ]; then exit 0; fi
             if [ "$1" = build ]; then exit 0; fi
-            if [ "$1" = rm ]; then exit 0; fi
-            if [ "$1" = run ]; then echo fake-container-id; exit 0; fi
-            if [ "$1" = inspect ] && [ "$2" = --format ]; then
-              echo true
+            if [ "$1" = rm ]; then
+              name="$3"
+              if [ "$name" = "$SC_TEST_PG_NAME" ] &&
+                 [ "${SC_TEST_PG_REMOVE_FAIL:-}" = 1 ]; then
+                exit 1
+              fi
+              rm -f "$state_dir/$name.id"
               exit 0
             fi
-            if [ "$1" = inspect ]; then exit 1; fi
-            if [ "$1" = exec ]; then exit 0; fi
+            if [ "$1" = run ]; then
+              shift
+              name=""
+              while [ "$#" -gt 0 ]; do
+                if [ "$1" = --name ]; then
+                  name="$2"
+                  break
+                fi
+                shift
+              done
+              if [ -n "$name" ]; then
+                next_file="$state_dir/next-id"
+                next=0
+                if [ -f "$next_file" ]; then next="$(cat "$next_file")"; fi
+                next=$((next + 1))
+                printf '%s\\n' "$next" > "$next_file"
+                printf 'container-%s\\n' "$next" > "$state_dir/$name.id"
+                echo "container-$next"
+              else
+                echo fake-container-id
+              fi
+              exit 0
+            fi
+            if [ "$1" = inspect ] && [ "$2" = --format ]; then
+              if [ -f "$state_dir/$4.id" ]; then
+                echo true
+                exit 0
+              fi
+              exit 1
+            fi
+            if [ "$1" = inspect ]; then
+              [ -f "$state_dir/$2.id" ]
+              exit
+            fi
+            if [ "$1" = ps ]; then
+              if [ -f "$state_dir/$SC_TEST_PG_NAME.id" ]; then
+                echo "$SC_TEST_PG_NAME"
+              fi
+              exit 0
+            fi
+            if [ "$1" = exec ]; then
+              [ -f "$state_dir/$2.id" ]
+              exit
+            fi
             exit 0
             """,
         )
@@ -192,6 +242,14 @@ class SupervisionFixture:
 
     def calls(self) -> list[str]:
         return self.log.read_text().splitlines() if self.log.exists() else []
+
+    def configure_pg(self) -> None:
+        (self.engine / "instance.json").write_text('{"pg": {}}\n')
+
+    def pg_identity(self) -> str:
+        return (
+            self.docker_state / f"{self.env['SC_TEST_PG_NAME']}.id"
+        ).read_text().strip()
 
 
 class RestrictedLaunchTests(unittest.TestCase):
@@ -297,8 +355,64 @@ class RestrictedLaunchTests(unittest.TestCase):
         self.assertIn("  vm-broker: failed (systemd restart)", result.stdout)
         self.assertIn("  postgres: skipped (unconfigured)", result.stdout)
 
+    def test_restart_replaces_configured_postgres_identity(self):
+        self.fx.configure_pg()
+        initial = self.fx.run("pg-up")
+        self.assertEqual(initial.returncode, 0, initial.stderr)
+        old_identity = self.fx.pg_identity()
+
+        result = self.fx.run("restart", "--yes", "--no-build")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertNotEqual(self.fx.pg_identity(), old_identity)
+        pg_runs = [
+            call
+            for call in self.fx.calls()
+            if f"--name {self.fx.env['SC_TEST_PG_NAME']}" in call
+        ]
+        self.assertEqual(len(pg_runs), 2)
+        self.assertIn("  postgres: restarted", result.stdout)
+
+    def test_restart_refuses_when_configured_postgres_removal_fails(self):
+        self.fx.configure_pg()
+        initial = self.fx.run("pg-up")
+        self.assertEqual(initial.returncode, 0, initial.stderr)
+        old_identity = self.fx.pg_identity()
+        self.fx.env["SC_TEST_PG_REMOVE_FAIL"] = "1"
+
+        result = self.fx.run("restart", "--yes", "--no-build")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(self.fx.pg_identity(), old_identity)
+        self.assertIn("could not verify removal", result.stderr)
+        self.assertIn("run ./sc pg-down, then retry ./sc restart", result.stderr)
+        self.assertIn("no replacement services were launched", result.stderr)
+        self.assertNotIn("postgres: restarted", result.stdout)
+        pg_runs = [
+            call
+            for call in self.fx.calls()
+            if f"--name {self.fx.env['SC_TEST_PG_NAME']}" in call
+        ]
+        self.assertEqual(len(pg_runs), 1)
+        self.assertFalse(
+            any(
+                f"--name sc-{self.fx.root.name}" in call
+                for call in self.fx.calls()
+            )
+        )
+
 
 class MakeDispatchTests(unittest.TestCase):
+    def test_dos_launch_forwards_no_build(self):
+        result = subprocess.run(
+            ["make", "-n", "dos-l", "ARGS=--no-build"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "./sc launch --no-build")
+
     def test_dos_restart_forwards_yes_and_no_build(self):
         result = subprocess.run(
             ["make", "-n", "dos-r", "ARGS=--yes --no-build"],

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Behavioral coverage for restricted-seat launch/restart supervision."""
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class SupervisionFixture:
+    def __init__(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name) / "restricted-fork"
+        self.engine = self.root / ".super-coder"
+        self.scripts = self.engine / "scripts"
+        self.fakebin = Path(self._tmp.name) / "bin"
+        self.home = Path(self._tmp.name) / "home"
+        self.log = Path(self._tmp.name) / "calls.log"
+        self.root.mkdir()
+        self.scripts.mkdir(parents=True)
+        self.fakebin.mkdir()
+        self.home.mkdir()
+        shutil.copy2(ROOT / "sc", self.root / "sc")
+        shutil.copy2(
+            ROOT / ".super-coder" / "scripts" / "db_backup.py",
+            self.scripts / "db_backup.py",
+        )
+        (self.engine / "Dockerfile").write_text("FROM scratch\n")
+        self._write_scripts()
+        self._write_fake_commands()
+        for directory in (
+            ".claude",
+            ".config/opencode",
+            ".local/share/opencode",
+            ".codex",
+            ".vibe",
+            ".kimi-code",
+        ):
+            (self.home / directory).mkdir(parents=True)
+        (self.home / ".claude.json").write_text("{}\n")
+        with sqlite3.connect(self.engine / "shell_db.db") as con:
+            con.execute("PRAGMA journal_mode=WAL")
+            con.execute("CREATE TABLE state (value TEXT)")
+            con.execute("INSERT INTO state VALUES ('durable')")
+        self.env = os.environ.copy()
+        self.env.update(
+            {
+                "HOME": str(self.home),
+                "PATH": f"{self.fakebin}:{self.env['PATH']}",
+                "SC_PYTHON": sys.executable,
+                "SC_TEST_LOG": str(self.log),
+                "SC_TEST_IMAGE": "present",
+                "NO_COLOR": "1",
+            }
+        )
+        self._sockets: list[socket.socket] = []
+
+    def close(self) -> None:
+        for sock in self._sockets:
+            sock.close()
+        self._tmp.cleanup()
+
+    def _write_scripts(self) -> None:
+        (self.scripts / "ports.py").write_text(
+            textwrap.dedent(
+                """\
+                import sys
+                if sys.argv[1] == "port":
+                    print(18800)
+                elif sys.argv[1] == "devport":
+                    print(15173)
+                elif sys.argv[1] == "ensure":
+                    pass
+                """
+            )
+        )
+        broker = textwrap.dedent(
+            """\
+            import os
+            import sys
+            from pathlib import Path
+            name = Path(sys.argv[0]).stem
+            command = sys.argv[1]
+            configured = set(filter(None, os.environ.get(
+                "SC_TEST_CONFIGURED", "").split(",")))
+            if command == "configured":
+                raise SystemExit(0 if name in configured else 1)
+            if command == "sock":
+                print(os.environ.get(f"SC_TEST_{name.upper()}_SOCK",
+                                     f"/absent/{name}.sock"))
+            """
+        )
+        for name in ("vm", "ts", "pm2", "dbq"):
+            (self.scripts / f"{name}.py").write_text(broker)
+
+    def _write_fake_commands(self) -> None:
+        self._write_executable(
+            "docker",
+            """\
+            #!/bin/sh
+            printf 'docker' >> "$SC_TEST_LOG"
+            printf ' %s' "$@" >> "$SC_TEST_LOG"
+            printf '\\n' >> "$SC_TEST_LOG"
+            if [ "$1" = info ]; then exit 0; fi
+            if [ "$1" = image ] && [ "$2" = inspect ]; then
+              [ "$SC_TEST_IMAGE" = present ]
+              exit
+            fi
+            if [ "$1" = network ] && [ "$2" = inspect ]; then exit 0; fi
+            if [ "$1" = network ] && [ "$2" = create ]; then exit 0; fi
+            if [ "$1" = build ]; then exit 0; fi
+            if [ "$1" = rm ]; then exit 0; fi
+            if [ "$1" = run ]; then echo fake-container-id; exit 0; fi
+            if [ "$1" = inspect ] && [ "$2" = --format ]; then
+              echo true
+              exit 0
+            fi
+            if [ "$1" = inspect ]; then exit 1; fi
+            if [ "$1" = exec ]; then exit 0; fi
+            exit 0
+            """,
+        )
+        self._write_executable(
+            "curl",
+            """\
+            #!/bin/sh
+            printf 'curl' >> "$SC_TEST_LOG"
+            printf ' %s' "$@" >> "$SC_TEST_LOG"
+            printf '\\n' >> "$SC_TEST_LOG"
+            printf '{"ok": true}\\n'
+            """,
+        )
+        self._write_executable(
+            "gh",
+            """\
+            #!/bin/sh
+            if [ "$1" = auth ] && [ "$2" = token ]; then echo test-token; fi
+            """,
+        )
+        self._write_executable(
+            "systemctl",
+            """\
+            #!/bin/sh
+            printf 'systemctl' >> "$SC_TEST_LOG"
+            printf ' %s' "$@" >> "$SC_TEST_LOG"
+            printf '\\n' >> "$SC_TEST_LOG"
+            if [ "$2" = show ]; then
+              case ",$SC_TEST_SYSTEMD_UNITS," in
+                *,"$3",*) echo loaded ;;
+                *) echo not-found ;;
+              esac
+              exit 0
+            fi
+            if [ "$2" = is-active ]; then exit 1; fi
+            if [ "$2" = restart ] && [ "$3" = "$SC_TEST_SYSTEMD_FAIL" ]; then
+              exit 1
+            fi
+            exit 0
+            """,
+        )
+
+    def _write_executable(self, name: str, body: str) -> None:
+        path = self.fakebin / name
+        path.write_text(textwrap.dedent(body))
+        path.chmod(0o755)
+
+    def add_socket(self, name: str) -> Path:
+        path = Path(self._tmp.name) / f"{name}.sock"
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(str(path))
+        self._sockets.append(sock)
+        self.env[f"SC_TEST_{name.upper()}_SOCK"] = str(path)
+        return path
+
+    def run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(self.root / "sc"), *args],
+            cwd=self.root,
+            env=self.env,
+            text=True,
+            capture_output=True,
+        )
+
+    def calls(self) -> list[str]:
+        return self.log.read_text().splitlines() if self.log.exists() else []
+
+
+class RestrictedLaunchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fx = SupervisionFixture()
+
+    def tearDown(self) -> None:
+        self.fx.close()
+
+    def test_launch_no_build_reuses_existing_image_without_buildx(self):
+        result = self.fx.run("launch", "--no-build")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.fx.calls()
+        self.assertIn("docker image inspect super-coder-sandbox", calls)
+        self.assertTrue(any(line.startswith("docker run -d") for line in calls))
+        self.assertFalse(any(line.startswith("docker build ") for line in calls))
+
+    def test_launch_no_build_missing_image_refuses_before_runtime_change(self):
+        self.fx.env["SC_TEST_IMAGE"] = "missing"
+        result = self.fx.run("launch", "--no-build")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Run ./sc build", result.stderr)
+        calls = self.fx.calls()
+        self.assertFalse(any(line.startswith("docker rm ") for line in calls))
+        self.assertFalse(any(line.startswith("docker run ") for line in calls))
+        self.assertFalse(any(line.startswith("docker build ") for line in calls))
+
+    def test_restart_missing_image_does_not_backup_or_stop(self):
+        self.fx.env["SC_TEST_IMAGE"] = "missing"
+        result = self.fx.run("restart", "--yes", "--no-build")
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse((self.fx.home / "db_backups").exists())
+        calls = self.fx.calls()
+        self.assertFalse(any(line.startswith("docker rm ") for line in calls))
+
+    def test_restart_no_writable_backup_destination_refuses_before_down(self):
+        bad_home = Path(self.fx._tmp.name) / "home-file"
+        bad_override = Path(self.fx._tmp.name) / "override-file"
+        bad_home.write_text("not a directory\n")
+        bad_override.write_text("not a directory\n")
+        (self.fx.root / ".sc-state").write_text("not a directory\n")
+        self.fx.env["HOME"] = str(bad_home)
+        self.fx.env["SC_DB_BACKUP_DIR"] = str(bad_override)
+
+        result = self.fx.run("restart", "--yes", "--no-build")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Set SC_DB_BACKUP_DIR", result.stderr)
+        self.assertFalse(
+            any(line.startswith("docker rm ") for line in self.fx.calls())
+        )
+
+    def test_restart_bounces_systemd_broker_and_reports_full_inventory(self):
+        self.fx.env["SC_TEST_CONFIGURED"] = "vm,ts,pm2,dbq"
+        units = {
+            name: f"sc-{name}-broker-{self.fx.root.name}.service"
+            for name in ("vm", "ts", "pm2", "db")
+        }
+        self.fx.env["SC_TEST_SYSTEMD_UNITS"] = ",".join(units.values())
+        for name in ("vm", "ts", "pm2", "dbq"):
+            self.fx.add_socket(name)
+
+        result = self.fx.run("restart", "--no-build", "--yes")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        backup_files = list(
+            (self.fx.home / "db_backups" / self.fx.root.name).glob(
+                "shell_db.prerestart.*.db"
+            )
+        )
+        self.assertEqual(len(backup_files), 1)
+        with sqlite3.connect(backup_files[0]) as con:
+            self.assertEqual(
+                con.execute("SELECT value FROM state").fetchall(),
+                [("durable",)],
+            )
+        calls = self.fx.calls()
+        for unit in units.values():
+            self.assertIn(f"systemctl --user restart {unit}", calls)
+        self.assertFalse(any(line.startswith("docker build ") for line in calls))
+        self.assertIn("  sandbox: restarted", result.stdout)
+        self.assertIn("  vm-broker: restarted (systemd)", result.stdout)
+        self.assertIn("  ts-broker: restarted (systemd)", result.stdout)
+        self.assertIn("  pm2-broker: restarted (systemd)", result.stdout)
+        self.assertIn("  db-broker: restarted (systemd)", result.stdout)
+        self.assertIn("  postgres: skipped (unconfigured)", result.stdout)
+        self.assertIn(
+            "  legacy-watch-daemon: skipped (retired; confirmed stopped)",
+            result.stdout,
+        )
+
+    def test_restart_aggregates_health_failure_and_returns_nonzero(self):
+        self.fx.env["SC_TEST_CONFIGURED"] = "vm"
+        unit = f"sc-vm-broker-{self.fx.root.name}.service"
+        self.fx.env["SC_TEST_SYSTEMD_UNITS"] = unit
+        self.fx.env["SC_TEST_SYSTEMD_FAIL"] = unit
+        self.fx.add_socket("vm")
+
+        result = self.fx.run("restart", "--yes", "--no-build")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("  sandbox: restarted", result.stdout)
+        self.assertIn("  vm-broker: failed (systemd restart)", result.stdout)
+        self.assertIn("  postgres: skipped (unconfigured)", result.stdout)
+
+
+class MakeDispatchTests(unittest.TestCase):
+    def test_dos_restart_forwards_yes_and_no_build(self):
+        result = subprocess.run(
+            ["make", "-n", "dos-r", "ARGS=--yes --no-build"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "./sc restart --yes --no-build")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- select WAL-safe backup destinations in deterministic override → home → repo-local order, with writable preflight and keep-five retention
- add `launch/restart --no-build`, validating the existing image before any runtime teardown
- make restart bounce and health-report the sandbox, pidfile/systemd VM, tailnet, PM2, DB brokers, Postgres, and retired watcher state
- forward `ARGS` through `dos-launch`/`dos-r` and distribute the repo-local backup ignore to forks

## Verification

- `python3 -m unittest -v tests.test_backup_dir tests.test_gitignore_sync tests.test_supervision_sc` (21 passed)
- `./sc lint .super-coder/scripts/db_backup.py .super-coder/scripts/rebuild.py .super-coder/scripts/rollback.py .super-coder/scripts/install.py tests/test_backup_dir.py tests/test_gitignore_sync.py tests/test_supervision_sc.py`
- `sh -n sc`
- `./sc test` (840 passed)

## Trade-off

Default restart now finishes the image build before `down`, then launches with `--no-build`. This moves build time ahead of teardown, but prevents a predictable build failure from taking a healthy fork offline and avoids building twice.

Refs #530
Refs #531