### PR TITLE
fix(interface): lifecycle convergence — one closure, cancel start, truthful errors (sprint 31 unit 1)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -469,7 +469,20 @@ def _create_session(actor, headers, body):
                 # AMBIGUOUS tmux outcome leaves it unreconciled (spec #20
                 # Interface Workflow 4) — never a second process, never an
                 # auto-kill.
-                from interface_runtime import InterfaceUnavailable
+                from interface_runtime import InterfaceUnavailable, SpawnAborted
+                if isinstance(exc, SpawnAborted):
+                    # Cancel start won the race mid-spawn (SC-064): the
+                    # cancel path already closed this row and the runtime
+                    # killed the pane by exact identity. Never persist the
+                    # pane identity onto the ended row, never a 201.
+                    con.commit()
+                    return 409, {"error": {
+                        "code": "session_cancelled",
+                        "message": "the session was cancelled while its "
+                                   "harness was still spawning — the "
+                                   "partial spawn was torn down",
+                        "details": {"session_id": session_id,
+                                    "occupancy": "ended"}}}
                 definite = isinstance(exc, (InterfaceUnavailable,
                                             FileNotFoundError, ValueError))
                 if definite:
@@ -489,6 +502,27 @@ def _create_session(actor, headers, body):
                 return code, {"session_id": session_id, "shell_id": shell_id,
                               "occupancy": "ended" if definite else "unreconciled",
                               "error": str(exc)[:200]}
+            # Cancel-during-spawn convergence (SC-064), the backstop for
+            # every interleaving the runtime's abort check can't see (a
+            # cancel that landed before the generation was registered, or
+            # one that parked the row unreconciled): the row was concluded
+            # while we spawned — tear the just-created pane down by its
+            # exact identity instead of persisting that identity onto a
+            # concluded row. A live harness on an ended generation is the
+            # unclosable #519 wound; an occupied row (the entrypoint hook
+            # already promoted it) is the healthy fast-boot path.
+            occ = con.execute(
+                "SELECT occupancy FROM interface_sessions WHERE session_id=?",
+                (session_id,)).fetchone()[0]
+            if occ in ("ended", "unreconciled"):
+                _runtime.call(_runtime.abandon(session_id))
+                con.commit()
+                return 409, {"error": {
+                    "code": "session_cancelled",
+                    "message": "the session was concluded by a concurrent "
+                               "cancel while its harness was spawning — "
+                               "the pane was torn down by exact identity",
+                    "details": {"session_id": session_id, "occupancy": occ}}}
             con.execute(
                 "UPDATE interface_sessions SET tmux_socket=?, tmux_session=?, "
                 "tmux_window=?, tmux_pane_id=?, pane_pid=?, pane_start_ticks=? "

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -36,6 +36,7 @@ import secrets
 import sys
 import threading
 import time
+import traceback
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
@@ -299,29 +300,62 @@ def _worktree_for(shortname: str, flavor: "str | None" = None) -> str:
 
 
 def _provision_worktree(worktree: str, shortname: str):
-    """Create the shell's git worktree on demand, exactly like the CLI boot
-    (run.ensure_worktree). A shell that was never CLI-booted has no
-    .sc-worktrees/<shortname> yet; the tmux pane's `cd` and the exec both
-    assume it exists, so it must be provisioned BEFORE the reservation is
-    written — never left to fail as a raw 'not a directory'. Returns an
-    error tuple for produce() on failure, None on success/no-op."""
-    path = Path(worktree)
-    if path.is_dir():
-        return None
+    """Validate, then create the shell's git worktree on demand, exactly
+    like the CLI boot (run.ensure_worktree). A shell that was never
+    CLI-booted has no .sc-worktrees/<shortname> yet; the tmux pane's `cd`
+    and the exec both assume it exists, so it must be provisioned BEFORE
+    the reservation is written — never left to fail as a raw 'not a
+    directory'. Path validation distinguishes the three failure shapes:
+    missing (provision it), existing-but-not-a-directory (refuse — a stray
+    file blocks the path), and existing-but-unusable (a bare directory
+    without git backing, or not writable — refuse, provisioning assumes an
+    existing dir is intact and would no-op). Returns an error tuple for
+    produce() on failure, None on success/no-op."""
     import run as run_mod
+    path = Path(worktree)
     if path == run_mod.REPO_ROOT:
         return None  # admin flavor boots at the repo root — nothing to add
+
+    def _err_tuple(code: str, message: str, reason: str):
+        return 500, {"error": {
+            "code": code, "message": message,
+            "details": {"worktree": worktree, "shortname": shortname,
+                        "reason": reason}}}
+
+    if path.exists() and not path.is_dir():
+        return _err_tuple(
+            "worktree_not_directory",
+            f"{worktree} exists but is not a directory — remove the stray "
+            f"file, then retry New chat", "non_directory")
+    if path.is_dir():
+        if not (path / ".git").exists():
+            return _err_tuple(
+                "worktree_unusable",
+                f"{worktree} is a plain directory, not a git worktree — "
+                f"remove it or provision it by hand (`./sc enter "
+                f"{shortname}`), then retry New chat", "not_a_worktree")
+        if not os.access(path, os.W_OK | os.X_OK):
+            return _err_tuple(
+                "worktree_unusable",
+                f"{worktree} is not writable by this service — fix its "
+                f"ownership/permissions, then retry New chat",
+                "not_writable")
+        return None
     try:
         run_mod.ensure_worktree(path, shortname)
     except SystemExit as e:  # ensure_worktree exits with the git stderr
         detail = str(e).removeprefix("FATAL: ").strip()
-        return 500, {"error": {
-            "code": "worktree_provision_failed",
-            "message": f"could not provision the shell worktree: {detail} — "
-                       f"fix the repo (`git worktree list`) or create it by "
-                       f"hand (`./sc enter {shortname}`), then retry New chat",
-            "details": {"worktree": worktree, "shortname": shortname}}}
-    return None
+    except (OSError, run_mod.LaunchError) as e:
+        # The expected launcher failures (git binary missing, mkdir
+        # refused, launch-gate refusal) — curated, never a raw 500.
+        detail = f"{type(e).__name__}: {e}"
+    else:
+        return None
+    return _err_tuple(
+        "worktree_provision_failed",
+        f"could not provision the shell worktree: {detail} — fix the repo "
+        f"(`git worktree list`) or create it by hand (`./sc enter "
+        f"{shortname}`), then retry New chat", "provision_failed")
 
 
 def _create_session(actor, headers, body):
@@ -430,25 +464,26 @@ def _create_session(actor, headers, body):
                     token_path=str(token_path), rows=rows, cols=cols))
             except Exception as exc:  # noqa: BLE001 — see below
                 # Definite pre-spawn failure (runtime down, bad worktree)
-                # closes the reservation; an AMBIGUOUS tmux outcome leaves it
-                # unreconciled (spec #20 Interface Workflow 4) — never a
-                # second process, never an auto-kill.
+                # closes the reservation through the one closure helper —
+                # occupancy AND lifecycle terminalize together; an
+                # AMBIGUOUS tmux outcome leaves it unreconciled (spec #20
+                # Interface Workflow 4) — never a second process, never an
+                # auto-kill.
                 from interface_runtime import InterfaceUnavailable
                 definite = isinstance(exc, (InterfaceUnavailable,
                                             FileNotFoundError, ValueError))
-                interface_state.transition(
-                    con, "occupancy", session_id,
-                    "ended" if definite else "unreconciled",
-                    extra_sets={"error_detail": f"spawn failed: {exc}"[:400],
-                                **({"ended_at": _now(con),
-                                    "end_reason": "spawn_failed"}
-                                   if definite else {})})
                 if definite:
+                    interface_broker.close_session(con, session_id,
+                                                   "spawn_failed")
                     con.execute(
-                        "UPDATE interface_generations SET "
-                        "ended_at=datetime('now') "
-                        "WHERE shell_id=? AND generation=?",
-                        (shell_id, gen_no))
+                        "UPDATE interface_sessions SET error_detail=? "
+                        "WHERE session_id=?",
+                        (f"spawn failed: {exc}"[:400], session_id))
+                else:
+                    interface_state.transition(
+                        con, "occupancy", session_id, "unreconciled",
+                        extra_sets={"error_detail":
+                                    f"spawn failed: {exc}"[:400]})
                 con.commit()
                 code = 503 if definite else 202
                 return code, {"session_id": session_id, "shell_id": shell_id,
@@ -479,14 +514,17 @@ def _create_session(actor, headers, body):
         if isinstance(exc, sqlite3.IntegrityError):
             # Lost the reservation race — the partial unique index fired;
             # return the existing owner (spec: a concurrent start returns the
-            # existing owner, never a second process).
+            # existing owner, never a second process). owner can momentarily
+            # be None if the winner committed only its generation row so far
+            # (the generations index fired first) — the retry reveals it.
             owner = con.execute(
-                "SELECT session_id FROM interface_sessions "
+                "SELECT session_id, occupancy FROM interface_sessions "
                 "WHERE shell_id=? AND occupancy <> 'ended'",
                 (shell_id,)).fetchone()
             return _err(409, "shell_occupied",
                         "a concurrent start owns this shell",
-                        {"session_id": owner[0] if owner else None})
+                        {"session_id": owner[0] if owner else None,
+                         "occupancy": owner[1] if owner else None})
         raise
     finally:
         con.close()
@@ -698,10 +736,13 @@ def _terminate(actor, headers, body):
         if sess is None:
             return _err(404, "no_such_session",
                         f"interface session {session_id} not found")
-        if sess[2] != "occupied":
+        if sess[2] == "unreconciled":
             return _err(409, "not_occupied",
-                        f"session {session_id} is {sess[2]}, not occupied")
-        if force and sess[4] is None:
+                        f"session {session_id} is unreconciled — termination "
+                        "needs a verified identity; reconcile and close "
+                        "after proved absence instead")
+        if force and sess[4] is None and sess[2] != "ended" \
+                and sess[3] != "ended":
             # Spec Workflow 9: force only AFTER graceful termination fails
             # and shows the PID/generation it will end. The UI sequences it;
             # the API (authority surface for the seq-6 CLI) enforces it.
