### PR TITLE
chore(git): ignore local db_backups and shared scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,12 @@
 /.sc-state/map.db-shm
 /.sc-state/db_backups/
 
+# Local DB safety backups (pre-migration snapshots) and the cross-shell
+# scratch/handoff dir — local-only artifacts, never tracked. A few ancient
+# backups predate this rule and stay tracked; gitignore doesn't affect them.
+/db_backups/
+/shared/
+
 # Python / tooling
 __pycache__/
 *.pyc


### PR DESCRIPTION
Pre-migration DB snapshots (`db_backups/pre-*.db`) and the cross-shell scratch/handoff dir (`shared/`) are local-only artifacts; recent convention leaves them untracked. Ancient tracked backups are unaffected by the ignore rule.

Approved by FnB in session (ADM1 standing maintenance pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)