### PR TITLE
fix(sprint): require scoped PR watches

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -1587,6 +1587,12 @@ _ALERT_COPY = {
         "Detach the unmanaged client before retrying automatic wake.",
         "warning",
     ),
+    "pr_watch_unscoped": (
+        "A live PR watch has no sprint scope, so it cannot emit planner wake "
+        "events or retire itself.",
+        "Rebind the watch with `sc watch pr … --sprint <doc-id>`.",
+        "warning",
+    ),
 }
 
 
@@ -1641,15 +1647,19 @@ def _sprint_alerts(actor, query: dict):
         conds.append(
             "(a.session_id IN (SELECT session_id FROM interface_sessions "
             "WHERE shell_id=?) OR a.binding_id IN (SELECT binding_id FROM "
-            "sprint_planner_bindings WHERE planner_shell_id=?))")
-        params += [actor.shell_id, actor.shell_id]
+            "sprint_planner_bindings WHERE planner_shell_id=?) OR "
+            "a.watch_id IN (SELECT watch_id FROM watched_prs "
+            "WHERE shell_id=?))")
+        params += [actor.shell_id, actor.shell_id, actor.shell_id]
         planner = actor.shell_id
     elif planner is not None:
         conds.append(
             "(a.session_id IN (SELECT session_id FROM interface_sessions "
             "WHERE shell_id=?) OR a.binding_id IN (SELECT binding_id FROM "
-            "sprint_planner_bindings WHERE planner_shell_id=?))")
-        params += [planner, planner]
+            "sprint_planner_bindings WHERE planner_shell_id=?) OR "
+            "a.watch_id IN (SELECT watch_id FROM watched_prs "
+            "WHERE shell_id=?))")
+        params += [planner, planner, planner]
     if session_id is not None:
         conds.append("a.session_id=?")
         params.append(session_id)
@@ -1672,7 +1682,8 @@ def _sprint_alerts(actor, query: dict):
         else:
             generation = current[0]
     if generation is not None:
