### PR TITLE
fix(engine): make update and snapshots refusal-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .super-coder/shell_db.db
 .super-coder/shell_db.db-wal
 .super-coder/shell_db.db-shm
+.super-coder/shell_db.db.rebuild
+.super-coder/shell_db.db.rebuild-wal
+.super-coder/shell_db.db.rebuild-shm
 
 # Boot artifact — rebuilt at launch from the DB. The harness dictates the name;
 # we dual-write both. Ignored everywhere. opencode.json is emitted from the

--- a/.super-coder/migrations/0078_interface_sessions.sql
+++ b/.super-coder/migrations/0078_interface_sessions.sql
@@ -17,9 +17,10 @@
 -- interface_reconcile.startup_reconcile + tests/test_interface_crash_window.py).
 --
 -- Snapshot stance: volatile runtime tables (interface_writer_leases,
--- interface_input_state, pr_poll_runs) are deliberately absent from
--- snapshot.py's PER_INSTANCE_TABLES (the 0075 precedent); durable audit tables
--- are snapshotted with row filters (live rows excluded — rebuild/update refuse
+-- pr_poll_runs) are deliberately absent from snapshot.py's
+-- PER_INSTANCE_TABLES (the 0075 precedent). interface_input_state preserves
+-- only terminal delivery-unknown metadata; durable audit tables are
+-- snapshotted with row filters (live rows excluded — rebuild/update refuse
 -- while any of them exist anyway) and volatile columns (tmux socket,
 -- PIDs/start ticks, hook token hash) ride SENSITIVE_COLUMNS.
 
@@ -112,10 +113,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_interface_writer_leases_current
     ON interface_writer_leases(session_id) WHERE revoked_at IS NULL;
 
 -- ── Input state: metadata only, never bytes ─────────────────────────────────
--- VOLATILE — excluded from snapshot (pending-input metadata). One row per
--- session. pending_seq is the crash-window reservation: set before the tmux
--- write, cleared only by the forward commit AFTER the write. last_submit_seq
--- is the fenced submit-callback proof that lets dirty → clean.
+-- LIVE rows are volatile and snapshot-excluded. A terminal
+-- delivery_unknown row is durable recovery metadata (never input bytes) and
+-- survives rebuild. One row per session. pending_seq is the crash-window
+-- reservation: set before the tmux write, cleared only by the forward commit
+-- AFTER the write. last_submit_seq is the fenced submit-callback proof that
+-- lets dirty → clean.
 
 CREATE TABLE IF NOT EXISTS interface_input_state (
     session_id          INTEGER PRIMARY KEY

--- a/.super-coder/migrations/0083_interface_integrity_cleanup.sql
+++ b/.super-coder/migrations/0083_interface_integrity_cleanup.sql
@@ -1,8 +1,10 @@
 -- 0083 — terminal Interface cleanup + orphan alert repair (#529, #533).
 --
 -- Older closure paths could leave generation-volatile input state attached to
--- a fully ended session. It can no longer be delivered or reconciled, so drop
--- it and revoke any lingering writer lease. Older snapshots could also load
+-- a fully ended session. Drop ordinary state, but preserve metadata-only
+-- pending/delivery-unknown evidence as a parked observation (decision #16);
+-- terminal audit must not block update, but it must not be silently erased.
+-- Revoke any lingering writer lease. Older snapshots could also load
 -- planner_alerts with FK enforcement disabled while omitting one of their
 -- parents; delete those alerts before a reused integer ID can reattach them to
 -- a different session/binding/message/watch generation.
@@ -16,7 +18,31 @@ WHERE session_id IN (
     WHERE occupancy='ended'
       AND lifecycle='ended'
       AND ended_at IS NOT NULL
-);
+)
+  AND pending_seq IS NULL
+  AND delivery <> 'delivery_unknown';
+
+UPDATE interface_input_state
+SET composer='unknown',
+    delivery='delivery_unknown',
+    updated_at=datetime('now')
+WHERE session_id IN (
+    SELECT session_id
+    FROM interface_sessions
+    WHERE occupancy='ended'
+      AND lifecycle='ended'
+      AND ended_at IS NOT NULL
+)
+  AND (pending_seq IS NOT NULL OR delivery='delivery_unknown');
+
+INSERT OR IGNORE INTO planner_alerts
+    (session_id, severity, reason, dedupe_key)
+SELECT session_id,
+       'critical',
+       'crash_window_delivery_unknown',
+       CAST(session_id AS TEXT) || '|-|-|crash_window_delivery_unknown'
+FROM interface_input_state
+WHERE delivery='delivery_unknown';
 
 UPDATE interface_writer_leases
 SET revoked_at=COALESCE(revoked_at, datetime('now')),

--- a/.super-coder/migrations/0083_interface_integrity_cleanup.sql
+++ b/.super-coder/migrations/0083_interface_integrity_cleanup.sql
@@ -1,0 +1,51 @@
+-- 0083 — terminal Interface cleanup + orphan alert repair (#529, #533).
+--
+-- Older closure paths could leave generation-volatile input state attached to
+-- a fully ended session. It can no longer be delivered or reconciled, so drop
+-- it and revoke any lingering writer lease. Older snapshots could also load
+-- planner_alerts with FK enforcement disabled while omitting one of their
+-- parents; delete those alerts before a reused integer ID can reattach them to
+-- a different session/binding/message/watch generation.
+
+BEGIN;
+
+DELETE FROM interface_input_state
+WHERE session_id IN (
+    SELECT session_id
+    FROM interface_sessions
+    WHERE occupancy='ended'
+      AND lifecycle='ended'
+      AND ended_at IS NOT NULL
+);
+
+UPDATE interface_writer_leases
+SET revoked_at=COALESCE(revoked_at, datetime('now')),
+    revoke_reason=COALESCE(revoke_reason, 'session_end')
+WHERE revoked_at IS NULL
+  AND session_id IN (
+      SELECT session_id
+      FROM interface_sessions
+      WHERE occupancy='ended'
+        AND lifecycle='ended'
+        AND ended_at IS NOT NULL
+  );
+
+DELETE FROM planner_alerts
+WHERE (session_id IS NOT NULL AND NOT EXISTS (
+           SELECT 1 FROM interface_sessions s
+           WHERE s.session_id=planner_alerts.session_id
+       ))
+   OR (binding_id IS NOT NULL AND NOT EXISTS (
+           SELECT 1 FROM sprint_planner_bindings b
+           WHERE b.binding_id=planner_alerts.binding_id
+       ))
+   OR (message_id IS NOT NULL AND NOT EXISTS (
+           SELECT 1 FROM shell_messages m
+           WHERE m.message_id=planner_alerts.message_id
+       ))
+   OR (watch_id IS NOT NULL AND NOT EXISTS (
+           SELECT 1 FROM watched_prs w
+           WHERE w.watch_id=planner_alerts.watch_id
+       ));
+
+COMMIT;

--- a/.super-coder/migrations/0084_interface_integrity_cleanup.sql
+++ b/.super-coder/migrations/0084_interface_integrity_cleanup.sql
@@ -54,6 +54,25 @@ WHERE delivery='delivery_unknown'
         )
   );
 
+-- Legacy closure could leave an already-raised session alert open.  Keep the
+-- original audit row, but a fully ended session has no live actor and therefore
+-- no session-scoped alert may remain actionable.
+UPDATE planner_alerts
+SET resolved_at=(
+    SELECT s.ended_at
+    FROM interface_sessions s
+    WHERE s.session_id=planner_alerts.session_id
+)
+WHERE resolved_at IS NULL
+  AND EXISTS (
+      SELECT 1
+      FROM interface_sessions s
+      WHERE s.session_id=planner_alerts.session_id
+        AND s.occupancy='ended'
+        AND s.lifecycle='ended'
+        AND s.ended_at IS NOT NULL
+  );
+
 UPDATE interface_writer_leases
 SET revoked_at=COALESCE(revoked_at, datetime('now')),
     revoke_reason=COALESCE(revoke_reason, 'session_end')

--- a/.super-coder/migrations/0084_interface_integrity_cleanup.sql
+++ b/.super-coder/migrations/0084_interface_integrity_cleanup.sql
@@ -1,4 +1,4 @@
--- 0083 — terminal Interface cleanup + orphan alert repair (#529, #533).
+-- 0084 — terminal Interface cleanup + orphan alert repair (#529, #533).
 --
 -- Older closure paths could leave generation-volatile input state attached to
 -- a fully ended session. Drop ordinary state, but preserve metadata-only
@@ -42,7 +42,17 @@ SELECT session_id,
        'crash_window_delivery_unknown',
        CAST(session_id AS TEXT) || '|-|-|crash_window_delivery_unknown'
 FROM interface_input_state
-WHERE delivery='delivery_unknown';
+WHERE delivery='delivery_unknown'
+  AND EXISTS (
+      SELECT 1
+      FROM interface_sessions s
+      WHERE s.session_id=interface_input_state.session_id
+        AND NOT (
+            s.occupancy='ended'
+            AND s.lifecycle='ended'
+            AND s.ended_at IS NOT NULL
+        )
+  );
 
 UPDATE interface_writer_leases
 SET revoked_at=COALESCE(revoked_at, datetime('now')),

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -330,9 +330,10 @@ CREATE TABLE daemon_heartbeats (
 -- per shell, exact-identity sessions, writer leases, metadata-only input
 -- state, idempotency keys, sprint planner bindings, wake items/batches,
 -- action receipts, PR poll audit, and alerts. Volatile runtime tables
--- (interface_writer_leases, interface_input_state, pr_poll_runs) are
--- deliberately NOT in snapshot.py's PER_INSTANCE_TABLES; volatile columns
--- (tmux socket, PIDs/start ticks, hook token hash) ride SENSITIVE_COLUMNS.
+-- (interface_writer_leases, pr_poll_runs) are deliberately NOT in
+-- snapshot.py's PER_INSTANCE_TABLES. interface_input_state preserves only
+-- terminal delivery-unknown metadata; volatile columns (tmux socket,
+-- PIDs/start ticks, hook token hash) ride SENSITIVE_COLUMNS.
 -- See migrations/0078_interface_sessions.sql (convergent — carries an
 -- existing fork) and scripts/interface_state.py (app-level edge maps — keep
 -- in sync with the transition triggers below).

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -76,6 +76,37 @@ def _alert(con, *, severity: str, reason: str, session_id=None,
            binding_id=None, message_id=None) -> None:
     """Raise an alert, deduplicated while open (partial unique index)."""
     dedupe = f"{session_id or '-'}|{binding_id or '-'}|{message_id or '-'}|{reason}"
+    if session_id is not None:
+        session = con.execute(
+            "SELECT occupancy, lifecycle, ended_at "
+            "FROM interface_sessions WHERE session_id=?",
+            (session_id,),
+        ).fetchone()
+        if session is not None and not interface_state.session_is_active(*session):
+            # A late runtime callback may race durable closure. Preserve one
+            # audit row for the event, but never attach an actionable alert to
+            # a session that can no longer act.
+            ended_at = session[2]
+            con.execute(
+                "UPDATE planner_alerts SET resolved_at=? "
+                "WHERE session_id=? AND resolved_at IS NULL",
+                (ended_at, session_id),
+            )
+            exists = con.execute(
+                "SELECT 1 FROM planner_alerts "
+                "WHERE session_id=? AND binding_id IS ? AND message_id IS ? "
+                "AND reason=? LIMIT 1",
+                (session_id, binding_id, message_id, reason),
+            ).fetchone()
+            if exists is None:
+                con.execute(
+                    "INSERT INTO planner_alerts "
+                    "(session_id, binding_id, message_id, severity, reason, "
+                    "dedupe_key, resolved_at) VALUES (?,?,?,?,?,?,?)",
+                    (session_id, binding_id, message_id, severity, reason,
+                     dedupe, ended_at),
+                )
+            return
     con.execute(
         "INSERT OR IGNORE INTO planner_alerts "
         "(session_id, binding_id, message_id, severity, reason, dedupe_key) "

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -299,13 +299,29 @@ def reconcile_input(con, session_id: int, outcome: str) -> None:
 
 
 def _close_volatile_children(con, session_id: int) -> None:
-    """Terminalize/remove generation-volatile state in the caller's txn."""
+    """Terminalize/remove generation-volatile state in the caller's txn.
+
+    A delivery-unknown input row is no longer live, but it remains the
+    metadata-only ambiguity record required by decision #16.  Preserve that
+    park and its operator alert; remove only input state with no pending or
+    ambiguous delivery evidence.
+    """
     con.execute(
         "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
         "revoke_reason='session_end' "
         "WHERE session_id=? AND revoked_at IS NULL", (session_id,))
-    con.execute(
-        "DELETE FROM interface_input_state WHERE session_id=?", (session_id,))
+    input_state = con.execute(
+        "SELECT pending_seq, delivery FROM interface_input_state "
+        "WHERE session_id=?", (session_id,)).fetchone()
+    if input_state is None:
+        return
+    pending_seq, delivery = input_state
+    if pending_seq is None and delivery != "delivery_unknown":
+        con.execute(
+            "DELETE FROM interface_input_state WHERE session_id=?",
+            (session_id,))
+        return
+    park_delivery_unknown(con, session_id)
 
 
 def close_session(con, session_id: int, end_reason: str) -> dict:
@@ -319,8 +335,9 @@ def close_session(con, session_id: int, end_reason: str) -> dict:
     `stopping` where no direct edge exists — a hook that won the race can
     never strand occupied/ended, and nothing ever moves terminal →
     nonterminal), ends the matching generation, revokes active leases,
-    removes volatile input state, and resolves or parks durable session-scoped
-    wake state by the existing ambiguity rules (a batch with a proven stop
+    removes ordinary volatile input state, preserves a metadata-only
+    delivery-unknown park, and resolves or parks durable session-scoped wake
+    state by the existing ambiguity rules (a batch with a proven stop
     reconciles from read state; a batch with no stop evidence parks — no live
     harness will re-drive it). Queued wake work is deliberately left queued
     for a future generation.
@@ -366,10 +383,10 @@ def close_session(con, session_id: int, end_reason: str) -> dict:
         "UPDATE interface_generations SET ended_at=datetime('now') "
         "WHERE shell_id=? AND generation=? AND ended_at IS NULL",
         (shell_id, generation))
-    # Input/composer state is generation-volatile. Once process absence and
-    # durable closure are proved there is nothing left to deliver or inspect,
-    # so remove it in this same transaction. Keeping an unknown/pending row
-    # made a safely closed session permanently block update (#529).
+    # Ordinary input/composer state is generation-volatile.  A pending or
+    # delivery-unknown row is different: it is the decision #16 ambiguity
+    # record, so park it durably while the live guard ignores its terminal
+    # parent.  Everything else is removed in this same transaction (#529).
     _close_volatile_children(con, session_id)
 
     # Session-scoped wake state: the generation is provably over, so a live

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -74,9 +74,16 @@ def _session(con, session_id: int):
 
 def _alert(con, *, severity: str, reason: str, session_id=None,
            binding_id=None, message_id=None) -> None:
-    """Raise an alert, deduplicated while open (partial unique index)."""
+    """Raise an alert, deduplicated while open (partial unique index).
+
+    A session-scoped alert takes the write lock before reading terminal state.
+    That makes the read + write atomic with durable closure: closure either
+    lands first and this row is resolved audit, or lands second and resolves
+    the row itself. The caller still owns the surrounding transaction.
+    """
     dedupe = f"{session_id or '-'}|{binding_id or '-'}|{message_id or '-'}|{reason}"
     if session_id is not None:
+        _begin_immediate(con)
         session = con.execute(
             "SELECT occupancy, lifecycle, ended_at "
             "FROM interface_sessions WHERE session_id=?",

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -298,6 +298,16 @@ def reconcile_input(con, session_id: int, outcome: str) -> None:
                     "forwarded_seq": new_forwarded})
 
 
+def _close_volatile_children(con, session_id: int) -> None:
+    """Terminalize/remove generation-volatile state in the caller's txn."""
+    con.execute(
+        "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
+        "revoke_reason='session_end' "
+        "WHERE session_id=? AND revoked_at IS NULL", (session_id,))
+    con.execute(
+        "DELETE FROM interface_input_state WHERE session_id=?", (session_id,))
+
+
 def close_session(con, session_id: int, end_reason: str) -> dict:
     """THE one closure helper (spec #30 Lifecycle Contract) — every close
     producer (operator terminate, cancel start, reconcile-close, spawn
@@ -309,11 +319,11 @@ def close_session(con, session_id: int, end_reason: str) -> dict:
     `stopping` where no direct edge exists — a hook that won the race can
     never strand occupied/ended, and nothing ever moves terminal →
     nonterminal), ends the matching generation, revokes active leases,
-    and resolves or parks session-scoped wake state by the existing
-    ambiguity rules (a pending human frame parks delivery_unknown; a
-    batch with a proven stop reconciles from read state; a batch with no
-    stop evidence parks — no live harness will re-drive it). Queued wake
-    work is deliberately left queued for a future generation.
+    removes volatile input state, and resolves or parks durable session-scoped
+    wake state by the existing ambiguity rules (a batch with a proven stop
+    reconciles from read state; a batch with no stop evidence parks — no live
+    harness will re-drive it). Queued wake work is deliberately left queued
+    for a future generation.
 
     Idempotent: a FULLY terminal session (occupancy AND lifecycle ended)
     returns its original terminal result without state churn. A partially
@@ -321,14 +331,15 @@ def close_session(con, session_id: int, end_reason: str) -> dict:
     left lifecycle nonterminal — is converged, never silently no-op'ed
     (SC-065); its original end reason/time are kept."""
     row = con.execute(
-        "SELECT shell_id, generation, occupancy, lifecycle, end_reason "
+        "SELECT shell_id, generation, occupancy, lifecycle, ended_at, end_reason "
         "FROM interface_sessions WHERE session_id=?",
         (session_id,),
     ).fetchone()
     if row is None:
         raise BrokerError(f"interface session {session_id} not found")
-    shell_id, generation, occupancy, lifecycle, prior_reason = row
-    if occupancy == "ended" and lifecycle == "ended":
+    shell_id, generation, occupancy, lifecycle, ended_at, prior_reason = row
+    if not interface_state.session_is_active(occupancy, lifecycle, ended_at):
+        _close_volatile_children(con, session_id)
         con.execute(
             "UPDATE planner_alerts SET resolved_at=datetime('now') "
             "WHERE session_id=? AND resolved_at IS NULL", (session_id,))
@@ -355,21 +366,15 @@ def close_session(con, session_id: int, end_reason: str) -> dict:
         "UPDATE interface_generations SET ended_at=datetime('now') "
         "WHERE shell_id=? AND generation=? AND ended_at IS NULL",
         (shell_id, generation))
-    con.execute(
-        "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
-        "revoke_reason='session_end' "
-        "WHERE session_id=? AND revoked_at IS NULL", (session_id,))
+    # Input/composer state is generation-volatile. Once process absence and
+    # durable closure are proved there is nothing left to deliver or inspect,
+    # so remove it in this same transaction. Keeping an unknown/pending row
+    # made a safely closed session permanently block update (#529).
+    _close_volatile_children(con, session_id)
 
-    # Session-scoped wake state: the generation is provably over, so a
-    # pending human frame can never be acked and a live batch can never
-    # see its stop hook. Resolve from durable evidence or park — the same
-    # rules startup reconciliation applies (decision #22).
-    istate = con.execute(
-        "SELECT pending_seq, delivery FROM interface_input_state "
-        "WHERE session_id=?", (session_id,)).fetchone()
-    if istate is not None and istate[0] is not None \
-            and istate[1] != "delivery_unknown":
-        park_delivery_unknown(con, session_id)
+    # Session-scoped wake state: the generation is provably over, so a live
+    # batch can never see its stop hook. Resolve from durable evidence or park
+    # the durable batch audit; queued work remains for a future generation.
     batches = con.execute(
         "SELECT batch_id, binding_id, state, stop_hook_seq "
         "FROM planner_wake_batches "

--- a/.super-coder/scripts/interface_reconcile.py
+++ b/.super-coder/scripts/interface_reconcile.py
@@ -57,19 +57,31 @@ def startup_reconcile(con) -> dict:
               "batches_delivery_unknown": 0, "batches_proven_running": 0,
               "batches_completed": 0, "leases_revoked": 0,
               "terminal_inputs_removed": 0,
+              "terminal_input_parks": 0,
               "terminal_leases_revoked": 0}
 
     active_session = interface_state.active_session_sql("s")
 
-    # A fully closed session has no actor left to accept or acknowledge input.
-    # Clean legacy volatile children before examining live crash windows so old
-    # composer/delivery/pending rows cannot re-park ended sessions (#529).
+    # A fully closed session has no actor left to accept new input.  Remove
+    # ordinary volatile state, but preserve metadata-only delivery ambiguity:
+    # decision #16 requires the pending sequence and operator action to survive
+    # closure without continuing to block update (#529).
     cur = con.execute(
         "DELETE FROM interface_input_state WHERE session_id IN ("
         "SELECT s.session_id FROM interface_sessions s "
-        f"WHERE NOT ({active_session}))"
+        f"WHERE NOT ({active_session})) "
+        "AND pending_seq IS NULL AND delivery <> 'delivery_unknown'"
     )
     counts["terminal_inputs_removed"] = cur.rowcount
+    terminal_parks = con.execute(
+        "SELECT i.session_id FROM interface_input_state i "
+        "JOIN interface_sessions s ON s.session_id=i.session_id "
+        f"WHERE NOT ({active_session}) "
+        "AND (i.pending_seq IS NOT NULL OR i.delivery='delivery_unknown')"
+    ).fetchall()
+    for (session_id,) in terminal_parks:
+        interface_broker.park_delivery_unknown(con, session_id)
+        counts["terminal_input_parks"] += 1
     cur = con.execute(
         "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
         "revoke_reason='session_end' WHERE revoked_at IS NULL "

--- a/.super-coder/scripts/interface_reconcile.py
+++ b/.super-coder/scripts/interface_reconcile.py
@@ -55,11 +55,34 @@ def startup_reconcile(con) -> dict:
 
     counts = {"reservations_unreconciled": 0, "parks": 0,
               "batches_delivery_unknown": 0, "batches_proven_running": 0,
-              "batches_completed": 0, "leases_revoked": 0}
+              "batches_completed": 0, "leases_revoked": 0,
+              "terminal_inputs_removed": 0,
+              "terminal_leases_revoked": 0}
+
+    active_session = interface_state.active_session_sql("s")
+
+    # A fully closed session has no actor left to accept or acknowledge input.
+    # Clean legacy volatile children before examining live crash windows so old
+    # composer/delivery/pending rows cannot re-park ended sessions (#529).
+    cur = con.execute(
+        "DELETE FROM interface_input_state WHERE session_id IN ("
+        "SELECT s.session_id FROM interface_sessions s "
+        f"WHERE NOT ({active_session}))"
+    )
+    counts["terminal_inputs_removed"] = cur.rowcount
+    cur = con.execute(
+        "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
+        "revoke_reason='session_end' WHERE revoked_at IS NULL "
+        "AND session_id IN (SELECT s.session_id FROM interface_sessions s "
+        f"WHERE NOT ({active_session}))"
+    )
+    counts["terminal_leases_revoked"] = cur.rowcount
 
     # 1. Crash-window parking — pending human frame at restart.
     parked = con.execute(
-        "SELECT session_id FROM interface_input_state WHERE pending_seq IS NOT NULL"
+        "SELECT i.session_id FROM interface_input_state i "
+        "JOIN interface_sessions s ON s.session_id=i.session_id "
+        f"WHERE i.pending_seq IS NOT NULL AND {active_session}"
     ).fetchall()
     for (session_id,) in parked:
         interface_broker.park_delivery_unknown(con, session_id)
@@ -110,7 +133,9 @@ def startup_reconcile(con) -> dict:
     #    Composer/dirty state is preserved (spec: dirty survives disconnect).
     cur = con.execute(
         "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
-        "revoke_reason='service_restart' WHERE revoked_at IS NULL")
+        "revoke_reason='service_restart' WHERE revoked_at IS NULL "
+        "AND session_id IN (SELECT s.session_id FROM interface_sessions s "
+        f"WHERE {active_session})")
     counts["leases_revoked"] = cur.rowcount
 
     con.commit()
@@ -137,31 +162,42 @@ def live_refusal_reasons(db_path) -> list[str]:
                 f"generation {shell_id}/{generation} is live — end it first "
                 "(a rebuilt live generation bricks that shell's next New "
                 "chat)")
