### PR TITLE
feat(admin): ./sc token + make dos-token — owner-only runtime credential to stdout (spec 30 req 23)

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -25,7 +25,7 @@
 #   make dos-help                list + describe the commands
 #
 #   LONG-ONLY: dos-build dos-logs dos-serve dos-health dos-ports dos-verify dos-map
-#              dos-render dos-snapshot dos-deps dos-install dos-rollback
+#              dos-render dos-snapshot dos-deps dos-install dos-rollback dos-token
 #              dos-update-harnesses dos-feat/dos-feature dos-eject
 #              passthrough: make dos ARGS=health
 #
@@ -33,7 +33,7 @@ SC := ./sc
 .PHONY: dos-e dos-enter dos-l dos-launch dos-r dos-restart dos-d dos-down dos-u dos-update \
         dos-t dos-test dos-h dos-help dos-build dos-logs dos-serve dos-health dos-ports \
         dos-verify dos-map dos-render dos-snapshot dos-deps dos-install dos-rollback \
-        dos-update-harnesses dos-feat dos-feature dos-eject dos
+        dos-update-harnesses dos-feat dos-feature dos-eject dos-token dos
 
 # Hot commands — long form, with a one-letter alias delegating to it.
 dos-enter:            ; $(SC) $(if $(s),enter-$(s),enter)
@@ -62,6 +62,9 @@ dos-snapshot:         ; $(SC) snapshot
 dos-deps:             ; $(SC) deps
 dos-install:          ; $(SC) install
 dos-rollback:         ; $(SC) rollback
+# Browser sign-in operator token — prints ONLY the owner-only runtime
+# credential to stdout (never rotates, never logs); exact alias of ./sc token.
+dos-token:            ; $(SC) token
 dos-update-harnesses: ; $(SC) update-harnesses
 # Opt-in features: make dos-feat (list) · make dos-feat ARGS="enable pg"
 dos-feature:          ; $(SC) feature $(ARGS)
@@ -115,6 +118,7 @@ dos-help:
 	@echo "  │ dos-deps             │ install python (.venv) + node deps into the bind-mount   │"
 	@echo "  │ dos-install          │ first-launch bootstrap for a fork                        │"
 	@echo "  │ dos-rollback         │ undo a bad update — restore DB + engine together         │"
