### PR TITLE
feat(interface): add details alerts and reliable submit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,9 @@ name: tests
 # The PR gate: the full engine suite + the headless end-to-end proof, on every
 # PR and every push to main. GitHub-hosted BY DESIGN — this repo is public, and
 # a self-hosted runner on a public repo lets any fork PR execute code on the
-# host (the same host that carries the substrates). The suite is hermetic
-# (stdlib + pytest, no docker, no network), so ubuntu-latest covers it free.
+# host (the same host that carries the substrates). The core suite is hermetic;
+# explicit browser/terminal acceptance jobs install only their pinned test
+# dependencies. Ubuntu-hosted runners keep every PR path isolated.
 # Anything that ever genuinely needs house hardware belongs in a separate
 # push-to-main-only workflow, never a PR-triggered one.
 
@@ -58,6 +59,37 @@ jobs:
           path: artifacts/interface-ui/
           if-no-files-found: error
           retention-days: 14
+
+  # Req 26's acceptance is a real terminal turn, not a byte-shape assertion.
+  # Install the tmux + headless-xterm dependencies explicitly so the exact
+  # composer proof cannot silently skip on a nominally green PR.
+  interface-tmux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install real-terminal test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tmux
+          python -m pip install pytest
+          npm install --prefix .super-coder/shadow --no-save \
+            --package-lock=false @xterm/headless@6.0.0
+      - name: Prove one composed acceptance starts one real turn
+        run: |
+          python - <<'PY'
+          import sys
+          sys.path.insert(0, "tests")
+          from test_interface_runtime import HAS_SHADOW_STACK
+          assert HAS_SHADOW_STACK, "real-tmux test dependencies unavailable"
+          PY
+          pytest -q \
+            tests/test_interface_wake_tmux.py::WakeTmuxE2ETest::test_composed_text_and_submit_start_one_real_turn
 
   # The end-to-end proof `./sc verify` runs: rebuild the DB from committed text
   # (schema + migrations + content.sql), flat-render, then a render-only boot —

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -345,12 +345,13 @@ def _availability(con, shell_id: int, snap) -> dict:
     clears it — a legacy/unmanaged harness makes it unreconciled."""
     active_session = interface_state.active_session_sql("s")
     row = con.execute(
-        "SELECT s.session_id, s.generation, s.occupancy, s.lifecycle, s.harness "
+        "SELECT s.session_id, s.generation, s.occupancy, s.lifecycle, "
+        "s.harness, s.model_route "
         "FROM interface_sessions s WHERE s.shell_id=? "
         f"AND {active_session} ORDER BY s.session_id DESC LIMIT 1",
         (shell_id,)).fetchone()
     if row is not None:
-        session_id, generation, occupancy, lifecycle, harness = row
+        session_id, generation, occupancy, lifecycle, harness, model_route = row
         client = _client_state(con, session_id)
         if occupancy == "reserved":
             availability = "starting"
@@ -365,15 +366,17 @@ def _availability(con, shell_id: int, snap) -> dict:
         return {"availability": availability, "session_id": session_id,
                 "generation": generation,
                 "lifecycle": lifecycle, "harness": harness,
+                "model_route": model_route,
                 "composer": composer[0] if composer else None,
                 "alerts": _alert_count(con, session_id), **client}
     state = shell_liveness.session_state(_shortname(con, shell_id), snap)
     if state is not None:
         return {"availability": "unreconciled", "session_id": None,
                 "lifecycle": None, "harness": None, "composer": None,
-                "alerts": 0}
+                "model_route": None, "alerts": 0}
     return {"availability": "available", "session_id": None,
-            "lifecycle": None, "harness": None, "composer": None, "alerts": 0}
+            "lifecycle": None, "harness": None, "model_route": None,
+            "composer": None, "alerts": 0}
 
 
 def _shortname(con, shell_id: int) -> str:

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2193,6 +2193,11 @@ const IF_BADGE = { available: "ok", starting: "warn", occupied: "accent",
 const IF_ATTACHABLE_LIFECYCLES = new Set(
   ["starting", "idle", "busy", "approval", "user_input"]);
 
+function ifModelLabel(route) {
+  if (!route) return "HARNESS DEFAULT";
+  return String(route).replace(/[-_]+/g, " ").trim().toUpperCase();
+}
+
 async function renderInterface(root) {
   root.replaceChildren();
   let shells;
@@ -2223,9 +2228,13 @@ async function renderInterface(root) {
       el("span", { className: "pill if-badge " + (IF_BADGE[s.availability] || "") }, s.availability));
     if (s.alerts > 0)
       head.append(el("span", { className: "pill if-badge bad",
-        title: s.alerts + " unread alert(s)" }, "⚠ " + s.alerts));
+        title: s.alerts + " current alert(s)" }, "⚠ " + s.alerts));
+    const occupiedModel = s.availability === "occupied"
+      ? " · " + ifModelLabel(s.model_route)
+      : "";
     row.append(head,
-      el("div", { className: "if-row-sub" }, s.shortname + (s.harness ? " · " + s.harness : "")));
+      el("div", { className: "if-row-sub" },
+        s.shortname + (s.harness ? " · " + s.harness : "") + occupiedModel));
     row.onclick = () => { location.hash = "interface/" + s.shortname; };
     rail.append(row);
     const opt = el("option", { value: s.shortname },
@@ -2633,7 +2642,8 @@ async function ifRecoveryPane(pane, sel, root) {
 // come from GET /interface/sprint-bindings + /interface/sprint-alerts; the
 // action gates mirror the server's own preconditions (retry.applicable /
 // retry.needs_outcome). Nothing renders for a shell with no sprint history.
-async function ifSprintPanel(pane, sel) {
+async function ifSprintPanel(pane, sel, sessionUi = null) {
+  const renderVersion = sessionUi ? ++sessionUi.sprintPanelVersion : 0;
   let bindings = [], alerts = [];
   const alertScope = sel.session_id
     ? "session_id=" + encodeURIComponent(sel.session_id) +
@@ -2648,16 +2658,31 @@ async function ifSprintPanel(pane, sel) {
     ]);
     bindings = b.bindings || [];
     alerts = a.alerts || [];
-  } catch { return; }   // surface down — never break the pane over the panel
-  if (!pane.isConnected || (!sel.session_id && !bindings.length && !alerts.length)) return;
-  const card = el("div", { className: "card" });
-  const note = el("div", { className: "if-note" });
+  } catch {
+    if (sessionUi && ifAttach === sessionUi) {
+      sessionUi.alertsBody.replaceChildren(
+        el("div", { className: "muted" }, "Alert state unavailable."));
+    }
+    return;
+  }
+  if (!pane.isConnected ||
+      (sessionUi && (ifAttach !== sessionUi ||
+        renderVersion !== sessionUi.sprintPanelVersion)) ||
+      (!sel.session_id && !bindings.length && !alerts.length)) return;
+
+  const detailNodes = [];
+  const actionNodes = [];
+  const alertNodes = [];
+  const actionNote = el("div", { className: "if-note" });
+  const alertNote = el("div", { className: "if-note" });
+  let legacyCard = null;
 
   if (bindings.length) {
     const b = bindings[0];   // unreleased first, then most recent
     const doc = b.sprint || {};
-    const diag = el("div", { className: "if-diag" });
-    const drow = (k, v) => diag.append(el("span", { className: "if-stat" }, k + " ", el("b", {}, String(v ?? "—"))));
+    const drow = (k, v) => detailNodes.push(
+      el("span", { className: "if-stat" },
+        k + " ", el("b", {}, String(v ?? "—"))));
     drow("sprint", "#" + b.sprint_doc_id + " " + (doc.title || "?") +
       " · " + (doc.active ? "ACTIVE" : "not-ACTIVE") + (doc.frozen ? " · frozen" : ""));
     drow("binding", "#" + b.binding_id + " " +
@@ -2672,25 +2697,26 @@ async function ifSprintPanel(pane, sel) {
     if (b.quarantined && b.quarantined.length)
       drow("quarantined", b.quarantined.length +
         " item(s) — " + (b.quarantined[0].error || "wake limit"));
-    card.append(diag);
     if (b.park)
-      card.append(el("div", { className: "if-note" },
+      detailNodes.push(el("div", { className: "if-note" },
         "PARKED: " + (b.park.reason || "delivery_unknown") +
         (b.park.input_park ? " — the input frame's delivery is unknown; retry needs your verdict" : "")));
     const retry = b.retry || {};
     if (retry.applicable && !b.released_at) {
-      const acts = el("div", {});
-      const refresh = () => { card.remove(); ifSprintPanel(pane, sel); };
+      const refresh = () => ifSprintPanel(pane, sel, sessionUi);
       const doRetry = async (outcome, btn) => {
-        btn.disabled = true; note.textContent = "";
+        btn.disabled = true; actionNote.textContent = "";
         try {
           const r = await apiIf("/interface/sprint-bindings/" + b.binding_id + "/retry",
             "POST", outcome ? { outcome } : {});
-          note.textContent = "retried — wake now " + r.wake_state +
+          actionNote.textContent = "retried — wake now " + r.wake_state +
             " (" + (r.actions || []).join("; ") + ")";
-          setTimeout(refresh, 800);
+          setTimeout(() => {
+            legacyCard?.remove();
+            refresh();
+          }, 800);
         } catch (e) {
-          note.textContent = (e.code ? e.code + ": " : "") + e.message;
+          actionNote.textContent = (e.code ? e.code + ": " : "") + e.message;
           btn.disabled = false;
         }
       };
@@ -2707,7 +2733,7 @@ async function ifSprintPanel(pane, sel) {
           if (confirm("Confirm the parked input NEVER reached the planner. The parked batch closes as audit and its items requeue as a NEW gated batch."))
             doRetry("not_delivered", lost);
         };
-        acts.append(landed, " ", lost);
+        actionNodes.push(landed, lost);
       } else {
         const retryBtn = el("button", { className: "act", type: "button", textContent: "Retry wake",
           title: "requeue parked/stalled wake work as a NEW gated batch — the parked batch is never resubmitted" });
@@ -2715,13 +2741,11 @@ async function ifSprintPanel(pane, sel) {
           if (confirm("Retry this binding's wake work? The parked batch closes as audit and its items requeue as a NEW gated batch."))
             doRetry(null, retryBtn);
         };
-        acts.append(retryBtn);
+        actionNodes.push(retryBtn);
       }
-      card.append(acts);
     }
   }
   if (alerts.length) {
-    const list = el("div", { className: "if-diag" });
     for (const a of alerts) {
       const capability = a.category === "capability";
       const item = el("div", {
@@ -2741,19 +2765,21 @@ async function ifSprintPanel(pane, sel) {
           try {
             await apiIf("/interface/sprint-alerts/" + a.alert_id + "/acknowledge",
               "POST", {});
-            card.remove();
-            ifSprintPanel(pane, sel);
+            legacyCard?.remove();
+            ifSprintPanel(pane, sel, sessionUi);
           } catch (e) {
-            note.textContent = (e.code ? e.code + ": " : "") + e.message;
+            alertNote.textContent = (e.code ? e.code + ": " : "") + e.message;
             ack.disabled = false;
           }
         };
         item.append(ack);
       }
-      list.append(item);
+      alertNodes.push(item);
     }
-    card.append(list);
   }
+  if (!alertNodes.length)
+    alertNodes.push(el("div", { className: "muted" },
+      "No current alerts or capability notices."));
   const history = el("button", { className: "act", type: "button",
     textContent: "Alert history" });
   history.onclick = async () => {
@@ -2774,12 +2800,36 @@ async function ifSprintPanel(pane, sel) {
         rows.append(el("div", { className: "muted" }, "No alert history for this generation."));
       history.replaceWith(rows);
     } catch (e) {
-      note.textContent = (e.code ? e.code + ": " : "") + e.message;
+      alertNote.textContent = (e.code ? e.code + ": " : "") + e.message;
       history.disabled = false;
     }
   };
-  card.append(history);
-  card.append(note);
+  alertNodes.push(history, alertNote);
+
+  if (sessionUi) {
+    sessionUi.sprintDetailsEl.replaceChildren(...detailNodes);
+    sessionUi.sprintActionsEl.replaceChildren(
+      ...actionNodes, ...(actionNodes.length ? [actionNote] : []));
+    sessionUi.alertsBody.replaceChildren(...alertNodes);
+    const current = alerts.filter((a) =>
+      a.category !== "capability" && a.severity !== "info" &&
+      !a.resolved_at && !a.acknowledged_at);
+    const severity = current.some((a) => a.severity === "critical")
+      ? "critical"
+      : current.length ? "warning" : "neutral";
+    sessionUi.alertsEl.className =
+      "if-disclosure if-alerts " + severity;
+    sessionUi.alertsSummary.textContent =
+      current.length ? "Alerts (" + current.length + ")" : "Alerts";
+    return;
+  }
+
+  const card = el("div", { className: "card" });
+  legacyCard = card;
+  if (detailNodes.length)
+    card.append(el("div", { className: "if-diag" }, ...detailNodes));
+  if (actionNodes.length) card.append(...actionNodes, actionNote);
+  card.append(...alertNodes);
   pane.append(card);
 }
 function ifCounts(counts) {
@@ -2901,7 +2951,9 @@ async function ifSessionPane(pane, sel) {
   if (ifAttach && ifAttach.sessionId === sessionId &&
       ifAttach.ws && ifAttach.ws.readyState <= WebSocket.OPEN) {
     pane.append(ifAttach.headEl, ifAttach.termEl, ifAttach.composerEl);
-    ifSprintPanel(pane, sel);
+    ifAttach.pane = pane;
+    ifAttach.sel = sel;
+    ifSprintPanel(pane, sel, ifAttach);
     return;
   }
   ifDetach();
@@ -2929,21 +2981,40 @@ async function ifSessionPane(pane, sel) {
     note: "",
   };
   const headEl = el("div", { className: "if-head" });
+  const sessionDetailsEl = el("div", { className: "if-diag" });
+  const sprintDetailsEl = el("div", { className: "if-diag" });
+  const detailsEl = el("details", { className: "if-disclosure if-details" },
+    el("summary", { textContent: "Details" }),
+    sessionDetailsEl, sprintDetailsEl);
+  const alertsSummary = el("summary", { textContent: "Alerts" });
+  const alertsBody = el("div", { className: "if-alerts-body" });
+  const alertsEl = el("details", { className: "if-disclosure if-alerts neutral" },
+    alertsSummary, alertsBody);
+  const sessionActionsEl = el("div", { className: "if-inline-actions" });
+  const sprintActionsEl = el("div", { className: "if-inline-actions" });
+  const statusNoteEl = el("div", { className: "if-note" });
+  headEl.append(detailsEl, alertsEl, sessionActionsEl, sprintActionsEl,
+    statusNoteEl);
   const termEl = el("div", { className: "if-term" });
   const composerEl = el("div", { className: "if-composer" });
   const a = { sessionId, shortname: sel.shortname, st, headEl, termEl,
-    composerEl,
+    composerEl, pane, sel, sessionDetailsEl, sprintDetailsEl, detailsEl,
+    alertsEl, alertsSummary, alertsBody, sessionActionsEl, sprintActionsEl,
+    statusNoteEl,
     legalActions: new Set(
       Array.isArray(sess.legal_actions) ? sess.legal_actions : []),
     stateReason: sess.state_reason || "",
     ws: null, term: null, leaseId: null, leaseToken: null, role: "viewer",
     seq: 1, inflight: 0, lastAck: 0, outBuf: "", awaiting: false, halted: false,
     heartbeat: 0, resizeObs: null, paint: null,
-    composerInput: null, composerSend: null, composerNote: null,
+    composerInput: null, composerSend: null, composerEnd: null,
+    composerNote: null,
     composerPendingSeq: null, browserComposerState: st.browserComposer,
     browserComposerWanted: st.browserComposer, browserComposerError: "",
     browserComposerSyncing: false, browserComposerVersion: 0,
     browserComposerChain: Promise.resolve(),
+    composerSubmitLatched: false,
+    sprintPanelVersion: 0,
     composerProjectionPending: false, composerProjectionVersion: 0,
     composerProjectionSync: Promise.resolve() };
   ifBuildComposer(a);
@@ -2953,7 +3024,7 @@ async function ifSessionPane(pane, sel) {
   };
   ifAttach = a;
   pane.append(headEl, termEl, composerEl);
-  ifSprintPanel(pane, sel);
+  ifSprintPanel(pane, sel, a);
   a.paint();
 
   try {
@@ -3012,21 +3083,19 @@ function ifPaintHeader(a, sel, pane) {
   const st = a.st;
   const controlsActive = IF_ATTACHABLE_LIFECYCLES.has(st.lifecycle);
   const stat = (k, v) => el("span", { className: "if-stat" }, k + " ", el("b", {}, String(v)));
-  // Spec Interface Layout header: harness/model, archive/session age, writer
-  // or read-only state, draft (composer) state, sprint wake state, then the
-  // exact recovery actions. idle/busy/approval/user_input stay lifecycle
-  // details HERE — they never replace occupancy in the rail.
-  const head = [
+  // Read-only session telemetry stays available without consuming the terminal
+  // header. Actions remain outside the disclosure beside the state they change.
+  a.sessionDetailsEl.replaceChildren(
     stat("harness", st.harness),
-    stat("model", st.model),
+    stat("model", ifModelLabel(st.model)),
     stat("session", "#" + a.sessionId + (st.archive != null ? " · arc #" + st.archive : "")),
     stat("age", ifAge(st.since)),
     stat("lifecycle", st.lifecycle),
-    stat("composer", st.composer),
+    stat("composer", st.composer + " · browser " + st.browserComposer),
     stat("writer", st.writer === "active" ? "you" : st.writer === "held" ? "read-only" : st.writer),
     stat("clients", st.clients),
-    stat("wake", st.wake),
-  ];
+    stat("wake", st.wake));
+  const actions = [];
   if (controlsActive && (st.writer === "held" || st.writer === "revoked")) {
     const take = el("button", { className: "act", type: "button", textContent: "Take-over",
       title: "explicitly take the writer lease — the current writer turns read-only" });
@@ -3034,7 +3103,7 @@ function ifPaintHeader(a, sel, pane) {
       if (confirm("Take control of this session? The current writer (another tab or CLI) becomes read-only."))
         ifTakeover(a);
     };
-    head.push(take);
+    actions.push(take);
   }
   if (controlsActive && (st.composer === "dirty" || st.composer === "unknown")) {
     const cert = el("button", { className: "act", type: "button", textContent: "certify clean" });
@@ -3047,16 +3116,14 @@ function ifPaintHeader(a, sel, pane) {
       } catch (e) { st.note = "certify failed: " + e.message; }
       a.paint();
     };
-    head.push(cert);
+    actions.push(cert);
   }
-  if (controlsActive) {
-    const end = el("button", { className: "act", type: "button", textContent: "End chat",
-      title: "explicit, confirmed — graceful first; force unlocks only after a graceful timeout" });
-    end.onclick = () => ifEndChat(a, sel, pane, end);
-    head.push(end);
+  a.sessionActionsEl.replaceChildren(...actions);
+  if (a.composerEnd) {
+    a.composerEnd.hidden = !controlsActive;
+    a.composerEnd.disabled = !controlsActive;
   }
-  if (st.note) head.push(el("span", { className: "if-note" }, st.note));
-  a.headEl.replaceChildren(...head);
+  a.statusNoteEl.textContent = st.note;
 }
 
 function ifSizeComposer(input) {
@@ -3067,6 +3134,7 @@ function ifSizeComposer(input) {
 function ifComposerWritable(a) {
   return a.legalActions.has("send_input") &&
     a.role === "writer" && a.st.writer === "active" && !a.halted &&
+    a.ws && a.ws.readyState === WebSocket.OPEN &&
     !a.composerProjectionPending;
 }
 
@@ -3076,11 +3144,13 @@ function ifComposerDisabledReason(a) {
   if (!a.legalActions.has("send_input"))
     return a.stateReason ||
       "Read-only — the server does not list input as legal.";
+  if (a.halted)
+    return a.st.note || "Input halted — reattach before sending.";
   if (a.role !== "writer" || a.st.writer !== "active")
     return a.st.writerReason ||
       "Read-only — this client does not hold the server writer lease.";
-  if (a.halted)
-    return a.st.note || "Input halted — reattach before sending.";
+  if (!a.ws || a.ws.readyState !== WebSocket.OPEN)
+    return "Connecting to the generation-fenced input broker…";
   return "";
 }
 
@@ -3095,12 +3165,18 @@ function ifPaintComposer(a) {
   // remains covered by the already-requested dirty state.
   a.composerInput.disabled = !writable || pending ||
     (a.browserComposerSyncing && a.browserComposerWanted === "clean");
+  const dirtyReady = a.browserComposerState === "dirty";
+  const dirtySyncing = a.browserComposerSyncing &&
+    a.browserComposerWanted === "dirty";
   a.composerSend.disabled = !writable || pending || a.awaiting ||
-    Boolean(a.outBuf) || !hasMessage || a.browserComposerSyncing ||
-    Boolean(a.browserComposerError) || a.browserComposerState !== "dirty";
+    Boolean(a.outBuf) || !hasMessage || Boolean(a.browserComposerError) ||
+    (!dirtyReady && !dirtySyncing);
   if (pending) {
     a.composerNote.textContent =
       "Sending through the generation-fenced input broker…";
+  } else if (a.composerSubmitLatched) {
+    a.composerNote.textContent =
+      "Send queued once; waiting for broker readiness…";
   } else if (a.browserComposerError) {
     a.composerNote.textContent =
       "Draft safety sync failed; sending is disabled: " +
@@ -3127,6 +3203,7 @@ function ifRefreshComposerProjection(a) {
     a.legalActions = new Set(
       Array.isArray(session.legal_actions) ? session.legal_actions : []);
     a.stateReason = session.state_reason || "";
+    if (!a.legalActions.has("send_input")) a.composerSubmitLatched = false;
   }).catch((e) => {
     if (ifAttach !== a || version !== a.composerProjectionVersion) return;
     a.legalActions.delete("send_input");
@@ -3153,12 +3230,20 @@ function ifSyncBrowserComposer(a, state) {
     if (ifAttach !== a) return;
     a.browserComposerState = result.browser_composer;
     a.st.browserComposer = result.browser_composer;
-    a.browserComposerError = "";
+    a.browserComposerError = result.browser_composer === state
+      ? ""
+      : "server did not acknowledge the requested draft state";
   }).catch((e) => {
-    if (ifAttach === a) a.browserComposerError = e.message;
+    if (ifAttach === a) {
+      a.browserComposerError = e.message;
+      a.composerSubmitLatched = false;
+    }
   }).finally(() => {
     if (ifAttach !== a || version !== a.browserComposerVersion) return;
     a.browserComposerSyncing = false;
+    if (a.browserComposerError) a.composerSubmitLatched = false;
+    else if (a.composerSubmitLatched && a.browserComposerState === "dirty")
+      ifComposerSend(a);
     a.paint();
   });
 }
@@ -3166,10 +3251,18 @@ function ifSyncBrowserComposer(a, state) {
 function ifComposerSend(a) {
   const value = a.composerInput.value;
   if (!value.trim() || !ifComposerWritable(a) ||
-      a.composerPendingSeq != null || a.awaiting || a.outBuf ||
-      a.browserComposerSyncing || a.browserComposerError ||
-      a.browserComposerState !== "dirty")
+      a.composerPendingSeq != null || a.browserComposerError)
     return;
+  if (a.browserComposerSyncing || a.browserComposerState !== "dirty" ||
+      a.awaiting || a.outBuf) {
+    if (a.browserComposerWanted === "dirty" ||
+        a.browserComposerState === "dirty") {
+      a.composerSubmitLatched = true;
+      a.paint();
+    }
+    return;
+  }
+  a.composerSubmitLatched = false;
   // xterm emits carriage return for Enter. Reuse that exact byte convention
   // after the composed text so the existing broker submits the message.
   const seq = ifSendInput(a, value + "\r");
@@ -3201,12 +3294,20 @@ function ifBuildComposer(a) {
     a.paint();
   };
   input.onkeydown = (event) => {
-    if (event.key !== "Enter" || event.shiftKey) return;
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing ||
+        event.keyCode === 229) return;
     event.preventDefault();
     ifComposerSend(a);
   };
   send.onclick = () => ifComposerSend(a);
-  a.composerEl.append(input, send, note);
+  const end = el("button", {
+    className: "act bad if-end-chat", type: "button", textContent: "End chat",
+    title: "explicit, confirmed — graceful first; force unlocks only after a graceful timeout",
+  });
+  end.onclick = () => ifEndChat(a, a.sel, a.pane, end);
+  a.composerEnd = end;
+  const actions = el("div", { className: "if-composer-actions" }, send, end);
+  a.composerEl.append(input, actions, note);
   ifSizeComposer(input);
 }
 
@@ -3310,7 +3411,16 @@ function ifOpenStream(a, ticket) {
   };
   ws.onclose = () => {
     if (ifAttach !== a) return;
-    a.st.note = "stream closed — reselect the shell to reattach";
+    if (a.composerPendingSeq != null || a.composerSubmitLatched) {
+      a.composerPendingSeq = null;
+      a.composerSubmitLatched = false;
+      a.awaiting = false;
+      a.halted = true;
+      a.st.note = "stream closed before the message acknowledgement — " +
+        "the draft was retained; inspect the terminal before retrying";
+    } else {
+      a.st.note = "stream closed — reselect the shell to reattach";
+    }
     if (a.role === "writer") a.st.writer = "none";
     a.paint();
   };
@@ -3333,6 +3443,7 @@ function ifOpenStream(a, ticket) {
   ws.onopen = () => {
     fit();
     ifSendResize(a, term.rows, term.cols);
+    a.paint();
   };
   fit();
 }
@@ -3372,6 +3483,7 @@ function ifRevoked(a) {
   a.role = "viewer"; a.leaseId = null; a.leaseToken = null;
   a.awaiting = false; a.halted = false; a.outBuf = "";
   a.composerPendingSeq = null;
+  a.composerSubmitLatched = false;
   a.st.writer = "held";
   a.st.writerReason = "Control was taken by another client.";
   a.st.note = "control was taken by another client — you are now read-only (Take-over to reclaim)";
@@ -3390,12 +3502,14 @@ function ifControl(a, m) {
           ifSyncBrowserComposer(a, "clean");
         }
         ifFlush(a);
+        if (a.composerSubmitLatched) ifComposerSend(a);
         a.paint();
       }
       break;
     case "input_reject":
       a.awaiting = false;
       if (m.seq === a.composerPendingSeq) a.composerPendingSeq = null;
+      a.composerSubmitLatched = false;
       // writer_revoked = a takeover revoked our lease; the runtime learns of
       // it at the next keystroke and rejects the frame. Same flip as a
       // writer-state revoke — not a halt.
@@ -3418,6 +3532,8 @@ function ifControl(a, m) {
     case "lifecycle":
       if (m.lifecycle != null && m.lifecycle !== a.st.lifecycle) {
         a.st.lifecycle = m.lifecycle;
+        if (!IF_ATTACHABLE_LIFECYCLES.has(m.lifecycle))
+          a.composerSubmitLatched = false;
         ifRefreshComposerProjection(a);
       }
       if (m.composer != null) a.st.composer = m.composer;

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2177,6 +2177,7 @@ function ifDetach() {
   if (!a) return;
   ifAttach = null;
   clearInterval(a.heartbeat);
+  ifClearComposerAckTimer(a);
   a.resizeObs?.disconnect();
   try { a.ws?.close(); } catch { /* already closed */ }
   a.term?.dispose();
@@ -2237,8 +2238,13 @@ async function renderInterface(root) {
         s.shortname + (s.harness ? " · " + s.harness : "") + occupiedModel));
     row.onclick = () => { location.hash = "interface/" + s.shortname; };
     rail.append(row);
+    const mobileModel = s.availability === "occupied"
+      ? " · " + ifModelLabel(s.model_route)
+      : "";
     const opt = el("option", { value: s.shortname },
-      `${s.display_name || s.shortname} · ${s.shortname} · ${s.availability}`);
+      `${s.display_name || s.shortname} · ${s.shortname}` +
+      `${s.harness ? " · " + s.harness : ""}${mobileModel}` +
+      ` · ${s.availability}`);
     if (s.shortname === ifSelected) opt.selected = true;
     picker.append(opt);
   }
@@ -3013,7 +3019,8 @@ async function ifSessionPane(pane, sel) {
     browserComposerWanted: st.browserComposer, browserComposerError: "",
     browserComposerSyncing: false, browserComposerVersion: 0,
     browserComposerChain: Promise.resolve(),
-    composerSubmitLatched: false,
+    composerSubmitLatched: false, composerLatchedValue: null,
+    composerAckTimer: null, composerAckTimeoutMs: null,
     sprintPanelVersion: 0,
     composerProjectionPending: false, composerProjectionVersion: 0,
     composerProjectionSync: Promise.resolve() };
@@ -3131,6 +3138,18 @@ function ifSizeComposer(input) {
   input.style.height = Math.max(42, input.scrollHeight || 42) + "px";
 }
 
+const IF_COMPOSER_ACK_TIMEOUT_MS = 15000;
+
+function ifClearComposerLatch(a) {
+  a.composerSubmitLatched = false;
+  a.composerLatchedValue = null;
+}
+
+function ifClearComposerAckTimer(a) {
+  if (a.composerAckTimer != null) clearTimeout(a.composerAckTimer);
+  a.composerAckTimer = null;
+}
+
 function ifComposerWritable(a) {
   return a.legalActions.has("send_input") &&
     a.role === "writer" && a.st.writer === "active" && !a.halted &&
@@ -3161,9 +3180,12 @@ function ifPaintComposer(a) {
   const hasMessage = Boolean(a.composerInput.value.trim());
   // Do not let a new draft appear while a clean transition is in flight:
   // that would briefly project clean server-side while the box is non-empty.
-  // Dirty transitions need not freeze typing because every later character
-  // remains covered by the already-requested dirty state.
+  // Dirty transitions normally need not freeze typing because every later
+  // character remains covered by the already-requested dirty state. Once a
+  // submit is accepted locally, though, its exact draft is fenced and the box
+  // freezes until that one draft is queued.
   a.composerInput.disabled = !writable || pending ||
+    a.composerSubmitLatched ||
     (a.browserComposerSyncing && a.browserComposerWanted === "clean");
   const dirtyReady = a.browserComposerState === "dirty";
   const dirtySyncing = a.browserComposerSyncing &&
@@ -3203,7 +3225,7 @@ function ifRefreshComposerProjection(a) {
     a.legalActions = new Set(
       Array.isArray(session.legal_actions) ? session.legal_actions : []);
     a.stateReason = session.state_reason || "";
-    if (!a.legalActions.has("send_input")) a.composerSubmitLatched = false;
+    if (!a.legalActions.has("send_input")) ifClearComposerLatch(a);
   }).catch((e) => {
     if (ifAttach !== a || version !== a.composerProjectionVersion) return;
     a.legalActions.delete("send_input");
@@ -3236,12 +3258,12 @@ function ifSyncBrowserComposer(a, state) {
   }).catch((e) => {
     if (ifAttach === a) {
       a.browserComposerError = e.message;
-      a.composerSubmitLatched = false;
+      ifClearComposerLatch(a);
     }
   }).finally(() => {
     if (ifAttach !== a || version !== a.browserComposerVersion) return;
     a.browserComposerSyncing = false;
-    if (a.browserComposerError) a.composerSubmitLatched = false;
+    if (a.browserComposerError) ifClearComposerLatch(a);
     else if (a.composerSubmitLatched && a.browserComposerState === "dirty")
       ifComposerSend(a);
     a.paint();
@@ -3249,20 +3271,24 @@ function ifSyncBrowserComposer(a, state) {
 }
 
 function ifComposerSend(a) {
-  const value = a.composerInput.value;
-  if (!value.trim() || !ifComposerWritable(a) ||
+  const value = a.composerSubmitLatched
+    ? a.composerLatchedValue
+    : a.composerInput.value;
+  if (typeof value !== "string" || !value.trim() || !ifComposerWritable(a) ||
       a.composerPendingSeq != null || a.browserComposerError)
     return;
   if (a.browserComposerSyncing || a.browserComposerState !== "dirty" ||
       a.awaiting || a.outBuf) {
     if (a.browserComposerWanted === "dirty" ||
         a.browserComposerState === "dirty") {
-      a.composerSubmitLatched = true;
+      if (!a.composerSubmitLatched) {
+        a.composerSubmitLatched = true;
+        a.composerLatchedValue = value;
+      }
       a.paint();
     }
     return;
   }
-  a.composerSubmitLatched = false;
   // xterm emits carriage return for Enter. Reuse that exact byte convention
   // after the composed text so the existing broker submits the message.
   const seq = ifSendInput(a, value + "\r");
@@ -3271,7 +3297,19 @@ function ifComposerSend(a) {
     a.paint();
     return;
   }
+  ifClearComposerLatch(a);
   a.composerPendingSeq = seq;
+  ifClearComposerAckTimer(a);
+  a.composerAckTimer = setTimeout(() => {
+    if (ifAttach !== a || a.composerPendingSeq !== seq) return;
+    a.composerAckTimer = null;
+    a.composerPendingSeq = null;
+    a.awaiting = false;
+    a.halted = true;
+    a.st.note = "message acknowledgement timed out — delivery is unknown; " +
+      "the draft was retained. Inspect the terminal, then reattach before retrying";
+    a.paint();
+  }, a.composerAckTimeoutMs || IF_COMPOSER_ACK_TIMEOUT_MS);
   a.paint();
 }
 
@@ -3324,17 +3362,21 @@ async function ifEndChat(a, sel, pane, btn) {
   let r;
   try { r = await apiIf("/interface/termination-requests", "POST", { session_id: a.sessionId, force: false }); }
   catch (e) {
-    // not_occupied: the generation is unreconciled, so there is no verified
-    // identity left to terminate. That is not a failure the operator can act
-    // on from here — it is the recovery path, which the server may now list a
-    // legal action for. Detach and re-render onto it (decision #49) instead
-    // of leaving a terminal error on a shell that can be unstranded.
-    if (e.status === 409 && e.code === "not_occupied") {
+    const reason = e.body && e.body.reason;
+    const needsRecovery = e.status === 409 && (
+      e.code === "not_occupied" || e.code === "identity_unverified" ||
+      reason === "identity_mismatch" || reason === "not_running");
+    if (needsRecovery) {
+      // The selected pane is stale: the server has already projected this
+      // session into a state that termination cannot safely signal. Drop the
+      // dead stream before refreshing so the lost/unreconciled shell reaches
+      // the server-authorized recovery preview instead of retaining a false
+      // occupied attachment and an inert End-chat error.
       ifDetach();
       if (root) return renderInterface(root);
       return;
     }
-    if (e.status === 409 && e.body && e.body.reason) r = e.body;
+    if (e.status === 409 && reason) r = e.body;
     else { a.st.note = "end chat failed: " + e.message; a.paint(); return; }
   }
   if (!r.terminated && r.reason === "identity_mismatch") {
@@ -3413,7 +3455,8 @@ function ifOpenStream(a, ticket) {
     if (ifAttach !== a) return;
     if (a.composerPendingSeq != null || a.composerSubmitLatched) {
       a.composerPendingSeq = null;
-      a.composerSubmitLatched = false;
+      ifClearComposerLatch(a);
+      ifClearComposerAckTimer(a);
       a.awaiting = false;
       a.halted = true;
       a.st.note = "stream closed before the message acknowledgement — " +
@@ -3483,7 +3526,8 @@ function ifRevoked(a) {
   a.role = "viewer"; a.leaseId = null; a.leaseToken = null;
   a.awaiting = false; a.halted = false; a.outBuf = "";
   a.composerPendingSeq = null;
-  a.composerSubmitLatched = false;
+  ifClearComposerLatch(a);
+  ifClearComposerAckTimer(a);
   a.st.writer = "held";
   a.st.writerReason = "Control was taken by another client.";
   a.st.note = "control was taken by another client — you are now read-only (Take-over to reclaim)";
@@ -3496,6 +3540,7 @@ function ifControl(a, m) {
         a.awaiting = false;
         a.lastAck = m.seq;
         if (m.seq === a.composerPendingSeq) {
+          ifClearComposerAckTimer(a);
           a.composerPendingSeq = null;
           a.composerInput.value = "";
           ifSizeComposer(a.composerInput);
@@ -3508,8 +3553,11 @@ function ifControl(a, m) {
       break;
     case "input_reject":
       a.awaiting = false;
-      if (m.seq === a.composerPendingSeq) a.composerPendingSeq = null;
-      a.composerSubmitLatched = false;
+      if (m.seq === a.composerPendingSeq) {
+        ifClearComposerAckTimer(a);
+        a.composerPendingSeq = null;
+      }
+      ifClearComposerLatch(a);
       // writer_revoked = a takeover revoked our lease; the runtime learns of
       // it at the next keystroke and rejects the frame. Same flip as a
       // writer-state revoke — not a halt.
@@ -3533,7 +3581,7 @@ function ifControl(a, m) {
       if (m.lifecycle != null && m.lifecycle !== a.st.lifecycle) {
         a.st.lifecycle = m.lifecycle;
         if (!IF_ATTACHABLE_LIFECYCLES.has(m.lifecycle))
-          a.composerSubmitLatched = false;
+          ifClearComposerLatch(a);
         ifRefreshComposerProjection(a);
       }
       if (m.composer != null) a.st.composer = m.composer;

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -720,6 +720,28 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   background: var(--panel); border: 1px solid var(--line); border-radius: var(--r);
   padding: .5rem .8rem;
 }
+.if-disclosure {
+  position: relative; color: var(--dim); font-size: .8rem;
+}
+.if-disclosure summary {
+  list-style: none; cursor: pointer; border: 1px solid var(--line);
+  border-radius: 999px; padding: .35rem .7rem; color: var(--ink);
+  user-select: none;
+}
+.if-disclosure summary::-webkit-details-marker { display: none; }
+.if-disclosure summary::after { content: " ▾"; color: var(--dim); }
+.if-disclosure[open] summary::after { content: " ▴"; }
+.if-disclosure > :not(summary) {
+  margin-top: .5rem;
+}
+.if-disclosure[open] {
+  flex-basis: 100%;
+  order: 10;
+}
+.if-alerts.warning summary { color: var(--warn); border-color: var(--warn); }
+.if-alerts.critical summary { color: #d45a5a; border-color: #d45a5a; }
+.if-alerts-body { color: var(--ink); }
+.if-inline-actions { display: flex; align-items: center; gap: .4rem; }
 .if-stat { color: var(--dim); font-size: .8rem; }
 .if-stat b { color: var(--ink); font-weight: 600; }
 .if-head .act { margin-top: 0; }
@@ -738,7 +760,12 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   min-height: 42px; resize: none; overflow-y: hidden;
   font: 14px/1.4 ui-monospace, monospace;
 }
+.if-composer-actions { display: flex; align-items: stretch; gap: .4rem; }
 .if-composer .act { margin: 0; min-height: 42px; }
+.if-composer .if-end-chat {
+  color: #ef7777; border-color: #a74444; background: rgba(167,68,68,.08);
+}
+.if-composer .if-end-chat:hover { border-color: #ef7777; }
 .if-composer .if-note { grid-column: 1 / -1; min-height: 1.2em; }
 .if-newchat .act { margin-top: .8rem; }
 .if-newchat .muted { margin-top: .5rem; }
@@ -765,10 +792,19 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
    terminal viewport, becomes the scroll surface. */
 .if-picker { display: none; }
 @media (max-width: 760px) {
+  body.interface-view header {
+    max-width: 100vw; overflow-x: auto; gap: .75rem;
+  }
+  body.interface-view header h1,
+  body.interface-view header .tools { display: none; }
+  body.interface-view header nav { flex: 0 0 max-content; }
   .if-wrap { flex-direction: column; }
   .if-rail { display: none; }
   .if-picker { display: block; width: 100%; background: var(--panel);
     border: 1px solid var(--line); border-radius: var(--r); color: var(--ink);
     font: inherit; padding: .45rem .6rem; }
   .if-pane { width: 100%; }
+  .if-head { gap: .5rem; }
+  .if-composer { grid-template-columns: minmax(0, 1fr); }
+  .if-composer-actions { justify-content: flex-end; }
 }

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -232,6 +232,7 @@ class InterfaceApiTest(unittest.TestCase):
                 for key in (
                     "shell_id", "shortname", "display_name", "flavor",
                     "availability", "default_harness", "default_model",
+                    "model_route",
                 )
             },
             {
@@ -242,11 +243,40 @@ class InterfaceApiTest(unittest.TestCase):
                 "availability": "available",
                 "default_harness": "codex",
                 "default_model": "gpt-5.6-sol",
+                "model_route": None,
             },
         )
         self.assertIsNone(body["shells"][1]["flavor"])
         self.assertIsNone(body["shells"][1]["default_harness"])
         self.assertIsNone(body["shells"][1]["default_model"])
+
+    def test_occupied_shell_projection_includes_live_model_route(self):
+        session_id = self.occupy()
+        with sqlite3.connect(self.db_path) as con:
+            con.execute(
+                "UPDATE interface_sessions SET model_route=? "
+                "WHERE session_id=?",
+                ("gpt-5.6-terra", session_id),
+            )
+
+        status, _, body = self.call("GET", "/api/interface/shells", (OP,))
+
+        self.assertEqual(status, 200)
+        shell = body["shells"][0]
+        self.assertEqual(
+            {
+                "availability": shell["availability"],
+                "session_id": shell["session_id"],
+                "harness": shell["harness"],
+                "model_route": shell["model_route"],
+            },
+            {
+                "availability": "occupied",
+                "session_id": session_id,
+                "harness": "claude",
+                "model_route": "gpt-5.6-terra",
+            },
+        )
 
     def test_browser_bootstrap_same_origin_fence(self):
         # Cross-site Origin cannot mint a session (rejected before the

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -1,4 +1,4 @@
-"""Browser contract checks for spec #30 requirements 18-20 and 24.
+"""Browser contract checks for spec #30 requirements 18-20, 24, and 26.
 
 The UI is deliberately build-free vanilla JS/CSS. These checks pin the shared
 picker and responsive terminal behavior without inventing a second JS runtime
@@ -246,6 +246,8 @@ def test_message_composer_uses_broker_ack_and_preserves_raw_terminal_input():
 globalThis.WebSocket = { OPEN: 1 };
 globalThis.ifClientId = "web-1";
 globalThis.ifAttach = null;
+const IF_ATTACHABLE_LIFECYCLES = new Set(
+  ["starting", "idle", "busy", "approval", "user_input"]);
 const apiCalls = [];
 let sessionProjection = {
   legal_actions: ["send_input"],
@@ -303,6 +305,7 @@ const a = {
   browserComposerSyncing: false,
   browserComposerVersion: 0,
   browserComposerChain: Promise.resolve(),
+  composerSubmitLatched: false,
   composerProjectionPending: false,
   composerProjectionVersion: 0,
   composerProjectionSync: Promise.resolve(),
@@ -316,11 +319,6 @@ a.paint();
   a.composerInput.value = "hello\nworld";
   a.composerInput.scrollHeight = 70;
   a.composerInput.oninput();
-  await a.browserComposerChain;
-  invariant(apiCalls.length === 1 &&
-    apiCalls[0].path === "/interface/browser-composer" &&
-    apiCalls[0].body.state === "dirty",
-    `draft state did not reach the server: ${JSON.stringify(apiCalls)}`);
   let prevented = false;
   a.composerInput.onkeydown({
     key: "Enter", shiftKey: true, preventDefault() { prevented = true; },
@@ -328,10 +326,24 @@ a.paint();
   invariant(!prevented && frames.length === 0,
     "Shift+Enter must remain a local newline");
   a.composerInput.onkeydown({
+    key: "Enter", shiftKey: false, isComposing: true,
+    preventDefault() { prevented = true; },
+  });
+  invariant(!prevented && frames.length === 0,
+    "IME composition Enter must not submit");
+  a.composerInput.onkeydown({
     key: "Enter", shiftKey: false, preventDefault() { prevented = true; },
   });
+  a.composerSend.onclick();
+  invariant(prevented && frames.length === 0 && a.composerSubmitLatched,
+    "send during dirty-state sync was not latched exactly once");
+  await a.browserComposerChain;
+  invariant(apiCalls.length === 1 &&
+    apiCalls[0].path === "/interface/browser-composer" &&
+    apiCalls[0].body.state === "dirty",
+    `draft state did not reach the server: ${JSON.stringify(apiCalls)}`);
   invariant(prevented && frames.length === 1,
-    "Enter did not send exactly one broker frame");
+    "latched Enter and Send did not converge on exactly one broker frame");
   const payload = new TextDecoder().decode(frames[0].subarray(9));
   invariant(payload === "hello\nworld\r",
     `composer bytes bypassed terminal Enter semantics: ${JSON.stringify(payload)}`);
@@ -349,14 +361,29 @@ a.paint();
   invariant(apiCalls.length === 2 && apiCalls[1].body.state === "clean",
     "acknowledged send did not release browser composing state");
 
+  a.halted = false;
+  a.composerInput.value = "retain on reject";
+  a.composerInput.oninput();
+  await a.browserComposerChain;
+  a.composerSend.onclick();
+  invariant(frames.length === 2 && a.composerPendingSeq === 5,
+    "visible Send did not use the same broker path");
+  ifControl(a, { type: "input_reject", seq: 5, reason: "stale_generation" });
+  invariant(a.composerInput.value === "retain on reject" &&
+    a.composerPendingSeq === null &&
+    a.composerNote.textContent.includes("input rejected"),
+    "broker rejection did not retain the draft with an actionable error");
+
   a.composerInput.value = " \n";
   a.composerInput.oninput();
   await a.browserComposerChain;
   a.composerInput.onkeydown({
     key: "Enter", shiftKey: false, preventDefault() {},
   });
-  invariant(frames.length === 1, "whitespace-only input sent a second frame");
+  invariant(frames.length === 2, "whitespace-only input sent another frame");
 
+  a.halted = false;
+  a.st.note = "";
   a.role = "viewer";
   a.st.writer = "held";
   a.st.writerReason = "writer held by another client";

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -337,6 +337,18 @@ a.paint();
   a.composerSend.onclick();
   invariant(prevented && frames.length === 0 && a.composerSubmitLatched,
     "send during dirty-state sync was not latched exactly once");
+  invariant(a.composerInput.disabled,
+    "the accepted draft stayed editable while dirty state was syncing");
+  const tryUserEdit = (value) => {
+    if (!a.composerInput.disabled) {
+      a.composerInput.value = value;
+      a.composerInput.oninput();
+    }
+  };
+  tryUserEdit("mutated after Enter");
+  tryUserEdit("");
+  invariant(a.composerInput.value === "hello\nworld",
+    "mutation or clear replaced the first accepted draft");
   await a.browserComposerChain;
   invariant(apiCalls.length === 1 &&
     apiCalls[0].path === "/interface/browser-composer" &&
@@ -416,6 +428,56 @@ a.paint();
         ["node", "-e", script], text=True, capture_output=True, check=False)
     assert result.returncode == 0, result.stderr
     assert "term.onData((d) => ifSendInput(a, d))" in APP
+
+
+def test_end_chat_not_running_transition_detaches_and_renders_recovery():
+    script = END_CHAT + r"""
+let detached = 0;
+let rendered = 0;
+let response;
+globalThis.confirm = () => true;
+function ifDetach() { detached += 1; }
+async function renderInterface(root) {
+  if (root !== view) throw new Error("End chat refreshed the wrong view");
+  rendered += 1;
+}
+async function apiIf() { throw response; }
+const view = {};
+const pane = { closest: (selector) => selector === ".view" ? view : null };
+const a = {
+  sessionId: 7,
+  st: { note: "" },
+  paint() { throw new Error("a recovery transition painted stale state"); },
+};
+const sel = { shortname: "DEV3", display_name: "Code-01" };
+
+async function exercise(error, label) {
+  response = error;
+  detached = 0;
+  rendered = 0;
+  await ifEndChat(a, sel, pane, { disabled: false });
+  if (detached !== 1 || rendered !== 1) {
+    throw new Error(`${label} kept the dead attachment: ` +
+      `${JSON.stringify({ detached, rendered })}`);
+  }
+}
+
+(async () => {
+  const becameUnreconciled = new Error("not running");
+  becameUnreconciled.status = 409;
+  becameUnreconciled.body = {
+    terminated: false,
+    reason: "not_running",
+  };
+  await exercise(becameUnreconciled, "not_running transition");
+})().catch((error) => {
+  console.error(error.stack || error);
+  process.exit(1);
+});
+"""
+    result = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
 
 
 def test_recovery_renders_only_server_listed_actions_and_full_diagnostics():

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -33,6 +33,15 @@ SHELL = {
     "model_route": "gpt-5.6-terra",
     "alerts": 2,
 }
+OTHER_SHELL = {
+    **SHELL,
+    "shell_id": 4,
+    "shortname": "DEV4",
+    "display_name": "Code-02",
+    "session_id": 8,
+    "model_route": "gpt-5.6-sol",
+    "alerts": 0,
+}
 SESSION = {
     "session_id": 7,
     "generation": 1,
@@ -81,6 +90,42 @@ CAPABILITY = {
     "reason": "optional_hook_missing",
     "meaning": "Optional hook detail is unavailable.",
     "dismissible": False,
+}
+BINDING = {
+    "binding_id": 44,
+    "sprint_doc_id": 31,
+    "planner_shell_id": 3,
+    "session_id": 7,
+    "generation": 1,
+    "armed_at": "2026-07-24 08:00:00",
+    "released_at": None,
+    "release_reason": None,
+    "sprint": {
+        "document_id": 31,
+        "title": "Interface corrective hardening",
+        "frozen": False,
+        "active": True,
+    },
+    "wake_state": "parked",
+    "items": {"queued": 2, "quarantined": 1},
+    "current_batch": {"batch_id": 91, "state": "queued"},
+    "last_batch": {
+        "batch_id": 90,
+        "state": "delivery_unknown",
+        "items": {"parked": 1},
+    },
+    "park": {
+        "batch_id": 90,
+        "input_park": True,
+        "reason": "wake_batch_delivery_unknown",
+    },
+    "quarantined": [{
+        "item_id": 93,
+        "message_id": 1390,
+        "error": "survived 3 wake turns",
+        "completed_wakes": 3,
+    }],
+    "retry": {"applicable": True, "needs_outcome": True},
 }
 
 
@@ -136,7 +181,7 @@ def _mock_api(route) -> None:
     if path == "/interface/browser-sessions":
         return _json(route, {"csrf": "rendered-fixture"})
     if path == "/interface/shells":
-        return _json(route, {"shells": [SHELL]})
+        return _json(route, {"shells": [SHELL, OTHER_SHELL]})
     if path == "/interface/sessions/7":
         return _json(route, SESSION)
     if path == "/interface/writer-leases":
@@ -150,7 +195,7 @@ def _mock_api(route) -> None:
         body = request.post_data_json or {}
         return _json(route, {"browser_composer": body.get("state", "clean")})
     if path.startswith("/interface/sprint-bindings"):
-        return _json(route, {"bindings": []})
+        return _json(route, {"bindings": [BINDING]})
     if path.startswith("/interface/sprint-alerts"):
         if "include_resolved=1" in path:
             history = [
@@ -229,14 +274,17 @@ window.Terminal = RenderedTerminal;
 """
 
 
