### PR TITLE
fix(interface): report working sprint devs as working, not unreconciled (S38 U4)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -338,11 +338,39 @@ def _exact_identity_verified(con, session_id: int) -> bool:
         return False
 
 
+_NO_SPRINT = {"sprint_ref": None, "sprint_title": None}
+
+
+def _sprint_context(con, shell_id: int) -> dict:
+    """The sprint a shell's CURRENT session is working, from the archive's
+    sprint_ref (migration 0071, written at headless boot by run.py). Lets the
+    rail name WHICH sprint holds a working shell rather than only that someone
+    is working. Empty when the shell has no active archive or the archive
+    carries no ref — an unlabelled worker is still a worker."""
+    row = con.execute(
+        "SELECT a.sprint_ref, d.title FROM shells s "
+        "JOIN shell_memory_archives a ON a.archive_id = s.active_archive_id "
+        "LEFT JOIN documents d ON CAST(d.document_id AS TEXT) = a.sprint_ref "
+        "WHERE s.shell_id=?", (shell_id,)).fetchone()
+    if row is None or not row[0]:
+        return dict(_NO_SPRINT)
+    return {"sprint_ref": row[0], "sprint_title": row[1]}
+
+
 def _availability(con, shell_id: int, snap) -> dict:
     """The rail projection (spec #20 Occupancy Model): occupancy + lifecycle
     projected for compact display; New-chat authority never changes here. A
     shell with no live session is available ONLY after the liveness scan
-    clears it — a legacy/unmanaged harness makes it unreconciled."""
+    clears it — an unmanaged harness process keeps holding the shell.
+
+    Which unmanaged verdict is the operator-visible part (flag #94):
+    session_state() already separates 'busy' (a LIVE non-orphan process holds
+    the worktree — someone is genuinely working, e.g. a `./sc run` sprint
+    worker whose parent is alive) from 'orphan' (EVERY pid is orphaned —
+    a closed terminal or dead parent, a real stranded remnant). Collapsing
+    both to 'unreconciled' told the operator to recover healthy live work,
+    inverting decision #45's preservation-first stance. 'busy' projects as
+    'working'; 'orphan' keeps 'unreconciled' and its recovery affordance."""
     active_session = interface_state.active_session_sql("s")
     row = con.execute(
         "SELECT s.session_id, s.generation, s.occupancy, s.lifecycle, "
@@ -363,20 +391,29 @@ def _availability(con, shell_id: int, snap) -> dict:
         composer = con.execute(
             "SELECT composer FROM interface_input_state WHERE session_id=?",
             (session_id,)).fetchone()
+        # A managed generation claims no sprint: the Interface launch path
+        # does not stamp sprint_ref, so reading the archive here would label
+        # the chat with a PREVIOUS headless boot's sprint. Silence is honest.
         return {"availability": availability, "session_id": session_id,
                 "generation": generation,
                 "lifecycle": lifecycle, "harness": harness,
                 "model_route": model_route,
                 "composer": composer[0] if composer else None,
-                "alerts": _alert_count(con, session_id), **client}
+                "alerts": _alert_count(con, session_id),
+                **_NO_SPRINT, **client}
     state = shell_liveness.session_state(_shortname(con, shell_id), snap)
     if state is not None:
-        return {"availability": "unreconciled", "session_id": None,
+        # Only a WORKING shell names a sprint. A remnant must not borrow its
+        # dead session's label and read as live work.
+        working = state == "busy"
+        return {"availability": "working" if working else "unreconciled",
+                "session_id": None,
                 "lifecycle": None, "harness": None, "composer": None,
-                "model_route": None, "alerts": 0}
+                "model_route": None, "alerts": 0,
+                **(_sprint_context(con, shell_id) if working else _NO_SPRINT)}
     return {"availability": "available", "session_id": None,
             "lifecycle": None, "harness": None, "model_route": None,
-            "composer": None, "alerts": 0}
+            "composer": None, "alerts": 0, **_NO_SPRINT}
 
 
 def _shortname(con, shell_id: int) -> str:
@@ -527,14 +564,25 @@ def _create_session(actor, headers, body):
             # harness process launched outside the API blocks New chat —
             # absence of a managed row is never proof of availability.
             snap = shell_liveness.compute()
-            if shell_liveness.session_state(shortname, snap) is not None:
+            state = shell_liveness.session_state(shortname, snap)
+            if state is not None:
+                # Authority is unchanged — BOTH verdicts still refuse (flag
+                # #94's bound: a working shell must not become startable).
+                # Only the reason differs: telling the operator to prove a
+                # LIVE worker absent is the inversion this unit removes.
                 return 409, {"error": {
                     "code": "unmanaged_harness",
-                    "message": "a legacy or directly launched harness "
-                               "process holds this shell's worktree — New "
-                               "chat is blocked as unreconciled until "
-                               "absence is proved",
-                    "details": {"shortname": shortname}}}
+                    "message": (
+                        "a live harness process is working in this shell's "
+                        "worktree outside the Interface — New chat is "
+                        "blocked until that session ends"
+                        if state == "busy" else
+                        "a legacy or directly launched harness "
+                        "process holds this shell's worktree — New "
+                        "chat is blocked as unreconciled until "
+                        "absence is proved"),
+                    "details": {"shortname": shortname,
+                                "liveness_state": state}}}
             harness, model = _resolved_launch_route(
                 con, flavor, body.get("harness"), body.get("model"))
             if model and not _model_route_available(con, harness, model):

--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -782,6 +782,9 @@ def _picker_status(shell: dict) -> str:
         "available": style.green,
         "occupied": style.amber,
         "starting": style.yellow,
+        # Live work outside the Interface — amber like `occupied`, never red:
+        # only the orphan verdict is a stranded remnant (flag #94).
+        "working": style.amber,
         "lost": style.red,
         "error": style.red,
         "unreconciled": style.red,

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -634,6 +634,49 @@ def _is_sprint_reserved(shell) -> bool:
     return bool(dict(shell).get("sprint_reserved"))
 
 
+def resolve_sprint_ref(con) -> "str | None":
+    """The tracker doc id to stamp on this boot's archive (migration 0071's
+    shell_memory_archives.sprint_ref) — the column that lets the Interface rail
+    and the session list name WHICH sprint a worker is on (flag #94). Designed
+    and left unwired: the recording path always worked, nothing ever set the
+    value.
+
+    Source priority is the planner's ruling, and deliberately excludes
+    current_state's `SPRINT doc=` marker: that is PROSE, and a surface deriving
+    hard state from prose is the exact defect class this unit exists to fix —
+    a shell whose state does not name the doc yields nothing, a stale mention
+    yields a confidently WRONG ref.
+
+    1. An explicit SC_SPRINT_REF wins — the designed hook, now set as standard
+       practice on planner-issued worker boots. Set-but-empty is meaningful:
+       it declares 'not a sprint boot' and stamps nothing.
+    2. Otherwise the ARMED BINDING: sprint_planner_bindings holds one
+       authoritative row per active sprint and is released transactionally at
+       sprint close, so it needs neither caller discipline nor prose parsing.
+       Exactly one armed sprint or nothing — two would be a guess.
+    3. Neither resolves → NULL. Never guess.
+
+    Rung 2's known approximation, accepted deliberately: the binding records
+    WHICH SPRINT IS ARMED, not which shells enlisted in it, so a non-sprint
+    boot during an active sprint is stamped with that sprint. Rung 1 is the
+    normal path and is exact; rung 2 is a best-effort safety net for
+    hand-booted or legacy workers, and an explicitly empty SC_SPRINT_REF opts
+    any known non-sprint boot out of it.
+
+    Best-effort throughout: a fork mid-migration without the table degrades to
+    None rather than failing a boot. TEXT, matching the column and server.py's
+    CAST join to documents."""
+    if "SC_SPRINT_REF" in os.environ:
+        return os.environ["SC_SPRINT_REF"].strip() or None
+    try:
+        armed = con.execute(
+            "SELECT DISTINCT sprint_doc_id FROM sprint_planner_bindings "
+            "WHERE released_at IS NULL").fetchall()
+    except db_driver.OperationalError:
+        return None
+    return str(armed[0][0]) if len(armed) == 1 else None
+
+
 def _shell_status(shell, snap: "dict | None") -> str:
     """Styled picker status derived from liveness plus sprint reservation."""
     if shell["flavor"] == "admin":
@@ -1319,7 +1362,7 @@ def main() -> None:
                 "harness": harness,
                 "provider": session_provider(harness, session_model),
                 "model": session_model,
-                "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
+                "sprint_ref": resolve_sprint_ref(con),
             })
         except SessionOpenError as exc:
             con.close()

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2189,8 +2189,11 @@ function ifDetach() {
 }
 window.addEventListener("pagehide", ifDetach);
 
+// `working` is amber, not red (flag #94): a live non-orphan harness holds the
+// worktree — someone is genuinely working outside the Interface. Only the
+// orphan verdict (`unreconciled`) is a stranded remnant worth recovering.
 const IF_BADGE = { available: "ok", starting: "warn", occupied: "accent",
-  lost: "bad", error: "bad", unreconciled: "bad" };
+  working: "warn", lost: "bad", error: "bad", unreconciled: "bad" };
 const IF_ATTACHABLE_LIFECYCLES = new Set(
   ["starting", "idle", "busy", "approval", "user_input"]);
 
@@ -2212,6 +2215,18 @@ const IF_LAUNCHED_TITLE =
 
 function ifLaunchedDisplay(route) {
   return { text: ifModelLabel(route) + " (launched)", title: IF_LAUNCHED_TITLE };
+}
+
+// The sprint a working shell is on, from the archive's sprint_ref (server-side
+// _sprint_context). Blank when the boot carried no sprint marker — an
+// unlabelled worker is still a worker, so absence never implies idle.
+function ifSprintLabel(sel) {
+  if (!sel || !sel.sprint_ref) return "";
+  return sel.sprint_title || "sprint #" + sel.sprint_ref;
+}
+function ifSprintSuffix(sel) {
+  const label = ifSprintLabel(sel);
+  return label ? " · " + label : "";
 }
 
 async function renderInterface(root) {
@@ -2252,6 +2267,7 @@ async function renderInterface(root) {
       s.shortname + (s.harness ? " · " + s.harness : ""));
     if (launched)
       sub.append(el("span", { title: launched.title }, " · " + launched.text));
+    sub.append(ifSprintSuffix(s));
     row.append(head, sub);
     row.onclick = () => { location.hash = "interface/" + s.shortname; };
     rail.append(row);
@@ -2259,7 +2275,7 @@ async function renderInterface(root) {
     const opt = el("option", { value: s.shortname },
       `${s.display_name || s.shortname} · ${s.shortname}` +
       `${s.harness ? " · " + s.harness : ""}${mobileModel}` +
-      ` · ${s.availability}`);
+      ` · ${s.availability}${ifSprintSuffix(s)}`);
     if (s.shortname === ifSelected) opt.selected = true;
     picker.append(opt);
   }
@@ -2272,6 +2288,10 @@ async function renderInterface(root) {
     return;
   }
   if (sel.availability === "available") return ifAvailablePane(pane, sel, root);
+  if (sel.availability === "working") {
+    ifDetach();
+    return ifWorkingPane(pane, sel, root);
+  }
   if (sel.availability === "lost" || sel.availability === "error" || sel.availability === "unreconciled") {
     ifDetach();
     return ifRecoveryPane(pane, sel, root);
@@ -2581,6 +2601,35 @@ function ifRecoveryControls(host, sel, root) {
     previewBtn.disabled = false;
   };
   previewBtn.onclick = () => load();
+}
+
+// Working pane (flag #94): a LIVE non-orphan harness holds this shell's
+// worktree — a `./sc run` sprint worker, or any harness launched outside the
+// Interface. It is not a fault and it is not stranded, so this pane states
+// what is happening, names the sprint when the archive carries one, and does
+// NOT lead with recovery. New chat stays blocked exactly as before (the server
+// refuses with unmanaged_harness either way); recovery is still reachable, but
+// demoted behind the fact that killing it would destroy live work.
+function ifWorkingPane(pane, sel, root) {
+  const sprint = ifSprintLabel(sel);
+  const card = el("div", { className: "card" },
+    el("div", {}, el("b", {}, sel.display_name || sel.shortname), " is ",
+      el("span", { className: "pill if-badge warn" }, "working"),
+      sprint ? " on " + sprint + "." : "."));
+  card.append(el("div", { className: "muted" },
+    "A live harness process holds this shell's worktree outside the " +
+    "Interface — there is no managed generation to attach to. New chat is " +
+    "blocked until that session ends. Nothing here needs recovering."));
+  pane.append(card);
+  const recovery = el("div", { className: "card if-recovery" },
+    el("div", {}, el("b", {}, "Shell recovery")),
+    el("div", { className: "muted" },
+      "Only if you believe this process is stuck. Recovery on a working " +
+      "shell destroys live work — the preview shows the exact process and " +
+      "worktree evidence first."));
+  ifRecoveryControls(recovery, sel, root);
+  pane.append(recovery);
+  ifSprintPanel(pane, sel);
 }
 
 // Lost/error/unreconciled pane (spec Interface Layout): diagnostics and

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -434,15 +434,29 @@ class InterfaceApiTest(unittest.TestCase):
 
     # -- New chat refusal ---------------------------------------------------------------
 
-    def test_unmanaged_harness_refusal(self):
+    def unmanaged(self, orphaned, shortname="s1"):
+        """Point the liveness scan at one unmanaged harness holding a shell's
+        worktree. `orphaned` is the per-process verdict classify_orphan would
+        return: falsy = a live parent (a working `./sc run` worker), a reason
+        string = a stranded remnant."""
         self.liveness.stop()
         self.liveness = mock.patch.object(
             routes.shell_liveness, "compute",
             return_value={"supported": True, "processes": [
-                {"pid": 777, "comm": "kimi", "cwd": "/x/.sc-worktrees/s1",
-                 "region": "worktree", "shortname": "s1",
-                 "display_name": "S1", "is_self": False, "orphaned": False}]})
+                {"pid": 777, "comm": "kimi",
+                 "cwd": f"/x/.sc-worktrees/{shortname}",
+                 "region": "worktree", "shortname": shortname,
+                 "display_name": shortname.upper(), "is_self": False,
+                 "orphaned": orphaned}]})
         self.liveness.start()
+
+    def rail(self, shell_id=1):
+        status, _, body = self.call("GET", "/api/interface/shells", (OP,))
+        self.assertEqual(status, 200)
+        return next(s for s in body["shells"] if s["shell_id"] == shell_id)
+
+    def test_unmanaged_harness_refusal(self):
+        self.unmanaged(orphaned="tty-gone")
         status, _, body = self.create_session()
         self.assertEqual(status, 409)
         self.assertEqual(body["error"]["code"], "unmanaged_harness")
@@ -453,8 +467,90 @@ class InterfaceApiTest(unittest.TestCase):
         con.close()
         self.assertEqual(count, 0)
         # …and the rail projects unreconciled, not available.
-        status, _, body = self.call("GET", "/api/interface/shells", (OP,))
-        self.assertEqual(body["shells"][0]["availability"], "unreconciled")
+        self.assertEqual(self.rail()["availability"], "unreconciled")
+
+    # -- working vs stranded (flag #94) -------------------------------------------
+
+    def test_working_shell_is_not_reported_unreconciled(self):
+        """The sprint-worker inversion: a LIVE non-orphan harness holds the
+        worktree, so session_state() says 'busy'. Reporting that as
+        'unreconciled' told the operator to recover healthy live work."""
+        self.unmanaged(orphaned=None)
+        shell = self.rail()
+        self.assertEqual(shell["availability"], "working")
+        self.assertIsNone(shell["session_id"])
+
+    def test_stranded_shell_still_reports_unreconciled(self):
+        """The other half of the split must not move: every pid orphaned is a
+        real remnant and keeps its recovery affordance."""
+        self.unmanaged(orphaned="detached")
+        self.assertEqual(self.rail()["availability"], "unreconciled")
+
+    def test_working_shell_still_refuses_new_chat(self):
+        """The hard bound: New-chat authority does not widen. A working shell
+        refuses exactly as before — only the stated reason changes, and it no
+        longer tells the operator to prove a live worker absent."""
+        self.unmanaged(orphaned=None)
+        status, _, body = self.create_session()
+        self.assertEqual(status, 409)
+        self.assertEqual(body["error"]["code"], "unmanaged_harness")
+        self.assertEqual(body["error"]["details"]["liveness_state"], "busy")
+        self.assertNotIn("absence", body["error"]["message"])
+        with contextlib.closing(sqlite3.connect(self.db_path)) as con:
+            self.assertEqual(con.execute(
+                "SELECT COUNT(*) FROM interface_sessions").fetchone()[0], 0)
+
+    def test_working_shell_names_its_sprint_from_the_archive(self):
+        """Deliverable 2's payoff: the rail names WHICH sprint, from the
+        archive's sprint_ref that run.py stamps on a headless boot."""
+        with contextlib.closing(sqlite3.connect(self.db_path)) as con:
+            con.execute(
+                "INSERT INTO documents (document_id, kind, title, body) "
+                "VALUES (38,'doc','SPRINT: Launcher operator surface','x')")
+            con.execute("UPDATE shell_memory_archives SET sprint_ref='38' "
+                        "WHERE archive_id=10")
+            con.execute("UPDATE shells SET active_archive_id=10 "
+                        "WHERE shell_id=1")
+            con.commit()
+        self.unmanaged(orphaned=None)
+        shell = self.rail()
+        self.assertEqual(shell["availability"], "working")
+        self.assertEqual(shell["sprint_ref"], "38")
+        self.assertEqual(shell["sprint_title"],
+                         "SPRINT: Launcher operator surface")
+
+    def test_unlabelled_worker_is_still_working(self):
+        """An archive with no sprint_ref must not demote the verdict — absence
+        of a marker is not evidence the shell is idle or stranded."""
+        with contextlib.closing(sqlite3.connect(self.db_path)) as con:
+            con.execute("UPDATE shells SET active_archive_id=10 "
+                        "WHERE shell_id=1")
+            con.commit()
+        self.unmanaged(orphaned=None)
+        shell = self.rail()
+        self.assertEqual(shell["availability"], "working")
+        self.assertIsNone(shell["sprint_ref"])
+        self.assertIsNone(shell["sprint_title"])
+
+    def test_stranded_shell_claims_no_sprint(self):
+        """A remnant must not borrow its dead session's sprint label and read
+        as live work — the operator needs recovery to stay unambiguous."""
+        with contextlib.closing(sqlite3.connect(self.db_path)) as con:
+            con.execute("UPDATE shell_memory_archives SET sprint_ref='38' "
+                        "WHERE archive_id=10")
+            con.execute("UPDATE shells SET active_archive_id=10 "
+                        "WHERE shell_id=1")
+            con.commit()
+        self.unmanaged(orphaned="tty-gone")
+        shell = self.rail()
+        self.assertEqual(shell["availability"], "unreconciled")
+        self.assertIsNone(shell["sprint_ref"])
+
+    def test_one_working_shell_does_not_taint_the_rest(self):
+        """The projection is per shell: s2 is dormant and stays available."""
+        self.unmanaged(orphaned=None, shortname="s1")
+        self.assertEqual(self.rail(1)["availability"], "working")
+        self.assertEqual(self.rail(2)["availability"], "available")
 
     def test_shell_occupied_race(self):
         status, _, _ = self.create_session()

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -806,6 +806,65 @@ invariant(!requested.some((path) => path.includes("/sessions/")),
 """)
 
 
+def test_working_shell_pane_states_the_work_and_never_leads_with_recovery():
+    """Flag #94: DEV3 and DEV5 were building sprint-38 units while this pane
+    told the operator they ran a legacy harness and offered Preview recovery
+    as the primary affordance. A working shell states what it is doing,
+    names its sprint, and demotes recovery behind that."""
+    run_recovery_js(r"""
+apiIf = async () => { throw new Error("working pane must not call the API"); };
+const pane = new FakeElement("div");
+ifWorkingPane(pane, {
+  shell_id: 6, shortname: "DEV6", display_name: "Code-04",
+  availability: "working", session_id: null,
+  sprint_ref: "38", sprint_title: "SPRINT: Launcher operator surface",
+}, new FakeElement("div"));
+const text = pane.textContent;
+invariant(text.includes("working"), `working pane never says working: ${text}`);
+invariant(text.includes("SPRINT: Launcher operator surface"),
+  `working pane did not name the sprint: ${text}`);
+invariant(!text.includes("legacy or unmanaged harness"),
+  "working pane reused the stranded-shell copy");
+invariant(!text.includes("Prove the process absent"),
+  "working pane told the operator to prove a LIVE worker absent");
+invariant(pane.children[0].textContent.includes("working"),
+  "recovery card preceded the statement that the shell is working");
+invariant(Boolean(button(pane, "Preview recovery")),
+  "working pane dropped recovery entirely — a stuck worker needs the path");
+invariant(pane.children[1].textContent.includes("destroys live work"),
+  "recovery on a working shell carried no live-work warning");
+""")
+
+
+def test_working_shell_without_a_sprint_marker_still_reads_as_working():
+    """An archive with no sprint_ref must not make the pane hedge — absence
+    of a label is not evidence the shell is idle or stranded."""
+    run_recovery_js(r"""
+const pane = new FakeElement("div");
+ifWorkingPane(pane, {
+  shell_id: 6, shortname: "DEV6", display_name: "Code-04",
+  availability: "working", session_id: null,
+  sprint_ref: null, sprint_title: null,
+}, new FakeElement("div"));
+const text = pane.textContent;
+invariant(text.includes("working"), `unlabelled worker not working: ${text}`);
+invariant(!text.includes("sprint #"), `invented a sprint label: ${text}`);
+invariant(!text.includes("null") && !text.includes("undefined"),
+  `leaked a missing sprint into the copy: ${text}`);
+""")
+
+
+def test_rail_routes_working_away_from_recovery_and_paints_it_amber():
+    """The rail projection itself: `working` is warn (live work), not bad
+    (stranded), and selecting it never lands on the recovery pane."""
+    assert 'working: "warn"' in RENDER_INTERFACE
+    assert 'sel.availability === "working"' in RENDER_INTERFACE
+    # The recovery route must not have grown a `working` arm.
+    recovery_route = RENDER_INTERFACE[
+        RENDER_INTERFACE.index('sel.availability === "lost"'):]
+    assert '"working"' not in recovery_route.split("ifRecoveryPane")[0]
+
+
 def test_recovery_partial_result_keeps_exact_remediation_until_refresh():
     run_recovery_js(r"""
 let rendered = 0;

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -311,6 +311,8 @@ class OpenSessionContentionTest(unittest.TestCase):
 class HeadlessSessionFailureTest(unittest.TestCase):
     def test_sc_run_exits_before_worktree_or_harness_artifacts(self) -> None:
         con = mock.Mock()
+        # No armed sprint binding — resolve_sprint_ref stamps nothing.
+        con.execute.return_value.fetchall.return_value = []
         chosen = {"shell_id": 1, "shortname": "DEV1", "flavor": "dev"}
         fdefaults = {
             "dev": {"default_harness": "claude", "models": {"claude": "sonnet"}}

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -118,7 +118,7 @@ class ShellStatusTest(unittest.TestCase):
             self.assertEqual("Unknown",
                              run._shell_status(sprint_shell, partial).strip())
 
-    def test_only_active_unfrozen_sprint_docs_reserve_shells(self) -> None:
+    def _sprint_db(self):
         con = sqlite3.connect(":memory:")
         self.addCleanup(con.close)
         con.row_factory = sqlite3.Row
@@ -153,6 +153,10 @@ class ShellStatusTest(unittest.TestCase):
                 (5, 'Bad marker', 'DEV4', '', 0, 'dev', 'SPRINT doc=oops unit=4', 1, 0),
                 (6, 'Bad tracker', 'DEV5', '', 0, 'dev', 'SPRINT doc=24 unit=5', 1, 0);
         """)
+        return con
+
+    def test_only_active_unfrozen_sprint_docs_reserve_shells(self) -> None:
+        con = self._sprint_db()
 
         shells = {shell["shortname"]: shell
                   for shell in run.list_shells(con, user_id=1)}
@@ -188,6 +192,129 @@ class ShellStatusTest(unittest.TestCase):
         self.assertIs(shell, chosen)
         self.assertIn("Shortname     Status      Default", stdout.getvalue())
         self.assertIn("DEV1          Available", stdout.getvalue())
+
+
+class SprintRefTest(unittest.TestCase):
+    """shell_memory_archives.sprint_ref (migration 0071) is what lets the
+    Interface rail name WHICH sprint a working shell is on (flag #94). The
+    recording path always worked; nothing ever set the value. Source priority
+    per the planner's ruling: explicit SC_SPRINT_REF, then the armed
+    sprint_planner_bindings row, then NULL. current_state's `SPRINT doc=`
+    marker is deliberately NOT a source — it is prose."""
+
+    def _bindings(self, *armed, released=()):
+        con = sqlite3.connect(":memory:")
+        self.addCleanup(con.close)
+        con.executescript("""
+            CREATE TABLE sprint_planner_bindings (
+                binding_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                sprint_doc_id INTEGER NOT NULL,
+                planner_shell_id INTEGER NOT NULL,
+                released_at TEXT);
+        """)
+        for doc in armed:
+            con.execute("INSERT INTO sprint_planner_bindings "
+                        "(sprint_doc_id, planner_shell_id) VALUES (?, 9)",
+                        (doc,))
+        for doc in released:
+            con.execute("INSERT INTO sprint_planner_bindings "
+                        "(sprint_doc_id, planner_shell_id, released_at) "
+                        "VALUES (?, 9, '2026-07-24T00:00:00Z')", (doc,))
+        con.commit()
+        return con
+
+    def test_explicit_env_wins_over_the_armed_binding(self) -> None:
+        con = self._bindings(38)
+        with mock.patch.dict(run.os.environ, {"SC_SPRINT_REF": "40"},
+                             clear=True):
+            self.assertEqual("40", run.resolve_sprint_ref(con))
+
+    def test_explicitly_empty_env_declares_a_non_sprint_boot(self) -> None:
+        """Set-but-empty is meaningful: it opts a known non-sprint boot out of
+        the armed-binding fallback rather than falling through to it."""
+        con = self._bindings(38)
+        for blank in ("", "   "):
+            with self.subTest(blank=blank):
+                with mock.patch.dict(run.os.environ,
+                                     {"SC_SPRINT_REF": blank}, clear=True):
+                    self.assertIsNone(run.resolve_sprint_ref(con))
+
+    def test_armed_binding_is_the_fallback(self) -> None:
+        con = self._bindings(38)
+        with mock.patch.dict(run.os.environ, {}, clear=True):
+            self.assertEqual("38", run.resolve_sprint_ref(con))
+
+    def test_released_binding_stamps_nothing(self) -> None:
+        """Released transactionally at sprint close — a closed sprint must
+        stop labelling later boots."""
+        con = self._bindings(released=(38,))
+        with mock.patch.dict(run.os.environ, {}, clear=True):
+            self.assertIsNone(run.resolve_sprint_ref(con))
+
+    def test_two_armed_sprints_refuse_to_guess(self) -> None:
+        con = self._bindings(31, 38)
+        with mock.patch.dict(run.os.environ, {}, clear=True):
+            self.assertIsNone(run.resolve_sprint_ref(con))
+
+    def test_one_sprint_bound_twice_still_resolves(self) -> None:
+        """Re-arming the same sprint is not ambiguity — DISTINCT collapses it."""
+        con = self._bindings(38, 38)
+        with mock.patch.dict(run.os.environ, {}, clear=True):
+            self.assertEqual("38", run.resolve_sprint_ref(con))
+
+    def test_missing_table_never_blocks_a_boot(self) -> None:
+        """A fork mid-migration degrades to no label, not a failed launch."""
+        con = sqlite3.connect(":memory:")
+        self.addCleanup(con.close)
+        with mock.patch.dict(run.os.environ, {}, clear=True):
+            self.assertIsNone(run.resolve_sprint_ref(con))
+
+    def test_current_state_prose_is_never_a_source(self) -> None:
+        """The ruling's whole point: a shell whose current_state names an
+        ACTIVE sprint doc still stamps nothing without a binding or the env.
+        Deriving hard state from prose is the defect class this unit fixes."""
+        con = self._bindings()
+        con.executescript("""
+            CREATE TABLE shells (
+                shell_id INTEGER PRIMARY KEY, display_name TEXT,
+                shortname TEXT, mandate TEXT,
+                is_shared INTEGER NOT NULL DEFAULT 0, flavor TEXT,
+                current_state TEXT, user_id INTEGER,
+                is_deleted INTEGER NOT NULL DEFAULT 0);
+            CREATE TABLE documents (
+                document_id INTEGER PRIMARY KEY, kind TEXT NOT NULL,
+                frozen INTEGER NOT NULL DEFAULT 0, body TEXT);
+            INSERT INTO documents VALUES (38,'doc',0,'# SPRINT\nstatus: ACTIVE');
+            INSERT INTO shells VALUES
+                (1,'Dev','DEV6','',0,'dev','SPRINT doc=38 unit=4',1,0);
+        """)
+        with mock.patch.dict(run.os.environ, {}, clear=True):
+            self.assertIsNone(run.resolve_sprint_ref(con))
+
+    def test_headless_boot_writes_the_resolved_ref_onto_the_archive(self) -> None:
+        """End to end through open_session: the column the rail reads is
+        populated by a `./sc run` boot, not left NULL."""
+        con = self._bindings(38)
+        con.executescript("""
+            CREATE TABLE shells (
+                shell_id INTEGER PRIMARY KEY, active_archive_id INTEGER);
+            CREATE TABLE shell_memory_archives (
+                archive_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                shell_id INTEGER NOT NULL, session_id TEXT NOT NULL,
+                date TEXT NOT NULL, full_narrative TEXT NOT NULL,
+                started_at TEXT, harness TEXT, provider TEXT, model TEXT,
+                sprint_ref TEXT, UNIQUE (shell_id, session_id));
+            CREATE TABLE session_token_usage (archive_id INTEGER);
+            INSERT INTO shells VALUES (1, NULL);
+        """)
+        with mock.patch.dict(run.os.environ, {}, clear=True):
+            run.open_session(con, 1, lifecycle={
+                "harness": "claude", "provider": "anthropic", "model": "opus",
+                "sprint_ref": run.resolve_sprint_ref(con)})
+        self.assertEqual(
+            ("38",),
+            tuple(con.execute(
+                "SELECT sprint_ref FROM shell_memory_archives").fetchone()))
 
 
 class SpinnerTest(unittest.TestCase):
@@ -295,6 +422,8 @@ class BootPhaseLabelTest(unittest.TestCase):
         full = {"shell_id": 1, "display_name": "Dev One", "api_key": None}
         con = mock.Mock()
         con.execute.return_value.fetchone.return_value = full
+        # No armed sprint binding — resolve_sprint_ref stamps nothing.
+        con.execute.return_value.fetchall.return_value = []
         labels: list[str] = []
 
         @contextmanager


### PR DESCRIPTION
Sprint 38, unit 4. Authority: flag `#94`. Reviewer: REV2. Planner rulings `#1454` / `#1464` applied.

## The problem

The rail invited the operator to recover healthy live work. DEV3 and DEV5 were actively building sprint-38 units while the Interface rendered them `unreconciled` — *"this shell runs a legacy or unmanaged harness. Prove the process absent…"* — with **Preview recovery** as the primary affordance. That inverts decision `#45`'s preservation-first stance.

## 1. Stop flattening a verdict the engine already computes

`shell_liveness.session_state()` already returns the richer answer:

- `busy` — a live **non-orphan** process holds the worktree. A `./sc run` worker has a live parent, so `classify_orphan` marks it not-orphaned.
- `orphan` — **every** pid is orphaned: closed terminal or dead parent, a real stranded remnant.

`_availability()` called it and hardcoded `availability='unreconciled'` on any non-None result, one line later. Now `busy` → new `working`; `orphan` → unchanged `unreconciled`, keeping its recovery affordance.

This is the same split `run.py`'s CLI picker has always drawn (`Busy` / `Orphaned` / `Sprint`, `run.py:637-655`). The rail now matches the CLI rather than contradicting it.

`working` is a **rail projection, not a shell-occupancy state** (spec `#20`, updated by the planner): it grants no New-chat authority, adds no occupancy edge, and leaves the occupancy vocabulary and its legal transitions untouched.

UI: `working` badges amber (live work), not red (stranded); it routes to a new `ifWorkingPane` that states what is happening, names the sprint, and demotes recovery behind a live-work warning instead of leading with it.

## 2. Wire `sprint_ref`

`shell_memory_archives.sprint_ref` has existed since migration 0071 and was NULL on every archive, including all three sprint-38 workers. `run.py` read `SC_SPRINT_REF`; nothing ever set it.

The recording path was always correct (the planner proved it end-to-end: archive 221 carries `sprint_ref='38'`), so this adds **no second writer** — only the resolution side:

1. an explicit `SC_SPRINT_REF` — **set-but-empty is meaningful** and declares *not a sprint boot*;
2. else the **armed binding** (`sprint_planner_bindings` where `released_at IS NULL`, released transactionally at sprint close) — exactly one armed sprint, or nothing;
3. else `NULL`. Never guess.

`current_state`'s `SPRINT doc=` marker is **deliberately not a source**, and a test pins it *out*: a shell whose `current_state` names an ACTIVE doc still stamps nothing without the env or a binding. Deriving hard state from prose is the defect class this unit exists to fix — using it here would reintroduce the bug inside its own fix.

## Bounds respected

- **New-chat authority does not widen.** Both verdicts still refuse with 409 `unmanaged_harness`; only the stated reason differs, so the operator is no longer told to prove a *live* worker absent. Pinned by `test_working_shell_still_refuses_new_chat`.
- Hook payload contract, `flavor_defaults`, and roadmap `#24` untouched. Interim correction only.
- `ended_at` on live archives left alone — documented behaviour per the board's NOT-A-DEFECT note and flag `#137`.

## Trade-offs and declared deviations

- **Rung 2 is a documented approximation** (ratified). The binding records which sprint is **armed**, not which shells enlisted, so a non-sprint boot during an active sprint is stamped with that sprint. The alternative — stamping only boots that drained a sprint task row — is **not implementable at this seam**: `sprint_ref` resolves inside `open_session` at boot, while a shell drains its inbox in-session, *after* the archive row exists. There is no durable per-shell membership signal outside message prose. The honest fix is a per-shell enlistment row, which is new tracking and therefore roadmap `#24`.
- **A managed Interface generation claims no sprint.** `prepare_launch` does not stamp `sprint_ref`, so reading the archive there would label the chat with a *previous* headless boot's sprint. Silence is honest.
- **Staleness window** (declared, ratified). A harness launched wholly outside the engine has no archive of its own, so the rail reads the shell's last engine-booted archive and could name a stale sprint. The `working` verdict is correct either way — the staleness is bounded to the sprint *label*, never the availability decision.

## Verification

- Full suite on this head: **1192 passed, 1 skipped, 106 subtests** (via `./sc job`, exit 0).
- `render_check.py` from this worktree: clean.
- New coverage: 7 API tests (busy→working, orphan→unreconciled, New chat still refused, sprint named from the archive, unlabelled worker still working, remnant claims no sprint, per-shell isolation); 9 `resolve_sprint_ref` tests incl. the prose-source negative test, released/ambiguous/re-armed bindings, missing-table degradation, and end-to-end through `open_session`; 3 UI contract tests.
- `test_unmanaged_harness_refusal` previously asserted `unreconciled` for a **non-orphaned** process — it pinned the bug. Rewritten to drive the orphan path, with the working case split out.

**Operator's question — can you tell a working dev from a stranded one without reading the DB?** The rail now shows `Code-04 · claude · SPRINT: Launcher operator surface` with an amber `working` badge, versus a red `unreconciled` badge with recovery. Yes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)