### PR TITLE
feat(interface): fit viewport and add message composer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,33 @@ jobs:
       - name: Run the suite
         run: pytest tests/ -q
 
+  # The Interface unit's contract is rendered geometry, not the presence of
+  # CSS/JS strings. Exercise the real page in Chromium and retain the two
+  # viewport captures required by spec #33 / visual QA feature #19.
+  interface-rendered:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install rendered-test browser
+        run: |
+          python -m pip install pytest playwright==1.54.0
+          python -m playwright install --with-deps chromium
+      - name: Exercise Interface layout and capture viewports
+        run: pytest tests/test_interface_ui_rendered.py -q
+        env:
+          INTERFACE_VISUAL_ARTIFACTS: artifacts/interface-ui
+      - name: Upload Interface tall/short screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: interface-ui-tall-short
+          path: artifacts/interface-ui/
+          if-no-files-found: error
+          retention-days: 14
+
   # The end-to-end proof `./sc verify` runs: rebuild the DB from committed text
   # (schema + migrations + content.sql), flat-render, then a render-only boot —
   # proving a fresh clone of this exact tree stands up. Complements

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -281,7 +281,10 @@ def _client_state(con, session_id: int) -> dict:
             verified = False
     attachable = compatible and verified
     if attachable:
-        actions = ["view", "acquire_writer", "takeover", "certify", "terminate"]
+        actions = [
+            "view", "acquire_writer", "takeover", "send_input", "certify",
+            "terminate",
+        ]
         reason = None
     elif occupancy == "reserved" and lifecycle == "starting":
         actions = ["cancel_start"]
@@ -712,7 +715,8 @@ def _get_session(session_id: int):
             return _err(404, "no_such_session",
                         f"interface session {session_id} not found")
         istate = con.execute(
-            "SELECT composer, delivery, forwarded_seq, last_human_input_at "
+            "SELECT composer, browser_composer, delivery, forwarded_seq, "
+            "last_human_input_at "
             "FROM interface_input_state WHERE session_id=?",
             (session_id,)).fetchone()
         writer = interface_broker.current_writer(con, session_id)
@@ -727,9 +731,10 @@ def _get_session(session_id: int):
             "ended_at": row[11], "end_reason": row[12],
             "error_detail": row[13],
             "composer": istate[0] if istate else None,
-            "delivery": istate[1] if istate else None,
-            "forwarded_seq": istate[2] if istate else None,
-            "last_human_input_at": istate[3] if istate else None,
+            "browser_composer": istate[1] if istate else None,
+            "delivery": istate[2] if istate else None,
+            "forwarded_seq": istate[3] if istate else None,
+            "last_human_input_at": istate[4] if istate else None,
             "writer": {"held": writer is not None,
                        "client_id": writer[1] if writer else None},
             "wake_state": _wake_state(con, session_id=session_id),
@@ -915,6 +920,45 @@ def _certify_clean(actor, headers, body):
             interface_wake.notify_session(session_id)
             return 201, {"session_id": session_id, "composer": "clean"}
         return _idempotent(con, actor, "certify_clean", headers, body, produce)
+    finally:
+        con.close()
+
+
+def _set_browser_composer(actor, headers, body):
+    session_id = body.get("session_id")
+    client_id = body.get("client_id")
+    state = body.get("state")
+    if not isinstance(session_id, int) or not client_id \
+            or state not in ("clean", "dirty"):
+        return _err(
+            422, "validation",
+            "session_id (int), client_id, and state (clean|dirty) required")
+    con = _db()
+    try:
+        def produce():
+            client_state = _client_state(con, session_id)
+            if not client_state["exists"]:
+                return 404, _err_obj(
+                    "no_such_session",
+                    f"interface session {session_id} not found")
+            if not client_state["attachable"]:
+                return _client_state_error(client_state)
+            lease = interface_broker.current_writer(con, session_id)
+            if lease is None or lease[1] != str(client_id):
+                return 409, _err_obj(
+                    "not_the_writer",
+                    "browser composer state rides the current writer lease")
+            interface_broker.set_browser_composer(
+                con, session_id, str(client_id), state)
+            if state == "clean":
+                interface_wake.notify_session(session_id)
+            return 200, {
+                "session_id": session_id,
+                "browser_composer": state,
+            }
+
+        return _idempotent(
+            con, actor, "browser_composer.set", headers, body, produce)
     finally:
         con.close()
 
@@ -2200,6 +2244,8 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
             return _release_lease(actor, headers, data, _path_id(p))
         if p == "/api/interface/clean-certifications" and method == "POST":
             return _certify_clean(actor, headers, data)
+        if p == "/api/interface/browser-composer" and method == "POST":
+            return _set_browser_composer(actor, headers, data)
         if p == "/api/interface/termination-requests" and method == "POST":
             return _terminate(actor, headers, data)
         if p == "/api/interface/reconciliations" and method == "POST":

--- a/.super-coder/migrations/0087_browser_composer.sql
+++ b/.super-coder/migrations/0087_browser_composer.sql
@@ -1,0 +1,9 @@
+-- 0087 — metadata-only browser composer state for the planner wake gate.
+--
+-- The existing composer column describes the harness/tmux composer. A draft
+-- in the browser must block planner wake independently: clearing one surface
+-- must never certify the other surface clean. No draft bytes are persisted.
+
+ALTER TABLE interface_input_state
+ADD COLUMN browser_composer TEXT NOT NULL DEFAULT 'clean'
+CHECK (browser_composer IN ('clean', 'dirty'));

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -304,6 +304,44 @@ def certify_clean(con, session_id: int, client_id: str, client_seq: int) -> None
                     "certified_at": _now(con)})
 
 
