### PR TITLE
feat(interface): 43-U5 live-model badge — say the observed model, or say launched

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2215,14 +2215,50 @@ function ifModelLabel(route) {
 // /model switch never reaches the engine — so it is labelled as the launch
 // route and never rendered as a claim about the live model. The analytics sweep
 // cannot supply the live one either: its rows carry one model per session-wide
-// window, so they cannot express switch order (flag #136). Deriving a truthful
-// current model is a feature #17 follow-up, not something this surface guesses.
+// window, so they cannot express switch order (flag #136).
 const IF_LAUNCHED_TITLE =
   "the route this session was launched with — not necessarily the model it is "
   + "running now, since an in-harness /model switch never reaches the engine";
 
 function ifLaunchedDisplay(route) {
   return { text: ifModelLabel(route) + " (launched)", title: IF_LAUNCHED_TITLE };
+}
+
+// The truthful current model, when a transcript actually recorded one: the
+// feature #17 probe (`live_model` / `live_model_at` / `live_model_verdict`,
+// server-side) read the last main-thread assistant message and says which model
+// answered it. That is a real observation, so the badge may state it — decision
+// #55 is honored here, not superseded: the label still only ever claims what a
+// transcript recorded, and everything short of that keeps the launch label.
+//
+// The `ok` verdict is required POSITIVELY rather than excluding the known bad
+// ones. `stale`, `none` and `unsupported` are today's other verdicts, but a
+// verdict this code has never heard of must fall back to the launch route too —
+// the failure direction that matters is never claiming live what is not.
+function ifLiveDisplay(s) {
+  if (!s || s.live_model_verdict !== "ok" || !s.live_model) return null;
+  // The hover carries the provenance the badge itself has no room for: what was
+  // read and when. `live_model_at` is the transcript's own clock and can be
+  // absent even on a good reading, which is said plainly rather than papered
+  // over with the time we rendered at — that would be a claim about the harness
+  // we did not observe.
+  const observed = s.live_model_at
+    ? "observed " + s.live_model_at
+    : "the transcript recorded no observation time";
+  return {
+    text: ifModelLabel(s.live_model) + " (live)",
+    title: "the model this session answered with last, read from the "
+      + (s.harness ? s.harness + " transcript" : "session transcript")
+      + " — " + observed,
+  };
+}
+
+// One decision point for every site that shows a session's model: the observed
+// model where the probe has a fresh explicit one, the launch route everywhere
+// else. Two call sites read it (rail row, mobile picker) and they must never
+// disagree about which claim the surface is making.
+function ifModelDisplay(s) {
+  return ifLiveDisplay(s) || ifLaunchedDisplay(s.model_route);
 }
 
 // The sprint a working shell is on, from the archive's sprint_ref (server-side
@@ -2296,18 +2332,16 @@ function ifBuildRail(rail, picker, shells) {
     if (s.alerts > 0)
       head.append(el("span", { className: "pill if-badge bad",
         title: s.alerts + " current alert(s)" }, "⚠ " + s.alerts));
-    const launched = s.availability === "occupied"
-      ? ifLaunchedDisplay(s.model_route)
-      : null;
+    const model = s.availability === "occupied" ? ifModelDisplay(s) : null;
     const sub = el("div", { className: "if-row-sub" },
       s.shortname + (s.harness ? " · " + s.harness : ""));
-    if (launched)
-      sub.append(el("span", { title: launched.title }, " · " + launched.text));
+    if (model)
+      sub.append(el("span", { title: model.title }, " · " + model.text));
     sub.append(ifSprintSuffix(s));
     row.append(head, sub);
     row.onclick = () => { location.hash = "interface/" + s.shortname; };
     rail.append(row);
-    const mobileModel = launched ? " · " + launched.text : "";
+    const mobileModel = model ? " · " + model.text : "";
     const opt = el("option", { value: s.shortname },
       `${s.display_name || s.shortname} · ${s.shortname}` +
       `${s.harness ? " · " + s.harness : ""}${mobileModel}` +
@@ -2334,9 +2368,23 @@ function ifBuildRail(rail, picker, shells) {
 const IF_POLL_MS = 5000;
 let ifPoll = null;
 
+// The whitelist below is what makes a payload field repaint anything: a field
+// the signature ignores can change every tick and the rail will never rebuild.
+// `live_model` and `live_model_verdict` are in because both change the badge's
+// TEXT — a /model switch, or a reading going stale and the badge falling back
+// to the launch label.
+//
+// `live_model_at` is deliberately OUT. It moves on every assistant message, so
+// in the signature it would rebuild the rail every few seconds for the whole
+// time a shell is working — dropping focus from a rail button and slamming a
+// mobile picker's open dropdown shut, the exact two harms the signature compare
+// exists to prevent. The cost is that the hover's observation time can lag
+// while the model itself is unchanged; that under-states how fresh a reading is
+// and never over-states it, which is the safe direction for this badge.
 function ifRailSig(shells) {
   return JSON.stringify(shells.map((s) => [s.shortname, s.availability, s.alerts,
-    s.harness, s.model_route, s.sprint_ref, s.sprint_title, s.display_name]));
+    s.harness, s.model_route, s.sprint_ref, s.sprint_title, s.display_name,
+    s.live_model, s.live_model_verdict]));
 }
 
 function ifStopRailPoll() {

--- a/tests/mutations/u5_live_model_badge.py
+++ b/tests/mutations/u5_live_model_badge.py
@@ -1,0 +1,133 @@
+"""Mutation round trips for spec #43 U5 — the live-model badge.
+
+Acceptance evidence, committed rather than run once in a worktree that dies
+with the session (REV1's U2 finding L3). Each entry below breaks ONE property
+in the real source, asserts the test that claims to pin it actually goes RED,
+restores the file, and asserts it goes green again. A property whose mutation
+stays green is not pinned, whatever the suite's colour says.
+
+    python3 tests/mutations/u5_live_model_badge.py [-v]
+
+Not named test_*.py on purpose: pytest must not collect it — it edits tracked
+source. It restores every file in a finally block, so an interrupted run still
+leaves the tree clean; `git diff` after a run is the check.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / ".super-coder" / "ui" / "app.js"
+SUITE = "tests/test_interface_ui_contract.py"
+
+GATE = ('  if (!s || s.live_model_verdict !== "ok" || !s.live_model) '
+        'return null;')
+OBSERVED = """  const observed = s.live_model_at
+    ? "observed " + s.live_model_at
+    : "the transcript recorded no observation time";"""
+
+# (label, -k selector for the test that must go red, file, old, new)
+MUTATIONS = [
+    (
+        "M1 rail signature drops the live fields (the planner's own: without "
+        "them the badge repaints nothing on the 5s poll)",
+        "repaints_the_badge", APP,
+        ",\n    s.live_model, s.live_model_verdict]));",
+        "]));",
+    ),
+    (
+        "M2 a STALE reading is allowed to paint as live (the fail direction "
+        "that matters — never claim live what is not)",
+        "stale_reading", APP, GATE,
+        '  if (!s || (s.live_model_verdict !== "ok"\n'
+        '      && s.live_model_verdict !== "stale") || !s.live_model) '
+        'return null;',
+    ),
+    (
+        "M3 the verdict is gated negatively, so an unknown future verdict "
+        "claims live instead of falling back",
+        "fresh_explicit_reading", APP, GATE,
+        '  if (!s || s.live_model_verdict === "stale"\n'
+        '      || s.live_model_verdict === "none"\n'
+        '      || s.live_model_verdict === "unsupported"\n'
+        '      || !s.live_model) return null;',
+    ),
+    (
+        "M4 an `ok` verdict with no model id still paints a badge",
+        "fresh_explicit_reading", APP, GATE,
+        '  if (!s || s.live_model_verdict !== "ok") return null;',
+    ),
+    (
+        "M5 the hover drops the observation time",
+        "fresh_explicit_reading", APP, '\n      + " — " + observed,', ",",
+    ),
+    (
+        "M6 the hover drops the source of the reading",
+        "fresh_explicit_reading", APP,
+        '\n      + (s.harness ? s.harness + " transcript" : "session transcript")',
+        ' + "transcript"',
+    ),
+    (
+        "M7 a missing observation time is papered over with render time — a "
+        "claim about the harness nobody observed",
+        "never_invents_an_observation_time", APP, OBSERVED,
+        '  const observed = "observed "\n'
+        '    + (s.live_model_at || new Date().toISOString());',
+    ),
+    (
+        "M8 the mobile picker makes its own model decision instead of "
+        "sharing the row's",
+        "one_model_decision", APP,
+        'const mobileModel = model ? " · " + model.text : "";',
+        'const mobileModel = model\n'
+        '      ? " · " + ifLaunchedDisplay(s.model_route).text : "";',
+    ),
+]
+
+
+def run(selector: str) -> bool:
+    """True when the selected tests pass."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", SUITE, "-q", "-k", selector],
+        cwd=ROOT, capture_output=True, text=True)
+    return proc.returncode == 0
+
+
+def main() -> int:
+    verbose = "-v" in sys.argv
+    failures = []
+    for label, selector, path, old, new in MUTATIONS:
+        original = path.read_text()
+        if original.count(old) != 1:
+            failures.append(f"{label}: anchor found {original.count(old)}x, "
+                            "expected exactly 1 — the driver has drifted from "
+                            "the source")
+            continue
+        try:
+            path.write_text(original.replace(old, new, 1))
+            red = not run(selector)
+        finally:
+            path.write_text(original)
+        green = run(selector)
+        ok = red and green
+        if not ok:
+            failures.append(
+                f"{label}: mutated={'RED' if red else 'GREEN (NOT PINNED)'} "
+                f"restored={'green' if green else 'RED (dirty revert)'}")
+        mark = "ok" if ok else "FAIL"
+        print(f"[{mark}] {label}\n       -k {selector}: "
+              f"{'red' if red else 'STAYED GREEN'} -> "
+              f"{'green' if green else 'STILL RED'}")
+        if verbose and not ok:
+            print("       ^ this property is not actually pinned")
+    print(f"\n{len(MUTATIONS) - len(failures)}/{len(MUTATIONS)} round trips "
+          "behaved (red under mutation, green on revert)")
+    for line in failures:
+        print("  FAIL " + line)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -1729,3 +1729,184 @@ def test_terminal_card_carries_no_dead_chrome_below_the_last_row():
     assert "padding: 6px 6px 0;" in term
     assert "padding: 6px;" not in term
     assert ".if-term + .if-composer { margin-top: -.5rem; }" in CSS
