### PR TITLE
fix(liveness): match runtime comm, ask the pty in the process's own namespace

### DIFF
--- a/.super-coder/README.md
+++ b/.super-coder/README.md
@@ -74,6 +74,7 @@ is harness-blind. Each holds an `adapter.json`:
 | field | meaning |
 |---|---|
 | `launch` | argv exec'd to start the harness |
+| `comm_aliases` | optional; extra `/proc/<pid>/comm` values a live harness presents when its runtime name differs from its launch binary (liveness scanning — see `scripts/shell_liveness.py`) |
 | `boot_artifact` | the context file this harness reads (informational) |
 | `emit` | files in the adapter dir copied to the repo root at launch (gitignored, regenerated each launch from the tracked template) |
 | `env` | extra env merged into the launch environment |

--- a/.super-coder/adapters/kimi/README.md
+++ b/.super-coder/adapters/kimi/README.md
@@ -16,6 +16,7 @@ catch-all; kimi is the native Moonshot path.
 | field | meaning |
 |---|---|
 | `launch` | argv exec'd to start the harness (`kimi` — cwd is the workspace; no dir flag exists) |
+| `comm_aliases` | extra `/proc/<pid>/comm` values a live kimi presents (`kimi-code` — see below) |
 | `boot_artifact` | the context file this harness reads (`AGENTS.md`, informational) |
 | `emit` | files copied to the repo root at launch (none — kimi reads `~/.kimi-code` + `AGENTS.md`) |
 | `headless.launch` | non-interactive base argv (`kimi`) |
@@ -42,6 +43,21 @@ discovers the exact local aliases (for example `kimi-code/k3`), the resolver
 accepts only a locally available high-effort route, and the adapter emits
 `kimi -m <alias> -p <prompt>`. A requested selector that cannot be applied fails
 before the worker session opens.
