### PR TITLE
fix(interface): verify the boundaries the guards assert (S38 U6)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -69,13 +69,24 @@ TICKET_TTL_S = 60
 RESERVATION_TTL_S = 60
 IDEM_TTL_S = 24 * 3600
 BROWSER_SESSION_TTL_S = 24 * 3600      # inactivity deadline (spec #26)
+# How long a bootstrap Idempotency-Key stays replayable. Short by intent: it
+# exists to absorb the retry of a lost 201 (spec #26 Session Lifecycle allows
+# exactly one), not to pin a credential for the session's whole 24 hours.
+BOOTSTRAP_REPLAY_TTL_S = 300
 _ALLOWED_HOSTS = ("127.0.0.1", "localhost", "[::1]")
+# The same allowlist as bare hosts, for comparing against a parsed authority
+# (`_authority_host()` returns the IPv6 literal unbracketed).
+_ALLOWED_HOST_SET = frozenset(h.strip("[]") for h in _ALLOWED_HOSTS)
 
 _runtime = None          # bound by bind_runtime()
 # Browser sessions are live-process state ONLY (spec #26 Session Lifecycle):
 # never the DB, a snapshot, or a log — so a service restart invalidates them
 # all, which is exactly the intended recovery path.
 _browser_sessions: dict = {}
+# Bootstrap idempotency replay records, same terms and same lock as the
+# sessions they shadow — live-process only, so a repeated key never reaches
+# the durable DB (spec #26) and a restart forgets it with everything else.
+_browser_bootstraps: dict = {}
 _browser_lock = threading.Lock()
 
 _ATTACHABLE_LIFECYCLES = {
@@ -149,9 +160,43 @@ class _Actor:
         self.sid = sid            # set for kind="browser" (re-checked at commit)
 
 
+def _authority_host(authority: str) -> str:
+    """The host of an `authority` (RFC 3986 `host[:port]`), port removed.
+
+    Splitting at the first colon is wrong for the one form that contains
+    colons in the host itself: a bracketed IPv6 literal. `[::1]:8800` split
+    that way yields `"["`, which is why conformance finding SC-150 found an
+    IPv6 loopback that `require_loopback_bind()` accepts at startup but that
+    could never pass this fence — a supported bind unable to reach its own
+    API. Bracketed literals are therefore read to their closing bracket, and
+    anything trailing that bracket which is not a port fails closed: this is
+    the DNS-rebind fence, so a malformed authority is never a near miss.
+
+    The port is validated for the same reason, and it closes a hole the old
+    `split(":")[0]` had on the IPv4 side too: `127.0.0.1:8800.evil.example.com`
+    parsed to `127.0.0.1` and passed. No browser emits it, so this is
+    hardening rather than a live exploit — but the fence's whole job is that
+    an authority which is not exactly an allowed one is refused, and
+    tightening the IPv6 branch while leaving that in place is just the next
+    finding."""
+    authority = (authority or "").strip()
+    if authority.startswith("["):
+        end = authority.find("]")
+        if end < 0:
+            return ""
+        host, rest = authority[1:end], authority[end + 1:]
+        if rest and not rest.startswith(":"):
+            return ""
+        port = rest[1:]
+    else:
+        host, _, port = authority.partition(":")
+    if port and not port.isdigit():
+        return ""
+    return host.lower()
+
+
 def _host_ok(headers) -> bool:
-    host = (headers.get("Host") or "").split(":")[0].strip("[]").lower()
-    return host in {h.strip("[]") for h in _ALLOWED_HOSTS}
+    return _authority_host(headers.get("Host") or "") in _ALLOWED_HOST_SET
 
 
 def _same_origin_as_host(origin: str, host: str) -> "str | None":
@@ -301,6 +346,17 @@ def _sweep_browser_sessions(now: float) -> None:
     for sid in [s for s, sess in _browser_sessions.items()
                 if now - sess["last_seen"] >= BROWSER_SESSION_TTL_S]:
         del _browser_sessions[sid]
+
+
+def _sweep_bootstrap_replays(now: float) -> None:
+    """Drop expired bootstrap replay records. Same request-driven cleanup as
+    the sessions (spec #26: no scheduled model or harness poll), and bounded
+    by the number of successful mints in the last BOOTSTRAP_REPLAY_TTL_S
+    seconds — not by `_browser_sessions`, which a record outlives when
+    rotation revokes the session it names. Caller holds `_browser_lock`."""
+    for key in [k for k, rec in _browser_bootstraps.items()
+                if now - rec["created"] >= BOOTSTRAP_REPLAY_TTL_S]:
+        del _browser_bootstraps[key]
 
 
 # ------------------------------------------------------------------ idempotency
@@ -2301,15 +2357,45 @@ def _browser_session(headers, body):
                     "browser bootstrap presents no capability — the operator "
                     "capability is CLI/server-only and must never be sent "
                     "from browser code")
-    if not (headers.get("Idempotency-Key") or ""):
+    key = headers.get("Idempotency-Key") or ""
+    if not key:
         return _err(422, "idempotency_key_required",
                     "Idempotency-Key header is required for Interface mutations")
+    # The key is HONOURED here, not merely demanded (conformance finding
+    # SC-151). It cannot ride the general `_idempotent()` path: that one
+    # persists its replay record in `interface_idempotency_keys`, and spec #26
+    # forbids a browser session or its credentials ever reaching the durable
+    # DB. So the replay store is live-process state on exactly the terms the
+    # sessions themselves are — same lock, same request-driven sweep, gone on
+    # restart — and it holds one record per mint for a 288th of a session's
+    # life, so it is never the store that grows.
+    #
+    # The replayed "request" is the provenance the response is derived from
+    # (proven scheme + Host); the route reads no body. A key seen with
+    # different provenance is a conflict, matching `_idempotent()`'s contract.
+    canonical = hashlib.sha256(
+        json.dumps({"scheme": scheme, "host": headers.get("Host") or ""},
+                   sort_keys=True).encode()).hexdigest()
     now = time.time()
     sid = secrets.token_hex(24)
     csrf = secrets.token_hex(24)
     prior = _cookie_session_id(headers)
+    cookie = (f"sc_if={sid}; HttpOnly; SameSite=Strict; Path=/"
+              + ("; Secure" if scheme == "https" else ""))
     with _browser_lock:
         _sweep_browser_sessions(now)
+        _sweep_bootstrap_replays(now)
+        seen = _browser_bootstraps.get(key)
+        if seen is not None and seen["hash"] != canonical:
+            return _err(409, "idempotency_conflict",
+                        "Idempotency-Key reused from a different origin")
+        # Replay only while the session it names is still live. A recorded
+        # session that has since been revoked or expired would otherwise hand
+        # back a dead credential — an idempotent answer that is also a wrong
+        # one — so a stale record falls through to a fresh mint.
+        if seen is not None and seen["sid"] in _browser_sessions:
+            return _json(201, {"csrf": seen["csrf"]},
+                         headers=[("Set-Cookie", seen["cookie"])])
         # Rotation revokes: the session the caller presented dies in the same
         # critical section that mints its replacement, so no window exists in
         # which both the old and the new identifier are usable.
@@ -2317,8 +2403,9 @@ def _browser_session(headers, body):
             _browser_sessions.pop(prior, None)
         _browser_sessions[sid] = {"csrf": csrf, "created": now,
                                   "last_seen": now}
-    cookie = (f"sc_if={sid}; HttpOnly; SameSite=Strict; Path=/"
-              + ("; Secure" if scheme == "https" else ""))
+        _browser_bootstraps[key] = {"hash": canonical, "sid": sid,
+                                    "csrf": csrf, "cookie": cookie,
+                                    "created": now}
     return _json(201, {"csrf": csrf}, headers=[("Set-Cookie", cookie)])
 
 

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -69,9 +69,10 @@ TICKET_TTL_S = 60
 RESERVATION_TTL_S = 60
 IDEM_TTL_S = 24 * 3600
 BROWSER_SESSION_TTL_S = 24 * 3600      # inactivity deadline (spec #26)
-# How long a bootstrap Idempotency-Key stays replayable. Short by intent: it
+# How long a bootstrap Idempotency-Key stays REPLAYABLE. Short by intent: it
 # exists to absorb the retry of a lost 201 (spec #26 Session Lifecycle allows
-# exactly one), not to pin a credential for the session's whole 24 hours.
+# exactly one), not to pin a credential for the session's whole 24 hours. Past
+# it the key is refused, never re-minted — see `_sweep_bootstrap_replays()`.
 BOOTSTRAP_REPLAY_TTL_S = 300
 _ALLOWED_HOSTS = ("127.0.0.1", "localhost", "[::1]")
 # The same allowlist as bare hosts, for comparing against a parsed authority
@@ -83,8 +84,8 @@ _runtime = None          # bound by bind_runtime()
 # never the DB, a snapshot, or a log — so a service restart invalidates them
 # all, which is exactly the intended recovery path.
 _browser_sessions: dict = {}
