### PR TITLE
feat(interface): open the browser session on same-origin trust (S38 U2)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -154,6 +154,27 @@ def _host_ok(headers) -> bool:
     return host in {h.strip("[]") for h in _ALLOWED_HOSTS}
 
 
+def _same_origin_as_host(origin: str, host: str) -> "str | None":
+    """Exact origin match, returning the matched scheme (None = no match).
+
+    A serialized origin (RFC 6454) is `scheme://host[:port]` and nothing
+    else — no path, no query, no fragment. Comparing only the netloc would
+    accept `http://127.0.0.1:8800/anything?q=1` as same-origin; no browser
+    emits that, so anything that does is a non-browser caller dressing up as
+    one, and this is the surface where exactness is the whole point.
+    Userinfo needs no separate rule: it lives in netloc, so `evil@host`
+    already fails the comparison."""
+    from urllib.parse import urlparse
+    parsed = urlparse(origin)
+    if parsed.scheme not in ("http", "https"):
+        return None
+    if parsed.path or parsed.params or parsed.query or parsed.fragment:
+        return None
+    if parsed.netloc != host:
+        return None
+    return parsed.scheme
+
+
 def _browser_origin(headers) -> "str | None":
     """The bootstrap's hostile-site fence (spec #26 Bootstrap Flow 2). This
     route is browser-only, so — unlike the header-tolerant mutation check
@@ -163,25 +184,20 @@ def _browser_origin(headers) -> "str | None":
     cross-site, or malformed provenance returns None (fail closed).
     Returns the proven Origin's scheme, which decides the cookie's
     `Secure` attribute."""
-    from urllib.parse import urlparse
     origin = headers.get("Origin") or ""
     host = headers.get("Host") or ""
     if not origin or not host:
         return None
-    parsed = urlparse(origin)
-    if parsed.scheme not in ("http", "https") or parsed.netloc != host:
-        return None
     if (headers.get("Sec-Fetch-Site") or "") != "same-origin":
         return None
-    return parsed.scheme
+    return _same_origin_as_host(origin, host)
 
 
 def _mutation_site_ok(headers) -> bool:
     origin = headers.get("Origin")
-    if origin:
-        from urllib.parse import urlparse
-        if urlparse(origin).netloc != (headers.get("Host") or ""):
-            return False
+    if origin and _same_origin_as_host(origin,
+                                       headers.get("Host") or "") is None:
+        return False
     sfs = headers.get("Sec-Fetch-Site")
     return sfs in (None, "same-origin", "none")
 

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -7,20 +7,29 @@ Runs on the transport's executor threads (blocking sqlite, per-request
 connections) and reaches the asyncio runtime only through its thread-safe
 `call()` facade.
 
