### PR TITLE
fix(interface): fence recovery on process/tmux/worktree evidence (S31 F1)

### DIFF
--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -694,14 +694,26 @@ def cmd_recover(args) -> int:
         print(f"→ parked ambiguous binding {parked['binding_id']}: "
               f"{parked['next_action']}")
     wt = result.get("worktree") or {}
-    if wt.get("discarded"):
-        print(f"→ worktree {wt['worktree']} changes discarded")
-    elif wt.get("failed"):
+    if wt.get("failed"):
         done = ", ".join(wt.get("completed") or []) or "nothing"
         print(f"→ worktree discard INCOMPLETE in {wt['worktree']}: completed "
               f"[{done}], failed at {wt['failed']['step']} "
               f"({wt['failed'].get('error', 'unknown error')}) — the closure "
               "is committed; finish the discard by hand", file=sys.stderr)
+    elif wt.get("kept_count"):
+        # Not a failure: these are left intact by design. Saying "preserved"
+        # (the nothing-was-touched line) would be false, and so would a bare
+        # "discarded" — so name them and say plainly why they can be there.
+        count = wt["kept_count"]
+        named = ", ".join(wt.get("kept") or [])
+        more = count - len(wt.get("kept") or [])
+        print(f"→ worktree {wt['worktree']} changes discarded, EXCEPT "
+              f"{count} entr{'y' if count == 1 else 'ies'} left intact: "
+              f"{named}" + (f" (+{more} more)" if more else "")
+              + " — changed after the confirmation, or a directory still "
+              "holding entries the discard was not allowed to remove")
+    elif wt.get("discarded"):
+        print(f"→ worktree {wt['worktree']} changes discarded")
     else:
         print("→ worktree preserved")
     print(f"→ {shortname} is {result.get('availability')}")

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -600,6 +600,16 @@ def _unpushed_count(worktree: str) -> int:
         raise refuse("rev-list --count gave a non-numeric answer") from exc
 
 
+def _is_dir(path: str) -> bool:
+    """A REAL directory at this path — lstat, so a symlink to one is not it.
+    `git restore` replaces a symlink outright; only a directory makes it
+    recurse."""
+    try:
+        return stat.S_ISDIR(os.lstat(path).st_mode)
+    except OSError:
+        return False
+
+
 def _prune_dirs(worktree: str, plan: dict) -> list[str]:
     """Remove the enumerated untracked directories once their enumerated files
     are gone. Returns the enumerated roots that are still there.
@@ -645,14 +655,19 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
     existing. The blast radius is exactly what the preview showed, which is
     what decision #41 requires of a consented destructive path.
 
+    Bounding the SET is not enough on its own, because one git command's own
+    footprint can exceed the path it is given: `git restore` on a path the
+    worktree has turned into a directory deletes that directory whole,
+    ignored files and all (SC-103). So the removal runs FIRST — clearing the
+    enumerated entries out of such a directory — and a path still standing as
+    a directory afterwards is left alone rather than restored over.
+
     Each entry is also re-verified against the identity the fence observed,
     immediately before it is touched, and left alone when it no longer
     matches — so a path is only ever removed while it still IS what the
     operator was shown. That check narrows, and does not close, the window
     between the check and the `unlink`/`restore` itself: no filesystem offers
-    "remove only if unchanged". What it does close is the case that window
-    used to swallow whole — work written during the several-millisecond
-    `git restore` spawn now survives.
+    "remove only if unchanged".
 
     Runs AFTER the durable closure is committed, so a failure here must never
     escape as a 500 that hides what happened: each step's outcome is recorded
@@ -680,12 +695,58 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
         if len(result["kept"]) < _KEPT_REPORTED:
             result["kept"].append(rel)
 
-    # -- restore the enumerated tracked paths -------------------------------
-    # Born HEAD: index + worktree back to HEAD. Unborn: HEAD holds nothing, so
-    # "back to HEAD" means dropping the index entry — the file then falls into
-    # the removal step below with the untracked ones.
+    # Decided BEFORE anything moves, because the removal below is what clears
+    # a directory sitting on a tracked path — after it, "absent" is our own
+    # doing and would read as a change.
     for rel in plan["tracked"]:
         (restore.append if unchanged(rel) else keep)(rel)
+
+    # -- remove the enumerated untracked entries ----------------------------
+    # FIRST, and that ordering is load-bearing (SC-103). `git restore` on a
+    # path the worktree has turned into a DIRECTORY deletes that directory
+    # whole — everything under it, enumerated or not. Removing the enumerated
+    # entries first empties such a directory so the restore has nothing to
+    # recurse through; whatever is left afterwards was never in the delete set,
+    # and the restore below refuses to run over it.
+    removable = list(plan["untracked_files"])
+    if not plan["head"]:
+        # Unborn: `git rm --cached` never touches the worktree, so these files
+        # are removed here with the untracked ones and unstaged below.
+        removable += restore
+    removed = []
+    for rel in sorted(removable):
+        if not unchanged(rel):
+            keep(rel)
+            continue
+        try:
+            os.unlink(os.path.join(worktree, rel))
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            result["failed"] = {"step": "remove",
+                                "error": f"{rel[-120:]}: errno {exc.errno}"}
+            return result
+        removed.append(rel)
+    for rel in _prune_dirs(worktree, plan):
+        keep(rel, is_file=False)
+    result["completed"].append("remove")
+
+    # -- restore the enumerated tracked paths -------------------------------
+    # Born HEAD: index + worktree back to HEAD. Unborn: HEAD holds nothing, so
+    # "back to HEAD" is just dropping the index entry — and only for entries
+    # the removal above actually handled.
+    if plan["head"]:
+        standing = [rel for rel in restore
+                    if _is_dir(os.path.join(worktree, rel))]
+        for rel in standing:
+            # Still a directory, so it holds something the discard was not
+            # allowed to remove — an ignored file, a nested repository, work
+            # written later. Restoring would erase it as collateral, so the
+            # path is left exactly as it is and reported.
+            keep(rel)
+        restore = [rel for rel in restore if rel not in set(standing)]
+    else:
+        restore = [rel for rel in restore if rel in set(removed)]
     if restore:
         args = ["restore", "--source=HEAD", "--staged", "--worktree"] \
             if plan["head"] else ["rm", "--cached", "--force", "--quiet"]
@@ -705,26 +766,6 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
                 "error": out.stderr.decode("utf-8", "replace").strip()[-200:]}
             return result
     result["completed"].append("restore")
-
-    # -- remove the enumerated untracked entries ----------------------------
-    removable = list(plan["untracked_files"])
-    if not plan["head"]:
-        removable += restore          # just unstaged; the files are still there
-    for rel in sorted(removable):
-        if not unchanged(rel):
-            keep(rel)
-            continue
-        try:
-            os.unlink(os.path.join(worktree, rel))
-        except FileNotFoundError:
-            pass
-        except OSError as exc:
-            result["failed"] = {"step": "remove",
-                                "error": f"{rel[-120:]}: errno {exc.errno}"}
-            return result
-    for rel in _prune_dirs(worktree, plan):
-        keep(rel, is_file=False)
-    result["completed"].append("remove")
     # A surviving DIRECTORY does not make the discard incomplete. It stands
     # because it holds something outside the delete set — an ignored file, a
     # nested repository, work written after the confirmation — and `clean -fd`

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -20,15 +20,20 @@ One API-owned preview/execute workflow shared by browser and CLI:
   re-verified once more at signal time (PID + /proc start ticks) — a PID
   reuse or unreadable /proc at that instant performs no signal and returns
   an indeterminate result. A confirmed discard re-reads the worktree ONE more
-  time immediately before `reset --hard`/`clean -fd`, because a shell can
-  write while it shuts down, i.e. after that fence has already passed; that
-  refusal deletes nothing but cannot unwind the signal or the closure, and it
-  says which of the two actually happened. Every worktree observation is
-  STABLE — each path read self-consistently, the whole observation repeated
-  identically — so a write landing during a read cannot produce an answer that
-  was never true (SC-092). See `_assert_worktree_unchanged` for the ONE window
-  that remains open — a worktree is not transactional and no claim of
-  atomicity is made here.
+  time immediately before it deletes, because a shell can write while it shuts
+  down, i.e. after that fence has already passed; that refusal deletes nothing
+  but cannot unwind the signal or the closure, and it says which of the two
+  actually happened. Every worktree observation is STABLE — each path read
+  self-consistently, the whole observation repeated identically — so a write
+  landing during a read cannot produce an answer that was never true (SC-092).
+  Freshness alone cannot make a discard safe, because no read sees work that
+  does not exist yet: the discard is therefore BOUNDED BY THE OBSERVATION
+  rather than by the tree's later state — it restores exactly the enumerated
+  tracked paths and removes exactly the enumerated untracked ones, so a file
+  written after the observation is not in the delete set and survives by
+  construction (SC-100). See `_assert_worktree_unchanged` for what remains
+  open — a worktree is not transactional and no claim of atomicity is made
+  here.
 
 Signaling discipline (spec Shell Recovery): SIGTERM to the exact verified
 process group, the bounded existing grace period, SIGKILL only while the
@@ -61,6 +66,7 @@ websockets-dependent Interface runtime (spec Restricted Admin).
 """
 from __future__ import annotations
 
+import contextlib
 import errno
 import hashlib
 import json
@@ -281,6 +287,9 @@ def _meta(st) -> str:
 # tree still being written, and that is a refusal, not something to wait out.
 _STABILITY_TRIES = 3
 
+# How many kept-back entries the discard result names before it only counts.
+_KEPT_REPORTED = 20
+
 # errnos that mean "the entry changed under us", not "we cannot read it":
 # gone, replaced by a symlink, or a parent component replaced by a file.
 _TORN_ERRNOS = (errno.ENOENT, errno.ELOOP, errno.ENOTDIR)
@@ -400,53 +409,82 @@ def _path_identity(path: str) -> str:
         "torn read: an entry kept changing while it was observed")
 
 
-def _change_digest(worktree: str, porcelain: list[str], head: bool) -> str:
-    """Fingerprint of what a discard would erase.
+def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
+    """WHAT a discard would destroy, named entry by entry: the exact SET of
+    worktree entries, each entry's identity, and the digest over the whole
+    thing.
 
-    INVARIANT: this digest MUST change if ANY safety-relevant aspect of the
-    worktree state a discard would destroy has changed since the preview.
-    Porcelain lines are far coarser than that — they stay byte-identical
-    while the work underneath them is rewritten, retargeted, re-permissioned
-    or changes type — so the line set is only the outer layer. Held against
-    the invariant, the state a discard destroys is: the SET of affected paths
-    (the lines), and for each path its ENTITY IDENTITY (`_path_identity`) —
-    type, permissions, ownership, timestamps, and regular-file bytes or
-    symlink target.
+    This set is not merely described to the operator — it BOUNDS the
+    destructive step (`_discard_worktree_files`). `reset --hard` and
+    `clean -fd` act on whatever is in the tree when they run, so an ordinary
+    file save landing after the observation was erased even though no
+    observation ever saw it, and no repetition of the read can close that:
+    two passes detect changes BETWEEN them, and a path created after each
+    pass's own enumeration is missed by both, so the digests agree (SC-100).
+    Discarding this enumerated set instead makes the race stop existing —
+    a path that is not in the set cannot be removed, whenever it appeared.
 
-    The path set is what `reset --hard` + `clean -fd` would act on: the paths
-    differing from HEAD, plus untracked files, plus untracked DIRECTORIES —
-    `clean -fd` removes an empty untracked directory that `ls-files -o` (a
-    file listing) never names. Ignored files stay out: `clean -fd` without
-    -x does not touch them, so they are not state the confirmation is about.
+    INVARIANT for the digest: it MUST change if ANY safety-relevant aspect of
+    the state a discard would destroy has changed since the preview. Porcelain
+    lines are far coarser than that — they stay byte-identical while the work
+    underneath them is rewritten, retargeted, re-permissioned or changes type —
+    so the line set is only the outer layer. Held against the invariant, that
+    state is: the SET of affected entries, and for each its ENTITY IDENTITY
+    (`_path_identity`) — type, permissions, ownership, timestamps, and
+    regular-file bytes or symlink target.
+
+    The set is what the discard must undo:
+    - untracked FILES individually (`ls-files -o`), never collapsed to a dir;
+    - untracked DIRECTORIES in their own right (`--directory`, trailing `/`),
+      empty ones included: `clean -fd` removes a directory that a file listing
+      never names;
+    - born HEAD -> every path differing from HEAD (`diff HEAD`): staged,
+      unstaged and deletions, one row each;
+    - unborn HEAD -> every INDEX entry (`ls-files`). Nothing has been
+      committed, so a discard drops the whole index and the files with it —
+      and `ls-files -o` cannot see a staged path, which left staged work
+      destroyed by a discard the digest never covered.
+
+    Ignored files stay out: `clean -fd` without -x does not touch them, so
+    they are not state the confirmation is about.
     """
     def paths(*args) -> list[str]:
         # -z: paths verbatim, no C-quoting to unescape.
         return [p for p in _git_out(worktree, *args, timeout=30).split("\0")
                 if p]
 
+    listed = set(paths("ls-files", "-o", "--exclude-standard", "-z"))
+    untracked_dirs = {p for p in
+                      paths("ls-files", "-o", "--directory",
+                            "--exclude-standard", "-z") if p.endswith("/")}
+    # A trailing slash in the FILE listing is a nested repository — git names
+    # it once and never descends. It is a directory: unlinking it would fail
+    # the whole discard, and `clean -fd` leaves it alone too.
+    untracked_dirs |= {p for p in listed if p.endswith("/")}
+    untracked_files = {p for p in listed if not p.endswith("/")}
+    tracked = set(paths("diff", "HEAD", "--name-only", "-z")) if head \
+        else set(paths("ls-files", "-z"))
+
     h = hashlib.sha256()
     for line in sorted(porcelain):
         h.update(line.encode("utf-8", "surrogateescape") + b"\n")
-    # ls-files -o: untracked FILES individually, never collapsed to a dir;
-    # --directory: the untracked DIRECTORIES themselves, empty ones included.
-    rels = set(paths("ls-files", "-o", "--exclude-standard", "-z")) \
-        | set(paths("ls-files", "-o", "--directory", "--exclude-standard",
-                    "-z"))
-    if head:
-        # staged + unstaged + deletions, one row per path.
-        rels |= set(paths("diff", "HEAD", "--name-only", "-z"))
-    for rel in sorted(rels):
+    identities = {}
+    for rel in sorted(tracked | untracked_files | untracked_dirs):
+        identities[rel] = _path_identity(os.path.join(worktree, rel))
         h.update(rel.encode("utf-8", "surrogateescape") + b"\0"
-                 + _path_identity(os.path.join(worktree, rel)).encode()
-                 + b"\0")
-    return h.hexdigest()
+                 + identities[rel].encode() + b"\0")
+    return {"head": head, "tracked": sorted(tracked),
+            "untracked_files": sorted(untracked_files),
+            "untracked_dirs": sorted(untracked_dirs),
+            "identities": identities, "digest": h.hexdigest()}
 
 
-def _observe_worktree(worktree: str) -> dict:
-    """ONE complete pass over the worktree facts. Every git read the fence
-    depends on happens here, so the whole answer can be repeated and compared —
-    the path SET is enumerated at a different instant from each path's identity,
-    and a pass is only trustworthy if the composite holds still."""
+def _observe_worktree(worktree: str) -> tuple[dict, dict]:
+    """ONE complete pass over the worktree facts, plus the discard plan that
+    pass enumerated. Every git read the fence depends on happens here, so the
+    whole answer can be repeated and compared — the entry SET is enumerated at
+    a different instant from each entry's identity, and a pass is only
+    trustworthy if the composite holds still."""
     head = _head_exists(worktree)
     branch = _git_out(worktree, "rev-parse", "--abbrev-ref", "HEAD") \
         if head else _git_out(worktree, "branch", "--show-current")
@@ -456,6 +494,7 @@ def _observe_worktree(worktree: str) -> dict:
     unpushed = int(_git_out(worktree, "rev-list", "HEAD", "--not",
                             "--remotes", "--count").strip() or 0) \
         if head else 0
+    plan = _discard_plan(worktree, porcelain, head)
     return {"worktree": worktree, "branch": branch.strip(),
             "dirty_tracked": dirty, "untracked": untracked,
             "unpushed_commits": unpushed,
@@ -465,12 +504,19 @@ def _observe_worktree(worktree: str) -> dict:
             # retarget, a chmod, and a type transition all move the
             # freshness fingerprint. Paths and contents stay out of the
             # payload.
-            "change_digest": _change_digest(worktree, porcelain, head)}
+            "change_digest": plan["digest"]}, plan
 
 
-def _git_facts(worktree: str | None) -> dict | None:
-    """Worktree facts for the freshness fence. Three outcomes, kept apart on
-    purpose:
+def _observe_stable(worktree: str | None) -> tuple[dict | None, dict | None]:
+    """`(facts, plan)` — the facts the fence compares, and the enumerated set
+    the discard is bounded by. They come from the SAME pass on purpose: the
+    digest equality proves that set IS the set the operator consented to, so
+    the discard needs no second enumeration to race against.
+
+    `plan` is None whenever there is nothing to discard against — no
+    repository, or an observation that could not be completed.
+
+    Three outcomes for the facts, kept apart on purpose:
 
     - `None` — there is no repository to observe (no worktree, or no `.git`).
       Complete evidence: there is no git-managed state here to erase.
@@ -488,23 +534,35 @@ def _git_facts(worktree: str | None) -> dict | None:
     moved (SC-092). Requiring two consecutive identical passes means the answer
     was true across a window, not merely at assorted instants inside one; a tree
     that keeps moving is refused rather than approximated.
+
+    Stability does NOT make the answer current, and is not relied on for that:
+    a path created after each pass's own enumeration is invisible to both
+    passes, so equal digests prove only that nothing the passes SAW moved
+    (SC-100). What protects an unseen path is that the discard cannot touch a
+    path outside `plan` at all.
     """
     if not worktree:
-        return None
+        return None, None
     dotgit = os.path.join(worktree, ".git")
     if not (os.path.isdir(dotgit) or os.path.isfile(dotgit)):
-        return None
+        return None, None
     try:
         previous = None
         for _ in range(_STABILITY_TRIES):
-            facts = _observe_worktree(worktree)
+            facts, plan = _observe_worktree(worktree)
             if facts == previous:
-                return facts
+                return facts, plan
             previous = facts
         raise _GitEvidenceUnavailable(
             "the worktree did not hold still across consecutive observations")
     except (_GitEvidenceUnavailable, ValueError) as exc:
-        return {"indeterminate": str(exc)}
+        return {"indeterminate": str(exc)}, None
+
+
+def _git_facts(worktree: str | None) -> dict | None:
+    """The fence's half of `_observe_stable` — the facts alone, for the
+    evidence payload. See `_observe_stable` for the three outcomes."""
+    return _observe_stable(worktree)[0]
 
 
 def _unpushed_count(worktree: str) -> int:
@@ -542,37 +600,140 @@ def _unpushed_count(worktree: str) -> int:
         raise refuse("rev-list --count gave a non-numeric answer") from exc
 
 
-def _discard_worktree_files(worktree: str) -> dict:
-    """Remove tracked + untracked file changes in the exact worktree. Never
-    deletes the worktree, its branch, or ignored files. Runs AFTER the
-    durable closure is committed, so a git failure here must never escape
-    as a 500 that hides what happened: each step's outcome is recorded and
-    a failure returns exactly what completed and where it stopped.
+def _prune_dirs(worktree: str, plan: dict) -> list[str]:
+    """Remove the enumerated untracked directories once their enumerated files
+    are gone. Returns the enumerated roots that are still there.
 