-# Bootstrap idempotency replay records, same terms and same lock as the
-# sessions they shadow — live-process only, so a repeated key never reaches
+# Bootstrap idempotency replay records, same terms, same lock and same life as
+# the sessions they shadow — live-process only, so a repeated key never reaches
 # the durable DB (spec #26) and a restart forgets it with everything else.
 _browser_bootstraps: dict = {}
 _browser_lock = threading.Lock()
@@ -349,14 +350,25 @@ def _sweep_browser_sessions(now: float) -> None:
 
 
 def _sweep_bootstrap_replays(now: float) -> None:
-    """Drop expired bootstrap replay records. Same request-driven cleanup as
-    the sessions (spec #26: no scheduled model or harness poll), and bounded
-    by the number of successful mints in the last BOOTSTRAP_REPLAY_TTL_S
-    seconds — not by `_browser_sessions`, which a record outlives when
-    rotation revokes the session it names. Caller holds `_browser_lock`."""
-    for key in [k for k, rec in _browser_bootstraps.items()
-                if now - rec["created"] >= BOOTSTRAP_REPLAY_TTL_S]:
-        del _browser_bootstraps[key]
+    """Age out bootstrap replay records without letting expiry decay into a
+    second mint (spec #26 API Contract, conformance finding SC-153). Same
+    request-driven cleanup as the sessions (spec #26: no scheduled model or
+    harness poll). Caller holds `_browser_lock`.
+
+    A record dies with the session it minted: once that session is gone the
+    record can replay nothing, and a repeat of its key mints a session that is
+    the only live one — which is what the guarantee is about. While the session
+    IS live, the record outlives the replay window as a tombstone with its
+    credentials scrubbed: past the window the key is refused, never honoured as
+    a fresh request, so the window's edge cannot hand out a second live session
+    on a 300-second delay. That bounds the store by `_browser_sessions` — one
+    record per live mint, no growth class the sessions dict does not already
+    have."""
+    for key, rec in list(_browser_bootstraps.items()):
+        if rec["sid"] not in _browser_sessions:
+            del _browser_bootstraps[key]
+        elif now - rec["created"] >= BOOTSTRAP_REPLAY_TTL_S:
+            rec["csrf"] = rec["cookie"] = None
 
 
 # ------------------------------------------------------------------ idempotency
@@ -2367,8 +2379,8 @@ def _browser_session(headers, body):
     # forbids a browser session or its credentials ever reaching the durable
     # DB. So the replay store is live-process state on exactly the terms the
     # sessions themselves are — same lock, same request-driven sweep, gone on
-    # restart — and it holds one record per mint for a 288th of a session's
-    # life, so it is never the store that grows.
+    # restart — and it holds one record per LIVE session, so it is never the
+    # store that grows.
     #
     # The replayed "request" is the provenance the response is derived from
     # (proven scheme + Host); the route reads no body. A key seen with
@@ -2385,15 +2397,24 @@ def _browser_session(headers, body):
     with _browser_lock:
         _sweep_browser_sessions(now)
         _sweep_bootstrap_replays(now)
+        # The sweep above settled which records survive: one whose session is
+        # gone is deleted (replaying a revoked credential is idempotent and
+        # wrong, so that key falls through to a real mint — and the session it
+        # mints is then the only live one), and one past the replay window is
+        # left as a scrubbed tombstone.
         seen = _browser_bootstraps.get(key)
-        if seen is not None and seen["hash"] != canonical:
-            return _err(409, "idempotency_conflict",
-                        "Idempotency-Key reused from a different origin")
-        # Replay only while the session it names is still live. A recorded
-        # session that has since been revoked or expired would otherwise hand
-        # back a dead credential — an idempotent answer that is also a wrong
-        # one — so a stale record falls through to a fresh mint.
-        if seen is not None and seen["sid"] in _browser_sessions:
+        if seen is not None:
+            if seen["hash"] != canonical:
+                return _err(409, "idempotency_conflict",
+                            "Idempotency-Key reused from a different origin")
+            # Past the window the key is REFUSED, never re-minted (spec #26 API
+            # Contract, conformance finding SC-153): expiring into a fresh mint
+            # would hand the same key a second live session with different
+            # credentials — the SC-151 defect, arriving on a delay.
+            if seen["cookie"] is None:
+                return _err(409, "idempotency_conflict",
+                            "Idempotency-Key reused after its replay window — "
+                            "retry with a fresh key")
             return _json(201, {"csrf": seen["csrf"]},
                          headers=[("Set-Cookie", seen["cookie"])])
         # Rotation revokes: the session the caller presented dies in the same

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -104,14 +104,48 @@ _STATIC = {
     "/vendor/xterm/xterm.css": ("vendor/xterm/xterm.css", "text/css; charset=utf-8"),
 }
 
-# Content-Security-Policy for the app shell (spec #20 Security And Privacy):
-# vendored scripts and same-origin (incl. WebSocket) connections only. Styles
-# keep 'unsafe-inline' — the no-build UI sets style attributes via DOM and the
-# doc renderer emits inline styling; scripts stay strict.
-_CSP = ("default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
-        "connect-src 'self' ws: wss:; img-src 'self' data:; "
-        "font-src 'self'; object-src 'none'; base-uri 'none'; "
-        "frame-ancestors 'none'")
+# The Interface's own authorities, for the socket sources in the CSP below —
+# the same three `interface_routes._ALLOWED_HOSTS` fences the API to. Spelled
+# out again here rather than imported: the Interface stack is an optional
+# import on this server, and the app shell must carry a policy either way.
+_CSP_HOSTS = ("127.0.0.1", "localhost", "[::1]")
+
+
+def _csp(port: int) -> str:
+    """Content-Security-Policy for the app shell (spec #20 Security And
+    Privacy; spec #26 Trust Boundary, where same-origin script execution is
+    operator-equivalent and this header is therefore release-critical):
+    vendored scripts and same-origin connections only.
+
+    `connect-src` names the socket origins EXPLICITLY. It used to read
+    `'self' ws: wss:`, and conformance finding SC-152 was right that this
+    contradicted the "same-origin only" claim standing next to it: `ws:` and
+    `wss:` are CSP *scheme-sources*, and a scheme-source matches any host
+    using that scheme (https://www.w3.org/TR/CSP3/#match-url-to-source-expression).
+    That left injected same-origin script an outbound WebSocket channel to
+    anywhere — the exact containment the policy exists to provide. Naming
+    `scheme://host:port` closes it to this server's own origins.
+
+    The socket origins are listed rather than left to `'self'` alone because
+    `'self'` matching ws/wss arrived late and unevenly across browsers, and
+    the terminal stream is not a feature to lose to a browser-version
+    difference. Styles keep 'unsafe-inline' — the no-build UI sets style
+    attributes via DOM and the doc renderer emits inline styling; scripts
+    stay strict.
+    """
+    sockets = " ".join(f"{scheme}://{host}:{port}"
+                       for host in _CSP_HOSTS for scheme in ("ws", "wss"))
+    return ("default-src 'self'; script-src 'self'; "
+            "style-src 'self' 'unsafe-inline'; "
+            f"connect-src 'self' {sockets}; img-src 'self' data:; "
+            "font-src 'self'; object-src 'none'; base-uri 'none'; "
+            "frame-ancestors 'none'")
+
+
+# Rebound in main() once the real port resolves — the socket sources are
+# port-exact, so a fork on a non-default port would otherwise refuse its own
+# terminal stream. This default only covers a shell rendered without main().
+_CSP = _csp(8800)
 
 # md-converter inline deep-link. The doc's markdown rides IN the URL as the `c=`
 # param — gzip → base64url (no padding) — which the live md-converter decodes on
@@ -2810,6 +2844,47 @@ async def _ws_unavailable(reader, writer, head_raw: bytes) -> None:
         writer.close()
 
 
