### PR TITLE
fix(interface): validate exact route shapes

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2100,6 +2100,19 @@ def _path_id(path: str, segment: int = -1) -> int:
         raise _BadPathId(f"invalid path identifier: {path!r}")
 
 
+def _route_shape(path: str, *segments: str | None) -> bool:
+    """Match one exact route shape; ``None`` is a single-segment wildcard."""
+    parts = path.split("/")
+    return (
+        len(parts) == len(segments) + 1
+        and parts[0] == ""
+        and all(
+            expected is None or actual == expected
+            for actual, expected in zip(parts[1:], segments)
+        )
+    )
+
+
 def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
     from urllib.parse import parse_qs, urlparse
     headers = _parse_headers(headers_raw)
@@ -2150,20 +2163,25 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
     try:
         if p == "/api/interface/shells" and method == "GET":
             return _list_shells()
-        if p.startswith("/api/interface/shells/") and p.endswith("/recovery"):
+        if _route_shape(
+                p, "api", "interface", "shells", None, "recovery"):
             if method == "GET":
                 return _get_recovery(_path_id(p, -2))
             if method == "POST":
                 return _post_recovery(actor, headers, data, _path_id(p, -2))
         if p == "/api/interface/sessions" and method == "POST":
             return _create_session(actor, headers, data)
-        if p.startswith("/api/interface/sessions/") and method == "GET":
+        if _route_shape(
+                p, "api", "interface", "sessions", None) \
+                and method == "GET":
             return _get_session(_path_id(p))
         if p == "/api/interface/stream-tickets" and method == "POST":
             return _mint_ticket(actor, headers, data)
         if p == "/api/interface/writer-leases" and method == "POST":
             return _acquire_lease(actor, headers, data)
-        if p.startswith("/api/interface/writer-leases/") and method == "DELETE":
+        if _route_shape(
+                p, "api", "interface", "writer-leases", None) \
+                and method == "DELETE":
             return _release_lease(actor, headers, data, _path_id(p))
         if p == "/api/interface/clean-certifications" and method == "POST":
             return _certify_clean(actor, headers, data)
@@ -2177,19 +2195,24 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
             return _binding_status(actor, query)
         if p == "/api/interface/sprint-alerts" and method == "GET":
             return _sprint_alerts(actor, query)
-        if p.startswith("/api/interface/sprint-alerts/") \
-                and p.endswith("/acknowledge") and method == "POST":
+        if _route_shape(
+                p, "api", "interface", "sprint-alerts", None,
+                "acknowledge") and method == "POST":
             return _acknowledge_alert(
                 actor, headers, data, _path_id(p, -2))
-        if p.startswith("/api/interface/sprint-bindings/") \
-                and p.endswith("/retry") and method == "POST":
+        if _route_shape(
+                p, "api", "interface", "sprint-bindings", None,
+                "retry") and method == "POST":
             return _retry_binding(actor, headers, data, _path_id(p, -2))
-        if p.startswith("/api/interface/sprint-bindings/") \
+        if _route_shape(
+                p, "api", "interface", "sprint-bindings", None) \
                 and method == "DELETE":
             return _release_binding(actor, headers, data, _path_id(p))
         if p == "/api/planner-action-receipts" and method == "POST":
             return _begin_receipt(actor, headers, data)
-        if p.startswith("/api/planner-action-receipts/") and method == "PATCH":
+        if _route_shape(
+                p, "api", "planner-action-receipts", None) \
+                and method == "PATCH":
             return _update_receipt(actor, headers, data, _path_id(p))
         return _err(404, "no_such_route", f"no route: {method} {p}")
     except _BadPathId as exc:

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -817,6 +817,27 @@ class InterfaceApiTest(unittest.TestCase):
              "lease_token": token2})
         self.assertEqual(status, 201)
         self.assertIn("ticket", body)