-    `reset --hard` without an explicit `HEAD`: identical everywhere HEAD
-    resolves, and the only form that works on an UNBORN head — where naming
-    HEAD is fatal, which failed the reset and stopped before the clean, so a
-    discard the gates had authorised silently did nothing. Unborn, it empties
-    the index (nothing has ever been committed, so that IS the baseline) and
-    the clean then removes the untracked files.
+    Two bounds, and both matter:
+
+    - only directories the observation covers are candidates: an enumerated
+      directory, or an ancestor of an enumerated entry (which is how a
+      directory emptied by the restore — the one holding a staged-new file —
+      still goes, as it did under `clean -fd`). Walking the tree instead would
+      rmdir an EMPTY directory created after the observation, which is the
+      SC-100 case one entity type over.
+    - rmdir, never a recursive delete. Emptiness is the whole guarantee: a
+      file created inside after the observation keeps its directory non-empty,
+      so the directory survives carrying it, and so does every parent. Ignored
+      files and a nested repository's contents have exactly the same effect —
+      as they did under `clean -fd`, which leaves both behind.
+    """
+    prunable = {rel.rstrip("/") for rel in plan["untracked_dirs"]}
+    for rel in plan["untracked_files"] + plan["tracked"]:
+        parent = os.path.dirname(rel)
+        while parent:                       # stops at the worktree root
+            prunable.add(parent)
+            parent = os.path.dirname(parent)
+    for rel in sorted(prunable, key=len, reverse=True):  # deepest first
+        with contextlib.suppress(OSError):
+            os.rmdir(os.path.join(worktree, rel))
+    return [rel for rel in plan["untracked_dirs"]
+            if os.path.lexists(os.path.join(worktree, rel.rstrip("/")))]
+
+
+def _discard_worktree_files(worktree: str, plan: dict) -> dict:
+    """Undo EXACTLY the entries `plan` enumerated — restore its tracked paths
+    from HEAD, remove its untracked ones — and nothing else. Never deletes the
+    worktree, its branch, or ignored files.
+
+    Bounded by the observation, not by the filesystem (SC-100). `reset --hard`
+    and `clean -fd` operate on whatever the tree holds at delete time, so an
+    ordinary editor save landing after the last observation was erased without
+    ever having been seen or consented to. Here the delete set is fixed by the
+    observation the operator confirmed: a path that appeared later is simply
+    not in it and survives BY CONSTRUCTION — the race is not won, it stops
+    existing. The blast radius is exactly what the preview showed, which is
+    what decision #41 requires of a consented destructive path.
+
+    Each entry is also re-verified against the identity the fence observed,
+    immediately before it is touched, and left alone when it no longer
+    matches — so a path is only ever removed while it still IS what the
+    operator was shown. That check narrows, and does not close, the window
+    between the check and the `unlink`/`restore` itself: no filesystem offers
+    "remove only if unchanged". What it does close is the case that window
+    used to swallow whole — work written during the several-millisecond
+    `git restore` spawn now survives.
+
+    Runs AFTER the durable closure is committed, so a failure here must never
+    escape as a 500 that hides what happened: each step's outcome is recorded
+    and a failure returns exactly what completed and where it stopped.
+    `discarded` is true only when every enumerated FILE was undone; anything
+    left behind — files and directories alike — is named in `kept`, never
+    silently dropped.
     """
     result: dict = {"worktree": worktree, "discarded": False,
-                    "completed": [], "failed": None}
-    for step, args in (("reset", ["reset", "--hard"]),
-                       ("clean", ["clean", "-fd"])):
+                    "completed": [], "failed": None,
+                    "kept": [], "kept_count": 0}
+    identities, restore, kept_files = plan["identities"], [], []
+
+    def unchanged(rel: str) -> bool:
         try:
-            out = subprocess.run(["git", "-C", worktree, *args],
-                                 capture_output=True, text=True, timeout=60,
-                                 check=False)
+            return _path_identity(
+                os.path.join(worktree, rel)) == identities[rel]
+        except _GitEvidenceUnavailable:
+            return False   # unreadable now: never a licence to delete
+
+    def keep(rel: str, *, is_file: bool = True) -> None:
+        result["kept_count"] += 1
+        if is_file:
+            kept_files.append(rel)
+        if len(result["kept"]) < _KEPT_REPORTED:
+            result["kept"].append(rel)
+
+    # -- restore the enumerated tracked paths -------------------------------
+    # Born HEAD: index + worktree back to HEAD. Unborn: HEAD holds nothing, so
+    # "back to HEAD" means dropping the index entry — the file then falls into
+    # the removal step below with the untracked ones.
+    for rel in plan["tracked"]:
+        (restore.append if unchanged(rel) else keep)(rel)
+    if restore:
+        args = ["restore", "--source=HEAD", "--staged", "--worktree"] \
+            if plan["head"] else ["rm", "--cached", "--force", "--quiet"]
+        try:
+            out = subprocess.run(
+                ["git", "-C", worktree, *args, "--pathspec-from-file=-",
+                 "--pathspec-file-nul"],
+                input=b"".join(rel.encode("utf-8", "surrogateescape") + b"\0"
+                               for rel in restore),
+                capture_output=True, timeout=60, check=False)
         except Exception as exc:  # noqa: BLE001 — timeout etc: report it
-            result["failed"] = {"step": step, "error": str(exc)[:200]}
+            result["failed"] = {"step": "restore", "error": str(exc)[:200]}
             return result
         if out.returncode != 0:
-            result["failed"] = {"step": step,
-                                "error": out.stderr.strip()[-200:]}
+            result["failed"] = {
+                "step": "restore",
+                "error": out.stderr.decode("utf-8", "replace").strip()[-200:]}
             return result
-        result["completed"].append(step)
-    result["discarded"] = True
+    result["completed"].append("restore")
+
+    # -- remove the enumerated untracked entries ----------------------------
+    removable = list(plan["untracked_files"])
+    if not plan["head"]:
+        removable += restore          # just unstaged; the files are still there
+    for rel in sorted(removable):
+        if not unchanged(rel):
+            keep(rel)
+            continue
+        try:
+            os.unlink(os.path.join(worktree, rel))
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            result["failed"] = {"step": "remove",
+                                "error": f"{rel[-120:]}: errno {exc.errno}"}
+            return result
+    for rel in _prune_dirs(worktree, plan):
+        keep(rel, is_file=False)
+    result["completed"].append("remove")
+    # A surviving DIRECTORY does not make the discard incomplete. It stands
+    # because it holds something outside the delete set — an ignored file, a
+    # nested repository, work written after the confirmation — and `clean -fd`
+    # left exactly those standing too. Reporting it as a failure would cry wolf
+    # on a very common shape (a build directory, `__pycache__`) and bury the
+    # signal that matters: a FILE the discard was confirmed to erase and did
+    # not, which is the only way consented work outlives a discard. Both are
+    # named in `kept`; only the second moves `discarded`.
+    result["discarded"] = not kept_files
     return result
 
 
@@ -1009,8 +1170,9 @@ def _assert_fresh(con, shell_id: int, observation_id: str, stored: dict,
 
 
 def _assert_worktree_unchanged(observation_id: str, stored: dict,
-                               worktree: str, signal_result) -> None:
-    """The last gate before `git reset --hard && git clean -fd`.
+                               worktree: str, signal_result) -> dict:
+    """The last gate before the discard — and the source of the set the
+    discard is allowed to touch.
 
     Why a SECOND gate exists at all: `_assert_fresh` is the last thing before
     the signal, but the signal is what makes a shell shut down, and a shell can
@@ -1022,26 +1184,34 @@ def _assert_worktree_unchanged(observation_id: str, stored: dict,
     destroys. So that is what is re-read here, immediately before the delete.
 
     The read itself is stable: each path is observed self-consistently and the
-    whole observation must repeat identically before it counts (`_git_facts`),
-    so a write landing DURING this gate's own read no longer produces a torn
-    answer that compares equal to the preview (SC-092).
+    whole observation must repeat identically before it counts
+    (`_observe_stable`), so a write landing DURING this gate's own read no
+    longer produces a torn answer that compares equal to the preview (SC-092).
 
-    NOT ATOMIC, and not claimed to be. A git worktree is not transactional:
-    unlike a row, `verify` and `reset --hard && clean -fd` cannot be made
-    indivisible. ONE window remains, and it is irreducible at this layer:
+    Stability is NOT what protects work this gate never saw, and was wrongly
+    described as if it were. Two observations detect only what changed BETWEEN
+    them: an ordinary file save landing after each pass's own `ls-files` is
+    missed by both passes, so the digests agree and the gate concludes
+    "unchanged" (SC-100). Reading more times narrows that window; nothing
+    closes it, because a read cannot see what does not exist yet.
 
-      everything written after the last observation completes — during the
-      `git reset`/`git clean` spawn, and during the reset and clean themselves
-      — is erased with no record that it existed. A file created after the
-      final `ls-files` is not in the digest, so it is not compared; it is
-      simply cleaned.
+    So the returned PLAN, not this comparison, is what makes the discard safe.
+    The digest matching proves the freshly enumerated set is the set the
+    operator consented to; `_discard_worktree_files` then touches that set and
+    only that set, so a path created at any point after the observation — during
+    this gate, during the `git restore` spawn, during the removal — is not in
+    it and survives. The race is bounded away rather than won.
 
-    Why it cannot be closed: closing it needs the worktree frozen against all
-    writers for the duration of the delete, and the filesystem offers no such
-    lock — any process with the path can write, and `git clean` cannot be made
-    to fail on concurrent writes.
+    NOT ATOMIC, and still not claimed to be. A git worktree is not
+    transactional and no filesystem offers "remove only if unchanged", so what
+    remains open is narrower and different in kind:
 
-    What bounds it is not a lock but the sequence: the exact process this
+      an entry the observation DID enumerate — a path the operator was shown
+      and confirmed erasing — can be rewritten in the moment between its
+      identity being re-checked and its removal, and that rewrite is lost.
+      Everything outside the enumerated set is unaffected.
+
+    What bounds that is not a lock but the sequence: the exact process this
     recovery targeted was proven dead via /proc before we got here, so the
     writer this protects against is already gone. A DIFFERENT process writing
     into the worktree was never inside the observation's scope. Operator
@@ -1054,9 +1224,10 @@ def _assert_worktree_unchanged(observation_id: str, stored: dict,
     stale durable lock has no process to signal and reporting one anyway is
     the same dishonesty in the opposite direction.
     """
