### PR TITLE
fix(interface): bind staged-index content to the recovery fence (S31 F12)

### DIFF
--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -693,6 +693,14 @@ def cmd_recover(args) -> int:
     for parked in closed.get("parked", []):
         print(f"→ parked ambiguous binding {parked['binding_id']}: "
               f"{parked['next_action']}")
+    runtime = closed.get("runtime")
+    if runtime and not runtime.get("abandoned"):
+        # The durable rows are closed either way, so this is not a failed
+        # recovery — but the generation may still be attached, and a field
+        # nobody prints is the same silence it was named to end (SC-128).
+        print("→ the runtime would not release the session generation "
+              f"({runtime.get('error', 'unknown error')}) — the durable "
+              "state IS closed; check the Interface runtime", file=sys.stderr)
     wt = result.get("worktree") or {}
     if wt.get("failed"):
         done = ", ".join(wt.get("completed") or []) or "nothing"

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -502,6 +502,46 @@ def _entry_identity(worktree: str, rel: str, index: dict[str, str]) -> str:
             + index.get(rel, _INDEX_ABSENT))
 
 
+def _enumerate(worktree: str, head: bool) -> tuple[set, set, set]:
+    """`(tracked, untracked_files, untracked_dirs)` — the entries a discard
+    would have to undo, as of now.
+
+    Factored out because this predicate is applied TWICE to the same worktree
+    and the two uses must never drift: once to build the plan (what the
+    operator is shown, and what bounds the destruction), and once after the
+    discard to decide whether it actually worked. "Undone" is then defined as
+    "this same enumeration no longer names it" — the contract itself, not a
+    proxy standing in for it (SC-129).
+    """
+    def paths(*args) -> list[str]:
+        # -z: paths verbatim, no C-quoting to unescape.
+        return [p for p in _git_out(worktree, *args, timeout=30).split("\0")
+                if p]
+
+    listed = set(paths("ls-files", "-o", "--exclude-standard", "-z"))
+    untracked_dirs = {p for p in
+                      paths("ls-files", "-o", "--directory",
+                            "--exclude-standard", "-z") if p.endswith("/")}
+    # A trailing slash in the FILE listing is a nested repository — git names
+    # it once and never descends. It is a directory: unlinking it would fail
+    # the whole discard, and `clean -fd` leaves it alone too.
+    untracked_dirs |= {p for p in listed if p.endswith("/")}
+    untracked_files = {p for p in listed if not p.endswith("/")}
+    if not head:
+        return set(paths("ls-files", "-z")), untracked_files, untracked_dirs
+    # BOTH diffs, because neither alone is the set. `diff HEAD` compares HEAD
+    # to the WORKING TREE, so a path staged and then deleted (`AD`) reads as
+    # no change — absent in HEAD, absent on disk — while the index still holds
+    # its blob. It was therefore in no delete set and no preview, survived the
+    # discard, and `discarded=true` was returned over staged work still
+    # sitting in the index. `reset --hard`, the operation this replaces, threw
+    # that entry away; found by asking the SC-129 question of the enumeration
+    # itself rather than of the check that reads it.
+    tracked = set(paths("diff", "HEAD", "--name-only", "-z"))
+    tracked |= set(paths("diff", "--cached", "HEAD", "--name-only", "-z"))
+    return tracked, untracked_files, untracked_dirs
+
+
 def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     """WHAT a discard would destroy, named entry by entry: the exact SET of
     worktree entries, each entry's identity, and the digest over the whole
@@ -534,8 +574,10 @@ def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     - untracked DIRECTORIES in their own right (`--directory`, trailing `/`),
       empty ones included: `clean -fd` removes a directory that a file listing
       never names;
-    - born HEAD -> every path differing from HEAD (`diff HEAD`): staged,
-      unstaged and deletions, one row each;
+    - born HEAD -> every path differing from HEAD in the working tree OR in
+      the index (`diff HEAD` and `diff --cached HEAD`): staged, unstaged and
+      deletions, one row each. Both, because a path staged and then deleted
+      differs from HEAD only in the index — see `_enumerate`;
     - unborn HEAD -> every INDEX entry (`ls-files`). Nothing has been
       committed, so a discard drops the whole index and the files with it —
       and `ls-files -o` cannot see a staged path, which left staged work
@@ -544,43 +586,27 @@ def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     Ignored files stay out: `clean -fd` without -x does not touch them, so
     they are not state the confirmation is about.
     """
-    def paths(*args) -> list[str]:
-        # -z: paths verbatim, no C-quoting to unescape.
-        return [p for p in _git_out(worktree, *args, timeout=30).split("\0")
-                if p]
-
-    listed = set(paths("ls-files", "-o", "--exclude-standard", "-z"))
-    untracked_dirs = {p for p in
-                      paths("ls-files", "-o", "--directory",
-                            "--exclude-standard", "-z") if p.endswith("/")}
-    # A trailing slash in the FILE listing is a nested repository — git names
-    # it once and never descends. It is a directory: unlinking it would fail
-    # the whole discard, and `clean -fd` leaves it alone too.
-    untracked_dirs |= {p for p in listed if p.endswith("/")}
-    untracked_files = {p for p in listed if not p.endswith("/")}
-    tracked = set(paths("diff", "HEAD", "--name-only", "-z")) if head \
-        else set(paths("ls-files", "-z"))
+    tracked, untracked_files, untracked_dirs = _enumerate(worktree, head)
     index = _index_identities(worktree)
 
     h = hashlib.sha256()
     for line in sorted(porcelain):
         h.update(line.encode("utf-8", "surrogateescape") + b"\n")
-    identities, index_of, fs_of = {}, {}, {}
+    identities, index_of = {}, {}
     for rel in sorted(tracked | untracked_files | untracked_dirs):
         index_of[rel] = index.get(rel, _INDEX_ABSENT)
-        fs_of[rel] = _path_identity(os.path.join(worktree, rel))
-        identities[rel] = fs_of[rel] + "\0" + index_of[rel]
+        identities[rel] = (_path_identity(os.path.join(worktree, rel)) + "\0"
+                           + index_of[rel])
         h.update(rel.encode("utf-8", "surrogateescape") + b"\0"
                  + identities[rel].encode() + b"\0")
-    # The two halves are kept separately as well as composed, because the
-    # discard has to re-verify each one ALONE at a point where the other has
-    # legitimately moved: the index just before the destructive call, when the
-    # removal may already have unlinked the file (SC-124), and the filesystem
-    # just after it, when the restore has already rewritten the index (SC-127).
+    # The INDEX half is kept separately as well as composed, because the
+    # discard has to re-verify it ALONE at a point where the filesystem half
+    # has legitimately moved: immediately before the destructive call, when the
+    # removal may already have unlinked the file (SC-124).
     return {"head": head, "tracked": sorted(tracked),
             "untracked_files": sorted(untracked_files),
             "untracked_dirs": sorted(untracked_dirs),
-            "identities": identities, "index": index_of, "fs": fs_of,
+            "identities": identities, "index": index_of,
             "digest": h.hexdigest()}
 
 
@@ -787,46 +813,57 @@ def _unrestored(worktree: str, plan: dict, restored: list[str]) -> list[str]:
     """Of the entries the restore reported success for, the ones it did NOT
     actually undo. Never raises.
 
-    An exit code is not an outcome. `git restore` can exit 0 having silently
-    skipped a path: with a SYMLINK standing in for one of its parent
-    directories it refuses to write through the link, updates the index, and
-    leaves the working file exactly as it was (SC-127, reproduced). The safety
-    property holds — nothing outside the worktree is touched, which is what
-    SC-105 asked for — and that is precisely what hid this: the result claimed
-    `discarded=true` over a dirty file still sitting there. Decision #45 ranks
-    that misreporting with destruction, so the outcome is VERIFIED.
+    An exit code is not an outcome. `git restore` can exit 0 without having
+    put the entry where it promised, and the result then claims `discarded`
+    over work still sitting on disk — misreporting, which decision #45 ranks
+    with destruction. So the outcome is VERIFIED rather than inferred.
 
-    What makes the check exact: every enumerated tracked entry differs from
-    HEAD by construction, and a restore that ran makes it equal HEAD — a
-    different entity, and in any case a rewritten one, so its identity cannot
-    still be the one the operator was shown. An entry whose filesystem
-    identity is byte-identical to the consented one was therefore not touched.
-    The INDEX cannot answer this: the skipped restore updated it (reproduced),
-    so the index reads discarded while the work is still on disk.
+    Verified against the CONTRACT, and that distinction is the whole of
+    SC-129. The first version of this check asked whether the entry had
+    changed from the identity the operator consented to — a PROXY: the
+    contract implies it, so the right answer satisfies it, but so does a
+    restore that writes some THIRD state, which is neither the old content nor
+    HEAD. It passed and the discard was reported complete. (Same shape as
+    F7's SC-121 one unit over: asserting a floor the correct implementation
+    also clears.)
+
+    The contract is "this entry is no longer one a discard would have to
+    undo", so that is what is asked — by re-running the enumeration that
+    DEFINED the set (`_enumerate`) and requiring the entry to be absent from
+    it. Nothing is restated in a second form that could drift: a third state
+    still differs from HEAD and is named; a staged-new path whose file
+    survived its de-staging is named as untracked; an entry the restore left
+    alone is named exactly as it was at plan time.
+
+    That enumeration reads the worktree half of a flagged entry THROUGH the
+    index — `git diff` trusts skip-worktree and assume-unchanged and will not
+    look at the file — so an entry still carrying a durable bit here cannot be
+    verified by it and is reported kept. Reachable enumerated entries do not
+    hit this: a bit only exists on an index entry, and an index entry the plan
+    holds differs from HEAD, so the restore rewrites it and drops the bit with
+    it (reproduced). An entry whose bit survived is one where something other
+    than that happened, which is not a state to report success from.
 
     Unreadable now -> unverifiable, and an unverifiable outcome is never
     reported as a success.
 
-    On an unborn HEAD there is nothing to restore TO — the removal loop
-    already unlinked these files and `git rm --cached` drops the entry — so
-    what is checked there is that the index no longer holds it.
+    On an unborn HEAD the same enumeration is the same contract: the entry
+    must be gone from the index (`ls-files`) and gone from disk, where it
+    would otherwise reappear in the untracked listing.
     """
-    if not plan["head"]:
-        try:
-            index = _index_identities(worktree)
-        except _GitEvidenceUnavailable:
-            return sorted(restored)
-        return sorted(rel for rel in restored if rel in index)
-    stale = []
-    for rel in restored:
-        try:
-            now = _path_identity(os.path.join(worktree, rel))
-        except _GitEvidenceUnavailable:
-            stale.append(rel)
-        else:
-            if now == plan["fs"][rel]:
-                stale.append(rel)
-    return sorted(stale)
+    if not restored:
+        return []
+    try:
+        tracked, untracked_files, untracked_dirs = _enumerate(worktree,
+                                                              plan["head"])
+        index = _index_identities(worktree)
+    except _GitEvidenceUnavailable:
+        return sorted(restored)
+    still = tracked | untracked_files | untracked_dirs
+    return sorted(
+        rel for rel in restored
+        if rel in still
+        or _index_flags(index.get(rel, _INDEX_ABSENT)) != "--")
 
 
 _INDEX_FLAG_OPTS = {"S": "--skip-worktree", "A": "--assume-unchanged"}