+        active_session = interface_state.active_session_sql("s")
         rows = con.execute(
-            "SELECT session_id, shell_id, occupancy FROM interface_sessions "
-            "WHERE occupancy <> 'ended'").fetchall()
+            "SELECT s.session_id, s.shell_id, s.occupancy "
+            "FROM interface_sessions s "
+            f"WHERE {active_session}").fetchall()
         for session_id, shell_id, occupancy in rows:
             reasons.append(
                 f"interface session {session_id} (shell {shell_id}) is "
                 f"{occupancy} — end/reconcile it first")
         rows = con.execute(
-            "SELECT binding_id, sprint_doc_id FROM sprint_planner_bindings "
-            "WHERE released_at IS NULL").fetchall()
+            "SELECT b.binding_id, b.sprint_doc_id "
+            "FROM sprint_planner_bindings b "
+            "LEFT JOIN interface_sessions s ON s.session_id=b.session_id "
+            "WHERE b.released_at IS NULL "
+            f"AND (s.session_id IS NULL OR {active_session})").fetchall()
         for binding_id, doc_id in rows:
             reasons.append(
                 f"sprint binding {binding_id} (doc {doc_id}) is armed — "
                 "release it first")
         rows = con.execute(
-            "SELECT batch_id, state FROM planner_wake_batches "
-            "WHERE state <> 'complete'").fetchall()
+            "SELECT wb.batch_id, wb.state FROM planner_wake_batches wb "
+            "LEFT JOIN sprint_planner_bindings b ON b.binding_id=wb.binding_id "
+            "LEFT JOIN interface_sessions s ON s.session_id=b.session_id "
+            "WHERE wb.state <> 'complete' "
+            f"AND (b.binding_id IS NULL OR s.session_id IS NULL "
+            f"OR {active_session})").fetchall()
         for batch_id, state in rows:
             reasons.append(
                 f"wake batch {batch_id} is {state} — drain or reconcile it "
                 "first")
         rows = con.execute(
-            "SELECT session_id FROM interface_input_state "
-            "WHERE composer='unknown' OR delivery='delivery_unknown' "
-            "OR pending_seq IS NOT NULL").fetchall()
+            "SELECT i.session_id FROM interface_input_state i "
+            "LEFT JOIN interface_sessions s ON s.session_id=i.session_id "
+            "WHERE (i.composer='unknown' OR i.delivery='delivery_unknown' "
+            "OR i.pending_seq IS NOT NULL) "
+            f"AND (s.session_id IS NULL OR {active_session})").fetchall()
         for (session_id,) in rows:
             reasons.append(
                 f"session {session_id} has input ambiguity — inspect the live "

--- a/.super-coder/scripts/interface_reconcile.py
+++ b/.super-coder/scripts/interface_reconcile.py
@@ -80,7 +80,12 @@ def startup_reconcile(con) -> dict:
         "AND (i.pending_seq IS NOT NULL OR i.delivery='delivery_unknown')"
     ).fetchall()
     for (session_id,) in terminal_parks:
-        interface_broker.park_delivery_unknown(con, session_id)
+        # Keep the metadata-only ambiguity, but do not raise a new
+        # session-scoped alert: every alert for an ended session is resolved
+        # audit, including across repeated service starts (spec #30 req 19).
+        interface_state.transition(con, "composer", session_id, "unknown")
+        interface_state.transition(
+            con, "delivery", session_id, "delivery_unknown")
         counts["terminal_input_parks"] += 1
     cur = con.execute(
         "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "

--- a/.super-coder/scripts/interface_reconcile.py
+++ b/.super-coder/scripts/interface_reconcile.py
@@ -58,7 +58,8 @@ def startup_reconcile(con) -> dict:
               "batches_completed": 0, "leases_revoked": 0,
               "terminal_inputs_removed": 0,
               "terminal_input_parks": 0,
-              "terminal_leases_revoked": 0}
+              "terminal_leases_revoked": 0,
+              "terminal_alerts_resolved": 0}
 
     active_session = interface_state.active_session_sql("s")
 
@@ -87,6 +88,16 @@ def startup_reconcile(con) -> dict:
         interface_state.transition(
             con, "delivery", session_id, "delivery_unknown")
         counts["terminal_input_parks"] += 1
