### PR TITLE
fix(interface): live_model must never report a dead session as live (S45 U10)

### DIFF
--- a/.super-coder/scripts/live_model/__init__.py
+++ b/.super-coder/scripts/live_model/__init__.py
@@ -26,7 +26,8 @@ Contract — every harness module exposes:
             MAIN-THREAD assistant message carrying an EXPLICIT model id, or
             None when the current session has no such record. None is a real
             answer (fresh session, unreadable dir, nothing but placeholders) —
-            never an exception.
+            never an exception. A read failure it swallows on the way there
+            goes to `note()`, so a blank answer is never a silent one.
 
 Rules, in decision #55's spirit — the claim this feature makes is exactly
 "`live_model` is the model id of the last main-thread assistant message in the
@@ -76,10 +77,35 @@ CACHE_TTL_S = 5.0  # the rail poll's own period: one disk read per poll, not per
 
 _cache: "dict[tuple, tuple]" = {}   # (harness, worktree) -> (expires_at, result)
 _logged: "set[tuple]" = set()       # (harness, worktree, kind) — log once, not per poll
+_log_sink = None                    # the caller's log, for the duration of one read
 
 
 def _default_log(msg: str) -> None:
     print(f"[live_model] {msg}", file=sys.stderr, flush=True)
+
+
+def note(kind: str, detail: str) -> None:
+    """Report a read failure a harness module swallowed — ONCE per message.
+
+    Spec doc 44 asks for "unreadable transcript -> `none`, LOGGED ONCE, never
+    an exception on the shells route". `_read`'s boundary covers the failures a
+    module lets escape; this covers the ones it handles itself — a permission
+    change on one transcript, a stat that races a rotation, a locked SQLite
+    file — which otherwise turn into a silently blank badge with nothing on
+    stderr to say why.
+
+    Routed through the same ledger and the same caller-supplied `log` as the
+    boundary, so `probe(log=…)` remains the single place everything this
+    package says comes out. `_log_sink` is set only for the duration of one
+    `mod.read()` call; a caller that injects its own log from one thread while
+    another polls can see a line on the wrong sink, which is why the sink is
+    never the thing being asserted — the ledger is.
+    """
+    mark = (kind, detail)
+    if mark in _logged:
+        return
+    _logged.add(mark)
+    (_log_sink or _default_log)(f"{kind}: {detail}")
 
 
 def placeholder(model) -> bool:
@@ -125,12 +151,14 @@ def _read(harness: str, worktree: str, log) -> "dict | None":
     a permission change, a format drift that trips an attribute error, a
     corrupt SQLite page.
     """
+    global _log_sink
     key = (harness, worktree)
     now = _time.monotonic()
     hit = _cache.get(key)
     if hit is not None and hit[0] > now:
         return hit[1]
     mod = _module(harness)
+    _log_sink = log  # `note()` from inside the module lands on the caller's log
     try:
         result = mod.read(worktree) if mod is not None else None
     except Exception as e:  # noqa: BLE001 — see docstring: never raise on the route
@@ -139,6 +167,8 @@ def _read(harness: str, worktree: str, log) -> "dict | None":
         if mark not in _logged:
             _logged.add(mark)
             log(f"{harness}: probe failed for {worktree}: {type(e).__name__}: {e}")
+    finally:
+        _log_sink = None
     _cache[key] = (now + CACHE_TTL_S, result)
     return result
 

--- a/.super-coder/scripts/live_model/claude.py
+++ b/.super-coder/scripts/live_model/claude.py
@@ -23,8 +23,12 @@ scout:
 The project-dir name is a lossy encoding of the cwd (`/`, `.` and `-` all land
 on `-`), so it is only a prefix PREFILTER; the per-record `cwd` decides which
 worktree a file belongs to. Current session = the newest-mtime top-level file
-whose `cwd` matches — verified live: the dev5 project dir holds 8 sessions and
-the newest is the running one, its mtime advancing during the scan.
+that could be this worktree's — verified live: the dev5 project dir holds 8
+sessions and the newest is the running one, its mtime advancing during the
+scan. "Could be" and not "is": a file we cannot read, or one written before
+its session's first user turn, carries no `cwd` to match, and treating that
+silence as someone else's file is what turns the PREVIOUS session's model into
+a confident `ok` (see `_scan`).
 """
 from __future__ import annotations
 
@@ -32,29 +36,55 @@ import json
 import os
 from pathlib import Path
 
