### PR TITLE
fix(mem): refuse symlinked credential artifacts; distinct token exit codes

### DIFF
--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -126,35 +126,63 @@ def _read_all(fd: int) -> bytes:
         chunks.append(chunk)
 
 
+def _unsafe_reason(st: os.stat_result) -> "str | None":
+    """The local trust boundary as a predicate on a stat result: a real file,
+    owned by this user, with no group/world permission bits (the service writes
+    0600 under a 0700 dir). Returns why it fails, or None when it passes."""
+    if stat.S_ISLNK(st.st_mode):
+        return "a symbolic link"
+    if not stat.S_ISREG(st.st_mode):
+        return "not a regular file"
+    if st.st_uid != os.geteuid():
+        return f"owned by another user (uid {st.st_uid})"
+    if st.st_mode & 0o077:
+        return f"not owner-only (mode {oct(stat.S_IMODE(st.st_mode))})"
+    return None
+
+
+def _refuse_unsafe(path: Path, reason: str) -> "NoReturn":  # noqa: F821
+    die(f"runtime credential {path} is {reason} — the trust boundary covers "
+        "only an owner-only regular file; remove what is there and let the "
+        "supervised service re-provision it with mode 0600 at boot "
+        "(`./sc restart` / `make dos-r`).", EXIT_UNSAFE)
+
+
 def _load_runtime_credential(path: Path) -> None:
     """Trust-boundary check, then adopt the artifact's bearer token + base.
 
-    Accepted only under the existing local trust boundary: a regular file,
-    owned by this user, with no group/world permission bits (the service
-    writes 0600 under a 0700 dir). Anything weaker is refused, not used.
+    Classified twice, deliberately. lstat first, because opening the path is
+    not a free observation: a FIFO planted at the artifact name blocks open()
+    forever — O_NOFOLLOW does not help, it only refuses symlinks — and a
+    wrong-owner artifact fails open() with EACCES, which is a trust-boundary
+    refusal (exit 2), not a "nothing to read" (exit 1). lstat answers both
+    without opening anything.
 
-    The check is on the opened inode, never on the path: O_NOFOLLOW refuses a
-    symlink outright (a same-user link could otherwise point discovery at a
-    file that passes the checks), and fstat + read on that one descriptor
-    leaves no window to swap the path between checking and using it."""
+    lstat is a path check, so it cannot be the authority: fstat on the opened
+    descriptor re-runs the same predicate, and the read comes off that same
+    descriptor — no window to swap the path between checking and using it.
+    O_NOFOLLOW closes the symlink half of that race, O_NONBLOCK the blocking
+    half."""
     global SC_API_TOKEN, SC_API_BASE, _DISCOVERED_FROM
     try:
-        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        pre = os.lstat(path)
+    except OSError as exc:
+        die(f"runtime credential {path} is unreadable ({exc}) — restart the "
+            "supervised service (`./sc restart` / `make dos-r`), which re-provisions it.")
+    reason = _unsafe_reason(pre)
+    if reason:
+        _refuse_unsafe(path, reason)
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
     except OSError as exc:
         if exc.errno in (errno.ELOOP, errno.EMLINK):
-            die(f"runtime credential {path} is a symbolic link — the trust "
-                "boundary covers only a real owner-only file; remove the link "
-                "and let the supervised service re-provision it "
-                "(`./sc restart` / `make dos-r`).", EXIT_UNSAFE)
+            _refuse_unsafe(path, "a symbolic link")
         die(f"runtime credential {path} is unreadable ({exc}) — restart the "
             "supervised service (`./sc restart` / `make dos-r`), which re-provisions it.")
     try:
-        st = os.fstat(fd)
-        if not stat.S_ISREG(st.st_mode) or st.st_uid != os.geteuid() or st.st_mode & 0o077:
-            die(f"runtime credential {path} is not an owner-only regular file "
-                f"(mode {oct(stat.S_IMODE(st.st_mode))}) — the supervised service "
-                "re-provisions it with mode 0600 at boot: `./sc restart` / `make dos-r`.",
-                EXIT_UNSAFE)
+        reason = _unsafe_reason(os.fstat(fd))   # the authoritative check
+        if reason:
+            _refuse_unsafe(path, reason)
         try:
             data = json.loads(_read_all(fd))
             token, base = data["token"], data["api_base"]

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -22,9 +22,9 @@ Host Admin discovery (spec doc #30 req 11): a host Admin seat booted outside
 run.py has neither var. When BOTH are absent, `sc mem` may adopt the unique
 owner-only runtime credential the supervised API provisions per Admin shell
 (`.super-coder/run/mem/<shortname>.json`, mode 0600) — `SC_MEM_AS=<shortname>`
-selects one when several exist; ambiguity, an insecure artifact, and a stale
-(rotated) token all refuse with the supported action. Discovery still calls
-the API; it is never a direct-DB path.
+selects one when several exist; ambiguity, a symlinked or otherwise insecure
+artifact, and a stale (rotated) token all refuse with the supported action.
+Discovery still calls the API; it is never a direct-DB path.
 
 Run from the repo root, like every engine command:
 
@@ -70,6 +70,7 @@ per-invocation dedupe_key, so a retry can never write a duplicate, #333).
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import signal
@@ -102,8 +103,27 @@ _DISCOVERED_FROM: "Path | None" = None  # artifact the token came from, if any
 _PROG = "mem"
 
 
-def die(msg: str) -> "NoReturn":  # noqa: F821
-    sys.exit(f"{_PROG}: {msg}")
+# Two refusal classes, two stable exit statuses (spec doc #30 req 23): a caller
+# can tell "there is nothing usable to read" from "an artifact is there but sits
+# outside the trust boundary" without parsing stderr.
+EXIT_UNAVAILABLE = 1   # service down / artifact missing, unreadable, malformed, ambiguous
+EXIT_UNSAFE = 2        # artifact present but not an owner-only regular file
+
+
+def die(msg: str, code: int = EXIT_UNAVAILABLE) -> "NoReturn":  # noqa: F821
+    if code == EXIT_UNAVAILABLE:
+        sys.exit(f"{_PROG}: {msg}")   # sys.exit(str) := stderr + status 1
+    print(f"{_PROG}: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def _read_all(fd: int) -> bytes:
+    chunks = []
+    while True:
+        chunk = os.read(fd, 65536)
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
 
 
 def _load_runtime_credential(path: Path) -> None:
@@ -111,23 +131,38 @@ def _load_runtime_credential(path: Path) -> None:
 
     Accepted only under the existing local trust boundary: a regular file,
     owned by this user, with no group/world permission bits (the service
-    writes 0600 under a 0700 dir). Anything weaker is refused, not used."""
+    writes 0600 under a 0700 dir). Anything weaker is refused, not used.
+
+    The check is on the opened inode, never on the path: O_NOFOLLOW refuses a
+    symlink outright (a same-user link could otherwise point discovery at a
+    file that passes the checks), and fstat + read on that one descriptor
+    leaves no window to swap the path between checking and using it."""
     global SC_API_TOKEN, SC_API_BASE, _DISCOVERED_FROM
     try:
-        st = path.stat()
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
     except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.EMLINK):
+            die(f"runtime credential {path} is a symbolic link — the trust "
+                "boundary covers only a real owner-only file; remove the link "
+                "and let the supervised service re-provision it "
+                "(`./sc restart` / `make dos-r`).", EXIT_UNSAFE)
         die(f"runtime credential {path} is unreadable ({exc}) — restart the "
             "supervised service (`./sc restart` / `make dos-r`), which re-provisions it.")
-    if not stat.S_ISREG(st.st_mode) or st.st_uid != os.geteuid() or st.st_mode & 0o077:
-        die(f"runtime credential {path} is not an owner-only regular file "
-            f"(mode {oct(stat.S_IMODE(st.st_mode))}) — the supervised service "
-            "re-provisions it with mode 0600 at boot: `./sc restart` / `make dos-r`.")
     try:
-        data = json.loads(path.read_text())
-        token, base = data["token"], data["api_base"]
-    except (OSError, ValueError, KeyError):
-        die(f"runtime credential {path} is malformed — the supervised service "
-            "re-provisions it at boot: `./sc restart` / `make dos-r`.")
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode) or st.st_uid != os.geteuid() or st.st_mode & 0o077:
+            die(f"runtime credential {path} is not an owner-only regular file "
+                f"(mode {oct(stat.S_IMODE(st.st_mode))}) — the supervised service "
+                "re-provisions it with mode 0600 at boot: `./sc restart` / `make dos-r`.",
+                EXIT_UNSAFE)
+        try:
+            data = json.loads(_read_all(fd))
+            token, base = data["token"], data["api_base"]
+        except (OSError, ValueError, KeyError):
+            die(f"runtime credential {path} is malformed — the supervised service "
+                "re-provisions it at boot: `./sc restart` / `make dos-r`.")
+    finally:
+        os.close(fd)
     SC_API_TOKEN, SC_API_BASE, _DISCOVERED_FROM = token, base, path
 
 

--- a/.super-coder/scripts/mem_credentials.py
+++ b/.super-coder/scripts/mem_credentials.py
@@ -11,7 +11,9 @@ discovers the unique Admin artifact instead of dying unwired (see
 
 Properties the spec pins:
 
-- mode 0600, parent dir 0700, regular files owned by the service user;
+- mode 0600, parent dir 0700, regular files owned by the service user —
+  written as a fresh temp inode and renamed into place, so a symlink at the
+  artifact path is replaced, never followed;
 - refreshed on every boot — an api_key rotation (startup backfill or rebuild
   re-key) is picked up the next time the service starts;
 - never snapshotted or rendered: `.super-coder/run/` is gitignored and the
@@ -25,6 +27,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import tempfile
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
@@ -58,14 +61,20 @@ def provision(db_path: str, api_base: str, run_dir: Path = RUN_DIR) -> list[str]
             "token": api_key,
         })
         path = run_dir / f"{shortname}.json"
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        # Never open the artifact path for writing: a symlink planted there
+        # would be followed and its target truncated and overwritten with a
+        # bearer token. Write a freshly created 0600 regular file (mkstemp is
+        # O_EXCL and ignores the umask) and rename it over the name — rename
+        # replaces the link itself, never what the link points at. This also
+        # repairs a previously weakened artifact: every boot writes a new inode.
+        fd, tmp = tempfile.mkstemp(dir=run_dir, prefix=f".{shortname}.", suffix=".tmp")
         try:
-            os.write(fd, payload.encode())
-        finally:
-            os.close(fd)
-        # O_CREAT's mode only applies at creation — chmod unconditionally so a
-        # previously weakened artifact is repaired, never left readable.
-        os.chmod(path, 0o600)
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(payload.encode())
+            os.replace(tmp, path)
+        except OSError:
+            os.unlink(tmp)
+            raise
     for stale in run_dir.glob("*.json"):
         if stale.stem not in live:
             stale.unlink()

--- a/.super-coder/scripts/mem_credentials.py
+++ b/.super-coder/scripts/mem_credentials.py
@@ -63,13 +63,18 @@ def provision(db_path: str, api_base: str, run_dir: Path = RUN_DIR) -> list[str]
         path = run_dir / f"{shortname}.json"
         # Never open the artifact path for writing: a symlink planted there
         # would be followed and its target truncated and overwritten with a
-        # bearer token. Write a freshly created 0600 regular file (mkstemp is
-        # O_EXCL and ignores the umask) and rename it over the name — rename
-        # replaces the link itself, never what the link points at. This also
-        # repairs a previously weakened artifact: every boot writes a new inode.
+        # bearer token. Write a freshly created regular file (mkstemp is
+        # O_EXCL) and rename it over the name — rename replaces the link
+        # itself, never what the link points at. This also repairs a previously
+        # weakened artifact: every boot writes a new inode.
         fd, tmp = tempfile.mkstemp(dir=run_dir, prefix=f".{shortname}.", suffix=".tmp")
         try:
             with os.fdopen(fd, "wb") as fh:
+                # mkstemp's own 0600 is an open() mode — the process umask
+                # still subtracts from it, so a permissive umask would hand
+                # out a mode-000 (unreadable) credential. Pin the mode on the
+                # descriptor instead: exactly 0600, whatever the umask is.
+                os.fchmod(fh.fileno(), 0o600)
                 fh.write(payload.encode())
             os.replace(tmp, path)
         except OSError:

--- a/.super-coder/scripts/operator_token.py
+++ b/.super-coder/scripts/operator_token.py
@@ -15,7 +15,10 @@ SC_MEM_AS=<shortname> when several Admin identities exist.
 
 A missing, unreadable, or insecurely permissioned artifact refuses on stderr
 with the supported service action (`./sc restart` / `make dos-r`, which
-re-provisions it at boot). The trust-boundary check itself lives in
+re-provisions it at boot), and the two classes carry distinct nonzero exit
+statuses: 1 = nothing to read (service not running / no artifact), 2 = an
+artifact is there but unsafe (symlink, wrong owner, group/world bits). stdout
+stays empty either way. The trust-boundary check itself lives in
 mem.py:_discover_runtime_credential — this command reuses it rather than
 duplicating security logic. (Named operator_token.py, not token.py: the
 stdlib `token` module would shadow an `import token`.)
@@ -32,7 +35,9 @@ _USAGE = ("usage: ./sc token — print the browser sign-in operator token (an "
           "operator capability: the Admin runtime credential from the "
           "owner-only artifact .super-coder/run/mem/<shortname>.json) to "
           "stdout, and nothing else. The value itself never appears in help, "
-          "logs, or command arguments.")
+          "logs, or command arguments. Refusals go to stderr with distinct "
+          "exit statuses: 1 = service not running / no artifact, 2 = unsafe "
+          "artifact (symlink, wrong owner, group/world-readable).")
 
 
 def main(argv: "list[str] | None" = None) -> int:

--- a/tests/test_runtime_credentials.py
+++ b/tests/test_runtime_credentials.py
@@ -9,8 +9,13 @@ Two halves, one contract:
   sweeps artifacts whose shell is gone, demoted, deleted, or unkeyed.
 - `mem.py` discovery — with BOTH SC_API_BASE/SC_API_TOKEN absent, `sc mem`
   adopts the unique Admin artifact and still calls the API; multiple Admins
-  refuse until SC_MEM_AS names one; an insecure artifact and a stale
-  (rotated) token refuse with the supported action.
+  refuse until SC_MEM_AS names one; a symlinked or otherwise insecure
+  artifact and a stale (rotated) token refuse with the supported action.
+
+The trust boundary is the real artifact, never a path: neither half may follow
+a symlink planted at the artifact name — discovery refuses it, provisioning
+replaces it — and `./sc token` gives the two refusal classes distinct nonzero
+exit statuses (1 nothing-to-read, 2 unsafe artifact; spec doc #30 req 23).
 
 Discovery tests stand up the real `server.Handler` against a throwaway engine
 DB (same harness as test_mem — the token is the only identity), so a
@@ -48,6 +53,24 @@ import mem_credentials  # noqa: E402
 import server  # noqa: E402
 import operator_token as sc_token  # noqa: E402
 from test_mem import TOKEN, PEER_TOKEN, build_engine_db  # noqa: E402
+
+
+def refuse(fn):
+    """Run a refusing entrypoint; return (exit status, stderr text).
+
+    `mem.die` keeps the historical `sys.exit("<message>")` for status 1 — there
+    the message IS the SystemExit payload — and prints + exits with the number
+    for the other classes. The process sees stderr plus a status either way, so
+    normalise both shapes into that here."""
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        try:
+            fn()
+        except SystemExit as exc:
+            if isinstance(exc.code, str):
+                return 1, exc.code
+            return exc.code, err.getvalue()
+    raise AssertionError("expected a refusal, got a clean return")
 
 
 def build_shells_db(path: Path) -> None:
@@ -118,6 +141,23 @@ class ProvisionTest(unittest.TestCase):
         self.provision()
         data = json.loads((self.run_dir / "ADM1.json").read_text())
         self.assertEqual(data["token"], "k-adm1-rotated")
+
+    def test_symlinked_artifact_is_replaced_never_followed(self):
+        """A same-user symlink at the artifact path must not become a write
+        channel: provisioning replaces the link with a real 0600 file and the
+        link's target keeps its contents (no truncate, no token written)."""
+        self.run_dir.mkdir(parents=True)
+        target = self.tmp / "victim.txt"
+        target.write_text("not-a-credential")
+        (self.run_dir / "ADM1.json").symlink_to(target)
+        self.provision()
+        artifact = self.run_dir / "ADM1.json"
+        self.assertFalse(artifact.is_symlink())
+        self.assertEqual(target.read_text(), "not-a-credential")
+        self.assertEqual(json.loads(artifact.read_text())["token"], "k-adm1")
+        self.assertEqual(stat.S_IMODE(artifact.stat().st_mode), 0o600)
+        # the write goes through a temp inode — none of it is left behind
+        self.assertEqual([p.name for p in self.run_dir.iterdir()], ["ADM1.json"])
 
     def test_stale_artifacts_are_swept(self):
         self.run_dir.mkdir(parents=True)
