### PR TITLE
feat: add browser recovery controls

### DIFF
--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -598,35 +598,27 @@ def _confirm(prompt: str, yes: bool) -> None:
         die("aborted by operator", EXIT_REFUSED)
 
 
+def _recovery_evidence_rows(preview: dict) -> list[tuple[str, str, str]]:
+    """Validate and expose the API's one canonical evidence projection."""
+    rows = preview.get("evidence_projection")
+    if not isinstance(rows, list) or not rows:
+        die("recovery preview omitted the canonical evidence projection — "
+            "update and restart the Interface service", EXIT_REFUSED)
+    projected = []
+    for row in rows:
+        if not isinstance(row, dict) or not all(
+                isinstance(row.get(field), str)
+                for field in ("key", "label", "value")):
+            die("recovery preview returned an invalid evidence projection — "
+                "update and restart the Interface service", EXIT_REFUSED)
+        projected.append((row["key"], row["label"], row["value"]))
+    return projected
+
+
 def _print_recovery_preview(preview: dict) -> None:
-    ev = preview["evidence"]
-    print(f"→ classification: {preview['classification']} "
-          f"(legal actions: {', '.join(preview['legal_actions']) or 'none'})")
-    sess = ev.get("session")
-    if sess:
-        print(f"  session {sess['session_id']} gen {sess['generation']}: "
-              f"{sess['occupancy']}/{sess['lifecycle']} "
-              f"({sess.get('harness') or '?'})")
-    proc = ev.get("process") or {}
-    if proc.get("pane_pid"):
-        print(f"  process: pid {proc['pane_pid']} "
-              f"ticks {proc['pane_start_ticks']} "
-              f"pgid {proc.get('pgid')} — {proc['pid_state']}"
-              + ("" if proc.get("pane_present") is None else
-                 f", pane {'present' if proc['pane_present'] else 'gone'}"))
-    archive = ev.get("archive")
-    if archive:
-        print(f"  archive {archive['archive_id']}: "
-              f"{'open' if archive['ended_at'] is None else 'closed'}"
-              + (" (active)" if archive.get("active") else ""))
-    if ev.get("sprint_binding"):
-        print(f"  sprint binding {ev['sprint_binding']['binding_id']} armed")
-    print(f"  unread messages: {ev['unread_messages']} (left unread)")
-    git = ev.get("git")
-    if git:
-        print(f"  worktree {git['worktree']}: branch {git['branch']}, "
-              f"{git['dirty_tracked']} dirty tracked, {git['untracked']} "
-              f"untracked, {git['unpushed_commits']} unpushed commit(s)")
+    print("→ recovery preview")
+    for _key, label, value in _recovery_evidence_rows(preview):
+        print(f"  {label}: {value}")
 
 
 def cmd_recover(args) -> int:

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -414,6 +414,125 @@ def classify(evidence: dict) -> tuple[str, list[str]]:
     return "available", []
 
 
