### PR TITLE
feat(interface): unified stranded-shell recovery — preview/execute API + CLI (sprint 31 unit 8)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -50,6 +50,7 @@ sys.path.insert(0, str(ENGINE / "api"))
 import db_driver  # noqa: E402
 import interface_broker  # noqa: E402
 import interface_hooks  # noqa: E402
+import interface_recovery  # noqa: E402
 import interface_state  # noqa: E402
 import interface_wake  # noqa: E402
 import ports as ports_mod  # noqa: E402
@@ -972,6 +973,62 @@ def _reconcile(actor, headers, body):
         con.close()
 
 
+# ------------------------------------------------------------------ recovery
+
+def _recovery_worktree(con, shell_id: int) -> "str | None":
+    """The shell's conventional worktree (advisory git facts / discard
+    target). None when it doesn't exist — never invented."""
+    row = con.execute("SELECT shortname, flavor FROM shells WHERE shell_id=?",
+                      (shell_id,)).fetchone()
+    if row is None:
+        return None
+    try:
+        path = _worktree_for(row[0], row[1])
+    except Exception:
+        return None
+    return path if os.path.isdir(path) else None
+
+
+def _get_recovery(shell_id: int):
+    """Preview (spec #30 Shell Recovery): the server derives ONE
+    classification + the legal actions and stores them as a fingerprinted
+    observation; the client renders, never infers."""
+    con = _db()
+    try:
+        payload = interface_recovery.preview(
+            con, shell_id, _recovery_worktree(con, shell_id))
+        return _json(200, payload)
+    except interface_recovery.RecoveryError as exc:
+        return _err(exc.status, exc.code, exc.message, exc.details)
+    finally:
+        con.close()
+
+
+def _post_recovery(actor, headers, body, shell_id: int):
+    """Execute against a fresh observation. Idempotency-Key discipline as
+    every Interface mutation; a stale observation or changed durable state
+    refuses with 409 recovery_observation_stale."""
+    con = _db()
+    try:
+        def produce():
+            try:
+                payload = interface_recovery.execute(
+                    con, shell_id, body,
+                    _recovery_worktree(con, shell_id),
+                    abandon=(lambda sid: _runtime.call(_runtime.abandon(sid)))
+                    if _runtime is not None and _runtime.available else None)
+            except interface_recovery.RecoveryError as exc:
+                con.commit()
+                return exc.status, {"error": {"code": exc.code,
+                                              "message": exc.message,
+                                              "details": exc.details}}
+            return 200, payload
+        return _idempotent(con, actor, "shell_recovery", headers, body,
+                           produce)
+    finally:
+        con.close()
+
+
 # ------------------------------------------------------------------ hooks
 
 # ------------------------------------------------------------------ sprint wake
@@ -1703,6 +1760,10 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
     u = urlparse(path)
     p = u.path
     query = parse_qs(u.query)
+    # The spec's canonical recovery prefix (spec #30 Shell Recovery) —
+    # identical authority and handlers as /api/interface/*.
+    if p.startswith("/_sc/interface/"):
+        p = "/api/interface/" + p[len("/_sc/interface/"):]
     try:
         data = json.loads(body) if body else {}
     except ValueError:
@@ -1741,6 +1802,11 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
     try:
         if p == "/api/interface/shells" and method == "GET":
             return _list_shells()