+	@echo "  │ dos-token            │ print the browser sign-in operator token (stdout only)     │"
 	@echo "  │ dos-update-harnesses │ update claude + opencode + codex + vibe to latest        │"
 	@echo "  │ dos-feat ARGS=<x>    │ opt-in features — list / enable pg·windows·tailnet       │"
 	@echo "  │ dos-eject            │ ONE-WAY: own the engine — stop tracking upstream         │"

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -97,8 +97,13 @@ _CRED_DIR = Path(os.environ.get("SC_MEM_CRED_DIR") or
 _DISCOVERED_FROM: "Path | None" = None  # artifact the token came from, if any
 
 
+# Refusal prefix — `sc token` overrides this so its refusals name the right
+# command (scripts/token.py reuses the discovery below).
+_PROG = "mem"
+
+
 def die(msg: str) -> "NoReturn":  # noqa: F821
-    sys.exit(f"mem: {msg}")
+    sys.exit(f"{_PROG}: {msg}")
 
 
 def _load_runtime_credential(path: Path) -> None:

--- a/.super-coder/scripts/operator_token.py
+++ b/.super-coder/scripts/operator_token.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Print the browser sign-in operator token (spec doc #30 req 23).
+
+`./sc token` (exact alias `make dos-token`) prints the current Admin runtime
+credential — the token a browser operator pastes into the sign-in prompt — and
+ONLY that token, on stdout. It never rotates the credential, never puts it in
+command arguments, and never writes it to a log.
+
+The source of truth is the owner-only runtime artifact the supervised API
+provisions at every boot (`.super-coder/run/mem/<shortname>.json`, dir 0700,
+file 0600 — see scripts/mem_credentials.py). Reading is artifact-only: env
+wiring (SC_API_TOKEN) never substitutes, so the refusal contract below always
+applies. Selection matches `sc mem` discovery — the unique artifact, or
+SC_MEM_AS=<shortname> when several Admin identities exist.
+
+A missing, unreadable, or insecurely permissioned artifact refuses on stderr
+with the supported service action (`./sc restart` / `make dos-r`, which
+re-provisions it at boot). The trust-boundary check itself lives in
+mem.py:_discover_runtime_credential — this command reuses it rather than
+duplicating security logic. (Named operator_token.py, not token.py: the
+stdlib `token` module would shadow an `import token`.)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import mem  # noqa: E402
+
+_USAGE = ("usage: ./sc token — print the browser sign-in operator token (an "
+          "operator capability: the Admin runtime credential from the "
+          "owner-only artifact .super-coder/run/mem/<shortname>.json) to "
+          "stdout, and nothing else. The value itself never appears in help, "
+          "logs, or command arguments.")
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if args and args[0] in ("-h", "--help"):
+        print(_USAGE)
+        return 0
+    # Refusals name this command, not `sc mem`.
+    mem._PROG = "sc token"
+    if not mem._discover_runtime_credential():
+        mem.die(f"no Admin runtime credential in {mem._CRED_DIR} — the "
+                "supervised service provisions one per Admin shell at boot "
+                "(`./sc restart` / `make dos-r`).")
+    print(mem.SC_API_TOKEN)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.super-coder/scripts/operator_token.py
+++ b/.super-coder/scripts/operator_token.py
@@ -46,6 +46,10 @@ def main(argv: "list[str] | None" = None) -> int:
         mem.die(f"no Admin runtime credential in {mem._CRED_DIR} — the "
                 "supervised service provisions one per Admin shell at boot "
                 "(`./sc restart` / `make dos-r`).")
+    # codeql[py/clear-text-logging-sensitive-data] — printing the operator
+    # token to stdout IS this command's spec'd function (doc #30 req 23):
+    # stdout is the paste channel for the browser sign-in prompt, never a
+    # log; nothing else is written anywhere.
     print(mem.SC_API_TOKEN)
     return 0
 

--- a/.super-coder/scripts/operator_token.py
+++ b/.super-coder/scripts/operator_token.py
@@ -46,11 +46,10 @@ def main(argv: "list[str] | None" = None) -> int:
         mem.die(f"no Admin runtime credential in {mem._CRED_DIR} — the "
                 "supervised service provisions one per Admin shell at boot "
                 "(`./sc restart` / `make dos-r`).")
-    # codeql[py/clear-text-logging-sensitive-data] — printing the operator
-    # token to stdout IS this command's spec'd function (doc #30 req 23):
-    # stdout is the paste channel for the browser sign-in prompt, never a
-    # log; nothing else is written anywhere.
-    print(mem.SC_API_TOKEN)
+    # Printing the operator token to stdout IS this command's spec'd function
+    # (doc #30 req 23): stdout is the paste channel for the browser sign-in
+    # prompt, never a log; nothing else is written anywhere.
+    print(mem.SC_API_TOKEN)  # codeql[py/clear-text-logging-sensitive-data]
     return 0
 
 

--- a/sc
+++ b/sc
@@ -998,6 +998,7 @@ case "$cmd" in
   migrate)      exec "$PY" "$S/migrate.py" "$DB" ;;
   snapshot)     exec "$PY" "$S/snapshot.py" ;;
   mem)          exec "$PY" "$S/mem.py" "$@" ;;
+  token)        exec "$PY" "$S/operator_token.py" "$@" ;;
   sprint)       exec "$PY" "$S/sprint.py" "$@" ;;
   # ── sprint eventing: PR watches + inbox watcher (shell-side, API) and the
   # GitHub watcher daemon (HOST-side foreground; -up/-down supervise it) ──
@@ -1318,6 +1319,11 @@ super-coder — forkable shell substrate
   ./sc snapshot            dump per-instance tables -> .sc-state/content.sql
   ./sc mem <cmd> [args]    a shell's own memory, over the engine API (get/state/seed/lns/decision/flag/roadmap/doc/narrative);
                              identity is the shell's token, server-resolved — no DB path, no direct-DB fallback. `./sc mem which` to orient