+    cur = con.execute(
+        "UPDATE planner_alerts SET resolved_at=("
+        "SELECT s.ended_at FROM interface_sessions s "
+        "WHERE s.session_id=planner_alerts.session_id) "
+        "WHERE resolved_at IS NULL AND EXISTS ("
+        "SELECT 1 FROM interface_sessions s "
+        "WHERE s.session_id=planner_alerts.session_id "
+        f"AND NOT ({active_session}))"
+    )
+    counts["terminal_alerts_resolved"] = cur.rowcount
     cur = con.execute(
         "UPDATE interface_writer_leases SET revoked_at=datetime('now'), "
         "revoke_reason='session_end' WHERE revoked_at IS NULL "

--- a/.super-coder/scripts/interface_runtime.py
+++ b/.super-coder/scripts/interface_runtime.py
@@ -1110,16 +1110,11 @@ class InterfaceRuntime:
             gen.broadcast_control({"type": "error", "code": "resync_failed"})
 
     def _alert(self, session_id: int, reason: str, severity: str) -> None:
-        """INSERT OR IGNORE shape replicated from interface_broker._alert
-        (private there): deduplicated while open via the partial unique
-        index on planner_alerts."""
+        """Write through the broker's terminal-session-aware alert helper."""
         con = db_driver.connect(self.db_path)
         try:
-            con.execute(
-                "INSERT OR IGNORE INTO planner_alerts "
-                "(session_id, severity, reason, dedupe_key) "
-                "VALUES (?,?,?,?)",
-                (session_id, severity, reason, f"{session_id}|-|{reason}"))
+            interface_broker._alert(
+                con, session_id=session_id, reason=reason, severity=severity)
             con.commit()
         finally:
             con.close()

--- a/.super-coder/scripts/interface_state.py
+++ b/.super-coder/scripts/interface_state.py
@@ -18,7 +18,6 @@ Delivery sections. Two deliberate readings of the spec's edge lists:
 """
 from __future__ import annotations
 
-
 # One definition of whether a durable Interface session can still act or needs
 # reconciliation. A row is closed only when all three terminal markers agree;
 # every partial/legacy combination remains active and therefore fail-closed.

--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -221,6 +221,16 @@ def main(argv: list[str]) -> int:
         else:
             print("rebuild: no .sc-state/content.sql — built empty (no per-instance content).")
 
+        # content.sql loads after migrations and older snapshots may contain
+        # legacy open alerts for fully ended sessions. Reconcile the completed
+        # candidate, not merely the pre-snapshot schema, so rebuild cannot
+        # reattach actionable state to terminal audit.
+        con = db_driver.connect(candidate)
+        try:
+            interface_reconcile.startup_reconcile(con)
+        finally:
+            con.close()
+
         # The migrations above seeded every engine skill live (is_deleted=0) —
         # re-assert the fork retire list so a rebuilt DB doesn't resurrect skills
         # this fork has retired (a shell created before the next launch/update

--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -43,7 +43,7 @@ def snapshot_path() -> Path:
     return SNAPSHOT if SNAPSHOT.exists() else SNAPSHOT_LEGACY
 
 
-def read_existing_keys() -> dict:
+def read_existing_keys(db_path: Path | None = None) -> dict:
     """shell_id -> (api_key, api_key_rotated_at) from the outgoing DB.
 
     content.sql never serializes api_key (secret in a git-tracked file), so
@@ -60,12 +60,13 @@ def read_existing_keys() -> dict:
     a CLI transaction racing `sc verify`) used to be swallowed into {}, which
     silently rotated every key and 401'd all live sessions (#279). A rebuild
     that cannot read the keys it is about to destroy must not proceed."""
-    if not DB_PATH.exists():
+    path = db_path or DB_PATH
+    if not path.exists():
         print("rebuild: no outgoing DB — every shell will be minted a fresh key.")
         return {}
     con = None
     try:
-        con = db_driver.connect(DB_PATH)
+        con = db_driver.connect(path)
         rows = con.execute(
             "SELECT shell_id, api_key, api_key_rotated_at FROM shells "
             "WHERE api_key IS NOT NULL"
@@ -91,14 +92,14 @@ def read_existing_keys() -> dict:
     return keys
 
 
-def restore_keys(keys: dict) -> int:
+def restore_keys(keys: dict, db_path: Path | None = None) -> int:
     """Re-attach carried keys to the rebuilt shells. Guarded on api_key IS
     NULL so a loaded value (should content.sql ever carry one) is never
     clobbered; a shell_id absent from the new content matches nothing and its
     key is dropped with it."""
     if not keys:
         return 0
-    con = db_driver.connect(DB_PATH)
+    con = db_driver.connect(db_path or DB_PATH)
     try:
         restored = 0
         for sid, (key, rotated) in keys.items():
@@ -128,12 +129,12 @@ def prune_backups(prefix: str, directory: Path | None = None) -> None:
         old.unlink(missing_ok=True)
 
 
-def backup_db(dst: Path, src: Path = DB_PATH) -> None:
+def backup_db(dst: Path, src: Path | None = None) -> None:
     """WAL-safe snapshot via sqlite3's online-backup API. A plain file copy of
     a live WAL database misses every un-checkpointed page (they live in the
     -wal sidecar), so a copy2 restore point could silently drop the most
     recent writes — the exact rows it exists to protect."""
-    src_con = sqlite3.connect(src)
+    src_con = sqlite3.connect(src or DB_PATH)
     dst_con = sqlite3.connect(dst)
     try:
         with dst_con:
@@ -154,13 +155,33 @@ def backup_existing() -> None:
     print(f"rebuild: backed up existing DB -> {dst}")
 
 
+def _remove_database(path: Path) -> None:
+    for suffix in ("", "-wal", "-shm"):
+        Path(str(path) + suffix).unlink(missing_ok=True)
+
+
+def validate_foreign_keys(path: Path) -> None:
+    """Refuse a candidate with the exact first orphan named."""
+    con = db_driver.connect(path)
+    try:
+        violations = con.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            table, rowid, parent, fk_id = violations[0]
+            raise SystemExit(
+                "rebuild: foreign-key check failed: "
+                f"table {table} row {rowid} references {parent} (fk {fk_id}) "
+                "— outgoing DB and backup preserved")
+        # Make the candidate main file self-contained before its atomic rename.
+        con.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchall()
+    finally:
+        con.close()
+
+
 def main(argv: list[str]) -> int:
     schema = SCHEMA_SQLITE
     if not schema.exists():
         sys.exit(f"rebuild: missing {schema}")
 
-    if "--no-backup" not in argv:
-        backup_existing()
     keys = read_existing_keys()
     # Spec #20: a rebuild destroys the live DB, so it refuses while any live
     # Interface state would be lost — non-ended session, unreleased binding,
@@ -172,55 +193,65 @@ def main(argv: list[str]) -> int:
             "rebuild: refusing — live Interface state exists; the clean "
             "operator drain path is required first:\n  - "
             + "\n  - ".join(reasons))
-    for suffix in ("", "-wal", "-shm"):
-        p = Path(str(DB_PATH) + suffix)
-        if p.exists():
-            p.unlink()
+    if "--no-backup" not in argv:
+        backup_existing()
 
-    con = db_driver.connect(DB_PATH)
+    candidate = Path(str(DB_PATH) + ".rebuild")
+    _remove_database(candidate)
     try:
-        con.executescript(schema.read_text())
-        con.commit()
-        print("rebuild: schema.sql applied")
-    finally:
-        con.close()
-
-    migrate_mod.migrate(str(DB_PATH))
-
-    snap = snapshot_path()
-    if snap.exists():
-        con = db_driver.connect(DB_PATH)
+        con = db_driver.connect(candidate)
         try:
-            con.executescript(snap.read_text())
+            con.executescript(schema.read_text())
             con.commit()
-            print(f"rebuild: loaded {snap.relative_to(REPO_ROOT)}")
+            print("rebuild: schema.sql applied")
         finally:
             con.close()
-    else:
-        print("rebuild: no .sc-state/content.sql — built empty (no per-instance content).")
 
-    # The migrations above seeded every engine skill live (is_deleted=0) —
-    # re-assert the fork retire list so a rebuilt DB doesn't resurrect skills
-    # this fork has retired (a shell created before the next launch/update
-    # would otherwise be granted them).
-    con = db_driver.connect(DB_PATH)
-    try:
-        flipped = seed_skills.apply_retired(con)
-    finally:
-        con.close()
-    if flipped:
-        print(f"rebuild: fork retire list applied ({', '.join(flipped)})")
+        migrate_mod.migrate(str(candidate))
 
-    # Re-attach the keys carried over from the outgoing DB (content.sql never
-    # carries api_key — it is a secret and content.sql is git-tracked, see
-    # snapshot.py's no-serialize set), then mint only what is still missing:
-    # new shells from the content load, or everything on a fresh/pre-key build.
-    # Rotation is never a rebuild side effect — live sessions keep the
-    # SC_API_TOKEN they booted with (#265). Rotate deliberately, not here.
-    restored = restore_keys(keys)
-    if restored:
-        print(f"rebuild: preserved {restored} shell api_key(s)")
-    backfill_shell_api_keys.backfill(str(DB_PATH))
+        snap = snapshot_path()
+        if snap.exists():
+            con = db_driver.connect(candidate)
+            try:
+                con.executescript(snap.read_text())
+                con.commit()
+                print(f"rebuild: loaded {snap.relative_to(REPO_ROOT)}")
+            finally:
+                con.close()
+        else:
+            print("rebuild: no .sc-state/content.sql — built empty (no per-instance content).")
+
+        # The migrations above seeded every engine skill live (is_deleted=0) —
+        # re-assert the fork retire list so a rebuilt DB doesn't resurrect skills
+        # this fork has retired (a shell created before the next launch/update
+        # would otherwise be granted them).
+        con = db_driver.connect(candidate)
+        try:
+            flipped = seed_skills.apply_retired(con)
+        finally:
+            con.close()
+        if flipped:
+            print(f"rebuild: fork retire list applied ({', '.join(flipped)})")
+
+        # Re-attach carried keys and mint only what remains absent on the
+        # candidate. The outgoing DB stays untouched until every load and
+        # integrity check has succeeded.
+        restored = restore_keys(keys, candidate)
+        if restored:
+            print(f"rebuild: preserved {restored} shell api_key(s)")
+        backfill_shell_api_keys.backfill(str(candidate))
+        validate_foreign_keys(candidate)
+    except BaseException:
+        _remove_database(candidate)
+        raise
+
+    # The candidate is closed, checkpointed, and valid. Remove stale sidecars
+    # belonging to the outgoing inode, then atomically replace only now.
+    for suffix in ("-wal", "-shm"):
+        Path(str(DB_PATH) + suffix).unlink(missing_ok=True)
+    candidate.replace(DB_PATH)
+    for suffix in ("-wal", "-shm"):
+        Path(str(candidate) + suffix).unlink(missing_ok=True)
 
     try:
         map_repo.main()

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -102,15 +102,93 @@ PER_INSTANCE_TABLES = [
 # quarantined wake audit, and transition/blind-window observations — and may
 # run while a chat is live). The dump still DELETEs the whole table on load;
 # rows outside the filter simply never existed as far as the rebuild knows.
+def _serialized_session(session_ref: str) -> str:
+    return (
+        "EXISTS (SELECT 1 FROM interface_sessions s "
+        "JOIN interface_generations g "
+        "ON g.shell_id=s.shell_id AND g.generation=s.generation "
+        f"WHERE s.session_id={session_ref} "
+        "AND s.occupancy='ended' AND s.lifecycle='ended' "
+        "AND s.ended_at IS NOT NULL AND g.ended_at IS NOT NULL)"
+    )
+
+
+def _serialized_binding(binding_ref: str) -> str:
+    return (
+        "EXISTS (SELECT 1 FROM sprint_planner_bindings b "
+        "JOIN interface_sessions s ON s.session_id=b.session_id "
+        "JOIN interface_generations sg "
+        "ON sg.shell_id=s.shell_id AND sg.generation=s.generation "
+        "JOIN interface_generations bg "
+        "ON bg.shell_id=b.shell_id AND bg.generation=b.generation "
+        f"WHERE b.binding_id={binding_ref} "
+        "AND b.released_at IS NOT NULL "
+        "AND s.occupancy='ended' AND s.lifecycle='ended' "
+        "AND s.ended_at IS NOT NULL "
+        "AND sg.ended_at IS NOT NULL AND bg.ended_at IS NOT NULL)"
+    )
+
+
+def _serialized_batch(batch_ref: str) -> str:
+    return (
+        "EXISTS (SELECT 1 FROM planner_wake_batches wb "
+        "JOIN sprint_planner_bindings b ON b.binding_id=wb.binding_id "
+        "JOIN interface_sessions s ON s.session_id=b.session_id "
+        "JOIN interface_generations sg "
+        "ON sg.shell_id=s.shell_id AND sg.generation=s.generation "
+        "JOIN interface_generations bg "
+        "ON bg.shell_id=b.shell_id AND bg.generation=b.generation "
+        "JOIN interface_generations wg "
+        "ON wg.shell_id=wb.shell_id AND wg.generation=wb.generation "
+        f"WHERE wb.batch_id={batch_ref} "
+        "AND wb.state IN ('complete','delivery_unknown') "
+        "AND b.released_at IS NOT NULL "
+        "AND s.occupancy='ended' AND s.lifecycle='ended' "
+        "AND s.ended_at IS NOT NULL "
+        "AND sg.ended_at IS NOT NULL AND bg.ended_at IS NOT NULL "
+        "AND wg.ended_at IS NOT NULL)"
+    )
+
+
 SNAPSHOT_ROW_FILTERS = {
     "interface_generations": "WHERE ended_at IS NOT NULL",
-    "interface_sessions": "WHERE occupancy = 'ended'",
-    "sprint_planner_bindings": "WHERE released_at IS NOT NULL",
-    "planner_wake_batches": "WHERE state IN ('complete','delivery_unknown')",
+    "interface_sessions":
+        "WHERE occupancy='ended' AND lifecycle='ended' AND ended_at IS NOT NULL "
+        "AND EXISTS (SELECT 1 FROM interface_generations g "
+        "WHERE g.shell_id=interface_sessions.shell_id "
+        "AND g.generation=interface_sessions.generation "
+        "AND g.ended_at IS NOT NULL)",
+    "sprint_planner_bindings":
+        "WHERE " + _serialized_binding(
+            "sprint_planner_bindings.binding_id"),
+    "planner_wake_batches":
+        "WHERE " + _serialized_batch("planner_wake_batches.batch_id"),
     "planner_wake_items":
-        "WHERE state IN ('done','reconcile','quarantined','cancelled')",
+        "WHERE state IN ('done','reconcile','quarantined','cancelled') "
+        "AND " + _serialized_binding("planner_wake_items.binding_id") + " "
+        "AND EXISTS (SELECT 1 FROM shell_messages m "
+        "WHERE m.message_id=planner_wake_items.message_id) "
+        "AND (batch_id IS NULL OR "
+        + _serialized_batch("planner_wake_items.batch_id") + ")",
     "pr_poll_observations":
-        "WHERE transition IS NOT NULL OR blind_window <> 0",
+        "WHERE (transition IS NOT NULL OR blind_window <> 0) "
+        "AND EXISTS (SELECT 1 FROM watched_prs w "
+        "WHERE w.watch_id=pr_poll_observations.watch_id)",
+    # Alerts are durable only when every referenced parent is in this same
+    # projection. This drops session-scoped alerts for excluded live sessions
+    # and all legacy orphans, preventing integer-ID reuse from reattaching old
+    # generation state (#533).
+    "planner_alerts":
+        "WHERE (session_id IS NULL OR "
+        + _serialized_session("planner_alerts.session_id") + ") "
+        "AND (binding_id IS NULL OR "
+        + _serialized_binding("planner_alerts.binding_id") + ") "
+        "AND (message_id IS NULL OR EXISTS ("
+        "SELECT 1 FROM shell_messages m "
+        "WHERE m.message_id=planner_alerts.message_id)) "
+        "AND (watch_id IS NULL OR EXISTS ("
+        "SELECT 1 FROM watched_prs w "
+        "WHERE w.watch_id=planner_alerts.watch_id))",
 }
 
 
@@ -183,7 +261,6 @@ def dump_local_skills(con) -> list[str]:
         delete_line = "DELETE FROM skills;"
 
     cols = [r[1] for r in con.execute("PRAGMA table_info(skills)")]
-    collist = ", ".join(cols)
     mutable_cols = [c for c in cols if c != "skill_id"]
     insert_cols = ", ".join(mutable_cols)
     update_cols = [c for c in mutable_cols if c != "name"]

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -81,10 +81,12 @@ PER_INSTANCE_TABLES = [
     # chat is live, and rebuild/update refuse while any live state exists, so
     # content.sql only ever carries closed/terminal rows. Volatile columns
     # (tmux socket, PIDs/start ticks, hook token hash) ride SENSITIVE_COLUMNS.
-    # Fully volatile tables (interface_writer_leases, interface_input_state,
-    # pr_poll_runs) are NOT in this list — a rebuild rederives them empty.
+    # Fully volatile tables (interface_writer_leases, pr_poll_runs) are NOT in
+    # this list — a rebuild rederives them empty. interface_input_state keeps
+    # only terminal delivery-unknown metadata (never terminal bytes).
     "interface_generations",
     "interface_sessions",
+    "interface_input_state",
     "interface_idempotency_keys",
     "sprint_planner_bindings",
     "planner_wake_batches",
@@ -122,7 +124,13 @@ def _serialized_binding(binding_ref: str) -> str:
         "JOIN interface_generations bg "
         "ON bg.shell_id=b.shell_id AND bg.generation=b.generation "
         f"WHERE b.binding_id={binding_ref} "
-        "AND b.released_at IS NOT NULL "
+        "AND (b.released_at IS NOT NULL "
+        "OR EXISTS (SELECT 1 FROM interface_input_state i "
+        "WHERE i.session_id=b.session_id "
+        "AND i.delivery='delivery_unknown') "
+        "OR EXISTS (SELECT 1 FROM planner_wake_batches p "
+        "WHERE p.binding_id=b.binding_id "
+        "AND p.state='delivery_unknown')) "
         "AND s.occupancy='ended' AND s.lifecycle='ended' "
         "AND s.ended_at IS NOT NULL "
         "AND sg.ended_at IS NOT NULL AND bg.ended_at IS NOT NULL)"
@@ -142,7 +150,6 @@ def _serialized_batch(batch_ref: str) -> str:
         "ON wg.shell_id=wb.shell_id AND wg.generation=wb.generation "
         f"WHERE wb.batch_id={batch_ref} "
         "AND wb.state IN ('complete','delivery_unknown') "
-        "AND b.released_at IS NOT NULL "
         "AND s.occupancy='ended' AND s.lifecycle='ended' "
         "AND s.ended_at IS NOT NULL "
         "AND sg.ended_at IS NOT NULL AND bg.ended_at IS NOT NULL "
@@ -158,6 +165,9 @@ SNAPSHOT_ROW_FILTERS = {
         "WHERE g.shell_id=interface_sessions.shell_id "
         "AND g.generation=interface_sessions.generation "
         "AND g.ended_at IS NOT NULL)",
+    "interface_input_state":
+        "WHERE delivery='delivery_unknown' "
+        "AND " + _serialized_session("interface_input_state.session_id"),
     "sprint_planner_bindings":
         "WHERE " + _serialized_binding(
             "sprint_planner_bindings.binding_id"),

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -137,7 +137,10 @@ def _serialized_binding(binding_ref: str) -> str:
     )
 
 
-def _serialized_batch(batch_ref: str) -> str:
+def _serialized_batch(
+        batch_ref: str,
+        states: tuple[str, ...] = ("complete", "delivery_unknown")) -> str:
+    state_list = ",".join(f"'{state}'" for state in states)
     return (
         "EXISTS (SELECT 1 FROM planner_wake_batches wb "
         "JOIN sprint_planner_bindings b ON b.binding_id=wb.binding_id "
@@ -149,7 +152,7 @@ def _serialized_batch(batch_ref: str) -> str:
         "JOIN interface_generations wg "
         "ON wg.shell_id=wb.shell_id AND wg.generation=wb.generation "
         f"WHERE wb.batch_id={batch_ref} "
-        "AND wb.state IN ('complete','delivery_unknown') "
+        f"AND wb.state IN ({state_list}) "
         "AND s.occupancy='ended' AND s.lifecycle='ended' "
         "AND s.ended_at IS NOT NULL "
         "AND sg.ended_at IS NOT NULL AND bg.ended_at IS NOT NULL "
@@ -173,8 +176,15 @@ SNAPSHOT_ROW_FILTERS = {
             "sprint_planner_bindings.binding_id"),
     "planner_wake_batches":
         "WHERE " + _serialized_batch("planner_wake_batches.batch_id"),
+    # In-flight items are normally volatile. The exception is an item owned
+    # by a serialized delivery_unknown batch: resolve_batch() needs that row
+    # after rebuild to requeue the still-unread message on explicit retry.
     "planner_wake_items":
-        "WHERE state IN ('done','reconcile','quarantined','cancelled') "
+        "WHERE (state IN ('done','reconcile','quarantined','cancelled') "
+        "OR (state IN ('batched','submitting','running') "
+        "AND batch_id IS NOT NULL AND "
+        + _serialized_batch(
+            "planner_wake_items.batch_id", ("delivery_unknown",)) + ")) "
         "AND " + _serialized_binding("planner_wake_items.binding_id") + " "
         "AND EXISTS (SELECT 1 FROM shell_messages m "
         "WHERE m.message_id=planner_wake_items.message_id) "

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -336,9 +336,19 @@ def dump_table(con, table: str) -> list[str]:
     if not cols:
         return []
     collist = ", ".join(cols)
+    select_cols = list(cols)
+    if table == "planner_alerts" and "resolved_at" in cols:
+        index = cols.index("resolved_at")
+        select_cols[index] = (
+            "CASE WHEN session_id IS NOT NULL THEN COALESCE("
+            "resolved_at, (SELECT s.ended_at FROM interface_sessions s "
+            "WHERE s.session_id=planner_alerts.session_id)) "
+            "ELSE resolved_at END"
+        )
     where = SNAPSHOT_ROW_FILTERS.get(table, "")
     rows = con.execute(
-        f"SELECT {collist} FROM {table} {where} ORDER BY rowid").fetchall()
+        f"SELECT {', '.join(select_cols)} FROM {table} "
+        f"{where} ORDER BY rowid").fetchall()
     lines = [f"DELETE FROM {table};"]
     for row in rows:
         vals = ", ".join(quote(v) for v in row)

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -17,20 +17,22 @@ kept as `.sc-state/engine.ref.prev` — the engine half of the restore point tha
 makes `./sc rollback` sound (DB + engine restored together).
 
 Flow:
-    1. capture the restore point: the current `engine.ref` → `engine.ref.prev`.
-    2. fetch upstream; materialize the engine paths at the new ref into the
+    1. fetch upstream objects, then run the installed engine's read-only live
+       state guard. A refusal changes no installed file or pin.
+    2. capture the restore point: the current `engine.ref` → `engine.ref.prev`.
+    3. materialize the engine paths at the new ref into the
        gitignored `.super-coder/` dir; write the new `engine.ref`. Per-instance
        content (`.sc-state/`, the DB, instance.json) is never in the materialize
        set, so it survives untouched. --no-fetch reconciles the working tree as-is.
-    3. back up the live DB (the other half of the restore point).
-    4. migrate IN PLACE — apply only un-applied migrations (ledger-tracked),
+    4. back up the live DB (the other half of the restore point).
+    5. migrate IN PLACE — apply only un-applied migrations (ledger-tracked),
        preserving all rows incl. in-session writes. No DB yet (fresh fork) ->
        fall back to a from-text rebuild.
-    5. sync the engine skills catalogue (idempotent, id-stable UPSERT) —
+    6. sync the engine skills catalogue (idempotent, id-stable UPSERT) —
        new/changed engine skills reach the fork without a rebuild, while
        project-local skills are left intact.
-    6. re-grant common skills to all shells.
-    7. wire the auto-remap hooks + map the repo + snapshot the (live) state.
+    7. re-grant common skills to all shells.
+    8. wire the auto-remap hooks + map the repo + snapshot the (live) state.
 
 Then review + commit (only `.sc-state/` — content.sql + engine.ref — moves; the
 engine is ignored). Restart the session to boot onto the new floor.
@@ -264,20 +266,27 @@ def check_local_edits(force: bool) -> None:
         "  - ./sc eject            one-way: stop tracking upstream and own the engine")
 
 
-def fetch_and_materialize(branch: str, ref: str | None = None,
-                          force: bool = False) -> None:
+def fetch_update_ref(branch: str, ref: str | None = None) -> str:
+    """Refresh remote objects and resolve the engine ref without touching the
+    installed floor. Git object refresh is the sole mutation allowed before
+    the live-state refusal preflight."""
     remote = super_coder_remote()
     if ref:
         # Pin to an explicit upstream version. `git fetch <remote> <ref>` serves
         # a branch, a tag, or (on GitHub) a reachable commit SHA; FETCH_HEAD is
         # the one name that works for all three.
-        print(f"→ fetch {remote} + materialize engine (pinned ref: {ref})")
+        print(f"→ fetch engine objects (pinned ref: {ref})")
         git("fetch", remote, ref)
         sha = git("rev-parse", "FETCH_HEAD").stdout.strip()
     else:
-        print(f"→ fetch {remote} + materialize engine ({remote}/{branch})")
+        print(f"→ fetch engine objects ({remote}/{branch})")
         git("fetch", remote, branch)
         sha = git("rev-parse", f"{remote}/{branch}").stdout.strip()
+    return sha
+
+
+def materialize_fetched_engine(sha: str, *, force: bool = False) -> None:
+    """Lay an already-fetched ref onto the installed floor."""
 
     check_local_edits(force)
 
@@ -295,6 +304,23 @@ def fetch_and_materialize(branch: str, ref: str | None = None,
     n = engine_manifest.write_manifest(_engine_paths_at(sha),
                                        files=_engine_files_at(sha))
     print(f"  engine pinned at {sha[:12]} (.sc-state/engine.ref) · manifest over {n} files")
+
+
+def fetch_and_materialize(branch: str, ref: str | None = None,
+                          force: bool = False) -> None:
+    """Compatibility wrapper for callers that already performed their own
+    preflight. update.main deliberately calls the two phases separately."""
+    sha = fetch_update_ref(branch, ref=ref)
+    materialize_fetched_engine(sha, force=force)
+
+
+def preflight_live_state() -> None:
+    """Refuse from the currently installed engine before any floor mutation."""
+    reasons = interface_reconcile.live_refusal_reasons(DB_PATH)
+    if reasons:
+        sys.exit(
+            "update: refusing — live Interface state exists; drain/reconcile "
+            "it first:\n  - " + "\n  - ".join(reasons))
 
 
 def migrate_engine_untrack() -> None:
@@ -316,19 +342,16 @@ def migrate_engine_untrack() -> None:
         print("→ B7: added /.super-coder/ to .gitignore")
 
 
-def migrate_or_rebuild() -> None:
+def migrate_or_rebuild(*, live_preflight_done: bool = False) -> None:
     if not DB_PATH.exists() or DB_PATH.stat().st_size == 0:
         print("→ no live DB (fresh fork) — building from text")
         rebuild_mod.main([])
         return
-    # Spec #20: update/materialize refuses while live Interface state exists
-    # (non-ended session, unreleased binding, nonterminal batch, input
-    # ambiguity) — same guard as rebuild, before any structural change.
-    reasons = interface_reconcile.live_refusal_reasons(DB_PATH)
-    if reasons:
-        sys.exit(
-            "update: refusing — live Interface state exists; drain/reconcile "
-            "it first:\n  - " + "\n  - ".join(reasons))
+    # Direct callers still get the live guard. update.main passes the explicit
+    # preflight receipt so no second, post-materialization refusal can strand a
+    # half-applied installed floor.
+    if not live_preflight_done:
+        preflight_live_state()
     rebuild_mod.backup_existing()  # restore point before any structural change
     print("→ migrate in place (pending migrations → the live DB; data preserved)")
     migrate_mod.migrate(str(DB_PATH))
@@ -404,6 +427,16 @@ def main(argv: list[str]) -> int:
                  "upstream to update from; edit .super-coder/ directly and commit "
                  "like any other code. (To re-adopt upstream, that's a manual "
                  "re-fork — see README → 'Customize a fork vs diverge from it'.)")
+
+    # Fetch may refresh remote Git objects, but nothing installed is touched
+    # until the CURRENT engine's guard has approved the live floor. In
+    # particular this precedes untracking/ignore edits, engine materialization,
+    # workflow seeding, and both pin files (#528).
+    target_sha = None
+    if not source and not no_fetch:
+        target_sha = fetch_update_ref(branch, ref=ref)
+    preflight_live_state()
+
     if source:
         # The source repo IS the engine — it has no upstream to materialize from
         # and must keep tracking .super-coder/. Reconcile its own tree only.
@@ -422,7 +455,8 @@ def main(argv: list[str]) -> int:
         print("→ --no-fetch: reconciling against the current working tree "
               "(engine + engine.ref unchanged)")
     else:
-        fetch_and_materialize(branch, ref=ref, force=force)
+        assert target_sha is not None
+        materialize_fetched_engine(target_sha, force=force)
 
     workflow_action, workflow_changes = ensure_workflows(source_repo=source)
     if workflow_action == "seeded":
@@ -443,7 +477,7 @@ def main(argv: list[str]) -> int:
     print("→ ensure harnesses installed (claude + opencode + codex + vibe + kimi)")
     install_mod.ensure_harnesses()
 
-    migrate_or_rebuild()
+    migrate_or_rebuild(live_preflight_done=True)
 
     print("→ sync skills catalogue (id-stable)")
     sync_skills()

--- a/tests/test_interface_crash_window.py
+++ b/tests/test_interface_crash_window.py
@@ -27,9 +27,11 @@ Run:
 """
 from __future__ import annotations
 