+        if p.startswith("/api/interface/shells/") and p.endswith("/recovery"):
+            if method == "GET":
+                return _get_recovery(_path_id(p, -2))
+            if method == "POST":
+                return _post_recovery(actor, headers, data, _path_id(p, -2))
         if p == "/api/interface/sessions" and method == "POST":
             return _create_session(actor, headers, data)
         if p.startswith("/api/interface/sessions/") and method == "GET":

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2655,6 +2655,7 @@ def dispatch_http(method: str, path: str, headers_raw: str,
     interface module; everything else runs through the shimmed Handler."""
     parsed = urlparse(path)
     if parsed.path.startswith("/api/interface/") or \
+            parsed.path.startswith("/_sc/interface/") or \
             parsed.path.startswith("/api/planner-action-receipts"):
         if interface_routes is None:
             return (503, [("Content-Type", "application/json")],

--- a/.super-coder/migrations/0083_interface_recovery.sql
+++ b/.super-coder/migrations/0083_interface_recovery.sql
@@ -1,0 +1,28 @@
+-- 0083 — Unified stranded-shell recovery (sprint 31 unit 8, spec #30 req 24
+-- / task #95; absorbs roadmap #22 and flag #38).
+--
+-- Recovery is preview-then-execute: the preview stores one observation row
+-- holding the server-derived classification, the full evidence payload, and
+-- a fingerprint of the durable state that justified them. Execution must
+-- name the observation; any change to the fingerprinted state (pane exit,
+-- PID reuse, a concurrent recovery, a new generation) mismatches the
+-- fingerprint and the request refuses with 409 recovery_observation_stale —
+-- the client previews again. Rows are short-lived (TTL enforced in app
+-- code); the table is an audit trail of what was observed and acted on.
+
+CREATE TABLE IF NOT EXISTS interface_recovery_observations (
+    observation_id  TEXT PRIMARY KEY,        -- opaque (uuid4 hex)
+    shell_id        INTEGER NOT NULL REFERENCES shells(shell_id),
+    classification  TEXT NOT NULL
+                    CHECK (classification IN
+                        ('available','stale_durable_lock','exact_idle_orphan',
+                         'verified_live','indeterminate')),
+    legal_actions   TEXT NOT NULL,           -- JSON array of action names
+    evidence        TEXT NOT NULL,           -- JSON payload shown to clients
+    fingerprint     TEXT NOT NULL,           -- sha256 of the durable state
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at      TEXT NOT NULL,
+    acted_at        TEXT                     -- set by a successful execution
+);
+CREATE INDEX IF NOT EXISTS idx_recovery_obs_shell
+    ON interface_recovery_observations(shell_id, created_at);

--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -582,6 +582,132 @@ def cmd_reconcile(args) -> int:
     return 0
 
 
+# ------------------------------------------------------------------ recover
+
+def _confirm(prompt: str, yes: bool) -> None:
+    """A scoped interactive confirmation; --yes pre-answers it. Never
+    prompt on a non-terminal — refuse instead (the eject.py convention)."""
+    if yes:
+        return
+    if not sys.stdin.isatty():
+        die("confirmation required on a terminal — re-run with --yes to "
+            "pre-confirm", EXIT_REFUSED)
+    if input(f"{prompt} [y/N] ").strip().lower() not in ("y", "yes"):
+        die("aborted by operator", EXIT_REFUSED)
+
+
+def _print_recovery_preview(preview: dict) -> None:
+    ev = preview["evidence"]
+    print(f"→ classification: {preview['classification']} "
+          f"(legal actions: {', '.join(preview['legal_actions']) or 'none'})")
+    sess = ev.get("session")
+    if sess:
+        print(f"  session {sess['session_id']} gen {sess['generation']}: "
+              f"{sess['occupancy']}/{sess['lifecycle']} "
+              f"({sess.get('harness') or '?'})")
+    proc = ev.get("process") or {}
+    if proc.get("pane_pid"):
+        print(f"  process: pid {proc['pane_pid']} "
+              f"ticks {proc['pane_start_ticks']} "
+              f"pgid {proc.get('pgid')} — {proc['pid_state']}"
+              + ("" if proc.get("pane_present") is None else
+                 f", pane {'present' if proc['pane_present'] else 'gone'}"))
+    archive = ev.get("archive")
+    if archive:
+        print(f"  archive {archive['archive_id']}: "
+              f"{'open' if archive['ended_at'] is None else 'closed'}"
+              + (" (active)" if archive.get("active") else ""))
+    if ev.get("sprint_binding"):
+        print(f"  sprint binding {ev['sprint_binding']['binding_id']} armed")
+    print(f"  unread messages: {ev['unread_messages']} (left unread)")
+    git = ev.get("git")
+    if git:
+        print(f"  worktree {git['worktree']}: branch {git['branch']}, "
+              f"{git['dirty_tracked']} dirty tracked, {git['untracked']} "
+              f"untracked, {git['unpushed_commits']} unpushed commit(s)")
+
+
+def cmd_recover(args) -> int:
+    shell = _find_shell(args.shell)
+    shell_id = shell["shell_id"]
+    shortname = shell.get("shortname")
+    try:
+        preview = api("GET", f"/api/interface/shells/{shell_id}/recovery")
+    except ApiError as exc:
+        _print_api_error(exc)
+        raise SystemExit(EXIT_REFUSED) from exc
+
+    classification = preview["classification"]
+    legal = preview["legal_actions"]
+    if not args.json:
+        _print_recovery_preview(preview)
+
+    mode = "force" if args.force else "recover"
+    if mode not in legal:
+        if args.json:
+            _print_json({"preview": preview, "result": None})
+        if classification == "available":
+            print(f"→ {shortname} is available — nothing to recover")
+            return 0
+        print(f"→ {classification.replace('_', ' ')} — no automatic action; "
+              "investigate the evidence above", file=sys.stderr)
+        return EXIT_REFUSED
+
+    body = {"observation_id": preview["observation_id"], "mode": mode,
+            "preserve_worktree": not args.discard_worktree}
+    if mode == "force":
+        proc = preview["evidence"]["process"]
+        _confirm(
+            f"Force recover {shortname}: SIGTERM the exact process group of "
+            f"pid {proc.get('pane_pid')} (ticks "
+            f"{proc.get('pane_start_ticks')}, pgid {proc.get('pgid')}), "
+            "SIGKILL after the bounded grace if it persists?",
+            args.yes)
+        body["confirm_force"] = True
+    if args.discard_worktree:
+        if not args.yes:
+            _confirm(
+                f"Discard ALL tracked and untracked file changes in "
+                f"{shortname}'s worktree (unpushed commits refuse)?",
+                False)
+        body["discard_worktree"] = True
+        body["confirm_shortname"] = shortname
+    try:
+        result = api("POST", f"/api/interface/shells/{shell_id}/recovery",
+                     body)
+    except ApiError as exc:
+        _print_api_error(exc)
+        if exc.code == "recovery_observation_stale":
+            print("  state changed since the preview — re-run to preview "
+                  "again", file=sys.stderr)
+        raise SystemExit(EXIT_REFUSED) from exc
+    if args.json:
+        _print_json({"preview": preview, "result": result})
+        return 0
+    sig = result.get("signaled")
+    if sig and sig.get("signaled"):
+        print(f"→ signaled pid {sig['pid']} (pgid {sig.get('pgid')}"
+              f"{', escalated to SIGKILL' if sig.get('escalated') else ''})")
+    closed = result.get("closed") or {}
+    if closed.get("session"):
+        print(f"→ session {closed['session']['session_id']} ended "
+              f"({closed['session']['end_reason']})")
+    if closed.get("archive"):
+        print(f"→ archive {closed['archive']['archive_id']} closed")
+    if closed.get("binding"):
+        print(f"→ sprint binding {closed['binding']['binding_id']} released")
+    for parked in closed.get("parked", []):
+        print(f"→ parked ambiguous binding {parked['binding_id']}: "
+              f"{parked['next_action']}")
+    wt = result.get("worktree") or {}
+    if wt.get("discarded"):
+        print(f"→ worktree {wt['worktree']} changes discarded")
+    else:
+        print("→ worktree preserved")
+    print(f"→ {shortname} is {result.get('availability')}")
+    return 0
+
+
 # ------------------------------------------------------------------ enter
 
 def _flavor_harness(shell: dict) -> str | None:
@@ -739,6 +865,18 @@ def build_parser() -> argparse.ArgumentParser:
                     help="end an unreconciled session after proved absence")
     sp.add_argument("--json", action="store_true")
     sp.set_defaults(fn=cmd_reconcile)
+
+    sp = sub.add_parser("recover", help="preview + execute shell recovery")
+    sp.add_argument("shell")
+    sp.add_argument("--force", action="store_true",
+                    help="terminate a verified-live exact process identity")
+    sp.add_argument("--discard-worktree", action="store_true",
+                    help="also discard tracked/untracked worktree changes "
+                         "(refuses unpushed commits; never implied)")
+    sp.add_argument("--yes", action="store_true",
+                    help="pre-answer the scoped confirmations")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(fn=cmd_recover)
 
     sp = sub.add_parser("enter", help="the `sc enter` flow (in-container)")
     sp.add_argument("shell", nargs="?")

--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -702,6 +702,12 @@ def cmd_recover(args) -> int:
     wt = result.get("worktree") or {}
     if wt.get("discarded"):
         print(f"→ worktree {wt['worktree']} changes discarded")
+    elif wt.get("failed"):
+        done = ", ".join(wt.get("completed") or []) or "nothing"
+        print(f"→ worktree discard INCOMPLETE in {wt['worktree']}: completed "
+              f"[{done}], failed at {wt['failed']['step']} "
+              f"({wt['failed'].get('error', 'unknown error')}) — the closure "
+              "is committed; finish the discard by hand", file=sys.stderr)
     else:
         print("→ worktree preserved")
     print(f"→ {shortname} is {result.get('availability')}")

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""Unified stranded-shell recovery (spec #30 req 24 / task #95).
+
+One API-owned preview/execute workflow shared by browser and CLI:
+
+- **Preview** gathers the durable + process evidence for one shell, derives
+  ONE server-side classification (available / stale durable lock / exact idle
+  orphan / verified live / indeterminate) and the legal actions, and stores
+  them as an opaque observation row fingerprinted against the durable state.
+  The client never infers safety from raw fields.
+- **Execute** requires a fresh observation: any change to the fingerprinted
+  durable state (pane exit surfaced durably, a concurrent recovery, a new
+  generation) refuses with 409 recovery_observation_stale. Process identity
+  is ALWAYS re-verified at signal time (PID + /proc start ticks) — a PID
+  reuse or unreadable /proc between preview and execute performs no signal
+  and returns an indeterminate result.
+
+Signaling discipline (spec Shell Recovery): SIGTERM to the exact verified
+process group, the bounded existing grace period, SIGKILL only while the
+same PID/start ticks still identify the process. Never a broad match.
+
+Closure discipline: on proven absence ONE transaction ends the Interface
+session + generation (via interface_broker.close_session), closes the
+matching archive, clears shells.active_archive_id only while it still
+points there, resolves session alerts, and releases only generation-bound
+sprint bindings (unambiguous ownership); ambiguous wake/binding state is
+parked with a named next action. Unread inbox messages stay unread.
+
+Worktree discipline: files are preserved by default. discard_worktree is an
+independently confirmed escalation (typed shell shortname) that refuses
+when unpushed commits exist and never deletes the worktree or branch.
+
+This module is stdlib-only: recovery must work HTTP-only, without the
+websockets-dependent Interface runtime (spec Restricted Admin).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import signal
+import subprocess
+import time
+
+import interface_broker
+from interface_runtime import GRACEFUL_TERMINATE_S
+
+OBSERVATION_TTL_S = 120
+
+CLASSIFICATIONS = ("available", "stale_durable_lock", "exact_idle_orphan",
+                   "verified_live", "indeterminate")
+
+
+class RecoveryError(Exception):
+    """A refusal the routes layer maps straight to an HTTP error."""
+
+    def __init__(self, status: int, code: str, message: str, details=None):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+        self.details = details or {}
+
+
+# ------------------------------------------------------------------ processes
+
+def _read_stat(pid: int) -> tuple[int, str]:
+    """(start_ticks, state) from /proc/<pid>/stat. FileNotFoundError means
+    the pid is gone; PermissionError etc. mean present-but-unreadable —
+    callers distinguish 'dead' from 'unknown'."""
+    with open(f"/proc/{pid}/stat") as fh:
+        text = fh.read()
+    rest = text[text.rindex(")") + 2:]
+    fields = rest.split()
+    return int(fields[19]), fields[0]  # field 22 starttime, field 3 state
+
+
+def _proc_state(pid: int, start_ticks: int) -> str:
+    """Exact-identity liveness: 'alive' (pid present, ticks match, not a
+    zombie), 'dead' (pid gone, recycled, or reaped), 'unreadable' (present
+    but /proc refuses us — fail closed, never 'dead')."""
+    try:
+        ticks, state = _read_stat(pid)
+    except FileNotFoundError:
+        return "dead"
+    except (PermissionError, ProcessLookupError):
+        return "unreadable"
+    except OSError:
+        return "unreadable"
+    if ticks != start_ticks:
+        return "dead"  # recycled pid: a different process, not ours
+    if state == "Z":
+        return "dead"
+    return "alive"
+
+
+def _pane_present(sock: str | None, pane_id: str) -> bool | None:
+    """Is the exact pane in the session's own tmux server? None when tmux
+    can't answer (binary missing, socket unreachable) — unknown is not
+    gone."""
+    if not sock:
+        return None
+    try:
+        out = subprocess.run(
+            ["tmux", "-S", sock, "display-message", "-p", "-t", pane_id,
+             "#{pane_id} #{pane_pid}"],
+            capture_output=True, text=True, timeout=10, check=False)
+    except Exception:  # noqa: BLE001 — any tmux failure means "unknown"
+        return None
+    if out.returncode != 0:
+        return None  # server unreachable — unknown, NOT proof of absence
+    try:
+        got_pane, _got_pid = out.stdout.split()
+    except ValueError:
+        return None
+    return got_pane == pane_id
+
+
+def terminate_process_group(pid: int, start_ticks: int,
+                            grace_s: float = GRACEFUL_TERMINATE_S) -> dict:
+    """SIGTERM the exact verified process group, bounded grace, SIGKILL only
+    while the same PID/start ticks still identify the process. Identity
+    mismatch or unreadable state performs NO signal and reports
+    indeterminate — the caller maps that to a refusal, never a closure."""
+    state = _proc_state(pid, start_ticks)
+    if state != "alive":
+        return {"signaled": False, "reason": "indeterminate",
+                "detail": f"process state {state} at signal time"}
+    try:
+        pgid = os.getpgid(pid)
+    except OSError:
+        return {"signaled": False, "reason": "indeterminate",
+                "detail": "process group unreadable at signal time"}
+    os.killpg(pgid, signal.SIGTERM)
+    deadline = time.monotonic() + grace_s
+    while time.monotonic() < deadline:
+        if _proc_state(pid, start_ticks) != "alive":
+            return {"signaled": True, "escalated": False, "pid": pid,
+                    "pgid": pgid}
+        time.sleep(0.1)
+    # Grace expired. Re-verify the EXACT identity before SIGKILL — the window
+    # is long enough for exit + PID reuse, and the rule is never signal an
+    # uncertain process.
+    if _proc_state(pid, start_ticks) != "alive":
+        return {"signaled": True, "escalated": False, "pid": pid,
+                "pgid": pgid,
+                "note": "identity changed during grace — no SIGKILL sent"}
+    try:
+        pgid = os.getpgid(pid)
+    except OSError:
+        return {"signaled": True, "escalated": False, "pid": pid,
+                "note": "process exited during grace — no SIGKILL sent"}
+    os.killpg(pgid, signal.SIGKILL)
+    deadline = time.monotonic() + grace_s
+    while time.monotonic() < deadline:
+        if _proc_state(pid, start_ticks) != "alive":
+            break
+        time.sleep(0.1)
+    return {"signaled": True, "escalated": True, "pid": pid, "pgid": pgid}
+
+
+# ------------------------------------------------------------------ git facts
+
+def _git_facts(worktree: str | None) -> dict | None:
+    """Advisory worktree facts. None on any failure — the preview stays
+    truthful ('no facts') rather than guessing. The discard path re-checks
+    unpushed commits itself and fails CLOSED."""
+    if not worktree:
+        return None
+    dotgit = os.path.join(worktree, ".git")
+    if not (os.path.isdir(dotgit) or os.path.isfile(dotgit)):
+        return None
+    try:
+        def git(*args) -> str:
+            return subprocess.run(
+                ["git", "-C", worktree, *args], capture_output=True,
+                text=True, timeout=15, check=True).stdout.strip()
+
+        branch = git("rev-parse", "--abbrev-ref", "HEAD")
+        porcelain = subprocess.run(
+            ["git", "-C", worktree, "status", "--porcelain"],
+            capture_output=True, text=True, timeout=15,
+            check=True).stdout.splitlines()
+        untracked = sum(1 for ln in porcelain if ln.startswith("??"))
+        dirty = len(porcelain) - untracked
+        unpushed = int(git("rev-list", "HEAD", "--not", "--remotes",
+                           "--count") or 0)
+        return {"worktree": worktree, "branch": branch,
+                "dirty_tracked": dirty, "untracked": untracked,
+                "unpushed_commits": unpushed}
+    except Exception:  # noqa: BLE001 — advisory facts degrade to "none"
+        return None
+
+
+def _unpushed_count(worktree: str) -> int:
+    """The discard gate — exact and fail-closed: any error is a refusal,
+    never an assumption of clean."""
+    out = subprocess.run(
+        ["git", "-C", worktree, "rev-list", "HEAD", "--not", "--remotes",
+         "--count"], capture_output=True, text=True, timeout=15, check=False)
+    if out.returncode != 0:
+        raise RecoveryError(
+            409, "worktree_state_unknown",
+            f"cannot enumerate unpushed commits in {worktree} — discard "
+            "refused (fail closed)",
+            {"stderr": out.stderr.strip()[-200:]})
+    return int(out.stdout.strip() or 0)
+
+
+def _discard_worktree_files(worktree: str) -> dict:
+    """Remove tracked + untracked file changes in the exact worktree. Never
+    deletes the worktree, its branch, or ignored files."""
+    subprocess.run(["git", "-C", worktree, "reset", "--hard", "HEAD"],
+                   capture_output=True, text=True, timeout=60, check=True)
+    subprocess.run(["git", "-C", worktree, "clean", "-fd"],
+                   capture_output=True, text=True, timeout=60, check=True)
+    return {"worktree": worktree, "discarded": True}
+
+
+# ------------------------------------------------------------------ evidence
+
+def _shell(con, shell_id: int):
+    row = con.execute(
+        "SELECT shell_id, shortname, active_archive_id, is_deleted "
+        "FROM shells WHERE shell_id=?", (shell_id,)).fetchone()
+    if row is None:
+        raise RecoveryError(404, "no_such_shell",
+                            f"shell {shell_id} not found")
+    return row
+
+
+def _live_session(con, shell_id: int):
+    return con.execute(
+        "SELECT session_id, generation, occupancy, lifecycle, harness, "
+        " worktree, archive_id, tmux_socket, tmux_session, tmux_window, "
+        " tmux_pane_id, pane_pid, pane_start_ticks, created_at "
+        "FROM interface_sessions "
+        "WHERE shell_id=? AND occupancy <> 'ended' "
+        "ORDER BY session_id DESC LIMIT 1", (shell_id,)).fetchone()
+
+
+def _last_session(con, shell_id: int):
+    return con.execute(
+        "SELECT session_id, generation, occupancy, lifecycle, harness, "
+        " worktree, archive_id, tmux_socket, tmux_session, tmux_window, "
+        " tmux_pane_id, pane_pid, pane_start_ticks, created_at "
+        "FROM interface_sessions WHERE shell_id=? "
+        "ORDER BY session_id DESC LIMIT 1", (shell_id,)).fetchone()
+
+
+_SESSION_COLS = ("session_id", "generation", "occupancy", "lifecycle",
+                 "harness", "worktree", "archive_id", "tmux_socket",
+                 "tmux_session", "tmux_window", "tmux_pane_id", "pane_pid",
+                 "pane_start_ticks", "created_at")
+
+
+def gather(con, shell_id: int, default_worktree: str | None) -> dict:
+    """Assemble the full evidence picture. Pure read — never mutates, never
+    signals. Secrets and terminal content are never included."""
+    shell_id, shortname, active_archive_id, _deleted = _shell(con, shell_id)
+    live = _live_session(con, shell_id)
+    sess_row = live or _last_session(con, shell_id)
+    sess = dict(zip(_SESSION_COLS, sess_row)) if sess_row else None
+
+    process: dict = {"pane_id": None, "pane_pid": None,
+                     "pane_start_ticks": None, "pane_present": None,
+                     "pid_state": "none", "pgid": None}
+    if sess and sess["pane_pid"] is not None \
+            and sess["pane_start_ticks"] is not None:
+        pid, ticks = sess["pane_pid"], sess["pane_start_ticks"]
+        process.update({
+            "pane_id": sess["tmux_pane_id"], "pane_pid": pid,
+            "pane_start_ticks": ticks,
+            "pid_state": _proc_state(pid, ticks)})
+        if sess["tmux_pane_id"]:
+            process["pane_present"] = _pane_present(sess["tmux_socket"],
+                                                    sess["tmux_pane_id"])
+        if process["pid_state"] == "alive":
+            try:
+                process["pgid"] = os.getpgid(pid)
+            except OSError:
+                process["pgid"] = None
+
+    generation = None
+    if sess:
+        grow = con.execute(
+            "SELECT generation, ended_at, last_hook_seq "
+            "FROM interface_generations WHERE shell_id=? AND generation=?",
+            (shell_id, sess["generation"])).fetchone()
+        if grow:
+            generation = {"generation": grow[0], "ended_at": grow[1],
+                          "last_hook_seq": grow[2]}
+
+    archive = None
+    archive_id = (sess or {}).get("archive_id") or active_archive_id
+    if archive_id is not None:
+        arow = con.execute(
+            "SELECT archive_id, ended_at FROM shell_memory_archives "
+            "WHERE archive_id=?", (archive_id,)).fetchone()
+        if arow:
+            archive = {"archive_id": arow[0], "ended_at": arow[1],
+                       "active": active_archive_id == arow[0]}
+
+    binding = None
+    if sess:
+        brow = con.execute(
+            "SELECT binding_id, sprint_doc_id FROM sprint_planner_bindings "
+            "WHERE shell_id=? AND generation=? AND released_at IS NULL",
+            (shell_id, sess["generation"])).fetchone()
+        if brow:
+            binding = {"binding_id": brow[0], "sprint_doc_id": brow[1]}
+
+    unread = con.execute(
+        "SELECT COUNT(*) FROM shell_messages "
+        "WHERE to_shell_id=? AND read_at IS NULL", (shell_id,)).fetchone()[0]
+
+    worktree = (sess or {}).get("worktree") or default_worktree
+    evidence = {
+        "shell": {"shell_id": shell_id, "shortname": shortname,
+                  "active_archive_id": active_archive_id},
+        "session": ({k: sess[k] for k in
+                     ("session_id", "generation", "occupancy", "lifecycle",
+                      "harness", "worktree", "archive_id", "created_at")}
+                    if sess else None),
+        "generation": generation,
+        "archive": archive,
+        "sprint_binding": binding,
+        "process": process,
+        "tmux": ({"socket": sess["tmux_socket"],
+                  "session": sess["tmux_session"],
+                  "window": sess["tmux_window"],
+                  "pane_id": sess["tmux_pane_id"]} if sess else None),
+        "unread_messages": unread,
+        "git": _git_facts(worktree),
+    }
+    evidence["live_session"] = live is not None
+    return evidence
+
+
+def classify(evidence: dict) -> tuple[str, list[str]]:
+    """The ONE server-side verdict. Clients render it; they never derive
+    their own."""
+    proc = evidence["process"]
+    pid_state = proc["pid_state"]
+    pane = proc["pane_present"]
+
+    if evidence["live_session"]:
+        if pid_state == "none":
+            # No process identity was ever recorded (a reservation that
+            # never spawned, or a legacy row): nothing live to disprove the
+            # lock — safe to close.
+            return "stale_durable_lock", ["recover"]
+        if pid_state == "unreadable" or pane is None:
+            return "indeterminate", []
+        if pane and pid_state == "alive":
+            return "verified_live", ["force"]
+        if not pane and pid_state == "alive":
+            # The pane is gone from our tmux server but the exact process
+            # lives on — a leaked orphan, exactly identified.
+            return "exact_idle_orphan", ["recover"]
+        if not pane and pid_state == "dead":
+            return "stale_durable_lock", ["recover"]
+        # pane present but its pid/ticks no longer match the record —
+        # something else owns that pane now.
+        return "indeterminate", []
+
+    # No live session: a residual exact process from the last generation is
+    # an orphan; an open active archive is a stale lock; otherwise the shell
+    # is simply available.
+    if pid_state == "alive":
+        return "exact_idle_orphan", ["recover"]
+    if pid_state == "unreadable":
+        return "indeterminate", []
+    archive = evidence["archive"]
+    if archive and archive["active"] and archive["ended_at"] is None:
+        return "stale_durable_lock", ["recover"]
+    return "available", []
+
+
+def _fingerprint(con, shell_id: int) -> str:
+    """sha256 over the durable state an observation depends on. Any change —
+    closure, a new generation, a binding release, an archive hand-off —
+    invalidates every outstanding observation."""
+    parts = []
+    live = _live_session(con, shell_id)
+    parts.append(json.dumps(list(live) if live is not None else None,
+                            default=str))
+    row = con.execute(
+        "SELECT active_archive_id FROM shells WHERE shell_id=?",
+        (shell_id,)).fetchone()
+    parts.append(str(row[0] if row else None))
+    rows = con.execute(
+        "SELECT binding_id FROM sprint_planner_bindings "
+        "WHERE shell_id=? AND released_at IS NULL ORDER BY binding_id",
+        (shell_id,)).fetchall()
+    parts.append(json.dumps([r[0] for r in rows]))
+    rows = con.execute(
+        "SELECT archive_id FROM shell_memory_archives "
+        "WHERE shell_id=? AND ended_at IS NULL ORDER BY archive_id",
+        (shell_id,)).fetchall()
+    parts.append(json.dumps([r[0] for r in rows]))
+    return hashlib.sha256("|".join(parts).encode()).hexdigest()
+
+
+# ------------------------------------------------------------------ preview
+
+def preview(con, shell_id: int, default_worktree: str | None) -> dict:
+    """Build the evidence, classify, store the observation, return the
+    client payload. Read-only against every non-observation table."""
+    evidence = gather(con, shell_id, default_worktree)
+    classification, legal_actions = classify(evidence)
+    observation_id = secrets.token_hex(16)
+    con.execute(
+        "DELETE FROM interface_recovery_observations "
+        "WHERE shell_id=? AND expires_at < datetime('now')", (shell_id,))
+    con.execute(
+        "INSERT INTO interface_recovery_observations "
+        "(observation_id, shell_id, classification, legal_actions, evidence,"
+        " fingerprint, expires_at) "
+        "VALUES (?,?,?,?,?,?, datetime('now', ?))",
+        (observation_id, shell_id, classification, json.dumps(legal_actions),
+         json.dumps(evidence, default=str), _fingerprint(con, shell_id),
+         f"+{OBSERVATION_TTL_S} seconds"))
+    con.commit()
+    return {"observation_id": observation_id,
+            "expires_in_s": OBSERVATION_TTL_S,
+            "classification": classification,
+            "legal_actions": legal_actions,
+            "evidence": evidence}
+
+
+# ------------------------------------------------------------------ execute
+
+def _load_observation(con, shell_id: int, observation_id: str):
+    row = con.execute(
+        "SELECT classification, legal_actions, evidence, fingerprint, "
+        " expires_at, acted_at FROM interface_recovery_observations "
+        "WHERE observation_id=? AND shell_id=?",
+        (observation_id, shell_id)).fetchone()
+    if row is None:
+        raise RecoveryError(404, "no_such_observation",
+                            f"recovery observation {observation_id} not "
+                            f"found for shell {shell_id}")
+    classification, legal_actions, evidence, fingerprint, expires_at, \
+        acted_at = row
+    now = con.execute("SELECT datetime('now')").fetchone()[0]
+    if expires_at < now:
+        raise RecoveryError(
+            409, "recovery_observation_stale",
+            "the observation has expired — preview again",
+            {"observation_id": observation_id})
+    if fingerprint != _fingerprint(con, shell_id):
+        raise RecoveryError(
+            409, "recovery_observation_stale",
+            "the shell's durable state changed since the preview — preview "
+            "again", {"observation_id": observation_id})
+    return classification, json.loads(legal_actions), \
+        json.loads(evidence), acted_at
+
+
+def _close_durable_state(con, shell_id: int, evidence: dict,
+                         end_reason: str) -> dict:
+    """The atomic closure (caller's transaction): session+generation+leases+
+    input/wake parking via the ONE closure helper, then the archive, the
+    alerts, and the generation-bound sprint binding. Ambiguous leftovers are
+    parked with a named next action — never force-closed."""
+    changed: dict = {"session": None, "archive": None, "alerts_resolved": 0,
+                     "binding": None, "parked": []}
+    sess = evidence["session"]
+    if evidence["live_session"] and sess:
+        result = interface_broker.close_session(con, sess["session_id"],
+                                                end_reason)
+        changed["session"] = {"session_id": sess["session_id"],
+                              "end_reason": result["end_reason"],
+                              "already_ended": result["already_ended"]}
+
+    archive = evidence["archive"]
+    if archive and archive["ended_at"] is None:
+        con.execute(
+            "UPDATE shell_memory_archives SET ended_at=datetime('now') "
+            "WHERE archive_id=? AND ended_at IS NULL",
+            (archive["archive_id"],))
+        # Clear the shell's pointer ONLY while it still names this archive —
+        # a newer session may already have handed over.
+        con.execute(
+            "UPDATE shells SET active_archive_id=NULL "
+            "WHERE shell_id=? AND active_archive_id=?",
+            (shell_id, archive["archive_id"]))
+        changed["archive"] = {"archive_id": archive["archive_id"],
+                              "closed": True}
+
+    if sess:
+        cur = con.execute(
+            "UPDATE planner_alerts SET resolved_at=datetime('now') "
+            "WHERE session_id=? AND resolved_at IS NULL",
+            (sess["session_id"],))
+        changed["alerts_resolved"] += cur.rowcount
+
+    # Generation-bound bindings are unambiguously owned by the ended
+    # generation — release them. Any OTHER unreleased binding for this shell
+    # is ambiguous: leave it, park it with a named next action.
+    generation = (sess or {}).get("generation")
+    rows = con.execute(
+        "SELECT binding_id, generation FROM sprint_planner_bindings "
+        "WHERE shell_id=? AND released_at IS NULL", (shell_id,)).fetchall()
+    for binding_id, bound_generation in rows:
+        if generation is not None and bound_generation == generation:
+            interface_broker.release_binding(con, binding_id,
+                                             "shell_recovery")
+            cur = con.execute(
+                "UPDATE planner_alerts SET resolved_at=datetime('now') "
+                "WHERE binding_id=? AND resolved_at IS NULL", (binding_id,))
+            changed["alerts_resolved"] += cur.rowcount
+            changed["binding"] = {"binding_id": binding_id,
+                                  "released": True}
+        else:
+            interface_broker._alert(
+                con, severity="warning",
+                reason="recovery_ambiguous_binding: generation not owned "
+                       "by this recovery — release via sprint close or "
+                       "DELETE /api/interface/sprint-bindings/"
+                       f"{binding_id}",
+                binding_id=binding_id)
+            changed["parked"].append({"binding_id": binding_id,
+                                      "next_action": "release via sprint "
+                                                     "close or explicit "
+                                                     "binding DELETE"})
+    return changed
+
+
+def execute(con, shell_id: int, body: dict,
+            default_worktree: str | None,
+            grace_s: float = GRACEFUL_TERMINATE_S,
+            abandon=None) -> dict:
+    """Run one recovery against a fresh observation.
+
+    `abandon` — optional callable(session_id) dropping the live runtime
+    generation after closure (routes passes the runtime bridge when the
+    Interface runtime is up; HTTP-only operation passes None).
+    """
+    observation_id = body.get("observation_id")
+    if not isinstance(observation_id, str) or not observation_id:
+        raise RecoveryError(422, "validation",
+                            "observation_id (string) required")
+    mode = body.get("mode", "recover")
+    if mode not in ("recover", "force"):
+        raise RecoveryError(422, "validation", "mode is recover|force")
+    preserve = body.get("preserve_worktree", True)
+    discard = bool(body.get("discard_worktree", False))
+    if discard and preserve:
+        raise RecoveryError(422, "validation",
+                            "discard_worktree requires "
+                            "preserve_worktree=false — discard is never "
+                            "implied by recover or force")
+
+    classification, legal_actions, evidence, _acted = _load_observation(
+        con, shell_id, observation_id)
+
+    if mode == "recover" and "recover" not in legal_actions:
+        raise RecoveryError(
+            409, "recovery_action_not_legal",
+            f"recover is not legal for a {classification} shell — the "
+            "preview lists the legal actions",
+            {"classification": classification,
+             "legal_actions": legal_actions})
+    if mode == "force":
+        if classification != "verified_live":
+            raise RecoveryError(
+                409, "recovery_action_not_legal",
+                "force is legal only against a verified-live exact process "
+                f"identity — this preview classified {classification}",
+                {"classification": classification})
+        if body.get("confirm_force") is not True:
+            raise RecoveryError(
+                409, "force_confirmation_required",
+                "force requires confirm_force=true after naming the exact "
+                "process identity to the operator",
+                {"process": evidence["process"]})
+
+    shortname = evidence["shell"]["shortname"]
+    worktree: str | None = None
+    if discard:
+        if body.get("confirm_shortname") != shortname:
+            raise RecoveryError(
+                409, "discard_confirmation_required",
+                "discard_worktree requires confirm_shortname naming the "
+                "exact shell — it is an independent escalation, never "
+                "implied", {"shell": shortname})
+        worktree = (evidence["git"] or {}).get("worktree") \
+            or (evidence["session"] or {}).get("worktree") \
+            or default_worktree
+        if not worktree or not os.path.isdir(worktree):
+            raise RecoveryError(409, "no_such_worktree",
+                                "no exact shell worktree to discard in")
+        unpushed = _unpushed_count(worktree)
+        if unpushed:
+            raise RecoveryError(
+                409, "unpushed_commits",
+                f"{worktree} has {unpushed} commit(s) not on any remote — "
+                "discard refused; push or abandon them explicitly first",
+                {"worktree": worktree, "unpushed_commits": unpushed})
+
+    # -- signal (exact process-group, re-verified at signal time) ----------
+    proc = evidence["process"]
+    signal_result = None
+    if classification in ("exact_idle_orphan", "verified_live") \
+            and proc["pid_state"] == "alive":
+        signal_result = terminate_process_group(
+            proc["pane_pid"], proc["pane_start_ticks"], grace_s)
+        if not signal_result["signaled"]:
+            raise RecoveryError(
+                409, "recovery_indeterminate",
+                "the exact process identity no longer verifies — no signal "
+                "sent, no state closed; preview again",
+                {"detail": signal_result.get("detail")})
+
+    # -- atomic durable closure on proven absence ---------------------------
+    end_reason = "operator_recovery_force" if mode == "force" \
+        else "operator_recovery"
+    try:
+        changed = _close_durable_state(con, shell_id, evidence, end_reason)
+        con.execute(
+            "UPDATE interface_recovery_observations "
+            "SET acted_at=datetime('now') WHERE observation_id=?",
+            (observation_id,))
+        con.commit()
+    except Exception:
+        con.rollback()
+        raise
+    if abandon is not None and evidence["live_session"] and evidence["session"]:
+        try:
+            abandon(evidence["session"]["session_id"])
+        except Exception:  # noqa: BLE001, S110 — runtime cleanup is
+            pass         # best-effort; durable state is already closed
+
+    discarded = None
+    if discard:
+        assert worktree is not None  # proven by the discard gate above
+        discarded = _discard_worktree_files(worktree)
+
+    return {"shell_id": shell_id, "shortname": shortname,
+            "classification": classification, "mode": mode,
+            "signaled": signal_result,
+            "closed": changed,
+            "worktree": discarded or {"preserved": True},
+            "unread_messages": evidence["unread_messages"],
+            "availability": "available"}

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -96,25 +96,35 @@ def _proc_state(pid: int, start_ticks: int) -> str:
 
 
 def _pane_present(sock: str | None, pane_id: str) -> bool | None:
-    """Is the exact pane in the session's own tmux server? None when tmux
-    can't answer (binary missing, socket unreachable) — unknown is not
-    gone."""
+    """Is the exact pane in the session's own tmux server? Membership is
+    answered by list-panes, so a server that answers proves BOTH ways:
+    False = the pane is gone (reachable classification), True = it lives.
+    None ONLY when tmux can't answer (binary missing, socket unreachable,
+    garbled output) — unknown is not gone."""
     if not sock:
         return None
     try:
         out = subprocess.run(
-            ["tmux", "-S", sock, "display-message", "-p", "-t", pane_id,
-             "#{pane_id} #{pane_pid}"],
+            ["tmux", "-S", sock, "list-panes", "-a", "-F", "#{pane_id}"],
             capture_output=True, text=True, timeout=10, check=False)
     except Exception:  # noqa: BLE001 — any tmux failure means "unknown"
         return None
     if out.returncode != 0:
         return None  # server unreachable — unknown, NOT proof of absence
-    try:
-        got_pane, _got_pid = out.stdout.split()
-    except ValueError:
-        return None
-    return got_pane == pane_id
+    return any(line.strip() == pane_id for line in out.stdout.splitlines())
+
+
+def _wait_dead(pid: int, start_ticks: int, grace_s: float) -> str:
+    """Poll exact-identity liveness for up to grace_s. Returns 'dead' the
+    moment /proc proves absence; otherwise the last observed state at the
+    deadline ('alive' or 'unreadable') — NEITHER is proof of absence, so
+    neither may satisfy closure."""
+    deadline = time.monotonic() + grace_s
+    state = _proc_state(pid, start_ticks)
+    while state != "dead" and time.monotonic() < deadline:
+        time.sleep(0.1)
+        state = _proc_state(pid, start_ticks)
+    return state
 
 
 def terminate_process_group(pid: int, start_ticks: int,
@@ -122,42 +132,52 @@ def terminate_process_group(pid: int, start_ticks: int,
     """SIGTERM the exact verified process group, bounded grace, SIGKILL only
     while the same PID/start ticks still identify the process. Identity
     mismatch or unreadable state performs NO signal and reports
-    indeterminate — the caller maps that to a refusal, never a closure."""
+    indeterminate — the caller maps that to a refusal, never a closure.
+    `dead` is True ONLY on /proc-proven absence: a signal is not proof of
+    death, and 'unreadable' or a SIGKILL survivor (D-state) leaves the
+    caller to refuse closure with a named next action."""
     state = _proc_state(pid, start_ticks)
     if state != "alive":
-        return {"signaled": False, "reason": "indeterminate",
+        return {"signaled": False, "dead": False, "reason": "indeterminate",
                 "detail": f"process state {state} at signal time"}
     try:
         pgid = os.getpgid(pid)
     except OSError:
-        return {"signaled": False, "reason": "indeterminate",
+        return {"signaled": False, "dead": False, "reason": "indeterminate",
                 "detail": "process group unreadable at signal time"}
     os.killpg(pgid, signal.SIGTERM)
-    deadline = time.monotonic() + grace_s
-    while time.monotonic() < deadline:
-        if _proc_state(pid, start_ticks) != "alive":
-            return {"signaled": True, "escalated": False, "pid": pid,
-                    "pgid": pgid}
-        time.sleep(0.1)
-    # Grace expired. Re-verify the EXACT identity before SIGKILL — the window
-    # is long enough for exit + PID reuse, and the rule is never signal an
-    # uncertain process.
-    if _proc_state(pid, start_ticks) != "alive":
-        return {"signaled": True, "escalated": False, "pid": pid,
-                "pgid": pgid,
+    state = _wait_dead(pid, start_ticks, grace_s)
+    if state == "dead":
+        return {"signaled": True, "dead": True, "escalated": False,
+                "pid": pid, "pgid": pgid}
+    if state == "unreadable":
+        return {"signaled": True, "dead": False, "escalated": False,
+                "pid": pid, "pgid": pgid, "reason": "absence_unproven",
+                "detail": "SIGTERM sent but /proc turned unreadable during "
+                          "the grace — absence not proven"}
+    # Grace expired with the process alive. Re-verify the EXACT identity
+    # before SIGKILL — the window is long enough for exit + PID reuse, and
+    # the rule is never signal an uncertain process.
+    state = _proc_state(pid, start_ticks)
+    if state != "alive":
+        return {"signaled": True, "dead": state == "dead",
+                "escalated": False, "pid": pid, "pgid": pgid,
                 "note": "identity changed during grace — no SIGKILL sent"}
     try:
         pgid = os.getpgid(pid)
     except OSError:
-        return {"signaled": True, "escalated": False, "pid": pid,
+        return {"signaled": True, "dead": False, "escalated": False,
+                "pid": pid, "pgid": pgid,
                 "note": "process exited during grace — no SIGKILL sent"}
     os.killpg(pgid, signal.SIGKILL)
-    deadline = time.monotonic() + grace_s
-    while time.monotonic() < deadline:
-        if _proc_state(pid, start_ticks) != "alive":
-            break
-        time.sleep(0.1)
-    return {"signaled": True, "escalated": True, "pid": pid, "pgid": pgid}
+    state = _wait_dead(pid, start_ticks, grace_s)
+    if state == "dead":
+        return {"signaled": True, "dead": True, "escalated": True,
+                "pid": pid, "pgid": pgid}
+    return {"signaled": True, "dead": False, "escalated": True,
+            "pid": pid, "pgid": pgid, "reason": "absence_unproven",
+            "detail": f"process state {state} after SIGKILL — absence not "
+                      "proven (an unkillable D-state process survives)"}
 
 
 # ------------------------------------------------------------------ git facts
@@ -210,12 +230,28 @@ def _unpushed_count(worktree: str) -> int:
 
 def _discard_worktree_files(worktree: str) -> dict:
     """Remove tracked + untracked file changes in the exact worktree. Never
-    deletes the worktree, its branch, or ignored files."""
-    subprocess.run(["git", "-C", worktree, "reset", "--hard", "HEAD"],
-                   capture_output=True, text=True, timeout=60, check=True)
-    subprocess.run(["git", "-C", worktree, "clean", "-fd"],
-                   capture_output=True, text=True, timeout=60, check=True)
-    return {"worktree": worktree, "discarded": True}
+    deletes the worktree, its branch, or ignored files. Runs AFTER the
+    durable closure is committed, so a git failure here must never escape
+    as a 500 that hides what happened: each step's outcome is recorded and
+    a failure returns exactly what completed and where it stopped."""
+    result: dict = {"worktree": worktree, "discarded": False,
+                    "completed": [], "failed": None}
+    for step, args in (("reset", ["reset", "--hard", "HEAD"]),
+                       ("clean", ["clean", "-fd"])):
+        try:
+            out = subprocess.run(["git", "-C", worktree, *args],
+                                 capture_output=True, text=True, timeout=60,
+                                 check=False)
+        except Exception as exc:  # noqa: BLE001 — timeout etc: report it
+            result["failed"] = {"step": step, "error": str(exc)[:200]}
+            return result
+        if out.returncode != 0:
+            result["failed"] = {"step": step,
+                                "error": out.stderr.strip()[-200:]}
+            return result
+        result["completed"].append(step)
+    result["discarded"] = True
+    return result
 
 
 # ------------------------------------------------------------------ evidence
@@ -614,6 +650,16 @@ def execute(con, shell_id: int, body: dict,
                 "the exact process identity no longer verifies — no signal "
                 "sent, no state closed; preview again",
                 {"detail": signal_result.get("detail")})
+        if not signal_result.get("dead"):
+            raise RecoveryError(
+                409, "recovery_absence_unproven",
+                "a signal was sent but /proc never proved the process gone "
+                "— durable closure refused (closure only on proven "
+                "absence). Next action: preview again; if the process "
+                "persists, inspect /proc/"
+                f"{proc['pane_pid']} and resolve it at the OS level first",
+                {"pid": proc["pane_pid"],
+                 "detail": signal_result.get("detail")})
 
     # -- atomic durable closure on proven absence ---------------------------
     end_reason = "operator_recovery_force" if mode == "force" \

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -1,0 +1,892 @@
+#!/usr/bin/env python3
+"""Unified stranded-shell recovery — hermetic proofs (spec #30 req 24 /
+task #95, sprint 31 unit 8).
+
+Covers the preview/execute contract WITHOUT tmux (pane presence is patched
+at the interface_recovery seam) and WITHOUT the websockets runtime (the
+module is stdlib-only by design — HTTP-only recovery):
+
+- classification table: available / stale durable lock (no identity, dead
+  process, open active archive) / exact idle orphan (pane gone, exact pid
+  alive; residual process after session end) / verified live / indeterminate
+  (pane unknown, /proc unreadable);
+- observation fencing: changed durable state or expiry → 409
+  recovery_observation_stale; unknown id → 404; replay via Idempotency-Key
+  returns the original response with no second side effect;
+- action legality: recover refused on verified_live, force refused without
+  confirm_force or against non-verified-live classifications;
+- exact process-group signaling against REAL child processes: SIGTERM
+  kills, SIGKILL only after the grace with the same identity, identity loss
+  performs no signal and closes nothing;
+- atomic closure: session+generation+leases, archive close with the
+  active_archive_id guard, alert resolution, generation-bound binding
+  release, ambiguous binding parked with a named next action, unread
+  messages left unread;
+- worktree: preserved by default; discard requires the typed shortname,
+  refuses unpushed commits (fail closed), never deletes the worktree;
+- CLI parity: ./sc interface recover drives GET preview → POST execute with
+  the spec's flags (--force/--discard-worktree/--yes/--json).
+
+Run:
+    python3 tests/test_interface_recovery.py
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from typing import ClassVar
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+TESTS = Path(__file__).resolve().parent
+
+sys.path.insert(0, str(TESTS))
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+
+import interface_cli as ic
+import interface_recovery as recovery
+import interface_routes as routes
+import run as run_mod
+from test_interface_api import FakeRuntime, build_engine_db
+from test_interface_cli import SHELLS, FakeResp
+
+
+def hdrs(*lines) -> str:
+    return "\r\n".join(("Host: 127.0.0.1:8800", *lines))
+
+
+OP = "Authorization: Bearer optok"
+IDEM = "Idempotency-Key: k-1"
+
+DEAD_PID = 2 ** 22 - 1  # pid_max on stock Linux; nothing lives there
+
+
+def spawn_child(*, ignore_sigterm: bool = False):
+    """A real process in its OWN process group (pgid == pid), plus its exact
+    /proc start ticks — the identity recovery fences on. The SIGTERM-ignoring
+    variant acks handler installation before returning (no signal race)."""
+    if ignore_sigterm:
+        argv = [sys.executable, "-c",
+                ("import signal,time;"
+                 "signal.signal(signal.SIGTERM,signal.SIG_IGN);"
+                 "print('ready',flush=True);time.sleep(60)")]
+        proc = subprocess.Popen(argv, start_new_session=True,
+                                stdin=subprocess.DEVNULL,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.DEVNULL, text=True)
+        assert proc.stdout.readline().strip() == "ready"
+    else:
+        argv = [sys.executable, "-c", "import time;time.sleep(60)"]
+        proc = subprocess.Popen(argv, start_new_session=True,
+                                stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL)
+    ticks, _state = recovery._read_stat(proc.pid)
+    return proc, ticks
+
+
+class RecoveryCase(unittest.TestCase):
+    """Shared hermetic rig: tmp engine DB (schema + every migration, incl.
+    0083), patched route paths, no runtime (HTTP-only by default)."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.db_path = root / "shell_db.db"
+        build_engine_db(self.db_path)
+        run_dir = root / "run" / "interface"
+        self.patches = [
+            mock.patch.object(routes, "DB_PATH", self.db_path),
+            mock.patch.object(routes, "RUN_DIR", run_dir),
+            mock.patch.object(routes, "OPERATOR_TOKEN_PATH",
+                              run_dir / "operator.token"),
+            mock.patch.object(run_mod, "ensure_worktree"),
+        ]
+        for p in self.patches:
+            p.start()
+        routes.ensure_operator_capability()
+        (run_dir / "operator.token").write_text("optok")
+        self.runtime = FakeRuntime()
+        routes.bind_runtime(self.runtime)
+        self.liveness = mock.patch.object(
+            routes.shell_liveness, "compute",
+            return_value={"supported": True, "processes": []})
+        self.liveness.start()
+        self.children = []
+
+    def tearDown(self):
+        for proc in getattr(self, "children", []):
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except OSError:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:  # noqa: BLE001, S110 — teardown best-effort
+                pass
+        self.liveness.stop()
+        for p in self.patches:
+            p.stop()
+        self.tmp.cleanup()
+
+    # -- helpers ---------------------------------------------------------------
+
+    def db(self):
+        con = sqlite3.connect(self.db_path)
+        con.execute("PRAGMA foreign_keys=ON")
+        return con
+
+    def call(self, method, path, header_lines=(), body=None):
+        payload = json.dumps(body).encode() if body is not None else b""
+        status, _headers, resp = routes.handle(
+            method, path, hdrs(*header_lines), payload)
+        return status, json.loads(resp or b"{}")
+
+    def child(self, **kw):
+        proc, ticks = spawn_child(**kw)
+        self.children.append(proc)
+        return proc, ticks
+
+    def make_session(self, shell_id, *, occupancy="occupied", lifecycle="idle",
+                     generation=1, pane_pid=None, pane_ticks=None,
+                     pane_id="%1", socket="/run/if/tmux.sock",
+                     archive_id=None, worktree=None) -> int:
+        con = self.db()
+        try:
+            con.execute(
+                "INSERT OR IGNORE INTO interface_generations "
+                "(shell_id, generation, hook_token_hash) VALUES (?,?,'h')",
+                (shell_id, generation))
+            cur = con.execute(
+                "INSERT INTO interface_sessions "
+                "(shell_id, generation, archive_id, harness, worktree, "
+                " tmux_socket, tmux_pane_id, pane_pid, pane_start_ticks, "
+                " occupancy, lifecycle) "
+                "VALUES (?,?,?,'claude',?,?,?,?,?,?,?)",
+                (shell_id, generation, archive_id, worktree, socket,
+                 pane_id, pane_pid, pane_ticks, occupancy, lifecycle))
+            con.execute(
+                "INSERT INTO interface_input_state "
+                "(session_id, shell_id, generation) VALUES (?,?,?)",
+                (cur.lastrowid, shell_id, generation))
+            con.commit()
+            return cur.lastrowid
+        finally:
+            con.close()
+
+    def end_session_rows(self, session_id: int) -> None:
+        """Drive a session to its terminal record through the ONE closure
+        helper (as a completed recovery or hook would)."""
+        import interface_broker
+        con = self.db()
+        try:
+            interface_broker.close_session(con, session_id, "operator_end")
+            con.commit()
+        finally:
+            con.close()
+
+    def preview(self, shell_id):
+        status, obj = self.call("GET",
+                                f"/api/interface/shells/{shell_id}/recovery",
+                                (OP,))
+        assert status == 200, obj
+        return obj
+
+
+# ------------------------------------------------------------------ classify
+
+class ClassificationTest(RecoveryCase):
+
+    def test_available_when_nothing_live(self):
+        con = self.db()
+        con.execute("UPDATE shell_memory_archives SET ended_at='t' "
+                    "WHERE archive_id=10")
+        con.commit()
+        con.close()
+        obj = self.preview(1)
+        self.assertEqual(obj["classification"], "available")
+        self.assertEqual(obj["legal_actions"], [])
+        self.assertTrue(obj["observation_id"])
+
+    def test_stale_lock_reservation_without_identity(self):
+        self.make_session(1, occupancy="reserved", lifecycle="starting",
+                          pane_pid=None, pane_ticks=None, pane_id=None)
+        obj = self.preview(1)
+        self.assertEqual(obj["classification"], "stale_durable_lock")
+        self.assertEqual(obj["legal_actions"], ["recover"])
+
+    def test_stale_lock_dead_process(self):
+        self.make_session(1, pane_pid=DEAD_PID, pane_ticks=1)
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+        self.assertEqual(obj["classification"], "stale_durable_lock")
+        self.assertEqual(obj["legal_actions"], ["recover"])
+
+    def test_exact_idle_orphan_pane_gone_process_alive(self):
+        proc, ticks = self.child()
+        self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+        self.assertEqual(obj["classification"], "exact_idle_orphan")
+        self.assertEqual(obj["legal_actions"], ["recover"])
+        self.assertEqual(obj["evidence"]["process"]["pgid"], proc.pid)
+
+    def test_verified_live(self):
+        proc, ticks = self.child()
+        self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=True):
+            obj = self.preview(1)
+        self.assertEqual(obj["classification"], "verified_live")
+        self.assertEqual(obj["legal_actions"], ["force"])
+
+    def test_indeterminate_when_tmux_cant_answer(self):
+        proc, ticks = self.child()
+        self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=None):
+            obj = self.preview(1)
+        self.assertEqual(obj["classification"], "indeterminate")
+        self.assertEqual(obj["legal_actions"], [])
+
+    def test_indeterminate_when_proc_unreadable(self):
+        self.make_session(1, pane_pid=DEAD_PID, pane_ticks=1)
+        with mock.patch.object(recovery, "_pane_present", return_value=False), \
+                mock.patch.object(recovery, "_proc_state",
+                                  return_value="unreadable"):
+            obj = self.preview(1)
+        self.assertEqual(obj["classification"], "indeterminate")
+
+    def test_residual_process_after_session_end_is_orphan(self):
+        proc, ticks = self.child()
+        sid = self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        self.end_session_rows(sid)
+        obj = self.preview(1)
+        self.assertEqual(obj["classification"], "exact_idle_orphan")
+        self.assertEqual(obj["legal_actions"], ["recover"])
+
+    def test_open_active_archive_is_stale_lock(self):
+        con = self.db()
+        con.execute("UPDATE shells SET active_archive_id=10 WHERE shell_id=1")
+        con.commit()
+        con.close()
+        obj = self.preview(1)
+        self.assertEqual(obj["classification"], "stale_durable_lock")
+        self.assertEqual(obj["legal_actions"], ["recover"])
+
+    def test_spec_prefix_alias(self):
+        con = self.db()
+        con.execute("UPDATE shell_memory_archives SET ended_at='t' "
+                    "WHERE archive_id=10")
+        con.commit()
+        con.close()
+        status, obj = self.call("GET",
+                                "/_sc/interface/shells/1/recovery", (OP,))
+        self.assertEqual(status, 200)
+        self.assertEqual(obj["classification"], "available")
+
+
+# ------------------------------------------------------------------ signaling
+
+class ProcessGroupSignalTest(unittest.TestCase):
+    """terminate_process_group against REAL processes (no API)."""
+
+    def setUp(self):
+        self.children = []
+
+    def tearDown(self):
+        for proc in self.children:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except OSError:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:  # noqa: BLE001, S110 — teardown best-effort
+                pass
+
+    def child(self, **kw):
+        proc, ticks = spawn_child(**kw)
+        self.children.append(proc)
+        return proc, ticks
+
+    def test_sigterm_kills_exact_group(self):
+        proc, ticks = self.child()
+        result = recovery.terminate_process_group(proc.pid, ticks, grace_s=2)
+        self.assertTrue(result["signaled"])
+        self.assertFalse(result["escalated"])
+        self.assertEqual(result["pgid"], proc.pid)
+        proc.wait(timeout=5)
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "dead")
+
+    def test_sigkill_only_after_grace_with_same_identity(self):
+        proc, ticks = self.child(ignore_sigterm=True)
+        result = recovery.terminate_process_group(proc.pid, ticks, grace_s=0.3)
+        self.assertTrue(result["signaled"])
+        self.assertTrue(result["escalated"])
+        proc.wait(timeout=5)
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "dead")
+
+    def test_no_signal_on_identity_mismatch(self):
+        proc, ticks = self.child()
+        # Wrong ticks = a recycled pid is NOT our process — never signaled.
+        result = recovery.terminate_process_group(proc.pid, ticks + 1,
+                                                  grace_s=0.2)
+        self.assertFalse(result["signaled"])
+        self.assertEqual(result["reason"], "indeterminate")
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "alive")
+
+    def test_no_signal_on_dead_pid(self):
+        result = recovery.terminate_process_group(DEAD_PID, 1, grace_s=0.2)
+        self.assertFalse(result["signaled"])
+
+    def test_zombie_counts_as_dead(self):
+        proc, ticks = self.child()
+        proc.terminate()
+        proc.wait(timeout=5)  # reaped by us: gone
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "dead")
+
+
+# ------------------------------------------------------------------ execute
+
+class ExecuteTest(RecoveryCase):
+
+    def test_recover_closes_everything_atomically(self):
+        sid = self.make_session(1, occupancy="reserved", lifecycle="starting",
+                                pane_pid=None, pane_ticks=None, pane_id=None,
+                                archive_id=10)
+        con = self.db()
+        con.execute("UPDATE shells SET active_archive_id=10 WHERE shell_id=1")
+        con.execute(
+            "INSERT INTO interface_writer_leases "
+            "(session_id, shell_id, generation, client_id, token_hash) "
+            "VALUES (?,1,1,'web-1','th')", (sid,))
+        con.execute(
+            "INSERT INTO documents (document_id, kind, title) "
+            "VALUES (50,'doc','SPRINT: t')")
+        con.execute(
+            "INSERT INTO sprint_planner_bindings "
+            "(sprint_doc_id, planner_shell_id, session_id, shell_id, "
+            " generation) VALUES (50,1,?,1,1)", (sid,))
+        con.execute(
+            "INSERT INTO planner_alerts (session_id, severity, reason, "
+            "dedupe_key) VALUES (?,'critical','wake_x','k1')", (sid,))
+        con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body) "
+            "VALUES (2,1,'hello')")
+        con.commit()
+        con.close()
+
+        obj = self.preview(1)
+        self.assertEqual(obj["classification"], "stale_durable_lock")
+        status, result = self.call(
+            "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+            {"observation_id": obj["observation_id"], "mode": "recover"})
+        self.assertEqual(status, 200, result)
+        self.assertEqual(result["availability"], "available")
+        self.assertIsNone(result["signaled"])
+        self.assertEqual(result["closed"]["session"]["session_id"], sid)
+        self.assertEqual(result["closed"]["archive"],
+                         {"archive_id": 10, "closed": True})
+        self.assertEqual(result["closed"]["binding"],
+                         {"binding_id": 1, "released": True})
+        self.assertTrue(result["closed"]["alerts_resolved"] >= 1)
+        self.assertEqual(result["worktree"], {"preserved": True})
+        self.assertEqual(result["unread_messages"], 1)
+
+        con = self.db()
+        sess = con.execute(
+            "SELECT occupancy, lifecycle, end_reason FROM interface_sessions "
+            "WHERE session_id=?", (sid,)).fetchone()
+        self.assertEqual(sess, ("ended", "ended", "operator_recovery"))
+        self.assertIsNotNone(con.execute(
+            "SELECT ended_at FROM interface_generations "
+            "WHERE shell_id=1 AND generation=1").fetchone()[0])
+        self.assertIsNotNone(con.execute(
+            "SELECT revoked_at FROM interface_writer_leases "
+            "WHERE session_id=?", (sid,)).fetchone()[0])
+        arch = con.execute(
+            "SELECT ended_at FROM shell_memory_archives "
+            "WHERE archive_id=10").fetchone()[0]
+        self.assertIsNotNone(arch)
+        self.assertIsNone(con.execute(
+            "SELECT active_archive_id FROM shells WHERE shell_id=1"
+        ).fetchone()[0])
+        self.assertIsNotNone(con.execute(
+            "SELECT resolved_at FROM planner_alerts WHERE session_id=?",
+            (sid,)).fetchone()[0])
+        self.assertIsNotNone(con.execute(
+            "SELECT released_at FROM sprint_planner_bindings "
+            "WHERE binding_id=1").fetchone()[0])
+        # Unread inbox messages remain unread.
+        self.assertIsNone(con.execute(
+            "SELECT read_at FROM shell_messages WHERE message_id=1"
+        ).fetchone()[0])
+        con.close()
+
+    def test_stale_observation_on_durable_change(self):
+        sid = self.make_session(1, occupancy="reserved", lifecycle="starting",
+                                pane_pid=None, pane_ticks=None, pane_id=None)
+        obj = self.preview(1)
+        self.end_session_rows(sid)  # another client recovers first
+        status, err = self.call(
+            "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+            {"observation_id": obj["observation_id"], "mode": "recover"})
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+
+    def test_expired_observation(self):
+        self.make_session(1, occupancy="reserved", lifecycle="starting",
+                          pane_pid=None, pane_ticks=None, pane_id=None)
+        obj = self.preview(1)
+        con = self.db()
+        con.execute(
+            "UPDATE interface_recovery_observations "
+            "SET expires_at='2000-01-01 00:00:00' WHERE observation_id=?",
+            (obj["observation_id"],))
+        con.commit()
+        con.close()
+        status, err = self.call(
+            "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+            {"observation_id": obj["observation_id"], "mode": "recover"})
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+
+    def test_unknown_observation(self):
+        status, err = self.call(
+            "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+            {"observation_id": "nope", "mode": "recover"})
+        self.assertEqual(status, 404)
+        self.assertEqual(err["error"]["code"], "no_such_observation")
+
+    def test_recover_refused_on_verified_live(self):
+        proc, ticks = self.child()
+        self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=True):
+            obj = self.preview(1)
+            status, err = self.call(
+                "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                {"observation_id": obj["observation_id"], "mode": "recover"})
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_action_not_legal")
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "alive")
+
+    def test_force_requires_confirmation(self):
+        proc, ticks = self.child()
+        self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=True):
+            obj = self.preview(1)
+            status, err = self.call(
+                "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                {"observation_id": obj["observation_id"], "mode": "force"})
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "force_confirmation_required")
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "alive")
+
+    def test_force_terminates_verified_live_and_closes(self):
+        proc, ticks = self.child()
+        sid = self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks,
+                                archive_id=10)
+        with mock.patch.object(recovery, "_pane_present", return_value=True):
+            obj = self.preview(1)
+            self.assertEqual(obj["classification"], "verified_live")
+            status, result = self.call(
+                "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                {"observation_id": obj["observation_id"], "mode": "force",
+                 "confirm_force": True})
+        self.assertEqual(status, 200, result)
+        self.assertTrue(result["signaled"]["signaled"])
+        self.assertEqual(result["closed"]["session"]["end_reason"],
+                         "operator_recovery_force")
+        proc.wait(timeout=5)
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "dead")
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE session_id=?",
+            (sid,)).fetchone()[0], "ended")
+        con.close()
+        self.assertIn(sid, self.runtime.abandoned)
+
+    def test_orphan_recover_signals_then_closes(self):
+        proc, ticks = self.child()
+        sid = self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+            self.assertEqual(obj["classification"], "exact_idle_orphan")
+            status, result = self.call(
+                "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                {"observation_id": obj["observation_id"], "mode": "recover"})
+        self.assertEqual(status, 200, result)
+        self.assertTrue(result["signaled"]["signaled"])
+        proc.wait(timeout=5)
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE session_id=?",
+            (sid,)).fetchone()[0], "ended")
+        con.close()
+
+    def test_identity_loss_at_execute_signals_nothing_closes_nothing(self):
+        proc, ticks = self.child()
+        sid = self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+        # The process vanishes between preview and execute (pid reused,
+        # exited): the durable state didn't change, so the observation is
+        # fresh — the signal-time re-verification is the fence.
+        with mock.patch.object(recovery, "_proc_state", return_value="dead"):
+            status, err = self.call(
+                "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                {"observation_id": obj["observation_id"], "mode": "recover"})
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_indeterminate")
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE session_id=?",
+            (sid,)).fetchone()[0], "occupied")
+        con.close()
+
+    def test_idempotent_replay_no_second_side_effect(self):
+        proc, ticks = self.child()
+        self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=True):
+            obj = self.preview(1)
+            status1, r1 = self.call(
+                "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                {"observation_id": obj["observation_id"], "mode": "force",
+                 "confirm_force": True})
+            self.assertEqual(status1, 200, r1)
+            # Same key + same body: the STORED response replays — no second
+            # signal attempt against the now-dead process.
+            status2, r2 = self.call(
+                "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                {"observation_id": obj["observation_id"], "mode": "force",
+                 "confirm_force": True})
+        self.assertEqual(status2, 200)
+        self.assertEqual(r1, r2)
+
+    def test_ambiguous_binding_parked_with_named_action(self):
+        sid = self.make_session(1, occupancy="reserved", lifecycle="starting",
+                                pane_pid=None, pane_ticks=None, pane_id=None)
+        con = self.db()
+        con.execute(
+            "INSERT INTO documents (document_id, kind, title) "
+            "VALUES (50,'doc','SPRINT: t')")
+        # A binding on a DIFFERENT (earlier) generation: not owned by this
+        # recovery — parked, never force-released.
+        con.execute(
+            "INSERT INTO interface_generations "
+            "(shell_id, generation, hook_token_hash, ended_at) "
+            "VALUES (1,99,'h','2026-01-01')")
+        con.execute(
+            "INSERT INTO sprint_planner_bindings "
+            "(sprint_doc_id, planner_shell_id, session_id, shell_id, "
+            " generation) VALUES (50,1,?,1,99)", (sid,))
+        con.commit()
+        con.close()
+        obj = self.preview(1)
+        status, result = self.call(
+            "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+            {"observation_id": obj["observation_id"], "mode": "recover"})
+        self.assertEqual(status, 200, result)
+        self.assertIsNone(result["closed"]["binding"])
+        self.assertEqual(result["closed"]["parked"][0]["binding_id"], 1)
+        self.assertIn("release", result["closed"]["parked"][0]["next_action"])
+        con = self.db()
+        self.assertIsNone(con.execute(
+            "SELECT released_at FROM sprint_planner_bindings "
+            "WHERE binding_id=1").fetchone()[0])
+        alert = con.execute(
+            "SELECT reason FROM planner_alerts WHERE binding_id=1 AND "
+            "resolved_at IS NULL").fetchone()
+        self.assertIn("recovery_ambiguous_binding", alert[0])
+        con.close()
+
+    def test_missing_idempotency_key(self):
+        obj = self.preview(1)
+        status, err = self.call(
+            "POST", "/api/interface/shells/1/recovery", (OP,),
+            {"observation_id": obj["observation_id"], "mode": "recover"})
+        self.assertEqual(status, 422)
+        self.assertEqual(err["error"]["code"], "idempotency_key_required")
+
+    def test_no_such_shell(self):
+        status, err = self.call("GET",
+                                "/api/interface/shells/99/recovery", (OP,))
+        self.assertEqual(status, 404)
+        self.assertEqual(err["error"]["code"], "no_such_shell")
+
+
+# ------------------------------------------------------------------ worktree
+
+class WorktreeTest(RecoveryCase):
+
+    def make_git_worktree(self, *, unpushed: bool = False) -> str:
+        """A real git repo standing in for the shell worktree, with a bare
+        origin so 'unpushed' is exact: one pushed commit, one dirty tracked
+        change, one untracked file (+ one local-only commit when unpushed)."""
+        origin = Path(self.tmp.name) / "origin.git"
+        subprocess.run(["git", "init", "-q", "--bare", str(origin)],
+                       check=True, capture_output=True)
+        wt = Path(self.tmp.name) / f"wt-{len(list(Path(self.tmp.name).glob('wt-*')))}"
+        wt.mkdir()
+
+        def git(*args):
+            return subprocess.run(["git", "-C", str(wt), *args],
+                                  capture_output=True, text=True, check=True)
+        git("init", "-q", "-b", "feat/x")
+        git("config", "user.email", "t@t")
+        git("config", "user.name", "t")
+        git("remote", "add", "origin", str(origin))
+        (wt / "tracked.txt").write_text("v1")
+        git("add", ".")
+        git("commit", "-qm", "base")
+        git("push", "-q", "-u", "origin", "feat/x")
+        if unpushed:
+            (wt / "tracked.txt").write_text("v2")
+            git("commit", "-qam", "local only")
+        (wt / "tracked.txt").write_text("dirty")
+        (wt / "untracked.txt").write_text("new")
+        return str(wt)
+
+    def session_with_worktree(self, wt: str) -> int:
+        return self.make_session(
+            1, occupancy="reserved", lifecycle="starting", pane_pid=None,
+            pane_ticks=None, pane_id=None, worktree=wt)
+
+    def post(self, obj, **extra):
+        body = {"observation_id": obj["observation_id"], "mode": "recover"}
+        body.update(extra)
+        return self.call("POST", "/api/interface/shells/1/recovery",
+                         (OP, IDEM), body)
+
+    def test_default_preserves_worktree(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        self.assertEqual(obj["evidence"]["git"]["dirty_tracked"], 1)
+        self.assertEqual(obj["evidence"]["git"]["untracked"], 1)
+        status, result = self.post(obj)
+        self.assertEqual(status, 200, result)
+        self.assertEqual(result["worktree"], {"preserved": True})
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
+
+    def test_discard_requires_typed_shortname(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        status, err = self.post(obj, preserve_worktree=False,
+                                discard_worktree=True,
+                                confirm_shortname="WRONG")
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "discard_confirmation_required")
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+
+    def test_discard_never_implied_by_preserve_default(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        status, _err = self.post(obj, discard_worktree=True,
+                                 confirm_shortname="s1")
+        self.assertEqual(status, 422)  # preserve_worktree defaults true        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+
+    def test_discard_refuses_unpushed_commits(self):
+        wt = self.make_git_worktree(unpushed=True)
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        self.assertEqual(obj["evidence"]["git"]["unpushed_commits"], 1)
+        status, err = self.post(obj, preserve_worktree=False,
+                                discard_worktree=True, confirm_shortname="s1")
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "unpushed_commits")
+        # Nothing discarded; the local commit and dirty files survive.
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
+
+    def test_discard_removes_changes_keeps_worktree(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        status, result = self.post(obj, preserve_worktree=False,
+                                   discard_worktree=True,
+                                   confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertTrue(result["worktree"]["discarded"])
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
+        self.assertFalse((Path(wt) / "untracked.txt").exists())
+        self.assertTrue(Path(wt).is_dir())  # worktree itself never deleted
+
+
+# ------------------------------------------------------------------ CLI parity
+
+class CliRecoverTest(unittest.TestCase):
+    """The verb end-to-end against the fake transport: request shape,
+    confirmation gating, refusal mapping, --json output."""
+
+    PREVIEW_ORPHAN: ClassVar = {
+        "observation_id": "obs-1", "expires_in_s": 120,
+        "classification": "exact_idle_orphan", "legal_actions": ["recover"],
+        "evidence": {
+            "shell": {"shell_id": 3, "shortname": "S3",
+                      "active_archive_id": None},
+            "session": {"session_id": 9, "generation": 1,
+                        "occupancy": "occupied", "lifecycle": "lost",
+                        "harness": "claude", "worktree": "/x/s3",
+                        "archive_id": None, "created_at": "t"},
+            "generation": None, "archive": None, "sprint_binding": None,
+            "process": {"pane_id": "%1", "pane_pid": 4321,
+                        "pane_start_ticks": 999, "pane_present": False,
+                        "pid_state": "alive", "pgid": 4321},
+            "tmux": None, "unread_messages": 2,
+            "git": {"worktree": "/x/s3", "branch": "fix/x",
+                    "dirty_tracked": 1, "untracked": 0,
+                    "unpushed_commits": 0},
+            "live_session": True}}
+
+    PREVIEW_LIVE: ClassVar = dict(PREVIEW_ORPHAN,
+                                  classification="verified_live",
+                                  legal_actions=["force"])
+
+    RESULT: ClassVar = {"shell_id": 3, "shortname": "S3",
+              "classification": "exact_idle_orphan", "mode": "recover",
+              "signaled": {"signaled": True, "escalated": False, "pid": 4321,
+                           "pgid": 4321},
+              "closed": {"session": {"session_id": 9,
+                                     "end_reason": "operator_recovery",
+                                     "already_ended": False},
+                         "archive": None, "alerts_resolved": 0,
+                         "binding": None, "parked": []},
+              "worktree": {"preserved": True}, "unread_messages": 2,
+              "availability": "available"}
+
+    def setUp(self):
+        self.requests = []
+        self.routes = {}
+
+        def fake_http(req):
+            path = req.full_url.replace(ic.API_BASE, "")
+            body = json.loads(req.data) if req.data else None
+            self.requests.append((req.get_method(), path, body,
+                                  dict(req.headers)))
+            key = (req.get_method(), path)
+            responder = self.routes.get(key)
+            if responder is None:
+                raise AssertionError(f"unexpected request: {key}")
+            outcome = responder.pop(0) if isinstance(responder, list) \
+                else responder
+            if isinstance(outcome, urllib.error.HTTPError):
+                raise outcome
+            return FakeResp(outcome)
+
+        self.patch_http = mock.patch.object(ic, "_http", side_effect=fake_http)
+        self.patch_http.start()
+        self.patch_token = mock.patch.object(ic, "_operator_token",
+                                             return_value="optok")
+        self.patch_token.start()
+        # Non-tty by default: confirmations must refuse, never hang.
+        self.patch_stdin = mock.patch.object(ic.sys, "stdin",
+                                             io.StringIO(""))
+        self.patch_stdin.start()
+        self.routes[("GET", "/api/interface/shells")] = SHELLS
+
+    def tearDown(self):
+        self.patch_stdin.stop()
+        self.patch_token.stop()
+        self.patch_http.stop()
+
+    def script(self, preview, result):
+        self.routes[("GET", "/api/interface/shells/3/recovery")] = preview
+        if result is not None:
+            self.routes[("POST", "/api/interface/shells/3/recovery")] = result
+
+    def run_cli(self, argv):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), \
+                contextlib.redirect_stderr(err):
+            try:
+                code = ic.main(argv)
+            except SystemExit as exc:
+                code = exc.code
+        return code, out.getvalue(), err.getvalue()
+
+    def test_recover_happy_path(self):
+        self.script(dict(self.PREVIEW_ORPHAN), dict(self.RESULT))
+        code, out, _ = self.run_cli(["recover", "s3", "--yes"])
+        self.assertEqual(code, 0)
+        get = self.requests[1]
+        post = self.requests[2]
+        self.assertEqual(get[0], "GET")
+        self.assertEqual(post[0], "POST")
+        self.assertEqual(post[1], "/api/interface/shells/3/recovery")
+        self.assertEqual(post[2], {"observation_id": "obs-1",
+                                   "mode": "recover",
+                                   "preserve_worktree": True})
+        header_keys = {k.lower() for k in post[3]}
+        self.assertIn("idempotency-key", header_keys)
+        self.assertIn("authorization", header_keys)
+        self.assertIn("classification: exact_idle_orphan", out)
+        self.assertIn("S3 is available", out)
+
+    def test_force_confirms_exact_identity(self):
+        self.script(dict(self.PREVIEW_LIVE), dict(self.RESULT, mode="force"))
+        code, _out, _err = self.run_cli(["recover", "s3", "--force", "--yes"])
+        self.assertEqual(code, 0)
+        body = self.requests[2][2]
+        self.assertEqual(body["mode"], "force")
+        self.assertIs(body["confirm_force"], True)
+
+    def test_force_without_yes_refuses_off_tty(self):
+        self.script(dict(self.PREVIEW_LIVE), None)
+        code, _out, err = self.run_cli(["recover", "s3", "--force"])
+        self.assertEqual(code, 1)
+        self.assertIn("--yes", err)
+        self.assertEqual(len(self.requests), 2)  # no POST was sent
+
+    def test_discard_sends_independent_confirmation(self):
+        self.script(dict(self.PREVIEW_ORPHAN), dict(self.RESULT))
+        code, _out, _ = self.run_cli(
+            ["recover", "s3", "--discard-worktree", "--yes"])
+        self.assertEqual(code, 0)
+        body = self.requests[2][2]
+        self.assertIs(body["discard_worktree"], True)
+        self.assertIs(body["preserve_worktree"], False)
+        self.assertEqual(body["confirm_shortname"], "S3")
+
+    def test_stale_observation_maps_to_refusal(self):
+        from test_interface_cli import http_error
+        self.routes[("GET", "/api/interface/shells/3/recovery")] = \
+            dict(self.PREVIEW_ORPHAN)
+        self.routes[("POST", "/api/interface/shells/3/recovery")] = \
+            http_error(409, "recovery_observation_stale", "changed")
+        code, _out, err = self.run_cli(["recover", "s3", "--yes"])
+        self.assertEqual(code, 1)
+        self.assertIn("recovery_observation_stale", err)
+        self.assertIn("preview again", err)
+
+    def test_available_shell_no_post(self):
+        self.script(dict(self.PREVIEW_ORPHAN, classification="available",
+                         legal_actions=[]), None)
+        code, out, _ = self.run_cli(["recover", "s3", "--yes"])
+        self.assertEqual(code, 0)
+        self.assertIn("nothing to recover", out)
+        self.assertEqual(len(self.requests), 2)
+
+    def test_json_output(self):
+        self.script(dict(self.PREVIEW_ORPHAN), dict(self.RESULT))
+        code, out, _ = self.run_cli(["recover", "s3", "--yes", "--json"])
+        self.assertEqual(code, 0)
+        payload = json.loads(out)
+        self.assertEqual(payload["preview"]["observation_id"], "obs-1")
+        self.assertEqual(payload["result"]["availability"], "available")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -17,13 +17,20 @@ module is stdlib-only by design — HTTP-only recovery):
   confirm_force or against non-verified-live classifications;
 - exact process-group signaling against REAL child processes: SIGTERM
   kills, SIGKILL only after the grace with the same identity, identity loss
-  performs no signal and closes nothing;
+  performs no signal and closes nothing, and closure follows ONLY on
+  /proc-proven absence — an unreadable grace or a SIGKILL survivor refuses
+  with a named next action;
+- pane presence: tmux list-panes membership proves BOTH ways — a dead pane
+  is provably gone (classification can reach pane-gone), only an
+  unanswering server is unknown;
 - atomic closure: session+generation+leases, archive close with the
   active_archive_id guard, alert resolution, generation-bound binding
   release, ambiguous binding parked with a named next action, unread
   messages left unread;
 - worktree: preserved by default; discard requires the typed shortname,
-  refuses unpushed commits (fail closed), never deletes the worktree;
+  refuses unpushed commits (fail closed), never deletes the worktree, and a
+  mid-discard git failure after the committed closure is reported
+  step-by-step — never a 500 that hides what completed;
 - CLI parity: ./sc interface recover drives GET preview → POST execute with
   the spec's flags (--force/--discard-worktree/--yes/--json).
 
@@ -294,6 +301,44 @@ class ClassificationTest(RecoveryCase):
         self.assertEqual(obj["classification"], "available")
 
 
+# ------------------------------------------------------------------ pane presence
+
+class PanePresentTest(unittest.TestCase):
+    """_pane_present against a mocked tmux: list-panes membership proves
+    BOTH ways — a dead pane is provably gone, only an unanswering server is
+    unknown (regression: the old targeted display-message probe mapped a
+    dead pane's nonzero exit to unknown, leaving pane-gone unreachable)."""
+
+    def run_tmux(self, returncode=0, stdout="", stderr=""):
+        return mock.patch.object(
+            recovery.subprocess, "run",
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=returncode, stdout=stdout,
+                stderr=stderr))
+
+    def test_pane_listed_is_present(self):
+        with self.run_tmux(stdout="%1\n%2\n") as run:
+            self.assertIs(recovery._pane_present("/s.sock", "%2"), True)
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[:4], ["tmux", "-S", "/s.sock", "list-panes"])
+
+    def test_pane_missing_from_listing_is_proven_gone(self):
+        with self.run_tmux(stdout="%1\n%3\n"):
+            self.assertIs(recovery._pane_present("/s.sock", "%2"), False)
+
+    def test_unreachable_server_is_unknown(self):
+        with self.run_tmux(returncode=1, stderr="no server running"):
+            self.assertIsNone(recovery._pane_present("/s.sock", "%1"))
+
+    def test_tmux_failure_is_unknown(self):
+        with mock.patch.object(recovery.subprocess, "run",
+                               side_effect=OSError("no tmux binary")):
+            self.assertIsNone(recovery._pane_present("/s.sock", "%1"))
+
+    def test_no_socket_is_unknown(self):
+        self.assertIsNone(recovery._pane_present(None, "%1"))
+
+
 # ------------------------------------------------------------------ signaling
 
 class ProcessGroupSignalTest(unittest.TestCase):
@@ -322,6 +367,7 @@ class ProcessGroupSignalTest(unittest.TestCase):
         proc, ticks = self.child()
         result = recovery.terminate_process_group(proc.pid, ticks, grace_s=2)
         self.assertTrue(result["signaled"])
+        self.assertTrue(result["dead"])
         self.assertFalse(result["escalated"])
         self.assertEqual(result["pgid"], proc.pid)
         proc.wait(timeout=5)
@@ -331,9 +377,33 @@ class ProcessGroupSignalTest(unittest.TestCase):
         proc, ticks = self.child(ignore_sigterm=True)
         result = recovery.terminate_process_group(proc.pid, ticks, grace_s=0.3)
         self.assertTrue(result["signaled"])
+        self.assertTrue(result["dead"])
         self.assertTrue(result["escalated"])
         proc.wait(timeout=5)
         self.assertEqual(recovery._proc_state(proc.pid, ticks), "dead")
+
+    def test_unreadable_during_grace_is_not_absence(self):
+        proc, ticks = self.child()
+        states = mock.Mock(side_effect=["alive"] + ["unreadable"] * 50)
+        with mock.patch.object(recovery, "_proc_state", states):
+            result = recovery.terminate_process_group(proc.pid, ticks,
+                                                      grace_s=0.3)
+        self.assertTrue(result["signaled"])  # SIGTERM really sent
+        self.assertFalse(result["dead"])
+        self.assertFalse(result["escalated"])
+        self.assertEqual(result["reason"], "absence_unproven")
+
+    def test_sigkill_survivor_is_not_absence(self):
+        # D-state analog: the process never leaves /proc even after SIGKILL.
+        proc, ticks = self.child(ignore_sigterm=True)
+        with mock.patch.object(recovery, "_proc_state",
+                               return_value="alive"):
+            result = recovery.terminate_process_group(proc.pid, ticks,
+                                                      grace_s=0.3)
+        self.assertTrue(result["signaled"])
+        self.assertTrue(result["escalated"])
+        self.assertFalse(result["dead"])
+        self.assertEqual(result["reason"], "absence_unproven")
 
     def test_no_signal_on_identity_mismatch(self):
         proc, ticks = self.child()
@@ -553,6 +623,35 @@ class ExecuteTest(RecoveryCase):
             (sid,)).fetchone()[0], "occupied")
         con.close()
 
+    def test_closure_refused_when_absence_unproven(self):
+        # A signal was sent but /proc never proved the process gone (an
+        # unkillable D-state survivor): closure is refused with a named
+        # next action and NO durable state is touched.
+        proc, ticks = self.child()
+        sid = self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+            self.assertEqual(obj["classification"], "exact_idle_orphan")
+            with mock.patch.object(
+                    recovery, "terminate_process_group",
+                    return_value={"signaled": True, "dead": False,
+                                  "escalated": True, "pid": proc.pid,
+                                  "pgid": proc.pid,
+                                  "reason": "absence_unproven",
+                                  "detail": "survives SIGKILL"}):
+                status, err = self.call(
+                    "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                    {"observation_id": obj["observation_id"],
+                     "mode": "recover"})
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_absence_unproven")
+        self.assertIn("preview again", err["error"]["message"])
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE session_id=?",
+            (sid,)).fetchone()[0], "occupied")
+        con.close()
+
     def test_idempotent_replay_no_second_side_effect(self):
         proc, ticks = self.child()
         self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