-from . import norm_iso, placeholder
+from . import norm_iso, note, placeholder
 
 HARNESS = "claude"
 DATA_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR") or Path.home() / ".claude") / "projects"
 
+# What a transcript file says about the worktree it belongs to.
+MINE, FOREIGN, UNKNOWN = "mine", "foreign", "unknown"
+
 
 def _encode(path: str) -> str:
-    """The harness's project-dir encoding of a cwd. Lossy — prefilter only."""
+    """The harness's project-dir encoding of a cwd. Lossy — prefilter only.
+
+    Lossy in ONE direction only: it maps each character to exactly one
+    character, so several cwds can share a dir name but a cwd can never
+    produce a name of a different length. That is what makes a project dir
+    name LONGER than `_encode(worktree)` provably not this worktree's.
+    """
     return "".join(c if c.isalnum() else "-" for c in path)
 
 
 def _scan(path: Path, worktree: str) -> tuple:
-    """(belongs_to_worktree, hit) for one transcript file, walking BACKWARD.
+    """(claim, hit) for one transcript file, walking BACKWARD.
 
     Backward is the point: the last explicit id wins, so an A->B->A switch
     resolves to the final A without ever consulting what came before it. A
     line that will not parse is skipped and the walk continues (spec doc 44:
     "malformed tail line -> skip backward to the last parseable record").