+# Filesystem artifacts a container RUNTIME creates inside the container — not
+# configuration this process, its operator, or a stray shell can assert. Docker
+# writes /.dockerenv; podman and the other OCI runtimes write /run/.containerenv.
+_CONTAINER_MARKERS = ("/.dockerenv", "/run/.containerenv")
+_PID1_CGROUP = Path("/proc/1/cgroup")
+
+
+def in_container() -> bool:
+    """Positive evidence that this process runs inside a container, observed
+    rather than asserted (spec #26, conformance finding SC-149).
+
+    What it checks, in order of trustworthiness: a runtime-created marker file
+    (`/.dockerenv`, `/run/.containerenv`), then PID 1's cgroup path naming a
+    container runtime — the cgroup-v1-shaped fallback for runtimes that write
+    no marker. Both are artifacts of the runtime that built the sandbox.
+
+    What it PROVES: this process's bind lands in a container network
+    namespace, so `0.0.0.0` here is the container's wildcard, not the host's.
+
+    What it does NOT prove, stated plainly because the finding this fixes was
+    a guard claiming more than it verified: it does not prove the host
+    published the port to loopback only. That mapping (`-p 127.0.0.1:PORT:PORT`,
+    `sc:1206-1207`) lives on the host side and is invisible from in here
+    without the docker socket. Two residual cases therefore pass this check
+    with no loopback boundary behind them — a container run with
+    `--network=host` (which shares the host's namespace), and a container
+    whose port is published wide. Both require someone to deliberately launch
+    the engine outside `./sc launch`'s mapping; neither is reachable by
+    setting an environment variable, which is the entire distance travelled
+    from the `SC_SANDBOX` check this replaces.
+    """
+    if any(os.path.exists(m) for m in _CONTAINER_MARKERS):
+        return True
+    try:
+        cgroup = _PID1_CGROUP.read_text()
+    except OSError:
+        return False
+    return any(tag in cgroup for tag in
+               ("/docker/", "/docker-", "containerd", "/lxc/", "kubepods"))
+
+
 def require_loopback_bind(bind: str) -> None:
     """Spec #26 Failure Modes: a non-loopback bind refuses to start, because
     the Interface hands a browser session to anything that can present an
@@ -2817,19 +2892,22 @@ def require_loopback_bind(bind: str) -> None:
     chooses freely. On a host, a non-loopback bind therefore turns automatic
     minting into remote authority, and no other fence stands behind it.
 
-    The guard is host-scoped by design, and the exception is not a loophole.
-    In the sandbox container `./sc launch` sets SC_BIND=0.0.0.0 deliberately
-    so docker can publish the port, and the boundary is supplied there by the
-    `-p 127.0.0.1:PORT:PORT` mapping — loopback-only on the host regardless of
-    the in-container bind. Refusing 0.0.0.0 unconditionally would make the
-    sandbox unlaunchable while removing no real exposure. SC_SANDBOX=1 is set
-    by that same launch path and is the available discriminator.
+    The sandbox is the one legitimate non-loopback bind: `./sc launch` sets
+    SC_BIND=0.0.0.0 (`sc:1198`) so docker can publish the port, and the
+    boundary is the `-p 127.0.0.1:PORT:PORT` mapping (`sc:1206-1207`) —
+    loopback-only on the host regardless of the in-container bind. Refusing
+    0.0.0.0 unconditionally would make the sandbox unlaunchable while removing
+    no real exposure.
 
-    So the guarantee is: reachable only from the host's loopback interface —
-    enforced in-process off-sandbox, and by docker's port mapping in it.
+    That exception is gated on `in_container()`, NOT on SC_SANDBOX. The
+    original amendment keyed it on the env var and conformance finding SC-149
+    was right to reject it: an environment variable is a CLAIM that a boundary
+    exists, and setting `SC_SANDBOX=1` does not create a publish mapping, so
+    `SC_SANDBOX=1 SC_BIND=0.0.0.0` on a bare host opened a listener the spec
+    asserted was fenced. Where the boundary cannot be positively observed, the
+    refusal applies — see `in_container()` for exactly how far the observation
+    reaches.
     """
-    if os.environ.get("SC_SANDBOX"):
-        return
     host = (bind or "").strip().strip("[]")
     if host.lower() == "localhost":
         return
@@ -2838,13 +2916,17 @@ def require_loopback_bind(bind: str) -> None:
             return
     except ValueError:
         pass
+    if in_container():
+        return
     sys.exit(
         f"server: refusing to start — SC_BIND={bind!r} is not a loopback "
-        "address (spec #26). The Interface mints a browser session for any "
-        "caller that can set Host and Origin, so a non-loopback bind would "
-        "expose it to the network. Unset SC_BIND or set it to 127.0.0.1. "
-        "Remote access needs a separately authenticated boundary (e.g. a "
-        "tailnet), not a wider bind."
+        "address and this process is not in a container (spec #26). The "
+        "Interface mints a browser session for any caller that can set Host "
+        "and Origin, so a non-loopback bind would expose it to the network. "
+        "Unset SC_BIND or set it to 127.0.0.1. SC_SANDBOX no longer grants "
+        "this exception — it is a claim, not a boundary. Remote access needs "
+        "a separately authenticated boundary (e.g. a tailnet), not a wider "
+        "bind."
     )
 
 
@@ -2854,6 +2936,10 @@ def main(argv):
         port = int(argv[argv.index("--port") + 1])
     if port is None:
         port = ports_mod.resolve().get("port", 8800)
+    # The app shell's socket sources are port-exact (see `_csp`), so bind the
+    # policy to the port actually being served before any request can render it.
+    global _CSP
+    _CSP = _csp(port)
     if not DB_PATH.exists():
         sys.exit(f"server: no DB at {DB_PATH} — run `./sc rebuild` first.")
     require_current_schema(DB_PATH)

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2860,20 +2860,25 @@ def in_container() -> bool:
     container runtime — the cgroup-v1-shaped fallback for runtimes that write
     no marker. Both are artifacts of the runtime that built the sandbox.
 
-    What it PROVES: this process's bind lands in a container network
-    namespace, so `0.0.0.0` here is the container's wildcard, not the host's.
+    What it ESTABLISHES: a container filesystem and cgroup context — this
+    process runs inside something a container runtime built. That is NOT a
+    distinct network namespace. `--network=host` shares the host's namespace
+    and passes every check here, so `0.0.0.0` under this exemption is not
+    guaranteed to be the container's own wildcard.
 