@@ -228,10 +268,35 @@ class DiscoveryTest(unittest.TestCase):
 
     def test_insecure_artifact_is_refused(self):
         self.write_artifact("TC", TOKEN, mode=0o644)
-        with self.assertRaises(SystemExit) as cm:
-            self.run_which()
-        self.assertIn("owner-only", str(cm.exception))
-        self.assertIn("restart", str(cm.exception))
+        code, err = refuse(self.run_which)
+        self.assertEqual(code, mem.EXIT_UNSAFE)
+        self.assertIn("owner-only", err)
+        self.assertIn("restart", err)
+
+    def test_symlinked_artifact_is_refused(self):
+        """A same-user symlink pointing at a perfectly valid, owner-only file
+        must not be adopted: the trust boundary is the real artifact, and a
+        link is someone else's choice of what discovery reads."""
+        outside = Path(tempfile.mkdtemp()) / "planted.json"
+        outside.write_text(json.dumps({
+            "shell_id": 1, "shortname": "TC",
+            "api_base": f"http://127.0.0.1:{self.port}", "token": TOKEN,
+        }))
+        outside.chmod(0o600)
+        before = outside.read_text()
+        (self.cred_dir / "TC.json").symlink_to(outside)
+        code, err = refuse(self.run_which)
+        self.assertEqual(code, mem.EXIT_UNSAFE)
+        self.assertIn("symbolic link", err)
+        self.assertIsNone(mem._DISCOVERED_FROM)      # nothing adopted
+        self.assertEqual(mem.SC_API_TOKEN, "")
+        self.assertEqual(outside.read_text(), before)  # target untouched
+
+    def test_dangling_symlink_is_refused_not_reported_missing(self):
+        (self.cred_dir / "TC.json").symlink_to(self.cred_dir / "gone.json")
+        code, err = refuse(self.run_which)
+        self.assertEqual(code, mem.EXIT_UNSAFE)
+        self.assertIn("symbolic link", err)
 
     def test_malformed_artifact_is_refused(self):
         p = self.cred_dir / "TC.json"