@@ -723,6 +822,64 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
         self.assertFalse((Path(wt) / "untracked.txt").exists())
         self.assertTrue(Path(wt).is_dir())  # worktree itself never deleted
+
+    def test_discard_git_failure_reports_exactly_what_completed(self):
+        # clean fails AFTER reset succeeded and the closure committed: the
+        # response stays 200 and names the completed/failed steps — never a
+        # bare 500 that hides a partial discard.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        real_run = recovery.subprocess.run
+
+        def flaky_clean(*args, **kwargs):
+            if "clean" in args[0]:
+                return subprocess.CompletedProcess(
+                    args=args[0], returncode=1, stdout="",
+                    stderr="fatal: clean boom")
+            return real_run(*args, **kwargs)
+
+        with mock.patch.object(recovery.subprocess, "run",
+                               side_effect=flaky_clean):
+            status, result = self.post(obj, preserve_worktree=False,
+                                       discard_worktree=True,
+                                       confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        wt_result = result["worktree"]
+        self.assertFalse(wt_result["discarded"])
+        self.assertEqual(wt_result["completed"], ["reset"])
+        self.assertEqual(wt_result["failed"]["step"], "clean")
+        self.assertIn("clean boom", wt_result["failed"]["error"])
+        # reset ran (tracked restored), clean did not (untracked survives),
+        # and the durable closure still committed.
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+        ).fetchone()[0], "ended")
+        con.close()
+
+    def test_discard_git_timeout_reported_not_raised(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        real_run = recovery.subprocess.run
+
+        def timeout_reset(*args, **kwargs):
+            if "reset" in args[0]:
+                raise subprocess.TimeoutExpired(cmd=args[0], timeout=60)
+            return real_run(*args, **kwargs)
+
+        with mock.patch.object(recovery.subprocess, "run",
+                               side_effect=timeout_reset):
+            status, result = self.post(obj, preserve_worktree=False,
+                                       discard_worktree=True,
+                                       confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertFalse(result["worktree"]["discarded"])
+        self.assertEqual(result["worktree"]["completed"], [])
+        self.assertEqual(result["worktree"]["failed"]["step"], "reset")
 
 
 # ------------------------------------------------------------------ CLI parity


### PR DESCRIPTION
## Sprint 31 · unit 8 · spec #30 req 24 / task #95

One API-owned stranded-shell recovery workflow shared by browser and CLI. Absorbs roadmap #22 and flag #38. Depends on units 1 (lifecycle contract), 4 (credential surface), 6 (liveness) — all merged.

**Preview** — `GET /_sc/interface/shells/{shell_id}/recovery` (also routed under `/api/interface/...`): durable session+generation, archive relation, sprint binding, pane PID/start-ticks, tmux target, process-group evidence, unread count, advisory git facts (no secrets/terminal content). The server derives ONE classification — `available` / `stale_durable_lock` / `exact_idle_orphan` / `verified_live` / `indeterminate` — plus the legal actions, stored as an opaque observation fingerprinted against the durable state.

**Execute** — `POST` with `observation_id`, `mode` (recover|force), `preserve_worktree=true` default, Idempotency-Key:
- changed durable state / expired observation → `409 recovery_observation_stale` (preview again);
- exact process-group SIGTERM → bounded existing grace → SIGKILL only while the same PID/start ticks identify it; identity mismatch or unreadable /proc → no signal, `409 recovery_indeterminate`;
- atomic closure on proven absence: session+generation+leases (one closure helper), archive close with the `active_archive_id` guard, session alert resolution, generation-bound binding release, ambiguous bindings parked with a named next action, unread messages untouched;
- force legal only against `verified_live` with `confirm_force`; `discard_worktree` independently confirmed by typed shortname, refuses unpushed commits (fail closed), never deletes worktree/branch.

**CLI** — `./sc interface recover <shortname> [--force] [--discard-worktree] [--yes] [--json]` at parity; off-TTY without `--yes` refuses rather than prompting.

Stdlib-only — recovery works HTTP-only without the websockets runtime (spec Restricted Admin).

## Ambiguity calls (sprint-scoped)

1. **Browser controls deferred.** The planner's task row scoped this unit to the API + CLI at parity; the UI's `ifRecoveryPane` belongs to unit 2's in-flight UI work — wiring it there avoids an app.js collision. The API carries everything the pane needs (classification, legal actions, evidence).
2. **`/_sc/interface/` served as an alias** of `/api/interface/` (same handlers, same authority) — the spec's canonical prefix, with the engine's existing prefix kept as the primary neighborhood path.
3. **Scoped confirmations:** force → `confirm_force: true` after the client names the exact process identity; discard → `confirm_shortname` typed. CLI `--yes` pre-answers both; off-TTY without it refuses.
4. **"Exact idle orphan"** = exact PID/start-ticks identity alive while its pane is gone (or its session already ended) — standard recover signals that exact process group. `verified_live` (pane present + identity verified) is force-only.
5. **Unpushed** = `git rev-list HEAD --not --remotes` — commits on no remote at all; the check fails closed.

## Verification

- New `tests/test_interface_recovery.py`: 40 proofs — classification table, stale/expired/unknown observations, action legality, real-process SIGTERM/SIGKILL/identity-mismatch signaling, atomic closure, ambiguous binding parking, idempotent replay, worktree preserve/discard/unpushed refusal, CLI parity (request shape, confirmations, refusals, --json).
- Touched suites: 188 passed (interface api/cli/transitions/liveness/reconcile-guard + recovery).
- Full suite via `./sc job` 65: green (exit 0, 4m20s) — including the previously flaky spike test.
- `ruff` clean on new files; `mypy` clean on the new module.

Review: REV2 per sprint doc.