+
+
+# ── spec #43 U5 — the live-model badge ───────────────────────────────────────
+# The display consumer of the feature #17 probe. The whole unit is one claim
+# and its boundary: say the observed model where a transcript actually recorded
+# one, and say nothing new anywhere else.
+
+LIVE_BADGE_SETUP = RAIL_POLL_SETUP + r"""
+const occupied = (extra = {}) => shellRow("S3", "occupied",
+  { harness: "kimi", model_route: "k3-coder", ...extra });
+const subOf = (root) => all(railOf(root), (n) =>
+  n.className === "if-row-sub")[0];
+// The hover lives on the model span, not on the row: reading it off the row
+// would pass even if the label carried no title at all.
+const hoverOf = (sub) => (sub.children.find((c) => c && c.title) || {}).title;
+const paint = async (extra) => {
+  serveShells([occupied(extra)]);
+  const root = new FakeElement("div");
+  await renderInterface(root);
+  ifStopRailPoll();
+  const sub = subOf(root);
+  return { text: sub.textContent, hover: hoverOf(sub) };
+};
+const FRESH = { live_model: "k3-coder-0711",
+  live_model_at: "2026-07-25T12:41:03Z", live_model_verdict: "ok" };
+"""
+
+
+def test_rail_badge_claims_a_live_model_only_on_a_fresh_explicit_reading():
+    """The unit's entire contract, as a matrix over the probe's verdict.
+
+    `ok` + an explicit id is the ONLY state that may say `(live)`; every other
+    verdict falls back to today's launch label, hover included. Text and hover
+    are asserted as two separate properties — a test pinning only the text
+    would pass with a badge that claims a live model and explains nothing.
+    """
+    run_recovery_js(LIVE_BADGE_SETUP + r"""
+// 1. A fresh explicit reading — the one case that may claim the live model.
+const live = await paint(FRESH);
+invariant(live.text.includes("K3 CODER 0711 (live)"),
+  `a fresh reading never reached the badge: ${live.text}`);
+invariant(!live.text.includes("(launched)"),
+  `the badge claimed live and launched at once: ${live.text}`);
+invariant(live.hover.includes("2026-07-25T12:41:03Z"),
+  `the hover named no observation time: ${live.hover}`);
+invariant(live.hover.includes("kimi transcript"),
+  `the hover named no source for the reading: ${live.hover}`);
+
+// 2. No probe fields at all — a server that never shipped feature #17, and
+//    the state every non-occupied rail row is in. Today's label, untouched.
+const bare = await paint();
+invariant(bare.text.includes("K3 CODER (launched)"),
+  `the launch label did not survive an absent probe: ${bare.text}`);
+invariant(bare.hover.includes("launched with"),
+  `the launch hover did not survive an absent probe: ${bare.hover}`);
+
+// 3. Every other verdict falls back — including one this code has never
+//    heard of, because the fallback is gated on `ok` positively.
+for (const verdict of ["stale", "none", "unsupported", "some-future-verdict"]) {
+  const r = await paint({ ...FRESH, live_model_verdict: verdict });
+  invariant(r.text === bare.text,
+    `verdict ${verdict} changed the badge text: ${r.text}`);
+  invariant(r.hover === bare.hover,
+    `verdict ${verdict} changed the badge hover: ${r.hover}`);
+}
+
+// 4. `ok` with nothing to report is not a reading either.
+for (const model of [null, ""]) {
+  const r = await paint({ ...FRESH, live_model: model });
+  invariant(r.text === bare.text,
+    `an empty live_model still claimed a live badge: ${r.text}`);
+}
+""")
+
+
+def test_a_stale_reading_never_paints_its_model_name_as_live():
+    """The fail direction that matters, on its own.
+
+    A stale reading is one the session has already moved past, so naming it
+    would be the surface asserting a model the harness may have switched away
+    from — the exact claim decision #55 forbids. Falling back is not enough:
+    the stale id must not appear on the rail in ANY form.
+    """
+    run_recovery_js(LIVE_BADGE_SETUP + r"""
+const stale = await paint({ ...FRESH, live_model_verdict: "stale" });
+invariant(!stale.text.includes("(live)"),
+  `a stale reading was labelled live: ${stale.text}`);
+invariant(!stale.text.includes("K3 CODER 0711") &&
+          !stale.text.includes("0711"),
+  `the stale model id was painted on the rail anyway: ${stale.text}`);
+invariant(stale.text.includes("K3 CODER (launched)"),
+  `a stale reading did not fall back to the launch route: ${stale.text}`);
+invariant(!stale.hover.includes("0711") &&
+          !stale.hover.includes("2026-07-25T12:41:03Z"),
+  `the stale reading leaked into the hover: ${stale.hover}`);
+""")
+
+
+def test_the_hover_never_invents_an_observation_time_it_does_not_have():
+    """`live_model_at` is the transcript's own clock and can be absent on a
+    perfectly good reading. The hover then says so — it must not fall back to
+    render time (a claim about the harness nobody observed) nor print the
+    missing value into the copy."""
+    run_recovery_js(LIVE_BADGE_SETUP + r"""
+const r = await paint({ ...FRESH, live_model_at: null });
+invariant(r.text.includes("K3 CODER 0711 (live)"),
+  `a missing clock suppressed a good reading: ${r.text}`);
+invariant(!r.hover.includes("null") && !r.hover.includes("undefined"),
+  `the hover printed the missing timestamp: ${r.hover}`);
+invariant(r.hover.includes("no observation time"),
+  `the hover did not state that the time is missing: ${r.hover}`);
+invariant(r.hover.includes("kimi transcript"),
+  `the hover dropped the source with the time: ${r.hover}`);
+""")
+
+
+def test_a_live_model_change_repaints_the_badge_without_rebuilding_the_pane():
+    """The membership property, behaviourally: `ifRailSig` is a whitelist, so
+    a live_model that is not in it repaints NOTHING on the 5s poll — the badge
+    would sit on the first model the session ever reported. And it must repaint
+    the rail ONLY: the selected shell stays occupied through a /model switch,
+    so re-rendering the pane would tear down a live terminal to change a word.
+    """
+    run_recovery_js(LIVE_BADGE_SETUP + r"""
+ifSelected = "S3";
+serveShells([occupied(FRESH)]);
+const root = new FakeElement("div");
+await renderInterface(root);
+const text = () => subOf(root).textContent;
+invariant(text().includes("K3 CODER 0711 (live)"), `first paint: ${text()}`);
+
+let rendered = 0;
+renderInterface = async () => { rendered += 1; };
+
+// An in-harness /model switch: same availability, a new observed model.
+serveShells([occupied({ ...FRESH, live_model: "k3-turbo" })]);
+await ifPollRail();
+invariant(text().includes("K3 TURBO (live)"),
+  `the switch never reached the badge — live_model is not in ifRailSig: ${text()}`);
+invariant(rendered === 0,
+  "a model switch re-rendered the pane and would drop the live terminal");
+
+// And the fallback direction repaints too: the reading going stale is a
+// badge change even though the model id is unchanged.
+serveShells([occupied({ ...FRESH, live_model: "k3-turbo",
+  live_model_verdict: "stale" })]);
+await ifPollRail();
+invariant(text().includes("K3 CODER (launched)"),
+  `a reading going stale left the live badge up — live_model_verdict is not `
+  + `in ifRailSig: ${text()}`);
+invariant(rendered === 0, "the fallback re-rendered the pane");
+ifStopRailPoll();
+""")
+
+
+def test_the_observation_clock_is_kept_out_of_the_rail_signature():
+    """The counterpart to the title whitelist test above. The two text-bearing
+    fields are in; `live_model_at` is hover-only and moves on every assistant
+    message, so in the signature it would rebuild the rail every few seconds
+    for the entire time a shell is working — dropping rail-button focus and
+    slamming the mobile dropdown shut, which is what the signature compare
+    exists to prevent."""
+    sig = APP[APP.index("function ifRailSig"):
+              APP.index("function ifStopRailPoll")]
+    assert "s.live_model," in sig
+    assert "s.live_model_verdict" in sig
+    assert "s.live_model_at" not in sig
+
+
+def test_both_rail_display_sites_read_one_model_decision():
+    """The desktop row and the mobile picker must never disagree about which
+    claim the surface is making — one helper, two consumers. Pinned in source
+    because the picker's option text is a string the DOM harness above reads
+    only as part of a longer line."""
+    rail = APP[APP.index("function ifBuildRail"):
+               APP.index("// ── Rail poll")]
+    assert "const model = s.availability === \"occupied\"" in rail
+    assert "ifModelDisplay(s)" in rail
+    assert rail.count("ifModelDisplay(") == 1      # one decision, not two
+    assert "ifLaunchedDisplay(" not in rail        # never the launch route direct
+    assert "model ? \" · \" + model.text : \"\"" in rail