@@ -326,10 +391,25 @@ class TokenCommandTest(unittest.TestCase):
 
     def test_insecure_artifact_is_refused(self):
         self.write_artifact("TC", TOKEN, mode=0o644)
-        with self.assertRaises(SystemExit) as cm:
-            self.run_token()
-        self.assertIn("owner-only", str(cm.exception))
-        self.assertNotIn(TOKEN, str(cm.exception))  # refusal never leaks the value
+        code, err = refuse(self.run_token)
+        self.assertEqual(code, mem.EXIT_UNSAFE)
+        self.assertIn("owner-only", err)
+        self.assertNotIn(TOKEN, err)                # refusal never leaks the value
+
+    def test_symlinked_artifact_is_refused(self):
+        outside = Path(tempfile.mkdtemp()) / "planted.json"
+        outside.write_text(json.dumps({
+            "shell_id": 1, "shortname": "TC",
+            "api_base": "http://127.0.0.1:8800", "token": TOKEN,
+        }))
+        outside.chmod(0o600)
+        before = outside.read_text()
+        (self.cred_dir / "TC.json").symlink_to(outside)
+        code, err = refuse(self.run_token)
+        self.assertEqual(code, mem.EXIT_UNSAFE)
+        self.assertIn("symbolic link", err)
+        self.assertNotIn(TOKEN, err)
+        self.assertEqual(outside.read_text(), before)
 
     def test_malformed_artifact_is_refused(self):
         p = self.cred_dir / "TC.json"