-Authority (spec #20 API Resources / Security):
+Authority (spec #20 API Resources / Security, spec #26 Trust Boundary):
 - reads + mutations: the operator bearer (`.super-coder/run/interface/
   operator.token`, mode 0600, provisioned at server boot) or a browser
   session cookie; mutations additionally need the session's anti-forgery
   token (X-CSRF).
-- browser bootstrap (POST /browser-sessions) EXCHANGES the operator
-  capability (bearer) for the cookie, and additionally requires same-origin
-  fetch proof (Origin == Host, or Sec-Fetch-Site: same-origin) — a hostile
-  site cannot mint a session, and a local process without the mode-0600
-  token cannot either. The cookie is HttpOnly + SameSite=Strict.
+- browser bootstrap (POST /browser-sessions) presents NO capability
+  (spec #26, decision #29): Subfloor is a personal-machine tool, so the
+  machine's own local users and processes are not the adversary — a request
+  the browser itself vouches for (exact allowed Host, exact same-origin
+  Origin, Sec-Fetch-Site: same-origin) mints a scoped session on its own.
+  The operator capability stays CLI/server-only; a bearer sent from browser
+  code is refused, because a capability reachable from browser JavaScript is
+  itself the leakage risk. The cookie is HttpOnly + SameSite=Strict.
+- browser sessions are live-process state only (never the DB, snapshot, or
+  logs), expire after 24h of inactivity, and rotate on every bootstrap.
 - hook callbacks authenticate with the generation-scoped hook token only;
   it can call NOTHING else.
 - every Interface route rejects a Host outside 127.0.0.1/localhost (DNS
   rebind) and a cross-site Origin/Sec-Fetch-Site on mutations.
+
+The retained boundary is the hostile web origin, not the local machine: a
+foreign page can forge neither Origin nor Sec-Fetch-Site, CORS stays off,
+and the SameSite=Strict cookie plus X-CSRF fences cross-site mutation.
 
 Every mutation (hook-callbacks excepted — hook_seq is its idempotency)
 requires Idempotency-Key; an exact retry replays the stored response, a key
@@ -59,9 +68,13 @@ import shell_liveness  # noqa: E402
 TICKET_TTL_S = 60
 RESERVATION_TTL_S = 60
 IDEM_TTL_S = 24 * 3600
+BROWSER_SESSION_TTL_S = 24 * 3600      # inactivity deadline (spec #26)
 _ALLOWED_HOSTS = ("127.0.0.1", "localhost", "[::1]")
 
 _runtime = None          # bound by bind_runtime()
+# Browser sessions are live-process state ONLY (spec #26 Session Lifecycle):
+# never the DB, a snapshot, or a log — so a service restart invalidates them
+# all, which is exactly the intended recovery path.
 _browser_sessions: dict = {}
 _browser_lock = threading.Lock()
 
@@ -140,17 +153,26 @@ def _host_ok(headers) -> bool:
     return host in {h.strip("[]") for h in _ALLOWED_HOSTS}
 
 
-def _same_origin_proof(headers) -> bool:
-    """The bootstrap's hostile-site fence: an explicit Origin must match the
-    request's Host; without one, Sec-Fetch-Site (which browsers forbid sites
-    from forging) must say same-origin or be absent (CLI)."""
-    origin = headers.get("Origin")
+def _browser_origin(headers) -> "str | None":
+    """The bootstrap's hostile-site fence (spec #26 Bootstrap Flow 2). This
+    route is browser-only, so — unlike the header-tolerant mutation check
+    below, which also serves the CLI — provenance must be positively proven:
+    an exact same-origin Origin AND `Sec-Fetch-Site: same-origin`, both of
+    which a browser forbids a foreign page from forging. Missing,
+    cross-site, or malformed provenance returns None (fail closed).
+    Returns the proven Origin's scheme, which decides the cookie's
+    `Secure` attribute."""
+    from urllib.parse import urlparse
+    origin = headers.get("Origin") or ""
     host = headers.get("Host") or ""
-    if origin:
-        from urllib.parse import urlparse
-        return urlparse(origin).netloc == host
-    sfs = headers.get("Sec-Fetch-Site")
-    return sfs in (None, "same-origin", "none")
+    if not origin or not host:
+        return None
+    parsed = urlparse(origin)
+    if parsed.scheme not in ("http", "https") or parsed.netloc != host:
+        return None
+    if (headers.get("Sec-Fetch-Site") or "") != "same-origin":
+        return None
+    return parsed.scheme
 
 
 def _mutation_site_ok(headers) -> bool:
@@ -185,17 +207,40 @@ def _resolve_actor(headers) -> "_Actor | None":
                 return _Actor("shell", f"shell:{row[0]}", True,
                               shell_id=row[0])
         return None
-    cookie = headers.get("Cookie") or ""
-    for part in cookie.split(";"):
-        k, _, v = part.strip().partition("=")
-        if k == "sc_if" and v:
-            with _browser_lock:
-                sess = _browser_sessions.get(v)
+    sid = _cookie_session_id(headers)
+    if sid:
+        now = time.time()
+        with _browser_lock:
+            _sweep_browser_sessions(now)
+            sess = _browser_sessions.get(sid)
             if sess is None:
                 return None
-            csrf_ok = (headers.get("X-CSRF") or "") == sess["csrf"]
-            return _Actor("browser", f"browser:{v[:16]}", csrf_ok)
+            # Successful authenticated use advances the inactivity deadline
+            # (spec #26 Session Lifecycle).
+            sess["last_seen"] = now
+            csrf = sess["csrf"]
+        return _Actor("browser", f"browser:{sid[:16]}",
+                      (headers.get("X-CSRF") or "") == csrf)
     return None
+
+
+def _cookie_session_id(headers) -> str:
+    """The `sc_if` browser-session identifier, or '' when absent."""
+    for part in (headers.get("Cookie") or "").split(";"):
+        k, _, v = part.strip().partition("=")
+        if k == "sc_if" and v:
+            return v
+    return ""
+
+
+def _sweep_browser_sessions(now: float) -> None:
+    """Drop every session past its inactivity deadline. Cleanup rides the
+    requests that touch the store (spec #26: no scheduled model or harness
+    poll); the store is one dict per live process, so the sweep is bounded
+    by the number of live browser sessions. Caller holds `_browser_lock`."""
+    for sid in [s for s, sess in _browser_sessions.items()
+                if now - sess["last_seen"] >= BROWSER_SESSION_TTL_S]:
+        del _browser_sessions[sid]
 
 
 # ------------------------------------------------------------------ idempotency
@@ -2170,28 +2215,50 @@ def _on_unexpected_exit(session_id: int) -> None:
 # ------------------------------------------------------------------ bootstrap
 
 def _browser_session(headers, body):
-    """Bootstrap = an EXCHANGE (spec #20 API Resources, decision on flag
-    #43): the caller presents the mode-0600 operator capability and gets an
-    HttpOnly SameSite=Strict browser session back. Same-origin proof alone
-    mints NOTHING — without the capability any local process could
-    self-mint operator-equivalent authority."""
-    if not _same_origin_proof(headers):
+    """Bootstrap = automatic same-origin minting (spec #26, decision #29,
+    superseding the operator-capability exchange of decision #26): Subfloor
+    is a personal-machine tool, so the machine's own local users and
+    processes are not principals it isolates itself from. A request the
+    browser itself vouches for therefore mints a scoped session with NO
+    capability presented.
+
+    What that trades away is friction against a local self-minter — an
+    excluded actor. What it buys is that the mode-0600 operator capability
+    never enters browser JavaScript at all, since a capability reachable
+    from page script is itself the leakage risk (decision #30). The bearer
+    is refused here rather than ignored, so browser code cannot start
+    sending one back. The fences that remain are the ones that face the web:
+    exact Host (DNS rebind), exact same-origin Origin + Sec-Fetch-Site
+    (hostile page), HttpOnly + SameSite=Strict cookie, and X-CSRF on every
+    mutation."""
+    scheme = _browser_origin(headers)
+    if scheme is None:
         return _err(403, "not_same_origin",
-                    "browser sessions mint only from the same-origin UI")
-    authz = headers.get("Authorization") or ""
-    token = authz[7:].strip() if authz[:7].lower() == "bearer " else ""
-    if not token or token != _operator_token():
-        return _err(401, "operator_capability_required",
-                    "browser bootstrap exchanges the operator capability "
-                    "(Authorization: Bearer <operator token>)")
+                    "browser sessions mint only from a same-origin Interface "
+                    "page (exact Origin + Sec-Fetch-Site: same-origin)")
+    if headers.get("Authorization"):
+        return _err(403, "bearer_not_accepted",
+                    "browser bootstrap presents no capability — the operator "
+                    "capability is CLI/server-only and must never be sent "
+                    "from browser code")
     if not (headers.get("Idempotency-Key") or ""):
         return _err(422, "idempotency_key_required",
                     "Idempotency-Key header is required for Interface mutations")
-    token = secrets.token_hex(24)
+    now = time.time()
+    sid = secrets.token_hex(24)
     csrf = secrets.token_hex(24)
+    prior = _cookie_session_id(headers)
     with _browser_lock:
-        _browser_sessions[token] = {"csrf": csrf, "created": time.time()}
-    cookie = (f"sc_if={token}; HttpOnly; SameSite=Strict; Path=/")
+        _sweep_browser_sessions(now)
+        # Rotation revokes: the session the caller presented dies in the same
+        # critical section that mints its replacement, so no window exists in
+        # which both the old and the new identifier are usable.
+        if prior:
+            _browser_sessions.pop(prior, None)
+        _browser_sessions[sid] = {"csrf": csrf, "created": now,
+                                  "last_seen": now}
+    cookie = (f"sc_if={sid}; HttpOnly; SameSite=Strict; Path=/"
+              + ("; Secure" if scheme == "https" else ""))
     return _json(201, {"csrf": csrf}, headers=[("Set-Cookie", cookie)])
 
 
@@ -2227,7 +2294,8 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
     from urllib.parse import parse_qs, urlparse
     headers = _parse_headers(headers_raw)
     if not _host_ok(headers):
-        return _err(403, "bad_host", "Interface API serves 127.0.0.1/localhost only")
+        return _err(403, "host_not_allowed",
+                    "Interface API serves 127.0.0.1/localhost only")
     u = urlparse(path)
     p = u.path
     query = parse_qs(u.query)
@@ -2250,6 +2318,13 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
 
     actor = _resolve_actor(headers)
     if actor is None:
+        # A cookie the store no longer knows — expired, revoked by a
+        # rotation, or wiped by a service restart. Naming that distinctly is
+        # what lets the UI bootstrap once and retry silently (spec #26
+        # Session Lifecycle) instead of surfacing an error to the operator.
+        if _cookie_session_id(headers) and not headers.get("Authorization"):
+            return _err(401, "browser_session_expired",
+                        "browser session expired — bootstrap a new one")
         return _err(401, "unauthorized",
                     "operator bearer or browser session required")
     # Shell actors (the planner's own API token) reach ONLY the sprint-wake

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -254,14 +254,21 @@ def _commit_browser_use(sid: str) -> bool:
     after the request was authorized but before its handler runs any side
     effect. Re-checking membership here, immediately before dispatch, is what
     makes spec #26's "atomically replaces" true against in-flight requests:
-    a revoked identifier cannot reach a handler.
+    it collapses that window from the whole fence chain to the gap described
+    below.
 
     The alternative — holding `_browser_lock` across dispatch — was rejected:
     handlers do blocking sqlite and subprocess work, so it would serialize
-    every Interface request behind the slowest one. The residual window is
-    therefore revocation landing DURING a handler's own execution, which is
-    not interrupted; that request completes under the authority it held when
-    it started. Stated rather than papered over.
+    every Interface request behind the slowest one. So the lock is released
+    when this returns, and route selection and the handler run outside it.
+    The residual window is therefore: ANY REQUEST THAT HAS PASSED THIS RECHECK
+    MAY FINISH. Revocation landing after the recheck returns True — whether
+    the handler has started or not — does not stop that request; it completes
+    under the authority it held when it passed. The narrower phrasing this
+    replaced ("a revoked identifier cannot reach a handler", residual =
+    revocation during a handler's own execution) claimed more than the code
+    does: rotation landing between this return and the handler's first line
+    still reaches the handler. Stated rather than papered over.
 
     Returns False when the session is gone (rotated away, expired, or lost to
     a restart) — the caller answers 401 and the UI recovers.

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -141,11 +141,12 @@ def _parse_headers(headers_raw: str):
 
 class _Actor:
     def __init__(self, kind: str, scope: str, csrf_ok: bool,
-                 shell_id: "int | None" = None):
+                 shell_id: "int | None" = None, sid: str = ""):
         self.kind = kind          # "operator" | "browser" | "shell"
         self.scope = scope        # idempotency actor_scope
         self.csrf_ok = csrf_ok    # mutation authority for browser actors
         self.shell_id = shell_id  # set for kind="shell" (the planner's token)
+        self.sid = sid            # set for kind="browser" (re-checked at commit)
 
 
 def _host_ok(headers) -> bool:
@@ -215,13 +216,49 @@ def _resolve_actor(headers) -> "_Actor | None":
             sess = _browser_sessions.get(sid)
             if sess is None:
                 return None
-            # Successful authenticated use advances the inactivity deadline
-            # (spec #26 Session Lifecycle).
-            sess["last_seen"] = now
             csrf = sess["csrf"]
+        # NB: the inactivity deadline is NOT advanced here. Resolving a cookie
+        # is not yet "successful authenticated use" (spec #26 Session
+        # Lifecycle) — the anti-forgery, provenance, and scope fences below
+        # can still reject this request, and a rejected request must not keep
+        # a session alive. `_commit_browser_use` does it once those pass.
         return _Actor("browser", f"browser:{sid[:16]}",
-                      (headers.get("X-CSRF") or "") == csrf)
+                      (headers.get("X-CSRF") or "") == csrf, sid=sid)
     return None
+
+
+def _commit_browser_use(sid: str) -> bool:
+    """Authorize a browser request at the point of dispatch, in one critical
+    section, and advance its inactivity deadline.
+
+    Two findings share this function because they are the same window. The
+    fences run against a session resolved earlier in the request, and
+    `_browser_lock` is released in between — so a bootstrap arriving
+    concurrently can revoke that session (rotation removes the presented sid)
+    after the request was authorized but before its handler runs any side
+    effect. Re-checking membership here, immediately before dispatch, is what
+    makes spec #26's "atomically replaces" true against in-flight requests:
+    a revoked identifier cannot reach a handler.
+
+    The alternative — holding `_browser_lock` across dispatch — was rejected:
+    handlers do blocking sqlite and subprocess work, so it would serialize
+    every Interface request behind the slowest one. The residual window is
+    therefore revocation landing DURING a handler's own execution, which is
+    not interrupted; that request completes under the authority it held when
+    it started. Stated rather than papered over.
+
+    Returns False when the session is gone (rotated away, expired, or lost to
+    a restart) — the caller answers 401 and the UI recovers.
+    """
+    now = time.time()
+    with _browser_lock:
+        _sweep_browser_sessions(now)
+        sess = _browser_sessions.get(sid)
+        if sess is None:
+            return False
+        # Only successful authenticated use advances the deadline (spec #26).
+        sess["last_seen"] = now
+        return True
 
 
 def _cookie_session_id(headers) -> str:
@@ -2344,6 +2381,13 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
         if not _mutation_site_ok(headers):
             return _err(403, "not_same_origin",
                         "cross-site mutation rejected")
+    # Every fence above has passed, and nothing below this line rejects on
+    # authority — so this is the one point where the request is known to be
+    # successful authenticated use. Re-check the session against a concurrent
+    # rotation and advance its deadline in the same critical section.
+    if actor.kind == "browser" and not _commit_browser_use(actor.sid):
+        return _err(401, "browser_session_expired",
+                    "browser session expired — bootstrap a new one")
 
     try:
         if p == "/api/interface/shells" and method == "GET":

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -27,6 +27,7 @@ import base64
 import gzip
 import http.client
 import io
+import ipaddress
 import json
 import os
 import subprocess
@@ -2809,6 +2810,44 @@ async def _ws_unavailable(reader, writer, head_raw: bytes) -> None:
         writer.close()
 
 
+def require_loopback_bind(bind: str) -> None:
+    """Spec #26 Failure Modes: a non-loopback bind refuses to start, because
+    the Interface hands a browser session to anything that can present an
+    allowed `Host` and a same-origin `Origin` — headers a REMOTE client
+    chooses freely. On a host, a non-loopback bind therefore turns automatic
+    minting into remote authority, and no other fence stands behind it.
+
+    The guard is host-scoped by design, and the exception is not a loophole.
+    In the sandbox container `./sc launch` sets SC_BIND=0.0.0.0 deliberately
+    so docker can publish the port, and the boundary is supplied there by the
+    `-p 127.0.0.1:PORT:PORT` mapping — loopback-only on the host regardless of
+    the in-container bind. Refusing 0.0.0.0 unconditionally would make the
+    sandbox unlaunchable while removing no real exposure. SC_SANDBOX=1 is set
+    by that same launch path and is the available discriminator.
+
+    So the guarantee is: reachable only from the host's loopback interface —
+    enforced in-process off-sandbox, and by docker's port mapping in it.
+    """
+    if os.environ.get("SC_SANDBOX"):
+        return
+    host = (bind or "").strip().strip("[]")
+    if host.lower() == "localhost":
+        return
+    try:
+        if ipaddress.ip_address(host).is_loopback:
+            return
+    except ValueError:
+        pass
+    sys.exit(
+        f"server: refusing to start — SC_BIND={bind!r} is not a loopback "
+        "address (spec #26). The Interface mints a browser session for any "
+        "caller that can set Host and Origin, so a non-loopback bind would "
+        "expose it to the network. Unset SC_BIND or set it to 127.0.0.1. "
+        "Remote access needs a separately authenticated boundary (e.g. a "
+        "tailnet), not a wider bind."
+    )
+
+
 def main(argv):
     port = None
     if "--port" in argv:
@@ -2857,6 +2896,7 @@ def main(argv):
     # publish the port — the jail is the `-p 127.0.0.1:PORT:PORT` mapping, which
     # keeps it loopback-only on the host regardless of the in-container bind.
     bind = os.environ.get("SC_BIND", "127.0.0.1")
+    require_loopback_bind(bind)
     import transport  # noqa: E402  (api/ — asyncio one-port multiplex)
 
     async def _serve():

--- a/.super-coder/docs/interface-trust-boundary.md
+++ b/.super-coder/docs/interface-trust-boundary.md
@@ -1,0 +1,147 @@
+---
+title: Interface trust boundary & browser sign-in
+tags: [super-coder, interface, security, browser, auth]
+date: 2026-07-24
+project: super-coder
+purpose: What the Interface defends against, why the browser is signed in automatically, and who owns the running service
+---
+
+# Interface trust boundary & browser sign-in
+
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/subfloor/blob/main/.super-coder/docs/interface-trust-boundary.md)
+
+## The short version
+
+Open the Interface tab and it works. There is nothing to paste, no sign-in
+step, and no credential to keep anywhere.
+
+That is deliberate, and this page is the reasoning — because "it just opens"
+is exactly the sentence that should make you ask what is being trusted.
+
+## What Subfloor treats as trusted
+
+**The personal machine and the people who use it** (decision `#29`).
+
+Subfloor is a personal-machine tool. The expected deployment is one user, or
+two or three mutually trusted family members. Under that model these are
+**not** adversaries and Subfloor does not try to isolate itself from them:
+
+- other processes running as you,
+- other same-UID shells,
+- other trusted local accounts on the same machine.
+
+That is not a concession — it is a statement of what the tool is for. Software
+already running as you can reach your repositories, your harness credentials,
+your terminal processes, and every loopback service you run. A lock on the
+Interface would not change that; it would only add friction for the owner.
+
+**If untrusted people use your machine, do not run Subfloor on it.** That is
+the boundary, stated plainly, rather than a control that implies a protection
+it cannot deliver.
+
+## What Subfloor defends against
+
+The web, and the network — in full, and these controls are release-critical:
+
+| Threat | Control |
+|---|---|
+| A webpage on another origin scripting your Interface | Exact same-origin `Origin` **and** `Sec-Fetch-Site: same-origin` on bootstrap; `SameSite=Strict` cookie; `X-CSRF` on every mutation; CORS stays off |
+| Cross-site request forgery | `SameSite=Strict` + an anti-forgery token held only in page memory |
+| DNS rebinding | Exact `Host` allowlist (`127.0.0.1` / `localhost`), every route |
+| Accidental network exposure | The service binds loopback only; a non-loopback bind refuses to start |
+| Credential leakage from the browser | The browser is never given a credential to leak — see below |
+| Remote clients | No route in; reach it through your own secure transport (e.g. a tailnet) or not at all |
+
+Same-origin script execution is operator-equivalent here. The restrictive CSP,
+the vendored scripts, the sanitized rendered content, and the absence of any
+third-party runtime asset are therefore security controls, not hygiene — an
+XSS bug in the Interface is a security defect, not a rendering defect.
+
+## Why the browser is not given the operator capability
+
+The Interface API has an operator capability: `.super-coder/run/interface/
+operator.token`, mode `0600`, provisioned at server boot. The **CLI** uses it.
+The **browser never sees it.**
+
+An earlier build asked the operator to paste that token into a browser prompt.
+That defended against a local process self-minting browser authority — an
+actor the trust boundary above excludes — and it did so by putting a
+long-lived filesystem capability into page JavaScript, where an XSS bug could
+exfiltrate it. It bought protection from a non-adversary at the cost of a real
+leak path (decisions `#29`, `#30`).
+
+So the browser presents nothing, and receives nothing durable:
+
+1. The Interface tab POSTs to `/api/interface/browser-sessions` with no
+   `Authorization` header. A bearer sent from browser code is **refused**, so
+   page script cannot start carrying one.
+2. The server checks provenance the browser itself vouches for and a foreign
+   page cannot forge: exact allowed `Host`, exact same-origin `Origin`,
+   `Sec-Fetch-Site: same-origin`. Anything missing or cross-site is `403`.
+3. It mints a scoped session, returned **only** as an `HttpOnly`,
+   `SameSite=Strict`, `Path=/` cookie (plus `Secure` if you front it with
+   HTTPS). `HttpOnly` means page script cannot read it either.
+4. The anti-forgery token comes back in the response body, lives in page
+   memory, and is sent as `X-CSRF` on every mutation.
+
+The session is scoped to the Interface. It is not an operator capability and
+does not become one: viewer versus writer authority still comes from the
+writer-lease protocol, streams still need single-use generation-bound tickets,
+and CLI and hook capabilities are unchanged.
+
+## Session lifecycle
+
+Browser sessions are **live-process state only** — never the DB, a snapshot,
+rendered state, or a log.
+
+- **24-hour inactivity deadline.** Authenticated use advances it; past it the
+  server deletes the session and answers `401 browser_session_expired`.
+- **Rotation revokes.** Every bootstrap mints a new identifier and a new
+  anti-forgery token, and destroys the session the caller presented in the
+  same step.
+- **A service restart invalidates every session.** That is the normal recovery
+  path, not a fault.
+- **One silent retry.** On the first `401` the UI bootstraps once and retries
+  the original request with its original idempotency key — so recovery cannot
+  duplicate a mutation. A second failure surfaces the error; it never loops.
+- **Cookies blocked?** The Interface says browser sessions are unavailable. It
+  does not fall back to a pasted token, because there is nothing to fall back
+  to.
+
+Several browsers may hold sessions at once. They all get the same scope and no
+distinct identity; only the writer-lease holder can send input.
+
+## Who owns the running service
+
+The supervised service runs **as the installing user, with no elevated host
+privilege**:
+
+- The sandbox container runs under your uid/gid — or, under rootless Docker,
+  as a namespace root that maps to your host user. Either way nothing it
+  writes to the bind-mounted repo lands root-owned.
+- Optional brokers install as `systemctl --user` units. User-level systemd, no
+  system units, no root.
+- The engine never invokes `sudo`. The only `sudo` in Subfloor is *printed
+  advice* during one-time host setup (`./sc doctor`) for installing Docker
+  itself — an OS package step you perform, not something the service does.
+- The published port is bound to `127.0.0.1` only.
+
+One caveat worth stating rather than hiding: on **rootful** Docker, membership
+in the `docker` group is effectively root-equivalent on the host. That is a
+property of Docker, not of Subfloor, and it is the reason `./sc doctor` offers
+rootless Docker first.
+
+There is no service account, no privilege broker, no OS keychain, and no
+per-user identity inside Subfloor — by design. Adding them would imply
+isolation between local users that the trust boundary above explicitly does
+not claim.
+
+## Related
+
+- `./sc token` — prints the **Review GUI** sign-in credential (the Admin
+  runtime credential under `.super-coder/run/mem/`). That is a different
+  surface from the Interface browser session described here, and it is
+  unaffected.
+- Decisions `#29` (browser mints a scoped same-origin session; the operator
+  capability stays out of browser JavaScript) and `#30` (the personal-machine
+  threat-model ruling that set the direction).