+
+    The claim is three-valued, and `unknown` is NOT `foreign`:
+
+      mine     a record carries `cwd == worktree`
+      foreign  a record carries a different `cwd` — the encoding collided
+      unknown  the file said nothing about its cwd: unreadable, or read in
+               full without a single `cwd` record. Every real transcript
+               opens with cwd-less lines (`queue-operation`, `ai-title`,
+               `mode`), so a session that has not reached its first user turn
+               is exactly this shape.
+
+    Answering `foreign` for an unreadable file is how an unreadable CURRENT
+    transcript fell through to an OLDER session of the same worktree and got
+    reported as the live model — a false `ok`, which is the one answer this
+    feature exists to never give.
     """
     try:
         lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError:
-        return False, None
+    except OSError as e:
+        note(HARNESS, f"unreadable transcript {path}: {type(e).__name__}: {e}")
+        return UNKNOWN, None
+    claim = UNKNOWN
     for line in reversed(lines):
         if not line.strip():
             continue
@@ -65,17 +95,19 @@ def _scan(path: Path, worktree: str) -> tuple:
         if not isinstance(rec, dict):
             continue
         cwd = rec.get("cwd")
-        if cwd and cwd != worktree:
-            return False, None  # another worktree's session — the encoding collided
+        if cwd:
+            if cwd != worktree:
+                return FOREIGN, None  # another worktree's session — encoding collided
+            claim = MINE
         if rec.get("type") != "assistant":
             continue
         model = (rec.get("message") or {}).get("model")
         if placeholder(model):
             continue
-        return True, {"model": model,
-                      "observed_at": norm_iso(rec.get("timestamp")),
-                      "source": str(path)}
-    return True, None
+        return claim, {"model": model,
+                       "observed_at": norm_iso(rec.get("timestamp")),
+                       "source": str(path)}
+    return claim, None
 
 
 def read(worktree) -> "dict | None":
@@ -87,15 +119,23 @@ def read(worktree) -> "dict | None":
     for proj in DATA_DIR.iterdir():
         if not (proj.is_dir() and proj.name.startswith(prefix)):
             continue
+        # Only a dir named EXACTLY this cwd's encoding can hold this cwd's
+        # sessions (see `_encode`) — so in a longer-named dir, a file that
+        # claims nothing claims nothing about US and is skipped rather than
+        # allowed to shadow the real session with `none`.
+        exact = proj.name == prefix
         for p in proj.glob("*.jsonl"):  # NON-recursive: subagents live below this
             try:
-                cands.append((p.stat().st_mtime, str(p), p))
-            except OSError:
+                cands.append((p.stat().st_mtime, str(p), p, exact))
+            except OSError as e:
+                note(HARNESS, f"unreadable transcript {p}: {type(e).__name__}: {e}")
                 continue
-    # Newest first; the first file that IS this worktree's is the current
-    # session, and its answer stands even when that answer is "nothing yet".
-    for _, _, path in sorted(cands, key=lambda c: (c[0], c[1]), reverse=True):
-        mine, hit = _scan(path, worktree)
-        if mine:
+    # Newest first; the first file that could be this worktree's current
+    # session is the answer, and its answer stands even when that answer is
+    # "nothing yet" — walking on past it reports a DEAD session's model as
+    # live, which is worse than reporting nothing.
+    for _, _, path, exact in sorted(cands, key=lambda c: (c[0], c[1]), reverse=True):
+        claim, hit = _scan(path, worktree)
+        if claim == MINE or (claim == UNKNOWN and exact):
             return hit
     return None

--- a/.super-coder/scripts/live_model/kimi.py
+++ b/.super-coder/scripts/live_model/kimi.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from . import iso_utc, placeholder
+from . import iso_utc, note, placeholder
 
 HARNESS = "kimi"
 DATA_DIR = Path.home() / ".kimi-code/sessions"
@@ -32,7 +32,8 @@ def _last_model(wire: Path) -> "dict | None":
     """The last `llm.request` on this wire carrying an explicit alias."""
     try:
         lines = wire.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError:
+    except OSError as e:
+        note(HARNESS, f"unreadable wire {wire}: {type(e).__name__}: {e}")
         return None
     for line in reversed(lines):
         if not line.strip():
@@ -62,14 +63,20 @@ def read(worktree) -> "dict | None":
         try:
             state = json.loads((sess / "state.json").read_text(
                 encoding="utf-8", errors="replace"))
-        except (OSError, json.JSONDecodeError, ValueError):
+        except OSError as e:
+            note(HARNESS, f"unreadable state {sess}: {type(e).__name__}: {e}")
             continue
+        except (json.JSONDecodeError, ValueError):
+            continue  # malformed, not unreadable — the spec's skip-and-walk-on
         if not isinstance(state, dict) or state.get("workDir") != worktree:
             continue
         wire = sess / "agents" / "main" / "wire.jsonl"  # main thread ONLY
         try:
             mtime = wire.stat().st_mtime
-        except OSError:
+        except FileNotFoundError:
+            continue  # a session with no main wire yet — nothing to report
+        except OSError as e:
+            note(HARNESS, f"unreadable wire {wire}: {type(e).__name__}: {e}")
             continue
         key = (mtime, str(sess))
         if best is None or key > best[0]:

--- a/.super-coder/scripts/live_model/opencode.py
+++ b/.super-coder/scripts/live_model/opencode.py
@@ -22,7 +22,7 @@ import os
 import sqlite3
 from pathlib import Path
 
-from . import iso_utc, placeholder
+from . import iso_utc, note, placeholder
 
 HARNESS = "opencode"
 DB = Path(os.environ.get("XDG_DATA_HOME") or Path.home() / ".local/share") / "opencode/opencode.db"
@@ -35,7 +35,8 @@ def read(worktree) -> "dict | None":
         return None
     try:
         con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
-    except sqlite3.Error:
+    except sqlite3.Error as e:
+        note(HARNESS, f"cannot open {db}: {type(e).__name__}: {e}")
         return None
     try:
         # The CURRENT session for this worktree — newest main-thread session,
@@ -54,7 +55,8 @@ def read(worktree) -> "dict | None":
             "AND json_extract(data,'$.role')='assistant' "
             "AND json_extract(data,'$.modelID') IS NOT NULL "
             "ORDER BY time_created DESC, id DESC LIMIT 1", (sess[0],)).fetchone()
-    except sqlite3.Error:
+    except sqlite3.Error as e:
+        note(HARNESS, f"cannot read {db}: {type(e).__name__}: {e}")
         return None
     finally:
         con.close()

--- a/tests/test_live_model.py
+++ b/tests/test_live_model.py
@@ -491,24 +491,54 @@ class Robustness(ProbeCase):
 class WorktreeIsolation(ProbeCase):
     """One shell's model must never be another's."""
 
+    # `_encode(CLAUDE_BACK)` is a PREFIX of all three, so a probe for
+    # CLAUDE_BACK scans their transcripts too.
+    NEIGHBOURS = (CLAUDE_AB, CLAUDE_SUB, CLAUDE_SINGLE)
+    ANSWERS = {CLAUDE_BACK: "claude-haiku-4-5-20251001",
+               CLAUDE_AB: "claude-sonnet-5",
+               CLAUDE_SUB: "claude-sonnet-5",
+               CLAUDE_SINGLE: "claude-haiku-4-5-20251001"}
+
+    def setUp(self):
+        super().setUp()
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.projects = self.tmp / "projects"
+        shutil.copytree(FIXTURES / "claude" / "projects", self.projects)
+        p_claude.DATA_DIR = self.projects
+
+    def assert_each_worktree_answers_for_itself(self):
+        for wt, model in self.ANSWERS.items():
+            r = self.probe("claude", wt)
+            self.assertEqual(r["last_model"], model, wt)
+            # ...and from its OWN project dir. Not redundant: two of these
+            # four worktrees answer the same model, so the source is the only
+            # thing that separates a right answer from a lucky one.
+            self.assertIn(p_claude._encode(wt) + "/",
+                          r["source"].replace("\\", "/"), wt)
+
     def test_claude_project_dir_prefix_collision_is_resolved_by_cwd(self):
         """`_encode` is lossy and `-tmp-lm-capture-claude` is a PREFIX of the
         -ab/-sub/-single fixture dirs, so the prefilter matches all four. Only
