### PR TITLE
feat(interface): chat titles, header identity, tab titles + launch_effort (S45 U4)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -555,12 +555,13 @@ def _availability(con, shell_id: int, snap) -> dict:
     active_session = interface_state.active_session_sql("s")
     row = con.execute(
         "SELECT s.session_id, s.generation, s.occupancy, s.lifecycle, "
-        "s.harness, s.model_route "
+        "s.harness, s.model_route, s.title, s.launch_effort "
         "FROM interface_sessions s WHERE s.shell_id=? "
         f"AND {active_session} ORDER BY s.session_id DESC LIMIT 1",
         (shell_id,)).fetchone()
     if row is not None:
-        session_id, generation, occupancy, lifecycle, harness, model_route = row
+        (session_id, generation, occupancy, lifecycle, harness, model_route,
+         title, launch_effort) = row
         client = _client_state(con, session_id)
         if occupancy == "reserved":
             availability = "starting"
@@ -579,6 +580,7 @@ def _availability(con, shell_id: int, snap) -> dict:
                 "generation": generation,
                 "lifecycle": lifecycle, "harness": harness,
                 "model_route": model_route,
+                "title": title, "launch_effort": launch_effort,
                 "composer": composer[0] if composer else None,
                 "alerts": _alert_count(con, session_id),
                 **_NO_SPRINT, **client}
@@ -590,10 +592,12 @@ def _availability(con, shell_id: int, snap) -> dict:
         return {"availability": "working" if working else "unreconciled",
                 "session_id": None,
                 "lifecycle": None, "harness": None, "composer": None,
-                "model_route": None, "alerts": 0,
+                "model_route": None, "title": None, "launch_effort": None,
+                "alerts": 0,
                 **(_sprint_context(con, shell_id) if working else _NO_SPRINT)}
     return {"availability": "available", "session_id": None,
             "lifecycle": None, "harness": None, "model_route": None,
+            "title": None, "launch_effort": None,
             "composer": None, "alerts": 0, **_NO_SPRINT}
 
 
@@ -797,13 +801,18 @@ def _create_session(actor, headers, body):
                 "(shell_id, generation, hook_token_hash) VALUES (?,?,?)",
                 (shell_id, gen_no,
                  hashlib.sha256(hook_token.encode()).hexdigest()))