-        conds.append("COALESCE(s.generation, b.generation)=?")
+        conds.append(
+            "(a.watch_id IS NOT NULL OR COALESCE(s.generation, b.generation)=?)")
         params.append(generation)
     if not include_resolved:
         conds.append("a.resolved_at IS NULL AND a.acknowledged_at IS NULL")

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -1625,7 +1625,8 @@ def _sprint_alerts(actor, query: dict):
     """GET /api/interface/sprint-alerts — the operator's window into wake
     failures (spec Data Model planner_alerts; deduplicated while open).
     Default lists OPEN alerts; include_resolved=1 adds the audit history.
-    A shell actor sees only alerts tied to its own sessions or bindings."""
+    A shell actor sees only alerts tied to its own sessions, bindings, or
+    watches. Watch alerts remain visible without a current Interface session."""
     session_id = _qint(query, "session_id")
     binding_id = _qint(query, "binding_id")
     planner = _qint(query, "planner_shell_id")
@@ -1678,7 +1679,10 @@ def _sprint_alerts(actor, query: dict):
         finally:
             con.close()
         if current is None:
-            conds.append("1=0")
+            # Session/binding alerts require a current generation by default,
+            # but a dormant watch may be the reason no planner session exists.
+            # Keep that repair signal owner-visible without a live session.
+            conds.append("a.watch_id IS NOT NULL")
         else:
             generation = current[0]
     if generation is not None:

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2220,15 +2220,18 @@ class Handler(BaseHTTPRequestHandler):
             if not repo or repo.count("/") != 1 or pr is None:
                 return self._send(400, {"error": "repo (owner/name) and pr_number (int) required"})
             sprint_doc_id = body.get("sprint_doc_id")
-            if sprint_doc_id is not None:
-                try:
-                    sprint_doc_id = int(sprint_doc_id)
-                except (TypeError, ValueError):
-                    return self._send(400, {"error": "sprint_doc_id must be an int"})
-                if not pr_poller.is_active_sprint(con, sprint_doc_id):
-                    return self._send(409, {"error":
-                        f"document {sprint_doc_id} is not an ACTIVE, unfrozen "
-                        "SPRINT doc — watches arm only to active sprints"})
+            if sprint_doc_id is None:
+                return self._send(400, {"error":
+                    "sprint_doc_id (int) required — unscoped watches are "
+                    "dormant and cannot be registered"})
+            try:
+                sprint_doc_id = int(sprint_doc_id)
+            except (TypeError, ValueError):
+                return self._send(400, {"error": "sprint_doc_id must be an int"})
+            if not pr_poller.is_active_sprint(con, sprint_doc_id):
+                return self._send(409, {"error":
+                    f"document {sprint_doc_id} is not an ACTIVE, unfrozen "
+                    "SPRINT doc — watches arm only to active sprints"})
             target = sid
             if body.get("shell"):
                 r = con.execute(
@@ -2273,6 +2276,11 @@ class Handler(BaseHTTPRequestHandler):
                     "UPDATE watched_prs SET sprint_doc_id=?, last_seen=? "
                     "WHERE watch_id=?",
                     (sprint_doc_id, json.dumps(fp), unscoped["watch_id"]))
+                con.execute(
+                    "UPDATE planner_alerts SET resolved_at=datetime('now') "
+                    "WHERE watch_id=? AND reason='pr_watch_unscoped' "
+                    "AND resolved_at IS NULL",
+                    (unscoped["watch_id"],))
                 con.commit()
                 return self._send(200, {"watch_id": unscoped["watch_id"],
                                         "rebound": True, "daemon": daemon})

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2255,13 +2255,6 @@ class Handler(BaseHTTPRequestHandler):
             if existing is not None:
                 return self._send(200, {"watch_id": existing["watch_id"],
                                         "existing": True, "daemon": daemon})
-            unscoped = None
-            if sprint_doc_id is not None:
-                unscoped = con.execute(
-                    "SELECT watch_id FROM watched_prs "
-                    "WHERE repo=? AND pr_number=? AND shell_id=? "
-                    "AND closed_at IS NULL AND sprint_doc_id IS NULL",
-                    (repo, pr, target)).fetchone()
             # Registration baseline (spec: an immediate GitHub read, normalized
             # and stored BEFORE arming; a failed baseline creates no armed
             # watch and returns a retryable sanitized error). The gh call
@@ -2271,6 +2264,30 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(502, {"error":
                     f"baseline read failed (retryable): {err}",
                     "retryable": True, "daemon": daemon})
+            # The baseline is an external read and cannot hold a DB writer
+            # reservation. Revalidate scope after it, under the same
+            # transaction that arms or rebinds the watch, so sprint closure
+            # cannot land between the ACTIVE decision and its write.
+            con.execute("BEGIN IMMEDIATE")
+            if not pr_poller.is_active_sprint(con, sprint_doc_id):
+                con.rollback()
+                return self._send(409, {"error":
+                    f"document {sprint_doc_id} is not an ACTIVE, unfrozen "
+                    "SPRINT doc — watches arm only to active sprints"})
+            existing = con.execute(
+                "SELECT watch_id FROM watched_prs "
+                "WHERE repo=? AND pr_number=? AND shell_id=? "
+                "AND closed_at IS NULL AND sprint_doc_id=?",
+                (repo, pr, target, sprint_doc_id)).fetchone()
+            if existing is not None:
+                con.rollback()
+                return self._send(200, {"watch_id": existing["watch_id"],
+                                        "existing": True, "daemon": daemon})
+            unscoped = con.execute(
+                "SELECT watch_id FROM watched_prs "
+                "WHERE repo=? AND pr_number=? AND shell_id=? "
+                "AND closed_at IS NULL AND sprint_doc_id IS NULL",
+                (repo, pr, target)).fetchone()
             if unscoped is not None:
                 con.execute(
                     "UPDATE watched_prs SET sprint_doc_id=?, last_seen=? "

--- a/.super-coder/assets/skills/sprint/SKILL.md
+++ b/.super-coder/assets/skills/sprint/SKILL.md
@@ -159,14 +159,16 @@ kickoff said "start now", or a planner `task` row says so):
 - push, open your PR — then, in the SAME step:
 
 ```
-./sc watch pr <owner/repo> <pr-number> --shell <planner-shortname>
+./sc watch pr <owner/repo> <pr-number> --shell <planner-shortname> --sprint <doc-id>
 sc mem message send <planner> "sprint <doc-id>: unit <seq> pr-open — PR #<n>" --kind result
 ```
 
 The watch is what makes the loop event-driven: the daemon now turns every
 CI conclusion, review, and merge on your PR into a `pr_event` row in the
 planner's inbox. Registration is explicit and happens at PR open — a PR
-without a watch is invisible to the sprint.
+without a watch is invisible to the sprint. Sprint scope is mandatory:
+registration without `--sprint`, or against a non-ACTIVE board, fails loudly
+instead of creating a dormant watch.
 
 **5. Babysit CI while live.** `gh pr checks <your-pr> --watch` blocks in
 your session at zero scheduled cost — use it while you're booted; if your

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3462,14 +3462,16 @@ kickoff said "start now", or a planner `task` row says so):
 - push, open your PR — then, in the SAME step:
 
 ```
-./sc watch pr <owner/repo> <pr-number> --shell <planner-shortname>
+./sc watch pr <owner/repo> <pr-number> --shell <planner-shortname> --sprint <doc-id>
 sc mem message send <planner> "sprint <doc-id>: unit <seq> pr-open — PR #<n>" --kind result
 ```
 
 The watch is what makes the loop event-driven: the daemon now turns every
 CI conclusion, review, and merge on your PR into a `pr_event` row in the
 planner''s inbox. Registration is explicit and happens at PR open — a PR
-without a watch is invisible to the sprint.
+without a watch is invisible to the sprint. Sprint scope is mandatory:
+registration without `--sprint`, or against a non-ACTIVE board, fails loudly
+instead of creating a dormant watch.
 
 **5. Babysit CI while live.** `gh pr checks <your-pr> --watch` blocks in
 your session at zero scheduled cost — use it while you''re booted; if your

--- a/.super-coder/migrations/0086_reseed_sprint_watch_scope.sql
+++ b/.super-coder/migrations/0086_reseed_sprint_watch_scope.sql
@@ -1,0 +1,34 @@
+-- 0086 — require sprint scope at watched-PR registration and repair the
+-- participant procedure that omitted it. Existing unscoped legacy watches
+-- remain readable/rebindable, but new registration cannot silently create
+-- dormant state.
+
+BEGIN;
+
+UPDATE skills
+SET content = replace(
+      content,
+      './sc watch pr <owner/repo> <pr-number> --shell <planner-shortname>',
+      './sc watch pr <owner/repo> <pr-number> --shell <planner-shortname> --sprint <doc-id>'
+    )
+WHERE name = 'sprint'
+  AND instr(
+        content,
+        './sc watch pr <owner/repo> <pr-number> --shell <planner-shortname> --sprint <doc-id>'
+      ) = 0;
+
+UPDATE skills
+SET content = replace(
+      content,
+      'without a watch is invisible to the sprint.',
+      'without a watch is invisible to the sprint. Sprint scope is mandatory:
+registration without `--sprint`, or against a non-ACTIVE board, fails loudly
+instead of creating a dormant watch.'
+    )
+WHERE name = 'sprint'
+  AND instr(
+        content,
+        'without a watch is invisible to the sprint. Sprint scope is mandatory:'
+      ) = 0;
+
+COMMIT;

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -240,6 +240,15 @@ def armed_watches(con) -> list:
         "ORDER BY repo, pr_number, watch_id", tuple(sorted(active))).fetchall()
 
 
+def live_unscoped_watch_ids(con) -> list[int]:
+    """Legacy watches that cannot be polled because they have no sprint scope.
+    New registration rejects this state; old rows remain repairable by rebind."""
+    return [r[0] for r in con.execute(
+        "SELECT watch_id FROM watched_prs "
+        "WHERE closed_at IS NULL AND sprint_doc_id IS NULL "
+        "ORDER BY watch_id").fetchall()]
+
+
 # ── Per-repo backoff + blind windows ─────────────────────────────────────────
 
 class PollerState:
@@ -296,6 +305,19 @@ def _alert(con, *, severity: str, reason: str, watch_id=None) -> None:
         (watch_id, severity, reason, dedupe))
 
 
+def surface_unscoped_watches(con) -> int:
+    """Turn dormant legacy state into an operator-visible, deduped alert.
+    Returns the number of affected watches, whether newly alerted or already
+    carrying the same open alert."""
+    watch_ids = live_unscoped_watch_ids(con)
+    for watch_id in watch_ids:
+        _alert(con, severity="critical", reason="pr_watch_unscoped",
+               watch_id=watch_id)
+    if watch_ids:
+        con.commit()
+    return len(watch_ids)
+
+
 def _emit_event(con, watch, event: dict, head_sha: str) -> "int | None":
     """One semantic transition → idempotent pr_event + same-transaction wake
     item. Dedupe keyed (watch, transition, head SHA, state) via the message's