-        the per-record `cwd` separates them — and the newest file among them
-        belongs to a DIFFERENT worktree, so a probe that trusted mtime alone
-        would answer with its model."""
-        by_worktree = {wt: self.probe("claude", wt)["last_model"]
-                       for wt in (CLAUDE_BACK, CLAUDE_AB, CLAUDE_SUB,
-                                  CLAUDE_SINGLE)}
-        self.assertEqual(by_worktree[CLAUDE_AB], "claude-sonnet-5")
-        self.assertEqual(by_worktree[CLAUDE_SUB], "claude-sonnet-5")
-        self.assertEqual(by_worktree[CLAUDE_BACK], "claude-haiku-4-5-20251001")
-        self.assertEqual(by_worktree[CLAUDE_SINGLE],
-                         "claude-haiku-4-5-20251001")
-        # and each answer came from its OWN project dir
-        for wt in (CLAUDE_BACK, CLAUDE_AB, CLAUDE_SUB, CLAUDE_SINGLE):
-            src = self.probe("claude", wt)["source"]
-            self.assertIn(p_claude._encode(wt) + "/", src.replace("\\", "/"))
+        the per-record `cwd` separates them.
+
+        The mtimes have to be OWNED here, and were not: git records content,
+        never mtimes, so a fresh checkout stamps all four in the same instant,
+        and the (mtime, path) tie-break then puts CLAUDE_BACK's OWN file first
+        every time — `/` sorts above `-`. The scan reached the right answer
+        before ever consulting a foreign `cwd`, so deleting the guard this
+        test is named for left it green. Each neighbour now takes a turn at
+        being the newest file in the scan, which is the only arrangement in
+        which the guard does any work.
+        """
+        transcripts = {wt: sorted((self.projects / p_claude._encode(wt))
+                                  .glob("*.jsonl"))
+                       for wt in self.ANSWERS}
+        every = [p for paths in transcripts.values() for p in paths]
+        for neighbour in self.NEIGHBOURS:
+            with self.subTest(newest=neighbour):
+                _stamp_newest(transcripts[neighbour][0], every)
+                self.assert_each_worktree_answers_for_itself()
 
     def test_a_longer_project_dir_name_still_answers_when_the_records_say_so(self):
         """The prefix prefilter's whole reason for existing: the dir NAME is a
@@ -521,19 +551,15 @@ class WorktreeIsolation(ProbeCase):
         a dir name this host has not produced — the same category as the
         truncation and `time_updated` perturbations.
         """
-        tmp = Path(tempfile.mkdtemp())
-        self.addCleanup(shutil.rmtree, tmp, True)
-        src = FIXTURES / "claude" / "projects" / p_claude._encode(CLAUDE_TWO)
-        projects = tmp / "projects"
-        shutil.copytree(src, projects / src.name)
+        own = self.projects / p_claude._encode(CLAUDE_TWO)
         sessions = _claude_session_models(CLAUDE_TWO)
         moved, expected = sorted(sessions.items())[0]
-        odd = projects / (src.name + "-2")
+        odd = self.projects / (own.name + "-2")
         odd.mkdir()
-        shutil.move(str(projects / src.name / moved.name), odd / moved.name)
-        p_claude.DATA_DIR = projects
-        others = list((projects / src.name).glob("*.jsonl"))
+        shutil.move(str(own / moved.name), odd / moved.name)
+        others = list(own.glob("*.jsonl"))
         self.assertTrue(others, "the pair must not both move")
+        self.assertNotIn(expected, [sessions[p] for p in sessions if p != moved])
         _stamp_newest(odd / moved.name, [odd / moved.name, *others])
 
         r = self.probe("claude", CLAUDE_TWO)