@@ -873,6 +910,15 @@ def _restore_index_flags(worktree: str, plan: dict,
         return sorted(want)
     return sorted(rel for rel, flags in want.items()
                   if _index_flags(after.get(rel, _INDEX_ABSENT)) != flags)
+
+
+def _discard_result(worktree: str) -> dict:
+    """The shape EVERY discard outcome is reported in, whether the sequence
+    ran to the end, stopped at a named step, or never started because the gate
+    ahead of it broke. One builder so those cannot drift into three answers to
+    the same question."""
+    return {"worktree": worktree, "discarded": False, "completed": [],
+            "failed": None, "kept": [], "kept_count": 0, "flags_lost": []}
 
 
 def _discard_worktree_files(worktree: str, plan: dict) -> dict:
@@ -927,9 +973,7 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
     part-filled result rather than raising, and an unexpected failure is NAMED
     in `failed` rather than swallowed.
     """
-    result: dict = {"worktree": worktree, "discarded": False,
-                    "completed": [], "failed": None,
-                    "kept": [], "kept_count": 0, "flags_lost": []}
+    result = _discard_result(worktree)
     try:
         _discard_steps(worktree, plan, result)
     except Exception as exc:  # noqa: BLE001 — post-commit: report, never raise
@@ -1101,12 +1145,17 @@ def _discard_steps(worktree: str, plan: dict, result: dict) -> None:
                 "error": out.stderr.decode("utf-8", "replace").strip()[-200:]}
             return
     result["completed"].append("restore")
-    # The restore's exit code says it ran, not that it worked (SC-127). Verify
-    # each entry actually moved before any of it is reported as discarded.
+    # The restore's exit code says it ran, not that it worked (SC-127), and
+    # "it moved" is not the promise either (SC-129). Verify each entry against
+    # the contract before any of it is reported as discarded.
     skipped = _unrestored(worktree, plan, restore)
     for rel in skipped:
         keep(rel)
-    restore = [rel for rel in restore if rel not in set(skipped)]
+    # Every entry the restore RAN OVER gets its bits put back, including the
+    # ones just reported kept: the command clears them whether or not it went
+    # on to do what it promised, and an entry reported as spared whose durable
+    # bit was silently dropped is spared in name only (SC-125's rule, applied
+    # to the set the command touched rather than the set it satisfied).
     result["flags_lost"] = _restore_index_flags(worktree, plan, restore)
     # A surviving DIRECTORY does not make the discard incomplete. It stands
     # because it holds something outside the delete set — an ignored file, a
@@ -1751,6 +1800,61 @@ def _close_durable_state(con, shell_id: int, evidence: dict,
     return changed
 
 
+def _abandon_runtime(abandon, evidence: dict) -> dict | None:
+    """Drop the live runtime generation now that the durable state is closed.
+    `None` when there was nothing to abandon.
+
+    Best-effort by design — the closure is already committed and a runtime
+    that will not let go is not something to fail a recovery over — but
+    REPORTED, which it was not. A swallowed failure here is post-commit
+    misreporting in the one shape that never produces a 500: the response says
+    the shell is available while a generation may still be attached to it, and
+    the operator has nothing to act on. Same rule as everywhere else in this
+    unit — handle it where something can be done about it, and name it either
+    way (SC-128).
+    """
+    if abandon is None or not evidence["live_session"] \
+            or not evidence["session"]:
+        return None
+    try:
+        abandon(evidence["session"]["session_id"])
+    except Exception as exc:  # noqa: BLE001 — post-commit: report, never raise
+        return {"abandoned": False,
+                "error": f"{type(exc).__name__}: {str(exc)[:200]}"}
+    return {"abandoned": True}
+
+
+def _discard_after_closure(observation_id: str, evidence: dict, worktree: str,
+                           signal_result) -> dict:
+    """The late gate AND the discard, under one result-producing boundary.
+
+    `_discard_worktree_files` promises never to raise (SC-126), and that
+    promise was read as covering the post-commit path. It covered the sequence
+    inside it: `_assert_worktree_unchanged` runs after the same durable commit,
+    can throw for reasons that are not its refusal — an unreadable worktree,
+    a git that will not spawn — and threw straight past the structure into a
+    500 with the session already ended (SC-128).
+
+    So the boundary belongs at the seam between "the durable state is closed"
+    and "the files are dealt with", not around one of the two helpers on the
+    far side of it. The gate's own `RecoveryError` still leaves: it is the
+    honest refusal, and states both the closure it performed and that nothing
+    was discarded. Anything else becomes a discard result naming the step that
+    broke, which at this point is all the operator can act on.
+    """
+    try:
+        plan = _assert_worktree_unchanged(observation_id, evidence, worktree,
+                                          signal_result)
+    except RecoveryError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — post-commit: report, never raise
+        result = _discard_result(worktree)
+        result["failed"] = {"step": "worktree_gate",
+                            "error": f"{type(exc).__name__}: {str(exc)[:200]}"}
+        return result
+    return _discard_worktree_files(worktree, plan)
+
+
 def execute(con, shell_id: int, body: dict,
             default_worktree: str | None,
             grace_s: float = GRACEFUL_TERMINATE_S,
@@ -1879,27 +1983,31 @@ def execute(con, shell_id: int, body: dict,
     except Exception:
         con.rollback()
         raise
-    if abandon is not None and evidence["live_session"] and evidence["session"]:
-        try:
-            abandon(evidence["session"]["session_id"])
-        except Exception:  # noqa: BLE001, S110 — runtime cleanup is
-            pass         # best-effort; durable state is already closed
-
-    discarded = None
+    # -- past the point of no return: NOTHING below may become a 500 --------
+    # The durable state is committed and cannot be unwound, and for a discard
+    # the operator's files are about to be — or by now already have been —
+    # touched. An exception escaping from here reaches the route as an opaque
+    # internal error whose body says which of those happened: nothing. That is
+    # the worst report there is, and decision #45 ranks it with the
+    # destruction itself. SC-126 gave that guarantee to the discard sequence;
+    # SC-128 was the identical defect one call EARLIER, in the late gate,
+    # which sat outside the structure built for it. So the boundary is drawn
+    # around the whole tail rather than around another helper: the response is
+    # assembled HERE, out of values already in hand, and every step after it
+    # only fills one of its fields in. Three things can still go wrong past
+    # this line and each returns rather than raises — the runtime abandon, the
+    # late gate, and the discard — the single exception being the gate's own
+    # refusal, which is not opaque: it names the closure it performed and that
+    # nothing was discarded.
+    result = {"shell_id": shell_id, "shortname": shortname,
+              "classification": classification, "mode": mode,
+              "signaled": signal_result,
+              "closed": changed,
+              "worktree": {"preserved": True},
+              "unread_messages": evidence["unread_messages"],
+              "availability": "available"}
+    changed["runtime"] = _abandon_runtime(abandon, evidence)
     if discard:
-        assert worktree is not None  # proven by the discard gate above
-        # Re-read the worktree immediately before the delete: the shell may
-        # have written during its own SIGTERM shutdown, after the fence above
-        # passed. The gate hands back the enumerated set that read confirmed,
-        # and the discard is bounded by it — see both docstrings.
-        plan = _assert_worktree_unchanged(observation_id, evidence, worktree,
-                                          signal_result)
-        discarded = _discard_worktree_files(worktree, plan)
-
-    return {"shell_id": shell_id, "shortname": shortname,
-            "classification": classification, "mode": mode,
-            "signaled": signal_result,
-            "closed": changed,
-            "worktree": discarded or {"preserved": True},
-            "unread_messages": evidence["unread_messages"],
-            "availability": "available"}
+        result["worktree"] = _discard_after_closure(
+            observation_id, evidence, worktree, signal_result)
+    return result

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -112,7 +112,17 @@ def _read_stat(pid: int) -> tuple[int, str]:
 def _proc_state(pid: int, start_ticks: int) -> str:
     """Exact-identity liveness: 'alive' (pid present, ticks match, not a
     zombie), 'dead' (pid gone, recycled, or reaped), 'unreadable' (present
-    but /proc refuses us — fail closed, never 'dead')."""
+    but /proc will not give us a usable answer — fail closed, never 'dead').
+
+    'Unreadable' covers a refused read AND an unusable one. A short or
+    malformed `/proc/<pid>/stat` — the file is a live snapshot and can be read
+    mid-teardown — makes `_read_stat` raise ValueError or IndexError, which
+    escaped every caller: this one is called from inside the signalling
+    sequence, where an escape after SIGTERM became an opaque 500 over an
+    already-delivered signal (SC-131). Answering 'unreadable' here is both the
+    honest reading and the fail-closed one, and it is fixed at the definition
+    so no caller has to guard it separately.
+    """
     try:
         ticks, state = _read_stat(pid)
     except FileNotFoundError:
@@ -120,6 +130,8 @@ def _proc_state(pid: int, start_ticks: int) -> str:
     except (PermissionError, ProcessLookupError):
         return "unreadable"
     except OSError:
+        return "unreadable"
+    except (ValueError, IndexError):
         return "unreadable"
     if ticks != start_ticks:
         return "dead"  # recycled pid: a different process, not ours
@@ -168,7 +180,26 @@ def terminate_process_group(pid: int, start_ticks: int,
     indeterminate — the caller maps that to a refusal, never a closure.
     `dead` is True ONLY on /proc-proven absence: a signal is not proof of
     death, and 'unreadable' or a SIGKILL survivor (D-state) leaves the
-    caller to refuse closure with a named next action."""
+    caller to refuse closure with a named next action.
+
+    ALWAYS returns a result; never raises. The delivery of the first signal is
+    a seam exactly like the durable commit: before it, a failure is a refusal
+    and nothing has happened; after it, an irreversible act has been performed
+    and an exception escaping to the route as an opaque 500 tells the operator
+    neither that their process was signalled nor that nothing was closed
+    (SC-131). So the boundary sits AT the seam, and the failure modes are
+    enumerated by where they fall relative to it rather than by which of them
+    a probe has already found:
+
+    - before delivery — a stale identity, an unreadable process group, and a
+      SIGTERM that cannot be delivered at all (EPERM on a group we may not
+      signal, ESRCH on one that died since the identity check). All report
+      `signaled: False`, which the caller maps to a refusal;
+    - after delivery — everything else, whatever it is. The grace poll, the
+      identity re-check, the SIGKILL itself and its poll all run under one
+      boundary that returns `signaled: True` with the phase it broke in, so
+      the caller can state what was done to the process and what was not.
+    """
     state = _proc_state(pid, start_ticks)
     if state != "alive":
         return {"signaled": False, "dead": False, "reason": "indeterminate",
@@ -178,39 +209,61 @@ def terminate_process_group(pid: int, start_ticks: int,
     except OSError:
         return {"signaled": False, "dead": False, "reason": "indeterminate",
                 "detail": "process group unreadable at signal time"}
-    os.killpg(pgid, signal.SIGTERM)
-    state = _wait_dead(pid, start_ticks, grace_s)
-    if state == "dead":
-        return {"signaled": True, "dead": True, "escalated": False,
-                "pid": pid, "pgid": pgid}
-    if state == "unreadable":
-        return {"signaled": True, "dead": False, "escalated": False,
-                "pid": pid, "pgid": pgid, "reason": "absence_unproven",
-                "detail": "SIGTERM sent but /proc turned unreadable during "
-                          "the grace — absence not proven"}
-    # Grace expired with the process alive. Re-verify the EXACT identity
-    # before SIGKILL — the window is long enough for exit + PID reuse, and
-    # the rule is never signal an uncertain process.
-    state = _proc_state(pid, start_ticks)
-    if state != "alive":
-        return {"signaled": True, "dead": state == "dead",
-                "escalated": False, "pid": pid, "pgid": pgid,
-                "note": "identity changed during grace — no SIGKILL sent"}
     try:
-        pgid = os.getpgid(pid)
-    except OSError:
-        return {"signaled": True, "dead": False, "escalated": False,
-                "pid": pid, "pgid": pgid,
-                "note": "process exited during grace — no SIGKILL sent"}
-    os.killpg(pgid, signal.SIGKILL)
-    state = _wait_dead(pid, start_ticks, grace_s)
-    if state == "dead":
-        return {"signaled": True, "dead": True, "escalated": True,
-                "pid": pid, "pgid": pgid}
-    return {"signaled": True, "dead": False, "escalated": True,
-            "pid": pid, "pgid": pgid, "reason": "absence_unproven",
-            "detail": f"process state {state} after SIGKILL — absence not "
-                      "proven (an unkillable D-state process survives)"}
+        os.killpg(pgid, signal.SIGTERM)
+    except OSError as exc:
+        # Nothing was delivered, so this is a refusal like the two above and
+        # not a partial act — the distinction the caller acts on.
+        return {"signaled": False, "dead": False, "reason": "indeterminate",
+                "detail": f"SIGTERM could not be delivered to PGID {pgid}: "
+                          f"{type(exc).__name__}: {str(exc)[:200]}"}
+    # -- the signal is delivered: NOTHING below may raise -------------------
+    phase, escalated = "grace_wait", False
+    try:
+        state = _wait_dead(pid, start_ticks, grace_s)
+        if state == "dead":
+            return {"signaled": True, "dead": True, "escalated": False,
+                    "pid": pid, "pgid": pgid}
+        if state == "unreadable":
+            return {"signaled": True, "dead": False, "escalated": False,
+                    "pid": pid, "pgid": pgid, "reason": "absence_unproven",
+                    "detail": "SIGTERM sent but /proc turned unreadable "
+                              "during the grace — absence not proven"}
+        # Grace expired with the process alive. Re-verify the EXACT identity
+        # before SIGKILL — the window is long enough for exit + PID reuse, and
+        # the rule is never signal an uncertain process.
+        phase = "escalation_recheck"
+        state = _proc_state(pid, start_ticks)
+        if state != "alive":
+            return {"signaled": True, "dead": state == "dead",
+                    "escalated": False, "pid": pid, "pgid": pgid,
+                    "note": "identity changed during grace — no SIGKILL sent"}
+        try:
+            pgid = os.getpgid(pid)
+        except OSError:
+            return {"signaled": True, "dead": False, "escalated": False,
+                    "pid": pid, "pgid": pgid,
+                    "note": "process exited during grace — no SIGKILL sent"}
+        phase = "sigkill"
+        os.killpg(pgid, signal.SIGKILL)
+        escalated, phase = True, "kill_wait"
+        state = _wait_dead(pid, start_ticks, grace_s)
+        if state == "dead":
+            return {"signaled": True, "dead": True, "escalated": True,
+                    "pid": pid, "pgid": pgid}
+        return {"signaled": True, "dead": False, "escalated": True,
+                "pid": pid, "pgid": pgid, "reason": "absence_unproven",
+                "detail": f"process state {state} after SIGKILL — absence not "
+                          "proven (an unkillable D-state process survives)"}
+    except Exception as exc:  # noqa: BLE001 — post-signal: report, never raise
+        return {"signaled": True, "dead": False, "escalated": escalated,
+                "pid": pid, "pgid": pgid, "reason": "signal_failed",
+                "phase": phase,
+                "error": f"{type(exc).__name__}: {str(exc)[:200]}",
+                "detail": f"SIGTERM was delivered to PGID {pgid} and cannot "
+                          f"be unwound; the sequence then failed in {phase} "
+                          f"({type(exc).__name__}: {str(exc)[:200]}) — "
+                          "absence not proven"}
 
 
 # ------------------------------------------------------------------ git facts
@@ -502,16 +555,30 @@ def _entry_identity(worktree: str, rel: str, index: dict[str, str]) -> str:
             + index.get(rel, _INDEX_ABSENT))
 
 
-def _enumerate(worktree: str, head: bool) -> tuple[set, set, set]:
-    """`(tracked, untracked_files, untracked_dirs)` — the entries a discard
-    would have to undo, as of now.
+def _enumerate(worktree: str, head: bool) -> tuple[set, set, set, set]:
+    """`(tracked, index_only, untracked_files, untracked_dirs)` — the entries a
+    discard would have to undo, as of now, classified by what undoing one does.
 
-    Factored out because this predicate is applied TWICE to the same worktree
-    and the two uses must never drift: once to build the plan (what the
-    operator is shown, and what bounds the destruction), and once after the
-    discard to decide whether it actually worked. "Undone" is then defined as
-    "this same enumeration no longer names it" — the contract itself, not a
-    proxy standing in for it (SC-129).
+    THE definition of the destructive set, and the only one. It has three
+    consumers and states itself to none of them: the plan the operator
+    confirms and the destruction it bounds (`_discard_plan`), the check that
+    decides whether the discard actually worked (`_unrestored`), and the
+    preview the operator reads (`evidence_projection`, through
+    `_observe_worktree`). Each restatement was a place the contract could
+    drift from itself, and each one drifted: the verification asked a proxy
+    question (SC-129), and the preview counted porcelain lines instead —
+    which is why it described a staged blob's destruction in the same words as
+    an ordinary file deletion (SC-130).
+
+    `index_only` is a SUBSET of `tracked`, and it is the class the operator
+    cannot otherwise see: the entry's content lives in the index and the
+    working tree does not show it, so nothing on disk changes appearance when
+    the discard destroys it. On a born HEAD that is exactly "differs from HEAD
+    in the index while the working tree agrees with HEAD" — the `AD` staged-
+    then-deleted path, and equally a staged edit whose file was written back
+    to HEAD's content. On an unborn HEAD, where there is no HEAD to agree
+    with, it is an index entry with no file on disk at all: the same class,
+    reached by the same reasoning rather than by the one case a probe found.
     """
     def paths(*args) -> list[str]:
         # -z: paths verbatim, no C-quoting to unescape.
@@ -528,7 +595,10 @@ def _enumerate(worktree: str, head: bool) -> tuple[set, set, set]:
     untracked_dirs |= {p for p in listed if p.endswith("/")}
     untracked_files = {p for p in listed if not p.endswith("/")}
     if not head:
-        return set(paths("ls-files", "-z")), untracked_files, untracked_dirs
+        tracked = set(paths("ls-files", "-z"))
+        index_only = {rel for rel in tracked
+                      if not os.path.lexists(os.path.join(worktree, rel))}
+        return tracked, index_only, untracked_files, untracked_dirs
     # BOTH diffs, because neither alone is the set. `diff HEAD` compares HEAD
     # to the WORKING TREE, so a path staged and then deleted (`AD`) reads as
     # no change — absent in HEAD, absent on disk — while the index still holds
@@ -537,9 +607,10 @@ def _enumerate(worktree: str, head: bool) -> tuple[set, set, set]:
     # sitting in the index. `reset --hard`, the operation this replaces, threw
     # that entry away; found by asking the SC-129 question of the enumeration
     # itself rather than of the check that reads it.
-    tracked = set(paths("diff", "HEAD", "--name-only", "-z"))
-    tracked |= set(paths("diff", "--cached", "HEAD", "--name-only", "-z"))
-    return tracked, untracked_files, untracked_dirs
+    in_worktree = set(paths("diff", "HEAD", "--name-only", "-z"))
+    in_index = set(paths("diff", "--cached", "HEAD", "--name-only", "-z"))
+    return in_worktree | in_index, in_index - in_worktree, \
+        untracked_files, untracked_dirs
 
 
 def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
@@ -586,7 +657,8 @@ def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     Ignored files stay out: `clean -fd` without -x does not touch them, so
     they are not state the confirmation is about.
     """
-    tracked, untracked_files, untracked_dirs = _enumerate(worktree, head)
+    tracked, index_only, untracked_files, untracked_dirs = _enumerate(
+        worktree, head)
     index = _index_identities(worktree)
 
     h = hashlib.sha256()
@@ -604,6 +676,7 @@ def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     # has legitimately moved: immediately before the destructive call, when the
     # removal may already have unlinked the file (SC-124).
     return {"head": head, "tracked": sorted(tracked),
+            "index_only": sorted(index_only),
             "untracked_files": sorted(untracked_files),
             "untracked_dirs": sorted(untracked_dirs),
             "identities": identities, "index": index_of,
@@ -620,14 +693,22 @@ def _observe_worktree(worktree: str) -> tuple[dict, dict]:
     branch = _git_out(worktree, "rev-parse", "--abbrev-ref", "HEAD") \
         if head else _git_out(worktree, "branch", "--show-current")
     porcelain = _git_out(worktree, "status", "--porcelain").splitlines()
-    untracked = sum(1 for ln in porcelain if ln.startswith("??"))
-    dirty = len(porcelain) - untracked
     unpushed = int(_git_out(worktree, "rev-list", "HEAD", "--not",
                             "--remotes", "--count").strip() or 0) \
         if head else 0
     plan = _discard_plan(worktree, porcelain, head)
+    # COUNTED OFF THE PLAN, never off porcelain. What the operator is shown
+    # has to be generated by the same thing that decides what happens, or the
+    # two can describe different worlds — and did: porcelain renders an `AD`
+    # staged-then-deleted path as one dirty line, indistinguishable from an
+    # ordinary deletion, while the plan destroys a staged blob nothing on disk
+    # shows (SC-130). Porcelain stays an INPUT to the digest, where its
+    # coarseness is harmless; it is no longer a second statement of the set.
     return {"worktree": worktree, "branch": branch.strip(),
-            "dirty_tracked": dirty, "untracked": untracked,
+            "dirty_tracked": len(plan["tracked"]),
+            "index_only": len(plan["index_only"]),
+            "untracked": len(plan["untracked_files"]),
+            "untracked_dirs": len(plan["untracked_dirs"]),
             "unpushed_commits": unpushed,
             # WHICH paths changed and WHAT each one now IS — not just how
             # many: equal-count churn (one file cleaned while another is
@@ -854,8 +935,8 @@ def _unrestored(worktree: str, plan: dict, restored: list[str]) -> list[str]:
     if not restored:
         return []
     try:
-        tracked, untracked_files, untracked_dirs = _enumerate(worktree,
-                                                              plan["head"])
+        tracked, _index_only, untracked_files, untracked_dirs = _enumerate(
+            worktree, plan["head"])
         index = _index_identities(worktree)
     except _GitEvidenceUnavailable:
         return sorted(restored)
@@ -1425,11 +1506,26 @@ def evidence_projection(evidence: dict, classification: str,
     elif git:
         tracked = git.get("dirty_tracked")
         untracked = git.get("untracked")
-        if isinstance(tracked, int) and isinstance(untracked, int):
-            cleanliness = "clean" if tracked == 0 and untracked == 0 \
-                else "not clean"
+        untracked_dirs = git.get("untracked_dirs")
+        index_only = git.get("index_only")
+        if all(isinstance(n, int)
+               for n in (tracked, untracked, untracked_dirs, index_only)):
+            cleanliness = "clean" if not (tracked or untracked
+                                          or untracked_dirs) else "not clean"
+            # The enumerated entries are rendered BY EFFECT, because the
+            # operator's consent is what makes destroying them legitimate and
+            # they cannot consent to what they cannot see. An index-only entry
+            # is the class with no appearance on disk at all — it read as an
+            # ordinary dirty file, so a discard destroying staged work looked
+            # byte-identical to one deleting a file the operator could see
+            # (SC-130). Named here, in the one projection both clients render.
+            staged = (f" ({index_only} of them staged-only: content held in "
+                      "the git index that the working tree does not show — a "
+                      "discard destroys it)") if index_only else ""
             worktree_value = (
-                f"{cleanliness} · {tracked} tracked · {untracked} untracked · "
+                f"{cleanliness} · {tracked} tracked{staged} · "
+                f"{untracked} untracked file(s) · "
+                f"{untracked_dirs} untracked dir(s) · "
                 f"{git.get('unpushed_commits', '—')} unpushed commit(s) · "
                 f"branch {git.get('branch') or '—'} · "
                 f"{git.get('worktree') or 'worktree path unavailable'}")
@@ -1460,8 +1556,9 @@ def evidence_projection(evidence: dict, classification: str,
 
 _VOLATILE_PROCESS_KEYS = ("pane_id", "pane_pid", "pane_start_ticks",
                           "pane_present", "pid_state", "pgid")
-_VOLATILE_GIT_KEYS = ("worktree", "branch", "dirty_tracked", "untracked",
-                      "unpushed_commits", "change_digest", "indeterminate")
+_VOLATILE_GIT_KEYS = ("worktree", "branch", "dirty_tracked", "index_only",
+                      "untracked", "untracked_dirs", "unpushed_commits",
+                      "change_digest", "indeterminate")
 
 
 def _volatile_git(git: dict | None) -> dict | None:
@@ -1960,14 +2057,32 @@ def execute(con, shell_id: int, body: dict,
                 "sent, no state closed; preview again",
                 {"detail": signal_result.get("detail")})
         if not signal_result.get("dead"):
+            # Two ways to reach here and the operator acts on them
+            # differently: the process outlived the signals, or the sequence
+            # itself broke after delivering one. Both are refusals — nothing
+            # closed, nothing discarded — and both say so rather than letting
+            # the second escape as an opaque 500 over an irreversible
+            # signal (SC-131).
+            failed = signal_result.get("reason") == "signal_failed"
             raise RecoveryError(
                 409, "recovery_absence_unproven",
-                "a signal was sent but /proc never proved the process gone "
-                "— durable closure refused (closure only on proven "
-                "absence). Next action: preview again; if the process "
-                "persists, inspect /proc/"
-                f"{proc['pane_pid']} and resolve it at the OS level first",
-                {"pid": proc["pane_pid"],
+                ("a signal was delivered and the termination sequence then "
+                 f"failed in {signal_result.get('phase')} "
+                 f"({signal_result.get('error')}) — absence never proven, so "
+                 "no session, archive, alert or binding was closed and "
+                 "nothing was reset or cleaned. "
+                 if failed else
+                 "a signal was sent but /proc never proved the process gone "
+                 "— durable closure refused (closure only on proven "
+                 "absence). ") +
+                "Next action: preview again; if the process persists, "
+                f"inspect /proc/{proc['pane_pid']} and resolve it at the OS "
+                "level first",
+                {"pid": proc["pane_pid"], "signaled": True,
+                 "escalated": signal_result.get("escalated"),
+                 "phase": signal_result.get("phase"),
+                 "error": signal_result.get("error"),
+                 "closed": False, "discarded": False,
                  "detail": signal_result.get("detail")})
 
     # -- atomic durable closure on proven absence ---------------------------

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -1980,9 +1980,31 @@ def execute(con, shell_id: int, body: dict,
             "SET acted_at=datetime('now') WHERE observation_id=?",
             (observation_id,))
         con.commit()
-    except Exception:
+    except Exception as exc:
+        # The rollback makes the DURABLE half a clean no-op — and says nothing
+        # about the half that cannot be rolled back. By here the exact process
+        # has been signalled and proven dead, so a bare 500 leaves the operator
+        # with a shell whose rows still read live and whose process is gone,
+        # and no way to tell that from a recovery that never started. Same rule
+        # as the post-commit paths, one step earlier: an irreversible action
+        # already performed is NAMED, whichever direction the failure goes
+        # (SC-128's category, taken to the whole sequence rather than to the
+        # side of the commit it was found on).
         con.rollback()
-        raise
+        raise RecoveryError(
+            500, "recovery_closure_failed",
+            "the durable closure failed and was rolled back — no session, "
+            "archive, alert or binding was changed, and NOTHING was reset or "
+            "cleaned. " + (
+                f"The exact process (PID {signal_result.get('pid')}) was "
+                "already signalled and proven dead (that cannot be unwound), "
+                "so the shell's rows still describe a process that is gone; "
+                "recover it again to close them."
+                if signal_result else
+                "No process was signalled. Recover again."),
+            {"observation_id": observation_id, "signaled": signal_result,
+             "closed": False, "discarded": False,
+             "error": f"{type(exc).__name__}: {str(exc)[:200]}"}) from exc
     # -- past the point of no return: NOTHING below may become a 500 --------
     # The durable state is committed and cannot be unwound, and for a discard
     # the operator's files are about to be — or by now already have been —

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -408,6 +408,58 @@ def _path_identity(path: str) -> str:
         "torn read: an entry kept changing while it was observed")
 
 
+# What `_entry_identity` records for a path the index holds nothing for.
+# A value, not an absence: a path GAINING or LOSING an index entry is itself
+# a change the digest must move on.
+_INDEX_ABSENT = "index:none"
+
+
+def _index_identities(worktree: str) -> dict[str, str]:
+    """What the INDEX holds, per path: mode, object id and merge stage.
+
+    Read in ONE pass over the whole index rather than per path — every entry
+    then comes from the same instant, the same way the path set does.
+
+    Blob id, mode and stage ONLY — never the index file's own mtime or its
+    stat cache. `git status` REFRESHES those as a side effect of the very
+    observation this fences, so binding them would make a preview stale
+    against itself and refuse every discard forever (the same trap st_atime
+    is excluded from `_path_identity` for). What a discard destroys is the
+    CONTENT the index holds, and that is what is recorded.
+
+    An unmerged path carries several stage entries; all of them are recorded,
+    sorted, because a conflict resolution rewrites exactly that set.
+    """
+    entries: dict[str, list[str]] = {}
+    for record in _git_out(worktree, "ls-files", "--stage", "-z",
+                           timeout=30).split("\0"):
+        if not record:
+            continue
+        meta, _tab, rel = record.partition("\t")
+        entries.setdefault(rel, []).append(" ".join(meta.split()))
+    return {rel: "+".join(sorted(stages)) for rel, stages in entries.items()}
+
+
+def _entry_identity(worktree: str, rel: str, index: dict[str, str]) -> str:
+    """One enumerated entry's COMPLETE identity — what the filesystem holds at
+    that path, and what the index holds for it.
+
+    Staged work does not live in the worktree, and a discard destroys it all
+    the same: `git restore --source=HEAD --staged` throws the index back to
+    HEAD, and on an unborn HEAD `git rm --cached` drops the entry outright. So
+    an operator who stages a change AFTER the preview had, until SC-123, work
+    inside the confirmed blast radius that no gate could see — the working
+    file, its lstat and the porcelain line all stay byte-identical while the
+    blob underneath is replaced (`git add -p` produces exactly that shape).
+
+    Same rule as every attribute already bound: if the discard would create,
+    delete or rewrite it, the digest binds it. The index is simply the one
+    place that state is not a file.
+    """
+    return (_path_identity(os.path.join(worktree, rel)) + "\0"
+            + index.get(rel, _INDEX_ABSENT))
+
+
 def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     """WHAT a discard would destroy, named entry by entry: the exact SET of
     worktree entries, each entry's identity, and the digest over the whole
@@ -429,8 +481,11 @@ def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     underneath them is rewritten, retargeted, re-permissioned or changes type —
     so the line set is only the outer layer. Held against the invariant, that
     state is: the SET of affected entries, and for each its ENTITY IDENTITY
-    (`_path_identity`) — type, permissions, ownership, timestamps, and
-    regular-file bytes or symlink target.
+    (`_entry_identity`) — type, permissions, ownership, timestamps, and
+    regular-file bytes or symlink target, PLUS the index entry (mode, object,
+    stage) standing behind it. The last is not a filesystem fact at all and
+    was missed for exactly that reason (SC-123): `git restore --staged`
+    destroys staged content the worktree never shows.
 
     The set is what the discard must undo:
     - untracked FILES individually (`ls-files -o`), never collapsed to a dir;
@@ -463,13 +518,14 @@ def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     untracked_files = {p for p in listed if not p.endswith("/")}
     tracked = set(paths("diff", "HEAD", "--name-only", "-z")) if head \
         else set(paths("ls-files", "-z"))
+    index = _index_identities(worktree)
 
     h = hashlib.sha256()
     for line in sorted(porcelain):
         h.update(line.encode("utf-8", "surrogateescape") + b"\n")
     identities = {}
     for rel in sorted(tracked | untracked_files | untracked_dirs):
-        identities[rel] = _path_identity(os.path.join(worktree, rel))
+        identities[rel] = _entry_identity(worktree, rel, index)
         h.update(rel.encode("utf-8", "surrogateescape") + b"\0"
                  + identities[rel].encode() + b"\0")
     return {"head": head, "tracked": sorted(tracked),
@@ -699,11 +755,14 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
     a directory afterwards is left alone rather than restored over.
 
     Each entry is also re-verified against the identity the fence observed,
-    immediately before it is touched, and left alone when it no longer
-    matches — so a path is only ever removed while it still IS what the
-    operator was shown. That check narrows, and does not close, the window
-    between the check and the `unlink`/`restore` itself: no filesystem offers
-    "remove only if unchanged".
+    and left alone when it no longer matches — so a path is only ever removed
+    while it still IS what the operator was shown. The filesystem half of that
+    identity is re-read immediately before the entry is touched; the index
+    half comes from ONE snapshot taken at the top of this function, since
+    nothing here writes to the index before the final restore. That check
+    narrows, and does not close, the window between the check and the
+    `unlink`/`restore` itself: no filesystem offers "remove only if
+    unchanged", and the index is not transactional against us either.
 
     Runs AFTER the durable closure is committed, so a failure here must never
     escape as a 500 that hides what happened: each step's outcome is recorded
@@ -716,11 +775,20 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
                     "completed": [], "failed": None,
                     "kept": [], "kept_count": 0}
     identities, restore, kept_files = plan["identities"], [], []
+    # One index read for the whole pass: nothing below writes to the index
+    # until the final `restore`/`rm --cached`, so this snapshot stays true for
+    # every re-check. Unreadable -> `index` is None and NOTHING verifies,
+    # which keeps every entry rather than deleting on an unchecked identity.
+    try:
+        index = _index_identities(worktree)
+    except _GitEvidenceUnavailable:
+        index = None
 
     def unchanged(rel: str) -> bool:
+        if index is None:
+            return False
         try:
-            return _path_identity(
-                os.path.join(worktree, rel)) == identities[rel]
+            return _entry_identity(worktree, rel, index) == identities[rel]
         except _GitEvidenceUnavailable:
             return False   # unreadable now: never a licence to delete
 

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -565,19 +565,22 @@ def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     h = hashlib.sha256()
     for line in sorted(porcelain):
         h.update(line.encode("utf-8", "surrogateescape") + b"\n")
-    identities, index_of = {}, {}
+    identities, index_of, fs_of = {}, {}, {}
     for rel in sorted(tracked | untracked_files | untracked_dirs):
         index_of[rel] = index.get(rel, _INDEX_ABSENT)
-        identities[rel] = _entry_identity(worktree, rel, index)
+        fs_of[rel] = _path_identity(os.path.join(worktree, rel))
+        identities[rel] = fs_of[rel] + "\0" + index_of[rel]
         h.update(rel.encode("utf-8", "surrogateescape") + b"\0"
                  + identities[rel].encode() + b"\0")
-    # The index half is kept separately as well as inside `identities`, so the
-    # discard can re-verify it ALONE — at a point where the filesystem half
-    # has legitimately moved because the discard itself moved it (SC-124).
+    # The two halves are kept separately as well as composed, because the
+    # discard has to re-verify each one ALONE at a point where the other has
+    # legitimately moved: the index just before the destructive call, when the
+    # removal may already have unlinked the file (SC-124), and the filesystem
+    # just after it, when the restore has already rewritten the index (SC-127).
     return {"head": head, "tracked": sorted(tracked),
             "untracked_files": sorted(untracked_files),
             "untracked_dirs": sorted(untracked_dirs),
-            "identities": identities, "index": index_of,
+            "identities": identities, "index": index_of, "fs": fs_of,
             "digest": h.hexdigest()}
 
 
@@ -780,6 +783,52 @@ def _prune_dirs(worktree: str, plan: dict) -> list[str]:
             if os.path.lexists(os.path.join(worktree, rel.rstrip("/")))]
 
 
+def _unrestored(worktree: str, plan: dict, restored: list[str]) -> list[str]:
+    """Of the entries the restore reported success for, the ones it did NOT
+    actually undo. Never raises.
+
+    An exit code is not an outcome. `git restore` can exit 0 having silently
+    skipped a path: with a SYMLINK standing in for one of its parent
+    directories it refuses to write through the link, updates the index, and
+    leaves the working file exactly as it was (SC-127, reproduced). The safety
+    property holds — nothing outside the worktree is touched, which is what
+    SC-105 asked for — and that is precisely what hid this: the result claimed
+    `discarded=true` over a dirty file still sitting there. Decision #45 ranks
+    that misreporting with destruction, so the outcome is VERIFIED.
+
+    What makes the check exact: every enumerated tracked entry differs from
+    HEAD by construction, and a restore that ran makes it equal HEAD — a
+    different entity, and in any case a rewritten one, so its identity cannot
+    still be the one the operator was shown. An entry whose filesystem
+    identity is byte-identical to the consented one was therefore not touched.
+    The INDEX cannot answer this: the skipped restore updated it (reproduced),
+    so the index reads discarded while the work is still on disk.
+
+    Unreadable now -> unverifiable, and an unverifiable outcome is never
+    reported as a success.
+
+    On an unborn HEAD there is nothing to restore TO — the removal loop
+    already unlinked these files and `git rm --cached` drops the entry — so
+    what is checked there is that the index no longer holds it.
+    """
+    if not plan["head"]:
+        try:
+            index = _index_identities(worktree)
+        except _GitEvidenceUnavailable:
+            return sorted(restored)
+        return sorted(rel for rel in restored if rel in index)
+    stale = []
+    for rel in restored:
+        try:
+            now = _path_identity(os.path.join(worktree, rel))
+        except _GitEvidenceUnavailable:
+            stale.append(rel)
+        else:
+            if now == plan["fs"][rel]:
+                stale.append(rel)
+    return sorted(stale)
+
+
 _INDEX_FLAG_OPTS = {"S": "--skip-worktree", "A": "--assume-unchanged"}
 
 
@@ -809,11 +858,15 @@ def _restore_index_flags(worktree: str, plan: dict,
         paths = [rel for rel, flags in want.items() if bit in flags]
         if not paths:
             continue
-        subprocess.run(
-            ["git", "-C", worktree, "update-index", "-z", opt, "--stdin"],
-            input=b"".join(rel.encode("utf-8", "surrogateescape") + b"\0"
-                           for rel in paths),
-            capture_output=True, timeout=60, check=False)
+        try:
+            subprocess.run(
+                ["git", "-C", worktree, "update-index", "-z", opt, "--stdin"],
+                input=b"".join(rel.encode("utf-8", "surrogateescape") + b"\0"
+                               for rel in paths),
+                capture_output=True, timeout=60, check=False)
+        except Exception:  # noqa: BLE001, S110 — timeout or spawn failure;
+            pass           # the verification below reports what actually
+                           # stuck, which is the truth an exit code is not
     try:
         after = _index_identities(worktree)
     except _GitEvidenceUnavailable:
@@ -865,10 +918,31 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
     `discarded` is true only when every enumerated FILE was undone; anything
     left behind — files and directories alike — is named in `kept`, never
     silently dropped.
+
+    That promise is now STRUCTURAL rather than a claim about the steps below
+    (SC-126). Every known failure mode is handled where it happens, but the
+    operator's files have already been touched by the time anything here can
+    go wrong, and a 500 tells them nothing about what state those files are
+    in — the worst report there is. So the whole sequence returns its
+    part-filled result rather than raising, and an unexpected failure is NAMED
+    in `failed` rather than swallowed.
     """
     result: dict = {"worktree": worktree, "discarded": False,
                     "completed": [], "failed": None,
                     "kept": [], "kept_count": 0, "flags_lost": []}
+    try:
+        _discard_steps(worktree, plan, result)
+    except Exception as exc:  # noqa: BLE001 — post-commit: report, never raise
+        result["discarded"] = False
+        result["failed"] = result["failed"] or {
+            "step": "unexpected",
+            "error": f"{type(exc).__name__}: {str(exc)[:200]}"}
+    return result
+
+
+def _discard_steps(worktree: str, plan: dict, result: dict) -> None:
+    """The discard itself, filling `result` as it goes. Split out so that
+    whatever happens, the caller still has what completed (see above)."""
     identities, restore, kept_files = plan["identities"], [], []
     # One index read for the whole pass: nothing below writes to the index
     # until the final `restore`/`rm --cached`, so this snapshot stays true for
@@ -933,7 +1007,7 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
         except OSError as exc:
             result["failed"] = {"step": "remove",
                                 "error": f"{rel[-120:]}: errno {exc.errno}"}
-            return result
+            return
         finally:
             os.close(fd)
         removed.append(rel)
@@ -1020,13 +1094,19 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
                 capture_output=True, timeout=60, check=False)
         except Exception as exc:  # noqa: BLE001 — timeout etc: report it
             result["failed"] = {"step": "restore", "error": str(exc)[:200]}
-            return result
+            return
         if out.returncode != 0:
             result["failed"] = {
                 "step": "restore",
                 "error": out.stderr.decode("utf-8", "replace").strip()[-200:]}
-            return result
+            return
     result["completed"].append("restore")
+    # The restore's exit code says it ran, not that it worked (SC-127). Verify
+    # each entry actually moved before any of it is reported as discarded.
+    skipped = _unrestored(worktree, plan, restore)
+    for rel in skipped:
+        keep(rel)
+    restore = [rel for rel in restore if rel not in set(skipped)]
     result["flags_lost"] = _restore_index_flags(worktree, plan, restore)
     # A surviving DIRECTORY does not make the discard incomplete. It stands
     # because it holds something outside the delete set — an ignored file, a
@@ -1037,7 +1117,7 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
     # not, which is the only way consented work outlives a discard. Both are
     # named in `kept`; only the second moves `discarded`.
     result["discarded"] = not kept_files
-    return result
+    return
 
 
 # ------------------------------------------------------------------ evidence

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -414,29 +414,71 @@ def _path_identity(path: str) -> str:
 _INDEX_ABSENT = "index:none"
 
 
+def _index_flags(identity: str) -> str:
+    """The durable-flag token out of one index identity — `--` for an entry
+    the index does not hold."""
+    return identity.rsplit(" ", 1)[-1] if " " in identity else "--"
+
+
 def _index_identities(worktree: str) -> dict[str, str]:
-    """What the INDEX holds, per path: mode, object id and merge stage.
+    """What the INDEX holds, per path: mode, object id, merge stage, and the
+    durable per-entry FLAGS.
 
     Read in ONE pass over the whole index rather than per path — every entry
     then comes from the same instant, the same way the path set does.
 
-    Blob id, mode and stage ONLY — never the index file's own mtime or its
-    stat cache. `git status` REFRESHES those as a side effect of the very
-    observation this fences, so binding them would make a preview stale
-    against itself and refuse every discard forever (the same trap st_atime
-    is excluded from `_path_identity` for). What a discard destroys is the
-    CONTENT the index holds, and that is what is recorded.
+    The index is a store in its own right, not a blob table, so what is bound
+    here is everything an entry durably carries that a discard can rewrite.
+    Enumerated from the on-disk index format rather than from memory, the
+    per-entry fields are: the stat cache (ctime/mtime/dev/ino/uid/gid/size),
+    mode, object id, and the flag word — assume-valid, merge stage, and the
+    v3 extended bits skip-worktree and intent-to-add. Of those:
+
+    - mode, object id and merge stage are the content a discard throws back to
+      HEAD, and are recorded.
+    - skip-worktree and assume-unchanged are recorded (SC-125). They are
+      durable index state that `restore --staged` CLEARS, and setting one
+      moves nothing else: on a staged-only entry the working file, its lstat,
+      the porcelain line and the entry's own mode/object/stage are all
+      byte-identical either side of the bit, so an unbound flag rode straight
+      through the fence.
+    - intent-to-add needs no separate field: it can only be set on a path the
+      index does not otherwise hold, and both transitions move the PORCELAIN
+      line the digest already binds (`??` <-> ` A`, which is distinct from a
+      real staged add's `A `). Recorded by the outer layer, not this one.
+    - the STAT CACHE is excluded, and by reproduction rather than by argument:
+      `git status` REFRESHES it as a side effect of the very observation this
+      fences, so binding it would make a preview stale against itself and
+      refuse every discard forever (the same trap st_atime is excluded from
+      `_path_identity` for). It is a cache of the worktree, and the worktree
+      half of `_entry_identity` binds the thing itself.
+
+    Index EXTENSIONS carry no per-entry work a discard destroys: cache-tree,
+    untracked-cache, fsmonitor and split-index are all caches git rebuilds,
+    and resolve-undo (REUC) survives the discard untouched — reproduced, not
+    assumed. `MERGE_HEAD` and an in-progress merge likewise survive it.
+
+    The flags are read via `ls-files -v`, whose tag letter is the only
+    interface to them. Its letter set also spans WORKTREE-derived states (`C`
+    modified, `R` removed, `K` to-be-killed) — none of which this invocation
+    can emit, since those require the matching listing option — so rather than
+    record the letter, the two durable bits are decoded out of it. A letter
+    this function does not expect therefore decodes to "no flags", exactly as
+    a plain `H` does, and can never move the digest on a volatile fact.
 
     An unmerged path carries several stage entries; all of them are recorded,
     sorted, because a conflict resolution rewrites exactly that set.
     """
     entries: dict[str, list[str]] = {}
-    for record in _git_out(worktree, "ls-files", "--stage", "-z",
+    for record in _git_out(worktree, "ls-files", "-v", "--stage", "-z",
                            timeout=30).split("\0"):
         if not record:
             continue
         meta, _tab, rel = record.partition("\t")
-        entries.setdefault(rel, []).append(" ".join(meta.split()))
+        tag, mode, obj, stage = meta.split()
+        flags = ("S" if tag.upper() == "S" else "-") \
+            + ("A" if tag.islower() else "-")
+        entries.setdefault(rel, []).append(f"{mode} {obj} {stage} {flags}")
     return {rel: "+".join(sorted(stages)) for rel, stages in entries.items()}
 
 
@@ -523,15 +565,20 @@ def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     h = hashlib.sha256()
     for line in sorted(porcelain):
         h.update(line.encode("utf-8", "surrogateescape") + b"\n")
-    identities = {}
+    identities, index_of = {}, {}
     for rel in sorted(tracked | untracked_files | untracked_dirs):
+        index_of[rel] = index.get(rel, _INDEX_ABSENT)
         identities[rel] = _entry_identity(worktree, rel, index)
         h.update(rel.encode("utf-8", "surrogateescape") + b"\0"
                  + identities[rel].encode() + b"\0")
+    # The index half is kept separately as well as inside `identities`, so the
+    # discard can re-verify it ALONE — at a point where the filesystem half
+    # has legitimately moved because the discard itself moved it (SC-124).
     return {"head": head, "tracked": sorted(tracked),
             "untracked_files": sorted(untracked_files),
             "untracked_dirs": sorted(untracked_dirs),
-            "identities": identities, "digest": h.hexdigest()}
+            "identities": identities, "index": index_of,
+            "digest": h.hexdigest()}
 
 
 def _observe_worktree(worktree: str) -> tuple[dict, dict]:
@@ -733,6 +780,48 @@ def _prune_dirs(worktree: str, plan: dict) -> list[str]:
             if os.path.lexists(os.path.join(worktree, rel.rstrip("/")))]
 
 
+_INDEX_FLAG_OPTS = {"S": "--skip-worktree", "A": "--assume-unchanged"}
+
+
+def _restore_index_flags(worktree: str, plan: dict,
+                         restored: list[str]) -> list[str]:
+    """Put back the durable index flags the restore cleared. Returns the
+    entries whose flags could NOT be put back.
+
+    The bits are not part of HEAD, so "throw the entry back to HEAD" does not
+    say what should happen to them — clearing them is a SIDE EFFECT of the
+    command, not a change the operator confirmed discarding. The content goes;
+    the operator's standing instruction about the path stays (SC-125, and
+    decision #45's preserve-and-report rather than silent clearing).
+
+    Where the store leaves no room for the flag it is REPORTED, never quietly
+    dropped: a staged-new path is gone from the index once the discard has
+    run, and on an unborn HEAD every entry is, so there is no entry left to
+    carry a bit. Outcomes are verified by re-reading the index rather than
+    trusted from an exit code — `update-index` is silent about a path it could
+    not mark.
+    """
+    want = {rel: _index_flags(plan["index"][rel]) for rel in restored}
+    want = {rel: flags for rel, flags in want.items() if flags != "--"}
+    if not want:
+        return []
+    for bit, opt in _INDEX_FLAG_OPTS.items():
+        paths = [rel for rel, flags in want.items() if bit in flags]
+        if not paths:
+            continue
+        subprocess.run(
+            ["git", "-C", worktree, "update-index", "-z", opt, "--stdin"],
+            input=b"".join(rel.encode("utf-8", "surrogateescape") + b"\0"
+                           for rel in paths),
+            capture_output=True, timeout=60, check=False)
+    try:
+        after = _index_identities(worktree)
+    except _GitEvidenceUnavailable:
+        return sorted(want)
+    return sorted(rel for rel, flags in want.items()
+                  if _index_flags(after.get(rel, _INDEX_ABSENT)) != flags)
+
+
 def _discard_worktree_files(worktree: str, plan: dict) -> dict:
     """Undo EXACTLY the entries `plan` enumerated — restore its tracked paths
     from HEAD, remove its untracked ones — and nothing else. Never deletes the
@@ -756,13 +845,19 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
 
     Each entry is also re-verified against the identity the fence observed,
     and left alone when it no longer matches — so a path is only ever removed
-    while it still IS what the operator was shown. The filesystem half of that
-    identity is re-read immediately before the entry is touched; the index
-    half comes from ONE snapshot taken at the top of this function, since
-    nothing here writes to the index before the final restore. That check
+    while it still IS what the operator was shown. BOTH halves of that
+    identity are re-read immediately before the command that destroys them:
+    the filesystem half before each `unlink`, the index half before the final
+    `restore`/`rm --cached`. Sampling the index ONCE at the top instead was
+    SC-124 — nothing HERE writes to the index before the restore, but the
+    operator does, and a `git add` landing while the removal loop runs was
+    then erased by a restore that had checked an older read. That check
     narrows, and does not close, the window between the check and the
     `unlink`/`restore` itself: no filesystem offers "remove only if
     unchanged", and the index is not transactional against us either.
+
+    Durable index flags the restore clears are put back afterwards, and named
+    in `flags_lost` where the store leaves nowhere to put them (SC-125).
 
     Runs AFTER the durable closure is committed, so a failure here must never
     escape as a 500 that hides what happened: each step's outcome is recorded
@@ -773,7 +868,7 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
     """
     result: dict = {"worktree": worktree, "discarded": False,
                     "completed": [], "failed": None,
-                    "kept": [], "kept_count": 0}
+                    "kept": [], "kept_count": 0, "flags_lost": []}
     identities, restore, kept_files = plan["identities"], [], []
     # One index read for the whole pass: nothing below writes to the index
     # until the final `restore`/`rm --cached`, so this snapshot stays true for
@@ -862,8 +957,59 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
         restore = [rel for rel in restore if rel not in set(standing)]
     else:
         restore = [rel for rel in restore if rel in set(removed)]
+
+    # -- revalidate the INDEX immediately before the destructive call -------
+    # The snapshot above is taken at the top of this function and the removal
+    # loop then runs for as many entries as the plan holds. A `git add`
+    # landing in that window is invisible to a read taken before it, so the
+    # restore threw a blob away that no gate had seen — a check-then-act gap
+    # of exactly the shape already closed twice on the worktree (SC-124). The
+    # index therefore gets its own re-read HERE, at the same point the
+    # worktree half is re-read: the last instant before the command that
+    # destroys it.
+    #
+    # Only the INDEX half is re-checked, deliberately. The filesystem half
+    # cannot be: on an unborn HEAD the removal above unlinked these very
+    # files, so re-reading it would compare "absent" against the observed
+    # content and keep everything the discard just did the work for.
+    # Unreadable now -> nothing is verifiable, so nothing is restored over.
+    try:
+        fresh_index = _index_identities(worktree)
+    except _GitEvidenceUnavailable:
+        fresh_index = None
+    still = []
+    for rel in restore:
+        if fresh_index is not None \
+                and fresh_index.get(rel, _INDEX_ABSENT) == plan["index"][rel]:
+            still.append(rel)
+        else:
+            keep(rel)
+    restore = still
+
     if restore:
-        args = ["restore", "--source=HEAD", "--staged", "--worktree"] \
+        # --no-recurse-submodules is PINNED, not left to config. A submodule is
+        # a third store — its own worktree, index and refs — and none of it is
+        # inside this fence: the host sees a gitlink and a directory, neither
+        # of which moves when work is committed inside the submodule. With
+        # `submodule.recurse` set, `git restore` follows the gitlink and
+        # resets that store too (reproduced: an inner commit and its files
+        # erased). The SC-103 `standing` guard happens to keep a checked-out
+        # submodule as well, since it is always a directory — but that guard is
+        # about collateral, not about submodules, and a consented blast radius
+        # must not depend on a coincidence or on the operator's config.
+        #
+        # --ignore-skip-worktree-bits is the other half of taking those bits
+        # seriously. Without it git filters our OWN pathspec down to
+        # non-sparse entries, and a staged-new path carrying skip-worktree
+        # matches neither HEAD nor the filtered index — so the command fails
+        # `pathspec did not match`, taking the restore of every other
+        # consented entry down with it. It cannot widen anything: the pathspec
+        # is the enumerated set, read from a file, and this only stops git
+        # discarding members of it. (A sparse checkout's excluded paths never
+        # reach here at all — they do not differ from HEAD, so nothing
+        # enumerates them.)
+        args = ["restore", "--source=HEAD", "--no-recurse-submodules",
+                "--ignore-skip-worktree-bits", "--staged", "--worktree"] \
             if plan["head"] else ["rm", "--cached", "--force", "--quiet"]
         try:
             out = subprocess.run(
@@ -881,6 +1027,7 @@ def _discard_worktree_files(worktree: str, plan: dict) -> dict:
                 "error": out.stderr.decode("utf-8", "replace").strip()[-200:]}
             return result
     result["completed"].append("restore")
+    result["flags_lost"] = _restore_index_flags(worktree, plan, restore)
     # A surviving DIRECTORY does not make the discard incomplete. It stands
     # because it holds something outside the delete set — an ignored file, a
     # nested repository, work written after the confirmation — and `clean -fd`

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2387,6 +2387,15 @@ function ifRecoveryResult(result) {
       `Parked ambiguous binding #${parked.binding_id}: ` +
       `${parked.next_action || "manual remediation required"}`));
   }
+  if (closed.runtime && !closed.runtime.abandoned) {
+    // Not a failed recovery — the durable rows are closed either way — but
+    // the generation may still be attached, and a field nobody renders is
+    // the same silence it was named to end (SC-128).
+    body.append(el("div", { className: "if-note bad" },
+      "The runtime would not release the session generation " +
+      `(${closed.runtime.error || "unknown error"}). Durable state IS ` +
+      "closed; check the Interface runtime."));
+  }
   if (worktree.failed) {
     const completed = (worktree.completed || []).join(", ") || "nothing";
     body.append(el("div", { className: "if-note bad" },

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -631,6 +631,40 @@ class ExecuteTest(RecoveryCase):
             (sid,)).fetchone()[0], "ended")
         con.close()
         self.assertIn(sid, self.runtime.abandoned)
+        self.assertEqual(result["closed"]["runtime"], {"abandoned": True})
+
+    def test_runtime_abandon_failure_is_reported_not_swallowed(self):
+        # The post-commit path that never reaches a 500, and was silent
+        # instead. Dropping the runtime generation is best-effort by design —
+        # the durable closure is already committed and a runtime that will not
+        # let go is not something to fail a recovery over — but the response
+        # said only that the shell was available, while a generation may still
+        # be attached to it. Handled where something can be done about it, and
+        # named either way (SC-128).
+        proc, ticks = self.child()
+        self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+
+        async def refusing(session_id):
+            raise RuntimeError("the runtime will not let go")
+
+        with mock.patch.object(recovery, "_pane_present", return_value=True):
+            obj = self.preview(1)
+            with mock.patch.object(self.runtime, "abandon", refusing):
+                status, result = self.call(
+                    "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                    {"observation_id": obj["observation_id"], "mode": "force",
+                     "confirm_force": True})
+        self.assertEqual(status, 200, result)
+        self.assertFalse(result["closed"]["runtime"]["abandoned"])
+        self.assertIn("RuntimeError", result["closed"]["runtime"]["error"])
+        # ...and the closure it could not unwind is still reported as done
+        self.assertEqual(result["availability"], "available")
+        proc.wait(timeout=5)
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+        ).fetchone()[0], "ended")
+        con.close()
 
     def test_orphan_recover_signals_then_closes(self):
         proc, ticks = self.child()
@@ -2666,6 +2700,215 @@ class WorktreeTest(RecoveryCase):
         self.assertFalse(result["worktree"]["discarded"])
         self.assertEqual(result["worktree"]["completed"], ["remove"])
         self.assertEqual(result["worktree"]["failed"]["step"], "restore")
+
+    # -- the outcome is checked against the CONTRACT, not a proxy (SC-129) --
+    # "Verified undone" was verified by asking whether the entry still held
+    # the identity the operator was shown. The contract implies that, so the
+    # right answer satisfies it — and so does a restore that writes some THIRD
+    # state, which is neither the consented content nor HEAD. The check now
+    # re-runs the enumeration that DEFINED the delete set and requires the
+    # entry to be absent from it, which is the contract itself.
+
+    def third_state_restore(self, wt: str, rel: str, text: str, *,
+                            stage: bool = False):
+        """A `git restore` replaced by one that exits 0 having put `rel` in a
+        state that is neither what the operator consented to discarding nor
+        HEAD. `stage=True` also does the INDEX half for real, so only the
+        worktree half is wrong."""
+        real_run = subprocess.run
+
+        def stub(args, **kw):
+            if "restore" not in args:
+                return real_run(args, **kw)
+            if stage:
+                real_run(["git", "-C", wt, "restore", "--source=HEAD",
+                          "--staged", "--", rel], capture_output=True,
+                         check=True)
+            (Path(wt) / rel).write_text(text)
+            return subprocess.CompletedProcess(args, 0, b"", b"")
+        return stub
+
+    def test_restore_that_writes_a_third_state_is_not_claimed_discarded(self):
+        # SC-129 itself. The entry changed, so the old check passed it and the
+        # discard was reported complete over content that was never committed
+        # and never consented to — the operator is told their work is gone AND
+        # that the tree is at HEAD, and neither is true.
+        wt = self.make_git_worktree()
+        plan = self.plan(wt)
+        with mock.patch.object(
+                recovery.subprocess, "run",
+                self.third_state_restore(wt, "tracked.txt", "NEITHER")):
+            result = recovery._discard_worktree_files(wt, plan)
+        # the proxy is SATISFIED — not the consented state, and it moved...
+        self.assertNotIn((Path(wt) / "tracked.txt").read_text(),
+                         ("dirty", "v1"))
+        # ...and the contract is not: the entry still differs from HEAD.
+        self.assertIn("tracked.txt", result["kept"])
+        self.assertFalse(result["discarded"])
+        self.assertIsNone(result["failed"])
+
+    def test_destaged_file_left_in_the_worktree_is_not_claimed_discarded(self):
+        # The same hole one entity over. A staged-NEW path is undone by
+        # leaving the index AND the worktree; drop the index entry, rewrite
+        # the file and the proxy sees a changed entry and reports it
+        # discarded, while the file sits there as untracked work. The
+        # enumeration names it exactly as it would have at plan time.
+        wt = self.make_git_worktree()
+        (Path(wt) / "added.txt").write_text("new")
+        self.git_run(wt, "add", "--", "added.txt")
+        plan = self.plan(wt)
+        real_run = subprocess.run
+
+        def destage_only(args, **kw):
+            if "restore" not in args:
+                return real_run(args, **kw)
+            real_run(["git", "-C", wt, "rm", "--cached", "--quiet", "--",
+                      "added.txt"], capture_output=True, check=True)
+            (Path(wt) / "added.txt").write_text("NEITHER")
+            return subprocess.CompletedProcess(args, 0, b"", b"")
+
+        with mock.patch.object(recovery.subprocess, "run", destage_only):
+            result = recovery._discard_worktree_files(wt, plan)
+        self.assertEqual((Path(wt) / "added.txt").read_text(), "NEITHER")
+        self.assertIn("added.txt", result["kept"])
+        self.assertFalse(result["discarded"])
+
+    def test_staged_then_deleted_path_is_enumerated_and_discarded(self):
+        # The same question asked of the ENUMERATION rather than of the check
+        # that reads it. `git add` then `rm` leaves a blob in the index and
+        # nothing on disk, so `git diff HEAD` — HEAD against the WORKING TREE
+        # — sees no change at all: the entry was in no preview and no delete
+        # set, survived the discard, and `discarded=true` was returned over
+        # staged work the operator believed they had thrown away. `reset
+        # --hard`, the operation this replaces, destroyed it.
+        wt = self.make_git_worktree()
+        (Path(wt) / "added.txt").write_text("staged then deleted")
+        self.git_run(wt, "add", "--", "added.txt")
+        (Path(wt) / "added.txt").unlink()
+        self.assertIn("AD added.txt", self.porcelain(wt))
+        self.assertEqual(self.git_run(wt, "diff", "HEAD", "--name-only",
+                                      "--", "added.txt"), "",
+                         "the worktree diff names it — this case no longer "
+                         "isolates the index-only difference")
+        plan = self.plan(wt)
+        self.assertIn("added.txt", plan["tracked"])
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertTrue(result["discarded"], result)
+        self.assertEqual(result["kept"], [])
+        self.assertEqual(self.git_run(wt, "ls-files", "--", "added.txt"), "")
+
+    def test_unborn_entry_left_on_disk_is_not_claimed_discarded(self):
+        # On an unborn HEAD "undone" means gone from the index AND gone from
+        # disk, and only the first half was checked — `git rm --cached`
+        # succeeds either way, so a file the removal loop failed to unlink was
+        # reported discarded while standing there as untracked work. One
+        # enumeration answers both halves.
+        wt = Path(self.tmp.name) / "unborn-third-state"
+        wt.mkdir()
+        self.git_run(str(wt), "init", "-q", "-b", "feat/x", ".")
+        (wt / "staged.txt").write_text("staged")
+        self.git_run(str(wt), "add", "--", "staged.txt")
+        plan = self.plan(str(wt))
+        self.assertIn("staged.txt", plan["tracked"])
+
+        def unlink_nothing(_name, **_kw):
+            return None
+
+        with mock.patch.object(recovery.os, "unlink", unlink_nothing):
+            result = recovery._discard_worktree_files(str(wt), plan)
+        self.assertEqual(self.git_run(str(wt), "ls-files"), "")  # index: gone
+        self.assertTrue((wt / "staged.txt").exists())            # disk: not
+        self.assertIn("staged.txt", result["kept"])
+        self.assertFalse(result["discarded"])
+
+    def test_entry_still_flagged_after_the_restore_is_not_verified(self):
+        # The enumeration reads a flagged entry's worktree half THROUGH the
+        # index — `git diff` trusts skip-worktree and will not look at the
+        # file — so an entry still carrying the bit here cannot be verified by
+        # it. Forced: the index half is done for real (so the entry no longer
+        # differs from HEAD there) while the worktree is left in a third state
+        # and the bit left standing, which is the one shape the enumeration
+        # cannot see.
+        wt = self.make_git_worktree()
+        self.stage_only(wt, "tracked.txt", "staged-only")
+        self.git_run(wt, "update-index", "--skip-worktree", "--",
+                     "tracked.txt")
+        plan = self.plan(wt)
+        with mock.patch.object(
+                recovery.subprocess, "run",
+                self.third_state_restore(wt, "tracked.txt", "NEITHER",
+                                         stage=True)):
+            result = recovery._discard_worktree_files(wt, plan)
+        # the premise, reproduced rather than argued: git reports nothing.
+        self.assertEqual(self.index_tag(wt, "tracked.txt"), "S")
+        self.assertEqual(self.git_run(wt, "diff", "HEAD", "--name-only"), "")
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "NEITHER")
+        self.assertIn("tracked.txt", result["kept"])
+        self.assertFalse(result["discarded"])
+
+    def test_kept_entry_keeps_the_durable_flags_the_restore_cleared(self):
+        # `restore --staged` clears the bits whether or not it goes on to do
+        # what it promised, and they were only put back for the entries that
+        # verified. An entry reported as SPARED whose durable bit was silently
+        # dropped is spared in name only — the flags follow the set the
+        # command ran over, not the set it satisfied.
+        wt = self.make_git_worktree()
+        self.stage_only(wt, "tracked.txt", "staged-only")
+        self.git_run(wt, "update-index", "--skip-worktree", "--",
+                     "tracked.txt")
+        plan = self.plan(wt)
+        real_run = subprocess.run
+
+        def restore_then_redirty(args, **kw):
+            out = real_run(args, **kw)
+            if "restore" in args:
+                (Path(wt) / "tracked.txt").write_text("NEITHER")
+            return out
+
+        with mock.patch.object(recovery.subprocess, "run",
+                               restore_then_redirty):
+            result = recovery._discard_worktree_files(wt, plan)
+        self.assertIn("tracked.txt", result["kept"])
+        self.assertFalse(result["discarded"])
+        self.assertEqual(result["flags_lost"], [])
+        self.assertEqual(self.index_tag(wt, "tracked.txt"), "S")
+
+    # -- NOTHING after the durable commit may surface as a 500 (SC-128) -----
+
+    def test_late_gate_failure_after_the_commit_reports_a_partial_discard(
+            self):
+        # SC-128. The guarantee was built INSIDE the discard sequence, and the
+        # late gate runs after the same commit and outside it: anything it
+        # threw that was not its own refusal reached the operator as an opaque
+        # internal error, with the session already ended and nothing said
+        # about their files. Caught twice now by the path just outside the
+        # structure, so the boundary is at the seam — everything past the
+        # commit returns a result naming what happened.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        with mock.patch.object(recovery, "_assert_worktree_unchanged",
+                               side_effect=RuntimeError("gate boom")):
+            status, result = self.post(obj, preserve_worktree=False,
+                                       discard_worktree=True,
+                                       confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertFalse(result["worktree"]["discarded"])
+        self.assertEqual(result["worktree"]["completed"], [])
+        self.assertEqual(result["worktree"]["failed"]["step"],
+                         "worktree_gate")
+        self.assertIn("RuntimeError", result["worktree"]["failed"]["error"])
+        # ...and every other claim in that response is true: the gate ran
+        # before anything destructive, so the files are untouched, and the
+        # closure it could not unwind is still reported as done.
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
+        self.assertEqual(result["availability"], "available")
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+        ).fetchone()[0], "ended")
+        con.close()
 
 
 # ------------------------------------------------------------------ CLI parity

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -2081,6 +2081,10 @@ class WorktreeTest(RecoveryCase):
         self.git_run(wt, "config", "submodule.recurse", "true")
         # work committed INSIDE the submodule — the host's gitlink now differs
         inner = str(Path(wt) / "sm")
+        # its own repo, so its own identity: a clone inherits neither the
+        # host worktree's config nor a global one CI does not have.
+        self.git_run(inner, "config", "user.email", "t@t")
+        self.git_run(inner, "config", "user.name", "t")
         (Path(inner) / "local.txt").write_text("work only the submodule holds")
         self.git_run(inner, "add", "-A")
         self.git_run(inner, "commit", "-qm", "inner work")

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -428,6 +428,87 @@ class ProcessGroupSignalTest(unittest.TestCase):
         self.assertFalse(result["dead"])
         self.assertEqual(result["reason"], "absence_unproven")
 
+    # -- SC-131: the seam is the FIRST DELIVERED SIGNAL --------------------
+    # Every failure mode is placed by which side of that seam it falls on,
+    # and each side has one contract. Before it: nothing happened, so it is a
+    # refusal (`signaled` False). After it: something irreversible happened,
+    # so the result says so instead of escaping as an opaque 500.
+
+    def test_sigkill_raising_after_sigterm_still_names_the_sent_signal(self):
+        # REV2's exact probe: SIGTERM lands, the grace expires with the
+        # process alive, and the SIGKILL call raises. Before the boundary
+        # this left the route with a bare PermissionError, so the operator
+        # was told nothing at all about a process that HAD been signalled.
+        proc, ticks = self.child(ignore_sigterm=True)
+        real = os.killpg
+        calls = []
+
+        def killpg(pgid, sig):
+            calls.append(sig)
+            if sig == signal.SIGKILL:
+                raise PermissionError(errno.EPERM, "Operation not permitted")
+            return real(pgid, sig)
+
+        with mock.patch.object(recovery.os, "killpg", killpg):
+            result = recovery.terminate_process_group(proc.pid, ticks,
+                                                      grace_s=0.3)
+        self.assertEqual(calls, [signal.SIGTERM, signal.SIGKILL])
+        self.assertTrue(result["signaled"])          # and it cannot be unwound
+        self.assertFalse(result["dead"])             # never claim absence
+        self.assertFalse(result["escalated"])        # SIGKILL never delivered
+        self.assertEqual(result["reason"], "signal_failed")
+        self.assertEqual(result["phase"], "sigkill")
+        self.assertIn("PermissionError", result["error"])
+        self.assertIn(str(proc.pid), result["detail"])
+
+    def test_undeliverable_sigterm_is_a_refusal_not_a_partial_act(self):
+        # The other side of the seam: nothing was delivered, so this must
+        # read exactly like an identity mismatch — signaled False, which the
+        # caller maps to a refusal that closes nothing.
+        proc, ticks = self.child()
+
+        def killpg(pgid, sig):
+            raise PermissionError(errno.EPERM, "Operation not permitted")
+
+        with mock.patch.object(recovery.os, "killpg", killpg):
+            result = recovery.terminate_process_group(proc.pid, ticks,
+                                                      grace_s=0.2)
+        self.assertFalse(result["signaled"])
+        self.assertFalse(result["dead"])
+        self.assertEqual(result["reason"], "indeterminate")
+        self.assertIn("PermissionError", result["detail"])
+        # The process is untouched — the refusal was truthful.
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "alive")
+
+    def test_grace_poll_failure_after_sigterm_is_reported_not_raised(self):
+        # Not the probe's instance: the boundary covers the whole post-signal
+        # sequence, so a failure in the grace poll reports the same contract
+        # as one in the SIGKILL call.
+        proc, ticks = self.child()
+        with mock.patch.object(recovery, "_wait_dead",
+                               side_effect=OSError("proc vanished")):
+            result = recovery.terminate_process_group(proc.pid, ticks,
+                                                      grace_s=0.2)
+        self.assertTrue(result["signaled"])
+        self.assertFalse(result["dead"])
+        self.assertFalse(result["escalated"])
+        self.assertEqual(result["reason"], "signal_failed")
+        self.assertEqual(result["phase"], "grace_wait")
+        self.assertIn("OSError", result["error"])
+
+    def test_malformed_proc_stat_reads_unreadable_never_dead(self):
+        # /proc/<pid>/stat is a live snapshot and can be read truncated. That
+        # made _read_stat raise ValueError/IndexError straight through every
+        # caller — including the post-signal poll. Fixed at the definition:
+        # an unusable answer is 'unreadable', which is fail-closed.
+        # No ')' at all; truncated before field 22; field 22 unparseable.
+        for text in ("", "1 (sh) S", "1 (sh) S " + "0 " * 18 + "notanint"):
+            with self.subTest(text=text), \
+                    mock.patch("builtins.open",
+                               mock.mock_open(read_data=text)):
+                self.assertEqual(recovery._proc_state(1234, 999),
+                                 "unreadable")
+
     def test_no_signal_on_identity_mismatch(self):
         proc, ticks = self.child()
         # Wrong ticks = a recycled pid is NOT our process — never signaled.
@@ -795,6 +876,48 @@ class ExecuteTest(RecoveryCase):
         self.assertEqual(status, 409)
         self.assertEqual(err["error"]["code"], "recovery_absence_unproven")
         self.assertIn("preview again", err["error"]["message"])
+        con = self.db()
+        self.assertEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE session_id=?",
+            (sid,)).fetchone()[0], "occupied")
+        con.close()
+
+    def test_broken_signal_sequence_answers_with_what_it_did(self):
+        # SC-131 at the API boundary. The sequence delivered SIGTERM and then
+        # broke; the response must name the irreversible half AND the two
+        # things that did not happen, rather than emitting an opaque 500 that
+        # is indistinguishable from a recovery which never started.
+        proc, ticks = self.child()
+        sid = self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        real = os.killpg
+
+        def killpg(pgid, sig):
+            if sig == signal.SIGKILL:
+                raise PermissionError(errno.EPERM, "Operation not permitted")
+            return real(pgid, sig)
+
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+            self.assertEqual(obj["classification"], "exact_idle_orphan")
+            with mock.patch.object(recovery, "_proc_state",
+                                   return_value="alive"), \
+                    mock.patch.object(recovery.os, "killpg", killpg):
+                status, err = self.call(
+                    "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                    {"observation_id": obj["observation_id"],
+                     "mode": "recover"})
+        # A refusal, NOT a 500 — the durable state is untouched and says so.
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["error"]["code"], "recovery_absence_unproven")
+        details = err["error"]["details"]
+        self.assertIs(details["signaled"], True)
+        self.assertIs(details["closed"], False)
+        self.assertIs(details["discarded"], False)
+        self.assertEqual(details["phase"], "sigkill")
+        self.assertIn("PermissionError", details["error"])
+        message = err["error"]["message"]
+        self.assertIn("sigkill", message)
+        self.assertIn("nothing was reset or cleaned", message)
         con = self.db()
         self.assertEqual(con.execute(
             "SELECT occupancy FROM interface_sessions WHERE session_id=?",
@@ -2831,6 +2954,101 @@ class WorktreeTest(RecoveryCase):
         self.assertTrue(result["discarded"], result)
         self.assertEqual(result["kept"], [])
         self.assertEqual(self.git_run(wt, "ls-files", "--", "added.txt"), "")
+
+    # -- SC-130: the preview is DERIVED from the enumeration ---------------
+
+    def projected_worktree(self, wt: str) -> str:
+        """The canonical worktree row both clients render, for `wt`."""
+        rows = recovery.evidence_projection(
+            {"shell": {}, "process": {}, "git": recovery._git_facts(wt)},
+            "exact_idle_orphan", ["recover"])
+        return next(row["value"] for row in rows if row["key"] == "worktree")
+
+    def test_index_only_entry_is_previewed_unlike_a_plain_deletion(self):
+        # The ratification condition. Widening the blast radius to the `AD`
+        # path is legitimate only because enumerated means previewed means
+        # consented — so if the operator cannot SEE that a staged blob will
+        # go, the consent is fictional and the widening does not stand.
+        #
+        # It was invisible because the preview was a THIRD STATEMENT of the
+        # plan: it counted porcelain lines instead of deriving from the set
+        # the destruction is built from, and porcelain renders both of these
+        # as exactly one dirty tracked line.
+        deleted = self.make_git_worktree()
+        (Path(deleted) / "tracked.txt").unlink()
+        (Path(deleted) / "untracked.txt").unlink()
+
+        staged = self.make_git_worktree()
+        (Path(staged) / "added.txt").write_text("staged then deleted")
+        self.git_run(staged, "add", "--", "added.txt")
+        (Path(staged) / "added.txt").unlink()
+        (Path(staged) / "tracked.txt").write_text("v1")   # back to HEAD
+        (Path(staged) / "untracked.txt").unlink()
+
+        # The premise, reproduced rather than argued: to porcelain — the old
+        # source of these counts — the two worktrees are the same shape.
+        self.assertEqual(len(self.porcelain(deleted).splitlines()), 1)
+        self.assertEqual(len(self.porcelain(staged).splitlines()), 1)
+        self.assertIn("AD added.txt", self.porcelain(staged))
+        self.assertIn(" D tracked.txt", self.porcelain(deleted))
+
+        deleted_row = self.projected_worktree(deleted)
+        staged_row = self.projected_worktree(staged)
+        self.assertNotEqual(
+            deleted_row, staged_row,
+            "a discard destroying an index-only staged blob still reads "
+            "byte-identically to one deleting a file on disk")
+        # The exact negative: an ordinary deletion must not acquire the
+        # staged-content wording, or the distinction says nothing.
+        self.assertNotIn("staged-only", deleted_row)
+        self.assertIn("1 tracked", deleted_row)
+        # And the index-only entry is named for what it actually is.
+        self.assertIn("1 of them staged-only", staged_row)
+        self.assertIn("the working tree does not show", staged_row)
+        self.assertIn("a discard destroys it", staged_row)
+
+    def test_preview_counts_come_from_the_enumeration_not_porcelain(self):
+        # One definition, three consumers. An untracked DIRECTORY is the case
+        # where the two sources visibly disagree: porcelain collapses it to a
+        # single `?? dir/` line, while the enumeration — which is what the
+        # discard acts on — names each file inside it plus the directory.
+        wt = self.make_git_worktree()
+        (Path(wt) / "untracked.txt").unlink()
+        (Path(wt) / "tracked.txt").write_text("v1")      # back to HEAD
+        nested = Path(wt) / "scratch"
+        nested.mkdir()
+        (nested / "a.txt").write_text("a")
+        (nested / "b.txt").write_text("b")
+        self.assertEqual(self.porcelain(wt).splitlines(), ["?? scratch/"])
+
+        plan = self.plan(wt)
+        self.assertEqual(sorted(plan["untracked_files"]),
+                         ["scratch/a.txt", "scratch/b.txt"])
+        self.assertEqual(plan["untracked_dirs"], ["scratch/"])
+        row = self.projected_worktree(wt)
+        self.assertIn("2 untracked file(s)", row)
+        self.assertIn("1 untracked dir(s)", row)
+
+    def test_unborn_staged_then_deleted_entry_is_index_only_too(self):
+        # The same CLASS one step out, tested where no bug has visited: with
+        # no HEAD to differ from, an index entry is invisible on disk exactly
+        # when there is no file. The born-HEAD case is the one that was
+        # reported; this one follows from the rule and would otherwise ship
+        # rendering a destroyed staged blob as an ordinary dirty entry.
+        wt = Path(self.tmp.name) / "unborn-index-only"
+        wt.mkdir()
+        self.git_run(str(wt), "init", "-q", "-b", "feat/x", ".")
+        (wt / "gone.txt").write_text("staged then deleted")
+        (wt / "kept.txt").write_text("staged and present")
+        self.git_run(str(wt), "add", "--", "gone.txt", "kept.txt")
+        (wt / "gone.txt").unlink()
+
+        plan = self.plan(str(wt))
+        self.assertEqual(sorted(plan["tracked"]), ["gone.txt", "kept.txt"])
+        self.assertEqual(plan["index_only"], ["gone.txt"])
+        row = self.projected_worktree(str(wt))
+        self.assertIn("2 tracked", row)
+        self.assertIn("1 of them staged-only", row)
 
     def test_unborn_entry_left_on_disk_is_not_claimed_discarded(self):
         # On an unborn HEAD "undone" means gone from the index AND gone from

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -1327,6 +1327,71 @@ class WorktreeTest(RecoveryCase):
         self.assertFalse(details["discarded"])
         self.assertTrue(details["closed"])
 
+    # -- the index's DURABLE FLAGS are state a discard rewrites (SC-125) ---
+    # The index is a store, not a blob table: alongside mode/object/stage each
+    # entry carries skip-worktree and assume-unchanged bits, and `git restore
+    # --staged` clears them. Setting one moves NOTHING else — the working
+    # file, its lstat, the porcelain line and the entry's own mode/object/
+    # stage are byte-identical either side — so only binding the flag can
+    # tell the states apart.
+
+    def stage_only(self, wt: str, rel: str, text: str) -> None:
+        """Stage `text` with the working file holding the SAME bytes, so the
+        entry is `M ` — the one shape where setting a flag leaves the
+        porcelain line alone (on `MM` git reports `M ` once the worktree half
+        is suppressed, which would move the digest by itself)."""
+        (Path(wt) / rel).write_text(text)
+        self.git_run(wt, "add", "--", rel)
+
+    def index_tag(self, wt: str, rel: str) -> str:
+        """The `ls-files -v` tag letter: `H` plain, `S` skip-worktree,
+        lowercase when assume-unchanged is set."""
+        return self.git_run(wt, "ls-files", "-v", "--", rel).split()[0]
+
+    def assert_flag_change_refuses(self, wt: str, rel: str, flag: str) -> None:
+        self.assertIn(f"M  {rel}", self.porcelain(wt))
+        before_stage = self.git_run(wt, "ls-files", "--stage", "--", rel)
+        before_stamp = self.stamp(Path(wt) / rel)
+        before_text = (Path(wt) / rel).read_text()
+        self.assert_mutation_refuses(
+            wt, lambda: self.git_run(wt, "update-index", flag, "--", rel))
+        self.assertEqual(self.git_run(wt, "ls-files", "--stage", "--", rel),
+                         before_stage,
+                         "mode/object/stage moved — this case no longer "
+                         "isolates the flag")
+        self.assertEqual(self.stamp(Path(wt) / rel), before_stamp,
+                         "the working file moved — this case no longer "
+                         "isolates the index")
+        self.assertEqual((Path(wt) / rel).read_text(), before_text)
+
+    def test_discard_clears_the_durable_index_flags(self):
+        # The premise, reproduced rather than argued: `restore --staged`
+        # throws the entry back to HEAD and drops the bits with it, which is
+        # what obliges the digest to bind them.
+        wt = self.make_git_worktree()
+        self.stage_only(wt, "tracked.txt", "staged-only")
+        self.git_run(wt, "update-index", "--skip-worktree", "--",
+                     "tracked.txt")
+        self.assertEqual(self.index_tag(wt, "tracked.txt"), "S")
+        self.git_run(wt, "restore", "--source=HEAD", "--staged", "--worktree",
+                     "--", "tracked.txt")
+        self.assertEqual(self.index_tag(wt, "tracked.txt"), "H",
+                         "restore left the flag standing — premise of SC-125 "
+                         "changed")
+
+    def test_skip_worktree_set_after_preview_refuses_discard(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.stage_only(wt, "tracked.txt", "staged-only")
+        self.assert_flag_change_refuses(wt, "tracked.txt", "--skip-worktree")
+
+    def test_assume_unchanged_set_after_preview_refuses_discard(self):
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.stage_only(wt, "tracked.txt", "staged-only")
+        self.assert_flag_change_refuses(wt, "tracked.txt",
+                                        "--assume-unchanged")
+
     # -- incomplete evidence REFUSES, it never degrades (SC-087) -----------
 
     def assert_gap_refuses_discard_but_frees_the_shell(self, wt, patcher=None):
@@ -1906,6 +1971,135 @@ class WorktreeTest(RecoveryCase):
         # ...and the rest of the consented set still goes: keeping one entry
         # is not a licence to abandon the discard.
         self.assertFalse((Path(wt) / "untracked.txt").exists())
+
+    def test_restage_during_the_removal_loop_is_kept(self):
+        # SC-124: the per-entry re-check read the index ONCE, at the top of
+        # the discard, and the removal loop then runs for arbitrarily many
+        # entries before the destructive `restore`. A stage landing in that
+        # window is invisible to a snapshot taken before it, so the restore
+        # threw the blob away and still reported discarded=true. The index has
+        # to be revalidated where the worktree is — immediately before the
+        # destructive call. Injecting from `_open_parent` puts the stage
+        # exactly inside the loop: after the snapshot, before the restore.
+        wt = self.make_git_worktree()
+        self.stage_over_working_copy(wt, "tracked.txt", staged="staged-a",
+                                     working="working-b")
+        plan = self.plan(wt)
+        real_open = recovery._open_parent
+
+        def staging_open(worktree, rel):
+            fd = real_open(worktree, rel)
+            self.stage_blob(wt, "tracked.txt", "staged-c-mid-removal")
+            return fd
+
+        with mock.patch.object(recovery, "_open_parent", staging_open):
+            result = recovery._discard_worktree_files(wt, plan)
+        self.assertEqual(self.staged(wt, "tracked.txt"),
+                         "staged-c-mid-removal")
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "working-b")
+        self.assertEqual(result["kept"], ["tracked.txt"])
+        self.assertFalse(result["discarded"])
+        # ...and the rest of the consented set still goes.
+        self.assertFalse((Path(wt) / "untracked.txt").exists())
+
+    def test_unreadable_index_before_the_restore_keeps_everything(self):
+        # The revalidation fails closed the same way the first read does: an
+        # index that cannot be read immediately before the destructive call
+        # leaves every enumerated entry unverifiable, and an unverifiable
+        # identity is never a licence to restore over it.
+        wt = self.make_git_worktree()
+        plan = self.plan(wt)
+        real = recovery._index_identities
+        calls = []
+
+        def failing_after_the_first(worktree):
+            calls.append(worktree)
+            if len(calls) > 1:
+                raise recovery._GitEvidenceUnavailable("index gone")
+            return real(worktree)
+
+        with mock.patch.object(recovery, "_index_identities",
+                               failing_after_the_first):
+            result = recovery._discard_worktree_files(wt, plan)
+        self.assertGreater(len(calls), 1, "the index was never re-read")
+        self.assertFalse(result["discarded"])
+        self.assertIn("tracked.txt", result["kept"])
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+
+    def test_discard_preserves_the_durable_index_flags(self):
+        # SC-125, the other half. The bits are not part of HEAD, so "throw the
+        # entry back to HEAD" does not say what should happen to them —
+        # clearing them is a side effect, not a discarded change. The content
+        # goes (that is what was consented to); the flags are put back.
+        wt = self.make_git_worktree()
+        self.stage_only(wt, "tracked.txt", "staged-only")
+        self.git_run(wt, "update-index", "--skip-worktree", "--",
+                     "tracked.txt")
+        self.git_run(wt, "update-index", "--assume-unchanged", "--",
+                     "tracked.txt")
+        self.assertEqual(self.index_tag(wt, "tracked.txt"), "s")
+        result = recovery._discard_worktree_files(wt, self.plan(wt))
+        self.assertTrue(result["discarded"], result)
+        self.assertEqual(result["flags_lost"], [])
+        self.assertEqual(self.staged(wt, "tracked.txt"), "v1")
+        self.assertEqual(self.index_tag(wt, "tracked.txt"), "s")
+
+    def test_flags_that_cannot_be_preserved_are_reported(self):
+        # A staged-NEW path leaves the index entirely, so its flag has nowhere
+        # to live. Preserve where the store allows it, report where it does
+        # not — never clear it silently.
+        wt = self.make_git_worktree()
+        (Path(wt) / "added.txt").write_text("new")
+        self.git_run(wt, "add", "--", "added.txt")
+        self.git_run(wt, "update-index", "--skip-worktree", "--", "added.txt")
+        result = recovery._discard_worktree_files(wt, self.plan(wt))
+        self.assertTrue(result["discarded"], result)
+        self.assertEqual(result["flags_lost"], ["added.txt"])
+        self.assertEqual(self.git_run(wt, "ls-files", "-v", "--",
+                                      "added.txt"), "")
+
+    def test_discard_never_recurses_into_a_submodule(self):
+        # The THIRD store. A submodule has its own worktree, index and refs,
+        # and none of them are inside this fence: the host sees only a gitlink
+        # and a directory, so a commit made inside the submodule after the
+        # preview moves neither. With `submodule.recurse` configured, `git
+        # restore` follows the gitlink and resets that store too — destroying
+        # work the operator was never shown. The discard pins the flag off, so
+        # a config setting cannot widen a consented blast radius.
+        wt = self.make_git_worktree()
+        sub = Path(self.tmp.name) / "submodule-origin"
+        sub.mkdir()
+        self.git_run(str(sub), "init", "-q", "-b", "main")
+        self.git_run(str(sub), "config", "user.email", "t@t")
+        self.git_run(str(sub), "config", "user.name", "t")
+        (sub / "s.txt").write_text("s1")
+        self.git_run(str(sub), "add", "-A")
+        self.git_run(str(sub), "commit", "-qm", "s1")
+        self.git_run(wt, "-c", "protocol.file.allow=always", "submodule",
+                     "add", "-q", str(sub), "sm")
+        self.git_run(wt, "commit", "-qm", "add submodule")
+        self.git_run(wt, "config", "submodule.recurse", "true")
+        # work committed INSIDE the submodule — the host's gitlink now differs
+        inner = str(Path(wt) / "sm")
+        (Path(inner) / "local.txt").write_text("work only the submodule holds")
+        self.git_run(inner, "add", "-A")
+        self.git_run(inner, "commit", "-qm", "inner work")
+        head = self.git_run(inner, "rev-parse", "HEAD")
+
+        result = recovery._discard_worktree_files(wt, self.plan(wt))
+        self.assertEqual(self.git_run(inner, "rev-parse", "HEAD"), head)
+        self.assertTrue((Path(inner) / "local.txt").exists())
+        # ...and say WHY it survived, so this cannot pass vacuously: today the
+        # SC-103 guard keeps it, because a checked-out submodule is a
+        # directory. That is a coincidence of a different rule.
+        self.assertIn("sm", result["kept"])
+
+        # So prove the pin does the work on its own, with that guard out of
+        # the way: the restore now really does run on the gitlink.
+        with mock.patch.object(recovery, "_is_dir", return_value=False):
+            recovery._discard_worktree_files(wt, self.plan(wt))
+        self.assertEqual(self.git_run(inner, "rev-parse", "HEAD"), head)
+        self.assertTrue((Path(inner) / "local.txt").exists())
 
     def test_unreadable_index_at_the_discard_keeps_everything(self):
         # An index that cannot be read between the gate and the delete means

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -2105,6 +2105,140 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual(self.git_run(inner, "rev-parse", "HEAD"), head)
         self.assertTrue((Path(inner) / "local.txt").exists())
 
+    # -- the REPORTED OUTCOME is a guarantee, not a by-product --------------
+    # Everything above asserts a safety property: the work survives. These
+    # assert the other half — that the result SAYS what actually happened.
+    # `discarded` true only if everything consented to was really undone,
+    # `kept` naming everything spared, `flags_lost` naming every bit that
+    # could not be put back, and a failure after the durable commit reported
+    # as a partial discard rather than an opaque 500 (decision #45 ranks
+    # misreporting alongside destruction).
+
+    def nested_dirty_tracked(self, wt: str) -> None:
+        """A tracked, dirty file one directory down — the shape whose parent
+        can be replaced without the entry's own identity moving."""
+        (Path(wt) / "d").mkdir()
+        (Path(wt) / "d" / "f.txt").write_text("v1")
+        self.git_run(wt, "add", "-A")
+        self.git_run(wt, "commit", "-qm", "nested")
+        (Path(wt) / "d" / "f.txt").write_text("dirty")
+
+    def test_restore_that_exits_zero_without_working_is_not_claimed(self):
+        # SC-127's class: an exit code is not an outcome. `discarded` must
+        # mean "verified undone", not "the command did not complain". Forced
+        # deterministically — the restore is replaced by a no-op that exits 0
+        # — because what must hold is independent of which git versions can be
+        # provoked into skipping a path.
+        wt = self.make_git_worktree()
+        plan = self.plan(wt)
+        real_run = subprocess.run
+
+        def lying_restore(args, **kw):
+            if "restore" in args:
+                return subprocess.CompletedProcess(args, 0, b"", b"")
+            return real_run(args, **kw)
+
+        with mock.patch.object(recovery.subprocess, "run", lying_restore):
+            result = recovery._discard_worktree_files(wt, plan)
+        self.assertIn("tracked.txt", result["kept"])
+        self.assertFalse(result["discarded"])
+        self.assertIsNone(result["failed"])
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+
+    def test_parent_swapped_for_a_same_inode_symlink_is_reported_truthfully(
+            self):
+        # The shape SC-127 was reported as: after the late gate the entry's
+        # parent is moved out of the worktree and a symlink to the SAME inode
+        # put in its place, so the per-entry re-check still matches — it
+        # lstats the leaf, and the leaf is the same file.
+        #
+        # On git 2.47.3 the restore does NOT skip: it removes the symlink,
+        # recreates the real directory and writes HEAD content, so the
+        # worktree entry genuinely IS discarded and `discarded=true` is
+        # truthful. The dirty bytes that survive are the copy the operator
+        # moved OUTSIDE the worktree, which no discard was ever scoped to
+        # touch. Pinned because the report and the safety property are easy to
+        # confuse here, and because a future git that really did skip would
+        # now be caught by the verification above rather than mis-reported.
+        wt = self.make_git_worktree()
+        self.nested_dirty_tracked(wt)
+        plan = self.plan(wt)
+        moved = Path(self.tmp.name) / "moved-parent"
+        os.rename(Path(wt) / "d", moved)
+        os.symlink(moved, Path(wt) / "d")
+
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertEqual((moved / "f.txt").read_text(), "dirty")  # outside
+        self.assertEqual((Path(wt) / "d" / "f.txt").read_text(), "v1")
+        self.assertFalse(Path(Path(wt) / "d").is_symlink())
+        self.assertTrue(result["discarded"], result)
+        self.assertEqual(result["kept"], [])
+
+    def test_parent_swapped_for_a_different_symlink_is_kept(self):
+        # ...and when the swap DOES make the entry unreadable as observed, it
+        # is kept and named — the existing per-entry check already covers it,
+        # which is the other half of why the same-inode case above is the only
+        # one that reaches the restore at all.
+        wt = self.make_git_worktree()
+        self.nested_dirty_tracked(wt)
+        (Path(wt) / "other").mkdir()
+        plan = self.plan(wt)
+        os.rename(Path(wt) / "d", Path(self.tmp.name) / "elsewhere")
+        os.symlink("other", Path(wt) / "d")
+
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertIn("d/f.txt", result["kept"])
+        self.assertFalse(result["discarded"])
+
+    def test_flag_restoration_failure_is_reported_not_raised(self):
+        # SC-126. `_restore_index_flags` runs AFTER the destructive restore
+        # and after the durable closure is committed, so an exception there
+        # cannot be unwound and must not escape: it would surface as an opaque
+        # 500 while the staged content is already reset and the flag already
+        # cleared — the truth absent exactly where it matters most. The
+        # failure is absorbed and the real loss is reported, verified by
+        # re-reading the index rather than trusted from an exit code.
+        wt = self.make_git_worktree()
+        self.stage_only(wt, "tracked.txt", "staged-only")
+        self.git_run(wt, "update-index", "--skip-worktree", "--",
+                     "tracked.txt")
+        plan = self.plan(wt)
+        real_run = subprocess.run
+
+        def timeout_on_update_index(args, **kw):
+            if "update-index" in args:
+                raise subprocess.TimeoutExpired(args, 60)
+            return real_run(args, **kw)
+
+        with mock.patch.object(recovery.subprocess, "run",
+                               timeout_on_update_index):
+            result = recovery._discard_worktree_files(wt, plan)
+        self.assertEqual(result["flags_lost"], ["tracked.txt"])
+        self.assertIsNone(result["failed"])   # the discard itself completed
+        self.assertTrue(result["discarded"])
+        self.assertEqual(self.index_tag(wt, "tracked.txt"), "H")
+
+    def test_unexpected_failure_after_the_commit_reports_a_partial_discard(
+            self):
+        # The net, at the endpoint. Whatever goes wrong once the durable
+        # closure is committed, the operator gets a result describing their
+        # files — never a 500 that says only that something broke. Reported,
+        # not swallowed: the exception is named in `failed`.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        with mock.patch.object(recovery, "_restore_index_flags",
+                               side_effect=RuntimeError("boom")):
+            status, result = self.post(obj, preserve_worktree=False,
+                                       discard_worktree=True,
+                                       confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertFalse(result["worktree"]["discarded"])
+        self.assertEqual(result["worktree"]["failed"]["step"], "unexpected")
+        self.assertIn("RuntimeError", result["worktree"]["failed"]["error"])
+        # the closure still happened and is still reported honestly
+        self.assertEqual(result["availability"], "available")
+
     def test_unreadable_index_at_the_discard_keeps_everything(self):
         # An index that cannot be read between the gate and the delete means
         # no entry's identity can be verified — and an unverifiable identity

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -3060,6 +3060,30 @@ class CliRecoverTest(unittest.TestCase):
         self.assertIn("classification: exact_idle_orphan", out)
         self.assertIn("S3 is available", out)
 
+    def test_runtime_that_would_not_let_go_is_printed(self):
+        # The operator-facing half of SC-128. Naming the failure in the
+        # payload and rendering nothing is the silence it was named to end:
+        # the recovery still succeeds (the durable rows ARE closed), so this
+        # belongs on stderr as a follow-up, not as a failed exit.
+        result = dict(self.RESULT)
+        result["closed"] = dict(result["closed"],
+                                runtime={"abandoned": False,
+                                         "error": "RuntimeError: no"})
+        self.script(dict(self.PREVIEW_ORPHAN), result)
+        code, out, err = self.run_cli(["recover", "s3", "--yes"])
+        self.assertEqual(code, 0)
+        self.assertIn("S3 is available", out)
+        self.assertIn("would not release the session generation", err)
+        self.assertIn("RuntimeError: no", err)
+
+    def test_runtime_released_cleanly_says_nothing(self):
+        result = dict(self.RESULT)
+        result["closed"] = dict(result["closed"], runtime={"abandoned": True})
+        self.script(dict(self.PREVIEW_ORPHAN), result)
+        code, _out, err = self.run_cli(["recover", "s3", "--yes"])
+        self.assertEqual(code, 0)
+        self.assertNotIn("generation", err)
+
     def test_force_confirms_exact_identity(self):
         self.script(dict(self.PREVIEW_LIVE), dict(self.RESULT, mode="force"))
         code, _out, _err = self.run_cli(["recover", "s3", "--force", "--yes"])

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -1198,6 +1198,135 @@ class WorktreeTest(RecoveryCase):
         self.assert_mutation_refuses(wt, late.mkdir)
         self.assertTrue(late.is_dir())
 
+    # -- the STAGING INDEX is state a discard destroys too (SC-123) --------
+    # Same rule as everything above — if the discard would rewrite it, the
+    # digest binds it — applied to the one place work lives that is not a
+    # file: the index. Every case here leaves the working file, its lstat and
+    # the porcelain line byte-identical, so nothing the FILESYSTEM carries
+    # can tell the states apart.
+
+    def git_run(self, wt: str, *args, stdin: str | None = None) -> str:
+        return subprocess.run(["git", "-C", wt, *args], input=stdin,
+                              capture_output=True, text=True,
+                              check=True).stdout
+
+    def stage_blob(self, wt: str, rel: str, text: str) -> None:
+        """Put `text` in the INDEX for `rel` WITHOUT touching the worktree
+        file — the shape ordinary partial staging (`git add -p`) produces.
+        `update-index --cacheinfo` writes only `.git/index`, so the working
+        copy's bytes, mode and timestamps are provably untouched."""
+        sha = self.git_run(wt, "hash-object", "-w", "--stdin",
+                           stdin=text).strip()
+        self.git_run(wt, "update-index", "--add", "--cacheinfo",
+                     f"100644,{sha},{rel}")
+
+    def staged(self, wt: str, rel: str) -> str:
+        return self.git_run(wt, "show", f":{rel}")
+
+    def stamp(self, path: Path) -> tuple:
+        return recovery._stamp(os.lstat(path))
+
+    def stage_over_working_copy(self, wt: str, rel: str, *, staged: str,
+                                working: str) -> None:
+        (Path(wt) / rel).write_text(working)
+        self.stage_blob(wt, rel, staged)
+
+    def assert_staged_change_refuses(self, wt: str, rel: str,
+                                     expected_line: str) -> None:
+        """Re-stage `rel` after the preview and require the refusal — pinning
+        that the FILESYSTEM did not move, so the refusal can only come from
+        the index being bound."""
+        self.assertIn(expected_line, self.porcelain(wt))
+        working = (Path(wt) / rel).read_text()
+        before = self.stamp(Path(wt) / rel)
+        self.assert_mutation_refuses(
+            wt, lambda: self.stage_blob(wt, rel, "staged-c-after-preview"))
+        self.assertEqual(self.stamp(Path(wt) / rel), before,
+                         "the working file moved — this case no longer "
+                         "isolates the index")
+        self.assertEqual((Path(wt) / rel).read_text(), working)
+        self.assertEqual(self.staged(wt, rel), "staged-c-after-preview")
+
+    def test_discard_destroys_staged_content(self):
+        # The premise, reproduced rather than argued (as SC-090's was): the
+        # discard's `git restore --staged` throws the index back to HEAD, so
+        # staged content is work a discard erases — which is what obliges the
+        # digest to bind it.
+        wt = self.make_git_worktree()
+        self.stage_over_working_copy(wt, "tracked.txt", staged="staged-a",
+                                     working="working-b")
+        recovery._discard_worktree_files(wt, self.plan(wt))
+        self.assertEqual(
+            self.staged(wt, "tracked.txt"), "v1",
+            "restore --staged left the staged blob intact — premise of "
+            "SC-123 changed")
+
+    def test_staged_content_change_after_preview_refuses_discard(self):
+        # SC-123: an already-tracked path staged with new content. Porcelain
+        # stays `MM tracked.txt` and the working copy stays `working-b`, so a
+        # digest built from status lines plus filesystem identity reads fresh
+        # while the blob the discard is about to erase has been replaced.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.stage_over_working_copy(wt, "tracked.txt", staged="staged-a",
+                                     working="working-b")
+        self.assert_staged_change_refuses(wt, "tracked.txt", "MM tracked.txt")
+
+    def test_newly_staged_content_change_after_preview_refuses_discard(self):
+        # The other half: a path that is not in HEAD at all, staged as an
+        # addition (`AM`). The discard drops it from the index and deletes it,
+        # so its staged blob is destroyed just as completely.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.stage_over_working_copy(wt, "added.txt", staged="staged-a",
+                                     working="working-b")
+        self.assert_staged_change_refuses(wt, "added.txt", "AM added.txt")
+
+    def test_staged_change_during_shutdown_refuses_discard(self):
+        # The LATE gate, for the index. The re-stage lands after the
+        # execute-entry gate has already passed — injected from the signal,
+        # exactly where a shell writes on its way out — so only the second
+        # gate can catch it. Its 409 must name the signal and closure it
+        # cannot unwind, and no work-destroying command may run.
+        wt = self.make_git_worktree()
+        self.stage_over_working_copy(wt, "tracked.txt", staged="staged-a",
+                                     working="working-b")
+        proc, _ticks = self.orphan_with_worktree(wt)
+        real = recovery.terminate_process_group
+
+        def writing(pid, start_ticks, grace_s):
+            result = real(pid, start_ticks, grace_s)
+            self.stage_blob(wt, "tracked.txt", "staged-c-after-the-fence")
+            return result
+
+        with mock.patch.object(recovery, "_pane_present", return_value=False):
+            obj = self.preview(1)
+            self.assertEqual(obj["classification"], "exact_idle_orphan")
+            with mock.patch.object(
+                    recovery, "_discard_worktree_files",
+                    return_value={"worktree": wt, "discarded": True,
+                                  "completed": ["remove", "restore"],
+                                  "failed": None}) as disc, \
+                    mock.patch.object(recovery, "terminate_process_group",
+                                      writing):
+                status, err = self.post(obj, preserve_worktree=False,
+                                        discard_worktree=True,
+                                        confirm_shortname="s1")
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["error"]["code"], "recovery_observation_stale")
+        disc.assert_not_called()   # nothing removed, nothing restored
+        # the post-fence staged blob and the working copy both survive
+        self.assertEqual(self.staged(wt, "tracked.txt"),
+                         "staged-c-after-the-fence")
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "working-b")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
+        # ...and the refusal is honest about what it could NOT unwind
+        self.assertIn(f"The exact process (PID {proc.pid}) was signalled",
+                      err["error"]["message"])
+        details = err["error"]["details"]
+        self.assertFalse(details["discarded"])
+        self.assertTrue(details["closed"])
+
     # -- incomplete evidence REFUSES, it never degrades (SC-087) -----------
 
     def assert_gap_refuses_discard_but_frees_the_shell(self, wt, patcher=None):
@@ -1745,6 +1874,55 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual(result["worktree"]["kept_count"], 1)
         self.assertFalse(result["worktree"]["discarded"])
         self.assertEqual((Path(wt) / "tracked.txt").read_text(), "v1")
+
+    def test_consented_path_restaged_after_the_gate_is_kept(self):
+        # The same guarantee for the index (SC-123). Re-staging after the gate
+        # passed leaves the working file untouched, so only the per-entry
+        # index re-check can tell that the blob about to be thrown away is no
+        # longer the one the operator confirmed. Kept and reported, never
+        # restored over.
+        wt = self.make_git_worktree()
+        self.stage_over_working_copy(wt, "tracked.txt", staged="staged-a",
+                                     working="working-b")
+        self.session_with_worktree(wt)
+        obj = self.preview(1)
+        real_discard = recovery._discard_worktree_files
+
+        def restage_then_discard(worktree, plan):
+            self.stage_blob(wt, "tracked.txt", "staged-c-after-the-gate")
+            return real_discard(worktree, plan)
+
+        with mock.patch.object(recovery, "_discard_worktree_files",
+                               restage_then_discard):
+            status, result = self.post(obj, preserve_worktree=False,
+                                       discard_worktree=True,
+                                       confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertEqual(self.staged(wt, "tracked.txt"),
+                         "staged-c-after-the-gate")
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "working-b")
+        self.assertEqual(result["worktree"]["kept"], ["tracked.txt"])
+        self.assertFalse(result["worktree"]["discarded"])
+        # ...and the rest of the consented set still goes: keeping one entry
+        # is not a licence to abandon the discard.
+        self.assertFalse((Path(wt) / "untracked.txt").exists())
+
+    def test_unreadable_index_at_the_discard_keeps_everything(self):
+        # An index that cannot be read between the gate and the delete means
+        # no entry's identity can be verified — and an unverifiable identity
+        # is never a licence to delete. Everything is kept and reported;
+        # nothing is silently erased on a half-check.
+        wt = self.make_git_worktree()
+        plan = self.plan(wt)
+        with mock.patch.object(
+                recovery, "_index_identities",
+                side_effect=recovery._GitEvidenceUnavailable("index gone")):
+            result = recovery._discard_worktree_files(wt, plan)
+        self.assertFalse(result["discarded"])
+        self.assertEqual(sorted(result["kept"]),
+                         ["tracked.txt", "untracked.txt"])
+        self.assertEqual((Path(wt) / "tracked.txt").read_text(), "dirty")
+        self.assertTrue((Path(wt) / "untracked.txt").exists())
 
     def test_discard_touches_nothing_outside_the_plan(self):
         # The bound stated directly: everything absent from the plan survives a

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -666,6 +666,41 @@ class ExecuteTest(RecoveryCase):
         ).fetchone()[0], "ended")
         con.close()
 
+    def test_closure_failure_names_the_signal_it_cannot_unwind(self):
+        # The mirror of the post-commit rule, one step earlier. The rollback
+        # makes the durable half a clean no-op and says nothing about the half
+        # that is not undoable: the exact process has already been signalled
+        # and proven dead. A bare 500 there leaves the operator unable to tell
+        # "the recovery never started" from "your shell is gone and its rows
+        # still say it is running".
+        proc, ticks = self.child()
+        self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
+        with mock.patch.object(recovery, "_pane_present", return_value=True):
+            obj = self.preview(1)
+            with mock.patch.object(recovery, "_close_durable_state",
+                                   side_effect=RuntimeError("db boom")):
+                status, err = self.call(
+                    "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                    {"observation_id": obj["observation_id"], "mode": "force",
+                     "confirm_force": True})
+        self.assertEqual(status, 500, err)
+        self.assertEqual(err["error"]["code"], "recovery_closure_failed")
+        details = err["error"]["details"]
+        self.assertTrue(details["signaled"]["signaled"])
+        self.assertFalse(details["closed"])
+        self.assertFalse(details["discarded"])
+        self.assertIn("RuntimeError", details["error"])
+        self.assertIn("proven dead", err["error"]["message"])
+        # ...and both claims are true: the process really is gone, and the
+        # durable state really was left alone.
+        proc.wait(timeout=5)
+        self.assertEqual(recovery._proc_state(proc.pid, ticks), "dead")
+        con = self.db()
+        self.assertNotEqual(con.execute(
+            "SELECT occupancy FROM interface_sessions WHERE shell_id=1"
+        ).fetchone()[0], "ended")
+        con.close()
+
     def test_orphan_recover_signals_then_closes(self):
         proc, ticks = self.child()
         sid = self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -64,7 +64,8 @@ BASE_PREVIEW = {
         "unread_messages": 2,
         "git": {
             "worktree": "/x/s3", "branch": "fix/x", "dirty_tracked": 1,
-            "untracked": 2, "unpushed_commits": 0,
+            "index_only": 0, "untracked": 2, "untracked_dirs": 0,
+            "unpushed_commits": 0,
         },
     },
 }
