### PR TITLE
fix(update): make live-state refusal atomic and consentable

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -217,14 +217,19 @@ def require_current_schema(db_path=DB_PATH,
     if not missing:
         return
     names = ", ".join(missing)
+    ref_path = REPO_ROOT / ".sc-state" / "engine.ref"
+    ref = ref_path.read_text().strip()[:12] if ref_path.exists() else "un-pinned"
     sys.exit(
         "server: installed engine/DB schema mismatch — "
-        f"{Path(db_path).name} is missing {len(missing)} required "
+        f"installed engine {ref} requires migrations that "
+        f"{Path(db_path).name} has not applied; its ledger is missing "
+        f"{len(missing)} required "
         f"migration(s): {names}\n"
         "Refusing startup before first DB use; continuing would run new code "
         "against an old schema.\n"
-        "Recovery: run `./sc rollback` to restore the matched engine+DB pair, "
-        "then drain/reconcile live Interface state and retry `./sc update`.")
+        "Recovery: run `./sc rollback --engine-only` to restore the previous "
+        "engine/pin while preserving this unchanged DB, then drain/reconcile "
+        "live Interface state and retry `./sc update`.")
 
 
 def rows(cur) -> list[dict]:

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -187,6 +187,46 @@ def db():
     return db_driver.connect(DB_PATH)
 
 
+def require_current_schema(db_path=DB_PATH,
+                           migrations_dir=ENGINE / "migrations") -> None:
+    """Fail loudly before new engine code touches an older DB schema.
+
+    A pre-fix updater can materialize the target engine and pin before its
+    live-state refusal fires.  The newly installed server must therefore
+    recognize that half-applied floor from the migration ledger before key
+    provisioning, Interface reconciliation, or request handling reaches a
+    column the old DB does not have.
+    """
+    expected = {path.name for path in migrations_dir.glob("*.sql")}
+    con = db_driver.connect(db_path)
+    try:
+        table = con.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='schema_migrations'"
+        ).fetchone()
+        applied = set() if table is None else {
+            row[0] for row in con.execute(
+                "SELECT filename FROM schema_migrations")
+        }
+    except db_driver.OperationalError:
+        applied = set()
+    finally:
+        con.close()
+
+    missing = sorted(expected - applied)
+    if not missing:
+        return
+    names = ", ".join(missing)
+    sys.exit(
+        "server: installed engine/DB schema mismatch — "
+        f"{Path(db_path).name} is missing {len(missing)} required "
+        f"migration(s): {names}\n"
+        "Refusing startup before first DB use; continuing would run new code "
+        "against an old schema.\n"
+        "Recovery: run `./sc rollback` to restore the matched engine+DB pair, "
+        "then drain/reconcile live Interface state and retry `./sc update`.")
+
+
 def rows(cur) -> list[dict]:
     return [dict(r) for r in cur.fetchall()]
 
@@ -2726,6 +2766,7 @@ def main(argv):
         port = ports_mod.resolve().get("port", 8800)
     if not DB_PATH.exists():
         sys.exit(f"server: no DB at {DB_PATH} — run `./sc rebuild` first.")
+    require_current_schema(DB_PATH)
     # Provision API keys at startup: every shell needs an api_key to reach this
     # server's token-scoped routes, but shells created before migration 0027 (or
     # on a fork that never ran the one-off backfill) come up NULL-keyed and would

--- a/.super-coder/scripts/interface_reconcile.py
+++ b/.super-coder/scripts/interface_reconcile.py
@@ -29,6 +29,7 @@ DB (no Interface tables → no reasons).
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import db_driver
@@ -40,6 +41,175 @@ def _has_table(con, name: str) -> bool:
     return con.execute(
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
     ).fetchone() is not None
+
+
+@dataclass(frozen=True)
+class LiveLossManifest:
+    """Exact durable rows an operator-approved update will terminalize."""
+
+    generations: tuple[tuple[int, int], ...] = ()
+    sessions: tuple[int, ...] = ()
+    archives: tuple[int, ...] = ()
+    archive_links: tuple[tuple[int, int], ...] = ()
+    writer_leases: tuple[int, ...] = ()
+    input_states: tuple[int, ...] = ()
+    orphan_inputs: tuple[int, ...] = ()
+    bindings: tuple[int, ...] = ()
+    batches: tuple[int, ...] = ()
+    items: tuple[int, ...] = ()
+    alerts: tuple[int, ...] = ()
+
+    def empty(self) -> bool:
+        return not any((
+            self.generations, self.sessions, self.archives,
+            self.archive_links, self.writer_leases, self.input_states,
+            self.orphan_inputs, self.bindings, self.batches, self.items,
+            self.alerts,
+        ))
+
+    def loss_lines(self) -> list[str]:
+        rows = [
+            ("Interface generation(s)",
+             ", ".join(f"{shell}/{generation}"
+                       for shell, generation in self.generations)),
+            ("Interface session ID(s)", _csv(self.sessions)),
+            ("open archive ID(s)", _csv(self.archives)),
+            ("active archive link(s)",
+             ", ".join(f"shell {shell}→archive {archive}"
+                       for shell, archive in self.archive_links)),
+            ("writer lease ID(s)", _csv(self.writer_leases)),
+            ("input-state session ID(s)", _csv(self.input_states)),
+            ("orphan input-state session ID(s)", _csv(self.orphan_inputs)),
+            ("sprint binding ID(s)", _csv(self.bindings)),
+            ("wake batch ID(s)", _csv(self.batches)),
+            ("wake item ID(s)", _csv(self.items)),
+            ("open planner alert ID(s)", _csv(self.alerts)),
+        ]
+        return [f"{label}: {values}" for label, values in rows if values]
+
+
+class LiveStateChanged(RuntimeError):
+    """The consented loss set changed before the discard write lock."""
+
+
+def _csv(values) -> str:
+    return ", ".join(str(value) for value in values)
+
+
+def _ids(con, query: str, params=()) -> tuple[int, ...]:
+    return tuple(row[0] for row in con.execute(query, params).fetchall())
+
+
+def _live_loss_manifest(con) -> LiveLossManifest:
+    if not _has_table(con, "interface_sessions"):
+        return LiveLossManifest()
+
+    active_session = interface_state.active_session_sql("s")
+    sessions = _ids(
+        con,
+        "SELECT s.session_id FROM interface_sessions s "
+        f"WHERE {active_session} ORDER BY s.session_id",
+    )
+    bindings = _ids(
+        con,
+        "SELECT binding_id FROM sprint_planner_bindings "
+        "WHERE released_at IS NULL ORDER BY binding_id",
+    )
+
+    session_filter = ",".join("?" for _ in sessions)
+    binding_filter = ",".join("?" for _ in bindings)
+    archives = ()
+    archive_links = ()
+    writer_leases = ()
+    input_states = ()
+    if sessions:
+        archives = _ids(
+            con,
+            "SELECT DISTINCT s.archive_id FROM interface_sessions s "
+            "JOIN shell_memory_archives a ON a.archive_id=s.archive_id "
+            f"WHERE s.session_id IN ({session_filter}) "
+            "AND a.ended_at IS NULL ORDER BY s.archive_id",
+            sessions,
+        )
+        archive_links = tuple(tuple(row) for row in con.execute(
+            "SELECT s.shell_id, s.archive_id FROM interface_sessions s "
+            "JOIN shells sh ON sh.shell_id=s.shell_id "
+            f"WHERE s.session_id IN ({session_filter}) "
+            "AND sh.active_archive_id=s.archive_id "
+            "ORDER BY s.shell_id, s.archive_id",
+            sessions,
+        ).fetchall())
+        writer_leases = _ids(
+            con,
+            "SELECT lease_id FROM interface_writer_leases "
+            f"WHERE session_id IN ({session_filter}) AND revoked_at IS NULL "
+            "ORDER BY lease_id",
+            sessions,
+        )
+        input_states = _ids(
+            con,
+            "SELECT session_id FROM interface_input_state "
+            f"WHERE session_id IN ({session_filter}) ORDER BY session_id",
+            sessions,
+        )
+
+    alert_clauses = []
+    alert_params = []
+    if sessions:
+        alert_clauses.append(f"session_id IN ({session_filter})")
+        alert_params.extend(sessions)
+    if bindings:
+        alert_clauses.append(f"binding_id IN ({binding_filter})")
+        alert_params.extend(bindings)
+    alerts = ()
+    if alert_clauses:
+        alerts = _ids(
+            con,
+            "SELECT alert_id FROM planner_alerts WHERE resolved_at IS NULL "
+            f"AND ({' OR '.join(alert_clauses)}) ORDER BY alert_id",
+            alert_params,
+        )
+
+    return LiveLossManifest(
+        generations=tuple(tuple(row) for row in con.execute(
+            "SELECT shell_id, generation FROM interface_generations "
+            "WHERE ended_at IS NULL ORDER BY shell_id, generation"
+        ).fetchall()),
+        sessions=sessions,
+        archives=archives,
+        archive_links=archive_links,
+        writer_leases=writer_leases,
+        input_states=input_states,
+        orphan_inputs=_ids(
+            con,
+            "SELECT i.session_id FROM interface_input_state i "
+            "WHERE NOT EXISTS (SELECT 1 FROM interface_sessions s "
+            "WHERE s.session_id=i.session_id) ORDER BY i.session_id",
+        ),
+        bindings=bindings,
+        batches=_ids(
+            con,
+            "SELECT batch_id FROM planner_wake_batches "
+            "WHERE state <> 'complete' ORDER BY batch_id",
+        ),
+        items=_ids(
+            con,
+            "SELECT item_id FROM planner_wake_items "
+            "WHERE state NOT IN ('done','cancelled') ORDER BY item_id",
+        ),
+        alerts=alerts,
+    )
+
+
+def live_loss_manifest(db_path) -> LiveLossManifest:
+    """Read the exact loss set shown before destructive update consent."""
+    if not Path(str(db_path)).exists():
+        return LiveLossManifest()
+    con = db_driver.connect(str(db_path))
+    try:
+        return _live_loss_manifest(con)
+    finally:
+        con.close()
 
 
 def _alert(con, **kw) -> None:
@@ -235,14 +405,16 @@ def live_refusal_reasons(db_path) -> list[str]:
         con.close()
 
 
-def discard_live_state(db_path) -> dict[str, int]:
-    """Atomically abandon every durable Interface actor before an update.
+def discard_live_state(
+        db_path, expected: LiveLossManifest) -> dict[str, int]:
+    """Atomically abandon exactly the operator-consented Interface actors.
 
     This is the deliberately destructive, operator-consented escape hatch for
     an update whose API is down: it uses only the current engine and its local
     DB, so it cannot deadlock on an API-only recovery command.  Durable audit
     rows are terminalized rather than deleted; unread messages and unrelated
-    shell memory are untouched.
+    shell memory are untouched. The manifest is re-read under BEGIN IMMEDIATE
+    before the first write; any change refuses with zero mutation.
     """
     counts = {
         "sessions_ended": 0,
@@ -261,63 +433,62 @@ def discard_live_state(db_path) -> dict[str, int]:
         if not _has_table(con, "interface_sessions"):
             return counts
         con.execute("BEGIN IMMEDIATE")
+        current = _live_loss_manifest(con)
+        if current != expected:
+            raise LiveStateChanged(
+                "live Interface state changed while awaiting consent")
 
-        active_session = interface_state.active_session_sql("s")
-        sessions = con.execute(
-            "SELECT s.session_id, s.shell_id, s.archive_id "
-            "FROM interface_sessions s "
-            f"WHERE {active_session} ORDER BY s.session_id"
-        ).fetchall()
-        for session_id, shell_id, archive_id in sessions:
+        for session_id in expected.sessions:
+            shell_id, archive_id = con.execute(
+                "SELECT shell_id, archive_id FROM interface_sessions "
+                "WHERE session_id=?", (session_id,)
+            ).fetchone()
             result = interface_broker.close_session(
                 con, session_id, "update_discard")
             if not result["already_ended"]:
                 counts["sessions_ended"] += 1
-            if archive_id is not None:
+            if archive_id in expected.archives:
                 cur = con.execute(
                     "UPDATE shell_memory_archives SET ended_at=datetime('now') "
                     "WHERE archive_id=? AND ended_at IS NULL", (archive_id,))
                 counts["archives_closed"] += cur.rowcount
+            if (shell_id, archive_id) in expected.archive_links:
                 con.execute(
                     "UPDATE shells SET active_archive_id=NULL "
                     "WHERE shell_id=? AND active_archive_id=?",
                     (shell_id, archive_id))
 
-        cur = con.execute(
-            "UPDATE interface_generations SET ended_at=datetime('now') "
-            "WHERE ended_at IS NULL")
-        counts["generations_ended"] = cur.rowcount
+        for shell_id, generation in expected.generations:
+            cur = con.execute(
+                "UPDATE interface_generations SET ended_at=datetime('now') "
+                "WHERE shell_id=? AND generation=? AND ended_at IS NULL",
+                (shell_id, generation))
+            counts["generations_ended"] += cur.rowcount
 
-        counts["batches_completed"] = con.execute(
-            "SELECT COUNT(*) FROM planner_wake_batches "
-            "WHERE state <> 'complete'").fetchone()[0]
-        counts["items_cancelled"] = con.execute(
-            "SELECT COUNT(*) FROM planner_wake_items "
-            "WHERE state NOT IN ('done','cancelled')").fetchone()[0]
+        counts["batches_completed"] = len(expected.batches)
+        counts["items_cancelled"] = len(expected.items)
 
-        bindings = con.execute(
-            "SELECT binding_id FROM sprint_planner_bindings "
-            "WHERE released_at IS NULL ORDER BY binding_id"
-        ).fetchall()
-        for (binding_id,) in bindings:
+        for binding_id in expected.bindings:
             interface_broker.release_binding(
                 con, binding_id, "update_discard")
             counts["bindings_released"] += 1
 
-        items = con.execute(
-            "SELECT item_id FROM planner_wake_items "
-            "WHERE state NOT IN ('done','cancelled') ORDER BY item_id"
-        ).fetchall()
-        for (item_id,) in items:
+        for item_id in expected.items:
+            state = con.execute(
+                "SELECT state FROM planner_wake_items WHERE item_id=?",
+                (item_id,)).fetchone()[0]
+            if state in ("done", "cancelled"):
+                continue
             interface_state.transition(
                 con, "wake_item", item_id, "cancelled",
                 extra_sets={"error": "discarded by operator-approved update"})
 
-        batches = con.execute(
-            "SELECT batch_id, state FROM planner_wake_batches "
-            "WHERE state <> 'complete' ORDER BY batch_id"
-        ).fetchall()
-        for batch_id, state in batches:
+        for batch_id in expected.batches:
+            state = con.execute(
+                "SELECT state FROM planner_wake_batches WHERE batch_id=?",
+                (batch_id,)).fetchone()[0]
+            if state == "complete":
+                continue
             if state == "submitting":
                 interface_state.transition(
                     con, "wake_batch", batch_id, "delivery_unknown")
@@ -326,20 +497,36 @@ def discard_live_state(db_path) -> dict[str, int]:
                 extra_sets={"completed_at": con.execute(
                     "SELECT datetime('now')").fetchone()[0]})
 
-        cur = con.execute(
-            "DELETE FROM interface_input_state "
-            "WHERE NOT EXISTS (SELECT 1 FROM interface_sessions s "
-            "WHERE s.session_id=interface_input_state.session_id)")
-        counts["orphan_inputs_removed"] = cur.rowcount
+        for session_id in expected.orphan_inputs:
+            cur = con.execute(
+                "DELETE FROM interface_input_state WHERE session_id=? "
+                "AND NOT EXISTS (SELECT 1 FROM interface_sessions s "
+                "WHERE s.session_id=interface_input_state.session_id)",
+                (session_id,))
+            counts["orphan_inputs_removed"] += cur.rowcount
 
-        con.execute(
-            "UPDATE planner_alerts SET resolved_at=datetime('now') "
-            "WHERE resolved_at IS NULL AND ("
-            "session_id IN (SELECT session_id FROM interface_sessions "
-            "WHERE occupancy='ended' AND lifecycle='ended' "
-            "AND ended_at IS NOT NULL) OR "
-            "binding_id IN (SELECT binding_id FROM sprint_planner_bindings "
-            "WHERE released_at IS NOT NULL))")
+        for alert_id in expected.alerts:
+            con.execute(
+                "UPDATE planner_alerts SET resolved_at=datetime('now') "
+                "WHERE alert_id=? AND resolved_at IS NULL", (alert_id,))
+        # close_session may have created a delivery-unknown alert after the
+        # manifest was locked. It is operation-local, not concurrently-created
+        # state; resolve only those new alerts tied to the confirmed actors.
+        if expected.sessions or expected.bindings:
+            clauses = []
+            params = []
+            if expected.sessions:
+                marks = ",".join("?" for _ in expected.sessions)
+                clauses.append(f"session_id IN ({marks})")
+                params.extend(expected.sessions)
+            if expected.bindings:
+                marks = ",".join("?" for _ in expected.bindings)
+                clauses.append(f"binding_id IN ({marks})")
+                params.extend(expected.bindings)
+            con.execute(
+                "UPDATE planner_alerts SET resolved_at=datetime('now') "
+                "WHERE resolved_at IS NULL "
+                f"AND ({' OR '.join(clauses)})", params)
         con.commit()
     except Exception:
         con.rollback()

--- a/.super-coder/scripts/interface_reconcile.py
+++ b/.super-coder/scripts/interface_reconcile.py
@@ -233,3 +233,123 @@ def live_refusal_reasons(db_path) -> list[str]:
         return reasons
     finally:
         con.close()
+
+
+def discard_live_state(db_path) -> dict[str, int]:
+    """Atomically abandon every durable Interface actor before an update.
+
+    This is the deliberately destructive, operator-consented escape hatch for
+    an update whose API is down: it uses only the current engine and its local
+    DB, so it cannot deadlock on an API-only recovery command.  Durable audit
+    rows are terminalized rather than deleted; unread messages and unrelated
+    shell memory are untouched.
+    """
+    counts = {
+        "sessions_ended": 0,
+        "generations_ended": 0,
+        "archives_closed": 0,
+        "bindings_released": 0,
+        "batches_completed": 0,
+        "items_cancelled": 0,
+        "orphan_inputs_removed": 0,
+    }
+    if not Path(str(db_path)).exists():
+        return counts
+
+    con = db_driver.connect(str(db_path))
+    try:
+        if not _has_table(con, "interface_sessions"):
+            return counts
+        con.execute("BEGIN IMMEDIATE")
+
+        active_session = interface_state.active_session_sql("s")
+        sessions = con.execute(
+            "SELECT s.session_id, s.shell_id, s.archive_id "
+            "FROM interface_sessions s "
+            f"WHERE {active_session} ORDER BY s.session_id"
+        ).fetchall()
+        for session_id, shell_id, archive_id in sessions:
+            result = interface_broker.close_session(
+                con, session_id, "update_discard")
+            if not result["already_ended"]:
+                counts["sessions_ended"] += 1
+            if archive_id is not None:
+                cur = con.execute(
+                    "UPDATE shell_memory_archives SET ended_at=datetime('now') "
+                    "WHERE archive_id=? AND ended_at IS NULL", (archive_id,))
+                counts["archives_closed"] += cur.rowcount
+                con.execute(
+                    "UPDATE shells SET active_archive_id=NULL "
+                    "WHERE shell_id=? AND active_archive_id=?",
+                    (shell_id, archive_id))
+
+        cur = con.execute(
+            "UPDATE interface_generations SET ended_at=datetime('now') "
+            "WHERE ended_at IS NULL")
+        counts["generations_ended"] = cur.rowcount
+
+        counts["batches_completed"] = con.execute(
+            "SELECT COUNT(*) FROM planner_wake_batches "
+            "WHERE state <> 'complete'").fetchone()[0]
+        counts["items_cancelled"] = con.execute(
+            "SELECT COUNT(*) FROM planner_wake_items "
+            "WHERE state NOT IN ('done','cancelled')").fetchone()[0]
+
+        bindings = con.execute(
+            "SELECT binding_id FROM sprint_planner_bindings "
+            "WHERE released_at IS NULL ORDER BY binding_id"
+        ).fetchall()
+        for (binding_id,) in bindings:
+            interface_broker.release_binding(
+                con, binding_id, "update_discard")
+            counts["bindings_released"] += 1
+
+        items = con.execute(
+            "SELECT item_id FROM planner_wake_items "
+            "WHERE state NOT IN ('done','cancelled') ORDER BY item_id"
+        ).fetchall()
+        for (item_id,) in items:
+            interface_state.transition(
+                con, "wake_item", item_id, "cancelled",
+                extra_sets={"error": "discarded by operator-approved update"})
+
+        batches = con.execute(
+            "SELECT batch_id, state FROM planner_wake_batches "
+            "WHERE state <> 'complete' ORDER BY batch_id"
+        ).fetchall()
+        for batch_id, state in batches:
+            if state == "submitting":
+                interface_state.transition(
+                    con, "wake_batch", batch_id, "delivery_unknown")
+            interface_state.transition(
+                con, "wake_batch", batch_id, "complete",
+                extra_sets={"completed_at": con.execute(
+                    "SELECT datetime('now')").fetchone()[0]})
+
+        cur = con.execute(
+            "DELETE FROM interface_input_state "
+            "WHERE NOT EXISTS (SELECT 1 FROM interface_sessions s "
+            "WHERE s.session_id=interface_input_state.session_id)")
+        counts["orphan_inputs_removed"] = cur.rowcount
+
+        con.execute(
+            "UPDATE planner_alerts SET resolved_at=datetime('now') "
+            "WHERE resolved_at IS NULL AND ("
+            "session_id IN (SELECT session_id FROM interface_sessions "
+            "WHERE occupancy='ended' AND lifecycle='ended' "
+            "AND ended_at IS NOT NULL) OR "
+            "binding_id IN (SELECT binding_id FROM sprint_planner_bindings "
+            "WHERE released_at IS NOT NULL))")
+        con.commit()
+    except Exception:
+        con.rollback()
+        raise
+    finally:
+        con.close()
+
+    remaining = live_refusal_reasons(db_path)
+    if remaining:
+        raise RuntimeError(
+            "operator-approved Interface discard did not drain: "
+            + "; ".join(remaining))
+    return counts

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -148,15 +148,21 @@ def verify_engine_only_floor(prev_sha: str) -> None:
         con.close()
 
     introduced = current - previous
-    if not introduced or not (current - applied):
+    if not introduced:
         sys.exit(
             "rollback: --engine-only refused — the current engine/DB pair is "
             "not a proved new-engine/old-schema half floor.")
-    if previous - applied or introduced & applied:
+    missing = previous - applied
+    unexpected = applied - previous
+    if missing or unexpected:
+        mismatch = (
+            f"missing={sorted(missing)!r}, "
+            f"unexpected={sorted(unexpected)!r}"
+        )
         sys.exit(
             "rollback: --engine-only refused — the DB does not exactly retain "
-            "the previous engine migration floor. Use a verified paired backup "
-            "or operator-directed recovery instead.")
+            f"the previous engine migration floor ({mismatch}). Use a verified "
+            "paired backup or operator-directed recovery instead.")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -19,11 +19,13 @@ never surprisingly lossy, always works. The only data lost is anything written
 
 Usage:
     ./sc rollback
+    ./sc rollback --engine-only  # new-engine / unchanged-old-DB half floor
     python3 .super-coder/scripts/rollback.py
 """
 from __future__ import annotations
 
 import shutil
