### PR TITLE
fix: make publish controls artifact-mode aware

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -940,6 +940,19 @@ def script_list() -> list[dict]:
             for k, v in _SCRIPTS.items()]
 
 
+def health_payload() -> dict:
+    """Runtime identity plus the artifact actions the Interface may offer."""
+    cfg = ports_mod.resolve()
+    active_mode = artifact_policy.mode()
+    return {
+        "ok": True,
+        "repo": cfg.get("repo"),
+        "port": cfg.get("port"),
+        "artifact_mode": active_mode,
+        "git_publication": active_mode == artifact_policy.TRACKED,
+    }
+
+
 def run_script(key: str) -> dict | None:
     spec = _SCRIPTS.get(key)
     if not spec:
@@ -2375,9 +2388,7 @@ class Handler(BaseHTTPRequestHandler):
         con = db()
         try:
             if path == "/api/health":
-                cfg = ports_mod.resolve()
-                return self._send(200, {"ok": True, "repo": cfg.get("repo"),
-                                        "port": cfg.get("port")})
+                return self._send(200, health_payload())
             if path == "/api/shells":
                 return self._send(200, {"shells": get_shells(con)})
             if path == "/api/shell-templates":

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3480,13 +3480,35 @@ document.addEventListener("keydown", (e) => {
     overlays[overlays.length - 1]?.remove();
   }
 });
+let localArtifactMode = false;
+function configureArtifactActions(health) {
+  localArtifactMode = health.artifact_mode === "local" || health.git_publication === false;
+  const snapshot = $("#snapshot");
+  const publish = $("#publish");
+  if (localArtifactMode) {
+    snapshot.textContent = "save locally ⤓";
+    snapshot.title = "snapshot + render into ignored .sc-state/local/";
+    publish.textContent = "publish off";
+    publish.title = "Git publication is disabled in local artifact mode";
+    publish.disabled = true;
+  } else {
+    snapshot.textContent = "snapshot ⤓";
+    publish.textContent = "publish ⤴";
+    publish.disabled = false;
+  }
+}
 $("#snapshot").onclick = async () => {
-  setStatus("snapshotting…");
-  try { const r = await api("/snapshot", "POST"); toast(r.output || "done"); setStatus("snapshot done"); }
+  setStatus(localArtifactMode ? "saving locally…" : "snapshotting…");
+  try {
+    const r = await api("/snapshot", "POST");
+    toast(r.output || "done");
+    setStatus(localArtifactMode ? "saved locally" : "snapshot done");
+  }
   catch (e) { toast("error: " + e.message); }
 };
 $("#publish").onclick = async (e) => {
   const btn = e.currentTarget;
+  if (localArtifactMode) return;
   btn.disabled = true;
   setStatus("publishing…");
   try {
@@ -3498,7 +3520,12 @@ $("#publish").onclick = async (e) => {
   finally { btn.disabled = false; }
 };
 (async () => {
-  try { const h = await api("/health"); $("#repo").textContent = h.repo; setStatus("port " + h.port); }
+  try {
+    const h = await api("/health");
+    $("#repo").textContent = h.repo;
+    configureArtifactActions(h);
+    setStatus(localArtifactMode ? "local artifacts · port " + h.port : "port " + h.port);
+  }
   catch { setStatus("offline"); }
   routeFromHash();   // honor #tab on load (refresh / deep link), else Shells
 })();

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -61,6 +61,9 @@ nav button.active::after {
   padding: .35rem .7rem; border-radius: var(--r); cursor: pointer; font: inherit;
 }
 #snapshot:hover { border-color: var(--accent); }
+#publish:disabled {
+  opacity: .45; cursor: not-allowed; filter: grayscale(1);
+}
 main { padding: 1.2rem; flex: 1 0 auto; min-height: 0; }
 /* One shared content width for every page — no per-tab jumps. */
 /* minmax(0,1fr): grid items default to min-width:auto, so any nowrap line

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -99,6 +99,23 @@ class AssemblerSmokeTest(unittest.TestCase):
     def test_get_shell_missing_returns_none(self) -> None:
         self.assertIsNone(server.get_shell(self.con, 999999))
 
+    def test_health_exposes_local_artifact_capabilities(self) -> None:
+        with mock.patch.object(server.ports_mod, "resolve",
+                               return_value={"repo": "source", "port": 17171}), \
+             mock.patch.object(server.artifact_policy, "mode", return_value="local"):
+            out = server.health_payload()
+        self.assertEqual(out["artifact_mode"], "local")
+        self.assertFalse(out["git_publication"])
+        self.assertEqual(out["repo"], "source")
+
+    def test_health_keeps_tracked_forks_publishable(self) -> None:
+        with mock.patch.object(server.ports_mod, "resolve",
+                               return_value={"repo": "fork", "port": 17172}), \
+             mock.patch.object(server.artifact_policy, "mode", return_value="tracked"):
+            out = server.health_payload()
+        self.assertEqual(out["artifact_mode"], "tracked")
+        self.assertTrue(out["git_publication"])
+
     def test_get_roadmap_with_linked_flag_and_doc(self) -> None:
         # The regression: this path raised KeyError('feature_id') when a flag
         # was linked to a feature. Assert it assembles and carries the links.

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -110,7 +110,12 @@ def _mock_api(route) -> None:
     request = route.request
     path = request.url.split("/api", 1)[-1]
     if path == "/health":
-        return _json(route, {"repo": "rendered-fixture", "port": 0})
+        return _json(route, {
+            "repo": "rendered-fixture",
+            "port": 0,
+            "artifact_mode": "local",
+            "git_publication": False,
+        })
     if path == "/interface/browser-sessions":
         return _json(route, {"csrf": "rendered-fixture"})
     if path == "/interface/shells":
@@ -253,6 +258,22 @@ def _artifact(tmp_path: Path, name: str) -> Path:
         directory = ROOT / directory
     directory.mkdir(parents=True, exist_ok=True)
     return directory / name
+
+
+def test_local_artifact_mode_keeps_save_and_disables_publish(browser, ui_url):
+    context = browser.new_context(viewport={"width": 1600, "height": 1000})
+    page = context.new_page()
+    page.route("**/api/**", _mock_api)
+    try:
+        page.goto(ui_url, wait_until="networkidle")
+        snapshot = page.locator("#snapshot")
+        publish = page.locator("#publish")
+        assert snapshot.text_content() == "save locally ⤓"
+        assert publish.text_content() == "publish off"
+        assert publish.is_disabled()
+        assert "local artifacts" in page.locator("#status").text_content()
+    finally:
+        context.close()
 
 
 def test_tall_fit_short_floor_and_visual_qa(browser, ui_url, tmp_path):


### PR DESCRIPTION
Expose artifact capabilities through health, retain local snapshot saving, and disable Git publication in the Interface when the engine is configured for local artifacts.