-    fresh = _volatile_git(_git_facts(worktree))
-    if fresh == _volatile_git(stored.get("git")):
-        return
+    fresh, plan = _observe_stable(worktree)
+    if plan is not None \
+            and _volatile_git(fresh) == _volatile_git(stored.get("git")):
+        return plan
     if signal_result:
         performed = (f"The exact process (PID {signal_result.get('pid')}) was "
                      "signalled and the durable state was closed before this "
@@ -1290,10 +1461,11 @@ def execute(con, shell_id: int, body: dict,
         assert worktree is not None  # proven by the discard gate above
         # Re-read the worktree immediately before the delete: the shell may
         # have written during its own SIGTERM shutdown, after the fence above
-        # passed. See the docstring for the windows this does NOT close.
-        _assert_worktree_unchanged(observation_id, evidence, worktree,
-                                   signal_result)
-        discarded = _discard_worktree_files(worktree)
+        # passed. The gate hands back the enumerated set that read confirmed,
+        # and the discard is bounded by it — see both docstrings.
+        plan = _assert_worktree_unchanged(observation_id, evidence, worktree,
+                                          signal_result)
+        discarded = _discard_worktree_files(worktree, plan)
 
     return {"shell_id": shell_id, "shortname": shortname,
             "classification": classification, "mode": mode,

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -22,9 +22,13 @@ One API-owned preview/execute workflow shared by browser and CLI:
   an indeterminate result. A confirmed discard re-reads the worktree ONE more
   time immediately before `reset --hard`/`clean -fd`, because a shell can
   write while it shuts down, i.e. after that fence has already passed; that
-  refusal deletes nothing but cannot unwind the signal or the closure. See
-  `_assert_worktree_unchanged` for the windows that remain open — a worktree
-  is not transactional and no claim of atomicity is made here.
+  refusal deletes nothing but cannot unwind the signal or the closure, and it
+  says which of the two actually happened. Every worktree observation is
+  STABLE — each path read self-consistently, the whole observation repeated
+  identically — so a write landing during a read cannot produce an answer that
+  was never true (SC-092). See `_assert_worktree_unchanged` for the ONE window
+  that remains open — a worktree is not transactional and no claim of
+  atomicity is made here.
 
 Signaling discipline (spec Shell Recovery): SIGTERM to the exact verified
 process group, the bounded existing grace period, SIGKILL only while the
@@ -57,6 +61,7 @@ websockets-dependent Interface runtime (spec Restricted Admin).
 """
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import os
@@ -254,9 +259,110 @@ def _head_exists(worktree: str) -> bool:
     raise _GitEvidenceUnavailable(f"git rev-parse: exit {out.returncode}")
 
 
+def _stamp(st) -> tuple:
+    """The comparable identity of one inode-as-seen-at-a-path. Everything the
+    metadata prefix binds, PLUS device/inode so a path replaced by a rename is
+    a different answer — and NOT st_atime, which our own read moves (see
+    `_path_identity`). Used only to prove an observation held still; the digest
+    records `_meta`."""
+    return (stat.S_IFMT(st.st_mode), stat.S_IMODE(st.st_mode), st.st_uid,
+            st.st_gid, st.st_size, st.st_mtime_ns, st.st_ctime_ns,
+            st.st_dev, st.st_ino)
+
+
+def _meta(st) -> str:
+    return (f"{stat.S_IFMT(st.st_mode):o}:{stat.S_IMODE(st.st_mode):04o}:"
+            f"{st.st_uid}:{st.st_gid}:{st.st_size}:{st.st_mtime_ns}:"
+            f"{st.st_ctime_ns}")
+
+
+# A torn observation is retried this many times before it becomes a gap.
+# Small on purpose: a path that will not hold still across three passes is a
+# tree still being written, and that is a refusal, not something to wait out.
+_STABILITY_TRIES = 3
+
+# errnos that mean "the entry changed under us", not "we cannot read it":
+# gone, replaced by a symlink, or a parent component replaced by a file.
+_TORN_ERRNOS = (errno.ENOENT, errno.ELOOP, errno.ENOTDIR)
+
+
+def _observe_path(path: str) -> str | None:
+    """ONE self-consistent attempt at `_path_identity`. Returns the identity,
+    or None when the path moved while it was being observed (the caller
+    retries, then fails closed).
+
+    Self-consistency is the whole point: metadata is read, the content behind
+    it is read, and the metadata is read AGAIN — via the OPEN FD (same inode,
+    whatever the path now names) and via the path (same inode still named) —
+    and the answer is returned only when every read agrees. Reading the two
+    halves separately is a torn read: a chmod landing between the lstat and
+    the open produced an identity that was never true at any instant — old
+    mode, new bytes — which then compared EQUAL to the preview and let the
+    discard erase the change (SC-092).
+    """
+    try:
+        st = os.lstat(path)
+    except (FileNotFoundError, NotADirectoryError):
+        return "absent"
+    except OSError as exc:
+        # Paths and contents never enter the payload — errno only.
+        raise _GitEvidenceUnavailable(f"lstat: errno {exc.errno}") from exc
+    stamp, meta, mode = _stamp(st), _meta(st), st.st_mode
+
+    if stat.S_ISLNK(mode):
+        try:
+            target = os.readlink(path)
+        except OSError as exc:
+            if exc.errno in _TORN_ERRNOS:
+                return None
+            raise _GitEvidenceUnavailable(
+                f"readlink: errno {exc.errno}") from exc
+        identity = f"link:{meta}:" + hashlib.sha256(
+            target.encode("utf-8", "surrogateescape")).hexdigest()
+    elif stat.S_ISDIR(mode):
+        identity = f"dir:{meta}"
+    elif not stat.S_ISREG(mode):
+        identity = f"special:{meta}"
+    else:
+        h = hashlib.sha256()
+        try:
+            # O_NOFOLLOW: the path was a regular file at lstat; if it became a
+            # symlink in between, refuse to read through it rather than hash
+            # whatever it now points at.
+            fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError as exc:
+            if exc.errno in _TORN_ERRNOS:
+                return None
+            raise _GitEvidenceUnavailable(f"open: errno {exc.errno}") from exc
+        try:
+            if _stamp(os.fstat(fd)) != stamp:
+                return None          # already moved between lstat and open
+            while chunk := os.read(fd, 1 << 16):
+                h.update(chunk)
+            if _stamp(os.fstat(fd)) != stamp:
+                return None          # rewritten or re-permissioned as we read
+        except OSError as exc:
+            raise _GitEvidenceUnavailable(f"read: errno {exc.errno}") from exc
+        finally:
+            os.close(fd)
+        identity = f"file:{meta}:{h.hexdigest()}"
+
+    # ...and the path must still name that same inode: an fstat cannot see a
+    # rename landing a different file on the path we are reporting about.
+    try:
+        after = os.lstat(path)
+    except OSError:
+        return None
+    return identity if _stamp(after) == stamp else None
+
+
 def _path_identity(path: str) -> str:
     """Identity of one working-tree path: its TYPE and lstat metadata first,
     then what that type carries. Classified with lstat — NO-FOLLOW, always.
+
+    Observed self-consistently and retried while it tears; a path that will
+    not hold still becomes a GAP (`_GitEvidenceUnavailable`), which refuses the
+    recovery. See `_observe_path`.
 
     The metadata prefix binds every attribute a discard REWRITES: the type,
     the FULL permission bits, owner and group, size, and the mtime/ctime
@@ -286,42 +392,12 @@ def _path_identity(path: str) -> str:
     own read, so binding it would make the preview stale against itself and
     refuse every discard forever.
     """
-    try:
-        st = os.lstat(path)
-    except (FileNotFoundError, NotADirectoryError):
-        return "absent"
-    except OSError as exc:
-        # Paths and contents never enter the payload — errno only.
-        raise _GitEvidenceUnavailable(f"lstat: errno {exc.errno}") from exc
-    mode = st.st_mode
-    meta = (f"{stat.S_IFMT(mode):o}:{stat.S_IMODE(mode):04o}:{st.st_uid}:"
-            f"{st.st_gid}:{st.st_size}:{st.st_mtime_ns}:{st.st_ctime_ns}")
-    if stat.S_ISLNK(mode):
-        try:
-            target = os.readlink(path)
-        except OSError as exc:
-            raise _GitEvidenceUnavailable(
-                f"readlink: errno {exc.errno}") from exc
-        return f"link:{meta}:" + hashlib.sha256(
-            target.encode("utf-8", "surrogateescape")).hexdigest()
-    if stat.S_ISDIR(mode):
-        return f"dir:{meta}"
-    if not stat.S_ISREG(mode):
-        return f"special:{meta}"
-    h = hashlib.sha256()
-    try:
-        # O_NOFOLLOW: the path was a regular file at lstat; if it became a
-        # symlink in between, refuse to read through it rather than hash
-        # whatever it now points at.
-        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
-        try:
-            while chunk := os.read(fd, 1 << 16):
-                h.update(chunk)
-        finally:
-            os.close(fd)
-    except OSError as exc:
-        raise _GitEvidenceUnavailable(f"read: errno {exc.errno}") from exc
-    return f"file:{meta}:{h.hexdigest()}"
+    for _ in range(_STABILITY_TRIES):
+        identity = _observe_path(path)
+        if identity is not None:
+            return identity
+    raise _GitEvidenceUnavailable(
+        "torn read: an entry kept changing while it was observed")
 
 
 def _change_digest(worktree: str, porcelain: list[str], head: bool) -> str:
@@ -366,16 +442,52 @@ def _change_digest(worktree: str, porcelain: list[str], head: bool) -> str:
     return h.hexdigest()
 
 
+def _observe_worktree(worktree: str) -> dict:
+    """ONE complete pass over the worktree facts. Every git read the fence
+    depends on happens here, so the whole answer can be repeated and compared —
+    the path SET is enumerated at a different instant from each path's identity,
+    and a pass is only trustworthy if the composite holds still."""
+    head = _head_exists(worktree)
+    branch = _git_out(worktree, "rev-parse", "--abbrev-ref", "HEAD") \
+        if head else _git_out(worktree, "branch", "--show-current")
+    porcelain = _git_out(worktree, "status", "--porcelain").splitlines()
+    untracked = sum(1 for ln in porcelain if ln.startswith("??"))
+    dirty = len(porcelain) - untracked
+    unpushed = int(_git_out(worktree, "rev-list", "HEAD", "--not",
+                            "--remotes", "--count").strip() or 0) \
+        if head else 0
+    return {"worktree": worktree, "branch": branch.strip(),
+            "dirty_tracked": dirty, "untracked": untracked,
+            "unpushed_commits": unpushed,
+            # WHICH paths changed and WHAT each one now IS — not just how
+            # many: equal-count churn (one file cleaned while another is
+            # dirtied), a rewrite of an already-listed path, a symlink
+            # retarget, a chmod, and a type transition all move the
+            # freshness fingerprint. Paths and contents stay out of the
+            # payload.
+            "change_digest": _change_digest(worktree, porcelain, head)}
+
+
 def _git_facts(worktree: str | None) -> dict | None:
     """Worktree facts for the freshness fence. Three outcomes, kept apart on
     purpose:
 
     - `None` — there is no repository to observe (no worktree, or no `.git`).
       Complete evidence: there is no git-managed state here to erase.
-    - a facts dict — the complete observation.
+    - a facts dict — the complete observation, STABLE: two consecutive passes
+      returned exactly the same answer.
     - `{"indeterminate": <reason>}` — a repository IS there and its evidence
-      could not be gathered whole. NOT "no facts": execute refuses on it, so
-      an unobservable worktree can never read as a safe one (SC-087).
+      could not be gathered whole, or it would not hold still. NOT "no facts":
+      execute refuses on it, so an unobservable worktree can never read as a
+      safe one (SC-087).
+
+    Stability is a correctness requirement, not politeness. A single pass reads
+    the path set at one instant and each path's identity at another, so a write
+    landing between them yields an answer that was never true as a whole — and
+    a torn answer can compare EQUAL to the preview and let a discard erase what
+    moved (SC-092). Requiring two consecutive identical passes means the answer
+    was true across a window, not merely at assorted instants inside one; a tree
+    that keeps moving is refused rather than approximated.
     """
     if not worktree:
         return None
@@ -383,25 +495,14 @@ def _git_facts(worktree: str | None) -> dict | None:
     if not (os.path.isdir(dotgit) or os.path.isfile(dotgit)):
         return None
     try:
-        head = _head_exists(worktree)
-        branch = _git_out(worktree, "rev-parse", "--abbrev-ref", "HEAD") \
-            if head else _git_out(worktree, "branch", "--show-current")
-        porcelain = _git_out(worktree, "status", "--porcelain").splitlines()
-        untracked = sum(1 for ln in porcelain if ln.startswith("??"))
-        dirty = len(porcelain) - untracked
-        unpushed = int(_git_out(worktree, "rev-list", "HEAD", "--not",
-                                "--remotes", "--count").strip() or 0) \
-            if head else 0
-        return {"worktree": worktree, "branch": branch.strip(),
-                "dirty_tracked": dirty, "untracked": untracked,
-                "unpushed_commits": unpushed,
-                # WHICH paths changed and WHAT each one now IS — not just how
-                # many: equal-count churn (one file cleaned while another is
-                # dirtied), a rewrite of an already-listed path, a symlink
-                # retarget, a chmod, and a type transition all move the
-                # freshness fingerprint. Paths and contents stay out of the
-                # payload.
-                "change_digest": _change_digest(worktree, porcelain, head)}
+        previous = None
+        for _ in range(_STABILITY_TRIES):
+            facts = _observe_worktree(worktree)
+            if facts == previous:
+                return facts
+            previous = facts
+        raise _GitEvidenceUnavailable(
+            "the worktree did not hold still across consecutive observations")
     except (_GitEvidenceUnavailable, ValueError) as exc:
         return {"indeterminate": str(exc)}
 
@@ -446,10 +547,18 @@ def _discard_worktree_files(worktree: str) -> dict:
     deletes the worktree, its branch, or ignored files. Runs AFTER the
     durable closure is committed, so a git failure here must never escape
     as a 500 that hides what happened: each step's outcome is recorded and
-    a failure returns exactly what completed and where it stopped."""
+    a failure returns exactly what completed and where it stopped.
+
+    `reset --hard` without an explicit `HEAD`: identical everywhere HEAD
+    resolves, and the only form that works on an UNBORN head — where naming
+    HEAD is fatal, which failed the reset and stopped before the clean, so a
+    discard the gates had authorised silently did nothing. Unborn, it empties
+    the index (nothing has ever been committed, so that IS the baseline) and
+    the clean then removes the untracked files.
+    """
     result: dict = {"worktree": worktree, "discarded": False,
                     "completed": [], "failed": None}
-    for step, args in (("reset", ["reset", "--hard", "HEAD"]),
+    for step, args in (("reset", ["reset", "--hard"]),
                        ("clean", ["clean", "-fd"])):
         try:
             out = subprocess.run(["git", "-C", worktree, *args],
@@ -912,35 +1021,57 @@ def _assert_worktree_unchanged(observation_id: str, stored: dict,
     of evidence a recovery must NOT change — and the only piece a discard
     destroys. So that is what is re-read here, immediately before the delete.
 
+    The read itself is stable: each path is observed self-consistently and the
+    whole observation must repeat identically before it counts (`_git_facts`),
+    so a write landing DURING this gate's own read no longer produces a torn
+    answer that compares equal to the preview (SC-092).
+
     NOT ATOMIC, and not claimed to be. A git worktree is not transactional:
     unlike a row, `verify` and `reset --hard && clean -fd` cannot be made
-    indivisible. Two windows remain and are irreducible at this layer:
+    indivisible. ONE window remains, and it is irreducible at this layer:
 
-      1. between this read and `git reset` actually opening a file — one
-         subprocess spawn, the smallest gap this ordering can reach;
-      2. anything writing DURING the reset/clean themselves.
+      everything written after the last observation completes — during the
+      `git reset`/`git clean` spawn, and during the reset and clean themselves
+      — is erased with no record that it existed. A file created after the
+      final `ls-files` is not in the digest, so it is not compared; it is
+      simply cleaned.
 
-    What bounds them is not a lock but the sequence: the exact process this
+    Why it cannot be closed: closing it needs the worktree frozen against all
+    writers for the duration of the delete, and the filesystem offers no such
+    lock — any process with the path can write, and `git clean` cannot be made
+    to fail on concurrent writes.
+
+    What bounds it is not a lock but the sequence: the exact process this
     recovery targeted was proven dead via /proc before we got here, so the
     writer this protects against is already gone. A DIFFERENT process writing
-    into the worktree was never inside the observation's scope, and no check
-    here can serialise against it.
+    into the worktree was never inside the observation's scope. Operator
+    remedy, and the only one: nothing else may be writing to the worktree while
+    a discard runs — if something is (an editor, a build, a second agent), stop
+    it first, or recover with the worktree preserved and clean up by hand.
 
-    The refusal is honest about what already happened: the signal was sent and
-    the durable closure committed, and neither can be unwound. Only the
-    escalation is refused — nothing is reset, nothing is cleaned.
+    The refusal is honest about what already happened — and about what did
+    NOT: it names the signal only when a signal was actually sent, because a
+    stale durable lock has no process to signal and reporting one anyway is
+    the same dishonesty in the opposite direction.
     """
     fresh = _volatile_git(_git_facts(worktree))
     if fresh == _volatile_git(stored.get("git")):
         return
+    if signal_result:
+        performed = (f"The exact process (PID {signal_result.get('pid')}) was "
+                     "signalled and the durable state was closed before this "
+                     "point")
+    else:
+        performed = ("NO process was signalled — there was none to signal, "
+                     "the durable lock was stale; the durable state was "
+                     "closed before this point")
     raise RecoveryError(
         409, "recovery_observation_stale",
         "the worktree changed after the freshness fence — the discard is "
-        "refused and NOTHING was reset or cleaned. The exact process was "
-        "signalled and the durable state closed before this point (that is "
-        "the recovery itself, and it cannot be unwound); the files are "
-        "untouched. Preview again to see the new state and confirm the "
-        "discard against it.",
+        f"refused and NOTHING was reset or cleaned. {performed} (that is the "
+        "recovery itself, and it cannot be unwound); the files are untouched. "
+        "Preview again to see the new state and confirm the discard against "
+        "it.",
         {"observation_id": observation_id, "worktree": worktree,
          "signaled": signal_result, "closed": True, "discarded": False})
 

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -1122,17 +1122,24 @@ def _volatile_git(git: dict | None) -> dict | None:
 
 
 def _volatile_evidence(evidence: dict) -> dict:
-    """The safety-relevant facts that live OUTSIDE the database: the exact
-    process identity and its liveness, pane/tmux membership, and the working
-    tree a discard would erase. The preview showed these to the operator, so
-    the operator's decision is only valid while they still hold — a changed
-    pid_state, a vanished pane, or a file written after the preview must
-    force a fresh preview, not ride the old one into a signal or a
-    `git clean`."""
+    """The safety-relevant facts that live OUTSIDE the database and govern
+    EVERY recovery: the exact process identity and its liveness, and pane/tmux
+    membership. The preview showed these to the operator, so the decision is
+    only valid while they still hold — a changed pid_state or a vanished pane
+    must force a fresh preview rather than ride the old one into a signal.
+
+    The WORKTREE is deliberately not here (SC-106). It governs the optional
+    discard escalation and nothing else, so it is compared separately, only
+    when a discard was asked for (`_assert_fresh`) and again at the destructive
+    gate (`_assert_worktree_unchanged`). Binding it here instead coupled plain
+    recovery — which touches no file at all — to the readability of a worktree
+    the operator asked us to LEAVE ALONE, and left a shell whose lock was
+    PROVEN absent stranded because a file had moved or `.git` was corrupt.
+    Failing closed is right for destruction; for availability it is the bug.
+    """
     process = evidence.get("process") or {}
     return {"process": {k: process.get(k) for k in _VOLATILE_PROCESS_KEYS},
-            "tmux": evidence.get("tmux"),
-            "git": _volatile_git(evidence.get("git"))}
+            "tmux": evidence.get("tmux")}
 
 
 def _fingerprint(con, shell_id: int, evidence: dict) -> str:
@@ -1223,37 +1230,66 @@ def _load_observation(con, shell_id: int, observation_id: str):
 
 
 def _assert_no_gap(observation_id: str, evidence: dict, when: str) -> None:
-    """Fail closed on incomplete evidence. A gap is deterministic — the same
-    unreadable path or undecodable git output yields the same absent facts at
-    preview and at execute — so it would fingerprint EQUAL and ride through as
-    "nothing changed" while the work behind it was rewritten (SC-087). Absence
-    of evidence is never evidence of safety."""
+    """Fail closed on incomplete worktree evidence — for a DISCARD only.
+
+    A gap is deterministic — the same unreadable path or undecodable git output
+    yields the same absent facts at preview and at execute — so it would
+    compare EQUAL and ride through as "nothing changed" while the work behind
+    it was rewritten (SC-087). Absence of evidence is never evidence of safety
+    when something is about to be destroyed.
+
+    It is not evidence of danger either. Callers must not reach here for a
+    plain recovery: that touches no file, so an unreadable worktree tells it
+    nothing, and refusing on one strands a shell whose lock is proven absent
+    (SC-106).
+    """
     reason = (evidence.get("git") or {}).get("indeterminate")
     if not reason:
         return
     raise RecoveryError(
         409, "recovery_observation_stale",
         f"the worktree could not be observed completely at {when} ({reason}) "
-        "— recovery refused before any signal, closure or file removal; "
-        "repair the repository and preview again",
+        "— the DISCARD is refused before any signal, closure or file removal. "
+        "Recover without discard_worktree to free the shell and leave every "
+        "file untouched, or repair the repository and preview again",
         {"observation_id": observation_id, "detail": reason})
 
 
 def _assert_fresh(con, shell_id: int, observation_id: str, stored: dict,
-                  fingerprint: str, default_worktree: str | None) -> None:
-    """Re-gather the whole evidence picture (a pure read) and refuse unless it
-    still matches the preview. Nothing has been signalled, closed or removed
-    when this runs — it is the last precondition, deliberately placed after
-    every other one so the check-then-act gap is as small as the sequence can
-    make it (SC-091)."""
+                  fingerprint: str, default_worktree: str | None, *,
+                  discard: bool) -> None:
+    """Re-gather the evidence (a pure read) and refuse unless what this
+    recovery actually depends on still matches the preview. Nothing has been
+    signalled, closed or removed when this runs — it is the last precondition,
+    deliberately placed after every other one so the check-then-act gap is as
+    small as the sequence can make it (SC-091).
+
+    Two tiers, and keeping them apart is the point (SC-106). The durable rows
+    and the process/pane identity gate EVERY recovery: they are what a signal
+    and a closure act on. The WORKTREE gates only the discard — it is the one
+    thing a discard destroys and the one thing a plain recovery never touches.
+    Checking it for both meant a corrupt `.git` or a moved file refused to free
+    a shell whose lock was already proven absent, which is the opposite of what
+    a recovery is for.
+    """
     fresh_evidence = gather(con, shell_id, default_worktree)
-    _assert_no_gap(observation_id, fresh_evidence, "now")
     if fingerprint != _fingerprint(con, shell_id, fresh_evidence):
         raise RecoveryError(
             409, "recovery_observation_stale",
-            "the shell's state changed since the preview — its durable rows, "
-            "process/pane identity or worktree contents no longer match what "
-            "the preview showed; preview again",
+            "the shell's state changed since the preview — its durable rows or "
+            "its process/pane identity no longer match what the preview "
+            "showed; preview again",
+            {"observation_id": observation_id})
+    if not discard:
+        return
+    _assert_no_gap(observation_id, fresh_evidence, "now")
+    if _volatile_git(fresh_evidence.get("git")) \
+            != _volatile_git(stored.get("git")):
+        raise RecoveryError(
+            409, "recovery_observation_stale",
+            "the worktree changed since the preview — the discard is refused "
+            "before any signal, closure or file removal; preview again to see "
+            "the new state and confirm the discard against it",
             {"observation_id": observation_id})
 
 
@@ -1442,10 +1478,14 @@ def execute(con, shell_id: int, body: dict,
     classification, legal_actions, evidence, fingerprint = _load_observation(
         con, shell_id, observation_id)
     # The stored half of the fail-closed check needs no live read, so it runs
-    # first: an observation that could not be gathered WHOLE is unusable no
-    # matter what the live gates below would say, and the operator needs that
-    # reason, not whichever live git call the same broken repo trips next.
-    _assert_no_gap(observation_id, evidence, "the preview")
+    # first: an observation whose WORKTREE could not be gathered whole cannot
+    # authorise a discard no matter what the live gates below would say, and
+    # the operator needs that reason rather than whichever live git call the
+    # same broken repo trips next. Only for a discard, though — a recovery that
+    # touches no file has no business asking whether the files were readable
+    # (SC-106).
+    if discard:
+        _assert_no_gap(observation_id, evidence, "the preview")
 
     if mode == "recover" and "recover" not in legal_actions:
         raise RecoveryError(
@@ -1499,7 +1539,7 @@ def execute(con, shell_id: int, body: dict,
     # preconditions ran was deleted by the clean (SC-091). A refusal from here
     # performs NO signal, NO closure, NO reset and NO clean.
     _assert_fresh(con, shell_id, observation_id, evidence, fingerprint,
-                  default_worktree)
+                  default_worktree, discard=discard)
 
     # -- signal (exact process-group, re-verified at signal time) ----------
     proc = evidence["process"]

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -187,6 +187,51 @@ def terminate_process_group(pid: int, start_ticks: int,
 
 # ------------------------------------------------------------------ git facts
 
+def _hash_file(path: str) -> str:
+    """Content identity of one working-tree file — its bytes, never its mtime
+    or size: a same-size overwrite must move the hash. An unreadable file
+    yields a marker, which is itself a change (fail toward stale, never
+    toward 'unchanged')."""
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 16), b""):
+                h.update(chunk)
+    except OSError as exc:
+        return f"unreadable:{exc.errno}"
+    return h.hexdigest()
+
+
+def _change_digest(worktree: str, porcelain: list[str]) -> str:
+    """Fingerprint of what a discard would erase, bound to file CONTENT.
+
+    A porcelain line stays byte-identical when the contents of an
+    already-dirty tracked path or an already-listed untracked file are
+    rewritten, so a digest over the line set alone reads fresh while the work
+    underneath it changed — and the confirmed discard then resets and cleans
+    post-preview work. So every path that differs from HEAD and every
+    untracked file is hashed by its bytes on top of the line set.
+    """
+    def paths(*args) -> list[str]:
+        # -z: paths verbatim, no C-quoting to unescape.
+        out = subprocess.run(["git", "-C", worktree, *args],
+                             capture_output=True, text=True, timeout=30,
+                             check=True).stdout
+        return [p for p in out.split("\0") if p]
+
+    h = hashlib.sha256()
+    for line in sorted(porcelain):
+        h.update(line.encode() + b"\n")
+    # diff HEAD --name-only: staged + unstaged + deletions, one row per path.
+    # ls-files -o: untracked FILES individually, never collapsed to a dir.
+    for rel in sorted(set(paths("diff", "HEAD", "--name-only", "-z"))
+                      | set(paths("ls-files", "-o", "--exclude-standard",
+                                  "-z"))):
+        h.update(rel.encode() + b"\0"
+                 + _hash_file(os.path.join(worktree, rel)).encode() + b"\0")
+    return h.hexdigest()
+
+
 def _git_facts(worktree: str | None) -> dict | None:
     """Advisory worktree facts. None on any failure — the preview stays
     truthful ('no facts') rather than guessing. The discard path re-checks
@@ -214,12 +259,12 @@ def _git_facts(worktree: str | None) -> dict | None:
         return {"worktree": worktree, "branch": branch,
                 "dirty_tracked": dirty, "untracked": untracked,
                 "unpushed_commits": unpushed,
-                # WHICH paths changed, not just how many: equal-count churn
-                # (one file cleaned while another is dirtied) still moves the
-                # freshness fingerprint. Paths themselves stay out of the
-                # payload.
-                "change_digest": hashlib.sha256(
-                    "\n".join(sorted(porcelain)).encode()).hexdigest()}
+                # WHICH paths changed and WHAT is in them — not just how many:
+                # equal-count churn (one file cleaned while another is
+                # dirtied) and a content rewrite of an already-listed path
+                # both move the freshness fingerprint. Paths and contents
+                # themselves stay out of the payload.
+                "change_digest": _change_digest(worktree, porcelain)}
     except Exception:  # noqa: BLE001 — advisory facts degrade to "none"
         return None
 

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -66,7 +66,6 @@ websockets-dependent Interface runtime (spec Restricted Admin).
 """
 from __future__ import annotations
 
-import contextlib
 import errno
 import hashlib
 import json
@@ -600,6 +599,35 @@ def _unpushed_count(worktree: str) -> int:
         raise refuse("rev-list --count gave a non-numeric answer") from exc
 
 
+def _open_parent(worktree: str, rel: str) -> int:
+    """A directory fd for `rel`'s parent, walked from the worktree root ONE
+    COMPONENT AT A TIME with O_NOFOLLOW. Raises OSError if any component is a
+    symlink or has stopped being a directory. Caller closes the fd.
+
+    Every destructive call resolves through this instead of through a joined
+    path, because O_NOFOLLOW on the final component says nothing about the
+    ANCESTORS (SC-105): move `d` out of the worktree and drop a symlink to it
+    at `d`, and `d/u.txt` still stats as the very same inode the observation
+    recorded — the identity check passes, and a path-based `unlink` follows the
+    symlink and deletes the file at its new home OUTSIDE the worktree. A
+    recovery may only ever destroy inside the exact worktree it was confirmed
+    against, so an ancestor that moved is a refusal, never a redirect.
+    """
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC
+    fd = os.open(worktree, flags)
+    try:
+        for part in os.path.dirname(rel).split("/"):
+            if not part or part == ".":
+                continue
+            nxt = os.open(part, flags | os.O_NOFOLLOW, dir_fd=fd)
+            os.close(fd)
+            fd = nxt
+    except OSError:
+        os.close(fd)
+        raise
+    return fd
+
+
 def _is_dir(path: str) -> bool:
     """A REAL directory at this path — lstat, so a symlink to one is not it.
     `git restore` replaces a symlink outright; only a directory makes it
@@ -635,8 +663,16 @@ def _prune_dirs(worktree: str, plan: dict) -> list[str]:
             prunable.add(parent)
             parent = os.path.dirname(parent)
     for rel in sorted(prunable, key=len, reverse=True):  # deepest first
-        with contextlib.suppress(OSError):
-            os.rmdir(os.path.join(worktree, rel))
+        try:
+            fd = _open_parent(worktree, rel)
+        except OSError:
+            continue                    # moved or symlinked ancestor: leave it
+        try:
+            os.rmdir(os.path.basename(rel), dir_fd=fd)
+        except OSError:
+            pass                        # not empty, or gone: both fine
+        finally:
+            os.close(fd)
     return [rel for rel in plan["untracked_dirs"]
             if os.path.lexists(os.path.join(worktree, rel.rstrip("/")))]
 
@@ -719,13 +755,24 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
             keep(rel)
             continue
         try:
-            os.unlink(os.path.join(worktree, rel))
+            fd = _open_parent(worktree, rel)
+        except OSError:
+            # An ancestor is no longer the directory it was, or is now a
+            # symlink. The entry may still stat as the observed inode through
+            # it — that is exactly the trap — so refuse and report rather than
+            # delete whatever is on the other side (SC-105).
+            keep(rel)
+            continue
+        try:
+            os.unlink(os.path.basename(rel), dir_fd=fd)
         except FileNotFoundError:
             pass
         except OSError as exc:
             result["failed"] = {"step": "remove",
                                 "error": f"{rel[-120:]}: errno {exc.errno}"}
             return result
+        finally:
+            os.close(fd)
         removed.append(rel)
     for rel in _prune_dirs(worktree, plan):
         keep(rel, is_file=False)

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -8,8 +8,9 @@ One API-owned preview/execute workflow shared by browser and CLI:
   orphan / verified live / indeterminate) and the legal actions, and stores
   them as an opaque observation row fingerprinted against that evidence.
   The client never infers safety from raw fields.
-- **Execute** requires a fresh observation. The evidence is re-gathered
-  immediately before anything is signalled or closed and fingerprinted
+- **Execute** requires a fresh observation. The evidence is re-gathered as the
+  LAST precondition — after the legality, confirmation and unpushed gates, and
+  immediately before anything is signalled or closed — and fingerprinted
   against the preview: durable state (a concurrent recovery, a new
   generation, an archive hand-off) AND the volatile safety evidence the
   operator actually saw — exact process identity + liveness, pane/tmux
@@ -18,7 +19,12 @@ One API-owned preview/execute workflow shared by browser and CLI:
   sent, a row is closed, or a file is touched. Process identity is then
   re-verified once more at signal time (PID + /proc start ticks) — a PID
   reuse or unreadable /proc at that instant performs no signal and returns
-  an indeterminate result.
+  an indeterminate result. A confirmed discard re-reads the worktree ONE more
+  time immediately before `reset --hard`/`clean -fd`, because a shell can
+  write while it shuts down, i.e. after that fence has already passed; that
+  refusal deletes nothing but cannot unwind the signal or the closure. See
+  `_assert_worktree_unchanged` for the windows that remain open — a worktree
+  is not transactional and no claim of atomicity is made here.
 
 Signaling discipline (spec Shell Recovery): SIGTERM to the exact verified
 process group, the bounded existing grace period, SIGKILL only while the
@@ -402,13 +408,25 @@ def _git_facts(worktree: str | None) -> dict | None:
 
 def _unpushed_count(worktree: str) -> int:
     """The discard gate — exact and fail-closed: any error is a refusal,
-    never an assumption of clean."""
+    never an assumption of clean.
+
+    An unborn HEAD is NOT an error, for the same reason `_git_facts` reads it
+    as complete evidence: a repo with no commits has nothing that can be
+    unpushed. Reading it as a failure here made the two disagree — the preview
+    showed `0 unpushed` and this gate refused the discard it had just
+    authorised.
+    """
     def refuse(detail: str):
         return RecoveryError(
             409, "worktree_state_unknown",
             f"cannot enumerate unpushed commits in {worktree} — discard "
             "refused (fail closed)", {"stderr": detail[-200:]})
 
+    try:
+        if not _head_exists(worktree):
+            return 0
+    except _GitEvidenceUnavailable as exc:
+        raise refuse(str(exc)) from exc
     try:
         out = subprocess.run(
             ["git", "-C", worktree, "rev-list", "HEAD", "--not", "--remotes",
@@ -738,6 +756,13 @@ _VOLATILE_GIT_KEYS = ("worktree", "branch", "dirty_tracked", "untracked",
                       "unpushed_commits", "change_digest", "indeterminate")
 
 
+def _volatile_git(git: dict | None) -> dict | None:
+    """The worktree facts the fence binds — every key, so a gap
+    (`indeterminate`) is a value like any other and can never read as absence."""
+    return {k: git.get(k) for k in _VOLATILE_GIT_KEYS} if git is not None \
+        else None
+
+
 def _volatile_evidence(evidence: dict) -> dict:
     """The safety-relevant facts that live OUTSIDE the database: the exact
     process identity and its liveness, pane/tmux membership, and the working
@@ -747,11 +772,9 @@ def _volatile_evidence(evidence: dict) -> dict:
     force a fresh preview, not ride the old one into a signal or a
     `git clean`."""
     process = evidence.get("process") or {}
-    git = evidence.get("git")
     return {"process": {k: process.get(k) for k in _VOLATILE_PROCESS_KEYS},
             "tmux": evidence.get("tmux"),
-            "git": ({k: git.get(k) for k in _VOLATILE_GIT_KEYS}
-                    if git is not None else None)}
+            "git": _volatile_git(evidence.get("git"))}
 
 
 def _fingerprint(con, shell_id: int, evidence: dict) -> str:
@@ -813,41 +836,60 @@ def preview(con, shell_id: int, default_worktree: str | None) -> dict:
 
 # ------------------------------------------------------------------ execute
 
-def _load_observation(con, shell_id: int, observation_id: str,
-                      fresh_evidence: dict):
+def _load_observation(con, shell_id: int, observation_id: str):
+    """Fetch the observation and reject an unknown or expired one.
+
+    Freshness is deliberately NOT judged here: the fence has to be the LAST
+    thing that happens before the destructive sequence, not the first thing
+    after the request is parsed (SC-091). This only loads what the
+    preconditions need to argue about.
+    """
     row = con.execute(
         "SELECT classification, legal_actions, evidence, fingerprint, "
-        " expires_at, acted_at FROM interface_recovery_observations "
+        " expires_at FROM interface_recovery_observations "
         "WHERE observation_id=? AND shell_id=?",
         (observation_id, shell_id)).fetchone()
     if row is None:
         raise RecoveryError(404, "no_such_observation",
                             f"recovery observation {observation_id} not "
                             f"found for shell {shell_id}")
-    classification, legal_actions, evidence, fingerprint, expires_at, \
-        acted_at = row
+    classification, legal_actions, evidence, fingerprint, expires_at = row
     now = con.execute("SELECT datetime('now')").fetchone()[0]
     if expires_at < now:
         raise RecoveryError(
             409, "recovery_observation_stale",
             "the observation has expired — preview again",
             {"observation_id": observation_id})
-    stored = json.loads(evidence)
-    # Fail closed on incomplete evidence, at EITHER end. A gap is
-    # deterministic — the same unreadable path or undecodable git output
-    # yields the same absent facts at preview and at execute — so it would
-    # fingerprint EQUAL and ride through as "nothing changed" while the work
-    # behind it was rewritten (SC-087). Absence of evidence is never
-    # evidence of safety.
-    for when, ev in (("the preview", stored), ("now", fresh_evidence)):
-        reason = (ev.get("git") or {}).get("indeterminate")
-        if reason:
-            raise RecoveryError(
-                409, "recovery_observation_stale",
-                f"the worktree could not be observed completely at {when} "
-                f"({reason}) — recovery refused before any signal, closure "
-                "or file removal; repair the repository and preview again",
-                {"observation_id": observation_id, "detail": reason})
+    return (classification, json.loads(legal_actions), json.loads(evidence),
+            fingerprint)
+
+
+def _assert_no_gap(observation_id: str, evidence: dict, when: str) -> None:
+    """Fail closed on incomplete evidence. A gap is deterministic — the same
+    unreadable path or undecodable git output yields the same absent facts at
+    preview and at execute — so it would fingerprint EQUAL and ride through as
+    "nothing changed" while the work behind it was rewritten (SC-087). Absence
+    of evidence is never evidence of safety."""
+    reason = (evidence.get("git") or {}).get("indeterminate")
+    if not reason:
+        return
+    raise RecoveryError(
+        409, "recovery_observation_stale",
+        f"the worktree could not be observed completely at {when} ({reason}) "
+        "— recovery refused before any signal, closure or file removal; "
+        "repair the repository and preview again",
+        {"observation_id": observation_id, "detail": reason})
+
+
+def _assert_fresh(con, shell_id: int, observation_id: str, stored: dict,
+                  fingerprint: str, default_worktree: str | None) -> None:
+    """Re-gather the whole evidence picture (a pure read) and refuse unless it
+    still matches the preview. Nothing has been signalled, closed or removed
+    when this runs — it is the last precondition, deliberately placed after
+    every other one so the check-then-act gap is as small as the sequence can
+    make it (SC-091)."""
+    fresh_evidence = gather(con, shell_id, default_worktree)
+    _assert_no_gap(observation_id, fresh_evidence, "now")
     if fingerprint != _fingerprint(con, shell_id, fresh_evidence):
         raise RecoveryError(
             409, "recovery_observation_stale",
@@ -855,7 +897,52 @@ def _load_observation(con, shell_id: int, observation_id: str,
             "process/pane identity or worktree contents no longer match what "
             "the preview showed; preview again",
             {"observation_id": observation_id})
-    return classification, json.loads(legal_actions), stored, acted_at
+
+
+def _assert_worktree_unchanged(observation_id: str, stored: dict,
+                               worktree: str, signal_result) -> None:
+    """The last gate before `git reset --hard && git clean -fd`.
+
+    Why a SECOND gate exists at all: `_assert_fresh` is the last thing before
+    the signal, but the signal is what makes a shell shut down, and a shell can
+    WRITE while it shuts down — the file appears after the fence passed and the
+    clean erases it (SC-091). Every other fact the fence binds (pid state, pane
+    membership, the durable rows) this recovery has by now deliberately
+    changed, so re-checking them is meaningless. The worktree is the one piece
+    of evidence a recovery must NOT change — and the only piece a discard
+    destroys. So that is what is re-read here, immediately before the delete.
+
+    NOT ATOMIC, and not claimed to be. A git worktree is not transactional:
+    unlike a row, `verify` and `reset --hard && clean -fd` cannot be made
+    indivisible. Two windows remain and are irreducible at this layer:
+
+      1. between this read and `git reset` actually opening a file — one
+         subprocess spawn, the smallest gap this ordering can reach;
+      2. anything writing DURING the reset/clean themselves.
+
+    What bounds them is not a lock but the sequence: the exact process this
+    recovery targeted was proven dead via /proc before we got here, so the
+    writer this protects against is already gone. A DIFFERENT process writing
+    into the worktree was never inside the observation's scope, and no check
+    here can serialise against it.
+
+    The refusal is honest about what already happened: the signal was sent and
+    the durable closure committed, and neither can be unwound. Only the
+    escalation is refused — nothing is reset, nothing is cleaned.
+    """
+    fresh = _volatile_git(_git_facts(worktree))
+    if fresh == _volatile_git(stored.get("git")):
+        return
+    raise RecoveryError(
+        409, "recovery_observation_stale",
+        "the worktree changed after the freshness fence — the discard is "
+        "refused and NOTHING was reset or cleaned. The exact process was "
+        "signalled and the durable state closed before this point (that is "
+        "the recovery itself, and it cannot be unwound); the files are "
+        "untouched. Preview again to see the new state and confirm the "
+        "discard against it.",
+        {"observation_id": observation_id, "worktree": worktree,
+         "signaled": signal_result, "closed": True, "discarded": False})
 
 
 def _close_durable_state(con, shell_id: int, evidence: dict,
@@ -962,12 +1049,13 @@ def execute(con, shell_id: int, body: dict,
                             "preserve_worktree=false — discard is never "
                             "implied by recover or force")
 
-    # The freshness fence: re-gather the whole evidence picture (a pure read)
-    # and refuse before any signal, closure or file removal if ANY of it moved
-    # since the preview.
-    classification, legal_actions, evidence, _acted = _load_observation(
-        con, shell_id, observation_id,
-        gather(con, shell_id, default_worktree))
+    classification, legal_actions, evidence, fingerprint = _load_observation(
+        con, shell_id, observation_id)
+    # The stored half of the fail-closed check needs no live read, so it runs
+    # first: an observation that could not be gathered WHOLE is unusable no
+    # matter what the live gates below would say, and the operator needs that
+    # reason, not whichever live git call the same broken repo trips next.
+    _assert_no_gap(observation_id, evidence, "the preview")
 
     if mode == "recover" and "recover" not in legal_actions:
         raise RecoveryError(
@@ -1012,6 +1100,16 @@ def execute(con, shell_id: int, body: dict,
                 f"{worktree} has {unpushed} commit(s) not on any remote — "
                 "discard refused; push or abandon them explicitly first",
                 {"worktree": worktree, "unpushed_commits": unpushed})
+
+    # -- the freshness fence: LAST precondition, nothing destructive yet ----
+    # Deliberately here and not at entry: every gate above is a pure read or a
+    # body check, and each one costs wall-clock (`_unpushed_count` shells out
+    # to git) during which the worktree can move. Validating at entry and
+    # destroying afterwards left exactly that gap — a file written while the
+    # preconditions ran was deleted by the clean (SC-091). A refusal from here
+    # performs NO signal, NO closure, NO reset and NO clean.
+    _assert_fresh(con, shell_id, observation_id, evidence, fingerprint,
+                  default_worktree)
 
     # -- signal (exact process-group, re-verified at signal time) ----------
     proc = evidence["process"]
@@ -1059,6 +1157,11 @@ def execute(con, shell_id: int, body: dict,
     discarded = None
     if discard:
         assert worktree is not None  # proven by the discard gate above
+        # Re-read the worktree immediately before the delete: the shell may
+        # have written during its own SIGTERM shutdown, after the fence above
+        # passed. See the docstring for the windows this does NOT close.
+        _assert_worktree_unchanged(observation_id, evidence, worktree,
+                                   signal_result)
         discarded = _discard_worktree_files(worktree)
 
     return {"shell_id": shell_id, "shortname": shortname,

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -1069,9 +1069,15 @@ def evidence_projection(evidence: dict, classification: str,
         else "unknown · left unread")
 
     if git and git.get("indeterminate"):
+        # Says what the system DOES, which stopped being "refuse everything"
+        # (SC-107). An operator told recovery is impossible does not attempt
+        # it, so the shell stays stranded on the strength of the sentence
+        # rather than the code — the objective failing through the projection.
+        # Canonical, so browser and CLI both inherit the correction.
         worktree_value = (
             f"state could not be observed completely ({git['indeterminate']})"
-            " · recovery refused until it can be")
+            " · discard declined · recover with files preserved (the default)"
+            " to free the shell — every file is left untouched")
     elif git:
         tracked = git.get("dirty_tracked")
         untracked = git.get("untracked")

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -6,14 +6,19 @@ One API-owned preview/execute workflow shared by browser and CLI:
 - **Preview** gathers the durable + process evidence for one shell, derives
   ONE server-side classification (available / stale durable lock / exact idle
   orphan / verified live / indeterminate) and the legal actions, and stores
-  them as an opaque observation row fingerprinted against the durable state.
+  them as an opaque observation row fingerprinted against that evidence.
   The client never infers safety from raw fields.
-- **Execute** requires a fresh observation: any change to the fingerprinted
-  durable state (pane exit surfaced durably, a concurrent recovery, a new
-  generation) refuses with 409 recovery_observation_stale. Process identity
-  is ALWAYS re-verified at signal time (PID + /proc start ticks) — a PID
-  reuse or unreadable /proc between preview and execute performs no signal
-  and returns an indeterminate result.
+- **Execute** requires a fresh observation. The evidence is re-gathered
+  immediately before anything is signalled or closed and fingerprinted
+  against the preview: durable state (a concurrent recovery, a new
+  generation, an archive hand-off) AND the volatile safety evidence the
+  operator actually saw — exact process identity + liveness, pane/tmux
+  membership, and the worktree's dirty/untracked/unpushed facts. Any
+  difference refuses with 409 recovery_observation_stale before a signal is
+  sent, a row is closed, or a file is touched. Process identity is then
+  re-verified once more at signal time (PID + /proc start ticks) — a PID
+  reuse or unreadable /proc at that instant performs no signal and returns
+  an indeterminate result.
 
 Signaling discipline (spec Shell Recovery): SIGTERM to the exact verified
 process group, the bounded existing grace period, SIGKILL only while the
@@ -208,7 +213,13 @@ def _git_facts(worktree: str | None) -> dict | None:
                            "--count") or 0)
         return {"worktree": worktree, "branch": branch,
                 "dirty_tracked": dirty, "untracked": untracked,
-                "unpushed_commits": unpushed}
+                "unpushed_commits": unpushed,
+                # WHICH paths changed, not just how many: equal-count churn
+                # (one file cleaned while another is dirtied) still moves the
+                # freshness fingerprint. Paths themselves stay out of the
+                # payload.
+                "change_digest": hashlib.sha256(
+                    "\n".join(sorted(porcelain)).encode()).hexdigest()}
     except Exception:  # noqa: BLE001 — advisory facts degrade to "none"
         return None
 
@@ -533,11 +544,35 @@ def evidence_projection(evidence: dict, classification: str,
             for key, label, value in values]
 
 
-def _fingerprint(con, shell_id: int) -> str:
-    """sha256 over the durable state an observation depends on. Any change —
-    closure, a new generation, a binding release, an archive hand-off —
+_VOLATILE_PROCESS_KEYS = ("pane_id", "pane_pid", "pane_start_ticks",
+                          "pane_present", "pid_state", "pgid")
+_VOLATILE_GIT_KEYS = ("worktree", "branch", "dirty_tracked", "untracked",
+                      "unpushed_commits", "change_digest")
+
+
+def _volatile_evidence(evidence: dict) -> dict:
+    """The safety-relevant facts that live OUTSIDE the database: the exact
+    process identity and its liveness, pane/tmux membership, and the working
+    tree a discard would erase. The preview showed these to the operator, so
+    the operator's decision is only valid while they still hold — a changed
+    pid_state, a vanished pane, or a file written after the preview must
+    force a fresh preview, not ride the old one into a signal or a
+    `git clean`."""
+    process = evidence.get("process") or {}
+    git = evidence.get("git")
+    return {"process": {k: process.get(k) for k in _VOLATILE_PROCESS_KEYS},
+            "tmux": evidence.get("tmux"),
+            "git": ({k: git.get(k) for k in _VOLATILE_GIT_KEYS}
+                    if git is not None else None)}
+
+
+def _fingerprint(con, shell_id: int, evidence: dict) -> str:
+    """sha256 over everything an observation depends on: the durable state
+    (closure, a new generation, a binding release, an archive hand-off) and
+    the volatile process/tmux/worktree evidence above. Any change
     invalidates every outstanding observation."""
-    parts = []
+    parts = [json.dumps(_volatile_evidence(evidence), sort_keys=True,
+                        default=str)]
     live = _live_session(con, shell_id)
     parts.append(json.dumps(list(live) if live is not None else None,
                             default=str))
@@ -575,7 +610,8 @@ def preview(con, shell_id: int, default_worktree: str | None) -> dict:
         " fingerprint, expires_at) "
         "VALUES (?,?,?,?,?,?, datetime('now', ?))",
         (observation_id, shell_id, classification, json.dumps(legal_actions),
-         json.dumps(evidence, default=str), _fingerprint(con, shell_id),
+         json.dumps(evidence, default=str),
+         _fingerprint(con, shell_id, evidence),
          f"+{OBSERVATION_TTL_S} seconds"))
     con.commit()
     return {"observation_id": observation_id,
@@ -589,7 +625,8 @@ def preview(con, shell_id: int, default_worktree: str | None) -> dict:
 
 # ------------------------------------------------------------------ execute
 
-def _load_observation(con, shell_id: int, observation_id: str):
+def _load_observation(con, shell_id: int, observation_id: str,
+                      fresh_evidence: dict):
     row = con.execute(
         "SELECT classification, legal_actions, evidence, fingerprint, "
         " expires_at, acted_at FROM interface_recovery_observations "
@@ -607,11 +644,13 @@ def _load_observation(con, shell_id: int, observation_id: str):
             409, "recovery_observation_stale",
             "the observation has expired — preview again",
             {"observation_id": observation_id})
-    if fingerprint != _fingerprint(con, shell_id):
+    if fingerprint != _fingerprint(con, shell_id, fresh_evidence):
         raise RecoveryError(
             409, "recovery_observation_stale",
-            "the shell's durable state changed since the preview — preview "
-            "again", {"observation_id": observation_id})
+            "the shell's state changed since the preview — its durable rows, "
+            "process/pane identity or worktree contents no longer match what "
+            "the preview showed; preview again",
+            {"observation_id": observation_id})
     return classification, json.loads(legal_actions), \
         json.loads(evidence), acted_at
 
@@ -720,8 +759,12 @@ def execute(con, shell_id: int, body: dict,
                             "preserve_worktree=false — discard is never "
                             "implied by recover or force")
 
+    # The freshness fence: re-gather the whole evidence picture (a pure read)
+    # and refuse before any signal, closure or file removal if ANY of it moved
+    # since the preview.
     classification, legal_actions, evidence, _acted = _load_observation(
-        con, shell_id, observation_id)
+        con, shell_id, observation_id,
+        gather(con, shell_id, default_worktree))
 
     if mode == "recover" and "recover" not in legal_actions:
         raise RecoveryError(

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -45,6 +45,7 @@ import json
 import os
 import secrets
 import signal
+import stat
 import subprocess
 import time
 
@@ -187,30 +188,74 @@ def terminate_process_group(pid: int, start_ticks: int,
 
 # ------------------------------------------------------------------ git facts
 
-def _hash_file(path: str) -> str:
-    """Content identity of one working-tree file — its bytes, never its mtime
-    or size: a same-size overwrite must move the hash. An unreadable file
-    yields a marker, which is itself a change (fail toward stale, never
-    toward 'unchanged')."""
+def _path_identity(path: str) -> str:
+    """Identity of one working-tree path: its TYPE first, then what that type
+    carries. Classified with lstat — NO-FOLLOW, always.
+
+    - regular file -> its bytes (never mtime or size: a same-size overwrite
+      must move the hash) plus the executable bit, the one mode bit git
+      records and a confirmed discard therefore restores.
+    - symlink -> the readlink TARGET STRING itself. Never the bytes behind
+      it: resolving would miss a retarget onto a byte-identical file, and it
+      would let the digest wander outside the worktree entirely. Link and
+      target are distinct entities and stay distinguished.
+    - directory / fifo / socket / device -> the type alone.
+    - absent or unreadable -> a marker, itself a change.
+
+    The type prefix is what makes a transition (regular <-> symlink,
+    file <-> directory) move the identity even when the visible content
+    matches. Every branch fails toward stale, never toward "unchanged".
+    """
+    try:
+        st = os.lstat(path)
+    except OSError as exc:
+        return f"absent:{exc.errno}"
+    mode = st.st_mode
+    if stat.S_ISLNK(mode):
+        try:
+            target = os.readlink(path)
+        except OSError as exc:
+            return f"link-unreadable:{exc.errno}"
+        return "link:" + hashlib.sha256(
+            target.encode("utf-8", "surrogateescape")).hexdigest()
+    if stat.S_ISDIR(mode):
+        return "dir:"
+    if not stat.S_ISREG(mode):
+        return f"special:{stat.S_IFMT(mode):o}"
     h = hashlib.sha256()
     try:
-        with open(path, "rb") as fh:
-            for chunk in iter(lambda: fh.read(1 << 16), b""):
+        # O_NOFOLLOW: the path was a regular file at lstat; if it became a
+        # symlink in between, refuse to read through it rather than hash
+        # whatever it now points at.
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        try:
+            while chunk := os.read(fd, 1 << 16):
                 h.update(chunk)
+        finally:
+            os.close(fd)
     except OSError as exc:
         return f"unreadable:{exc.errno}"
-    return h.hexdigest()
+    return f"file:{'x' if mode & stat.S_IXUSR else '-'}:{h.hexdigest()}"
 
 
 def _change_digest(worktree: str, porcelain: list[str]) -> str:
-    """Fingerprint of what a discard would erase, bound to file CONTENT.
+    """Fingerprint of what a discard would erase.
 
-    A porcelain line stays byte-identical when the contents of an
-    already-dirty tracked path or an already-listed untracked file are
-    rewritten, so a digest over the line set alone reads fresh while the work
-    underneath it changed — and the confirmed discard then resets and cleans
-    post-preview work. So every path that differs from HEAD and every
-    untracked file is hashed by its bytes on top of the line set.
+    INVARIANT: this digest MUST change if ANY safety-relevant aspect of the
+    worktree state a discard would destroy has changed since the preview.
+    Porcelain lines are far coarser than that — they stay byte-identical
+    while the work underneath them is rewritten, retargeted, or changes type
+    — so the line set is only the outer layer. Held against the invariant,
+    the state a discard destroys is: the SET of affected paths (the lines),
+    and for each path its ENTITY IDENTITY (`_path_identity`) — regular-file
+    bytes, symlink target string, or bare type, so that a content rewrite, a
+    same-size overwrite, a link retarget, and a type transition each move the
+    digest.
+
+    Excluded deliberately: mode bits beyond the executable bit. Git records
+    only that bit, so it is the only one `git checkout`/`git clean` can
+    destroy or restore; a chmod 644->640 survives the discard untouched and
+    is not state the operator's confirmation was about.
     """
     def paths(*args) -> list[str]:
         # -z: paths verbatim, no C-quoting to unescape.
@@ -228,7 +273,8 @@ def _change_digest(worktree: str, porcelain: list[str]) -> str:
                       | set(paths("ls-files", "-o", "--exclude-standard",
                                   "-z"))):
         h.update(rel.encode() + b"\0"
-                 + _hash_file(os.path.join(worktree, rel)).encode() + b"\0")
+                 + _path_identity(os.path.join(worktree, rel)).encode()
+                 + b"\0")
     return h.hexdigest()
 
 
@@ -259,11 +305,11 @@ def _git_facts(worktree: str | None) -> dict | None:
         return {"worktree": worktree, "branch": branch,
                 "dirty_tracked": dirty, "untracked": untracked,
                 "unpushed_commits": unpushed,
-                # WHICH paths changed and WHAT is in them — not just how many:
-                # equal-count churn (one file cleaned while another is
-                # dirtied) and a content rewrite of an already-listed path
-                # both move the freshness fingerprint. Paths and contents
-                # themselves stay out of the payload.
+                # WHICH paths changed and WHAT each one now IS — not just how
+                # many: equal-count churn (one file cleaned while another is
+                # dirtied), a rewrite of an already-listed path, a symlink
+                # retarget, and a type transition all move the freshness
+                # fingerprint. Paths and contents stay out of the payload.
                 "change_digest": _change_digest(worktree, porcelain)}
     except Exception:  # noqa: BLE001 — advisory facts degrade to "none"
         return None

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -35,6 +35,17 @@ Worktree discipline: files are preserved by default. discard_worktree is an
 independently confirmed escalation (typed shell shortname) that refuses
 when unpushed commits exist and never deletes the worktree or branch.
 
+Evidence discipline, both directions:
+- the freshness digest binds every attribute a discard REWRITES — content,
+  type, symlink target, permissions, ownership, timestamps — so that any
+  post-preview change to state the operator confirmed erasing moves it;
+- an observation that cannot be gathered WHOLE refuses. Git facts are a
+  complete observation, an explicit gap, or "there is no repository here";
+  a gap never degrades to absent facts, because a gap is deterministic — the
+  same undecodable output or unreadable entry at preview and at execute would
+  fingerprint EQUAL and let a discard run as though nothing had changed.
+  Absence of evidence is not evidence of safety.
+
 This module is stdlib-only: recovery must work HTTP-only, without the
 websockets-dependent Interface runtime (spec Restricted Admin).
 """
@@ -188,40 +199,109 @@ def terminate_process_group(pid: int, start_ticks: int,
 
 # ------------------------------------------------------------------ git facts
 
-def _path_identity(path: str) -> str:
-    """Identity of one working-tree path: its TYPE first, then what that type
-    carries. Classified with lstat — NO-FOLLOW, always.
+class _GitEvidenceUnavailable(Exception):
+    """A repository is there but its evidence could not be gathered whole.
 
-    - regular file -> its bytes (never mtime or size: a same-size overwrite
-      must move the hash) plus the executable bit, the one mode bit git
-      records and a confirmed discard therefore restores.
+    Distinct from "there is no repository": one is a gap, the other is a
+    complete observation. A gap must never reach the fence as absent facts —
+    absence of evidence is not evidence of safety.
+    """
+
+
+def _git_out(worktree: str, *args, timeout: int = 15) -> str:
+    """Git stdout, decoded losslessly; any failure raises.
+
+    surrogateescape, NEVER strict: a valid non-UTF-8 filename is real working
+    -tree state, and decoding it strictly raises — which is exactly how this
+    guard used to collapse to "no facts" (SC-087). Surrogates keep such names
+    distinct in the digest and hand os.* calls back the original bytes.
+    Non-zero exit, timeout and spawn failure all become a refusal, never a
+    partial answer.
+    """
+    try:
+        out = subprocess.run(["git", "-C", worktree, *args],
+                             capture_output=True, timeout=timeout,
+                             check=False)
+    except Exception as exc:  # spawn failure / timeout: a gap, not a fact
+        raise _GitEvidenceUnavailable(
+            f"git {args[0]}: {type(exc).__name__}") from exc
+    if out.returncode != 0:
+        raise _GitEvidenceUnavailable(f"git {args[0]}: exit {out.returncode}")
+    return out.stdout.decode("utf-8", "surrogateescape")
+
+
+def _head_exists(worktree: str) -> bool:
+    """True when HEAD resolves; False for an unborn HEAD — a repo with no
+    commits is a COMPLETE observation (nothing committed to diff against,
+    nothing that can be unpushed), not a gap. Any other exit is a gap."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", worktree, "rev-parse", "--verify", "-q", "HEAD"],
+            capture_output=True, timeout=15, check=False)
+    except Exception as exc:  # spawn failure / timeout: a gap, not a fact
+        raise _GitEvidenceUnavailable(
+            f"git rev-parse: {type(exc).__name__}") from exc
+    if out.returncode == 0:
+        return True
+    if out.returncode == 1 and not out.stdout.strip():
+        return False
+    raise _GitEvidenceUnavailable(f"git rev-parse: exit {out.returncode}")
+
+
+def _path_identity(path: str) -> str:
+    """Identity of one working-tree path: its TYPE and lstat metadata first,
+    then what that type carries. Classified with lstat — NO-FOLLOW, always.
+
+    The metadata prefix binds every attribute a discard REWRITES: the type,
+    the FULL permission bits, owner and group, size, and the mtime/ctime
+    `git checkout` replaces. `reset --hard` does not restore a dirty file in
+    place — it recreates it from the index, so its mode comes back as
+    umask-derived 0644/0666 and its owner as the recovering process's
+    (reproduced: 0640 -> reset -> 0666). Permissions are work; discard
+    destroys them; the digest therefore binds them.
+
+    On top of the prefix:
+    - regular file -> its bytes (never size or mtime alone: a same-size
+      overwrite must move the hash).
     - symlink -> the readlink TARGET STRING itself. Never the bytes behind
       it: resolving would miss a retarget onto a byte-identical file, and it
       would let the digest wander outside the worktree entirely. Link and
       target are distinct entities and stay distinguished.
-    - directory / fifo / socket / device -> the type alone.
-    - absent or unreadable -> a marker, itself a change.
+    - directory / fifo / socket / device -> the prefix alone.
+    - genuinely absent (ENOENT/ENOTDIR) -> a marker; that IS the state.
+    - unreadable for any other reason -> a GAP: raise, never a marker. A
+      marker is deterministic, so it would read equal at preview and execute
+      and let a discard erase whatever changed behind it.
 
-    The type prefix is what makes a transition (regular <-> symlink,
-    file <-> directory) move the identity even when the visible content
-    matches. Every branch fails toward stale, never toward "unchanged".
+    Only st_atime is excluded, and by reproduction rather than by argument:
+    this function lstats a path and then READS it, and on a file the shell
+    just wrote (every dirty file) that read moves atime — measured moving
+    ~1ms under relatime. The value recorded is the one observed BEFORE our
+    own read, so binding it would make the preview stale against itself and
+    refuse every discard forever.
     """
     try:
         st = os.lstat(path)
+    except (FileNotFoundError, NotADirectoryError):
+        return "absent"
     except OSError as exc:
-        return f"absent:{exc.errno}"
+        # Paths and contents never enter the payload — errno only.
+        raise _GitEvidenceUnavailable(f"lstat: errno {exc.errno}") from exc
     mode = st.st_mode
+    meta = (f"{stat.S_IFMT(mode):o}:{stat.S_IMODE(mode):04o}:{st.st_uid}:"
+            f"{st.st_gid}:{st.st_size}:{st.st_mtime_ns}:{st.st_ctime_ns}")
     if stat.S_ISLNK(mode):
         try:
             target = os.readlink(path)
         except OSError as exc:
-            return f"link-unreadable:{exc.errno}"
-        return "link:" + hashlib.sha256(
+            raise _GitEvidenceUnavailable(
+                f"readlink: errno {exc.errno}") from exc
+        return f"link:{meta}:" + hashlib.sha256(
             target.encode("utf-8", "surrogateescape")).hexdigest()
     if stat.S_ISDIR(mode):
-        return "dir:"
+        return f"dir:{meta}"
     if not stat.S_ISREG(mode):
-        return f"special:{stat.S_IFMT(mode):o}"
+        return f"special:{meta}"
     h = hashlib.sha256()
     try:
         # O_NOFOLLOW: the path was a regular file at lstat; if it became a
@@ -234,100 +314,113 @@ def _path_identity(path: str) -> str:
         finally:
             os.close(fd)
     except OSError as exc:
-        return f"unreadable:{exc.errno}"
-    return f"file:{'x' if mode & stat.S_IXUSR else '-'}:{h.hexdigest()}"
+        raise _GitEvidenceUnavailable(f"read: errno {exc.errno}") from exc
+    return f"file:{meta}:{h.hexdigest()}"
 
 
-def _change_digest(worktree: str, porcelain: list[str]) -> str:
+def _change_digest(worktree: str, porcelain: list[str], head: bool) -> str:
     """Fingerprint of what a discard would erase.
 
     INVARIANT: this digest MUST change if ANY safety-relevant aspect of the
     worktree state a discard would destroy has changed since the preview.
     Porcelain lines are far coarser than that — they stay byte-identical
-    while the work underneath them is rewritten, retargeted, or changes type
-    — so the line set is only the outer layer. Held against the invariant,
-    the state a discard destroys is: the SET of affected paths (the lines),
-    and for each path its ENTITY IDENTITY (`_path_identity`) — regular-file
-    bytes, symlink target string, or bare type, so that a content rewrite, a
-    same-size overwrite, a link retarget, and a type transition each move the
-    digest.
+    while the work underneath them is rewritten, retargeted, re-permissioned
+    or changes type — so the line set is only the outer layer. Held against
+    the invariant, the state a discard destroys is: the SET of affected paths
+    (the lines), and for each path its ENTITY IDENTITY (`_path_identity`) —
+    type, permissions, ownership, timestamps, and regular-file bytes or
+    symlink target.
 
-    Excluded deliberately: mode bits beyond the executable bit. Git records
-    only that bit, so it is the only one `git checkout`/`git clean` can
-    destroy or restore; a chmod 644->640 survives the discard untouched and
-    is not state the operator's confirmation was about.
+    The path set is what `reset --hard` + `clean -fd` would act on: the paths
+    differing from HEAD, plus untracked files, plus untracked DIRECTORIES —
+    `clean -fd` removes an empty untracked directory that `ls-files -o` (a
+    file listing) never names. Ignored files stay out: `clean -fd` without
+    -x does not touch them, so they are not state the confirmation is about.
     """
     def paths(*args) -> list[str]:
         # -z: paths verbatim, no C-quoting to unescape.
-        out = subprocess.run(["git", "-C", worktree, *args],
-                             capture_output=True, text=True, timeout=30,
-                             check=True).stdout
-        return [p for p in out.split("\0") if p]
+        return [p for p in _git_out(worktree, *args, timeout=30).split("\0")
+                if p]
 
     h = hashlib.sha256()
     for line in sorted(porcelain):
-        h.update(line.encode() + b"\n")
-    # diff HEAD --name-only: staged + unstaged + deletions, one row per path.
-    # ls-files -o: untracked FILES individually, never collapsed to a dir.
-    for rel in sorted(set(paths("diff", "HEAD", "--name-only", "-z"))
-                      | set(paths("ls-files", "-o", "--exclude-standard",
-                                  "-z"))):
-        h.update(rel.encode() + b"\0"
+        h.update(line.encode("utf-8", "surrogateescape") + b"\n")
+    # ls-files -o: untracked FILES individually, never collapsed to a dir;
+    # --directory: the untracked DIRECTORIES themselves, empty ones included.
+    rels = set(paths("ls-files", "-o", "--exclude-standard", "-z")) \
+        | set(paths("ls-files", "-o", "--directory", "--exclude-standard",
+                    "-z"))
+    if head:
+        # staged + unstaged + deletions, one row per path.
+        rels |= set(paths("diff", "HEAD", "--name-only", "-z"))
+    for rel in sorted(rels):
+        h.update(rel.encode("utf-8", "surrogateescape") + b"\0"
                  + _path_identity(os.path.join(worktree, rel)).encode()
                  + b"\0")
     return h.hexdigest()
 
 
 def _git_facts(worktree: str | None) -> dict | None:
-    """Advisory worktree facts. None on any failure — the preview stays
-    truthful ('no facts') rather than guessing. The discard path re-checks
-    unpushed commits itself and fails CLOSED."""
+    """Worktree facts for the freshness fence. Three outcomes, kept apart on
+    purpose:
+
+    - `None` — there is no repository to observe (no worktree, or no `.git`).
+      Complete evidence: there is no git-managed state here to erase.
+    - a facts dict — the complete observation.
+    - `{"indeterminate": <reason>}` — a repository IS there and its evidence
+      could not be gathered whole. NOT "no facts": execute refuses on it, so
+      an unobservable worktree can never read as a safe one (SC-087).
+    """
     if not worktree:
         return None
     dotgit = os.path.join(worktree, ".git")
     if not (os.path.isdir(dotgit) or os.path.isfile(dotgit)):
         return None
     try:
-        def git(*args) -> str:
-            return subprocess.run(
-                ["git", "-C", worktree, *args], capture_output=True,
-                text=True, timeout=15, check=True).stdout.strip()
-
-        branch = git("rev-parse", "--abbrev-ref", "HEAD")
-        porcelain = subprocess.run(
-            ["git", "-C", worktree, "status", "--porcelain"],
-            capture_output=True, text=True, timeout=15,
-            check=True).stdout.splitlines()
+        head = _head_exists(worktree)
+        branch = _git_out(worktree, "rev-parse", "--abbrev-ref", "HEAD") \
+            if head else _git_out(worktree, "branch", "--show-current")
+        porcelain = _git_out(worktree, "status", "--porcelain").splitlines()
         untracked = sum(1 for ln in porcelain if ln.startswith("??"))
         dirty = len(porcelain) - untracked
-        unpushed = int(git("rev-list", "HEAD", "--not", "--remotes",
-                           "--count") or 0)
-        return {"worktree": worktree, "branch": branch,
+        unpushed = int(_git_out(worktree, "rev-list", "HEAD", "--not",
+                                "--remotes", "--count").strip() or 0) \
+            if head else 0
+        return {"worktree": worktree, "branch": branch.strip(),
                 "dirty_tracked": dirty, "untracked": untracked,
                 "unpushed_commits": unpushed,
                 # WHICH paths changed and WHAT each one now IS — not just how
                 # many: equal-count churn (one file cleaned while another is
                 # dirtied), a rewrite of an already-listed path, a symlink
-                # retarget, and a type transition all move the freshness
-                # fingerprint. Paths and contents stay out of the payload.
-                "change_digest": _change_digest(worktree, porcelain)}
-    except Exception:  # noqa: BLE001 — advisory facts degrade to "none"
-        return None
+                # retarget, a chmod, and a type transition all move the
+                # freshness fingerprint. Paths and contents stay out of the
+                # payload.
+                "change_digest": _change_digest(worktree, porcelain, head)}
+    except (_GitEvidenceUnavailable, ValueError) as exc:
+        return {"indeterminate": str(exc)}
 
 
 def _unpushed_count(worktree: str) -> int:
     """The discard gate — exact and fail-closed: any error is a refusal,
     never an assumption of clean."""
-    out = subprocess.run(
-        ["git", "-C", worktree, "rev-list", "HEAD", "--not", "--remotes",
-         "--count"], capture_output=True, text=True, timeout=15, check=False)
-    if out.returncode != 0:
-        raise RecoveryError(
+    def refuse(detail: str):
+        return RecoveryError(
             409, "worktree_state_unknown",
             f"cannot enumerate unpushed commits in {worktree} — discard "
-            "refused (fail closed)",
-            {"stderr": out.stderr.strip()[-200:]})
-    return int(out.stdout.strip() or 0)
+            "refused (fail closed)", {"stderr": detail[-200:]})
+
+    try:
+        out = subprocess.run(
+            ["git", "-C", worktree, "rev-list", "HEAD", "--not", "--remotes",
+             "--count"], capture_output=True, timeout=15, check=False)
+    except Exception as exc:  # timeout / spawn failure: refuse, never guess
+        raise refuse(f"{type(exc).__name__}: {exc}") from exc
+    if out.returncode != 0:
+        raise refuse(out.stderr.decode("utf-8", "replace").strip())
+    try:
+        return int(out.stdout.decode("utf-8", "replace").strip() or 0)
+    except ValueError as exc:
+        raise refuse("rev-list --count gave a non-numeric answer") from exc
 
 
 def _discard_worktree_files(worktree: str) -> dict:
@@ -599,7 +692,11 @@ def evidence_projection(evidence: dict, classification: str,
         f"{unread} · left unread" if isinstance(unread, int)
         else "unknown · left unread")
 
-    if git:
+    if git and git.get("indeterminate"):
+        worktree_value = (
+            f"state could not be observed completely ({git['indeterminate']})"
+            " · recovery refused until it can be")
+    elif git:
         tracked = git.get("dirty_tracked")
         untracked = git.get("untracked")
         if isinstance(tracked, int) and isinstance(untracked, int):
@@ -638,7 +735,7 @@ def evidence_projection(evidence: dict, classification: str,
 _VOLATILE_PROCESS_KEYS = ("pane_id", "pane_pid", "pane_start_ticks",
                           "pane_present", "pid_state", "pgid")
 _VOLATILE_GIT_KEYS = ("worktree", "branch", "dirty_tracked", "untracked",
-                      "unpushed_commits", "change_digest")
+                      "unpushed_commits", "change_digest", "indeterminate")
 
 
 def _volatile_evidence(evidence: dict) -> dict:
@@ -735,6 +832,22 @@ def _load_observation(con, shell_id: int, observation_id: str,
             409, "recovery_observation_stale",
             "the observation has expired — preview again",
             {"observation_id": observation_id})
+    stored = json.loads(evidence)
+    # Fail closed on incomplete evidence, at EITHER end. A gap is
+    # deterministic — the same unreadable path or undecodable git output
+    # yields the same absent facts at preview and at execute — so it would
+    # fingerprint EQUAL and ride through as "nothing changed" while the work
+    # behind it was rewritten (SC-087). Absence of evidence is never
+    # evidence of safety.
+    for when, ev in (("the preview", stored), ("now", fresh_evidence)):
+        reason = (ev.get("git") or {}).get("indeterminate")
+        if reason:
+            raise RecoveryError(
+                409, "recovery_observation_stale",
+                f"the worktree could not be observed completely at {when} "
+                f"({reason}) — recovery refused before any signal, closure "
+                "or file removal; repair the repository and preview again",
+                {"observation_id": observation_id, "detail": reason})
     if fingerprint != _fingerprint(con, shell_id, fresh_evidence):
         raise RecoveryError(
             409, "recovery_observation_stale",
@@ -742,8 +855,7 @@ def _load_observation(con, shell_id: int, observation_id: str,
             "process/pane identity or worktree contents no longer match what "
             "the preview showed; preview again",
             {"observation_id": observation_id})
-    return classification, json.loads(legal_actions), \
-        json.loads(evidence), acted_at
+    return classification, json.loads(legal_actions), stored, acted_at
 
 
 def _close_durable_state(con, shell_id: int, evidence: dict,

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2394,6 +2394,19 @@ function ifRecoveryResult(result) {
       `completed [${completed}], failed at ${worktree.failed.step || "unknown"} ` +
       `(${worktree.failed.error || "unknown error"}). Durable closure is ` +
       "committed; finish the discard remediation manually."));
+  } else if (worktree.kept_count) {
+    // Not a failure: these are left intact by design. "Preserved" (nothing
+    // touched) would be as false here as a bare "discarded" — so name them
+    // and say plainly why they can be there.
+    const kept = worktree.kept || [];
+    const more = worktree.kept_count - kept.length;
+    body.append(el("div", { className: "if-note" },
+      `Worktree ${worktree.worktree || ""} changes discarded, except ` +
+      `${worktree.kept_count} entr${worktree.kept_count === 1 ? "y" : "ies"} ` +
+      `left intact: ${kept.join(", ")}` +
+      (more > 0 ? ` (+${more} more)` : "") +
+      " — changed after the confirmation, or a directory still holding " +
+      "entries the discard was not allowed to remove."));
   } else if (worktree.discarded) {
     body.append(el("div", { className: "if-note" },
       `Worktree ${worktree.worktree || ""} changes discarded.`));

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -1692,6 +1692,54 @@ class WorktreeTest(RecoveryCase):
         # a surviving DIRECTORY is reported, but every consented FILE is gone
         self.assertTrue(result["discarded"], result)
 
+    def test_symlinked_ancestor_cannot_redirect_the_delete_outside(self):
+        # SC-105: O_NOFOLLOW on the FINAL component says nothing about the
+        # ancestors. Move `d` out of the worktree and drop a symlink to it at
+        # `d`, and `d/u.txt` still stats as the very same inode the plan
+        # recorded — so the identity check passes and a path-based unlink
+        # follows the symlink and deletes the file at its new home OUTSIDE the
+        # worktree, while the result reports discarded=true. Resolving each
+        # component with O_NOFOLLOW refuses instead of redirecting.
+        wt = self.make_git_worktree()
+        (Path(wt) / "d").mkdir()
+        (Path(wt) / "d" / "u.txt").write_text("moved out of the worktree")
+        plan = self.plan(wt)
+        self.assertIn("d/u.txt", plan["untracked_files"])
+        outside = Path(self.tmp.name) / "moved-away"
+        (Path(wt) / "d").rename(outside)              # same inodes, new home
+        (Path(wt) / "d").symlink_to(outside)
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertIsNone(result["failed"], result)
+        self.assertEqual((outside / "u.txt").read_text(),
+                         "moved out of the worktree")
+        self.assertIn("d/u.txt", result["kept"])
+        self.assertFalse(result["discarded"])
+        # the rest of the confirmed set still went
+        self.assertFalse((Path(wt) / "untracked.txt").exists())
+
+    def test_symlinked_ancestor_cannot_redirect_the_restore_outside(self):
+        # The same trap on the other seam. git refuses to write through a
+        # symlinked leading path — measured, not assumed, because the restore
+        # is the one destructive step this module does not perform itself.
+        wt = self.make_git_worktree()
+
+        def git(*args):
+            subprocess.run(["git", "-C", wt, *args], check=True,
+                           capture_output=True)
+
+        (Path(wt) / "dir").mkdir()
+        (Path(wt) / "dir" / "node").write_text("committed")
+        git("add", "dir/node")
+        git("commit", "-qm", "node")
+        (Path(wt) / "dir" / "node").write_text("dirty")
+        plan = self.plan(wt)
+        self.assertIn("dir/node", plan["tracked"])
+        outside = Path(self.tmp.name) / "moved-dir"
+        (Path(wt) / "dir").rename(outside)
+        (Path(wt) / "dir").symlink_to(outside)
+        recovery._discard_worktree_files(wt, plan)
+        self.assertEqual((outside / "node").read_text(), "dirty")
+
     def test_nothing_outside_the_plan_survives_adversarial_shapes(self):
         """The boundary claim, tested the way the closure claim is: build every
         shape that could let the discard reach outside the enumerated set, run
@@ -1987,7 +2035,7 @@ class WorktreeTest(RecoveryCase):
         self.session_with_worktree(wt)
         obj = self.preview(1)
 
-        def denied(_path):
+        def denied(_name, **_kw):
             raise OSError(errno.EACCES, "denied")
 
         with mock.patch.object(recovery.os, "unlink", side_effect=denied):

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -15,6 +15,11 @@ module is stdlib-only by design — HTTP-only recovery):
   after the preview → 409 recovery_observation_stale with NO signal, closure,
   reset or clean; unknown id → 404; replay via Idempotency-Key returns the
   original response with no second side effect;
+- freshness at the DESTRUCTIVE COMMIT, not merely at execute entry: work
+  written while the preconditions run refuses before anything happens, and
+  work written while the shell shuts down (after the fence, during SIGTERM)
+  refuses the discard with nothing reset or cleaned — the refusal naming the
+  signal and closure it cannot unwind;
 - action legality: recover refused on verified_live, force refused without
   confirm_force or against non-verified-live classifications;
 - exact process-group signaling against REAL child processes: SIGTERM
@@ -1319,6 +1324,115 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual(err["error"]["code"], "recovery_observation_stale")
         self.assertEqual((wt / "late.txt").read_text(),
                          "written after the preview")
+
+    # -- freshness must hold at the DESTRUCTIVE COMMIT, not just at entry
+    #    (SC-091) -----------------------------------------------------------
+
+    def test_work_written_during_preconditions_refuses(self):
+        # The check-then-act gap: the fence used to run at execute ENTRY while
+        # the clean ran at the END, so everything in between — the confirmation
+        # gates and the `git rev-list` behind the unpushed check, real
+        # wall-clock — was unprotected. Work written there was deleted and 200
+        # returned. Injecting from _unpushed_count writes strictly inside that
+        # old gap; the fence is now the LAST precondition, so it refuses.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        late = Path(wt) / "late_during_preconditions.txt"
+        real = recovery._unpushed_count
+
+        def writing(worktree):
+            late.write_text("written while the preconditions ran")
+            return real(worktree)
+
+        with mock.patch.object(recovery, "_unpushed_count", writing), \
+                mock.patch.object(
+                    recovery, "_discard_worktree_files",
+                    return_value={"worktree": wt, "discarded": True,
+                                  "completed": ["reset", "clean"],
+                                  "failed": None}) as disc, \
+                mock.patch.object(recovery,
+                                  "terminate_process_group") as term:
+            status, err = self.post(obj, preserve_worktree=False,
+                                    discard_worktree=True,
+                                    confirm_shortname="s1")
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        self.assertEqual(late.read_text(),
+                         "written while the preconditions ran")
+        disc.assert_not_called()   # no reset, no clean
+        term.assert_not_called()   # no signal
+        self.assert_nothing_discarded(wt)   # no closure either
+
+    def orphan_with_worktree(self, wt: str):
+        """A shell whose exact process is alive but whose pane is gone —
+        `recover` is legal and DOES signal, so the discard runs on the far
+        side of a real termination."""
+        proc, ticks = self.child()
+        self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks, worktree=wt)
+        return proc, ticks
+
+    def test_work_written_during_shutdown_refuses_discard(self):
+        # The window no entry fence can cover: the signal is what makes the
+        # shell shut down, and a shell can write on its way out — after every
+        # earlier check has already passed. The discard must not run on top of
+        # it. Injecting from terminate_process_group reproduces exactly that.
+        wt = self.make_git_worktree()
+        self.orphan_with_worktree(wt)
+        late = Path(wt) / "late_during_shutdown.txt"
+        real = recovery.terminate_process_group
+
+        def writing(pid, start_ticks, grace_s):
+            result = real(pid, start_ticks, grace_s)
+            late.write_text("flushed while the shell shut down")
+            return result
+
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+            self.assertEqual(obj["classification"], "exact_idle_orphan")
+            with mock.patch.object(recovery, "terminate_process_group",
+                                   writing):
+                status, err = self.post(obj, preserve_worktree=False,
+                                        discard_worktree=True,
+                                        confirm_shortname="s1")
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        # Nothing was deleted: the late write, the dirty tracked file and the
+        # untracked file all survive.
+        self.assertEqual(late.read_text(), "flushed while the shell shut down")
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
+        # ...and the refusal is honest about what it could NOT unwind: the
+        # signal was sent and the durable closure committed before this point.
+        details = err["error"]["details"]
+        self.assertFalse(details["discarded"])
+        self.assertTrue(details["closed"])
+        self.assertTrue(details["signaled"]["signaled"])
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+        ).fetchone()[0], "ended")
+        con.close()
+
+    def test_discard_after_real_termination_still_runs(self):
+        # The other side of the same gate: a termination that changes nothing
+        # in the worktree must NOT be read as a change. The second fence
+        # re-reads only the worktree precisely because the signal and the
+        # closure legitimately move everything else.
+        wt = self.make_git_worktree()
+        proc, ticks = self.orphan_with_worktree(wt)
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+            status, result = self.post(obj, preserve_worktree=False,
+                                       discard_worktree=True,
+                                       confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertTrue(result["signaled"]["signaled"])
+        self.assertTrue(result["worktree"]["discarded"])
+        proc.wait(timeout=5)
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "dead")
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
+        self.assertFalse((Path(wt) / "untracked.txt").exists())
 
     def test_discard_git_failure_reports_exactly_what_completed(self):
         # clean fails AFTER reset succeeded and the closure committed: the

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -47,6 +47,7 @@ Run:
 from __future__ import annotations
 
 import contextlib