@@ -345,9 +425,9 @@ class TokenCommandTest(unittest.TestCase):
         self.write_artifact("TC", TOKEN, mode=0o644)
         mem.SC_API_TOKEN = "env-token"
         mem.SC_API_BASE = "http://127.0.0.1:8800"
-        with self.assertRaises(SystemExit) as cm:
-            self.run_token()
-        self.assertIn("owner-only", str(cm.exception))
+        code, err = refuse(self.run_token)
+        self.assertEqual(code, mem.EXIT_UNSAFE)
+        self.assertIn("owner-only", err)
 
     def test_help_labels_without_printing(self):
         self.write_artifact("TC", TOKEN)
@@ -357,20 +437,59 @@ class TokenCommandTest(unittest.TestCase):
         self.assertIn("./sc token", out)
         self.assertNotIn(TOKEN, out)
 
+    def run_script(self):
+        """Real interpreter, real process — the only place the exit *status*
+        (as opposed to the SystemExit payload) is observable."""
+        env = dict(os.environ, SC_MEM_CRED_DIR=str(self.cred_dir))
+        env.pop("SC_MEM_AS", None)
+        return subprocess.run(
+            [sys.executable, str(ENGINE / "scripts" / "operator_token.py")],
+            capture_output=True, text=True, env=env)
+
     def test_script_end_to_end(self):
         """Real interpreter, real artifact: stdout is the token and only the
         token. (The `token)` line in ./sc is the same one-line exec pattern as
         every other verb; a bash-dispatcher subprocess test would resolve the
         engine at the MAIN worktree root and break in linked dev worktrees.)"""
         self.write_artifact("TC", TOKEN)