@@ -710,58 +751,117 @@ def _terminate(actor, headers, body):
                         "termination timed out for this session")
 
         def produce():
-            interface_state.transition(con, "lifecycle", session_id, "stopping")
-            con.commit()
-            result = _runtime.call(_runtime.terminate(session_id, force=force))
-            if not result.get("terminated"):
-                if result.get("reason") == "identity_mismatch":
-                    # Fail closed (spec: never kill an uncertain process) —
-                    # the session is now uncertain, not endable.
-                    interface_state.transition(con, "occupancy", session_id,
-                                               "unreconciled")
+            # Re-read inside produce: the gate above ran before the
+            # idempotency store, and a hook/close may have raced in since.
+            cur = con.execute(
+                "SELECT occupancy, lifecycle, tmux_pane_id, pane_pid "
+                "FROM interface_sessions WHERE session_id=?",
+                (session_id,)).fetchone()
+            occ, lif, pane_id, pane_pid = cur
+            if occ == "ended" or lif == "ended":
+                # Terminal already (a repeated request, or a session_end
+                # hook that won the race): complete durable closure
+                # idempotently — never transition back to stopping (#532).
+                interface_broker.close_session(con, session_id, "operator_end")
+                con.commit()
+                return 202, {"terminated": True, "already_ended": True}
+            if occ == "reserved":
+                # Cancel start (spec Lifecycle Contract / #519).
+                if pane_id is None and pane_pid is None:
+                    # No pane or harness identity was ever established:
+                    # nothing live to signal — cancel the reservation.
+                    interface_broker.close_session(
+                        con, session_id, "cancelled_before_spawn")
+                    con.commit()
+                    _runtime.call(_runtime.abandon(session_id))
+                    return 202, {"terminated": True,
+                                 "end_reason": "cancelled_before_spawn"}
+                if not _runtime.call(_runtime.verify_identity(session_id)):
+                    # Spawn outcome uncertain — never silently ended: park
+                    # as unreconciled and require absence proof.
+                    interface_state.transition(
+                        con, "occupancy", session_id, "unreconciled",
+                        extra_sets={"error_detail":
+                                    "cancel start: pane identity "
+                                    "unverifiable"})
                     interface_state.transition(con, "lifecycle", session_id,
                                                "lost")
                     con.commit()
-                    return 409, {"terminated": False,
-                                 "reason": "identity_mismatch"}
-                # graceful timeout: stays stopping, and the timeout is
-                # recorded durably — it is what unlocks the force follow-up.
-                interface_state.transition(
-                    con, "lifecycle", session_id, "stopping",
-                    extra_sets={"graceful_timed_out_at": _now(con)})
+                    return 409, {"error": {
+                        "code": "identity_unverified",
+                        "message": "the reserved pane's identity cannot be "
+                                   "verified — the session is unreconciled; "
+                                   "prove absence and close it via "
+                                   "reconciliation",
+                        "details": {"session_id": session_id}}}
+                # Verified identity live — the normal stop path below runs.
+            try:
+                interface_state.transition(con, "lifecycle", session_id,
+                                           "stopping")
                 con.commit()
-                return 200, {"terminated": False,
-                             "reason": result.get("reason", "graceful_timeout"),
-                             "pid": result.get("pid"),
-                             "generation": result.get("generation")}
-            _end_session(con, session_id,
-                         "operator_force" if force else "operator_end")
-            con.commit()
-            return 202, {"terminated": True}
+                result = _runtime.call(_runtime.terminate(session_id,
+                                                          force=force))
+                if not result.get("terminated"):
+                    reason = result.get("reason")
+                    if reason == "identity_mismatch":
+                        # Fail closed (spec: never kill an uncertain
+                        # process) — the session is uncertain, not endable.
+                        interface_state.transition(con, "occupancy",
+                                                   session_id, "unreconciled")
+                        interface_state.transition(con, "lifecycle",
+                                                   session_id, "lost")
+                        con.commit()
+                        return 409, {"terminated": False,
+                                     "reason": "identity_mismatch"}
+                    if reason == "not_running":
+                        # The runtime holds no live generation — absence,
+                        # not a timeout. Prove it and converge rather than
+                        # recording a phantom graceful timeout.
+                        if _runtime.call(_runtime.prove_absence(session_id)):
+                            interface_broker.close_session(
+                                con, session_id, "operator_end")
+                            con.commit()
+                            _runtime.call(_runtime.abandon(session_id))
+                            return 202, {"terminated": True,
+                                         "reason": "already_absent"}
+                        interface_state.transition(con, "occupancy",
+                                                   session_id, "unreconciled")
+                        interface_state.transition(con, "lifecycle",
+                                                   session_id, "lost")
+                        con.commit()
+                        return 409, {"terminated": False,
+                                     "reason": "not_running"}
+                    # graceful timeout: stays stopping, and the timeout is
+                    # recorded durably — it is what unlocks the force
+                    # follow-up.
+                    interface_state.transition(
+                        con, "lifecycle", session_id, "stopping",
+                        extra_sets={"graceful_timed_out_at": _now(con)})
+                    con.commit()
+                    return 200, {"terminated": False,
+                                 "reason": result.get("reason",
+                                                      "graceful_timeout"),
+                                 "pid": result.get("pid"),
+                                 "generation": result.get("generation")}
+                interface_broker.close_session(
+                    con, session_id,
+                    "operator_force" if force else "operator_end")
+                con.commit()
+                return 202, {"terminated": True}
+            except interface_state.InterfaceTransitionError:
+                # A session_end hook (or a concurrent close) terminalized
+                # mid-flight — the race the old code lost as a false
+                # no_such_route (#532). Roll back the partial attempt and
+                # converge closure; the semantic result is still success.
+                con.rollback()
+                interface_broker.close_session(con, session_id, "operator_end")
+                con.commit()
+                _runtime.call(_runtime.abandon(session_id))
+                return 202, {"terminated": True, "already_ended": True}
 
         return _idempotent(con, actor, "terminate", headers, body, produce)
     finally:
         con.close()
-
-
-def _end_session(con, session_id: int, end_reason: str) -> None:
-    """Durable closure: occupancy → ended (availability derives), generation
-    ended, leases revoked. The shell offers New chat only after this."""
-    row = con.execute(
-        "SELECT shell_id, generation FROM interface_sessions "
-        "WHERE session_id=?", (session_id,)).fetchone()
-    interface_state.transition(
-        con, "occupancy", session_id, "ended",
-        extra_sets={"ended_at": _now(con), "end_reason": end_reason})
-    interface_state.transition(con, "lifecycle", session_id, "ended")
-    con.execute(
-        "UPDATE interface_generations SET ended_at=datetime('now') "
-        "WHERE shell_id=? AND generation=? AND ended_at IS NULL",
-        (row[0], row[1]))
-    con.execute(
-        "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
-        "revoke_reason='session_end' "
-        "WHERE session_id=? AND revoked_at IS NULL", (session_id,))
 
 
 def _reconcile(actor, headers, body):
@@ -807,7 +907,8 @@ def _reconcile(actor, headers, body):
                                    "reconcile or investigate first",
                         "details": {}}}
                 _runtime.call(_runtime.abandon(session_id))
-                _end_session(con, session_id, "operator_close")
+                interface_broker.close_session(con, session_id,
+                                               "operator_close")
                 con.commit()
                 return 200, {"session_id": session_id, "closed": True,
                              "occupancy": "ended",
@@ -1410,10 +1511,23 @@ def _hook_callback(headers, body):
             "SELECT hook_token_hash, ended_at FROM interface_generations "
             "WHERE shell_id=? AND generation=?", (shell_id, generation)
         ).fetchone()
-        if gen is None or gen[1] is not None or \
+        if gen is None or \
                 hashlib.sha256(token.encode()).hexdigest() != gen[0]:
             _log(f"hook auth rejected shell={shell_id} gen={generation} "
                  f"event={event}")