+
+    def test_extra_segment_writer_release_does_not_revoke_lease(self):
+        sid = self.occupy()
+        status, _, lease = self.acquire_lease(sid)
+        self.assertEqual(status, 201, lease)
+        lease_id = lease["lease_id"]
+
+        status, _, body = self.call(
+            "DELETE",
+            f"/api/interface/writer-leases/999/{lease_id}",
+            (OP, "Idempotency-Key: malformed-release"),
+            {"lease_token": lease["lease_token"]})
+
+        self.assertEqual(status, 404, body)
+        self.assertEqual(body["error"]["code"], "no_such_route")
+        with contextlib.closing(sqlite3.connect(self.db_path)) as con:
+            row = con.execute(
+                "SELECT revoked_at, revoke_reason "
+                "FROM interface_writer_leases WHERE lease_id=?",
+                (lease_id,)).fetchone()
+        self.assertEqual(row, (None, None))
         # Viewer ticket needs no lease.
         status, _, body = self.call(
             "POST", "/api/interface/stream-tickets",
@@ -1508,6 +1529,15 @@ class InterfaceApiTest(unittest.TestCase):
                                     (OP,))
         self.assertEqual(status, 422)
         self.assertEqual(body["error"]["code"], "invalid_path_id")
+
+    def test_extra_segment_session_read_is_404(self):
+        status, _, created = self.create_session()
+        self.assertEqual(status, 201, created)
+        status, _, body = self.call(
+            "GET", f"/api/interface/sessions/999/{created['session_id']}",
+            (OP,))
+        self.assertEqual(status, 404, body)
+        self.assertEqual(body["error"]["code"], "no_such_route")
 
     def test_unknown_route_still_404(self):
         status, _, body = self.call("GET", "/api/interface/bogus", (OP,))

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -442,6 +442,30 @@ class ProcessGroupSignalTest(unittest.TestCase):
 
 class ExecuteTest(RecoveryCase):
 
+    def test_extra_segment_recovery_leaves_session_unchanged(self):
+        sid = self.make_session(
+            1, occupancy="reserved", lifecycle="starting",
+            pane_pid=None, pane_ticks=None, pane_id=None)
+        observation = self.preview(1)
+
+        status, body = self.call(
+            "POST", "/api/interface/shells/999/1/recovery", (OP, IDEM),
+            {"observation_id": observation["observation_id"],
+             "mode": "recover"})
+
+        self.assertEqual(status, 404, body)
+        self.assertEqual(body["error"]["code"], "no_such_route")
+        with contextlib.closing(self.db()) as con:
+            session = con.execute(
+                "SELECT occupancy, lifecycle, ended_at, end_reason "
+                "FROM interface_sessions WHERE session_id=?",
+                (sid,)).fetchone()
+            generation = con.execute(
+                "SELECT ended_at FROM interface_generations "
+                "WHERE shell_id=1 AND generation=1").fetchone()
+        self.assertEqual(session, ("reserved", "starting", None, None))
+        self.assertEqual(generation, (None,))
+
     def test_recover_closes_everything_atomically(self):
         sid = self.make_session(1, occupancy="reserved", lifecycle="starting",
                                 pane_pid=None, pane_ticks=None, pane_id=None,

--- a/tests/test_interface_sprint_ops.py
+++ b/tests/test_interface_sprint_ops.py
@@ -347,6 +347,30 @@ class SprintOpsRoutesTest(unittest.TestCase):
         self.assertIn("meaning", body["alerts"][0])
         self.assertIn("next_action", body["alerts"][0])
 
+    def test_extra_segment_alert_acknowledgement_leaves_alert_open(self):
+        con = sqlite3.connect(self.db_path)
+        interface_broker._alert(
+            con, severity="warning", reason="turn_failure",
+            session_id=self.sid)
+        alert_id = con.execute(
+            "SELECT alert_id FROM planner_alerts WHERE session_id=?",
+            (self.sid,)).fetchone()[0]
+        con.commit()
+        con.close()
+
+        status, body = self.call(
+            "POST",
+            f"/api/interface/sprint-alerts/999/{alert_id}/acknowledge",
+            (OP, "Idempotency-Key: malformed-ack"), {})
+
+        self.assertEqual(status, 404, body)
+        self.assertEqual(body["error"]["code"], "no_such_route")
+        self.assertEqual(
+            self.q(
+                "SELECT acknowledged_at, acknowledged_by, resolved_at "
+                "FROM planner_alerts WHERE alert_id=?", (alert_id,)),
+            (None, None, None))
+
     def test_planner_alert_query_defaults_to_current_generation(self):
         con = sqlite3.connect(self.db_path)
         con.execute(
@@ -411,6 +435,60 @@ class SprintOpsRoutesTest(unittest.TestCase):
             "SELECT 1 FROM planner_alerts WHERE resolved_at IS NULL"))
         # The coordinator was signalled — the drain re-gates from live state.
         self.assertIn(binding_id, self.coordinator.bindings)