-        env = dict(os.environ, SC_MEM_CRED_DIR=str(self.cred_dir))
-        env.pop("SC_MEM_AS", None)
-        proc = subprocess.run(
-            [sys.executable,
-             str(ENGINE / "scripts" / "operator_token.py")],
-            capture_output=True, text=True, env=env)
+        proc = self.run_script()
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertEqual(proc.stdout, TOKEN + "\n")
+
+    def test_script_exit_status_unavailable(self):
+        """Nothing to read (service not running / no artifact) → status 1."""
+        proc = self.run_script()
+        self.assertEqual(proc.returncode, mem.EXIT_UNAVAILABLE)
+        self.assertEqual(proc.stdout, "")
+        self.assertIn("./sc restart", proc.stderr)
+
+    def test_script_exit_status_unsafe_artifact(self):
+        """An artifact that fails the trust boundary is a DIFFERENT nonzero
+        status from 'nothing to read' (spec doc #30 req 23) — a caller can
+        branch on it without parsing stderr."""
+        self.write_artifact("TC", TOKEN, mode=0o644)
+        proc = self.run_script()
+        self.assertEqual(proc.returncode, mem.EXIT_UNSAFE)
+        self.assertNotEqual(mem.EXIT_UNSAFE, mem.EXIT_UNAVAILABLE)
+        self.assertEqual(proc.stdout, "")
+        self.assertIn("owner-only", proc.stderr)
+        self.assertNotIn(TOKEN, proc.stderr)
+
+    def test_script_symlinked_artifact_refuses_without_printing(self):
+        outside = Path(tempfile.mkdtemp()) / "planted.json"
+        outside.write_text(json.dumps({
+            "shell_id": 1, "shortname": "TC",
+            "api_base": "http://127.0.0.1:8800", "token": TOKEN,
+        }))
+        outside.chmod(0o600)
+        before = outside.read_text()
+        (self.cred_dir / "TC.json").symlink_to(outside)
+        proc = self.run_script()
+        self.assertEqual(proc.returncode, mem.EXIT_UNSAFE)
+        self.assertEqual(proc.stdout, "")            # the planted token stays unread
+        self.assertIn("symbolic link", proc.stderr)
+        self.assertNotIn(TOKEN, proc.stderr)
+        self.assertEqual(outside.read_text(), before)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_credentials.py
+++ b/tests/test_runtime_credentials.py
@@ -30,6 +30,7 @@ import contextlib
 import io
 import json
 import os