+import errno
 import io
 import json
 import os
@@ -965,6 +966,11 @@ class WorktreeTest(RecoveryCase):
                          "edited after the preview")
         self.assert_nothing_discarded(wt)
 
+    def plan(self, wt: str) -> dict:
+        """The enumerated discard set for `wt`, as the final gate hands it to
+        `_discard_worktree_files`."""
+        return recovery._observe_stable(wt)[1]
+
     def porcelain(self, wt: str) -> str:
         return subprocess.run(["git", "-C", wt, "status", "--porcelain"],
                               capture_output=True, text=True,
@@ -1144,7 +1150,7 @@ class WorktreeTest(RecoveryCase):
         wt = self.make_git_worktree()
         path = Path(wt) / "tracked.txt"
         os.chmod(path, 0o640)
-        recovery._discard_worktree_files(wt)
+        recovery._discard_worktree_files(wt, self.plan(wt))
         self.assertNotEqual(
             self.mode_of(path), 0o640,
             "reset --hard left the mode intact — premise of SC-090 changed")
@@ -1330,6 +1336,10 @@ class WorktreeTest(RecoveryCase):
         # something: `reset --hard HEAD` is fatal where nothing has ever been
         # committed, so the reset failed and the clean never ran — an
         # authorised discard that silently left everything in place.
+        # Bounding the discard to the enumerated set (SC-100) keeps that live:
+        # a STAGED path on an unborn HEAD is invisible to `ls-files -o`, so
+        # unless the plan enumerates the index too it is not in the delete set
+        # and the authorised discard quietly leaves it again.
         wt = Path(self.tmp.name) / "unborn-discard"
         wt.mkdir()
         subprocess.run(["git", "init", "-q", "-b", "feat/x", str(wt)],
@@ -1345,7 +1355,7 @@ class WorktreeTest(RecoveryCase):
                                    confirm_shortname="s1")
         self.assertEqual(status, 200, result)
         self.assertTrue(result["worktree"]["discarded"], result["worktree"])
-        self.assertEqual(result["worktree"]["completed"], ["reset", "clean"])
+        self.assertEqual(result["worktree"]["completed"], ["restore", "remove"])
         self.assertFalse((wt / "staged.txt").exists())
         self.assertFalse((wt / "untracked.txt").exists())
         self.assertTrue(wt.is_dir())   # the worktree itself is never deleted
@@ -1537,6 +1547,206 @@ class WorktreeTest(RecoveryCase):
         self.assert_gap_refuses(
             wt, mock.patch.object(recovery.os, "open", never_settles))
 
+    # -- the discard is bounded by the OBSERVATION, not by the tree (SC-100) --
+
+    def late_write_inside_the_final_gate(self, wt, write):
+        """Run a discard whose LAST gate is blind by construction: `write`
+        fires after the accepted pass has finished enumerating.
+
+        This is the window no amount of re-reading can close. `_observe_stable`
+        needs two passes that agree; a path created after the SECOND pass's own
+        enumeration is missed by both, so the digests match, the gate concludes
+        "unchanged" and the destructive step runs. Freshness cannot see work
+        that does not exist yet — only bounding the delete set can protect it.
+        """
+        armed, passes, fired = [], [], []
+        real_term = recovery.terminate_process_group
+        real_plan = recovery._discard_plan
+
+        def arming(pid, start_ticks, grace_s):
+            result = real_term(pid, start_ticks, grace_s)
+            armed.append(True)      # every pass from here is the LAST gate's
+            return result
+
+        def write_after_enumerating(*args, **kwargs):
+            plan = real_plan(*args, **kwargs)
+            if armed:
+                passes.append(True)
+                if len(passes) == 2 and not fired:
+                    write()      # after THIS pass listed the tree, before the
+                    fired.append(True)   # gate compares it to the previous one
+            return plan
+
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+            self.assertEqual(obj["classification"], "exact_idle_orphan")
+            with mock.patch.object(recovery, "terminate_process_group",
+                                   arming), \
+                    mock.patch.object(recovery, "_discard_plan",
+                                      write_after_enumerating):
+                status, result = self.post(obj, preserve_worktree=False,
+                                           discard_worktree=True,
+                                           confirm_shortname="s1")
+        self.assertTrue(fired, "the injection never ran — repro is stale")
+        return status, result
+
+    def test_ordinary_save_during_the_final_gate_is_not_erased(self):
+        # SC-100, REV1's repro: an ORDINARY new-file save — an editor, a tool,
+        # anything — landing during the gate's own second pass. Both passes
+        # enumerated before it existed, so the composite digests agreed, the
+        # gate accepted, and `git clean -fd` (which acts on the tree at delete
+        # time, not on the set that was consented to) erased it while the API
+        # returned 200 / discarded=true.
+        wt = self.make_git_worktree()
+        late = Path(wt) / "ordinary_editor_save.txt"
+        self.orphan_with_worktree(wt)
+        status, result = self.late_write_inside_the_final_gate(
+            wt, lambda: late.write_text("an ordinary save"))
+        self.assertEqual(status, 200, result)
+        # The file was never in the delete set, so it is not deleted — and it
+        # is not "preserved" either: the discard did exactly what it was
+        # confirmed to do, and the new work is simply outside that.
+        self.assertEqual(late.read_text(), "an ordinary save")
+        self.assertTrue(result["worktree"]["discarded"], result["worktree"])
+        self.assertEqual(result["worktree"]["kept"], [])
+        # ...and the work the operator DID confirm erasing is gone.
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
+        self.assertFalse((Path(wt) / "untracked.txt").exists())
+
+    def test_late_file_inside_an_enumerated_dir_survives_with_its_dir(self):
+        # The same save one level down. The directory IS in the delete set, so
+        # a recursive removal of it would take the new file with it; the
+        # removal is rmdir-only, so a non-empty directory survives and carries
+        # the new work with it.
+        wt = self.make_git_worktree()
+        (Path(wt) / "untracked_dir").mkdir()
+        (Path(wt) / "untracked_dir" / "old.txt").write_text("consented")
+        late = Path(wt) / "untracked_dir" / "late.txt"
+        self.orphan_with_worktree(wt)
+        status, result = self.late_write_inside_the_final_gate(
+            wt, lambda: late.write_text("an ordinary save"))
+        self.assertEqual(status, 200, result)
+        self.assertEqual(late.read_text(), "an ordinary save")
+        self.assertFalse((Path(wt) / "untracked_dir" / "old.txt").exists())
+        self.assertEqual(result["worktree"]["kept"], ["untracked_dir/"])
+        self.assertTrue(result["worktree"]["discarded"], result["worktree"])
+
+    def test_consented_path_rewritten_after_the_gate_is_kept(self):
+        # The narrower case the bound does NOT cover on its own: a path that
+        # IS in the delete set, rewritten after the gate read it. Each entry is
+        # re-verified against the identity the gate observed immediately before
+        # it is touched, so the rewrite is left alone and named — never removed
+        # on the strength of an identity that no longer holds.
+        wt = self.make_git_worktree()
+        untracked = Path(wt) / "untracked.txt"
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        real_discard = recovery._discard_worktree_files
+
+        def rewrite_then_discard(worktree, plan):
+            untracked.write_text("saved again after the gate passed")
+            return real_discard(worktree, plan)
+
+        with mock.patch.object(recovery, "_discard_worktree_files",
+                               rewrite_then_discard):
+            status, result = self.post(obj, preserve_worktree=False,
+                                       discard_worktree=True,
+                                       confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertEqual(untracked.read_text(),
+                         "saved again after the gate passed")
+        self.assertEqual(result["worktree"]["kept"], ["untracked.txt"])
+        self.assertEqual(result["worktree"]["kept_count"], 1)
+        self.assertFalse(result["worktree"]["discarded"])
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
+
+    def test_discard_touches_nothing_outside_the_plan(self):
+        # The bound stated directly: everything absent from the plan survives a
+        # discard, whatever the tree holds when it runs.
+        wt = self.make_git_worktree()
+        plan = self.plan(wt)
+        (Path(wt) / "not_in_plan.txt").write_text("later")
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertTrue(result["discarded"], result)
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
+        self.assertFalse((Path(wt) / "untracked.txt").exists())
+        self.assertEqual((Path(wt) / "not_in_plan.txt").read_text(), "later")
+
+    def test_late_empty_dir_inside_an_enumerated_dir_survives(self):
+        # The same bound one entity-type over. Pruning by walking the tree
+        # would rmdir an EMPTY directory created after the observation — it is
+        # removable and it is under an enumerated root, but nobody consented
+        # to it. Only directories the plan covers are candidates.
+        wt = self.make_git_worktree()
+        (Path(wt) / "unt" / "sub").mkdir(parents=True)
+        (Path(wt) / "unt" / "sub" / "old.txt").write_text("consented")
+        plan = self.plan(wt)
+        late = Path(wt) / "unt" / "late_empty"
+        late.mkdir()
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertTrue(late.is_dir())
+        self.assertFalse((Path(wt) / "unt" / "sub").exists())  # plan's own
+        self.assertEqual(result["kept"], ["unt/"])
+        self.assertIsNone(result["failed"])
+        # a surviving DIRECTORY is reported, but every consented FILE is gone
+        self.assertTrue(result["discarded"], result)
+
+    def test_dir_emptied_by_the_restore_goes_too(self):
+        # Parity with the operation this replaces: `clean -fd` removed the
+        # directory a staged-new file left behind. Git tracks no directories,
+        # so `git restore` alone leaves it standing — pruning ancestors of the
+        # enumerated entries, not just the enumerated directories, keeps a
+        # discard from littering empty directories through the tree.
+        wt = self.make_git_worktree()
+        (Path(wt) / "staged").mkdir()
+        (Path(wt) / "staged" / "new.txt").write_text("staged")
+        subprocess.run(["git", "-C", wt, "add", "staged/new.txt"], check=True,
+                       capture_output=True)
+        result = recovery._discard_worktree_files(wt, self.plan(wt))
+        self.assertTrue(result["discarded"], result)
+        self.assertFalse((Path(wt) / "staged").exists())
+
+    def test_untracked_dir_of_only_ignored_files_is_not_reported_kept(self):
+        # `clean -fd` leaves such a directory standing too, so its survival is
+        # not an incomplete discard. Reporting it would cry wolf on a very
+        # common shape (a build dir, __pycache__) and bury the survivor that
+        # does matter — one held open by work written after the confirmation.
+        wt = self.make_git_worktree()
+        (Path(wt) / ".gitignore").write_text("*.pyc\n")
+        subprocess.run(["git", "-C", wt, "add", ".gitignore"], check=True,
+                       capture_output=True)
+        subprocess.run(["git", "-C", wt, "commit", "-qm", "ignore"],
+                       check=True, capture_output=True)
+        cache = Path(wt) / "__pycache__"
+        cache.mkdir()
+        (cache / "m.pyc").write_bytes(b"\x00")
+        plan = self.plan(wt)
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertTrue((cache / "m.pyc").exists())   # ignored: never touched
+        self.assertEqual(result["kept"], ["__pycache__/"])
+        self.assertTrue(result["discarded"], result)   # no FILE was left
+
+    def test_nested_untracked_repository_is_not_unlinked(self):
+        # git names a nested repository ONCE, with a trailing slash, in the
+        # plain FILE listing — it never descends. Treating that entry as a
+        # file unlinks a directory: EISDIR, and the whole discard reports a
+        # failure. It is a directory, it survives (as it did under
+        # `clean -fd`), and it is reported because git still lists it.
+        wt = self.make_git_worktree()
+        nested = Path(wt) / "nested"
+        nested.mkdir()
+        subprocess.run(["git", "init", "-q", str(nested)], check=True,
+                       capture_output=True)
+        (nested / "inner.txt").write_text("someone else's repo")
+        plan = self.plan(wt)
+        self.assertIn("nested/", plan["untracked_dirs"])
+        self.assertNotIn("nested/", plan["untracked_files"])
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertIsNone(result["failed"], result)
+        self.assertEqual((nested / "inner.txt").read_text(),
+                         "someone else's repo")
+        self.assertEqual(result["kept"], ["nested/"])
+
     # -- a refusal names what it actually did, in BOTH directions -----------
 
     def test_no_signal_refusal_does_not_claim_a_signal(self):
@@ -1586,34 +1796,28 @@ class WorktreeTest(RecoveryCase):
         self.assertTrue((Path(wt) / "untracked.txt").exists())
 
     def test_discard_git_failure_reports_exactly_what_completed(self):
-        # clean fails AFTER reset succeeded and the closure committed: the
-        # response stays 200 and names the completed/failed steps — never a
+        # removal fails AFTER the restore succeeded and the closure committed:
+        # the response stays 200 and names the completed/failed steps — never a
         # bare 500 that hides a partial discard.
         wt = self.make_git_worktree()
         self.session_with_worktree(wt)
         obj = self.preview(1)
-        real_run = recovery.subprocess.run
 
-        def flaky_clean(*args, **kwargs):
-            if "clean" in args[0]:
-                return subprocess.CompletedProcess(
-                    args=args[0], returncode=1, stdout="",
-                    stderr="fatal: clean boom")
-            return real_run(*args, **kwargs)
+        def denied(_path):
+            raise OSError(errno.EACCES, "denied")
 
-        with mock.patch.object(recovery.subprocess, "run",
-                               side_effect=flaky_clean):
+        with mock.patch.object(recovery.os, "unlink", side_effect=denied):
             status, result = self.post(obj, preserve_worktree=False,
                                        discard_worktree=True,
                                        confirm_shortname="s1")
         self.assertEqual(status, 200, result)
         wt_result = result["worktree"]
         self.assertFalse(wt_result["discarded"])
-        self.assertEqual(wt_result["completed"], ["reset"])
-        self.assertEqual(wt_result["failed"]["step"], "clean")
-        self.assertIn("clean boom", wt_result["failed"]["error"])
-        # reset ran (tracked restored), clean did not (untracked survives),
-        # and the durable closure still committed.
+        self.assertEqual(wt_result["completed"], ["restore"])
+        self.assertEqual(wt_result["failed"]["step"], "remove")
+        self.assertIn("untracked.txt", wt_result["failed"]["error"])
+        # the restore ran (tracked restored), the removal did not (untracked
+        # survives), and the durable closure still committed.
         self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
         self.assertTrue((Path(wt) / "untracked.txt").exists())
         con = self.db()
@@ -1628,20 +1832,20 @@ class WorktreeTest(RecoveryCase):
         obj = self.preview(1)
         real_run = recovery.subprocess.run
 
-        def timeout_reset(*args, **kwargs):
-            if "reset" in args[0]:
+        def timeout_restore(*args, **kwargs):
+            if "restore" in args[0]:
                 raise subprocess.TimeoutExpired(cmd=args[0], timeout=60)
             return real_run(*args, **kwargs)
 
         with mock.patch.object(recovery.subprocess, "run",
-                               side_effect=timeout_reset):
+                               side_effect=timeout_restore):
             status, result = self.post(obj, preserve_worktree=False,
                                        discard_worktree=True,
                                        confirm_shortname="s1")
         self.assertEqual(status, 200, result)
         self.assertFalse(result["worktree"]["discarded"])
         self.assertEqual(result["worktree"]["completed"], [])
-        self.assertEqual(result["worktree"]["failed"]["step"], "reset")
+        self.assertEqual(result["worktree"]["failed"]["step"], "restore")
 
 
 # ------------------------------------------------------------------ CLI parity
@@ -1782,6 +1986,24 @@ class CliRecoverTest(unittest.TestCase):
         self.assertIs(body["discard_worktree"], True)
         self.assertIs(body["preserve_worktree"], False)
         self.assertEqual(body["confirm_shortname"], "S3")
+
+    def test_discard_that_kept_entries_says_so(self):
+        # A bounded discard can complete with entries left intact (SC-100).
+        # That is neither "changes discarded" nor "worktree preserved" — both
+        # would be false, and the operator needs the names to finish by hand.
+        self.script(dict(self.PREVIEW_ORPHAN), dict(
+            self.RESULT, worktree={"worktree": "/w", "discarded": False,
+                                   "completed": ["restore", "remove"],
+                                   "failed": None, "kept": ["late.txt"],
+                                   "kept_count": 1}))
+        code, out, err = self.run_cli(
+            ["recover", "s3", "--discard-worktree", "--yes"])
+        self.assertEqual(code, 0)
+        self.assertIn("discarded, EXCEPT 1 entry left intact", out)
+        self.assertIn("changed after the confirmation", out)
+        self.assertIn("late.txt", out)
+        self.assertNotIn("worktree preserved", out)
+        self.assertEqual(err, "")
 
     def test_stale_observation_maps_to_refusal(self):
         from test_interface_cli import http_error

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -51,6 +51,7 @@ import errno
 import io
 import json
 import os
+import shutil
 import signal
 import sqlite3
 import stat
@@ -1355,7 +1356,7 @@ class WorktreeTest(RecoveryCase):
                                    confirm_shortname="s1")
         self.assertEqual(status, 200, result)
         self.assertTrue(result["worktree"]["discarded"], result["worktree"])
