### PR TITLE
fix(interface): enumerate the work assume-unchanged hides (S31 F13)

### DIFF
--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -1510,7 +1510,15 @@ def classify(evidence: dict) -> tuple[str, list[str]]:
             # never spawned, or a legacy row): nothing live to disprove the
             # lock — safe to close.
             return "stale_durable_lock", ["recover"]
-        if pid_state == "unreadable" or pane is None:
+        if pid_state == "unreadable":
+            return "indeterminate", []
+        if pane is None:
+            # tmux could not answer. A positively dead recorded identity
+            # still proves the managed process cannot act, so the shell is
+            # unstrandable without signalling anything (decision #49); with
+            # any other pid state the pane could still hold a live harness.
+            if pid_state == "dead":
+                return "stale_durable_lock", ["recover"]
             return "indeterminate", []
         if pane and pid_state == "alive":
             return "verified_live", ["force"]

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -74,6 +74,7 @@ import secrets
 import signal
 import stat
 import subprocess
+import tempfile
 import time
 
 import interface_broker
@@ -277,7 +278,8 @@ class _GitEvidenceUnavailable(Exception):
     """
 
 
-def _git_out(worktree: str, *args, timeout: int = 15) -> str:
+def _git_out(worktree: str, *args, timeout: int = 15,
+             index_file: str | None = None) -> str:
     """Git stdout, decoded losslessly; any failure raises.
 
     surrogateescape, NEVER strict: a valid non-UTF-8 filename is real working
@@ -286,11 +288,16 @@ def _git_out(worktree: str, *args, timeout: int = 15) -> str:
     distinct in the digest and hand os.* calls back the original bytes.
     Non-zero exit, timeout and spawn failure all become a refusal, never a
     partial answer.
+
+    `index_file` points git at a DIFFERENT index for this one call. Only
+    `_enumerate` uses it, and only ever at a throwaway copy — see there.
     """
     try:
         out = subprocess.run(["git", "-C", worktree, *args],
                              capture_output=True, timeout=timeout,
-                             check=False)
+                             check=False,
+                             env={**os.environ, "GIT_INDEX_FILE": index_file}
+                             if index_file else None)
     except Exception as exc:  # spawn failure / timeout: a gap, not a fact
         raise _GitEvidenceUnavailable(
             f"git {args[0]}: {type(exc).__name__}") from exc
@@ -473,6 +480,23 @@ def _index_flags(identity: str) -> str:
     return identity.rsplit(" ", 1)[-1] if " " in identity else "--"
 
 
+def _hides_worktree(flags: str) -> bool:
+    """True when these durable flags stop git comparing the path's working
+    file to HEAD in a way `_enumerate` CANNOT undo.
+
+    Only skip-worktree does. It is the one bit that survives the unhiding in
+    `_worktree_vs_head`, so it is also the one bit that leaves an entry
+    genuinely unverifiable — which is what `_unrestored` needs to know.
+    """
+    return "S" in flags
+
+
+def _unhideable(flags: str) -> bool:
+    """True for assume-unchanged with no skip-worktree over it — the class
+    `_worktree_vs_head` clears on its throwaway copy so the entry is seen."""
+    return "A" in flags and not _hides_worktree(flags)
+
+
 def _index_identities(worktree: str) -> dict[str, str]:
     """What the INDEX holds, per path: mode, object id, merge stage, and the
     durable per-entry FLAGS.
@@ -555,7 +579,91 @@ def _entry_identity(worktree: str, rel: str, index: dict[str, str]) -> str:
             + index.get(rel, _INDEX_ABSENT))
 
 