--- a/.super-coder/docs/interface-trust-boundary.md
+++ b/.super-coder/docs/interface-trust-boundary.md
@@ -123,9 +123,12 @@ rendered state, or a log.
 - **Rotation revokes.** Every bootstrap mints a new identifier and a new
   anti-forgery token, and destroys the session the caller presented in the
   same step. A request still in flight under the revoked identifier is
-  re-checked at dispatch and answered `401` rather than completing — the one
-  exception being a handler already executing, which finishes under the
-  authority it started with.
+  re-checked at dispatch and answered `401` rather than completing. The
+  exception is bounded by that check, not by the handler: once a request has
+  passed the dispatch re-check it finishes under the authority it held when it
+  passed, whether or not its handler has started. The re-check is not held
+  across dispatch — doing so would serialize every Interface request behind
+  the slowest blocking handler.
 - **A service restart invalidates every session.** That is the normal recovery
   path, not a fault.
 - **One silent retry.** On the first `401` the UI bootstraps once and retries

--- a/.super-coder/docs/interface-trust-boundary.md
+++ b/.super-coder/docs/interface-trust-boundary.md
@@ -48,9 +48,33 @@ The web, and the network — in full, and these controls are release-critical:
 | A webpage on another origin scripting your Interface | Exact same-origin `Origin` **and** `Sec-Fetch-Site: same-origin` on bootstrap; `SameSite=Strict` cookie; `X-CSRF` on every mutation; CORS stays off |
 | Cross-site request forgery | `SameSite=Strict` + an anti-forgery token held only in page memory |
 | DNS rebinding | Exact `Host` allowlist (`127.0.0.1` / `localhost`), every route |
-| Accidental network exposure | The service binds loopback only; a non-loopback bind refuses to start |
+| Accidental network exposure | Reachable from the host's loopback interface only — see [the exact guarantee](#the-bind-guarantee-exactly) |
 | Credential leakage from the browser | The browser is never given a credential to leak — see below |
 | Remote clients | No route in; reach it through your own secure transport (e.g. a tailnet) or not at all |
+
+### The bind guarantee, exactly
+
+Because the browser session mints automatically, the *only* thing standing
+between a remote client and Interface authority is that the remote client
+cannot reach the port — a network client able to choose its own `Host` and
+`Origin` headers passes every other fence. So it is worth being precise about
+what enforces that, rather than restating "binds loopback only":
+
+- **On your host** (`./sc serve`, the supervised stack): the server checks
+  `SC_BIND` at startup and **exits** unless it is a loopback address. Setting
+  `SC_BIND=0.0.0.0` does not widen the Interface; it stops it booting.
+- **Inside the sandbox container**: the bind *is* `0.0.0.0`, deliberately, so
+  docker can publish the port — and the boundary is the published mapping,
+  `-p 127.0.0.1:PORT:PORT`, which is loopback-only on the host whatever the
+  container binds. The in-process guard stands down there (it detects
+  `SC_SANDBOX`) because refusing would break `./sc launch` without removing
+  any exposure.
+
+Net: reachable from the host's loopback interface only, enforced in-process
+off-sandbox and by docker's port mapping in it. Neither path exposes the
+Interface to the network, and neither claims more than it does. Remote access
+is a separate authenticated boundary you put in front (e.g. a tailnet) — never
+a wider bind.
 
 Same-origin script execution is operator-equivalent here. The restrictive CSP,
 the vendored scripts, the sanitized rendered content, and the absence of any
@@ -98,7 +122,10 @@ rendered state, or a log.
   server deletes the session and answers `401 browser_session_expired`.
 - **Rotation revokes.** Every bootstrap mints a new identifier and a new
   anti-forgery token, and destroys the session the caller presented in the
-  same step.
+  same step. A request still in flight under the revoked identifier is
+  re-checked at dispatch and answered `401` rather than completing — the one
+  exception being a handler already executing, which finishes under the
+  authority it started with.
 - **A service restart invalidates every session.** That is the normal recovery
   path, not a fault.
 - **One silent retry.** On the first `401` the UI bootstraps once and retries

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2132,10 +2132,16 @@ async function ifBootstrap() {
   ifCsrf = data.csrf;
 }
 // api() twin for /api/interface/* — same-origin credentials + X-CSRF. One