--- a/tests/test_live_model.py
+++ b/tests/test_live_model.py
@@ -351,15 +351,27 @@ class Freshness(ProbeCase):
         self.assertEqual(r["verdict"], "ok")
 
     def test_the_same_instant_in_either_form_gets_the_same_verdict(self):
-        """The defect itself. One instant, one minute after the observation,
-        written the two ways the two sides of this comparison write it: the
-        verdict is a fact about time and must not depend on which."""
+        """The defect itself, and the boundary it sits on.
+
+        One instant, written the two ways the two sides of this comparison
+        write it: the verdict is a fact about time and must not depend on
+        which. Run at two shifts, because the pair only says everything at
+        both — +60s pins that `stale` can fire at all (SC-165), and 0 pins
+        WHERE it starts. `stale` means the session moved AFTER we observed it,
+        so activity at the very instant of the observation is not stale: the
+        comparison is `<`, and a `<=` survives every other test in this file
+        (REV2 L5). Same-second is the everyday case here — the observation and
+        the keystroke that produced it are one turn apart, not one minute.
+        """
         observed = self.observation()
-        verdicts = {fmt: self.probe("claude", CLAUDE_BACK,
-                                    active_since=_shift(observed, 60, fmt))
-                    ["verdict"] for fmt in (BROKER_TS, HARNESS_TS)}
-        self.assertEqual(verdicts[BROKER_TS], verdicts[HARNESS_TS], verdicts)
-        self.assertEqual(verdicts[BROKER_TS], "stale")
+        for shift, expected in ((60, "stale"), (0, "ok")):
+            verdicts = {fmt: self.probe("claude", CLAUDE_BACK,
+                                        active_since=_shift(observed, shift, fmt))
+                        ["verdict"] for fmt in (BROKER_TS, HARNESS_TS)}
+            with self.subTest(shift=shift):
+                self.assertEqual(verdicts[BROKER_TS], verdicts[HARNESS_TS],
+                                 verdicts)
+                self.assertEqual(verdicts[BROKER_TS], expected)
 
     def test_an_unreadable_active_since_asserts_no_freshness(self):
         """Absent and unparseable are the same answer — `ok` without a
@@ -498,6 +510,36 @@ class WorktreeIsolation(ProbeCase):
             src = self.probe("claude", wt)["source"]
             self.assertIn(p_claude._encode(wt) + "/", src.replace("\\", "/"))
 
+    def test_a_longer_project_dir_name_still_answers_when_the_records_say_so(self):
+        """The prefix prefilter's whole reason for existing: the dir NAME is a
+        hint, the per-record `cwd` is the fact.
+
+        A SILENT file in a longer-named dir is not ours — that dir cannot be
+        an encoding of our cwd, and `SilentTranscripts` pins it. But one whose
+        records name our cwd is ours wherever it sits, or the prefilter would
+        be matching dirs it can never act on. Real transcript bytes, placed in
+        a dir name this host has not produced — the same category as the
+        truncation and `time_updated` perturbations.
+        """
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        src = FIXTURES / "claude" / "projects" / p_claude._encode(CLAUDE_TWO)
+        projects = tmp / "projects"
+        shutil.copytree(src, projects / src.name)
+        sessions = _claude_session_models(CLAUDE_TWO)
+        moved, expected = sorted(sessions.items())[0]
+        odd = projects / (src.name + "-2")
+        odd.mkdir()
+        shutil.move(str(projects / src.name / moved.name), odd / moved.name)
+        p_claude.DATA_DIR = projects
+        others = list((projects / src.name).glob("*.jsonl"))
+        self.assertTrue(others, "the pair must not both move")
+        _stamp_newest(odd / moved.name, [odd / moved.name, *others])
+
+        r = self.probe("claude", CLAUDE_TWO)
+        self.assertEqual(r["last_model"], expected)
+        self.assertTrue(r["source"].startswith(str(odd)), r["source"])
+
     def test_kimi_and_opencode_separate_worktrees(self):
         self.assertNotEqual(self.probe("kimi", KIMI_AB)["last_model"],
                             self.probe("kimi", KIMI_BACK)["last_model"])
@@ -588,6 +630,164 @@ class CurrentSessionSelection(ProbeCase):
         self.assertGreaterEqual(len(answered), 2, opencode)
         self.assertIsNotNone(opencode[-1][1], opencode)
         self.assertNotIn(opencode[-1][1], answered[:-1], opencode)
+
+
+class SilentTranscripts(ProbeCase):
+    """A transcript that says nothing about the worktree it belongs to.
+
+    Two ways a real file goes silent: it cannot be read at all, or it was
+    written before its session's first user turn — every captured transcript
+    opens with cwd-less lines (`queue-operation`, `ai-title`, `mode`) and only
+    names its `cwd` when the operator first speaks, so a session caught in its
+    first seconds is exactly this shape, and a 5s rail poll is exactly what
+    catches it.
+
+    Silence is not evidence of ANOTHER worktree, and reading it as such is
+    what these tests exist to stop. Read as "not mine", a silent CURRENT
+    transcript hands the answer to the PREVIOUS session in the same project
+    dir and the probe reports a dead session's model as `ok` — the one
+    falsehood this feature can state (sprint 45 L1). Read as "mine", a silent
+    file in a NEIGHBOUR's project dir blanks an answer that was perfectly good
+    (L2). One fact decides both: `_encode` maps one character to one, so only
+    a dir named EXACTLY this cwd's encoding can hold this cwd's sessions.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.projects = self.tmp / "projects"
+        shutil.copytree(FIXTURES / "claude" / "projects", self.projects)
+        p_claude.DATA_DIR = self.projects
+
+    def dir_of(self, worktree):
+        return self.projects / p_claude._encode(worktree)
+
+    def two_sessions(self):
+        """The copied CLAUDE_TWO pair, {path: its own last model}.
+
+        Two REAL sessions of ONE worktree answering DIFFERENT models is the
+        premise the fall-through is visible through: with one session, or with
+        two that agree, the wrong answer and the right one are the same string.
+        """
+        models = {self.dir_of(CLAUDE_TWO) / path.name: model
+                  for path, model in _claude_session_models(CLAUDE_TWO).items()}
+        self.assertEqual(len(models), 2, models)
+        self.assertEqual(len(set(models.values())), 2, models)
+        return models
+
+    def test_an_unreadable_current_transcript_never_answers_with_an_older_one(self):
+        sessions = self.two_sessions()
+        current, previous = sorted(sessions)
+        _stamp_newest(current, list(sessions))
+        # Precondition, stated as an assertion: while the current transcript
+        # is readable the probe answers with ITS model, and the previous
+        # session — still on disk, still readable — answers a different one.
+        self.assertEqual(self.probe("claude", CLAUDE_TWO)["last_model"],
+                         sessions[current])
+        self.assertNotEqual(sessions[previous], sessions[current])
+
+        _unreadable(current)
+        _stamp_newest(current, list(sessions))  # unlink+mkdir reset the mtime
+        r = self.probe("claude", CLAUDE_TWO)
+        self.assertEqual(r["verdict"], "none", r)
+        self.assertIsNone(r["last_model"], r)
+        self.assertIsNone(r["live_model_at"], r)
+
+    def test_a_session_before_its_first_turn_answers_nothing_for_its_own_worktree(self):
+        """Same rule, the other silence: the CURRENT session has simply not
+        said anything yet. `none` is the honest answer — the previous
+        session's model is not what is running."""
+        sessions = self.two_sessions()
+        fresh = _pre_first_turn(self.dir_of(CLAUDE_TWO))
+        self.assertTrue(fresh.read_text(encoding="utf-8").strip(), "empty cut")
+        self.assertNotIn('"cwd"', fresh.read_text(encoding="utf-8"))
+        _stamp_newest(fresh, [fresh, *sessions])
+
+        r = self.probe("claude", CLAUDE_TWO)
+        self.assertEqual(r["verdict"], "none", r)
+        self.assertNotIn(r["last_model"], set(sessions.values()))
+
+    def test_a_session_before_its_first_turn_does_not_shadow_a_neighbour(self):
+        """And the direction that must NOT become `none`.
+
+        `-tmp-lm-capture-claude-ab` is longer than `-tmp-lm-capture-claude`,
+        so it cannot be an encoding of CLAUDE_BACK's cwd — a silent file there
+        is not CLAUDE_BACK's newest session however recently it was touched,
+        and CLAUDE_BACK's own answer stands.
+        """
+        expected = self.probe("claude", CLAUDE_BACK)["last_model"]
+        self.assertIsNotNone(expected)
+        fresh = _pre_first_turn(self.dir_of(CLAUDE_AB))
+        self.assertNotIn('"cwd"', fresh.read_text(encoding="utf-8"))
+        _stamp_newest(fresh, [fresh, *self.projects.glob("*/*.jsonl")])
+
+        r = self.probe("claude", CLAUDE_BACK)
+        self.assertEqual(r["last_model"], expected)
+        self.assertEqual(r["verdict"], "ok")
+        # ...and the same file does not leak into the worktree it IS next to
+        self.assertEqual(self.probe("claude", CLAUDE_AB)["verdict"], "none")
+
+
+class SwallowedFailuresAreLogged(ProbeCase):
+    """Spec doc 44: an unreadable transcript is `none`, LOGGED ONCE.
+
+    `_read`'s boundary logs what a harness module lets ESCAPE. These are the
+    failures each module handles itself — a permission change on one
+    transcript, a wire that is not a file, a database that will not open — and
+    which used to return `None` in silence, leaving the operator a blank badge
+    and stderr with nothing to say why. Once per message, not per 5s poll:
+    the rail would otherwise turn one bad file into a stderr flood.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    def claude_case(self):
+        proj = self.tmp / "projects" / p_claude._encode(CLAUDE_AB)
+        broken = proj / "broken.jsonl"
+        broken.mkdir(parents=True)
+        p_claude.DATA_DIR = self.tmp / "projects"
+        return CLAUDE_AB, broken
+
+    def kimi_case(self):
+        base = self.tmp / "sessions"
+        shutil.copytree(FIXTURES / "kimi" / "sessions", base)
+        wire = next(p for p in base.glob("wd_*/session_*/agents/main/wire.jsonl")
+                    if json.loads((p.parents[2] / "state.json").read_text(
+                        encoding="utf-8")).get("workDir") == KIMI_BACK)
+        wire.unlink()
+        wire.mkdir()
+        p_kimi.DATA_DIR = base
+        return KIMI_BACK, wire
+
+    def opencode_case(self):
+        db = self.tmp / "opencode.db"
+        db.mkdir()
+        p_opencode.DB = db
+        return OC_BACK, db
+
+    def test_a_read_failure_the_module_swallows_is_logged_once(self):
+        for harness, build in (("claude", self.claude_case),
+                               ("kimi", self.kimi_case),
+                               ("opencode", self.opencode_case)):
+            with self.subTest(harness=harness):
+                worktree, path = build()
+                seen = []
+                live_model.cache_clear()
+                first = live_model.probe(harness, worktree, log=seen.append)
+                # Expire the READING only — `cache_clear()` would also drop the
+                # log-once ledger, which is the thing under test.
+                live_model._cache.clear()
+                second = live_model.probe(harness, worktree, log=seen.append)
+
+                self.assertEqual(first["verdict"], "none", first)
+                self.assertEqual(second["verdict"], "none", second)
+                self.assertEqual(len(seen), 1, seen)
+                self.assertIn(harness, seen[0])
+                self.assertIn(str(path), seen[0])
 
 
 class Caching(ProbeCase):
@@ -698,6 +898,37 @@ def _stamp_newest(newest, paths, *, gap_s=600):
     base = 1_800_000_000
     for path in paths:
         os.utime(path, (base, base if path == newest else base - gap_s))
+
+
+def _unreadable(path):
+    """Put the path beyond reading, at any uid.
+
+    These run as uid 0 in the sandbox, where a mode-000 file is still
+    readable; a DIRECTORY where a transcript is expected raises the same
+    OSError family for the same reason — the path cannot be read as a file —
+    and does so for every user.
+    """
+    path.unlink()
+    path.mkdir()
+
+
+def _pre_first_turn(proj, name="0" * 8 + "-0000-0000-0000-" + "0" * 12 + ".jsonl"):
+    """A real transcript from `proj`, cut where its first `cwd` record starts.
+
+    A prefix of real bytes, not a hand-authored shape: this is the file as it
+    existed on disk in the seconds between the session opening and the
+    operator's first message, which is a state every captured session passed
+    through and none of them could be asked to hold still in.
+    """
+    src = sorted(proj.glob("*.jsonl"))[0]
+    kept = []
+    for line in src.read_text(encoding="utf-8", errors="replace").splitlines():
+        if json.loads(line).get("cwd"):
+            break
+        kept.append(line)
+    out = proj / name
+    out.write_text("\n".join(kept) + "\n", encoding="utf-8")
+    return out
 
 
 # ----------------------------------------------------------------- fixture readers


### PR DESCRIPTION
Sprint 45, unit 10 (44-cleanup) — the four follow-ups 44-U1's review left open, all inside the `live_model` probe. No API shape change, no `ifRailSig`, no `app.js`.

**L1 first, and it is the only one that could state a falsehood.** 43-U5 is about to render verdict-`ok` models on the rail badge, so the honest-label invariant — never claim live what is not — ships fixed with it, not after it.

## L1 — an unreadable current transcript answered with the previous session

`_scan` mapped `OSError` to "not this worktree's", so the walk stepped over the unreadable file and the NEXT candidate answered. Reproduced against the two-session fixture before changing anything:

```
newest readable        -> claude-haiku-4-5-20251001  verdict ok   (correct)
newest UNREADABLE      -> claude-sonnet-5            verdict ok   (the previous session, presented as live)
```

Now `none`.

## L2 — and the same collapse in the other direction

A session written before its first user turn carries no `cwd` at all: every captured transcript opens with cwd-less `queue-operation` / `ai-title` / `mode` lines and only names its cwd when the operator first speaks. Read as "mine", such a file in a *neighbour's* project dir blanked a good answer.

**Both are one rule.** `_scan` returns a three-valued claim — `mine` / `foreign` / `unknown` — and `unknown` is resolved by the one fact that settles it: `_encode` maps one character to one character, so a project dir named LONGER than `_encode(worktree)` cannot be an encoding of this cwd.

| where the silent file sits | answer | why |
|---|---|---|
| our own dir (name == encoding) | stop, `none` | it could be our current session; the previous one is not what is running |
| a longer-named dir | skip it | it provably cannot hold our sessions |

The safe direction is the tie-break throughout: `none` falls back to the launch label, a wrong `ok` does not.

## L3 — "logged once" was true of the boundary, not of the modules

Spec doc 44 asks for "unreadable transcript → `none`, logged once, never an exception". `_read`'s boundary covers what a module lets *escape*; the failures each module handled itself returned silently, so the operator got a blank badge and stderr said nothing. `note()` routes them through the existing log-once ledger and the caller's `probe(log=…)`, in all three probes (claude transcript + stat, kimi state + wire, opencode open + query). Kimi's `state.json` keeps its silent skip for *malformed* JSON — that is the spec's skip-and-walk-on, not a read failure — and a missing main wire stays silent for the same reason.

## L5 — the freshness boundary

`observed_at < active_since` survived mutation to `<=` on 44 green tests. Equality is the everyday case here: the observation and the keystroke that produced it are one turn apart, not one minute, and `<=` would silently flip those to `stale`. `test_the_same_instant_in_either_form_gets_the_same_verdict` now runs at shift 0 and +60, pinning where `stale` starts as well as that it can fire at all.

## Declared scope addition — a can't-fail test found by this unit's own mutations

Removing the `cwd != worktree` guard left `test_claude_project_dir_prefix_collision_is_resolved_by_cwd` — the test named for that guard — green.

Cause is the mtime hazard this file already documents one class down: git records content, never mtimes, so a fresh checkout stamps all four colliding fixture dirs in the same instant, and the `(mtime, path)` tie-break then puts `CLAUDE_BACK`'s own transcript first every time (`/` sorts above `-`). The scan reached the right answer before ever reading a foreign `cwd`. Deterministically vacuous, not flaky — never exercised on any checkout.

The test now owns the field it depends on: each neighbour takes a turn as the newest file in the scan. Fixed here rather than deferred because L1 and L2 lean on that branch harder than U1 did.

## Trade-off taken

The obvious alternative for L2 was tightening the prefilter to an exact dir-name match, which deletes the ambiguity outright. Rejected: the `startswith` prefilter is deliberate (the dir name is a hint, the per-record `cwd` is the fact), and an exact match would make the collision fixtures un-scannable and quietly retire the isolation coverage they exist for. A new test pins the direction that keeps the prefilter honest — a longer-named dir whose records DO name our cwd is still ours.

## Verification

- 49/49 in `tests/test_live_model.py`; **1390 passed, 384 subtests** across `tests/` (6m11s, via `sc job`).
- **12/12 mutation round trips red-then-green**, one per property rather than per test: L1 fall-through, L2 in both directions, `claim = MINE`, the foreign-cwd guard, the log-once call in each of the three probes, the ledger itself, the log wiring, and the boundary in both directions. Every leg ran with `PYTHONDONTWRITEBYTECODE=1` and `__pycache__` cleared, and the **baseline is asserted green after every revert** — flag #182's hazard, which produced two false readings in 44-U1.
- Rule 1: nothing has merged since this branch's base (`origin/main` is still `f72a68b`), so the intersection is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)