+            # launch_effort completes the launch TRIPLE on the row. Until now
+            # effort rode only in the transient launch-<id>.json token, so a
+            # relaunch that reused "the same model" silently dropped it —
+            # U7's +Chat is the consumer. Unset stays NULL → harness default.
+            effort = body.get("effort") or None
             cur = con.execute(
                 "INSERT INTO interface_sessions "
-                "(shell_id, generation, harness, model_route, worktree, "
-                " occupancy, lifecycle, reservation_expires_at) "
-                "VALUES (?,?,?,?,?, 'reserved', 'starting', "
+                "(shell_id, generation, harness, model_route, launch_effort, "
+                " worktree, occupancy, lifecycle, reservation_expires_at) "
+                "VALUES (?,?,?,?,?,?, 'reserved', 'starting', "
                 "        datetime('now', ?))",
-                (shell_id, gen_no, harness, model,
+                (shell_id, gen_no, harness, model, effort,
                  worktree, f"+{RESERVATION_TTL_S} seconds"))
             session_id = cur.lastrowid
             con.execute(
@@ -819,7 +828,7 @@ def _create_session(actor, headers, body):
                 "api_port": ports_mod.resolve().get("port", 8800),
                 "worktree": worktree,
                 "harness": harness, "model": model,
-                "effort": body.get("effort")}))
+                "effort": effort}))
             os.chmod(token_path, 0o600)
             try:
                 identity = _runtime.call(_runtime.spawn(
@@ -940,7 +949,8 @@ def _get_session(session_id: int):
         row = con.execute(
             "SELECT session_id, shell_id, generation, archive_id, harness, "
             "model_route, worktree, occupancy, lifecycle, created_at, "
-            "occupied_at, ended_at, end_reason, error_detail "
+            "occupied_at, ended_at, end_reason, error_detail, "
+            "title, launch_effort "
             "FROM interface_sessions WHERE session_id=?",
             (session_id,)).fetchone()
         if row is None:
@@ -962,6 +972,10 @@ def _get_session(session_id: int):
             "created_at": row[9], "occupied_at": row[10],
             "ended_at": row[11], "end_reason": row[12],
             "error_detail": row[13],
+            # The launch route's third field (U7's +Chat reuses the triple)
+            # and the chat title — both describe how the session STARTED,
+            # never what the harness is running now (decision #55).
+            "title": row[14], "launch_effort": row[15],
             "composer": istate[0] if istate else None,
             "browser_composer": istate[1] if istate else None,
             "delivery": istate[2] if istate else None,
@@ -1191,6 +1205,59 @@ def _set_browser_composer(actor, headers, body):
 
         return _idempotent(
             con, actor, "browser_composer.set", headers, body, produce)
+    finally:
+        con.close()
+
+
+TITLE_MAX = 60
+
+
+def _derive_title(raw: str) -> str:
+    """First line of a composer message, capped — the spec's title rule.
+
+    Applied server-side as well as client-side deliberately: the cap is a
+    privacy bound, not a formatting preference (spec #43 U4 names this column
+    the one sanctioned exception to the broker's content-blindness), so it is
+    enforced where the write happens rather than trusted from the caller.
+    """
+    return raw.strip().splitlines()[0].strip()[:TITLE_MAX] if raw.strip() else ""
+
+
+def _set_title(actor, headers, body, session_id: int):
+    """Mint a session's chat title ONCE, from its first composer message.
+
+    Set-if-unset in a single UPDATE, so a replayed or concurrent send is a
+    no-op rather than a rewrite: the title records what opened the chat and
+    never tracks it. Deliberately NOT behind the writer lease — a read-only
+    viewer cannot reach this path anyway (it fires on the sender's own
+    input_ack), and gating it would make the mint fail exactly when a
+    take-over raced the first message.
+    """
+    raw = body.get("title")
+    if not isinstance(raw, str):
+        return _err(422, "validation", "title (string) is required")
+    title = _derive_title(raw)
+    if not title:
+        return _err(422, "validation",
+                    "title has no non-empty first line to derive from")
+    con = _db()
+    try:
+        row = con.execute(
+            "SELECT title FROM interface_sessions WHERE session_id=?",
+            (session_id,)).fetchone()
+        if row is None:
+            return _err(404, "no_such_session",
+                        f"interface session {session_id} not found")
+        con.execute(
+            "UPDATE interface_sessions SET title=? "
+            "WHERE session_id=? AND title IS NULL",
+            (title, session_id))
+        con.commit()
+        current = con.execute(
+            "SELECT title FROM interface_sessions WHERE session_id=?",
+            (session_id,)).fetchone()[0]
+        return _json(200, {"session_id": session_id, "title": current,
+                           "minted": current == title and row[0] is None})
     finally:
         con.close()
 
@@ -2543,6 +2610,10 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
                 p, "api", "interface", "sessions", None) \
                 and method == "GET":
             return _get_session(_path_id(p))
+        if _route_shape(
+                p, "api", "interface", "sessions", None, "title") \
+                and method == "POST":
+            return _set_title(actor, headers, data, _path_id(p, -2))
         if p == "/api/interface/stream-tickets" and method == "POST":
             return _mint_ticket(actor, headers, data)
         if p == "/api/interface/writer-leases" and method == "POST":

--- a/.super-coder/migrations/0092_interface_session_title_effort.sql
+++ b/.super-coder/migrations/0092_interface_session_title_effort.sql
@@ -1,0 +1,25 @@
+-- 0092 — chat title + launch effort on interface_sessions (spec #43 U4).
+--
+-- Two columns, ONE migration, deliberately: U7's +Chat reuses the launch
+-- triple (harness, model_route, effort) of the session it ends, and effort
+-- rides only in the transient launch-<id>.json token today — so "same model"
+-- would silently drop a chosen effort. Splitting the columns across two
+-- migrations would land U7's dependency behind a second deploy for no gain.
+--
+-- title: minted ONCE per session by the CLIENT at the first successful
+-- composer send — first line of that message, capped at 60 chars, never
+-- updated after (set-if-unset). NULL = no composer message has been sent
+-- yet; a session driven only by raw terminal typing keeps no title. The
+-- input broker stays content-blind (decision #16 byte privacy): it cannot
+-- tell a composer send from a raw keystroke, so a broker-side rule would
+-- mint one-character titles. This column is the one NAMED exception —
+-- exactly one operator-visible 60-char line from the composer path.
+--
+-- launch_effort: the effort the session was LAUNCHED with, written at
+-- session creation from the request body. NULL on pre-migration rows and
+-- on launches that named no effort → +Chat sends no effort → harness
+-- default. Like model_route this records the launch route, never a claim
+-- about what the harness is running now (decision #55).
+
+ALTER TABLE interface_sessions ADD COLUMN title TEXT;
+ALTER TABLE interface_sessions ADD COLUMN launch_effort TEXT;

--- a/.super-coder/migrations/0093_interface_session_title_effort.sql
+++ b/.super-coder/migrations/0093_interface_session_title_effort.sql
@@ -1,4 +1,4 @@
--- 0092 — chat title + launch effort on interface_sessions (spec #43 U4).
+-- 0093 — chat title + launch effort on interface_sessions (spec #43 U4).
 --
 -- Two columns, ONE migration, deliberately: U7's +Chat reuses the launch
 -- triple (harness, model_route, effort) of the session it ends, and effort

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -383,6 +383,9 @@ CREATE TABLE interface_sessions (
     -- session_start hook; the wake gate's quiet baseline, flag #49),
     -- migration 0081. Both ride the migration-only ADD COLUMN precedent
     -- (schema.sql + migrations both apply on rebuild — never inline).
+    -- title TEXT — chat title, client-minted once from the first composer
+    -- message (60-char cap, set-if-unset); launch_effort TEXT — the effort
+    -- the session was launched with, for U7's +Chat relaunch. Migration 0092.
     UNIQUE (shell_id, generation),
     FOREIGN KEY (shell_id, generation)
         REFERENCES interface_generations(shell_id, generation)

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -385,7 +385,7 @@ CREATE TABLE interface_sessions (
     -- (schema.sql + migrations both apply on rebuild — never inline).
     -- title TEXT — chat title, client-minted once from the first composer
     -- message (60-char cap, set-if-unset); launch_effort TEXT — the effort
-    -- the session was launched with, for U7's +Chat relaunch. Migration 0092.
+    -- the session was launched with, for U7's +Chat relaunch. Migration 0093.
     UNIQUE (shell_id, generation),
     FOREIGN KEY (shell_id, generation)
         REFERENCES interface_generations(shell_id, generation)

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3133,9 +3133,11 @@ async function ifSessionPane(pane, sel) {
     wake: sess.wake_state || "disarmed",
     archive: sess.archive_id ?? null,
     since: sess.occupied_at || sess.created_at || null,
+    title: sess.title || null,      // minted once, from the first composer send
     note: "",
   };
   const headEl = el("div", { className: "if-head" });
+  const identityEl = el("div", { className: "if-identity" });
   const sessionDetailsEl = el("div", { className: "if-diag" });
   const sprintDetailsEl = el("div", { className: "if-diag" });
   const detailsEl = el("details", { className: "if-disclosure if-details" },
@@ -3148,14 +3150,14 @@ async function ifSessionPane(pane, sel) {
   const sessionActionsEl = el("div", { className: "if-inline-actions" });
   const sprintActionsEl = el("div", { className: "if-inline-actions" });
   const statusNoteEl = el("div", { className: "if-note" });
-  headEl.append(detailsEl, alertsEl, sessionActionsEl, sprintActionsEl,
-    statusNoteEl);
+  headEl.append(identityEl, detailsEl, alertsEl, sessionActionsEl,
+    sprintActionsEl, statusNoteEl);
   const termEl = el("div", { className: "if-term" });
   const composerEl = el("div", { className: "if-composer" });
   const a = { sessionId, shortname: sel.shortname, st, headEl, termEl,
     composerEl, pane, sel, sessionDetailsEl, sprintDetailsEl, detailsEl,
     alertsEl, alertsSummary, alertsBody, sessionActionsEl, sprintActionsEl,
-    statusNoteEl,
+    statusNoteEl, identityEl,
     legalActions: new Set(
       Array.isArray(sess.legal_actions) ? sess.legal_actions : []),
     stateReason: sess.state_reason || "",
@@ -3164,7 +3166,8 @@ async function ifSessionPane(pane, sel) {
     heartbeat: 0, resizeObs: null, paint: null,
     composerInput: null, composerSend: null, composerEnd: null,
     composerNote: null,
-    composerPendingSeq: null, browserComposerState: st.browserComposer,
+    composerPendingSeq: null, composerPendingText: null,
+    browserComposerState: st.browserComposer,
     browserComposerWanted: st.browserComposer, browserComposerError: "",
     browserComposerSyncing: false, browserComposerVersion: 0,
     browserComposerChain: Promise.resolve(),
@@ -3238,6 +3241,13 @@ function ifAge(ts) {
 function ifPaintHeader(a, sel, pane) {
   const st = a.st;
   const controlsActive = IF_ATTACHABLE_LIFECYCLES.has(st.lifecycle);
+  // Whose session this is, on the left of the header (spec #43 U4). A chat
+  // with no title yet — nothing sent from the composer — renders the segment
+  // without one rather than reserving an empty slot for it.
+  const identity = [sel.display_name, sel.shortname, st.title]
+    .filter(Boolean).join(" · ");
+  a.identityEl.textContent = identity;
+  a.identityEl.title = identity;
   const stat = (k, v, title) => el("span",
     title ? { className: "if-stat", title } : { className: "if-stat" },
     k + " ", el("b", {}, String(v)));
@@ -3452,6 +3462,7 @@ function ifComposerSend(a) {
   }
   ifClearComposerLatch(a);
   a.composerPendingSeq = seq;
+  a.composerPendingText = value;   // the title is minted from it on the ack
   ifClearComposerAckTimer(a);
   a.composerAckTimer = setTimeout(() => {
     if (ifAttach !== a || a.composerPendingSeq !== seq) return;
@@ -3464,6 +3475,39 @@ function ifComposerSend(a) {
     a.paint();
   }, a.composerAckTimeoutMs || IF_COMPOSER_ACK_TIMEOUT_MS);
   a.paint();
+}
+
+const IF_TITLE_MAX = 60;
+
+function ifDeriveTitle(text) {
+  return typeof text === "string"
+    ? text.trim().split("\n")[0].trim().slice(0, IF_TITLE_MAX) : "";
+}
+
+// The CLIENT mints the chat title, not the input broker. Composer sends and
+// raw terminal keystrokes are indistinguishable on the wire — term.onData
+// forwards every keystroke through the same ifSendInput frames — so a
+// broker-side rule would title a chat with whatever single character the
+// operator typed into the terminal first, and would have to read bytes the
+// broker is deliberately blind to (decision #16). This fires on the first
+// successful composer send's own input_ack, which is the only place the two
+// are distinguishable. The server's UPDATE is set-if-unset, so a replayed ack
+// or a second client racing the same first message is a no-op there too.
+//
+// A failed mint is swallowed on purpose: the title is cosmetic and must never
+// disturb the send path or paint an alarming note. It self-heals — the guard
+// below re-fires on the NEXT message for as long as the title is unset.
+async function ifMintTitle(a, text) {
+  if (a.st.title) return;
+  const title = ifDeriveTitle(text);
+  if (!title) return;
+  try {
+    const r = await apiIf(`/interface/sessions/${a.sessionId}/title`, "POST",
+                          { title });
+    if (ifAttach !== a) return;      // operator moved on mid-flight
+    a.st.title = r.title || null;
+    a.paint();
+  } catch { /* cosmetic — retried by the next send while the title is unset */ }
 }
 
 function ifBuildComposer(a) {
@@ -3715,6 +3759,8 @@ function ifControl(a, m) {
         if (m.seq === a.composerPendingSeq) {
           ifClearComposerAckTimer(a);
           a.composerPendingSeq = null;
+          ifMintTitle(a, a.composerPendingText);
+          a.composerPendingText = null;
           a.composerInput.value = "";
           ifSizeComposer(a.composerInput);
           ifSyncBrowserComposer(a, "clean");
@@ -3787,11 +3833,26 @@ async function load(tab) {
   const [sel, fn] = VIEWS[tab];
   try { await fn($(sel)); } catch (e) { $(sel).replaceChildren(el("div", { className: "card" }, "error: " + e.message)); }
 }
+// The tab title names the view and the fork (spec #43 U4), replacing a static
+// per-fork string that named neither: an Interface tab with a shell selected
+// reads "<SHORTNAME> · <fork>", every other tab "<tab name> · <fork>". <fork>
+// is the repo root basename, read from the same /health field the header
+// breadcrumb renders, so the two can never disagree. It stays empty until
+// /health answers — the title then omits the fork rather than naming one we
+// have not confirmed.
+let forkName = "";
+function setDocumentTitle(tab) {
+  const label = (tab === "interface" && ifSelected) ? ifSelected
+    : (document.querySelector(`nav button[data-tab="${tab}"]`)?.textContent
+       || tab);
+  document.title = forkName ? `${label} · ${forkName}` : label;
+}
 function show(tab) {
   for (const b of document.querySelectorAll("nav button")) b.classList.toggle("active", b.dataset.tab === tab);
   for (const k of Object.keys(VIEWS)) $(VIEWS[k][0]).hidden = k !== tab;
   document.body.classList.toggle("interface-view", tab === "interface");
   if (tab !== "interface") { ifDetach(); ifStopRailPoll(); }   // leaving drops stream + lease + poll
+  setDocumentTitle(tab);
   load(tab);
 }
 // Hash routing: the active tab lives in the URL (#roadmap), so a refresh stays
@@ -3870,6 +3931,7 @@ $("#publish").onclick = async (e) => {
   try {
     const h = await api("/health");
     $("#repo").textContent = h.repo;
+    forkName = h.repo || "";
     configureArtifactActions(h);
     setStatus(localArtifactMode ? "local artifacts · port " + h.port : "port " + h.port);
   }

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3479,9 +3479,15 @@ function ifComposerSend(a) {
 
 const IF_TITLE_MAX = 60;
 
+// Array.from before the cap: String.slice counts UTF-16 code units, so an
+// astral character straddling the 60th unit would be cut into a lone
+// surrogate — which sqlite3 refuses to encode server-side, 500ing a mint that
+// then retries the same first line forever. Python's [:60] counts code points,
+// so this is also what makes the two caps agree.
 function ifDeriveTitle(text) {
   return typeof text === "string"
-    ? text.trim().split("\n")[0].trim().slice(0, IF_TITLE_MAX) : "";
+    ? Array.from(text.trim().split("\n")[0].trim())
+      .slice(0, IF_TITLE_MAX).join("") : "";
 }
 
 // The CLIENT mints the chat title, not the input broker. Composer sends and

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -742,11 +742,18 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .if-alerts.critical summary { color: #d45a5a; border-color: #d45a5a; }
 .if-alerts-body { color: var(--ink); }
 /* Who this pane is — "<display name> · <SHORTNAME> · <chat title>" on the
-   header's left. It shrinks to nothing before it will wrap, so a long chat
-   title truncates instead of pushing the controls onto a second header line
-   (min-width:0 is what lets a flex item shrink below its content width). */
+   header's left. It truncates instead of pushing the controls onto a second
+   header line — but .if-head wraps (the note and an open disclosure claim
+   their own line through flex-basis:100%), and a wrapping flex container
+   breaks the line on an item's CONTENT width before it will shrink that item,
+   so min-width:0 alone never got the chance to engage. A zero flex-basis
+   keeps the segment out of the line-breaking decision entirely; it then grows
+   into whatever room the controls leave, capped at its own content width so a
+   short identity sits exactly where it always did, and ellipsis-truncates
+   once there is no room left (min-width:0 is what lets it shrink that far). */
 .if-identity {
-  flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+  flex: 1 1 0; max-width: max-content; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis;
   white-space: nowrap; color: var(--ink); font-size: .85rem;
 }
 .if-inline-actions { display: flex; align-items: center; gap: .4rem; }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -741,6 +741,14 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .if-alerts.warning summary { color: var(--warn); border-color: var(--warn); }
 .if-alerts.critical summary { color: #d45a5a; border-color: #d45a5a; }
 .if-alerts-body { color: var(--ink); }
+/* Who this pane is — "<display name> · <SHORTNAME> · <chat title>" on the
+   header's left. It shrinks to nothing before it will wrap, so a long chat
+   title truncates instead of pushing the controls onto a second header line
+   (min-width:0 is what lets a flex item shrink below its content width). */
+.if-identity {
+  flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; color: var(--ink); font-size: .85rem;
+}
 .if-inline-actions { display: flex; align-items: center; gap: .4rem; }
 .if-stat { color: var(--dim); font-size: .8rem; }
 .if-stat b { color: var(--ink); font-weight: 600; }
@@ -752,14 +760,21 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
    has something to say lays out exactly as before. Scoped to .if-head so the
    composer's note keeps its reserved min-height line (no jump on first note). */
 .if-head > .if-note:empty { display: none; }
+/* The card's own 6px bottom padding plus the pane's 8px row-gap stacked 14px
+   of dead chrome between the last terminal row and the composer — measured in
+   the browser, and exactly the "14px less" the QAQC annotation asks for. Both
+   go: the terminal's bottom edge now sits on the composer. Top and side
+   padding are unchanged, so the row estimate below subtracts 6px of vertical
+   padding rather than 12. */
 .if-term {
   background: #000; border: 1px solid var(--line); border-radius: var(--r);
-  padding: 6px; width: 100%; max-width: 1300px;
+  padding: 6px 6px 0; width: 100%; max-width: 1300px;
   flex: 1 1 500px; min-height: 500px; overflow: hidden;
 }
 /* The grid is measured against this wrapper, so it must carry no padding or
    border of its own — it is exactly the card's content box. */
 .if-term > .if-term-fit { height: 100%; width: 100%; }
+.if-term + .if-composer { margin-top: -.5rem; }
 .if-term .xterm { height: 100%; }
 .if-composer {
   flex: 0 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) auto;

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -2254,7 +2254,20 @@ class InterfaceApiTest(unittest.TestCase):
         self.assertFalse(body["minted"])
         self.assertEqual(self.stored_title(sid), "deploy the migration")
 
-    def test_title_takes_the_first_line_and_caps_at_sixty(self):
+    def test_title_takes_the_first_line_only(self):
+        """The first-line rule and the 60-char cap are SEPARATE properties.
+        A long first line truncates to the same 60 chars whether or not the
+        rest of the message was folded in, so a cap test cannot witness this
+        one — it needs a first line short enough that the remainder would
+        show up if it leaked."""
+        sid = self.occupy()
+        status, _, body = self.title(
+            sid, "ship it\nand then a good deal more context\nand more")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["title"], "ship it")
+        self.assertEqual(self.stored_title(sid), "ship it")
+
+    def test_title_skips_leading_blank_lines_and_caps_at_sixty(self):
         sid = self.occupy()
         long_first_line = "x" * 80
         status, _, body = self.title(

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -2221,6 +2221,132 @@ class InterfaceApiTest(unittest.TestCase):
         self.assertEqual(body["error"]["code"], "worktree_provision_failed")
         self.assertIn("LaunchError", body["error"]["message"])
 
+    # -- chat title + launch effort (spec #43 U4) ------------------------------
+
+    def title(self, session_id, text, key="k-title"):
+        return self.call(
+            "POST", f"/api/interface/sessions/{session_id}/title",
+            (OP, f"Idempotency-Key: {key}"), {"title": text})
+
+    def stored_title(self, session_id):
+        con = sqlite3.connect(self.db_path)
+        try:
+            return con.execute(
+                "SELECT title FROM interface_sessions WHERE session_id=?",
+                (session_id,)).fetchone()[0]
+        finally:
+            con.close()
+
+    def test_title_is_minted_once_and_never_overwritten(self):
+        """Set-if-unset is the whole contract: the title records what OPENED
+        the chat. A second send — or a replayed ack, or a second client
+        racing the same first message — must leave the first one standing."""
+        sid = self.occupy()
+        status, _, body = self.title(sid, "deploy the migration")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["title"], "deploy the migration")
+        self.assertTrue(body["minted"])
+
+        status, _, body = self.title(sid, "something else entirely",
+                                     key="k-title-2")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["title"], "deploy the migration")
+        self.assertFalse(body["minted"])
+        self.assertEqual(self.stored_title(sid), "deploy the migration")
+
+    def test_title_takes_the_first_line_and_caps_at_sixty(self):
+        sid = self.occupy()
+        long_first_line = "x" * 80
+        status, _, body = self.title(
+            sid, f"  \n{long_first_line}\nsecond line\n")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["title"], "x" * 60)
+        self.assertEqual(self.stored_title(sid), "x" * 60)
+
+    def test_title_cap_is_enforced_server_side_not_trusted_from_the_client(self):
+        """The 60-char bound is a privacy bound (the ONE sanctioned exception
+        to the broker's content-blindness), so it is enforced where the write
+        happens — a caller that sends more does not get more persisted."""
+        sid = self.occupy()
+        self.title(sid, "y" * 5000)
+        self.assertEqual(len(self.stored_title(sid)), 60)
+
+    def test_title_without_a_derivable_first_line_is_refused(self):
+        sid = self.occupy()
+        for raw in ("", "   ", "\n\n  \n"):
+            status, _, body = self.title(sid, raw, key=f"k-blank-{raw!r}")
+            self.assertEqual(status, 422, raw)
+            self.assertEqual(body["error"]["code"], "validation")
+        self.assertIsNone(self.stored_title(sid))
+
+    def test_title_non_string_is_refused(self):
+        sid = self.occupy()
+        status, _, body = self.call(
+            "POST", f"/api/interface/sessions/{sid}/title",
+            (OP, "Idempotency-Key: k-nonstr"), {"title": 42})
+        self.assertEqual(status, 422)
+        self.assertEqual(body["error"]["code"], "validation")
+
+    def test_title_on_unknown_session_is_404(self):
+        status, _, body = self.title(9999, "hello")
+        self.assertEqual(status, 404)
+        self.assertEqual(body["error"]["code"], "no_such_session")
+
+    def test_title_is_exposed_on_the_session_and_shell_payloads(self):
+        sid = self.occupy()
+        status, _, body = self.call("GET", f"/api/interface/sessions/{sid}",
+                                    (OP,))
+        self.assertEqual(status, 200)
+        self.assertIsNone(body["title"])
+
+        self.title(sid, "first message here")
+        _, _, body = self.call("GET", f"/api/interface/sessions/{sid}", (OP,))
+        self.assertEqual(body["title"], "first message here")
+        _, _, shells = self.call("GET", "/api/interface/shells", (OP,))
+        row = next(s for s in shells["shells"] if s["session_id"] == sid)
+        self.assertEqual(row["title"], "first message here")
+
+    def test_launch_effort_is_persisted_and_exposed(self):
+        """U7's +Chat reuses the launch TRIPLE. Effort used to ride only in
+        the transient launch token, so a relaunch reusing "the same model"
+        silently dropped it — the column is what makes the triple durable."""
+        status, _, body = self.create_session(effort="high")
+        self.assertEqual(status, 201)
+        sid = body["session_id"]
+        _, _, session = self.call("GET", f"/api/interface/sessions/{sid}",
+                                  (OP,))
+        self.assertEqual(session["launch_effort"], "high")
+        _, _, shells = self.call("GET", "/api/interface/shells", (OP,))
+        row = next(s for s in shells["shells"] if s["session_id"] == sid)
+        self.assertEqual(row["launch_effort"], "high")
+
+    def test_launch_effort_matches_the_token_and_defaults_to_null(self):
+        """No effort named → NULL on the row and null in the token, so +Chat
+        sends no effort and the harness default applies."""
+        status, _, body = self.create_session()
+        self.assertEqual(status, 201)
+        sid = body["session_id"]
+        _, _, session = self.call("GET", f"/api/interface/sessions/{sid}",
+                                  (OP,))
+        self.assertIsNone(session["launch_effort"])
+        token = json.loads(
+            (routes.RUN_DIR / f"launch-{sid}.json").read_text())
+        self.assertIsNone(token["effort"])
+
+        status, _, body = self.create_session(shell_id=2, key="k-eff",
+                                              effort="low")
+        sid2 = body["session_id"]
+        token2 = json.loads(
+            (routes.RUN_DIR / f"launch-{sid2}.json").read_text())
+        self.assertEqual(token2["effort"], "low")
+        con = sqlite3.connect(self.db_path)
+        try:
+            self.assertEqual(con.execute(
+                "SELECT launch_effort FROM interface_sessions "
+                "WHERE session_id=?", (sid2,)).fetchone()[0], "low")
+        finally:
+            con.close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -662,6 +662,10 @@ a.paint();
     (c) => c.path === "/interface/sessions/7/title");
   invariant(titleCalls.length === 1 && titleCalls[0].body.title === "hello",
     `title was not minted from the acknowledged send: ${JSON.stringify(apiCalls)}`);
+  // Closed world: the two filters above are the whole call set, so a future
+  // call to some third route from the ack path cannot slip past them.
+  invariant(apiCalls.length === 3,
+    `the ack path made unexpected API calls: ${JSON.stringify(apiCalls)}`);
 
   a.halted = false;
   a.composerInput.value = "retain on reject";
@@ -1574,6 +1578,11 @@ const makeAttach = (title) => {
     "leading blank lines must not produce an empty title");
   invariant(ifDeriveTitle("z".repeat(200)).length === 60,
     "the 60-char cap must hold");
+  const astral = "z".repeat(59) + "\u{1F600}" + " and the rest";
+  invariant(Array.from(ifDeriveTitle(astral)).length === 60 &&
+    ifDeriveTitle(astral).endsWith("\u{1F600}"),
+    "the cap must count code points: cutting an astral character in half " +
+    "leaves a lone surrogate sqlite3 refuses to store");
   invariant(ifDeriveTitle("   ") === "" && ifDeriveTitle(undefined) === "",
     "whitespace-only and non-string input derive nothing");
 

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -651,8 +651,17 @@ a.paint();
     "acknowledged composer draft was not cleared");
   invariant(!a.composerInput.disabled,
     "composer stayed disabled after the clean transition was acknowledged");
-  invariant(apiCalls.length === 2 && apiCalls[1].body.state === "clean",
+  const composerCalls = apiCalls.filter(
+    (c) => c.path === "/interface/browser-composer");
+  invariant(composerCalls.length === 2 && composerCalls[1].body.state === "clean",
     "acknowledged send did not release browser composing state");
+  // The same ack mints the chat title from that message's first line
+  // (spec #43 U4) — a separate route, so it must not be mistaken for, or
+  // displace, the browser-composer transitions asserted above.
+  const titleCalls = apiCalls.filter(
+    (c) => c.path === "/interface/sessions/7/title");
+  invariant(titleCalls.length === 1 && titleCalls[0].body.title === "hello",
+    `title was not minted from the acknowledged send: ${JSON.stringify(apiCalls)}`);
 
   a.halted = false;
   a.composerInput.value = "retain on reject";
@@ -1528,3 +1537,177 @@ confirm = () => true;
     result = subprocess.run(
         ["node", "-e", script], text=True, capture_output=True, check=False)
     assert result.returncode == 0, result.stderr
+
+
+# ── Identity, titles, padding (spec #43 U4) ─────────────────────────────────
+
+TITLE_MINT = APP[APP.index("const IF_TITLE_MAX"):
+                 APP.index("function ifBuildComposer")]
+DOC_TITLE = APP[APP.index("let forkName ="):APP.index("function show(tab)")]
+
+
+def test_chat_title_is_minted_client_side_once_from_the_first_composer_send():
+    """The mint is the CLIENT's because the broker cannot tell a composer
+    send from a raw keystroke. Guard the properties that make it safe: it
+    fires once, derives the first line under the cap, and a failure neither
+    throws into the ack path nor pins the title so a later send can retry.
+    """
+    script = TITLE_MINT + r"""
+function invariant(ok, message) { if (!ok) throw new Error(message); }
+const calls = [];
+let nextError = null;
+globalThis.apiIf = async (path, method, body) => {
+  calls.push({ path, method, body });
+  if (nextError) throw nextError;
+  return { title: body.title };
+};
+const makeAttach = (title) => {
+  const a = { sessionId: 7, st: { title }, painted: 0 };
+  a.paint = () => { a.painted += 1; };
+  return a;
+};
+
+(async () => {
+  invariant(ifDeriveTitle("  hello world  \nsecond") === "hello world",
+    "the title must be the trimmed FIRST line");
+  invariant(ifDeriveTitle("\n\nlate first line") === "late first line",
+    "leading blank lines must not produce an empty title");
+  invariant(ifDeriveTitle("z".repeat(200)).length === 60,
+    "the 60-char cap must hold");
+  invariant(ifDeriveTitle("   ") === "" && ifDeriveTitle(undefined) === "",
+    "whitespace-only and non-string input derive nothing");
+
+  let a = makeAttach(null);
+  globalThis.ifAttach = a;
+  await ifMintTitle(a, "deploy the migration\nrest of the message");
+  invariant(calls.length === 1, `expected one mint call, got ${calls.length}`);
+  invariant(calls[0].path === "/interface/sessions/7/title" &&
+    calls[0].method === "POST", `wrong mint route: ${JSON.stringify(calls[0])}`);
+  invariant(calls[0].body.title === "deploy the migration",
+    `wrong minted title: ${calls[0].body.title}`);
+  invariant(a.st.title === "deploy the migration" && a.painted === 1,
+    "the sender's own header must update locally at mint time");
+
+  await ifMintTitle(a, "a totally different second message");
+  invariant(calls.length === 1,
+    "a session that already has a title must never call the mint again");
+
+  a = makeAttach(null);
+  globalThis.ifAttach = a;
+  await ifMintTitle(a, "   \n  ");
+  invariant(calls.length === 1,
+    "a message with no derivable first line must not be sent to the server");
+  invariant(a.st.title === null, "a blank message must not pin a title");
+
+  nextError = new Error("network down");
+  await ifMintTitle(a, "first attempt");
+  invariant(calls.length === 2, "a failing mint must still have been tried");
+  invariant(a.st.title === null,
+    "a failed mint must leave the title unset so the next send retries");
+  nextError = null;
+  await ifMintTitle(a, "second attempt");
+  invariant(a.st.title === "second attempt",
+    "the mint must self-heal on the next message");
+
+  const stale = makeAttach(null);
+  globalThis.ifAttach = makeAttach(null);   // operator moved to another pane
+  await ifMintTitle(stale, "landed too late");
+  invariant(stale.st.title === null && stale.painted === 0,
+    "a mint that resolves after the operator moved on must not paint");
+})().catch((error) => {
+  console.error(error.stack || error);
+  process.exit(1);
+});
+"""
+    result = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+def test_a_failed_title_mint_never_blocks_the_ack_path():
+    """ifMintTitle is called from the input_ack handler, which also clears
+    the composer and flushes output. Awaiting it there would stall that
+    handler behind a slow or failing title call."""
+    assert "ifMintTitle(a, a.composerPendingText);" in APP
+    ack = APP[APP.index('case "input_ack":'):APP.index('case "input_reject":')]
+    assert "ifMintTitle" in ack
+    assert "await ifMintTitle" not in ack, (
+        "the ack handler must not await the mint — a slow or failing title "
+        "call would stall clearing the composer and flushing output")
+
+
+def test_tab_titles_name_the_view_and_the_fork():
+    script = DOC_TITLE + r"""
+function invariant(ok, message) { if (!ok) throw new Error(message); }
+const NAV = { interface: "Interface", roadmap: "Roadmap", shells: "Shells" };
+globalThis.document = {
+  title: "",
+  querySelector: (sel) => {
+    const tab = sel.match(/data-tab="([^"]+)"/)[1];
+    return NAV[tab] ? { textContent: NAV[tab] } : null;
+  },
+};
+globalThis.ifSelected = null;
+
+forkName = "super-coder";
+setDocumentTitle("roadmap");
+invariant(document.title === "Roadmap · super-coder", document.title);
+setDocumentTitle("interface");
+invariant(document.title === "Interface · super-coder", document.title);
+ifSelected = "DEV4";
+setDocumentTitle("interface");
+invariant(document.title === "DEV4 · super-coder", document.title);
+setDocumentTitle("shells");
+invariant(document.title === "Shells · super-coder",
+  "a selected shell must not leak into another tab's title: " + document.title);
+
+// /health has not answered (or failed): name the view, never guess a fork.
+forkName = "";
+setDocumentTitle("interface");
+invariant(document.title === "DEV4", document.title);
+
+// An unknown tab still yields a title rather than "undefined".
+forkName = "super-coder";
+ifSelected = null;
+setDocumentTitle("mystery");
+invariant(document.title === "mystery · super-coder", document.title);
+"""
+    result = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+    assert "subfloor — review" not in APP
+    assert "setDocumentTitle(tab);" in APP
+
+
+def test_title_is_not_added_to_the_rail_signature():
+    """ifRailSig is a field WHITELIST driving the 5s repaint. The rail does
+    not display chat titles this round, so adding the field would repaint the
+    rail on every first message for nothing — and re-render the pane (dropping
+    the xterm attach and writer lease) whenever the selected shell's changed.
+    """
+    sig = APP[APP.index("function ifRailSig"):
+              APP.index("function ifStopRailPoll")]
+    assert "s.title" not in sig        # s.sprint_title is a different field
+    assert "s.launch_effort" not in sig
+
+
+def test_header_identity_segment_truncates_instead_of_wrapping():
+    assert 'el("div", { className: "if-identity" })' in APP
+    assert "[sel.display_name, sel.shortname, st.title]" in APP
+    identity = CSS[CSS.index(".if-identity {"):CSS.index(".if-inline-actions")]
+    assert "min-width: 0" in identity
+    assert "text-overflow: ellipsis" in identity
+    assert "white-space: nowrap" in identity
+
+
+def test_terminal_card_carries_no_dead_chrome_below_the_last_row():
+    """The QAQC annotation's 14px: the card's own bottom padding plus the
+    pane's row-gap. Both must be gone, and the row estimate must subtract the
+    padding that actually remains — leaving it at 12 would silently hand back
+    6px of the space this unit reclaimed."""
+    term = CSS[CSS.index(".if-term {"):CSS.index(".if-term .xterm")]
+    assert "padding: 6px 6px 0;" in term
+    assert "padding: 6px;" not in term
+    assert ".if-term + .if-composer { margin-top: -.5rem; }" in CSS
+    assert "Math.floor((h - 6) / 17)" in APP
+    assert "Math.floor((h - 12) / 17)" not in APP

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -1717,12 +1717,15 @@ def test_header_identity_segment_is_composed_and_styled_to_truncate():
 
 def test_terminal_card_carries_no_dead_chrome_below_the_last_row():
     """The QAQC annotation's 14px: the card's own bottom padding plus the
-    pane's row-gap. Both must be gone, and the row estimate must subtract the
-    padding that actually remains — leaving it at 12 would silently hand back
-    6px of the space this unit reclaimed."""
-    term = CSS[CSS.index(".if-term {"):CSS.index(".if-term .xterm")]
+    pane's row-gap. Both must be gone.
+
+    This test also used to pin the row estimate's `(h - 6)` divisor — the
+    padding term this unit's change made correct. U6 (#590) landed first and
+    deleted the estimate outright in favour of the renderer's measured cell,
+    so there is no divisor left to pin: the grid now re-measures against
+    whatever padding these rules leave, and U6's own tests own that property.
+    """
+    term = CSS[CSS.index(".if-term {"):CSS.index(".if-term > .if-term-fit")]
     assert "padding: 6px 6px 0;" in term
     assert "padding: 6px;" not in term
     assert ".if-term + .if-composer { margin-top: -.5rem; }" in CSS
-    assert "Math.floor((h - 6) / 17)" in APP
-    assert "Math.floor((h - 12) / 17)" not in APP

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -1700,7 +1700,13 @@ def test_title_is_not_added_to_the_rail_signature():
     assert "s.launch_effort" not in sig
 
 
-def test_header_identity_segment_truncates_instead_of_wrapping():
+def test_header_identity_segment_is_composed_and_styled_to_truncate():
+    """Composition and the truncation styling only. Whether the header ACTUALLY
+    stays one line is a layout fact no CSS-text assertion can witness — this
+    file once asserted all three properties below while a long title still
+    wrapped the controls onto a second line (SC-156). That property is pinned
+    in a real browser by test_interface_ui_rendered's header-line test.
+    """
     assert 'el("div", { className: "if-identity" })' in APP
     assert "[sel.display_name, sel.shortname, st.title]" in APP
     identity = CSS[CSS.index(".if-identity {"):CSS.index(".if-inline-actions")]

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -1000,3 +1000,67 @@ def test_terminal_bottom_edge_carries_no_dead_chrome(browser, ui_url):
         )
     finally:
         context.close()
+
+
+HEADER_LINES = """() => {
+  const head = document.querySelector(".if-head");
+  const identity = document.querySelector(".if-identity");
+  const box = identity.getBoundingClientRect();
+  // .if-head centres its items, so a shared flex line is a shared centre —
+  // the tops differ whenever a button is taller than the identity text.
+  const controls = Array.from(head.children)
+    .filter((child) => child !== identity)
+    .map((child) => child.getBoundingClientRect())
+    .filter((rect) => rect.height > 0);
+  const centre = (rect) => Math.round(rect.top + rect.height / 2);
+  return {
+    lines: new Set([box, ...controls].map(centre)).size,
+    truncated: identity.scrollWidth > identity.clientWidth,
+    gapToControls: Math.min(...controls.map((rect) => rect.left)) - box.right,
+  };
+}"""
+
+
+def test_long_identity_truncates_without_wrapping_the_header(browser, ui_url):
+    """Spec #43 U4: the identity segment "stays one line at any width" and the
+    action controls "keep their placement" (SC-156). .if-head wraps, and a
+    wrapping flex container breaks the line on an item's content width before
+    it shrinks that item — so a segment sized by its content dropped the
+    controls onto a second header line and never reached its own ellipsis.
+    Narrow viewport + a title at the 60-char cap forces the choice.
+    """
+    titled = {**SESSION, "title": "Wire the watcher daemon into the planner "
+                                  "inbox before freeze"}
+    assert len(titled["title"]) == 60
+
+    def titled_api(route) -> None:
+        if route.request.url.split("/api", 1)[-1] == "/interface/sessions/7":
+            return _json(route, titled)
+        return _mock_api(route)
+
+    context, page = _open_interface(
+        browser, ui_url, height=1000, width=700, api_handler=titled_api
+    )
+    try:
+        narrow = page.evaluate(HEADER_LINES)
+        assert narrow["lines"] == 1, (
+            f"the header laid out on {narrow['lines']} lines: the identity "
+            "wrapped the controls instead of truncating"
+        )
+        assert narrow["truncated"], (
+            "the identity fits at 700px — widen the fixture title, this test "
+            "is not measuring anything"
+        )
+
+        # ...and it is capped at its content width, so a segment with room to
+        # spare does not grow and shove the controls to the far right.
+        page.set_viewport_size({"width": 1600, "height": 1000})
+        wide = page.evaluate(HEADER_LINES)
+        assert wide["lines"] == 1
+        assert not wide["truncated"]
+        assert wide["gapToControls"] <= 17, (
+            f"{wide['gapToControls']}px between identity and controls — the "
+            "segment grew past its text (.if-head's own gap is 16px)"
+        )
+    finally:
+        context.close()

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -344,7 +344,15 @@ def _layout(page) -> dict[str, object]:
           const nonTermHeight = children
             .filter((child) => child !== termElement)
             .reduce((height, child) => height + child.getBoundingClientRect().height, 0);
-          const gap = parseFloat(getComputedStyle(pane).rowGap);
+          // Spacing is MEASURED between consecutive children rather than
+          // derived from rowGap × (n-1): the terminal's bottom boundary
+          // cancels the pane gap (spec #43 U4 removed the 14px of dead chrome
+          // under the last row), so a uniform-gap model now under-counts the
+          // height the terminal is entitled to fill.
+          const rects = children.map((child) => child.getBoundingClientRect());
+          let spacing = 0;
+          for (let i = 1; i < rects.length; i += 1)
+            spacing += rects[i].top - rects[i - 1].bottom;
           const docHeight = Math.max(
             document.documentElement.scrollHeight,
             document.body.scrollHeight
@@ -355,9 +363,7 @@ def _layout(page) -> dict[str, object]:
             pageScrolls: docHeight > window.innerHeight + 1,
             termHeight: term.height,
             availableTermHeight:
-              pane.getBoundingClientRect().height -
-              nonTermHeight -
-              gap * Math.max(children.length - 1, 0),
+              pane.getBoundingClientRect().height - nonTermHeight - spacing,
             composerHeight: composer.height,
           };
         }"""
@@ -959,6 +965,38 @@ def test_terminal_grid_refits_and_reports_the_measured_size_to_tmux(
         # number — the resize path this unit deliberately left unchanged.
         assert page.evaluate("window.__wsResizeFrames.at(-1).rows") == (
             after["rowCount"]
+        )
+    finally:
+        context.close()
+
+
+def test_terminal_bottom_edge_carries_no_dead_chrome(browser, ui_url):
+    """Spec #43 U4's padding line, measured rather than eyeballed: the card's
+    own 6px bottom padding plus the pane's 8px row-gap put 14px of dead space
+    between the last terminal row and the composer. Only the card's 1px border
+    may remain — this is the number the QAQC annotation asked to reclaim.
+    """
+    context, page = _open_interface(browser, ui_url, height=1000)
+    try:
+        measured = page.evaluate(
+            """() => {
+              const term = document.querySelector(".if-term");
+              const xterm = document.querySelector(".if-term .xterm");
+              const composer = document.querySelector(".if-composer");
+              return {
+                underLastRow: composer.getBoundingClientRect().top -
+                              xterm.getBoundingClientRect().bottom,
+                padBottom: getComputedStyle(term).paddingBottom,
+                padTop: getComputedStyle(term).paddingTop,
+              };
+            }"""
+        )
+        assert measured["padBottom"] == "0px"
+        # The top/side padding is deliberately kept — only the bottom went.
+        assert measured["padTop"] == "6px"
+        assert measured["underLastRow"] <= 2, (
+            f"{measured['underLastRow']}px of chrome still sits between the "
+            "last terminal row and the composer"
         )
     finally:
         context.close()

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -1013,10 +1013,18 @@ HEADER_LINES = """() => {
     .map((child) => child.getBoundingClientRect())
     .filter((rect) => rect.height > 0);
   const centre = (rect) => Math.round(rect.top + rect.height / 2);
+  // The identity holds a bare text node, so a Range over its contents measures
+  // the TEXT — unclipped by the segment's overflow, and independent of the box
+  // sized around it. The distance to the controls cannot see the segment
+  // overgrow its content: the controls are the next flex items along, so they
+  // travel with it and the 16px between them never moves.
+  const range = document.createRange();
+  range.selectNodeContents(identity);
   return {
     lines: new Set([box, ...controls].map(centre)).size,
     truncated: identity.scrollWidth > identity.clientWidth,
-    gapToControls: Math.min(...controls.map((rect) => rect.left)) - box.right,
+    boxWidth: box.width,
+    textWidth: range.getBoundingClientRect().width,
   };
 }"""
 
@@ -1058,9 +1066,10 @@ def test_long_identity_truncates_without_wrapping_the_header(browser, ui_url):
         wide = page.evaluate(HEADER_LINES)
         assert wide["lines"] == 1
         assert not wide["truncated"]
-        assert wide["gapToControls"] <= 17, (
-            f"{wide['gapToControls']}px between identity and controls — the "
-            "segment grew past its text (.if-head's own gap is 16px)"
+        assert wide["boxWidth"] - wide["textWidth"] <= 1, (
+            f"a {wide['boxWidth']:.0f}px segment around "
+            f"{wide['textWidth']:.0f}px of text — it grew past its content and "
+            "shoved the controls to the far right"
         )
     finally:
         context.close()


### PR DESCRIPTION
Sprint 45, unit 3 — spec doc 43, U4 (identity, titles, padding + migration). Reviewer: REV2.

## What ships

**Migration 0093 — `interface_sessions.title` + `launch_effort`, one file.**
Deliberately not split: U7's +Chat reuses the launch *triple* (harness, model_route, effort), and effort rode only in the transient `launch-<id>.json` token, so "same model" silently dropped a chosen effort.

**Chat titles, minted client-side.** On the first successful composer send, at that seq's `input_ack` — *not* in the input broker. Composer sends and raw terminal keystrokes are indistinguishable on the wire (`term.onData` forwards every keystroke through the same input frames), so a broker-side rule would mint a one-character title the moment someone typed in the terminal, and a content-reading broker would breach decision #16's byte-privacy rationale. `POST /api/interface/sessions/<id>/title` is set-if-unset in a single UPDATE, so a replay or a racing client is a no-op. First-line derivation and the 60-char cap are enforced **server-side too**: the cap is a privacy bound, not formatting, so it belongs where the write happens.

`title` is exposed on the session and shell payloads but **not** added to `ifRailSig` — that signature is a field whitelist, and the rail does not display titles this round.

**Header identity segment** — `<display name> · <SHORTNAME> · <chat title>`, left-aligned, ellipsis-truncated (`min-width: 0`), rendered cleanly without a title.

**Tab titles** — `<SHORTNAME> · <fork>` with a shell selected, `<tab name> · <fork>` elsewhere, replacing the static "subfloor — review". `<fork>` is the repo basename from the same `/health` field the header breadcrumb uses, so the two cannot disagree; empty until `/health` answers rather than guessing.

**Padding.** Measured in Chromium rather than eyeballed: the card's own 6px bottom padding **plus** `.if-pane`'s 8px row-gap put exactly 14px between the xterm viewport's bottom and the composer — the annotation's "14px less" to the pixel (15px including the 1px border). Both go; measured after: 1px, the border alone. Bottom-edge acceptance is judged jointly with U6.

## Trade-offs

- The gap is cancelled with `.if-term + .if-composer { margin-top: -.5rem }` rather than restructuring `.if-pane`'s gap. A negative margin is a smell, but the alternative (gap: 0 plus per-child margins) touches four rules including the sprint panel's spacing, for the same pixels. One scoped line beats four.
- The row estimate moves `h - 12` → `h - 6` (clientHeight includes padding; only the 6px top remains). **DEV6 will delete this line** — U6 replaces the estimate with FitAddon measurement. Flagged to them directly; resolve that conflict in U6's favour.
- `tests/test_interface_ui_rendered.py::_layout` computed `availableTermHeight` as `rowGap × (n-1)`, which the removed gap made wrong (726 vs 718±2). Changed it to **measure** real spacing between consecutive children rather than loosening the tolerance.
- A failed title mint is swallowed on purpose: the title is cosmetic and must not disturb the send path. It self-heals — the guard re-fires on the next message while the title is unset. The ack handler does not `await` it.

## Ambiguity calls (all four ratified by PLN1, #1687)

- **Migration timing** — 0093 is *not* applied to the live DB pre-review. The ledger stamps by filename, so applying it and then changing its body in review would leave the live DB permanently missing the change. Verified against a scratch rebuild instead; applied at merge with a WAL-safe backup and an explicit DB path.
- **Blank first line** — 422 server-side (never store an empty title), client skips the POST, mint re-fires on the next message.
- **Writer lease** — the mint does *not* ride it. It fires on the sender's own `input_ack`, and gating it would fail the mint exactly when a take-over raced the first message; set-if-unset makes the race a no-op anyway.
- **spec_tasks band** — U4's plan sits at doc 43 seq 40-46 (laid before the band convention landed); PLN1 ruled keep-as-is and reassigned U6's band.

## Verification

**16 mutation round trips, run by hand** — each property broken in source, the guarding test watched go RED, reverted, watched go GREEN: set-if-unset · 60-char cap (server + client) · first-line derivation · blank refusal · launch_effort persistence · launch_effort payload exposure · client mint-once · failed-mint retry · tab-title fork suffix · selected-shell leak into other tabs · rail-signature exclusion · identity truncation · `.if-term` padding · pane gap (rendered) · row-estimate constant.

One of them **found a hole in my own test**: the cap fixture used an 80-char first line, so a mutation folding the *whole message* into the title stayed green — the cap masked the first-line property. Split into a separate short-first-line test (`fc4ee6f`).

Full suite: 1292 passed. Two failures in `tests/test_interface_wake.py` (debounce timing) under the 20-minute full-suite run — **53/53 pass in isolation**, nothing in this diff touches wake. Classified anomalous; CI is the gate.

Rendered suite run locally against the baked Chromium (flag #169's drift worked around locally, not in CI).

## Note for the merge protocol

`origin/main` landed its own `0092_reseed_anticipated_activity_worker_fault.sql` mid-build. The **file-level** intersection with main is empty (skills assets, a reseed migration, a shell template), so the standard overlap check would have said the head stands — the collision was in the migration **ordinal**. Renumbered 0092 → 0093 (`aa0931e`) and rebased.