@@ -336,7 +358,8 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
     state = state if state is not None else PollerState()
     now = now if now is not None else time.monotonic()
     summary = {"watches": 0, "repos": 0, "skipped_backoff": 0,
-               "events": 0, "errors": 0, "retired": 0}
+               "events": 0, "errors": 0, "retired": 0,
+               "unscoped_alerts": surface_unscoped_watches(con)}
     emitted_ids: list[int] = []
     watches = armed_watches(con)
     summary["watches"] = len(watches)
@@ -466,7 +489,7 @@ class Poller(threading.Thread):
                         print(f"pr-poller: heartbeat error ({e})", flush=True)
                     # The DB read is cheap and local; the bounded GitHub poll
                     # happens only while ACTIVE sprint watches exist.
-                    if armed_watches(con):
+                    if armed_watches(con) or live_unscoped_watch_ids(con):
                         n = poll_cycle(con, fetch=self._fetch, source=source,
                                        state=self.state, interval=self._interval)
                         if n["events"] or n["errors"]:

--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -6,12 +6,12 @@ Spec: specs_sc/sprint-eventing.md + spec #20 (polling cutover). Three verbs,
 one vantage — everything shell-side rides the engine API (token identity,
 the `sc mem` doctrine):
 
-    ./sc watch pr <owner/repo> <n> [--shell <shortname>] [--sprint <doc-id>]
+    ./sc watch pr <owner/repo> <n> [--shell <shortname>] --sprint <doc-id>
                                                            register a watch
                                                            (defaults to the
                                                            calling shell;
-                                                           --sprint arms it
-                                                           to an ACTIVE sprint)
+                                                           scope is required
+                                                           and must be ACTIVE)
     ./sc watch list [--all]                                live watches
     ./sc watch inbox [--interval 30] [--timeout 21600]     block until this
                                                            shell has unread
@@ -146,8 +146,7 @@ def cmd_pr(args) -> int:
     payload: dict = {"repo": repo, "pr_number": args.number}
     if args.shell:
         payload["shell"] = args.shell