-def _open_interface(browser, ui_url: str, *, height: int, width: int = 1600):
+def _open_interface(
+    browser, ui_url: str, *, height: int, width: int = 1600,
+    api_handler=_mock_api,
+):
     context = browser.new_context(viewport={"width": width, "height": height})
     page = context.new_page()
     page.add_init_script(INIT_SCRIPT)
     page.route("**/vendor/xterm/xterm.js", lambda route: route.fulfill(
         status=200, content_type="application/javascript", body=""
     ))
-    page.route("**/api/**", _mock_api)
+    page.route("**/api/**", api_handler)
     page.goto(f"{ui_url}/#interface/DEV3", wait_until="networkidle")
     page.locator(".if-term .xterm").wait_for()
     page.wait_for_function("window.__wsResizeFrames.length > 0")
@@ -395,9 +443,9 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
     desktop, page = _open_interface(browser, ui_url, height=1100)
     try:
         page.get_by_text("Alerts (2)", exact=True).wait_for()
-        assert "DEV3 · codex · GPT 5.6 TERRA" in page.locator(
-            ".if-row-sub"
-        ).inner_text()
+        rail_models = page.locator(".if-row-sub").all_inner_texts()
+        assert "DEV3 · codex · GPT 5.6 TERRA" in rail_models
+        assert "DEV4 · codex · GPT 5.6 SOL" in rail_models
         assert page.locator(".if-alerts").get_attribute("class").endswith(
             "critical"
         )
