### PR TITLE
docs(sprint): make binding arm request idempotent

### DIFF
--- a/.super-coder/assets/skills/sprint_orchestration/SKILL.md
+++ b/.super-coder/assets/skills/sprint_orchestration/SKILL.md
@@ -277,23 +277,32 @@ projection. None of it is scheduled polling — they are on-demand reads of
 durable state, and the events still wake you.
 
 - **Arm before the sprint's first wake.** Once your Interface chat is
-  live, arm the binding with the required idempotency header:
+  live, start one arm attempt by generating an attempt nonce once:
+
+  ```sh
+  arm_attempt_id="$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
+  ```
+
+  Retain that value until the attempt ends, then arm the binding with the
+  required idempotency header:
 
   ```http
   POST /api/interface/sprint-bindings
-  Idempotency-Key: sprint-bind-<sprint-doc-id>-<planner-shell-id>
+  Idempotency-Key: sprint-bind-<sprint-doc-id>-<planner-shell-id>-<arm-attempt-id>
 
   {"sprint_doc_id": <sprint-doc-id>, "planner_shell_id": <planner-shell-id>}
   ```
 
-  Reuse that caller-stable key when retrying the same arm intent. Derive it
-  from stable intent inputs (the sprint document + planner), not a timestamp
-  or a new random value, so a retry replays the first result instead of
-  arming twice. A shell may arm only itself; the operator may arm any planner.
-  Arming is fail-closed: a frozen or non-ACTIVE doc, a mandatory-hook gap, or
-  a second ACTIVE binding is refused. PR watches registered with
-  `--sprint <doc-id>` ride the binding — an unarmed binding means `pr_event`
-  rows arrive but nothing wakes you.
+  Reuse that exact caller-stable key only for retries of this arm attempt,
+  including after an ambiguous transport failure. A successful release or a
+  conclusive refusal ends the attempt. Generate a new `arm_attempt_id` for
+  every later arm or re-arm; reusing a released attempt's key would replay its
+  released binding and leave the sprint unarmed. Never generate a timestamp or
+  random value separately for each transport retry. A shell may arm only
+  itself; the operator may arm any planner. Arming is fail-closed: a frozen or
+  non-ACTIVE doc, a mandatory-hook gap, or a second ACTIVE binding is refused.
+  PR watches registered with `--sprint <doc-id>` ride the binding — an unarmed
+  binding means `pr_event` rows arrive but nothing wakes you.
 - **Monitor wake status.** `./sc sprint status` shows binding
   armed/released, the sprint doc ACTIVE/frozen, the derived wake state
   (armed/queued/submitting/running/parked), the current batch, the last

--- a/.super-coder/assets/skills/sprint_orchestration/SKILL.md
+++ b/.super-coder/assets/skills/sprint_orchestration/SKILL.md
@@ -277,13 +277,23 @@ projection. None of it is scheduled polling — they are on-demand reads of
 durable state, and the events still wake you.
 
 - **Arm before the sprint's first wake.** Once your Interface chat is
-  live, arm the binding: `POST /api/interface/sprint-bindings` with
-  `sprint_doc_id` + `planner_shell_id` (a shell may arm only itself; the
-  operator may arm any planner). Arming is fail-closed: a frozen or
-  non-ACTIVE doc, a mandatory-hook gap, or a second ACTIVE binding is
-  refused. PR watches registered with `--sprint <doc-id>` ride the
-  binding — an unarmed binding means `pr_event` rows arrive but nothing
-  wakes you.
+  live, arm the binding with the required idempotency header:
+
+  ```http
+  POST /api/interface/sprint-bindings
+  Idempotency-Key: sprint-bind-<sprint-doc-id>-<planner-shell-id>
+
+  {"sprint_doc_id": <sprint-doc-id>, "planner_shell_id": <planner-shell-id>}
+  ```
+
+  Reuse that caller-stable key when retrying the same arm intent. Derive it
+  from stable intent inputs (the sprint document + planner), not a timestamp
+  or a new random value, so a retry replays the first result instead of
+  arming twice. A shell may arm only itself; the operator may arm any planner.
+  Arming is fail-closed: a frozen or non-ACTIVE doc, a mandatory-hook gap, or
+  a second ACTIVE binding is refused. PR watches registered with
+  `--sprint <doc-id>` ride the binding — an unarmed binding means `pr_event`
+  rows arrive but nothing wakes you.
 - **Monitor wake status.** `./sc sprint status` shows binding
   armed/released, the sprint doc ACTIVE/frozen, the derived wake state
   (armed/queued/submitting/running/parked), the current batch, the last