+def set_browser_composer(con, session_id: int, client_id: str,
+                         state: str) -> None:
+    """Set the current writer's metadata-only browser draft state.
+
+    Browser draft bytes never cross this boundary. The separate column is
+    deliberate: clearing a browser textarea must not certify the harness/tmux
+    composer clean. BEGIN IMMEDIATE serializes this state with the planner wake
+    gate so whichever action commits first is observed by the other.
+    """
+    if state not in ("clean", "dirty"):
+        raise BrokerError(f"invalid browser composer state {state!r}")
+    began = _begin_immediate(con)
+    try:
+        sess = _session(con, session_id)
+        if sess[3] != "occupied":
+            raise BrokerError(
+                f"session {session_id} is {sess[3]}, not occupied")
+        lease = current_writer(con, session_id)
+        if lease is None or lease[1] != client_id:
+            raise BrokerError(
+                "browser composer state rides the current writer lease")
+        row = con.execute(
+            "SELECT browser_composer FROM interface_input_state "
+            "WHERE session_id=?", (session_id,)).fetchone()
+        if row is None:
+            raise BrokerError(f"session {session_id} has no input state row")
+        if row[0] != state:
+            con.execute(
+                "UPDATE interface_input_state SET browser_composer=?, "
+                "updated_at=datetime('now') WHERE session_id=?",
+                (state, session_id))
+        con.commit()
+    except Exception:
+        if began and con.in_transaction:
+            con.rollback()
+        raise
+
+
 def reconcile_input(con, session_id: int, outcome: str) -> None:
     """Explicit operator reconciliation of a delivery_unknown park.
 
@@ -900,8 +938,9 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
     fire), a live occupied session (an ended session gate-fails with an
     ALERT and the batch stays queued for a future generation — End chat
     deliberately does not release the sprint binding, so this gate must
-    never crash on it), idle lifecycle, clean
-    composer, quiet >= quiet_s since the last accepted human input AND since
+    never crash on it), idle lifecycle, clean harness/tmux composer, clean
+    metadata-only browser composer, quiet >= quiet_s since the last accepted
+    human input AND since
     REAL provider readiness (flag #49: the provider session_start stamp, NOT
     the pre-exec occupied_at — a >3s claude/codex boot must not submit into
     an unpainted TUI) AND since the last service restart (a fresh full
@@ -1001,8 +1040,8 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
             con.commit()
             return {"submitted": False, "reason": "session ended"}
         istate = con.execute(
-            "SELECT composer, pending_seq, forwarded_seq, last_human_input_at "
-            "FROM interface_input_state WHERE session_id=?",
+            "SELECT composer, browser_composer, pending_seq, forwarded_seq, "
+            "last_human_input_at FROM interface_input_state WHERE session_id=?",
             (sess[0],)).fetchone()
 
         def gate_fail(reason, **extra):
@@ -1015,7 +1054,9 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
                 f"session not occupied+idle ({sess[1]}/{sess[2]})")
         if istate[0] != "clean":
             return gate_fail(f"composer is {istate[0]}")
-        if istate[1] is not None:
+        if istate[1] != "clean":
+            return gate_fail(f"browser composer is {istate[1]}")
+        if istate[2] is not None:
             return gate_fail("a human frame is pending")
         cap = interface_hooks.capability(sess[6], sess[7])
         if not cap["mandatory_ok"]:
@@ -1044,7 +1085,7 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
         # never the pre-exec occupied_at), session start, and the last
         # service restart (startup_reconcile revokes every lease with reason
         # 'service_restart'; that stamp is the restart time).
-        baseline = max(t for t in (istate[3], sess[3], sess[4], sess[5])
+        baseline = max(t for t in (istate[4], sess[3], sess[4], sess[5])
                        if t is not None)
         restart_at = con.execute(
             "SELECT MAX(revoked_at) FROM interface_writer_leases "
@@ -1059,7 +1100,7 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
             return gate_fail(f"quiet {quiet:.2f}s < {quiet_s}s",
                              retry_after=quiet_s - quiet)
 
-        fence = istate[2] + 1
+        fence = istate[3] + 1
         interface_state.transition(
             con, "wake_batch", batch_id, "submitting",
             extra_sets={"input_seq_fence": fence})

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2629,7 +2629,6 @@ async function ifSprintPanel(pane, sel) {
   } catch { return; }   // surface down — never break the pane over the panel
   if (!pane.isConnected || (!sel.session_id && !bindings.length && !alerts.length)) return;
   const card = el("div", { className: "card" });
-  card.append(el("div", {}, el("b", {}, "Generation alerts / Sprint wake")));
   const note = el("div", { className: "if-note" });
 
   if (bindings.length) {
@@ -2879,7 +2878,7 @@ async function ifSessionPane(pane, sel) {
   // hash no-op) — the terminal keeps its scrollback; only the DOM is re-parented.
   if (ifAttach && ifAttach.sessionId === sessionId &&
       ifAttach.ws && ifAttach.ws.readyState <= WebSocket.OPEN) {
-    pane.append(ifAttach.headEl, ifAttach.termEl);
+    pane.append(ifAttach.headEl, ifAttach.termEl, ifAttach.composerEl);
     ifSprintPanel(pane, sel);
     return;
   }
@@ -2898,7 +2897,9 @@ async function ifSessionPane(pane, sel) {
     model: sess.model_route || "harness default",
     lifecycle: sess.lifecycle || "—",
     composer: sess.composer || "unknown",
+    browserComposer: sess.browser_composer || "clean",
     writer: sess.writer && sess.writer.held ? "held" : "none",
+    writerReason: "",
     clients: sess.clients ?? 0,
     wake: sess.wake_state || "disarmed",
     archive: sess.archive_id ?? null,
@@ -2907,13 +2908,29 @@ async function ifSessionPane(pane, sel) {
   };
   const headEl = el("div", { className: "if-head" });
   const termEl = el("div", { className: "if-term" });
+  const composerEl = el("div", { className: "if-composer" });
   const a = { sessionId, shortname: sel.shortname, st, headEl, termEl,
+    composerEl,
+    legalActions: new Set(
+      Array.isArray(sess.legal_actions) ? sess.legal_actions : []),
+    stateReason: sess.state_reason || "",
     ws: null, term: null, leaseId: null, leaseToken: null, role: "viewer",
     seq: 1, inflight: 0, lastAck: 0, outBuf: "", awaiting: false, halted: false,
-    heartbeat: 0, resizeObs: null, paint: null };
-  a.paint = () => ifPaintHeader(a, sel, pane);
+    heartbeat: 0, resizeObs: null, paint: null,
+    composerInput: null, composerSend: null, composerNote: null,
+    composerPendingSeq: null, browserComposerState: st.browserComposer,
+    browserComposerWanted: st.browserComposer, browserComposerError: "",
+    browserComposerSyncing: false, browserComposerVersion: 0,
+    browserComposerChain: Promise.resolve(),
+    composerProjectionPending: false, composerProjectionVersion: 0,
+    composerProjectionSync: Promise.resolve() };
+  ifBuildComposer(a);
+  a.paint = () => {
+    ifPaintHeader(a, sel, pane);
+    ifPaintComposer(a);
+  };
   ifAttach = a;
-  pane.append(headEl, termEl);
+  pane.append(headEl, termEl, composerEl);
   ifSprintPanel(pane, sel);
   a.paint();
 
@@ -2928,9 +2945,11 @@ async function ifSessionPane(pane, sel) {
       // The lease reseeds input seqs from the session's forwarded_seq + 1.
       a.seq = lease.next_input_seq ?? 1;
       a.st.writer = "active";
+      a.st.writerReason = "";
     } catch (e) {
       if (e.status !== 409 || e.code !== "writer_held") throw e;
       a.st.writer = "held";   // read-only attach; Take-over button in the header
+      a.st.writerReason = e.message;
     }
     a.paint();
     const t = await apiIf("/interface/stream-tickets", "POST",
@@ -3018,6 +3037,157 @@ function ifPaintHeader(a, sel, pane) {
   a.headEl.replaceChildren(...head);
 }
 
+function ifSizeComposer(input) {
+  input.style.height = "auto";
+  input.style.height = Math.max(42, input.scrollHeight || 42) + "px";
+}
+
+function ifComposerWritable(a) {
+  return a.legalActions.has("send_input") &&
+    a.role === "writer" && a.st.writer === "active" && !a.halted &&
+    !a.composerProjectionPending;
+}
+
+function ifComposerDisabledReason(a) {
+  if (a.composerProjectionPending)
+    return "Read-only while server input authority refreshes.";
+  if (!a.legalActions.has("send_input"))
+    return a.stateReason ||
+      "Read-only — the server does not list input as legal.";
+  if (a.role !== "writer" || a.st.writer !== "active")
+    return a.st.writerReason ||
+      "Read-only — this client does not hold the server writer lease.";
+  if (a.halted)
+    return a.st.note || "Input halted — reattach before sending.";
+  return "";
+}
+
+function ifPaintComposer(a) {
+  if (!a.composerInput) return;
+  const writable = ifComposerWritable(a);
+  const pending = a.composerPendingSeq != null;
+  const hasMessage = Boolean(a.composerInput.value.trim());
+  // Do not let a new draft appear while a clean transition is in flight:
+  // that would briefly project clean server-side while the box is non-empty.
+  // Dirty transitions need not freeze typing because every later character
+  // remains covered by the already-requested dirty state.
+  a.composerInput.disabled = !writable || pending ||
+    (a.browserComposerSyncing && a.browserComposerWanted === "clean");
+  a.composerSend.disabled = !writable || pending || a.awaiting ||
+    Boolean(a.outBuf) || !hasMessage || a.browserComposerSyncing ||
+    Boolean(a.browserComposerError) || a.browserComposerState !== "dirty";
+  if (pending) {
+    a.composerNote.textContent =
+      "Sending through the generation-fenced input broker…";
+  } else if (a.browserComposerError) {
+    a.composerNote.textContent =
+      "Draft safety sync failed; sending is disabled: " +
+      a.browserComposerError;
+  } else {
+    const disabled = ifComposerDisabledReason(a);
+    if (disabled) a.composerNote.textContent = disabled;
+    else if (!a.composerInput.value && a.browserComposerState === "dirty")
+      a.composerNote.textContent =
+        "A prior browser draft is still marked composing; edit then clear " +
+        "this box to release the planner wake gate.";
+    else a.composerNote.textContent = "";
+  }
+}
+
+function ifRefreshComposerProjection(a) {
+  const version = ++a.composerProjectionVersion;
+  a.composerProjectionPending = true;
+  a.paint();
+  a.composerProjectionSync = apiIf(
+    "/interface/sessions/" + a.sessionId
+  ).then((session) => {
+    if (ifAttach !== a || version !== a.composerProjectionVersion) return;
+    a.legalActions = new Set(
+      Array.isArray(session.legal_actions) ? session.legal_actions : []);
+    a.stateReason = session.state_reason || "";
+  }).catch((e) => {
+    if (ifAttach !== a || version !== a.composerProjectionVersion) return;
+    a.legalActions.delete("send_input");
+    a.stateReason = "Server input authority unavailable: " + e.message;
+  }).finally(() => {
+    if (ifAttach !== a || version !== a.composerProjectionVersion) return;
+    a.composerProjectionPending = false;
+    a.paint();
+  });
+}
+
+function ifSyncBrowserComposer(a, state) {
+  if (state === a.browserComposerWanted && !a.browserComposerError) return;
+  a.browserComposerWanted = state;
+  const version = ++a.browserComposerVersion;
+  a.browserComposerSyncing = true;
+  a.paint();
+  a.browserComposerChain = a.browserComposerChain.catch(() => {}).then(async () => {
+    const result = await apiIf("/interface/browser-composer", "POST", {
+      session_id: a.sessionId,
+      client_id: ifClientId,
+      state,
+    });
+    if (ifAttach !== a) return;
+    a.browserComposerState = result.browser_composer;
+    a.st.browserComposer = result.browser_composer;
+    a.browserComposerError = "";
+  }).catch((e) => {
+    if (ifAttach === a) a.browserComposerError = e.message;
+  }).finally(() => {
+    if (ifAttach !== a || version !== a.browserComposerVersion) return;
+    a.browserComposerSyncing = false;
+    a.paint();
+  });
+}
+
+function ifComposerSend(a) {
+  const value = a.composerInput.value;
+  if (!value.trim() || !ifComposerWritable(a) ||
+      a.composerPendingSeq != null || a.awaiting || a.outBuf ||
+      a.browserComposerSyncing || a.browserComposerError ||
+      a.browserComposerState !== "dirty")
+    return;
+  // xterm emits carriage return for Enter. Reuse that exact byte convention
+  // after the composed text so the existing broker submits the message.
+  const seq = ifSendInput(a, value + "\r");
+  if (seq == null) {
+    a.st.note = "message was not queued — reattach and try again";
+    a.paint();
+    return;
+  }
+  a.composerPendingSeq = seq;
+  a.paint();
+}
+
+function ifBuildComposer(a) {
+  const input = el("textarea", {
+    className: "if-composer-input", rows: 1,
+    placeholder: "Message this session…",
+    ariaLabel: "Message composer",
+  });
+  const send = el("button", {
+    className: "act primary", type: "button", textContent: "Send",
+  });
+  const note = el("div", { className: "if-note" });
+  a.composerInput = input;
+  a.composerSend = send;
+  a.composerNote = note;
+  input.oninput = () => {
+    ifSizeComposer(input);
+    ifSyncBrowserComposer(a, input.value ? "dirty" : "clean");
+    a.paint();
+  };
+  input.onkeydown = (event) => {
+    if (event.key !== "Enter" || event.shiftKey) return;
+    event.preventDefault();
+    ifComposerSend(a);
+  };
+  send.onclick = () => ifComposerSend(a);
+  a.composerEl.append(input, send, note);
+  ifSizeComposer(input);
+}
+
 // End chat (spec Workflow 9): explicit + confirmed, graceful first. Force is
 // a SEPARATE action that exists only after the graceful request timed out —
 // the API enforces the same gate (force_requires_graceful_timeout) and the
@@ -3066,6 +3236,7 @@ async function ifTakeover(a) {
     a.seq = lease.next_input_seq ?? 1;
     a.inflight = 0; a.outBuf = ""; a.awaiting = false; a.halted = false;
     a.st.writer = "active";
+    a.st.writerReason = "";
     a.paint();
     const t = await apiIf("/interface/stream-tickets", "POST",
       { session_id: a.sessionId, role: "writer", client_id: ifClientId, lease_token: a.leaseToken });
@@ -3135,13 +3306,13 @@ function ifOpenStream(a, ticket) {
 }
 
 function ifSendInput(a, data) {
-  if (a.halted || a.role !== "writer") return;
+  if (a.halted || a.role !== "writer") return null;
   a.outBuf += data;   // one unacked frame per writer — buffer while awaiting ack
-  ifFlush(a);
+  return ifFlush(a);
 }
 function ifFlush(a) {
-  if (a.awaiting || a.halted || !a.outBuf) return;
-  if (!a.ws || a.ws.readyState !== WebSocket.OPEN) return;
+  if (a.awaiting || a.halted || !a.outBuf) return null;
+  if (!a.ws || a.ws.readyState !== WebSocket.OPEN) return null;
   const payload = new TextEncoder().encode(a.outBuf);
   const frame = new Uint8Array(9 + payload.length);
   frame[0] = 0x01;
@@ -3152,6 +3323,7 @@ function ifFlush(a) {
   a.seq++;
   a.outBuf = "";
   a.awaiting = true;
+  return a.inflight;
 }
 function ifSendResize(a, rows, cols) {
   if (!a.ws || a.ws.readyState !== WebSocket.OPEN) return;
@@ -3167,17 +3339,31 @@ function ifSendResize(a, rows, cols) {
 function ifRevoked(a) {
   a.role = "viewer"; a.leaseId = null; a.leaseToken = null;
   a.awaiting = false; a.halted = false; a.outBuf = "";
+  a.composerPendingSeq = null;
   a.st.writer = "held";
+  a.st.writerReason = "Control was taken by another client.";
   a.st.note = "control was taken by another client — you are now read-only (Take-over to reclaim)";
 }
 
 function ifControl(a, m) {
   switch (m.type) {
     case "input_ack":   // may carry replayed:true — either way the frame landed
-      if (m.seq === a.inflight) { a.awaiting = false; a.lastAck = m.seq; ifFlush(a); }
+      if (m.seq === a.inflight) {
+        a.awaiting = false;
+        a.lastAck = m.seq;
+        if (m.seq === a.composerPendingSeq) {
+          a.composerPendingSeq = null;
+          a.composerInput.value = "";
+          ifSizeComposer(a.composerInput);
+          ifSyncBrowserComposer(a, "clean");
+        }
+        ifFlush(a);
+        a.paint();
+      }
       break;
     case "input_reject":
       a.awaiting = false;
+      if (m.seq === a.composerPendingSeq) a.composerPendingSeq = null;
       // writer_revoked = a takeover revoked our lease; the runtime learns of
       // it at the next keystroke and rejects the frame. Same flip as a
       // writer-state revoke — not a halt.
@@ -3198,7 +3384,10 @@ function ifControl(a, m) {
       a.paint();
       break;
     case "lifecycle":
-      if (m.lifecycle != null) a.st.lifecycle = m.lifecycle;
+      if (m.lifecycle != null && m.lifecycle !== a.st.lifecycle) {
+        a.st.lifecycle = m.lifecycle;
+        ifRefreshComposerProjection(a);
+      }
       if (m.composer != null) a.st.composer = m.composer;
       a.paint();
       break;
@@ -3232,6 +3421,7 @@ async function load(tab) {
 function show(tab) {
   for (const b of document.querySelectorAll("nav button")) b.classList.toggle("active", b.dataset.tab === tab);
   for (const k of Object.keys(VIEWS)) $(VIEWS[k][0]).hidden = k !== tab;
+  document.body.classList.toggle("interface-view", tab === "interface");
   if (tab !== "interface") ifDetach();   // leaving the tab drops the stream + lease
   load(tab);
 }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -19,6 +19,7 @@
 body {
   margin: 0; background: var(--bg); color: var(--ink);
   font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  min-height: 100dvh; display: flex; flex-direction: column;
 }
 /* thin scrollbars — on EVERY scrollable element, never the browser default.
    The `*` selector (not html) catches textareas/pres/popovers that don't
@@ -33,7 +34,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible { box-shadow: 
 header {
   display: flex; align-items: center; gap: 1.5rem; height: 52px; padding: 0 1.2rem;
   border-bottom: 1px solid var(--line); position: sticky; top: 0;
-  background: var(--bg); z-index: 5;
+  background: var(--bg); z-index: 5; flex: 0 0 52px;
 }
 h1 { font-size: 1.05rem; margin: 0; font-weight: 650; letter-spacing: .2px; flex: 1 1 0; }
 h1 span { color: var(--dim); font-weight: 400; }
@@ -60,7 +61,7 @@ nav button.active::after {
   padding: .35rem .7rem; border-radius: var(--r); cursor: pointer; font: inherit;
 }
 #snapshot:hover { border-color: var(--accent); }
-main { padding: 1.2rem; }
+main { padding: 1.2rem; flex: 1 0 auto; min-height: 0; }
 /* One shared content width for every page — no per-tab jumps. */
 /* minmax(0,1fr): grid items default to min-width:auto, so any nowrap line
    (e.g. a skill row's one-line description) would force the track — and the
@@ -68,6 +69,11 @@ main { padding: 1.2rem; }
 .view { display: grid; grid-template-columns: minmax(0, 1fr); gap: 1rem; margin: 0 auto; width: 100%; max-width: 1000px; }
 .view[hidden] { display: none; }  /* class selector would otherwise beat [hidden] */
 #view-interface { max-width: calc(230px + 1rem + 1300px); }
+body.interface-view { height: 100dvh; overflow-y: auto; }
+body.interface-view main {
+  flex: 1 1 auto; display: flex; flex-direction: column; min-height: 0;
+}
+body.interface-view #view-interface { flex: 1 1 auto; min-height: 0; }
 
 /* ── Tight card rhythm (Skills / Roadmap / Docs / Flags) ────────────────────
    Stacked card panels on these tabs sit a small 5px apart. Section headers
@@ -683,8 +689,13 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   pointer-events: none; white-space: nowrap; box-shadow: var(--menu-shadow); }
 
 /* ── Interface tab ── */
-.if-wrap { display: flex; gap: 1rem; align-items: flex-start; }
-.if-rail { flex: 0 0 230px; display: flex; flex-direction: column; gap: 5px; }
+.if-wrap {
+  display: flex; gap: 1rem; align-items: stretch; min-height: 0; height: 100%;
+}
+.if-rail {
+  flex: 0 0 230px; display: flex; flex-direction: column; gap: 5px;
+  min-height: 0; overflow-y: auto;
+}
 .if-row {
   background: var(--panel); border: 1px solid var(--line); border-radius: var(--r);
   padding: .5rem .7rem; cursor: pointer; color: var(--ink); font: inherit; text-align: left;
@@ -699,7 +710,7 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .if-badge.bad { color: #d45a5a; border-color: #d45a5a; }
 .if-pane {
   flex: 1 1 auto; min-width: 0; width: 100%; max-width: 1300px;
-  display: flex; flex-direction: column; gap: .5rem;
+  display: flex; flex-direction: column; gap: .5rem; min-height: 0;
 }
 .if-head {
   display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
@@ -713,10 +724,19 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .if-term {
   background: #000; border: 1px solid var(--line); border-radius: var(--r);
   padding: 6px; width: 100%; max-width: 1300px;
-  height: clamp(260px, calc(100dvh - 140px), 850px);
-  max-height: 850px; min-height: 260px; overflow: hidden;
+  flex: 1 1 500px; min-height: 500px; overflow: hidden;
 }
 .if-term .xterm { height: 100%; }
+.if-composer {
+  flex: 0 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) auto;
+  gap: .4rem .5rem; align-items: end;
+}
+.if-composer textarea {
+  min-height: 42px; resize: none; overflow-y: hidden;
+  font: 14px/1.4 ui-monospace, monospace;
+}
+.if-composer .act { margin: 0; min-height: 42px; }
+.if-composer .if-note { grid-column: 1 / -1; min-height: 1.2em; }
 .if-newchat .act { margin-top: .8rem; }
 .if-newchat .muted { margin-top: .5rem; }
 .if-newchat .dm-row { margin-top: .6rem; grid-template-columns: 100px minmax(10rem, 26rem) 1fr;
@@ -737,8 +757,9 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   width: 100%; max-height: 12rem; overflow-y: auto; margin-top: .5rem;
   color: var(--dim); font: 11px/1.55 ui-monospace, monospace;
 }
-/* Mobile: the rail collapses into a shell picker above the terminal; the
-   terminal keeps a stable minimum height and the header stays above it. */
+/* Mobile: the rail collapses into a shell picker above the terminal. The same
+   500px terminal floor applies; below that budget the page, not a guessed
+   terminal viewport, becomes the scroll surface. */
 .if-picker { display: none; }
 @media (max-width: 760px) {
   .if-wrap { flex-direction: column; }
@@ -747,5 +768,4 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
     border: 1px solid var(--line); border-radius: var(--r); color: var(--ink);
     font: inherit; padding: .45rem .6rem; }
   .if-pane { width: 100%; }
-  .if-term { height: clamp(240px, 55dvh, 850px); min-height: 240px; }
 }

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -818,6 +818,83 @@ class InterfaceApiTest(unittest.TestCase):
         self.assertEqual(status, 201)
         self.assertIn("ticket", body)
 
+    def test_browser_composer_is_server_projected_and_writer_scoped(self):
+        sid = self.occupy()
+        status, _, detail = self.call(
+            "GET", f"/api/interface/sessions/{sid}", (OP,))
+        self.assertEqual(status, 200, detail)
+        self.assertEqual(detail["browser_composer"], "clean")
+        self.assertIn("send_input", detail["legal_actions"])
+
+        dirty = {
+            "session_id": sid, "client_id": "web-1", "state": "dirty",
+        }
+        status, _, body = self.call(
+            "POST", "/api/interface/browser-composer",
+            (OP, "Idempotency-Key: draft-no-writer"), dirty)
+        self.assertEqual(status, 409, body)
+        self.assertEqual(body["error"]["code"], "not_the_writer")
+
+        status, _, lease = self.acquire_lease(sid)
+        self.assertEqual(status, 201, lease)
+        status, _, body = self.call(
+            "POST", "/api/interface/browser-composer",
+            (OP, "Idempotency-Key: draft-dirty"), dirty)
+        self.assertEqual(status, 200, body)
+        self.assertEqual(body, {
+            "session_id": sid, "browser_composer": "dirty",
+        })
+        # Exact retry replays without changing the state.
+        retry_status, _, retry = self.call(
+            "POST", "/api/interface/browser-composer",
+            (OP, "Idempotency-Key: draft-dirty"), dirty)
+        self.assertEqual((retry_status, retry), (status, body))
+
+        status, _, rejected = self.call(
+            "POST", "/api/interface/browser-composer",
+            (OP, "Idempotency-Key: draft-wrong-writer"),
+            {"session_id": sid, "client_id": "web-2", "state": "clean"})
+        self.assertEqual(status, 409, rejected)
+        self.assertEqual(rejected["error"]["code"], "not_the_writer")
+        with contextlib.closing(sqlite3.connect(self.db_path)) as con:
+            state = con.execute(
+                "SELECT browser_composer FROM interface_input_state "
+                "WHERE session_id=?", (sid,)).fetchone()[0]
+        self.assertEqual(state, "dirty",
+                         "a non-writer must not clear the wake gate")
+
+        status, _, body = self.call(
+            "POST", "/api/interface/browser-composer",
+            (OP, "Idempotency-Key: draft-clean"),
+            {"session_id": sid, "client_id": "web-1", "state": "clean"})
+        self.assertEqual(status, 200, body)
+        self.assertEqual(body["browser_composer"], "clean")
+        status, _, released = self.call(
+            "DELETE", f"/api/interface/writer-leases/{lease['lease_id']}",
+            (OP, "Idempotency-Key: draft-release"),
+            {"lease_token": lease["lease_token"]})
+        self.assertEqual(status, 204, released)
+        # A retry is identified before mutable writer state is revalidated:
+        # replay the original response, but never reapply the old dirty state.
+        status, _, replay_after_release = self.call(
+            "POST", "/api/interface/browser-composer",
+            (OP, "Idempotency-Key: draft-dirty"), dirty)
+        self.assertEqual((status, replay_after_release), (200, {
+            "session_id": sid, "browser_composer": "dirty",
+        }))
+        with contextlib.closing(sqlite3.connect(self.db_path)) as con:
+            state = con.execute(
+                "SELECT browser_composer FROM interface_input_state "
+                "WHERE session_id=?", (sid,)).fetchone()[0]
+        self.assertEqual(state, "clean",
+                         "an idempotent replay must not reapply stale state")
+        status, _, invalid = self.call(
+            "POST", "/api/interface/browser-composer",
+            (OP, "Idempotency-Key: draft-invalid"),
+            {"session_id": sid, "client_id": "web-1", "state": "unknown"})
+        self.assertEqual(status, 422, invalid)
+        self.assertEqual(invalid["error"]["code"], "validation")
+
     def test_extra_segment_writer_release_does_not_revoke_lease(self):
         sid = self.occupy()
         status, _, lease = self.acquire_lease(sid)

--- a/tests/test_interface_schema.py
+++ b/tests/test_interface_schema.py
@@ -153,6 +153,21 @@ class InterfaceSchemaTest(unittest.TestCase):
             "(session_id, shell_id, generation, client_id, token_hash) "
             "VALUES (?,1,1,'c2','h2')", (sid,))
 
+    def test_browser_composer_defaults_clean_and_rejects_unknown_states(self):
+        sid = self._session(occupancy="occupied")
+        self.con.execute(
+            "INSERT INTO interface_input_state "
+            "(session_id, shell_id, generation, composer) "
+            "VALUES (?,1,1,'clean')", (sid,))
+        state = self.con.execute(
+            "SELECT browser_composer FROM interface_input_state "
+            "WHERE session_id=?", (sid,)).fetchone()[0]
+        self.assertEqual(state, "clean")
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "UPDATE interface_input_state SET browser_composer='unknown' "
+                "WHERE session_id=?", (sid,))
+
     def test_one_live_batch_per_binding(self):
         bid = self._binding()
         self.con.execute(

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -24,6 +24,10 @@ PICKER = APP[APP.index("function dmModelPicker"):
              APP.index("async function renderDefaultModels")]
 RECOVERY = APP[APP.index("function ifRecoveryEvidenceRows"):
                APP.index("// Sprint wake panel")]
+COMPOSER = APP[APP.index("function ifSizeComposer"):
+               APP.index("// End chat")]
+INPUT_BROKER = APP[APP.index("function ifSendInput"):
+                   APP.index("// ── Tabs + boot")]
 RENDER_INTERFACE = APP[APP.index("const IF_BADGE"):
                        APP.index("// A reservation is not a terminal")]
 AVAILABLE = APP[APP.index("function ifAvailablePane"):
@@ -205,10 +209,14 @@ if (lastScrolled.title !== "model-59" || lastScrolled.block !== "nearest") {
     assert result.returncode == 0, result.stderr
 
 
-def test_interface_terminal_has_exact_caps_and_live_resize_reporting():
+def test_interface_terminal_flexes_to_viewport_with_floor_and_live_resize():
     assert "#view-interface { max-width: calc(230px + 1rem + 1300px); }" in CSS
     assert "max-width: 1300px" in CSS
-    assert "max-height: 850px" in CSS
+    assert "body.interface-view { height: 100dvh; overflow-y: auto; }" in CSS
+    assert "flex: 1 1 500px; min-height: 500px" in CSS
+    assert "max-height: 850px" not in CSS
+    assert "calc(100dvh - 140px)" not in CSS
+    assert "document.body.classList.toggle(\"interface-view\"" in APP
     assert "ResizeObserver(fit)" in APP
     assert "ws.onopen" in APP
     assert "ifSendResize(a, term.rows, term.cols)" in APP
@@ -228,6 +236,158 @@ def test_alerts_render_provenance_action_and_durable_acknowledgement():
     assert "a.generation" in APP
     assert "/acknowledge" in APP
     assert "Alert history" in APP
+    assert "Generation alerts / Sprint wake" not in APP
+
+
+def test_message_composer_uses_broker_ack_and_preserves_raw_terminal_input():
+    el_helper = APP[APP.index("const el ="):APP.index("const esc =")]
+    script = el_helper + COMPOSER + INPUT_BROKER + r"""
+globalThis.WebSocket = { OPEN: 1 };
+globalThis.ifClientId = "web-1";
+globalThis.ifAttach = null;
+const apiCalls = [];
+let sessionProjection = {
+  legal_actions: ["send_input"],
+  state_reason: null,
+};
+async function apiIf(path, method, body) {
+  if (path === "/interface/sessions/7") return sessionProjection;
+  apiCalls.push({ path, method, body });
+  return { browser_composer: body.state };
+}
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag;
+    this.nodeType = 1;
+    this.children = [];
+    this.style = {};
+    this.value = "";
+    this.disabled = false;
+    this.scrollHeight = 42;
+    this._text = "";
+  }
+  append(...nodes) { this.children.push(...nodes); }
+  set textContent(value) { this._text = String(value ?? ""); }
+  get textContent() { return this._text; }
+}
+globalThis.document = {
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({ nodeType: 3, textContent: String(text ?? "") }),
+};
+function invariant(ok, message) {
+  if (!ok) throw new Error(message);
+}
+const frames = [];
+const a = {
+  sessionId: 7,
+  legalActions: new Set(["send_input"]),
+  stateReason: "",
+  role: "writer",
+  st: {
+    writer: "active", writerReason: "", note: "", lifecycle: "idle",
+    browserComposer: "clean",
+  },
+  halted: false,
+  awaiting: false,
+  outBuf: "",
+  seq: 4,
+  inflight: 0,
+  lastAck: 0,
+  ws: { readyState: 1, send: (frame) => frames.push(frame) },
+  composerEl: new FakeElement("div"),
+  composerPendingSeq: null,
+  browserComposerState: "clean",
+  browserComposerWanted: "clean",
+  browserComposerError: "",
+  browserComposerSyncing: false,
+  browserComposerVersion: 0,
+  browserComposerChain: Promise.resolve(),
+  composerProjectionPending: false,
+  composerProjectionVersion: 0,
+  composerProjectionSync: Promise.resolve(),
+};
+a.paint = () => ifPaintComposer(a);
+ifAttach = a;
+ifBuildComposer(a);
+a.paint();
+
+(async () => {
+  a.composerInput.value = "hello\nworld";
+  a.composerInput.scrollHeight = 70;
+  a.composerInput.oninput();
+  await a.browserComposerChain;
+  invariant(apiCalls.length === 1 &&
+    apiCalls[0].path === "/interface/browser-composer" &&
+    apiCalls[0].body.state === "dirty",
+    `draft state did not reach the server: ${JSON.stringify(apiCalls)}`);
+  let prevented = false;
+  a.composerInput.onkeydown({
+    key: "Enter", shiftKey: true, preventDefault() { prevented = true; },
+  });
+  invariant(!prevented && frames.length === 0,
+    "Shift+Enter must remain a local newline");
+  a.composerInput.onkeydown({
+    key: "Enter", shiftKey: false, preventDefault() { prevented = true; },
+  });
+  invariant(prevented && frames.length === 1,
+    "Enter did not send exactly one broker frame");
+  const payload = new TextDecoder().decode(frames[0].subarray(9));
+  invariant(payload === "hello\nworld\r",
+    `composer bytes bypassed terminal Enter semantics: ${JSON.stringify(payload)}`);
+  invariant(a.composerInput.value === "hello\nworld" &&
+    a.composerPendingSeq === 4,
+    "draft cleared before the generation-fenced broker ack");
+  ifControl(a, { type: "input_ack", seq: 4 });
+  invariant(a.composerInput.disabled,
+    "new typing was allowed while the server clean transition was in flight");
+  await a.browserComposerChain;
+  invariant(a.composerInput.value === "" && a.composerPendingSeq === null,
+    "acknowledged composer draft was not cleared");
+  invariant(!a.composerInput.disabled,
+    "composer stayed disabled after the clean transition was acknowledged");
+  invariant(apiCalls.length === 2 && apiCalls[1].body.state === "clean",
+    "acknowledged send did not release browser composing state");
+
+  a.composerInput.value = " \n";
+  a.composerInput.oninput();
+  await a.browserComposerChain;
+  a.composerInput.onkeydown({
+    key: "Enter", shiftKey: false, preventDefault() {},
+  });
+  invariant(frames.length === 1, "whitespace-only input sent a second frame");
+
+  a.role = "viewer";
+  a.st.writer = "held";
+  a.st.writerReason = "writer held by another client";
+  a.paint();
+  invariant(a.composerInput.disabled &&
+    a.composerNote.textContent.includes("writer held"),
+    "non-writer composer was not disabled with the server reason");
+
+  a.role = "writer";
+  a.st.writer = "active";
+  a.legalActions = new Set(["send_input"]);
+  sessionProjection = {
+    legal_actions: [],
+    state_reason: "generation has ended",
+  };
+  ifControl(a, { type: "lifecycle", lifecycle: "ended" });
+  invariant(a.composerInput.disabled &&
+    a.composerNote.textContent.includes("authority refreshes"),
+    "lifecycle change left input enabled before server projection refreshed");
+  await a.composerProjectionSync;
+  invariant(a.composerInput.disabled &&
+    a.composerNote.textContent.includes("generation has ended"),
+    "ended session did not retain the server-projected disabled reason");
+})().catch((error) => {
+  console.error(error.stack || error);
+  process.exit(1);
+});
+"""
+    result = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+    assert "term.onData((d) => ifSendInput(a, d))" in APP
 
 
 def test_recovery_renders_only_server_listed_actions_and_full_diagnostics():

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -1,0 +1,330 @@
+"""Rendered Interface layout and live-resize coverage for spec #33.
+
+The normal engine suite stays dependency-light, so this module skips unless
+Playwright is installed.  The ``interface-rendered`` CI job installs the same
+pinned browser stack as visual QA and uploads the tall/short screenshots.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+
+sync_api = pytest.importorskip("playwright.sync_api")
+sync_playwright = sync_api.sync_playwright
+
+ROOT = Path(__file__).resolve().parents[1]
+UI = ROOT / ".super-coder" / "ui"
+
+SHELL = {
+    "shell_id": 3,
+    "shortname": "DEV3",
+    "display_name": "Code-01",
+    "availability": "occupied",
+    "session_id": 7,
+    "generation": 1,
+    "harness": "codex",
+    "alerts": 1,
+}
+SESSION = {
+    "session_id": 7,
+    "generation": 1,
+    "attachable": True,
+    "identity_verified": True,
+    "harness": "codex",
+    "model_route": "gpt-5.6-sol",
+    "lifecycle": "idle",
+    "composer": "clean",
+    "browser_composer": "clean",
+    "writer": {"held": False},
+    "clients": 1,
+    "wake_state": "armed",
+    "archive_id": 172,
+    "occupied_at": "2026-07-24 08:00:00",
+    "legal_actions": ["send_input"],
+    "state_reason": None,
+}
+ALERT = {
+    "alert_id": 120,
+    "session_id": 7,
+    "generation": 1,
+    "category": "delivery",
+    "severity": "warning",
+    "reason": "visual_qa_fixture",
+    "meaning": "A rendered alert row reserves real layout space.",
+    "next_action": "Inspect the session before retrying.",
+    "opened_at": "2026-07-24 08:30:00",
+    "dismissible": True,
+    "acknowledged_at": None,
+    "acknowledged_by": None,
+    "resolved_at": None,
+}
+
+
+class QuietHandler(SimpleHTTPRequestHandler):
+    def log_message(self, _format: str, *_args: object) -> None:
+        pass
+
+
+@pytest.fixture(scope="module")
+def ui_url():
+    handler = lambda *args, **kwargs: QuietHandler(  # noqa: E731
+        *args, directory=str(UI), **kwargs
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture(scope="module")
+def browser():
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        try:
+            yield browser
+        finally:
+            browser.close()
+
+
+def _json(route, value: object, status: int = 200) -> None:
+    route.fulfill(
+        status=status,
+        content_type="application/json",
+        body=json.dumps(value),
+    )
+
+
+def _mock_api(route) -> None:
+    request = route.request
+    path = request.url.split("/api", 1)[-1]
+    if path == "/health":
+        return _json(route, {"repo": "rendered-fixture", "port": 0})
+    if path == "/interface/browser-sessions":
+        return _json(route, {"csrf": "rendered-fixture"})
+    if path == "/interface/shells":
+        return _json(route, {"shells": [SHELL]})
+    if path == "/interface/sessions/7":
+        return _json(route, SESSION)
+    if path == "/interface/writer-leases":
+        return _json(
+            route,
+            {"lease_id": 11, "lease_token": "lease", "next_input_seq": 1},
+        )
+    if path == "/interface/stream-tickets":
+        return _json(route, {"ticket": "stream-ticket"})
+    if path == "/interface/browser-composer":
+        body = request.post_data_json or {}
+        return _json(route, {"browser_composer": body.get("state", "clean")})
+    if path.startswith("/interface/sprint-bindings"):
+        return _json(route, {"bindings": []})
+    if path.startswith("/interface/sprint-alerts"):
+        if "include_resolved=1" in path:
+            history = [
+                {
+                    **ALERT,
+                    "alert_id": 200 + index,
+                    "reason": f"rendered_history_{index:02d}",
+                    "resolved_at": "2026-07-24 08:40:00",
+                }
+                for index in range(14)
+            ]
+            return _json(route, {"alerts": history})
+        return _json(route, {"alerts": [ALERT]})
+    return _json(route, {})
+
+
+INIT_SCRIPT = r"""
+window.__wsInstances = 0;
+window.__wsResizeFrames = [];
+window.__terminalResizes = [];
+
+class RenderedWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  constructor() {
+    window.__wsInstances += 1;
+    this.readyState = RenderedWebSocket.OPEN;
+    queueMicrotask(() => this.onopen?.());
+  }
+  send(frame) {
+    if (frame instanceof Uint8Array && frame[0] === 0x03) {
+      const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
+      window.__wsResizeFrames.push({
+        rows: view.getUint16(1),
+        cols: view.getUint16(3),
+      });
+    }
+  }
+  close() { this.readyState = RenderedWebSocket.CLOSED; }
+}
+window.WebSocket = RenderedWebSocket;
+
+class RenderedTerminal {
+  constructor() {
+    this.rows = 24;
+    this.cols = 80;
+    this._resize = null;
+  }
+  open(container) {
+    const terminal = document.createElement("div");
+    terminal.className = "xterm";
+    terminal.textContent = "Rendered xterm viewport";
+    container.append(terminal);
+  }
+  onData(callback) { this._data = callback; }
+  onResize(callback) { this._resize = callback; }
+  resize(cols, rows) {
+    this.cols = cols;
+    this.rows = rows;
+    window.__terminalResizes.push({ rows, cols });
+    this._resize?.({ rows, cols });
+  }
+  write() {}
+  reset() {}
+  dispose() {}
+}
+window.Terminal = RenderedTerminal;
+"""
+
+
+def _open_interface(browser, ui_url: str, *, height: int):
+    context = browser.new_context(viewport={"width": 1600, "height": height})
+    page = context.new_page()
+    page.add_init_script(INIT_SCRIPT)
+    page.route("**/vendor/xterm/xterm.js", lambda route: route.fulfill(
+        status=200, content_type="application/javascript", body=""
+    ))
+    page.route("**/api/**", _mock_api)
+    page.goto(f"{ui_url}/#interface/DEV3", wait_until="networkidle")
+    page.locator(".if-term .xterm").wait_for()
+    page.wait_for_function("window.__wsResizeFrames.length > 0")
+    return context, page
+
+
+def _layout(page) -> dict[str, object]:
+    return page.evaluate(
+        """() => {
+          const term = document.querySelector(".if-term").getBoundingClientRect();
+          const composer = document.querySelector(".if-composer").getBoundingClientRect();
+          const docHeight = Math.max(
+            document.documentElement.scrollHeight,
+            document.body.scrollHeight
+          );
+          return {
+            innerHeight: window.innerHeight,
+            docHeight,
+            pageScrolls: docHeight > window.innerHeight + 1,
+            termHeight: term.height,
+            composerHeight: composer.height,
+          };
+        }"""
+    )
+
+
+def _artifact(tmp_path: Path, name: str) -> Path:
+    configured = os.environ.get("INTERFACE_VISUAL_ARTIFACTS")
+    directory = Path(configured) if configured else tmp_path
+    if not directory.is_absolute():
+        directory = ROOT / directory
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory / name
+
+
+def test_tall_fit_short_floor_and_visual_qa(browser, ui_url, tmp_path):
+    context, page = _open_interface(browser, ui_url, height=1400)
+    try:
+        tall = _layout(page)
+        assert tall["termHeight"] > 850
+        assert tall["pageScrolls"] is False
+        page.screenshot(path=str(_artifact(tmp_path, "interface-tall.png")),
+                        full_page=True)
+
+        page.set_viewport_size({"width": 1600, "height": 1000})
+        page.wait_for_timeout(100)
+        fitted = _layout(page)
+        assert fitted["termHeight"] >= 500
+        assert fitted["pageScrolls"] is False
+
+        page.set_viewport_size({"width": 1600, "height": 900})
+        page.wait_for_timeout(100)
+        short = _layout(page)
+        assert 500 <= short["termHeight"] <= 502
+        assert short["pageScrolls"] is True
+        page.screenshot(path=str(_artifact(tmp_path, "interface-short.png")),
+                        full_page=True)
+    finally:
+        context.close()
+
+
+def test_attached_resize_refits_and_reports_without_reconnect(
+    browser, ui_url
+):
+    context, page = _open_interface(browser, ui_url, height=1000)
+    try:
+        before = page.evaluate(
+            """() => ({
+              sockets: window.__wsInstances,
+              terminals: window.__terminalResizes.slice(),
+              frames: window.__wsResizeFrames.slice()
+            })"""
+        )
+        page.set_viewport_size({"width": 1600, "height": 1400})
+        page.wait_for_function(
+            "(count) => window.__terminalResizes.length > count",
+            arg=len(before["terminals"]),
+        )
+        after = page.evaluate(
+            """() => ({
+              sockets: window.__wsInstances,
+              terminals: window.__terminalResizes.slice(),
+              frames: window.__wsResizeFrames.slice()
+            })"""
+        )
+        assert before["sockets"] == after["sockets"] == 1
+        assert after["terminals"][-1]["rows"] > before["terminals"][-1]["rows"]
+        assert len(after["frames"]) > len(before["frames"])
+        assert after["frames"][-1] == after["terminals"][-1]
+    finally:
+        context.close()
+
+
+def test_alert_history_and_multiline_composer_respect_terminal_floor(
+    browser, ui_url
+):
+    context, page = _open_interface(browser, ui_url, height=1100)
+    try:
+        initial = _layout(page)
+        assert initial["pageScrolls"] is False
+
+        composer = page.locator(".if-composer-input")
+        composer.fill("\n".join(f"message line {index}" for index in range(12)))
+        page.wait_for_timeout(100)
+        composed = _layout(page)
+        assert composed["composerHeight"] > initial["composerHeight"]
+        assert composed["termHeight"] >= 500
+        assert (
+            composed["termHeight"] < initial["termHeight"]
+            or composed["pageScrolls"] is True
+        )
+
+        page.get_by_role("button", name="Alert history").click()
+        page.locator(".if-history").wait_for()
+        expanded = _layout(page)
+        assert expanded["termHeight"] >= 500
+        assert expanded["pageScrolls"] is True
+    finally:
+        context.close()

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -218,8 +218,15 @@ def _open_interface(browser, ui_url: str, *, height: int):
 def _layout(page) -> dict[str, object]:
     return page.evaluate(
         """() => {
-          const term = document.querySelector(".if-term").getBoundingClientRect();
+          const pane = document.querySelector(".if-pane");
+          const termElement = document.querySelector(".if-term");
+          const term = termElement.getBoundingClientRect();
           const composer = document.querySelector(".if-composer").getBoundingClientRect();
+          const children = Array.from(pane.children);
+          const nonTermHeight = children
+            .filter((child) => child !== termElement)
+            .reduce((height, child) => height + child.getBoundingClientRect().height, 0);
+          const gap = parseFloat(getComputedStyle(pane).rowGap);
           const docHeight = Math.max(
             document.documentElement.scrollHeight,
             document.body.scrollHeight
@@ -229,6 +236,10 @@ def _layout(page) -> dict[str, object]:
             docHeight,
             pageScrolls: docHeight > window.innerHeight + 1,
             termHeight: term.height,
+            availableTermHeight:
+              pane.getBoundingClientRect().height -
+              nonTermHeight -
+              gap * Math.max(children.length - 1, 0),
             composerHeight: composer.height,
           };
         }"""
@@ -257,6 +268,9 @@ def test_tall_fit_short_floor_and_visual_qa(browser, ui_url, tmp_path):
         page.wait_for_timeout(100)
         fitted = _layout(page)
         assert fitted["termHeight"] >= 500
+        assert fitted["termHeight"] == pytest.approx(
+            fitted["availableTermHeight"], abs=2
+        )
         assert fitted["pageScrolls"] is False
 
         page.set_viewport_size({"width": 1600, "height": 900})

--- a/tests/test_interface_wake.py
+++ b/tests/test_interface_wake.py
@@ -319,6 +319,28 @@ class WakeGateHardeningTest(WakeFixture):
         self.assertEqual(writes, [])
         self.assertEqual(self.batch_state(batch_id), "queued")
 
+    def test_nonempty_browser_composer_blocks_same_wake_gate(self):
+        batch_id = self._armed_batch()
+        self.con.execute(
+            "UPDATE interface_input_state SET browser_composer='dirty' "
+            "WHERE session_id=?", (self.sid,))
+        self.con.commit()
+        writes = []
+        out = self.submit(batch_id, writes.append)
+        self.assertFalse(out["submitted"])
+        self.assertEqual(out["reason"], "browser composer is dirty")
+        self.assertEqual(writes, [], "a browser draft must block every wake byte")
+        self.assertEqual(self.batch_state(batch_id), "queued")
+
+        self.con.execute(
+            "UPDATE interface_input_state SET browser_composer='clean' "
+            "WHERE session_id=?", (self.sid,))
+        self.con.commit()
+        out = self.submit(batch_id, writes.append)
+        self.assertTrue(out["submitted"])
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(self.batch_state(batch_id), "submitting")
+
     def test_unmanaged_writable_client_disarms_and_alerts(self):
         batch_id = self._armed_batch()
         writes = []


### PR DESCRIPTION
## Summary
- make the Interface workspace fill the viewport while preserving the 500px terminal floor and independently scrolling rail
- add a writer-gated browser composer projected entirely from canonical server legal actions and lifecycle state
- persist only clean/dirty composer metadata and include it in the atomic planner wake gate

## Verification
- `pytest tests/ -q`: 1035 passed, 8 skipped, 101 subtests
- focused Interface API/schema/wake/UI-contract suites green
- lint, Python compilation, Node syntax, and `git diff --check` green
- Chromium viewport proof at 1600x1400 and 1600x700; multiline growth and alert expansion preserved one WebSocket

## Notes
- `./sc test` additionally exercises optional interface-stream spike tests; 12 fail when tmux is absent, while the repository CI command above is fully green.
- Engine worktree migration targeting issue filed as #569.

Sprint 31 F7 · Spec doc #33