### PR DESCRIPTION
Sprint 45, unit 9 (final build unit) — spec doc 43 U5, the display consumer of the feature #17 probe shipped by 44-U1 (#595).

## What it does

Where the probe returns a fresh, explicit reading, the rail badge shows `<MODEL> (live)` with a hover naming the observation time and what was read. Stale, absent, and unsupported readings keep today's `(launched)` label **unchanged, hover included**.

Decision #55 is honored, not superseded: the label still only ever claims what a transcript actually recorded.

Two design points worth the reviewer's attention:

- **The `ok` verdict is required positively**, not by excluding the known-bad ones. A verdict this code has never heard of falls back to the launch route. The failure direction that matters is never claiming live what is not.
- **`ifRailSig` is a whitelist**, so the fields repaint nothing until they are in it — the trap both specs warned about. `live_model` + `live_model_verdict` go in (both change badge text). `live_model_at` stays **out**: it moves on every assistant message, so in the signature it would rebuild the rail every few seconds for the whole time a shell is working — dropping rail-button focus and slamming the mobile dropdown shut, the exact harms the signature compare exists to prevent. The cost is a hover timestamp that can lag while the model is unchanged: that under-states freshness and never over-states it.

## Ambiguity calls (both RATIFIED by PLN1, #1818, pre-build)