+  ./sc token               print the browser sign-in operator token (an operator capability: the Admin runtime
+                             credential from the owner-only artifact .super-coder/run/mem/<shortname>.json, mode 0600)
+                             — stdout carries ONLY the token, for paste into the browser sign-in prompt. Never
+                             rotates; a missing/unreadable/insecure artifact refuses on stderr with the service
+                             action (`./sc restart` / `make dos-r`). Alias: make dos-token
   ./sc sprint action <cmd>  planner action receipts over the API: begin (--message/--operation/--target) records
                              intent before a side effect; complete|unknown|reconcile <receipt_id> records the result
   ./sc sprint status       wake status per binding: armed/released, sprint ACTIVE/frozen, batch state,

--- a/tests/test_runtime_credentials.py
+++ b/tests/test_runtime_credentials.py
@@ -27,6 +27,7 @@ import json
 import os
 import sqlite3
 import stat
+import subprocess
 import sys
 import tempfile
 import threading
@@ -45,6 +46,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import mem  # noqa: E402
 import mem_credentials  # noqa: E402
 import server  # noqa: E402
+import operator_token as sc_token  # noqa: E402
 from test_mem import TOKEN, PEER_TOKEN, build_engine_db  # noqa: E402
 
 
@@ -251,6 +253,124 @@ class DiscoveryTest(unittest.TestCase):
             self.run_which()
         self.assertIn("isn't API-wired", str(cm.exception))
         self.assertIn("runtime", str(cm.exception))  # …and names the new path