@@ -436,7 +437,8 @@ for (const test of cases) {
     "tmux evidence missing from diagnostics");
   invariant(host.textContent.includes("2 · left unread"),
     "unread-message evidence missing from diagnostics");
-  invariant(host.textContent.includes("not clean · 1 tracked · 2 untracked"),
+  invariant(host.textContent.includes(
+    "not clean · 1 tracked · 2 untracked file(s) · 0 untracked dir(s)"),
     "worktree cleanliness missing from diagnostics");
   invariant(host.textContent.includes("branch fix/x"),
     "git branch missing from diagnostics");
@@ -485,6 +487,108 @@ console.log(JSON.stringify(rendered));
         for row in BASE_PREVIEW["evidence_projection"]
     ]
     assert browser_rows == cli_rows == expected
+
+
+def _worktree_row_in_both_clients(preview):
+    """The canonical worktree row as each client actually renders it."""
+    browser = json.loads(run_recovery_js(
+        "const PREVIEW = " + json.dumps(preview) + r""";
+confirm = () => false;
+prompt = () => null;
+apiIf = async () => PREVIEW;
+const host = new FakeElement("div");
+ifRecoveryControls(host, { shell_id: 3, shortname: "S3" }, {});
+await button(host, "Preview recovery").onclick();
+const row = all(host, (node) => node.recoveryEvidenceKey === "worktree")[0];
+invariant(row, "the browser dropped the canonical worktree row entirely");
+console.log(JSON.stringify(row.recoveryEvidenceValue));
+"""))
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        ic._print_recovery_preview(preview)
+    label = next(row["label"] for row in preview["evidence_projection"]
+                 if row["key"] == "worktree")
+    cli = next(line.strip().split(": ", 1)[1]
+               for line in captured.getvalue().splitlines()
+               if line.strip().startswith(f"{label}: "))
+    return browser, cli
+
+
+def test_index_only_discard_is_visible_and_identical_in_both_clients():
+    """SC-130: enumerated means previewed means consented — in BOTH clients.
+
+    A staged blob with no file on disk is destroyed by a discard while
+    nothing on the filesystem changes appearance, so the preview is the only
+    place an operator can learn it will go. Either client rendering that fact
+    less clearly than the other would consent to more than it displays, which
+    is precisely what the shared projection exists to prevent.
+    """
+    def preview_with(**git):
+        evidence = json.loads(json.dumps(BASE_PREVIEW["evidence"]))
+        evidence["git"].update(git)
+        preview = {**BASE_PREVIEW, "evidence": evidence}
+        preview["evidence_projection"] = recovery.evidence_projection(
+            evidence, preview["classification"], preview["legal_actions"])
+        return preview
+
+    staged_browser, staged_cli = _worktree_row_in_both_clients(
+        preview_with(dirty_tracked=2, index_only=1))
+    plain_browser, plain_cli = _worktree_row_in_both_clients(
+        preview_with(dirty_tracked=2, index_only=0))
+
+    assert staged_browser == staged_cli, (staged_browser, staged_cli)
+    assert plain_browser == plain_cli, (plain_browser, plain_cli)
+    # The exact negative: the same entry count must NOT read the same way
+    # once one of those entries is index-only.
+    assert staged_browser != plain_browser
+    assert "1 of them staged-only" in staged_browser
+    assert "the working tree does not show" in staged_browser
+    assert "staged-only" not in plain_browser
+
+
+def test_browser_renders_the_runtime_that_would_not_release_the_generation():
+    # The CLI branch was asserted and the browser branch was not, so a
+    # browser-only regression would have survived the tests that were added
+    # with it — the recovery succeeds either way, which is exactly what makes
+    # a silently dropped follow-up easy to miss.
+    run_recovery_js(r"""
+let rendered = 0;
+confirm = () => true;
+prompt = () => null;
+renderInterface = async () => { rendered += 1; };
+apiIf = async (path, method = "GET") => {
+  if (method === "GET") return BASE_PREVIEW;
+  return {
+    shell_id: 3, shortname: "S3",
+    classification: "exact_idle_orphan", mode: "recover",
+    signaled: null,
+    closed: {
+      session: {
+        session_id: 9, end_reason: "operator_recovery", already_ended: false,
+      },
+      archive: { archive_id: 12, closed: true },
+      binding: null,
+      alerts_resolved: 0,
+      parked: [],
+      runtime: { abandoned: false, error: "RuntimeError: bridge is down" },
+    },
+    worktree: { preserved: true },
+    unread_messages: 2,
+    availability: "available",
+  };
+};
+const host = new FakeElement("div");
+ifRecoveryControls(host, { shell_id: 3, shortname: "S3" }, {});
+await button(host, "Preview recovery").onclick();
+await button(host, "Recover").onclick();
+invariant(host.textContent.includes(
+  "The runtime would not release the session generation"),
+  `runtime-abandon failure not rendered: ${host.textContent}`);
+invariant(host.textContent.includes("RuntimeError: bridge is down"),
+  `runtime-abandon error detail not rendered: ${host.textContent}`);
+invariant(host.textContent.includes("Durable state IS closed"),
+  "the browser did not separate the closed durable state from the runtime");
+""")
 
 
 def test_recovery_preview_execute_happy_path_uses_opaque_observation():