-    if args.sprint:
-        payload["sprint_doc_id"] = args.sprint
+    payload["sprint_doc_id"] = args.sprint
     r = _api("POST", "/_sc/watches", payload)
     who = args.shell or "you"
     if r.get("existing"):
@@ -170,7 +169,8 @@ def cmd_reconcile(args) -> int:
     r = _api("POST", "/_sc/watches/reconcile")
     print(f"watch: reconcile — {r.get('watches', 0)} armed watch(es), "
           f"{r.get('repos', 0)} repo(s) polled, {r.get('events', 0)} event(s), "
-          f"{r.get('errors', 0)} error(s), {r.get('skipped_backoff', 0)} in backoff")
+          f"{r.get('errors', 0)} error(s), {r.get('skipped_backoff', 0)} in backoff, "
+          f"{r.get('unscoped_alerts', 0)} unscoped alert(s)")
     return 0
 
 
@@ -273,8 +273,8 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("repo", help="owner/name")
     sp.add_argument("number", type=int, help="PR number")
     sp.add_argument("--shell", help="subscribe another shell (e.g. the planner) instead of you")
-    sp.add_argument("--sprint", type=int, default=0, metavar="DOC_ID",
-                    help="arm the watch to an ACTIVE sprint document (polls only while it stays ACTIVE)")
+    sp.add_argument("--sprint", type=int, required=True, metavar="DOC_ID",
+                    help="required ACTIVE sprint document scope")
     sp.set_defaults(fn=cmd_pr)
 
     sp = sub.add_parser("list", help="live watches (--all includes retired)")

--- a/skills_sc/sprint.md
+++ b/skills_sc/sprint.md
@@ -166,14 +166,16 @@ kickoff said "start now", or a planner `task` row says so):
 - push, open your PR — then, in the SAME step:
 
 ```
-./sc watch pr <owner/repo> <pr-number> --shell <planner-shortname>
+./sc watch pr <owner/repo> <pr-number> --shell <planner-shortname> --sprint <doc-id>
 sc mem message send <planner> "sprint <doc-id>: unit <seq> pr-open — PR #<n>" --kind result
 ```
 
 The watch is what makes the loop event-driven: the daemon now turns every
 CI conclusion, review, and merge on your PR into a `pr_event` row in the
 planner's inbox. Registration is explicit and happens at PR open — a PR
-without a watch is invisible to the sprint.
+without a watch is invisible to the sprint. Sprint scope is mandatory:
+registration without `--sprint`, or against a non-ACTIVE board, fails loudly
+instead of creating a dormant watch.
 
 **5. Babysit CI while live.** `gh pr checks <your-pr> --watch` blocks in
 your session at zero scheduled cost — use it while you're booted; if your

--- a/tests/test_interface_sprint_ops.py
+++ b/tests/test_interface_sprint_ops.py
@@ -317,6 +317,37 @@ class SprintOpsRoutesTest(unittest.TestCase):
                                  (SHELL2,))
         self.assertEqual(body["alerts"], [])
 
+    def test_unscoped_watch_alert_is_visible_only_to_its_owner(self):
+        con = sqlite3.connect(self.db_path)
+        watch_id = con.execute(
+            "INSERT INTO watched_prs (repo, pr_number, shell_id) "
+            "VALUES ('o/r', 7, 1)").lastrowid
+        con.execute(
+            "INSERT INTO planner_alerts "
+            "(watch_id, severity, reason, dedupe_key) VALUES "
+            "(?, 'critical', 'pr_watch_unscoped', ?)",
+            (watch_id, f"-|-|{watch_id}|-|pr_watch_unscoped"))
+        con.commit()
+        con.close()
+
+        status, body = self.call(
+            "GET", "/api/interface/sprint-alerts", (SHELL1,))
+        self.assertEqual(status, 200)
+        self.assertEqual(len(body["alerts"]), 1)
+        self.assertEqual(body["alerts"][0]["reason"], "pr_watch_unscoped")
+        self.assertIn("--sprint <doc-id>", body["alerts"][0]["next_action"])
+
+        status, body = self.call(
+            "GET", "/api/interface/sprint-alerts", (SHELL2,))
+        self.assertEqual(status, 200)
+        self.assertEqual(body["alerts"], [])
+
+        status, body = self.call(
+            "GET", "/api/interface/sprint-alerts?planner_shell_id=1", (OP,))
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            [a["reason"] for a in body["alerts"]], ["pr_watch_unscoped"])
+
     def test_alert_acknowledgement_dismisses_current_but_keeps_audit(self):
         con = sqlite3.connect(self.db_path)
         interface_broker._alert(

--- a/tests/test_interface_sprint_ops.py
+++ b/tests/test_interface_sprint_ops.py
@@ -319,6 +319,13 @@ class SprintOpsRoutesTest(unittest.TestCase):
 
     def test_unscoped_watch_alert_is_visible_only_to_its_owner(self):
         con = sqlite3.connect(self.db_path)
+        con.execute("DELETE FROM interface_input_state")
+        con.execute("DELETE FROM interface_sessions")
+        self.assertEqual(
+            con.execute(
+                "SELECT COUNT(*) FROM interface_sessions "
+                "WHERE shell_id=1 AND occupancy <> 'ended'").fetchone()[0],
+            0)
         watch_id = con.execute(
             "INSERT INTO watched_prs (repo, pr_number, shell_id) "
             "VALUES ('o/r', 7, 1)").lastrowid

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -220,6 +220,22 @@ class PollCycleTest(unittest.TestCase):
                 "r1": {"pullRequest": gh_node(checks="PENDING")}})
         pr_poller.poll_cycle(self.con, fetch)
 