+
+    def test_extra_segment_binding_retry_leaves_parked_work_unchanged(self):
+        _, body = self.arm()
+        binding_id = body["binding_id"]
+        mid = self.queue_message()
+        batch = self.park_batch(binding_id, mid)
+        notifications_before = list(self.coordinator.bindings)
+
+        status, body = self.call(
+            "POST",
+            f"/api/interface/sprint-bindings/999/{binding_id}/retry",
+            (OP, "Idempotency-Key: malformed-retry"),
+            {"outcome": "not_delivered"})
+
+        self.assertEqual(status, 404, body)
+        self.assertEqual(body["error"]["code"], "no_such_route")
+        self.assertEqual(
+            self.q(
+                "SELECT state, completed_at FROM planner_wake_batches "
+                "WHERE batch_id=?", (batch,)),
+            ("delivery_unknown", None))
+        self.assertEqual(
+            self.q(
+                "SELECT state, batch_id FROM planner_wake_items "
+                "WHERE message_id=?", (mid,)),
+            ("batched", batch))
+        self.assertEqual(
+            self.q(
+                "SELECT delivery FROM interface_input_state "
+                "WHERE session_id=?", (self.sid,))[0],
+            "delivery_unknown")
+        self.assertIsNotNone(self.q(
+            "SELECT 1 FROM planner_alerts WHERE binding_id=? "
+            "AND resolved_at IS NULL", (binding_id,)))
+        self.assertEqual(self.coordinator.bindings, notifications_before)
+
+    def test_extra_segment_binding_release_leaves_binding_armed(self):
+        _, body = self.arm()
+        binding_id = body["binding_id"]
+
+        status, body = self.call(
+            "DELETE",
+            f"/api/interface/sprint-bindings/999/{binding_id}",
+            (OP, "Idempotency-Key: malformed-binding-release"),
+            {"reason": "must not release"})
+
+        self.assertEqual(status, 404, body)
+        self.assertEqual(body["error"]["code"], "no_such_route")
+        self.assertEqual(
+            self.q(
+                "SELECT released_at, release_reason "
+                "FROM sprint_planner_bindings WHERE binding_id=?",
+                (binding_id,)),
+            (None, None))
 
     def test_retry_presend_stalled_resignals(self):
         _, body = self.arm()
@@ -544,6 +622,29 @@ class SprintOpsRoutesTest(unittest.TestCase):
                                 "WHERE batch_id=?", (batch,))[0], "complete")
         self.assertEqual(self.q("SELECT COUNT(*) FROM planner_wake_items "
                                 "WHERE state='queued'")[0], 1)
+
+    def test_extra_segment_receipt_patch_leaves_intent_unchanged(self):
+        status, body = self.call(
+            "POST", "/api/planner-action-receipts",
+            (SHELL1, "Idempotency-Key: malformed-receipt-begin"),
+            {"operation": "merge", "target": "#42"})
+        self.assertEqual(status, 201, body)
+        receipt_id = body["receipt_id"]
+
+        status, body = self.call(
+            "PATCH",
+            f"/api/planner-action-receipts/999/{receipt_id}",
+            (SHELL1, "Idempotency-Key: malformed-receipt-patch"),
+            {"state": "complete"})
+
+        self.assertEqual(status, 404, body)
+        self.assertEqual(body["error"]["code"], "no_such_route")
+        self.assertEqual(
+            self.q(
+                "SELECT state, completed_at, reconciled_at "
+                "FROM planner_action_receipts WHERE receipt_id=?",
+                (receipt_id,)),
+            ("intent", None, None))
 
 
 class SprintCloseTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- require exact segment counts and literals before parsing route identifiers
- reject malformed extra-segment paths with `404 no_such_route` while preserving `422 invalid_path_id` for legal shapes
- cover one read path and every parameterized mutation family, asserting the underlying resource remains unchanged

## Verification

- `.venv/bin/pytest -q tests/test_interface_api.py tests/test_interface_recovery.py tests/test_interface_sprint_ops.py` — 138 passed
- `./sc lint .super-coder/api/interface_routes.py tests/test_interface_api.py tests/test_interface_recovery.py tests/test_interface_sprint_ops.py` — passed
- `git diff --check` — passed

Refs Sprint 31 conformance doc #32 finding F3 / SC-083.