+import sqlite3
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -78,6 +80,19 @@ def restore_db(src: Path) -> None:
 def restore_engine(prev_sha: str) -> None:
     """Re-materialize the engine at the prior pin. The SHA should already be in
     the object store (it is the ref we updated *from*); fetch as a fallback."""
+    previous_files = set(update_mod._engine_files_at(prev_sha))
+    current_sha = ENGINE_REF.read_text().strip() if ENGINE_REF.exists() else ""
+    current_files = (set(update_mod._engine_files_at(current_sha))
+                     if current_sha else set())
+    # materialize_engine overlays an archive and deliberately leaves upstream-
+    # retired files alone during a forward update. Rollback is different: a
+    # target-only migration left behind would make the restored old server
+    # demand the new schema again. Remove only files proved upstream-owned by
+    # the current pin and absent from the previous pin; fork-local files remain.
+    for rel in sorted(current_files - previous_files):
+        path = REPO_ROOT / rel
+        if path.is_file() or path.is_symlink():
+            path.unlink()
     try:
         update_mod.materialize_engine(prev_sha)
     except SystemExit:
@@ -93,16 +108,88 @@ def restore_engine(prev_sha: str) -> None:
     print(f"→ engine re-materialized at {prev_sha[:12]} (engine.ref restored)")
 
 
