### PR TITLE
fix(interface): state the launch route, never claim the live model (S38 U3)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -338,51 +338,20 @@ def _exact_identity_verified(con, session_id: int) -> bool:
         return False
 
 
-def _observed_model(con, archive_id) -> "str | None":
-    """The model this session was OBSERVED running, or None if unobserved.
-
-    `interface_sessions.model_route` is only the route the session was LAUNCHED
-    with; an in-harness `/model` switch never reaches the engine (the lifecycle
-    hook contract discards the native payload by design — spec #20 Harness
-    Hooks), so the route goes stale the moment the operator switches. The
-    feature #17 analytics sweep is the seam that does observe it:
-    `session_token_usage` carries harness-reported model ids read out of the
-    harness's own transcript, one row per (harness session x model), so a
-    switch shows up as an extra row and the most recently active one is what
-    is actually running.
-
-    The sweep runs at boot, not in real time, so a live session may have no row
-    yet — that is None, and callers must render it as unobserved rather than
-    falling back silently to the launch route (flag #130)."""
-    if archive_id is None:
-        return None
-    row = con.execute(
-        "SELECT model FROM session_token_usage "
-        "WHERE archive_id=? AND model IS NOT NULL "
-        "ORDER BY ended_at DESC, started_at DESC, usage_id DESC LIMIT 1",
-        (archive_id,)).fetchone()
-    return row[0] if row else None
-
-
 def _availability(con, shell_id: int, snap) -> dict:
     """The rail projection (spec #20 Occupancy Model): occupancy + lifecycle
     projected for compact display; New-chat authority never changes here. A
     shell with no live session is available ONLY after the liveness scan
-    clears it — a legacy/unmanaged harness makes it unreconciled.
-
-    `model_route` and `model_observed` are two different claims and ship as two
-    fields: the route the session was launched with, and the model the sweep
-    has actually seen it run (None = not observed yet)."""
+    clears it — a legacy/unmanaged harness makes it unreconciled."""
     active_session = interface_state.active_session_sql("s")
     row = con.execute(
         "SELECT s.session_id, s.generation, s.occupancy, s.lifecycle, "
-        "s.harness, s.model_route, s.archive_id "
+        "s.harness, s.model_route "
         "FROM interface_sessions s WHERE s.shell_id=? "
         f"AND {active_session} ORDER BY s.session_id DESC LIMIT 1",
         (shell_id,)).fetchone()
     if row is not None:
-        (session_id, generation, occupancy, lifecycle, harness, model_route,
-         archive_id) = row
+        session_id, generation, occupancy, lifecycle, harness, model_route = row
         client = _client_state(con, session_id)
         if occupancy == "reserved":
             availability = "starting"
@@ -398,17 +367,16 @@ def _availability(con, shell_id: int, snap) -> dict:
                 "generation": generation,
                 "lifecycle": lifecycle, "harness": harness,
                 "model_route": model_route,
-                "model_observed": _observed_model(con, archive_id),
                 "composer": composer[0] if composer else None,
                 "alerts": _alert_count(con, session_id), **client}
     state = shell_liveness.session_state(_shortname(con, shell_id), snap)
     if state is not None:
         return {"availability": "unreconciled", "session_id": None,
                 "lifecycle": None, "harness": None, "composer": None,
-                "model_route": None, "model_observed": None, "alerts": 0}
+                "model_route": None, "alerts": 0}
     return {"availability": "available", "session_id": None,
             "lifecycle": None, "harness": None, "model_route": None,
-            "model_observed": None, "composer": None, "alerts": 0}
+            "composer": None, "alerts": 0}
 
 
 def _shortname(con, shell_id: int) -> str:
@@ -761,7 +729,6 @@ def _get_session(session_id: int):
         return _json(200, {
             "session_id": row[0], "shell_id": row[1], "generation": row[2],
             "archive_id": row[3], "harness": row[4], "model_route": row[5],
-            "model_observed": _observed_model(con, row[3]),
             "worktree": row[6], "occupancy": row[7], "lifecycle": row[8],
             "created_at": row[9], "occupied_at": row[10],
             "ended_at": row[11], "end_reason": row[12],

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -338,20 +338,51 @@ def _exact_identity_verified(con, session_id: int) -> bool:
         return False
 
 
+def _observed_model(con, archive_id) -> "str | None":
+    """The model this session was OBSERVED running, or None if unobserved.
+
+    `interface_sessions.model_route` is only the route the session was LAUNCHED
+    with; an in-harness `/model` switch never reaches the engine (the lifecycle
+    hook contract discards the native payload by design — spec #20 Harness
+    Hooks), so the route goes stale the moment the operator switches. The
+    feature #17 analytics sweep is the seam that does observe it:
+    `session_token_usage` carries harness-reported model ids read out of the
+    harness's own transcript, one row per (harness session x model), so a
+    switch shows up as an extra row and the most recently active one is what
+    is actually running.
+
+    The sweep runs at boot, not in real time, so a live session may have no row
+    yet — that is None, and callers must render it as unobserved rather than
+    falling back silently to the launch route (flag #130)."""
+    if archive_id is None:
+        return None
+    row = con.execute(
+        "SELECT model FROM session_token_usage "
+        "WHERE archive_id=? AND model IS NOT NULL "
+        "ORDER BY ended_at DESC, started_at DESC, usage_id DESC LIMIT 1",
+        (archive_id,)).fetchone()
+    return row[0] if row else None
+
+
 def _availability(con, shell_id: int, snap) -> dict:
     """The rail projection (spec #20 Occupancy Model): occupancy + lifecycle
     projected for compact display; New-chat authority never changes here. A
     shell with no live session is available ONLY after the liveness scan
-    clears it — a legacy/unmanaged harness makes it unreconciled."""
+    clears it — a legacy/unmanaged harness makes it unreconciled.
+
+    `model_route` and `model_observed` are two different claims and ship as two
+    fields: the route the session was launched with, and the model the sweep
+    has actually seen it run (None = not observed yet)."""
     active_session = interface_state.active_session_sql("s")
     row = con.execute(
         "SELECT s.session_id, s.generation, s.occupancy, s.lifecycle, "
-        "s.harness, s.model_route "
+        "s.harness, s.model_route, s.archive_id "
         "FROM interface_sessions s WHERE s.shell_id=? "
         f"AND {active_session} ORDER BY s.session_id DESC LIMIT 1",
         (shell_id,)).fetchone()
     if row is not None:
-        session_id, generation, occupancy, lifecycle, harness, model_route = row
+        (session_id, generation, occupancy, lifecycle, harness, model_route,
+         archive_id) = row
         client = _client_state(con, session_id)
         if occupancy == "reserved":
             availability = "starting"
@@ -367,16 +398,17 @@ def _availability(con, shell_id: int, snap) -> dict:
                 "generation": generation,
                 "lifecycle": lifecycle, "harness": harness,
                 "model_route": model_route,
+                "model_observed": _observed_model(con, archive_id),
                 "composer": composer[0] if composer else None,
                 "alerts": _alert_count(con, session_id), **client}
     state = shell_liveness.session_state(_shortname(con, shell_id), snap)
     if state is not None:
         return {"availability": "unreconciled", "session_id": None,
                 "lifecycle": None, "harness": None, "composer": None,
-                "model_route": None, "alerts": 0}
+                "model_route": None, "model_observed": None, "alerts": 0}
     return {"availability": "available", "session_id": None,
             "lifecycle": None, "harness": None, "model_route": None,
-            "composer": None, "alerts": 0}
+            "model_observed": None, "composer": None, "alerts": 0}
 
 
 def _shortname(con, shell_id: int) -> str:
@@ -729,6 +761,7 @@ def _get_session(session_id: int):
         return _json(200, {
             "session_id": row[0], "shell_id": row[1], "generation": row[2],
             "archive_id": row[3], "harness": row[4], "model_route": row[5],
+            "model_observed": _observed_model(con, row[3]),
             "worktree": row[6], "occupancy": row[7], "lifecycle": row[8],
             "created_at": row[9], "occupied_at": row[10],
             "ended_at": row[11], "end_reason": row[12],

--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -205,6 +205,18 @@ def _status_line(s: dict) -> str:
     return f"{short} {name} {avail} {' · '.join(bits)}".rstrip()
 
 
+def _model_cell(detail: dict) -> str:
+    """Same honesty rule as the browser rail (flag #130): report the model the
+    session was observed running, or the launch route MARKED as the launch
+    route when the analytics sweep has not seen this session yet. `model_route`
+    alone is the route it started on and goes stale on an in-harness /model
+    switch, so it is never printed as a bare 'model'."""
+    observed = detail.get("model_observed")
+    if observed:
+        return str(observed)
+    return f"{detail.get('model_route') or 'harness default'} (launched)"
+
+
 def cmd_status(args) -> int:
     if not args.shell:
         shells = _shells()
@@ -231,7 +243,7 @@ def cmd_status(args) -> int:
             ("occupancy", detail.get("occupancy")),
             ("lifecycle", detail.get("lifecycle")),
             ("harness", detail.get("harness")),
-            ("model", detail.get("model_route")),
+            ("model", _model_cell(detail)),
             ("composer", detail.get("composer")),
             ("writer", held),
             ("wake", detail.get("wake_state")),

--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -205,16 +205,13 @@ def _status_line(s: dict) -> str:
     return f"{short} {name} {avail} {' · '.join(bits)}".rstrip()
 
 
-def _model_cell(detail: dict) -> str:
-    """Same honesty rule as the browser rail (flag #130): report the model the
-    session was observed running, or the launch route MARKED as the launch
-    route when the analytics sweep has not seen this session yet. `model_route`
-    alone is the route it started on and goes stale on an in-harness /model
-    switch, so it is never printed as a bare 'model'."""
-    observed = detail.get("model_observed")
-    if observed:
-        return str(observed)
-    return f"{detail.get('model_route') or 'harness default'} (launched)"
+def _launched_cell(detail: dict) -> str:
+    """Same honesty rule as the browser rail (flag #130, decision #55): state
+    the LAUNCH ROUTE as the launch route and never claim the live model.
+    `model_route` is only what the session was started with — an in-harness
+    `/model` switch never reaches the engine (spec #20 Harness Hooks discards
+    the native payload) — so it is never printed under a bare `model` key."""
+    return str(detail.get("model_route") or "harness default")
 
 
 def cmd_status(args) -> int:
@@ -243,7 +240,7 @@ def cmd_status(args) -> int:
             ("occupancy", detail.get("occupancy")),
             ("lifecycle", detail.get("lifecycle")),
             ("harness", detail.get("harness")),
-            ("model", _model_cell(detail)),
+            ("launched", _launched_cell(detail)),
             ("composer", detail.get("composer")),
             ("writer", held),
             ("wake", detail.get("wake_state")),

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2199,6 +2199,20 @@ function ifModelLabel(route) {
   return String(route).replace(/[-_]+/g, " ").trim().toUpperCase();
 }
 
+// What the surface may say about a session's model (flag #130). `model_route`
+// is only the route the session was LAUNCHED with — an in-harness /model switch
+// never reaches the engine — so it is never rendered as a bare claim about the
+// live model. `model_observed` comes from the analytics sweep, which reads the
+// harness's own transcript but is not real-time: an unswept session has none,
+// and then the launch route is shown MARKED as the launch route.
+function ifModelDisplay(observed, route) {
+  if (observed) return { text: ifModelLabel(observed),
+    title: "the model this session was last observed running (analytics sweep)" };
+  return { text: ifModelLabel(route) + " (launched)",
+    title: "the route this session was launched with — its live model has not "
+         + "been observed yet, and an in-harness /model switch would not show here" };
+}
+
 async function renderInterface(root) {
   root.replaceChildren();
   let shells;
@@ -2230,17 +2244,16 @@ async function renderInterface(root) {
     if (s.alerts > 0)
       head.append(el("span", { className: "pill if-badge bad",
         title: s.alerts + " current alert(s)" }, "⚠ " + s.alerts));
-    const occupiedModel = s.availability === "occupied"
-      ? " · " + ifModelLabel(s.model_route)
-      : "";
-    row.append(head,
-      el("div", { className: "if-row-sub" },
-        s.shortname + (s.harness ? " · " + s.harness : "") + occupiedModel));
+    const model = s.availability === "occupied"
+      ? ifModelDisplay(s.model_observed, s.model_route)
+      : null;
+    const sub = el("div", { className: "if-row-sub" },
+      s.shortname + (s.harness ? " · " + s.harness : ""));
+    if (model) sub.append(el("span", { title: model.title }, " · " + model.text));
+    row.append(head, sub);
     row.onclick = () => { location.hash = "interface/" + s.shortname; };
     rail.append(row);
-    const mobileModel = s.availability === "occupied"
-      ? " · " + ifModelLabel(s.model_route)
-      : "";
+    const mobileModel = model ? " · " + model.text : "";
     const opt = el("option", { value: s.shortname },
       `${s.display_name || s.shortname} · ${s.shortname}` +
       `${s.harness ? " · " + s.harness : ""}${mobileModel}` +
@@ -2974,7 +2987,8 @@ async function ifSessionPane(pane, sel) {
 
   const st = {
     harness: sess.harness || sel.harness || "—",
-    model: sess.model_route || "harness default",
+    model: sess.model_observed || null,      // observed live model, or unobserved
+    modelRoute: sess.model_route || null,    // the route it was LAUNCHED with
     lifecycle: sess.lifecycle || "—",
     composer: sess.composer || "unknown",
     browserComposer: sess.browser_composer || "clean",
@@ -3089,12 +3103,19 @@ function ifAge(ts) {
 function ifPaintHeader(a, sel, pane) {
   const st = a.st;
   const controlsActive = IF_ATTACHABLE_LIFECYCLES.has(st.lifecycle);
-  const stat = (k, v) => el("span", { className: "if-stat" }, k + " ", el("b", {}, String(v)));
+  const stat = (k, v, title) => el("span",
+    title ? { className: "if-stat", title } : { className: "if-stat" },
+    k + " ", el("b", {}, String(v)));
   // Read-only session telemetry stays available without consuming the terminal
   // header. Actions remain outside the disclosure beside the state they change.
+  // model = what the session was observed running; the launch route is only
+  // shown as its own labelled stat, never as a claim about the live model.
+  const model = ifModelDisplay(st.model, st.modelRoute);
   a.sessionDetailsEl.replaceChildren(
     stat("harness", st.harness),
-    stat("model", ifModelLabel(st.model)),
+    stat("model", model.text, model.title),
+    ...(st.model ? [stat("launched", ifModelLabel(st.modelRoute),
+      "the route this session was launched with")] : []),
     stat("session", "#" + a.sessionId + (st.archive != null ? " · arc #" + st.archive : "")),
     stat("age", ifAge(st.since)),
     stat("lifecycle", st.lifecycle),

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2199,18 +2199,19 @@ function ifModelLabel(route) {
   return String(route).replace(/[-_]+/g, " ").trim().toUpperCase();
 }
 
-// What the surface may say about a session's model (flag #130). `model_route`
-// is only the route the session was LAUNCHED with — an in-harness /model switch
-// never reaches the engine — so it is never rendered as a bare claim about the
-// live model. `model_observed` comes from the analytics sweep, which reads the
-// harness's own transcript but is not real-time: an unswept session has none,
-// and then the launch route is shown MARKED as the launch route.
-function ifModelDisplay(observed, route) {
-  if (observed) return { text: ifModelLabel(observed),
-    title: "the model this session was last observed running (analytics sweep)" };
-  return { text: ifModelLabel(route) + " (launched)",
-    title: "the route this session was launched with — its live model has not "
-         + "been observed yet, and an in-harness /model switch would not show here" };
+// What the surface may say about a session's model (flag #130, decision #55).
+// `model_route` is only the route the session was LAUNCHED with — an in-harness
+// /model switch never reaches the engine — so it is labelled as the launch
+// route and never rendered as a claim about the live model. The analytics sweep
+// cannot supply the live one either: its rows carry one model per session-wide
+// window, so they cannot express switch order (flag #136). Deriving a truthful
+// current model is a feature #17 follow-up, not something this surface guesses.
+const IF_LAUNCHED_TITLE =
+  "the route this session was launched with — not necessarily the model it is "
+  + "running now, since an in-harness /model switch never reaches the engine";
+
+function ifLaunchedDisplay(route) {
+  return { text: ifModelLabel(route) + " (launched)", title: IF_LAUNCHED_TITLE };
 }
 
 async function renderInterface(root) {
@@ -2244,16 +2245,17 @@ async function renderInterface(root) {
     if (s.alerts > 0)
       head.append(el("span", { className: "pill if-badge bad",
         title: s.alerts + " current alert(s)" }, "⚠ " + s.alerts));
-    const model = s.availability === "occupied"
-      ? ifModelDisplay(s.model_observed, s.model_route)
+    const launched = s.availability === "occupied"
+      ? ifLaunchedDisplay(s.model_route)
       : null;
     const sub = el("div", { className: "if-row-sub" },
       s.shortname + (s.harness ? " · " + s.harness : ""));
-    if (model) sub.append(el("span", { title: model.title }, " · " + model.text));
+    if (launched)
+      sub.append(el("span", { title: launched.title }, " · " + launched.text));
     row.append(head, sub);
     row.onclick = () => { location.hash = "interface/" + s.shortname; };
     rail.append(row);
-    const mobileModel = model ? " · " + model.text : "";
+    const mobileModel = launched ? " · " + launched.text : "";
     const opt = el("option", { value: s.shortname },
       `${s.display_name || s.shortname} · ${s.shortname}` +
       `${s.harness ? " · " + s.harness : ""}${mobileModel}` +
@@ -2987,7 +2989,6 @@ async function ifSessionPane(pane, sel) {
 
   const st = {
     harness: sess.harness || sel.harness || "—",
-    model: sess.model_observed || null,      // observed live model, or unobserved
     modelRoute: sess.model_route || null,    // the route it was LAUNCHED with
     lifecycle: sess.lifecycle || "—",
     composer: sess.composer || "unknown",
@@ -3108,14 +3109,11 @@ function ifPaintHeader(a, sel, pane) {
     k + " ", el("b", {}, String(v)));
   // Read-only session telemetry stays available without consuming the terminal
   // header. Actions remain outside the disclosure beside the state they change.
-  // model = what the session was observed running; the launch route is only
-  // shown as its own labelled stat, never as a claim about the live model.
-  const model = ifModelDisplay(st.model, st.modelRoute);
+  // The launch route gets its own labelled stat — there is no `model` stat,
+  // because nothing here observes the model the session is running now.
   a.sessionDetailsEl.replaceChildren(
     stat("harness", st.harness),
-    stat("model", model.text, model.title),
-    ...(st.model ? [stat("launched", ifModelLabel(st.modelRoute),
-      "the route this session was launched with")] : []),
+    stat("launched", ifModelLabel(st.modelRoute), IF_LAUNCHED_TITLE),
     stat("session", "#" + a.sessionId + (st.archive != null ? " · arc #" + st.archive : "")),
     stat("age", ifAge(st.since)),
     stat("lifecycle", st.lifecycle),

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -250,19 +250,36 @@ class InterfaceApiTest(unittest.TestCase):
         self.assertIsNone(body["shells"][1]["default_harness"])
         self.assertIsNone(body["shells"][1]["default_model"])
 
-    def test_occupied_shell_projection_includes_live_model_route(self):
-        session_id = self.occupy()
+    # -- model: launch route vs observed model (flag #130) ----------------------
+
+    def set_route(self, session_id, route):
         with sqlite3.connect(self.db_path) as con:
             con.execute(
                 "UPDATE interface_sessions SET model_route=? "
-                "WHERE session_id=?",
-                ("gpt-5.6-terra", session_id),
-            )
+                "WHERE session_id=?", (route, session_id))
 
+    def sweep_usage(self, model, archive_id=10, ref="t1", ended_at=None):
+        """One analytics-sweep row (feature #17) — the ground truth the rail
+        reads. UNIQUE(harness, harness_session_ref, model) lets one harness
+        session carry several models, which is the /model-switch case."""
+        with sqlite3.connect(self.db_path) as con:
+            con.execute(
+                "INSERT INTO session_token_usage "
+                "(archive_id, shell_id, harness, harness_session_ref, model, "
+                " ended_at, status) VALUES (?,1,'claude',?,?,?,'ok')",
+                (archive_id, ref, model, ended_at))
+
+    def shell_projection(self):
         status, _, body = self.call("GET", "/api/interface/shells", (OP,))
-
         self.assertEqual(status, 200)
-        shell = body["shells"][0]
+        return body["shells"][0]
+
+    def test_occupied_shell_projection_includes_launch_model_route(self):
+        session_id = self.occupy()
+        self.set_route(session_id, "gpt-5.6-terra")
+
+        shell = self.shell_projection()
+
         self.assertEqual(
             {
                 "availability": shell["availability"],
@@ -277,6 +294,49 @@ class InterfaceApiTest(unittest.TestCase):
                 "model_route": "gpt-5.6-terra",
             },
         )
+        # Nothing swept yet: the projection says so instead of passing the
+        # launch route off as the live model.
+        self.assertIsNone(shell["model_observed"])
+
+    def test_projection_reports_swept_model_beside_the_launch_route(self):
+        # The reproduction from flag #130: launched on fable, running Opus 5.
+        session_id = self.occupy()
+        self.set_route(session_id, "fable")
+        self.sweep_usage("claude-opus-5")
+
+        shell = self.shell_projection()
+
+        self.assertEqual(shell["model_observed"], "claude-opus-5")
+        self.assertEqual(shell["model_route"], "fable")
+
+    def test_observed_model_follows_the_latest_in_harness_switch(self):
+        session_id = self.occupy()
+        self.set_route(session_id, "fable")
+        self.sweep_usage("claude-fable-5", ended_at="2026-07-24 09:00:00")
+        self.sweep_usage("claude-opus-5", ended_at="2026-07-24 11:00:00")
+
+        self.assertEqual(self.shell_projection()["model_observed"],
+                         "claude-opus-5")
+
+    def test_observed_model_is_scoped_to_this_session_archive(self):
+        # occupy() attributes session 1 to archive 10; a sweep row on another
+        # archive belongs to another session and must not be reported here.
+        self.occupy()
+        self.sweep_usage("claude-opus-5", archive_id=20, ref="other")
+
+        self.assertIsNone(self.shell_projection()["model_observed"])
+
+    def test_session_detail_carries_route_and_observed_model(self):
+        session_id = self.occupy()
+        self.set_route(session_id, "fable")
+        self.sweep_usage("claude-opus-5")
+
+        status, _, body = self.call(
+            "GET", f"/api/interface/sessions/{session_id}", (OP,))
+
+        self.assertEqual(status, 200)
+        self.assertEqual((body["model_route"], body["model_observed"]),
+                         ("fable", "claude-opus-5"))
 
     def test_browser_bootstrap_same_origin_fence(self):
         # Cross-site Origin cannot mint a session (rejected before the

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -250,7 +250,7 @@ class InterfaceApiTest(unittest.TestCase):
         self.assertIsNone(body["shells"][1]["default_harness"])
         self.assertIsNone(body["shells"][1]["default_model"])
 
-    # -- model: launch route vs observed model (flag #130) ----------------------
+    # -- the model surfaces carry the launch route only (flag #130, dec #55) ---
 
     def set_route(self, session_id, route):
         with sqlite3.connect(self.db_path) as con:
@@ -258,16 +258,30 @@ class InterfaceApiTest(unittest.TestCase):
                 "UPDATE interface_sessions SET model_route=? "
                 "WHERE session_id=?", (route, session_id))
 
-    def sweep_usage(self, model, archive_id=10, ref="t1", ended_at=None):
-        """One analytics-sweep row (feature #17) — the ground truth the rail
-        reads. UNIQUE(harness, harness_session_ref, model) lets one harness
-        session carry several models, which is the /model-switch case."""
+    def sweep_switch_back(self, archive_id=10):
+        """The analytics sweep's REAL output for an A→B→A model switch inside
+        one harness session, as `token_parsers/claude.py` emits it — the shape
+        that makes a current-model claim underivable (flag #136):
+
+        * one row per (session × model), both stamped with the SAME
+          session-wide started_at/ended_at (the parser builds them from the
+          transcript's first/last timestamp and reuses that pair for every
+          model row — verified live on archive 8, usage_id 6 and 7);
+        * UNIQUE (harness, harness_session_ref, model) collapses the return to
+          A into the existing A row, so the switch-back leaves no trace and
+          the LAST-inserted row is B — the model that is not running now.
+
+        Any ordering over these rows therefore reports B. That is why the
+        surfaces state the launch route instead of guessing."""
+        window = ("2026-07-24T09:39:27Z", "2026-07-24T11:53:12Z")
         with sqlite3.connect(self.db_path) as con:
-            con.execute(
-                "INSERT INTO session_token_usage "
-                "(archive_id, shell_id, harness, harness_session_ref, model, "
-                " ended_at, status) VALUES (?,1,'claude',?,?,?,'ok')",
-                (archive_id, ref, model, ended_at))
+            for model in ("claude-opus-5", "claude-fable-5"):
+                con.execute(
+                    "INSERT INTO session_token_usage "
+                    "(archive_id, shell_id, harness, harness_session_ref, "
+                    " model, started_at, ended_at, status) "
+                    "VALUES (?,1,'claude','t1',?,?,?,'ok')",
+                    (archive_id, model, *window))
 
     def shell_projection(self):
         status, _, body = self.call("GET", "/api/interface/shells", (OP,))
@@ -294,49 +308,29 @@ class InterfaceApiTest(unittest.TestCase):
                 "model_route": "gpt-5.6-terra",
             },
         )
-        # Nothing swept yet: the projection says so instead of passing the
-        # launch route off as the live model.
-        self.assertIsNone(shell["model_observed"])
 
-    def test_projection_reports_swept_model_beside_the_launch_route(self):
-        # The reproduction from flag #130: launched on fable, running Opus 5.
+    def test_model_surfaces_stay_the_launch_route_across_a_switch_back(self):
+        # Launched on fable, ran opus, switched back to opus's predecessor and
+        # back again: the sweep cannot express that, so neither surface may
+        # derive a "current" model from it. `model_route` — the launch route,
+        # named as such — stays the only model-bearing field on both.
         session_id = self.occupy()
         self.set_route(session_id, "fable")
-        self.sweep_usage("claude-opus-5")
+        self.sweep_switch_back()
 
         shell = self.shell_projection()
-
-        self.assertEqual(shell["model_observed"], "claude-opus-5")
-        self.assertEqual(shell["model_route"], "fable")
-
-    def test_observed_model_follows_the_latest_in_harness_switch(self):
-        session_id = self.occupy()
-        self.set_route(session_id, "fable")
-        self.sweep_usage("claude-fable-5", ended_at="2026-07-24 09:00:00")
-        self.sweep_usage("claude-opus-5", ended_at="2026-07-24 11:00:00")
-
-        self.assertEqual(self.shell_projection()["model_observed"],
-                         "claude-opus-5")
-
-    def test_observed_model_is_scoped_to_this_session_archive(self):
-        # occupy() attributes session 1 to archive 10; a sweep row on another
-        # archive belongs to another session and must not be reported here.
-        self.occupy()
-        self.sweep_usage("claude-opus-5", archive_id=20, ref="other")
-
-        self.assertIsNone(self.shell_projection()["model_observed"])
-
-    def test_session_detail_carries_route_and_observed_model(self):
-        session_id = self.occupy()
-        self.set_route(session_id, "fable")
-        self.sweep_usage("claude-opus-5")
-
-        status, _, body = self.call(
+        status, _, detail = self.call(
             "GET", f"/api/interface/sessions/{session_id}", (OP,))
 
         self.assertEqual(status, 200)
-        self.assertEqual((body["model_route"], body["model_observed"]),
-                         ("fable", "claude-opus-5"))
+        self.assertEqual(shell["model_route"], "fable")
+        self.assertEqual(detail["model_route"], "fable")
+        # `default_model` is the flavor default the NEXT launch would use, not
+        # a claim about this session, so it is excluded here.
+        session_model_keys = sorted(
+            k for k in (*shell, *detail)
+            if "model" in k and not k.startswith("default_"))
+        self.assertEqual(set(session_model_keys), {"model_route"})
 
     def test_browser_bootstrap_same_origin_fence(self):
         # Cross-site Origin cannot mint a session (rejected before the

--- a/tests/test_interface_cli.py
+++ b/tests/test_interface_cli.py
@@ -204,6 +204,25 @@ class InterfaceCliTest(unittest.TestCase):
         rc, out, _ = self.run_cli(["status", "s2"])
         self.assertIn("held by web-1", out)
 
+    def test_status_model_row_never_asserts_an_unobserved_route(self):
+        """flag #130 — `model_route` is the route the session was LAUNCHED
+        with, so status prints it marked as such; the swept live model wins
+        when the sweep has seen one."""
+        self.http.add("GET", "/api/interface/sessions/7",
+                      {**SESSION7, "model_route": "fable",
+                       "model_observed": None})
+        rc, out, _ = self.run_cli(["status", "s2"])
+        self.assertEqual(rc, 0)
+        self.assertIn("model       fable (launched)", out)
+
+        self.http.add("GET", "/api/interface/sessions/7",
+                      {**SESSION7, "model_route": "fable",
+                       "model_observed": "claude-opus-5"})
+        rc, out, _ = self.run_cli(["status", "s2"])
+        self.assertEqual(rc, 0)
+        self.assertIn("model       claude-opus-5", out)
+        self.assertNotIn("fable", out)
+
     def test_status_available_shell_has_no_session_fetch(self):
         rc, out, _ = self.run_cli(["status", "s1", "--json"])
         self.assertEqual(rc, 0)

--- a/tests/test_interface_cli.py
+++ b/tests/test_interface_cli.py
@@ -204,24 +204,24 @@ class InterfaceCliTest(unittest.TestCase):
         rc, out, _ = self.run_cli(["status", "s2"])
         self.assertIn("held by web-1", out)
 
-    def test_status_model_row_never_asserts_an_unobserved_route(self):
-        """flag #130 — `model_route` is the route the session was LAUNCHED
-        with, so status prints it marked as such; the swept live model wins
-        when the sweep has seen one."""
+    def test_status_states_the_launch_route_as_the_launch_route(self):
+        """flag #130 / decision #55 — `model_route` is only what the session
+        was LAUNCHED with, so status reports it under `launched` and never
+        under a bare `model` key that would read as the live model. Same rule
+        as the browser rail, which is the parity the sprint unit requires."""
         self.http.add("GET", "/api/interface/sessions/7",
-                      {**SESSION7, "model_route": "fable",
-                       "model_observed": None})
+                      {**SESSION7, "model_route": "fable"})
         rc, out, _ = self.run_cli(["status", "s2"])
         self.assertEqual(rc, 0)
-        self.assertIn("model       fable (launched)", out)
+        self.assertIn("launched    fable", out)
+        self.assertNotIn("model", out)
 
+    def test_status_launch_route_falls_back_to_the_harness_default(self):
         self.http.add("GET", "/api/interface/sessions/7",
-                      {**SESSION7, "model_route": "fable",
-                       "model_observed": "claude-opus-5"})
+                      {**SESSION7, "model_route": None})
         rc, out, _ = self.run_cli(["status", "s2"])
         self.assertEqual(rc, 0)
-        self.assertIn("model       claude-opus-5", out)
-        self.assertNotIn("fable", out)
+        self.assertIn("launched    harness default", out)
 
     def test_status_available_shell_has_no_session_fetch(self):
         rc, out, _ = self.run_cli(["status", "s1", "--json"])

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -30,10 +30,10 @@ SHELL = {
     "session_id": 7,
     "generation": 1,
     "harness": "codex",
-    # Launched on one route, observed running another (flag #130): the rail
-    # must show what was observed, never the stale launch route.
-    "model_route": "gpt-5.6-sol",
-    "model_observed": "gpt-5.6-terra",
+    # The route the session was LAUNCHED with — the only model fact the engine
+    # has (flag #130, decision #55), so every surface must label it as such
+    # rather than render it as the model the session is running now.
+    "model_route": "gpt-5.6-terra",
     "alerts": 2,
 }
 OTHER_SHELL = {
@@ -43,7 +43,6 @@ OTHER_SHELL = {
     "display_name": "Code-02",
     "session_id": 8,
     "model_route": "gpt-5.6-sol",
-    "model_observed": None,     # unswept — the fallback must say so
     "alerts": 0,
 }
 SESSION = {
@@ -52,8 +51,7 @@ SESSION = {
     "attachable": True,
     "identity_verified": True,
     "harness": "codex",
-    "model_route": "gpt-5.6-sol",
-    "model_observed": "gpt-5.6-terra",
+    "model_route": "gpt-5.6-terra",
     "lifecycle": "idle",
     "composer": "clean",
     "browser_composer": "clean",
@@ -448,8 +446,10 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
     desktop, page = _open_interface(browser, ui_url, height=1100)
     try:
         page.get_by_text("Alerts (2)", exact=True).wait_for()
+        # Every occupied row labels its route as the launch route — the rail
+        # never states a bare model it does not observe (flag #130, dec #55).
         rail_models = page.locator(".if-row-sub").all_inner_texts()
-        assert "DEV3 · codex · GPT 5.6 TERRA" in rail_models
+        assert "DEV3 · codex · GPT 5.6 TERRA (launched)" in rail_models
         assert "DEV4 · codex · GPT 5.6 SOL (launched)" in rail_models
         assert page.locator(".if-alerts").get_attribute("class").endswith(
             "critical"
@@ -459,8 +459,8 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
 
         page.get_by_text("Details", exact=True).click()
         details = page.locator(".if-details")
-        assert "model GPT 5.6 TERRA" in details.inner_text()
-        assert "launched GPT 5.6 SOL" in details.inner_text()
+        assert "launched GPT 5.6 TERRA" in details.inner_text()
+        assert "model " not in details.inner_text()
         assert "session #7 · arc #172" in details.inner_text()
         assert "wake armed" in details.inner_text()
         assert "sprint #31 Interface corrective hardening · ACTIVE" in (
@@ -549,7 +549,7 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
         assert geometry["headerOverflowX"] == "auto"
         options = page.locator(".if-picker option").all_inner_texts()
         assert (
-            "Code-01 · DEV3 · codex · GPT 5.6 TERRA · occupied"
+            "Code-01 · DEV3 · codex · GPT 5.6 TERRA (launched) · occupied"
             in options
         )
         assert (

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -553,7 +553,7 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
             in options
         )
         assert (
-            "Code-02 · DEV4 · codex · GPT 5.6 SOL · occupied"
+            "Code-02 · DEV4 · codex · GPT 5.6 SOL (launched) · occupied"
             in options
         )
         assert page.locator(".if-composer-actions button").all_inner_texts() == [

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -30,7 +30,10 @@ SHELL = {
     "session_id": 7,
     "generation": 1,
     "harness": "codex",
-    "model_route": "gpt-5.6-terra",
+    # Launched on one route, observed running another (flag #130): the rail
+    # must show what was observed, never the stale launch route.
+    "model_route": "gpt-5.6-sol",
+    "model_observed": "gpt-5.6-terra",
     "alerts": 2,
 }
 OTHER_SHELL = {
@@ -40,6 +43,7 @@ OTHER_SHELL = {
     "display_name": "Code-02",
     "session_id": 8,
     "model_route": "gpt-5.6-sol",
+    "model_observed": None,     # unswept — the fallback must say so
     "alerts": 0,
 }
 SESSION = {
@@ -48,7 +52,8 @@ SESSION = {
     "attachable": True,
     "identity_verified": True,
     "harness": "codex",
-    "model_route": "gpt-5.6-terra",
+    "model_route": "gpt-5.6-sol",
+    "model_observed": "gpt-5.6-terra",
     "lifecycle": "idle",
     "composer": "clean",
     "browser_composer": "clean",
@@ -445,7 +450,7 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
         page.get_by_text("Alerts (2)", exact=True).wait_for()
         rail_models = page.locator(".if-row-sub").all_inner_texts()
         assert "DEV3 · codex · GPT 5.6 TERRA" in rail_models
-        assert "DEV4 · codex · GPT 5.6 SOL" in rail_models
+        assert "DEV4 · codex · GPT 5.6 SOL (launched)" in rail_models
         assert page.locator(".if-alerts").get_attribute("class").endswith(
             "critical"
         )
@@ -455,6 +460,7 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
         page.get_by_text("Details", exact=True).click()
         details = page.locator(".if-details")
         assert "model GPT 5.6 TERRA" in details.inner_text()
+        assert "launched GPT 5.6 SOL" in details.inner_text()
         assert "session #7 · arc #172" in details.inner_text()
         assert "wake armed" in details.inner_text()
         assert "sprint #31 Interface corrective hardening · ACTIVE" in (


### PR DESCRIPTION
Sprint 38 unit 3 · authority: flag #130 · reviewer: REV1

**Revised 2026-07-24 under decision #55** — the planner's superseding ruling
withdrew this unit's original "show the observed model" deliverable. See
[Revision](#revision) below for what changed and why; the description above it
now matches what actually ships.

## The defect

The Interface rail rendered `interface_sessions.model_route` as a claim about
the model a session is running. It is only the route the session was **launched**
with: `flavor_defaults planner/claude = 'fable'`, so the planner really was
launched `--model fable`, the operator then switched to Opus 5 in-harness, and
the engine never observed it — the lifecycle hook contract discards the native
payload by design. Result: `PLN1 · claude · FABLE` on the rail while the pane ran
Opus 5. Not a wrong value; a launch-time value rendered as a live one.

## The fix

**Deliverable 1 — stop asserting what is not observed.** The unit allowed either
labelling the value for what it is or showing the observed live model; decision
#55 ruled the second undeliverable from this data (see Revision), so the
**label** form ships. Every surface states the launch route *as* the launch
route and never names a current model.

**Deliverable 2 — the not-yet-observed case.** Now satisfied by construction
rather than by a fallback branch: since no surface claims a current model, no
surface can render the launch route as though it were observed. The browser rail
and `sc interface status` behave identically — the parity the unit requires.

Surfaces:

- rail row + mobile picker → `GPT 5.6 SOL (launched)`, with a tooltip stating
  it is the launch route and that an in-harness `/model` switch would not appear
  there;
- session Details disclosure → a `launched` stat, and **no** `model` stat;
- `sc interface status` → the route under a `launched` key, never a bare `model`.

The fix is presentational: the API is unchanged and keeps returning
`model_route` under its correct name.

Out of scope per the unit and untouched: the hook payload contract,
`flavor_defaults`, exact-variant model routes.

## Revision — decision #55 (what was withdrawn, and why)

The first version of this branch derived a `model_observed` from the feature #17
sweep and took the most recently active row. REV1's finding SC-135 (flag #136)
showed that ordering cannot work, the planner verified it independently, and
decision #55 recorded that the earlier ratification of the tiebreak was the
planner's error rather than a defect in this unit.

I re-verified it at both ends before reversing:

- **live rows** — archive 8 carries `usage_id` 6 (`claude-fable-5`) and 7
  (`claude-opus-4-8`) with the *identical* session-wide window
  `09:39:27 → 11:53:12`;
- **the parser** — `token_parsers/claude.py` stamps every model row of a session
  from one `common` dict built from the transcript's first/last timestamp, and
  emits per-model rows in first-appearance order.

So `ORDER BY ended_at` degenerates to insertion order, and
`UNIQUE (harness, harness_session_ref, model)` collapses an A→B→A switch into two
rows, destroying the return to A. Folded subagent models are indistinguishable
from a deliberate switch as well. No tiebreak over these rows can be truthful, so
`_observed_model()` and the `model_observed` field are reverted in full.

Deriving a truthful current model — most plausibly a `last_model` recorded by the
feature #17 parser from the transcript's per-message model ids — is a **follow-up
under feature #17**, deliberately not built here: it is a parser plus schema
change needing its own review, and growing this unit into it mid-sprint would
repeat the mistake of shipping an unverified mechanism.

## Tests

- `test_interface_api.py` — the fabricated-`ended_at` test is **removed** (it
  asserted against data the production parser never emits, which manufactures
  confidence rather than proving anything). Replaced by a parser-realistic
  switch-back regression: it seeds the rows the sweep actually writes for an
  A→B→A switch — one row per model, both stamped with the same session-wide
  window, the return to A collapsed away — and asserts `model_route` remains the
  only session model field on both the projection and the session detail. It
  turns red the moment anyone re-derives a current model from these rows.
- `test_interface_cli.py` — `status` prints the route under `launched` and no
  `model` key at all; a null route falls back to `harness default`.
- `test_interface_ui_rendered.py` — the rendered rail, mobile picker and Details
  disclosure all carry the launch-route label; Details has no `model` stat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