-// silent re-bootstrap + retry on 401/403 (the session expired, or the server
-// restarted). The Idempotency-Key is minted once per CALL, never per attempt,
-// so that retry replays the original mutation instead of running a second
-// one — recovery must not be able to duplicate a mutation (spec #26).
+// silent re-bootstrap + retry on the first 401 ONLY: 401 is the spec's
+// recovery signal (the session expired, was rotated away, or the server
+// restarted). A 403 is a fence that fired — a malformed anti-forgery token, a
+// cross-site mutation, a disallowed Host — and those must fail closed and
+// surface, because re-bootstrapping on 403 would hand the caller a fresh
+// valid token and turn the CSRF gate into a retry (spec #26 Session
+// Lifecycle: "On the first 401"). The Idempotency-Key is minted once per
+// CALL, never per attempt, so that retry replays the original mutation
+// instead of running a second one — recovery must not be able to duplicate a
+// mutation (spec #26).
 async function apiIf(path, method = "GET", body, idemKey) {
   const key = method === "GET" ? undefined : (idemKey || crypto.randomUUID());
   for (let attempt = 0; attempt < 2; attempt++) {
@@ -2147,7 +2153,7 @@ async function apiIf(path, method = "GET", body, idemKey) {
       method, credentials: "same-origin", headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });
-    if ((r.status === 401 || r.status === 403) && attempt === 0) { ifCsrf = null; continue; }
+    if (r.status === 401 && attempt === 0) { ifCsrf = null; continue; }
     const data = r.status === 204 ? {} : await r.json().catch(() => ({}));
     if (!r.ok) throw ifError(r, data);
     return data;

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2108,50 +2108,34 @@ function ifError(r, data) {
   err.body = data;
   return err;
 }
-// Bootstrap the operator browser session: EXCHANGES the operator capability
-// (the mode-0600 token at .super-coder/run/interface/operator.token) for the
-// HttpOnly SameSite=Strict cookie + the CSRF token we then send as X-CSRF on
-// every call. The capability is used ONCE for the exchange, then discarded —
-// never persisted (no sessionStorage) and cleared from JS memory the moment
-// the session mints, so no long-lived credential sits where XSS can reach it.
-// A later 401 (session gone: refresh, server restart) re-prompts the operator.
-let ifOpToken = null;
-// Drop any capability an older build persisted before the one-shot model.
+// Bootstrap the browser session (spec #26, decision #29): a same-origin POST
+// mints the HttpOnly SameSite=Strict cookie plus the anti-forgery token we
+// send as X-CSRF on every call. The browser presents NO capability — the
+// mode-0600 operator token stays CLI/server-only and never enters this file,
+// page memory, storage, a URL, or a request, because a credential reachable
+// from page script is itself what leaks. The anti-forgery token lives in JS
+// memory only and is replaced on every bootstrap.
+// Drop any capability an older build left behind — nothing here writes one.
 try { sessionStorage.removeItem("sc-if-op"); } catch { /* storage blocked */ }
 async function ifBootstrap() {
-  for (let attempt = 0; attempt < 2; attempt++) {
-    const headers = { "Content-Type": "application/json", "Idempotency-Key": crypto.randomUUID() };
-    if (ifOpToken) headers["Authorization"] = "Bearer " + ifOpToken;
-    let r;
-    try {
-      r = await fetch("/api/interface/browser-sessions", {
-        method: "POST", credentials: "same-origin", headers, body: "{}",
-      });
-    } catch (e) {
-      ifOpToken = null;   // network failure — never keep a half-used capability
-      throw e;
-    }
-    const data = await r.json().catch(() => ({}));
-    if (r.ok) { ifCsrf = data.csrf; ifOpToken = null; return; }
-    if (r.status === 401 && attempt === 0) {
-      const t = prompt(
-        "Interface operator capability required — paste the contents of\n" +
-        ".super-coder/run/interface/operator.token (mode 0600, operator-only):",
-        "");
-      if (!t) { ifOpToken = null; throw ifError(r, data); }
-      ifOpToken = t.trim();
-      continue;
-    }
-    // EVERY other non-ok exit (rejected 401 retry, 403, 409, 422, 5xx,
-    // malformed body) drops the capability uniformly — it never survives a
-    // failed exchange, no matter which branch failed.
-    ifOpToken = null;
-    throw ifError(r, data);
-  }
+  // The session IS the cookie, so a browser refusing cookies cannot hold one.
+  // Say that plainly rather than looping: there is no credential to fall back
+  // on by design.
+  if (!navigator.cookieEnabled)
+    throw new Error("Interface browser sessions unavailable — this browser is blocking cookies.");
+  const r = await fetch("/api/interface/browser-sessions", {
+    method: "POST", credentials: "same-origin", body: "{}",
+    headers: { "Content-Type": "application/json", "Idempotency-Key": crypto.randomUUID() },
+  });
+  const data = await r.json().catch(() => ({}));
+  if (!r.ok) throw ifError(r, data);
+  ifCsrf = data.csrf;
 }
-// api() twin for /api/interface/* — same-origin credentials + X-CSRF, fresh
-// Idempotency-Key per ATTEMPT on POST/DELETE (an intentional retry reuses the
-// caller's key). One silent re-bootstrap + retry on 401/403.
+// api() twin for /api/interface/* — same-origin credentials + X-CSRF. One
+// silent re-bootstrap + retry on 401/403 (the session expired, or the server
+// restarted). The Idempotency-Key is minted once per CALL, never per attempt,
+// so that retry replays the original mutation instead of running a second
+// one — recovery must not be able to duplicate a mutation (spec #26).
 async function apiIf(path, method = "GET", body, idemKey) {
   const key = method === "GET" ? undefined : (idemKey || crypto.randomUUID());
   for (let attempt = 0; attempt < 2; attempt++) {

--- a/sc
+++ b/sc
@@ -1432,6 +1432,8 @@ super-coder — forkable shell substrate
                              view <shell> (read-only) · attach <shell> (writer) · take-control <shell>
                              stop <shell> [--force] · reconcile <shell> [--close]
                              recover <shell> [--force] [--discard-worktree] [--yes] — mutations take --json
+                             (the browser opens the Interface with no sign-in step: what that trusts and
+                             what it still defends against is .super-coder/docs/interface-trust-boundary.md)
   make dos-help            supported operator aliases for lifecycle, Interface, models,
                              sprint/watch/job, maintenance, browser token, and generic ./sc forwarding
   ./sc run <shortname>     headless boot: render + exec the harness NON-interactively (claude · codex ·

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -584,6 +584,48 @@ class InterfaceApiTest(unittest.TestCase):
                                  (f"Cookie: {new_cookie}",))
         self.assertEqual(status, 200)
 
+    def test_rotation_after_the_dispatch_recheck_does_not_stop_the_request(self):
+        """The residual window, pinned instead of only described.
+
+        The re-check above is deliberately NOT held across dispatch — handlers
+        do blocking sqlite and subprocess work, so holding it would serialize
+        every Interface request behind the slowest one. The honest consequence
+        is that a rotation landing after the re-check returns True cannot stop
+        that request, whether or not its handler has started: it finishes under
+        the authority it held when it passed. `_commit_browser_use` and the
+        trust-boundary doc state exactly that bound, and this test is what
+        holds the prose to it — strengthen the synchronization and this goes
+        red, which is the correct time to rewrite both."""
+        cookie, csrf = self._browser()
+        first = cookie.split("=", 1)[1]
+        rotated = []
+        real_commit = routes._commit_browser_use
+
+        def commit_then_rotate(sid):
+            # Runs once, AFTER the real re-check has authorized this request —
+            # the exact gap before route selection reaches the handler.
+            ok = real_commit(sid)
+            if ok and not rotated:
+                status, hdrs_, _ = self._bootstrap(f"Cookie: {cookie}",
+                                                   key="b-postcheck")
+                assert status == 201
+                rotated.append(hdrs_["Set-Cookie"].split(";")[0])
+            return ok
+
+        with mock.patch.object(routes, "_commit_browser_use",
+                               commit_then_rotate):
+            status, _, body = self.call(
+                "POST", "/api/interface/sessions",
+                (f"Cookie: {cookie}", f"X-CSRF: {csrf}",
+                 "Idempotency-Key: c-postcheck"), {"shell_id": 1})
+        # The request completed: revocation after the re-check does not reach
+        # back into a request the re-check already let through.
+        self.assertEqual(status, 201, body)
+        # And the rotation really did happen — this is the residual window,
+        # not a test that quietly failed to revoke anything.
+        self.assertTrue(rotated, "the concurrent bootstrap never ran")
+        self.assertNotIn(first, routes._browser_sessions)
+
     def test_browser_sessions_are_live_process_state_only(self):
         """A restart wipes them — which is exactly the contract the UI's one
         silent re-bootstrap relies on, and why they never touch the DB."""

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -491,6 +491,88 @@ class InterfaceApiTest(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertGreater(routes._browser_sessions[sid]["last_seen"], stale)
 
+    def test_rejected_calls_do_not_advance_the_deadline(self):
+        """Spec #26: ONLY successful authenticated use advances the
+        inactivity deadline. A call that a fence rejected is not use — so a
+        session cannot be kept alive indefinitely by traffic that never
+        authenticates, including traffic a hostile page can cause."""
+        cookie, csrf = self._browser()
+        sid = cookie.split("=", 1)[1]
+        stale = time.time() - routes.BROWSER_SESSION_TTL_S + 60
+        rejected = (
+            ("cookie-only mutation", (f"Cookie: {cookie}",
+                                      "Idempotency-Key: d1")),
+            ("malformed anti-forgery token",
+             (f"Cookie: {cookie}", "X-CSRF: not-the-token",
+              "Idempotency-Key: d2")),
+            ("cross-site mutation",
+             (f"Cookie: {cookie}", f"X-CSRF: {csrf}",
+              "Origin: http://evil.example.com",
+              "Sec-Fetch-Site: cross-site", "Idempotency-Key: d3")),
+        )
+        for label, header_lines in rejected:
+            with self.subTest(label):
+                routes._browser_sessions[sid]["last_seen"] = stale
+                status, _, _ = self.call("POST", "/api/interface/sessions",
+                                         header_lines, {"shell_id": 1})
+                self.assertEqual(status, 403)
+                self.assertEqual(
+                    routes._browser_sessions[sid]["last_seen"], stale,
+                    f"{label} refreshed the inactivity deadline")
+
+    def test_rotation_revokes_a_request_already_in_flight(self):
+        """Spec #26 Bootstrap Flow 4: a bootstrap atomically REPLACES the
+        session named by the presented cookie. Sequential revocation is
+        already covered above; what this pins is the concurrent case, which
+        is where the claim was previously false.
+
+        The interleaving is forced deterministically rather than raced: the
+        rotation is driven from inside the fence that runs after the old
+        cookie resolved to an actor and before dispatch — exactly the window
+        a concurrent bootstrap would land in. The in-flight request must be
+        answered 401 and must NOT reach its handler."""
+        cookie, csrf = self._browser()
+        first = cookie.split("=", 1)[1]
+        rotated = []
+        real_site_ok = routes._mutation_site_ok
+
+        def rotate_then_check(headers):
+            # Runs once, after _resolve_actor accepted the old cookie.
+            if not rotated:
+                status, hdrs_, _ = self._bootstrap(f"Cookie: {cookie}",
+                                                   key="b-inflight")
+                assert status == 201
+                rotated.append(hdrs_["Set-Cookie"].split(";")[0])
+            return real_site_ok(headers)
+
+        def count_sessions():
+            con = sqlite3.connect(self.db_path)
+            try:
+                return con.execute(
+                    "SELECT COUNT(*) FROM interface_sessions").fetchone()[0]
+            finally:
+                con.close()
+
+        before = count_sessions()
+        with mock.patch.object(routes, "_mutation_site_ok",
+                               rotate_then_check):
+            status, _, body = self.call(
+                "POST", "/api/interface/sessions",
+                (f"Cookie: {cookie}", f"X-CSRF: {csrf}",
+                 "Idempotency-Key: c-inflight"), {"shell_id": 1})
+        self.assertEqual(status, 401, body)
+        self.assertEqual(body["error"]["code"], "browser_session_expired")
+        # The handler never ran: revocation beat the side effect, not just
+        # the response code.
+        self.assertEqual(count_sessions(), before,
+                         "a revoked session still created a chat")
+        self.assertNotIn(first, routes._browser_sessions)
+        # The replacement minted in that same window is the live one.
+        new_cookie = rotated[0]
+        status, _, _ = self.call("GET", "/api/interface/shells",
+                                 (f"Cookie: {new_cookie}",))
+        self.assertEqual(status, 200)
+
     def test_browser_sessions_are_live_process_state_only(self):
         """A restart wipes them — which is exactly the contract the UI's one
         silent re-bootstrap relies on, and why they never touch the DB."""

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -398,6 +398,17 @@ class InterfaceApiTest(unittest.TestCase):
              ("Origin: http://127.0.0.1:8800", "Sec-Fetch-Site: none")),
             ("scheme-relative junk Origin",
              ("Origin: 127.0.0.1:8800", "Sec-Fetch-Site: same-origin")),
+            # A serialized origin is scheme://host[:port] and stops there. A
+            # netloc-only comparison would wave all three of these through.
+            ("Origin bearing a path",
+             ("Origin: http://127.0.0.1:8800/ui/app.js",
+              "Sec-Fetch-Site: same-origin")),
+            ("Origin bearing a query",
+             ("Origin: http://127.0.0.1:8800?x=1",
+              "Sec-Fetch-Site: same-origin")),
+            ("Origin bearing a fragment",
+             ("Origin: http://127.0.0.1:8800#frag",
+              "Sec-Fetch-Site: same-origin")),
             ("no browser provenance at all", ()),
         ):
             with self.subTest(label):
@@ -638,6 +649,17 @@ class InterfaceApiTest(unittest.TestCase):
             (f"Cookie: {cookie}", f"X-CSRF: {csrf}",
              "Origin: http://evil.example.com",
              "Sec-Fetch-Site: cross-site", "Idempotency-Key: c4"),
+            {"shell_id": 1})
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error"]["code"], "not_same_origin")
+        # The mutation fence is header-tolerant (it also serves the CLI, which
+        # sends no Origin at all), but tolerant is not the same as loose: an
+        # Origin that IS present still has to be an exact serialized origin,
+        # not merely one whose netloc happens to match.
+        status, _, body = self.call(
+            "POST", "/api/interface/sessions",
+            (OP, "Idempotency-Key: c5",
+             "Origin: http://127.0.0.1:8800/ui/index.html?x=1"),
             {"shell_id": 1})
         self.assertEqual(status, 403)
         self.assertEqual(body["error"]["code"], "not_same_origin")

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -4,8 +4,9 @@ seq 5). Covers the vertical-slice contract WITHOUT tmux (the runtime is a
 fake implementing the facade; tmux integration lives in
 tests/test_interface_runtime.py):
 
-- authority: host allowlist, operator bearer, browser bootstrap same-origin
-  fence, CSRF on browser mutations, cross-site Origin rejection;
+- authority: host allowlist, operator bearer, automatic same-origin browser
+  bootstrap and its provenance fence (spec #26), browser-session rotation and
+  inactivity expiry, CSRF on browser mutations, cross-site Origin rejection;
 - idempotency: missing key → 422, exact replay returns the original
   resource with NO second side effect, key + different body → 409;
 - New chat: legacy/unmanaged harness refusal (409 unmanaged_harness),
@@ -33,6 +34,7 @@ import stat
 import sys
 import tempfile
 import threading
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -117,6 +119,9 @@ def hdrs(*lines) -> str:
 
 
 OP = "Authorization: Bearer optok"
+# What a real Interface page sends: exact same-origin Origin plus the fetch
+# metadata a browser forbids a foreign page from forging.
+BROWSER = ("Origin: http://127.0.0.1:8800", "Sec-Fetch-Site: same-origin")
 
 
 class InterfaceApiTest(unittest.TestCase):
@@ -140,6 +145,9 @@ class InterfaceApiTest(unittest.TestCase):
         for p in self.patches:
             p.start()
         self.ensure_wt = run_mod.ensure_worktree
+        # Browser sessions are process-global live state — start each test
+        # from the empty store a fresh server would have.
+        routes._browser_sessions.clear()
         routes.ensure_operator_capability()
         (run_dir / "operator.token").write_text("optok")
         self.runtime = FakeRuntime()
@@ -210,7 +218,7 @@ class InterfaceApiTest(unittest.TestCase):
         raw = "Host: evil.example.com\r\n" + OP
         status, _, body = routes.handle("GET", "/api/interface/shells", raw, b"")
         self.assertEqual(status, 403)
-        self.assertEqual(json.loads(body)["error"]["code"], "bad_host")
+        self.assertEqual(json.loads(body)["error"]["code"], "host_not_allowed")
 
     def test_auth_required(self):
         status, _, _ = self.call("GET", "/api/interface/shells")
@@ -332,49 +340,179 @@ class InterfaceApiTest(unittest.TestCase):
             if "model" in k and not k.startswith("default_"))
         self.assertEqual(set(session_model_keys), {"model_route"})
 
-    def test_browser_bootstrap_same_origin_fence(self):
-        # Cross-site Origin cannot mint a session (rejected before the
-        # capability is even consulted).
-        status, _, _ = self.call(
+    def _bootstrap(self, *extra, key="b-mint"):
+        return self.call(
             "POST", "/api/interface/browser-sessions",
-            ("Origin: http://evil.example.com", "Idempotency-Key: b1"), {})
-        self.assertEqual(status, 403)
-        # Missing idempotency key → 422.
-        status, _, _ = self.call(
-            "POST", "/api/interface/browser-sessions",
-            ("Origin: http://127.0.0.1:8800", OP), {})
-        self.assertEqual(status, 422)
-        # Same-origin proof + the operator capability mints cookie +
-        # anti-forgery token.
-        status, headers, body = self.call(
-            "POST", "/api/interface/browser-sessions",
-            ("Origin: http://127.0.0.1:8800", OP, "Idempotency-Key: b2"), {})
-        self.assertEqual(status, 201)
-        self.assertIn("csrf", body)
+            (*BROWSER, f"Idempotency-Key: {key}", *extra), {})
+
+    def test_browser_bootstrap_mints_without_a_capability(self):
+        # Spec #26 / decision #29: the browser presents NOTHING and still
+        # gets a scoped session — the operator capability never has to reach
+        # page JavaScript.
+        status, headers, body = self._bootstrap()
+        self.assertEqual(status, 201, body)
+        self.assertTrue(body.get("csrf"))
         cookie = headers["Set-Cookie"]
         self.assertIn("HttpOnly", cookie)
         self.assertIn("SameSite=Strict", cookie)