+import queue
 import sqlite3
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from typing import ClassVar
@@ -611,6 +613,96 @@ class CloseSessionMatrixTest(unittest.TestCase):
             "SELECT ended_at, end_reason FROM interface_sessions "
             "WHERE session_id=?", (sid,)).fetchone()
         self.assertEqual(first, second)
+
+    def test_terminal_alert_write_serializes_with_concurrent_close(self):
+        """SC-080: _alert must lock before its terminal-state read.
+
+        Hold an uncommitted closure on one connection while the runtime alert
+        starts on another. Without pre-read serialization, the alert reads the
+        old active row, closure commits, and the stale branch inserts a new
+        open alert on the ended session. With BEGIN IMMEDIATE first, the alert
+        waits, re-reads the committed terminal row, and writes resolved audit.
+        """
+        sid = self._make("occupied", "idle")
+        self.con.execute("PRAGMA journal_mode=WAL")
+        self.con.execute("PRAGMA busy_timeout=5000")
+        self.con.execute("BEGIN IMMEDIATE")
+        interface_broker.close_session(self.con, sid, "operator_end")
+
+        stages = queue.Queue()
+        errors = []
+        alert_con = sqlite3.connect(
+            self.db, timeout=5, check_same_thread=False)
+        alert_con.execute("PRAGMA journal_mode=WAL")
+        alert_con.execute("PRAGMA busy_timeout=5000")
+
+        class ObservedCursor:
+            def __init__(self, cursor):
+                self.cursor = cursor
+
+            def fetchone(self):
+                row = self.cursor.fetchone()
+                stages.put("terminal-read")
+                return row
+
+        class ObservedConnection:
+            @property
+            def in_transaction(self):
+                return alert_con.in_transaction
+
+            def execute(self, sql, parameters=()):
+                if sql == "BEGIN IMMEDIATE":
+                    stages.put("begin-immediate")
+                cursor = alert_con.execute(sql, parameters)
+                if sql.startswith(
+                        "SELECT occupancy, lifecycle, ended_at "):
+                    return ObservedCursor(cursor)
+                return cursor
+
+        def write_alert():
+            try:
+                interface_broker._alert(
+                    ObservedConnection(), severity="warning",
+                    reason="interface_continuity_broken", session_id=sid)
+                alert_con.commit()
+            except Exception as exc:  # surfaced on the test thread below
+                errors.append(exc)
+            finally:
+                alert_con.close()
+
+        worker = threading.Thread(target=write_alert)
+        worker.start()
+        try:
+            first_stage = stages.get(timeout=5)
+        finally:
+            self.con.commit()
+            worker.join(10)
+
+        self.assertFalse(worker.is_alive(), "alert writer stayed blocked")
+        if errors:
+            raise errors[0]
+        self.assertEqual(
+            first_stage, "begin-immediate",
+            "the alert must take the write lock before reading session state")
+        ended_at = self.con.execute(
+            "SELECT ended_at FROM interface_sessions WHERE session_id=?",
+            (sid,)).fetchone()[0]
+        alerts = self.con.execute(
+            "SELECT session_id, severity, reason, resolved_at "
+            "FROM planner_alerts "
+            "WHERE session_id=? AND reason='interface_continuity_broken'",
+            (sid,)).fetchall()
+        self.assertEqual(
+            alerts,
+            [(sid, "warning", "interface_continuity_broken", ended_at)],
+            "the late event remains as exactly one resolved audit row")
+        open_count = self.con.execute(
+            "SELECT COUNT(*) FROM planner_alerts "
+            "WHERE session_id=? AND resolved_at IS NULL",
+            (sid,)).fetchone()[0]
+        self.assertEqual(
+            open_count, 0,
+            "no actionable alert may land on the closed session")
 
     def test_close_converges_legacy_partial_row(self):
         """SC-065: a pre-convergence closure (the old spawn-failure path)

--- a/tests/test_interface_crash_window.py
+++ b/tests/test_interface_crash_window.py
@@ -721,9 +721,15 @@ class CloseSessionMatrixTest(unittest.TestCase):
 
         # Case 2: submitted with NO durable submit evidence → parked
         # (alert), never left awaiting a stop hook that can never arrive.
+        # Closure also resolves the ended generation's session alerts without
+        # consuming the parked batch's unread item; explicit batch resolution
+        # must still be able to requeue that item after snapshot/rebuild.
         sid = self._make("occupied", "idle")
         interface_broker.acquire_writer(self.con, sid, "tab-1", "tok-1")
         bid = self._binding_with_message(sid)
+        interface_broker._alert(
+            self.con, severity="warning", reason="approval_wait",
+            session_id=sid)
         batch_s = interface_broker.form_batch(self.con, bid)
         rec1 = Recorder("ok")
         out = interface_broker.submit_wake_batch(
@@ -736,11 +742,33 @@ class CloseSessionMatrixTest(unittest.TestCase):
             "SELECT state FROM planner_wake_batches WHERE batch_id=?",
             (batch_s,)).fetchone()[0]
         self.assertEqual(state, "delivery_unknown")
+        session_alert = self.con.execute(
+            "SELECT resolved_at FROM planner_alerts WHERE session_id=? AND "
+            "reason='approval_wait'", (sid,)).fetchone()
+        self.assertIsNotNone(
+            session_alert[0], "ended-generation alerts become resolved audit")
         alert = self.con.execute(
             "SELECT 1 FROM planner_alerts WHERE binding_id=? AND "
             "reason='wake_batch_delivery_unknown' AND resolved_at IS NULL",
             (bid,)).fetchone()
         self.assertIsNotNone(alert)
+        item = self.con.execute(
+            "SELECT i.state, i.batch_id, m.read_at "
+            "FROM planner_wake_items i "
+            "JOIN shell_messages m ON m.message_id=i.message_id "
+            "WHERE i.binding_id=?", (bid,)).fetchone()
+        self.assertEqual(
+            item, ("submitting", batch_s, None),
+            "park keeps the in-flight unread item for durable retry")
+        interface_broker.resolve_batch(self.con, batch_s)
+        item = self.con.execute(
+            "SELECT i.state, i.batch_id, m.read_at "
+            "FROM planner_wake_items i "
+            "JOIN shell_messages m ON m.message_id=i.message_id "
+            "WHERE i.binding_id=?", (bid,)).fetchone()
+        self.assertEqual(
+            item, ("queued", None, None),
+            "explicit resolution requeues without consuming the message")
 
         # Case 3: running with a proven stop stamp → complete, items
         # reconciled from durable read state (unread → requeued).

--- a/tests/test_interface_crash_window.py
+++ b/tests/test_interface_crash_window.py
@@ -651,10 +651,9 @@ class CloseSessionMatrixTest(unittest.TestCase):
         self.assertTrue(out["already_ended"])
         self.assertEqual(out["end_reason"], "spawn_failed")
 
-    def test_close_removes_terminal_input_state(self):
-        """Once absence-proved closure ends the generation, pending input is
-        volatile terminal state: remove it instead of leaving an ambiguity
-        that no live TUI can ever reconcile (#529)."""
+    def test_close_parks_pending_human_input_without_blocking_update(self):
+        """Closure neutralizes the live blocker but keeps decision #16's
+        metadata-only ambiguity evidence and named operator alert."""
         sid = self._make("occupied", "idle")
         interface_broker.acquire_writer(self.con, sid, "tab-1", "tok-1")
         self.con.execute(
@@ -664,9 +663,9 @@ class CloseSessionMatrixTest(unittest.TestCase):
         interface_broker.close_session(self.con, sid, "operator_end")
         self.con.commit()
         ist = self.con.execute(
-            "SELECT 1 FROM "
+            "SELECT composer, delivery, pending_seq FROM "
             "interface_input_state WHERE session_id=?", (sid,)).fetchone()
-        self.assertIsNone(ist)
+        self.assertEqual(ist, ("unknown", "delivery_unknown", 1))
         alert = self.con.execute(
             "SELECT resolved_at FROM planner_alerts WHERE session_id=? AND "
             "reason='crash_window_delivery_unknown'",

--- a/tests/test_interface_crash_window.py
+++ b/tests/test_interface_crash_window.py
@@ -651,10 +651,10 @@ class CloseSessionMatrixTest(unittest.TestCase):
         self.assertTrue(out["already_ended"])
         self.assertEqual(out["end_reason"], "spawn_failed")
 
-    def test_close_parks_pending_human_input(self):
-        """A pending unacknowledged frame can never be acked once the
-        generation is over — the close parks it by the crash-window rule
-        (evidence kept, alert raised), never drops it."""
+    def test_close_removes_terminal_input_state(self):
+        """Once absence-proved closure ends the generation, pending input is
+        volatile terminal state: remove it instead of leaving an ambiguity
+        that no live TUI can ever reconcile (#529)."""
         sid = self._make("occupied", "idle")
         interface_broker.acquire_writer(self.con, sid, "tab-1", "tok-1")
         self.con.execute(
@@ -664,11 +664,9 @@ class CloseSessionMatrixTest(unittest.TestCase):
         interface_broker.close_session(self.con, sid, "operator_end")
         self.con.commit()
         ist = self.con.execute(
-            "SELECT composer, delivery, pending_seq FROM "
+            "SELECT 1 FROM "
             "interface_input_state WHERE session_id=?", (sid,)).fetchone()
-        self.assertEqual(ist[0], "unknown")
-        self.assertEqual(ist[1], "delivery_unknown")
-        self.assertEqual(ist[2], 1, "evidence must survive the close")
+        self.assertIsNone(ist)
         alert = self.con.execute(
             "SELECT resolved_at FROM planner_alerts WHERE session_id=? AND "
             "reason='crash_window_delivery_unknown'",

--- a/tests/test_interface_reconcile_guard.py
+++ b/tests/test_interface_reconcile_guard.py
@@ -230,7 +230,7 @@ class LiveRefusalGuardTest(unittest.TestCase):
         reasons = interface_reconcile.live_refusal_reasons(self.db)
         self.assertTrue(any("ambiguity" in r for r in reasons))
 
-    def test_terminal_session_park_survives_startup_without_blocking(self):
+    def test_terminal_session_park_survives_restart_without_reopening_alert(self):
         sid = self._occupied_session()
         self.con.execute(
             "UPDATE interface_sessions SET occupancy='ended', lifecycle='ended', "
@@ -241,20 +241,31 @@ class LiveRefusalGuardTest(unittest.TestCase):
             "INSERT INTO interface_input_state (session_id, shell_id, generation, "
             "composer, delivery, pending_seq) "
             "VALUES (?,1,1,'unknown','delivery_unknown',9)", (sid,))
+        self.con.execute(
+            "INSERT INTO planner_alerts "
+            "(session_id, severity, reason, dedupe_key, resolved_at) "
+            "VALUES (?,'critical','crash_window_delivery_unknown',"
+            "? || '|-|-|crash_window_delivery_unknown',"
+            "'2026-07-23 00:00:00')", (sid, sid))
         self.con.commit()
         self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
 
         counts = interface_reconcile.startup_reconcile(self.con)
         self.assertEqual(counts["terminal_inputs_removed"], 0)
         self.assertEqual(counts["terminal_input_parks"], 1)
+        interface_reconcile.startup_reconcile(self.con)
         self.assertEqual(self.con.execute(
             "SELECT composer, delivery, pending_seq "
             "FROM interface_input_state WHERE session_id=?",
             (sid,)).fetchone(), ("unknown", "delivery_unknown", 9))
         self.assertEqual(self.con.execute(
-            "SELECT reason FROM planner_alerts WHERE session_id=? "
-            "AND resolved_at IS NULL", (sid,)).fetchone(),
-            ("crash_window_delivery_unknown",))
+            "SELECT reason, resolved_at FROM planner_alerts WHERE session_id=?",
+            (sid,)).fetchall(), [
+                ("crash_window_delivery_unknown", "2026-07-23 00:00:00")
+            ])
+        self.assertIsNone(self.con.execute(
+            "SELECT 1 FROM planner_alerts WHERE session_id=? "
+            "AND resolved_at IS NULL", (sid,)).fetchone())
 
     def test_shared_close_revokes_writer_and_preserves_ambiguity(self):
         sid = self._occupied_session()

--- a/tests/test_interface_reconcile_guard.py
+++ b/tests/test_interface_reconcile_guard.py
@@ -25,6 +25,7 @@ MIGRATIONS = ENGINE / "migrations"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import interface_reconcile  # noqa: E402
+import interface_broker  # noqa: E402
 import rebuild  # noqa: E402
 import update  # noqa: E402
 
@@ -213,7 +214,8 @@ class LiveRefusalGuardTest(unittest.TestCase):
         self.con.execute(
             "UPDATE sprint_planner_bindings SET released_at=datetime('now')")
         self.con.execute(
-            "UPDATE interface_sessions SET occupancy='ended'")
+            "UPDATE interface_sessions SET occupancy='ended', lifecycle='ended', "
+            "ended_at=datetime('now')")
         self.con.execute(
             "UPDATE interface_generations SET ended_at=datetime('now')")
         self.con.commit()
@@ -227,6 +229,61 @@ class LiveRefusalGuardTest(unittest.TestCase):
         self.con.commit()
         reasons = interface_reconcile.live_refusal_reasons(self.db)
         self.assertTrue(any("ambiguity" in r for r in reasons))
+
+    def test_terminal_session_stale_input_does_not_block(self):
+        sid = self._occupied_session()
+        self.con.execute(
+            "UPDATE interface_sessions SET occupancy='ended', lifecycle='ended', "
+            "ended_at=datetime('now') WHERE session_id=?", (sid,))
+        self.con.execute(
+            "UPDATE interface_generations SET ended_at=datetime('now')")
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id, generation, "
+            "composer, delivery, pending_seq) "
+            "VALUES (?,1,1,'unknown','delivery_unknown',9)", (sid,))
+        self.con.commit()
+        self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
+
+        counts = interface_reconcile.startup_reconcile(self.con)
+        self.assertEqual(counts["terminal_inputs_removed"], 1)
+        self.assertIsNone(self.con.execute(
+            "SELECT 1 FROM interface_input_state WHERE session_id=?",
+            (sid,)).fetchone())
+
+    def test_shared_close_removes_volatile_children(self):
+        sid = self._occupied_session()
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id, generation, "
+            "composer, pending_seq) VALUES (?,1,1,'unknown',4)", (sid,))
+        self.con.execute(
+            "INSERT INTO interface_writer_leases (session_id, shell_id, "
+            "generation, client_id, token_hash) VALUES (?,1,1,'client','hash')",
+            (sid,))
+        interface_broker.close_session(self.con, sid, "operator_end")
+        self.con.commit()
+
+        self.assertIsNone(self.con.execute(
+            "SELECT 1 FROM interface_input_state WHERE session_id=?",
+            (sid,)).fetchone())
+        revoked_at, reason = self.con.execute(
+            "SELECT revoked_at, revoke_reason FROM interface_writer_leases "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertIsNotNone(revoked_at)
+        self.assertEqual(reason, "session_end")
+        self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
+
+        # A repeated close also curates stale legacy volatile state without
+        # reopening or restamping the terminal session.
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id, generation, "
+            "composer, pending_seq) VALUES (?,1,1,'unknown',8)", (sid,))
+        result = interface_broker.close_session(
+            self.con, sid, "different_retry_reason")
+        self.assertTrue(result["already_ended"])
+        self.assertEqual(result["end_reason"], "operator_end")
+        self.assertIsNone(self.con.execute(
+            "SELECT 1 FROM interface_input_state WHERE session_id=?",
+            (sid,)).fetchone())
 
     def test_fully_drained_passes(self):
         sid = self._occupied_session()