-def main() -> int:
+def verify_engine_only_floor(prev_sha: str) -> None:
+    """Prove the DB is still on the previous engine migration floor."""
+    current_sha = ENGINE_REF.read_text().strip() if ENGINE_REF.exists() else ""
+    if not current_sha or current_sha == prev_sha:
+        sys.exit(
+            "rollback: --engine-only is safe only for a newer materialized "
+            "engine over an unchanged older DB; the two engine pins do not "
+            "prove that state.")
+    if not DB_PATH.exists():
+        sys.exit("rollback: --engine-only cannot verify a missing DB.")
+
+    previous = {
+        Path(line).name
+        for line in update_mod.git(
+            "ls-tree", "-r", "--name-only", prev_sha, "--",
+            ".super-coder/migrations"
+        ).stdout.splitlines()
+        if line.endswith(".sql")
+    }
+    current = {
+        path.name for path in (ENGINE / "migrations").glob("*.sql")
+    }
+    con = sqlite3.connect(DB_PATH)
+    try:
+        table = con.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='schema_migrations'"
+        ).fetchone()
+        if table is None:
+            sys.exit(
+                "rollback: --engine-only cannot prove the DB migration floor "
+                "(schema_migrations is absent).")
+        applied = {
+            row[0] for row in con.execute(
+                "SELECT filename FROM schema_migrations")
+        }
+    finally:
+        con.close()
+
+    introduced = current - previous
+    if not introduced or not (current - applied):
+        sys.exit(
+            "rollback: --engine-only refused — the current engine/DB pair is "
+            "not a proved new-engine/old-schema half floor.")
+    if previous - applied or introduced & applied:
+        sys.exit(
+            "rollback: --engine-only refused — the DB does not exactly retain "
+            "the previous engine migration floor. Use a verified paired backup "
+            "or operator-directed recovery instead.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    unknown = [arg for arg in argv if arg != "--engine-only"]
+    if unknown:
+        sys.exit(f"rollback: unknown argument(s): {' '.join(unknown)}")
+    engine_only = "--engine-only" in argv
+
     if update_mod.EJECTED_MARKER.exists() and not update_mod.is_source_repo():
         sys.exit("rollback: this fork has EJECTED (.sc-state/ejected) — the "
                  "engine is fork source now, so update/rollback no longer apply. "
                  "Use plain git (revert/reset) on the tracked .super-coder/.")
+    prev_sha = ENGINE_REF_PREV.read_text().strip() if ENGINE_REF_PREV.exists() else ""
+    if engine_only:
+        if not prev_sha:
+            sys.exit(
+                "rollback: --engine-only requires .sc-state/engine.ref.prev; "
+                "the previous installed engine cannot be identified.")
+        verify_engine_only_floor(prev_sha)
+        print("→ repairing a new-engine / unchanged-DB half floor")
+        backup_current_db()
+        restore_engine(prev_sha)
+        ENGINE_REF_PREV.unlink(missing_ok=True)
+        print("\nrollback: done — restored the previous engine and preserved "
+              "the current DB byte-for-byte.")
+        print("  Restart your session to boot onto the restored state.")
+        return 0
+
     src = latest_db_restore_point()
     if src is None:
         sys.exit("rollback: no shell_db.prerebuild.*.db restore point found in "
                  f"{rebuild_mod.backup_dir()} — nothing to roll back to.")
-    prev_sha = ENGINE_REF_PREV.read_text().strip() if ENGINE_REF_PREV.exists() else ""
 
     print("→ rolling back the last update (DB + engine pair-restore)")
     backup_current_db()

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -45,6 +45,7 @@ materialize to a specific upstream version instead of the branch head.
 
 Usage:
     ./sc update [--no-fetch] [--branch <name>] [--ref <tag|sha>] [--force]
+                [--discard-live-state]
     python3 .super-coder/scripts/update.py [same flags]
 """
 from __future__ import annotations
@@ -314,13 +315,57 @@ def fetch_and_materialize(branch: str, ref: str | None = None,
     materialize_fetched_engine(sha, force=force)
 
 
-def preflight_live_state() -> None:
-    """Refuse from the currently installed engine before any floor mutation."""
+def preflight_live_state(*, allow_discard: bool = False,
+                         discard_requested: bool = False) -> None:
+    """Guard from the current engine before any installed-floor mutation.
+
+    Normal callers fail closed.  ``update.main`` additionally offers an
+    interactive continue-or-roll-back choice, or accepts the explicit
+    ``--discard-live-state`` flag for a headless invocation.  The destructive
+    path is deliberately local-DB only so it still works while the API is down.
+    """
     reasons = interface_reconcile.live_refusal_reasons(DB_PATH)
-    if reasons:
+    if not reasons:
+        return
+    details = "\n  - " + "\n  - ".join(reasons)
+    if not allow_discard:
         sys.exit(
             "update: refusing — live Interface state exists; drain/reconcile "
-            "it first:\n  - " + "\n  - ".join(reasons))
+            "it first:" + details)
+
+    print(
+        "WARNING: update detected durable live Interface state.\n"
+        "Continuing will permanently end/cancel exactly this state:"
+        + details,
+        file=sys.stderr,
+    )
+    if not discard_requested:
+        if not sys.stdin.isatty():
+            sys.exit(
+                "update: refusing — no interactive consent is available. "
+                "Drain/reconcile after starting the API, or explicitly accept "
+                "the loss with `./sc update --discard-live-state`.")
+        answer = input(
+            "Choose 'continue' to discard it, or 'rollback' to leave the "
+            "installed floor unchanged [rollback]: "
+        ).strip().lower()
+        if answer != "continue":
+            sys.exit(
+                "update: rolled back — installed engine, pins, and database "
+                "state are unchanged.")
+    else:
+        print(
+            "  --discard-live-state: explicit consent received; discarding.",
+            file=sys.stderr,
+        )
+
+    counts = interface_reconcile.discard_live_state(DB_PATH)
+    changed = ", ".join(
+        f"{name.replace('_', ' ')}={value}"
+        for name, value in counts.items()
+        if value
+    ) or "no rows changed"
+    print(f"→ discarded durable Interface state ({changed})")
 
 
 def migrate_engine_untrack() -> None:
@@ -406,6 +451,7 @@ def regrant() -> int:
 def main(argv: list[str]) -> int:
     no_fetch = "--no-fetch" in argv
     force = "--force" in argv
+    discard_live_state = "--discard-live-state" in argv
     branch = "main"
     if "--branch" in argv:
         i = argv.index("--branch")
@@ -435,7 +481,8 @@ def main(argv: list[str]) -> int:
     target_sha = None
     if not source and not no_fetch:
         target_sha = fetch_update_ref(branch, ref=ref)
-    preflight_live_state()
+    preflight_live_state(
+        allow_discard=True, discard_requested=discard_live_state)
 
     if source:
         # The source repo IS the engine — it has no upstream to materialize from

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -324,18 +324,22 @@ def preflight_live_state(*, allow_discard: bool = False,
     ``--discard-live-state`` flag for a headless invocation.  The destructive
     path is deliberately local-DB only so it still works while the API is down.
     """
-    reasons = interface_reconcile.live_refusal_reasons(DB_PATH)
-    if not reasons:
-        return
-    details = "\n  - " + "\n  - ".join(reasons)
     if not allow_discard:
+        reasons = interface_reconcile.live_refusal_reasons(DB_PATH)
+        if not reasons:
+            return
+        details = "\n  - " + "\n  - ".join(reasons)
         sys.exit(
             "update: refusing — live Interface state exists; drain/reconcile "
             "it first:" + details)
 
+    manifest = interface_reconcile.live_loss_manifest(DB_PATH)
+    if manifest.empty():
+        return
+    details = "\n  - " + "\n  - ".join(manifest.loss_lines())
     print(
         "WARNING: update detected durable live Interface state.\n"
-        "Continuing will permanently end/cancel exactly this state:"
+        "Continuing will permanently terminalize exactly this loss manifest:"
         + details,
         file=sys.stderr,
     )
@@ -359,7 +363,13 @@ def preflight_live_state(*, allow_discard: bool = False,
             file=sys.stderr,
         )
 
-    counts = interface_reconcile.discard_live_state(DB_PATH)
+    try:
+        counts = interface_reconcile.discard_live_state(DB_PATH, manifest)
+    except interface_reconcile.LiveStateChanged:
+        sys.exit(
+            "update: refusing — live Interface state changed while consent "
+            "was pending; no rows were mutated. Re-run update to review and "
+            "consent to the fresh exact loss manifest.")
     changed = ", ".join(
         f"{name.replace('_', ' ')}={value}"
         for name, value in counts.items()

--- a/sc
+++ b/sc
@@ -1312,6 +1312,7 @@ super-coder — forkable shell substrate
                              --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
   ./sc update-harnesses    update claude + opencode + codex + vibe + kimi to latest (force-reruns official installers)
   ./sc rollback            sound undo of a bad update — restore the DB + engine (engine.ref.prev) together
+                             --engine-only repairs a new-engine / unchanged-old-DB half floor without restoring a DB backup
   ./sc feature             list the opt-in features (pg · windows · tailnet · pm2 · app-deploy) and the state of both halves (config block + skill grants)
   ./sc feature enable <f>  enable one: grant its skills to the owning flavors + create/point-at its instance.json block (disable reverses)
   ./sc eject               ONE-WAY: stop tracking upstream and own the engine — un-gitignore + stage .super-coder/ as fork source (confirm-gated)

--- a/sc
+++ b/sc
@@ -1308,6 +1308,7 @@ super-coder — forkable shell substrate
   ./sc ensure-harness      install claude + opencode + codex + vibe + kimi if missing (official native installers, no npm)
   ./sc doctor              sandbox readiness: docker (rootless/rootful) + harness login
   ./sc update              fetch + materialize the engine (gitignored dep) + reconcile IN PLACE (migrate, sync skills, map);
+                             live Interface state asks continue-or-rollback; headless discard requires --discard-live-state
                              --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
   ./sc update-harnesses    update claude + opencode + codex + vibe + kimi to latest (force-reruns official installers)
   ./sc rollback            sound undo of a bad update — restore the DB + engine (engine.ref.prev) together

--- a/tests/test_interface_reconcile_guard.py
+++ b/tests/test_interface_reconcile_guard.py
@@ -306,6 +306,97 @@ class LiveRefusalGuardTest(unittest.TestCase):
             "WHERE session_id=?", (sid,)).fetchone(),
             ("delivery_unknown", 4))
 