+            return _err(403, "hook_auth",
+                        "unknown generation or bad hook token")
+        if gen[1] is not None:
+            # The generation has ended. Every event is rejected EXCEPT a
+            # session_end acknowledgement: a provider hook (its own end, or
+            # one that lost the race to an operator close) gets a clean 200
+            # — acknowledged, never reopened, never a rejection loop (#532).
+            if event == "session_end":
+                return _json(200, {"hook_seq": hook_seq, "event": event,
+                                   "acknowledged": True,
+                                   "already_ended": True})
+            _log(f"hook rejected (ended generation) shell={shell_id} "
+                 f"gen={generation} event={event}")
             return _err(403, "hook_auth",
                         "unknown generation or bad hook token")
         sess = con.execute(
@@ -1534,6 +1648,19 @@ def _browser_session(headers, body):
 
 # ------------------------------------------------------------------ dispatch
 
+class _BadPathId(ValueError):
+    """A route-shaped path whose identifier segment is not an int."""
+
+
+def _path_id(path: str, segment: int = -1) -> int:
+    """Parse one path segment as a route identifier; a bad segment is a
+    422 parsing error, never a 404 no_such_route (spec #30 req 4)."""
+    try:
+        return int(path.split("/")[segment])
+    except (ValueError, IndexError):
+        raise _BadPathId(f"invalid path identifier: {path!r}")
+
+
 def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
     from urllib.parse import parse_qs, urlparse
     headers = _parse_headers(headers_raw)
@@ -1583,14 +1710,13 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
         if p == "/api/interface/sessions" and method == "POST":
             return _create_session(actor, headers, data)
         if p.startswith("/api/interface/sessions/") and method == "GET":
-            return _get_session(int(p.rsplit("/", 1)[1]))
+            return _get_session(_path_id(p))
         if p == "/api/interface/stream-tickets" and method == "POST":
             return _mint_ticket(actor, headers, data)
         if p == "/api/interface/writer-leases" and method == "POST":
             return _acquire_lease(actor, headers, data)
         if p.startswith("/api/interface/writer-leases/") and method == "DELETE":
-            return _release_lease(actor, headers, data,
-                                  int(p.rsplit("/", 1)[1]))
+            return _release_lease(actor, headers, data, _path_id(p))
         if p == "/api/interface/clean-certifications" and method == "POST":
             return _certify_clean(actor, headers, data)
         if p == "/api/interface/termination-requests" and method == "POST":
@@ -1605,17 +1731,32 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
             return _sprint_alerts(actor, query)
         if p.startswith("/api/interface/sprint-bindings/") \
                 and p.endswith("/retry") and method == "POST":
-            return _retry_binding(actor, headers, data,
-                                  int(p.split("/")[4]))
+            return _retry_binding(actor, headers, data, _path_id(p, -2))
         if p.startswith("/api/interface/sprint-bindings/") \
                 and method == "DELETE":
-            return _release_binding(actor, headers, data,
-                                    int(p.rsplit("/", 1)[1]))
+            return _release_binding(actor, headers, data, _path_id(p))
         if p == "/api/planner-action-receipts" and method == "POST":
             return _begin_receipt(actor, headers, data)
         if p.startswith("/api/planner-action-receipts/") and method == "PATCH":
-            return _update_receipt(actor, headers, data,
-                                   int(p.rsplit("/", 1)[1]))
+            return _update_receipt(actor, headers, data, _path_id(p))
         return _err(404, "no_such_route", f"no route: {method} {p}")
-    except ValueError:
-        return _err(404, "no_such_route", f"no route: {method} {p}")
+    except _BadPathId as exc:
+        # Route PARSING error — a legal route shape with a bad identifier.
+        return _err(422, "invalid_path_id", str(exc))
+    except (interface_state.InterfaceTransitionError,
+            interface_broker.BrokerError) as exc:
+        # A legal route whose durable state refused the transition. NEVER
+        # no_such_route (#523): the old broad `except ValueError` rewrote
+        # these internal state conflicts to a false 404.
+        _log(f"state conflict {method} {p}: {exc}")
+        return _err(409, "state_conflict", str(exc))
+    except Exception as exc:  # noqa: BLE001 — the last-resort boundary
+        # Unexpected handler failure: sanitized 500 with a server-side
+        # correlation record; internals never cross the wire.
+        correlation = secrets.token_hex(8)
+        _log(f"handler failure {method} {p} correlation={correlation}: "
+             f"{exc!r}\n{traceback.format_exc()}")
+        return _err(500, "internal",
+                    "unexpected server failure — quote correlation "
+                    f"{correlation} when reporting",
+                    {"correlation": correlation})

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -298,6 +298,83 @@ def reconcile_input(con, session_id: int, outcome: str) -> None:
                     "forwarded_seq": new_forwarded})
 
 
+def close_session(con, session_id: int, end_reason: str) -> dict:
+    """THE one closure helper (spec #30 Lifecycle Contract) — every close
+    producer (operator terminate, cancel start, reconcile-close, spawn
+    failure, provider session_end) converges through here instead of
+    composing lifecycle/occupancy moves independently.
+
+    One transaction boundary (the caller's connection): records end
+    reason/time, terminalizes occupancy AND lifecycle (walking through
+    `stopping` where no direct edge exists — a hook that won the race can
+    never strand occupied/ended, and nothing ever moves terminal →
+    nonterminal), ends the matching generation, revokes active leases,
+    and resolves or parks session-scoped wake state by the existing
+    ambiguity rules (a pending human frame parks delivery_unknown; a
+    batch with a proven stop reconciles from read state; a batch with no
+    stop evidence parks — no live harness will re-drive it). Queued wake
+    work is deliberately left queued for a future generation.
+
+    Idempotent: an already-ended session returns its original terminal
+    result without state churn."""
+    row = con.execute(
+        "SELECT shell_id, generation, occupancy, lifecycle, end_reason "
+        "FROM interface_sessions WHERE session_id=?",
+        (session_id,),
+    ).fetchone()
+    if row is None:
+        raise BrokerError(f"interface session {session_id} not found")
+    shell_id, generation, occupancy, lifecycle, prior_reason = row
+    if occupancy == "ended":
+        return {"session_id": session_id, "already_ended": True,
+                "end_reason": prior_reason}
+
+    interface_state.transition(
+        con, "occupancy", session_id, "ended",
+        extra_sets={"ended_at": _now(con), "end_reason": end_reason})
+    if lifecycle != "ended":
+        if lifecycle in ("idle", "busy", "approval", "user_input"):
+            # No direct edge to ended — converge through stopping (the
+            # only nonterminal staging state every live state can reach).
+            interface_state.transition(con, "lifecycle", session_id,
+                                       "stopping")
+        interface_state.transition(con, "lifecycle", session_id, "ended")
+    con.execute(
+        "UPDATE interface_generations SET ended_at=datetime('now') "
+        "WHERE shell_id=? AND generation=? AND ended_at IS NULL",
+        (shell_id, generation))
+    con.execute(
+        "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
+        "revoke_reason='session_end' "
+        "WHERE session_id=? AND revoked_at IS NULL", (session_id,))
+
+    # Session-scoped wake state: the generation is provably over, so a
+    # pending human frame can never be acked and a live batch can never
+    # see its stop hook. Resolve from durable evidence or park — the same
+    # rules startup reconciliation applies (decision #22).
+    istate = con.execute(
+        "SELECT pending_seq, delivery FROM interface_input_state "
+        "WHERE session_id=?", (session_id,)).fetchone()
+    if istate is not None and istate[0] is not None \
+            and istate[1] != "delivery_unknown":
+        park_delivery_unknown(con, session_id)
+    batches = con.execute(
+        "SELECT batch_id, binding_id, state, stop_hook_seq "
+        "FROM planner_wake_batches "
+        "WHERE shell_id=? AND generation=? AND state IN ('submitting','running')",
+        (shell_id, generation)).fetchall()
+    for batch_id, binding_id, _state, stop_seq in batches:
+        if stop_seq is not None:
+            _complete_batch(con, batch_id, stop_seq)
+        else:
+            interface_state.transition(con, "wake_batch", batch_id,
+                                       "delivery_unknown")
+            _alert(con, severity="critical",
+                   reason="wake_batch_delivery_unknown", binding_id=binding_id)
+    return {"session_id": session_id, "already_ended": False,
+            "end_reason": end_reason}
+
+
 def record_hook(con, shell_id: int, generation: int, hook_seq: int,
                 event: str, source: str = "provider") -> dict:
     """Record one authenticated harness hook with its durable sequence.
@@ -325,6 +402,12 @@ def record_hook(con, shell_id: int, generation: int, hook_seq: int,
     if gen is None:
         raise BrokerError(f"unknown generation {shell_id}/{generation}")
     if gen[1] is not None:
+        if event == "session_end":
+            # A provider hook may ACKNOWLEDGE an already-ended generation
+            # (its own end, or a close that won the race) without reopening
+            # it — a clean 200, never a rejection loop the emitter retries.
+            return {"hook_seq": hook_seq, "event": event,
+                    "acknowledged": True, "already_ended": True}
         raise BrokerError(f"generation {shell_id}/{generation} has ended")
     if hook_seq <= gen[0]:
         raise BrokerError(
@@ -416,15 +499,12 @@ def record_hook(con, shell_id: int, generation: int, hook_seq: int,
         if _turn_finished(con, sess, shell_id, generation, hook_seq):
             result["wake_batch_complete"] = True
     elif event == "session_end":
-        interface_state.transition(con, "lifecycle", sess[0], "ended")
-        # The chat is provably over: end the generation too. Without this the
-        # one-live-generation index keeps the shell occupied forever — and a
-        # snapshot/rebuild cycle would resurrect a "live" generation that
-        # bricks the shell's next New chat.
-        con.execute(
-            "UPDATE interface_generations SET ended_at=datetime('now') "
-            "WHERE shell_id=? AND generation=? AND ended_at IS NULL",
-            (shell_id, generation))
+        # The chat is provably over: converge FULL durable closure through
+        # the one helper — occupancy AND lifecycle terminal, generation
+        # ended, leases revoked, wake state resolved/parked. Ending only
+        # the lifecycle here stranded occupied/ended sessions that no
+        # route could converge (#532).
+        close_session(con, sess[0], "provider_session_end")
     elif event == "approval_wait":
         # Optional (kimi PermissionRequest): busy → approval + alert. A
         # harness without this event simply stays busy — safe (spec).

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -315,8 +315,11 @@ def close_session(con, session_id: int, end_reason: str) -> dict:
     stop evidence parks — no live harness will re-drive it). Queued wake
     work is deliberately left queued for a future generation.
 
-    Idempotent: an already-ended session returns its original terminal
-    result without state churn."""
+    Idempotent: a FULLY terminal session (occupancy AND lifecycle ended)
+    returns its original terminal result without state churn. A partially
+    closed legacy row — a pre-convergence closure that ended occupancy but
+    left lifecycle nonterminal — is converged, never silently no-op'ed
+    (SC-065); its original end reason/time are kept."""
     row = con.execute(
         "SELECT shell_id, generation, occupancy, lifecycle, end_reason "
         "FROM interface_sessions WHERE session_id=?",
@@ -325,13 +328,19 @@ def close_session(con, session_id: int, end_reason: str) -> dict:
     if row is None:
         raise BrokerError(f"interface session {session_id} not found")
     shell_id, generation, occupancy, lifecycle, prior_reason = row
-    if occupancy == "ended":
+    if occupancy == "ended" and lifecycle == "ended":
         return {"session_id": session_id, "already_ended": True,
                 "end_reason": prior_reason}
 
-    interface_state.transition(
-        con, "occupancy", session_id, "ended",
-        extra_sets={"ended_at": _now(con), "end_reason": end_reason})
+    if occupancy != "ended":
+        interface_state.transition(
+            con, "occupancy", session_id, "ended",
+            extra_sets={"ended_at": _now(con), "end_reason": end_reason})
+        recorded_reason = end_reason
+    else:
+        # Legacy partial row: occupancy already ended — re-stamping the
+        # reason/time would falsify the original terminal record.
+        recorded_reason = prior_reason
     if lifecycle != "ended":
         if lifecycle in ("idle", "busy", "approval", "user_input"):
             # No direct edge to ended — converge through stopping (the
@@ -372,7 +381,7 @@ def close_session(con, session_id: int, end_reason: str) -> dict:
             _alert(con, severity="critical",
                    reason="wake_batch_delivery_unknown", binding_id=binding_id)
     return {"session_id": session_id, "already_ended": False,
-            "end_reason": end_reason}
+            "end_reason": recorded_reason}
 
 
 def record_hook(con, shell_id: int, generation: int, hook_seq: int,

--- a/.super-coder/scripts/interface_runtime.py
+++ b/.super-coder/scripts/interface_runtime.py
@@ -75,6 +75,11 @@ class InterfaceUnavailable(RuntimeError):
     """tmux/node stack missing or too old — review UI keeps working."""
 
 
+class SpawnAborted(RuntimeError):
+    """The generation was abandoned (cancel start) while its spawn was
+    still in flight — the spawn must not complete (SC-064)."""
+
+
 class _Rejected(Exception):
     """Pre-broker rejection carrying a stable wire reason string."""
 
@@ -405,10 +410,13 @@ class Generation:
             for client in list(self.clients):
                 client.send_control({"type": "error", "code": "terminated"})
                 client.close(1000, "generation terminated")
-            try:
-                await self.runtime.tmux("kill-window", "-t", self.pane_id)
-            except Exception:
-                pass
+            if self.pane_id:
+                # A generation abandoned mid-spawn can have no pane yet —
+                # never hand tmux an empty target (SC-064).
+                try:
+                    await self.runtime.tmux("kill-window", "-t", self.pane_id)
+                except Exception:
+                    pass
         self.runtime.shadow.dispose(self.sid)
         if self._pump_fd >= 0:
             try:
@@ -738,6 +746,10 @@ class InterfaceRuntime:
             f"&& exec cat >&9")
         deadline = time.monotonic() + TMUX_SYNC_TIMEOUT_S
         while not os.path.exists(marker):
+            if gen.terminated:
+                # Abandoned mid-spawn (SC-064) — the writer will never
+                # attach; let spawn's abort check raise SpawnAborted.
+                return
             if time.monotonic() > deadline:
                 raise RuntimeError(
                     f"pipe-pane writer never attached for {fifo}")
@@ -754,76 +766,112 @@ class InterfaceRuntime:
             asyncio.create_task(gen._input_consumer()),
         ]
 
+    async def _abort_if_torn_down(self, gen: Generation) -> None:
+        """Cancel-during-spawn convergence (SC-064): abandon() popped and
+        tore down this generation while its spawn was in flight. Kill the
+        just-created pane by its exact identity — provably ours, created
+        seconds ago — and refuse to complete the spawn: a completed spawn
+        on an already-ended row is a live harness nobody can close."""
+        if not gen.terminated:
+            return
+        if gen.pane_id:
+            try:
+                await self.tmux("kill-window", "-t", gen.pane_id)
+            except Exception:  # noqa: BLE001,S110 — already dead is the goal
+                pass
+        raise SpawnAborted(
+            f"session {gen.session_id} abandoned during spawn")
+
     async def spawn(self, *, session_id: int, shell_id: int, generation: int,
                     worktree: str, sc_path: str, token_path: str,
                     rows: int, cols: int,
                     command: list[str] | None = None) -> dict:
         """Create the tmux window + FIFO pump + shadow for one generation.
         `command` overrides the exec line — tests only. Returns the pane