### PR DESCRIPTION
Sprint 31 fix unit **F12** — re-conformance finding **SC-123** (Major, doc #35), spec 30 requirement 24.

## The defect

The recovery observation bound the filesystem — porcelain lines plus each entry's lstat identity, bytes and symlink target — but not the git **index**. The discard destroys both: `git restore --source=HEAD --staged --worktree` throws the index back to HEAD, and on an unborn HEAD `git rm --cached` drops the entry outright.

So an operator who staged a change *after* the preview had that work inside the confirmed blast radius while no gate could see it. Re-staging leaves the working file, its lstat and the `MM` porcelain line byte-identical, both `change_digest` values equal, and the API returned `discarded=true` over erased staged content. `git add -p` produces exactly that shape.

This is rule 2 again — *if reset/clean would create, delete or rewrite it, the digest MUST bind it* — already applied to content, symlink targets, type transitions, mode, ownership and timestamps. The index is simply the one place that state is not a file, which is why it was missed.

## The fix

Bind the index entry (mode, object id, merge stage — all stages of an unmerged path) for every enumerated entry, composed with the filesystem identity into one `_entry_identity`. It therefore rides **both** ratified gates unchanged: the full-evidence compare at execute entry and the worktree-only compare immediately before the destructive commands.

**On the two-gate interaction** (PLN1 asked me to say so explicitly if I disagreed — I don't): the late gate compares the worktree because recovery deliberately changes process state, pane membership and durable rows, so re-comparing those is not implementable. The index is *not* altered by a recovery, so it belongs in that comparison for exactly the same reason the worktree does.

### Trade-offs taken

- **The index's own mtime and stat cache are deliberately NOT bound.** `git status` refreshes those as a side effect of the very observation this fences, so binding them would make a preview stale against itself and refuse every discard forever — the same trap `st_atime` is excluded from `_path_identity` for. Only the *content* the index holds is recorded.
- **Blob ids stay internal to the plan** — never in the evidence payload, same as paths and contents.
- **One index read per pass**, not per path, so every entry's index identity comes from the same instant the path set does.
- **The per-entry re-check** before each destructive operation composes the same identity from one index snapshot taken at the top of the discard (nothing there writes to the index before the final restore). A simpler fix would have bound the index in the digest only; I rejected it because it would leave `unchanged()` restoring over a blob that was no longer the one the operator confirmed. An index that cannot be read verifies nothing and **keeps** every entry rather than deleting on an unchecked identity.

Everything ratified is preserved: two-gate design, bounded-set discard, removal-before-restore, no-follow ancestor walk, preserve-and-report on a D/F conflict, decision #45's priority order, and the fail-closed scoping that declines the DISCARD on an evidence gap without ever gating availability.

## Tests

Every fence test was **proven RED before the fix** (`200`, `discarded=true` — the SC-123 repro) and each is **mutation-killed**:

| test | proves |
|---|---|
| `test_staged_content_change_after_preview_refuses_discard` | already-tracked path, `MM`, working bytes + lstat pinned unchanged → exact `409 recovery_observation_stale`, no signal/closure/removal/restore, staged blob intact |
| `test_newly_staged_content_change_after_preview_refuses_discard` | newly-staged addition, `AM`, same guarantee |
| `test_staged_change_during_shutdown_refuses_discard` | re-stage injected **from the signal** — after the execute-entry gate passed — refuses at the **late** gate, 409 naming the signal and closure it cannot unwind |
| `test_discard_destroys_staged_content` | the premise reproduced rather than argued: `restore --staged` does erase the blob |
| `test_consented_path_restaged_after_the_gate_is_kept` | a consented path re-staged after the gate is **kept and reported**, not restored over |
| `test_unreadable_index_at_the_discard_keeps_everything` | unverifiable identity is never a licence to delete |

**Mutation proof:** dropping the index from `_entry_identity` reddens the three fence tests; dropping it from the per-entry re-check *alone* reddens the keep test.

## Verification

- `tests/test_interface_recovery.py` — **105 passed**
- interface API + CLI + recovery — 232 passed
- full engine suite — **1097 passed**, 9 skipped. The 12 `spikes/interface-stream` failures are this seat's missing `tmux` (`No such file or directory: 'tmux'`) and **fail identically on clean `main`** — verified by stashing.
- lint at baseline: 902 errors before and after.

Spec write-back is PLN1's — requirement 24 already states the obligation; PLN1 will name staged-index content once this lands.

Co-Authored-By: Code-03 (super-coder) <noreply@super-coder.local>