-
-    def test_browser_bootstrap_requires_operator_capability(self):
-        # Same-origin alone mints NOTHING (flag #43): a local process without
-        # the mode-0600 operator token cannot self-mint browser authority.
-        status, _, body = self.call(
-            "POST", "/api/interface/browser-sessions",
-            ("Origin: http://127.0.0.1:8800", "Idempotency-Key: b5"), {})
-        self.assertEqual(status, 401)
-        self.assertEqual(body["error"]["code"], "operator_capability_required")
-        # A wrong token is refused the same way.
+        self.assertIn("Path=/", cookie)
+        # Plain http on loopback: no Secure attribute to make the cookie
+        # unsendable. The anti-forgery token is body-only, never a cookie.
+        self.assertNotIn("Secure", cookie)
+        self.assertNotIn(body["csrf"], cookie)
+        # CORS stays off — no header invites another origin to read this.
+        self.assertNotIn("Access-Control-Allow-Origin", headers)
+        # The minted session is immediately usable for reads.
         status, _, _ = self.call(
+            "GET", "/api/interface/shells",
+            (f"Cookie: {cookie.split(';')[0]}",))
+        self.assertEqual(status, 200)
+
+    def test_browser_bootstrap_sets_secure_on_https(self):
+        status, headers, _ = self.call(
             "POST", "/api/interface/browser-sessions",
-            ("Origin: http://127.0.0.1:8800", "Authorization: Bearer wrong",
-             "Idempotency-Key: b6"), {})
+            ("Origin: https://127.0.0.1:8800", "Sec-Fetch-Site: same-origin",
+             "Idempotency-Key: b-https"), {})
+        self.assertEqual(status, 201)
+        self.assertIn("Secure", headers["Set-Cookie"])
+
+    def test_browser_bootstrap_provenance_fence(self):
+        """Automatic minting rests entirely on provenance a foreign page
+        cannot forge, so every way of arriving without it must fail closed."""
+        for label, hdr_lines in (
+            ("other-origin page",
+             ("Origin: http://evil.example.com",
+              "Sec-Fetch-Site: cross-site")),
+            ("other-origin page claiming same-origin fetch metadata",
+             ("Origin: http://evil.example.com",
+              "Sec-Fetch-Site: same-origin")),
+            ("cross-site form submission (no Origin echo we can trust)",
+             ("Sec-Fetch-Site: cross-site",)),
+            ("missing Origin",
+             ("Sec-Fetch-Site: same-origin",)),
+            ("missing fetch metadata",
+             ("Origin: http://127.0.0.1:8800",)),
+            ("opaque Origin",
+             ("Origin: null", "Sec-Fetch-Site: same-origin")),
+            ("top-level navigation, not a page fetch",
+             ("Origin: http://127.0.0.1:8800", "Sec-Fetch-Site: none")),
+            ("scheme-relative junk Origin",
+             ("Origin: 127.0.0.1:8800", "Sec-Fetch-Site: same-origin")),
+            ("no browser provenance at all", ()),
+        ):
+            with self.subTest(label):
+                status, _, body = self.call(
+                    "POST", "/api/interface/browser-sessions",
+                    (*hdr_lines, "Idempotency-Key: b-deny"), {})
+                self.assertEqual(status, 403, label)
+                self.assertEqual(body["error"]["code"], "not_same_origin")
+        self.assertEqual(routes._browser_sessions, {})
+
+    def test_browser_bootstrap_rejects_a_rebound_host(self):
+        raw = ("Host: interface.evil.example.com\r\n"
+               "Origin: http://interface.evil.example.com\r\n"
+               "Sec-Fetch-Site: same-origin\r\nIdempotency-Key: b-rebind")
+        status, _, body = routes.handle(
+            "POST", "/api/interface/browser-sessions", raw, b"{}")
+        self.assertEqual(status, 403)
+        self.assertEqual(json.loads(body)["error"]["code"], "host_not_allowed")
+        self.assertEqual(routes._browser_sessions, {})
+
+    def test_browser_bootstrap_refuses_a_browser_supplied_bearer(self):
+        # The operator capability is CLI/server-only. Refusing it here (not
+        # ignoring it) is what stops page code from ever carrying one.
+        for label, bearer in (("the real capability", OP),
+                              ("a guess", "Authorization: Bearer wrong")):
+            with self.subTest(label):
+                status, _, body = self._bootstrap(bearer, key=f"b-{label[:4]}")
+                self.assertEqual(status, 403)
+                self.assertEqual(body["error"]["code"], "bearer_not_accepted")
+        self.assertEqual(routes._browser_sessions, {})
+
+    def test_browser_bootstrap_requires_idempotency_key(self):
+        status, _, body = self.call(
+            "POST", "/api/interface/browser-sessions", BROWSER, {})
+        self.assertEqual(status, 422)
+        self.assertEqual(body["error"]["code"], "idempotency_key_required")
+
+    def test_browser_bootstrap_rotates_and_revokes(self):
+        first, first_csrf = self._browser()
+        status, headers, body = self._bootstrap(f"Cookie: {first}",
+                                                key="b-rotate")
+        self.assertEqual(status, 201)
+        second = headers["Set-Cookie"].split(";")[0]
+        self.assertNotEqual(second, first)
+        self.assertNotEqual(body["csrf"], first_csrf)
+        # The presented session died in the same step that minted its
+        # replacement — no window where both identifiers work.
+        self.assertEqual(len(routes._browser_sessions), 1)
+        status, _, err = self.call("GET", "/api/interface/shells",
+                                   (f"Cookie: {first}",))
         self.assertEqual(status, 401)
+        self.assertEqual(err["error"]["code"], "browser_session_expired")
+        status, _, _ = self.call("GET", "/api/interface/shells",
+                                 (f"Cookie: {second}",))
+        self.assertEqual(status, 200)
+
+    def test_independent_browsers_hold_separate_sessions(self):
+        # A second tab bootstraps without presenting the first's cookie, so
+        # nothing is revoked: both read concurrently, with no distinct
+        # identity or privilege between them (writer authority stays with the
+        # lease protocol).
+        first, _ = self._browser()
+        status, headers, _ = self._bootstrap(key="b-second")
+        self.assertEqual(status, 201)
+        second = headers["Set-Cookie"].split(";")[0]
+        self.assertNotEqual(second, first)
+        for cookie in (first, second):
+            status, _, _ = self.call("GET", "/api/interface/shells",
+                                     (f"Cookie: {cookie}",))
+            self.assertEqual(status, 200)
+
+    def test_browser_session_expires_after_inactivity(self):
+        cookie, _ = self._browser()
+        sid = cookie.split("=", 1)[1]
+        routes._browser_sessions[sid]["last_seen"] = (
+            time.time() - routes.BROWSER_SESSION_TTL_S - 1)
+        status, _, body = self.call("GET", "/api/interface/shells",
+                                    (f"Cookie: {cookie}",))
+        self.assertEqual(status, 401)
+        self.assertEqual(body["error"]["code"], "browser_session_expired")
+        # Expiry deletes server-side state rather than merely refusing it.
+        self.assertNotIn(sid, routes._browser_sessions)
+
+    def test_browser_use_advances_the_deadline(self):
+        cookie, _ = self._browser()
+        sid = cookie.split("=", 1)[1]
+        stale = time.time() - routes.BROWSER_SESSION_TTL_S + 60
+        routes._browser_sessions[sid]["last_seen"] = stale
+        status, _, _ = self.call("GET", "/api/interface/shells",
+                                 (f"Cookie: {cookie}",))
+        self.assertEqual(status, 200)
+        self.assertGreater(routes._browser_sessions[sid]["last_seen"], stale)
+
+    def test_browser_sessions_are_live_process_state_only(self):
+        """A restart wipes them — which is exactly the contract the UI's one
+        silent re-bootstrap relies on, and why they never touch the DB."""
+        cookie, _ = self._browser()
+        with contextlib.closing(sqlite3.connect(self.db_path)) as con:
+            tables = [r[0] for r in con.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'")]
+            for table in tables:
+                rows = con.execute(f"SELECT * FROM {table}").fetchall()
+                self.assertNotIn(
+                    cookie.split("=", 1)[1],
+                    " ".join(str(c) for row in rows for c in row),
+                    f"browser session leaked into {table}")
+        routes._browser_sessions.clear()          # what a restart does
+        status, _, body = self.call("GET", "/api/interface/shells",
+                                    (f"Cookie: {cookie}",))
+        self.assertEqual(status, 401)
+        self.assertEqual(body["error"]["code"], "browser_session_expired")
 
     def _browser(self):
-        status, headers, body = self.call(
-            "POST", "/api/interface/browser-sessions",
-            ("Origin: http://127.0.0.1:8800", OP, "Idempotency-Key: b3"), {})
-        assert status == 201
+        status, headers, body = self._bootstrap(key="b3")
+        assert status == 201, body
         cookie = headers["Set-Cookie"].split(";")[0]
         return cookie, body["csrf"]
 
@@ -387,6 +525,13 @@ class InterfaceApiTest(unittest.TestCase):
         status, _, body = self.call(
             "POST", "/api/interface/sessions",
             (f"Cookie: {cookie}", "Idempotency-Key: c1"), {"shell_id": 1})
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error"]["code"], "csrf")
+        # A malformed / guessed anti-forgery token is refused the same way.
+        status, _, body = self.call(
+            "POST", "/api/interface/sessions",
+            (f"Cookie: {cookie}", "X-CSRF: not-the-token",
+             "Idempotency-Key: c1b"), {"shell_id": 1})
         self.assertEqual(status, 403)
         self.assertEqual(body["error"]["code"], "csrf")
         # Cookie + anti-forgery token: mutation proceeds.
@@ -402,6 +547,18 @@ class InterfaceApiTest(unittest.TestCase):
             (OP, "Idempotency-Key: c3", "Origin: http://evil.example.com"),
             {"shell_id": 1})
         self.assertEqual(status, 403)
+        # Same for a browser session driven from a foreign page: even holding
+        # both the cookie and its anti-forgery token, cross-site provenance
+        # loses.
+        cookie, csrf = self._browser()
+        status, _, body = self.call(
+            "POST", "/api/interface/sessions",
+            (f"Cookie: {cookie}", f"X-CSRF: {csrf}",
+             "Origin: http://evil.example.com",
+             "Sec-Fetch-Site: cross-site", "Idempotency-Key: c4"),
+            {"shell_id": 1})
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error"]["code"], "not_same_origin")
 
     # -- idempotency ---------------------------------------------------------------
 