+    def test_unscoped_watch_raises_one_deduped_alert_without_being_fetched(self):
+        pr_poller.poll_cycle(
+            self.con,
+            fetch_ok(gh_node(checks="PENDING"), gh_node(checks="PENDING")))
+        pr_poller.poll_cycle(
+            self.con,
+            fetch_ok(gh_node(checks="PENDING"), gh_node(checks="PENDING")))
+
+        alerts = self.con.execute(
+            "SELECT watch_id, severity, reason, resolved_at "
+            "FROM planner_alerts WHERE reason='pr_watch_unscoped'").fetchall()
+        self.assertEqual(len(alerts), 1)
+        self.assertEqual(alerts[0]["watch_id"], 4)
+        self.assertEqual(alerts[0]["severity"], "critical")
+        self.assertIsNone(alerts[0]["resolved_at"])
+
     def test_transition_fans_out_scoped_and_idempotent(self):
         pr_poller.poll_cycle(self.con, fetch_ok(
             gh_node(checks="PENDING"), gh_node(checks="PENDING")))
@@ -288,6 +304,43 @@ class PollCycleTest(unittest.TestCase):
         live = {r["pr_number"] for r in self.con.execute(
             "SELECT pr_number FROM watched_prs WHERE closed_at IS NULL")}
         self.assertEqual(live, {1, 3})               # now retired
+
+    def test_scoped_merge_emits_pr_event_queues_wake_and_retires(self):
+        self.con.executescript(
+            "INSERT INTO interface_generations (shell_id, generation) VALUES (1, 1);"
+            "INSERT INTO interface_sessions "
+            "(shell_id, generation, occupancy, lifecycle) "
+            "VALUES (1, 1, 'occupied', 'idle');"
+            "INSERT INTO sprint_planner_bindings "
+            "(sprint_doc_id, planner_shell_id, session_id, shell_id, generation) "
+            "VALUES (100, 1, 1, 1, 1);"
+            "UPDATE watched_prs SET last_seen="
+            "'{\"state\":\"OPEN\",\"sha\":\"abc1234def\",\"checks\":\"PENDING\","
+            "\"reviews\":0,\"review_state\":null}' "
+            "WHERE repo='o/r' AND pr_number=2 AND shell_id=1;")
+        self.con.commit()
+
+        n = pr_poller.poll_cycle(
+            self.con,
+            fetch_ok(gh_node(checks="PENDING"),
+                     gh_node(state="MERGED", checks="SUCCESS")))
+
+        self.assertEqual(n["events"], 2)
+        self.assertEqual(n["retired"], 1)
+        merge = self.con.execute(
+            "SELECT message_id, kind, body, sprint_doc_id FROM shell_messages "
+            "WHERE body LIKE '%merged%'").fetchone()
+        self.assertEqual(merge["kind"], "pr_event")
+        self.assertEqual(merge["sprint_doc_id"], 100)
+        self.assertIn("watch retired", merge["body"])
+        item = self.con.execute(
+            "SELECT binding_id, state FROM planner_wake_items "
+            "WHERE message_id=?", (merge["message_id"],)).fetchone()
+        self.assertEqual((item["binding_id"], item["state"]), (1, "queued"))
+        row = self.con.execute(
+            "SELECT closed_at FROM watched_prs "
+            "WHERE repo='o/r' AND pr_number=2 AND shell_id=1").fetchone()
+        self.assertIsNotNone(row["closed_at"])
 
     def test_failed_fetch_audits_backs_off_then_marks_blind_window(self):
         state = pr_poller.PollerState()
@@ -481,6 +534,32 @@ class CutoverTest(unittest.TestCase):
             run = con.execute("SELECT source, status FROM pr_poll_runs").fetchone()
             self.assertEqual(run["source"], "startup")
             self.assertEqual(run["status"], "ok")
+        finally:
+            con.close()
+
+    def test_scheduler_surfaces_unscoped_watch_without_fetching_it(self):
+        tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
+        con = build_db(tmp)
+        seed_shells(con)
+        con.execute(
+            "INSERT INTO watched_prs (repo, pr_number, shell_id) "
+            "VALUES ('o/r', 1, 1)")
+        con.commit()
+        con.close()
+        poller = pr_poller.Poller(
+            tmp, interval=30,
+            fetch=lambda q: self.fail("unscoped watch must not be fetched"))
+        poller.start()
+        time.sleep(0.5)
+        poller.stop()
+        poller.join(timeout=5)
+        con = sqlite3.connect(tmp)
+        try:
+            row = con.execute(
+                "SELECT severity, reason, resolved_at FROM planner_alerts "
+                "WHERE watch_id=1").fetchone()
+            self.assertEqual(row[:2], ("critical", "pr_watch_unscoped"))
+            self.assertIsNone(row[2])
         finally:
             con.close()
 

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -67,6 +67,14 @@ def seed_shells(con: sqlite3.Connection) -> None:
     con.commit()
 
 