-def _enumerate(worktree: str, head: bool) -> tuple[set, set, set, set]:
+def _git_paths(worktree: str, *args, index_file: str | None = None) -> list[str]:
+    """A `-z` git listing as paths — verbatim, no C-quoting to unescape."""
+    return [p for p in _git_out(worktree, *args, timeout=30,
+                                index_file=index_file).split("\0") if p]
+
+
+def _worktree_vs_head(worktree: str, hidden: list[str]) -> set[str]:
+    """Every path whose WORKING FILE differs from HEAD — including the ones the
+    index has been told to stop looking at.
+
+    `assume-unchanged` is a promise the OPERATOR makes to git, not a fact about
+    the file. Git stops stat'ing the entry, and every worktree comparison built
+    on it — `diff HEAD`, `status`, porcelain — then calls the path clean
+    whatever its bytes are. `reset --hard`, the operation this discard stands
+    in for, does NOT honour that promise: it overwrites the modified file and
+    recreates the deleted one (both reproduced). So an enumeration that trusts
+    the hint under-discards against the very operation it replaces, shows the
+    operator a clean preview of work that is really there, and then reports
+    `discarded=true` over their surviving bytes — false consent and a false
+    outcome, which decision #45 ranks with destruction (SC-132).
+
+    The hint is therefore cleared on a THROWAWAY COPY of the index and the SAME
+    `git diff` is asked against that. The operator's own index is never written:
+    the bits are standing instructions about a path, not state the discard was
+    confirmed to change (SC-125's rule, one layer earlier). This is not a second
+    statement of the predicate — it is the one predicate, asked of an index that
+    will answer it.
+
+    `skip-worktree` is deliberately NOT cleared, and that exclusion is what the
+    audit CONCLUDED rather than something it overlooked. Four reproductions:
+    it dominates assume-unchanged (an entry carrying both is untouched),
+    `reset --hard` leaves such an entry alone, `git restore` refuses the
+    pathspec outright, and clearing it would re-materialise a sparse checkout's
+    deliberately absent files. The entry is outside the blast radius of the
+    operation being replaced, so enumerating it would promise a destruction
+    that cannot be performed — the opposite error, equally a false report.
+
+    Rejected alternative: `update-index --really-refresh`, which ignores the
+    hint without clearing it. It finds only paths that still EXIST — it missed
+    a hidden path deleted from the worktree, which `reset --hard` restores.
+
+    A failure here RAISES rather than falling back to the hint-trusting diff:
+    silently returning the incomplete set is exactly the defect, and req 24
+    fails closed for the destructive path on a gap.
+    """
+    if not hidden:
+        return set(_git_paths(worktree, "diff", "HEAD", "--name-only", "-z"))
+    git_dir = _git_out(worktree, "rev-parse", "--absolute-git-dir").strip()
+    # NEVER inside the worktree: a file there would itself enumerate as
+    # untracked and land in the delete set being computed.
+    fd, copy = tempfile.mkstemp(prefix="sc-recovery-index-")
+    os.close(fd)
+    try:
+        with open(os.path.join(git_dir, "index"), "rb") as src, \
+                open(copy, "wb") as dst:
+            while chunk := src.read(1 << 20):
+                dst.write(chunk)
+        try:
+            out = subprocess.run(
+                ["git", "-C", worktree, "update-index", "-z",
+                 "--no-assume-unchanged", "--stdin"],
+                input=b"".join(rel.encode("utf-8", "surrogateescape") + b"\0"
+                               for rel in hidden),
+                capture_output=True, timeout=30, check=False,
+                env={**os.environ, "GIT_INDEX_FILE": copy})
+        except Exception as exc:  # spawn failure / timeout: a gap, not a fact
+            raise _GitEvidenceUnavailable(
+                f"git update-index: {type(exc).__name__}") from exc
+        if out.returncode != 0:
+            raise _GitEvidenceUnavailable(
+                f"git update-index: exit {out.returncode}")
+        return set(_git_paths(worktree, "diff", "HEAD", "--name-only", "-z",
+                              index_file=copy))
+    except OSError as exc:
+        raise _GitEvidenceUnavailable(f"index copy: {exc.errno}") from exc
+    finally:
+        try:
+            os.unlink(copy)
+        except OSError:
+            pass  # a temp file we could not remove is not a fact about the
+                  # operator's worktree, and must not mask the real answer
+
+
+def _enumerate(worktree: str, head: bool,
+               index: dict[str, str]) -> tuple[set, set, set, set]:
     """`(tracked, index_only, untracked_files, untracked_dirs)` — the entries a
     discard would have to undo, as of now, classified by what undoing one does.
 
@@ -581,9 +689,7 @@ def _enumerate(worktree: str, head: bool) -> tuple[set, set, set, set]:
     reached by the same reasoning rather than by the one case a probe found.
     """
     def paths(*args) -> list[str]:
-        # -z: paths verbatim, no C-quoting to unescape.
-        return [p for p in _git_out(worktree, *args, timeout=30).split("\0")
-                if p]
+        return _git_paths(worktree, *args)
 
     listed = set(paths("ls-files", "-o", "--exclude-standard", "-z"))
     untracked_dirs = {p for p in
@@ -607,7 +713,14 @@ def _enumerate(worktree: str, head: bool) -> tuple[set, set, set, set]:
     # sitting in the index. `reset --hard`, the operation this replaces, threw
     # that entry away; found by asking the SC-129 question of the enumeration
     # itself rather than of the check that reads it.
-    in_worktree = set(paths("diff", "HEAD", "--name-only", "-z"))
+    # The worktree half is asked of an index that will ANSWER it: an entry the
+    # operator marked assume-unchanged is hidden from `diff HEAD` while its
+    # bytes really differ, and `reset --hard` destroys it regardless (SC-132).
+    # The index half needs no such care — it never consults the working file,
+    # so no worktree-suppressing bit can hide a staged difference from it.
+    in_worktree = _worktree_vs_head(
+        worktree, sorted(rel for rel, identity in index.items()
+                         if _unhideable(_index_flags(identity))))
     in_index = set(paths("diff", "--cached", "HEAD", "--name-only", "-z"))
     return in_worktree | in_index, in_index - in_worktree, \
         untracked_files, untracked_dirs
@@ -657,9 +770,9 @@ def _discard_plan(worktree: str, porcelain: list[str], head: bool) -> dict:
     Ignored files stay out: `clean -fd` without -x does not touch them, so
     they are not state the confirmation is about.
     """
-    tracked, index_only, untracked_files, untracked_dirs = _enumerate(
-        worktree, head)
     index = _index_identities(worktree)
+    tracked, index_only, untracked_files, untracked_dirs = _enumerate(
+        worktree, head, index)
 
     h = hashlib.sha256()
     for line in sorted(porcelain):
@@ -916,14 +1029,21 @@ def _unrestored(worktree: str, plan: dict, restored: list[str]) -> list[str]:
     survived its de-staging is named as untracked; an entry the restore left
     alone is named exactly as it was at plan time.
 
-    That enumeration reads the worktree half of a flagged entry THROUGH the
-    index — `git diff` trusts skip-worktree and assume-unchanged and will not
-    look at the file — so an entry still carrying a durable bit here cannot be
-    verified by it and is reported kept. Reachable enumerated entries do not
-    hit this: a bit only exists on an index entry, and an index entry the plan
-    holds differs from HEAD, so the restore rewrites it and drops the bit with
-    it (reproduced). An entry whose bit survived is one where something other
-    than that happened, which is not a state to report success from.
+    An entry the enumeration CANNOT see is reported kept rather than assumed
+    discarded, and exactly one durable bit still hides one: skip-worktree
+    (`_hides_worktree`). `git diff` will not look at such a file, and
+    `_worktree_vs_head` deliberately leaves that bit alone, so the contract
+    cannot be asked about the entry at all — and an unanswerable question is
+    never answered with success.
+
+    assume-unchanged USED to be counted here too, and that became wrong the
+    moment `_worktree_vs_head` started clearing it (SC-132): the restore puts
+    such an entry back to HEAD correctly and LEAVES THE BIT STANDING —
+    reproduced with the exact destructive command — so treating the surviving
+    bit as unverifiable reported `kept` over work that had in fact been
+    discarded. That is the same misreport this function exists to prevent,
+    merely inverted, so the guard asks the enumeration's real blind spot
+    instead of "is any bit set".
 
     Unreadable now -> unverifiable, and an unverifiable outcome is never
     reported as a success.
@@ -935,16 +1055,16 @@ def _unrestored(worktree: str, plan: dict, restored: list[str]) -> list[str]:
     if not restored:
         return []
     try:
-        tracked, _index_only, untracked_files, untracked_dirs = _enumerate(
-            worktree, plan["head"])
         index = _index_identities(worktree)
+        tracked, _index_only, untracked_files, untracked_dirs = _enumerate(
+            worktree, plan["head"], index)
     except _GitEvidenceUnavailable:
         return sorted(restored)
     still = tracked | untracked_files | untracked_dirs
     return sorted(
         rel for rel in restored
         if rel in still
-        or _index_flags(index.get(rel, _INDEX_ABSENT)) != "--")
+        or _hides_worktree(_index_flags(index.get(rel, _INDEX_ABSENT))))
 
 
 _INDEX_FLAG_OPTS = {"S": "--skip-worktree", "A": "--assume-unchanged"}

--- a/.super-coder/scripts/interface_recovery.py
+++ b/.super-coder/scripts/interface_recovery.py
@@ -622,16 +622,23 @@ def _worktree_vs_head(worktree: str, hidden: list[str]) -> set[str]:
 
     A failure here RAISES rather than falling back to the hint-trusting diff:
     silently returning the incomplete set is exactly the defect, and req 24
-    fails closed for the destructive path on a gap.
+    fails closed for the destructive path on a gap. EVERY step raises the same
+    refusal, the copy's own creation included — a full or unwritable temp dir
+    and an exhausted fd table are gaps in the observation exactly like a failed
+    `update-index`, and an OSError escaping raw would leave the public path
+    answering a sanitized 500 instead of an indeterminate worktree (SC-133).
     """
     if not hidden:
         return set(_git_paths(worktree, "diff", "HEAD", "--name-only", "-z"))
     git_dir = _git_out(worktree, "rev-parse", "--absolute-git-dir").strip()
     # NEVER inside the worktree: a file there would itself enumerate as
     # untracked and land in the delete set being computed.
-    fd, copy = tempfile.mkstemp(prefix="sc-recovery-index-")
-    os.close(fd)
     try:
+        fd, copy = tempfile.mkstemp(prefix="sc-recovery-index-")
+    except OSError as exc:   # no temp space, no permission, fds exhausted
+        raise _GitEvidenceUnavailable(f"index copy: {exc.errno}") from exc
+    try:
+        os.close(fd)
         with open(os.path.join(git_dir, "index"), "rb") as src, \
                 open(copy, "wb") as dst:
             while chunk := src.read(1 << 20):

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3223,6 +3223,16 @@ async function ifEndChat(a, sel, pane, btn) {
   let r;
   try { r = await apiIf("/interface/termination-requests", "POST", { session_id: a.sessionId, force: false }); }
   catch (e) {
+    // not_occupied: the generation is unreconciled, so there is no verified
+    // identity left to terminate. That is not a failure the operator can act
+    // on from here — it is the recovery path, which the server may now list a
+    // legal action for. Detach and re-render onto it (decision #49) instead
+    // of leaving a terminal error on a shell that can be unstranded.
+    if (e.status === 409 && e.code === "not_occupied") {
+      ifDetach();
+      if (root) return renderInterface(root);
+      return;
+    }
     if (e.status === 409 && e.body && e.body.reason) r = e.body;
     else { a.st.note = "end chat failed: " + e.message; a.paint(); return; }
   }

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -3126,6 +3126,222 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual(result["flags_lost"], [])
         self.assertEqual(self.index_tag(wt, "tracked.txt"), "S")
 
+    # -- a HIDDEN entry is still the operator's work (SC-132) --------------
+    # `assume-unchanged` is a promise the operator makes to git, not a fact
+    # about the file: git stops stat'ing the entry, so `diff HEAD`, `status`
+    # and porcelain all call it clean while its bytes really differ. The
+    # enumeration trusted that hint, so the work was in no preview, no gate and
+    # no delete set — and the discard reported success over it. `reset --hard`,
+    # the operation being replaced, destroys it. Every premise below is
+    # reproduced against real git rather than argued.
+
+    def hidden_dirty(self, wt: str, rel: str, text: str) -> None:
+        """Write `text` to a tracked, currently-clean `rel` behind the
+        assume-unchanged hint, and pin the premise: git reports NOTHING."""
+        self.git_run(wt, "update-index", "--assume-unchanged", "--", rel)
+        (Path(wt) / rel).write_text(text)
+        self.assertNotIn(rel, self.git_run(wt, "diff", "HEAD",
+                                           "--name-only").split(),
+                         "git sees the change — the hint no longer hides it "
+                         "and this case tests nothing")
+        self.assertEqual(self.index_tag(wt, rel), "h")
+
+    def commit_pushed(self, wt: str, rel: str, text: str) -> None:
+        """A second tracked, clean, PUSHED file — pushed because an unpushed
+        commit refuses the discard on its own and would mask the case."""
+        (Path(wt) / rel).write_text(text)
+        self.git_run(wt, "add", "--", rel)
+        self.git_run(wt, "commit", "-qm", f"add {rel}")
+        self.git_run(wt, "push", "-q", "origin", "feat/x")
+
+    def test_reset_hard_destroys_hidden_work_but_spares_skip_worktree(self):
+        # THE PREMISE, and the reason the two bits are treated differently.
+        # This discard stands in for `reset --hard`, so what that command does
+        # is the boundary: under-discarding leaves consented work alive and
+        # reports it destroyed, over-discarding destroys work the operator
+        # never put inside the radius. Reproduced, because the whole fix turns
+        # on which side of that line each bit falls.
+        wt = self.make_git_worktree()
+        self.commit_pushed(wt, "sparse.txt", "s1")
+        self.hidden_dirty(wt, "clean.txt", "HIDDEN")
+        self.git_run(wt, "update-index", "--skip-worktree", "--", "sparse.txt")
+        (Path(wt) / "sparse.txt").write_text("SPARSE-DIRTY")
+
+        self.git_run(wt, "reset", "--hard", "HEAD")
+        self.assertEqual((Path(wt) / "clean.txt").read_text(), "c1",
+                         "reset --hard spared the assume-unchanged file — it "
+                         "is outside the replaced blast radius after all")
+        self.assertEqual((Path(wt) / "sparse.txt").read_text(), "SPARSE-DIRTY",
+                         "reset --hard destroyed the skip-worktree file — "
+                         "excluding it now under-discards")
+        # ...and the bits themselves are durable across it, which is why the
+        # discard has to put them back rather than treat them as content.
+        self.assertEqual(self.index_tag(wt, "clean.txt"), "h")
+        self.assertEqual(self.index_tag(wt, "sparse.txt"), "S")
+
+    def test_preview_exposes_hidden_work_as_tracked(self):
+        # The consent half. The operator is shown what the discard will
+        # destroy, so a preview that renders this worktree "clean" is asking
+        # for consent to something it has not disclosed.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.hidden_dirty(wt, "clean.txt", "HIDDEN")
+        obj = self.preview(1)
+        self.assertEqual(obj["evidence"]["git"]["dirty_tracked"], 2,
+                         "the hidden file is missing from the preview")
+        self.assertIn("clean.txt", self.plan(wt)["tracked"])
+
+    def test_public_discard_restores_hidden_work_and_keeps_the_flag(self):
+        # The whole contract end-to-end on the PUBLIC path: previewed, so
+        # consented; restored to HEAD, so the report is true; and the
+        # operator's standing instruction about the path survives, because
+        # clearing the bit is a side effect of the command rather than a change
+        # they confirmed (SC-125).
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.hidden_dirty(wt, "clean.txt", "HIDDEN")
+        obj = self.preview(1)
+        status, result = self.post(obj, preserve_worktree=False,
+                                   discard_worktree=True,
+                                   confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertEqual((Path(wt) / "clean.txt").read_text(), "c1")
+        self.assertTrue(result["worktree"]["discarded"], result["worktree"])
+        self.assertEqual(result["worktree"]["kept"], [])
+        self.assertEqual(result["worktree"]["flags_lost"], [])
+        self.assertEqual(self.index_tag(wt, "clean.txt"), "h")
+
+    def test_hidden_deletion_is_enumerated_and_restored(self):
+        # The same hint hides a DELETION, and `reset --hard` puts the file
+        # back. This is the case that rules out `update-index --really-refresh`
+        # as the fix: it ignores the hint but only re-stats paths that still
+        # exist, so it never names this one.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.git_run(wt, "update-index", "--assume-unchanged", "--",
+                     "clean.txt")
+        (Path(wt) / "clean.txt").unlink()
+        self.assertNotIn("clean.txt", self.git_run(wt, "diff", "HEAD",
+                                                   "--name-only").split())
+        obj = self.preview(1)
+        self.assertEqual(obj["evidence"]["git"]["dirty_tracked"], 2)
+        status, result = self.post(obj, preserve_worktree=False,
+                                   discard_worktree=True,
+                                   confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertEqual((Path(wt) / "clean.txt").read_text(), "c1")
+        self.assertTrue(result["worktree"]["discarded"], result["worktree"])
+
+    def test_hidden_bytes_changed_after_preview_refuse_the_discard(self):
+        # The freshness fence over the newly-enumerated class. The porcelain
+        # line set stays byte-identical here — it is EMPTY either side, since
+        # the hint suppresses both states — so nothing but binding the entry
+        # itself can tell the two worlds apart.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.hidden_dirty(wt, "clean.txt", "HIDDEN")
+        self.assert_content_edit_refuses(wt, "clean.txt", "HIDDEN-AGAIN")
+
+    def test_hidden_bytes_changed_before_the_late_gate_are_preserved(self):
+        # Past the execute-entry gate, the per-entry re-check immediately
+        # before the destructive command is the last thing standing between
+        # late work and deletion. An entry that moved since the plan is spared
+        # and NAMED, and the result must not claim a full discard.
+        wt = self.make_git_worktree()
+        self.hidden_dirty(wt, "clean.txt", "HIDDEN")
+        plan = self.plan(wt)
+        self.assertIn("clean.txt", plan["tracked"])
+        (Path(wt) / "clean.txt").write_text("WRITTEN-AFTER-THE-GATE")
+
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertEqual((Path(wt) / "clean.txt").read_text(),
+                         "WRITTEN-AFTER-THE-GATE")
+        self.assertIn("clean.txt", result["kept"])
+        self.assertFalse(result["discarded"])
+
+    def test_skip_worktree_dirty_file_is_left_outside_the_discard(self):
+        # The audit's conclusion, pinned as behaviour. skip-worktree is NOT
+        # unhidden: `reset --hard` spares such an entry (above), `git restore`
+        # refuses the pathspec outright, and clearing the bit would re-
+        # materialise a sparse checkout's deliberately absent files. So it is
+        # excluded on purpose — and the report stays true, because an entry
+        # outside the enumerated set is outside every claim made about it.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.commit_pushed(wt, "sparse.txt", "s1")
+        self.git_run(wt, "update-index", "--skip-worktree", "--", "sparse.txt")
+        (Path(wt) / "sparse.txt").write_text("SPARSE-DIRTY")
+
+        obj = self.preview(1)
+        self.assertNotIn("sparse.txt", self.plan(wt)["tracked"])
+        status, result = self.post(obj, preserve_worktree=False,
+                                   discard_worktree=True,
+                                   confirm_shortname="s1")
+        self.assertEqual(status, 200, result)
+        self.assertEqual((Path(wt) / "sparse.txt").read_text(),
+                         "SPARSE-DIRTY")
+        self.assertEqual(self.index_tag(wt, "sparse.txt"), "S")
+        # The entry was never enumerated, so it is not a kept obstruction and
+        # the entries that WERE consented did complete.
+        self.assertNotIn("sparse.txt", result["worktree"]["kept"])
+        self.assertTrue(result["worktree"]["discarded"], result["worktree"])
+
+    def test_restored_hidden_entry_is_not_reported_kept(self):
+        # The inverse misreport, and the reason the verification guard had to
+        # move with the enumeration. The real restore command puts a hidden
+        # entry back to HEAD and LEAVES THE BIT STANDING, so a guard that reads
+        # "any durable bit still set" as "unverifiable" would report `kept`
+        # over work it had in fact discarded — a false claim in the other
+        # direction, which decision #45 ranks the same. Only skip-worktree, the
+        # bit the enumeration really cannot see through, may do that.
+        wt = self.make_git_worktree()
+        self.hidden_dirty(wt, "clean.txt", "HIDDEN")
+        plan = self.plan(wt)
+
+        result = recovery._discard_worktree_files(wt, plan)
+        self.assertEqual((Path(wt) / "clean.txt").read_text(), "c1")
+        self.assertEqual(self.index_tag(wt, "clean.txt"), "h",
+                         "the restore cleared the bit — this case no longer "
+                         "reproduces the guard's input")
+        self.assertEqual(result["kept"], [])
+        self.assertTrue(result["discarded"], result)
+
+    def test_the_operators_index_is_never_written_by_enumeration(self):
+        # The unhiding runs against a THROWAWAY COPY. The operator's own index
+        # — flags, staged content and all — must come through untouched, or the
+        # fence would be mutating the very state it exists to protect.
+        wt = self.make_git_worktree()
+        self.hidden_dirty(wt, "clean.txt", "HIDDEN")
+        self.stage_only(wt, "tracked.txt", "staged-only")
+        before = self.git_run(wt, "ls-files", "-v", "--stage")
+
+        self.assertIn("clean.txt", self.plan(wt)["tracked"])
+        self.assertEqual(self.git_run(wt, "ls-files", "-v", "--stage"), before)
+        # ...and the hint is still doing its job for everyone else afterwards.
+        self.assertNotIn("clean.txt", self.git_run(wt, "diff", "HEAD",
+                                                   "--name-only").split())
+
+    def test_unhiding_failure_is_a_gap_not_a_clean_worktree(self):
+        # Fail closed, the SC-087 way. If the unhiding cannot run, the honest
+        # answer is "this worktree could not be observed completely" — which
+        # declines the discard while still freeing the shell (SC-106). The
+        # tempting alternative, falling back to the hint-trusting diff, would
+        # hand back the incomplete set as though it were the whole truth, which
+        # is precisely the defect being fixed.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.hidden_dirty(wt, "clean.txt", "HIDDEN")
+        real_run = subprocess.run
+
+        def fail_update_index(args, **kw):
+            if "update-index" in args:
+                return subprocess.CompletedProcess(args, 1, b"", b"boom")
+            return real_run(args, **kw)
+
+        self.assert_gap_refuses_discard_but_frees_the_shell(
+            wt, mock.patch.object(recovery.subprocess, "run",
+                                  fail_update_index))
+
     # -- NOTHING after the durable commit may surface as a 500 (SC-128) -----
 
     def test_late_gate_failure_after_the_commit_reports_a_partial_discard(

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -3342,6 +3342,28 @@ class WorktreeTest(RecoveryCase):
             wt, mock.patch.object(recovery.subprocess, "run",
                                   fail_update_index))
 
+    def test_temp_index_creation_failure_is_a_gap_not_a_500(self):
+        # SC-133. The unhiding needs a throwaway index, and CREATING it can
+        # fail for reasons that have nothing to do with git: a full or
+        # unwritable temp dir, an exhausted fd table. That OSError used to be
+        # raised outside the translation, so it escaped the observation
+        # entirely and the public endpoint answered a sanitized 500 — an
+        # operator told "internal error" learns nothing about their files,
+        # where "could not be observed completely" tells them the discard is
+        # declined and the shell can still be freed. Same gap, same refusal,
+        # whichever step could not run.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.hidden_dirty(wt, "clean.txt", "HIDDEN")
+
+        self.assert_gap_refuses_discard_but_frees_the_shell(
+            wt, mock.patch.object(
+                recovery.tempfile, "mkstemp",
+                side_effect=OSError(errno.ENOSPC, "No space left on device")))
+        # ...and the hidden file is untouched by the refusal, hint and all.
+        self.assertEqual((Path(wt) / "clean.txt").read_text(), "HIDDEN")
+        self.assertEqual(self.index_tag(wt, "clean.txt"), "h")
+
     # -- NOTHING after the durable commit may surface as a 500 (SC-128) -----
 
     def test_late_gate_failure_after_the_commit_reports_a_partial_discard(

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -295,6 +295,41 @@ class ClassificationTest(RecoveryCase):
             obj = self.preview(1)
         self.assertEqual(obj["classification"], "indeterminate")
 
+    def test_dead_identity_with_unknown_pane_is_a_stale_lock(self):
+        """The AMI /exit repro: the session went unreconciled/lost, its
+        recorded identity is positively dead, and tmux cannot be reached so
+        pane presence is unknown. Death proves the managed process cannot
+        act, so recovery is legal (decision #49); classifying this
+        indeterminate left the shell stranded with no supported action."""
+        self.make_session(1, occupancy="unreconciled", lifecycle="lost",
+                          pane_pid=DEAD_PID, pane_ticks=1)
+        with mock.patch.object(recovery, "_pane_present", return_value=None):
+            obj = self.preview(1)
+        self.assertEqual(obj["classification"], "stale_durable_lock")
+        self.assertEqual(obj["legal_actions"], ["recover"])
+
+    def test_dead_identity_with_pane_present_stays_indeterminate(self):
+        """The other side of that boundary: a pane that IS there is owned by
+        something we cannot identify, so a dead record proves nothing about
+        it."""
+        self.make_session(1, occupancy="unreconciled", lifecycle="lost",
+                          pane_pid=DEAD_PID, pane_ticks=1)
+        with mock.patch.object(recovery, "_pane_present", return_value=True):
+            obj = self.preview(1)
+        self.assertEqual(obj["classification"], "indeterminate")
+        self.assertEqual(obj["legal_actions"], [])
+
+    def test_unreadable_identity_with_unknown_pane_stays_indeterminate(self):
+        """Unreadable is not dead: nothing is proven, whatever tmux says."""
+        self.make_session(1, occupancy="unreconciled", lifecycle="lost",
+                          pane_pid=DEAD_PID, pane_ticks=1)
+        with mock.patch.object(recovery, "_pane_present", return_value=None), \
+                mock.patch.object(recovery, "_proc_state",
+                                  return_value="unreadable"):
+            obj = self.preview(1)
+        self.assertEqual(obj["classification"], "indeterminate")
+        self.assertEqual(obj["legal_actions"], [])
+
     def test_residual_process_after_session_end_is_orphan(self):
         proc, ticks = self.child()
         sid = self.make_session(1, pane_pid=proc.pid, pane_ticks=ticks)
@@ -629,6 +664,70 @@ class ExecuteTest(RecoveryCase):
             "SELECT read_at FROM shell_messages WHERE message_id=1"
         ).fetchone()[0])
         con.close()
+
+    def test_dead_identity_unknown_pane_recovers_without_signalling(self):
+        """The AMI /exit repro end to end, over the public routes: preview
+        offers `recover`, the recovery signals NOTHING (there is nothing left
+        to signal), closes the durable state, abandons the runtime generation
+        best-effort, preserves the worktree — and the shell can take a new
+        chat again, which is the whole point of unstranding it."""
+        sid = self.make_session(1, occupancy="unreconciled", lifecycle="lost",
+                                pane_pid=DEAD_PID, pane_ticks=1,
+                                archive_id=10)
+        con = self.db()
+        con.execute("UPDATE shells SET active_archive_id=10 WHERE shell_id=1")
+        con.execute(
+            "INSERT INTO documents (document_id, kind, title) "
+            "VALUES (50,'doc','SPRINT: t')")
+        con.execute(
+            "INSERT INTO sprint_planner_bindings "
+            "(sprint_doc_id, planner_shell_id, session_id, shell_id, "
+            " generation) VALUES (50,1,?,1,1)", (sid,))
+        con.commit()
+        con.close()
+
+        with mock.patch.object(recovery, "_pane_present", return_value=None):
+            obj = self.preview(1)
+            self.assertEqual(obj["classification"], "stale_durable_lock")
+            self.assertEqual(obj["legal_actions"], ["recover"])
+            with mock.patch.object(recovery, "terminate_process_group") as kill:
+                status, result = self.call(
+                    "POST", "/api/interface/shells/1/recovery", (OP, IDEM),
+                    {"observation_id": obj["observation_id"],
+                     "mode": "recover"})
+        self.assertEqual(status, 200, result)
+        kill.assert_not_called()
+        self.assertIsNone(result["signaled"])
+        self.assertEqual(self.runtime.terminated, [])
+        self.assertEqual(self.runtime.abandoned, [sid])
+        self.assertEqual(result["closed"]["runtime"], {"abandoned": True})
+        self.assertEqual(result["classification"], "stale_durable_lock")
+        self.assertEqual(result["worktree"], {"preserved": True})
+        self.assertEqual(result["availability"], "available")
+        self.assertEqual(result["closed"]["session"]["session_id"], sid)
+        self.assertEqual(result["closed"]["archive"],
+                         {"archive_id": 10, "closed": True})
+        self.assertEqual(result["closed"]["binding"],
+                         {"binding_id": 1, "released": True})
+
+        con = self.db()
+        self.assertEqual(
+            con.execute("SELECT occupancy, lifecycle, end_reason "
+                        "FROM interface_sessions WHERE session_id=?",
+                        (sid,)).fetchone(),
+            ("ended", "ended", "operator_recovery"))
+        self.assertIsNotNone(con.execute(
+            "SELECT ended_at FROM interface_generations "
+            "WHERE shell_id=1 AND generation=1").fetchone()[0])
+        self.assertIsNone(con.execute(
+            "SELECT active_archive_id FROM shells WHERE shell_id=1"
+        ).fetchone()[0])
+        con.close()
+
+        status, body = self.call(
+            "POST", "/api/interface/sessions",
+            (OP, "Idempotency-Key: k-newchat"), {"shell_id": 1})
+        self.assertEqual(status, 201, body)
 
     def test_stale_observation_on_durable_change(self):
         sid = self.make_session(1, occupancy="reserved", lifecycle="starting",

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -1014,10 +1014,17 @@ class WorktreeTest(RecoveryCase):
         through a link, or ignores type, cannot tell the states apart.
         Pre-dirtied: `tlink` (tracked symlink, retargeted a->b), `ulink`
         (untracked symlink -> b), `ufile.txt` (untracked regular file)."""
-        origin = Path(self.tmp.name) / "origin.git"
+        nth = len(list(Path(self.tmp.name).glob("wt-*")))
+        wt = Path(self.tmp.name) / f"wt-{nth}"
+        # Each worktree gets its OWN bare origin. A shared one made the second
+        # worktree in a test push an unrelated history to the same `feat/x`,
+        # rejected as non-fast-forward — EXCEPT while both `base` commits
+        # landed in the same clock second, where identical trees, messages and
+        # timestamps hash to the identical SHA and the push is a silent no-op.
+        # So it passed on a fast machine and went red in CI on a slow one.
+        origin = Path(self.tmp.name) / f"origin-{nth}.git"
         subprocess.run(["git", "init", "-q", "--bare", str(origin)],
                        check=True, capture_output=True)
-        wt = Path(self.tmp.name) / f"wt-{len(list(Path(self.tmp.name).glob('wt-*')))}"
         wt.mkdir()
 
         def git(*args):

--- a/tests/test_interface_recovery.py
+++ b/tests/test_interface_recovery.py
@@ -3364,6 +3364,58 @@ class WorktreeTest(RecoveryCase):
         self.assertEqual((Path(wt) / "clean.txt").read_text(), "HIDDEN")
         self.assertEqual(self.index_tag(wt, "clean.txt"), "h")
 
+    def test_temp_index_close_failure_is_a_gap_not_a_500(self):
+        # SC-133, the second failing step. `mkstemp` returns a descriptor AND
+        # a path already on disk, so closing it is the one step whose failure
+        # leaves a file behind: raised outside the translation it escaped as a
+        # sanitized 500 *and* leaked the copy the `finally` exists to remove.
+        # The mkstemp negative above cannot see that — moving `os.close` back
+        # out of the try leaves every one of its assertions green — so the
+        # step gets its own proof, taken through the public endpoint.
+        wt = self.make_git_worktree()
+        self.session_with_worktree(wt)
+        self.hidden_dirty(wt, "clean.txt", "HIDDEN")
+
+        real_mkstemp, real_close = recovery.tempfile.mkstemp, recovery.os.close
+        made, ours = [], set()
+
+        def watched_mkstemp(*args, **kwargs):
+            fd, path = real_mkstemp(*args, **kwargs)
+            made.append(path)
+            ours.add(fd)
+            return fd, path
+
+        def refusing_close(fd, *args, **kwargs):
+            # ONLY the descriptor we handed out: `recovery.os` is the real os
+            # module, so an unconditional raise would break subprocess's own
+            # fd bookkeeping and prove nothing about the recovery path. Fire
+            # once and forget the number — freed fds get reused.
+            mine = fd in ours
+            ours.discard(fd)
+            real_close(fd, *args, **kwargs)   # the descriptor still goes back
+            if mine:
+                raise OSError(errno.EIO, "input/output error")
+
+        @contextlib.contextmanager
+        def closing_the_copy_fails():
+            with mock.patch.object(recovery.tempfile, "mkstemp",
+                                   watched_mkstemp), \
+                    mock.patch.object(recovery.os, "close", refusing_close):
+                yield
+
+        self.assert_gap_refuses_discard_but_frees_the_shell(
+            wt, closing_the_copy_fails())
+        # ...the hidden file and its hint are untouched by the refusal...
+        self.assertEqual((Path(wt) / "clean.txt").read_text(), "HIDDEN")
+        self.assertEqual(self.index_tag(wt, "clean.txt"), "h")
+        # ...and the copy the close aborted over is gone, which only holds
+        # while the close sits inside the try whose `finally` unlinks it.
+        self.assertTrue(made, "no throwaway index was created — the case "
+                              "never reached the code it claims to test")
+        for path in made:
+            self.assertFalse(os.path.exists(path),
+                             f"leaked throwaway index {path}")
+
     # -- NOTHING after the durable commit may surface as a 500 (SC-128) -----
 
     def test_late_gate_failure_after_the_commit_reports_a_partial_discard(

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -869,3 +869,73 @@ invariant(confirmText.includes("PID 4321") &&
   confirmText.includes("start ticks 999"),
   "force confirmation did not name exact verified identity");
 """)
+
+
+END_CHAT = APP[APP.index("// End chat (spec Workflow 9)"):
+               APP.index("// Take-over:")]
+
+
+def test_end_chat_on_an_unreconciled_session_renders_recovery():
+    """The AMI /exit repro from the browser: End chat on a session the server
+    has already given up on answers 409 not_occupied. That is the recovery
+    path, not a dead end — the client must detach and re-render onto it
+    (decision #49). An unrelated failure must still say what broke."""
+    el_helper = APP[APP.index("const el ="):APP.index("const esc =")]
+    script = el_helper + r"""
+let apiIf, confirm;
+let detached = 0;
+let rendered = 0;
+function ifDetach() { detached += 1; }
+async function renderInterface() { rendered += 1; }
+""" + END_CHAT + r"""
+class FakeElement {
+  constructor(tag) { this.tagName = tag; this.nodeType = 1; this.children = []; }
+  append(...nodes) { this.children.push(...nodes); }
+  closest() { return this; }
+}
+globalThis.document = {
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({ nodeType: 3, textContent: String(text ?? "") }),
+};
+function invariant(ok, message) { if (!ok) throw new Error(message); }
+function attach() {
+  return { sessionId: 4, painted: 0, st: { note: "" },
+           paint() { this.painted += 1; } };
+}
+function fail(status, code, message) {
+  const e = new Error(message);
+  e.status = status;
+  e.code = code;
+  e.body = { error: { code, message } };
+  return e;
+}
+confirm = () => true;
+
+(async () => {
+  const a = attach();
+  apiIf = async () => {
+    throw fail(409, "not_occupied",
+      "session 4 is unreconciled — termination needs a verified identity");
+  };
+  await ifEndChat(a, { shortname: "S3" }, new FakeElement("div"), null);
+  invariant(detached === 1, `unreconciled End chat did not detach: ${detached}`);
+  invariant(rendered === 1,
+    `unreconciled End chat did not re-render onto recovery: ${rendered}`);
+  invariant(a.st.note === "",
+    `unstrandable shell was left with a terminal error: ${a.st.note}`);
+
+  const b = attach();
+  apiIf = async () => { throw fail(500, "internal", "boom"); };
+  await ifEndChat(b, { shortname: "S3" }, new FakeElement("div"), null);
+  invariant(detached === 1 && rendered === 1,
+    "an unrelated failure was swallowed as a recovery re-render");
+  invariant(b.st.note.includes("end chat failed") && b.painted === 1,
+    `unrelated failure was not reported: ${b.st.note}`);
+})().catch((error) => {
+  console.error(error.stack || error);
+  process.exit(1);
+});
+"""
+    result = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Sprint 31 fix unit **F13** — SC-132 (re-conformance doc #36, Major) against spec #30 requirement 24.

## The defect

`_enumerate` built the worktree half of the union with `git diff HEAD`, which **trusts the `assume-unchanged` hint**. A tracked file whose index entry equals HEAD but whose worktree bytes differ is invisible to that predicate and to porcelain — so it appeared in no preview, no gate, no plan and no verification, and a confirmed discard returned `discarded=true` with the operator's bytes still on disk.

Both the consent claim and the outcome claim were false. Decision #45 ranks misreporting with destruction.

## Why the bit does not protect the file

`assume-unchanged` is a promise the *operator* makes to git, not a fact about the file — and `reset --hard`, the operation this discard stands in for, does not honour it. **Reproduced both directions:** it overwrites the modified file *and* recreates the deleted one.

## The fix

The worktree half is asked of an index that will answer it: the hint is cleared on a **throwaway copy** of the index and the **same** `git diff` runs against that copy.

This adds no second predicate — it is the one predicate, given an index that is not lying to it — so plan, preview, both gates and verification stay generated from the single `_enumerate`. The operator's own index is never written, so their standing instruction about the path survives (SC-125's rule, one layer earlier). Verified under linked worktrees and split-index. The copy is created **outside** the worktree, since a temp file inside it would enumerate as untracked and land in the very delete set being computed.

A failure **raises** rather than falling back to the hint-trusting diff: silently returning the incomplete set *is* the defect. Req 24 then fails closed for the destructive path while still freeing the shell (SC-106).

## skip-worktree is audited and deliberately excluded

The conclusion, not an oversight — on four reproductions:

| | `reset --hard` (the replaced operation) | |
|---|---|---|
| `assume-unchanged` | **overwrites** dirty, **recreates** deleted | must be enumerated |
| `skip-worktree` | **leaves it alone** — dominates even when both bits are set | must not be |

Plus: `git restore` refuses a skip-worktree pathspec outright, and clearing the bit would re-materialise a sparse checkout's deliberately absent files. The entry is outside the blast radius of the operation being replaced, so enumerating it would promise a destruction that cannot be performed — the opposite error, equally a false report.

## Second half, found by reading the flow rather than reported

The real destructive command restores a hidden entry to HEAD correctly **and leaves the bit standing**. `_unrestored` treated any surviving durable bit as "unverifiable" and would have reported `kept` over work it had in fact discarded — the same misreport, inverted. The guard now asks the enumeration's real blind spot (`_hides_worktree` — skip-worktree only) instead of "is any bit set".

F12's own docstring already recorded that `diff` trusts *both* bits. It applied that fact to verification and never extended it to enumeration — which is exactly how SC-123 happened, one layer out.

## Trade-off / rejected alternative

`update-index --really-refresh` ignores the hint without clearing it and needs no index copy — the obvious simpler fix. **Rejected on evidence:** it only re-stats paths that still *exist*, so it never names a hidden path deleted from the worktree, which `reset --hard` restores.

## Verification

10 new tests, covering all five required negatives, **mutation-proved in two passes**:

- restoring the hint-trusting enumeration kills **8/10**. The 2 survivors are principled: a pure git-premise test, and the skip-worktree exclusion (identical under both versions).
- reverting the verification guard kills **3**, failing with exactly the predicted `kept: ['clean.txt']` over work that was restored.

`tests/test_interface_recovery.py` 147/147 and `tests/test_interface_ui_contract.py` 15/15 — **162 passed**. Lint at main's baseline on both touched files (7 = 7).

Unborn HEAD is unaffected: it enumerates from `ls-files`, which no worktree-suppressing bit hides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)