### PR TITLE
feat(cli): restore grouped launcher and Make surface

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -24,19 +24,30 @@
 #   make dos-h                   list the commands
 #   make dos-help                list + describe the commands
 #
-#   LONG-ONLY: dos-build dos-logs dos-serve dos-health dos-ports dos-verify dos-map
-#              dos-render dos-snapshot dos-deps dos-install dos-rollback dos-token
-#              dos-update-harnesses dos-feat/dos-feature dos-eject
+#   LONG-ONLY: Interface status/start/view/attach/take-control/stop/reconcile/
+#              recover; models; sprint/watch/job; build/logs/serve/health/ports;
+#              verify/map/render/snapshot/deps/install/rollback/token/
+#              update-harnesses/feature/eject
 #              passthrough: make dos ARGS=health
 #
 SC := ./sc
 .PHONY: dos-e dos-enter dos-l dos-launch dos-r dos-restart dos-d dos-down dos-u dos-update \
         dos-t dos-test dos-h dos-help dos-build dos-logs dos-serve dos-health dos-ports \
         dos-verify dos-map dos-render dos-snapshot dos-deps dos-install dos-rollback \
-        dos-update-harnesses dos-feat dos-feature dos-eject dos-token dos
+        dos-update-harnesses dos-feat dos-feature dos-eject dos-token dos-status \
+        dos-start dos-view dos-attach dos-take dos-take-control dos-stop \
+        dos-reconcile dos-recover dos-models dos-model-refresh dos-model-list \
+        dos-model-resolve dos-sprint dos-watch dos-job dos-setup dos
+
+# Interface actions other than enter/status require an exact shell. Fail in
+# Make before ./sc is invoked so a typo cannot silently widen an operation.
+require-shell = $(if $(strip $(s)),,$(error $@: requires s=<shell-shortname>))
+shell-arg = $(if $(strip $(s)),$(s))
+require-model-route = $(if $(and $(strip $(h)),$(strip $(m))),,$(error $@: requires h=<harness> m=<model> [s=<shell-shortname>]))
+model-shell-arg = $(if $(strip $(s)),--shell $(s))
 
 # Hot commands — long form, with a one-letter alias delegating to it.
-dos-enter:            ; $(SC) $(if $(s),enter-$(s),enter)
+dos-enter:            ; $(SC) $(if $(strip $(s)),enter-$(s),enter) $(ARGS)
 dos-e: dos-enter
 dos-launch:           ; $(SC) launch $(ARGS)
 dos-l: dos-launch
@@ -44,23 +55,45 @@ dos-restart:          ; $(SC) restart $(ARGS)
 dos-r: dos-restart
 dos-down:             ; $(SC) down
 dos-d: dos-down
-dos-update:           ; $(SC) update
+dos-update:           ; $(SC) update $(ARGS)
 dos-u: dos-update
-dos-test:             ; $(SC) test
+dos-test:             ; $(SC) test $(ARGS)
 dos-t: dos-test
+
+# Interface operator workflow. These are the accepted public API-backed verbs;
+# server-only primitives and direct DB/tmux operations intentionally stay out.
+dos-status:           ; $(SC) interface status $(shell-arg) $(ARGS)
+dos-start:            ; $(call require-shell)$(SC) interface start $(s) $(ARGS)
+dos-view:             ; $(call require-shell)$(SC) interface view $(s)
+dos-attach:           ; $(call require-shell)$(SC) interface attach $(s)
+dos-take:             ; $(call require-shell)$(SC) interface take-control $(s)
+dos-take-control:     ; $(call require-shell)$(SC) interface take-control $(s)
+dos-stop:             ; $(call require-shell)$(SC) interface stop $(s) $(ARGS)
+dos-reconcile:        ; $(call require-shell)$(SC) interface reconcile $(s) $(ARGS)
+dos-recover:          ; $(call require-shell)$(SC) interface recover $(s) $(ARGS)
+
+# Model catalogue and durable sprint operator surfaces.
+dos-models:           ; $(SC) models $(ARGS)
+dos-model-refresh:    ; $(SC) models refresh
+dos-model-list:       ; $(SC) models list $(h)
+dos-model-resolve:    ; $(call require-model-route)$(SC) models resolve $(h) $(m) $(model-shell-arg)
+dos-sprint:           ; $(SC) sprint $(ARGS)
+dos-watch:            ; $(SC) watch $(ARGS)
+dos-job:              ; $(SC) job $(ARGS)
 
 # Long-only commands.
 dos-build:            ; $(SC) build
 dos-logs:             ; $(SC) logs