@@ -409,6 +457,19 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
         assert "model GPT 5.6 TERRA" in details.inner_text()
         assert "session #7 · arc #172" in details.inner_text()
         assert "wake armed" in details.inner_text()
+        assert "sprint #31 Interface corrective hardening · ACTIVE" in (
+            details.inner_text()
+        )
+        assert "last outcome #90 delivery_unknown · parked:1" in (
+            details.inner_text()
+        )
+        assert "PARKED: wake_batch_delivery_unknown" in details.inner_text()
+        assert page.get_by_role(
+            "button", name="Retry — input landed"
+        ).is_visible()
+        assert page.get_by_role(
+            "button", name="Retry — input lost"
+        ).is_visible()
 
         page.get_by_text("Alerts (2)", exact=True).click()
         alerts = page.locator(".if-alerts")
@@ -480,6 +541,15 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
         assert geometry["paneRight"] <= geometry["viewport"]
         assert geometry["headerScrollWidth"] > geometry["headerClientWidth"]
         assert geometry["headerOverflowX"] == "auto"
+        options = page.locator(".if-picker option").all_inner_texts()
+        assert (
+            "Code-01 · DEV3 · codex · GPT 5.6 TERRA · occupied"
+            in options
+        )
+        assert (
+            "Code-02 · DEV4 · codex · GPT 5.6 SOL · occupied"
+            in options
+        )
         assert page.locator(".if-composer-actions button").all_inner_texts() == [
             "Send",
             "End chat",
@@ -492,7 +562,7 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
         mobile.close()
 
 
-def test_enter_sends_one_frame_and_missing_ack_retains_draft(
+def test_enter_sends_one_frame_and_open_silent_stream_retains_draft(
     browser, ui_url
 ):
     context, page = _open_interface(browser, ui_url, height=1000)
@@ -503,6 +573,7 @@ def test_enter_sends_one_frame_and_missing_ack_retains_draft(
         page.wait_for_function(
             "() => !document.querySelector('.if-composer-actions button').disabled"
         )
+        page.evaluate("ifAttach.composerAckTimeoutMs = 40")
 
         composer.press("Enter")
         page.wait_for_function("window.__inputFrames.length === 1")
@@ -511,11 +582,124 @@ def test_enter_sends_one_frame_and_missing_ack_retains_draft(
         assert payload == "one composed turn\r"
         assert composer.input_value() == "one composed turn"
 
-        page.evaluate("window.__lastWs.onclose()")
+        page.locator(".if-composer .if-note").filter(
+            has_text="message acknowledgement timed out"
+        ).wait_for()
         assert composer.input_value() == "one composed turn"
-        assert "draft was retained" in page.locator(
+        assert "delivery is unknown" in page.locator(
             ".if-composer .if-note"
         ).inner_text()
         assert page.evaluate("window.__inputFrames.length") == 1
+        assert page.evaluate("window.__lastWs.readyState") == 1
+        assert page.evaluate("ifAttach.halted") is True
+    finally:
+        context.close()
+
+
+def test_not_occupied_end_chat_detaches_into_preserving_recovery(
+    browser, ui_url
+):
+    state: dict[str, object] = {"lost": False, "recovery_body": None}
+    preview = {
+        "observation_id": "obs-not-occupied",
+        "expires_in_s": 120,
+        "classification": "stale_durable_lock",
+        "legal_actions": ["recover"],
+        "evidence": {
+            "shell": {"shell_id": 3, "shortname": "DEV3"},
+            "session": {
+                "session_id": 7,
+                "generation": 1,
+                "occupancy": "unreconciled",
+                "lifecycle": "lost",
+            },
+        },
+        "evidence_projection": [
+            {
+                "key": "classification",
+                "label": "classification",
+                "value": "stale_durable_lock",
+            },
+            {
+                "key": "session",
+                "label": "session",
+                "value": "session #7 · generation 1 · unreconciled/lost",
+            },
+            {
+                "key": "process",
+                "label": "process",
+                "value": "PID absent · pane gone",
+            },
+            {
+                "key": "worktree",
+                "label": "worktree",
+                "value": "not clean · preserve by default",
+            },
+        ],
+    }
+
+    def recovery_api(route) -> None:
+        request = route.request
+        path = request.url.split("/api", 1)[-1]
+        if path == "/interface/termination-requests":
+            state["lost"] = True
+            return _json(route, {
+                "error": {
+                    "code": "not_occupied",
+                    "message": "session 7 is unreconciled — termination "
+                    "needs a verified identity",
+                },
+            }, status=409)
+        if path == "/interface/shells":
+            shell = {
+                **SHELL,
+                "availability": "lost" if state["lost"] else "occupied",
+            }
+            return _json(route, {"shells": [shell]})
+        if path == "/interface/shells/3/recovery":
+            if request.method == "GET":
+                return _json(route, preview)
+            state["recovery_body"] = request.post_data_json
+            return _json(route, {
+                "shell_id": 3,
+                "shortname": "DEV3",
+                "classification": "stale_durable_lock",
+                "mode": "recover",
+                "availability": "available",
+                "closed": {"alerts_resolved": 1, "parked": []},
+                "worktree": {"preserved": True},
+                "unread_messages": 0,
+            })
+        return _mock_api(route)
+
+    context, page = _open_interface(
+        browser, ui_url, height=1000, api_handler=recovery_api
+    )
+    page.on("dialog", lambda dialog: dialog.accept())
+    try:
+        page.get_by_role("button", name="End chat").click()
+        preview_button = page.get_by_role("button", name="Preview recovery")
+        preview_button.wait_for()
+        assert page.evaluate("window.__lastWs.readyState") == 3
+        assert page.locator(".if-term").count() == 0
+
+        preview_button.click()
+        recover = page.get_by_role("button", name="Recover", exact=True)
+        recover.wait_for()
+        discard = page.get_by_text(
+            "Discard worktree changes", exact=False
+        ).locator("input")
+        assert discard.is_checked() is False
+
+        recover.click()
+        page.get_by_text("Recovery result", exact=True).wait_for()
+        assert state["recovery_body"] == {
+            "observation_id": "obs-not-occupied",
+            "mode": "recover",
+            "preserve_worktree": True,
+        }
+        assert "Worktree preserved" in page.locator(
+            ".if-recovery-result"
+        ).inner_text()
     finally:
         context.close()

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -1,4 +1,4 @@
-"""Rendered Interface layout and live-resize coverage for spec #33.
+"""Rendered Interface layout, disclosures, and submit coverage for spec #30.
 
 The normal engine suite stays dependency-light, so this module skips unless
 Playwright is installed.  The ``interface-rendered`` CI job installs the same
@@ -30,7 +30,8 @@ SHELL = {
     "session_id": 7,
     "generation": 1,
     "harness": "codex",
-    "alerts": 1,
+    "model_route": "gpt-5.6-terra",
+    "alerts": 2,
 }
 SESSION = {
     "session_id": 7,
@@ -38,7 +39,7 @@ SESSION = {
     "attachable": True,
     "identity_verified": True,
     "harness": "codex",
-    "model_route": "gpt-5.6-sol",
+    "model_route": "gpt-5.6-terra",
     "lifecycle": "idle",
     "composer": "clean",
     "browser_composer": "clean",
@@ -64,6 +65,22 @@ ALERT = {
     "acknowledged_at": None,
     "acknowledged_by": None,
     "resolved_at": None,
+}
+CRITICAL_ALERT = {
+    **ALERT,
+    "alert_id": 121,
+    "severity": "critical",
+    "reason": "delivery_unknown",
+    "meaning": "Delivery may have crossed the broker crash boundary.",
+}
+CAPABILITY = {
+    **ALERT,
+    "alert_id": 122,
+    "category": "capability",
+    "severity": "info",
+    "reason": "optional_hook_missing",
+    "meaning": "Optional hook detail is unavailable.",
+    "dismissible": False,
 }
 
 
@@ -146,7 +163,7 @@ def _mock_api(route) -> None:
                 for index in range(14)
             ]
             return _json(route, {"alerts": history})
-        return _json(route, {"alerts": [ALERT]})
+        return _json(route, {"alerts": [ALERT, CRITICAL_ALERT, CAPABILITY]})
     return _json(route, {})
 
 
@@ -154,6 +171,8 @@ INIT_SCRIPT = r"""
 window.__wsInstances = 0;
 window.__wsResizeFrames = [];
 window.__terminalResizes = [];
+window.__inputFrames = [];
+window.__lastWs = null;
 
 class RenderedWebSocket {
   static CONNECTING = 0;
@@ -162,6 +181,7 @@ class RenderedWebSocket {
   static CLOSED = 3;
   constructor() {
     window.__wsInstances += 1;
+    window.__lastWs = this;
     this.readyState = RenderedWebSocket.OPEN;
     queueMicrotask(() => this.onopen?.());
   }
@@ -172,6 +192,9 @@ class RenderedWebSocket {
         rows: view.getUint16(1),
         cols: view.getUint16(3),
       });
+    }
+    if (frame instanceof Uint8Array && frame[0] === 0x01) {
+      window.__inputFrames.push(Array.from(frame));
     }
   }
   close() { this.readyState = RenderedWebSocket.CLOSED; }
@@ -206,8 +229,8 @@ window.Terminal = RenderedTerminal;
 """
 
 
-def _open_interface(browser, ui_url: str, *, height: int):
-    context = browser.new_context(viewport={"width": 1600, "height": height})
+def _open_interface(browser, ui_url: str, *, height: int, width: int = 1600):
+    context = browser.new_context(viewport={"width": width, "height": height})
     page = context.new_page()
     page.add_init_script(INIT_SCRIPT)
     page.route("**/vendor/xterm/xterm.js", lambda route: route.fulfill(
@@ -294,7 +317,7 @@ def test_tall_fit_short_floor_and_visual_qa(browser, ui_url, tmp_path):
         )
         assert fitted["pageScrolls"] is False
 
-        page.set_viewport_size({"width": 1600, "height": 900})
+        page.set_viewport_size({"width": 1600, "height": 700})
         page.wait_for_timeout(100)
         short = _layout(page)
         assert 500 <= short["termHeight"] <= 502
@@ -356,10 +379,143 @@ def test_alert_history_and_multiline_composer_respect_terminal_floor(
             or composed["pageScrolls"] is True
         )
 
+        page.get_by_text("Alerts (2)", exact=True).click()
         page.get_by_role("button", name="Alert history").click()
         page.locator(".if-history").wait_for()
         expanded = _layout(page)
         assert expanded["termHeight"] >= 500
         assert expanded["pageScrolls"] is True
+    finally:
+        context.close()
+
+
+def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
+    browser, ui_url, tmp_path
+):
+    desktop, page = _open_interface(browser, ui_url, height=1100)
+    try:
+        page.get_by_text("Alerts (2)", exact=True).wait_for()
+        assert "DEV3 · codex · GPT 5.6 TERRA" in page.locator(
+            ".if-row-sub"
+        ).inner_text()
+        assert page.locator(".if-alerts").get_attribute("class").endswith(
+            "critical"
+        )
+        assert page.locator(".if-details").get_attribute("open") is None
+        assert page.locator(".if-alerts").get_attribute("open") is None
+
+        page.get_by_text("Details", exact=True).click()
+        details = page.locator(".if-details")
+        assert "model GPT 5.6 TERRA" in details.inner_text()
+        assert "session #7 · arc #172" in details.inner_text()
+        assert "wake armed" in details.inner_text()
+
+        page.get_by_text("Alerts (2)", exact=True).click()
+        alerts = page.locator(".if-alerts")
+        assert alerts.get_by_text("critical", exact=True).count() == 1
+        assert alerts.get_by_text("warning", exact=True).count() == 1
+        assert alerts.get_by_text(
+            "Capability information", exact=True
+        ).count() == 1
+
+        actions = page.locator(".if-composer-actions")
+        assert actions.locator("button").all_inner_texts() == [
+            "Send",
+            "End chat",
+        ]
+        boxes = actions.locator("button").evaluate_all(
+            """(buttons) => buttons.map((button) => {
+              const box = button.getBoundingClientRect();
+              return { x: box.x, y: box.y };
+            })"""
+        )
+        assert abs(boxes[0]["y"] - boxes[1]["y"]) < 1
+        assert boxes[1]["x"] > boxes[0]["x"]
+        page.evaluate(
+            "ifControl(ifAttach, { type: 'lifecycle', lifecycle: 'ended' })"
+        )
+        assert page.get_by_role("button", name="End chat").is_hidden()
+        page.evaluate(
+            "ifControl(ifAttach, { type: 'lifecycle', lifecycle: 'idle' })"
+        )
+        assert page.get_by_role("button", name="End chat").is_visible()
+        page.screenshot(
+            path=str(_artifact(tmp_path, "interface-details-desktop.png")),
+            full_page=True,
+        )
+    finally:
+        desktop.close()
+
+    mobile, page = _open_interface(
+        browser, ui_url, width=390, height=900
+    )
+    try:
+        page.get_by_text("Alerts (2)", exact=True).wait_for()
+        geometry = page.evaluate(
+            """() => ({
+              viewport: window.innerWidth,
+              documentWidth: document.documentElement.scrollWidth,
+              pickerDisplay: getComputedStyle(
+                document.querySelector(".if-picker")
+              ).display,
+              actionsWidth: document.querySelector(
+                ".if-composer-actions"
+              ).getBoundingClientRect().width,
+              paneWidth: document.querySelector(
+                ".if-pane"
+              ).getBoundingClientRect().width,
+              paneRight: document.querySelector(
+                ".if-pane"
+              ).getBoundingClientRect().right,
+              headerClientWidth: document.querySelector("header").clientWidth,
+              headerScrollWidth: document.querySelector("header").scrollWidth,
+              headerOverflowX: getComputedStyle(
+                document.querySelector("header")
+              ).overflowX,
+            })"""
+        )
+        assert geometry["documentWidth"] <= geometry["viewport"]
+        assert geometry["pickerDisplay"] != "none"
+        assert geometry["actionsWidth"] <= geometry["paneWidth"]
+        assert geometry["paneRight"] <= geometry["viewport"]
+        assert geometry["headerScrollWidth"] > geometry["headerClientWidth"]
+        assert geometry["headerOverflowX"] == "auto"
+        assert page.locator(".if-composer-actions button").all_inner_texts() == [
+            "Send",
+            "End chat",
+        ]
+        page.screenshot(
+            path=str(_artifact(tmp_path, "interface-details-mobile.png")),
+            full_page=True,
+        )
+    finally:
+        mobile.close()
+
+
+def test_enter_sends_one_frame_and_missing_ack_retains_draft(
+    browser, ui_url
+):
+    context, page = _open_interface(browser, ui_url, height=1000)
+    try:
+        composer = page.locator(".if-composer-input")
+        composer.fill("one composed turn")
+        page.get_by_role("button", name="Send").wait_for(state="visible")
+        page.wait_for_function(
+            "() => !document.querySelector('.if-composer-actions button').disabled"
+        )
+
+        composer.press("Enter")
+        page.wait_for_function("window.__inputFrames.length === 1")
+        frame = page.evaluate("window.__inputFrames[0]")
+        payload = bytes(frame[9:]).decode()
+        assert payload == "one composed turn\r"
+        assert composer.input_value() == "one composed turn"
+
+        page.evaluate("window.__lastWs.onclose()")
+        assert composer.input_value() == "one composed turn"
+        assert "draft was retained" in page.locator(
+            ".if-composer .if-note"
+        ).inner_text()
+        assert page.evaluate("window.__inputFrames.length") == 1
     finally:
         context.close()

--- a/tests/test_interface_wake_tmux.py
+++ b/tests/test_interface_wake_tmux.py
@@ -10,6 +10,8 @@ integration paths earlier units deferred to the real-tmux gate:
   holds (out-of-order and replayed seqs rejected, last_hook_seq monotonic)
   while ordered input streams through real tmux — no lost frames, no
   interleaved bytes.
+- composer submit: one frame containing text plus terminal Enter advances a
+  real tmux command past its line read exactly once.
 - parking-under-crash: a broker crash mid-write (the private tmux server
   dies between the wake preflight and send-keys) parks the batch
   delivery_unknown with an alert, and no drain, startup pass, or notify
@@ -275,7 +277,56 @@ class WakeTmuxE2ETest(unittest.TestCase):
             self.rt.runtime_state(self.sid)["continuity_broken"])
         await self.rt.stop()
 
-    # -- e2e 3: parking under a mid-write broker crash ----------------------------
+    # -- e2e 3: one composed frame starts one real terminal turn ------------------
+
+    def test_composed_text_and_submit_start_one_real_turn(self):
+        asyncio.run(self._flow_composed_turn())
+
+    async def _flow_composed_turn(self):
+        await self._spawn([
+            "/bin/sh",
+            "-c",
+            "printf READY; IFS= read -r line; "
+            "printf '\\nTURN_STARTED:%s\\n' \"$line\"; sleep 5",
+        ])
+        lease_id = self._acquire_writer()
+        writer = FakeClient(
+            self.sid,
+            role="writer",
+            client_id="tab-1",
+            lease_id=lease_id,
+            lease_token="tok-1",
+        )
+        await self.rt.attach(writer)
+
+        # This is the browser composer's one generation-fenced acceptance:
+        # text and terminal submit share one sequence and one broker frame.
+        self.rt.enqueue_input(writer, 1, b"one composed turn\r")
+        await wait_for(
+            lambda: len([
+                ack for ack in writer.by_type("input_ack")
+                if ack.get("seq") == 1 and not ack.get("replayed")
+            ]) == 1,
+            what="one composer input acknowledgement",
+        )
+        marker = b"TURN_STARTED:one composed turn"
+        await wait_for(
+            lambda: marker in b"".join(writer.outputs),
+            what="real terminal command advanced past its line read",
+        )
+        await asyncio.sleep(0.3)
+        self.assertEqual(
+            b"".join(writer.outputs).count(marker),
+            1,
+            "one composed acceptance must start exactly one turn",
+        )
+        self.assertEqual(
+            [ack["seq"] for ack in writer.by_type("input_ack")],
+            [1],
+        )
+        await self.rt.stop()
+
+    # -- e2e 4: parking under a mid-write broker crash ----------------------------
 
     def test_broker_crash_mid_write_parks_delivery_unknown(self):
         asyncio.run(self._flow_parking_under_crash())


### PR DESCRIPTION
## Summary
- show the active model route in occupied shell rows and move session/sprint telemetry into Details
- add generation-scoped, severity/count-aware Alerts disclosure with acknowledgement and history
- move End chat beside Send and make Enter/Send converge on one broker-fenced text-plus-terminal-submit frame
- latch submit during dirty-state sync; retain drafts on rejection or missing acknowledgement

## Verification
- focused API/JS/rendered/real-tmux gate: 92 passed
- rendered Chromium artifacts inspected at tall, short, desktop-details, and mobile sizes
- full suite: 1169 passed; known untouched spike slow-consumer test timed out once, then passed isolated on the second rerun (1.22s)
- ruff: changed Python paths clean

## Runtime evidence
The sandbox does not expose the host operator token or SC_DEV_PORT by design, so a live host browser attach was unavailable here. The exact submit boundary is covered by the real tmux broker test, and browser behavior/layout by rendered Playwright.

Sprint 31 F14 · spec 30 requirement 26.