+def evidence_projection(evidence: dict, classification: str,
+                        legal_actions: list[str]) -> list[dict[str, str]]:
+    """Canonical client-visible recovery evidence.
+
+    Browser and CLI render these exact rows.  Keeping the field selection and
+    absence wording here prevents either client from presenting a safer-looking
+    subset than the other for the same observation.
+    """
+    shell = evidence.get("shell") or {}
+    session = evidence.get("session")
+    generation = evidence.get("generation")
+    archive = evidence.get("archive")
+    binding = evidence.get("sprint_binding")
+    process = evidence.get("process") or {}
+    tmux = evidence.get("tmux")
+    git = evidence.get("git")
+
+    shortname = shell.get("shortname") or "unknown"
+    shell_id = shell.get("shell_id")
+    shell_value = f"{shortname} · id {shell_id if shell_id is not None else '—'}"
+
+    if session:
+        session_value = (
+            f"session #{session.get('session_id', '—')} · generation "
+            f"{session.get('generation', '—')} · "
+            f"{session.get('occupancy', '—')}/{session.get('lifecycle', '—')}"
+            f" · harness {session.get('harness') or '—'}")
+    else:
+        session_value = "no Interface session"
+
+    if generation:
+        ended = generation.get("ended_at")
+        generation_value = (
+            f"generation {generation.get('generation', '—')} · "
+            f"{'open' if ended is None else f'ended {ended}'} · "
+            f"last hook {generation.get('last_hook_seq', '—')}")
+    else:
+        generation_value = "no generation record"
+
+    if archive:
+        ended = archive.get("ended_at")
+        archive_value = (
+            f"archive #{archive.get('archive_id', '—')} · "
+            f"{'open' if ended is None else f'closed {ended}'}"
+            f"{' · active' if archive.get('active') else ''}")
+    else:
+        archive_value = "no archive relation"
+
+    if binding:
+        binding_value = (
+            f"binding #{binding.get('binding_id', '—')} · sprint doc "
+            f"#{binding.get('sprint_doc_id', '—')}")
+    else:
+        binding_value = "no armed sprint binding"
+
+    if process.get("pane_pid") is None or \
+            process.get("pane_start_ticks") is None:
+        process_value = "no recorded process identity"
+    else:
+        presence = process.get("pane_present")
+        presence_value = "presence unknown" if presence is None else \
+            ("present" if presence else "gone")
+        process_value = (
+            f"PID {process['pane_pid']} · start ticks "
+            f"{process['pane_start_ticks']} · PGID "
+            f"{process.get('pgid') if process.get('pgid') is not None else '—'}"
+            f" · {process.get('pid_state') or 'unknown'} · pane "
+            f"{process.get('pane_id') or '—'} ({presence_value})")
+
+    if tmux:
+        tmux_value = (
+            f"socket {tmux.get('socket') or '—'} · "
+            f"session {tmux.get('session') or '—'} · "
+            f"window {tmux.get('window') or '—'} · "
+            f"pane {tmux.get('pane_id') or '—'}")
+    else:
+        tmux_value = "no tmux relation"
+
+    unread = evidence.get("unread_messages")
+    unread_value = (
+        f"{unread} · left unread" if isinstance(unread, int)
+        else "unknown · left unread")
+
+    if git:
+        tracked = git.get("dirty_tracked")
+        untracked = git.get("untracked")
+        if isinstance(tracked, int) and isinstance(untracked, int):
+            cleanliness = "clean" if tracked == 0 and untracked == 0 \
+                else "not clean"
+            worktree_value = (
+                f"{cleanliness} · {tracked} tracked · {untracked} untracked · "
+                f"{git.get('unpushed_commits', '—')} unpushed commit(s) · "
+                f"branch {git.get('branch') or '—'} · "
+                f"{git.get('worktree') or 'worktree path unavailable'}")
+        else:
+            worktree_value = (
+                f"unknown cleanliness · branch {git.get('branch') or '—'} · "
+                f"{git.get('worktree') or 'worktree path unavailable'}")
+    else:
+        worktree_value = "worktree facts unavailable"
+
+    values = (
+        ("shell", "shell", shell_value),
+        ("classification", "classification", classification),
+        ("legal_actions", "legal actions",
+         ", ".join(legal_actions) if legal_actions else "none"),
+        ("session", "session", session_value),
+        ("generation", "generation", generation_value),
+        ("archive", "archive", archive_value),
+        ("sprint_binding", "sprint binding", binding_value),
+        ("process", "process", process_value),
+        ("tmux", "tmux", tmux_value),
+        ("unread_messages", "unread messages", unread_value),
+        ("worktree", "worktree", worktree_value),
+    )
+    return [{"key": key, "label": label, "value": value}
+            for key, label, value in values]
+
+
 def _fingerprint(con, shell_id: int) -> str:
     """sha256 over the durable state an observation depends on. Any change —
     closure, a new generation, a binding release, an archive hand-off —
@@ -463,7 +582,9 @@ def preview(con, shell_id: int, default_worktree: str | None) -> dict:
             "expires_in_s": OBSERVATION_TTL_S,
             "classification": classification,
             "legal_actions": legal_actions,
-            "evidence": evidence}
+            "evidence": evidence,
+            "evidence_projection": evidence_projection(
+                evidence, classification, legal_actions)}
 
 
 # ------------------------------------------------------------------ execute

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2301,17 +2301,46 @@ function ifRecoveryContext(sel, preview) {
   const evidence = preview.evidence || {};
   const shell = evidence.shell || {};
   const session = evidence.session || {};
+  const generation = evidence.generation;
+  const archive = evidence.archive;
+  const sprintBinding = evidence.sprint_binding;
   const process = evidence.process || {};
+  const tmux = evidence.tmux;
   const git = evidence.git;
   const shellName = shell.shortname || sel.shortname || String(sel.shell_id);
   const sessionName = session.session_id == null
     ? "no Interface session"
     : `session #${session.session_id} · generation ${session.generation ?? "—"} · ` +
       `${session.occupancy ?? "—"}/${session.lifecycle ?? "—"}`;
+  const generationName = !generation
+    ? "no generation record"
+    : `generation ${generation.generation ?? "—"} · ` +
+      (generation.ended_at == null ? "open" : `ended ${generation.ended_at}`) +
+      ` · last hook ${generation.last_hook_seq ?? "—"}`;
+  const archiveName = !archive
+    ? "no archive relation"
+    : `archive #${archive.archive_id} · ` +
+      (archive.ended_at == null ? "open" : `closed ${archive.ended_at}`) +
+      (archive.active ? " · active" : "");
+  const sprintBindingName = !sprintBinding
+    ? "no armed sprint binding"
+    : `binding #${sprintBinding.binding_id} · sprint doc ` +
+      `#${sprintBinding.sprint_doc_id}`;
   const processName = process.pane_pid == null || process.pane_start_ticks == null
     ? "no recorded process identity"
     : `PID ${process.pane_pid} · start ticks ${process.pane_start_ticks} · ` +
-      `PGID ${process.pgid ?? "—"} · pane ${process.pane_id ?? "—"}`;
+      `PGID ${process.pgid ?? "—"} · ${process.pid_state ?? "unknown"} · ` +
+      `pane ${process.pane_id ?? "—"} ` +
+      (process.pane_present == null
+        ? "(presence unknown)"
+        : process.pane_present ? "(present)" : "(gone)");
+  const tmuxName = !tmux
+    ? "no tmux relation"
+    : `socket ${tmux.socket ?? "—"} · session ${tmux.session ?? "—"} · ` +
+      `window ${tmux.window ?? "—"} · pane ${tmux.pane_id ?? "—"}`;
+  const unreadMessagesName = Number.isInteger(evidence.unread_messages)
+    ? `${evidence.unread_messages} · left unread`
+    : "unknown · left unread";
   let worktreeName = "unknown";
   if (git) {
     const tracked = Number.isInteger(git.dirty_tracked) ? git.dirty_tracked : null;
@@ -2326,7 +2355,10 @@ function ifRecoveryContext(sel, preview) {
     if (Number.isInteger(git.unpushed_commits))
       worktreeName += ` · ${git.unpushed_commits} unpushed commit(s)`;
   }
-  return { shellName, sessionName, processName, worktreeName };
+  return {
+    shellName, sessionName, generationName, archiveName, sprintBindingName,
+    processName, tmuxName, unreadMessagesName, worktreeName,
+  };
 }
 
 function ifRecoveryBody(preview, mode, discard, confirmShortname) {
@@ -2342,6 +2374,71 @@ function ifRecoveryBody(preview, mode, discard, confirmShortname) {
   if (discard) {
     body.discard_worktree = true;
     body.confirm_shortname = confirmShortname;
+  }
+  return body;
+}
+
+function ifRecoveryResult(result) {
+  const closed = result.closed || {};
+  const signaled = result.signaled;
+  const worktree = result.worktree || {};
+  const body = el("div", { className: "if-recovery-result" },
+    el("div", {}, el("b", {}, "Recovery result")),
+    el("div", { className: "if-diag" },
+      el("span", { className: "if-stat" }, "shell ",
+        el("b", {}, result.shortname || String(result.shell_id ?? "—"))),
+      el("span", { className: "if-stat" }, "classification ",
+        el("b", {}, result.classification || "—")),
+      el("span", { className: "if-stat" }, "mode ",
+        el("b", {}, result.mode || "—")),
+      el("span", { className: "if-stat" }, "availability ",
+        el("b", {}, result.availability || "—")),
+      el("span", { className: "if-stat" }, "unread messages ",
+        el("b", {}, `${result.unread_messages ?? "—"} · left unread`))));
+  if (signaled) {
+    body.append(el("div", { className: "if-note" },
+      signaled.signaled
+        ? `Process signal completed for PID ${signaled.pid ?? "—"} · ` +
+          `PGID ${signaled.pgid ?? "—"}` +
+          (signaled.escalated ? " · escalated to SIGKILL" : "")
+        : `Process signal did not complete${signaled.detail
+          ? ` · ${signaled.detail}` : ""}.`));
+  }
+  if (closed.session) {
+    body.append(el("div", { className: "if-note" },
+      `Session #${closed.session.session_id} ended · ` +
+      `${closed.session.end_reason || "reason unavailable"}` +
+      (closed.session.already_ended ? " · already ended" : "")));
+  }
+  if (closed.archive) {
+    body.append(el("div", { className: "if-note" },
+      `Archive #${closed.archive.archive_id} ` +
+      (closed.archive.closed ? "closed" : "unchanged")));
+  }
+  if (closed.binding) {
+    body.append(el("div", { className: "if-note" },
+      `Sprint binding #${closed.binding.binding_id} ` +
+      (closed.binding.released ? "released" : "unchanged")));
+  }
+  body.append(el("div", { className: "if-note" },
+    `Alerts resolved: ${closed.alerts_resolved ?? 0}.`));
+  for (const parked of closed.parked || []) {
+    body.append(el("div", { className: "if-note bad" },
+      `Parked ambiguous binding #${parked.binding_id}: ` +
+      `${parked.next_action || "manual remediation required"}`));
+  }
+  if (worktree.failed) {
+    const completed = (worktree.completed || []).join(", ") || "nothing";
+    body.append(el("div", { className: "if-note bad" },
+      `Worktree discard INCOMPLETE in ${worktree.worktree || "unknown worktree"}: ` +
+      `completed [${completed}], failed at ${worktree.failed.step || "unknown"} ` +
+      `(${worktree.failed.error || "unknown error"}). Durable closure is ` +
+      "committed; finish the discard remediation manually."));
+  } else if (worktree.discarded) {
+    body.append(el("div", { className: "if-note" },
+      `Worktree ${worktree.worktree || ""} changes discarded.`));
+  } else {
+    body.append(el("div", { className: "if-note" }, "Worktree preserved."));
   }
   return body;
 }
@@ -2376,8 +2473,18 @@ function ifRecoveryControls(host, sel, root) {
           el("b", {}, preview.classification || "—")),
         el("span", { className: "if-stat" }, "session ",
           el("b", {}, context.sessionName)),
+        el("span", { className: "if-stat" }, "generation ",
+          el("b", {}, context.generationName)),
+        el("span", { className: "if-stat" }, "archive ",
+          el("b", {}, context.archiveName)),
+        el("span", { className: "if-stat" }, "sprint binding ",
+          el("b", {}, context.sprintBindingName)),
         el("span", { className: "if-stat" }, "process ",
           el("b", {}, context.processName)),
+        el("span", { className: "if-stat" }, "tmux ",
+          el("b", {}, context.tmuxName)),
+        el("span", { className: "if-stat" }, "unread messages ",
+          el("b", {}, context.unreadMessagesName)),
         el("span", { className: "if-stat" }, "worktree ",
           el("b", {}, context.worktreeName))),
       el("div", { className: "muted" },
@@ -2430,9 +2537,17 @@ function ifRecoveryControls(host, sel, root) {
       discard.disabled = true;
       note.textContent = `${label} in progress…`;
       try {
-        await apiIf("/interface/shells/" + sel.shell_id + "/recovery",
+        const result = await apiIf(
+          "/interface/shells/" + sel.shell_id + "/recovery",
           "POST", request);
-        return renderInterface(root);
+        const refresh = el("button", { className: "act", type: "button",
+          textContent: "Refresh shell state" });
+        refresh.onclick = () => renderInterface(root);
+        previewBtn.disabled = false;
+        note.textContent = "";
+        host.replaceChildren(
+          previewBtn, ifRecoveryResult(result), refresh, note);
+        return;
       } catch (e) {
         if (e.status === 409 && e.code === "recovery_observation_stale") {
           return load(
@@ -2471,54 +2586,61 @@ async function ifRecoveryPane(pane, sel, root) {
     el("div", {}, el("b", {}, sel.display_name || sel.shortname), " is ",
       el("span", { className: "pill if-badge bad" }, sel.availability), "."));
   pane.append(card);
+  let sess = null;
   if (!sel.session_id) {
     card.append(el("div", { className: "muted" },
       "New chat is blocked — this shell runs a legacy or unmanaged harness. " +
       "Prove the process absent (or adopt a managed generation) to free it."));
-    return;
-  }
-  let sess;
-  try { sess = await apiIf("/interface/sessions/" + sel.session_id); }
-  catch (e) {
-    card.append(el("div", { className: "muted" },
-      "session state unavailable (" + e.message + ") — reselect the shell to retry. " +
-      "Recovery actions stay hidden while the exact state is unknown."));
-    return;
-  }
-  const diag = el("div", { className: "if-diag" });
-  const drow = (k, v) => diag.append(el("span", { className: "if-stat" }, k + " ", el("b", {}, String(v ?? "—"))));
-  drow("session", "#" + sess.session_id + " · gen " + (sess.generation ?? "—"));
-  drow("occupancy", sess.occupancy);
-  drow("lifecycle", sess.lifecycle);
-  drow("harness", sess.harness || "—");
-  drow("composer", sess.composer);
-  drow("delivery", sess.delivery);
-  drow("forwarded seq", sess.forwarded_seq);
-  drow("wake", sess.wake_state);
-  drow("alerts", sess.alerts ?? 0);
-  card.append(diag);
-  if (sess.error_detail)
-    card.append(el("div", { className: "if-note" }, "diagnostics: " + sess.error_detail));
-  card.append(el("div", { className: "muted" },
-    "New chat is blocked until this generation is reconciled or closed."));
-
-  const note = el("div", { className: "if-note" });
-  const acts = el("div", {});
-  const recon = el("button", { className: "act", type: "button", textContent: "Reconcile",
-    title: "re-verify tmux/process identity — a verified unreconciled session returns to occupied" });
-  recon.onclick = async () => {
-    recon.disabled = true; note.textContent = "";
+  } else {
     try {
-      const r = await apiIf("/interface/reconciliations", "POST",
-        { session_id: sess.session_id, action: "verify" });
-      if (r.verified) return renderInterface(root);
-      note.textContent = (r.actions || [])[0] ||
-        "identity could not be verified — close it if the process is gone.";
-    } catch (e) { note.textContent = (e.code ? e.code + ": " : "") + e.message; }
-    recon.disabled = false;
-  };
-  acts.append(recon);
-  card.append(acts, note);
+      sess = await apiIf("/interface/sessions/" + sel.session_id);
+    } catch (e) {
+      card.append(el("div", { className: "muted" },
+        "session state unavailable (" + e.message + ") — recovery preview " +
+        "remains available from the shell-level evidence."));
+    }
+  }
+  if (sess) {
+    const diag = el("div", { className: "if-diag" });
+    const drow = (k, v) => diag.append(el("span", { className: "if-stat" },
+      k + " ", el("b", {}, String(v ?? "—"))));
+    drow("session", "#" + sess.session_id + " · gen " + (sess.generation ?? "—"));
+    drow("occupancy", sess.occupancy);
+    drow("lifecycle", sess.lifecycle);
+    drow("harness", sess.harness || "—");
+    drow("composer", sess.composer);
+    drow("delivery", sess.delivery);
+    drow("forwarded seq", sess.forwarded_seq);
+    drow("wake", sess.wake_state);
+    drow("alerts", sess.alerts ?? 0);
+    card.append(diag);
+    if (sess.error_detail)
+      card.append(el("div", { className: "if-note" },
+        "diagnostics: " + sess.error_detail));
+    card.append(el("div", { className: "muted" },
+      "New chat is blocked until this generation is reconciled or closed."));
+
+    const note = el("div", { className: "if-note" });
+    const acts = el("div", {});
+    const recon = el("button", { className: "act", type: "button",
+      textContent: "Reconcile",
+      title: "re-verify tmux/process identity — a verified unreconciled session returns to occupied" });
+    recon.onclick = async () => {
+      recon.disabled = true; note.textContent = "";
+      try {
+        const r = await apiIf("/interface/reconciliations", "POST",
+          { session_id: sess.session_id, action: "verify" });
+        if (r.verified) return renderInterface(root);
+        note.textContent = (r.actions || [])[0] ||
+          "identity could not be verified — close it if the process is gone.";
+      } catch (e) {
+        note.textContent = (e.code ? e.code + ": " : "") + e.message;
+      }
+      recon.disabled = false;
+    };
+    acts.append(recon);
+    card.append(acts, note);
+  }
   const recovery = el("div", { className: "if-recovery" });
   card.append(recovery);
   ifRecoveryControls(recovery, sel, root);
@@ -2704,7 +2826,10 @@ function ifAvailablePane(pane, sel, root) {
   const open = el("button", { className: "act primary", type: "button", textContent: "New chat" });
   open.onclick = () => { open.remove(); ifNewChatForm(card, sel, root); };
   card.append(open);
-  pane.append(card);
+  const recovery = el("div", { className: "card if-recovery" },
+    el("div", {}, el("b", {}, "Shell recovery")));
+  ifRecoveryControls(recovery, sel, root);
+  pane.append(card, recovery);
 }
 
 async function ifNewChatForm(card, sel, root) {

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2293,15 +2293,179 @@ async function ifStartingPane(pane, sel, root) {
   card.append(cancel, note);
 }
 
+// Recovery evidence is descriptive only. The browser may display it, but the
+// server's legal_actions list is the sole authority for Recover / Force
+// recover. Keeping request construction in one helper also makes discard an
+// explicit escalation rather than an accidental option on ordinary recovery.
+function ifRecoveryContext(sel, preview) {
+  const evidence = preview.evidence || {};
+  const shell = evidence.shell || {};
+  const session = evidence.session || {};
+  const process = evidence.process || {};
+  const git = evidence.git;
+  const shellName = shell.shortname || sel.shortname || String(sel.shell_id);
+  const sessionName = session.session_id == null
+    ? "no Interface session"
+    : `session #${session.session_id} · generation ${session.generation ?? "—"} · ` +
+      `${session.occupancy ?? "—"}/${session.lifecycle ?? "—"}`;
+  const processName = process.pane_pid == null || process.pane_start_ticks == null
+    ? "no recorded process identity"
+    : `PID ${process.pane_pid} · start ticks ${process.pane_start_ticks} · ` +
+      `PGID ${process.pgid ?? "—"} · pane ${process.pane_id ?? "—"}`;
+  let worktreeName = "unknown";
+  if (git) {
+    const tracked = Number.isInteger(git.dirty_tracked) ? git.dirty_tracked : null;
+    const untracked = Number.isInteger(git.untracked) ? git.untracked : null;
+    const clean = tracked === 0 && untracked === 0;
+    worktreeName = tracked == null || untracked == null
+      ? "unknown"
+      : clean
+        ? `clean · ${git.worktree || "worktree path unavailable"}`
+        : `not clean · ${tracked} tracked · ${untracked} untracked · ` +
+          `${git.worktree || "worktree path unavailable"}`;
+    if (Number.isInteger(git.unpushed_commits))
+      worktreeName += ` · ${git.unpushed_commits} unpushed commit(s)`;
+  }
+  return { shellName, sessionName, processName, worktreeName };
+}
+
+function ifRecoveryBody(preview, mode, discard, confirmShortname) {
+  const legal = Array.isArray(preview.legal_actions)
+    ? preview.legal_actions : [];
+  if (!legal.includes(mode)) return null;
+  const body = {
+    observation_id: preview.observation_id,
+    mode,
+    preserve_worktree: !discard,
+  };
+  if (mode === "force") body.confirm_force = true;
+  if (discard) {
+    body.discard_worktree = true;
+    body.confirm_shortname = confirmShortname;
+  }
+  return body;
+}
+
+function ifRecoveryControls(host, sel, root) {
+  const note = el("div", { className: "if-note" });
+  const previewBtn = el("button", { className: "act", type: "button",
+    textContent: "Preview recovery",
+    title: "inspect server-classified recovery evidence; preview never changes state" });
+  host.append(previewBtn, note);
+
+  const load = async (notice = "") => {
+    previewBtn.disabled = true;
+    note.textContent = notice || "Loading recovery evidence…";
+    let preview;
+    try {
+      preview = await apiIf(
+        "/interface/shells/" + sel.shell_id + "/recovery");
+    } catch (e) {
+      note.textContent = (e.code ? e.code + ": " : "") + e.message;
+      previewBtn.disabled = false;
+      return;
+    }
+    const context = ifRecoveryContext(sel, preview);
+    const legal = Array.isArray(preview.legal_actions)
+      ? preview.legal_actions : [];
+    const body = el("div", { className: "if-recovery-preview" },
+      el("div", { className: "if-diag" },
+        el("span", { className: "if-stat" }, "shell ",
+          el("b", {}, context.shellName)),
+        el("span", { className: "if-stat" }, "classification ",
+          el("b", {}, preview.classification || "—")),
+        el("span", { className: "if-stat" }, "session ",
+          el("b", {}, context.sessionName)),
+        el("span", { className: "if-stat" }, "process ",
+          el("b", {}, context.processName)),
+        el("span", { className: "if-stat" }, "worktree ",
+          el("b", {}, context.worktreeName))),
+      el("div", { className: "muted" },
+        `Observation ${preview.observation_id} · expires in ` +
+        `${preview.expires_in_s ?? "—"}s.`));
+    if (notice) body.append(el("div", { className: "if-note" }, notice));
+
+    const actions = el("div", { className: "if-recovery-actions" });
+    if (!legal.includes("recover") && !legal.includes("force")) {
+      actions.append(el("div", { className: "muted" },
+        "The server lists no legal recovery action for this observation."));
+      host.replaceChildren(previewBtn, body, actions, note);
+      previewBtn.disabled = false;
+      return;
+    }
+
+    const discard = el("input", { type: "checkbox" });
+    const discardLabel = el("label", { className: "muted" }, discard,
+      " Discard worktree changes (separate escalation; unpushed commits are refused)");
+    const execute = async (mode, button) => {
+      const label = mode === "force" ? "Force recover" : "Recover";
+      const preserve = !discard.checked;
+      if (!confirm(
+        `${label} ${context.shellName}? ${context.sessionName}; ` +
+        `${context.processName}; worktree ${context.worktreeName}. ` +
+        (preserve
+          ? "All worktree files will be preserved."
+          : "Worktree discard still requires a separate typed confirmation.")))
+        return;
+
+      let typed = null;
+      if (!preserve) {
+        typed = prompt(
+          `Discard tracked and untracked changes only in ${context.shellName}'s ` +
+          `exact worktree? Unpushed commits are never removed.\n` +
+          `Type ${context.shellName} to confirm:`, "");
+        if (typed !== context.shellName) {
+          note.textContent =
+            `Discard cancelled — confirmation must exactly match ${context.shellName}.`;
+          return;
+        }
+      }
+      const request = ifRecoveryBody(preview, mode, !preserve, typed);
+      if (!request) {
+        note.textContent =
+          `${label} is no longer listed as legal; preview again.`;
+        return;
+      }
+      button.disabled = true;
+      discard.disabled = true;
+      note.textContent = `${label} in progress…`;
+      try {
+        await apiIf("/interface/shells/" + sel.shell_id + "/recovery",
+          "POST", request);
+        return renderInterface(root);
+      } catch (e) {
+        if (e.status === 409 && e.code === "recovery_observation_stale") {
+          return load(
+            "Recovery state changed. Review this fresh preview before acting.");
+        }
+        note.textContent = (e.code ? e.code + ": " : "") + e.message;
+        button.disabled = false;
+        discard.disabled = false;
+      }
+    };
+    if (legal.includes("recover")) {
+      const recover = el("button", { className: "act primary", type: "button",
+        textContent: "Recover" });
+      recover.onclick = () => execute("recover", recover);
+      actions.append(recover);
+    }
+    if (legal.includes("force")) {
+      const force = el("button", { className: "act bad", type: "button",
+        textContent: "Force recover" });
+      force.onclick = () => execute("force", force);
+      actions.append(force);
+    }
+    actions.append(discardLabel);
+    host.replaceChildren(previewBtn, body, actions, note);
+    previewBtn.disabled = false;
+  };
+  previewBtn.onclick = () => load();
+}
+
 // Lost/error/unreconciled pane (spec Interface Layout): diagnostics and
-// queued-work counts come straight from GET /sessions/<id> — occupancy,
-// lifecycle, error_detail, the input pipeline (composer/delivery/forwarded
-// seq), wake and alerts. The API exposes no explicit allowed-actions field,
-// so the action gates mirror the route's own 409 preconditions exactly:
-// verify any time the session isn't ended (this pane never shows ended),
-// close ONLY while occupancy is unreconciled (occupied refuses with
-// not_unreconciled; absence is re-proved server-side on every close). A
-// closed session derives available → New chat IS the fresh-generation action.
+// queued-work counts come straight from GET /sessions/<id>. Reconcile remains
+// the exact-identity repair path; closure and process recovery are offered only
+// after the API returns a fresh recovery observation with a legal action.
 async function ifRecoveryPane(pane, sel, root) {
   const card = el("div", { className: "card" },
     el("div", {}, el("b", {}, sel.display_name || sel.shortname), " is ",
@@ -2354,24 +2518,10 @@ async function ifRecoveryPane(pane, sel, root) {
     recon.disabled = false;
   };
   acts.append(recon);
-  if (sess.occupancy === "unreconciled") {
-    const close = el("button", { className: "act", type: "button", textContent: "Close session",
-      title: "only after absence is proved (re-checked server-side) — frees the shell for a fresh generation" });
-    close.onclick = async () => {
-      if (!confirm(`Close session #${sess.session_id}? Allowed only after the process is proved absent. This frees ${sel.display_name || sel.shortname} for a new chat.`)) return;
-      close.disabled = true; note.textContent = "";
-      try {
-        await apiIf("/interface/reconciliations", "POST",
-          { session_id: sess.session_id, action: "close" });
-        return renderInterface(root);
-      } catch (e) {
-        note.textContent = (e.code ? e.code + ": " : "") + e.message;
-        close.disabled = false;
-      }
-    };
-    acts.append(" ", close);
-  }
   card.append(acts, note);
+  const recovery = el("div", { className: "if-recovery" });
+  card.append(recovery);
+  ifRecoveryControls(recovery, sel, root);
   ifSprintPanel(pane, sel);
 }
 

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2293,71 +2293,31 @@ async function ifStartingPane(pane, sel, root) {
   card.append(cancel, note);
 }
 
-// Recovery evidence is descriptive only. The browser may display it, but the
-// server's legal_actions list is the sole authority for Recover / Force
-// recover. Keeping request construction in one helper also makes discard an
-// explicit escalation rather than an accidental option on ordinary recovery.
+// Recovery evidence is descriptive only. Browser and CLI render the API's one
+// canonical evidence_projection; neither client independently chooses a safer-
+// looking subset. legal_actions remains the sole authority for Recover / Force.
+function ifRecoveryEvidenceRows(preview) {
+  const rows = preview.evidence_projection;
+  if (!Array.isArray(rows) || !rows.length) return [];
+  if (rows.some((row) => !row || typeof row.key !== "string" ||
+      typeof row.label !== "string" || typeof row.value !== "string"))
+    return [];
+  return rows.map((row) => ({
+    key: row.key, label: row.label, value: row.value,
+  }));
+}
+
 function ifRecoveryContext(sel, preview) {
   const evidence = preview.evidence || {};
   const shell = evidence.shell || {};
-  const session = evidence.session || {};
-  const generation = evidence.generation;
-  const archive = evidence.archive;
-  const sprintBinding = evidence.sprint_binding;
-  const process = evidence.process || {};
-  const tmux = evidence.tmux;
-  const git = evidence.git;
+  const rows = new Map(ifRecoveryEvidenceRows(preview)
+    .map((row) => [row.key, row.value]));
   const shellName = shell.shortname || sel.shortname || String(sel.shell_id);
-  const sessionName = session.session_id == null
-    ? "no Interface session"
-    : `session #${session.session_id} · generation ${session.generation ?? "—"} · ` +
-      `${session.occupancy ?? "—"}/${session.lifecycle ?? "—"}`;
-  const generationName = !generation
-    ? "no generation record"
-    : `generation ${generation.generation ?? "—"} · ` +
-      (generation.ended_at == null ? "open" : `ended ${generation.ended_at}`) +
-      ` · last hook ${generation.last_hook_seq ?? "—"}`;
-  const archiveName = !archive
-    ? "no archive relation"
-    : `archive #${archive.archive_id} · ` +
-      (archive.ended_at == null ? "open" : `closed ${archive.ended_at}`) +
-      (archive.active ? " · active" : "");
-  const sprintBindingName = !sprintBinding
-    ? "no armed sprint binding"
-    : `binding #${sprintBinding.binding_id} · sprint doc ` +
-      `#${sprintBinding.sprint_doc_id}`;
-  const processName = process.pane_pid == null || process.pane_start_ticks == null
-    ? "no recorded process identity"
-    : `PID ${process.pane_pid} · start ticks ${process.pane_start_ticks} · ` +
-      `PGID ${process.pgid ?? "—"} · ${process.pid_state ?? "unknown"} · ` +
-      `pane ${process.pane_id ?? "—"} ` +
-      (process.pane_present == null
-        ? "(presence unknown)"
-        : process.pane_present ? "(present)" : "(gone)");
-  const tmuxName = !tmux
-    ? "no tmux relation"
-    : `socket ${tmux.socket ?? "—"} · session ${tmux.session ?? "—"} · ` +
-      `window ${tmux.window ?? "—"} · pane ${tmux.pane_id ?? "—"}`;
-  const unreadMessagesName = Number.isInteger(evidence.unread_messages)
-    ? `${evidence.unread_messages} · left unread`
-    : "unknown · left unread";
-  let worktreeName = "unknown";
-  if (git) {
-    const tracked = Number.isInteger(git.dirty_tracked) ? git.dirty_tracked : null;
-    const untracked = Number.isInteger(git.untracked) ? git.untracked : null;
-    const clean = tracked === 0 && untracked === 0;
-    worktreeName = tracked == null || untracked == null
-      ? "unknown"
-      : clean
-        ? `clean · ${git.worktree || "worktree path unavailable"}`
-        : `not clean · ${tracked} tracked · ${untracked} untracked · ` +
-          `${git.worktree || "worktree path unavailable"}`;
-    if (Number.isInteger(git.unpushed_commits))
-      worktreeName += ` · ${git.unpushed_commits} unpushed commit(s)`;
-  }
   return {
-    shellName, sessionName, generationName, archiveName, sprintBindingName,
-    processName, tmuxName, unreadMessagesName, worktreeName,
+    shellName,
+    sessionName: rows.get("session") || "session evidence unavailable",
+    processName: rows.get("process") || "process evidence unavailable",
+    worktreeName: rows.get("worktree") || "worktree evidence unavailable",
   };
 }
 
@@ -2462,31 +2422,25 @@ function ifRecoveryControls(host, sel, root) {
       previewBtn.disabled = false;
       return;
     }
+    const evidenceRows = ifRecoveryEvidenceRows(preview);
+    if (!evidenceRows.length) {
+      note.textContent =
+        "Recovery preview omitted the canonical evidence projection. " +
+        "Update and restart the Interface service before recovering.";
+      previewBtn.disabled = false;
+      return;
+    }
     const context = ifRecoveryContext(sel, preview);
     const legal = Array.isArray(preview.legal_actions)
       ? preview.legal_actions : [];
     const body = el("div", { className: "if-recovery-preview" },
       el("div", { className: "if-diag" },
-        el("span", { className: "if-stat" }, "shell ",
-          el("b", {}, context.shellName)),
-        el("span", { className: "if-stat" }, "classification ",
-          el("b", {}, preview.classification || "—")),
-        el("span", { className: "if-stat" }, "session ",
-          el("b", {}, context.sessionName)),
-        el("span", { className: "if-stat" }, "generation ",
-          el("b", {}, context.generationName)),
-        el("span", { className: "if-stat" }, "archive ",
-          el("b", {}, context.archiveName)),
-        el("span", { className: "if-stat" }, "sprint binding ",
-          el("b", {}, context.sprintBindingName)),
-        el("span", { className: "if-stat" }, "process ",
-          el("b", {}, context.processName)),
-        el("span", { className: "if-stat" }, "tmux ",
-          el("b", {}, context.tmuxName)),
-        el("span", { className: "if-stat" }, "unread messages ",
-          el("b", {}, context.unreadMessagesName)),
-        el("span", { className: "if-stat" }, "worktree ",
-          el("b", {}, context.worktreeName))),
+        ...evidenceRows.map((row) => el("span", {
+          className: "if-stat",
+          recoveryEvidenceKey: row.key,
+          recoveryEvidenceLabel: row.label,
+          recoveryEvidenceValue: row.value,
+        }, row.label + " ", el("b", {}, row.value)))),
       el("div", { className: "muted" },
         `Observation ${preview.observation_id} · expires in ` +
         `${preview.expires_in_s ?? "—"}s.`));

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -61,12 +61,12 @@ sys.path.insert(0, str(TESTS))
 sys.path.insert(0, str(ENGINE / "scripts"))
 sys.path.insert(0, str(ENGINE / "api"))
 
-import interface_cli as ic
-import interface_recovery as recovery
-import interface_routes as routes
-import run as run_mod
-from test_interface_api import FakeRuntime, build_engine_db
-from test_interface_cli import SHELLS, FakeResp
+import interface_cli as ic  # noqa: E402
+import interface_recovery as recovery  # noqa: E402
+import interface_routes as routes  # noqa: E402
+import run as run_mod  # noqa: E402
+from test_interface_api import FakeRuntime, build_engine_db  # noqa: E402
+from test_interface_cli import SHELLS, FakeResp  # noqa: E402
 
 
 def hdrs(*lines) -> str:
@@ -224,6 +224,19 @@ class ClassificationTest(RecoveryCase):
         self.assertEqual(obj["classification"], "available")
         self.assertEqual(obj["legal_actions"], [])
         self.assertTrue(obj["observation_id"])
+        self.assertEqual(
+            [row["key"] for row in obj["evidence_projection"]],
+            ["shell", "classification", "legal_actions", "session",
+             "generation", "archive", "sprint_binding", "process", "tmux",
+             "unread_messages", "worktree"])
+        projected = {
+            row["key"]: row["value"] for row in obj["evidence_projection"]
+        }
+        self.assertEqual(projected["classification"], "available")
+        self.assertEqual(projected["legal_actions"], "none")
+        self.assertEqual(projected["session"], "no Interface session")
+        self.assertEqual(projected["process"],
+                         "no recorded process identity")
 
     def test_stale_lock_reservation_without_identity(self):
         self.make_session(1, occupancy="reserved", lifecycle="starting",
@@ -960,6 +973,10 @@ class CliRecoverTest(unittest.TestCase):
         self.patch_http.stop()
 
     def script(self, preview, result):
+        preview = dict(preview)
+        preview["evidence_projection"] = recovery.evidence_projection(
+            preview["evidence"], preview["classification"],
+            preview["legal_actions"])
         self.routes[("GET", "/api/interface/shells/3/recovery")] = preview
         if result is not None:
             self.routes[("POST", "/api/interface/shells/3/recovery")] = result
@@ -1019,8 +1036,11 @@ class CliRecoverTest(unittest.TestCase):
 
     def test_stale_observation_maps_to_refusal(self):
         from test_interface_cli import http_error
-        self.routes[("GET", "/api/interface/shells/3/recovery")] = \
-            dict(self.PREVIEW_ORPHAN)
+        preview = dict(self.PREVIEW_ORPHAN)
+        preview["evidence_projection"] = recovery.evidence_projection(
+            preview["evidence"], preview["classification"],
+            preview["legal_actions"])
+        self.routes[("GET", "/api/interface/shells/3/recovery")] = preview
         self.routes[("POST", "/api/interface/shells/3/recovery")] = \
             http_error(409, "recovery_observation_stale", "changed")
         code, _out, err = self.run_cli(["recover", "s3", "--yes"])

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -4,21 +4,69 @@ The UI is deliberately build-free vanilla JS/CSS. These checks pin the shared
 picker and responsive terminal behavior without inventing a second JS runtime
 or duplicating application logic in a test fixture.
 """