-dos-serve:            ; $(SC) serve
+dos-serve:            ; $(SC) serve $(ARGS)
 dos-health:           ; $(SC) health
 dos-ports:            ; $(SC) ports
 dos-verify:           ; $(SC) verify
-dos-map:              ; $(SC) map
+dos-map:              ; $(SC) map $(ARGS)
 dos-render:           ; $(SC) render $(ARGS)
 dos-snapshot:         ; $(SC) snapshot
-dos-deps:             ; $(SC) deps
+dos-deps:             ; $(SC) deps $(ARGS)
 dos-install:          ; $(SC) install
+dos-setup: dos-install
 dos-rollback:         ; $(SC) rollback
 # Browser sign-in operator token — prints ONLY the owner-only runtime
 # credential to stdout (never rotates, never logs); exact alias of ./sc token.
@@ -93,36 +126,43 @@ dos-h:
 	@echo ""
 dos-help:
 	@echo ""
-	@echo "  super-coder — make dos-<cmd>   every target delegates to ./sc  (designs-OS 'dos-' standard)"
-	@echo "  ┌──────────────────────┬──────────────────────────────────────────────────────────┐"
-	@echo "  │ HOT  (short + long)  │ what it does                                             │"
-	@echo "  ├──────────────────────┼──────────────────────────────────────────────────────────┤"
-	@echo "  │ dos-e  dos-enter     │ attach a session — pick shell + harness (dos-e s=ap01)   │"
-	@echo "  │ dos-l  dos-launch    │ build + start the docker sandbox (server + review GUI)   │"
-	@echo "  │ dos-r  dos-restart   │ confirm (YES) + DB backup -> down + launch (fresh)       │"
-	@echo "  │ dos-d  dos-down      │ stop + remove the sandbox container                      │"
-	@echo "  │ dos-u  dos-update    │ fetch + materialize the engine, reconcile in place       │"
-	@echo "  │ dos-t  dos-test      │ backend (pytest/unittest) + UI (vitest) suites           │"
-	@echo "  ├──────────────────────┼──────────────────────────────────────────────────────────┤"
-	@echo "  │ MORE  (long-only)    │ what it does                                             │"
-	@echo "  ├──────────────────────┼──────────────────────────────────────────────────────────┤"
-	@echo "  │ dos-build            │ (re)build the sandbox image                              │"
-	@echo "  │ dos-logs             │ tail the sandbox server logs                             │"
-	@echo "  │ dos-serve            │ run the review layer (api + UI) in the foreground        │"
-	@echo "  │ dos-health           │ curl the review layer's /api/health                      │"
-	@echo "  │ dos-ports            │ show this fork's derived port                            │"
-	@echo "  │ dos-verify           │ rebuild + render + render-only boot (headless proof)     │"
-	@echo "  │ dos-map              │ scan the repo into the dr_* catalogue                    │"
-	@echo "  │ dos-render ARGS=<x>  │ render tracked flat _sc files (specs/docs/skills)        │"
-	@echo "  │ dos-snapshot         │ dump per-instance tables -> .sc-state/content.sql        │"
-	@echo "  │ dos-deps             │ install python (.venv) + node deps into the bind-mount   │"
-	@echo "  │ dos-install          │ first-launch bootstrap for a fork                        │"
-	@echo "  │ dos-rollback         │ undo a bad update — restore DB + engine together         │"
-	@echo "  │ dos-token            │ print the browser sign-in operator token (stdout only)     │"
-	@echo "  │ dos-update-harnesses │ update claude + opencode + codex + vibe to latest        │"
-	@echo "  │ dos-feat ARGS=<x>    │ opt-in features — list / enable pg·windows·tailnet       │"
-	@echo "  │ dos-eject            │ ONE-WAY: own the engine — stop tracking upstream         │"
-	@echo "  ├──────────────────────┼──────────────────────────────────────────────────────────┤"
-	@echo "  │ dos ARGS=<cmd>       │ passthrough to any ./sc subcommand (make dos ARGS=doctor)│"
-	@echo "  └──────────────────────┴──────────────────────────────────────────────────────────┘"
+	@echo "  super-coder — make dos-<cmd>   every target delegates to ./sc"
+	@echo ""
+	@echo "  HOT"
+	@echo "    dos-e / dos-enter [s=x]     pick/enter a shell, or enter x directly"
+	@echo "    dos-l / dos-launch          build + start the sandbox and review GUI"
+	@echo "    dos-r / dos-restart         confirm + backup + fully restart (ARGS forwarded)"
+	@echo "    dos-d / dos-down            stop and remove the sandbox"
+	@echo "    dos-u / dos-update          update and reconcile the engine (ARGS forwarded)"
+	@echo "    dos-t / dos-test            run backend + UI suites (ARGS forwarded)"
+	@echo ""
+	@echo "  INTERFACE  (API-backed; actions marked s=x require a shell shortname)"
+	@echo "    dos-status [s=x]            rail status, optionally one shell"
+	@echo "    dos-start s=x               start a New chat"
+	@echo "    dos-view s=x                attach read-only"
+	@echo "    dos-attach s=x              attach as writer without takeover"
+	@echo "    dos-take s=x                explicitly transfer the writer role"
+	@echo "    dos-take-control s=x        descriptive alias of dos-take"
+	@echo "    dos-stop s=x                gracefully end; ARGS=--force after timeout"
+	@echo "    dos-reconcile s=x           revalidate; ARGS=--close after proved absence"
+	@echo "    dos-recover s=x             preview/recover; force/discard via explicit ARGS"
+	@echo ""
+	@echo "  MODELS + SPRINT"
+	@echo "    dos-model-refresh           refresh the local model catalogue"
+	@echo "    dos-model-list [h=x]        list all routes or one harness"
+	@echo "    dos-model-resolve h=x m=y   resolve an exact route; optional s=<shell>"
+	@echo "    dos-models ARGS='<cmd>'     generic model catalogue command"
+	@echo "    dos-sprint ARGS='<cmd>'      sprint action/status/alerts/retry"
+	@echo "    dos-watch ARGS='<cmd>'       PR watch register/list/reconcile/inbox"
+	@echo "    dos-job ARGS='<cmd>'         durable local job start/wait/list/status/tail/kill"
+	@echo ""
+	@echo "  MAINTENANCE"
+	@echo "    dos-build · dos-logs · dos-serve · dos-health · dos-ports"
+	@echo "    dos-verify · dos-map · dos-render · dos-snapshot · dos-deps"
+	@echo "    dos-setup / dos-install · dos-rollback · dos-update-harnesses"
+	@echo "    dos-feat / dos-feature      list/enable/disable opt-in features"
+	@echo "    dos-token                   print the browser sign-in token (stdout only)"
+	@echo "    dos-eject                   ONE-WAY: own the engine"
+	@echo ""
+	@echo "    dos ARGS='<cmd>'            generic ./sc passthrough"
 	@echo ""

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -745,14 +745,28 @@ def _list_shells():
     con = _db()
     try:
         snap = shell_liveness.compute()