-        self.assertEqual(result["worktree"]["completed"], ["restore", "remove"])
+        self.assertEqual(result["worktree"]["completed"], ["remove", "restore"])
         self.assertFalse((wt / "staged.txt").exists())
         self.assertFalse((wt / "untracked.txt").exists())
         self.assertTrue(wt.is_dir())   # the worktree itself is never deleted
@@ -1691,6 +1692,87 @@ class WorktreeTest(RecoveryCase):
         # a surviving DIRECTORY is reported, but every consented FILE is gone
         self.assertTrue(result["discarded"], result)
 
+    def df_worktree(self, obstruction: str, *, ignored: bool) -> str:
+        """HEAD tracks the FILE `node`; the worktree has replaced it with a
+        DIRECTORY holding `obstruction`. `git diff HEAD` names `node`, so the
+        plan enumerates it — as one entity, `dir:…`, which says nothing about
+        what is inside."""
+        wt = self.make_git_worktree()
+
+        def git(*args):
+            subprocess.run(["git", "-C", wt, *args], check=True,
+                           capture_output=True)
+
+        (Path(wt) / ".gitignore").write_text("*.pyc\n")
+        (Path(wt) / "node").write_text("the committed file")
+        git("add", ".gitignore", "node")
+        git("commit", "-qm", "node")
+        (Path(wt) / "node").unlink()
+        (Path(wt) / "node").mkdir()
+        (Path(wt) / "node" / obstruction).write_text("not in the delete set"
+                                                     if ignored else "consented")
+        return wt
+
+    def test_tracked_path_now_a_dir_of_ignored_files_is_not_restored_over(self):
+        # SC-103, and no concurrent writer is needed. `git restore` on a path
+        # the worktree turned into a directory deletes the DIRECTORY — here
+        # taking an ignored file the plan never enumerated, so the bounded-set
+        # claim failed on the command's own footprint rather than on a race.
+        wt = self.df_worktree("cache.pyc", ignored=True)
+        plan = self.plan(wt)
+        self.assertIn("node", plan["tracked"])
+        self.assertNotIn("node/cache.pyc", plan["untracked_files"])
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertIsNone(result["failed"], result)
+        self.assertEqual((Path(wt) / "node" / "cache.pyc").read_text(),
+                         "not in the delete set")
+        self.assertEqual(result["kept"], ["node"])
+        self.assertFalse(result["discarded"])
+        # the rest of the confirmed set still went
+        self.assertFalse((Path(wt) / "untracked.txt").exists())
+
+    def test_tracked_path_now_a_dir_of_enumerated_files_is_restored(self):
+        # The other half, and the truth bug: with the obstruction ENUMERATED,
+        # restoring first deleted it as collateral and the removal loop then
+        # saw it gone, decided it had "changed", and reported it kept — a file
+        # named as spared that the discard had in fact just erased. Removing
+        # first empties the directory, so the restore is bounded and the
+        # report is true.
+        wt = self.df_worktree("u.txt", ignored=False)
+        plan = self.plan(wt)
+        self.assertIn("node/u.txt", plan["untracked_files"])
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertIsNone(result["failed"], result)
+        self.assertEqual((Path(wt) / "node").read_text(), "the committed file")
+        self.assertEqual(result["kept"], [])
+        self.assertTrue(result["discarded"], result)
+
+    def test_tracked_dir_now_a_file_is_restored(self):
+        # The mirror: HEAD tracks `d/x`, the worktree replaced `d` with a
+        # FILE. Restoring first cannot create `d/x` through it — and under the
+        # old order the restore deleted the untracked file `d` and the removal
+        # loop then reported it kept. Removal first clears the path.
+        wt = self.make_git_worktree()
+
+        def git(*args):
+            subprocess.run(["git", "-C", wt, *args], check=True,
+                           capture_output=True)
+
+        (Path(wt) / "d").mkdir()
+        (Path(wt) / "d" / "x").write_text("committed")
+        git("add", "d/x")
+        git("commit", "-qm", "d")
+        shutil.rmtree(Path(wt) / "d")
+        (Path(wt) / "d").write_text("a file now")
+        plan = self.plan(wt)
+        self.assertIn("d/x", plan["tracked"])
+        self.assertIn("d", plan["untracked_files"])
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertIsNone(result["failed"], result)
+        self.assertEqual((Path(wt) / "d" / "x").read_text(), "committed")
+        self.assertEqual(result["kept"], [])
+        self.assertTrue(result["discarded"], result)
+
     def test_dir_emptied_by_the_restore_goes_too(self):
         # Parity with the operation this replaces: `clean -fd` removed the
         # directory a staged-new file left behind. Git tracks no directories,