--- a/.super-coder/migrations/0085_reseed_sprint_orchestration_idempotency.sql
+++ b/.super-coder/migrations/0085_reseed_sprint_orchestration_idempotency.sql
@@ -1,0 +1,39 @@
+-- 0085 — document the required idempotency key when arming sprint wake.
+--
+-- The sprint_orchestration skill named the Interface mutation and payload but
+-- omitted its mandatory Idempotency-Key header, so following the workflow
+-- failed before it could arm a binding. Source asset and this idempotent delta
+-- converge fresh builds and existing installs.
+
+BEGIN;
+
+UPDATE skills SET content = replace(content,
+'- **Arm before the sprint''s first wake.** Once your Interface chat is
+  live, arm the binding: `POST /api/interface/sprint-bindings` with
+  `sprint_doc_id` + `planner_shell_id` (a shell may arm only itself; the
+  operator may arm any planner). Arming is fail-closed: a frozen or
+  non-ACTIVE doc, a mandatory-hook gap, or a second ACTIVE binding is
+  refused. PR watches registered with `--sprint <doc-id>` ride the
+  binding — an unarmed binding means `pr_event` rows arrive but nothing
+  wakes you.',
+'- **Arm before the sprint''s first wake.** Once your Interface chat is
+  live, arm the binding with the required idempotency header:
+
+  ```http
+  POST /api/interface/sprint-bindings
+  Idempotency-Key: sprint-bind-<sprint-doc-id>-<planner-shell-id>
+
+  {"sprint_doc_id": <sprint-doc-id>, "planner_shell_id": <planner-shell-id>}
+  ```
+
+  Reuse that caller-stable key when retrying the same arm intent. Derive it
+  from stable intent inputs (the sprint document + planner), not a timestamp
+  or a new random value, so a retry replays the first result instead of
+  arming twice. A shell may arm only itself; the operator may arm any planner.
+  Arming is fail-closed: a frozen or non-ACTIVE doc, a mandatory-hook gap, or
+  a second ACTIVE binding is refused. PR watches registered with
+  `--sprint <doc-id>` ride the binding — an unarmed binding means `pr_event`
+  rows arrive but nothing wakes you.')
+WHERE name='sprint_orchestration';
+
+COMMIT;

--- a/.super-coder/migrations/0085_reseed_sprint_orchestration_idempotency.sql
+++ b/.super-coder/migrations/0085_reseed_sprint_orchestration_idempotency.sql
@@ -17,23 +17,32 @@ UPDATE skills SET content = replace(content,
   binding — an unarmed binding means `pr_event` rows arrive but nothing
   wakes you.',
 '- **Arm before the sprint''s first wake.** Once your Interface chat is
-  live, arm the binding with the required idempotency header:
+  live, start one arm attempt by generating an attempt nonce once:
+
+  ```sh
+  arm_attempt_id="$(python3 -c ''import secrets; print(secrets.token_hex(16))'')"
+  ```
+
+  Retain that value until the attempt ends, then arm the binding with the
+  required idempotency header:
 
   ```http
   POST /api/interface/sprint-bindings
-  Idempotency-Key: sprint-bind-<sprint-doc-id>-<planner-shell-id>
+  Idempotency-Key: sprint-bind-<sprint-doc-id>-<planner-shell-id>-<arm-attempt-id>
 
   {"sprint_doc_id": <sprint-doc-id>, "planner_shell_id": <planner-shell-id>}
   ```
 
-  Reuse that caller-stable key when retrying the same arm intent. Derive it
-  from stable intent inputs (the sprint document + planner), not a timestamp
-  or a new random value, so a retry replays the first result instead of
-  arming twice. A shell may arm only itself; the operator may arm any planner.
-  Arming is fail-closed: a frozen or non-ACTIVE doc, a mandatory-hook gap, or
-  a second ACTIVE binding is refused. PR watches registered with
-  `--sprint <doc-id>` ride the binding — an unarmed binding means `pr_event`
-  rows arrive but nothing wakes you.')
+  Reuse that exact caller-stable key only for retries of this arm attempt,
+  including after an ambiguous transport failure. A successful release or a
+  conclusive refusal ends the attempt. Generate a new `arm_attempt_id` for
+  every later arm or re-arm; reusing a released attempt''s key would replay its
+  released binding and leave the sprint unarmed. Never generate a timestamp or
+  random value separately for each transport retry. A shell may arm only
+  itself; the operator may arm any planner. Arming is fail-closed: a frozen or
+  non-ACTIVE doc, a mandatory-hook gap, or a second ACTIVE binding is refused.
+  PR watches registered with `--sprint <doc-id>` ride the binding — an unarmed
+  binding means `pr_event` rows arrive but nothing wakes you.')
 WHERE name='sprint_orchestration';
 
 COMMIT;

--- a/skills_sc/sprint_orchestration.md
+++ b/skills_sc/sprint_orchestration.md
@@ -284,23 +284,32 @@ projection. None of it is scheduled polling — they are on-demand reads of
 durable state, and the events still wake you.
 
 - **Arm before the sprint's first wake.** Once your Interface chat is
-  live, arm the binding with the required idempotency header:
+  live, start one arm attempt by generating an attempt nonce once:
+
+  ```sh
+  arm_attempt_id="$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
+  ```
+
+  Retain that value until the attempt ends, then arm the binding with the
+  required idempotency header:
 
   ```http
   POST /api/interface/sprint-bindings
-  Idempotency-Key: sprint-bind-<sprint-doc-id>-<planner-shell-id>
+  Idempotency-Key: sprint-bind-<sprint-doc-id>-<planner-shell-id>-<arm-attempt-id>
 
   {"sprint_doc_id": <sprint-doc-id>, "planner_shell_id": <planner-shell-id>}
   ```
 
-  Reuse that caller-stable key when retrying the same arm intent. Derive it
-  from stable intent inputs (the sprint document + planner), not a timestamp
-  or a new random value, so a retry replays the first result instead of
-  arming twice. A shell may arm only itself; the operator may arm any planner.
-  Arming is fail-closed: a frozen or non-ACTIVE doc, a mandatory-hook gap, or
-  a second ACTIVE binding is refused. PR watches registered with
-  `--sprint <doc-id>` ride the binding — an unarmed binding means `pr_event`
-  rows arrive but nothing wakes you.
+  Reuse that exact caller-stable key only for retries of this arm attempt,
+  including after an ambiguous transport failure. A successful release or a
+  conclusive refusal ends the attempt. Generate a new `arm_attempt_id` for
+  every later arm or re-arm; reusing a released attempt's key would replay its
+  released binding and leave the sprint unarmed. Never generate a timestamp or
+  random value separately for each transport retry. A shell may arm only
+  itself; the operator may arm any planner. Arming is fail-closed: a frozen or
+  non-ACTIVE doc, a mandatory-hook gap, or a second ACTIVE binding is refused.
+  PR watches registered with `--sprint <doc-id>` ride the binding — an unarmed
+  binding means `pr_event` rows arrive but nothing wakes you.
 - **Monitor wake status.** `./sc sprint status` shows binding
   armed/released, the sprint doc ACTIVE/frozen, the derived wake state
   (armed/queued/submitting/running/parked), the current batch, the last

--- a/skills_sc/sprint_orchestration.md
+++ b/skills_sc/sprint_orchestration.md
@@ -284,13 +284,23 @@ projection. None of it is scheduled polling — they are on-demand reads of
 durable state, and the events still wake you.
 
 - **Arm before the sprint's first wake.** Once your Interface chat is
-  live, arm the binding: `POST /api/interface/sprint-bindings` with
-  `sprint_doc_id` + `planner_shell_id` (a shell may arm only itself; the
-  operator may arm any planner). Arming is fail-closed: a frozen or
-  non-ACTIVE doc, a mandatory-hook gap, or a second ACTIVE binding is
-  refused. PR watches registered with `--sprint <doc-id>` ride the
-  binding — an unarmed binding means `pr_event` rows arrive but nothing
-  wakes you.
+  live, arm the binding with the required idempotency header:
+
+  ```http
+  POST /api/interface/sprint-bindings
+  Idempotency-Key: sprint-bind-<sprint-doc-id>-<planner-shell-id>
+
+  {"sprint_doc_id": <sprint-doc-id>, "planner_shell_id": <planner-shell-id>}
+  ```
+
+  Reuse that caller-stable key when retrying the same arm intent. Derive it
+  from stable intent inputs (the sprint document + planner), not a timestamp
+  or a new random value, so a retry replays the first result instead of
+  arming twice. A shell may arm only itself; the operator may arm any planner.
+  Arming is fail-closed: a frozen or non-ACTIVE doc, a mandatory-hook gap, or
+  a second ACTIVE binding is refused. PR watches registered with
+  `--sprint <doc-id>` ride the binding — an unarmed binding means `pr_event`
+  rows arrive but nothing wakes you.
 - **Monitor wake status.** `./sc sprint status` shows binding
   armed/released, the sprint doc ACTIVE/frozen, the derived wake state
   (armed/queued/submitting/running/parked), the current batch, the last


### PR DESCRIPTION
## Summary

- add the mandatory Idempotency-Key header to the sprint binding arm example
- define a caller-stable key from sprint document and planner identity so retries replay the original arm
- carry the change through migration 0085 and the hermetically rendered skills_sc mirror
- keep the change isolated from F9 watch-registration scope

Refs #561

## Verification

- branch-local render_check.py: green across 86 migrations
- test_skills_freshness.py: 8 passed
- test_migrate.py: 4 passed
- test_interface_sprint_ops.py: 22 passed
- raw Interface mutation sweep: one POST example, now header-complete
- running isolated HTTP API: missing header returned 422 idempotency_key_required; documented request returned 201 armed; same-key retry replayed the identical result; one active binding remained
- full suite: 1026 passed, 8 skipped; 12 unrelated spike tests failed because tmux is absent from this sandbox

## Trade-off

Use a narrow idempotent content replacement in the trailing reseed instead of duplicating the full skill body. This minimizes collision surface for the already-sequenced F9 follow-up while preserving the source asset as the canonical body.