+import contextlib
+import io
+import json
 import subprocess
+import sys
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+
+import interface_cli as ic  # noqa: E402
+import interface_recovery as recovery  # noqa: E402
+
 APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
 CSS = (ROOT / ".super-coder" / "ui" / "style.css").read_text()
 PICKER = APP[APP.index("function dmModelPicker"):
              APP.index("async function renderDefaultModels")]
-RECOVERY = APP[APP.index("function ifRecoveryContext"):
+RECOVERY = APP[APP.index("function ifRecoveryEvidenceRows"):
                APP.index("// Sprint wake panel")]
 RENDER_INTERFACE = APP[APP.index("const IF_BADGE"):
                        APP.index("// A reservation is not a terminal")]
 AVAILABLE = APP[APP.index("function ifAvailablePane"):
                 APP.index("async function ifNewChatForm")]
+
+BASE_PREVIEW = {
+    "observation_id": "obs-1",
+    "expires_in_s": 120,
+    "classification": "exact_idle_orphan",
+    "legal_actions": ["recover"],
+    "evidence": {
+        "shell": {"shell_id": 3, "shortname": "S3"},
+        "session": {
+            "session_id": 9, "generation": 1, "occupancy": "occupied",
+            "lifecycle": "lost", "harness": "claude",
+        },
+        "generation": {
+            "generation": 1, "ended_at": None, "last_hook_seq": 7,
+        },
+        "archive": {
+            "archive_id": 12, "ended_at": None, "active": True,
+        },
+        "sprint_binding": {
+            "binding_id": 15, "sprint_doc_id": 31,
+        },
+        "process": {
+            "pane_id": "%1", "pane_pid": 4321, "pane_start_ticks": 999,
+            "pane_present": False, "pid_state": "alive", "pgid": 4321,
+        },
+        "tmux": {
+            "socket": "/run/if/tmux.sock", "session": "sc-S3",
+            "window": "chat", "pane_id": "%1",
+        },
+        "unread_messages": 2,
+        "git": {
+            "worktree": "/x/s3", "branch": "fix/x", "dirty_tracked": 1,
+            "untracked": 2, "unpushed_commits": 0,
+        },
+    },
+}
+BASE_PREVIEW["evidence_projection"] = recovery.evidence_projection(
+    BASE_PREVIEW["evidence"], BASE_PREVIEW["classification"],
+    BASE_PREVIEW["legal_actions"])
 
 
 def run_recovery_js(body):
@@ -77,42 +125,8 @@ function button(root, label) {
 function invariant(ok, message) {
   if (!ok) throw new Error(message);
 }
-const BASE_PREVIEW = {
-  observation_id: "obs-1",
-  expires_in_s: 120,
-  classification: "exact_idle_orphan",
-  legal_actions: ["recover"],
-  evidence: {
-    shell: { shell_id: 3, shortname: "S3" },
-    session: {
-      session_id: 9, generation: 1, occupancy: "occupied",
-      lifecycle: "lost",
-    },
-    generation: {
-      generation: 1, ended_at: null, last_hook_seq: 7,
-    },
-    archive: {
-      archive_id: 12, ended_at: null, active: true,
-    },
-    sprint_binding: {
-      binding_id: 15, sprint_doc_id: 31,
-    },
-    process: {
-      pane_id: "%1", pane_pid: 4321, pane_start_ticks: 999,
-      pane_present: false, pid_state: "alive", pgid: 4321,
-    },
-    tmux: {
-      socket: "/run/if/tmux.sock", session: "sc-S3",
-      window: "chat", pane_id: "%1",
-    },
-    unread_messages: 2,
-    git: {
-      worktree: "/x/s3", branch: "fix/x", dirty_tracked: 1,
-      untracked: 2, unpushed_commits: 0,
-    },
-  },
-};
-""" + "\n(async () => {\n" + body + r"""
+""" + "\nconst BASE_PREVIEW = " + json.dumps(BASE_PREVIEW) + ";\n" + \
+        "\n(async () => {\n" + body + r"""
 })().catch((error) => {
   console.error(error.stack || error);
   process.exit(1);
@@ -121,6 +135,7 @@ const BASE_PREVIEW = {
     result = subprocess.run(
         ["node", "-e", script], text=True, capture_output=True, check=False)
     assert result.returncode == 0, result.stderr
+    return result.stdout
 
 
 def test_shared_picker_is_list_only_and_exact_route_only():
@@ -226,7 +241,15 @@ const cases = [
   { legal: [], present: null, absent: "Recover" },
 ];
 for (const test of cases) {
-  apiIf = async () => ({ ...BASE_PREVIEW, legal_actions: test.legal });
+  const projection = BASE_PREVIEW.evidence_projection.map((row) =>
+    row.key === "legal_actions"
+      ? { ...row, value: test.legal.join(", ") || "none" }
+      : row);
+  apiIf = async () => ({
+    ...BASE_PREVIEW,
+    legal_actions: test.legal,
+    evidence_projection: projection,
+  });
   const host = new FakeElement("div");
   ifRecoveryControls(host, { shell_id: 3, shortname: "S3" }, {});
   await button(host, "Preview recovery").onclick();
@@ -238,6 +261,8 @@ for (const test of cases) {
     `rendered unlisted ${test.absent}: ${labels}`);
   invariant(host.textContent.includes("session #9 · generation 1"),
     "session identity missing from diagnostics");
+  invariant(host.textContent.includes("harness claude"),
+    "session harness missing from diagnostics");
   invariant(host.textContent.includes("PID 4321 · start ticks 999 · PGID 4321"),
     "exact process identity missing from diagnostics");
   invariant(host.textContent.includes("generation 1 · open · last hook 7"),
@@ -253,11 +278,53 @@ for (const test of cases) {
     "unread-message evidence missing from diagnostics");
   invariant(host.textContent.includes("not clean · 1 tracked · 2 untracked"),
     "worktree cleanliness missing from diagnostics");
+  invariant(host.textContent.includes("branch fix/x"),
+    "git branch missing from diagnostics");
   if (!test.legal.length) invariant(
     host.textContent.includes("server lists no legal recovery action"),
     "empty legal-action explanation missing");
 }
 """)
+
+
+def test_browser_and_cli_render_identical_canonical_recovery_evidence():
+    browser_output = run_recovery_js(r"""
+confirm = () => false;
+prompt = () => null;
+apiIf = async () => BASE_PREVIEW;
+const host = new FakeElement("div");
+ifRecoveryControls(host, { shell_id: 3, shortname: "S3" }, {});
+await button(host, "Preview recovery").onclick();
+const rendered = all(host, (node) => Boolean(node.recoveryEvidenceKey))
+  .map((node) => [
+    node.recoveryEvidenceKey,
+    node.recoveryEvidenceLabel,
+    node.recoveryEvidenceValue,
+  ]);
+console.log(JSON.stringify(rendered));
+""")
+    browser_rows = json.loads(browser_output)
+
+    cli_output = io.StringIO()
+    with contextlib.redirect_stdout(cli_output):
+        ic._print_recovery_preview(BASE_PREVIEW)
+    cli_rows = []
+    by_label = {
+        row["label"]: (row["key"], row["label"], row["value"])
+        for row in BASE_PREVIEW["evidence_projection"]
+    }
+    for line in cli_output.getvalue().splitlines():
+        if not line.startswith("  "):
+            continue
+        label, value = line.strip().split(": ", 1)
+        key, _, _ = by_label[label]
+        cli_rows.append([key, label, value])
+
+    expected = [
+        [row["key"], row["label"], row["value"]]
+        for row in BASE_PREVIEW["evidence_projection"]
+    ]
+    assert browser_rows == cli_rows == expected
 
 
 def test_recovery_preview_execute_happy_path_uses_opaque_observation():
@@ -306,6 +373,18 @@ const archiveOnly = {
   ...BASE_PREVIEW,
   classification: "stale_durable_lock",
   legal_actions: ["recover"],
+  evidence_projection: BASE_PREVIEW.evidence_projection.map((row) => {
+    const replacements = {
+      classification: "stale_durable_lock",
+      session: "no Interface session",
+      generation: "no generation record",
+      sprint_binding: "no armed sprint binding",
+      process: "no recorded process identity",
+      tmux: "no tmux relation",
+    };
+    return replacements[row.key] === undefined
+      ? row : { ...row, value: replacements[row.key] };
+  }),
   evidence: {
     ...BASE_PREVIEW.evidence,
     session: null,
@@ -344,6 +423,10 @@ invariant(root.textContent.includes("no Interface session") &&
 const residual = {
   ...archiveOnly,
   classification: "exact_idle_orphan",
+  evidence_projection: archiveOnly.evidence_projection.map((row) =>
+    row.key === "classification"
+      ? { ...row, value: "exact_idle_orphan" }
+      : row),
   evidence: {
     ...BASE_PREVIEW.evidence,
     live_session: false,
@@ -433,6 +516,13 @@ const fresh = {
   observation_id: "obs-2",
   classification: "verified_live",
   legal_actions: ["force"],
+  evidence_projection: BASE_PREVIEW.evidence_projection.map((row) => {
+    if (row.key === "classification")
+      return { ...row, value: "verified_live" };
+    if (row.key === "legal_actions")
+      return { ...row, value: "force" };
+    return row;
+  }),
 };
 let previews = 0;
 confirm = () => true;
@@ -466,6 +556,13 @@ const preview = {
   ...BASE_PREVIEW,
   classification: "verified_live",
   legal_actions: ["force"],
+  evidence_projection: BASE_PREVIEW.evidence_projection.map((row) => {
+    if (row.key === "classification")
+      return { ...row, value: "verified_live" };
+    if (row.key === "legal_actions")
+      return { ...row, value: "force" };
+    return row;
+  }),
 };
 const calls = [];
 let allowForce = false;

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -1,4 +1,4 @@
-"""Static browser contract checks for spec #30 requirements 18-20.
+"""Browser contract checks for spec #30 requirements 18-20 and 24.
 
 The UI is deliberately build-free vanilla JS/CSS. These checks pin the shared
 picker and responsive terminal behavior without inventing a second JS runtime
@@ -14,14 +14,27 @@ CSS = (ROOT / ".super-coder" / "ui" / "style.css").read_text()
 PICKER = APP[APP.index("function dmModelPicker"):
              APP.index("async function renderDefaultModels")]
 RECOVERY = APP[APP.index("function ifRecoveryContext"):
-               APP.index("// Lost/error/unreconciled pane")]
+               APP.index("// Sprint wake panel")]
+RENDER_INTERFACE = APP[APP.index("const IF_BADGE"):
+                       APP.index("// A reservation is not a terminal")]
+AVAILABLE = APP[APP.index("function ifAvailablePane"):
+                APP.index("async function ifNewChatForm")]
 
 
 def run_recovery_js(body):
     """Exercise the real recovery UI helpers in Node with a minimal DOM."""
     el_helper = APP[APP.index("const el ="):APP.index("const esc =")]
-    script = el_helper + "\nlet apiIf, renderInterface, confirm, prompt;\n" + \
-        RECOVERY + r"""
+    script = el_helper + r"""
+let apiIf, confirm, prompt;
+let ifSelected = "S3";
+let ifAttach = null;
+function ifDetach() {}
+async function ifStartingPane() {}
+async function ifSessionPane() {}
+async function ifSprintPanel() {}
+async function ifNewChatForm() {}
+globalThis.location = { hash: "" };
+""" + RENDER_INTERFACE + RECOVERY + AVAILABLE + r"""
 class FakeElement {
   constructor(tag) {
     this.tagName = tag;
@@ -30,9 +43,12 @@ class FakeElement {
     this._text = "";
     this.checked = false;
     this.disabled = false;
+    this.isConnected = true;
   }
   append(...nodes) { this.children.push(...nodes); }
   replaceChildren(...nodes) { this.children = [...nodes]; this._text = ""; }
+  remove() {}
+  closest() { return this; }
   set textContent(value) {
     this._text = String(value ?? "");
     this.children = [];
@@ -72,10 +88,24 @@ const BASE_PREVIEW = {
       session_id: 9, generation: 1, occupancy: "occupied",
       lifecycle: "lost",
     },
+    generation: {
+      generation: 1, ended_at: null, last_hook_seq: 7,
+    },
+    archive: {
+      archive_id: 12, ended_at: null, active: true,
+    },
+    sprint_binding: {
+      binding_id: 15, sprint_doc_id: 31,
+    },
     process: {
       pane_id: "%1", pane_pid: 4321, pane_start_ticks: 999,
       pane_present: false, pid_state: "alive", pgid: 4321,
     },
+    tmux: {
+      socket: "/run/if/tmux.sock", session: "sc-S3",
+      window: "chat", pane_id: "%1",
+    },
+    unread_messages: 2,
     git: {
       worktree: "/x/s3", branch: "fix/x", dirty_tracked: 1,
       untracked: 2, unpushed_commits: 0,
@@ -210,6 +240,17 @@ for (const test of cases) {
     "session identity missing from diagnostics");
   invariant(host.textContent.includes("PID 4321 · start ticks 999 · PGID 4321"),
     "exact process identity missing from diagnostics");
+  invariant(host.textContent.includes("generation 1 · open · last hook 7"),
+    "generation evidence missing from diagnostics");
+  invariant(host.textContent.includes("archive #12 · open · active"),
+    "archive evidence missing from diagnostics");
+  invariant(host.textContent.includes("binding #15 · sprint doc #31"),
+    "sprint binding evidence missing from diagnostics");
+  invariant(host.textContent.includes(
+    "socket /run/if/tmux.sock · session sc-S3 · window chat · pane %1"),
+    "tmux evidence missing from diagnostics");
+  invariant(host.textContent.includes("2 · left unread"),
+    "unread-message evidence missing from diagnostics");
   invariant(host.textContent.includes("not clean · 1 tracked · 2 untracked"),
     "worktree cleanliness missing from diagnostics");
   if (!test.legal.length) invariant(
@@ -249,7 +290,138 @@ invariant(!("confirm_force" in calls[1].body),
 invariant(confirmText.includes("S3") && confirmText.includes("session #9") &&
   confirmText.includes("PID 4321") && confirmText.includes("worktree not clean"),
   `confirmation omitted scoped diagnostics: ${confirmText}`);
-invariant(rendered === 1, `expected one successful rerender, got ${rendered}`);
+invariant(rendered === 0,
+  `result was discarded by an automatic rerender: ${rendered}`);
+invariant(host.textContent.includes("Recovery result") &&
+  host.textContent.includes("Worktree preserved"),
+  `successful result was not retained: ${host.textContent}`);
+await button(host, "Refresh shell state").onclick();
+invariant(rendered === 1, `explicit refresh did not rerender: ${rendered}`);
+""")
+
+
+def test_available_and_no_session_states_can_reach_server_owned_recovery():
+    run_recovery_js(r"""
+const archiveOnly = {
+  ...BASE_PREVIEW,
+  classification: "stale_durable_lock",
+  legal_actions: ["recover"],
+  evidence: {
+    ...BASE_PREVIEW.evidence,
+    session: null,
+    generation: null,
+    sprint_binding: null,
+    process: {
+      pane_id: null, pane_pid: null, pane_start_ticks: null,
+      pane_present: null, pid_state: "none", pgid: null,
+    },
+    tmux: null,
+  },
+};
+confirm = () => false;
+prompt = () => null;
+apiIf = async (path) => path === "/interface/shells"
+  ? { shells: [{
+      shell_id: 3, shortname: "S3", display_name: "Shell 3",
+      availability: "available", session_id: null,
+    }] }
+  : archiveOnly;
+const root = new FakeElement("div");
+await renderInterface(root);
+const availablePreview = button(root, "Preview recovery");
+invariant(Boolean(availablePreview),
+  "available/archive-only route omitted shell recovery preview");
+await availablePreview.onclick();
+invariant(Boolean(button(root, "Recover")),
+  "available/archive-only route hid the server-listed recovery action");
+invariant(root.textContent.includes("no Interface session") &&
+  root.textContent.includes("no generation record") &&
+  root.textContent.includes("no armed sprint binding") &&
+  root.textContent.includes("no recorded process identity") &&
+  root.textContent.includes("no tmux relation"),
+  `absent recovery evidence was not rendered truthfully: ${root.textContent}`);
+
+const residual = {
+  ...archiveOnly,
+  classification: "exact_idle_orphan",
+  evidence: {
+    ...BASE_PREVIEW.evidence,
+    live_session: false,
+  },
+};
+const requested = [];
+apiIf = async (path) => {
+  requested.push(path);
+  return residual;
+};
+const pane = new FakeElement("div");
+await ifRecoveryPane(pane, {
+  shell_id: 3, shortname: "S3", display_name: "Shell 3",
+  availability: "unreconciled", session_id: null,
+}, root);
+const orphanPreview = button(pane, "Preview recovery");
+invariant(Boolean(orphanPreview),
+  "unreconciled/no-session route omitted shell recovery preview");
+await orphanPreview.onclick();
+invariant(Boolean(button(pane, "Recover")),
+  "unreconciled/no-session route hid the server-listed recovery action");
+invariant(!requested.some((path) => path.includes("/sessions/")),
+  `no-session route fetched invalid session detail: ${requested}`);
+""")
+
+
+def test_recovery_partial_result_keeps_exact_remediation_until_refresh():
+    run_recovery_js(r"""
+let rendered = 0;
+confirm = () => true;
+prompt = () => "S3";
+renderInterface = async () => { rendered += 1; };
+apiIf = async (path, method = "GET") => {
+  if (method === "GET") return BASE_PREVIEW;
+  return {
+    shell_id: 3, shortname: "S3",
+    classification: "exact_idle_orphan", mode: "recover",
+    signaled: null,
+    closed: {
+      session: {
+        session_id: 9, end_reason: "operator_recovery",
+        already_ended: false,
+      },
+      archive: { archive_id: 12, closed: true },
+      binding: null,
+      alerts_resolved: 3,
+      parked: [{
+        binding_id: 15,
+        next_action: "review sprint delivery and release binding manually",
+      }],
+    },
+    worktree: {
+      worktree: "/x/s3", discarded: false, completed: ["reset"],
+      failed: { step: "clean", error: "fatal: clean boom" },
+    },
+    unread_messages: 2,
+    availability: "available",
+  };
+};
+const host = new FakeElement("div");
+ifRecoveryControls(host, { shell_id: 3, shortname: "S3" }, {});
+await button(host, "Preview recovery").onclick();
+const discard = all(host, (node) =>
+  node.tagName === "input" && node.type === "checkbox")[0];
+discard.checked = true;
+await button(host, "Recover").onclick();
+invariant(rendered === 0,
+  "partial recovery result was swallowed by an automatic refresh");
+invariant(host.textContent.includes(
+  "Parked ambiguous binding #15: review sprint delivery and release binding manually"),
+  `parked-binding remediation missing: ${host.textContent}`);
+invariant(host.textContent.includes(
+  "completed [reset], failed at clean (fatal: clean boom)"),
+  `per-step discard remediation missing: ${host.textContent}`);
+invariant(host.textContent.includes("Durable closure is committed"),
+  "partial-success boundary was not explained");
+await button(host, "Refresh shell state").onclick();
+invariant(rendered === 1, "explicit refresh did not rerender");
 """)
 
 

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -13,6 +13,84 @@ APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
 CSS = (ROOT / ".super-coder" / "ui" / "style.css").read_text()
 PICKER = APP[APP.index("function dmModelPicker"):
              APP.index("async function renderDefaultModels")]
+RECOVERY = APP[APP.index("function ifRecoveryContext"):
+               APP.index("// Lost/error/unreconciled pane")]
+
+
+def run_recovery_js(body):
+    """Exercise the real recovery UI helpers in Node with a minimal DOM."""
+    el_helper = APP[APP.index("const el ="):APP.index("const esc =")]
+    script = el_helper + "\nlet apiIf, renderInterface, confirm, prompt;\n" + \
+        RECOVERY + r"""
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag;
+    this.nodeType = 1;
+    this.children = [];
+    this._text = "";
+    this.checked = false;
+    this.disabled = false;
+  }
+  append(...nodes) { this.children.push(...nodes); }
+  replaceChildren(...nodes) { this.children = [...nodes]; this._text = ""; }
+  set textContent(value) {
+    this._text = String(value ?? "");
+    this.children = [];
+  }
+  get textContent() {
+    return this._text + this.children.map(
+      (child) => typeof child === "string" ? child : child.textContent || ""
+    ).join("");
+  }
+}
+globalThis.document = {
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({ nodeType: 3, textContent: String(text ?? "") }),
+};
+function all(root, predicate, found = []) {
+  if (predicate(root)) found.push(root);
+  for (const child of root.children || []) {
+    if (child && child.nodeType === 1) all(child, predicate, found);
+  }
+  return found;
+}
+function button(root, label) {
+  return all(root, (node) =>
+    node.tagName === "button" && node.textContent === label)[0];
+}
+function invariant(ok, message) {
+  if (!ok) throw new Error(message);
+}
+const BASE_PREVIEW = {
+  observation_id: "obs-1",
+  expires_in_s: 120,
+  classification: "exact_idle_orphan",
+  legal_actions: ["recover"],
+  evidence: {
+    shell: { shell_id: 3, shortname: "S3" },
+    session: {
+      session_id: 9, generation: 1, occupancy: "occupied",
+      lifecycle: "lost",
+    },
+    process: {
+      pane_id: "%1", pane_pid: 4321, pane_start_ticks: 999,
+      pane_present: false, pid_state: "alive", pgid: 4321,
+    },
+    git: {
+      worktree: "/x/s3", branch: "fix/x", dirty_tracked: 1,
+      untracked: 2, unpushed_commits: 0,
+    },
+  },
+};
+""" + "\n(async () => {\n" + body + r"""
+})().catch((error) => {
+  console.error(error.stack || error);
+  process.exit(1);
+});
+"""
+    result = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
 
 
 def test_shared_picker_is_list_only_and_exact_route_only():
@@ -105,3 +183,156 @@ def test_alerts_render_provenance_action_and_durable_acknowledgement():
     assert "a.generation" in APP
     assert "/acknowledge" in APP
     assert "Alert history" in APP
+
+
+def test_recovery_renders_only_server_listed_actions_and_full_diagnostics():
+    run_recovery_js(r"""
+renderInterface = async () => {};
+confirm = () => true;
+prompt = () => "S3";
+const cases = [
+  { legal: ["recover"], present: "Recover", absent: "Force recover" },
+  { legal: ["force"], present: "Force recover", absent: "Recover" },
+  { legal: [], present: null, absent: "Recover" },
+];
+for (const test of cases) {
+  apiIf = async () => ({ ...BASE_PREVIEW, legal_actions: test.legal });
+  const host = new FakeElement("div");
+  ifRecoveryControls(host, { shell_id: 3, shortname: "S3" }, {});
+  await button(host, "Preview recovery").onclick();
+  const labels = all(host, (node) => node.tagName === "button")
+    .map((node) => node.textContent);
+  if (test.present) invariant(labels.includes(test.present),
+    `missing server-listed ${test.present}: ${labels}`);
+  invariant(!labels.includes(test.absent),
+    `rendered unlisted ${test.absent}: ${labels}`);
+  invariant(host.textContent.includes("session #9 · generation 1"),
+    "session identity missing from diagnostics");
+  invariant(host.textContent.includes("PID 4321 · start ticks 999 · PGID 4321"),
+    "exact process identity missing from diagnostics");
+  invariant(host.textContent.includes("not clean · 1 tracked · 2 untracked"),
+    "worktree cleanliness missing from diagnostics");
+  if (!test.legal.length) invariant(
+    host.textContent.includes("server lists no legal recovery action"),
+    "empty legal-action explanation missing");
+}
+""")
+
+
+def test_recovery_preview_execute_happy_path_uses_opaque_observation():
+    run_recovery_js(r"""
+const calls = [];
+let rendered = 0;
+let confirmText = "";
+confirm = (text) => { confirmText = text; return true; };
+prompt = () => null;
+renderInterface = async () => { rendered += 1; };
+apiIf = async (path, method = "GET", body) => {
+  calls.push({ path, method, body });
+  if (method === "GET") return BASE_PREVIEW;
+  return { availability: "available" };
+};
+const host = new FakeElement("div");
+ifRecoveryControls(host, { shell_id: 3, shortname: "S3" }, {});
+await button(host, "Preview recovery").onclick();
+await button(host, "Recover").onclick();
+invariant(calls.length === 2, `expected GET+POST, got ${calls.length}`);
+invariant(calls[1].path === "/interface/shells/3/recovery",
+  `wrong POST path: ${calls[1].path}`);
+invariant(calls[1].body.observation_id === "obs-1",
+  "opaque observation id was not forwarded");
+invariant(calls[1].body.mode === "recover", "wrong recovery mode");
+invariant(calls[1].body.preserve_worktree === true,
+  "ordinary recovery did not preserve the worktree");
+invariant(!("confirm_force" in calls[1].body),
+  "ordinary recovery carried force confirmation");
+invariant(confirmText.includes("S3") && confirmText.includes("session #9") &&
+  confirmText.includes("PID 4321") && confirmText.includes("worktree not clean"),
+  `confirmation omitted scoped diagnostics: ${confirmText}`);
+invariant(rendered === 1, `expected one successful rerender, got ${rendered}`);
+""")
+
+
+def test_stale_recovery_observation_repreviews_without_replaying_action():
+    run_recovery_js(r"""
+const calls = [];
+const fresh = {
+  ...BASE_PREVIEW,
+  observation_id: "obs-2",
+  classification: "verified_live",
+  legal_actions: ["force"],
+};
+let previews = 0;
+confirm = () => true;
+prompt = () => null;
+renderInterface = async () => {};
+apiIf = async (path, method = "GET", body) => {
+  calls.push({ path, method, body });
+  if (method === "GET") return previews++ === 0 ? BASE_PREVIEW : fresh;
+  const error = new Error("changed");
+  error.status = 409;
+  error.code = "recovery_observation_stale";
+  throw error;
+};
+const host = new FakeElement("div");
+ifRecoveryControls(host, { shell_id: 3, shortname: "S3" }, {});
+await button(host, "Preview recovery").onclick();
+await button(host, "Recover").onclick();
+invariant(calls.map((call) => call.method).join(",") === "GET,POST,GET",
+  `stale flow replayed or failed to preview: ${JSON.stringify(calls)}`);
+invariant(!button(host, "Recover"), "stale action remained rendered");
+invariant(Boolean(button(host, "Force recover")),
+  "fresh server-listed action was not rendered");
+invariant(host.textContent.includes("Review this fresh preview before acting"),
+  "fresh-preview notice missing");
+""")
+
+
+def test_force_and_discard_require_independent_scoped_confirmations():
+    run_recovery_js(r"""
+const preview = {
+  ...BASE_PREVIEW,
+  classification: "verified_live",
+  legal_actions: ["force"],
+};
+const calls = [];
+let allowForce = false;
+let typed = "WRONG";
+let confirmText = "";
+confirm = (text) => { confirmText = text; return allowForce; };
+prompt = () => typed;
+renderInterface = async () => {};
+apiIf = async (path, method = "GET", body) => {
+  calls.push({ path, method, body });
+  return method === "GET" ? preview : { availability: "available" };
+};
+const host = new FakeElement("div");
+ifRecoveryControls(host, { shell_id: 3, shortname: "S3" }, {});
+await button(host, "Preview recovery").onclick();
+const force = button(host, "Force recover");
+await force.onclick();
+invariant(calls.length === 1, "force POST escaped the scoped confirmation");
+
+allowForce = true;
+const discard = all(host, (node) =>
+  node.tagName === "input" && node.type === "checkbox")[0];
+discard.checked = true;
+await force.onclick();
+invariant(calls.length === 1,
+  "discard POST escaped the exact-shortname confirmation");
+invariant(host.textContent.includes("confirmation must exactly match S3"),
+  "discard mismatch was not explained");
+
+typed = "S3";
+await force.onclick();
+invariant(calls.length === 2, `expected one confirmed POST, got ${calls.length}`);
+const body = calls[1].body;
+invariant(body.mode === "force" && body.confirm_force === true,
+  `force confirmation missing: ${JSON.stringify(body)}`);
+invariant(body.preserve_worktree === false &&
+  body.discard_worktree === true && body.confirm_shortname === "S3",
+  `discard escalation incomplete: ${JSON.stringify(body)}`);
+invariant(confirmText.includes("PID 4321") &&
+  confirmText.includes("start ticks 999"),
+  "force confirmation did not name exact verified identity");
+""")


### PR DESCRIPTION
## Summary
- add Preview recovery to fail-closed Interface recovery panes
- render Recover and Force recover only from server-listed legal actions
- require opaque observations, stale re-preview, exact force confirmation, and independent typed worktree-discard confirmation
- replace the inferred Close session path while preserving Reconcile

## Verification
- ./sc test tests/test_interface_recovery.py tests/test_interface_ui_contract.py -q — 59 passed
- ./sc test tests -q — 970 passed, 8 skipped, 40 subtests passed
- ./sc lint tests/test_interface_ui_contract.py
- node --check .super-coder/ui/app.js

## Environment note
The aggregate ./sc test also collects the interface-stream spike: 12 tests cannot start because tmux is absent from this sandbox. Its one additional interface_wake SQLite -shm teardown race passed on immediate isolated rerun and is already tracked in the sprint report.

Spec #30 step 8 · Sprint #31 unit 8b