@@ -1796,9 +1878,45 @@ class WorktreeTest(RecoveryCase):
         self.assertTrue((Path(wt) / "untracked.txt").exists())
 
     def test_discard_git_failure_reports_exactly_what_completed(self):
-        # removal fails AFTER the restore succeeded and the closure committed:
-        # the response stays 200 and names the completed/failed steps — never a
-        # bare 500 that hides a partial discard.
+        # the restore fails AFTER the removal succeeded and the closure
+        # committed: the response stays 200 and names the completed/failed
+        # steps — never a bare 500 that hides a partial discard.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        real_run = recovery.subprocess.run
+
+        def failing_restore(*args, **kwargs):
+            if "restore" in args[0]:
+                return subprocess.CompletedProcess(
+                    args=args[0], returncode=1, stdout=b"",
+                    stderr=b"fatal: restore boom")
+            return real_run(*args, **kwargs)
+
+        with mock.patch.object(recovery.subprocess, "run",
+                               side_effect=failing_restore):
+            status, result = self.post(obj, preserve_worktree=False,
+                                       discard_worktree=True,
+                                       confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        wt_result = result["worktree"]
+        self.assertFalse(wt_result["discarded"])
+        self.assertEqual(wt_result["completed"], ["remove"])
+        self.assertEqual(wt_result["failed"]["step"], "restore")
+        self.assertIn("restore boom", wt_result["failed"]["error"])
+        # the removal ran (untracked gone), the restore did not (tracked is
+        # still dirty), and the durable closure still committed.
+        self.assertFalse((Path(wt) / "untracked.txt").exists())
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+        ).fetchone()[0], "ended")
+        con.close()
+
+    def test_discard_remove_failure_stops_before_the_restore(self):
+        # The first step failing stops the sequence: nothing is restored, so a
+        # partial discard never reads as a completed one.
         wt = self.make_git_worktree()
         self.session_with_worktree(wt)
         obj = self.preview(1)
@@ -1813,18 +1931,11 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual(status, 200, result)
         wt_result = result["worktree"]
         self.assertFalse(wt_result["discarded"])
-        self.assertEqual(wt_result["completed"], ["restore"])
+        self.assertEqual(wt_result["completed"], [])
         self.assertEqual(wt_result["failed"]["step"], "remove")
         self.assertIn("untracked.txt", wt_result["failed"]["error"])
-        # the restore ran (tracked restored), the removal did not (untracked
-        # survives), and the durable closure still committed.
-        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
         self.assertTrue((Path(wt) / "untracked.txt").exists())
-        con = self.db()
-        self.assertEqual(con.execute(
-            "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
-        ).fetchone()[0], "ended")
-        con.close()
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
 
     def test_discard_git_timeout_reported_not_raised(self):
         wt = self.make_git_worktree()
@@ -1844,7 +1955,7 @@ class WorktreeTest(RecoveryCase):
                                        confirm_shortname="s1")
         self.assertEqual(status, 200, result)
         self.assertFalse(result["worktree"]["discarded"])
-        self.assertEqual(result["worktree"]["completed"], [])
+        self.assertEqual(result["worktree"]["completed"], ["remove"])
         self.assertEqual(result["worktree"]["failed"]["step"], "restore")
 
 

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -1200,14 +1200,22 @@ class WorktreeTest(RecoveryCase):
 
     # -- incomplete evidence REFUSES, it never degrades (SC-087) -----------
 
-    def assert_gap_refuses(self, wt, patcher=None):
-        """A gap in the evidence must refuse at execute.
+    def assert_gap_refuses_discard_but_frees_the_shell(self, wt, patcher=None):
+        """A gap in the worktree evidence must refuse the DISCARD at execute —
+        and must NOT hold the shell hostage.
 
         The danger is precisely that a gap is DETERMINISTIC: the same
         undecodable output or unreadable entry yields the same absent facts at
-        preview and at execute, so it fingerprints EQUAL and rides through as
+        preview and at execute, so it compares EQUAL and would ride through as
         'nothing changed'. Both the preview and the execute run under the
         patch here for exactly that reason.