--- a/tests/test_interface_reconcile_guard.py
+++ b/tests/test_interface_reconcile_guard.py
@@ -243,26 +243,31 @@ class LiveRefusalGuardTest(unittest.TestCase):
             "VALUES (?,1,1,'unknown','delivery_unknown',9)", (sid,))
         self.con.execute(
             "INSERT INTO planner_alerts "
-            "(session_id, severity, reason, dedupe_key, resolved_at) "
-            "VALUES (?,'critical','crash_window_delivery_unknown',"
-            "? || '|-|-|crash_window_delivery_unknown',"
-            "'2026-07-23 00:00:00')", (sid, sid))
+            "(alert_id, session_id, severity, reason, dedupe_key) "
+            "VALUES (42,?,'critical','crash_window_delivery_unknown',"
+            "? || '|-|-|crash_window_delivery_unknown')", (sid, sid))
         self.con.commit()
         self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
 
         counts = interface_reconcile.startup_reconcile(self.con)
         self.assertEqual(counts["terminal_inputs_removed"], 0)
         self.assertEqual(counts["terminal_input_parks"], 1)
-        interface_reconcile.startup_reconcile(self.con)
+        self.assertEqual(counts["terminal_alerts_resolved"], 1)
+        first_alert = self.con.execute(
+            "SELECT alert_id, reason, resolved_at FROM planner_alerts "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(first_alert[:2], (
+            42, "crash_window_delivery_unknown"))
+        self.assertIsNotNone(first_alert[2])
+        second = interface_reconcile.startup_reconcile(self.con)
+        self.assertEqual(second["terminal_alerts_resolved"], 0)
         self.assertEqual(self.con.execute(
             "SELECT composer, delivery, pending_seq "
             "FROM interface_input_state WHERE session_id=?",
             (sid,)).fetchone(), ("unknown", "delivery_unknown", 9))
         self.assertEqual(self.con.execute(
-            "SELECT reason, resolved_at FROM planner_alerts WHERE session_id=?",
-            (sid,)).fetchall(), [
-                ("crash_window_delivery_unknown", "2026-07-23 00:00:00")
-            ])
+            "SELECT alert_id, reason, resolved_at FROM planner_alerts "
+            "WHERE session_id=?", (sid,)).fetchall(), [first_alert])
         self.assertIsNone(self.con.execute(
             "SELECT 1 FROM planner_alerts WHERE session_id=? "
             "AND resolved_at IS NULL", (sid,)).fetchone())

--- a/tests/test_interface_reconcile_guard.py
+++ b/tests/test_interface_reconcile_guard.py
@@ -230,7 +230,7 @@ class LiveRefusalGuardTest(unittest.TestCase):
         reasons = interface_reconcile.live_refusal_reasons(self.db)
         self.assertTrue(any("ambiguity" in r for r in reasons))
 