+        defaults = {}
+        for flavor, harness, model in con.execute(
+                "SELECT flavor, harness, model FROM flavor_defaults "
+                "WHERE is_default=1"):
+            defaults[flavor] = {
+                "default_harness": harness,
+                "default_model": model,
+            }
         shells = con.execute(
-            "SELECT shell_id, shortname, display_name FROM shells "
+            "SELECT shell_id, shortname, display_name, flavor FROM shells "
             "WHERE COALESCE(is_deleted,0)=0 ORDER BY shell_id").fetchall()
         out = []
-        for shell_id, shortname, display_name in shells:
+        for shell_id, shortname, display_name, flavor in shells:
             proj = _availability(con, shell_id, snap)
+            launch_default = defaults.get(flavor, {})
             out.append({"shell_id": shell_id, "shortname": shortname,
                         "display_name": display_name,
+                        "flavor": flavor,
+                        "default_harness":
+                            launch_default.get("default_harness"),
+                        "default_model":
+                            launch_default.get("default_model"),
                         "wake_state": _wake_state(
                             con, planner_shell_id=shell_id), **proj})
         return _json(200, {"shells": out})

--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -37,8 +37,10 @@ from collections import deque
 import os
 import select
 import signal
+import shutil
 import sys
 import termios
+import textwrap
 import threading
 import time
 import tty
@@ -716,57 +718,148 @@ def cmd_recover(args) -> int:
 
 # ------------------------------------------------------------------ enter
 