+
+        The gap gates the DISCARD and nothing else (SC-106). A plain recovery
+        touches no file, so unreadable files tell it nothing — and refusing it
+        left a shell whose lock was already proven absent stranded, which
+        inverts what a recovery is for. So this asserts BOTH halves: the
+        discard refuses, and the same broken worktree still frees the shell
+        with every file untouched.
         """
         with patcher or contextlib.nullcontext():
             obj = self.preview(1)
@@ -1221,23 +1229,85 @@ class WorktreeTest(RecoveryCase):
                 status, err = self.post(obj, preserve_worktree=False,
                                         discard_worktree=True,
                                         confirm_shortname="s1")
-                # Fail closed for the WHOLE execute, not just the discard: a
-                # closure the operator decided on unobservable evidence is the
-                # same defect one blast radius smaller. (Fresh idempotency
-                # key — a different body under the old one is a conflict.)
-                plain_status, plain_err = self.call(
+                self.assertEqual(status, 409, err)
+                self.assertEqual(err["error"]["code"],
+                                 "recovery_observation_stale")
+                self.assert_nothing_discarded(wt)   # not even a closure
+                # ...and now the core path, on the same broken worktree.
+                # (Fresh idempotency key — a different body under the old one
+                # is a conflict.)
+                plain_status, plain = self.call(
                     "POST", "/api/interface/shells/1/recovery",
                     (OP, "Idempotency-Key: k-2"),
                     {"observation_id": obj["observation_id"],
                      "mode": "recover"})
-        self.assertEqual(status, 409, err)
-        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
-        self.assertEqual(plain_status, 409, plain_err)
-        self.assertEqual(plain_err["error"]["code"],
-                         "recovery_observation_stale")
-        disc.assert_not_called()   # no reset, no clean
-        term.assert_not_called()   # no signal
-        self.assert_nothing_discarded(wt)
+        self.assertEqual(plain_status, 200, plain)
+        self.assertEqual(plain["availability"], "available")
+        self.assertEqual(plain["worktree"], {"preserved": True})
+        self.assertTrue(plain["closed"]["session"]["session_id"])
+        disc.assert_not_called()   # nothing removed, nothing restored
+        term.assert_not_called()   # a stale lock has no process to signal
+        # the lock is gone AND every file is exactly where it was
+        con = self.db()
+        try:
+            self.assertEqual(con.execute(
+                "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+            ).fetchone()[0], "ended")
+        finally:
+            con.close()
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
+
+    def test_corrupt_git_still_unstrands_an_absence_proved_lock(self):
+        # SC-106, the core objective end to end: a stale durable lock with no
+        # process identity — absence already proven — and a repository that
+        # cannot be read at all. Eight cycles of hardening the OPTIONAL discard
+        # had made worktree evidence a precondition of the closure itself, so
+        # a corrupt `.git` left this shell reported busy forever with no file
+        # operation ever requested. Unstranding is priority one; the files are
+        # protected by not touching them, not by refusing to help.
+        wt = self.make_git_worktree()
+        (Path(wt) / ".git" / "HEAD").write_text("not a ref\n")
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        self.assertEqual(obj["classification"], "stale_durable_lock")
+        self.assertIn("recover", obj["legal_actions"])
+        self.assertIn("indeterminate", obj["evidence"]["git"])
+
+        status, result = self.post(obj)          # the default: preserve
+        self.assertEqual(status, 200, result)
+        self.assertEqual(result["availability"], "available")
+        self.assertEqual(result["worktree"], {"preserved": True})
+        self.assertIsNone(result["signaled"])    # nothing to signal
+        # the lock is actually gone — not merely reported closed
+        con = self.db()
+        try:
+            self.assertEqual(con.execute(
+                "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+            ).fetchone()[0], "ended")
+        finally:
+            con.close()
+        # and every file survived, dirty and untracked alike
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        self.assertEqual((Path(wt) / "untracked.txt").read_text(), "new")
+
+    def test_worktree_change_after_preview_does_not_block_plain_recovery(self):
+        # The milder half of the same coupling: the shell keeps writing while
+        # it is stranded, so its worktree moves between preview and execute.
+        # Nothing is being destroyed, so that must not refuse — while the
+        # process/pane and durable evidence still gate every recovery.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        late = Path(wt) / "written_while_stranded.txt"
+        late.write_text("the shell was still writing")
+        (Path(wt) / "tracked.txt").write_text("and editing")
+
+        status, result = self.post(obj)
+        self.assertEqual(status, 200, result)
+        self.assertEqual(result["availability"], "available")
+        self.assertEqual(late.read_text(), "the shell was still writing")
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "and editing")
 
     def test_non_utf8_path_is_observed_not_degraded(self):
         # A valid non-UTF-8 filename is worktree STATE, not a failure. Reading
@@ -1271,7 +1341,7 @@ class WorktreeTest(RecoveryCase):
                 raise recovery._GitEvidenceUnavailable("git status: exit 128")
             return real(worktree, *args, **kwargs)
 
-        self.assert_gap_refuses(
+        self.assert_gap_refuses_discard_but_frees_the_shell(
             wt, mock.patch.object(recovery, "_git_out", failing))
 
     def test_git_timeout_refuses(self):
@@ -1284,7 +1354,7 @@ class WorktreeTest(RecoveryCase):
                 raise subprocess.TimeoutExpired(cmd, 30)
             return real(cmd, *args, **kwargs)
 
-        self.assert_gap_refuses(
+        self.assert_gap_refuses_discard_but_frees_the_shell(
             wt, mock.patch.object(recovery.subprocess, "run", timing_out))
 
     def test_unreadable_entry_refuses(self):
@@ -1297,7 +1367,7 @@ class WorktreeTest(RecoveryCase):
                 raise PermissionError(13, "permission denied")
             return real(path, *args, **kwargs)
 
-        self.assert_gap_refuses(
+        self.assert_gap_refuses_discard_but_frees_the_shell(
             wt, mock.patch.object(recovery.os, "lstat", denied))
 
     def test_corrupt_repository_refuses(self):
@@ -1307,7 +1377,7 @@ class WorktreeTest(RecoveryCase):
         wt = self.make_git_worktree()
         self.session_with_worktree(wt)
         (Path(wt) / ".git" / "HEAD").write_text("not-a-ref\n")
-        self.assert_gap_refuses(wt)
+        self.assert_gap_refuses_discard_but_frees_the_shell(wt)
 
     def test_unborn_head_is_complete_evidence_not_a_gap(self):
         # A repo with no commits is fully observable — nothing to diff
@@ -1545,7 +1615,7 @@ class WorktreeTest(RecoveryCase):
                 os.chmod(tracked, modes[0])
             return fd
 
-        self.assert_gap_refuses(
+        self.assert_gap_refuses_discard_but_frees_the_shell(
             wt, mock.patch.object(recovery.os, "open", never_settles))
 
     # -- the discard is bounded by the OBSERVATION, not by the tree (SC-100) --

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -799,12 +799,21 @@ class ExecuteTest(RecoveryCase):
 
 class WorktreeTest(RecoveryCase):
 
-    def make_git_worktree(self, *, unpushed: bool = False) -> str:
+    def make_git_worktree(self, *, unpushed: bool = False,
+                          links: bool = False) -> str:
         """A real git repo standing in for the shell worktree, with a bare
         origin so 'unpushed' is exact: one pushed commit, one dirty tracked
         change, one untracked file (+ one local-only commit when unpushed).
         `clean.txt` is committed and left clean so a test can dirty it AFTER
-        the preview."""
+        the preview.
+
+        `links=True` adds the entity-identity fixture: `a/b/c.txt` all hold
+        the SAME bytes and `dirty_target.txt` holds the same bytes as dirty
+        `tracked.txt`, so every post-preview mutation below can be made
+        without the *resolved* content ever changing — a digest that reads
+        through a link, or ignores type, cannot tell the states apart.
+        Pre-dirtied: `tlink` (tracked symlink, retargeted a->b), `ulink`
+        (untracked symlink -> b), `ufile.txt` (untracked regular file)."""
         origin = Path(self.tmp.name) / "origin.git"
         subprocess.run(["git", "init", "-q", "--bare", str(origin)],
                        check=True, capture_output=True)
@@ -820,6 +829,11 @@ class WorktreeTest(RecoveryCase):
         git("remote", "add", "origin", str(origin))
         (wt / "tracked.txt").write_text("v1")
         (wt / "clean.txt").write_text("c1")
+        if links:
+            for name in ("a.txt", "b.txt", "c.txt"):
+                (wt / name).write_text("same")
+            (wt / "dirty_target.txt").write_text("dirty")
+            (wt / "tlink").symlink_to("a.txt")
         git("add", ".")
         git("commit", "-qm", "base")
         git("push", "-q", "-u", "origin", "feat/x")
@@ -828,6 +842,11 @@ class WorktreeTest(RecoveryCase):
             git("commit", "-qam", "local only")
         (wt / "tracked.txt").write_text("dirty")
         (wt / "untracked.txt").write_text("new")
+        if links:
+            (wt / "tlink").unlink()
+            (wt / "tlink").symlink_to("b.txt")     # tracked, now dirty
+            (wt / "ulink").symlink_to("b.txt")     # untracked symlink
+            (wt / "ufile.txt").write_text("dirty")  # untracked regular file
         return str(wt)
 
     def session_with_worktree(self, wt: str) -> int:
@@ -945,15 +964,22 @@ class WorktreeTest(RecoveryCase):
                               capture_output=True, text=True,
                               check=True).stdout
 
-    def assert_content_edit_refuses(self, wt, rel: str, text: str):
-        """Rewrite `rel` AFTER the preview without touching the path list, then
-        confirm the discard: the fence must refuse before anything runs."""
+    def assert_mutation_refuses(self, wt, mutate, *,
+                                porcelain_stable: bool = True):
+        """Mutate the worktree AFTER the preview, then confirm the discard:
+        the fence must refuse before anything runs.
+
+        `porcelain_stable` pins the regression that makes the case worth
+        testing — the status lines stay byte-identical, so any digest built
+        from them alone still reads fresh while the work underneath moved.
+        Set it False only where git's own line set already reflects the
+        change (a TRACKED typechange reports ' T'); the refusal is still
+        required, it just is not the line set that is being trusted."""
         obj = self.preview(1)
         before = self.porcelain(wt)
-        (Path(wt) / rel).write_text(text)
-        # The regression this pins: the status lines are byte-identical, so a
-        # path-list digest reads fresh while the content changed.
-        self.assertEqual(self.porcelain(wt), before)
+        mutate()
+        if porcelain_stable:
+            self.assertEqual(self.porcelain(wt), before)
         with mock.patch.object(
                 recovery, "_discard_worktree_files",
                 return_value={"worktree": wt, "discarded": True,
@@ -968,7 +994,6 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual(err["error"]["code"], "recovery_observation_stale")
         disc.assert_not_called()   # no reset, no clean
         term.assert_not_called()   # no signal
-        self.assertEqual((Path(wt) / rel).read_text(), text)
         con = self.db()
         try:  # no closure
             self.assertEqual(con.execute(
@@ -976,6 +1001,26 @@ class WorktreeTest(RecoveryCase):
             ).fetchone()[0], "reserved")
         finally:
             con.close()
+
+    def assert_content_edit_refuses(self, wt, rel: str, text: str):
+        """Rewrite `rel` after the preview, path list untouched."""
+        self.assert_mutation_refuses(
+            wt, lambda: (Path(wt) / rel).write_text(text))
+        self.assertEqual((Path(wt) / rel).read_text(), text)
+
+    def retarget(self, wt, rel: str, target: str):
+        """Repoint an existing symlink — the link's own identity changes, the
+        bytes it resolves to do not."""
+        link = Path(wt) / rel
+        self.assertTrue(link.is_symlink())
+        resolved_before = link.read_text()
+
+        def mutate():
+            link.unlink()
+            link.symlink_to(target)
+        self.assert_mutation_refuses(wt, mutate)
+        self.assertEqual(os.readlink(link), target)
+        self.assertEqual(link.read_text(), resolved_before)  # content equal
 
     def test_tracked_content_edit_after_preview_refuses_discard(self):
         # Same already-dirty tracked path, new contents: SC-086 — the operator
@@ -998,6 +1043,72 @@ class WorktreeTest(RecoveryCase):
         self.session_with_worktree(wt)
         self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
         self.assert_content_edit_refuses(wt, "tracked.txt", "drity")
+
+    # -- entity identity: link vs target, and type transitions (SC-086) ----
+    # Every case below leaves the *resolved* bytes identical, so a digest
+    # that reads through a link or ignores an entity's type reads fresh.
+
+    def test_tracked_symlink_retarget_after_preview_refuses_discard(self):
+        # An already-dirty tracked symlink repointed b.txt -> c.txt. Both
+        # targets hold "same", so hashing what the link resolves to cannot
+        # see it; git reports ' M tlink' either way. Only the link's own
+        # target string moved — and a discard would reset it.
+        wt = self.make_git_worktree(links=True)
+        self.session_with_worktree(wt)
+        self.retarget(wt, "tlink", "c.txt")
+
+    def test_untracked_symlink_retarget_after_preview_refuses_discard(self):
+        # Same defect on an untracked link: '?? ulink' is fixed, the
+        # resolved bytes are equal, and a discard would clean it away.
+        wt = self.make_git_worktree(links=True)
+        self.session_with_worktree(wt)
+        self.retarget(wt, "ulink", "c.txt")
+
+    def test_untracked_file_becoming_symlink_refuses_discard(self):
+        # Regular file -> symlink resolving to identical bytes. Untracked, so
+        # porcelain shows '?? ufile.txt' before and after: git's line set
+        # cannot distinguish the types at all — only the digest's type
+        # prefix can.
+        wt = self.make_git_worktree(links=True)
+        self.session_with_worktree(wt)
+        path = Path(wt) / "ufile.txt"
+        self.assertEqual(path.read_text(), "dirty")
+
+        def mutate():
+            path.unlink()
+            path.symlink_to("dirty_target.txt")
+        self.assert_mutation_refuses(wt, mutate)
+        self.assertTrue(path.is_symlink())
+        self.assertEqual(path.read_text(), "dirty")  # content equal
+
+    def test_untracked_symlink_becoming_file_refuses_discard(self):
+        # The reverse transition, same invariant.
+        wt = self.make_git_worktree(links=True)
+        self.session_with_worktree(wt)
+        path = Path(wt) / "ulink"
+        self.assertEqual(path.read_text(), "same")
+
+        def mutate():
+            path.unlink()
+            path.write_text("same")
+        self.assert_mutation_refuses(wt, mutate)
+        self.assertFalse(path.is_symlink())
+        self.assertEqual(path.read_text(), "same")
+
+    def test_tracked_file_becoming_symlink_refuses_discard(self):
+        # Tracked typechange: git DOES move the line (' M' -> ' T'), so the
+        # line set already fences this one — pinned anyway so the refusal
+        # survives a future digest that stops reading porcelain.
+        wt = self.make_git_worktree(links=True)
+        self.session_with_worktree(wt)
+        path = Path(wt) / "tracked.txt"
+
+        def mutate():
+            path.unlink()
+            path.symlink_to("dirty_target.txt")
+        self.assert_mutation_refuses(wt, mutate, porcelain_stable=False)
+        self.assertTrue(path.is_symlink())
+        self.assertEqual(path.read_text(), "dirty")
 
     def test_equal_count_churn_after_preview_refuses_discard(self):
         # One file cleaned, another dirtied: dirty_tracked/untracked counts

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -47,6 +47,7 @@ import json
 import os
 import signal
 import sqlite3
+import stat
 import subprocess
 import sys
 import tempfile
@@ -1124,6 +1125,200 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual(err["error"]["code"], "recovery_observation_stale")
         self.assertEqual((Path(wt) / "clean.txt").read_text(), "newly dirty")
         self.assertTrue((Path(wt) / "untracked.txt").exists())
+
+    # -- the digest binds every attribute a discard REWRITES (SC-090) ------
+
+    def mode_of(self, path: Path) -> int:
+        return stat.S_IMODE(os.lstat(path).st_mode)
+
+    def test_discard_destroys_permissions(self):
+        # The premise, reproduced rather than argued: `reset --hard` does not
+        # edit a dirty file in place — it recreates it from the index, so the
+        # mode comes back umask-derived and a tightened one is simply gone.
+        # Permissions are work a discard destroys; that is why they are bound.
+        wt = self.make_git_worktree()
+        path = Path(wt) / "tracked.txt"
+        os.chmod(path, 0o640)
+        recovery._discard_worktree_files(wt)
+        self.assertNotEqual(
+            self.mode_of(path), 0o640,
+            "reset --hard left the mode intact — premise of SC-090 changed")
+
+    def test_mode_tightening_after_preview_refuses_discard(self):
+        # SC-090: same bytes, same porcelain, tighter permissions. Git records
+        # only the exec bit, but a discard rewrites ALL of them, so the digest
+        # must move on any of them.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        path = Path(wt) / "tracked.txt"
+        os.chmod(path, 0o640)
+        self.assert_mutation_refuses(wt, lambda: os.chmod(path, 0o600))
+        self.assertEqual(self.mode_of(path), 0o600)
+        self.assertEqual(path.read_text(), "dirty")
+
+    def test_untracked_mode_change_after_preview_refuses_discard(self):
+        # `clean -fd` deletes untracked files outright, so their mode is work
+        # a discard destroys just as completely.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        path = Path(wt) / "untracked.txt"
+        os.chmod(path, 0o644)
+        self.assert_mutation_refuses(wt, lambda: os.chmod(path, 0o600))
+        self.assertEqual(self.mode_of(path), 0o600)
+
+    @unittest.skipUnless(os.geteuid() == 0, "chown requires root")
+    def test_owner_change_after_preview_refuses_discard(self):
+        # Same recreate-from-index step hands the file to whoever runs the
+        # recovery, so ownership is destroyed by a discard too.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        path = Path(wt) / "tracked.txt"
+        self.assert_mutation_refuses(wt, lambda: os.chown(path, 1, 1))
+        self.assertEqual(os.lstat(path).st_uid, 1)
+
+    def test_empty_untracked_dir_after_preview_refuses_discard(self):
+        # `clean -fd` removes untracked DIRECTORIES, and an empty one is named
+        # by neither porcelain (git ignores empty dirs) nor a file listing —
+        # the digest enumerates directories in their own right.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        late = Path(wt) / "late_dir"
+        self.assert_mutation_refuses(wt, late.mkdir)
+        self.assertTrue(late.is_dir())
+
+    # -- incomplete evidence REFUSES, it never degrades (SC-087) -----------
+
+    def assert_gap_refuses(self, wt, patcher=None):
+        """A gap in the evidence must refuse at execute.
+
+        The danger is precisely that a gap is DETERMINISTIC: the same
+        undecodable output or unreadable entry yields the same absent facts at
+        preview and at execute, so it fingerprints EQUAL and rides through as
+        'nothing changed'. Both the preview and the execute run under the
+        patch here for exactly that reason.
+        """
+        with patcher or contextlib.nullcontext():
+            obj = self.preview(1)
+            self.assertIn("indeterminate", obj["evidence"]["git"])
+            rows = {r["key"]: r["value"] for r in obj["evidence_projection"]}
+            self.assertIn("could not be observed completely", rows["worktree"])
+            with mock.patch.object(recovery,
+                                   "_discard_worktree_files") as disc, \
+                    mock.patch.object(recovery,
+                                      "terminate_process_group") as term:
+                status, err = self.post(obj, preserve_worktree=False,
+                                        discard_worktree=True,
+                                        confirm_shortname="s1")
+                # Fail closed for the WHOLE execute, not just the discard: a
+                # closure the operator decided on unobservable evidence is the
+                # same defect one blast radius smaller. (Fresh idempotency
+                # key — a different body under the old one is a conflict.)
+                plain_status, plain_err = self.call(
+                    "POST", "/api/interface/shells/1/recovery",
+                    (OP, "Idempotency-Key: k-2"),
+                    {"observation_id": obj["observation_id"],
+                     "mode": "recover"})
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        self.assertEqual(plain_status, 409, plain_err)
+        self.assertEqual(plain_err["error"]["code"],
+                         "recovery_observation_stale")
+        disc.assert_not_called()   # no reset, no clean
+        term.assert_not_called()   # no signal
+        self.assert_nothing_discarded(wt)
+
+    def test_non_utf8_path_is_observed_not_degraded(self):
+        # A valid non-UTF-8 filename is worktree STATE, not a failure. Reading
+        # git's NUL-delimited output as strict text raised on it and collapsed
+        # the whole observation to 'no facts' — which then compared equal at
+        # execute and let a discard run over post-preview work (SC-087).
+        wt = self.make_git_worktree()
+        (Path(wt) / os.fsdecode(b"caf\xe9.txt")).write_bytes(b"latin-1 name")
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        self.assertNotIn("indeterminate", obj["evidence"]["git"])
+        self.assertEqual(obj["evidence"]["git"]["untracked"], 2)
+        # ...and the fence still fences: unrelated tracked work written after
+        # the preview refuses the confirmed discard.
+        (Path(wt) / "clean.txt").write_text("work written after the preview")
+        status, err = self.post(obj, preserve_worktree=False,
+                                discard_worktree=True, confirm_shortname="s1")
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        self.assertEqual((Path(wt) / "clean.txt").read_text(),
+                         "work written after the preview")
+        self.assert_nothing_discarded(wt)
+
+    def test_git_command_failure_refuses(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        real = recovery._git_out
+
+        def failing(worktree, *args, **kwargs):
+            if args[0] == "status":
+                raise recovery._GitEvidenceUnavailable("git status: exit 128")
+            return real(worktree, *args, **kwargs)
+
+        self.assert_gap_refuses(
+            wt, mock.patch.object(recovery, "_git_out", failing))
+
+    def test_git_timeout_refuses(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        real = recovery.subprocess.run
+
+        def timing_out(cmd, *args, **kwargs):
+            if cmd[0] == "git" and "ls-files" in cmd:
+                raise subprocess.TimeoutExpired(cmd, 30)
+            return real(cmd, *args, **kwargs)
+
+        self.assert_gap_refuses(
+            wt, mock.patch.object(recovery.subprocess, "run", timing_out))
+
+    def test_unreadable_entry_refuses(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        real = os.lstat
+
+        def denied(path, *args, **kwargs):
+            if str(path).endswith("untracked.txt"):
+                raise PermissionError(13, "permission denied")
+            return real(path, *args, **kwargs)
+
+        self.assert_gap_refuses(
+            wt, mock.patch.object(recovery.os, "lstat", denied))
+
+    def test_corrupt_repository_refuses(self):
+        # No patching at all: a repository whose HEAD does not resolve. Every
+        # observation the fence depends on is unavailable, so recovery refuses
+        # instead of reading the gap as an unchanged worktree.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        (Path(wt) / ".git" / "HEAD").write_text("not-a-ref\n")
+        self.assert_gap_refuses(wt)
+
+    def test_unborn_head_is_complete_evidence_not_a_gap(self):
+        # A repo with no commits is fully observable — nothing to diff
+        # against, nothing that can be unpushed. It must NOT be refused as an
+        # evidence gap, and its untracked side is still fenced.
+        wt = Path(self.tmp.name) / "unborn"
+        wt.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "feat/x", str(wt)],
+                       check=True, capture_output=True)
+        (wt / "untracked.txt").write_text("new")
+        (wt / "tracked.txt").write_text("dirty")
+        self.session_with_worktree(str(wt))
+        obj = self.preview(1)
+        self.assertNotIn("indeterminate", obj["evidence"]["git"])
+        self.assertEqual(obj["evidence"]["git"]["unpushed_commits"], 0)
+        self.assertEqual(obj["evidence"]["git"]["branch"], "feat/x")
+        (wt / "late.txt").write_text("written after the preview")
+        status, err = self.post(obj, preserve_worktree=False,
+                                discard_worktree=True, confirm_shortname="s1")
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        self.assertEqual((wt / "late.txt").read_text(),
+                         "written after the preview")
 
     def test_discard_git_failure_reports_exactly_what_completed(self):
         # clean fails AFTER reset succeeded and the closure committed: the

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -940,6 +940,65 @@ class WorktreeTest(RecoveryCase):
                          "edited after the preview")
         self.assert_nothing_discarded(wt)
 
+    def porcelain(self, wt: str) -> str:
+        return subprocess.run(["git", "-C", wt, "status", "--porcelain"],
+                              capture_output=True, text=True,
+                              check=True).stdout
+
+    def assert_content_edit_refuses(self, wt, rel: str, text: str):
+        """Rewrite `rel` AFTER the preview without touching the path list, then
+        confirm the discard: the fence must refuse before anything runs."""
+        obj = self.preview(1)
+        before = self.porcelain(wt)
+        (Path(wt) / rel).write_text(text)
+        # The regression this pins: the status lines are byte-identical, so a
+        # path-list digest reads fresh while the content changed.
+        self.assertEqual(self.porcelain(wt), before)
+        with mock.patch.object(
+                recovery, "_discard_worktree_files",
+                return_value={"worktree": wt, "discarded": True,
+                              "completed": ["reset", "clean"],
+                              "failed": None}) as disc, \
+                mock.patch.object(recovery,
+                                  "terminate_process_group") as term:
+            status, err = self.post(obj, preserve_worktree=False,
+                                    discard_worktree=True,
+                                    confirm_shortname="s1")
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        disc.assert_not_called()   # no reset, no clean
+        term.assert_not_called()   # no signal
+        self.assertEqual((Path(wt) / rel).read_text(), text)
+        con = self.db()
+        try:  # no closure
+            self.assertEqual(con.execute(
+                "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+            ).fetchone()[0], "reserved")
+        finally:
+            con.close()
+
+    def test_tracked_content_edit_after_preview_refuses_discard(self):
+        # Same already-dirty tracked path, new contents: SC-086 — the operator
+        # confirmed erasing what the preview showed, not this.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.assert_content_edit_refuses(wt, "tracked.txt",
+                                         "rewritten after the preview")
+
+    def test_untracked_content_edit_after_preview_refuses_discard(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.assert_content_edit_refuses(wt, "untracked.txt",
+                                         "rewritten after the preview")
+
+    def test_same_size_content_edit_after_preview_refuses_discard(self):
+        # "dirty" -> "drity": identical length, so a size/mtime-based digest
+        # would miss it. The fence is bound to the bytes.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        self.assert_content_edit_refuses(wt, "tracked.txt", "drity")
+
     def test_equal_count_churn_after_preview_refuses_discard(self):
         # One file cleaned, another dirtied: dirty_tracked/untracked counts
         # are unchanged, but it is not the same work — the digest catches it.

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -10,9 +10,11 @@ module is stdlib-only by design — HTTP-only recovery):
   process, open active archive) / exact idle orphan (pane gone, exact pid
   alive; residual process after session end) / verified live / indeterminate
   (pane unknown, /proc unreadable);
-- observation fencing: changed durable state or expiry → 409
-  recovery_observation_stale; unknown id → 404; replay via Idempotency-Key
-  returns the original response with no second side effect;
+- observation fencing: expiry, changed durable state, a process/pane
+  transition after the preview, or tracked/untracked worktree work appearing
+  after the preview → 409 recovery_observation_stale with NO signal, closure,
+  reset or clean; unknown id → 404; replay via Idempotency-Key returns the
+  original response with no second side effect;
 - action legality: recover refused on verified_live, force refused without
   confirm_force or against non-verified-live classifications;
 - exact process-group signaling against REAL child processes: SIGTERM
@@ -640,20 +642,53 @@ class ExecuteTest(RecoveryCase):
             (sid,)).fetchone()[0], "ended")
         con.close()
 