-    def test_terminal_session_stale_input_does_not_block(self):
+    def test_terminal_session_park_survives_startup_without_blocking(self):
         sid = self._occupied_session()
         self.con.execute(
             "UPDATE interface_sessions SET occupancy='ended', lifecycle='ended', "
@@ -245,12 +245,18 @@ class LiveRefusalGuardTest(unittest.TestCase):
         self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
 
         counts = interface_reconcile.startup_reconcile(self.con)
-        self.assertEqual(counts["terminal_inputs_removed"], 1)
-        self.assertIsNone(self.con.execute(
-            "SELECT 1 FROM interface_input_state WHERE session_id=?",
-            (sid,)).fetchone())
+        self.assertEqual(counts["terminal_inputs_removed"], 0)
+        self.assertEqual(counts["terminal_input_parks"], 1)
+        self.assertEqual(self.con.execute(
+            "SELECT composer, delivery, pending_seq "
+            "FROM interface_input_state WHERE session_id=?",
+            (sid,)).fetchone(), ("unknown", "delivery_unknown", 9))
+        self.assertEqual(self.con.execute(
+            "SELECT reason FROM planner_alerts WHERE session_id=? "
+            "AND resolved_at IS NULL", (sid,)).fetchone(),
+            ("crash_window_delivery_unknown",))
 
-    def test_shared_close_removes_volatile_children(self):
+    def test_shared_close_revokes_writer_and_preserves_ambiguity(self):
         sid = self._occupied_session()
         self.con.execute(
             "INSERT INTO interface_input_state (session_id, shell_id, generation, "
@@ -262,9 +268,10 @@ class LiveRefusalGuardTest(unittest.TestCase):
         interface_broker.close_session(self.con, sid, "operator_end")
         self.con.commit()
 
-        self.assertIsNone(self.con.execute(
-            "SELECT 1 FROM interface_input_state WHERE session_id=?",
-            (sid,)).fetchone())
+        self.assertEqual(self.con.execute(
+            "SELECT composer, delivery, pending_seq "
+            "FROM interface_input_state WHERE session_id=?",
+            (sid,)).fetchone(), ("unknown", "delivery_unknown", 4))
         revoked_at, reason = self.con.execute(
             "SELECT revoked_at, revoke_reason FROM interface_writer_leases "
             "WHERE session_id=?", (sid,)).fetchone()
@@ -272,18 +279,16 @@ class LiveRefusalGuardTest(unittest.TestCase):
         self.assertEqual(reason, "session_end")
         self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
 
-        # A repeated close also curates stale legacy volatile state without
-        # reopening or restamping the terminal session.
-        self.con.execute(
-            "INSERT INTO interface_input_state (session_id, shell_id, generation, "
-            "composer, pending_seq) VALUES (?,1,1,'unknown',8)", (sid,))
+        # A repeated close preserves the same evidence without reopening or
+        # restamping the terminal session.
         result = interface_broker.close_session(
             self.con, sid, "different_retry_reason")
         self.assertTrue(result["already_ended"])
         self.assertEqual(result["end_reason"], "operator_end")
-        self.assertIsNone(self.con.execute(
-            "SELECT 1 FROM interface_input_state WHERE session_id=?",
-            (sid,)).fetchone())
+        self.assertEqual(self.con.execute(
+            "SELECT delivery, pending_seq FROM interface_input_state "
+            "WHERE session_id=?", (sid,)).fetchone(),
+            ("delivery_unknown", 4))
 
     def test_fully_drained_passes(self):
         sid = self._occupied_session()

--- a/tests/test_interface_runtime.py
+++ b/tests/test_interface_runtime.py
@@ -175,6 +175,40 @@ class AvailabilityTest(unittest.TestCase):
         return interface_runtime.InterfaceRuntime(
             str(self.db), run_dir=str(self.tmp / "run"))
 
+    def test_late_runtime_alert_keeps_ended_session_audit_resolved(self):
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO interface_generations "
+            "(shell_id, generation, ended_at) "
+            "VALUES (1,1,'2026-07-20 00:00:00')")
+        sid = con.execute(
+            "INSERT INTO interface_sessions "
+            "(shell_id, generation, occupancy, lifecycle, ended_at) "
+            "VALUES (1,1,'ended','ended','2026-07-20 00:00:00')"
+        ).lastrowid
+        con.execute(
+            "INSERT INTO planner_alerts "
+            "(alert_id, session_id, severity, reason, dedupe_key) "
+            "VALUES (42,?,'warning','interface_continuity_broken',"
+            "? || '|-|-|interface_continuity_broken')", (sid, sid))
+        con.commit()
+        con.close()
+
+        rt = self._runtime()
+        rt._alert(sid, "interface_continuity_broken", "warning")
+        rt._alert(sid, "interface_continuity_broken", "warning")
+
+        con = sqlite3.connect(self.db)
+        try:
+            alerts = con.execute(
+                "SELECT alert_id, reason, resolved_at FROM planner_alerts "
+                "WHERE session_id=?", (sid,)).fetchall()
+        finally:
+            con.close()
+        self.assertEqual(alerts, [
+            (42, "interface_continuity_broken", "2026-07-20 00:00:00")
+        ])
+
     def test_no_tmux_marks_unavailable(self):
         with mock.patch.object(interface_runtime.shutil, "which",
                                return_value=None):

--- a/tests/test_interface_snapshot.py
+++ b/tests/test_interface_snapshot.py
@@ -323,6 +323,9 @@ class InterfaceSnapshotTest(unittest.TestCase):
             alerts = set(rebuilt.execute(
                 "SELECT reason FROM planner_alerts "
                 "WHERE session_id=2 OR binding_id=2").fetchall())
+            open_session_alerts = rebuilt.execute(
+                "SELECT alert_id FROM planner_alerts "
+                "WHERE session_id=2 AND resolved_at IS NULL").fetchall()
             binding_row = rebuilt.execute(
                 "SELECT binding_id, sprint_doc_id, planner_shell_id, "
                 "session_id, generation, armed_at, released_at, release_reason "
@@ -341,6 +344,7 @@ class InterfaceSnapshotTest(unittest.TestCase):
         self.assertEqual(parked_item, ("submitting", 3, None))
         self.assertIn(("crash_window_delivery_unknown",), alerts)
         self.assertIn(("wake_batch_delivery_unknown",), alerts)
+        self.assertEqual(open_session_alerts, [])
         self.assertEqual(projected["wake_state"], "parked")
         self.assertEqual(projected["park"], {
             "batch_id": 3,

--- a/tests/test_interface_snapshot.py
+++ b/tests/test_interface_snapshot.py
@@ -10,8 +10,8 @@ content.sql carries only durable audit. These tests pin:
 - volatile columns (tmux socket, PIDs/start ticks, hook token hash) never
   appear in a dump even on preserved rows;
 - row filters keep live rows out: non-ended sessions, their bindings,
-  nonterminal batches/items, and no-transition observations are excluded
-  while terminal audit and parked ambiguity are preserved;
+  ordinary nonterminal batches/items, and no-transition observations are
+  excluded while terminal audit and parked recovery items are preserved;
 - alerts are serialized only when every referenced parent is preserved.
 
 Run:
@@ -19,11 +19,13 @@ Run:
 """
 from __future__ import annotations
 
+import json
 import sqlite3
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 SCHEMA = ENGINE / "schema.sql"
@@ -118,7 +120,7 @@ class InterfaceSnapshotTest(unittest.TestCase):
             "INSERT INTO planner_wake_batches (batch_id, binding_id,"
             " shell_id, generation, state) "
             "VALUES (3,2,2,2,'delivery_unknown')")
-        # Items: done (audit) + queued (live).
+        # Items: done audit + parked in-flight recovery state + queued live.
         self.con.execute(
             "INSERT INTO shell_messages (message_id, from_shell_id,"
             " to_shell_id, body) VALUES (1,1,2,'a')")
@@ -126,11 +128,17 @@ class InterfaceSnapshotTest(unittest.TestCase):
             "INSERT INTO shell_messages (message_id, from_shell_id,"
             " to_shell_id, body) VALUES (2,1,2,'b')")
         self.con.execute(
+            "INSERT INTO shell_messages (message_id, from_shell_id,"
+            " to_shell_id, body) VALUES (3,1,2,'parked-unread')")
+        self.con.execute(
             "INSERT INTO planner_wake_items (item_id, binding_id, message_id,"
             " batch_id, state) VALUES (1,2,1,1,'done')")
         self.con.execute(
             "INSERT INTO planner_wake_items (item_id, binding_id, message_id,"
             " state) VALUES (2,1,2,'queued')")
+        self.con.execute(
+            "INSERT INTO planner_wake_items (item_id, binding_id, message_id,"
+            " batch_id, state) VALUES (3,2,3,3,'submitting')")
         # Observations: transition + blind-window (audit), plain (noise).
         self.con.execute(
             "INSERT INTO watched_prs (watch_id, repo, pr_number, shell_id) "
@@ -246,9 +254,10 @@ class InterfaceSnapshotTest(unittest.TestCase):
         self.assertIn("'delivery_unknown'", out)
         self.assertNotIn("'queued'", out)
 
-    def test_wake_items_keep_terminal_only(self):
+    def test_wake_items_keep_terminal_and_parked_recovery_state(self):
         out = self._dump("planner_wake_items")
         self.assertIn("'done'", out)
+        self.assertIn("'submitting'", out)
         self.assertNotIn("'queued'", out)
 
     def test_observations_keep_transitions_and_blind_windows(self):
@@ -284,7 +293,7 @@ class InterfaceSnapshotTest(unittest.TestCase):
                 self.fail(f"{table}: row filter broken against schema "
                           f"({filt!r}): {e}")
 
-    def test_complete_snapshot_projection_is_foreign_key_closed(self):
+    def test_projection_is_fk_closed_and_parked_retry_survives_rebuild(self):
         target = self.tmp / "rebuilt.db"
         build_engine_db(target)
         lines = ["PRAGMA foreign_keys=OFF;", "BEGIN;"]
@@ -306,6 +315,11 @@ class InterfaceSnapshotTest(unittest.TestCase):
             wake_park = rebuilt.execute(
                 "SELECT state FROM planner_wake_batches "
                 "WHERE batch_id=3").fetchone()
+            parked_item = rebuilt.execute(
+                "SELECT i.state, i.batch_id, m.read_at "
+                "FROM planner_wake_items i "
+                "JOIN shell_messages m ON m.message_id=i.message_id "
+                "WHERE i.item_id=3").fetchone()
             alerts = set(rebuilt.execute(
                 "SELECT reason FROM planner_alerts "
                 "WHERE session_id=2 OR binding_id=2").fetchall())
@@ -315,12 +329,16 @@ class InterfaceSnapshotTest(unittest.TestCase):
                 "FROM sprint_planner_bindings WHERE binding_id=2").fetchone()
             projected = interface_routes._project_binding(
                 rebuilt, binding_row)
+            rebuilt.execute(
+                "UPDATE shells SET api_key='shelltok2' WHERE shell_id=2")
+            rebuilt.commit()
         finally:
             rebuilt.close()
         self.assertEqual(violations, [])
         self.assertEqual(input_park, ("unknown", "delivery_unknown", 9))
         self.assertEqual(binding, (None,))
         self.assertEqual(wake_park, ("delivery_unknown",))
+        self.assertEqual(parked_item, ("submitting", 3, None))
         self.assertIn(("crash_window_delivery_unknown",), alerts)
         self.assertIn(("wake_batch_delivery_unknown",), alerts)
         self.assertEqual(projected["wake_state"], "parked")
@@ -333,6 +351,29 @@ class InterfaceSnapshotTest(unittest.TestCase):
             "applicable": True,
             "needs_outcome": True,
         })
+        headers = (
+            "Host: 127.0.0.1:8800\r\n"
+            "Authorization: Bearer shelltok2\r\n"
+            "Idempotency-Key: snapshot-rebuild-retry"
+        )
+        with mock.patch.object(interface_routes, "DB_PATH", target):
+            status, _, body = interface_routes.handle(
+                "POST", "/api/interface/sprint-bindings/2/retry", headers,
+                json.dumps({"outcome": "not_delivered"}).encode())
+        self.assertEqual(status, 200, body)
+        retry = json.loads(body)
+        self.assertIn("parked batch 3 resolved", "; ".join(retry["actions"]))
+
+        rebuilt = sqlite3.connect(target)
+        try:
+            requeued = rebuilt.execute(
+                "SELECT i.state, i.batch_id, m.read_at "
+                "FROM planner_wake_items i "
+                "JOIN shell_messages m ON m.message_id=i.message_id "
+                "WHERE i.item_id=3").fetchone()
+        finally:
+            rebuilt.close()
+        self.assertEqual(requeued, ("queued", None, None))
 
 
 if __name__ == "__main__":

--- a/tests/test_interface_snapshot.py
+++ b/tests/test_interface_snapshot.py
@@ -5,15 +5,14 @@ The snapshot contract: it may run while a chat is live because it omits all
 volatile state, and rebuild/update refuse while live state exists — so
 content.sql carries only durable audit. These tests pin:
 
-- volatile tables (interface_writer_leases, interface_input_state,
-  pr_poll_runs) are NOT in PER_INSTANCE_TABLES;
+- fully volatile tables (interface_writer_leases, pr_poll_runs) are NOT in
+  PER_INSTANCE_TABLES; terminal delivery-unknown input metadata is preserved;
 - volatile columns (tmux socket, PIDs/start ticks, hook token hash) never
   appear in a dump even on preserved rows;
-- row filters keep live rows out: non-ended sessions, armed bindings,
+- row filters keep live rows out: non-ended sessions, their bindings,
   nonterminal batches/items, and no-transition observations are excluded
-  while their terminal counterparts are preserved;
-- durable guard tables (action receipts, idempotency keys, alerts) dump
-  whole.
+  while terminal audit and parked ambiguity are preserved;
+- alerts are serialized only when every referenced parent is preserved.
 
 Run:
     python3 tests/test_interface_snapshot.py
@@ -31,6 +30,8 @@ SCHEMA = ENGINE / "schema.sql"
 MIGRATIONS = ENGINE / "migrations"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+import interface_routes  # noqa: E402
 import snapshot  # noqa: E402
 
 SECRET_SOCKET = "/run/sc/SECRET-tmux-socket-0700"
@@ -49,9 +50,9 @@ def build_engine_db(path: Path) -> None:
             "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
             "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
             "VALUES (?,?,?,'test','sp',1,0,1,1)", (sid, f"S{sid}", f"s{sid}"))
-    con.execute(
-        "INSERT INTO documents (document_id, kind, title) "
-        "VALUES (1,'doc','SPRINT: test')")
+    con.executemany(
+        "INSERT INTO documents (document_id, kind, title) VALUES (?,?,?)",
+        [(1, "doc", "SPRINT: live"), (2, "doc", "SPRINT: ended")])
     con.commit()
     con.close()
 
@@ -82,23 +83,41 @@ class InterfaceSnapshotTest(unittest.TestCase):
             " tmux_socket, pane_pid) "
             "VALUES (2,2,2,'ended','ended',datetime('now'),'operator_end',"
             " ?, 999)", (SECRET_SOCKET,))
-        # Bindings: one armed, one released.
+        # Input state: only the terminal delivery-unknown record is durable.
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id, "
+            "generation, composer, delivery, pending_seq) "
+            "VALUES (1,1,1,'unknown','delivery_unknown',4)")
+        self.con.execute(
+            "INSERT INTO interface_input_state (session_id, shell_id, "
+            "generation, composer, delivery, pending_seq) "
+            "VALUES (2,2,2,'unknown','delivery_unknown',9)")
+        # Bindings: one on a live parent, one still armed on a terminal
+        # parent so its parked audit and recovery action survive rebuild.
         self.con.execute(
             "INSERT INTO sprint_planner_bindings (binding_id, sprint_doc_id,"
             " planner_shell_id, session_id, shell_id, generation) "
             "VALUES (1,1,1,1,1,1)")
         self.con.execute(
             "INSERT INTO sprint_planner_bindings (binding_id, sprint_doc_id,"
+            " planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (2,2,2,2,2,2)")
+        self.con.execute(
+            "INSERT INTO sprint_planner_bindings (binding_id, sprint_doc_id,"
             " planner_shell_id, session_id, shell_id, generation,"
             " released_at, release_reason) "
-            "VALUES (2,1,2,2,2,2,datetime('now'),'sprint_closed')")
-        # Batches: complete (audit) + queued (live).
+            "VALUES (4,2,2,2,2,2,datetime('now'),'sprint_closed')")
+        # Batches: complete + delivery-unknown audit, plus queued live state.
         self.con.execute(
             "INSERT INTO planner_wake_batches (batch_id, binding_id,"
             " shell_id, generation, state) VALUES (1,2,2,2,'complete')")
         self.con.execute(
             "INSERT INTO planner_wake_batches (batch_id, binding_id,"
             " shell_id, generation, state) VALUES (2,1,1,1,'queued')")
+        self.con.execute(
+            "INSERT INTO planner_wake_batches (batch_id, binding_id,"
+            " shell_id, generation, state) "
+            "VALUES (3,2,2,2,'delivery_unknown')")
         # Items: done (audit) + queued (live).
         self.con.execute(
             "INSERT INTO shell_messages (message_id, from_shell_id,"
@@ -143,11 +162,19 @@ class InterfaceSnapshotTest(unittest.TestCase):
             "INSERT INTO planner_alerts (session_id, severity, reason, dedupe_key) "
             "VALUES (2,'warning','ended-session','2|-|-|-|ended')")
         self.con.execute(
+            "INSERT INTO planner_alerts (session_id, severity, reason, dedupe_key) "
+            "VALUES (2,'critical','crash_window_delivery_unknown',"
+            "'2|-|-|crash_window_delivery_unknown')")
+        self.con.execute(
             "INSERT INTO planner_alerts (binding_id, severity, reason, dedupe_key) "
             "VALUES (1,'warning','live-binding','-|1|-|-|live')")
         self.con.execute(
             "INSERT INTO planner_alerts (binding_id, severity, reason, dedupe_key) "
             "VALUES (2,'warning','ended-binding','-|2|-|-|ended')")
+        self.con.execute(
+            "INSERT INTO planner_alerts (binding_id, severity, reason, dedupe_key) "
+            "VALUES (2,'critical','wake_batch_delivery_unknown',"
+            "'-|2|-|wake_batch_delivery_unknown')")
         self.con.execute(
             "INSERT INTO planner_alerts (session_id, binding_id, severity, "
             "reason, dedupe_key) "
@@ -167,10 +194,10 @@ class InterfaceSnapshotTest(unittest.TestCase):
         return "\n".join(snapshot.dump_table(self.con, table))
 
     def test_volatile_tables_not_snapshotted(self):
-        for table in ("interface_writer_leases", "interface_input_state",
-                      "pr_poll_runs"):
+        for table in ("interface_writer_leases", "pr_poll_runs"):
             self.assertNotIn(table, snapshot.PER_INSTANCE_TABLES,
                              f"{table} must never reach content.sql")
+        self.assertIn("interface_input_state", snapshot.PER_INSTANCE_TABLES)
 
     def test_session_rows_filtered_and_redacted(self):
         out = self._dump("interface_sessions")
@@ -197,16 +224,26 @@ class InterfaceSnapshotTest(unittest.TestCase):
         self.assertNotIn("VALUES (1, 1,", out, "live generation leaked")
         self.assertIn("VALUES (2, 2,", out, "ended generation audit dropped")
 
-    def test_bindings_keep_released_only(self):
+    def test_bindings_keep_released_or_parked_terminal_state(self):
         out = self._dump("sprint_planner_bindings")
-        self.assertIn("'sprint_closed'", out)
-        # binding 1 (armed) must not appear; binding 2 (released) must.
+        # Live-parent binding 1 is excluded. Terminal binding 2 survives while
+        # unreleased because it owns a park; released binding 4 remains audit.
         self.assertNotIn("VALUES (1,", out)
         self.assertIn("VALUES (2,", out)
+        self.assertIn("VALUES (4,", out)
+        self.assertIn("'sprint_closed'", out)
+
+    def test_input_state_keeps_terminal_ambiguity_only(self):
+        out = self._dump("interface_input_state")
+        self.assertNotIn("VALUES (1,", out, "live input state leaked")
+        self.assertIn("VALUES (2,", out, "terminal ambiguity evidence dropped")
+        self.assertIn("'delivery_unknown'", out)
+        self.assertIn(", 9,", out)
 
     def test_wake_batches_keep_terminal_only(self):
         out = self._dump("planner_wake_batches")
         self.assertIn("'complete'", out)
+        self.assertIn("'delivery_unknown'", out)
         self.assertNotIn("'queued'", out)
 
     def test_wake_items_keep_terminal_only(self):
@@ -260,9 +297,42 @@ class InterfaceSnapshotTest(unittest.TestCase):
         try:
             rebuilt.executescript("\n".join(lines))
             violations = rebuilt.execute("PRAGMA foreign_key_check").fetchall()
+            input_park = rebuilt.execute(
+                "SELECT composer, delivery, pending_seq "
+                "FROM interface_input_state WHERE session_id=2").fetchone()
+            binding = rebuilt.execute(
+                "SELECT released_at FROM sprint_planner_bindings "
+                "WHERE binding_id=2").fetchone()
+            wake_park = rebuilt.execute(
+                "SELECT state FROM planner_wake_batches "
+                "WHERE batch_id=3").fetchone()
+            alerts = set(rebuilt.execute(
+                "SELECT reason FROM planner_alerts "
+                "WHERE session_id=2 OR binding_id=2").fetchall())
+            binding_row = rebuilt.execute(
+                "SELECT binding_id, sprint_doc_id, planner_shell_id, "
+                "session_id, generation, armed_at, released_at, release_reason "
+                "FROM sprint_planner_bindings WHERE binding_id=2").fetchone()
+            projected = interface_routes._project_binding(
+                rebuilt, binding_row)
         finally:
             rebuilt.close()
         self.assertEqual(violations, [])
+        self.assertEqual(input_park, ("unknown", "delivery_unknown", 9))
+        self.assertEqual(binding, (None,))
+        self.assertEqual(wake_park, ("delivery_unknown",))
+        self.assertIn(("crash_window_delivery_unknown",), alerts)
+        self.assertIn(("wake_batch_delivery_unknown",), alerts)
+        self.assertEqual(projected["wake_state"], "parked")
+        self.assertEqual(projected["park"], {
+            "batch_id": 3,
+            "input_park": True,
+            "reason": "wake_batch_delivery_unknown",
+        })
+        self.assertEqual(projected["retry"], {
+            "applicable": True,
+            "needs_outcome": True,
+        })
 
 
 if __name__ == "__main__":

--- a/tests/test_interface_snapshot.py
+++ b/tests/test_interface_snapshot.py
@@ -68,7 +68,7 @@ class InterfaceSnapshotTest(unittest.TestCase):
             " hook_token_hash) VALUES (1,1,?)", (SECRET_HOOK_HASH,))
         self.con.execute(
             "INSERT INTO interface_generations (shell_id, generation,"
-            " ended_at) VALUES (1,2,datetime('now'))")
+            " ended_at) VALUES (2,2,datetime('now'))")
         # Sessions: one live with volatile identity, one ended audit row.
         self.con.execute(
             "INSERT INTO interface_sessions (session_id, shell_id,"
@@ -80,13 +80,13 @@ class InterfaceSnapshotTest(unittest.TestCase):
             "INSERT INTO interface_sessions (session_id, shell_id,"
             " generation, occupancy, lifecycle, ended_at, end_reason,"
             " tmux_socket, pane_pid) "
-            "VALUES (2,1,2,'ended','ended',datetime('now'),'operator_end',"
+            "VALUES (2,2,2,'ended','ended',datetime('now'),'operator_end',"
             " ?, 999)", (SECRET_SOCKET,))
         # Bindings: one armed, one released.
         self.con.execute(
             "INSERT INTO sprint_planner_bindings (binding_id, sprint_doc_id,"
             " planner_shell_id, session_id, shell_id, generation) "
-            "VALUES (1,1,2,1,2,1)")
+            "VALUES (1,1,1,1,1,1)")
         self.con.execute(
             "INSERT INTO sprint_planner_bindings (binding_id, sprint_doc_id,"
             " planner_shell_id, session_id, shell_id, generation,"
@@ -98,7 +98,7 @@ class InterfaceSnapshotTest(unittest.TestCase):
             " shell_id, generation, state) VALUES (1,2,2,2,'complete')")
         self.con.execute(
             "INSERT INTO planner_wake_batches (batch_id, binding_id,"
-            " shell_id, generation, state) VALUES (2,1,2,1,'queued')")
+            " shell_id, generation, state) VALUES (2,1,1,1,'queued')")
         # Items: done (audit) + queued (live).
         self.con.execute(
             "INSERT INTO shell_messages (message_id, from_shell_id,"
@@ -136,6 +136,25 @@ class InterfaceSnapshotTest(unittest.TestCase):
         self.con.execute(
             "INSERT INTO planner_alerts (severity, reason, dedupe_key) "
             "VALUES ('critical','crash','-|-|crash')")
+        self.con.execute(
+            "INSERT INTO planner_alerts (session_id, severity, reason, dedupe_key) "
+            "VALUES (1,'warning','live-session','1|-|-|-|live')")
+        self.con.execute(
+            "INSERT INTO planner_alerts (session_id, severity, reason, dedupe_key) "
+            "VALUES (2,'warning','ended-session','2|-|-|-|ended')")
+        self.con.execute(
+            "INSERT INTO planner_alerts (binding_id, severity, reason, dedupe_key) "
+            "VALUES (1,'warning','live-binding','-|1|-|-|live')")
+        self.con.execute(
+            "INSERT INTO planner_alerts (binding_id, severity, reason, dedupe_key) "
+            "VALUES (2,'warning','ended-binding','-|2|-|-|ended')")
+        self.con.execute(
+            "INSERT INTO planner_alerts (session_id, binding_id, severity, "
+            "reason, dedupe_key) "
+            "VALUES (2,1,'warning','mixed-live-parent','2|1|-|-|mixed')")
+        self.con.execute(
+            "INSERT INTO planner_alerts (session_id, severity, reason, dedupe_key) "
+            "VALUES (999,'warning','orphan-session','999|-|-|-|orphan')")
         self.con.commit()
 
     def tearDown(self):
@@ -176,7 +195,7 @@ class InterfaceSnapshotTest(unittest.TestCase):
         # New chat (flag #36). Ended generations are durable audit.
         out = self._dump("interface_generations")
         self.assertNotIn("VALUES (1, 1,", out, "live generation leaked")
-        self.assertIn("VALUES (1, 2,", out, "ended generation audit dropped")
+        self.assertIn("VALUES (2, 2,", out, "ended generation audit dropped")
 
     def test_bindings_keep_released_only(self):
         out = self._dump("sprint_planner_bindings")
@@ -201,10 +220,19 @@ class InterfaceSnapshotTest(unittest.TestCase):
         self.assertIn("VALUES (2,", out, "blind-window observation dropped")
         self.assertNotIn("VALUES (3,", out, "no-transition observation kept")
 
-    def test_durable_guard_tables_dump_whole(self):
+    def test_durable_guard_tables_preserve_closed_projection(self):
         self.assertIn("'k1'", self._dump("planner_action_receipts"))
         self.assertIn("'operator'", self._dump("interface_idempotency_keys"))
         self.assertIn("'crash'", self._dump("planner_alerts"))
+
+    def test_alerts_require_every_referenced_parent_in_projection(self):
+        out = self._dump("planner_alerts")
+        self.assertIn("'ended-session'", out)
+        self.assertIn("'ended-binding'", out)
+        self.assertNotIn("'live-session'", out)
+        self.assertNotIn("'live-binding'", out)
+        self.assertNotIn("'mixed-live-parent'", out)
+        self.assertNotIn("'orphan-session'", out)
 
     def test_row_filters_reference_live_columns(self):
         # Drift guard: each filter must parse and execute against the live
@@ -218,6 +246,23 @@ class InterfaceSnapshotTest(unittest.TestCase):
             except sqlite3.OperationalError as e:
                 self.fail(f"{table}: row filter broken against schema "
                           f"({filt!r}): {e}")
+
+    def test_complete_snapshot_projection_is_foreign_key_closed(self):
+        target = self.tmp / "rebuilt.db"
+        build_engine_db(target)
+        lines = ["PRAGMA foreign_keys=OFF;", "BEGIN;"]
+        for table in snapshot.PER_INSTANCE_TABLES:
+            if snapshot.table_exists(self.con, table):
+                lines.extend(snapshot.dump_table(self.con, table))
+        lines.extend(["COMMIT;", "PRAGMA foreign_keys=ON;"])
+
+        rebuilt = sqlite3.connect(target)
+        try:
+            rebuilt.executescript("\n".join(lines))
+            violations = rebuilt.execute("PRAGMA foreign_key_check").fetchall()
+        finally:
+            rebuilt.close()
+        self.assertEqual(violations, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_rebuild_integrity.py
+++ b/tests/test_rebuild_integrity.py
@@ -32,7 +32,7 @@ def digest(path: Path) -> str:
 
 
 class RebuildIntegrityTest(unittest.TestCase):
-    def test_cleanup_migration_removes_orphans_and_terminal_volatile_state(self):
+    def test_cleanup_migration_parks_terminal_ambiguity_and_removes_orphans(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             db = Path(raw_tmp) / "shell_db.db"
             apply_engine_schema(db)
@@ -67,9 +67,14 @@ class RebuildIntegrityTest(unittest.TestCase):
 
             con.executescript(
                 (MIGRATIONS / "0083_interface_integrity_cleanup.sql").read_text())
-            self.assertIsNone(con.execute(
-                "SELECT 1 FROM interface_input_state WHERE session_id=1"
-            ).fetchone())
+            self.assertEqual(con.execute(
+                "SELECT composer, delivery, pending_seq "
+                "FROM interface_input_state WHERE session_id=1"
+            ).fetchone(), ("unknown", "delivery_unknown", 7))
+            self.assertEqual(con.execute(
+                "SELECT reason FROM planner_alerts WHERE session_id=1 "
+                "AND resolved_at IS NULL"
+            ).fetchone(), ("crash_window_delivery_unknown",))
             revoked_at, reason = con.execute(
                 "SELECT revoked_at, revoke_reason FROM interface_writer_leases "
                 "WHERE session_id=1").fetchone()

--- a/tests/test_rebuild_integrity.py
+++ b/tests/test_rebuild_integrity.py
@@ -32,7 +32,7 @@ def digest(path: Path) -> str:
 
 
 class RebuildIntegrityTest(unittest.TestCase):
-    def test_cleanup_migration_parks_terminal_ambiguity_and_removes_orphans(self):
+    def test_cleanup_migration_keeps_ended_alert_resolved_and_removes_orphans(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             db = Path(raw_tmp) / "shell_db.db"
             apply_engine_schema(db)
@@ -61,20 +61,33 @@ class RebuildIntegrityTest(unittest.TestCase):
                 "VALUES (1,1,1,'client','hash')")
             con.execute(
                 "INSERT INTO planner_alerts "
+                "(alert_id, session_id, severity, reason, dedupe_key, resolved_at) "
+                "VALUES (42,1,'critical','crash_window_delivery_unknown',"
+                "'1|-|-|crash_window_delivery_unknown','2026-07-23 00:00:00')")
+            con.execute(
+                "INSERT INTO planner_alerts "
                 "(alert_id, session_id, severity, reason, dedupe_key) "
                 "VALUES (41,999,'warning','legacy-orphan','orphan')")
             con.commit()
 
-            con.executescript(
-                (MIGRATIONS / "0083_interface_integrity_cleanup.sql").read_text())
+            migration = (
+                MIGRATIONS / "0084_interface_integrity_cleanup.sql").read_text()
+            con.executescript(migration)
+            con.executescript(migration)
             self.assertEqual(con.execute(
                 "SELECT composer, delivery, pending_seq "
                 "FROM interface_input_state WHERE session_id=1"
             ).fetchone(), ("unknown", "delivery_unknown", 7))
             self.assertEqual(con.execute(
-                "SELECT reason FROM planner_alerts WHERE session_id=1 "
+                "SELECT reason, resolved_at FROM planner_alerts "
+                "WHERE session_id=1"
+            ).fetchall(), [
+                ("crash_window_delivery_unknown", "2026-07-23 00:00:00")
+            ])
+            self.assertIsNone(con.execute(
+                "SELECT 1 FROM planner_alerts WHERE session_id=1 "
                 "AND resolved_at IS NULL"
-            ).fetchone(), ("crash_window_delivery_unknown",))
+            ).fetchone())
             revoked_at, reason = con.execute(
                 "SELECT revoked_at, revoke_reason FROM interface_writer_leases "
                 "WHERE session_id=1").fetchone()

--- a/tests/test_rebuild_integrity.py
+++ b/tests/test_rebuild_integrity.py
@@ -61,9 +61,9 @@ class RebuildIntegrityTest(unittest.TestCase):
                 "VALUES (1,1,1,'client','hash')")
             con.execute(
                 "INSERT INTO planner_alerts "
-                "(alert_id, session_id, severity, reason, dedupe_key, resolved_at) "
+                "(alert_id, session_id, severity, reason, dedupe_key) "
                 "VALUES (42,1,'critical','crash_window_delivery_unknown',"
-                "'1|-|-|crash_window_delivery_unknown','2026-07-23 00:00:00')")
+                "'1|-|-|crash_window_delivery_unknown')")
             con.execute(
                 "INSERT INTO planner_alerts "
                 "(alert_id, session_id, severity, reason, dedupe_key) "
@@ -73,17 +73,21 @@ class RebuildIntegrityTest(unittest.TestCase):
             migration = (
                 MIGRATIONS / "0084_interface_integrity_cleanup.sql").read_text()
             con.executescript(migration)
+            first_alert = con.execute(
+                "SELECT alert_id, reason, resolved_at FROM planner_alerts "
+                "WHERE session_id=1").fetchone()
+            self.assertEqual(first_alert[:2], (
+                42, "crash_window_delivery_unknown"))
+            self.assertIsNotNone(first_alert[2])
             con.executescript(migration)
             self.assertEqual(con.execute(
                 "SELECT composer, delivery, pending_seq "
                 "FROM interface_input_state WHERE session_id=1"
             ).fetchone(), ("unknown", "delivery_unknown", 7))
             self.assertEqual(con.execute(
-                "SELECT reason, resolved_at FROM planner_alerts "
+                "SELECT alert_id, reason, resolved_at FROM planner_alerts "
                 "WHERE session_id=1"
-            ).fetchall(), [
-                ("crash_window_delivery_unknown", "2026-07-23 00:00:00")
-            ])
+            ).fetchall(), [first_alert])
             self.assertIsNone(con.execute(
                 "SELECT 1 FROM planner_alerts WHERE session_id=1 "
                 "AND resolved_at IS NULL"
@@ -97,6 +101,75 @@ class RebuildIntegrityTest(unittest.TestCase):
                 "SELECT 1 FROM planner_alerts WHERE alert_id=41"
             ).fetchone())
             con.close()
+
+    def test_rebuild_reconciles_open_ended_alert_loaded_after_migrations(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            outgoing = tmp / "shell_db.db"
+            snapshot = tmp / "content.sql"
+            apply_engine_schema(outgoing)
+            con = sqlite3.connect(outgoing)
+            con.execute(
+                "INSERT INTO users (user_id, username, is_active) "
+                "VALUES (1,'before',1)")
+            con.execute(
+                "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+                "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+                "VALUES (1,'Before','s1','test','sp',1,0,1,1)")
+            con.commit()
+            con.close()
+
+            snapshot.write_text(
+                "PRAGMA foreign_keys=OFF;\n"
+                "BEGIN;\n"
+                "DELETE FROM users;\n"
+                "INSERT INTO users (user_id, username, is_active) "
+                "VALUES (1,'after',1);\n"
+                "DELETE FROM shells;\n"
+                "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+                "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+                "VALUES (1,'After','s1','test','sp',1,0,1,1);\n"
+                "INSERT INTO interface_generations "
+                "(shell_id, generation, ended_at) "
+                "VALUES (1,1,'2026-07-20 00:00:00');\n"
+                "INSERT INTO interface_sessions "
+                "(session_id, shell_id, generation, occupancy, lifecycle, "
+                "ended_at) VALUES "
+                "(1,1,1,'ended','ended','2026-07-20 00:00:00');\n"
+                "INSERT INTO interface_input_state "
+                "(session_id, shell_id, generation, composer, delivery, "
+                "pending_seq) VALUES "
+                "(1,1,1,'unknown','delivery_unknown',7);\n"
+                "INSERT INTO planner_alerts "
+                "(alert_id, session_id, severity, reason, dedupe_key) "
+                "VALUES (42,1,'critical','crash_window_delivery_unknown',"
+                "'1|-|-|crash_window_delivery_unknown');\n"
+                "COMMIT;\n"
+                "PRAGMA foreign_keys=ON;\n"
+            )
+
+            with mock.patch.multiple(
+                rebuild,
+                ENGINE=tmp / ".super-coder",
+                DB_PATH=outgoing,
+                REPO_ROOT=tmp,
+                SNAPSHOT=snapshot,
+                SNAPSHOT_LEGACY=tmp / "missing-content.sql",
+            ), mock.patch.object(rebuild.map_repo, "main"):
+                self.assertEqual(rebuild.main(["--no-backup"]), 0)
+                self.assertEqual(rebuild.main(["--no-backup"]), 0)
+
+            con = sqlite3.connect(outgoing)
+            try:
+                alerts = con.execute(
+                    "SELECT alert_id, reason, resolved_at "
+                    "FROM planner_alerts WHERE session_id=1").fetchall()
+            finally:
+                con.close()
+            self.assertEqual(alerts, [
+                (42, "crash_window_delivery_unknown",
+                 "2026-07-20 00:00:00")
+            ])
 
     def test_valid_candidate_atomically_replaces_outgoing_db(self):
         with tempfile.TemporaryDirectory() as raw_tmp:

--- a/tests/test_rebuild_integrity.py
+++ b/tests/test_rebuild_integrity.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Candidate-DB integrity and outgoing-preservation tests for rebuild (#533)."""
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import rebuild  # noqa: E402
+
+
+def apply_engine_schema(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.commit()
+    con.execute("PRAGMA journal_mode=WAL").fetchone()
+    con.close()
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class RebuildIntegrityTest(unittest.TestCase):
+    def test_cleanup_migration_removes_orphans_and_terminal_volatile_state(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            db = Path(raw_tmp) / "shell_db.db"
+            apply_engine_schema(db)
+            con = sqlite3.connect(db)
+            con.execute(
+                "INSERT INTO users (user_id, username, is_active) "
+                "VALUES (1,'test',1)")
+            con.execute(
+                "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+                "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+                "VALUES (1,'S1','s1','test','sp',1,0,1,1)")
+            con.execute(
+                "INSERT INTO interface_generations "
+                "(shell_id, generation, ended_at) VALUES (1,1,datetime('now'))")
+            con.execute(
+                "INSERT INTO interface_sessions "
+                "(session_id, shell_id, generation, occupancy, lifecycle, ended_at) "
+                "VALUES (1,1,1,'ended','ended',datetime('now'))")
+            con.execute(
+                "INSERT INTO interface_input_state "
+                "(session_id, shell_id, generation, composer, pending_seq) "
+                "VALUES (1,1,1,'unknown',7)")
+            con.execute(
+                "INSERT INTO interface_writer_leases "
+                "(session_id, shell_id, generation, client_id, token_hash) "
+                "VALUES (1,1,1,'client','hash')")
+            con.execute(
+                "INSERT INTO planner_alerts "
+                "(alert_id, session_id, severity, reason, dedupe_key) "
+                "VALUES (41,999,'warning','legacy-orphan','orphan')")
+            con.commit()
+
+            con.executescript(
+                (MIGRATIONS / "0083_interface_integrity_cleanup.sql").read_text())
+            self.assertIsNone(con.execute(
+                "SELECT 1 FROM interface_input_state WHERE session_id=1"
+            ).fetchone())
+            revoked_at, reason = con.execute(
+                "SELECT revoked_at, revoke_reason FROM interface_writer_leases "
+                "WHERE session_id=1").fetchone()
+            self.assertIsNotNone(revoked_at)
+            self.assertEqual(reason, "session_end")
+            self.assertIsNone(con.execute(
+                "SELECT 1 FROM planner_alerts WHERE alert_id=41"
+            ).fetchone())
+            con.close()
+
+    def test_valid_candidate_atomically_replaces_outgoing_db(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            outgoing = tmp / "shell_db.db"
+            snapshot = tmp / "content.sql"
+            apply_engine_schema(outgoing)
+            con = sqlite3.connect(outgoing)
+            con.execute(
+                "INSERT INTO users (user_id, username, is_active) "
+                "VALUES (1,'before',1)")
+            con.execute(
+                "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+                "system_prompt, user_id, is_shared, has_identity, bootstrapped, "
+                "api_key) VALUES (1,'Before','s1','test','sp',1,0,1,1,'keep-key')")
+            con.commit()
+            con.close()
+
+            snapshot.write_text(
+                "PRAGMA foreign_keys=OFF;\n"
+                "BEGIN;\n"
+                "DELETE FROM users;\n"
+                "INSERT INTO users (user_id, username, is_active) "
+                "VALUES (1,'after',1);\n"
+                "DELETE FROM shells;\n"
+                "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+                "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+                "VALUES (1,'After','s1','test','sp',1,0,1,1);\n"
+                "COMMIT;\n"
+                "PRAGMA foreign_keys=ON;\n"
+            )
+
+            with mock.patch.multiple(
+                rebuild,
+                ENGINE=tmp / ".super-coder",
+                DB_PATH=outgoing,
+                REPO_ROOT=tmp,
+                SNAPSHOT=snapshot,
+                SNAPSHOT_LEGACY=tmp / "missing-content.sql",
+            ), mock.patch.object(rebuild.map_repo, "main"):
+                self.assertEqual(rebuild.main(["--no-backup"]), 0)
+
+            con = sqlite3.connect(outgoing)
+            try:
+                row = con.execute(
+                    "SELECT u.username, s.display_name, s.api_key "
+                    "FROM users u JOIN shells s ON s.user_id=u.user_id"
+                ).fetchone()
+            finally:
+                con.close()
+            self.assertEqual(row, ("after", "After", "keep-key"))
+            self.assertFalse(Path(str(outgoing) + ".rebuild").exists())
+
+    def test_orphan_snapshot_refuses_without_replacing_outgoing_db_or_backup(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            outgoing = tmp / "shell_db.db"
+            snapshot = tmp / "content.sql"
+            backups = tmp / "backups"
+            backups.mkdir()
+
+            apply_engine_schema(outgoing)
+            con = sqlite3.connect(outgoing)
+            con.execute(
+                "INSERT INTO planner_alerts "
+                "(alert_id, session_id, severity, reason, dedupe_key) "
+                "VALUES (41,999,'warning','legacy-orphan','orphan')")
+            con.commit()
+            con.close()
+            outgoing_before = digest(outgoing)
+
+            snapshot.write_text(
+                "PRAGMA foreign_keys=OFF;\n"
+                "BEGIN;\n"
+                "DELETE FROM planner_alerts;\n"
+                "INSERT INTO planner_alerts "
+                "(alert_id, session_id, severity, reason, dedupe_key) "
+                "VALUES (41,999,'warning','legacy-orphan','orphan');\n"
+                "COMMIT;\n"
+                "PRAGMA foreign_keys=ON;\n"
+            )
+
+            with mock.patch.multiple(
+                rebuild,
+                DB_PATH=outgoing,
+                REPO_ROOT=tmp,
+                SNAPSHOT=snapshot,
+                SNAPSHOT_LEGACY=tmp / "missing-content.sql",
+            ), mock.patch.object(
+                rebuild, "backup_dir", return_value=backups
+            ), mock.patch.object(rebuild.map_repo, "main"):
+                with self.assertRaises(SystemExit) as ctx:
+                    rebuild.main([])
+
+            message = str(ctx.exception)
+            self.assertIn("foreign-key check failed", message)
+            self.assertIn("table planner_alerts row 41", message)
+            self.assertEqual(digest(outgoing), outgoing_before)
+            self.assertFalse(Path(str(outgoing) + ".rebuild").exists())
+
+            backup_files = list(backups.glob("shell_db.prerebuild.*.db"))
+            self.assertEqual(len(backup_files), 1)
+            backup = sqlite3.connect(backup_files[0])
+            try:
+                row = backup.execute(
+                    "SELECT session_id, reason FROM planner_alerts "
+                    "WHERE alert_id=41").fetchone()
+            finally:
+                backup.close()
+            self.assertEqual(row, (999, "legacy-orphan"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_preflight.py
+++ b/tests/test_update_preflight.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Mutation sentinel for update's installed live-state preflight (#528)."""
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import update  # noqa: E402
+
+
+def fingerprint(paths: list[Path]) -> dict[str, tuple[int, int, str | None]]:
+    out = {}
+    for path in paths:
+        stat = path.stat()
+        digest = None
+        if path.is_file():
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        out[str(path)] = (stat.st_mtime_ns, stat.st_size, digest)
+    return out
+
+
+class UpdatePreflightSentinelTest(unittest.TestCase):
+    def test_live_refusal_precedes_every_installed_floor_mutation(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            root = Path(raw_tmp)
+            engine = root / ".super-coder"
+            state = root / ".sc-state"
+            workflow = root / ".github" / "workflows"
+            engine.mkdir()
+            state.mkdir()
+            workflow.mkdir(parents=True)
+
+            paths = [
+                root / "sc",
+                engine,
+                engine / "schema.sql",
+                engine / "scripts",
+                engine / "scripts" / "update.py",
+                workflow,
+                workflow / "subfloor-visual-qa.yml",
+                root / ".gitignore",
+                state / "engine.ref.prev",
+                state / "engine.ref",
+            ]
+            for path in paths:
+                if path.suffix == "" and path.name in {"scripts"}:
+                    path.mkdir()
+                elif path in {engine, workflow}:
+                    continue
+                else:
+                    path.write_text(f"sentinel:{path.name}\n")
+
+            before = fingerprint(paths)
+            with mock.patch.multiple(
+                update,
+                REPO_ROOT=root,
+                ENGINE=engine,
+                DB_PATH=engine / "shell_db.db",
+                STATE_DIR=state,
+                ENGINE_REF=state / "engine.ref",
+                ENGINE_REF_PREV=state / "engine.ref.prev",
+                EJECTED_MARKER=state / "ejected",
+            ), mock.patch.object(
+                update, "is_source_repo", return_value=False
+            ), mock.patch.object(
+                update, "fetch_update_ref", return_value="a" * 40
+            ) as fetch, mock.patch.object(
+                update.interface_reconcile,
+                "live_refusal_reasons",
+                return_value=["interface session 7 is occupied"],
+            ), mock.patch.object(
+                update, "migrate_engine_untrack"
+            ) as untrack, mock.patch.object(
+                update.install_mod, "ensure_gitignore"
+            ) as gitignore, mock.patch.object(
+                update, "materialize_fetched_engine"
+            ) as materialize, mock.patch.object(
+                update, "ensure_workflows"
+            ) as workflows:
+                with self.assertRaises(SystemExit) as ctx:
+                    update.main([])
+
+            self.assertIn("refusing", str(ctx.exception))
+            fetch.assert_called_once()
+            untrack.assert_not_called()
+            gitignore.assert_not_called()
+            materialize.assert_not_called()
+            workflows.assert_not_called()
+            self.assertEqual(
+                fingerprint(paths),
+                before,
+                "update refusal changed installed hashes or mtimes",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- run the installed live-state guard before update mutates engine files, workflows, ignore rules, or pin files
- share one active-session definition across closure and refusal, removing terminal volatile input state
- serialize only referentially closed Interface audit rows and clean legacy orphan alerts
- build and foreign-key-check rebuild candidates before atomic replacement

## Verification
- ./sc test: 907 passed, 8 skipped
- Interface/update/snapshot regression: 327 passed, 8 skipped, 21 subtests
- post-rebase focused integrity suite: 45 passed
- ruff and git diff --check: green

## Notes
- One unrelated bounded-buffer spike timed out in the first full run after pumping the complete corpus; its isolated rerun passed immediately and the full rerun passed.
- Rebuild uses a same-directory candidate so the final replacement stays atomic; candidate artifacts are gitignored and removed on failure.

Refs #528 #529 #533