+
+
+class TokenCommandTest(unittest.TestCase):
+    """`./sc token` (spec doc #30 req 23) — artifact-only read of the Admin
+    runtime credential: stdout carries ONLY the token; missing/unreadable/
+    insecure artifacts refuse on stderr with the service action; help labels
+    the value without printing it. No API needed — the artifact is the
+    contract, so these tests run without a server."""
+
+    def setUp(self):
+        self.cred_dir = Path(tempfile.mkdtemp())
+        self._saved = (mem.SC_API_TOKEN, mem.SC_API_BASE,
+                       mem._CRED_DIR, mem._DISCOVERED_FROM, mem._PROG)
+        mem.SC_API_TOKEN = ""
+        mem.SC_API_BASE = ""
+        mem._CRED_DIR = self.cred_dir
+        mem._DISCOVERED_FROM = None
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        (mem.SC_API_TOKEN, mem.SC_API_BASE,
+         mem._CRED_DIR, mem._DISCOVERED_FROM, mem._PROG) = self._saved
+
+    def write_artifact(self, shortname, token, mode=0o600):
+        p = self.cred_dir / f"{shortname}.json"
+        p.write_text(json.dumps({
+            "shell_id": 1, "shortname": shortname,
+            "api_base": "http://127.0.0.1:8800",
+            "token": token,
+        }))
+        p.chmod(mode)
+        return p
+
+    def run_token(self, argv=()):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = sc_token.main(list(argv))
+        return rc, out.getvalue()
+
+    def test_prints_exactly_the_token(self):
+        self.write_artifact("TC", TOKEN)
+        rc, out = self.run_token()
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, TOKEN + "\n")   # stdout purity — nothing else
+
+    def test_sc_mem_as_selects_among_admins(self):
+        self.write_artifact("TC", TOKEN)
+        self.write_artifact("PEER", PEER_TOKEN)
+        with mock.patch.dict(os.environ, {"SC_MEM_AS": "peer"}):
+            rc, out = self.run_token()
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, PEER_TOKEN + "\n")
+
+    def test_ambiguity_refuses_without_printing(self):
+        self.write_artifact("TC", TOKEN)
+        self.write_artifact("PEER", PEER_TOKEN)
+        with self.assertRaises(SystemExit) as cm:
+            self.run_token()
+        self.assertIn("ambiguous", str(cm.exception))
+        self.assertIn("SC_MEM_AS", str(cm.exception))
+        self.assertNotIn(TOKEN, str(cm.exception))
+        self.assertNotIn(PEER_TOKEN, str(cm.exception))
+
+    def test_missing_artifact_names_the_service_action(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.run_token()
+        msg = str(cm.exception)
+        self.assertIn("sc token:", msg)            # refusal names this command
+        self.assertIn("./sc restart", msg)
+        self.assertIn("make dos-r", msg)
+
+    def test_insecure_artifact_is_refused(self):
+        self.write_artifact("TC", TOKEN, mode=0o644)
+        with self.assertRaises(SystemExit) as cm:
+            self.run_token()
+        self.assertIn("owner-only", str(cm.exception))
+        self.assertNotIn(TOKEN, str(cm.exception))  # refusal never leaks the value
+
+    def test_malformed_artifact_is_refused(self):
+        p = self.cred_dir / "TC.json"
+        p.write_text("not json")
+        p.chmod(0o600)
+        with self.assertRaises(SystemExit) as cm:
+            self.run_token()
+        self.assertIn("malformed", str(cm.exception))
+
+    def test_env_wiring_never_substitutes_for_the_artifact(self):
+        # An injected SC_API_TOKEN must not bypass the artifact contract:
+        # insecure artifact still refuses even when env is fully wired.
+        self.write_artifact("TC", TOKEN, mode=0o644)
+        mem.SC_API_TOKEN = "env-token"
+        mem.SC_API_BASE = "http://127.0.0.1:8800"
+        with self.assertRaises(SystemExit) as cm:
+            self.run_token()
+        self.assertIn("owner-only", str(cm.exception))
+
+    def test_help_labels_without_printing(self):
+        self.write_artifact("TC", TOKEN)
+        rc, out = self.run_token(["--help"])
+        self.assertEqual(rc, 0)
+        self.assertIn("operator capability", out)
+        self.assertIn("./sc token", out)
+        self.assertNotIn(TOKEN, out)
+
+    def test_script_end_to_end(self):
+        """Real interpreter, real artifact: stdout is the token and only the
+        token. (The `token)` line in ./sc is the same one-line exec pattern as
+        every other verb; a bash-dispatcher subprocess test would resolve the
+        engine at the MAIN worktree root and break in linked dev worktrees.)"""
+        self.write_artifact("TC", TOKEN)
+        env = dict(os.environ, SC_MEM_CRED_DIR=str(self.cred_dir))
+        env.pop("SC_MEM_AS", None)
+        proc = subprocess.run(
+            [sys.executable,
+             str(ENGINE / "scripts" / "operator_token.py")],
+            capture_output=True, text=True, env=env)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout, TOKEN + "\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sprint 31 unit 9b (spec doc #30 req 23). Depends on U4 (merged at 40bf072 — main now carries the credential artifact).

## What
`./sc token` and its exact alias `make dos-token` print the current browser sign-in operator token — the Admin runtime credential from the owner-only artifact `.super-coder/run/mem/<shortname>.json` (dir 0700, file 0600, provisioned by the supervised API at every boot; U4) — and **only** that token, to stdout, for paste into the browser sign-in prompt.

- **No rotation, no logs, no argv** — the value only ever rides stdout.
- **Artifact-only semantics** — env wiring (`SC_API_TOKEN`) never substitutes, so the refusal contract always applies: a missing, unreadable, or insecurely permissioned artifact refuses on stderr with the supported service action (`./sc restart` / `make dos-r`).
- **Selection = `sc mem` discovery** — unique artifact, or `SC_MEM_AS=<shortname>` among several; ambiguity refuses, never guesses.
- **Help labels, never prints** — `./sc help`, `./sc token --help`, and `make dos-help` describe the value as an operator capability without emitting it.
- **Zero duplicated security logic** — the trust-boundary check is U4's `mem.py:_discover_runtime_credential`, reused; `die()`'s prefix became a module-level `_PROG` (one line, `mem` behavior unchanged) so `sc token` refusals name the right command.
- Named `operator_token.py`, not `token.py` — the stdlib `token` module would shadow `import token`.

## Tests
`TokenCommandTest` in `tests/test_runtime_credentials.py` (9 new: stdout purity, SC_MEM_AS selection, ambiguity/missing/insecure/malformed refusals with no value leak, env-never-substitutes, help-labels-without-printing, real-interpreter e2e). File total 23 passed. Refusal path smoke-tested live on a seat with no artifact (stderr service action, empty stdout, rc 1).

## Ambiguity calls (ratify or overrule)
- **artifact-only vs env-wins** → chose artifact-only: req 23's refusal clause ("a missing, unreadable, or insecurely permissioned runtime artifact refuses") is unconditional, so env wiring must not bypass it.
- **no freshness/validation API call** → print what the artifact holds; provisioning refreshes it at every boot and rotation only happens at boot, so a live service's artifact is current by construction. (Matches req 23's silence on validation.)

Refs #516 #518 — closure deferred to U10 AMI acceptance.