-    def test_identity_loss_at_execute_signals_nothing_closes_nothing(self):
+    def test_process_exit_after_preview_is_stale_not_indeterminate(self):
+        # The exact process vanishes (exit, or a pid reused by a stranger)
+        # between preview and execute. The durable rows never moved, so the
+        # freshness fence is what must catch it — BEFORE any signal.
         proc, ticks = self.child()
         sid = self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
         with mock.patch.object(recovery, "_pane_present", return_value=False):
             obj = self.preview(1)
-        # The process vanishes between preview and execute (pid reused,
-        # exited): the durable state didn't change, so the observation is
-        # fresh — the signal-time re-verification is the fence.
-        with mock.patch.object(recovery, "_proc_state", return_value="dead"):
+            self.assertEqual(obj["classification"], "exact_idle_orphan")
+            with mock.patch.object(recovery, "_proc_state",
+                                   return_value="dead") as proc_state, \
+                    mock.patch.object(recovery,
+                                      "terminate_process_group") as term:
+                status, err = self.call(
+                    "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                    {"observation_id": obj["observation_id"],
+                     "mode": "recover"})
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        self.assertTrue(proc_state.called)  # the fence re-read /proc
+        term.assert_not_called()            # and refused before signalling
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE session_id=?",
+            (sid,)).fetchone()[0], "occupied")
+        con.close()
+
+    def test_pane_exit_after_preview_is_stale(self):
+        # Pane membership is part of what the operator was shown: a pane that
+        # disappears from the tmux server after the preview re-classifies the
+        # shell, so the old observation may not act.
+        proc, ticks = self.child()
+        sid = self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=True):
+            obj = self.preview(1)
+            self.assertEqual(obj["classification"], "verified_live")
+        with mock.patch.object(recovery, "_pane_present", return_value=False), \
+                mock.patch.object(recovery,
+                                  "terminate_process_group") as term:
             status, err = self.call(
                 "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
-                {"observation_id": obj["observation_id"], "mode": "recover"})
+                {"observation_id": obj["observation_id"], "mode": "force",
+                 "confirm_force": True})
         self.assertEqual(status, 409)
-        self.assertEqual(err["error"]["code"], "recovery_indeterminate")
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        term.assert_not_called()
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "alive")
         con = self.db()
         self.assertEqual(con.execute(
             "SELECT occupancy FROM interface_sessions WHERE session_id=?",
@@ -767,7 +802,9 @@ class WorktreeTest(RecoveryCase):
     def make_git_worktree(self, *, unpushed: bool = False) -> str:
         """A real git repo standing in for the shell worktree, with a bare
         origin so 'unpushed' is exact: one pushed commit, one dirty tracked
-        change, one untracked file (+ one local-only commit when unpushed)."""
+        change, one untracked file (+ one local-only commit when unpushed).
+        `clean.txt` is committed and left clean so a test can dirty it AFTER
+        the preview."""
         origin = Path(self.tmp.name) / "origin.git"
         subprocess.run(["git", "init", "-q", "--bare", str(origin)],
                        check=True, capture_output=True)
@@ -782,6 +819,7 @@ class WorktreeTest(RecoveryCase):
         git("config", "user.name", "t")
         git("remote", "add", "origin", str(origin))
         (wt / "tracked.txt").write_text("v1")
+        (wt / "clean.txt").write_text("c1")
         git("add", ".")
         git("commit", "-qm", "base")
         git("push", "-q", "-u", "origin", "feat/x")
@@ -859,6 +897,63 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
         self.assertFalse((Path(wt) / "untracked.txt").exists())
         self.assertTrue(Path(wt).is_dir())  # worktree itself never deleted
+
+    def assert_nothing_discarded(self, wt: str) -> None:
+        """No reset, no clean, no closure — the previewed state is intact."""
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
+        con = self.db()
+        try:
+            self.assertEqual(con.execute(
+                "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+            ).fetchone()[0], "reserved")
+        finally:
+            con.close()
+
+    def test_untracked_file_after_preview_refuses_discard(self):
+        # New work appears between the preview and the confirmed discard: the
+        # operator confirmed erasing what the preview listed, not this.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        self.assertEqual(obj["evidence"]["git"]["untracked"], 1)
+        (Path(wt) / "late.txt").write_text("work written after the preview")
+        status, err = self.post(obj, preserve_worktree=False,
+                                discard_worktree=True, confirm_shortname="s1")
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        self.assertEqual((Path(wt) / "late.txt").read_text(),
+                         "work written after the preview")
+        self.assert_nothing_discarded(wt)
+
+    def test_tracked_change_after_preview_refuses_discard(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        self.assertEqual(obj["evidence"]["git"]["dirty_tracked"], 1)
+        (Path(wt) / "clean.txt").write_text("edited after the preview")
+        status, err = self.post(obj, preserve_worktree=False,
+                                discard_worktree=True, confirm_shortname="s1")
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        self.assertEqual((Path(wt) / "clean.txt").read_text(),
+                         "edited after the preview")
+        self.assert_nothing_discarded(wt)
+
+    def test_equal_count_churn_after_preview_refuses_discard(self):
+        # One file cleaned, another dirtied: dirty_tracked/untracked counts
+        # are unchanged, but it is not the same work — the digest catches it.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        (Path(wt) / "tracked.txt").write_text("v1")  # back to HEAD: clean
+        (Path(wt) / "clean.txt").write_text("newly dirty")
+        status, err = self.post(obj, preserve_worktree=False,
+                                discard_worktree=True, confirm_shortname="s1")
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        self.assertEqual((Path(wt) / "clean.txt").read_text(), "newly dirty")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
 
     def test_discard_git_failure_reports_exactly_what_completed(self):
         # clean fails AFTER reset succeeded and the closure committed: the

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -1221,7 +1221,17 @@ class WorktreeTest(RecoveryCase):
             obj = self.preview(1)
             self.assertIn("indeterminate", obj["evidence"]["git"])
             rows = {r["key"]: r["value"] for r in obj["evidence_projection"]}
-            self.assertIn("could not be observed completely", rows["worktree"])
+            # WHAT IT SAYS, not just that it says something (SC-107). The
+            # projection is canonical — browser and CLI render it verbatim —
+            # and it used to promise "recovery refused until it can be", which
+            # the two-tier gate made false. An operator who believes recovery
+            # is impossible does not attempt it, so a stale sentence strands
+            # the shell just as effectively as a refusing code path.
+            worktree = rows["worktree"]
+            self.assertIn("could not be observed completely", worktree)
+            self.assertIn("discard declined", worktree)
+            self.assertIn("free the shell", worktree)
+            self.assertNotIn("recovery refused", worktree)
             with mock.patch.object(recovery,
                                    "_discard_worktree_files") as disc, \
                     mock.patch.object(recovery,
@@ -1232,6 +1242,11 @@ class WorktreeTest(RecoveryCase):
                 self.assertEqual(status, 409, err)
                 self.assertEqual(err["error"]["code"],
                                  "recovery_observation_stale")
+                # the refusal names the escape route that actually works,
+                # rather than leaving the operator to guess there is one
+                message = err["error"]["message"]
+                self.assertIn("DISCARD is refused", message)
+                self.assertIn("without discard_worktree", message)
                 self.assert_nothing_discarded(wt)   # not even a closure
                 # ...and now the core path, on the same broken worktree.
                 # (Fresh idempotency key — a different body under the old one

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -1692,6 +1692,72 @@ class WorktreeTest(RecoveryCase):
         # a surviving DIRECTORY is reported, but every consented FILE is gone
         self.assertTrue(result["discarded"], result)
 
+    def test_nothing_outside_the_plan_survives_adversarial_shapes(self):
+        """The boundary claim, tested the way the closure claim is: build every
+        shape that could let the discard reach outside the enumerated set, run
+        it, and only then say the boundary holds.
+
+        'Nothing outside the enumerated set is exposed' was stated three times
+        before it was true — ignored descendants of a file/directory conflict
+        were exposed the whole time (SC-103). The claim now has a test that
+        would go red if any of these leaked.
+        """
+        wt = self.make_git_worktree()
+        outside = Path(self.tmp.name) / "outside-the-worktree"
+        outside.mkdir()
+        (outside / "victim.txt").write_text("outside the worktree entirely")
+
+        def git(*args):
+            subprocess.run(["git", "-C", wt, *args], check=True,
+                           capture_output=True)
+
+        (Path(wt) / ".gitignore").write_text("*.pyc\n")
+        (Path(wt) / "node").write_text("committed")
+        (Path(wt) / "steady.txt").write_text("clean and tracked")
+        git("add", ".gitignore", "node", "steady.txt")
+        git("commit", "-qm", "boundary base")
+
+        # (a) tracked FILE replaced by a directory hiding an ignored descendant
+        #     several levels down — the bulk restore's own footprint (SC-103).
+        (Path(wt) / "node").unlink()
+        (Path(wt) / "node" / "deep").mkdir(parents=True)
+        (Path(wt) / "node" / "deep" / "keep.pyc").write_text("ignored deep")
+        # (b) an ignored file inside a directory that IS in the delete set
+        (Path(wt) / "untdir").mkdir()
+        (Path(wt) / "untdir" / "u.txt").write_text("consented")
+        (Path(wt) / "untdir" / "skip.pyc").write_text("ignored, inside it")
+        # (c) somebody else's repository inside that same directory
+        nested = Path(wt) / "untdir" / "nested"
+        nested.mkdir()
+        subprocess.run(["git", "init", "-q", str(nested)], check=True,
+                       capture_output=True)
+        (nested / "theirs.txt").write_text("another repo's work")
+        # (d) an enumerated untracked symlink AIMED out of the worktree: the
+        #     link goes, never the thing it points at
+        (Path(wt) / "ulink_out").symlink_to(outside / "victim.txt")
+        # (e) an ignored file at the top, and a clean tracked file — neither is
+        #     enumerated, so neither may move
+        (Path(wt) / "top.pyc").write_text("ignored at the root")
+
+        result = recovery._discard_worktree_files(wt, self.plan(wt))
+        self.assertIsNone(result["failed"], result)
+        for path, text in (
+                (outside / "victim.txt", "outside the worktree entirely"),
+                (Path(wt) / "node" / "deep" / "keep.pyc", "ignored deep"),
+                (Path(wt) / "untdir" / "skip.pyc", "ignored, inside it"),
+                (nested / "theirs.txt", "another repo's work"),
+                (Path(wt) / "top.pyc", "ignored at the root"),
+                (Path(wt) / "steady.txt", "clean and tracked")):
+            self.assertEqual(path.read_text(), text,
+                             f"{path} is outside the plan and was touched")
+        # ...while everything that WAS enumerated went, and the report says so
+        self.assertFalse((Path(wt) / "untdir" / "u.txt").exists())
+        self.assertFalse((Path(wt) / "untracked.txt").exists())
+        self.assertFalse((Path(wt) / "ulink_out").exists())
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
+        self.assertIn("node", result["kept"])       # refused, not exceeded
+        self.assertFalse(result["discarded"])
+
     def df_worktree(self, obstruction: str, *, ignored: bool) -> str:
         """HEAD tracks the FILE `node`; the worktree has replaced it with a
         DIRECTORY holding `obstruction`. `git diff HEAD` names `node`, so the

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -1325,6 +1325,31 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual((wt / "late.txt").read_text(),
                          "written after the preview")
 
+    def test_unborn_head_discard_actually_discards(self):
+        # ...and having let it past the unpushed gate, the discard must DO
+        # something: `reset --hard HEAD` is fatal where nothing has ever been
+        # committed, so the reset failed and the clean never ran — an
+        # authorised discard that silently left everything in place.
+        wt = Path(self.tmp.name) / "unborn-discard"
+        wt.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "feat/x", str(wt)],
+                       check=True, capture_output=True)
+        (wt / "staged.txt").write_text("staged")
+        subprocess.run(["git", "-C", str(wt), "add", "staged.txt"],
+                       check=True, capture_output=True)
+        (wt / "untracked.txt").write_text("new")
+        self.session_with_worktree(str(wt))
+        obj = self.preview(1)
+        status, result = self.post(obj, preserve_worktree=False,
+                                   discard_worktree=True,
+                                   confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertTrue(result["worktree"]["discarded"], result["worktree"])
+        self.assertEqual(result["worktree"]["completed"], ["reset", "clean"])
+        self.assertFalse((wt / "staged.txt").exists())
+        self.assertFalse((wt / "untracked.txt").exists())
+        self.assertTrue(wt.is_dir())   # the worktree itself is never deleted
+
     # -- freshness must hold at the DESTRUCTIVE COMMIT, not just at entry
     #    (SC-091) -----------------------------------------------------------
 
@@ -1378,7 +1403,7 @@ class WorktreeTest(RecoveryCase):
         # earlier check has already passed. The discard must not run on top of
         # it. Injecting from terminate_process_group reproduces exactly that.
         wt = self.make_git_worktree()
-        self.orphan_with_worktree(wt)
+        proc, _ticks = self.orphan_with_worktree(wt)
         late = Path(wt) / "late_during_shutdown.txt"
         real = recovery.terminate_process_group
 
@@ -1404,6 +1429,10 @@ class WorktreeTest(RecoveryCase):
         self.assertTrue((Path(wt) / "untracked.txt").exists())
         # ...and the refusal is honest about what it could NOT unwind: the
         # signal was sent and the durable closure committed before this point.
+        # It names the process it signalled — this half of the wording is only
+        # truthful because the no-signal half says the opposite (below).
+        self.assertIn(f"The exact process (PID {proc.pid}) was signalled",
+                      err["error"]["message"])
         details = err["error"]["details"]
         self.assertFalse(details["discarded"])
         self.assertTrue(details["closed"])
@@ -1433,6 +1462,128 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual(recovery._proc_state(proc.pid, ticks), "dead")
         self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
         self.assertFalse((Path(wt) / "untracked.txt").exists())
+
+    # -- the observation itself must not be TORN (SC-092) -------------------
+
+    def test_mode_change_during_the_gates_own_read_refuses_discard(self):
+        # SC-092: the observation was torn. _path_identity lstat'ed a path and
+        # THEN opened and read it, so a chmod landing in between produced an
+        # identity that was never true at any instant — the old mode against
+        # the current bytes. That identity compared EQUAL to the preview, so
+        # the last gate passed and reset/clean erased the change while the API
+        # returned 200. Injecting from os.open reproduces exactly that window;
+        # each observation is now self-consistent, so it refuses instead.
+        wt = self.make_git_worktree()
+        tracked = Path(wt) / "tracked.txt"
+        os.chmod(tracked, 0o640)
+        self.orphan_with_worktree(wt)
+        # Armed only once the signal has been sent, so the injection fires
+        # inside the LAST gate's read — the one window where a torn
+        # observation still ends in a discard.
+        armed: list[bool] = []
+        fired: list[bool] = []
+        real_term = recovery.terminate_process_group
+        real_open = recovery.os.open
+
+        def arming(pid, start_ticks, grace_s):
+            result = real_term(pid, start_ticks, grace_s)
+            armed.append(True)
+            return result
+
+        def chmod_inside_the_read(path, *args, **kwargs):
+            fd = real_open(path, *args, **kwargs)
+            if armed and not fired and str(path) == str(tracked):
+                os.chmod(tracked, 0o600)   # after the lstat, before the read
+                fired.append(True)
+            return fd
+
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+            self.assertEqual(obj["classification"], "exact_idle_orphan")
+            with mock.patch.object(recovery, "terminate_process_group",
+                                   arming), \
+                    mock.patch.object(recovery.os, "open",
+                                      chmod_inside_the_read):
+                status, err = self.post(obj, preserve_worktree=False,
+                                        discard_worktree=True,
+                                        confirm_shortname="s1")
+        self.assertTrue(fired, "the injection never ran — repro is stale")
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        # The tightened mode, the dirty content and the untracked file all
+        # survive: nothing was reset, nothing was cleaned.
+        self.assertEqual(self.mode_of(tracked), 0o600)
+        self.assertEqual(tracked.read_text(), "dirty")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
+
+    def test_worktree_that_will_not_hold_still_refuses(self):
+        # The other half of stability: when the tree keeps moving under the
+        # read, there is no true answer to give. Re-reading forever is not an
+        # option and approximating is the SC-092 defect — so it becomes a gap,
+        # and a gap refuses (SC-087) with nothing signalled, closed or removed.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        tracked = Path(wt) / "tracked.txt"
+        real_open = recovery.os.open
+        modes = [0o640, 0o600]
+
+        def never_settles(path, *args, **kwargs):
+            fd = real_open(path, *args, **kwargs)
+            if str(path) == str(tracked):
+                modes.append(modes.pop(0))
+                os.chmod(tracked, modes[0])
+            return fd
+
+        self.assert_gap_refuses(
+            wt, mock.patch.object(recovery.os, "open", never_settles))
+
+    # -- a refusal names what it actually did, in BOTH directions -----------
+
+    def test_no_signal_refusal_does_not_claim_a_signal(self):
+        # The last gate's refusal used to state that the exact process had been
+        # signalled — inherited boilerplate. A stale durable lock has no
+        # process to signal (details signaled=null), so that sentence was
+        # false: reporting a signal that never happened is the same defect as
+        # implying a clean no-op after having closed. With nothing to signal,
+        # the closure is the only thing between the two gates, so that is
+        # where the late write is injected.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        self.assertEqual(obj["classification"], "stale_durable_lock")
+        late = Path(wt) / "late_after_closure.txt"
+        real = recovery._close_durable_state
+
+        def writing(con, shell_id, evidence, end_reason):
+            changed = real(con, shell_id, evidence, end_reason)
+            late.write_text("written after the closure committed")
+            return changed
+
+        with mock.patch.object(recovery, "_close_durable_state", writing), \
+                mock.patch.object(recovery,
+                                  "terminate_process_group") as term:
+            status, err = self.post(obj, preserve_worktree=False,
+                                    discard_worktree=True,
+                                    confirm_shortname="s1")
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        term.assert_not_called()
+        message = err["error"]["message"]
+        self.assertIn("NO process was signalled", message)
+        self.assertNotIn("The exact process", message)
+        self.assertIsNone(err["error"]["details"]["signaled"])
+        # ...and what it DOES claim is true: the closure committed, and the
+        # files — the late write included — are untouched.
+        self.assertTrue(err["error"]["details"]["closed"])
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+        ).fetchone()[0], "ended")
+        con.close()
+        self.assertEqual(late.read_text(), "written after the closure "
+                                           "committed")
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
 
     def test_discard_git_failure_reports_exactly_what_completed(self):
         # clean fails AFTER reset succeeded and the closure committed: the


### PR DESCRIPTION
## Sprint 31 conformance fix — F1 (Major, SC-082 / flag #85 / spec 30 req 24)

Conformance doc #32 finding **F1**: the recovery freshness fence
(`interface_recovery._fingerprint` / `_load_observation`) hashed only
durable DB rows and omitted the pane PID/tmux and git working-tree
evidence that `preview` returned to the operator. A confirmed discard
could therefore run `git reset --hard` + `git clean -fd` on local work
created **after** the preview, without the spec-required
`409 recovery_observation_stale` round trip.

### Fix
- **Re-gather immediately before execute.** `execute` now re-reads the
  full evidence picture (a pure read) and fingerprints it against the
  preview *before* any signal, closure, or file removal.
- **Fingerprint the volatile safety facts the operator saw:** exact
  process identity + liveness (`pane_pid` / `pane_start_ticks` /
  `pane_present` / `pid_state` / `pgid`), tmux membership, and the
  worktree's `dirty_tracked` / `untracked` / `unpushed_commits`.
- **`change_digest`** over `git status --porcelain` catches equal-count
  churn (one file cleaned, another dirtied) that count-only comparison
  would miss. Paths stay out of the stored payload.
- Any difference → `409 recovery_observation_stale` before a signal is
  sent, a row closed, or a file touched.

### Preserved (ratified contracts)
Exact force-confirm, independent shortname discard-confirm, unpushed-commit
refusal, and the signal-time `/proc` re-verification all unchanged.

### Negative tests (each asserts NO signal / closure / reset / clean)
- process exit / PID reuse after preview → 409 stale (was accepting
  `recovery_indeterminate`)
- pane exit after preview → 409 stale
- tracked change / untracked file / equal-count churn after preview →
  409 stale, worktree intact

`tests/test_interface_recovery.py`: 54 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)