+    def test_operator_approved_discard_terminalizes_all_live_state(self):
+        sid = self._occupied_session()
+        self.con.execute(
+            "INSERT INTO shell_memory_archives "
+            "(archive_id, shell_id, date, full_narrative) "
+            "VALUES (10,1,'2026-07-24','unsaved turn')")
+        self.con.execute(
+            "UPDATE interface_sessions SET archive_id=10 WHERE session_id=?",
+            (sid,))
+        self.con.execute(
+            "UPDATE shells SET active_archive_id=10 WHERE shell_id=1")
+        self.con.execute(
+            "INSERT INTO interface_input_state "
+            "(session_id, shell_id, generation, composer, pending_seq) "
+            "VALUES (?,1,1,'unknown',4)", (sid,))
+        self.con.execute(
+            "INSERT INTO interface_writer_leases "
+            "(session_id, shell_id, generation, client_id, token_hash) "
+            "VALUES (?,1,1,'client','hash')", (sid,))
+        binding_id = self.con.execute(
+            "INSERT INTO sprint_planner_bindings "
+            "(sprint_doc_id, planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (1,1,?,1,1)", (sid,)).lastrowid
+        batch_id = self.con.execute(
+            "INSERT INTO planner_wake_batches "
+            "(binding_id, shell_id, generation, state) "
+            "VALUES (?,1,1,'running')", (binding_id,)).lastrowid
+        message_id = self.con.execute(
+            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body) "
+            "VALUES (2,1,'must remain unread')").lastrowid
+        item_id = self.con.execute(
+            "INSERT INTO planner_wake_items "
+            "(binding_id, message_id, batch_id, state) "
+            "VALUES (?,?,?,'running')",
+            (binding_id, message_id, batch_id)).lastrowid
+        self.con.commit()
+
+        before = interface_reconcile.live_refusal_reasons(self.db)
+        self.assertTrue(any("session" in reason for reason in before))
+        self.assertTrue(any("batch" in reason for reason in before))
+        counts = interface_reconcile.discard_live_state(self.db)
+
+        self.assertEqual(counts["sessions_ended"], 1)
+        self.assertEqual(counts["generations_ended"], 0,
+                         "close_session owns the matching generation")
+        self.assertEqual(counts["archives_closed"], 1)
+        self.assertEqual(counts["bindings_released"], 1)
+        self.assertEqual(counts["batches_completed"], 1)
+        self.assertEqual(counts["items_cancelled"], 1)
+        self.assertEqual(
+            self.con.execute(
+                "SELECT occupancy, lifecycle, end_reason "
+                "FROM interface_sessions WHERE session_id=?", (sid,)
+            ).fetchone(),
+            ("ended", "ended", "update_discard"),
+        )
+        self.assertIsNotNone(self.con.execute(
+            "SELECT ended_at FROM interface_generations "
+            "WHERE shell_id=1 AND generation=1").fetchone()[0])
+        self.assertEqual(
+            self.con.execute(
+                "SELECT ended_at FROM shell_memory_archives "
+                "WHERE archive_id=10").fetchone()[0] is not None,
+            True,
+        )
+        self.assertIsNone(self.con.execute(
+            "SELECT active_archive_id FROM shells WHERE shell_id=1"
+        ).fetchone()[0])
+        self.assertEqual(
+            self.con.execute(
+                "SELECT release_reason FROM sprint_planner_bindings "
+                "WHERE binding_id=?", (binding_id,)).fetchone()[0],
+            "update_discard",
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT state, completed_at FROM planner_wake_batches "
+                "WHERE batch_id=?", (batch_id,)).fetchone()[0],
+            "complete",
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT state, error FROM planner_wake_items WHERE item_id=?",
+                (item_id,)).fetchone(),
+            ("cancelled", "discarded by operator-approved update"),
+        )
+        self.assertIsNone(self.con.execute(
+            "SELECT read_at FROM shell_messages WHERE message_id=?",
+            (message_id,)).fetchone()[0])
+        self.assertEqual(interface_reconcile.live_refusal_reasons(self.db), [])
+
     def test_fully_drained_passes(self):
         sid = self._occupied_session()
         self.con.execute(

--- a/tests/test_interface_reconcile_guard.py
+++ b/tests/test_interface_reconcile_guard.py
@@ -341,12 +341,22 @@ class LiveRefusalGuardTest(unittest.TestCase):
             "(binding_id, message_id, batch_id, state) "
             "VALUES (?,?,?,'running')",
             (binding_id, message_id, batch_id)).lastrowid
+        alert_id = self.con.execute(
+            "INSERT INTO planner_alerts "
+            "(session_id, binding_id, severity, reason, dedupe_key) "
+            "VALUES (?,?,'warning','turn_failure','discard-test')",
+            (sid, binding_id)).lastrowid
         self.con.commit()
 
         before = interface_reconcile.live_refusal_reasons(self.db)
         self.assertTrue(any("session" in reason for reason in before))
         self.assertTrue(any("batch" in reason for reason in before))
-        counts = interface_reconcile.discard_live_state(self.db)
+        manifest = interface_reconcile.live_loss_manifest(self.db)
+        warning = "\n".join(manifest.loss_lines())
+        self.assertIn("open archive ID(s): 10", warning)
+        self.assertIn(f"wake item ID(s): {item_id}", warning)
+        self.assertIn(f"open planner alert ID(s): {alert_id}", warning)
+        counts = interface_reconcile.discard_live_state(self.db, manifest)
 
         self.assertEqual(counts["sessions_ended"], 1)
         self.assertEqual(counts["generations_ended"], 0,

--- a/tests/test_rollback_half_floor.py
+++ b/tests/test_rollback_half_floor.py
@@ -25,7 +25,11 @@ def git(root: Path, *args: str) -> str:
     ).stdout.strip()
 
 
-def write_db(path: Path, value: str) -> None:
+def write_db(
+    path: Path,
+    value: str,
+    migrations: tuple[str, ...] = ("0001_old.sql",),
+) -> None:
     con = sqlite3.connect(path)
     try:
         con.execute("CREATE TABLE state (value TEXT)")
@@ -33,8 +37,10 @@ def write_db(path: Path, value: str) -> None:
         con.execute(
             "CREATE TABLE schema_migrations "
             "(filename TEXT PRIMARY KEY, applied_at TEXT)")
-        con.execute(
-            "INSERT INTO schema_migrations (filename) VALUES ('0001_old.sql')")
+        con.executemany(
+            "INSERT INTO schema_migrations (filename) VALUES (?)",
+            ((filename,) for filename in migrations),
+        )
         con.commit()
     finally:
         con.close()
@@ -49,6 +55,58 @@ def read_db(path: Path) -> str:
 
 
 class HalfFloorRollbackTest(unittest.TestCase):
