### PR TITLE
fix(admin,interface): runtime Admin credential discovery + lazy websockets (#516 #518)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -65,6 +65,7 @@ import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import interface_reconcile  # noqa: E402  (Interface startup reconciliation)
 import interface_wake  # noqa: E402  (transactional wake ingress + coordinator)
 import interface_broker  # noqa: E402  (sprint close → binding release, seq 10)
+import mem_credentials  # noqa: E402  (runtime Admin credential provisioning, spec #30 req 11)
 sys.path.insert(0, str(ENGINE / "api"))
 try:
     import interface_routes  # noqa: E402  (Interface HTTP API, spec #20)
@@ -2704,6 +2705,13 @@ def main(argv):
     # auth path resolves against; a `make launch/restart` thus self-heals keys
     # (no separate `./sc update` step). New shells are still keyed at creation.
     backfill_shell_api_keys.backfill(str(DB_PATH))
+    # Runtime Admin credentials (spec #30 req 11, #516): one owner-only
+    # artifact per Admin shell, so a host Admin seat without injected
+    # SC_API_BASE/SC_API_TOKEN can still reach this API through `sc mem`
+    # discovery. Rewritten on every boot, right after the key backfill — an
+    # api_key rotation is picked up here. Lives under the gitignored,
+    # never-snapshotted .super-coder/run/.
+    mem_credentials.provision(str(DB_PATH), f"http://127.0.0.1:{port}")
     # Interface startup reconciliation (spec #20): idempotent, once per boot —
     # parks any crash-window pending input as delivery_unknown (never
     # replays), recovers wake batches from durable hook-sequence evidence,

--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -357,9 +357,17 @@ def _read_stdin() -> bytes:
 
 
 def _ws_connect(ws_url: str):
-    """The WS seam — tests patch this, never a socket. Lazy import: the CLI
-    verbs (and their test env) never need the websockets package."""
-    from websockets.sync.client import connect
+    """The WS seam — tests patch this, never a socket. Lazy import: HTTP-only
+    verbs (status/start/stop/reconcile) run on a stdlib python (spec #30 req
+    12, #518); only attach/view/take-control reach here, and a missing
+    package refuses with the exact dependency action."""
+    try:
+        from websockets.sync.client import connect
+    except ImportError:
+        die("this command streams the terminal over websockets, but no "
+            "importable `websockets` package was found — run ./sc deps (or "
+            "./sc build to refresh the sandbox image). The HTTP-only verbs "
+            "(status/start/stop/reconcile) work without it.", EXIT_API_DOWN)
     return connect(ws_url, subprotocols=[SUBPROTOCOL])
 
 

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -18,6 +18,14 @@ act as another shell (identity isn't a spoofable argument; it's the secret
 token). The one place a *recipient* is named is `message send <to>` — that
 addresses someone else's inbox; the sender is always the token.
 
+Host Admin discovery (spec doc #30 req 11): a host Admin seat booted outside
+run.py has neither var. When BOTH are absent, `sc mem` may adopt the unique
+owner-only runtime credential the supervised API provisions per Admin shell
+(`.super-coder/run/mem/<shortname>.json`, mode 0600) — `SC_MEM_AS=<shortname>`
+selects one when several exist; ambiguity, an insecure artifact, and a stale
+(rotated) token all refuse with the supported action. Discovery still calls
+the API; it is never a direct-DB path.
+
 Run from the repo root, like every engine command:
 
     ./sc mem which                                 # confirm API reachability + who your token resolves to
@@ -65,6 +73,7 @@ import argparse
 import json
 import os
 import signal
+import stat
 import sys
 import time
 import urllib.error
@@ -77,9 +86,71 @@ from pathlib import Path
 SC_API_TOKEN = os.environ.get("SC_API_TOKEN", "")
 SC_API_BASE  = os.environ.get("SC_API_BASE", "")
 
+# Runtime credential discovery (spec doc #30 req 11, issue #516): a host Admin
+# seat booted outside run.py has neither var. The supervised API provisions one
+# owner-only artifact per Admin shell at every boot (scripts/mem_credentials.py)
+# under .super-coder/run/mem/; when BOTH vars are absent we may discover the
+# unique Admin artifact. We still call the API and only the API — the artifact
+# carries the same bearer token run.py would have injected, never a DB path.
+_CRED_DIR = Path(os.environ.get("SC_MEM_CRED_DIR") or
+                 (Path(__file__).resolve().parents[1] / "run" / "mem"))
+_DISCOVERED_FROM: "Path | None" = None  # artifact the token came from, if any
+
 
 def die(msg: str) -> "NoReturn":  # noqa: F821
     sys.exit(f"mem: {msg}")
+
+
+def _load_runtime_credential(path: Path) -> None:
+    """Trust-boundary check, then adopt the artifact's bearer token + base.
+
+    Accepted only under the existing local trust boundary: a regular file,
+    owned by this user, with no group/world permission bits (the service
+    writes 0600 under a 0700 dir). Anything weaker is refused, not used."""
+    global SC_API_TOKEN, SC_API_BASE, _DISCOVERED_FROM
+    try:
+        st = path.stat()
+    except OSError as exc:
+        die(f"runtime credential {path} is unreadable ({exc}) — restart the "
+            "supervised service (`./sc restart` / `make dos-r`), which re-provisions it.")
+    if not stat.S_ISREG(st.st_mode) or st.st_uid != os.geteuid() or st.st_mode & 0o077:
+        die(f"runtime credential {path} is not an owner-only regular file "
+            f"(mode {oct(stat.S_IMODE(st.st_mode))}) — the supervised service "
+            "re-provisions it with mode 0600 at boot: `./sc restart` / `make dos-r`.")
+    try:
+        data = json.loads(path.read_text())
+        token, base = data["token"], data["api_base"]
+    except (OSError, ValueError, KeyError):
+        die(f"runtime credential {path} is malformed — the supervised service "
+            "re-provisions it at boot: `./sc restart` / `make dos-r`.")
+    SC_API_TOKEN, SC_API_BASE, _DISCOVERED_FROM = token, base, path
+
+
+def _discover_runtime_credential() -> bool:
+    """Adopt the unique Admin runtime credential when no env wiring exists.
+
+    Selection: SC_MEM_AS=<shortname> picks one artifact explicitly; without
+    it exactly one artifact must exist — multiple Admin identities are
+    ambiguous and refused, never guessed."""
+    try:
+        artifacts = sorted(p for p in _CRED_DIR.glob("*.json"))
+    except OSError:
+        return False
+    want = os.environ.get("SC_MEM_AS", "")
+    if want:
+        artifacts = [p for p in artifacts if p.stem.lower() == want.lower()]
+        if not artifacts:
+            die(f"no runtime credential for Admin shell '{want}' in {_CRED_DIR} — "
+                "the supervised service provisions one per Admin shell at boot "
+                "(`./sc restart` / `make dos-r`).")
+    if not artifacts:
+        return False
+    if len(artifacts) > 1:
+        die(f"multiple Admin runtime credentials in {_CRED_DIR} "
+            f"({', '.join(p.stem for p in artifacts)}) — identity is ambiguous; "
+            "re-run with SC_MEM_AS=<shortname> to choose one explicitly.")
+    _load_runtime_credential(artifacts[0])
+    return True
 
 
 def _require_api() -> None:
@@ -88,11 +159,15 @@ def _require_api() -> None:
     shell think a write was API-backed when it wasn't)."""
     if SC_API_TOKEN and SC_API_BASE:
         return
+    if not SC_API_TOKEN and not SC_API_BASE and _discover_runtime_credential():
+        return
     missing = [n for n, v in (("SC_API_BASE", SC_API_BASE), ("SC_API_TOKEN", SC_API_TOKEN)) if not v]
     die(f"the engine API is required but {' + '.join(missing)} "
         f"{'is' if len(missing) == 1 else 'are'} unset — this shell isn't API-wired. "
         f"Boot via `./sc enter` (run.py injects them) with the server up (`./sc launch`). "
-        f"`./sc mem` does not fall back to direct DB.")
+        f"On a host Admin seat, the supervised service provisions a runtime "
+        f"credential at {_CRED_DIR}/<shortname>.json that `sc mem` discovers "
+        f"automatically. `./sc mem` does not fall back to direct DB.")
 
 
 _RETRIES = 3          # extra attempts beyond the first
@@ -144,6 +219,11 @@ def _api(method: str, path: str, payload: "dict | None" = None,
                     pause = _RETRY_PAUSE
                 time.sleep(pause)
                 continue
+            if e.code == 401 and _DISCOVERED_FROM is not None:
+                die(f"the runtime credential {_DISCOVERED_FROM} is stale — the API "
+                    "refused it (the key was rotated after the artifact was written). "
+                    "The supervised service refreshes the artifact at boot: "
+                    "`./sc restart` / `make dos-r`, then retry.")
             try:
                 msg = json.loads(e.read()).get("error", e.reason)
             except Exception:
@@ -172,7 +252,10 @@ def cmd_which(args) -> int:
     me = _api("GET", "/_sc/mem/whoami")
     print(f"engine API : {SC_API_BASE}")
     print(f"shell      : {me.get('display_name')} ({me.get('shortname')}) #{me.get('shell_id')}")
-    print("identity   : resolved from your bearer token (SC_API_TOKEN), server-side")
+    if _DISCOVERED_FROM is not None:
+        print(f"credential : discovered from runtime artifact {_DISCOVERED_FROM}")
+    else:
+        print("identity   : resolved from your bearer token (SC_API_TOKEN), server-side")
     return 0
 
 

--- a/.super-coder/scripts/mem_credentials.py
+++ b/.super-coder/scripts/mem_credentials.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Runtime Admin credential artifacts (spec doc #30 req 11, issue #516).
+
+The supervised engine API provisions one owner-only credential artifact per
+Admin shell at every boot, under `.super-coder/run/mem/<shortname>.json` —
+the same local trust-boundary pattern as the Interface operator capability
+(`api/interface_routes.py:ensure_operator_capability`). A host Admin seat that
+was NOT booted through run.py has no `SC_API_BASE`/`SC_API_TOKEN`; `sc mem`
+discovers the unique Admin artifact instead of dying unwired (see
+`mem.py:_discover_runtime_credential`).
+
+Properties the spec pins:
+
+- mode 0600, parent dir 0700, regular files owned by the service user;
+- refreshed on every boot — an api_key rotation (startup backfill or rebuild
+  re-key) is picked up the next time the service starts;
+- never snapshotted or rendered: `.super-coder/run/` is gitignored and the
+  snapshot serializes DB tables only, so nothing to exclude elsewhere;
+- the token IS the shell's existing `shells.api_key` — no second credential
+  is minted (a rotation would 401 every live session's injected SC_API_TOKEN;
+  see tests/test_rebuild_keys.py).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+RUN_DIR = ENGINE / "run" / "mem"
+
+
+def provision(db_path: str, api_base: str, run_dir: Path = RUN_DIR) -> list[str]:
+    """(Re)write one mode-0600 artifact per live, keyed Admin shell and remove
+    artifacts whose shell is gone, deleted, demoted, or unkeyed. Idempotent.
+    Returns the provisioned shortnames."""
+    con = sqlite3.connect(db_path)
+    try:
+        rows = con.execute(
+            "SELECT shell_id, shortname, api_key FROM shells "
+            "WHERE flavor='admin' AND COALESCE(is_deleted,0)=0").fetchall()
+    finally:
+        con.close()
+    run_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(run_dir, 0o700)
+    live: set[str] = set()
+    for shell_id, shortname, api_key in rows:
+        # An unkeyed shell can't authenticate (pre-backfill DB) — skip it, and
+        # let the stale-artifact sweep below drop any file it left behind.
+        if not api_key or "/" in shortname or shortname.startswith("."):
+            continue
+        live.add(shortname)
+        payload = json.dumps({
+            "shell_id": shell_id,
+            "shortname": shortname,
+            "api_base": api_base,
+            "token": api_key,
+        })
+        path = run_dir / f"{shortname}.json"
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, payload.encode())
+        finally:
+            os.close(fd)
+        # O_CREAT's mode only applies at creation — chmod unconditionally so a
+        # previously weakened artifact is repaired, never left readable.
+        os.chmod(path, 0o600)
+    for stale in run_dir.glob("*.json"):
+        if stale.stem not in live:
+            stale.unlink()
+    return sorted(live)

--- a/sc
+++ b/sc
@@ -25,15 +25,17 @@ DB="$ENGINE/shell_db.db"
 MAPDB="$ROOT/.sc-state/map.db"
 S="$ENGINE/scripts"
 
-# Python for the Interface verbs: the attach client needs `websockets` —
-# baked into the sandbox image's own python (Dockerfile) and pinned in
-# requirements.txt for the ./sc deps .venv. Take the first interpreter that
-# has it; else fail with the fix, like _sc_devtool.
+# Python for the Interface verbs: PREFER an interpreter with `websockets`
+# (baked into the sandbox image's own python and pinned in requirements.txt
+# for the ./sc deps .venv) because attach/view/take-control stream over it.
+# Never a hard gate here (spec #30 req 12, #518): HTTP-only verbs
+# (status/start/stop/reconcile) are stdlib-only and run on any python3 —
+# the stream dependency is checked lazily, inside the verbs that stream,
+# where interface_cli refuses with the exact dependency action.
 ifpy() {
   if "$PY" -c 'import websockets' >/dev/null 2>&1; then printf '%s\n' "$PY"; return 0; fi
   if [ -x "$here/.venv/bin/python" ] && "$here/.venv/bin/python" -c 'import websockets' >/dev/null 2>&1; then printf '%s\n' "$here/.venv/bin/python"; return 0; fi
-  echo "✗ sc interface: no python with websockets — run ./sc deps (or ./sc build to refresh the sandbox image)" >&2
-  return 1
+  printf '%s\n' "$PY"
 }
 
 port() { "$PY" "$S/ports.py" port; }
@@ -962,8 +964,9 @@ case "$cmd" in
   interface-exec)  exec "$PY" "$S/interface_exec.py" "$@" ;;
   # Interface CLI parity (spec #20 seq 6) — status/start/view/attach/
   # take-control/stop/reconcile, and the in-container half of `sc enter`.
-  # API-backed only; the attach client needs websockets (ifpy).
-  interface)    IFPY="$(ifpy)" && exec "$IFPY" "$S/interface_cli.py" "$@" ;;
+  # API-backed only. ifpy prefers a websockets-capable interpreter for the
+  # stream verbs but never blocks the stdlib-only HTTP verbs (spec #30).
+  interface)    exec "$(ifpy)" "$S/interface_cli.py" "$@" ;;
   # Headless boot (sprint eventing): same render-then-exec path as boot, minus
   # the picker and the TTY. In-container primitive like boot — the planner
   # calls it to stand up an ephemeral worker; also the no-docker host path.

