### PR TITLE
fix(run): make session open contention-safe

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -42,6 +42,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import time
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import NamedTuple
@@ -69,6 +70,7 @@ import model_catalog  # noqa: E402  — HARNESS_PROVIDER: one source for harness
 ADAPTERS = ENGINE / "adapters"
 
 DEFAULT_HEADLESS_PROMPT = "Check your inbox and act on your unread messages."
+SESSION_OPEN_RETRY_DELAYS_S = (0.1, 0.3)
 
 
 def resolve_headless_model(flag_model: "str | None", fdef: "dict | None",
@@ -748,15 +750,17 @@ def session_provider(harness: str, model: "str | None") -> "str | None":
     return model_catalog.HARNESS_PROVIDER.get(harness)
 
 
-def open_session(con, shell_id: int,
-                 lifecycle: "dict | None" = None) -> tuple[str, int]:
-    """`lifecycle` carries the launch telemetry persisted onto the archive row
-    (started_at/harness/provider/model/sprint_ref — migration 0071). ended_at is
-    NOT written here: run.py execs the harness, so no code runs at exit; the
-    analytics sweep backfills it from harness session data."""
-    life = {"started_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            **(lifecycle or {})}
-    life_cols = ["started_at", "harness", "provider", "model", "sprint_ref"]
+class SessionOpenError(RuntimeError):
+    """A bounded session-open refusal that is safe to show to the operator."""
+
+
+def _is_db_busy(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    return "locked" in text or "busy" in text
+
+
+def _write_session(con, shell_id: int, life: dict,
+                   life_cols: list[str]) -> tuple[str, int]:
     # Reuse the active session if it was opened but never used (e.g. install
     # opened session 0001, or a prior launch did no work) — avoids phantom empty
     # sessions and the incidental first-snapshot diff. The reused stub becomes
@@ -781,7 +785,6 @@ def open_session(con, shell_id: int,
                 f"UPDATE shell_memory_archives SET {', '.join(c + '=?' for c in life_cols)} "
                 "WHERE archive_id=?",
                 [life.get(c) for c in life_cols] + [row["archive_id"]])
-            con.commit()
             return row["session_id"], row["archive_id"]
 
     last = con.execute(
@@ -801,8 +804,57 @@ def open_session(con, shell_id: int,
     archive_id = cur.lastrowid
     con.execute("UPDATE shells SET active_archive_id=? WHERE shell_id=?",
                 (archive_id, shell_id))
-    con.commit()
     return session_id, archive_id
+
+
+def open_session(con, shell_id: int,
+                 lifecycle: "dict | None" = None) -> tuple[str, int]:
+    """Atomically open a lifecycle archive, with bounded lock retries.
+
+    `lifecycle` carries the launch telemetry persisted onto the archive row
+    (started_at/harness/provider/model/sprint_ref — migration 0071). ended_at is
+    NOT written here: run.py execs the harness, so no code runs at exit; the
+    analytics sweep backfills it from harness session data.
+
+    Launch connections enter with no transaction. BEGIN IMMEDIATE obtains the
+    writer reservation before the read/allocate/write sequence, so a retry
+    always restarts from fresh state and can never leave a half-open archive.
+    shell_factory calls inside its own write transaction; preserve its existing
+    transaction and commit contract rather than nesting BEGIN.
+    """
+    life = {"started_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            **(lifecycle or {})}
+    life_cols = ["started_at", "harness", "provider", "model", "sprint_ref"]
+    delays = SESSION_OPEN_RETRY_DELAYS_S if not con.in_transaction else ()
+    attempts = len(delays) + 1
+
+    for attempt in range(attempts):
+        try:
+            if not con.in_transaction:
+                con.execute("BEGIN IMMEDIATE")
+            result = _write_session(con, shell_id, life, life_cols)
+            con.commit()
+            return result
+        except db_driver.OperationalError as exc:
+            con.rollback()
+            if not _is_db_busy(exc):
+                raise
+            if attempt < len(delays):
+                time.sleep(delays[attempt])
+                continue
+            wait_ms = con.execute("PRAGMA busy_timeout").fetchone()[0]
+            raise SessionOpenError(
+                f"engine DB remained busy across {attempts} bounded "
+                f"session-open attempt(s) (up to {wait_ms} ms each); no session "
+                "or archive was created. Retry after the concurrent engine write "
+                "finishes; if this persists, inspect the engine API/worker logs "
+                "for a long-running DB writer."
+            ) from exc
+        except Exception:
+            con.rollback()
+            raise
+
+    raise AssertionError("unreachable")
 
 
 def atomic_write(path: Path, content: str) -> None:
@@ -937,12 +989,16 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
         except Exception:
             pass
 
-    session_id, archive_id = open_session(con, shell_id, lifecycle={
-        "harness": harness,
-        "provider": session_provider(harness, session_model),
-        "model": session_model,
-        "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
-    })
+    try:
+        session_id, archive_id = open_session(con, shell_id, lifecycle={
+            "harness": harness,
+            "provider": session_provider(harness, session_model),
+            "model": session_model,
+            "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
+        })
+    except SessionOpenError as exc:
+        con.close()
+        raise LaunchError(str(exc)) from exc
 
     full = con.execute(
         "SELECT shell_id, display_name, shortname, partner, role, mandate, "
@@ -1257,12 +1313,17 @@ def main() -> None:
         # The model this launch will actually route (headless resolves via flags →
         # flavor default; interactive routes the flavor default). None = the harness
         # picks its own — recorded as NULL, honest about what we know at boot.
-        session_id, archive_id = open_session(con, chosen["shell_id"], lifecycle={
-            "harness": harness,
-            "provider": session_provider(harness, session_model),
-            "model": session_model,
-            "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
-        })
+        try:
+            session_id, archive_id = open_session(con, chosen["shell_id"], lifecycle={
+                "harness": harness,
+                "provider": session_provider(harness, session_model),
+                "model": session_model,
+                "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
+            })
+        except SessionOpenError as exc:
+            con.close()
+            prefix = "sc run" if headless else "session launch"
+            sys.exit(f"{prefix}: {exc}")
 
         full = con.execute(
             "SELECT shell_id, display_name, shortname, partner, role, mandate, "

--- a/.super-coder/scripts/seed_skills.py
+++ b/.super-coder/scripts/seed_skills.py
@@ -164,6 +164,12 @@ def apply_retired(con) -> list[str]:
     flipped: list[str] = []
     for name in sorted(engine):
         want = 1 if name in retired else 0
+        row = con.execute(
+            "SELECT is_deleted FROM skills WHERE name=?",
+            (name,),
+        ).fetchone()
+        if row is None or row[0] == want:
+            continue
         cur = con.execute(
             "UPDATE skills SET is_deleted=? WHERE name=? AND is_deleted<>?",
             (want, name, want))

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -40,6 +40,16 @@ CREATE TABLE shell_memory_archives (
 CREATE TABLE session_token_usage (
     archive_id INTEGER
 );
+CREATE TABLE skills (
+    skill_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL,
+    category TEXT NOT NULL,
+    command TEXT,
+    common INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    is_deleted INTEGER NOT NULL DEFAULT 0
+);
 CREATE TABLE lock_probe (
     probe_id INTEGER PRIMARY KEY,
     value INTEGER NOT NULL
@@ -81,6 +91,10 @@ class _RollbackSignal:
         return getattr(self._con, name)
 
 
+class _StopAfterSession(RuntimeError):
+    """Stop main after the real boot prelude and session-open path complete."""
+
+
 class OpenSessionContentionTest(unittest.TestCase):
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
@@ -96,6 +110,23 @@ class OpenSessionContentionTest(unittest.TestCase):
         con.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
         self.addCleanup(con.close)
         return con
+
+    def _seed_fresh_engine_skills(self, con) -> None:
+        for skill in run.seed_skills._engine_specs():
+            con.execute(
+                "INSERT INTO skills "
+                "(name, description, category, command, common, content) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    skill["name"],
+                    skill["description"],
+                    skill["category"],
+                    skill["command"],
+                    skill["common"],
+                    skill["content"],
+                ),
+            )
+        con.commit()
 
     def test_retries_from_clean_boundary_after_concurrent_writer(self) -> None:
         holder = self._connect()
@@ -168,6 +199,113 @@ class OpenSessionContentionTest(unittest.TestCase):
             ).fetchone()[0]
         )
         self.assertFalse(con.in_transaction)
+
+    def test_real_headless_boot_prelude_retries_from_clean_boundary(self) -> None:
+        setup = self._connect()
+        self._seed_fresh_engine_skills(setup)
+
+        first_attempt_rolled_back = threading.Event()
+        contender = db_driver.connect(self.path)
+        contender.execute("PRAGMA busy_timeout=30")
+        self.addCleanup(contender.close)
+        proxy = _RollbackSignal(contender, first_attempt_rolled_back)
+        holder_ready = threading.Event()
+        holder_errors: list[BaseException] = []
+        outcome: list[tuple[str, int]] = []
+
+        def hold_concurrent_write() -> None:
+            holder = db_driver.connect(self.path)
+            holder.execute("PRAGMA busy_timeout=30")
+            try:
+                try:
+                    holder.execute("BEGIN IMMEDIATE")
+                    holder.execute(
+                        "UPDATE lock_probe SET value=1 WHERE probe_id=1"
+                    )
+                except BaseException as exc:
+                    holder_errors.append(exc)
+                    holder_ready.set()
+                    return
+                holder_ready.set()
+                if first_attempt_rolled_back.wait(2):
+                    holder.commit()
+                else:
+                    holder.rollback()
+            finally:
+                holder.close()
+
+        holder_thread: list[threading.Thread] = []
+        chosen = {"shell_id": 1, "shortname": "DEV1", "flavor": "dev"}
+        fdefaults = {
+            "dev": {"default_harness": "claude", "models": {"claude": "sonnet"}}
+        }
+        analytics = mock.Mock()
+        analytics.sweep.return_value = {"inserted": 0, "updated": 0}
+        real_open_session = run.open_session
+
+        def pick_after_prelude(*_args):
+            thread = threading.Thread(target=hold_concurrent_write)
+            holder_thread.append(thread)
+            thread.start()
+            self.assertTrue(holder_ready.wait(2))
+            return chosen
+
+        def stop_after_session(*args, **kwargs):
+            outcome.append(real_open_session(*args, **kwargs))
+            raise _StopAfterSession
+
+        @contextmanager
+        def spinner(_label: str, *, enabled: bool):
+            self.assertFalse(enabled)
+            yield SimpleNamespace(label="")
+
+        with mock.patch.dict(run.os.environ, {}, clear=True), \
+                mock.patch.dict(sys.modules, {"analytics": analytics}), \
+                mock.patch.object(
+                    run.sys, "argv",
+                    ["run.py", "--headless", "DEV1", "--harness", "claude"]), \
+                mock.patch.object(run, "open_db", return_value=proxy), \
+                mock.patch.object(
+                    run, "authenticate", return_value={"user_id": 1}), \
+                mock.patch.object(run, "flavor_defaults", return_value=fdefaults), \
+                mock.patch.object(run, "list_shells", return_value=[chosen]), \
+                mock.patch.object(run, "pick_shell", side_effect=pick_after_prelude), \
+                mock.patch.object(
+                    run.shell_liveness, "compute",
+                    return_value={"supported": False, "indeterminate": 0}), \
+                mock.patch.object(run, "ensure_harness_path"), \
+                mock.patch.object(run, "load_adapter", return_value={}), \
+                mock.patch.object(run, "validate_headless_request"), \
+                mock.patch.object(run.style, "spinner", side_effect=spinner), \
+                mock.patch.object(
+                    run, "SESSION_OPEN_RETRY_DELAYS_S", (0.1,)), \
+                mock.patch.object(
+                    run, "open_session", side_effect=stop_after_session), \
+                self.assertRaises(_StopAfterSession):
+            run.main()
+
+        holder_thread[0].join(2)
+        self.assertFalse(holder_thread[0].is_alive())
+        self.assertEqual(holder_errors, [])
+        self.assertTrue(first_attempt_rolled_back.is_set())
+        self.assertEqual(proxy.rollback_count, 1)
+        self.assertEqual(outcome, [("0001", 1)])
+
+        verifier = self._connect()
+        archives = verifier.execute(
+            "SELECT shell_id, session_id, harness "
+            "FROM shell_memory_archives ORDER BY archive_id"
+        ).fetchall()
+        self.assertEqual(
+            [tuple(row) for row in archives],
+            [(1, "0001", "claude")],
+        )
+        self.assertEqual(
+            verifier.execute(
+                "SELECT active_archive_id FROM shells WHERE shell_id=1"
+            ).fetchone()[0],
+            1,
+        )
 
 
 class HeadlessSessionFailureTest(unittest.TestCase):

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Regression tests for atomic, contention-safe launcher session opening."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from contextlib import contextmanager
+from types import SimpleNamespace
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS = Path(__file__).resolve().parents[1] / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import db_driver  # noqa: E402
+import run  # noqa: E402
+
+
+SCHEMA = """
+CREATE TABLE shells (
+    shell_id INTEGER PRIMARY KEY,
+    active_archive_id INTEGER
+);
+CREATE TABLE shell_memory_archives (
+    archive_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    shell_id INTEGER NOT NULL,
+    session_id TEXT NOT NULL,
+    date TEXT NOT NULL,
+    full_narrative TEXT NOT NULL,
+    started_at TEXT,
+    harness TEXT,
+    provider TEXT,
+    model TEXT,
+    sprint_ref TEXT,
+    UNIQUE (shell_id, session_id)
+);
+CREATE TABLE session_token_usage (
+    archive_id INTEGER
+);
+CREATE TABLE lock_probe (
+    probe_id INTEGER PRIMARY KEY,
+    value INTEGER NOT NULL
+);
+INSERT INTO shells (shell_id, active_archive_id) VALUES (1, NULL);
+INSERT INTO lock_probe (probe_id, value) VALUES (1, 0);
+"""
+
+
+class _FailAfterArchive:
+    """Connection proxy that injects a lock after the archive INSERT."""
+
+    def __init__(self, con: sqlite3.Connection) -> None:
+        self._con = con
+
+    def execute(self, sql: str, parameters=()):
+        if sql.startswith("UPDATE shells SET active_archive_id"):
+            raise sqlite3.OperationalError("database is locked")
+        return self._con.execute(sql, parameters)
+
+    def __getattr__(self, name: str):
+        return getattr(self._con, name)
+
+
+class _RollbackSignal:
+    """Connection proxy that exposes the first failed attempt to the test."""
+
+    def __init__(self, con: sqlite3.Connection, rolled_back: threading.Event) -> None:
+        self._con = con
+        self._rolled_back = rolled_back
+        self.rollback_count = 0
+
+    def rollback(self) -> None:
+        self._con.rollback()
+        self.rollback_count += 1
+        self._rolled_back.set()
+
+    def __getattr__(self, name: str):
+        return getattr(self._con, name)
+
+
+class OpenSessionContentionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.path = Path(self.tempdir.name) / "shell.db"
+        con = db_driver.connect(self.path)
+        con.executescript(SCHEMA)
+        con.commit()
+        con.close()
+
+    def _connect(self, busy_timeout_ms: int = 5000):
+        con = db_driver.connect(self.path)
+        con.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+        self.addCleanup(con.close)
+        return con
+
+    def test_retries_from_clean_boundary_after_concurrent_writer(self) -> None:
+        holder = self._connect()
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("UPDATE lock_probe SET value=1 WHERE probe_id=1")
+        outcome: list[tuple[str, int]] = []
+        errors: list[BaseException] = []
+        first_attempt_rolled_back = threading.Event()
+        contender_proxy: list[_RollbackSignal] = []
+
+        def open_contender() -> None:
+            contender = db_driver.connect(self.path)
+            contender.execute("PRAGMA busy_timeout=30")
+            proxy = _RollbackSignal(contender, first_attempt_rolled_back)
+            contender_proxy.append(proxy)
+            try:
+                with mock.patch.object(
+                        run, "SESSION_OPEN_RETRY_DELAYS_S", (0.1,)):
+                    outcome.append(run.open_session(
+                        proxy, 1, lifecycle={"harness": "claude"}))
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                contender.close()
+
+        contender_thread = threading.Thread(target=open_contender)
+        contender_thread.start()
+        self.assertTrue(
+            first_attempt_rolled_back.wait(2),
+            "the first bounded SQLite wait should expire while the writer holds",
+        )
+        holder.commit()
+        contender_thread.join(2)
+
+        self.assertFalse(contender_thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(contender_proxy[0].rollback_count, 1)
+        self.assertEqual(outcome, [("0001", 1)])
+        verifier = self._connect()
+        archive = verifier.execute(
+            "SELECT shell_id, session_id, harness FROM shell_memory_archives"
+        ).fetchone()
+        self.assertEqual(tuple(archive), (1, "0001", "claude"))
+        self.assertEqual(
+            verifier.execute(
+                "SELECT active_archive_id FROM shells WHERE shell_id=1"
+            ).fetchone()[0],
+            1,
+        )
+
+    def test_terminal_busy_failure_rolls_back_partial_archive(self) -> None:
+        con = self._connect(busy_timeout_ms=1)
+        failing = _FailAfterArchive(con)
+
+        with mock.patch.object(run, "SESSION_OPEN_RETRY_DELAYS_S", (0,)), \
+                self.assertRaises(run.SessionOpenError) as raised:
+            run.open_session(failing, 1)
+
+        message = str(raised.exception)
+        self.assertIn("2 bounded session-open attempt(s)", message)
+        self.assertIn("no session or archive was created", message)
+        self.assertIn("Retry after the concurrent engine write finishes", message)
+        self.assertEqual(
+            con.execute("SELECT COUNT(*) FROM shell_memory_archives").fetchone()[0],
+            0,
+        )
+        self.assertIsNone(
+            con.execute(
+                "SELECT active_archive_id FROM shells WHERE shell_id=1"
+            ).fetchone()[0]
+        )
+        self.assertFalse(con.in_transaction)
+
+
+class HeadlessSessionFailureTest(unittest.TestCase):
+    def test_sc_run_exits_before_worktree_or_harness_artifacts(self) -> None:
+        con = mock.Mock()
+        chosen = {"shell_id": 1, "shortname": "DEV1", "flavor": "dev"}
+        fdefaults = {
+            "dev": {"default_harness": "claude", "models": {"claude": "sonnet"}}
+        }
+        analytics = mock.Mock()
+        analytics.sweep.return_value = {"inserted": 0, "updated": 0}
+        ensure_worktree = mock.Mock()
+        atomic_write = mock.Mock()
+        execvpe = mock.Mock()
+
+        @contextmanager
+        def spinner(_label: str, *, enabled: bool):
+            self.assertFalse(enabled)
+            yield SimpleNamespace(label="")
+
+        with mock.patch.dict(run.os.environ, {}, clear=True), \
+                mock.patch.dict(sys.modules, {"analytics": analytics}), \
+                mock.patch.object(
+                    run.sys, "argv",
+                    ["run.py", "--headless", "DEV1", "--harness", "claude"]), \
+                mock.patch.object(run, "open_db", return_value=con), \
+                mock.patch.object(
+                    run.seed_skills, "sync_engine_skills", return_value=[]), \
+                mock.patch.object(
+                    run, "authenticate", return_value={"user_id": 1}), \
+                mock.patch.object(run, "flavor_defaults", return_value=fdefaults), \
+                mock.patch.object(run, "list_shells", return_value=[chosen]), \
+                mock.patch.object(run, "pick_shell", return_value=chosen), \
+                mock.patch.object(
+                    run.shell_liveness, "compute",
+                    return_value={"supported": False, "indeterminate": 0}), \
+                mock.patch.object(run, "ensure_harness_path"), \
+                mock.patch.object(run, "load_adapter", return_value={}), \
+                mock.patch.object(run, "validate_headless_request"), \
+                mock.patch.object(run.style, "spinner", side_effect=spinner), \
+                mock.patch.object(
+                    run, "open_session",
+                    side_effect=run.SessionOpenError(
+                        "engine DB remained busy; no session or archive was created")), \
+                mock.patch.object(run, "ensure_worktree", ensure_worktree), \
+                mock.patch.object(run, "atomic_write", atomic_write), \
+                mock.patch.object(run.os, "execvpe", execvpe):
+            with self.assertRaises(SystemExit) as raised:
+                run.main()
+
+        self.assertIn("sc run: engine DB remained busy", str(raised.exception))
+        self.assertIn("no session or archive was created", str(raised.exception))
+        con.close.assert_called_once_with()
+        ensure_worktree.assert_not_called()
+        atomic_write.assert_not_called()
+        execvpe.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_retire.py
+++ b/tests/test_skill_retire.py
@@ -109,6 +109,14 @@ class RetireTest(unittest.TestCase):
         self.assertEqual(seed_skills.apply_retired(self.con), [],
                          "second apply must flip nothing")
 
+    def test_noop_apply_does_not_open_write_transaction(self):
+        self.assertFalse(self.con.in_transaction)
+        self.assertEqual(seed_skills.apply_retired(self.con), [])
+        self.assertFalse(
+            self.con.in_transaction,
+            "fresh skill retirement convergence must stay read-only",
+        )
+
     def test_unlisting_restores(self):
         self._retire_file(["test_authoring"])
         seed_skills.apply_retired(self.con)


### PR DESCRIPTION
## Summary
- serialize session open from a clean `BEGIN IMMEDIATE` boundary before reading or allocating archive state
- retry the complete transaction twice with bounded backoff, rolling back every failed attempt
- fail `sc run` cleanly and actionably before worktree, boot-file, or harness artifacts if contention persists

## Diagnosis
`db_driver.connect()` already enables WAL and a 5-second `busy_timeout`; the liveness scan is read-only. The defect was a one-shot read/allocate/write session open with no explicit atomic writer boundary or retry after genuine concurrent engine writers exhausted that wait. This change does not widen the timeout: it retries only the whole clean transaction, bounded to three attempts.

Other kickoff writers can still encounter engine-DB contention: API-backed memory writes already receive retryable HTTP 503 handling, while unrelated direct CLI writers retain their existing behavior. This PR deliberately scopes resilience to the worker session-open hot path from AMI #562.

## Verification
- 110 related tests + 11 subtests passed
- full repository run: 1,029 passed, 8 skipped; 12 unrelated interface-stream spike tests failed because `tmux` is absent from this sandbox
- Ruff passed

Refs #562