+    def test_engine_only_refuses_previous_floor_with_unrelated_extra(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            root = Path(raw_tmp)
+            engine = root / ".super-coder"
+            state = root / ".sc-state"
+            migrations = engine / "migrations"
+            migrations.mkdir(parents=True)
+            state.mkdir()
+            (migrations / "0001_old.sql").write_text("old\n")
+            (migrations / "0002_new.sql").write_text("new\n")
+            db_path = engine / "shell_db.db"
+            write_db(
+                db_path,
+                "unknown schema floor",
+                ("0001_old.sql", "9999_unrelated.sql"),
+            )
+            (state / "engine.ref").write_text("new-sha\n")
+            (state / "engine.ref.prev").write_text("old-sha\n")
+
+            previous_tree = subprocess.CompletedProcess(
+                args=(), returncode=0,
+                stdout=".super-coder/migrations/0001_old.sql\n",
+            )
+            with mock.patch.multiple(
+                rollback,
+                ENGINE=engine,
+                DB_PATH=db_path,
+                ENGINE_REF=state / "engine.ref",
+                ENGINE_REF_PREV=state / "engine.ref.prev",
+            ), mock.patch.multiple(
+                rollback.update_mod,
+                EJECTED_MARKER=state / "ejected",
+                git=mock.Mock(return_value=previous_tree),
+            ), mock.patch.object(
+                rollback, "backup_current_db"
+            ) as backup, mock.patch.object(
+                rollback, "restore_engine"
+            ) as restore, self.assertRaises(SystemExit) as refused:
+                rollback.main(["--engine-only"])
+
+            self.assertIn(
+                "does not exactly retain the previous engine migration floor",
+                str(refused.exception),
+            )
+            self.assertIn("missing=[]", str(refused.exception))
+            self.assertIn(
+                "unexpected=['9999_unrelated.sql']",
+                str(refused.exception),
+            )
+            backup.assert_not_called()
+            restore.assert_not_called()
+
     def test_engine_only_preserves_db_with_no_or_older_restore_point(self):
         for older_backup in (False, True):
             with self.subTest(older_backup=older_backup), \

--- a/tests/test_rollback_half_floor.py
+++ b/tests/test_rollback_half_floor.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""End-to-end recovery for a materialized-engine / unchanged-DB half floor."""
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import rollback  # noqa: E402
+
+
+def git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def write_db(path: Path, value: str) -> None:
+    con = sqlite3.connect(path)
+    try:
+        con.execute("CREATE TABLE state (value TEXT)")
+        con.execute("INSERT INTO state VALUES (?)", (value,))
+        con.execute(
+            "CREATE TABLE schema_migrations "
+            "(filename TEXT PRIMARY KEY, applied_at TEXT)")
+        con.execute(
+            "INSERT INTO schema_migrations (filename) VALUES ('0001_old.sql')")
+        con.commit()
+    finally:
+        con.close()
+
+
+def read_db(path: Path) -> str:
+    con = sqlite3.connect(path)
+    try:
+        return con.execute("SELECT value FROM state").fetchone()[0]
+    finally:
+        con.close()
+
+
+class HalfFloorRollbackTest(unittest.TestCase):
+    def test_engine_only_preserves_db_with_no_or_older_restore_point(self):
+        for older_backup in (False, True):
+            with self.subTest(older_backup=older_backup), \
+                    tempfile.TemporaryDirectory() as raw_tmp:
+                root = Path(raw_tmp)
+                engine = root / ".super-coder"
+                state = root / ".sc-state"
+                backups = state / "db_backups"
+                scripts = engine / "scripts"
+                migrations = engine / "migrations"
+                scripts.mkdir(parents=True)
+                migrations.mkdir()
+                state.mkdir()
+                backups.mkdir()
+
+                git(root, "init", "-b", "main")
+                git(root, "config", "user.name", "Rollback Test")
+                git(root, "config", "user.email",
+                    "rollback@example.invalid")
+                (root / "sc").write_text("old dispatcher\n")
+                (scripts / "floor.txt").write_text("old engine\n")
+                (migrations / "0001_old.sql").write_text(
+                    "CREATE TABLE old_floor(x);\n")
+                git(root, "add", ".")
+                git(root, "commit", "-m", "old floor")
+                old_sha = git(root, "rev-parse", "HEAD")
+
+                (root / "sc").write_text("new dispatcher\n")
+                (scripts / "floor.txt").write_text("new engine\n")
+                (migrations / "0002_new.sql").write_text(
+                    "ALTER TABLE state ADD COLUMN new_floor TEXT;\n")
+                git(root, "add", ".")
+                git(root, "commit", "-m", "new floor")
+                new_sha = git(root, "rev-parse", "HEAD")
+
+                db_path = engine / "shell_db.db"
+                write_db(db_path, "current unchanged DB")
+                (state / "engine.ref").write_text(new_sha + "\n")
+                (state / "engine.ref.prev").write_text(old_sha + "\n")
+                if older_backup:
+                    write_db(
+                        backups / "shell_db.prerebuild.20000101_000000.db",
+                        "stale older backup",
+                    )
+
+                db_before = db_path.read_bytes()
+                with contextlib.ExitStack() as stack:
+                    stack.enter_context(mock.patch.multiple(
+                        rollback,
+                        REPO_ROOT=root,
+                        ENGINE=engine,
+                        DB_PATH=db_path,
+                        STATE_DIR=state,
+                        ENGINE_REF=state / "engine.ref",
+                        ENGINE_REF_PREV=state / "engine.ref.prev",
+                    ))
+                    stack.enter_context(mock.patch.multiple(
+                        rollback.update_mod,
+                        REPO_ROOT=root,
+                        ENGINE=engine,
+                    ))
+                    stack.enter_context(mock.patch.multiple(
+                        rollback.rebuild_mod,
+                        REPO_ROOT=root,
+                        ENGINE=engine,
+                        DB_PATH=db_path,
+                    ))
+                    stack.enter_context(mock.patch.object(
+                        rollback.rebuild_mod,
+                        "backup_dir",
+                        return_value=backups,
+                    ))
+                    stack.enter_context(mock.patch.multiple(
+                        rollback.engine_manifest,
+                        REPO_ROOT=root,
+                        ENGINE=engine,
+                        MANIFEST=engine / "engine.manifest",
+                    ))
+                    self.assertEqual(
+                        rollback.main(["--engine-only"]), 0)
+
+                self.assertEqual(db_path.read_bytes(), db_before)
+                self.assertEqual(read_db(db_path), "current unchanged DB")
+                self.assertEqual((root / "sc").read_text(), "old dispatcher\n")
+                self.assertEqual(
+                    (scripts / "floor.txt").read_text(), "old engine\n")
+                self.assertFalse((migrations / "0002_new.sql").exists())
+                self.assertEqual(
+                    (state / "engine.ref").read_text(), old_sha + "\n")
+                self.assertFalse((state / "engine.ref.prev").exists())
+                self.assertEqual(
+                    read_db(next(backups.glob("shell_db.prerollback.*.db"))),
+                    "current unchanged DB",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Startup refusal for a materialized-engine / unmigrated-DB half floor."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+ACK_MIGRATION = "0083_planner_alert_acknowledgement.sql"
+
+sys.path.insert(0, str(ENGINE / "api"))
+import server  # noqa: E402
+
+
+def build_pre_acknowledgement_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    try:
+        con.executescript(SCHEMA.read_text())
+        for migration in sorted(MIGRATIONS.glob("*.sql")):
+            if migration.name == ACK_MIGRATION:
+                break
+            con.executescript(migration.read_text())
+            con.execute(
+                "INSERT INTO schema_migrations (filename) VALUES (?)",
+                (migration.name,))
+        con.commit()
+    finally:
+        con.close()
+
+
+class ServerSchemaGuardTest(unittest.TestCase):
+    def test_new_code_old_schema_refuses_startup_with_rollback_recovery(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            db_path = Path(raw_tmp) / "shell_db.db"
+            build_pre_acknowledgement_db(db_path)
+            con = sqlite3.connect(db_path)
+            try:
+                with self.assertRaises(sqlite3.OperationalError) as raw:
+                    con.execute(
+                        "SELECT acknowledged_at FROM planner_alerts").fetchall()
+            finally:
+                con.close()
+            self.assertIn("no such column", str(raw.exception))
+
+            with mock.patch.object(
+                server, "DB_PATH", db_path
+            ), mock.patch.object(
+                server.ports_mod, "resolve", return_value={"port": 8800}
+            ), mock.patch.object(
+                server.backfill_shell_api_keys, "backfill"
+            ) as backfill, self.assertRaises(SystemExit) as refused:
+                server.main([])
+
+            message = str(refused.exception)
+            self.assertIn("installed engine/DB schema mismatch", message)
+            self.assertIn(ACK_MIGRATION, message)
+            self.assertIn("before first DB use", message)
+            self.assertIn("`./sc rollback`", message)
+            self.assertNotIn("no such column", message)
+            backfill.assert_not_called()
+
+    def test_current_migration_ledger_passes(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            db_path = Path(raw_tmp) / "shell_db.db"
+            con = sqlite3.connect(db_path)
+            try:
+                con.executescript(SCHEMA.read_text())
+                for migration in sorted(MIGRATIONS.glob("*.sql")):
+                    con.execute(
+                        "INSERT INTO schema_migrations (filename) VALUES (?)",
+                        (migration.name,))
+                con.commit()
+            finally:
+                con.close()
+
+            server.require_current_schema(db_path, MIGRATIONS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -61,7 +61,8 @@ class ServerSchemaGuardTest(unittest.TestCase):
             self.assertIn("installed engine/DB schema mismatch", message)
             self.assertIn(ACK_MIGRATION, message)
             self.assertIn("before first DB use", message)
-            self.assertIn("`./sc rollback`", message)
+            self.assertIn("`./sc rollback --engine-only`", message)
+            self.assertIn("preserving this unchanged DB", message)
             self.assertNotIn("no such column", message)
             backfill.assert_not_called()
 

--- a/tests/test_update_preflight.py
+++ b/tests/test_update_preflight.py
@@ -113,8 +113,9 @@ class UpdatePreflightSentinelTest(unittest.TestCase):
                 update, "fetch_update_ref", return_value="a" * 40
             ) as fetch, mock.patch.object(
                 update.interface_reconcile,
-                "live_refusal_reasons",
-                return_value=["interface session 7 is occupied"],
+                "live_loss_manifest",
+                return_value=update.interface_reconcile.LiveLossManifest(
+                    sessions=(7,)),
             ), mock.patch.object(
                 update, "migrate_engine_untrack"
             ) as untrack, mock.patch.object(
@@ -239,12 +240,9 @@ class UpdateConsentTest(unittest.TestCase):
         patches = [
             mock.patch.object(
                 update.interface_reconcile,
-                "live_refusal_reasons",
-                return_value=[
-                    "generation 1/1 is live — end it first",
-                    "interface session 7 (shell 1) is occupied — "
-                    "end/reconcile it first",
-                ],
+                "live_loss_manifest",
+                return_value=update.interface_reconcile.LiveLossManifest(
+                    generations=((1, 1),), sessions=(7,)),
             ),
             mock.patch.object(
                 update.interface_reconcile,
@@ -266,17 +264,22 @@ class UpdateConsentTest(unittest.TestCase):
     def test_down_api_interactive_continue_warns_then_discards(self):
         discard, warning, prompt = self._preflight(
             interactive=True, answer="continue")
-        discard.assert_called_once_with(update.DB_PATH)
-        self.assertIn("generation 1/1 is live", warning)
-        self.assertIn("interface session 7", warning)
+        discard.assert_called_once_with(
+            update.DB_PATH,
+            update.interface_reconcile.LiveLossManifest(
+                generations=((1, 1),), sessions=(7,)),
+        )
+        self.assertIn("Interface generation(s): 1/1", warning)
+        self.assertIn("Interface session ID(s): 7", warning)
         self.assertIn("'continue'", prompt)
         self.assertIn("'rollback'", prompt)
 
     def test_interactive_rollback_mutates_nothing(self):
         with mock.patch.object(
             update.interface_reconcile,
-            "live_refusal_reasons",
-            return_value=["interface session 7 is occupied"],
+            "live_loss_manifest",
+            return_value=update.interface_reconcile.LiveLossManifest(
+                sessions=(7,)),
         ), mock.patch.object(
             update.interface_reconcile, "discard_live_state"
         ) as discard, mock.patch.object(
@@ -291,8 +294,9 @@ class UpdateConsentTest(unittest.TestCase):
     def test_headless_without_explicit_flag_fails_closed(self):
         with mock.patch.object(
             update.interface_reconcile,
-            "live_refusal_reasons",
-            return_value=["interface session 7 is occupied"],
+            "live_loss_manifest",
+            return_value=update.interface_reconcile.LiveLossManifest(
+                sessions=(7,)),
         ), mock.patch.object(
             update.interface_reconcile, "discard_live_state"
         ) as discard, mock.patch.object(
@@ -305,9 +309,58 @@ class UpdateConsentTest(unittest.TestCase):
     def test_headless_explicit_flag_discards_and_proceeds(self):
         discard, warning, prompt = self._preflight(
             interactive=False, explicit=True)
-        discard.assert_called_once_with(update.DB_PATH)
+        discard.assert_called_once_with(
+            update.DB_PATH,
+            update.interface_reconcile.LiveLossManifest(
+                generations=((1, 1),), sessions=(7,)),
+        )
         self.assertIn("explicit consent received", warning)
         self.assertIsNone(prompt)
+
+    def test_post_prompt_insertion_refuses_without_mutating_any_row(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            db_path = Path(raw_tmp) / "shell_db.db"
+            build_live_db(db_path)
+            after_insert = {}
+
+            def insert_new_live_state(_prompt):
+                con = sqlite3.connect(db_path)
+                try:
+                    con.execute(
+                        "INSERT INTO shells "
+                        "(shell_id, display_name, shortname, mandate, "
+                        "system_prompt, user_id, is_shared, has_identity, "
+                        "bootstrapped) "
+                        "VALUES (2,'Worker','WORK','test','test',1,0,1,1)")
+                    con.execute(
+                        "INSERT INTO interface_generations "
+                        "(shell_id, generation) VALUES (2,1)")
+                    con.execute(
+                        "INSERT INTO interface_sessions "
+                        "(shell_id, generation, occupancy, lifecycle) "
+                        "VALUES (2,1,'occupied','idle')")
+                    con.commit()
+                    after_insert["dump"] = list(con.iterdump())
+                finally:
+                    con.close()
+                return "continue"
+
+            with mock.patch.object(
+                update, "DB_PATH", db_path
+            ), mock.patch.object(
+                sys.stdin, "isatty", return_value=True
+            ), mock.patch(
+                "builtins.input", side_effect=insert_new_live_state
+            ), self.assertRaises(SystemExit) as refused:
+                update.preflight_live_state(allow_discard=True)
+
+            self.assertIn("changed while consent was pending",
+                          str(refused.exception))
+            con = sqlite3.connect(db_path)
+            try:
+                self.assertEqual(list(con.iterdump()), after_insert["dump"])
+            finally:
+                con.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_update_preflight.py
+++ b/tests/test_update_preflight.py
@@ -2,7 +2,11 @@
 """Mutation sentinel for update's installed live-state preflight (#528)."""
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import io
+import sqlite3
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -10,6 +14,8 @@ from pathlib import Path
 from unittest import mock
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
 sys.path.insert(0, str(ENGINE / "scripts"))
 import update  # noqa: E402
 
@@ -23,6 +29,41 @@ def fingerprint(paths: list[Path]) -> dict[str, tuple[int, int, str | None]]:
             digest = hashlib.sha256(path.read_bytes()).hexdigest()
         out[str(path)] = (stat.st_mtime_ns, stat.st_size, digest)
     return out
+
+
+def git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def build_live_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    try:
+        con.executescript(SCHEMA.read_text())
+        for migration in sorted(MIGRATIONS.glob("*.sql")):
+            con.executescript(migration.read_text())
+        con.execute(
+            "INSERT INTO users (user_id, username, is_active) "
+            "VALUES (1,'operator',1)")
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id, display_name, shortname, mandate, system_prompt, "
+            "user_id, is_shared, has_identity, bootstrapped) "
+            "VALUES (1,'Admin','AMI','test','test',1,0,1,1)")
+        con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (1,1)")
+        con.execute(
+            "INSERT INTO interface_sessions "
+            "(shell_id, generation, occupancy, lifecycle) "
+            "VALUES (1,1,'occupied','idle')")
+        con.commit()
+    finally:
+        con.close()
 
 
 class UpdatePreflightSentinelTest(unittest.TestCase):