+
+**`comm_aliases: ["kimi-code"]` — the liveness seam:** the shell-liveness scan
+identifies a live harness by `/proc/<pid>/comm`, which is the process's RUNTIME
+name, not its launch binary. kimi execs `/usr/local/bin/kimi` (a single ELF; no
+wrapper, no child) and then renames ITSELF to `kimi-code` via `PR_SET_NAME`
+roughly 0.7s in — measured on a real headless worker, `exe → /usr/local/bin/kimi`,
+no child processes, 11 threads in the one tgid. Without the alias a live kimi
+worker matched nothing, so its shell projected as **available** and the operator
+was invited to double-book it. Two consequences worth knowing: during that ~0.7s
+startup window comm reads `MainThread` (the bun runtime's initial thread name)
+and the worker is briefly invisible — deliberately NOT aliased, because
+`MainThread` would match every unrelated bun/node process on the machine, trading
+a 0.7s false-available for a permanent false-busy. And a finished-but-unreaped
+kimi keeps `comm=kimi-code` while its `cwd` link becomes unreadable, so it lands
+in the scan's existing `indeterminate` bucket rather than holding a shell.
 
 **Skills:** kimi does not read `.claude/skills/` (its discovery dirs are
 `.kimi-code/skills/` + `.agents/skills/`), so like codex/vibe it loads skills

--- a/.super-coder/adapters/kimi/adapter.json
+++ b/.super-coder/adapters/kimi/adapter.json
@@ -1,6 +1,7 @@
 {
   "harness": "kimi",
   "launch": ["kimi"],
+  "comm_aliases": ["kimi-code"],
   "boot_artifact": "AGENTS.md",
   "emit": [],
   "env": {},

--- a/.super-coder/scripts/shell_liveness.py
+++ b/.super-coder/scripts/shell_liveness.py
@@ -15,7 +15,8 @@ staleness window. Reporting only, by design — like git_hygiene.py, it surfaces
 state and never mutates.
 
 Mechanism (Linux): scan /proc/<pid>/{comm,cwd}. A process whose comm is one of the
-fork's harness binaries (adapters/*/adapter.json `launch[0]`) and whose cwd is
+fork's harness comm values (adapters/*/adapter.json `launch[0]`,
+`headless.launch[0]`, and `comm_aliases` — see harness_binaries) and whose cwd is
 under THIS repo is a live shell session:
   • cwd == repo root            → the admin itself (the one shell that boots in
                                   root, not a worktree)
@@ -29,7 +30,10 @@ is positively present, the gate is about OTHER shells.
 
 Permissions: /proc/<pid>/cwd is readable only for same-user processes. A harness
 owned by another OS user is counted but unreadable → `indeterminate`. When
-`indeterminate > 0` the admin must NOT assume all-clear — surface instead.
+`indeterminate > 0` the admin must NOT assume all-clear — surface instead. A
+ZOMBIE harness is excluded before that question is asked: it kept its comm but
+has already exited, so counting it would pin `indeterminate` — and with it the
+cleanup gate — on a process that is gone.
 
 Orphans: closing a terminal window does not reliably kill the harness on every
 host — the session survives, holds its shell's one-session slot, and blocks
@@ -37,6 +41,10 @@ every headless boot of that shell until someone kills it by hand. Each process
 is therefore classified (`orphaned`): 'tty-gone' (had a controlling terminal;
 the pty vanished — the window closed under it), 'detached' (no controlling
 TTY and reparented to init — its spawning session is gone), or None (normal).
+"Vanished" is asked in the PROCESS's mount namespace (/proc/<pid>/root<tty>),
+never the scanner's: a container-hosted session's pty lives in the container's
+devpts, so testing the bare path from the host answers about a different device
+and turns live work into a false orphan.
 Classification is reporting only — an orphan may still be mid-work (a merge,
 a suite), so nothing here kills anything. The consumer (`sc run`'s guard, the
 operator) verifies idleness first: `ps -o etime=,stat= -p <pid>`, no child
@@ -67,9 +75,22 @@ _FALLBACK_BINS = {"claude", "codex", "opencode", "vibe", "kimi"}
 
 
 def harness_binaries() -> set[str]:
-    """The fork's harness launch binaries, from adapters/*/adapter.json `launch[0]`.
-    /proc/<pid>/comm is truncated to 15 chars — harness names are short, but we
-    truncate the expected set to match so a long name would still compare."""
+    """The comm values a live harness of this fork can present, from
+    adapters/*/adapter.json: `launch[0]`, `headless.launch[0]`, and the optional
+    `comm_aliases` list.
+
+    Why aliases: comm is the RUNTIME name, which a harness may set for itself
+    (PR_SET_NAME) rather than inherit from its launch binary. `kimi` execs
+    /usr/local/bin/kimi and then renames itself `kimi-code`, so matching launch
+    names alone made a live kimi worker invisible — and an invisible worker
+    projects as "available", the wrong failure direction for a badge whose job
+    is to stop the operator double-booking a shell.
+
+    /proc/<pid>/comm is truncated to 15 chars, so the expected set is truncated
+    to match: a longer declared alias still compares against what the kernel
+    actually reports. Duplicate aliases across adapters are harmless — this is a
+    set. An adapter dir with no adapter.json contributes nothing, leaving the
+    fallback set as the floor exactly as before."""
     bins: set[str] = set()
     if ADAPTERS.is_dir():
         for d in ADAPTERS.iterdir():
@@ -77,11 +98,17 @@ def harness_binaries() -> set[str]:
             if not cfg.is_file():
                 continue
             try:
-                launch = json.loads(cfg.read_text()).get("launch") or []
+                spec = json.loads(cfg.read_text())
             except (json.JSONDecodeError, OSError):
                 continue
-            if launch:
-                bins.add(Path(launch[0]).name)
+            launches = [spec.get("launch") or [],
+                        (spec.get("headless") or {}).get("launch") or []]
+            for launch in launches:
+                if launch:
+                    bins.add(Path(launch[0]).name)
+            for alias in spec.get("comm_aliases") or []:
+                if alias:
+                    bins.add(Path(alias).name)
     bins |= _FALLBACK_BINS
     return {b[:15] for b in bins}
 
@@ -111,6 +138,20 @@ def _ppid(pid: int) -> int | None:
         return None
 
 
+def _is_zombie(pid: int) -> bool:
+    """Has this process already exited, waiting only on a reaper?
+
+    A zombie keeps its comm — so a finished `claude`/`kimi-code` worker still
+    LOOKS like a harness — but it holds no worktree, runs no code, and its cwd
+    link is empty. Counted, it lands in `indeterminate` and pins
+    `safe_to_clean_all` False forever on the word of a process that ended. The
+    unreadable-cwd honesty gap this scan does own is about LIVE processes; a
+    zombie is not that case. Container PID 1 is often not a reaper (here it is
+    the engine server), so these accumulate and never clear on their own."""
+    rest = _stat_fields(pid)
+    return bool(rest) and rest[0] == "Z"
+
+
 def _tty_nr(pid: int) -> int | None:
     rest = _stat_fields(pid)
     try:
@@ -135,6 +176,43 @@ def _tty_fd(pid: int) -> str | None:
     return None
 
 
+def _tty_exists(pid: int, tty_fd: "str | None") -> "bool | None":
+    """Does this process's terminal device still exist — asked in the process's
+    OWN mount namespace, via /proc/<pid>/root<tty_fd>.
+
+    Testing the bare path instead asks the SCANNER's namespace, which is a
+    different question whenever the two disagree. A post-TMUX session holds a pty
+    from the container's devpts; scanned from the host, `/dev/pts/3` names the
+    HOST's pts 3 — a device that is absent, or worse, belongs to some unrelated
+    terminal. The live session then read as `tty-gone`, the rail projected
+    `unreconciled` with a recovery affordance instead of `working`, and the
+    scan's own advice invited killing work in progress — the exact inversion
+    decision #45 exists to prevent.
+
+    None when the answer cannot be obtained (no tty_fd, or /proc/<pid>/root is
+    unreadable — a foreign user, or the process exited mid-scan). The caller
+    turns that into no verdict: never call an orphan on missing data.
+
+    Deliberately os.stat and not os.path.exists: exists() folds PermissionError
+    into False, so an unreadable namespace would come back as "the pty is gone"
+    — a confident orphan verdict derived from our own lack of access. Only a
+    FileNotFoundError, reached THROUGH a root we could stat, means gone."""
+    if not tty_fd:
+        return None
+    root = PROC / str(pid) / "root"
+    try:
+        os.stat(root)                    # can we see this pid's namespace at all?
+    except OSError:
+        return None                      # foreign user, or the process is gone
+    try:
+        os.stat(root / tty_fd.lstrip("/"))
+    except FileNotFoundError:
+        return False                     # the device really is not there
+    except OSError:
+        return None                      # unreadable → no verdict, not an orphan
+    return True
+
+
 def classify_orphan(tty_nr: "int | None", ppid: "int | None",
                     tty_fd: "str | None",
                     tty_exists: "bool | None" = None) -> "str | None":
@@ -148,6 +226,12 @@ def classify_orphan(tty_nr: "int | None", ppid: "int | None",
                   ppid==1 is the discriminator.
     None        — attached and normal, or not enough signal to say otherwise
                   (conservative: never call an orphan on missing data).
+
+    `tty_exists` is supplied by the caller (see _tty_exists) because only the
+    caller knows the pid, and the question is namespace-scoped to that pid.
+    Unknown (None) is therefore a real answer here — no verdict — not an
+    invitation to go and test the path in whatever namespace we happen to
+    occupy, which is the bug this signature now forecloses.
     """
     if tty_nr is None:
         return None
@@ -158,8 +242,16 @@ def classify_orphan(tty_nr: "int | None", ppid: "int | None",
     if tty_fd.endswith(" (deleted)"):
         return "tty-gone"
     if tty_exists is None:
-        tty_exists = os.path.exists(tty_fd)
+        return None
     return None if tty_exists else "tty-gone"
+
+
+def _orphan_verdict(pid: int) -> "str | None":
+    """One process's orphan state, reading every input from /proc for that pid.
+    The seam that keeps classify_orphan pure and namespace-blind."""
+    tty_fd = _tty_fd(pid)
+    return classify_orphan(_tty_nr(pid), _ppid(pid), tty_fd,
+                           _tty_exists(pid, tty_fd))
 
 
 def _self_harness_pid(harness_pids: set[int]) -> int | None:
@@ -213,10 +305,13 @@ def compute() -> dict:
         if not entry.name.isdigit():
             continue
         comm = _read(entry / "comm").strip()
-        if comm and comm in bins:
-            pid = int(entry.name)
-            harness_pids.add(pid)
-            raw.append((pid, comm))
+        if not comm or comm not in bins:
+            continue
+        pid = int(entry.name)
+        if _is_zombie(pid):
+            continue                 # already exited — holds no shell, no slot
+        harness_pids.add(pid)
+        raw.append((pid, comm))
 
     self_pid = _self_harness_pid(harness_pids)
 
@@ -254,7 +349,7 @@ def compute() -> dict:
             "display_name": (labels.get(shortname or "", {}).get("display_name")),
             "is_self": pid == self_pid,
             "orphaned": (None if pid == self_pid
-                         else classify_orphan(_tty_nr(pid), _ppid(pid), _tty_fd(pid))),
+                         else _orphan_verdict(pid)),
         })
 
     active_other = sorted(worktree_sessions)

--- a/tests/test_shell_liveness.py
+++ b/tests/test_shell_liveness.py
@@ -271,13 +271,18 @@ class NamespaceAwareTtyTest(unittest.TestCase):
 
     def _proc(self, td: str, *, tty=TTY, ns_has_tty=True, ns_readable=True,
               tty_nr=34816, ppid=4242) -> Path:
-        """A fake /proc with one pid: stat, fd/0 → tty, and root → its own
-        namespace root (which may or may not hold the tty device)."""
+        """A fake /proc with one pid: comm, stat, cwd → this repo, fd/0 → tty,
+        and root → its own namespace root (which may or may not hold the tty
+        device). comm + cwd are what let compute() pick the pid up as a live
+        session, so the same fixture serves both the seam tests below and the
+        end-to-end ones."""
         proc = Path(td) / "proc"
         entry = proc / "4242"
         (entry / "fd").mkdir(parents=True)
+        entry.joinpath("comm").write_text("kimi-code\n")
         entry.joinpath("stat").write_text(
             f"4242 (kimi-code) S {ppid} 4242 4242 {tty_nr} -1 0 0 0\n")
+        entry.joinpath("cwd").symlink_to(shell_liveness.REPO_ROOT)
         entry.joinpath("fd", "0").symlink_to(tty)
         if ns_readable:
             ns_root = Path(td) / "nsroot"
@@ -349,6 +354,35 @@ class NamespaceAwareTtyTest(unittest.TestCase):
             with mock.patch.object(shell_liveness, "PROC", proc):
                 self.assertEqual("detached",
                                  shell_liveness._orphan_verdict(4242))
+
+    def _snapshot(self, **kw) -> dict:
+        """compute() over the same fake /proc — the end-to-end vantage."""
+        with tempfile.TemporaryDirectory() as td:
+            proc = self._proc(td, **kw)
+            with mock.patch.object(shell_liveness, "PROC", proc), \
+                    mock.patch.object(shell_liveness, "harness_binaries",
+                                      return_value={"kimi-code"}), \
+                    mock.patch.object(shell_liveness, "_shell_labels",
+                                      return_value={}):
+                return shell_liveness.compute()
+
+    # The two below are the only tests that pin compute()'s orphan seam. Every
+    # case above drives _orphan_verdict directly, so dropping compute()'s
+    # tty_exists argument — the pre-PR call shape, and exactly what a partial
+    # revert or conflict resolution restores — leaves them all green while
+    # silently disabling every existence-based tty-gone verdict in production.
+
+    def test_compute_reports_a_dead_pty_as_tty_gone(self):
+        snap = self._snapshot(ns_has_tty=False)
+        self.assertEqual(["tty-gone"], [p["orphaned"] for p in snap["processes"]])
+        self.assertEqual([4242], snap["orphaned_pids"])
+
+    def test_compute_leaves_a_live_container_pty_unaccused(self):
+        # Present through the process's own root, absent at the bare path: a
+        # scanner-namespace check would convict this live session here.
+        snap = self._snapshot()
+        self.assertEqual([None], [p["orphaned"] for p in snap["processes"]])
+        self.assertEqual([], snap["orphaned_pids"])
 
 
 class ZombieHarnessTest(unittest.TestCase):

--- a/tests/test_shell_liveness.py
+++ b/tests/test_shell_liveness.py
@@ -11,6 +11,8 @@ Run:
 from __future__ import annotations
 
 import io
+import json
+import os
 import sys
 import tempfile
 import unittest
@@ -57,6 +59,14 @@ class ClassifyOrphanTest(unittest.TestCase):
     def test_tty_present_but_stdio_redirected_is_conservative(self):
         # tty_nr says attached, but no stdio fd resolves to a tty → no verdict.
         self.assertIsNone(shell_liveness.classify_orphan(34816, 4242, None, None))
+
+    def test_unknown_tty_existence_is_conservative(self):
+        # The classifier is namespace-BLIND: it is handed the answer, and an
+        # unknown answer stays unknown. It must never go and test the path in
+        # the scanner's own namespace — that is a different question about a
+        # different device, and answering it confidently is the U1 Part 2 bug.
+        self.assertIsNone(shell_liveness.classify_orphan(
+            34816, 4242, "/dev/pts/3", None))
 
 
 class OrphanSplitTest(unittest.TestCase):
@@ -166,6 +176,237 @@ class AdminPresenceTest(unittest.TestCase):
         self.assertEqual("present", snap["admin_presence"])
         self.assertEqual([123], snap["admin_root_pids"])
         self.assertTrue(snap["safe_to_clean_all"])
+
+
+def _adapter(root: Path, name: str, spec: "dict | None") -> None:
+    """One adapters/<name>/ dir; spec None = a dir with no adapter.json."""
+    d = root / name
+    d.mkdir()
+    if spec is not None:
+        (d / "adapter.json").write_text(json.dumps(spec))
+
+
+class HarnessBinariesTest(unittest.TestCase):
+    """comm is the RUNTIME name — the expected set unions launch[0],
+    headless.launch[0] and the adapter's declared comm_aliases."""
+
+    def _bins(self, build) -> set:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            build(root)
+            with mock.patch.object(shell_liveness, "ADAPTERS", root):
+                return shell_liveness.harness_binaries()
+
+    def test_comm_alias_is_matched(self):
+        bins = self._bins(lambda r: _adapter(r, "kimi", {
+            "launch": ["kimi"], "comm_aliases": ["kimi-code"]}))
+        self.assertIn("kimi-code", bins)
+
+    def test_headless_launch_binary_is_matched(self):
+        # A harness whose headless entry point differs from its interactive one
+        # is live under BOTH names; matching only launch[0] misses half of them.
+        bins = self._bins(lambda r: _adapter(r, "h", {
+            "launch": ["h-tui"], "headless": {"launch": ["h-batch"]}}))
+        self.assertIn("h-tui", bins)
+        self.assertIn("h-batch", bins)
+
+    def test_long_alias_truncated_to_comm_width(self):
+        # /proc/<pid>/comm is capped at 15 chars, so a longer declared alias
+        # must be compared in its truncated form or it can never match.
+        long = "a-very-long-harness-name"
+        bins = self._bins(lambda r: _adapter(r, "long", {
+            "launch": ["short"], "comm_aliases": [long]}))
+        self.assertIn(long[:15], bins)
+        self.assertNotIn(long, bins)
+        self.assertTrue(all(len(b) <= 15 for b in bins))
+
+    def test_alias_is_basenamed(self):
+        bins = self._bins(lambda r: _adapter(r, "p", {
+            "launch": ["p"], "comm_aliases": ["/opt/vendor/bin/p-runtime"]}))
+        self.assertIn("p-runtime", bins)
+
+    def test_duplicate_aliases_across_adapters_union_harmlessly(self):
+        def build(r):
+            _adapter(r, "a", {"launch": ["a"], "comm_aliases": ["shared-rt"]})
+            _adapter(r, "b", {"launch": ["b"], "comm_aliases": ["shared-rt"]})
+        bins = self._bins(build)
+        self.assertIn("shared-rt", bins)
+
+    def test_adapter_dir_without_json_leaves_the_fallback_floor(self):
+        bins = self._bins(lambda r: _adapter(r, "empty", None))
+        self.assertEqual(shell_liveness._FALLBACK_BINS, bins)
+
+    def test_malformed_adapter_json_is_skipped_not_fatal(self):
+        def build(r):
+            (r / "broken").mkdir()
+            (r / "broken" / "adapter.json").write_text("{not json")
+            _adapter(r, "ok", {"launch": ["ok"], "comm_aliases": ["ok-rt"]})
+        bins = self._bins(build)
+        self.assertIn("ok-rt", bins)
+
+    def test_adapter_without_aliases_is_unaffected(self):
+        bins = self._bins(lambda r: _adapter(r, "plain", {"launch": ["plain"]}))
+        self.assertIn("plain", bins)
+
+
+class KimiCommAliasTest(unittest.TestCase):
+    """Against the REAL adapters dir. A live headless kimi execs
+    /usr/local/bin/kimi and then renames itself `kimi-code` (PR_SET_NAME) —
+    captured from a real worker, not quoted from a transcript. Unaliased, the
+    worker matched nothing and its shell projected `available`, inviting the
+    operator to double-book a shell that was busy."""
+
+    def test_kimi_runtime_comm_is_recognised(self):
+        self.assertIn("kimi-code", shell_liveness.harness_binaries())
+
+
+class NamespaceAwareTtyTest(unittest.TestCase):
+    """The pty existence question is asked in the PROCESS's mount namespace.
+
+    Every case below uses a tty path that does NOT exist in the scanner's own
+    namespace, so a check against the bare path cannot pass them by accident.
+    """
+
+    TTY = "/dev/pts/99999"           # absent in this test runner's namespace
+
+    def _proc(self, td: str, *, tty=TTY, ns_has_tty=True, ns_readable=True,
+              tty_nr=34816, ppid=4242) -> Path:
+        """A fake /proc with one pid: stat, fd/0 → tty, and root → its own
+        namespace root (which may or may not hold the tty device)."""
+        proc = Path(td) / "proc"
+        entry = proc / "4242"
+        (entry / "fd").mkdir(parents=True)
+        entry.joinpath("stat").write_text(
+            f"4242 (kimi-code) S {ppid} 4242 4242 {tty_nr} -1 0 0 0\n")
+        entry.joinpath("fd", "0").symlink_to(tty)
+        if ns_readable:
+            ns_root = Path(td) / "nsroot"
+            (ns_root / tty.lstrip("/")).parent.mkdir(parents=True, exist_ok=True)
+            if ns_has_tty:
+                (ns_root / tty.lstrip("/")).write_text("")
+            entry.joinpath("root").symlink_to(ns_root)
+        return proc
+
+    def test_live_container_pty_is_not_an_orphan(self):
+        # The repro: a tmux-hosted session holding a pty from the container's
+        # devpts, scanned from the host. The device is absent at the bare path
+        # and present through the process's own root → the session is LIVE.
+        with tempfile.TemporaryDirectory() as td:
+            proc = self._proc(td)
+            self.assertFalse(os.path.exists(self.TTY),
+                             "fixture invalid: tty must be absent to the scanner")
+            with mock.patch.object(shell_liveness, "PROC", proc):
+                self.assertTrue(shell_liveness._tty_exists(4242, self.TTY))
+                self.assertIsNone(shell_liveness._orphan_verdict(4242))
+
+    def test_dead_pty_still_classifies_tty_gone(self):
+        # The regression case: same vantage, but the device is genuinely gone
+        # inside the process's own namespace too. Still an orphan.
+        with tempfile.TemporaryDirectory() as td:
+            proc = self._proc(td, ns_has_tty=False)
+            with mock.patch.object(shell_liveness, "PROC", proc):
+                self.assertFalse(shell_liveness._tty_exists(4242, self.TTY))
+                self.assertEqual("tty-gone",
+                                 shell_liveness._orphan_verdict(4242))
+
+    def test_unreadable_namespace_yields_no_verdict(self):
+        # /proc/<pid>/root unreadable (foreign user) or the process exited
+        # mid-scan: we cannot tell, so we do not accuse. os.path.exists would
+        # have folded this into False and called a live session an orphan.
+        with tempfile.TemporaryDirectory() as td:
+            proc = self._proc(td, ns_readable=False)
+            with mock.patch.object(shell_liveness, "PROC", proc):
+                self.assertIsNone(shell_liveness._tty_exists(4242, self.TTY))
+                self.assertIsNone(shell_liveness._orphan_verdict(4242))
+
+    def test_unresolvable_tty_path_is_not_an_absent_device(self):
+        # ONLY "the device is not there" (ENOENT) may become a tty-gone verdict.
+        # Any other failure to resolve the path — here a non-directory component
+        # inside the namespace — is us being unable to answer, and an unanswered
+        # question must not convict a live session. Distinct from the case
+        # above: /proc/<pid>/root itself stats fine, so the first guard passes
+        # and it is the SECOND lookup that has to stay conservative.
+        with tempfile.TemporaryDirectory() as td:
+            proc = self._proc(td, ns_has_tty=False)
+            pts = Path(td) / "nsroot" / "dev" / "pts"
+            pts.rmdir()
+            pts.write_text("not a directory")
+            with mock.patch.object(shell_liveness, "PROC", proc):
+                self.assertIsNone(shell_liveness._tty_exists(4242, self.TTY))
+                self.assertIsNone(shell_liveness._orphan_verdict(4242))
+
+    def test_no_tty_fd_is_unknown(self):
+        with tempfile.TemporaryDirectory() as td:
+            proc = self._proc(td)
+            with mock.patch.object(shell_liveness, "PROC", proc):
+                self.assertIsNone(shell_liveness._tty_exists(4242, None))
+
+    def test_detached_verdict_survives_the_new_seam(self):
+        # tty_nr == 0 and reparented to init: decided before the pty question
+        # is ever asked, so the namespace change must not disturb it.
+        with tempfile.TemporaryDirectory() as td:
+            proc = self._proc(td, tty_nr=0, ppid=1)
+            with mock.patch.object(shell_liveness, "PROC", proc):
+                self.assertEqual("detached",
+                                 shell_liveness._orphan_verdict(4242))
+
+
+class ZombieHarnessTest(unittest.TestCase):
+    """A zombie keeps its comm, so it still LOOKS like a harness — but it has
+    exited, holds no worktree, and its cwd link is empty. Counting it files it
+    under `indeterminate`, which pins safe_to_clean_all False permanently on the
+    word of a process that is gone. Container PID 1 is frequently not a reaper,
+    so these accumulate and never clear (ruled into U1 by the planner, #1660)."""
+
+    def _snapshot(self, state: str, *, with_cwd: bool):
+        with tempfile.TemporaryDirectory() as td:
+            proc = Path(td) / "proc"
+            entry = proc / "4242"
+            entry.mkdir(parents=True)
+            entry.joinpath("comm").write_text("kimi-code\n")
+            entry.joinpath("stat").write_text(
+                f"4242 (kimi-code) {state} 1 4242 4242 0 -1 0 0 0\n")
+            if with_cwd:
+                entry.joinpath("cwd").symlink_to(shell_liveness.REPO_ROOT)
+            with mock.patch.object(shell_liveness, "PROC", proc), \
+                    mock.patch.object(shell_liveness, "harness_binaries",
+                                      return_value={"kimi-code"}), \
+                    mock.patch.object(shell_liveness, "_shell_labels",
+                                      return_value={}):
+                return shell_liveness.compute()
+
+    def test_zombie_harness_is_not_a_live_session(self):
+        # No cwd link — exactly what a real zombie looks like in /proc.
+        snap = self._snapshot("Z", with_cwd=False)
+        self.assertEqual([], snap["processes"])
+        self.assertEqual([], snap["indeterminate_pids"])
+        self.assertEqual(0, snap["indeterminate"])
+
+    def test_zombie_does_not_pin_the_cleanup_gate(self):
+        # The consequence that matters: a dead process must not be able to hold
+        # the admin's cleanup gate shut forever.
+        snap = self._snapshot("Z", with_cwd=False)
+        self.assertNotIn(4242, snap["admin_root_pids"])
+        self.assertEqual([], snap["active_other_shells"])
+
+    def test_zombie_never_holds_a_shell_slot(self):
+        # Even with a readable cwd inside the repo, an exited process must not
+        # be attributed to a shell — that is what blocks a headless re-boot.
+        snap = self._snapshot("Z", with_cwd=True)
+        self.assertEqual([], snap["processes"])
+        self.assertEqual({}, snap["worktree_sessions"])
+
+    def test_live_harness_with_the_same_comm_is_still_counted(self):
+        # The guard keys on state, not on the name — a running process with the
+        # identical comm must survive it, or the guard has eaten the feature.
+        snap = self._snapshot("S", with_cwd=True)
+        self.assertEqual([4242], [p["pid"] for p in snap["processes"]])
+
+    def test_live_harness_with_unreadable_cwd_is_still_indeterminate(self):
+        # The honesty gap the scan DOES own (roadmap #24's case) is untouched.
+        snap = self._snapshot("S", with_cwd=False)
+        self.assertEqual([4242], snap["indeterminate_pids"])
+        self.assertFalse(snap["safe_to_clean_all"])
 
 
 class ComputeSmokeTest(unittest.TestCase):


### PR DESCRIPTION
Sprint 45, unit 1 — spec doc 43, U1 ("liveness scanner truth"). Reviewer: REV1.

Three defects in one scanner. All three fail in the same direction: **a live shell reads as free, or live work reads as a remnant worth killing.**

## Part 1 — comm aliases

`harness_binaries()` matched only `launch[0]`, but `/proc/<pid>/comm` is the process's **runtime** name.

U1's Task 0 is a hard gate: the alias must be *measured*, not quoted from a transcript. It was. A real headless kimi worker was booted (exec-replace, so the recorded pid IS the harness pid — the same shape as `run.py`'s `os.execvpe`):

| observation | value |
|---|---|
| `comm` at t=0 | `MainThread` (bun runtime's initial thread name) |
| `comm` from t≈0.7s | **`kimi-code`** |
| `exe` | `/usr/local/bin/kimi` (one 161MB ELF; no wrapper, no symlink) |
| children | none — the process renames **itself** (PR_SET_NAME) |
| threads | 11, all in the one tgid (so they never appear as separate /proc entries) |
| `cwd` | correct worktree → attribution works |

So the spec's sighting is confirmed and the cause is pinned: not a child process, a self-rename. Unaliased, a live kimi worker matched nothing, its shell projected `available`, and the operator was invited to double-book a shell that was busy — the wrong failure direction for a badge whose whole job is to prevent that.

The expected set now unions `launch[0]`, `headless.launch[0]`, and an optional `comm_aliases`, basenamed and truncated to comm's 15 chars.

**`MainThread` is deliberately NOT aliased.** It would match every unrelated bun/node process on the machine — trading a 0.7s false-available for a permanent false-busy. Stated in the adapter README rather than left as a silence.

Edge cases from the spec, each with a test: alias >15 chars (truncated to match comm truncation) · adapter dir with no `adapter.json` (fallback set unchanged) · duplicate aliases across adapters (harmless, it is a set) · malformed `adapter.json` (skipped, not fatal).

## Part 2 — false ORPHAN across the container boundary

`classify_orphan` tested the pty path in the **scanner's** mount namespace. A post-TMUX session holds a pty from the container's devpts, so scanned from the host, `/dev/pts/3` names the *host's* pts 3 — absent, or worse, some unrelated terminal. Live sessions classified `tty-gone`; the rail projected `unreconciled` with a recovery affordance instead of `working`; and the scan's own printed advice ("verify idle, then kill") invited killing work in progress. That is precisely the inversion decision #45 exists to prevent.

The question is now asked through `/proc/<pid>/root<tty_fd>` — the process's own namespace.

Two design points worth the reviewer's attention:

1. **`classify_orphan` no longer asks the question at all.** It is *handed* the answer, and `tty_exists=None` now means "no verdict" instead of "go and find out". This forecloses the bug in the signature, not just in the body: there is no longer a code path in which the classifier can consult a namespace it has no business consulting. `tty_exists=None` changing meaning is the one behavioural trade-off in this PR — the old default *is* the bug, and no caller relied on it.
2. **`os.stat`, not `os.path.exists`.** `exists()` folds `PermissionError` into `False`, so an unreadable namespace would have returned a confident "the pty is gone" derived entirely from our own lack of access. Only `FileNotFoundError`, reached *through* a root we could stat, means gone.

## Part 3 — zombie harnesses (planner-ruled addition)

Escalated **before** building, not absorbed: reported to PLN1 with live evidence, ruled into this unit as option (a) (msg #1660).

A zombie keeps its comm, so a finished worker still looks like a harness — but it holds no worktree, runs no code, and its `cwd` link is empty. It therefore landed in `indeterminate`, which pins `safe_to_clean_all` False **forever**, on the word of a process that has already exited. Container PID 1 is frequently not a reaper (here it is the engine server), so these accumulate and never clear.

Pre-existing on `main` and reproduced live — pid 63, `state=Z`, `ppid=1`, `comm=claude`, empty cwd — and Part 1 would have *widened* it to kimi. The unreadable-cwd honesty gap the scan genuinely owns (roadmap #24's case) is about LIVE processes and is untouched; there is a test pinning that it still behaves as before.

## Verification

**Nine mutation round trips, each red → revert → green:**

| mutation | result |
|---|---|
| kimi comm alias removed from the adapter | red *(spec-mandated proof, Part 1)* |
| pty tested in the scanner's namespace | red *(spec-mandated proof, Part 2)* |
| call site unwired (`tty_exists` not passed) | red |
| `headless.launch` dropped from the union | red |
| EACCES/ENOTDIR folded into "the device is gone" | red |
| state-Z guard removed | red *(Part 3)* |
| guard keyed on `S` instead of `Z` | red |
| classifier re-acquires the namespace check itself | red |
| alias declared but never basenamed/truncated | red |

Two things the mutation pass caught that the first green run did not:

- **A test that could not fail.** Folding `EACCES`/`ENOTDIR` into "gone" passed the first matrix — my unreadable-namespace test exercised a *missing* `/proc/<pid>/root`, which returns early at the first guard, so the second lookup's conservatism was never pinned. Added `test_unresolvable_tty_path_is_not_an_absent_device`, and that mutation now goes red.
- **A false green in my own harness.** `"Z"` → `"S"` is a *same-size* source mutation; within one second, `__pycache__` invalidation (mtime + size) does not fire and Python serves stale bytecode. The first matrix run reported that mutation as green while `inspect.getsource` showed the mutated source — the classic "verified against the wrong artifact". Every verdict here was re-taken with the cache cleared between runs. Flagging it because it will silently bite any same-size mutation test in this repo.

40 tests in `tests/test_shell_liveness.py`, green.

## Files, and a note on the board's disjointness map

The board named `scripts/shell_liveness.py` + `adapters/kimi/adapter.json`. This PR also touches two READMEs — `.super-coder/README.md` (the generic adapter field table, where the new optional key belongs) and `.super-coder/adapters/kimi/README.md` (the kimi field table + the measured-alias rationale). Both are documentation of the field this unit introduces; neither is in any other unit's path. Flagging it so the disjointness claim is checked, not assumed.

## Known limits

- **CI is the gate for the full suite.** Locally, `tests/test_interface_ui_rendered.py` errors 7× on `BrowserType.launch: Executable doesn't exist at /opt/ms-playwright/chromium_headless_shell-1181/...` — the baked browser has drifted from the installed Playwright package in this sandbox. Environmental, unrelated to this diff, and reported separately.
- **The container-boundary fix is verified by construction, not by a host-vantage run.** The tests build a fake `/proc` whose tty is absent at the bare path and present through `<pid>/root`, so a scanner-namespace check cannot pass them by accident. I did not scan this container *from the host* — I have no host vantage from inside it. The mechanism is pinned; the field repro is the FnB's to confirm if they want it.
- Two zombie `kimi-code` processes (pids 12828, 13653) were created by Task 0's mandated real-worker capture and persist until the container restarts. Disclosed to the planner; unattributed to any shell, and this PR's Part 3 is exactly what stops them mattering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)