-    What it does NOT prove, stated plainly because the finding this fixes was
-    a guard claiming more than it verified: it does not prove the host
-    published the port to loopback only. That mapping (`-p 127.0.0.1:PORT:PORT`,
-    `sc:1206-1207`) lives on the host side and is invisible from in here
-    without the docker socket. Two residual cases therefore pass this check
-    with no loopback boundary behind them — a container run with
-    `--network=host` (which shares the host's namespace), and a container
-    whose port is published wide. Both require someone to deliberately launch
-    the engine outside `./sc launch`'s mapping; neither is reachable by
-    setting an environment variable, which is the entire distance travelled
-    from the `SC_SANDBOX` check this replaces.
+    The loopback boundary therefore rests on an operator PRECONDITION, not on
+    a verified property: that the engine was launched by `./sc launch`, which
+    publishes `-p 127.0.0.1:PORT:PORT` (`sc:1206-1207`) and does not pass
+    `--network=host`. Nothing observable from in here can confirm it — the
+    publish mapping is host-side and invisible without the docker socket — and
+    a stated assumption is not a verified one. Deliberately do not add a
+    namespace probe to close that gap: a check that fails open would be worse
+    than an honest narrow one, and claiming more than is verified is the
+    defect this replaced (SC-149, then SC-154 one layer up).
+
+    What the check does buy: the exemption now costs a deliberate launch
+    outside `./sc launch`, where the `SC_SANDBOX` check it replaces cost an
+    `export`.
     """
     if any(os.path.exists(m) for m in _CONTAINER_MARKERS):
         return True
@@ -2895,9 +2900,10 @@ def require_loopback_bind(bind: str) -> None:
     The sandbox is the one legitimate non-loopback bind: `./sc launch` sets
     SC_BIND=0.0.0.0 (`sc:1198`) so docker can publish the port, and the
     boundary is the `-p 127.0.0.1:PORT:PORT` mapping (`sc:1206-1207`) —
-    loopback-only on the host regardless of the in-container bind. Refusing
-    0.0.0.0 unconditionally would make the sandbox unlaunchable while removing
-    no real exposure.
+    loopback-only on the host provided that is how the container was launched,
+    which is a precondition this process cannot check (see `in_container()`).
+    Refusing 0.0.0.0 unconditionally would make the sandbox unlaunchable while
+    removing no real exposure.
 
     That exception is gated on `in_container()`, NOT on SC_SANDBOX. The
     original amendment keyed it on the env var and conformance finding SC-149

--- a/.super-coder/docs/interface-trust-boundary.md
+++ b/.super-coder/docs/interface-trust-boundary.md
@@ -66,20 +66,43 @@ what enforces that, rather than restating "binds loopback only":
 - **Inside the sandbox container**: the bind *is* `0.0.0.0`, deliberately, so
   docker can publish the port — and the boundary is the published mapping,
   `-p 127.0.0.1:PORT:PORT`, which is loopback-only on the host whatever the
-  container binds. The in-process guard stands down there (it detects
-  `SC_SANDBOX`) because refusing would break `./sc launch` without removing
-  any exposure.
+  container binds. The in-process guard stands down there because refusing
+  would break `./sc launch` without removing any exposure.
+
+The exemption is granted on **observed** container evidence — a marker file a
+container runtime writes (`/.dockerenv`, `/run/.containerenv`), or PID 1's
+cgroup naming one. It is deliberately **not** granted on `SC_SANDBOX`, which
+is how this first shipped: an environment variable is a *claim* that a
+boundary exists, and setting `SC_SANDBOX=1` does not create a publish mapping,
+so `SC_SANDBOX=1 SC_BIND=0.0.0.0` on a bare host opened a listener this page
+described as fenced. Where the boundary cannot be positively observed, the
+refusal applies.
+
+Two things that evidence does **not** prove, said plainly, because a guard
+claiming more than it verifies is the defect this replaced. It shows the bind
+lands in a container's network namespace; it cannot show what the host did
+with the port, since the publish mapping is host-side and invisible from
+inside without the docker socket. So a container run with `--network=host`, or
+one whose port is published wide, still passes. Both require launching the
+engine outside `./sc launch`'s mapping — neither is reachable by setting a
+variable, which is the whole distance travelled.
 
 Net: reachable from the host's loopback interface only, enforced in-process
-off-sandbox and by docker's port mapping in it. Neither path exposes the
-Interface to the network, and neither claims more than it does. Remote access
-is a separate authenticated boundary you put in front (e.g. a tailnet) — never
-a wider bind.
+off-sandbox and by docker's port mapping in it. Remote access is a separate
+authenticated boundary you put in front (e.g. a tailnet) — never a wider bind.
 
 Same-origin script execution is operator-equivalent here. The restrictive CSP,
 the vendored scripts, the sanitized rendered content, and the absence of any
 third-party runtime asset are therefore security controls, not hygiene — an
 XSS bug in the Interface is a security defect, not a rendering defect.
+
+That CSP names its socket destinations explicitly —
+`connect-src 'self' ws://HOST:PORT …` for the Interface's own origins — rather
+than allowing the `ws:`/`wss:` schemes. Scheme sources match *any* host, so
+the earlier policy left injected same-origin script an outbound WebSocket
+channel to anywhere while the comment beside it promised same-origin only.
+Containment after an injection is the point of the header; a destination list
+that admits every host does not provide it.
 
 ## Why the browser is not given the operator capability
 

--- a/.super-coder/docs/interface-trust-boundary.md
+++ b/.super-coder/docs/interface-trust-boundary.md
@@ -48,7 +48,7 @@ The web, and the network — in full, and these controls are release-critical:
 | A webpage on another origin scripting your Interface | Exact same-origin `Origin` **and** `Sec-Fetch-Site: same-origin` on bootstrap; `SameSite=Strict` cookie; `X-CSRF` on every mutation; CORS stays off |
 | Cross-site request forgery | `SameSite=Strict` + an anti-forgery token held only in page memory |
 | DNS rebinding | Exact `Host` allowlist (`127.0.0.1` / `localhost`), every route |
-| Accidental network exposure | Reachable from the host's loopback interface only — see [the exact guarantee](#the-bind-guarantee-exactly) |
+| Accidental network exposure | Loopback-only: off-sandbox the server exits unless the bind is loopback; in the sandbox it is an operator precondition, not something the process verifies — see [the exact guarantee](#the-bind-guarantee-exactly) |
 | Credential leakage from the browser | The browser is never given a credential to leak — see below |
 | Remote clients | No route in; reach it through your own secure transport (e.g. a tailnet) or not at all |
 
@@ -58,16 +58,17 @@ Because the browser session mints automatically, the *only* thing standing
 between a remote client and Interface authority is that the remote client
 cannot reach the port — a network client able to choose its own `Host` and
 `Origin` headers passes every other fence. So it is worth being precise about
-what enforces that, rather than restating "binds loopback only":
+what enforces that, rather than restating the headline:
 
 - **On your host** (`./sc serve`, the supervised stack): the server checks
   `SC_BIND` at startup and **exits** unless it is a loopback address. Setting
   `SC_BIND=0.0.0.0` does not widen the Interface; it stops it booting.
 - **Inside the sandbox container**: the bind *is* `0.0.0.0`, deliberately, so
-  docker can publish the port — and the boundary is the published mapping,
-  `-p 127.0.0.1:PORT:PORT`, which is loopback-only on the host whatever the
-  container binds. The in-process guard stands down there because refusing
-  would break `./sc launch` without removing any exposure.
+  docker can publish the port — and the boundary is `./sc launch`'s published
+  mapping, `-p 127.0.0.1:PORT:PORT`, which is loopback-only on the host
+  provided that is how the container was launched. The in-process guard stands
+  down there because refusing would break `./sc launch` without removing any
+  exposure.
 
 The exemption is granted on **observed** container evidence — a marker file a
 container runtime writes (`/.dockerenv`, `/run/.containerenv`), or PID 1's
@@ -78,18 +79,26 @@ so `SC_SANDBOX=1 SC_BIND=0.0.0.0` on a bare host opened a listener this page
 described as fenced. Where the boundary cannot be positively observed, the
 refusal applies.
 
-Two things that evidence does **not** prove, said plainly, because a guard
-claiming more than it verifies is the defect this replaced. It shows the bind
-lands in a container's network namespace; it cannot show what the host did
-with the port, since the publish mapping is host-side and invisible from
-inside without the docker socket. So a container run with `--network=host`, or
-one whose port is published wide, still passes. Both require launching the
-engine outside `./sc launch`'s mapping — neither is reachable by setting a
-variable, which is the whole distance travelled.
+What that evidence establishes, exactly, because a guard claiming more than it
+verifies is the defect this replaced: a container **filesystem and cgroup**
+context. That is **not** a distinct network namespace — `--network=host`
+shares the host's and passes every check. Nor can anything in here see what
+the host did with the port: the publish mapping is host-side and invisible
+without the docker socket.
 
-Net: reachable from the host's loopback interface only, enforced in-process
-off-sandbox and by docker's port mapping in it. Remote access is a separate
-authenticated boundary you put in front (e.g. a tailnet) — never a wider bind.
+So in the sandbox, loopback-only is a **precondition**, not a verified
+property: it holds provided the container was launched by `./sc launch`, which
+publishes to `127.0.0.1` and does not pass `--network=host`. Launch the engine
+some other way and the evidence check still passes with no loopback boundary
+behind it. That residual is real; what it costs is a deliberate launch outside
+`./sc launch`, where the variable this replaced cost an `export`. There is no
+namespace probe here on purpose — a check that failed open would be worse than
+an honest narrow one.
+
+Net: off-sandbox the guard verifies it, exiting unless the bind is loopback;
+in the sandbox it is loopback-only on the stated precondition above, which
+this process cannot confirm. Remote access is a separate authenticated
+boundary you put in front (e.g. a tailnet) — never a wider bind.
 
 Same-origin script execution is operator-equivalent here. The restrictive CSP,
 the vendored scripts, the sanitized rendered content, and the absence of any
@@ -177,7 +186,7 @@ privilege**:
 - The engine never invokes `sudo`. The only `sudo` in Subfloor is *printed
   advice* during one-time host setup (`./sc doctor`) for installing Docker
   itself — an OS package step you perform, not something the service does.
-- The published port is bound to `127.0.0.1` only.
+- The port `./sc launch` publishes is bound to `127.0.0.1` only.
 
 One caveat worth stating rather than hiding: on **rootful** Docker, membership
 in the `docker` group is effectively root-equivalent on the host. That is a

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -148,6 +148,7 @@ class InterfaceApiTest(unittest.TestCase):
         # Browser sessions are process-global live state — start each test
         # from the empty store a fresh server would have.
         routes._browser_sessions.clear()
+        routes._browser_bootstraps.clear()
         routes.ensure_operator_capability()
         (run_dir / "operator.token").write_text("optok")
         self.runtime = FakeRuntime()
@@ -640,6 +641,7 @@ class InterfaceApiTest(unittest.TestCase):
                     " ".join(str(c) for row in rows for c in row),
                     f"browser session leaked into {table}")
         routes._browser_sessions.clear()          # what a restart does
+        routes._browser_bootstraps.clear()        # ...including replays
         status, _, body = self.call("GET", "/api/interface/shells",
                                     (f"Cookie: {cookie}",))
         self.assertEqual(status, 401)

--- a/tests/test_interface_release_gate.py
+++ b/tests/test_interface_release_gate.py
@@ -39,6 +39,7 @@ sys.path.insert(0, str(ENGINE / "api"))
 
 import interface_routes as routes  # noqa: E402
 import run as run_mod  # noqa: E402
+import server  # noqa: E402  (the app shell's CSP, served)
 import transport as transport_mod  # noqa: E402
 
 from test_interface_api import FakeRuntime, build_engine_db  # noqa: E402
@@ -66,6 +67,7 @@ class ReleaseGateTest(unittest.TestCase):
         for p in self.patches:
             p.start()
         routes._browser_sessions.clear()
+        routes._browser_bootstraps.clear()
         routes.ensure_operator_capability()
         (run_dir / "operator.token").write_text("optok")
         routes.bind_runtime(FakeRuntime())
@@ -364,6 +366,7 @@ class ReleaseGateTest(unittest.TestCase):
         # A service restart drops live-process state: every session dies, and
         # the client is told to bootstrap rather than shown an error.
         routes._browser_sessions.clear()
+        routes._browser_bootstraps.clear()
         status, _, body = self.http("GET", "/api/interface/shells",
                                     {"Cookie": second})
         self.assertEqual(status, 401)
@@ -378,6 +381,127 @@ class ReleaseGateTest(unittest.TestCase):
                                  {"Cookie": third})
         self.assertEqual(status, 200)
 
+    # -- SC-150: the Host fence and the bind guard must agree ----------------
+
+    def test_an_ipv6_loopback_host_reaches_the_api_it_is_accepted_for(self):
+        """`require_loopback_bind()` accepts `::1` and `[::1]`, so a fork may
+        legitimately be configured that way — and every call used to come back
+        `403 host_not_allowed`, because the Host fence split `[::1]:PORT` at
+        the first colon and compared `"["` against the allowlist. A bind the
+        engine accepts at startup but that cannot use its own API is not a
+        supported bind, it is a broken one.
+
+        The socket still runs over 127.0.0.1: the fence reads the Host HEADER,
+        so the header is what this varies.
+        """
+        v6 = f"[::1]:{self.port}"
+        status, headers, body = self.http(
+            "POST", "/api/interface/browser-sessions",
+            {"Host": v6, "Origin": f"http://{v6}",
+             "Sec-Fetch-Site": "same-origin", "Idempotency-Key": "v6-mint"},
+            {})
+        self.assertEqual(status, 201, body)
+        cookie = headers["Set-Cookie"].split(";")[0]
+        status, _, body = self.http("GET", "/api/interface/shells",
+                                    {"Host": v6, "Cookie": cookie})
+        self.assertEqual(status, 200, body)
+
+    def test_a_malformed_bracketed_host_fails_closed(self):
+        # Widening the parse must not soften the DNS-rebind fence: anything
+        # that is not exactly an allowed authority is still refused.
+        # The last two are the port hole: an allowed host with a non-numeric
+        # "port" that the old `split(":")[0]` waved through on the IPv4 side.
+        for host in ("[::1", "[::1]evil.example.com", "[]", "[evil]:8800",
+                     "[::2]:8800", "[::1]:8800.evil.example.com",
+                     "127.0.0.1:8800.evil.example.com"):
+            with self.subTest(host=host):
+                status, _, body = self.http(
+                    "GET", "/api/interface/shells", {"Host": host})
+                self.assertEqual(status, 403, body)
+                self.assertEqual(body["error"]["code"], "host_not_allowed")
+
+    # -- SC-151: the bootstrap honours the key it demands --------------------
+
+    def _boot(self, key, **extra):
+        return self.http("POST", "/api/interface/browser-sessions",
+                         self.browser_headers(**{"Idempotency-Key": key,
+                                                 **extra}), {})
+
+    def test_an_exact_bootstrap_retry_replays_instead_of_minting_again(self):
+        """The endpoint required an `Idempotency-Key` and never keyed on it,
+        so the retry of a lost `201` minted a SECOND live session with
+        DIFFERENT credentials — the client keeping one and the server holding
+        two, with the orphan live for its full 24 hours. Demanding a guarantee
+        the route does not provide is the defect; this pins the guarantee."""
+        first = self._boot("boot-retry")
+        second = self._boot("boot-retry")
+        self.assertEqual((first[0], second[0]), (201, 201))
+        self.assertEqual(first[1]["Set-Cookie"], second[1]["Set-Cookie"])
+        self.assertEqual(first[2]["csrf"], second[2]["csrf"])
+        self.assertEqual(
+            len(routes._browser_sessions), 1,
+            "an exact retry minted a second live session")
+        # The replayed credential is a working one, not just an equal string.
+        status, _, body = self.http(
+            "GET", "/api/interface/shells",
+            {"Cookie": first[1]["Set-Cookie"].split(";")[0]})
+        self.assertEqual(status, 200, body)
+
+    def test_a_fresh_key_still_mints_an_independent_session(self):
+        # The counterweight to the replay: a second tab bootstraps with its
+        # own key and must get its own session, or the fix has broken
+        # concurrent browsers (spec #26 Session Lifecycle).
+        first = self._boot("boot-tab-1")
+        second = self._boot("boot-tab-2")
+        self.assertNotEqual(first[1]["Set-Cookie"], second[1]["Set-Cookie"])
+        self.assertNotEqual(first[2]["csrf"], second[2]["csrf"])
+        self.assertEqual(len(routes._browser_sessions), 2)
+
+    def test_a_key_reused_from_a_different_origin_conflicts(self):
+        # Both authorities are allowed, so this passes the provenance fence
+        # and fails on the key alone — matching `_idempotent()`'s contract
+        # rather than silently handing origin A's credential to origin B.
+        self.assertEqual(self._boot("boot-shared")[0], 201)
+        other = f"localhost:{self.port}"
+        status, _, body = self.http(
+            "POST", "/api/interface/browser-sessions",
+            {"Host": other, "Origin": f"http://{other}",
+             "Sec-Fetch-Site": "same-origin",
+             "Idempotency-Key": "boot-shared"}, {})
+        self.assertEqual(status, 409, body)
+        self.assertEqual(body["error"]["code"], "idempotency_conflict")
+
+    def test_a_replay_whose_session_died_mints_fresh(self):
+        # Replaying a revoked or restart-lost credential would be idempotent
+        # and useless — an answer that is consistent and wrong. The record
+        # falls through to a real mint instead.
+        first = self._boot("boot-stale")
+        routes._browser_sessions.clear()          # what a restart does
+        second = self._boot("boot-stale")
+        self.assertEqual(second[0], 201)
+        self.assertNotEqual(second[1]["Set-Cookie"], first[1]["Set-Cookie"])
+        status, _, body = self.http(
+            "GET", "/api/interface/shells",
+            {"Cookie": second[1]["Set-Cookie"].split(";")[0]})
+        self.assertEqual(status, 200, body)
+
+    def test_a_replayed_bootstrap_never_reaches_the_durable_db(self):
+        # Spec #26: browser sessions and their credentials are live-process
+        # state only. The general `_idempotent()` path would have persisted
+        # the response body — which holds the anti-forgery token — so the
+        # replay store deliberately does not use it.
+        import sqlite3
+        self._boot("boot-durable")
+        self._boot("boot-durable")
+        con = sqlite3.connect(self.db_path)
+        try:
+            rows = con.execute(
+                "SELECT COUNT(*) FROM interface_idempotency_keys").fetchone()[0]
+        finally:
+            con.close()
+        self.assertEqual(rows, 0,
+                         "a browser-session credential reached the durable DB")
+
     def test_expiry_over_the_wire_deletes_the_session(self):
         import time
         cookie, _ = self.mint()
@@ -389,6 +513,83 @@ class ReleaseGateTest(unittest.TestCase):
         self.assertEqual(status, 401)
         self.assertEqual(body["error"]["code"], "browser_session_expired")
         self.assertNotIn(sid, routes._browser_sessions)
+
+
+class AppShellCspTest(unittest.TestCase):
+    """The Content-Security-Policy a browser actually receives, read off a
+    real socket through the real `server.dispatch_http`.
+
+    Spec #26 Delivery Plan step 6 owed a CSP check and the tree contained
+    none, which is how `connect-src 'self' ws: wss:` shipped while the
+    comment above it promised same-origin connections only (conformance
+    finding SC-152). `CspSourceListTest` in test_server_schema_guard.py pins
+    the policy STRING; this pins that a served response carries it, because a
+    policy no response emits fences nothing — and the Playwright server that
+    rendered the UI never served the production header at all.
+    """
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def run():
+            asyncio.set_event_loop(self.loop)
+            self.transport = transport_mod.Transport(
+                "127.0.0.1", 0, server.dispatch_http, self._no_ws,
+                log=lambda *_: None)
+            self.loop.run_until_complete(self.transport.start())
+            self.port = self.transport.port
+            ready.set()
+            self.loop.run_forever()
+
+        self.thread = threading.Thread(target=run, daemon=True)
+        self.thread.start()
+        self.assertTrue(ready.wait(10), "transport did not start")
+        # main() binds the policy to the port it serves; do the same for the
+        # ephemeral port here so the assertion below is end-to-end and not a
+        # comparison of the module default against itself.
+        csp = server._CSP
+        self.addCleanup(lambda: setattr(server, "_CSP", csp))
+        server._CSP = server._csp(self.port)
+
+    async def _no_ws(self, reader, writer, head_raw):  # pragma: no cover
+        writer.close()
+
+    def tearDown(self):
+        asyncio.run_coroutine_threadsafe(
+            self.transport.stop(), self.loop).result(timeout=10)
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join(timeout=10)
+        self.loop.close()
+
+    def _get(self, path):
+        con = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        try:
+            con.request("GET", path)
+            resp = con.getresponse()
+            resp.read()
+            return resp.status, dict(resp.getheaders())
+        finally:
+            con.close()
+
+    def test_the_app_shell_is_served_with_the_policy(self):
+        status, headers = self._get("/")
+        self.assertEqual(status, 200)
+        self.assertEqual(headers.get("Content-Security-Policy"), server._CSP)
+
+    def test_the_served_connect_src_authorises_no_arbitrary_socket_host(self):
+        _, headers = self._get("/")
+        connect = next(
+            part.split()[1:] for part in
+            headers["Content-Security-Policy"].split(";")
+            if part.split() and part.split()[0] == "connect-src")
+        for src in connect:
+            with self.subTest(source=src):
+                self.assertFalse(
+                    src.endswith(":") and "//" not in src,
+                    f"{src!r} is a CSP scheme-source and matches any host")
+        # ...and the stream the UI actually opens is still authorised.
+        self.assertIn(f"ws://127.0.0.1:{self.port}", connect)
 
 
 if __name__ == "__main__":

--- a/tests/test_interface_release_gate.py
+++ b/tests/test_interface_release_gate.py
@@ -623,11 +623,19 @@ class AppShellCspTest(unittest.TestCase):
             part.split()[1:] for part in
             headers["Content-Security-Policy"].split(";")
             if part.split() and part.split()[0] == "connect-src")
+        # Membership, not a scheme-source check: rejecting `ws:` alone let an
+        # explicit hostile origin through the served header while the sibling
+        # exact-string test correctly failed the same widening (REV2 Low).
+        allowed = {f"{scheme}://{host}:{self.port}"
+                   for scheme in ("ws", "wss")
+                   for host in routes._ALLOWED_HOSTS}
         for src in connect:
             with self.subTest(source=src):
-                self.assertFalse(
-                    src.endswith(":") and "//" not in src,
-                    f"{src!r} is a CSP scheme-source and matches any host")
+                self.assertTrue(
+                    src == "'self'" or src in allowed,
+                    f"{src!r} authorises a socket host this server does not "
+                    f"serve — a scheme-source matches any host, and so does "
+                    f"a named foreign origin")
         # ...and the stream the UI actually opens is still authorised.
         self.assertIn(f"ws://127.0.0.1:{self.port}", connect)
 

--- a/tests/test_interface_release_gate.py
+++ b/tests/test_interface_release_gate.py
@@ -485,6 +485,46 @@ class ReleaseGateTest(unittest.TestCase):
             {"Cookie": second[1]["Set-Cookie"].split(";")[0]})
         self.assertEqual(status, 200, body)
 
+    # -- SC-153: the window's edge refuses, it does not mint again -----------
+
+    def test_a_key_reused_past_the_replay_window_is_refused_not_reminted(self):
+        """The replay window is bounded on purpose, but expiring it into a
+        fresh mint reintroduced SC-151 on a 300-second delay: the same key,
+        the same provenance, a SECOND live session with different credentials.
+        A happy-path replay test cannot see this, which is why it survived a
+        review — so this one advances past the window and asserts a REFUSAL
+        (spec #26 API Contract: `409 idempotency_conflict` past the window).
+        """
+        first = self._boot("boot-window")
+        self.assertEqual(first[0], 201)
+        cookie = first[1]["Set-Cookie"].split(";")[0]
+        routes._browser_bootstraps["boot-window"]["created"] -= (
+            routes.BOOTSTRAP_REPLAY_TTL_S + 1)
+
+        status, headers, body = self._boot("boot-window")
+        self.assertEqual(status, 409, body)
+        self.assertEqual(body["error"]["code"], "idempotency_conflict")
+        self.assertNotIn("Set-Cookie", headers)
+        self.assertEqual(
+            len(routes._browser_sessions), 1,
+            "the replay window expired into a second live session")
+        # The refusal is not a revocation either: the credential the client
+        # already holds keeps working, so the caller loses nothing by being
+        # told to use a fresh key.
+        status, _, body = self.http("GET", "/api/interface/shells",
+                                    {"Cookie": cookie})
+        self.assertEqual(status, 200, body)
+
+    def test_the_replay_store_does_not_outlive_the_sessions_it_shadows(self):
+        # The counterweight to the tombstone: bounding the store is the reason
+        # the window exists at all, so a record whose session is gone must not
+        # linger. Expiry is what makes the refusal above affordable.
+        self._boot("boot-bounded")
+        self.assertIn("boot-bounded", routes._browser_bootstraps)
+        routes._browser_sessions.clear()          # what a revoke/expiry does
+        self._boot("boot-other")
+        self.assertNotIn("boot-bounded", routes._browser_bootstraps)
+
     def test_a_replayed_bootstrap_never_reaches_the_durable_db(self):
         # Spec #26: browser sessions and their credentials are live-process
         # state only. The general `_idempotent()` path would have persisted

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -88,42 +88,113 @@ class ServerSchemaGuardTest(unittest.TestCase):
             server.require_current_schema(db_path, MIGRATIONS)
 
 
+class ContainerEvidenceTest(unittest.TestCase):
+    """`in_container()` reads artifacts a container RUNTIME wrote, and nothing
+    a caller can assert (spec #26, conformance finding SC-149).
+
+    The distinction is the whole finding: the check this replaced returned
+    True for `SC_SANDBOX=1`, so the "boundary" it certified was a string an
+    operator, a stray shell, or a `.env` could set. These tests hold the
+    evidence to the filesystem — patched to a temp path so they say something
+    on a host runner AND inside the sandbox, where the real `/.dockerenv`
+    would otherwise make every case pass for free.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.marker = Path(self.tmp.name) / ".dockerenv"
+        self.cgroup = Path(self.tmp.name) / "cgroup"
+        self.addCleanup(self.tmp.cleanup)
+        for p in (mock.patch.object(server, "_CONTAINER_MARKERS",
+                                    (str(self.marker),)),
+                  mock.patch.object(server, "_PID1_CGROUP", self.cgroup)):
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_no_evidence_is_not_a_container(self):
+        self.assertFalse(server.in_container())
+
+    def test_an_environment_variable_is_never_evidence(self):
+        # The SC-149 pin at its narrowest: the old discriminator, alone,
+        # must now prove exactly nothing.
+        for value in ("1", "true", "yes"):
+            with self.subTest(value=value):
+                with mock.patch.dict(os.environ, {"SC_SANDBOX": value}):
+                    self.assertFalse(server.in_container())
+
+    def test_a_runtime_marker_file_is_evidence(self):
+        self.marker.touch()
+        self.assertTrue(server.in_container())
+
+    def test_pid1_cgroup_naming_a_runtime_is_evidence(self):
+        self.cgroup.write_text(
+            "12:pids:/docker/6f2c1a\n11:cpu:/docker/6f2c1a\n")
+        self.assertTrue(server.in_container())
+
+    def test_a_host_pid1_cgroup_is_not_evidence(self):
+        self.cgroup.write_text("0::/init.scope\n")
+        self.assertFalse(server.in_container())
+
+    def test_an_unreadable_cgroup_fails_closed(self):
+        # No /proc at all (a stripped chroot, a non-Linux runner): absence of
+        # evidence is not evidence, so the refusal applies.
+        self.assertFalse(server.in_container())
+
+
 class LoopbackBindGuardTest(unittest.TestCase):
-    """Spec #26 Failure Modes: a non-loopback bind refuses to start.
+    """Spec #26 Failure Modes: a non-loopback bind refuses to start unless the
+    replacement boundary is POSITIVELY VERIFIED.
 
     This is the fence behind the automatic browser bootstrap: a session mints
     for any caller that can present an allowed `Host` and a same-origin
     `Origin`, both of which a remote client chooses freely. Unreachability is
-    therefore the control, and it has to be enforced rather than assumed.
+    therefore the control, and it has to be enforced rather than assumed —
+    including in the sandbox exception, which is what SC-149 caught.
+
+    Every case patches `in_container` rather than the environment, because the
+    suite runs INSIDE the sandbox: reading the real evidence would make the
+    refusal cases unreachable here and the file would quietly stop testing
+    the guard at all.
     """
 
+    def _guard(self, bind, *, container):
+        with mock.patch.object(server, "in_container", return_value=container):
+            server.require_loopback_bind(bind)
+
     def test_host_refuses_a_non_loopback_bind(self):
-        with mock.patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SC_SANDBOX", None)
-            for bind in ("0.0.0.0", "", "::", "192.168.1.10",
-                         "10.0.0.5", "example.com"):
-                with self.subTest(bind=bind):
-                    with self.assertRaises(SystemExit) as caught:
-                        server.require_loopback_bind(bind)
-                    self.assertIn("loopback", str(caught.exception))
+        for bind in ("0.0.0.0", "", "::", "192.168.1.10",
+                     "10.0.0.5", "example.com"):
+            with self.subTest(bind=bind):
+                with self.assertRaises(SystemExit) as caught:
+                    self._guard(bind, container=False)
+                self.assertIn("loopback", str(caught.exception))
 
     def test_host_accepts_loopback_binds(self):
+        for bind in ("127.0.0.1", "localhost", "LocalHost", "::1",
+                     "[::1]", "127.0.0.53"):
+            with self.subTest(bind=bind):
+                self._guard(bind, container=False)
+
+    def test_a_claimed_sandbox_off_container_still_refuses(self):
+        # SC-149 exactly as conformance reproduced it: `SC_SANDBOX=1` with
+        # `SC_BIND=0.0.0.0` on a bare host used to open a wide listener the
+        # spec asserted was fenced. Setting the variable does not create a
+        # docker publish mapping, so it must not buy the exemption.
+        with mock.patch.dict(os.environ, {"SC_SANDBOX": "1"}):
+            with self.assertRaises(SystemExit) as caught:
+                self._guard("0.0.0.0", container=False)
+        self.assertIn("SC_SANDBOX", str(caught.exception))
+
+    def test_container_keeps_the_wide_bind_docker_publishes(self):
+        # The counterweight. `./sc launch` sets SC_BIND=0.0.0.0 in the
+        # container ON PURPOSE so docker can publish the port; the boundary
+        # there is the `-p 127.0.0.1:PORT:PORT` mapping, loopback-only on the
+        # host whatever the container binds. Over-refusing here would make the
+        # sandbox unlaunchable while removing no exposure — and it must hold
+        # with SC_SANDBOX absent, since the evidence is now the filesystem's.
         with mock.patch.dict(os.environ, {}, clear=False):
             os.environ.pop("SC_SANDBOX", None)
-            for bind in ("127.0.0.1", "localhost", "LocalHost", "::1",
-                         "[::1]", "127.0.0.53"):
-                with self.subTest(bind=bind):
-                    server.require_loopback_bind(bind)
-
-    def test_sandbox_keeps_the_wide_bind_docker_publishes(self):
-        # `./sc launch` sets SC_BIND=0.0.0.0 in the container ON PURPOSE so
-        # docker can publish the port; the boundary there is the
-        # `-p 127.0.0.1:PORT:PORT` mapping, which is loopback-only on the
-        # host whatever the container binds. Refusing here would make the
-        # sandbox unlaunchable while removing no exposure — so the guard
-        # stands down, and only here.
-        with mock.patch.dict(os.environ, {"SC_SANDBOX": "1"}):
-            server.require_loopback_bind("0.0.0.0")
+            self._guard("0.0.0.0", container=True)
 
 
 class LoopbackBindStartupWiringTest(unittest.TestCase):
@@ -138,7 +209,13 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
     and the sandbox's deliberate wide bind still reaches it.
     """
 
-    def _start(self, bind, *, sandbox=False):
+    def setUp(self):
+        # main() rebinds the module-level `_CSP` to the served port; put it
+        # back so test order cannot matter.
+        csp = server._CSP
+        self.addCleanup(lambda: setattr(server, "_CSP", csp))
+
+    def _start(self, bind, *, container=False, port=8800):
         """Run main([]) to the bind decision. Returns (refusal, served): the
         SystemExit main() raised or None, and the host transport.serve was
         actually called with or None if the listener was never reached."""
@@ -148,20 +225,22 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
             served.append(host)
             return port
 
-        env = {"SC_BIND": bind}
-        if sandbox:
-            env["SC_SANDBOX"] = "1"
         with tempfile.TemporaryDirectory() as tmp:
             db_path = Path(tmp) / "shell_db.db"
             db_path.touch()
             with contextlib.ExitStack() as stack:
                 enter = stack.enter_context
-                enter(mock.patch.dict(os.environ, env, clear=False))
-                if not sandbox:
-                    os.environ.pop("SC_SANDBOX", None)
+                # SC_SANDBOX is pinned ON throughout: post-SC-149 it grants
+                # nothing, so leaving it set proves the wiring keys on the
+                # container evidence and not on the variable.
+                enter(mock.patch.dict(os.environ,
+                                      {"SC_BIND": bind, "SC_SANDBOX": "1"},
+                                      clear=False))
+                enter(mock.patch.object(server, "in_container",
+                                        return_value=container))
                 enter(mock.patch.object(server, "DB_PATH", db_path))
                 enter(mock.patch.object(server.ports_mod, "resolve",
-                                        return_value={"port": 8800}))
+                                        return_value={"port": port}))
                 # Everything main() does between the DB check and the bind is
                 # someone else's contract — stub it so only the ordering of
                 # guard vs. serve is under test here.
@@ -203,8 +282,76 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
     def test_startup_serves_the_wide_bind_in_the_sandbox(self):
         # The counterweight: over-refusing here would make `./sc launch`
         # unbootable, so the sandbox exception has to survive the wiring too.
-        self.assertEqual(self._start("0.0.0.0", sandbox=True),
+        self.assertEqual(self._start("0.0.0.0", container=True),
                          (None, "0.0.0.0"))
+
+    def test_startup_binds_the_csp_to_the_served_port(self):
+        # The app shell's socket sources are port-exact (SC-152), so main()
+        # rebinding `_CSP` is load-bearing: skip it and a fork on any port but
+        # the module default serves a policy that forbids its own terminal
+        # stream. Assert against a port that cannot come from the default.
+        self._start("127.0.0.1", port=8899)
+        self.assertIn("ws://127.0.0.1:8899", server._CSP)
+        self.assertNotIn("8800", server._CSP)
+
+
+class CspSourceListTest(unittest.TestCase):
+    """The app shell's CSP is release-critical (spec #26 Trust Boundary), and
+    spec #26 Delivery Plan step 6 owes it a check. Nothing asserted it until
+    conformance finding SC-152 — which is how `connect-src 'self' ws: wss:`
+    shipped while the comment above it said "same-origin connections only".
+
+    `ws:` and `wss:` are CSP scheme-sources: they match ANY host on that
+    scheme, so they left injected same-origin script an outbound socket to
+    anywhere. These tests fail if that widening is reintroduced in any form.
+    """
+
+    def _directive(self, csp, name):
+        for part in csp.split(";"):
+            tokens = part.split()
+            if tokens and tokens[0] == name:
+                return tokens[1:]
+        self.fail(f"CSP has no {name!r} directive: {csp!r}")
+
+    def test_connect_src_names_no_scheme_source(self):
+        sources = self._directive(server._csp(8800), "connect-src")
+        for src in sources:
+            with self.subTest(source=src):
+                # A scheme-source is `scheme:` with no `//authority` — the
+                # exact shape that matches every host.
+                self.assertFalse(
+                    src.endswith(":") and "//" not in src,
+                    f"{src!r} is a CSP scheme-source and matches any host")
+
+    def test_connect_src_is_limited_to_this_servers_own_origins(self):
+        sources = self._directive(server._csp(8800), "connect-src")
+        self.assertIn("'self'", sources)
+        self.assertEqual(
+            {s for s in sources if s != "'self'"},
+            {"ws://127.0.0.1:8800", "wss://127.0.0.1:8800",
+             "ws://localhost:8800", "wss://localhost:8800",
+             "ws://[::1]:8800", "wss://[::1]:8800"})
+
+    def test_socket_sources_cover_every_allowed_interface_host(self):
+        # The UI opens its stream at `location.host` (app.js:3498-3499), so a
+        # host the API fence admits but the CSP omits is a terminal that
+        # cannot connect. Read the allowlist from the fence itself: drift
+        # between the two lists is the failure this catches.
+        sys.path.insert(0, str(ENGINE / "api"))
+        import interface_routes  # noqa: PLC0415 — optional stack, imported late
+
+        sources = set(self._directive(server._csp(8800), "connect-src"))
+        for host in interface_routes._ALLOWED_HOSTS:
+            with self.subTest(host=host):
+                self.assertIn(f"ws://{host}:8800", sources)
+
+    def test_the_rest_of_the_policy_stays_strict(self):
+        csp = server._csp(8800)
+        self.assertEqual(self._directive(csp, "script-src"), ["'self'"])
+        self.assertEqual(self._directive(csp, "default-src"), ["'self'"])
+        self.assertEqual(self._directive(csp, "object-src"), ["'none'"])
+        self.assertEqual(self._directive(csp, "frame-ancestors"), ["'none'"])
+        self.assertEqual(self._directive(csp, "base-uri"), ["'none'"])
 
 
 if __name__ == "__main__":

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import contextlib
 import io
 import os
+import re
 import sqlite3
 import sys
 import tempfile
@@ -188,13 +189,113 @@ class LoopbackBindGuardTest(unittest.TestCase):
     def test_container_keeps_the_wide_bind_docker_publishes(self):
         # The counterweight. `./sc launch` sets SC_BIND=0.0.0.0 in the
         # container ON PURPOSE so docker can publish the port; the boundary
-        # there is the `-p 127.0.0.1:PORT:PORT` mapping, loopback-only on the
-        # host whatever the container binds. Over-refusing here would make the
-        # sandbox unlaunchable while removing no exposure — and it must hold
-        # with SC_SANDBOX absent, since the evidence is now the filesystem's.
+        # there is its `-p 127.0.0.1:PORT:PORT` mapping — a precondition, not
+        # something this check verifies (see BoundaryClaimTest). Over-refusing
+        # here would make the sandbox unlaunchable while removing no exposure —
+        # and it must hold with SC_SANDBOX absent, since the evidence is now
+        # the filesystem's.
         with mock.patch.dict(os.environ, {}, clear=False):
             os.environ.pop("SC_SANDBOX", None)
             self._guard("0.0.0.0", container=True)
+
+
+class BoundaryClaimTest(unittest.TestCase):
+    """What we SAY the bind guard establishes, held to what it establishes
+    (conformance finding SC-154 — SC-149 one layer up).
+
+    SC-149 was a guard claiming more than it enforced. SC-154 was the same
+    defect one layer up: the code comment and the public trust-boundary page
+    honestly admitted that `--network=host` shares the host's namespace and
+    still passes, then concluded host-loopback-only anyway. Both statements
+    cannot be true, and it is the conclusion that was wrong — the summary
+    sentence had not inherited its own caveat.
+
+    So the pin is per SENTENCE, deliberately: a loopback-only claim must name
+    what makes it true where it makes it, because a caveat three paragraphs
+    away is exactly what failed here. These are prose assertions, and prose is
+    the artifact — the guarantee an operator acts on is the one they read.
+    """
+
+    TRUST_DOC = ENGINE / "docs" / "interface-trust-boundary.md"
+
+    # A sentence asserting the loopback guarantee, in either word order.
+    LOOPBACK_ONLY = re.compile(r"loopback[^.]*\bonly\b|\bonly\b[^.]*loopback",
+                               re.I)
+    # What may make that claim true, named in the same sentence: the in-process
+    # guard (which EXITS unless the bind is loopback) or the operator
+    # precondition the sandbox exemption rests on. "Enforced in-process and by
+    # docker's port mapping" is NOT one of these — it is the overclaim.
+    QUALIFIED = re.compile(r"precondition|assum\w+|unless|provided|"
+                           r"--network=host", re.I)
+    # The claim the evidence cannot support: that it demonstrates a network
+    # namespace. A marker file and a cgroup path show a container filesystem
+    # and cgroup context; `--network=host` has neither of its own.
+    NAMESPACE_CLAIM = re.compile(
+        r"(shows?|proves?|establish\w*|demonstrat\w*|means)[^.]*"
+        r"network namespace", re.I)
+    NAMESPACE_LIMIT = re.compile(r"\bnot\b[^.]*network namespace", re.I)
+
+    def sentences(self, text: str) -> list[str]:
+        """Prose split into sentences. Soft-wrapped lines fold together first
+        (or a claim and its qualifier land in different fragments purely
+        because the paragraph was rewrapped); a bullet, table row, or heading
+        starts a new block. A sentence ends at `. ` before a capital, so
+        `127.0.0.1` and `e.g.` do not split one."""
+        blocks: list[str] = []
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                blocks.append("")
+            elif stripped[0] in "-*|#" or not blocks or not blocks[-1]:
+                blocks.append(stripped)
+            else:
+                blocks[-1] += " " + stripped
+        out: list[str] = []
+        for block in blocks:
+            out.extend(s for s in re.split(r"(?<=\.)\s+(?=[A-Z*`\"])", block)
+                       if s.strip())
+        return out
+
+    def prose(self):
+        """Every place the guarantee is stated: the operator-facing page and
+        the two docstrings a maintainer reads before touching the guard."""
+        return (("the trust-boundary doc", self.TRUST_DOC.read_text()),
+                ("in_container()", server.in_container.__doc__),
+                ("require_loopback_bind()",
+                 server.require_loopback_bind.__doc__))
+
+    def test_no_loopback_only_claim_stands_without_its_precondition(self):
+        for where, text in self.prose():
+            for sentence in self.sentences(text):
+                if not self.LOOPBACK_ONLY.search(sentence):
+                    continue
+                with self.subTest(where=where, sentence=sentence[:70]):
+                    self.assertRegex(
+                        sentence, self.QUALIFIED,
+                        f"{where}: this concludes loopback-only without "
+                        f"naming what makes it true — the in-process refusal "
+                        f"or the operator precondition:\n  {sentence}")
+
+    def test_nothing_claims_the_evidence_shows_a_network_namespace(self):
+        for where, text in self.prose():
+            for sentence in self.sentences(text):
+                with self.subTest(where=where, sentence=sentence[:70]):
+                    self.assertNotRegex(
+                        sentence, self.NAMESPACE_CLAIM,
+                        f"{where}: a marker file and a cgroup path do not "
+                        f"establish a network namespace — `--network=host` "
+                        f"passes both:\n  {sentence}")
+
+    def test_the_namespace_limit_is_stated_where_the_evidence_is(self):
+        # The negative above passes trivially on prose that says nothing at
+        # all; the limit has to be stated, not merely not-contradicted.
+        for where, text in self.prose()[:2]:
+            with self.subTest(where=where):
+                self.assertTrue(
+                    any(self.NAMESPACE_LIMIT.search(s)
+                        for s in self.sentences(text)),
+                    f"{where} never says the evidence is not a network "
+                    f"namespace")
 
 
 class LoopbackBindStartupWiringTest(unittest.TestCase):


### PR DESCRIPTION
Sprint 38 unit 6 — the conformance fix unit. Authority: decision `#61`, conformance doc `#40`, spec `#26` (re-amended). Findings SC-149..SC-152 (flag_ids **150–153** — the display names are offset by one from the flag ids; REV1 filed them and closes them).

All four are the same defect class the sprint exists to correct: **a guard trusting an assertion instead of verifying the thing asserted.**

## SC-149 — Major — an env var is a claim, not a boundary

`require_loopback_bind()` returned early on the mere presence of `SC_SANDBOX`, so `SC_SANDBOX=1 SC_BIND=0.0.0.0` on a bare host started a wide listener that spec `#26` described as fenced. Setting the variable does not create docker's publish mapping.

The exemption now requires **observed** container evidence — `in_container()`: a runtime-written marker (`/.dockerenv`, `/run/.containerenv`), else PID 1's cgroup naming a runtime. `./sc launch` still boots: it runs in a real container, and the check no longer depends on the `SC_SANDBOX` it happens to set.

**Trade-off, stated rather than implied.** The check proves the bind lands in a container network namespace. It cannot prove the host published the port to loopback — that mapping is host-side and invisible from inside without the docker socket. So `--network=host`, or a container published wide, still passes. Both need a deliberate launch outside `./sc launch`'s mapping; the old check needed an `export`. That gap is documented in the function, in `require_loopback_bind()`, and in the trust-boundary doc, because a guard that overstates its reach is what this finding was.

## SC-150 — Medium — the fence disagreed with the bind guard

Startup accepts `::1`/`[::1]`; `_host_ok()` split `Host: [::1]:PORT` at the first colon and compared `"["`, so an accepted bind could never call its own API. Authorities are now parsed as `host[:port]`.

Extended one step past the finding: the port is validated, which closes the same hole on the IPv4 branch — `127.0.0.1:8800.evil.example.com` parsed to `127.0.0.1` and passed the allowlist. No browser emits it, so this is hardening, not a live exploit. Tightening the IPv6 branch and leaving that in place is just the next finding.

## SC-151 — Medium — a required key with no semantics

The bootstrap demanded an `Idempotency-Key` and never keyed on it: an exact retry returned `201` with **different** credentials and left two live sessions, the client holding one and the server the other for 24 hours.

Honoured rather than removed (removal would be a spec change, and the planner's). It cannot use `_idempotent()` — that persists the response body, which carries the anti-forgery token, and spec `#26` forbids a browser credential reaching the durable DB. So the replay store is live-process state on the sessions' own terms: same lock, same request-driven sweep, gone on restart, 300s TTL.

A replay whose recorded session has since been revoked or expired **falls through to a fresh mint** — replaying a dead credential is idempotent and wrong.

**Spec-facing note for the planner:** this adds `409 idempotency_conflict` to the endpoint (a key reused from a different allowed origin), matching `_idempotent()`'s contract. Spec `#26`'s API contract table does not list it. I did not edit the spec — flagging it for amendment.

## SC-152 — Medium — a same-origin claim that authorised every host

`connect-src 'self' ws: wss:` — `ws:`/`wss:` are CSP *scheme-sources* and match any host, contradicting the "same-origin connections only" comment directly above and leaving injected same-origin script an outbound WebSocket channel anywhere. `connect-src` now names this server's own origins, port-exact, bound in `main()` to the port actually served.

The socket origins are listed rather than left to `'self'` alone: `'self'` does match same-origin ws/wss in current browsers, but that arrived late and unevenly, and the terminal stream is not worth losing to a browser-version difference.

The CSP regression check spec `#26` Delivery Plan step 6 has owed since unit 2 now exists, in two layers: the policy string (no scheme-source, sources equal the API's own allowlist — drift between the two lists fails), and the header **read off a real socket** through `server.dispatch_http`, since the Playwright server never served the production CSP.

## Verification

Per flag `#142` — five tests in this sprint could not fail — every guarantee is pinned by a **mutation round trip**: break it in the source, watch the test go red, revert, watch it pass.

| Mutation | Test that went red |
|---|---|
| `SC_SANDBOX` presence re-grants the exemption | `test_a_claimed_sandbox_off_container_still_refuses` |
| authority parse back to `split(":")[0]` | `test_an_ipv6_loopback_host_reaches_the_api_it_is_accepted_for` + `test_a_malformed_bracketed_host_fails_closed` |
| bootstrap ignores the key it requires | `test_an_exact_bootstrap_retry_replays_instead_of_minting_again` + `test_a_key_reused_from_a_different_origin_conflicts` |
| replay ignores session liveness | `test_a_replay_whose_session_died_mints_fresh` |
| `connect-src` widened back to `ws: wss:` | `CspSourceListTest` + `AppShellCspTest` (9 failures) |
| `main()` stops binding the CSP to the port | `test_startup_binds_the_csp_to_the_served_port` |

One of these tests failed when first written — `[::1]:8800.evil.example.com` passed my widened parse. That is the port validation above; the test found it, not review.

Every new negative has a counterweight so the fix cannot pass by over-refusing: the genuine container still boots, a fresh key still mints an independent session, and the CSP still authorises the stream the UI opens.

**Suites:** 1270 passed locally on the rebased head (`tests/`, full pytest run). The 7 `test_interface_ui_rendered.py` errors are `playwright.chromium.launch` fixture-setup failures — no browser binary in this sandbox; CI installs it in its own job. Focused: 124 passed across `test_interface_api` / `test_interface_release_gate` / `test_server_schema_guard`. Lint and typecheck introduce nothing new (all reported items are pre-existing, in files this branch does not touch).

Rebased on `35b0f57`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)