+def seed_sprint_doc(con: sqlite3.Connection, doc_id: int = 100) -> None:
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title, body, frozen) "
+        "VALUES (?, 'doc', 'SPRINT: T', '# SPRINT: T\nstatus: ACTIVE\n', 0)",
+        (doc_id,))
+    con.commit()
+
+
 # ── schema: kind column + watched_prs ────────────────────────────────────────
 
 class SchemaTest(unittest.TestCase):
@@ -121,6 +129,32 @@ class SchemaTest(unittest.TestCase):
         body = self.con.execute(
             "SELECT content FROM skills WHERE name='sprint_orchestration'").fetchone()[0]
         self.assertEqual(body, asset)
+
+    def test_sprint_watch_scope_reseed_matches_asset_and_is_idempotent(self):
+        con = sqlite3.connect(":memory:")
+        self.addCleanup(con.close)
+        con.executescript(SCHEMA.read_text())
+        for migration in sorted(MIGRATIONS.glob("*.sql")):
+            if migration.name == "0086_reseed_sprint_watch_scope.sql":
+                break
+            con.executescript(migration.read_text())
+
+        old = con.execute(
+            "SELECT content FROM skills WHERE name='sprint'").fetchone()[0]
+        self.assertNotIn("--sprint <doc-id>", old.split("**5. Babysit", 1)[0])
+
+        reseed = (MIGRATIONS / "0086_reseed_sprint_watch_scope.sql").read_text()
+        con.executescript(reseed)
+        once = con.execute(
+            "SELECT content FROM skills WHERE name='sprint'").fetchone()[0]
+        con.executescript(reseed)
+        twice = con.execute(
+            "SELECT content FROM skills WHERE name='sprint'").fetchone()[0]
+        asset = (ENGINE / "assets" / "skills" / "sprint" /
+                 "SKILL.md").read_text().split("---", 2)[2].strip()
+
+        self.assertEqual(once, asset)
+        self.assertEqual(twice, once)
 
     def test_sprint_orchestration_requires_plan_billing_by_default(self):
         body = self.con.execute(
@@ -356,6 +390,7 @@ class ApiTest(unittest.TestCase):
         cls.db = cls.tmp / "shell_db.db"
         con = build_db(cls.db)
         seed_shells(con)
+        seed_sprint_doc(con)
         con.close()
         server.DB_PATH = cls.db  # db() reads the module global at call time
         cls.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
@@ -387,39 +422,43 @@ class ApiTest(unittest.TestCase):
             con.close()
 
     def test_register_defaults_to_the_token_shell(self):
-        self.assertEqual(watch.main(["pr", "own/repo", "11"]), 0)
-        rows = self.q("SELECT shell_id, closed_at FROM watched_prs "
+        self.assertEqual(
+            watch.main(["pr", "own/repo", "11", "--sprint", "100"]), 0)
+        rows = self.q("SELECT shell_id, closed_at, sprint_doc_id FROM watched_prs "
                       "WHERE repo='own/repo' AND pr_number=11")
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["shell_id"], 1)   # the token shell (plan1)
+        self.assertEqual(rows[0]["sprint_doc_id"], 100)
 
     def test_register_for_another_shell(self):
-        watch.main(["pr", "own/repo", "12", "--shell", "dev1"])
+        watch.main(["pr", "own/repo", "12", "--shell", "dev1",
+                    "--sprint", "100"])
         rows = self.q("SELECT shell_id FROM watched_prs WHERE pr_number=12")
         self.assertEqual(rows[0]["shell_id"], 2)
 
     def test_register_unknown_shell_dies(self):
         with self.assertRaises(SystemExit):
-            watch.main(["pr", "own/repo", "13", "--shell", "nobody"])
+            watch.main(["pr", "own/repo", "13", "--shell", "nobody",
+                        "--sprint", "100"])
 
     def test_register_bad_repo_dies(self):
         with self.assertRaises(SystemExit):
-            watch.main(["pr", "not-a-repo", "14"])
+            watch.main(["pr", "not-a-repo", "14", "--sprint", "100"])
 
     def test_duplicate_live_watch_is_idempotent(self):
-        watch.main(["pr", "own/repo", "15"])
-        watch.main(["pr", "own/repo", "15"])
+        watch.main(["pr", "own/repo", "15", "--sprint", "100"])
+        watch.main(["pr", "own/repo", "15", "--sprint", "100"])
         self.assertEqual(len(self.q(
             "SELECT 1 FROM watched_prs WHERE pr_number=15")), 1)
 
     def test_retired_watch_reregisters_as_new_row_keeping_history(self):
-        watch.main(["pr", "own/repo", "16"])
+        watch.main(["pr", "own/repo", "16", "--sprint", "100"])
         con = sqlite3.connect(self.db)
         con.execute("UPDATE watched_prs SET closed_at=datetime('now'), "
                     "last_seen='{\"state\":\"MERGED\"}' WHERE pr_number=16")
         con.commit()
         con.close()
-        watch.main(["pr", "own/repo", "16"])
+        watch.main(["pr", "own/repo", "16", "--sprint", "100"])
         rows = self.q("SELECT closed_at, last_seen FROM watched_prs "
                       "WHERE pr_number=16 ORDER BY watch_id")
         # The 0080 cutover: the closed row is RETAINED (with its fingerprint)
@@ -435,20 +474,56 @@ class ApiTest(unittest.TestCase):
         pr_poller.gh_fetch = lambda q: pr_poller.GhResult(error="connect timeout")
         try:
             with self.assertRaises(SystemExit):   # _api dies on the 502
-                watch.main(["pr", "own/repo", "18"])
+                watch.main(["pr", "own/repo", "18", "--sprint", "100"])
         finally:
             pr_poller.gh_fetch = real
         self.assertEqual(self.q("SELECT 1 FROM watched_prs WHERE pr_number=18"), [])
 
     def test_registration_stores_the_baseline(self):
-        watch.main(["pr", "own/repo", "19"])
+        watch.main(["pr", "own/repo", "19", "--sprint", "100"])
         row = self.q("SELECT last_seen FROM watched_prs WHERE pr_number=19")[0]
         self.assertIn('"state": "OPEN"', row["last_seen"])
         self.assertIn('"sha": "abc1234def"', row["last_seen"])
 
+    def test_scoped_registration_rebinds_legacy_and_resolves_alert(self):
+        con = sqlite3.connect(self.db)
+        watch_id = con.execute(
+            "INSERT INTO watched_prs (repo, pr_number, shell_id) "
+            "VALUES ('own/repo', 21, 1)").lastrowid
+        con.execute(
+            "INSERT INTO planner_alerts "
+            "(watch_id, severity, reason, dedupe_key) VALUES "
+            "(?, 'critical', 'pr_watch_unscoped', ?)",
+            (watch_id, f"-|-|{watch_id}|-|pr_watch_unscoped"))
+        con.commit()
+        con.close()
+
+        watch.main(["pr", "own/repo", "21", "--sprint", "100"])
+
+        rows = self.q(
+            "SELECT watch_id, sprint_doc_id, last_seen FROM watched_prs "
+            "WHERE pr_number=21")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["watch_id"], watch_id)
+        self.assertEqual(rows[0]["sprint_doc_id"], 100)
+        self.assertIn('"checks": "PENDING"', rows[0]["last_seen"])
+        alert = self.q(
+            "SELECT resolved_at FROM planner_alerts WHERE watch_id=?",
+            watch_id)[0]
+        self.assertIsNotNone(alert["resolved_at"])
+
     def test_list_shows_live_watches(self):