@@ -97,6 +138,176 @@ class UpdatePreflightSentinelTest(unittest.TestCase):
                 before,
                 "update refusal changed installed hashes or mtimes",
             )
+
+    def test_real_fork_fetch_refusal_preserves_dispatcher_pins_db_and_engine(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            root = Path(raw_tmp)
+            upstream_work = root / "upstream-work"
+            upstream_remote = root / "subfloor.git"
+            fork = root / "fork"
+            upstream_work.mkdir()
+            fork.mkdir()
+
+            git(upstream_work, "init", "-b", "main")
+            git(upstream_work, "config", "user.name", "Update Test")
+            git(upstream_work, "config", "user.email", "update@example.invalid")
+            (upstream_work / ".super-coder" / "migrations").mkdir(parents=True)
+            (upstream_work / "sc").write_text("target dispatcher\n")
+            (upstream_work / ".super-coder" / "schema.sql").write_text(
+                "target engine schema\n")
+            (upstream_work / ".super-coder" / "migrations"
+             / "9999_target.sql").write_text("CREATE TABLE target_new(x);\n")
+            git(upstream_work, "add", ".")
+            git(upstream_work, "commit", "-m", "target floor")
+            subprocess.run(
+                ["git", "clone", "--bare", str(upstream_work),
+                 str(upstream_remote)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            git(fork, "init", "-b", "main")
+            git(fork, "config", "user.name", "Update Test")
+            git(fork, "config", "user.email", "update@example.invalid")
+            git(fork, "remote", "add", "origin", str(root / "ami-fork.git"))
+            git(fork, "remote", "add", "super-coder", str(upstream_remote))
+            engine = fork / ".super-coder"
+            state = fork / ".sc-state"
+            scripts = engine / "scripts"
+            migrations = engine / "migrations"
+            scripts.mkdir(parents=True)
+            migrations.mkdir()
+            state.mkdir()
+            installed = {
+                fork / "sc": "installed dispatcher\n",
+                engine / "schema.sql": "installed engine schema\n",
+                engine / "engine.manifest": "{\"installed\": true}\n",
+                scripts / "update.py": "installed updater\n",
+                migrations / "0084_installed.sql": "installed migration\n",
+                state / "engine.ref": "1" * 40 + "\n",
+                state / "engine.ref.prev": "0" * 40 + "\n",
+            }
+            for path, content in installed.items():
+                path.write_text(content)
+            db_path = engine / "shell_db.db"
+            build_live_db(db_path)
+            git(fork, "add", ".")
+            git(fork, "commit", "-m", "installed fork floor")
+
+            watched = list(installed)
+            before_files = fingerprint(watched)
+            with contextlib.closing(sqlite3.connect(db_path)) as con:
+                before_ledger = con.execute(
+                    "SELECT filename, applied_at FROM schema_migrations "
+                    "ORDER BY filename").fetchall()
+                before_schema = con.execute(
+                    "SELECT type, name, sql FROM sqlite_master "
+                    "WHERE sql IS NOT NULL ORDER BY type, name").fetchall()
+
+            with mock.patch.multiple(
+                update,
+                REPO_ROOT=fork,
+                ENGINE=engine,
+                DB_PATH=db_path,
+                STATE_DIR=state,
+                ENGINE_REF=state / "engine.ref",
+                ENGINE_REF_PREV=state / "engine.ref.prev",
+                EJECTED_MARKER=state / "ejected",
+            ), mock.patch.object(
+                sys.stdin, "isatty", return_value=False
+            ), self.assertRaises(SystemExit) as ctx:
+                update.main([])
+
+            self.assertIn("refusing", str(ctx.exception))
+            self.assertIn("--discard-live-state", str(ctx.exception))
+            self.assertEqual(fingerprint(watched), before_files)
+            with contextlib.closing(sqlite3.connect(db_path)) as con:
+                self.assertEqual(con.execute(
+                    "SELECT filename, applied_at FROM schema_migrations "
+                    "ORDER BY filename").fetchall(), before_ledger)
+                self.assertEqual(con.execute(
+                    "SELECT type, name, sql FROM sqlite_master "
+                    "WHERE sql IS NOT NULL ORDER BY type, name").fetchall(),
+                    before_schema)
+
+
+class UpdateConsentTest(unittest.TestCase):
+    def _preflight(self, *, interactive: bool, answer: str | None = None,
+                   explicit: bool = False):
+        stderr = io.StringIO()
+        patches = [
+            mock.patch.object(
+                update.interface_reconcile,
+                "live_refusal_reasons",
+                return_value=[
+                    "generation 1/1 is live — end it first",
+                    "interface session 7 (shell 1) is occupied — "
+                    "end/reconcile it first",
+                ],
+            ),
+            mock.patch.object(
+                update.interface_reconcile,
+                "discard_live_state",
+                return_value={"sessions_ended": 1, "batches_completed": 1},
+            ),
+            mock.patch.object(sys.stdin, "isatty", return_value=interactive),
+            contextlib.redirect_stderr(stderr),
+        ]
+        if answer is not None:
+            patches.append(mock.patch("builtins.input", return_value=answer))
+        with contextlib.ExitStack() as stack:
+            entered = [stack.enter_context(patch) for patch in patches]
+            update.preflight_live_state(
+                allow_discard=True, discard_requested=explicit)
+        prompt = entered[-1].call_args.args[0] if answer is not None else None
+        return entered[1], stderr.getvalue(), prompt
+
+    def test_down_api_interactive_continue_warns_then_discards(self):
+        discard, warning, prompt = self._preflight(
+            interactive=True, answer="continue")
+        discard.assert_called_once_with(update.DB_PATH)
+        self.assertIn("generation 1/1 is live", warning)
+        self.assertIn("interface session 7", warning)
+        self.assertIn("'continue'", prompt)
+        self.assertIn("'rollback'", prompt)
+
+    def test_interactive_rollback_mutates_nothing(self):
+        with mock.patch.object(
+            update.interface_reconcile,
+            "live_refusal_reasons",
+            return_value=["interface session 7 is occupied"],
+        ), mock.patch.object(
+            update.interface_reconcile, "discard_live_state"
+        ) as discard, mock.patch.object(
+            sys.stdin, "isatty", return_value=True
+        ), mock.patch(
+            "builtins.input", return_value="rollback"
+        ), self.assertRaises(SystemExit) as ctx:
+            update.preflight_live_state(allow_discard=True)
+        self.assertIn("unchanged", str(ctx.exception))
+        discard.assert_not_called()
+
+    def test_headless_without_explicit_flag_fails_closed(self):
+        with mock.patch.object(
+            update.interface_reconcile,
+            "live_refusal_reasons",
+            return_value=["interface session 7 is occupied"],
+        ), mock.patch.object(
+            update.interface_reconcile, "discard_live_state"
+        ) as discard, mock.patch.object(
+            sys.stdin, "isatty", return_value=False
+        ), self.assertRaises(SystemExit) as ctx:
+            update.preflight_live_state(allow_discard=True)
+        self.assertIn("--discard-live-state", str(ctx.exception))
+        discard.assert_not_called()
+
+    def test_headless_explicit_flag_discards_and_proceeds(self):
+        discard, warning, prompt = self._preflight(
+            interactive=False, explicit=True)
+        discard.assert_called_once_with(update.DB_PATH)
+        self.assertIn("explicit consent received", warning)
+        self.assertIsNone(prompt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Outcome

- adds an API-independent continue-or-rollback consent path for durable live Interface state
- defaults interactive rollback and all headless calls to refusal; headless discard requires `--discard-live-state`
- atomically terminalizes sessions/generations, closes archives, releases bindings, and cancels wake work only after explicit consent
- adds a real-fork fetch regression proving refusal preserves tracked `sc`, installed engine content/manifest, both pin files, migration ledger, and SQLite schema
- detects the residual old-updater half floor at server startup and refuses before application DB use with the exact `./sc rollback` recovery

## Judgements

- explicit headless flag: `--discard-live-state`
- cross-version F5 guard: pin the current installed updater protocol with a real target ref that would replace the dispatcher and add a migration; an already-running pre-fix Python updater cannot be retroactively reordered by its target ref
- residual caveat: a fork still on the pre-fix updater retains one exposure during the update that installs this fix; the fixed server now turns that half floor into an actionable rollback refusal instead of a raw missing-column error

## Verification

- `.venv/bin/python -m pytest tests` — 1012 passed, 8 skipped
- focused update/reconcile/server/materialize/API suites — 58 passed
- `./sc lint` on changed Python files — clean
- full `./sc test` before the amendment — engine tests green; 12 spike-only failures because this sandbox lacks `tmux`

Refs #557 #558