+import signal
 import sqlite3
 import stat
 import subprocess
@@ -71,6 +72,24 @@ def refuse(fn):
                 return 1, exc.code
             return exc.code, err.getvalue()
     raise AssertionError("expected a refusal, got a clean return")
+
+
+@contextlib.contextmanager
+def deadline(seconds=5):
+    """Fail the test if the body blocks longer than `seconds`.
+
+    Discovery classifies the artifact before opening it precisely so a FIFO at
+    the artifact path cannot wedge the caller. A regression there hangs
+    forever; this turns that into a failure instead of a stuck suite."""
+    def _expired(signum, frame):
+        raise AssertionError(f"blocked for more than {seconds}s")
+    previous = signal.signal(signal.SIGALRM, _expired)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
 
 
 def build_shells_db(path: Path) -> None:
@@ -124,6 +143,24 @@ class ProvisionTest(unittest.TestCase):
         self.assertEqual(mode, 0o600)
         dmode = stat.S_IMODE(self.run_dir.stat().st_mode)
         self.assertEqual(dmode, 0o700)
+
+    def test_mode_is_exactly_0600_under_any_umask(self):
+        """The credential's mode is pinned, not inherited from the process.
+
+        mkstemp asks for 0600 through open(), so the umask still subtracts
+        from it: under 0o077 the result happens to be right, under 0o777 the
+        service would hand every Admin seat a mode-000 artifact its own
+        discovery then refuses. The mode must be exactly 0600 either way."""
+        original = os.umask(0o022)
+        self.addCleanup(os.umask, original)
+        for mask in (0o000, 0o022, 0o077, 0o777):
+            with self.subTest(umask=oct(mask)):
+                os.umask(mask)
+                self.provision()
+                artifact = self.run_dir / "ADM1.json"
+                self.assertEqual(stat.S_IMODE(artifact.stat().st_mode), 0o600)
+                self.assertEqual(stat.S_IMODE(self.run_dir.stat().st_mode), 0o700)
+                artifact.unlink()   # next round writes a fresh inode
 
     def test_reprovision_repairs_weakened_permissions(self):
         self.provision()