-        identity the caller persists to interface_sessions."""
+        identity the caller persists to interface_sessions.
+
+        The generation is registered BEFORE the tmux work so a cancel
+        start landing mid-spawn (SC-064) can see and tear it down through
+        abandon(); the abort checks then stop the spawn before the harness
+        ever boots and SpawnAborted tells the caller the session was
+        cancelled — never a completed spawn on an ended row."""
         self._require_available()
         gen = Generation(self, session_id, shell_id, generation, rows, cols)
-        fifo = self._fifo_path(session_id)
-        sentinel = self._sentinel_path(session_id)
-        for stale in (fifo, sentinel):
-            if os.path.exists(stale):
-                os.unlink(stale)
-        os.mkfifo(fifo)
-        self._open_fifo(gen)
+        self.generations[session_id] = gen
+        try:
+            fifo = self._fifo_path(session_id)
+            sentinel = self._sentinel_path(session_id)
+            for stale in (fifo, sentinel):
+                if os.path.exists(stale):
+                    os.unlink(stale)
+            os.mkfifo(fifo)
+            self._open_fifo(gen)
 
-        if command is not None:
-            exec_line = shlex.join(command)
-        else:
-            exec_line = (f"{shlex.quote(sc_path)} interface-exec "
-                         f"{shlex.quote(token_path)}")
-        shell_line = (
-            f"cd {shlex.quote(worktree)} && "
-            f"while [ ! -f {shlex.quote(sentinel)} ]; do sleep 0.02; done; "
-            f"exec {exec_line}")
-        window = gen.sid
-        if not self._tmux_session_started:
-            await self.tmux("new-session", "-d", "-s", TMUX_SESSION,
-                            "-n", window, "-x", str(cols), "-y", str(rows),
-                            shell_line)
-            self._tmux_session_started = True
-        else:
-            try:
-                await self.tmux("new-window", "-d", "-t", f"{TMUX_SESSION}:",
-                                "-n", window, shell_line)
-            except RuntimeError as exc:
-                if "no server running" not in str(exc):
-                    raise
-                # last kill-window took the session (and server) down with it
-                self._tmux_session_started = False
+            if command is not None:
+                exec_line = shlex.join(command)
+            else:
+                exec_line = (f"{shlex.quote(sc_path)} interface-exec "
+                             f"{shlex.quote(token_path)}")
+            shell_line = (
+                f"cd {shlex.quote(worktree)} && "
+                f"while [ ! -f {shlex.quote(sentinel)} ]; do sleep 0.02; done; "
+                f"exec {exec_line}")
+            window = gen.sid
+            if not self._tmux_session_started:
                 await self.tmux("new-session", "-d", "-s", TMUX_SESSION,
-                                "-n", window, "-x", str(cols), "-y",
-                                str(rows), shell_line)
+                                "-n", window, "-x", str(cols), "-y", str(rows),
+                                shell_line)
                 self._tmux_session_started = True
             else:
-                await self.tmux("resize-window", "-t",
-                                f"{TMUX_SESSION}:{window}",
-                                "-x", str(cols), "-y", str(rows))
-        out = await self.tmux("display-message", "-p", "-t",
-                              f"{TMUX_SESSION}:{window}",
-                              "#{pane_id} #{pane_pid}")
-        pane_id, pane_pid = out.decode().split()
-        gen.pane_id, gen.pane_pid = pane_id, int(pane_pid)
-        gen.pane_start_ticks = await asyncio.to_thread(
-            _read_start_ticks, gen.pane_pid)
+                try:
+                    await self.tmux("new-window", "-d", "-t", f"{TMUX_SESSION}:",
+                                    "-n", window, shell_line)
+                except RuntimeError as exc:
+                    if "no server running" not in str(exc):
+                        raise
+                    # last kill-window took the session (and server) down with it
+                    self._tmux_session_started = False
+                    await self.tmux("new-session", "-d", "-s", TMUX_SESSION,
+                                    "-n", window, "-x", str(cols), "-y",
+                                    str(rows), shell_line)
+                    self._tmux_session_started = True
+                else:
+                    await self.tmux("resize-window", "-t",
+                                    f"{TMUX_SESSION}:{window}",
+                                    "-x", str(cols), "-y", str(rows))
+            out = await self.tmux("display-message", "-p", "-t",
+                                  f"{TMUX_SESSION}:{window}",
+                                  "#{pane_id} #{pane_pid}")
+            pane_id, pane_pid = out.decode().split()
+            gen.pane_id, gen.pane_pid = pane_id, int(pane_pid)
+            gen.pane_start_ticks = await asyncio.to_thread(
+                _read_start_ticks, gen.pane_pid)
+            await self._abort_if_torn_down(gen)
 
-        self.shadow.create(gen.sid, rows, cols)
-        await self._pipe_pane(gen)
-        # boot the harness only now: zero lost boot bytes
-        open(sentinel, "w").close()
+            self.shadow.create(gen.sid, rows, cols)
+            await self._pipe_pane(gen)
+            # boot the harness only when the spawn was not cancelled: zero
+            # lost boot bytes, and never a live harness on an ended row.
+            await self._abort_if_torn_down(gen)
+            open(sentinel, "w").close()
 
-        self.generations[session_id] = gen
-        self._start_consumers(gen)
-        _log(gen.sid, f"session spawned: shell={shell_id} gen={generation} "
-                      f"pane={pane_id} pid={pane_pid} {cols}x{rows}")
-        return {"pane_id": pane_id, "pane_pid": gen.pane_pid,
-                "pane_start_ticks": gen.pane_start_ticks,
-                "tmux_socket": self.sock, "tmux_session": TMUX_SESSION,
-                "tmux_window": window}
+            self._start_consumers(gen)
+            _log(gen.sid, f"session spawned: shell={shell_id} gen={generation} "
+                          f"pane={pane_id} pid={pane_pid} {cols}x{rows}")
+            return {"pane_id": pane_id, "pane_pid": gen.pane_pid,
+                    "pane_start_ticks": gen.pane_start_ticks,
+                    "tmux_socket": self.sock, "tmux_session": TMUX_SESSION,
+                    "tmux_window": window}
+        except Exception:
+            # A failed spawn leaves NO generation registered (the pre-SC-064
+            # shape): a later terminate/abandon must not mistake a
+            # half-spawned entry for a live one. The window itself is NOT
+            # killed here — an ambiguous tmux outcome stays for the
+            # unreconciled path to judge (only a proven-abandoned spawn
+            # kills, in _abort_if_torn_down, by exact identity).
+            if self.generations.get(session_id) is gen:
+                self.generations.pop(session_id, None)
+            raise
 
     def get_generation(self, session_id: int) -> Generation | None:
         return self.generations.get(session_id)

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -31,6 +31,7 @@ import sqlite3
 import stat
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -1220,6 +1221,64 @@ class InterfaceApiTest(unittest.TestCase):
             {"session_id": sid, "action": "close"})
         self.assertEqual(status, 200, body)
         self.assertTrue(body["closed"])