--- a/tests/test_interface_cli.py
+++ b/tests/test_interface_cli.py
@@ -623,5 +623,46 @@ class RawLaunchRefusalTest(unittest.TestCase):
             self._main(["run.py", "--first"], {"RENDER_ONLY": "1"})
 
 
+# ── spec #30 req 12 / #518: lazy websockets ─────────────────────────────────
+# The real seam, captured at import time before any test patches it — the
+# stream-refusal test puts it back so the verb reaches the actual import.
+_REAL_RUN_STREAM = ic.run_stream
+
+# A host python without the package: any websockets import raises ImportError.
+WS_BLOCKED = {"websockets": None, "websockets.sync": None,
+              "websockets.sync.client": None}
+
+
+class LazyWebsocketsTest(InterfaceCliTest):
+    """Host python without `websockets` (spec #30 req 12, issue #518): the
+    stream dependency is checked lazily, inside the verbs that stream —
+    HTTP-only verbs (status/stop/reconcile) run on a stdlib python, and a
+    stream verb refuses with the exact dependency action instead of the old
+    dispatch-time `no python with websockets` gate."""
+
+    def test_http_verbs_pass_without_the_package(self):
+        self.http.add("POST", "/api/interface/termination-requests",
+                      {"terminated": True})
+        self.http.add("POST", "/api/interface/reconciliations",
+                      {"session_id": 9, "verified": True,
+                       "occupancy": "unreconciled", "actions": []})
+        with mock.patch.dict(sys.modules, WS_BLOCKED):
+            rc, _, _ = self.run_cli(["status"])
+            self.assertEqual(rc, 0)
+            rc, _, _ = self.run_cli(["stop", "s2", "--json"])
+            self.assertEqual(rc, 0)
+            rc, _, _ = self.run_cli(["reconcile", "s3", "--json"])
+            self.assertEqual(rc, 0)
+
+    def test_stream_verb_refuses_with_the_dependency_action(self):
+        with mock.patch.dict(sys.modules, WS_BLOCKED), \
+                mock.patch.object(ic, "run_stream", _REAL_RUN_STREAM):
+            rc, _, err = self.run_cli(["view", "s2"])
+        self.assertEqual(rc, ic.EXIT_API_DOWN)
+        self.assertIn("websockets", err)
+        self.assertIn("./sc deps", err)
+        self.assertIn("status/start/stop/reconcile", err)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime_credentials.py
+++ b/tests/test_runtime_credentials.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Runtime Admin credentials (spec doc #30 req 11, issue #516).
+
+Two halves, one contract:
+
+- `mem_credentials.provision` — the supervised API writes one owner-only
+  (0600, dir 0700) artifact per live, keyed Admin shell under
+  `.super-coder/run/mem/`, refreshes them every boot (key rotation), and
+  sweeps artifacts whose shell is gone, demoted, deleted, or unkeyed.
+- `mem.py` discovery — with BOTH SC_API_BASE/SC_API_TOKEN absent, `sc mem`
+  adopts the unique Admin artifact and still calls the API; multiple Admins
+  refuse until SC_MEM_AS names one; an insecure artifact and a stale
+  (rotated) token refuse with the supported action.
+
+Discovery tests stand up the real `server.Handler` against a throwaway engine
+DB (same harness as test_mem — the token is the only identity), so a
+discovered credential is proved against the actual auth path, not a stub.
+
+Run:
+    python3 tests/test_runtime_credentials.py
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import sqlite3
+import stat
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import mem  # noqa: E402
+import mem_credentials  # noqa: E402
+import server  # noqa: E402
+from test_mem import TOKEN, PEER_TOKEN, build_engine_db  # noqa: E402
+
+
+def build_shells_db(path: Path) -> None:
+    """Engine-shaped DB with a keyed Admin, a keyed dev, an unkeyed Admin,
+    and a deleted Admin — the full provisioning matrix."""
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute("INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1)")
+    rows = [
+        (1, "Adm One", "ADM1", "admin", "k-adm1", 0),
+        (2, "Dev One", "DEV1", "dev", "k-dev1", 0),
+        (3, "Adm Two", "ADM2", "admin", None, 0),
+        (4, "Adm Three", "ADM3", "admin", "k-adm3", 1),
+    ]
+    con.executemany(
+        "INSERT INTO shells (shell_id, display_name, shortname, mandate, system_prompt, "
+        "user_id, is_shared, has_identity, bootstrapped, flavor, api_key, is_deleted) "
+        "VALUES (?, ?, ?, 'm', 'sp', 1, 0, 1, 0, ?, ?, ?)", rows)
+    con.commit()
+    con.close()
+
+
+class ProvisionTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_shells_db(self.db)
+        self.run_dir = self.tmp / "run" / "mem"
+
+    def provision(self, base="http://127.0.0.1:8800"):
+        return mem_credentials.provision(str(self.db), base, self.run_dir)
+
+    def test_one_artifact_per_live_keyed_admin(self):
+        names = self.provision()
+        self.assertEqual(names, ["ADM1"])
+        artifact = self.run_dir / "ADM1.json"
+        data = json.loads(artifact.read_text())
+        self.assertEqual(data["token"], "k-adm1")
+        self.assertEqual(data["api_base"], "http://127.0.0.1:8800")
+        self.assertEqual(data["shortname"], "ADM1")
+        # dev / unkeyed / deleted shells get nothing
+        self.assertFalse((self.run_dir / "DEV1.json").exists())
+        self.assertFalse((self.run_dir / "ADM2.json").exists())
+        self.assertFalse((self.run_dir / "ADM3.json").exists())
+
+    def test_permissions_are_owner_only(self):
+        self.provision()
+        mode = stat.S_IMODE((self.run_dir / "ADM1.json").stat().st_mode)
+        self.assertEqual(mode, 0o600)
+        dmode = stat.S_IMODE(self.run_dir.stat().st_mode)
+        self.assertEqual(dmode, 0o700)
+
+    def test_reprovision_repairs_weakened_permissions(self):
+        self.provision()
+        artifact = self.run_dir / "ADM1.json"
+        artifact.chmod(0o644)
+        self.provision()
+        self.assertEqual(stat.S_IMODE(artifact.stat().st_mode), 0o600)
+
+    def test_refresh_picks_up_key_rotation(self):
+        self.provision()
+        con = sqlite3.connect(self.db)
+        con.execute("UPDATE shells SET api_key='k-adm1-rotated' WHERE shell_id=1")
+        con.commit()
+        con.close()
+        self.provision()
+        data = json.loads((self.run_dir / "ADM1.json").read_text())
+        self.assertEqual(data["token"], "k-adm1-rotated")
+
+    def test_stale_artifacts_are_swept(self):
+        self.run_dir.mkdir(parents=True)
+        stale = self.run_dir / "GONE.json"
+        stale.write_text("{}")
+        self.provision()
+        self.assertFalse(stale.exists())
+        # demote ADM1 → its artifact disappears on the next boot too
+        con = sqlite3.connect(self.db)
+        con.execute("UPDATE shells SET flavor='dev' WHERE shell_id=1")
+        con.commit()
+        con.close()
+        self.assertEqual(self.provision(), [])
+        self.assertFalse((self.run_dir / "ADM1.json").exists())
+
+
+class DiscoveryTest(unittest.TestCase):
+    """mem.py discovery against the real API auth path (no env wiring)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = Path(tempfile.mkdtemp())
+        cls.db = cls.tmp / "shell_db.db"
+        build_engine_db(cls.db)
+        server.DB_PATH = cls.db  # db() reads the module global at call time
+        cls.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        cls.port = cls.httpd.server_address[1]
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+
+    def setUp(self):
+        self.cred_dir = Path(tempfile.mkdtemp())
+        self._saved = (mem.SC_API_TOKEN, mem.SC_API_BASE,
+                       mem._CRED_DIR, mem._DISCOVERED_FROM)
+        # Fully unwired client, discovery pointed at the temp dir.
+        mem.SC_API_TOKEN = ""
+        mem.SC_API_BASE = ""
+        mem._CRED_DIR = self.cred_dir
+        mem._DISCOVERED_FROM = None
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        (mem.SC_API_TOKEN, mem.SC_API_BASE,
+         mem._CRED_DIR, mem._DISCOVERED_FROM) = self._saved
+
+    def write_artifact(self, shortname, token, mode=0o600, base=None):
+        p = self.cred_dir / f"{shortname}.json"
+        p.write_text(json.dumps({
+            "shell_id": 1, "shortname": shortname,
+            "api_base": base or f"http://127.0.0.1:{self.port}",
+            "token": token,
+        }))
+        p.chmod(mode)
+        return p
+
+    def run_which(self):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = mem.main(["which"])
+        return rc, out.getvalue()
+
+    def test_unique_admin_artifact_is_discovered(self):
+        artifact = self.write_artifact("TC", TOKEN)
+        rc, out = self.run_which()
+        self.assertEqual(rc, 0)
+        self.assertIn("TC", out)                       # whoami resolved shell 1
+        self.assertIn("discovered from runtime artifact", out)
+        self.assertEqual(mem._DISCOVERED_FROM, artifact)
+        # discovery adopted the artifact's wiring, and it authenticates
+        self.assertEqual(mem.SC_API_TOKEN, TOKEN)
+
+    def test_env_wiring_wins_over_artifacts(self):
+        self.write_artifact("TC", TOKEN)
+        mem.SC_API_TOKEN = PEER_TOKEN
+        mem.SC_API_BASE = f"http://127.0.0.1:{self.port}"
+        rc, out = self.run_which()
+        self.assertEqual(rc, 0)
+        self.assertIn("Peer", out)                     # env identity, not TC's
+        self.assertIsNone(mem._DISCOVERED_FROM)
+
+    def test_ambiguous_admin_identity_refuses(self):
+        self.write_artifact("TC", TOKEN)
+        self.write_artifact("PEER", PEER_TOKEN)
+        with self.assertRaises(SystemExit) as cm:
+            self.run_which()
+        self.assertIn("ambiguous", str(cm.exception))
+        self.assertIn("SC_MEM_AS", str(cm.exception))
+
+    def test_sc_mem_as_selects_among_admins(self):
+        self.write_artifact("TC", TOKEN)
+        self.write_artifact("PEER", PEER_TOKEN)
+        with mock.patch.dict(os.environ, {"SC_MEM_AS": "peer"}):
+            rc, out = self.run_which()
+        self.assertEqual(rc, 0)
+        self.assertIn("Peer", out)
+
+    def test_sc_mem_as_unknown_shell_refuses(self):
+        self.write_artifact("TC", TOKEN)
+        with mock.patch.dict(os.environ, {"SC_MEM_AS": "NOPE"}), \
+                self.assertRaises(SystemExit) as cm:
+            self.run_which()
+        self.assertIn("NOPE", str(cm.exception))
+
+    def test_insecure_artifact_is_refused(self):
+        self.write_artifact("TC", TOKEN, mode=0o644)
+        with self.assertRaises(SystemExit) as cm:
+            self.run_which()
+        self.assertIn("owner-only", str(cm.exception))
+        self.assertIn("restart", str(cm.exception))
+
+    def test_malformed_artifact_is_refused(self):
+        p = self.cred_dir / "TC.json"
+        p.write_text("not json")
+        p.chmod(0o600)
+        with self.assertRaises(SystemExit) as cm:
+            self.run_which()
+        self.assertIn("malformed", str(cm.exception))
+
+    def test_stale_credential_names_the_refresh_action(self):
+        self.write_artifact("TC", "rotated-away-token")
+        with self.assertRaises(SystemExit) as cm:
+            self.run_which()
+        self.assertIn("stale", str(cm.exception))
+        self.assertIn("restart", str(cm.exception))
+
+    def test_no_artifact_keeps_the_original_unwired_death(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.run_which()
+        self.assertIn("isn't API-wired", str(cm.exception))
+        self.assertIn("runtime", str(cm.exception))  # …and names the new path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sprint 31 (doc #31) unit 4 · spec doc #30 reqs 11–12 · reviewer REV2.

## What

**#516 — host Admin bootstrap without injected API vars.** The supervised API now provisions one owner-only runtime credential artifact per live keyed Admin shell at every boot (`.super-coder/run/mem/<shortname>.json`, dir 0700 / file 0600, written right after the api_key backfill so rotations are picked up). When **both** `SC_API_BASE`/`SC_API_TOKEN` are absent, `sc mem` discovers the unique Admin artifact and calls the API with it — still API-only, never direct-DB. Ambiguity (multiple Admin artifacts) refuses and asks for `SC_MEM_AS=<shortname>`; an insecure (non-0600/non-owner) or malformed artifact is refused; a rotated-out token dies with a named stale-credential remediation (`./sc restart` / `make dos-r`). The artifact is the shell's existing `shells.api_key` — no second credential is minted — and lives under gitignored, never-snapshotted `.super-coder/run/`.

**#518 — host Interface CLI without `websockets`.** `sc`'s `ifpy` was a hard dispatch-time gate for every verb. It now only *prefers* a websockets-capable interpreter; HTTP-only verbs (`status`/`start`/`stop`/`reconcile`) run on any stdlib python3 (the module import chain is stdlib-clean — verified). The already-lazy import in `_ws_connect` is now the single dependency check: only attach/view/take-control reach it, and a missing package refuses with the exact dependency action (`./sc deps` / `./sc build`) plus the verbs that work without it.

## Ambiguity calls (sprint-scoped)

- **Selector mechanism for "asks for an explicit shortname"** — spec didn't name one → chose env var `SC_MEM_AS=<shortname>` over a new CLI flag: zero argparse surface, matches the env-based wiring model.
- **Artifact contents include `api_base`** (`http://127.0.0.1:<port>`) rather than deriving host-side from instance.json → one self-describing artifact, same URL on both sides of the bind mount.
- **watch.py duplicates mem's old unwired gate** — left as-is (spec scopes req 11 to `sc mem`); follow-up candidate.

## Verification

- `tests/test_runtime_credentials.py` (14): provisioning matrix (admin/dev/unkeyed/deleted), 0600/0700 + repair, rotation refresh, stale sweep; discovery against the real API auth path — unique artifact, env-wins, ambiguity + SC_MEM_AS select/unknown, insecure/malformed/stale refusals, unwired death preserved.
- `tests/test_interface_cli.py` LazyWebsocketsTest: HTTP verbs pass with the package blocked in `sys.modules`; a stream verb (`view`) refuses with the dependency action at exit 3.
- Full suite: **858 passed, 7 skipped** (job 49-s31-u4-full-suite). Ruff: only pre-existing findings (identical count with the diff stashed).

Closes #516, closes #518 — pending the AMI restricted-seat reproduction in unit 10.

Co-authored-by: Code-04 (super-coder) <noreply@super-coder.local>