@@ -292,6 +329,32 @@ class DiscoveryTest(unittest.TestCase):
         self.assertEqual(mem.SC_API_TOKEN, "")
         self.assertEqual(outside.read_text(), before)  # target untouched
 
+    def test_fifo_artifact_is_refused_without_blocking(self):
+        """A FIFO planted at the artifact name is a denial-of-service on
+        discovery, not just a bad file: opening it blocks until someone writes,
+        and O_NOFOLLOW does nothing about that. It must be classified as unsafe
+        without ever being opened — bounded, exit 2, nothing adopted."""
+        os.mkfifo(self.cred_dir / "TC.json", 0o600)
+        with deadline():
+            code, err = refuse(self.run_which)
+        self.assertEqual(code, mem.EXIT_UNSAFE)
+        self.assertIn("not a regular file", err)
+        self.assertIn("restart", err)
+        self.assertIsNone(mem._DISCOVERED_FROM)
+        self.assertEqual(mem.SC_API_TOKEN, "")
+
+    def test_wrong_owner_artifact_is_unsafe_not_unavailable(self):
+        """An artifact owned by someone else is outside the trust boundary
+        (exit 2) — and it must be classified as such by ownership, not by
+        whether open() happens to fail EACCES first (which would report the
+        'nothing to read' class instead)."""
+        self.write_artifact("TC", TOKEN)
+        with mock.patch("os.geteuid", return_value=os.geteuid() + 1):
+            code, err = refuse(self.run_which)
+        self.assertEqual(code, mem.EXIT_UNSAFE)
+        self.assertIn("owned by another user", err)
+        self.assertIsNone(mem._DISCOVERED_FROM)
+
     def test_dangling_symlink_is_refused_not_reported_missing(self):
         (self.cred_dir / "TC.json").symlink_to(self.cred_dir / "gone.json")
         code, err = refuse(self.run_which)