-def _flavor_harness(shell: dict) -> str | None:
-    """The shell's flavor default harness, read from the engine DB exactly as
-    the boot path does (launch routing data — never interface state, which
-    comes from the API only). Best-effort: any failure degrades to the
-    instance default."""
-    try:
-        con = run_mod.db_driver.connect(str(run_mod.DB_PATH))
-        try:
-            row = con.execute("SELECT flavor FROM shells WHERE shell_id=?",
-                              (shell["shell_id"],)).fetchone()
-            fdef = run_mod.flavor_defaults(con).get(row["flavor"] if row
-                                                    else None)
-        finally:
-            con.close()
-    except Exception:
-        return None
-    return fdef["default_harness"] if fdef else None
-
-
 def _pick_harness(shell: dict, args) -> str | None:
     """The normal boot picker (run.py's own): an explicit --harness / HARNESS
     wins silently; else the harnesses on PATH, defaulting to this shell's
-    flavor default → instance.json → 'claude'. Model/effort resolve through
-    the reservation (prepare_launch's flavor_defaults), like the GUI's New
-    chat; explicit --model/--effort flags override."""
+    API-projected flavor default → instance.json → 'claude'. Model/effort
+    resolve through the reservation (prepare_launch's flavor_defaults), like
+    the GUI's New chat; explicit --model/--effort flags override."""
     if args.harness:
         return args.harness
     if os.environ.get("HARNESS"):
         return os.environ["HARNESS"]
-    default = (_flavor_harness(shell) or run_mod._configured_harness()
+    default = (shell.get("default_harness") or run_mod._configured_harness()
                or "claude")
     picked = run_mod.pick_harness(run_mod.detect_harnesses(), default,
                                   first=False)
     return picked or default
 
 
+def _fit(value, width: int) -> str:
+    """Fit one plain-text picker cell without letting long names break rows."""
+    text = str(value or "")
+    if len(text) <= width:
+        return text
+    return text[:max(0, width - 1)] + "…"
+
+
+def _picker_status(shell: dict) -> str:
+    availability = (shell.get("availability") or "unknown").replace("_", " ")
+    paint = {
+        "available": style.green,
+        "occupied": style.amber,
+        "starting": style.yellow,
+        "lost": style.red,
+        "error": style.red,
+        "unreconciled": style.red,
+        "unknown": style.dim,
+    }.get(availability, style.dim)
+    return paint(availability)
+
+
+def _picker_default(shell: dict) -> str:
+    harness = shell.get("default_harness")
+    if not harness:
+        return ""
+    model = shell.get("default_model")
+    return harness + (f" · {str(model).split('/')[-1]}" if model else "")
+
+
+def _grouped_shells(shells: list[dict]) -> list[dict]:
+    """Stable flavor groups without changing the API rail's canonical order."""
+    return sorted(
+        shells,
+        key=lambda shell: (
+            shell.get("flavor") is None,
+            (shell.get("flavor") or "").lower(),
+            shell.get("shell_id") or 0,
+        ),
+    )
+
+
+def _render_shell_picker(shells: list[dict]) -> list[dict]:
+    """Render the grouped launcher table, with a compact narrow-terminal form."""
+    ordered = _grouped_shells(shells)
+    columns = shutil.get_terminal_size((100, 24)).columns
+    full = columns >= 78
+    print(style.bold("\nShells"))
+    if full:
+        default_width = max(12, min(30, columns - 61))
+        print(style.dim(
+            f"{'#':>3}  {'Name':<18}{'Shortname':<13}{'State':<15}"
+            f"{'Default (harness · model)':<{default_width}}"
+        ))
+    current = object()
+    for number, shell in enumerate(ordered, 1):
+        flavor = shell.get("flavor")
+        if flavor != current:
+            current = flavor
+            print(f"\n{style.accent(flavor or '(bespoke)')}")
+        shortname = shell.get("shortname") or "?"
+        status = _picker_status(shell)
+        default = _picker_default(shell)
+        if full:
+            display = f"{_fit(shell.get('display_name'), 17):<18}"
+            state_width = len(str(shell.get("availability") or "unknown"))
+            print(
+                f"{style.dim(f'{number:>3}')}  "
+                f"{style.bold(display)}"
+                f"{_fit(shortname, 12):<13}"
+                f"{status}{' ' * max(1, 15 - state_width)}"
+                f"{style.dim(_fit(default, default_width))}"
+            )
+            continue
+        if columns >= 32:
+            short_width = min(14, max(6, columns - 22))
+            print(
+                f"{number:>3}  "
+                f"{_fit(shortname, short_width):<{short_width + 1}} "
+                f"{_picker_status(shell)}"
+            )
+        else:
+            print(f"{number:>3} {_fit(shortname, max(1, columns - 4))}")
+            print(f"     {_picker_status(shell)}")
+        detail = " · ".join(
+            str(part) for part in (shell.get("display_name"), default) if part
+        )
+        if detail:
+            for line in textwrap.wrap(
+                    detail, width=max(1, columns - 5),
+                    break_long_words=True, break_on_hyphens=False):
+                print(style.dim(f"     {line}"))
+    return ordered
+
+
 def _pick_shell(shells: list[dict], requested: str | None) -> dict:
     """The `sc enter` shell picker, API-backed: the rail's own data (the
     operator bearer is the auth — no username round-trip)."""
     if requested:
-        return _find_shell(requested)
+        chosen = next(
+            (shell for shell in shells
+             if (shell.get("shortname") or "").lower() == requested.lower()),
+            None,
+        )
+        if chosen is None:
+            avail = ", ".join(
+                shell.get("shortname") or "?" for shell in shells
+            ) or "none"
+            die(f"no shell '{requested}'. Available: {avail}", EXIT_USAGE)
+        return chosen
     if not shells:
         die("no shells")
     if not sys.stdin.isatty():
         return shells[0]
-    for n, s in enumerate(shells, 1):
-        print(f"{style.dim(f'{n:>3}')}  {_status_line(s)}")
+    ordered = _render_shell_picker(shells)
     while True:
-        choice = input("\nPick (#): ").strip()
-        if choice.isdigit() and 1 <= int(choice) <= len(shells):
-            return shells[int(choice) - 1]
+        try:
+            choice = input("\nPick (#, q to cancel): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            die("selection cancelled")
+        if choice.lower() in ("q", "quit"):
+            die("selection cancelled")
+        if choice.isdigit() and 1 <= int(choice) <= len(ordered):
+            return ordered[int(choice) - 1]
         print("  invalid choice")
 
 

--- a/sc
+++ b/sc
@@ -1376,7 +1376,10 @@ super-coder — forkable shell substrate
   ./sc interface <verb>    Interface CLI parity (spec #20), API-backed (never direct DB/tmux):
                              status [shell] [--json] · start <shell> [--harness H] [--model M] [--effort E]
                              view <shell> (read-only) · attach <shell> (writer) · take-control <shell>
-                             stop <shell> [--force] · reconcile <shell> [--close] — mutations take --json
+                             stop <shell> [--force] · reconcile <shell> [--close]
+                             recover <shell> [--force] [--discard-worktree] [--yes] — mutations take --json
+  make dos-help            supported operator aliases for lifecycle, Interface, models,
+                             sprint/watch/job, maintenance, browser token, and generic ./sc forwarding
   ./sc run <shortname>     headless boot: render + exec the harness NON-interactively (claude · codex ·
                              opencode · kimi) to drain the shell's inbox and act; -p "<prompt>" overrides the
                              default prompt · --harness <h> · -m <model> (else flavor_defaults);

--- a/tests/test_aliases_make.py
+++ b/tests/test_aliases_make.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Contract tests for the supported Make operator surface.
+
+Every target is a thin delegation to ./sc. These tests pin the public command
+and argument shape so a Make-only behavior fork, a missing shell guard, or help
+drift fails before it reaches an operator.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def make(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["make", "--no-print-directory", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+
+@unittest.skipUnless(shutil.which("make"), "GNU Make is not installed")
+class MakeAliasContractTest(unittest.TestCase):
+    def test_documented_targets_delegate_exactly_to_sc(self):
+        cases = [
+            (("dos-enter",), "./sc enter"),
+            (("dos-e", "s=DEV1"), "./sc enter-DEV1"),
+            (("dos-launch", "ARGS=--no-build"), "./sc launch --no-build"),
+            (("dos-l",), "./sc launch"),
+            (("dos-restart", "ARGS=--yes --no-build"),
+             "./sc restart --yes --no-build"),
+            (("dos-r", "ARGS=--yes"), "./sc restart --yes"),
+            (("dos-down",), "./sc down"),
+            (("dos-d",), "./sc down"),
+            (("dos-update", "ARGS=--no-fetch"), "./sc update --no-fetch"),
+            (("dos-u",), "./sc update"),
+            (("dos-test", "ARGS=tests/test_aliases_make.py"),
+             "./sc test tests/test_aliases_make.py"),
+            (("dos-t",), "./sc test"),
+            (("dos-status", "s=DEV1", "ARGS=--json"),
+             "./sc interface status DEV1 --json"),
+            (("dos-start", "s=DEV1", "ARGS=--harness codex"),
+             "./sc interface start DEV1 --harness codex"),
+            (("dos-view", "s=DEV1"), "./sc interface view DEV1"),
+            (("dos-attach", "s=DEV1"), "./sc interface attach DEV1"),
+            (("dos-take", "s=DEV1"),
+             "./sc interface take-control DEV1"),
+            (("dos-take-control", "s=DEV1"),
+             "./sc interface take-control DEV1"),
+            (("dos-stop", "s=DEV1", "ARGS=--force"),
+             "./sc interface stop DEV1 --force"),
+            (("dos-reconcile", "s=DEV1", "ARGS=--close"),
+             "./sc interface reconcile DEV1 --close"),
+            (("dos-recover", "s=DEV1", "ARGS=--force --yes"),
+             "./sc interface recover DEV1 --force --yes"),
+            (("dos-models", "ARGS=list codex"), "./sc models list codex"),
+            (("dos-model-refresh",), "./sc models refresh"),
+            (("dos-model-list", "h=codex"), "./sc models list codex"),
+            (("dos-model-resolve", "h=codex", "m=gpt-5.6-sol", "s=DEV1"),
+             "./sc models resolve codex gpt-5.6-sol --shell DEV1"),
+            (("dos-sprint", "ARGS=status --all"), "./sc sprint status --all"),
+            (("dos-watch", "ARGS=list --all"), "./sc watch list --all"),
+            (("dos-job", "ARGS=status 7"), "./sc job status 7"),
+            (("dos-build",), "./sc build"),
+            (("dos-logs",), "./sc logs"),
+            (("dos-serve", "ARGS=--port 9900"), "./sc serve --port 9900"),
+            (("dos-health",), "./sc health"),
+            (("dos-ports",), "./sc ports"),
+            (("dos-verify",), "./sc verify"),
+            (("dos-map", "ARGS=--help"), "./sc map --help"),
+            (("dos-render", "ARGS=flat"), "./sc render flat"),
+            (("dos-snapshot",), "./sc snapshot"),
+            (("dos-deps", "ARGS=--help"), "./sc deps --help"),
+            (("dos-install",), "./sc install"),
+            (("dos-setup",), "./sc install"),
+            (("dos-rollback",), "./sc rollback"),
+            (("dos-token",), "./sc token"),
+            (("dos-update-harnesses",), "./sc update-harnesses"),
+            (("dos-feature", "ARGS=enable pg"), "./sc feature enable pg"),
+            (("dos-feat",), "./sc feature"),
+            (("dos-eject",), "./sc eject"),
+            (("dos", "ARGS=doctor"), "./sc doctor"),
+        ]
+        for args, expected in cases:
+            with self.subTest(target=args[0]):
+                result = make("-n", *args)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), expected)
+
+    def test_shell_actions_fail_before_dispatch_when_s_is_missing(self):
+        for target in (
+            "dos-start",
+            "dos-view",
+            "dos-attach",
+            "dos-take",
+            "dos-take-control",
+            "dos-stop",
+            "dos-reconcile",
+            "dos-recover",
+        ):
+            with self.subTest(target=target):
+                result = make("-n", target)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertIn(
+                    f"{target}: requires s=<shell-shortname>", result.stderr
+                )
+
+    def test_model_resolve_requires_harness_and_model_before_dispatch(self):
+        result = make("-n", "dos-model-resolve", "h=codex")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn(
+            "dos-model-resolve: requires h=<harness> m=<model> "
+            "[s=<shell-shortname>]",
+            result.stderr,
+        )
+
+    def test_full_help_covers_token_dispatch_and_operator_groups(self):
+        result = make("dos-help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        help_text = result.stdout
+        self.assertEqual(
+            help_text.count(
+                "dos-token                   print the browser sign-in token "
+                "(stdout only)"
+            ),
+            1,
+        )
+        for heading in ("HOT", "INTERFACE", "MODELS + SPRINT", "MAINTENANCE"):
+            self.assertIn(heading, help_text)
+        for target in (
+            "dos-status",
+            "dos-start",
+            "dos-view",
+            "dos-attach",
+            "dos-take-control",
+            "dos-stop",
+            "dos-reconcile",
+            "dos-recover",
+            "dos-models",
+            "dos-model-refresh",
+            "dos-model-list",
+            "dos-model-resolve",
+            "dos-sprint",
+            "dos-watch",
+            "dos-job",
+            "dos-setup",
+            "dos-token",
+            "dos ARGS='<cmd>'",
+        ):
+            self.assertIn(target, help_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -26,6 +26,7 @@ Run:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import sqlite3
 import stat
@@ -219,10 +220,33 @@ class InterfaceApiTest(unittest.TestCase):
         self.assertEqual(status, 401)
 
     def test_operator_bearer_lists_shells(self):
+        with contextlib.closing(sqlite3.connect(self.db_path)) as con:
+            con.execute("UPDATE shells SET flavor='dev' WHERE shell_id=1")
+            con.commit()
         status, _, body = self.call("GET", "/api/interface/shells", (OP,))
         self.assertEqual(status, 200)
         self.assertEqual(len(body["shells"]), 2)
-        self.assertEqual(body["shells"][0]["availability"], "available")
+        self.assertEqual(
+            {
+                key: body["shells"][0][key]
+                for key in (
+                    "shell_id", "shortname", "display_name", "flavor",
+                    "availability", "default_harness", "default_model",
+                )
+            },
+            {
+                "shell_id": 1,
+                "shortname": "s1",
+                "display_name": "S1",
+                "flavor": "dev",
+                "availability": "available",
+                "default_harness": "codex",
+                "default_model": "gpt-5.6-sol",
+            },
+        )
+        self.assertIsNone(body["shells"][1]["flavor"])
+        self.assertIsNone(body["shells"][1]["default_harness"])
+        self.assertIsNone(body["shells"][1]["default_model"])
 
     def test_browser_bootstrap_same_origin_fence(self):
         # Cross-site Origin cannot mint a session (rejected before the

--- a/tests/test_interface_cli.py
+++ b/tests/test_interface_cli.py
@@ -43,14 +43,20 @@ import run as run_mod  # noqa: E402
 SHELLS = {
     "shells": [
         {"shell_id": 1, "shortname": "S1", "display_name": "One",
+         "flavor": "dev", "default_harness": "codex",
+         "default_model": "openai/gpt-5.6-sol",
          "availability": "available", "session_id": None, "lifecycle": None,
          "harness": None, "composer": None, "alerts": 0,
          "wake_state": "disarmed"},
         {"shell_id": 2, "shortname": "S2", "display_name": "Two",
+         "flavor": "dev", "default_harness": "codex",
+         "default_model": "openai/gpt-5.6-sol",
          "availability": "occupied", "session_id": 7, "lifecycle": "idle",
          "harness": "claude", "composer": "clean", "alerts": 0,
          "wake_state": "disarmed"},
         {"shell_id": 3, "shortname": "S3", "display_name": "Three",
+         "flavor": "reviewer", "default_harness": "claude",
+         "default_model": "opus",
          "availability": "lost", "session_id": 9, "lifecycle": "lost",
          "harness": "claude", "composer": "unknown", "alerts": 1,
          "wake_state": "disarmed"},
@@ -394,6 +400,11 @@ class InterfaceCliTest(unittest.TestCase):
                        "next_input_seq": 5})
         rc, _, _ = self.run_cli(["enter", "s2"])
         self.assertEqual(rc, 0)
+        self.assertEqual(
+            len(self.http.find("GET", "/api/interface/shells")), 1,
+            "direct selection must reuse the API rail response, not fetch a "
+            "second potentially different snapshot",
+        )
         self.assertEqual(self.http.find("POST", "/api/interface/sessions"), [])
         self.assertEqual(self.stream.call_args[0][1], "writer")
 
@@ -428,6 +439,95 @@ class InterfaceCliTest(unittest.TestCase):
         self.assertIn("reconcile", err)
         self.assertEqual(self.http.find("POST", "/api/interface/sessions"), [])
         self.stream.assert_not_called()
+
+    def test_harness_default_comes_from_api_projection_without_db_read(self):
+        args = mock.Mock(harness=None)
+        with mock.patch.dict(ic.os.environ, {}, clear=True), \
+                mock.patch.object(run_mod, "detect_harnesses",
+                                  return_value=["codex"]), \
+                mock.patch.object(run_mod.db_driver, "connect",
+                                  side_effect=AssertionError(
+                                      "CLI must not read Interface state "
+                                      "from the DB")):
+            picked = ic._pick_harness(SHELLS["shells"][0], args)
+        self.assertEqual(picked, "codex")
+
+    def test_grouped_picker_snapshot_and_selection_order(self):
+        shells = [
+            {"shell_id": 1, "shortname": "REV1",
+             "display_name": "Reviewer", "flavor": "reviewer",
+             "availability": "lost", "default_harness": "claude",
+             "default_model": "opus"},
+            {"shell_id": 2, "shortname": "DEV1",
+             "display_name": "Builder", "flavor": "dev",
+             "availability": "available", "default_harness": "codex",
+             "default_model": "openai/gpt-5.6-sol"},
+            {"shell_id": 3, "shortname": "CUSTOM-LONG-NAME",
+             "display_name": "A bespoke shell with a long display name",
+             "flavor": None, "availability": None,
+             "default_harness": None, "default_model": None},
+        ]
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), \
+                mock.patch.object(ic.sys.stdin, "isatty", return_value=True), \
+                mock.patch.object(ic.shutil, "get_terminal_size",
+                                  return_value=ic.os.terminal_size((100, 24))), \
+                mock.patch("builtins.input", return_value="2"):
+            chosen = ic._pick_shell(shells, None)
+        self.assertEqual(chosen["shortname"], "REV1")
+        self.assertEqual(
+            out.getvalue(),
+            "\nShells\n"
+            "  #  Name              Shortname    State          "
+            "Default (harness · model)     \n"
+            "\n"
+            "dev\n"
+            "  1  Builder           DEV1         available      "
+            "codex · gpt-5.6-sol\n"
+            "\n"
+            "reviewer\n"
+            "  2  Reviewer          REV1         lost           "
+            "claude · opus\n"
+            "\n"
+            "(bespoke)\n"
+            "  3  A bespoke shell … CUSTOM-LONG… unknown        \n",
+        )
+
+    def test_grouped_picker_is_readable_in_a_narrow_terminal(self):
+        shell = {
+            "shell_id": 1,
+            "shortname": "EXTRAORDINARILY-LONG",
+            "display_name": "A very long display name",
+            "flavor": "dev",
+            "availability": "starting",
+            "default_harness": "codex",
+            "default_model": "openai/gpt-5.6-sol",
+        }
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), \
+                mock.patch.object(ic.sys.stdin, "isatty", return_value=True), \
+                mock.patch.object(ic.shutil, "get_terminal_size",
+                                  return_value=ic.os.terminal_size((36, 24))), \
+                mock.patch("builtins.input", return_value="1"):
+            chosen = ic._pick_shell([shell], None)
+        self.assertEqual(chosen["shell_id"], 1)
+        lines = out.getvalue().splitlines()
+        self.assertLessEqual(max(map(len, lines)), 36)
+        self.assertIn("EXTRAORDINARI…", out.getvalue())
+        self.assertIn("starting", out.getvalue())
+        self.assertIn("codex · gpt-5.6-sol", out.getvalue())
+
+    def test_grouped_picker_can_be_cancelled_without_an_action(self):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err), \
+                mock.patch.object(ic.sys.stdin, "isatty", return_value=True), \
+                mock.patch.object(ic.shutil, "get_terminal_size",
+                                  return_value=ic.os.terminal_size((80, 24))), \
+                mock.patch("builtins.input", return_value="q"):
+            with self.assertRaises(SystemExit) as raised:
+                ic._pick_shell([SHELLS["shells"][0]], None)
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("selection cancelled", err.getvalue())
 
 
 class FakeWS:


### PR DESCRIPTION
## What shipped

- restores the flavor-grouped, color-coded `sc enter` chooser with display name, shortname, lifecycle state, default harness/model, direct selection, cancellation, and narrow-terminal rendering
- keeps launcher state/action API-only by projecting flavor/default metadata on the Interface rail instead of reopening a CLI DB read
- expands `aliases.mk` into the supported operator surface: guarded Interface actions, model refresh/list/resolve, sprint/watch/job, setup, lifecycle, maintenance, token, and generic `dos` forwarding
- preserves existing short aliases and pins the carry-forward `dos-token` help/dispatch contract

## Trade-off

Reused the engine's existing ANSI-aware style helpers instead of adding a Rich dependency; the presentation is rich but remains stdlib-compatible for the host CLI. The API projection is additive, so existing browser consumers remain unchanged.

## Verification

- `python3 tests/test_aliases_make.py` — 4 passed
- `python3 tests/test_interface_cli.py` — 60 passed
- Interface API projection test + adjacent supervision Make tests — passed
- focused Ruff lint — passed
- full `./sc test`: 958 passed, 8 skipped; 12 independent interface-stream spike failures because this sandbox lacks `tmux` (all fail session creation with errno 2)

Refs #521. Sprint 31 unit 9a; spec #30 requirements 21-22.