-        watch.main(["pr", "own/repo", "17"])
+        watch.main(["pr", "own/repo", "17", "--sprint", "100"])
         self.assertEqual(watch.main(["list"]), 0)
+
+    def test_unscoped_registration_fails_loudly_without_a_row(self):
+        with self.assertRaises(SystemExit):
+            watch.main(["pr", "own/repo", "20"])
+        with self.assertRaises(SystemExit):
+            watch._api("POST", "/_sc/watches",
+                       {"repo": "own/repo", "pr_number": 20})
+        self.assertEqual(
+            self.q("SELECT 1 FROM watched_prs WHERE pr_number=20"), [])
 
     def test_send_with_kind_lands_typed(self):
         mem.main(["message", "send", "dev1", "build unit 2", "--kind", "task"])
@@ -568,6 +643,7 @@ class DaemonLivenessApiTest(unittest.TestCase):
         cls.db = cls.tmp / "shell_db.db"
         con = build_db(cls.db)
         seed_shells(con)
+        seed_sprint_doc(con)
         con.close()
         server.DB_PATH = cls.db
         cls.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
@@ -614,9 +690,13 @@ class DaemonLivenessApiTest(unittest.TestCase):
         self.assertGreaterEqual(d["age_s"], 3600)
 
     def test_d_registration_response_carries_daemon(self):
-        r = watch._api("POST", "/_sc/watches", {"repo": "own/repo", "pr_number": 44})
+        r = watch._api("POST", "/_sc/watches",
+                       {"repo": "own/repo", "pr_number": 44,
+                        "sprint_doc_id": 100})
         self.assertTrue(r["daemon"]["stale"])   # still the -1h beat from test_c
-        r = watch._api("POST", "/_sc/watches", {"repo": "own/repo", "pr_number": 44})
+        r = watch._api("POST", "/_sc/watches",
+                       {"repo": "own/repo", "pr_number": 44,
+                        "sprint_doc_id": 100})
         self.assertTrue(r.get("existing"))      # idempotent path carries it too
         self.assertTrue(r["daemon"]["stale"])
 

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -485,6 +485,39 @@ class ApiTest(unittest.TestCase):
         self.assertIn('"state": "OPEN"', row["last_seen"])
         self.assertIn('"sha": "abc1234def"', row["last_seen"])
 