+
+    def test_cancel_during_inflight_spawn_tears_down_pane(self):
+        """SC-064: a cancel start landing while the runtime spawn is still
+        in flight (reservation committed, pane identity never persisted)
+        must not conclude as a live harness on an ended row — the #519
+        wound with no API path out. The create call converges instead: no
+        201, the pane torn down by exact identity, and the row stays the
+        cancel's terminal record with NULL identity."""
+        started = threading.Event()
+        release = threading.Event()
+        real_spawn = self.runtime.spawn
+
+        async def slow_spawn(**kw):
+            started.set()
+            release.wait(10)
+            return await real_spawn(**kw)
+
+        self.runtime.spawn = slow_spawn
+        outcome = {}
+
+        def create():
+            outcome["result"] = self.create_session()
+
+        t = threading.Thread(target=create)
+        t.start()
+        self.assertTrue(started.wait(10), "spawn in flight")
+        con = sqlite3.connect(self.db_path)
+        sid = con.execute(
+            "SELECT session_id FROM interface_sessions WHERE shell_id=1"
+        ).fetchone()[0]
+        con.close()
+        # The SC-064 window: reserved/starting, pane identity still NULL.
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: cx-race"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 202, body)
+        self.assertEqual(body["end_reason"], "cancelled_before_spawn")
+        release.set()
+        t.join(10)
+        status, _, body = outcome["result"]
+        self.assertEqual(status, 409, body)
+        self.assertEqual(body["error"]["code"], "session_cancelled",
+                         "never a 201 + live harness on an ended row")
+        self.assertIn(sid, self.runtime.abandoned,
+                      "the just-spawned pane is torn down by exact identity")
+        con = sqlite3.connect(self.db_path)
+        sess = con.execute(
+            "SELECT occupancy, lifecycle, end_reason, tmux_pane_id, pane_pid "
+            "FROM interface_sessions WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess[:3], ("ended", "ended",
+                                    "cancelled_before_spawn"))
+        self.assertEqual(sess[3:], (None, None),
+                         "no pane identity persisted onto the ended row")
+        con.close()
+        # The shell is immediately available — no unmanaged-harness wound.
+        status, _, body = self.create_session(key="k-after-race-cancel")
+        self.assertEqual(status, 201, body)
 
     def test_terminate_unreconciled_points_at_reconcile(self):
         """An unreconciled session still refuses termination — but with a

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -14,7 +14,11 @@ tests/test_interface_runtime.py):
 - hook callback: generation-token auth, exact pid identity proof, reserved →
   occupied promotion, replay rejection;
 - writer leases, stream tickets, clean certification, explicit end — and
-  New chat available again after durable closure.
+  New chat available again after durable closure;
+- lifecycle convergence (spec #30): session_end hook runs the one closure
+  helper, cancel start on a reservation (#519), hook/terminate races end
+  in one terminal record (#532), repeated ends are idempotent successes,
+  and route/state/server errors stay distinct (#523).
 
 Run:
     python3 tests/test_interface_api.py
@@ -350,6 +354,7 @@ class InterfaceApiTest(unittest.TestCase):
         self.assertEqual(status, 409)
         self.assertEqual(body["error"]["code"], "shell_occupied")
         self.assertEqual(body["error"]["details"]["session_id"], 1)
+        self.assertEqual(body["error"]["details"]["occupancy"], "reserved")
 
     def test_unknown_fields_rejected(self):
         status, _, body = self.create_session(shell_id=1, bogus=True)
@@ -378,7 +383,9 @@ class InterfaceApiTest(unittest.TestCase):
 
     def test_new_chat_existing_worktree_not_reprovisioned(self):
         root = Path(self.tmp.name)
-        (root / ".sc-worktrees" / "s1").mkdir(parents=True)
+        wt = root / ".sc-worktrees" / "s1"
+        wt.mkdir(parents=True)
+        (wt / ".git").touch()  # a real git worktree carries a .git file
         with mock.patch.object(run_mod, "REPO_ROOT", root):
             status, _, body = self.create_session()
         self.assertEqual(status, 201, body)
@@ -979,6 +986,388 @@ class InterfaceApiTest(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertTrue(body["verified"])
         self.assertEqual(body["occupancy"], "occupied")
+
+    # -- lifecycle convergence (sprint 31 unit 1, spec #30 / #519 #523 #532) --
+
+    def test_session_end_hook_converges_full_closure(self):
+        """#532: the provider's session_end hook runs the ONE closure helper —
+        occupancy, lifecycle, generation, and leases converge atomically; the
+        occupied/ended divergence no route could close is gone."""
+        sid = self.occupy()
+        self.acquire_lease(sid)
+        tok = "Authorization: Bearer " + self.hook_token(sid)
+        status, _, body = self.call(
+            "POST", "/api/interface/hook-callbacks", (tok,),
+            {"shell_id": 1, "generation": 1, "hook_seq": 3,
+             "event": "session_end", "pid": 4321})
+        self.assertEqual(status, 200, body)
+        con = sqlite3.connect(self.db_path)
+        sess = con.execute(
+            "SELECT occupancy, lifecycle, end_reason FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess, ("ended", "ended", "provider_session_end"))
+        gen = con.execute(
+            "SELECT ended_at FROM interface_generations "
+            "WHERE shell_id=1 AND generation=1").fetchone()[0]
+        self.assertIsNotNone(gen)
+        leases = con.execute(
+            "SELECT COUNT(*) FROM interface_writer_leases "
+            "WHERE session_id=? AND revoked_at IS NULL", (sid,)).fetchone()[0]
+        self.assertEqual(leases, 0)
+        con.close()
+        # New chat immediately — no service restart, no reconcile (#532's
+        # workaround is gone).
+        status, _, body = self.call("GET", "/api/interface/shells", (OP,))
+        self.assertEqual(body["shells"][0]["availability"], "available")
+        status, _, body = self.create_session(key="k-after-end")
+        self.assertEqual(status, 201, body)
+        # A duplicate session_end acknowledges without reopening …
+        status, _, body = self.call(
+            "POST", "/api/interface/hook-callbacks", (tok,),
+            {"shell_id": 1, "generation": 1, "hook_seq": 4,
+             "event": "session_end", "pid": 4321})
+        self.assertEqual(status, 200, body)
+        self.assertTrue(body["already_ended"])
+        # …but any other event on the ended generation is still rejected.
+        status, _, _ = self.call(
+            "POST", "/api/interface/hook-callbacks", (tok,),
+            {"shell_id": 1, "generation": 1, "hook_seq": 5,
+             "event": "turn_stop", "pid": 4321})
+        self.assertEqual(status, 403)
+
+    def test_terminate_on_ended_lifecycle_converges(self):
+        """The #532 legacy state (occupied + lifecycle ended): termination
+        completes durable closure idempotently — success, never a transition
+        back to stopping, never a false no_such_route."""
+        sid = self.occupy()
+        self.acquire_lease(sid)
+        con = sqlite3.connect(self.db_path)
+        routes.interface_state.transition(con, "lifecycle", sid, "stopping")
+        routes.interface_state.transition(con, "lifecycle", sid, "ended")
+        con.execute(
+            "UPDATE interface_generations SET ended_at=datetime('now') "
+            "WHERE shell_id=1 AND generation=1")
+        con.commit()
+        con.close()
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: x-leg"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 202, body)
+        self.assertTrue(body["terminated"])
+        self.assertTrue(body["already_ended"])
+        self.assertEqual(self.runtime.terminated, [],
+                         "nothing live to signal — closure only")
+        con = sqlite3.connect(self.db_path)
+        sess = con.execute(
+            "SELECT occupancy, lifecycle FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess, ("ended", "ended"))
+        leases = con.execute(
+            "SELECT COUNT(*) FROM interface_writer_leases "
+            "WHERE session_id=? AND revoked_at IS NULL", (sid,)).fetchone()[0]
+        self.assertEqual(leases, 0)
+        con.close()
+
+    def test_terminate_race_session_end_hook_wins(self):
+        """The exact #532 interleaving: the harness exits DURING the graceful
+        window — its session_end hook lands while the termination request is
+        in flight. One clean terminal record, success response, no 404."""
+        sid = self.occupy()
+        tok = "Authorization: Bearer " + self.hook_token(sid)
+        test = self
+
+        async def race_terminate(session_id, force=False):
+            status, _, b = test.call(
+                "POST", "/api/interface/hook-callbacks", (tok,),
+                {"shell_id": 1, "generation": 1, "hook_seq": 3,
+                 "event": "session_end", "pid": 4321})
+            assert status == 200, b
+            return {"terminated": False, "reason": "graceful_timeout",
+                    "pid": 4321, "generation": 1}
+
+        self.runtime.terminate = race_terminate
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: x-race"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 202, body)
+        self.assertTrue(body["terminated"])
+        self.assertTrue(body["already_ended"])
+        con = sqlite3.connect(self.db_path)
+        sess = con.execute(
+            "SELECT occupancy, lifecycle, end_reason FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess[:2], ("ended", "ended"))
+        con.close()
+        # New chat immediately — the race leaves a converged terminal record.
+        status, _, body = self.create_session(key="k-after-race")
+        self.assertEqual(status, 201, body)
+
+    def test_repeated_end_chat_fresh_key_semantic_success(self):
+        """Spec Lifecycle Contract: a repeated request races the completed
+        closure — the same idempotency key replays the original response; a
+        FRESH key against the ended session returns the same semantic
+        success without a second signal."""
+        sid = self.occupy()
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: x-repeat"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 202)
+        # Same key: exact replay of the stored response.
+        status, _, replay = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: x-repeat"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 202)
+        self.assertEqual(replay, body)
+        # Fresh key: semantic success, no second signal to the runtime.
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: x-repeat-2"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 202, body)
+        self.assertTrue(body["terminated"])
+        self.assertTrue(body["already_ended"])
+        self.assertEqual(len(self.runtime.terminated), 1)
+
+    # -- cancel start (#519) ----------------------------------------------------
+
+    def test_cancel_start_without_identity(self):
+        """#519: End chat on a reservation that never established pane or
+        harness identity cancels it — cancelled_before_spawn, no signal, the
+        shell available again."""
+        status, _, body = self.create_session()
+        assert status == 201
+        sid = body["session_id"]
+        con = sqlite3.connect(self.db_path)
+        con.execute(
+            "UPDATE interface_sessions SET tmux_pane_id=NULL, pane_pid=NULL, "
+            "pane_start_ticks=NULL WHERE session_id=?", (sid,))
+        con.commit()
+        con.close()
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: cx1"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 202, body)
+        self.assertTrue(body["terminated"])
+        self.assertEqual(body["end_reason"], "cancelled_before_spawn")
+        self.assertEqual(self.runtime.terminated, [],
+                         "no identity ever established — nothing to signal")
+        con = sqlite3.connect(self.db_path)
+        sess = con.execute(
+            "SELECT occupancy, lifecycle, end_reason FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess, ("ended", "ended", "cancelled_before_spawn"))
+        gen = con.execute(
+            "SELECT ended_at FROM interface_generations "
+            "WHERE shell_id=1 AND generation=1").fetchone()[0]
+        self.assertIsNotNone(gen)
+        con.close()
+        # The reservation no longer blocks New chat (#519's actual complaint).
+        status, _, body = self.create_session(key="k-after-cancel")
+        self.assertEqual(status, 201, body)
+
+    def test_cancel_start_verified_identity_runs_stop_path(self):
+        """Cancel start with a verified live pane identity signals the exact
+        generation and converges through normal closure."""
+        status, _, body = self.create_session()
+        assert status == 201
+        sid = body["session_id"]
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: cx2"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 202, body)
+        self.assertTrue(body["terminated"])
+        self.assertEqual(self.runtime.terminated, [(sid, False)],
+                         "verified identity — the exact pane is signalled")
+        con = sqlite3.connect(self.db_path)
+        sess = con.execute(
+            "SELECT occupancy, lifecycle, end_reason FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess, ("ended", "ended", "operator_end"))
+        con.close()
+
+    def test_cancel_start_unverifiable_identity_parks_unreconciled(self):
+        """Spawn outcome uncertain: cancel start never silently ends — the
+        session becomes unreconciled and requires absence proof."""
+        async def no_verify(session_id):
+            return False
+        self.runtime.verify_identity = no_verify
+        status, _, body = self.create_session()
+        assert status == 201
+        sid = body["session_id"]
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: cx3"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 409, body)
+        self.assertEqual(body["error"]["code"], "identity_unverified")
+        con = sqlite3.connect(self.db_path)
+        sess = con.execute(
+            "SELECT occupancy, lifecycle, error_detail FROM "
+            "interface_sessions WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess[:2], ("unreconciled", "lost"))
+        self.assertIn("cancel start", sess[2])
+        con.close()
+        # The road out: prove absence, then reconcile-close.
+        status, _, body = self.call(
+            "POST", "/api/interface/reconciliations",
+            (OP, "Idempotency-Key: cx4"),
+            {"session_id": sid, "action": "close"})
+        self.assertEqual(status, 200, body)
+        self.assertTrue(body["closed"])
+
+    def test_terminate_unreconciled_points_at_reconcile(self):
+        """An unreconciled session still refuses termination — but with a
+        truthful code and the supported next action, not a bare 'not
+        occupied'."""
+        sid = self._unreconciled()
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: x-unrec"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 409)
+        self.assertEqual(body["error"]["code"], "not_occupied")
+        self.assertIn("reconcile", body["error"]["message"])
+
+    def test_terminate_not_running_proves_absence_and_closes(self):
+        """The runtime holding no live generation is absence, not a graceful
+        timeout: prove it and converge — never a phantom
+        graceful_timed_out_at."""
+        sid = self.occupy()
+        self.runtime.terminate_result = {"terminated": False,
+                                         "reason": "not_running"}
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: x-nr"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 202, body)
+        self.assertTrue(body["terminated"])
+        self.assertEqual(body["reason"], "already_absent")
+        con = sqlite3.connect(self.db_path)
+        sess = con.execute(
+            "SELECT occupancy, graceful_timed_out_at FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess[0], "ended")
+        self.assertIsNone(sess[1], "absence is not a graceful timeout")
+        con.close()
+
+    def test_terminate_not_running_without_absence_fails_closed(self):
+        sid = self.occupy()
+        self.runtime.terminate_result = {"terminated": False,
+                                         "reason": "not_running"}
+        self.runtime.absence_proved = False
+        status, _, body = self.call(
+            "POST", "/api/interface/termination-requests",
+            (OP, "Idempotency-Key: x-nr2"),
+            {"session_id": sid, "force": False})
+        self.assertEqual(status, 409, body)
+        self.assertEqual(body["reason"], "not_running")
+        con = sqlite3.connect(self.db_path)
+        sess = con.execute(
+            "SELECT occupancy, lifecycle FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess, ("unreconciled", "lost"))
+        con.close()
+
+    # -- API error mapping (#523, spec req 4) ------------------------------------
+
+    def test_bad_path_id_is_422_never_no_such_route(self):
+        status, _, body = self.call("GET", "/api/interface/sessions/abc",
+                                    (OP,))
+        self.assertEqual(status, 422)
+        self.assertEqual(body["error"]["code"], "invalid_path_id")
+
+    def test_unknown_route_still_404(self):
+        status, _, body = self.call("GET", "/api/interface/bogus", (OP,))
+        self.assertEqual(status, 404)
+        self.assertEqual(body["error"]["code"], "no_such_route")
+
+    def test_escaped_state_conflict_is_409_never_no_such_route(self):
+        """#523: an illegal transition raised inside a handler was rewritten
+        to a false 404 no_such_route by the broad `except ValueError`. State
+        conflicts now map to 409 with a stable code."""
+        sid = self._unreconciled()
+        with mock.patch.object(
+                routes.interface_state, "transition",
+                side_effect=routes.interface_state.InterfaceTransitionError(
+                    "illegal transition: ended -> stopping")):
+            status, _, body = self.call(
+                "POST", "/api/interface/reconciliations",
+                (OP, "Idempotency-Key: em1"),
+                {"session_id": sid, "action": "verify"})
+        self.assertEqual(status, 409)
+        self.assertEqual(body["error"]["code"], "state_conflict")
+        self.assertIn("ended -> stopping", body["error"]["message"])
+
+    def test_unexpected_failure_is_sanitized_500_with_correlation(self):
+        """Unexpected handler failures: a sanitized 500 whose correlation id
+        matches a server-side record — internals never cross the wire."""
+        self.create_session()
+        with mock.patch.object(
+                routes.interface_broker, "current_writer",
+                side_effect=RuntimeError("db on fire")):
+            status, _, body = self.call("GET", "/api/interface/sessions/1",
+                                        (OP,))
+        self.assertEqual(status, 500)
+        self.assertEqual(body["error"]["code"], "internal")
+        self.assertNotIn("db on fire", json.dumps(body),
+                         "internals never leak into the response")
+        self.assertTrue(body["error"]["details"]["correlation"])
+
+    # -- worktree path validation + launcher exception curation (#526 lows) -----
+
+    def test_worktree_path_not_directory_refused(self):
+        """A stray FILE at the worktree path is a distinct, actionable
+        refusal — provisioning would no-op on it and the pane would die."""
+        root = Path(self.tmp.name)
+        wt = root / ".sc-worktrees" / "s1"
+        wt.parent.mkdir(parents=True)
+        wt.touch()
+        with mock.patch.object(run_mod, "REPO_ROOT", root):
+            status, _, body = self.create_session()
+        self.assertEqual(status, 500)
+        self.assertEqual(body["error"]["code"], "worktree_not_directory")
+        self.assertEqual(body["error"]["details"]["reason"], "non_directory")
+        self.ensure_wt.assert_not_called()
+
+    def test_worktree_plain_directory_unusable_refused(self):
+        """A bare directory without git backing is unusable, not
+        'existing' — provisioning assumes an existing dir is intact."""
+        root = Path(self.tmp.name)
+        (root / ".sc-worktrees" / "s1").mkdir(parents=True)
+        with mock.patch.object(run_mod, "REPO_ROOT", root):
+            status, _, body = self.create_session()
+        self.assertEqual(status, 500)
+        self.assertEqual(body["error"]["code"], "worktree_unusable")
+        self.assertEqual(body["error"]["details"]["reason"], "not_a_worktree")
+        self.ensure_wt.assert_not_called()
+
+    def test_provision_oserror_curated(self):
+        """Expected launcher failures (git binary missing, mkdir refused)
+        are curated into the actionable 500, never a raw 500."""
+        self.ensure_wt.side_effect = FileNotFoundError(
+            "No such file or directory: 'git'")
+        root = Path(self.tmp.name)
+        with mock.patch.object(run_mod, "REPO_ROOT", root):
+            status, _, body = self.create_session()
+        self.assertEqual(status, 500)
+        self.assertEqual(body["error"]["code"], "worktree_provision_failed")
+        self.assertIn("git", body["error"]["message"])
+
+    def test_provision_launch_error_curated(self):
+        self.ensure_wt.side_effect = run_mod.LaunchError(
+            "shell is not launchable")
+        root = Path(self.tmp.name)
+        with mock.patch.object(run_mod, "REPO_ROOT", root):
+            status, _, body = self.create_session()
+        self.assertEqual(status, 500)
+        self.assertEqual(body["error"]["code"], "worktree_provision_failed")
+        self.assertIn("LaunchError", body["error"]["message"])
 
 
 if __name__ == "__main__":

--- a/tests/test_interface_crash_window.py
+++ b/tests/test_interface_crash_window.py
@@ -32,6 +32,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from typing import ClassVar
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 SCHEMA = ENGINE / "schema.sql"
@@ -40,6 +41,7 @@ MIGRATIONS = ENGINE / "migrations"
 sys.path.insert(0, str(ENGINE / "scripts"))
 import interface_broker  # noqa: E402
 import interface_reconcile  # noqa: E402
+import interface_state  # noqa: E402
 
 
 class Crash(Exception):
@@ -495,6 +497,234 @@ class CrashWindowTest(unittest.TestCase):
         # Hooks for the ended generation are rejected from here on.
         with self.assertRaises(interface_broker.BrokerError):
             interface_broker.record_hook(self.con, 1, 1, 4, "prompt_submit")
+
+
+class CloseSessionMatrixTest(unittest.TestCase):
+    """close_session — THE one closure helper (spec #30 Lifecycle Contract,
+    sprint 31 unit 1). From EVERY legal (occupancy, lifecycle) pair it
+    produces one ended session, one ended generation, and revoked leases in
+    one transaction; a repeated close returns the original terminal result
+    without state churn. Session-scoped wake state resolves or parks by the
+    existing ambiguity rules."""
+
+    # Legal walks from the INSERTed (reserved, starting) row to each state.
+    OCCUPANCY_WALKS: ClassVar[dict] = {
+        "reserved": [],
+        "occupied": ["occupied"],
+        "unreconciled": ["unreconciled"],
+    }
+    LIFECYCLE_WALKS: ClassVar[dict] = {
+        "starting": [],
+        "idle": ["idle"],
+        "busy": ["idle", "busy"],
+        "approval": ["idle", "busy", "approval"],
+        "user_input": ["idle", "busy", "user_input"],
+        "stopping": ["idle", "stopping"],
+        "lost": ["lost"],
+        "error": ["error"],
+    }
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        self.con = sqlite3.connect(self.db)
+        self.gen = 0
+
+    def tearDown(self):
+        self.con.close()
+        for p in self.tmp.glob("*"):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def _make(self, occupancy, lifecycle):
+        """One shell-1 session walked legally to (occupancy, lifecycle)."""
+        self.gen += 1
+        self.con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,?)", (self.gen,))
+        sid = self.con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle, harness, cli_version) VALUES (1,?,'reserved',"
+            "'starting','kimi','kimi-code 0.27.0')",
+            (self.gen,)).lastrowid
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id,"
+            " generation, composer) VALUES (?,1,?,'clean')", (sid, self.gen))
+        for occ in self.OCCUPANCY_WALKS[occupancy]:
+            interface_state.transition(self.con, "occupancy", sid, occ)
+        for lif in self.LIFECYCLE_WALKS[lifecycle]:
+            interface_state.transition(self.con, "lifecycle", sid, lif)
+        self.con.commit()
+        return sid
+
+    def _assert_converged(self, sid, reason):
+        sess = self.con.execute(
+            "SELECT occupancy, lifecycle, end_reason, ended_at FROM "
+            "interface_sessions WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess[0], "ended")
+        self.assertEqual(sess[1], "ended")
+        self.assertEqual(sess[2], reason)
+        self.assertIsNotNone(sess[3])
+        gen = self.con.execute(
+            "SELECT g.ended_at FROM interface_generations g "
+            "JOIN interface_sessions s ON s.shell_id=g.shell_id "
+            "AND s.generation=g.generation WHERE s.session_id=?",
+            (sid,)).fetchone()[0]
+        self.assertIsNotNone(gen)
+
+    def test_closure_matrix(self):
+        cases = ([("occupied", lif) for lif in self.LIFECYCLE_WALKS]
+                 + [("reserved", "starting"),
+                    ("unreconciled", "starting"),
+                    ("unreconciled", "lost"),
+                    ("unreconciled", "error")])
+        for occupancy, lifecycle in cases:
+            with self.subTest(occupancy=occupancy, lifecycle=lifecycle):
+                sid = self._make(occupancy, lifecycle)
+                out = interface_broker.close_session(self.con, sid,
+                                                     "operator_end")
+                self.assertFalse(out["already_ended"])
+                self.con.commit()
+                self._assert_converged(sid, "operator_end")
+
+    def test_close_revokes_leases_and_is_idempotent(self):
+        sid = self._make("occupied", "idle")
+        interface_broker.acquire_writer(self.con, sid, "tab-1", "tok-1")
+        self.con.commit()
+        interface_broker.close_session(self.con, sid, "operator_end")
+        self.con.commit()
+        lease = self.con.execute(
+            "SELECT revoked_at, revoke_reason FROM interface_writer_leases "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertIsNotNone(lease[0])
+        self.assertEqual(lease[1], "session_end")
+        # A repeated close returns the original terminal result — no churn.
+        first = self.con.execute(
+            "SELECT ended_at, end_reason FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        out = interface_broker.close_session(self.con, sid, "operator_close")
+        self.assertTrue(out["already_ended"])
+        self.assertEqual(out["end_reason"], "operator_end")
+        self.con.commit()
+        second = self.con.execute(
+            "SELECT ended_at, end_reason FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(first, second)
+
+    def test_close_parks_pending_human_input(self):
+        """A pending unacknowledged frame can never be acked once the
+        generation is over — the close parks it by the crash-window rule
+        (evidence kept, alert raised), never drops it."""
+        sid = self._make("occupied", "idle")
+        interface_broker.acquire_writer(self.con, sid, "tab-1", "tok-1")
+        self.con.execute(
+            "UPDATE interface_input_state SET pending_seq=1, "
+            "pending_reserved_at=datetime('now') WHERE session_id=?", (sid,))
+        self.con.commit()
+        interface_broker.close_session(self.con, sid, "operator_end")
+        self.con.commit()
+        ist = self.con.execute(
+            "SELECT composer, delivery, pending_seq FROM "
+            "interface_input_state WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(ist[0], "unknown")
+        self.assertEqual(ist[1], "delivery_unknown")
+        self.assertEqual(ist[2], 1, "evidence must survive the close")
+        alert = self.con.execute(
+            "SELECT 1 FROM planner_alerts WHERE session_id=? AND "
+            "reason='crash_window_delivery_unknown' AND resolved_at IS NULL",
+            (sid,)).fetchone()
+        self.assertIsNotNone(alert)
+
+    def _binding_with_message(self, sid):
+        """A binding on sid's generation (its own sprint doc — one ACTIVE
+        binding per doc and per planner shell) + one queued wake item.
+        Returns binding_id."""
+        self.con.execute(
+            "UPDATE sprint_planner_bindings SET released_at=datetime('now'),"
+            " release_reason='superseded test case' WHERE released_at IS NULL")
+        self.con.execute(
+            "INSERT INTO documents (kind, title, body) VALUES "
+            "('doc','SPRINT: t','# SPRINT: t\nstatus: ACTIVE')")
+        doc = self.con.execute("SELECT last_insert_rowid()").fetchone()[0]
+        self.con.execute(
+            "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (?,1,?,1,?)", (doc, sid, self.gen))
+        bid = self.con.execute("SELECT last_insert_rowid()").fetchone()[0]
+        self.con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+            " kind, sprint_doc_id) VALUES (2,1,'wake','task',?)", (doc,))
+        mid = self.con.execute("SELECT last_insert_rowid()").fetchone()[0]
+        self.con.execute(
+            "INSERT INTO planner_wake_items (binding_id, message_id) "
+            "VALUES (?,?)", (bid, mid))
+        self.con.commit()
+        return bid
+
+    def test_close_parks_unevidenced_batch_completes_proven_one(self):
+        """Session-scoped wake batches at close: no live harness will
+        re-drive them, so an unevidenced submitting batch parks (alert) —
+        never a blind resubmit — while a batch with a proven stop hook
+        reconciles from durable read state. A merely QUEUED batch survives:
+        its work belongs to a future generation."""
+        # Case 1: queued batch on the closing generation → untouched.
+        sid = self._make("occupied", "idle")
+        bid = self._binding_with_message(sid)
+        batch_q = interface_broker.form_batch(self.con, bid)
+        self.con.commit()
+        interface_broker.close_session(self.con, sid, "operator_end")
+        self.con.commit()
+        self.assertEqual(
+            self.con.execute(
+                "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+                (batch_q,)).fetchone()[0], "queued",
+            "queued work survives the close for a future generation")
+
+        # Case 2: submitted with NO durable submit evidence → parked
+        # (alert), never left awaiting a stop hook that can never arrive.
+        sid = self._make("occupied", "idle")
+        interface_broker.acquire_writer(self.con, sid, "tab-1", "tok-1")
+        bid = self._binding_with_message(sid)
+        batch_s = interface_broker.form_batch(self.con, bid)
+        rec1 = Recorder("ok")
+        out = interface_broker.submit_wake_batch(
+            self.con, batch_s, writer=rec1, now_iso="2030-01-01 00:00:10")
+        self.assertTrue(out["submitted"])
+        self.con.commit()
+        interface_broker.close_session(self.con, sid, "operator_end")
+        self.con.commit()
+        state = self.con.execute(
+            "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+            (batch_s,)).fetchone()[0]
+        self.assertEqual(state, "delivery_unknown")
+        alert = self.con.execute(
+            "SELECT 1 FROM planner_alerts WHERE binding_id=? AND "
+            "reason='wake_batch_delivery_unknown' AND resolved_at IS NULL",
+            (bid,)).fetchone()
+        self.assertIsNotNone(alert)
+
+        # Case 3: running with a proven stop stamp → complete, items
+        # reconciled from durable read state (unread → requeued).
+        sid2 = self._make("occupied", "idle")
+        interface_broker.acquire_writer(self.con, sid2, "tab-1", "tok-1")
+        bid2 = self._binding_with_message(sid2)
+        batch2 = interface_broker.form_batch(self.con, bid2)
+        rec = Recorder("ok")
+        out = interface_broker.submit_wake_batch(
+            self.con, batch2, writer=rec, now_iso="2030-01-01 00:00:10")
+        self.assertTrue(out["submitted"])
+        interface_broker.record_hook(self.con, 1, self.gen, 1, "prompt_submit")
+        self.con.execute(
+            "UPDATE planner_wake_batches SET stop_hook_seq=9 WHERE batch_id=?",
+            (batch2,))
+        self.con.commit()
+        interface_broker.close_session(self.con, sid2, "operator_end")
+        self.con.commit()
+        state = self.con.execute(
+            "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+            (batch2,)).fetchone()[0]
+        self.assertEqual(state, "complete")
 
 
 if __name__ == "__main__":

--- a/tests/test_interface_crash_window.py
+++ b/tests/test_interface_crash_window.py
@@ -612,6 +612,45 @@ class CloseSessionMatrixTest(unittest.TestCase):
             "WHERE session_id=?", (sid,)).fetchone()
         self.assertEqual(first, second)
 
+    def test_close_converges_legacy_partial_row(self):
+        """SC-065: a pre-convergence closure (the old spawn-failure path)
+        ended occupancy but left lifecycle nonterminal, the generation open,
+        and leases held. The one closure helper must CONVERGE that row —
+        never silently no-op on occupancy=='ended' alone — while keeping
+        the original terminal record (reason/time) intact."""
+        sid = self._make("occupied", "idle")
+        interface_broker.acquire_writer(self.con, sid, "tab-1", "tok-1")
+        # The legacy shape: occupancy ended directly, children untouched.
+        interface_state.transition(
+            self.con, "occupancy", sid, "ended",
+            extra_sets={"ended_at": "2026-07-20 00:00:00",
+                        "end_reason": "spawn_failed"})
+        self.con.commit()
+        out = interface_broker.close_session(self.con, sid, "operator_end")
+        self.con.commit()
+        self.assertFalse(out["already_ended"],
+                         "a partially closed row converges — never a no-op")
+        self.assertEqual(out["end_reason"], "spawn_failed",
+                         "the original terminal record is kept, not re-stamped")
+        sess = self.con.execute(
+            "SELECT occupancy, lifecycle, ended_at, end_reason FROM "
+            "interface_sessions WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess, ("ended", "ended", "2026-07-20 00:00:00",
+                                "spawn_failed"),
+                         "lifecycle must not stay nonterminal forever")
+        gen = self.con.execute(
+            "SELECT ended_at FROM interface_generations "
+            "WHERE shell_id=1 AND generation=1").fetchone()[0]
+        self.assertIsNotNone(gen, "the open generation ends too")
+        lease = self.con.execute(
+            "SELECT revoked_at FROM interface_writer_leases "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertIsNotNone(lease[0], "held leases are revoked")
+        # Fully terminal now: a repeated close is a true no-op.
+        out = interface_broker.close_session(self.con, sid, "operator_end")
+        self.assertTrue(out["already_ended"])
+        self.assertEqual(out["end_reason"], "spawn_failed")
+
     def test_close_parks_pending_human_input(self):
         """A pending unacknowledged frame can never be acked once the
         generation is over — the close parks it by the crash-window rule

--- a/tests/test_interface_runtime.py
+++ b/tests/test_interface_runtime.py
@@ -828,6 +828,54 @@ class TmuxIntegrationTest(unittest.TestCase):
         self.assertIsNotNone(gen, "generation must survive a refused kill")
         await self.rt.stop()
 
+    def test_abandon_during_spawn_aborts_and_kills_pane(self):
+        asyncio.run(self._flow_abandon_during_spawn())
+
+    async def _flow_abandon_during_spawn(self):
+        """SC-064: cancel start lands mid-spawn (the pane created, the
+        spawn not yet complete). abandon() — the cancel path's teardown —
+        must see the in-flight generation, spawn must refuse to complete
+        (SpawnAborted) before the harness boots, and the just-created pane
+        must be killed by exact identity — never left live on a cancelled
+        session."""
+        await self.rt.start()
+        self.assertTrue(self.rt.available, self.rt.unavailable_reason)
+        piped = asyncio.Event()
+        release = asyncio.Event()
+        orig_pipe = self.rt._pipe_pane
+
+        async def held_pipe(gen):
+            piped.set()
+            await release.wait()
+
+        self.rt._pipe_pane = held_pipe
+        try:
+            spawn_task = asyncio.create_task(self.rt.spawn(
+                session_id=self.sid, shell_id=1, generation=1,
+                worktree=str(self.tmp), sc_path="/bin/sc",
+                token_path="/tmp/tok", rows=24, cols=80,
+                command=["/bin/sh", "-c",
+                         "stty raw -echo; printf READY; cat"]))
+            await asyncio.wait_for(piped.wait(), 10)
+            gen = self.rt.generations.get(self.sid)
+            self.assertIsNotNone(
+                gen, "an in-flight spawn is visible to the cancel path")
+            pane_id = gen.pane_id
+            self.assertTrue(pane_id.startswith("%"))
+            # The cancel start's teardown, mid-spawn.
+            await self.rt.abandon(self.sid)
+            self.assertNotIn(self.sid, self.rt.generations)
+            release.set()
+            with self.assertRaises(interface_runtime.SpawnAborted):
+                await asyncio.wait_for(spawn_task, 10)
+            self.assertFalse(
+                await self.rt._pane_exists(pane_id),
+                "the just-created pane is killed — never live on an "
+                "ended session")
+        finally:
+            self.rt._pipe_pane = orig_pipe
+        await self.rt.stop()
+
     def test_pane_death_drives_real_lost_transition(self):
         asyncio.run(self._flow_pane_death())
 


### PR DESCRIPTION
## Sprint 31 · unit 1 · spec #30

Critical-path foundation — units 2, 3, and 8 consume this unit's lifecycle error codes + terminal-closure contract. Refs #519, #523, #532 and the three #526 low follow-ups (closure deferred to U10 AMI acceptance). Reviewer: REV2.

## What changed

**One closure helper** — `interface_broker.close_session` (spec Lifecycle Contract): atomically records end reason/time, terminalizes occupancy AND lifecycle (walking through `stopping` where no direct edge exists), ends the matching generation, revokes active leases, and resolves or parks session-scoped wake state by the existing ambiguity rules (pending human frame parks `delivery_unknown` with evidence kept; an unevidenced submitting batch parks + alerts; a batch with a proven stop reconciles from read state; queued work survives for a future generation). Idempotent — an already-ended session returns its original terminal result without churn. Every close producer now calls it: operator terminate, cancel start, reconcile-close, spawn failure, and the provider `session_end` hook.

**#532 (hook/stop race):** the `session_end` hook now runs full closure — no more `occupied` + `lifecycle=ended` divergence no route could close. Provider hooks can acknowledge an already-ended generation (clean 200, never reopen, never a rejection loop). Termination on a terminal state completes durable closure idempotently (`already_ended`) instead of raising `ended → stopping`; a hook winning the race mid-termination converges to success instead of the false `no_such_route`. Runtime `not_running` proves absence and converges rather than recording a phantom graceful timeout.

**#519 (cancel start):** End chat on a `reserved/starting` session now works per the contract — no pane/harness identity ever established → `cancelled_before_spawn`, shell available immediately; verified live identity → the exact generation is signalled and converges through normal closure; unverifiable identity → unreconciled with the exact reason, requiring absence proof (never silently ended).

**#523 (truthful errors):** the dispatch's broad `except ValueError → 404 no_such_route` is gone. Bad path identifiers → `422 invalid_path_id`; escaped state conflicts (`InterfaceTransitionError`/`BrokerError`) → `409 state_conflict`; unexpected handler failures → sanitized `500 internal` with a server-side correlation record (traceback logged server-side only).

**#526 lows:** the reservation-race 409 now carries the existing owner's `occupancy` alongside `session_id`; worktree provisioning curates `OSError`/`LaunchError` alongside `SystemExit`; path validation distinguishes missing (provision), non-directory (`worktree_not_directory`), and unusable (`worktree_unusable`: no git backing / not writable) — each with its named remediation.

## Judgement calls (spec ambiguity readings)

- `end_reason` vocabulary: `cancelled_before_spawn` only for the no-identity case (spec-named); a verified-identity cancel closes as `operator_end` (the "normal verified stop path").
- Closure from `idle`/`busy`/`approval`/`user_input` walks through `stopping` (the only nonterminal staging state every live state can reach) — no edge-map or trigger changes, no migration.
- Alert resolution semantics left to unit 2 (its track owns req 19); the helper resolves/parks *wake state* only, per the contract text.
- Real-fork AMI reproductions (the class4 gate) remain unit 10's FnB-coordinated acceptance matrix; this unit ships hermetic interleavings + the existing real-tmux integration green.

## Verification

- +19 hermetic regression tests: hook convergence, legacy `occupied/ended` terminate, the exact #532 mid-stop race interleaving, repeated-end idempotency (same-key replay + fresh-key semantic success), all three cancel-start branches, `not_running` absence both ways, error-mapping matrix (422/409/500 distinct, sanitized internals), worktree path shapes, and a 12-case `close_session` (occupancy × lifecycle) matrix with lease revocation, pending-input park, and wake-batch resolve/park.
- Full suite: **831 passed, 7 skipped** (shadow-sidecar gates) — incl. the real-tmux runtime integration tests.
- `ruff` on touched files: only pre-existing findings (repo-wide lint carries 828 pre-existing).

Co-Authored-By: Code-03 (super-coder) <noreply@super-coder.local>