@@ -444,7 +507,7 @@ class TokenCommandTest(unittest.TestCase):
         env.pop("SC_MEM_AS", None)
         return subprocess.run(
             [sys.executable, str(ENGINE / "scripts" / "operator_token.py")],
-            capture_output=True, text=True, env=env)
+            capture_output=True, text=True, env=env, timeout=30)
 
     def test_script_end_to_end(self):
         """Real interpreter, real artifact: stdout is the token and only the
@@ -474,6 +537,16 @@ class TokenCommandTest(unittest.TestCase):
         self.assertEqual(proc.stdout, "")
         self.assertIn("owner-only", proc.stderr)
         self.assertNotIn(TOKEN, proc.stderr)
+
+    def test_script_fifo_artifact_refuses_bounded(self):
+        """The FIFO case, in a real process: `./sc token` must exit 2 promptly
+        with empty stdout. A regression blocks in open() forever, which the
+        subprocess timeout turns into a failure rather than a hung CI job."""
+        os.mkfifo(self.cred_dir / "TC.json", 0o600)
+        proc = self.run_script()
+        self.assertEqual(proc.returncode, mem.EXIT_UNSAFE)
+        self.assertEqual(proc.stdout, "")
+        self.assertIn("not a regular file", proc.stderr)
 
     def test_script_symlinked_artifact_refuses_without_printing(self):
         outside = Path(tempfile.mkdtemp()) / "planted.json"


### PR DESCRIPTION
Sprint 31 conformance fix units **F2** (Major, spec 30 req 11/23) and **F4** (Low, req 23). Reviewer: REV1.

## F2 — credential trust boundary followed symlinks
`_load_runtime_credential` checked with `Path.stat()` and read with `Path.read_text()` (both follow links); provisioning opened the artifact `O_TRUNC` without `O_NOFOLLOW` and chmod'd the followed path. A same-user symlink could redirect discovery at a file that passes the owner/mode checks, and the supervised service could truncate a same-user-writable target and write bearer JSON into it.

- **Discovery** now opens with `O_NOFOLLOW` and does `fstat` + read on that one descriptor — a link is refused outright, with no check→use race window to swap the path.
- **Provisioning** writes a freshly created `0600` temp inode and atomically renames it over the artifact name — rename replaces the link, never its target. Re-creating the inode each boot still repairs a weakened artifact, so the chmod is gone.

## F4 — distinct token exit codes (req 23)
"Distinct nonzero result for service-not-running vs unsafe permissions" is read as distinct process exit statuses:
- `1` = nothing usable to read
- `2` = an artifact exists but is outside the trust boundary

stdout stays empty and stderr actionable in both. `mem.die` keeps the historical `sys.exit("<message>")` shape for status 1, so every other refusal is unchanged.

## Tests (`tests/test_runtime_credentials.py`, +157)
- provisioning replaces a planted symlink with the target's contents intact, no temp left behind;
- discovery and `sc token` refuse a symlink pointing at a valid owner-only artifact (nothing adopted, stdout empty, target untouched);
- real-subprocess coverage pins both exit statuses.

Reverting the source turns 9 tests red, including the symlink case printing the planted token at exit 0. Focused suite: **30 passed**.

Refs #516 #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)