1. **The specs disagree about `source`.** Spec 43 U5 asks the hover to name the source; spec 44 U1's field list deliberately excludes the probe's `source` (an absolute transcript path), so the payload has no such field. Reported before building, not at merge. Ratified reading: the hover names the source at the granularity the payload supports — the harness whose transcript was read — rather than making a display-only unit an API change that ships a host path into the browser. Queued by the planner for the spec-accuracy pass against both docs.
2. **`live_model_at` out of the signature**, per the reasoning above. Ratified.

## Trade-off rejected

Adding `live_model_source` server-side would have satisfied spec 43's wording literally. Rejected: it makes a declared display-only unit an API change and exposes a host filesystem path to the browser, which no spec asked for.

## Tests

`tests/test_interface_ui_contract.py` — driven through the real `ifBuildRail`, not a reimplementation:

- verdict matrix (`ok` / `stale` / `none` / `unsupported` / an unknown future verdict / no probe fields at all / `ok` with an empty id), asserting **text and hover as two separate properties**
- the stale fail-direction on its own: the stale id must not appear on the rail in any form
- the missing-clock hover: it says so rather than falling back to render time
- the repaint path: a `/model` switch reaches the badge without re-rendering the pane, and a reading going stale falls back the same way — signature membership proven behaviourally, not just by source assertion
- source-level: `live_model_at` kept out of the signature; both display sites read one model decision