+    def test_registration_refuses_scope_closed_during_baseline(self):
+        con = sqlite3.connect(self.db)
+        seed_sprint_doc(con, 101)
+        con.close()
+        real = pr_poller.baseline_read
+
+        def close_scope(repo, pr):
+            con = sqlite3.connect(self.db)
+            try:
+                con.execute(
+                    "UPDATE documents SET body="
+                    "'# SPRINT: T\nstatus: CLOSED\n' WHERE document_id=101")
+                con.commit()
+            finally:
+                con.close()
+            return ({"state": "OPEN", "sha": "closed-during-baseline",
+                     "checks": "PENDING", "reviews": 0,
+                     "review_state": None}, None)
+
+        pr_poller.baseline_read = close_scope
+        try:
+            with self.assertRaises(SystemExit) as denied:
+                watch.main(
+                    ["pr", "own/repo", "22", "--sprint", "101"])
+        finally:
+            pr_poller.baseline_read = real
+
+        self.assertIn("HTTP 409", str(denied.exception))
+        self.assertIn("not an ACTIVE, unfrozen SPRINT doc",
+                      str(denied.exception))
+        self.assertEqual(
+            self.q("SELECT 1 FROM watched_prs WHERE pr_number=22"), [])
+
     def test_scoped_registration_rebinds_legacy_and_resolves_alert(self):
         con = sqlite3.connect(self.db)
         watch_id = con.execute(
@@ -511,6 +544,53 @@ class ApiTest(unittest.TestCase):
             "SELECT resolved_at FROM planner_alerts WHERE watch_id=?",
             watch_id)[0]
         self.assertIsNotNone(alert["resolved_at"])
+
+    def test_legacy_rebind_refuses_scope_closed_during_baseline(self):
+        con = sqlite3.connect(self.db)
+        seed_sprint_doc(con, 102)
+        watch_id = con.execute(
+            "INSERT INTO watched_prs "
+            "(repo, pr_number, shell_id, last_seen) "
+            "VALUES ('own/repo', 23, 1, '{\"state\":\"OPEN\"}')").lastrowid
+        con.execute(
+            "INSERT INTO planner_alerts "
+            "(watch_id, severity, reason, dedupe_key) VALUES "
+            "(?, 'critical', 'pr_watch_unscoped', ?)",
+            (watch_id, f"-|-|{watch_id}|-|pr_watch_unscoped"))
+        con.commit()
+        con.close()
+        real = pr_poller.baseline_read
+
+        def freeze_scope(repo, pr):
+            con = sqlite3.connect(self.db)
+            try:
+                con.execute(
+                    "UPDATE documents SET frozen=1 WHERE document_id=102")
+                con.commit()
+            finally:
+                con.close()
+            return ({"state": "OPEN", "sha": "frozen-during-baseline",
+                     "checks": "SUCCESS", "reviews": 1,
+                     "review_state": "APPROVED"}, None)
+
+        pr_poller.baseline_read = freeze_scope
+        try:
+            with self.assertRaises(SystemExit) as denied:
+                watch.main(
+                    ["pr", "own/repo", "23", "--sprint", "102"])
+        finally:
+            pr_poller.baseline_read = real
+
+        self.assertIn("HTTP 409", str(denied.exception))
+        row = self.q(
+            "SELECT sprint_doc_id, last_seen FROM watched_prs "
+            "WHERE watch_id=?", watch_id)[0]
+        self.assertIsNone(row["sprint_doc_id"])
+        self.assertEqual(row["last_seen"], '{"state":"OPEN"}')
+        alert = self.q(
+            "SELECT resolved_at FROM planner_alerts WHERE watch_id=?",
+            watch_id)[0]
+        self.assertIsNone(alert["resolved_at"])
 
     def test_list_shows_live_watches(self):
         watch.main(["pr", "own/repo", "17", "--sprint", "100"])


### PR DESCRIPTION
## Summary

- require `sprint_doc_id` at both CLI and API watch registration boundaries, and reject non-ACTIVE sprint boards instead of reporting success with dormant state
- prove the scoped merge path end to end: merge `pr_event`, planner wake eligibility, and terminal watch retirement
- actively surface legacy unscoped watches for operator rebind while preserving them rather than silently deleting evidence
- update the sprint participant procedure and reseed it in migration `0086`, ordered after F10's idempotency migration

## Verification

- focused: 128 passed (`test_interface_sprint_ops`, `test_pr_poller`, `test_sprint_eventing`, `test_skills_freshness`)
- worktree-hermetic render-check: all 87 migrations applied; flat mirror matches
- ruff: clean across all touched Python files
- full suite: 1038 passed, 8 skipped, 101 subtests passed; 12 known interface-stream spike failures because sandbox `tmux` is unavailable

## Trade-off

Legacy unscoped rows remain readable and rebindable so operators get an actionable alert and retain evidence; only new registration is made mandatory/fail-loud.

Refs #564
