### PR TITLE
fix(interface): live rail badges, header dead row, and clickable model picker

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -349,6 +349,15 @@ function dmModelPicker(harness, cat, row, save) {
                               role: "combobox", ariaExpanded: "false" });
   const results = el("div", { className: "dm-results", hidden: true });
   let open = false, highlighted = 0, choices = [];
+  // Moving the highlight must never go through paint(). paint() rebuilds every
+  // card node, so a repaint driven by hover destroys the card under the cursor
+  // — mousedown lands on one node, the rebuild detaches it, mouseup lands on
+  // its replacement, and with no common ancestor the browser never fires a
+  // click. That is why picking a model by mouse did nothing and only
+  // search-then-Enter worked. The highlight is presentational: move it in
+  // place. paint() stays for changes that genuinely alter the list.
+  let applyHighlight = () => {};
+  const setHighlight = (i) => { highlighted = i; applyHighlight(); };
 
   const close = () => {
     open = false; highlighted = 0; input.value = "";
@@ -376,6 +385,7 @@ function dmModelPicker(harness, cat, row, save) {
 
   const paint = () => {
     results.textContent = "";
+    applyHighlight = () => {};   // the list this closed over is detached now
     if (!open) { results.hidden = true; return; }
     const q = input.value.trim().toLowerCase();
     const hit = (m) => !q || [m.id, m.name, m.family]
@@ -394,18 +404,27 @@ function dmModelPicker(harness, cat, row, save) {
     const list = el("div", { className: "dm-cardlist", role: "listbox" });
     choices.forEach((choice, i) => {
       const card = el("button", {
-        className: "dm-mcard" + (i === highlighted ? " dm-highlight" : ""),
-        type: "button", role: "option", ariaSelected: String(i === highlighted),
+        className: "dm-mcard", type: "button", role: "option",
         title: choice.value || "Harness default",
       });
       card.append(el("b", {}, choice.label),
         el("span", { className: "dm-mcard-sub" }, choice.sub));
-      card.onmouseenter = () => { highlighted = i; paint(); };
+      card.onmouseenter = () => setHighlight(i);
       card.onclick = () => pick(choice.value);
       list.append(card);
     });
+    applyHighlight = () => {
+      // Index loop, not forEach — `children` is a live HTMLCollection in the
+      // browser and has no forEach, so an array method would silently no-op.
+      for (let j = 0; j < list.children.length; j += 1) {
+        const node = list.children[j];
+        node.classList.toggle("dm-highlight", j === highlighted);
+        node.ariaSelected = String(j === highlighted);
+      }
+      list.children[highlighted]?.scrollIntoView({ block: "nearest" });
+    };
     results.append(list);
-    list.children[highlighted]?.scrollIntoView({ block: "nearest" });
+    applyHighlight();
     results.hidden = false;
   };
 
@@ -418,8 +437,7 @@ function dmModelPicker(harness, cat, row, save) {
     if (e.key === "ArrowDown" || e.key === "ArrowUp") {
       e.preventDefault();
       const delta = e.key === "ArrowDown" ? 1 : -1;
-      highlighted = Math.max(0, Math.min(highlighted + delta, choices.length - 1));
-      paint();
+      setHighlight(Math.max(0, Math.min(highlighted + delta, choices.length - 1)));
       return;
     }
     if (e.key === "Enter" && choices[highlighted]) {

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2221,6 +2221,7 @@ function ifSprintSuffix(sel) {
 
 async function renderInterface(root) {
   root.replaceChildren();
+  ifStopRailPoll();   // every early return below leaves no orphan timer
   let shells;
   try { ({ shells } = await apiIf("/interface/shells")); }
   catch (e) {
@@ -2235,8 +2236,35 @@ async function renderInterface(root) {
   const pane = el("div", { className: "if-pane" });
   // Mobile shell picker (CSS-hidden on desktop): same selection, same hash.
   const picker = el("select", { className: "if-picker", title: "shell" });
-  picker.append(el("option", { value: "" }, "select a shell…"));
   root.append(el("div", { className: "if-wrap" }, picker, rail, pane));
+  ifBuildRail(rail, picker, shells);
+  ifStartRailPoll(root, rail, picker, shells);
+  const sel = shells.find((s) => s.shortname === ifSelected);
+  if (!sel) {
+    ifDetach();
+    if (shells.length) pane.append(el("div", { className: "card muted" }, "Select a shell on the left."));
+    return;
+  }
+  if (sel.availability === "available") return ifAvailablePane(pane, sel, root);
+  if (sel.availability === "working") {
+    ifDetach();
+    return ifWorkingPane(pane, sel, root);
+  }
+  if (sel.availability === "lost" || sel.availability === "error" || sel.availability === "unreconciled") {
+    ifDetach();
+    return ifRecoveryPane(pane, sel, root);
+  }
+  if (sel.availability === "starting") return ifStartingPane(pane, sel, root);
+  return ifSessionPane(pane, sel);   // verified occupied generation only
+}
+
+// The rail + mobile picker, rebuilt from a shells payload. Split out of
+// renderInterface so the poll below can repaint the badges alone — re-running
+// renderInterface would tear down and rebuild the pane, and with it the live
+// terminal attachment.
+function ifBuildRail(rail, picker, shells) {
+  rail.replaceChildren();
+  picker.replaceChildren(el("option", { value: "" }, "select a shell…"));
   for (const s of shells) {
     // Projection happens SERVER-side (_availability): reserved+starting →
     // starting, occupied+(idle|busy|approval|user_input) → occupied,
@@ -2271,23 +2299,64 @@ async function renderInterface(root) {
   }
   picker.onchange = () => { if (picker.value) location.hash = "interface/" + picker.value; };
   if (!shells.length) rail.append(el("div", { className: "muted" }, "No shells."));
+}
+
+// ── Rail poll ─────────────────────────────────────────────────────────────────
+// The rail badges were a snapshot taken at render: a shell going occupied or
+// falling over showed a stale pill until the operator navigated. Poll
+// /interface/shells and repaint.
+//
+// Two rules keep it from fighting the terminal. Repaint only on an actual
+// change (signature compare) — an unconditional rebuild would drop focus from a
+// rail button and slam a mobile picker's open dropdown shut every tick. And
+// repaint the RAIL only; the pane is re-rendered solely when the SELECTED
+// shell's availability changes, i.e. when the pane is showing the wrong thing
+// anyway. A selected shell that merely stays occupied never triggers a
+// re-render, so the xterm attach, scrollback, and writer lease survive.
+const IF_POLL_MS = 5000;
+let ifPoll = null;
+
+function ifRailSig(shells) {
+  return JSON.stringify(shells.map((s) => [s.shortname, s.availability, s.alerts,
+    s.harness, s.model_route, s.sprint_ref, s.sprint_title, s.display_name]));
+}
+
+function ifStopRailPoll() {
+  if (!ifPoll) return;
+  clearInterval(ifPoll.timer);
+  ifPoll = null;
+}
+
+function ifStartRailPoll(root, rail, picker, shells) {
+  ifStopRailPoll();
   const sel = shells.find((s) => s.shortname === ifSelected);
-  if (!sel) {
-    ifDetach();
-    if (shells.length) pane.append(el("div", { className: "card muted" }, "Select a shell on the left."));
-    return;
-  }
-  if (sel.availability === "available") return ifAvailablePane(pane, sel, root);
-  if (sel.availability === "working") {
-    ifDetach();
-    return ifWorkingPane(pane, sel, root);
-  }
-  if (sel.availability === "lost" || sel.availability === "error" || sel.availability === "unreconciled") {
-    ifDetach();
-    return ifRecoveryPane(pane, sel, root);
-  }
-  if (sel.availability === "starting") return ifStartingPane(pane, sel, root);
-  return ifSessionPane(pane, sel);   // verified occupied generation only
+  ifPoll = { root, rail, picker, sig: ifRailSig(shells), timer: null,
+    rendered: sel ? sel.availability : null };   // what the pane was built for
+  ifPoll.timer = setInterval(ifPollRail, IF_POLL_MS);
+}
+
+async function ifPollRail() {
+  const p = ifPoll;
+  // A background tab has no one watching; a detached rail means some other
+  // render already replaced us and this tick is stale.
+  if (!p || document.hidden || !p.rail.isConnected) return;
+  let shells;
+  try { ({ shells } = await apiIf("/interface/shells")); }
+  catch { return; }              // transient — the next tick retries
+  if (!Array.isArray(shells)) return;                // nothing to repaint from
+  if (ifPoll !== p || !p.rail.isConnected) return;   // re-rendered while in flight
+  const sig = ifRailSig(shells);
+  if (sig === p.sig) return;
+  p.sig = sig;
+  const sel = shells.find((s) => s.shortname === ifSelected);
+  const now = sel ? sel.availability : null;
+  // Same catch the router's load() puts around a view render — without it a
+  // single failed re-render rejects into nothing, having already blanked the
+  // view and stopped the poll.
+  if (now !== p.rendered)
+    return void renderInterface(p.root).catch((e) => p.root.replaceChildren(
+      el("div", { className: "card" }, "error: " + e.message)));
+  ifBuildRail(p.rail, p.picker, shells);
 }
 
 // A reservation is not a terminal. It exposes only Cancel start; cached output,
@@ -3676,7 +3745,7 @@ function show(tab) {
   for (const b of document.querySelectorAll("nav button")) b.classList.toggle("active", b.dataset.tab === tab);
   for (const k of Object.keys(VIEWS)) $(VIEWS[k][0]).hidden = k !== tab;
   document.body.classList.toggle("interface-view", tab === "interface");
-  if (tab !== "interface") ifDetach();   // leaving the tab drops the stream + lease
+  if (tab !== "interface") { ifDetach(); ifStopRailPoll(); }   // leaving drops stream + lease + poll
   load(tab);
 }
 // Hash routing: the active tab lives in the URL (#roadmap), so a refresh stays

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -746,6 +746,12 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .if-stat b { color: var(--ink); font-weight: 600; }
 .if-head .act { margin-top: 0; }
 .if-note { color: var(--warn); font-size: .8rem; flex-basis: 100%; }
+/* The header's status notes are usually empty, but flex-basis:100% still forced
+   a second flex line — costing .if-head's 1rem row-gap (16px) of dead space
+   under the toolbar for no visible text. Collapse the empty ones; a note that
+   has something to say lays out exactly as before. Scoped to .if-head so the
+   composer's note keeps its reserved min-height line (no jump on first note). */
+.if-head > .if-note:empty { display: none; }
 .if-term {
   background: #000; border: 1px solid var(--line); border-radius: var(--r);
   padding: 6px; width: 100%; max-width: 1300px;

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -212,6 +212,158 @@ if (lastScrolled.title !== "model-59" || lastScrolled.block !== "nearest") {
     assert result.returncode == 0, result.stderr
 
 
+PICKER_DOM = r"""
+class FakeClassList {
+  constructor() { this.names = new Set(); }
+  toggle(name, on) { if (on) this.names.add(name); else this.names.delete(name); }
+  remove(name) { this.names.delete(name); }
+  contains(name) { return this.names.has(name); }
+}
+// `children` is a live HTMLCollection in the browser: indexable and iterable,
+// but with NO array methods. Modelling it as a plain array lets code that calls
+// children.map/forEach pass here and silently no-op in the real UI, so this
+// fake withholds them on purpose.
+const collection = (nodes) => {
+  const c = { length: nodes.length,
+              [Symbol.iterator]: () => nodes[Symbol.iterator]() };
+  nodes.forEach((n, i) => { c[i] = n; });
+  return c;
+};
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag;
+    this.nodeType = 1;
+    this._kids = [];
+    this.classList = new FakeClassList();
+    this.isConnected = true;
+    this.value = "";
+    this._text = "";
+  }
+  get children() { return collection(this._kids); }
+  append(...nodes) { this._kids.push(...nodes); }
+  set textContent(value) {
+    this._text = value;
+    if (value === "") this._kids = [];
+  }
+  get textContent() {
+    return this._text + this._kids.map(
+      (c) => typeof c === "string" ? c : (c.textContent || "")).join("");
+  }
+  contains(node) { return this === node || this._kids.includes(node); }
+  scrollIntoView() {}
+  blur() {}
+}
+globalThis.document = {
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({ nodeType: 3, textContent: text }),
+  addEventListener() {},
+  removeEventListener() {},
+};
+const CAT = { stale: false, harnesses: { codex: { models: [
+  { id: "gpt-5.6-sol", name: "Sol", family: null, availability: "available" },
+  { id: "gpt-5.6-lun", name: "Lun", family: null, availability: "available" },
+] } } };
+const cardList = (picker) => picker.results.children[1];
+const invariant = (ok, message) => { if (!ok) throw new Error(message); };
+"""
+
+
+def run_picker_js(body):
+    el_helper = APP[APP.index("const el ="):APP.index("const esc =")]
+    result = subprocess.run(
+        ["node", "-e", el_helper + PICKER + PICKER_DOM +
+         "\n(async () => {\n" + body + "\n})().catch((e) => {"
+         "\n  console.error(e.stack || e); process.exit(1);\n});\n"],
+        text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def test_hovering_a_model_card_never_replaces_the_node_being_clicked():
+    """The click-does-nothing bug. Hover moved the highlight by calling
+    paint(), which rebuilds every card — so the card under the cursor was
+    destroyed and replaced mid-gesture. mousedown landed on one node, mouseup
+    on its replacement, and with no common ancestor the browser never
+    synthesised a click. Only search-then-Enter could select a model.
+
+    Hover must move the highlight WITHOUT detaching a single card node."""
+    run_picker_js(r"""
+const picker = dmModelPicker("codex", CAT, { model: null }, async () => {});
+picker.input.onfocus();
+const before = [...cardList(picker).children];
+invariant(before.length === 3, `expected default + 2 models: ${before.length}`);
+
+// Hover each card in turn — the gesture a mouse makes crossing the list.
+for (let i = 0; i < before.length; i += 1) before[i].onmouseenter();
+
+const after = [...cardList(picker).children];
+invariant(after.length === before.length, "hover changed the option count");
+for (let i = 0; i < before.length; i += 1)
+  invariant(after[i] === before[i],
+    `hover replaced card ${i} — a real click would be swallowed mid-gesture`);
+""")
+
+
+def test_hover_still_moves_the_highlight_and_clicking_a_card_selects_it():
+    """Keeping the nodes alive is only half of it: hover must still visibly
+    highlight, and the click must actually reach save() and land on the row."""
+    run_picker_js(r"""
+const saved = [];
+const row = { model: null };
+const picker = dmModelPicker("codex", CAT, row,
+  async (v) => { saved.push(v); });
+picker.input.onfocus();
+const cards = cardList(picker).children;
+
+invariant(cards[0].classList.contains("dm-highlight"),
+  "the first option did not start highlighted");
+cards[2].onmouseenter();
+invariant(cards[2].classList.contains("dm-highlight") &&
+  !cards[0].classList.contains("dm-highlight"),
+  "hover did not move the highlight to the hovered card");
+invariant(cards[2].ariaSelected === "true" && cards[0].ariaSelected === "false",
+  "the highlight moved visually but aria-selected did not follow");
+
+await cards[2].onclick();
+invariant(saved.length === 1 && saved[0] === "gpt-5.6-lun",
+  `clicking a card did not save that model: ${JSON.stringify(saved)}`);
+invariant(row.model === "gpt-5.6-lun",
+  `the picked model never reached the row: ${row.model}`);
+
+// "Harness default" clears the override through the same click path.
+picker.input.onfocus();
+await cardList(picker).children[0].onclick();
+invariant(saved[1] === null && row.model === null,
+  `clicking Harness default did not clear the override: ${row.model}`);
+""")
+
+
+def test_arrow_keys_and_hover_share_one_in_place_highlight():
+    """Arrow keys repainted the whole list too. Same in-place move now — and
+    keyboard and mouse must agree on which option is active, or Enter selects
+    something other than what is highlighted."""
+    run_picker_js(r"""
+const saved = [];
+const picker = dmModelPicker("codex", CAT, { model: null },
+  async (v) => { saved.push(v); });
+picker.input.onfocus();
+const cards = [...cardList(picker).children];
+
+picker.input.onkeydown({ key: "ArrowDown", preventDefault() {} });
+invariant(cardList(picker).children[1] === cards[1],
+  "an arrow key rebuilt the list instead of moving the highlight");
+invariant(cards[1].classList.contains("dm-highlight"),
+  "ArrowDown did not highlight the next option");
+
+// Mouse takes over from the keyboard; Enter must follow the mouse.
+cards[2].onmouseenter();
+picker.input.onkeydown({ key: "Enter", preventDefault() {} });
+await new Promise((r) => setTimeout(r, 0));
+invariant(saved[0] === "gpt-5.6-lun",
+  `Enter selected an option other than the highlighted one: ${saved[0]}`);
+""")
+
+
 def test_browser_bootstrap_carries_no_capability_and_retries_once():
     """Spec #26: the browser signs itself in with same-origin provenance
     alone. The capability must not reappear in page code, the one silent

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -916,6 +916,9 @@ invariant(Boolean(button(pane, "Recover")),
   "unreconciled/no-session route hid the server-listed recovery action");
 invariant(!requested.some((path) => path.includes("/sessions/")),
   `no-session route fetched invalid session detail: ${requested}`);
+// renderInterface above armed the rail poll; stop it the way leaving the tab
+// does, so this harness's event loop can drain and node can exit.
+ifStopRailPoll();
 """)
 
 
@@ -976,6 +979,105 @@ def test_rail_routes_working_away_from_recovery_and_paints_it_amber():
     recovery_route = RENDER_INTERFACE[
         RENDER_INTERFACE.index('sel.availability === "lost"'):]
     assert '"working"' not in recovery_route.split("ifRecoveryPane")[0]
+
+
+RAIL_POLL_SETUP = r"""
+const shellRow = (shortname, availability, extra = {}) => ({
+  shell_id: shortname === "S3" ? 3 : 4, shortname,
+  display_name: "Shell " + shortname, availability,
+  session_id: availability === "occupied" ? 9 : null, ...extra });
+let served = [];
+const serveShells = (rows) => { served = rows; };
+apiIf = async (path) => path === "/interface/shells"
+  ? { shells: served }
+  : BASE_PREVIEW;
+const railOf = (root) => all(root, (n) => n.className === "if-rail")[0];
+const badges = (root) => all(railOf(root), (n) =>
+  String(n.className || "").includes("if-badge")).map((n) => n.textContent);
+"""
+
+
+def test_rail_poll_repaints_badges_without_rebuilding_the_pane():
+    """The badges must go live without the poll tearing down a live terminal.
+    A change anywhere else in the fleet repaints the rail only; the pane (and
+    with it the xterm attach, scrollback, and writer lease) is rebuilt solely
+    when the SELECTED shell's own availability moves."""
+    run_recovery_js(RAIL_POLL_SETUP + r"""
+serveShells([shellRow("S3", "available"), shellRow("S4", "available")]);
+const root = new FakeElement("div");
+await renderInterface(root);
+invariant(badges(root).join(",") === "available,available",
+  `rail did not paint the served fleet: ${badges(root)}`);
+
+// From here the real renderInterface is replaced by a counter: any pane
+// rebuild is now observable.
+let rendered = 0;
+renderInterface = async () => { rendered += 1; };
+
+// 1. Another shell moves. The badge follows; the pane is untouched.
+serveShells([shellRow("S3", "available"), shellRow("S4", "occupied")]);
+await ifPollRail();
+invariant(badges(root).join(",") === "available,occupied",
+  `poll did not repaint a peer shell's badge: ${badges(root)}`);
+invariant(rendered === 0,
+  "a peer shell's badge change rebuilt the pane and would kill the terminal");
+
+// 2. Nothing moved. No repaint at all — an unconditional rebuild would drop
+//    focus from a rail button every tick.
+const railBefore = railOf(root).children[0];
+await ifPollRail();
+invariant(railOf(root).children[0] === railBefore,
+  "an unchanged poll still rebuilt the rail rows");
+invariant(rendered === 0, "an unchanged poll rebuilt the pane");
+
+// 3. The SELECTED shell moves. Now the pane is showing the wrong thing, so a
+//    full re-render is the correct — and only — response.
+serveShells([shellRow("S3", "occupied"), shellRow("S4", "occupied")]);
+await ifPollRail();
+invariant(rendered === 1,
+  "the selected shell changed availability and the pane was left stale");
+ifStopRailPoll();
+""")
+
+
+def test_rail_poll_leaves_a_busy_selected_session_attached():
+    """The regression that would hurt most: a shell the operator is typing in
+    stays `occupied` while its alert count or sprint label churns. That must
+    never re-render the pane — the terminal would be torn down mid-session."""
+    run_recovery_js(RAIL_POLL_SETUP + r"""
+ifSelected = "S3";
+serveShells([shellRow("S3", "occupied", { alerts: 0 })]);
+const root = new FakeElement("div");
+await renderInterface(root);
+let rendered = 0;
+renderInterface = async () => { rendered += 1; };
+
+serveShells([shellRow("S3", "occupied", { alerts: 2, sprint_ref: "38" })]);
+await ifPollRail();
+invariant(rendered === 0,
+  "a still-occupied session was re-rendered — the live terminal would drop");
+invariant(badges(root).some((b) => b.includes("2")),
+  `the new alert count never reached the rail: ${badges(root)}`);
+ifStopRailPoll();
+""")
+
+
+def test_rail_poll_stops_when_the_operator_leaves_the_interface_tab():
+    """A timer that outlives the view keeps polling forever in the background."""
+    assert "ifStopRailPoll();" in APP[APP.index('if (tab !== "interface")'):
+                                      APP.index('if (tab !== "interface")') + 200]
+    # Every early return in renderInterface must leave no orphan timer.
+    head = RENDER_INTERFACE[RENDER_INTERFACE.index("async function renderInterface"):]
+    assert "ifStopRailPoll();" in head[:head.index("let shells;")]
+
+
+def test_empty_header_note_does_not_reserve_a_flex_row():
+    """The header's status note is empty almost always, but flex-basis:100%
+    still forced a second flex line and charged .if-head's 1rem row-gap for
+    it — dead padding under the toolbar. The composer's note keeps its
+    reserved line (it has min-height to stop a jump), so the rule is scoped."""
+    assert ".if-head > .if-note:empty { display: none; }" in CSS
+    assert ".if-composer .if-note" in CSS and "min-height: 1.2em" in CSS
 
 
 def test_recovery_partial_result_keeps_exact_remediation_until_refresh():


### PR DESCRIPTION
Three small operator-surface tweaks on the Interface tab. Independent commits; the third was reported after the first two were already up, and is folded in here as the same batch.

---

## 1. The rail badges now poll (`4e860cb`)

They were a snapshot taken at render — a shell going occupied, or falling over, showed a stale pill until the operator navigated away and back. `/interface/shells` is now polled every 5s and the rail repainted.

The whole difficulty is that the pane beside it holds a live xterm attach, its scrollback, and a writer lease. Re-running `renderInterface` on a tick would destroy all three. Two rules keep the poll off it:

- **Repaint only on an actual change** (signature compare over the fields the rail renders). An unconditional rebuild would drop focus from a rail button and slam a mobile picker's open dropdown shut every 5 seconds.
- **Repaint the rail only.** The pane re-renders *solely* when the **selected** shell's availability moves — i.e. exactly when it is already showing the wrong thing. A session that merely stays `occupied` while its alert count or sprint label churns stays attached.

The rail build is split out of `renderInterface` into `ifBuildRail` for this. The timer stops on leaving the tab, on every early return in `renderInterface`, and idles while the browser tab is hidden.

## 2. The header's dead row under the toolbar (`4e860cb`)

The redline called this "way too much padding at the bottom of this window, 14px less". It is not padding — `.if-head`'s vertical padding is only 8px total, so there was no 14px to take off it.

The real cause: `.if-head` always contains a status note that is empty almost always, and `.if-note` carries `flex-basis: 100%`. An empty element still forces a second flex line, and the container's `gap: 1rem` charges 16px of row-gap for a row with nothing in it. Collapsing the empty one removes the row.

Scoped to `.if-head` deliberately — the composer's note has `min-height: 1.2em` on purpose, to stop the layout jumping when its first note appears.

**Trade-off:** the redline asked for 13–14px; this removes 16px. I took the structural cause over an arbitrary number, rather than keep an invisible row and hand-tune a magic offset around it. If 16px overshoots in the real layout, the follow-up is a smaller `row-gap` on `.if-head`, not putting the empty row back.

## 3. Clicking a model in the picker now selects it (`42b8cc4`)

Clicking a model card did nothing — in the Shells tab's Default Models matrix and in the Interface New-chat form, which share one `dmModelPicker`. The only way to select was to search and hit Enter.

Cause: hover moved the highlight by calling `paint()`, and `paint()` rebuilds every card node from scratch. The card under the cursor was destroyed and replaced mid-gesture — mousedown landed on one node, the rebuild detached it, mouseup landed on its replacement, and with no common ancestor the browser never synthesised a click. The keyboard path worked because it never depends on element identity.

The highlight is presentational, so it now moves in place: `applyHighlight` toggles `dm-highlight`/`aria-selected` across the existing cards and scrolls the active one into view. Hover and arrow keys both route through it; `paint()` is reserved for changes that genuinely alter the list. Cards keep their identity for the life of a list, so a click is just a click.

---

## Tests

Seven new contract tests in `tests/test_interface_ui_contract.py`.

Poll:
- a peer shell's badge change repaints the rail and does **not** rebuild the pane
- an unchanged poll rebuilds nothing at all
- the selected shell changing availability **does** re-render
- a busy `occupied` session survives alert/sprint churn still attached
- the CSS rule is pinned, along with the composer's reserved line

Picker:
- hover never replaces a card node
- hover still moves the highlight, and a click reaches `save()` and the row — including "Harness default" clearing the override
- keyboard and mouse share one highlight, so Enter picks what is highlighted

Every one was verified to fail against deliberately mutated source, not just to pass against the fix.

### A note on the test fake

The picker's test DOM now models `children` as an HTMLCollection — indexable and iterable, **no array methods** — because the previous array-backed fake could not catch this class of bug. My first draft of the fix used `children.forEach`, which passes against an array and silently no-ops in a real browser; the faithful fake is what caught it. Same reason the fix uses an index loop.

## Follow-ups I did not take

- Neither UI change is visually verified: there is no browser in this container, and the app you watch is the host-supervised stack outside it. The layout reasoning for #2 is from the CSS, not a screenshot — worth an eyeball before merge.
- One pre-existing test (`test_available_and_no_session_states_can_reach_server_owned_recovery`) needed a one-line teardown: it drives the real `renderInterface`, which now arms a timer, and its Node harness could not exit while the timer was live. It calls `ifStopRailPoll()` — the same thing leaving the tab does in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)