## Mutation proof — 8/8 red then green

Driver committed at `tests/mutations/u5_live_model_badge.py` (REV1's U2 finding L3: acceptance evidence in untracked `shared/` dies with the worktree). Run it with `python3 tests/mutations/u5_live_model_badge.py`; it restores every file in a `finally`.

| # | Mutation | Test that went red |
|---|---|---|
| M1 | rail signature drops the live fields (the planner's own) | `repaints_the_badge` |
| M2 | a STALE reading is allowed to paint as live | `stale_reading` |
| M3 | verdict gated negatively — an unknown verdict claims live | `fresh_explicit_reading` |
| M4 | `ok` with no model id still paints a badge | `fresh_explicit_reading` |
| M5 | hover drops the observation time | `fresh_explicit_reading` |
| M6 | hover drops the source of the reading | `fresh_explicit_reading` |
| M7 | missing observation time papered over with render time | `never_invents_an_observation_time` |
| M8 | mobile picker makes its own model decision | `one_model_decision` |

## Suite

Full local suite: 1402 passed, 1 failed — `test_interface_wake.py::test_quiet_debounce_reschedules_at_the_deadline`, which passes in isolation and has no import path from this diff (app.js + one test file + a non-collected driver). Classified anomalous/timing-sensitive under full-suite load; CI is the arbiter and I will report if it recurs there. Lint clean on all three changed files (the 22 repo-wide ruff errors are pre-existing on main, none in my files).

## Not in scope

The session-details pane's `launched` stat is left unchanged — it is explicitly labelled as the launch route and stays honest. The session payload carries the live fields, so a `live` stat there is a cheap follow-up, not this unit.

Shell: DEV4 (Code-02) · reviewer REV1