--- a/tests/test_interface_release_gate.py
+++ b/tests/test_interface_release_gate.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Spec #26's release gate, proven over the real transport.
+
+The gate says the change fails if "any foreign origin can mint or use a
+browser session", if a malformed anti-forgery token stops failing closed, or
+if a cookie alone can mutate. Those are the cases this file proves, and it
+proves them with NOTHING between the assertion and the code under test: a
+real socket, the real `transport` multiplex, the real `interface_routes`
+authority. No fetch interception, no stubbed responses, no direct call into
+the handler.
+
+That constraint is the point. The Interface's browser-facing verification ran
+through Playwright with every `/api` response intercepted, which meant the
+layer being asserted was the layer being stubbed — and two real defects
+(a bind fence that did not exist, a rotation window that let a revoked
+session complete a mutation) lived underneath it. A test that mints a session
+by writing to a dict proves the dict; a test that mints one by sending bytes
+at a listening port proves the boundary.
+
+Scope, deliberately bounded: the release-gate negatives plus the cookie
+lifecycle they depend on (mint → rotate → revoke → restart). Rendering,
+terminal streaming, and the rest of the UI stay with the existing suites —
+this is not a general end-to-end harness.
+"""
+from __future__ import annotations
+
+import asyncio
+import http.client
+import json
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "api"))
+
+import interface_routes as routes  # noqa: E402
+import run as run_mod  # noqa: E402
+import transport as transport_mod  # noqa: E402
+
+from test_interface_api import FakeRuntime, build_engine_db  # noqa: E402
+
+
+class ReleaseGateTest(unittest.TestCase):
+    """Every request here crosses a real TCP connection."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.db_path = root / "shell_db.db"
+        build_engine_db(self.db_path)
+        run_dir = root / "run" / "interface"
+        self.patches = [
+            mock.patch.object(routes, "DB_PATH", self.db_path),
+            mock.patch.object(routes, "RUN_DIR", run_dir),
+            mock.patch.object(routes, "OPERATOR_TOKEN_PATH",
+                              run_dir / "operator.token"),
+            mock.patch.object(run_mod, "ensure_worktree"),
+            mock.patch.object(routes.shell_liveness, "compute",
+                              return_value={"supported": True,
+                                            "processes": []}),
+        ]
+        for p in self.patches:
+            p.start()
+        routes._browser_sessions.clear()
+        routes.ensure_operator_capability()
+        (run_dir / "operator.token").write_text("optok")
+        routes.bind_runtime(FakeRuntime())
+        self._start_transport()
+
+    def tearDown(self):
+        self._stop_transport()
+        for p in self.patches:
+            p.stop()
+        self.tmp.cleanup()
+
+    # -- the live server -----------------------------------------------------
+
+    def _start_transport(self):
+        """The real multiplex on an ephemeral loopback port, in its own loop.
+
+        `routes.handle` is passed as the HTTP handler exactly as `server.py`
+        passes it, so the header parsing under test is the transport's own,
+        not a test double's reconstruction of it."""
+        self.loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def run():
+            asyncio.set_event_loop(self.loop)
+            self.transport = transport_mod.Transport(
+                "127.0.0.1", 0, routes.handle, self._no_ws, log=lambda *_: None)
+            self.loop.run_until_complete(self.transport.start())
+            self.port = self.transport.port
+            ready.set()
+            self.loop.run_forever()
+
+        self.thread = threading.Thread(target=run, daemon=True)
+        self.thread.start()
+        self.assertTrue(ready.wait(10), "transport did not start")
+        self.origin = f"http://127.0.0.1:{self.port}"
+
+    async def _no_ws(self, reader, writer, head_raw):  # pragma: no cover
+        writer.close()
+
+    def _stop_transport(self):
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join(timeout=10)
+        self.loop.call_soon_threadsafe(
+            lambda: asyncio.ensure_future(self.transport.stop()))
+        self.loop.close()
+
+    # -- a real HTTP request -------------------------------------------------
+
+    def http(self, method, path, headers=None, body=None):
+        """One request on a fresh connection (responses are Connection:
+        close). Returns (status, headers, parsed-json-body)."""
+        payload = json.dumps(body).encode() if body is not None else None
+        sent = dict(headers or {})
+        if payload is not None:
+            sent.setdefault("Content-Type", "application/json")
+        con = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        try:
+            con.request(method, path, body=payload, headers=sent)
+            resp = con.getresponse()
+            raw = resp.read()
+            try:
+                parsed = json.loads(raw or b"{}")
+            except ValueError:
+                parsed = {}
+            return resp.status, dict(resp.getheaders()), parsed
+        finally:
+            con.close()
+
+    def browser_headers(self, **extra):
+        """What a real Interface page's fetch() puts on the wire."""
+        return {"Origin": self.origin, "Sec-Fetch-Site": "same-origin",
+                **extra}
+
+    def mint(self, **extra):
+        """Bootstrap a session the legitimate way, over the wire."""
+        status, headers, body = self.http(
+            "POST", "/api/interface/browser-sessions",
+            self.browser_headers(**{"Idempotency-Key": "gate-mint", **extra}),
+            {})
+        self.assertEqual(status, 201, body)
+        cookie = headers["Set-Cookie"].split(";")[0]
+        return cookie, body["csrf"]
+
+    def chat_count(self):
+        import sqlite3
+        con = sqlite3.connect(self.db_path)
+        try:
+            return con.execute(
+                "SELECT COUNT(*) FROM interface_sessions").fetchone()[0]
+        finally:
+            con.close()
+
+    # -- release gate: no foreign origin mints a session ---------------------
+
+    def test_a_foreign_origin_cannot_mint_a_session(self):
+        hostile = (
+            ("a hostile page's fetch",
+             {"Origin": "http://evil.example.com",
+              "Sec-Fetch-Site": "cross-site"}),
+            ("a hostile page lying about its Origin",
+             {"Origin": self.origin, "Sec-Fetch-Site": "cross-site"}),
+            ("provenance stripped entirely", {}),
+            ("Origin without fetch metadata", {"Origin": self.origin}),
+            ("fetch metadata without an Origin",
+             {"Sec-Fetch-Site": "same-origin"}),
+            # Same machine is NOT same origin: a page served on another port
+            # of this host is a different origin and must lose, even though
+            # it can honestly claim same-origin fetch metadata for itself.
+            ("another port on the same host",
+             {"Origin": "http://127.0.0.1:1",
+              "Sec-Fetch-Site": "same-origin"}),
+            ("the same host under a different name",
+             {"Origin": f"http://localhost:{self.port}",
+              "Sec-Fetch-Site": "same-origin"}),
+            ("an opaque origin (sandboxed frame / redirect)",
+             {"Origin": "null", "Sec-Fetch-Site": "same-origin"}),
+        )
+        for label, headers in hostile:
+            with self.subTest(label):
+                status, resp_headers, body = self.http(
+                    "POST", "/api/interface/browser-sessions",
+                    {**headers, "Idempotency-Key": f"gate-{len(label)}"}, {})
+                self.assertEqual(status, 403, body)
+                self.assertEqual(body["error"]["code"], "not_same_origin")
+                self.assertNotIn("Set-Cookie", resp_headers,
+                                 f"{label} was handed a session cookie")
+        self.assertEqual(routes._browser_sessions, {},
+                         "a rejected mint left server-side state behind")
+
+    def test_a_rebound_host_cannot_mint_a_session(self):
+        # DNS rebinding: the attacker controls the name, so the Host header is
+        # theirs to choose. The allowlist is checked before anything else.
+        status, resp_headers, body = self.http(
+            "POST", "/api/interface/browser-sessions",
+            {"Host": "evil.example.com", "Origin": "http://evil.example.com",
+             "Sec-Fetch-Site": "same-origin", "Idempotency-Key": "gate-dns"},
+            {})
+        self.assertEqual(status, 403, body)
+        self.assertEqual(body["error"]["code"], "host_not_allowed")
+        self.assertNotIn("Set-Cookie", resp_headers)
+        self.assertEqual(routes._browser_sessions, {})
+
+    # -- release gate: no foreign origin USES a session ----------------------
+
+    def test_a_foreign_origin_cannot_use_a_session(self):
+        # The strongest form of the case: the attacker is assumed to hold BOTH
+        # the cookie and its anti-forgery token, and still loses on
+        # provenance. (SameSite=Strict is what actually stops the cookie
+        # riding along; this proves the server does not rely on it alone.)
+        cookie, csrf = self.mint()
+        before = self.chat_count()
+        status, _, body = self.http(
+            "POST", "/api/interface/sessions",
+            {"Cookie": cookie, "X-CSRF": csrf,
+             "Origin": "http://evil.example.com",
+             "Sec-Fetch-Site": "cross-site",
+             "Idempotency-Key": "gate-xsite"},
+            {"shell_id": 1})
+        self.assertEqual(status, 403, body)
+        self.assertEqual(body["error"]["code"], "not_same_origin")
+        self.assertEqual(self.chat_count(), before,
+                         "a cross-site mutation reached its handler")
+
+    # -- release gate: the anti-forgery gate fails closed --------------------
+
+    def test_a_malformed_anti_forgery_token_fails_closed(self):
+        cookie, csrf = self.mint()
+        before = self.chat_count()
+        for label, value in (("a guessed token", "not-the-token"),
+                             ("an empty token", ""),
+                             ("another session's token", "0" * 48)):
+            with self.subTest(label):
+                status, resp_headers, body = self.http(
+                    "POST", "/api/interface/sessions",
+                    {"Cookie": cookie, "X-CSRF": value,
+                     "Idempotency-Key": f"gate-csrf-{len(label)}"},
+                    {"shell_id": 1})
+                self.assertEqual(status, 403, body)
+                self.assertEqual(body["error"]["code"], "csrf")
+                # Fails CLOSED: the rejection must not hand back a usable
+                # token, or the gate becomes a retry.
+                self.assertNotIn("Set-Cookie", resp_headers)
+                self.assertNotIn("csrf", body)
+        self.assertEqual(self.chat_count(), before)
+        # The legitimate token still works — the gate rejects forgery, not
+        # everything.
+        status, _, body = self.http(
+            "POST", "/api/interface/sessions",
+            {"Cookie": cookie, "X-CSRF": csrf,
+             "Idempotency-Key": "gate-ok"}, {"shell_id": 1})
+        self.assertEqual(status, 201, body)
+        self.assertEqual(self.chat_count(), before + 1)
+
+    def test_a_cookie_alone_cannot_mutate(self):
+        cookie, _ = self.mint()
+        before = self.chat_count()
+        status, _, body = self.http(
+            "POST", "/api/interface/sessions",
+            {"Cookie": cookie, "Idempotency-Key": "gate-cookieonly"},
+            {"shell_id": 1})
+        self.assertEqual(status, 403, body)
+        self.assertEqual(body["error"]["code"], "csrf")
+        self.assertEqual(self.chat_count(), before)
+        # ...while a read on the same cookie is fine: the cookie is an
+        # identity, the anti-forgery token is the mutation authority.
+        status, _, _ = self.http("GET", "/api/interface/shells",
+                                 {"Cookie": cookie})
+        self.assertEqual(status, 200)
+
+    def test_no_permissive_cors_on_any_response(self):
+        # CORS staying OFF is what keeps a hostile page from READING a
+        # response even where it can cause a request. Probe the real
+        # responses rather than one route's success path.
+        cookie, csrf = self.mint()
+        probes = (
+            ("GET", "/api/interface/shells", {"Cookie": cookie}, None),
+            ("OPTIONS", "/api/interface/sessions",
+             {"Origin": "http://evil.example.com",
+              "Access-Control-Request-Method": "POST"}, None),
+            ("POST", "/api/interface/browser-sessions",
+             {"Origin": "http://evil.example.com",
+              "Sec-Fetch-Site": "cross-site",
+              "Idempotency-Key": "gate-cors"}, {}),
+            ("POST", "/api/interface/sessions",
+             {"Cookie": cookie, "X-CSRF": csrf,
+              "Idempotency-Key": "gate-cors2"}, {"shell_id": 1}),
+        )
+        banned = ("access-control-allow-origin",
+                  "access-control-allow-credentials",
+                  "access-control-allow-methods",
+                  "access-control-allow-headers")
+        for method, path, headers, body in probes:
+            with self.subTest(f"{method} {path}"):
+                _, resp_headers, _ = self.http(method, path, headers, body)
+                present = {k.lower() for k in resp_headers}
+                for name in banned:
+                    self.assertNotIn(name, present,
+                                     f"{method} {path} answered with {name}")
+
+    # -- the cookie lifecycle those fences depend on -------------------------
+
+    def test_the_cookie_lifecycle_holds_over_the_wire(self):
+        """Mint → rotate → revoke → restart, on real connections.
+
+        Rotation and restart recovery need a real cookie round-trip to mean
+        anything (an in-process call can 'rotate' a dict without ever proving
+        the browser is handed a different credential); they do not need
+        browser automation."""
+        status, headers, body = self.http(
+            "POST", "/api/interface/browser-sessions",
+            self.browser_headers(**{"Idempotency-Key": "life-1"}), {})
+        self.assertEqual(status, 201, body)
+        set_cookie = headers["Set-Cookie"]
+        # The attributes are the control, so assert them on the wire.
+        self.assertIn("HttpOnly", set_cookie)
+        self.assertIn("SameSite=Strict", set_cookie)
+        self.assertIn("Path=/", set_cookie)
+        self.assertNotIn("Secure", set_cookie)  # plain http origin
+        first, first_csrf = set_cookie.split(";")[0], body["csrf"]
+        self.assertNotIn(first_csrf, set_cookie,
+                         "the anti-forgery token rode along in the cookie")
+
+        status, _, _ = self.http("GET", "/api/interface/shells",
+                                 {"Cookie": first})
+        self.assertEqual(status, 200)
+
+        # Rotation: the presented session is replaced, and the replacement is
+        # a genuinely different credential delivered to the client.
+        status, headers, body = self.http(
+            "POST", "/api/interface/browser-sessions",
+            self.browser_headers(**{"Cookie": first,
+                                    "Idempotency-Key": "life-2"}), {})
+        self.assertEqual(status, 201, body)
+        second, second_csrf = headers["Set-Cookie"].split(";")[0], body["csrf"]
+        self.assertNotEqual(second, first)
+        self.assertNotEqual(second_csrf, first_csrf)
+
+        status, _, body = self.http("GET", "/api/interface/shells",
+                                    {"Cookie": first})
+        self.assertEqual(status, 401)
+        self.assertEqual(body["error"]["code"], "browser_session_expired")
+        # The old anti-forgery token is dead with it.
+        status, _, body = self.http(
+            "POST", "/api/interface/sessions",
+            {"Cookie": first, "X-CSRF": first_csrf,
+             "Idempotency-Key": "life-3"}, {"shell_id": 1})
+        self.assertEqual(status, 401)
+
+        status, _, _ = self.http("GET", "/api/interface/shells",
+                                 {"Cookie": second})
+        self.assertEqual(status, 200)
+
+        # A service restart drops live-process state: every session dies, and
+        # the client is told to bootstrap rather than shown an error.
+        routes._browser_sessions.clear()
+        status, _, body = self.http("GET", "/api/interface/shells",
+                                    {"Cookie": second})
+        self.assertEqual(status, 401)
+        self.assertEqual(body["error"]["code"], "browser_session_expired")
+        status, headers, body = self.http(
+            "POST", "/api/interface/browser-sessions",
+            self.browser_headers(**{"Cookie": second,
+                                    "Idempotency-Key": "life-4"}), {})
+        self.assertEqual(status, 201, body)
+        third = headers["Set-Cookie"].split(";")[0]
+        status, _, _ = self.http("GET", "/api/interface/shells",
+                                 {"Cookie": third})
+        self.assertEqual(status, 200)
+
+    def test_expiry_over_the_wire_deletes_the_session(self):
+        import time
+        cookie, _ = self.mint()
+        sid = cookie.split("=", 1)[1]
+        routes._browser_sessions[sid]["last_seen"] = (
+            time.time() - routes.BROWSER_SESSION_TTL_S - 1)
+        status, _, body = self.http("GET", "/api/interface/shells",
+                                    {"Cookie": cookie})
+        self.assertEqual(status, 401)
+        self.assertEqual(body["error"]["code"], "browser_session_expired")
+        self.assertNotIn(sid, routes._browser_sessions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_release_gate.py
+++ b/tests/test_interface_release_gate.py
@@ -106,10 +106,13 @@ class ReleaseGateTest(unittest.TestCase):
         writer.close()
 
     def _stop_transport(self):
+        # Shut the transport down while the loop is still RUNNING and wait for
+        # it. Scheduling stop() after loop.stop() only creates a task nothing
+        # ever executes, so the listening socket outlives the test class.
+        asyncio.run_coroutine_threadsafe(
+            self.transport.stop(), self.loop).result(timeout=10)
         self.loop.call_soon_threadsafe(self.loop.stop)
         self.thread.join(timeout=10)
-        self.loop.call_soon_threadsafe(
-            lambda: asyncio.ensure_future(self.transport.stop()))
         self.loop.close()
 
     # -- a real HTTP request -------------------------------------------------

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -214,9 +214,10 @@ if (lastScrolled.title !== "model-59" || lastScrolled.block !== "nearest") {
 
 def test_browser_bootstrap_carries_no_capability_and_retries_once():
     """Spec #26: the browser signs itself in with same-origin provenance
-    alone. The capability must not reappear in page code, and the one silent
+    alone. The capability must not reappear in page code, the one silent
     recovery must reuse the original idempotency key so a retry cannot
-    duplicate a mutation."""
+    duplicate a mutation, and recovery fires on 401 ONLY — a 403 fence must
+    fail closed rather than be answered with a fresh token."""
     assert "operator.token" not in BOOTSTRAP
     assert "Authorization" not in BOOTSTRAP
     assert "prompt(" not in BOOTSTRAP
@@ -284,6 +285,24 @@ const invariant = (cond, msg) => { if (!cond) throw new Error(msg); };
   try { await apiIf("/interface/shells"); } catch (e) { raised = e; }
   invariant(raised && raised.code === "browser_session_expired", "second 401 did not surface");
   invariant(calls.length === 3, `retry looped: ${calls.length} calls`);
+
+  // 3b. A 403 is a fence that fired, NOT a recovery signal: fail closed.
+  //     Re-bootstrapping here would answer a rejected anti-forgery token with
+  //     a freshly minted valid one, turning the CSRF gate into a retry — the
+  //     exact negative case spec #26's release gate names. One call, no
+  //     bootstrap, error surfaced.
+  for (const code of ["csrf", "not_same_origin"]) {
+    calls.length = 0;
+    ifCsrf = "tok-live";
+    plan = [{ status: 403, body: { error: { code } } }];
+    raised = null;
+    try { await apiIf("/interface/sessions", "POST", { shell_id: 1 }); } catch (e) { raised = e; }
+    invariant(raised && raised.code === code, `403 ${code} did not surface`);
+    invariant(calls.length === 1, `403 ${code} was retried: ${calls.length} calls`);
+    invariant(calls[0].url !== "/api/interface/browser-sessions",
+      `403 ${code} triggered a re-bootstrap`);
+    invariant(ifCsrf === "tok-live", `403 ${code} discarded the live token`);
+  }
 
   // 4. No cookies, no session — and no fallback to a pasted credential.
   calls.length = 0;

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -32,6 +32,8 @@ RENDER_INTERFACE = APP[APP.index("const IF_BADGE"):
                        APP.index("// A reservation is not a terminal")]
 AVAILABLE = APP[APP.index("function ifAvailablePane"):
                 APP.index("async function ifNewChatForm")]
+BOOTSTRAP = APP[APP.index("function ifError"):
+                APP.index("// Best-effort teardown")]
 
 BASE_PREVIEW = {
     "observation_id": "obs-1",
@@ -204,6 +206,98 @@ for (let i = 0; i < 60; i += 1) {
 if (lastScrolled.title !== "model-59" || lastScrolled.block !== "nearest") {
   throw new Error(`active option was not scrolled: ${JSON.stringify(lastScrolled)}`);
 }
+"""
+    result = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+def test_browser_bootstrap_carries_no_capability_and_retries_once():
+    """Spec #26: the browser signs itself in with same-origin provenance
+    alone. The capability must not reappear in page code, and the one silent
+    recovery must reuse the original idempotency key so a retry cannot
+    duplicate a mutation."""
+    assert "operator.token" not in BOOTSTRAP
+    assert "Authorization" not in BOOTSTRAP
+    assert "prompt(" not in BOOTSTRAP
+    script = r"""
+let ifCsrf = null;
+const calls = [];
+let cookiesOn = true;
+// Node ships a read-only `navigator` global, so define over it.
+Object.defineProperty(globalThis, "navigator", {
+  configurable: true,
+  get: () => ({ cookieEnabled: cookiesOn }),
+});
+let plan = [];
+globalThis.fetch = async (url, opts) => {
+  calls.push({ url, ...opts });
+  const next = plan.shift();
+  return {
+    ok: next.status < 400, status: next.status, statusText: "",
+    json: async () => next.body || {},
+  };
+};
+const invariant = (cond, msg) => { if (!cond) throw new Error(msg); };
+""" + BOOTSTRAP + r"""
+(async () => {
+  // 1. A mutation on a cold tab: bootstrap, then the call itself.
+  plan = [{ status: 201, body: { csrf: "tok-1" } }, { status: 201, body: {} }];
+  await apiIf("/interface/sessions", "POST", { shell_id: 1 });
+  invariant(calls.length === 2, `expected bootstrap + call, got ${calls.length}`);
+  const boot = calls[0];
+  invariant(boot.url === "/api/interface/browser-sessions", boot.url);
+  invariant(boot.credentials === "same-origin", "bootstrap dropped same-origin credentials");
+  invariant(!("Authorization" in boot.headers), "bootstrap sent a capability");
+  invariant(boot.headers["Idempotency-Key"], "bootstrap sent no idempotency key");
+  invariant(calls[1].headers["X-CSRF"] === "tok-1", "anti-forgery token not carried");
+  const firstKey = calls[1].headers["Idempotency-Key"];
+
+  // 2. The session dies (expiry / restart): ONE silent bootstrap, and the
+  //    retry reuses the ORIGINAL key — including the one apiIf generated
+  //    itself — so the server replays the mutation instead of running it
+  //    twice.
+  calls.length = 0;
+  plan = [{ status: 401, body: {} }, { status: 201, body: { csrf: "tok-2" } },
+          { status: 201, body: {} }];
+  await apiIf("/interface/sessions", "POST", { shell_id: 1 });
+  invariant(calls.length === 3, `expected call+bootstrap+retry, got ${calls.length}`);
+  const generated = calls[0].headers["Idempotency-Key"];
+  invariant(generated && generated !== firstKey, "no fresh key for a new mutation");
+  invariant(calls[2].headers["Idempotency-Key"] === generated,
+    "retry changed the idempotency key — recovery could duplicate the mutation");
+  invariant(calls[2].headers["X-CSRF"] === "tok-2", "retry reused the dead anti-forgery token");
+
+  // ...and an explicit caller key is honoured on both attempts.
+  calls.length = 0;
+  plan = [{ status: 401, body: {} }, { status: 201, body: { csrf: "tok-2b" } },
+          { status: 201, body: {} }];
+  await apiIf("/interface/sessions", "POST", { shell_id: 1 }, "caller-key");
+  invariant(calls[0].headers["Idempotency-Key"] === "caller-key", "first attempt lost the key");
+  invariant(calls[2].headers["Idempotency-Key"] === "caller-key", "retry lost the caller key");
+
+  // 3. A second failure surfaces the error instead of looping forever.
+  calls.length = 0;
+  plan = [{ status: 401, body: {} }, { status: 201, body: { csrf: "tok-3" } },
+          { status: 401, body: { error: { code: "browser_session_expired" } } }];
+  let raised = null;
+  try { await apiIf("/interface/shells"); } catch (e) { raised = e; }
+  invariant(raised && raised.code === "browser_session_expired", "second 401 did not surface");
+  invariant(calls.length === 3, `retry looped: ${calls.length} calls`);
+
+  // 4. No cookies, no session — and no fallback to a pasted credential.
+  calls.length = 0;
+  cookiesOn = false;
+  ifCsrf = null;
+  plan = [];
+  raised = null;
+  try { await apiIf("/interface/shells"); } catch (e) { raised = e; }
+  invariant(raised && /unavailable/i.test(raised.message), `unclear failure: ${raised}`);
+  invariant(calls.length === 0, "asked the server for a session it could not hold");
+})().catch((error) => {
+  console.error(error.stack || error);
+  process.exit(1);
+});
 """
     result = subprocess.run(
         ["node", "-e", script], text=True, capture_output=True, check=False)

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-"""Startup refusal for a materialized-engine / unmigrated-DB half floor."""
+"""Startup refusals: a materialized-engine / unmigrated-DB half floor, and a
+non-loopback bind (spec #26)."""
 from __future__ import annotations
 
+import os
 import sqlite3
 import sys
 import tempfile
@@ -81,6 +83,44 @@ class ServerSchemaGuardTest(unittest.TestCase):
                 con.close()
 
             server.require_current_schema(db_path, MIGRATIONS)
+
+
+class LoopbackBindGuardTest(unittest.TestCase):
+    """Spec #26 Failure Modes: a non-loopback bind refuses to start.
+
+    This is the fence behind the automatic browser bootstrap: a session mints
+    for any caller that can present an allowed `Host` and a same-origin
+    `Origin`, both of which a remote client chooses freely. Unreachability is
+    therefore the control, and it has to be enforced rather than assumed.
+    """
+
+    def test_host_refuses_a_non_loopback_bind(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SC_SANDBOX", None)
+            for bind in ("0.0.0.0", "", "::", "192.168.1.10",
+                         "10.0.0.5", "example.com"):
+                with self.subTest(bind=bind):
+                    with self.assertRaises(SystemExit) as caught:
+                        server.require_loopback_bind(bind)
+                    self.assertIn("loopback", str(caught.exception))
+
+    def test_host_accepts_loopback_binds(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SC_SANDBOX", None)
+            for bind in ("127.0.0.1", "localhost", "LocalHost", "::1",
+                         "[::1]", "127.0.0.53"):
+                with self.subTest(bind=bind):
+                    server.require_loopback_bind(bind)
+
+    def test_sandbox_keeps_the_wide_bind_docker_publishes(self):
+        # `./sc launch` sets SC_BIND=0.0.0.0 in the container ON PURPOSE so
+        # docker can publish the port; the boundary there is the
+        # `-p 127.0.0.1:PORT:PORT` mapping, which is loopback-only on the
+        # host whatever the container binds. Refusing here would make the
+        # sandbox unlaunchable while removing no exposure — so the guard
+        # stands down, and only here.
+        with mock.patch.dict(os.environ, {"SC_SANDBOX": "1"}):
+            server.require_loopback_bind("0.0.0.0")
 
 
 if __name__ == "__main__":

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -3,6 +3,8 @@
 non-loopback bind (spec #26)."""
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import sqlite3
 import sys
@@ -18,6 +20,7 @@ ACK_MIGRATION = "0083_planner_alert_acknowledgement.sql"
 
 sys.path.insert(0, str(ENGINE / "api"))
 import server  # noqa: E402
+import transport  # noqa: E402  (main()'s serve call — the line the guard precedes)
 
 
 def build_pre_acknowledgement_db(path: Path) -> None:
@@ -121,6 +124,87 @@ class LoopbackBindGuardTest(unittest.TestCase):
         # stands down, and only here.
         with mock.patch.dict(os.environ, {"SC_SANDBOX": "1"}):
             server.require_loopback_bind("0.0.0.0")
+
+
+class LoopbackBindStartupWiringTest(unittest.TestCase):
+    """The guard only fences anything if main() actually calls it.
+
+    LoopbackBindGuardTest above pins the FUNCTION: delete the single
+    `require_loopback_bind(bind)` line from main() and every one of its
+    subtests still passes while the unsafe startup it exists to stop comes
+    straight back. So these drive `server.main([])` itself, with the
+    neighbouring startup steps stubbed, and assert the one thing that is
+    load-bearing — an unsafe SC_BIND exits BEFORE the transport ever serves,
+    and the sandbox's deliberate wide bind still reaches it.
+    """
+
+    def _start(self, bind, *, sandbox=False):
+        """Run main([]) to the bind decision. Returns (refusal, served): the
+        SystemExit main() raised or None, and the host transport.serve was
+        actually called with or None if the listener was never reached."""
+        served = []
+
+        async def _fake_serve(host, port, http_handler, ws_handler, log=print):
+            served.append(host)
+            return port
+
+        env = {"SC_BIND": bind}
+        if sandbox:
+            env["SC_SANDBOX"] = "1"
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "shell_db.db"
+            db_path.touch()
+            with contextlib.ExitStack() as stack:
+                enter = stack.enter_context
+                enter(mock.patch.dict(os.environ, env, clear=False))
+                if not sandbox:
+                    os.environ.pop("SC_SANDBOX", None)
+                enter(mock.patch.object(server, "DB_PATH", db_path))
+                enter(mock.patch.object(server.ports_mod, "resolve",
+                                        return_value={"port": 8800}))
+                # Everything main() does between the DB check and the bind is
+                # someone else's contract — stub it so only the ordering of
+                # guard vs. serve is under test here.
+                enter(mock.patch.object(server, "require_current_schema"))
+                enter(mock.patch.object(server.backfill_shell_api_keys,
+                                        "backfill"))
+                enter(mock.patch.object(server.mem_credentials, "provision"))
+                enter(mock.patch.object(server.db_driver, "connect"))
+                enter(mock.patch.object(server.interface_reconcile,
+                                        "startup_reconcile", return_value={}))
+                enter(mock.patch.object(server.pr_poller, "Poller"))
+                enter(mock.patch.object(server, "interface_ws", None))
+                enter(mock.patch.object(transport, "serve", _fake_serve))
+                enter(contextlib.redirect_stdout(io.StringIO()))
+                enter(contextlib.redirect_stderr(io.StringIO()))
+                refusal = None
+                try:
+                    server.main([])
+                except SystemExit as exc:
+                    refusal = exc
+        return refusal, (served[0] if served else None)
+
+    def test_startup_refuses_an_unsafe_bind_before_serving(self):
+        for bind in ("0.0.0.0", "::", "192.168.1.10", "example.com"):
+            with self.subTest(bind=bind):
+                refusal, served = self._start(bind)
+                self.assertIsNotNone(
+                    refusal, "main() accepted a non-loopback bind on a host")
+                self.assertIn("loopback", str(refusal))
+                self.assertIn("SC_BIND", str(refusal))
+                # The refusal is only a fence if the listener never opened —
+                # assert that directly rather than inferring it from the exit.
+                self.assertIsNone(
+                    served, f"transport served {served!r} despite the refusal")
+
+    def test_startup_serves_a_loopback_bind(self):
+        self.assertEqual(self._start("127.0.0.1"), (None, "127.0.0.1"))
+
+    def test_startup_serves_the_wide_bind_in_the_sandbox(self):
+        # The counterweight: over-refusing here would make `./sc launch`
+        # unbootable, so the sandbox exception has to survive the wiring too.
+        self.assertEqual(self._start("0.0.0.0", sandbox=True),
+                         (None, "0.0.0.0"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sprint 38, unit 2. Builds spec `#26` (Interface local trust and browser bootstrap) under decisions `#29` (the direction), `#30` (the personal-machine boundary ruling) and `#51` (released to build now).

## What changes

Opening the Interface no longer asks the operator to paste
`.super-coder/run/interface/operator.token` into a browser prompt. A fresh
same-origin visit silently receives a scoped browser session.

**Why that is safe, stated plainly:** Subfloor is a personal-machine tool — one
user, or two or three mutually trusted family members. Local processes and
same-UID shells are not principals it isolates itself from (decision `#30`), so
the paste prompt only ever added friction against an excluded actor. It did so
by putting a long-lived filesystem capability into page JavaScript, where an XSS
bug could exfiltrate it. That trade is now reversed: **the browser receives no
capability at all.**

The boundary that is kept is the one that faces the web, and it got *stricter*,
not looser: bootstrap now demands an exact allowed `Host`, an exact same-origin
`Origin`, **and** `Sec-Fetch-Site: same-origin` — where the old check tolerated a
missing `Origin` and an absent `Sec-Fetch-Site` (it had to, because the same
helper served the CLI). A browser-supplied bearer is now **refused** rather than
ignored, so page code cannot start carrying one.

## Server

- `_browser_origin()` replaces `_same_origin_proof()`. The bootstrap is
  browser-only, so provenance is positively proven instead of tolerated; the
  proven scheme is what decides the cookie's `Secure` attribute.
- Session lifecycle: 24h inactivity deadline advanced on authenticated use;
  rotation revokes the presented session **in the same critical section** that
  mints its replacement, so no window exists where both identifiers work;
  cleanup rides the requests that touch the store (no scheduled poll).
- Sessions stay live-process state — never the DB, a snapshot, or a log — so a
  restart invalidates them, which is the intended recovery path.
- A cookie the store no longer knows answers `401 browser_session_expired`.
  Naming it distinctly is what lets the UI recover silently instead of surfacing
  an error.

## UI

The prompt and all browser token handling are deleted. The one silent
bootstrap-and-retry remains and reuses the call's **original** idempotency key —
including one `apiIf` generated itself — so recovery cannot duplicate a
mutation. Cookies blocked reports browser sessions unavailable; there is
deliberately no fallback, because there is nothing to fall back to.

## Docs

New `.super-coder/docs/interface-trust-boundary.md` (linked from `./sc help`):
what is trusted and why, what is still defended (hostile origins, CSRF, DNS
rebind, accidental network exposure, credential leakage), the session lifecycle,
and the installing-user ownership contract — verified: the container runs under
the installing user's uid/gid, brokers are `systemctl --user`, the port is
loopback-only, and the engine never invokes `sudo` (the only `sudo` in the repo
is *printed advice* for one-time Docker setup). The rootful-Docker `docker`-group
caveat is stated rather than hidden.

## Tests

Spec `#26`'s Verification section is the gate, negatives included:

- bootstrap mints with no capability; cookie is `HttpOnly` + `SameSite=Strict` +
  `Path=/`, `Secure` only on https, and the anti-forgery token is body-only;
- provenance fence — 9 subtests: other-origin page, other-origin page *claiming*
  same-origin metadata, cross-site form submission, missing `Origin`, missing
  fetch metadata, opaque `Origin`, top-level navigation, junk `Origin`, and no
  provenance at all — every one 403 with an empty session store afterwards;
- rebound `Host` → 403; browser-supplied bearer (real *and* guessed) → 403;
- rotation revokes the old session; inactivity expiry deletes server-side state;
  use inside the window advances the deadline; a restart-equivalent wipe yields
  `browser_session_expired`; independent tabs coexist;
- the session identifier appears in **no** table of the engine DB (asserted
  against every table, not a named list);
- cookie-only, malformed-`X-CSRF`, and cross-site mutation each 403 — the last
  even when holding both the cookie and its valid token;
- no `Access-Control-Allow-Origin` on the bootstrap response.

A new browser-contract test runs the real shipped `ifBootstrap`/`apiIf` in Node
against a fake fetch: no `Authorization`, same-origin credentials, one silent
retry that reuses the original idempotency key, a second failure that surfaces
instead of looping, and cookies-blocked short-circuiting before any request.
It was mutation-checked — reverting the key to per-attempt turns it red.

Full suite: **1193 passed**. The 7 `test_interface_ui_rendered.py` errors in this
sandbox are environmental and pre-existing — the baked Playwright browser
(`chromium-1223`) does not match the pinned wheel's expected build (`1181`), so
`BrowserType.launch` cannot find its executable. CI's `interface-rendered` job
installs its own pinned browser stack.

## Judgement call

Spec `#26`'s API table names `403 host_not_allowed` for a bad Host; the
pre-existing global Host fence returned `bad_host`. The fence is global to every
Interface route, so this renames an error code slightly outside unit scope — one
call site, one assertion, identical status and behaviour. Chose spec conformance
over leaving a documented code unimplemented; happy to revert if the reviewer
reads the table as bootstrap-local.

---

## Re-review round 2 — SC-144, SC-145, and both Lows (@40de85c)

Rebased onto `origin/main` @0ce9ed9 per the sprint merge protocol. My production
files (`api/server.py`, `api/interface_routes.py`, `docs/interface-trust-boundary.md`)
are **byte-identical across the rebase**; only `tests/test_interface_api.py` took
content, absorbing unit 3's `set_route`/`sweep_switch_back` refactor. Every line
the rebase removed from that file belongs to unit 3's own refactor — none of this
unit's tests were dropped. **This is not a test-only change**: `interface_routes.py`
changed behaviour (Origin exactness) and prose (SC-145).

Each fix below names the property it protects and the mutation that pins it, and
every round trip was run: green → break the property in the source → RED → restore
→ green.

**SC-144 (Medium) — the loopback guard was unpinned.** `LoopbackBindGuardTest`
called `require_loopback_bind` directly, so deleting `main()`'s sole call to it
left 3 tests / 12 subtests green while the original unsafe startup returned.
`LoopbackBindStartupWiringTest` now drives `server.main([])` itself and asserts an
unsafe `SC_BIND` exits **before** `transport.serve` — asserting the negative
directly rather than inferring it from `SystemExit` — while the sandbox's
deliberate `0.0.0.0` still reaches serve, so the wiring cannot be "fixed" by
over-refusing and making `./sc launch` unbootable.
*Mutation:* delete `require_loopback_bind(bind)` from `main()` → 4 subtests RED on
the new class, every `LoopbackBindGuardTest` subtest still green (REV2's exact
mutation) → restore → 8 passed.

**SC-145 (Medium) — the revocation residual was described too narrowly.**
`_commit_browser_use` releases `_browser_lock` before returning, and route
selection plus the handler run outside it, so rotation landing between that return
and the handler's first line still reaches the handler. Fixed by correcting the
claim, not the synchronization: holding the lock across dispatch is the
alternative SC-131 already rejected and the planner ratified. The residual now
reads at its real bound — *any request that has passed the dispatch re-check may
finish, handler started or not* — in both the docstring and the trust doc.
*Mutation:* a residual described only in prose is the same unpinned shape as
SC-144, so `test_rotation_after_the_dispatch_recheck_does_not_stop_the_request`
rotates **after** the real re-check authorizes the request and asserts it still
completes `201` while the old sid is genuinely revoked. Adding a post-re-check
membership test to dispatch (actually strengthening the synchronization) turns it
RED — the correct moment to rewrite both prose sites.

**Low — Origin exactness (fixed).** Both fences compared only `netloc`, so
`http://127.0.0.1:8800/ui/app.js?x=1` passed as same-origin. A serialized origin
(RFC 6454) is `scheme://host[:port]` and stops there. `_same_origin_as_host` now
rejects path/query/fragment at the mint fence **and** the mutation fence —
tightening one and leaving the other loose would only become the next finding.
Wrong-scheme (https `Origin`, http bind) still passes, as REV2 accepted, for HTTPS
termination. The doc already claimed "exact same-origin `Origin`"; it is now true.
*Mutation:* revert the exactness check → 3 bootstrap subtests plus the
mutation-fence case go RED.

**Low — release-gate teardown (fixed).** `_stop_transport` scheduled
`Transport.stop()` after stopping and joining the loop, so the coroutine never ran
and the listening socket outlived the class. It now runs on the live loop via
`run_coroutine_threadsafe(...).result()` before the loop stops.

Full suite on the rebased head: **1227 passed**. The same 7
`test_interface_ui_rendered.py` errors remain environmental (sandbox Playwright
browser absent — flagged separately); CI's `interface-rendered` job passes. Lint
is unchanged by this work: 22 findings, all pre-existing on `origin/main`
(the 2 not in the earlier count of 20 are in unit 1's `tests/test_operator_surface.py`).
