### PR TITLE
fix(interface): composer actions — Enter-only send, red End, +Chat (S45 U7)

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3293,10 +3293,6 @@ function ifPaintHeader(a, sel, pane) {
     actions.push(cert);
   }
   a.sessionActionsEl.replaceChildren(...actions);
-  if (a.composerEnd) {
-    a.composerEnd.hidden = !controlsActive;
-    a.composerEnd.disabled = !controlsActive;
-  }
   a.statusNoteEl.textContent = st.note;
 }
 
@@ -3392,10 +3388,18 @@ function ifPaintComposer(a) {
   a.composerInput.disabled = !writable || pending ||
     a.composerSubmitLatched ||
     (a.browserComposerSyncing && a.browserComposerWanted === "clean");
-  // Both actions terminate the session, so both are held for the whole
-  // duration of an End or a +Chat chain — the spec's double-activation guard.
-  if (a.composerEnd) a.composerEnd.disabled = a.composerActionsBusy;
-  if (a.composerNewChat) a.composerNewChat.disabled = a.composerActionsBusy;
+  // Both actions terminate the session, so both are gated the same way and
+  // from ONE place: an inactive lifecycle hides and disables them (nothing to
+  // end, and +Chat's own chain begins with an End), and a chain in flight
+  // holds them for its whole duration — the spec's double-activation guard.
+  // Splitting these two writers across header and composer paint is what let
+  // +Chat outlive the lifecycle gate the End button already respected.
+  const controlsActive = IF_ATTACHABLE_LIFECYCLES.has(a.st.lifecycle);
+  for (const button of [a.composerEnd, a.composerNewChat]) {
+    if (!button) continue;
+    button.hidden = !controlsActive;
+    button.disabled = !controlsActive || a.composerActionsBusy;
+  }
   // One note, sourced from the one table. A BLOCKED row is a live condition
   // and always explains itself; a QUEUED row only speaks once a submit is
   // actually latched (mid-typing draft sync is not a queued message).
@@ -3606,7 +3610,7 @@ function ifBuildComposer(a) {
     className: "act bad if-end-chat", type: "button", textContent: "End",
     title: "explicit, confirmed — graceful first; force unlocks only after a graceful timeout",
   });
-  end.onclick = () => ifEndChat(a, a.sel, a.pane, end);
+  end.onclick = () => ifEndChat(a, a.sel, a.pane);
   a.composerEnd = end;
   const fresh = el("button", {
     className: "act if-new-chat", type: "button", textContent: "+Chat",
@@ -3673,9 +3677,16 @@ async function ifTerminateSession(a, root) {
   return { kind: "failed", note: "not terminated: " + (r.reason || "?") };
 }
 
-async function ifEndChat(a, sel, pane, btn) {
+// End holds the SAME busy flag +Chat does, rather than disabling its own button
+// directly. Two reasons, both of which were live defects: a direct
+// `btn.disabled` is a second writer of state ifPaintComposer owns, so any
+// repaint mid-chain (a ws lifecycle frame is enough) re-enabled End; and +Chat
+// stayed clickable for the whole of an End, which is the double-activation the
+// guard exists to prevent — +Chat's chain opens with a termination of its own.
+async function ifEndChat(a, sel, pane) {
   if (!confirm(`End chat with ${sel.display_name || sel.shortname}? This terminates session #${a.sessionId}.`)) return;
-  if (btn) btn.disabled = true;
+  a.composerActionsBusy = true;
+  a.paint();
   const root = pane.closest(".view");
   const out = await ifTerminateSession(a, root);
   if (out.kind === "recovery") return;      // already on the recovery pane
@@ -3684,7 +3695,10 @@ async function ifEndChat(a, sel, pane, btn) {
     if (root) renderInterface(root);
     return;
   }
+  // The only leg that stays on this pane, so the only one that must release:
+  // recovery and terminated have both re-rendered it away.
   a.st.note = out.note;
+  a.composerActionsBusy = false;
   a.paint();
 }
 

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3124,6 +3124,10 @@ async function ifSessionPane(pane, sel) {
   const st = {
     harness: sess.harness || sel.harness || "—",
     modelRoute: sess.model_route || null,    // the route it was LAUNCHED with
+    // The third leg of the launch TRIPLE, for +Chat to reuse verbatim. NULL is
+    // a real value here (pre-migration rows, and launches that named no
+    // effort) and must stay NULL: it means "harness default", not "unknown".
+    launchEffort: sess.launch_effort ?? null,
     lifecycle: sess.lifecycle || "—",
     composer: sess.composer || "unknown",
     browserComposer: sess.browser_composer || "clean",
@@ -3164,8 +3168,8 @@ async function ifSessionPane(pane, sel) {
     ws: null, term: null, leaseId: null, leaseToken: null, role: "viewer",
     seq: 1, inflight: 0, lastAck: 0, outBuf: "", awaiting: false, halted: false,
     heartbeat: 0, resizeObs: null, paint: null,
-    composerInput: null, composerSend: null, composerEnd: null,
-    composerNote: null,
+    composerInput: null, composerEnd: null, composerNewChat: null,
+    composerNote: null, composerActionsBusy: false,
     composerPendingSeq: null, composerPendingText: null,
     browserComposerState: st.browserComposer,
     browserComposerWanted: st.browserComposer, browserComposerError: "",
@@ -3379,7 +3383,6 @@ function ifPaintComposer(a) {
   if (!a.composerInput) return;
   const writable = ifComposerWritable(a);
   const pending = a.composerPendingSeq != null;
-  const hasMessage = Boolean(a.composerInput.value.trim());
   // Do not let a new draft appear while a clean transition is in flight:
   // that would briefly project clean server-side while the box is non-empty.
   // Dirty transitions normally need not freeze typing because every later
@@ -3389,12 +3392,10 @@ function ifPaintComposer(a) {
   a.composerInput.disabled = !writable || pending ||
     a.composerSubmitLatched ||
     (a.browserComposerSyncing && a.browserComposerWanted === "clean");
-  const dirtyReady = a.browserComposerState === "dirty";
-  const dirtySyncing = a.browserComposerSyncing &&
-    a.browserComposerWanted === "dirty";
-  a.composerSend.disabled = !writable || pending || a.awaiting ||
-    Boolean(a.outBuf) || !hasMessage || Boolean(a.browserComposerError) ||
-    (!dirtyReady && !dirtySyncing);
+  // Both actions terminate the session, so both are held for the whole
+  // duration of an End or a +Chat chain — the spec's double-activation guard.
+  if (a.composerEnd) a.composerEnd.disabled = a.composerActionsBusy;
+  if (a.composerNewChat) a.composerNewChat.disabled = a.composerActionsBusy;
   // One note, sourced from the one table. A BLOCKED row is a live condition
   // and always explains itself; a QUEUED row only speaks once a submit is
   // actually latched (mid-typing draft sync is not a queued message).
@@ -3574,18 +3575,21 @@ async function ifMintTitle(a, text) {
   } catch { /* cosmetic — retried by the next send while the title is unset */ }
 }
 
+// The Send button is deliberately absent (U7): Enter already submits, and U2's
+// note is the ONE state surface. The hint below is STATIC for that reason — a
+// hint that tracked gate state would be a second surface disagreeing with the
+// note, which is the defect U2 existed to delete. Shift+Enter still newlines.
 function ifBuildComposer(a) {
   const input = el("textarea", {
     className: "if-composer-input", rows: 1,
     placeholder: "Message this session…",
     ariaLabel: "Message composer",
   });
-  const send = el("button", {
-    className: "act primary", type: "button", textContent: "Send",
+  const hint = el("div", {
+    className: "if-composer-hint", textContent: "enter to send",
   });
   const note = el("div", { className: "if-note" });
   a.composerInput = input;
-  a.composerSend = send;
   a.composerNote = note;
   input.oninput = () => {
     ifSizeComposer(input);
@@ -3598,15 +3602,20 @@ function ifBuildComposer(a) {
     event.preventDefault();
     ifComposerSend(a);
   };
-  send.onclick = () => ifComposerSend(a);
   const end = el("button", {
-    className: "act bad if-end-chat", type: "button", textContent: "End chat",
+    className: "act bad if-end-chat", type: "button", textContent: "End",
     title: "explicit, confirmed — graceful first; force unlocks only after a graceful timeout",
   });
   end.onclick = () => ifEndChat(a, a.sel, a.pane, end);
   a.composerEnd = end;
-  const actions = el("div", { className: "if-composer-actions" }, send, end);
-  a.composerEl.append(input, actions, note);
+  const fresh = el("button", {
+    className: "act if-new-chat", type: "button", textContent: "+Chat",
+    title: "end this chat and start a fresh one on the same shell, same harness · model · effort",
+  });
+  fresh.onclick = () => ifNewChatSameRoute(a, a.sel, a.pane);
+  a.composerNewChat = fresh;
+  const actions = el("div", { className: "if-composer-actions" }, end, fresh);
+  a.composerEl.append(input, actions, hint, note);
   ifSizeComposer(input);
 }
 
@@ -3616,10 +3625,18 @@ function ifBuildComposer(a) {
 // prompt names the exact PID/generation from its response. The shell returns
 // to available only when the API says terminated; identity_mismatch fails
 // closed into unreconciled/lost, so we re-render onto the recovery pane.
-async function ifEndChat(a, sel, pane, btn) {
-  if (!confirm(`End chat with ${sel.display_name || sel.shortname}? This terminates session #${a.sessionId}.`)) return;
-  if (btn) btn.disabled = true;
-  const root = pane.closest(".view");
+// The graceful-first sequence itself, shared by End and +Chat. It is factored
+// out rather than copied because the spec's requirement for +Chat is that it
+// "lands on the recovery pane exactly as End does" — one path makes that true
+// by construction, where two copies would only be true until they drifted.
+// Returns exactly one outcome, and RECOVERY IS TERMINAL: the caller is told
+// only that the chain must stop, never given a reason to continue.
+//
+//   terminated — the session is down; a caller may proceed
+//   recovery   — recovery-shaped; already re-rendered, caller must NOT proceed
+//   declined   — the operator declined the force kill
+//   failed     — anything else; `note` is the operator-facing text
+async function ifTerminateSession(a, root) {
   let r;
   try { r = await apiIf("/interface/termination-requests", "POST", { session_id: a.sessionId, force: false }); }
   catch (e) {
@@ -3634,29 +3651,113 @@ async function ifEndChat(a, sel, pane, btn) {
       // the server-authorized recovery preview instead of retaining a false
       // occupied attachment and an inert End-chat error.
       ifDetach();
-      if (root) return renderInterface(root);
-      return;
+      if (root) await renderInterface(root);
+      return { kind: "recovery" };
     }
     if (e.status === 409 && reason) r = e.body;
-    else { a.st.note = "end chat failed: " + e.message; a.paint(); return; }
+    else return { kind: "failed", note: "end chat failed: " + e.message };
   }
   if (!r.terminated && r.reason === "identity_mismatch") {
-    if (root) return renderInterface(root);
-    return;
+    if (root) await renderInterface(root);
+    return { kind: "recovery" };
   }
   if (!r.terminated && r.reason === "graceful_timeout") {
     if (!confirm(`Graceful stop timed out. Force-kill PID ${r.pid} (generation ${r.generation})?`)) {
-      a.st.note = "graceful stop timed out — End chat again to retry, or confirm the force kill.";
-      a.paint();
-      return;
+      return { kind: "declined",
+               note: "graceful stop timed out — End again to retry, or confirm the force kill." };
     }
     try { r = await apiIf("/interface/termination-requests", "POST", { session_id: a.sessionId, force: true }); }
-    catch (e) { a.st.note = "force kill failed: " + e.message; a.paint(); return; }
+    catch (e) { return { kind: "failed", note: "force kill failed: " + e.message }; }
   }
-  if (r.terminated) {
+  if (r.terminated) return { kind: "terminated" };
+  return { kind: "failed", note: "not terminated: " + (r.reason || "?") };
+}
+
+async function ifEndChat(a, sel, pane, btn) {
+  if (!confirm(`End chat with ${sel.display_name || sel.shortname}? This terminates session #${a.sessionId}.`)) return;
+  if (btn) btn.disabled = true;
+  const root = pane.closest(".view");
+  const out = await ifTerminateSession(a, root);
+  if (out.kind === "recovery") return;      // already on the recovery pane
+  if (out.kind === "terminated") {
     ifDetach();
     if (root) renderInterface(root);
-  } else { a.st.note = "not terminated: " + (r.reason || "?"); a.paint(); }
+    return;
+  }
+  a.st.note = out.note;
+  a.paint();
+}
+
+// +Chat: end this chat and start a fresh one on the SAME shell with the SAME
+// LAUNCH TRIPLE — harness, model route, effort — reused verbatim from the
+// session being ended, NULLs included (a harness-default launch relaunches as
+// harness default). Deliberately the LAUNCH route and not the live model, per
+// decision #55: the engine relaunches only what it can truthfully claim.
+//
+// FAIL-CLOSED is this chain's load-bearing property. A new session is started
+// on exactly one condition — an explicit `terminated` from the shared
+// termination path. Recovery-shaped, declined and failed outcomes all stop,
+// because auto-starting over an unreconciled shell is precisely the thing this
+// must never do; that is why the start POST hangs off a single equality test
+// and not off "no error so far".
+async function ifNewChatSameRoute(a, sel, pane) {
+  // Read the triple BEFORE anything can re-render `a` out from under us.
+  const harness = a.st.harness;
+  const model = a.st.modelRoute;
+  const effort = a.st.launchEffort;
+  if (!confirm(`End session #${a.sessionId} and start a new chat with ` +
+               `${harness} · ${ifModelLabel(model)}? ` +
+               "Any unsent draft is discarded.")) return;
+  a.composerActionsBusy = true;
+  a.paint();
+  const root = pane.closest(".view");
+  const out = await ifTerminateSession(a, root);
+  if (out.kind !== "terminated") {
+    if (out.kind !== "recovery") a.st.note = out.note;
+    a.composerActionsBusy = false;
+    a.paint();
+    return;
+  }
+  ifDetach();
+  const body = { shell_id: sel.shell_id };
+  // NULLs are omitted, not sent as null: an absent field is how the API spells
+  // "harness default", which is what a NULL launch leg meant in the first place.
+  if (harness && harness !== "—") body.harness = harness;
+  if (model) body.model = model;
+  if (effort) body.effort = effort;
+  // One retry, and only for the occupancy race the spec names: the shell we
+  // just emptied can still read as occupied for a moment. Every other failure
+  // is surfaced as the server phrased it and the shell is left to the normal
+  // New-chat path — never retried, never downgraded to a different launch.
+  //
+  // The bound is TWO STATEMENTS rather than a loop, deliberately. A loop is the
+  // shape that lets "retry once" drift, and a retry loop whose guard is later
+  // widened does not merely misbehave — it spins the tab forever against a
+  // shell that stays occupied. (That is not hypothetical: the first draft of
+  // this was a loop, and the mutation that widened its guard hung the suite
+  // instead of failing it.) Written this way, unbounded retry is not
+  // expressible, so it needs no test to stay impossible.
+  let failure = await ifStartSession(body);
+  if (failure && failure.status === 409 && failure.code === "shell_occupied") {
+    await new Promise((done) => setTimeout(done, 2000));
+    failure = await ifStartSession(body);
+  }
+  if (failure)
+    toast("new chat not started — " +
+          (failure.code ? failure.code + ": " : "") + failure.message);
+  // 201 → the starting pane; 202 (ambiguous spawn) → the server projects the
+  // recovery pane; a failure → the available pane's normal New-chat path. All
+  // three are the same re-render, exactly as New chat does it.
+  if (root) await renderInterface(root);
+}
+
+// The start POST with its error returned rather than thrown, so the caller's
+// retry bound can read as two statements instead of a loop.
+async function ifStartSession(body) {
+  try {
+    await apiIf("/interface/sessions", "POST", body);
+    return null;
+  } catch (e) { return e; }
 }
 
 // Take-over: fresh lease with takeover:true (new idempotency key — different

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -797,6 +797,14 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   color: #ef7777; border-color: #a74444; background: rgba(167,68,68,.08);
 }
 .if-composer .if-end-chat:hover { border-color: #ef7777; }
+/* Static submit hint: Enter is the sole submit affordance, so the composer must
+   say so somewhere. Dim and small on purpose — it is a label, not a status. The
+   note below it owns every gate state (U2), and two surfaces that can disagree
+   is the defect that contract exists to prevent. */
+.if-composer .if-composer-hint {
+  grid-column: 1; justify-self: end; align-self: center;
+  color: var(--dim); font-size: .72rem;
+}
 .if-composer .if-note { grid-column: 1 / -1; min-height: 1.2em; }
 .if-newchat .act { margin-top: .8rem; }
 .if-newchat .muted { margin-top: .5rem; }

--- a/tests/mutations/u7_composer_actions.py
+++ b/tests/mutations/u7_composer_actions.py
@@ -23,6 +23,7 @@ Exit 0 = every mutation reproduced red->revert->green.
 from __future__ import annotations
 
 import argparse
+import signal
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -254,12 +255,57 @@ MUTATIONS = [
         new="  const actions = el(\"div\", { className: \"if-composer-actions\" }, end);",
     ),
     # ── Double activation ────────────────────────────────────────────────────
+    # Both chains raise the same guard, so the anchors carry the confirm line
+    # above them: a bare `composerActionsBusy = true` now matches twice, and the
+    # driver's exactly-one-anchor check would (correctly) call itself stale.
     Mutation(
         name="actions-not-disabled-during-chain",
-        property="both actions are held for the chain's whole duration",
+        property="both actions are held for the +Chat chain's whole duration",
         path=APP,
-        old="  a.composerActionsBusy = true;\n  a.paint();",
-        new="  a.paint();",
+        old='               "Any unsent draft is discarded.")) return;\n'
+            "  a.composerActionsBusy = true;\n  a.paint();",
+        new='               "Any unsent draft is discarded.")) return;\n'
+            "  a.paint();",
+    ),
+    Mutation(
+        name="end-chain-leaves-new-chat-clickable",
+        property="End raises the same guard, so +Chat cannot fire underneath it",
+        path=APP,
+        old="This terminates session #${a.sessionId}.`)) return;\n"
+            "  a.composerActionsBusy = true;\n  a.paint();",
+        new="This terminates session #${a.sessionId}.`)) return;\n"
+            "  a.paint();",
+    ),
+    Mutation(
+        name="failed-end-never-releases-the-guard",
+        property="the one leg that stays on the pane releases both actions",
+        path=APP,
+        old="  a.st.note = out.note;\n  a.composerActionsBusy = false;\n  a.paint();\n}",
+        new="  a.st.note = out.note;\n  a.paint();\n}",
+    ),
+    # ── The lifecycle gate both actions obey (SC-167, flag #184) ─────────────
+    # The defect was the gate applying to End alone, so it is mutated per half:
+    # dropping either one, or the button it reaches, has to redden on its own.
+    Mutation(
+        name="new-chat-escapes-the-lifecycle-gate",
+        property="+Chat is gated by the lifecycle exactly as End is",
+        path=APP,
+        old="  for (const button of [a.composerEnd, a.composerNewChat]) {",
+        new="  for (const button of [a.composerEnd]) {",
+    ),
+    Mutation(
+        name="terminated-pane-still-offers-its-actions",
+        property="an inactive lifecycle hides both actions",
+        path=APP,
+        old="    button.hidden = !controlsActive;",
+        new="    button.hidden = false;",
+    ),
+    Mutation(
+        name="busy-flag-never-reaches-the-buttons",
+        property="paint applies the busy flag, not just the chain that sets it",
+        path=APP,
+        old="    button.disabled = !controlsActive || a.composerActionsBusy;",
+        new="    button.disabled = !controlsActive;",
     ),
     # ── End's own contract, which U7 must not disturb ────────────────────────
     Mutation(
@@ -310,7 +356,16 @@ def apply(mutation: Mutation) -> str:
     return original
 
 
+# Ctrl-C already unwinds through the revert; SIGTERM did not, and killing the
+# driver from an outer timeout left app.js MUTATED in the worktree — which then
+# reads as a source-level defect rather than as an interrupted run. Turning the
+# signal into an exception makes the `finally` that reverts actually run.
+def _die(signum, frame):
+    raise SystemExit(f"interrupted by signal {signum}")
+
+
 def main() -> int:
+    signal.signal(signal.SIGTERM, _die)
     parser = argparse.ArgumentParser()
     parser.add_argument("--list", action="store_true")
     parser.add_argument("--only", default=None,
@@ -344,6 +399,8 @@ def main() -> int:
                   end="", flush=True)
         finally:
             m.path.write_text(original)     # restored even on Ctrl-C / SIGTERM
+                                            # (see _die, which makes SIGTERM
+                                            #  unwind rather than kill)
         green, _ = run_suites()
         print("-> revert -> " + ("green" if green else "STILL RED"))
         # A hang is not an acceptable red: the suite never demonstrated the

--- a/tests/mutations/u7_composer_actions.py
+++ b/tests/mutations/u7_composer_actions.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Mutation driver for spec #43 U7 (composer actions).
+
+Acceptance for U7 names one mutation explicitly — "make the identity_mismatch
+branch fall through to the start POST -> the fail-closed test goes red" — but a
+single round trip only pins a single branch, and the unit's value is that the
++Chat chain is fail-closed on EVERY recovery-shaped outcome. So each mutation
+below breaks one property in the real source, runs the suites, and demands red;
+the driver then reverts and demands green again. A mutation that stays GREEN is
+a finding about the test, not a success.
+
+This lives in the repo on purpose. U2's acceptance evidence was run from an
+untracked scratch directory and died with the worktree (REV1's Low L3 on
+PR #596), so the round trips were unreproducible the moment the session ended.
+
+Usage:
+    python3 tests/mutations/u7_composer_actions.py          # all mutations
+    python3 tests/mutations/u7_composer_actions.py --list
+
+Exit 0 = every mutation reproduced red->revert->green.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / ".super-coder" / "ui" / "app.js"
+CSS = ROOT / ".super-coder" / "ui" / "style.css"
+
+SUITES = [
+    "tests/test_interface_composer_actions.py",
+    "tests/test_interface_composer_contract.py",
+    "tests/test_interface_ui_contract.py",
+    # The rendered suite is in the gate because two of U7's properties have no
+    # other witness: that the launch triple is READ from the session payload,
+    # and that the hint's CSS hook matches the markup. It SKIPS when Playwright
+    # or its browser is absent (flag #169 — the sandbox image ships a browser
+    # layout this Playwright cannot find), and a skip is silently green, so run
+    # it with a working browser before trusting those two round trips.
+    "tests/test_interface_ui_rendered.py",
+]
+
+
+@dataclass
+class Mutation:
+    name: str
+    property: str
+    path: Path
+    old: str
+    new: str
+
+
+MUTATIONS = [
+    # ── The spec's named mutation ────────────────────────────────────────────
+    Mutation(
+        name="identity-mismatch-falls-through",
+        property="fail-closed: identity_mismatch must not reach the start POST",
+        path=APP,
+        old="""  if (!r.terminated && r.reason === "identity_mismatch") {
+    if (root) await renderInterface(root);
+    return { kind: "recovery" };
+  }""",
+        new="""  if (!r.terminated && r.reason === "identity_mismatch") {
+    if (root) await renderInterface(root);
+    return { kind: "terminated" };
+  }""",
+    ),
+    # ── The other fail-closed legs, same property, different branch ──────────
+    Mutation(
+        name="thrown-recovery-409-falls-through",
+        property="fail-closed: not_occupied / identity_unverified / not_running",
+        path=APP,
+        old="""      ifDetach();
+      if (root) await renderInterface(root);
+      return { kind: "recovery" };""",
+        new="""      ifDetach();
+      if (root) await renderInterface(root);
+      return { kind: "terminated" };""",
+    ),
+    Mutation(
+        name="declined-force-falls-through",
+        property="fail-closed: a declined force kill starts nothing",
+        path=APP,
+        old="""      return { kind: "declined",
+               note: "graceful stop timed out — End again to retry, or confirm the force kill." };""",
+        new="""      return { kind: "terminated" };""",
+    ),
+    Mutation(
+        name="start-gated-on-absence-of-error",
+        property=(
+            "fail-closed is an EQUALITY test on terminated, not "
+            '"nothing went wrong so far"'
+        ),
+        path=APP,
+        old='  if (out.kind !== "terminated") {\n    if (out.kind !== "recovery") a.st.note = out.note;',
+        new='  if (out.kind === "failed") {\n    a.st.note = out.note;',
+    ),
+    # ── The launch triple, reused verbatim ───────────────────────────────────
+    Mutation(
+        name="effort-dropped-from-relaunch",
+        property="the effort leg of the launch triple survives +Chat",
+        path=APP,
+        old="  if (effort) body.effort = effort;",
+        new="  if (false) body.effort = effort;",
+    ),
+    Mutation(
+        name="model-dropped-from-relaunch",
+        property="the model-route leg of the launch triple survives +Chat",
+        path=APP,
+        old="  if (model) body.model = model;",
+        new="  if (false) body.model = model;",
+    ),
+    Mutation(
+        name="null-effort-sent-as-null",
+        property='a NULL leg is OMITTED, not sent as null ("harness default")',
+        path=APP,
+        old="  if (effort) body.effort = effort;",
+        new="  body.effort = effort ?? null;",
+    ),
+    # Only the RENDERED suite witnesses this one: the node-driven chain tests
+    # set st.launchEffort themselves, so they pin what the chain does with the
+    # triple but not that it is read from the session payload at all. This
+    # mutation was GREEN until the rendered relaunch test was added.
+    Mutation(
+        name="launch-effort-not-read-from-session",
+        property="+Chat reads effort from the session payload, not from nowhere",
+        path=APP,
+        old="    launchEffort: sess.launch_effort ?? null,",
+        new="    launchEffort: null,",
+    ),
+    # ── The bounded retry ────────────────────────────────────────────────────
+    # There is deliberately NO "retry is unbounded" mutation here. The first
+    # draft of the start leg was a retry loop, and widening its guard made this
+    # driver HANG rather than go red — a suite that spins forever demonstrates
+    # nothing. The loop was replaced with two straight-line attempts, which
+    # makes unbounded retry unexpressible instead of merely untested. The
+    # timeout in run_suites() remains as the backstop for that whole class.
+    Mutation(
+        name="occupancy-retry-absent",
+        property="the occupancy race IS retried once (the race is real)",
+        path=APP,
+        old='  if (failure && failure.status === 409 && failure.code === "shell_occupied") {',
+        new="  if (false) {",
+    ),
+    Mutation(
+        name="422-retried-like-a-race",
+        property="only shell_occupied is retried; a 422 route error is not",
+        path=APP,
+        old='  if (failure && failure.status === 409 && failure.code === "shell_occupied") {',
+        new="  if (failure) {",
+    ),
+    # Required by the planner's ratification of the 422 judgement call (task
+    # #1800): the unavailable-route leg must not fall through to a
+    # default-route start. This is the silent-substitution failure — the launch
+    # triple is the unit's invariant, so relaunching on a DIFFERENT route is
+    # worse than refusing, and a test that only checked "did not crash" would
+    # miss it entirely.
+    Mutation(
+        name="422-falls-through-to-default-route-start",
+        property="an unavailable route is refused, never downgraded and started",
+        path=APP,
+        old="  if (failure)\n"
+            '    toast("new chat not started — " +\n'
+            '          (failure.code ? failure.code + ": " : "") + failure.message);',
+        new="  if (failure) {\n"
+            "    delete body.model;\n"
+            "    delete body.effort;\n"
+            "    failure = await ifStartSession(body);\n"
+            "  }",
+    ),
+    Mutation(
+        name="retry-wait-dropped",
+        property="the retry waits 2s rather than hammering the occupancy flip",
+        path=APP,
+        old="    await new Promise((done) => setTimeout(done, 2000));",
+        new="    await new Promise((done) => setTimeout(done, 0));",
+    ),
+    Mutation(
+        name="server-message-swallowed",
+        property="an exhausted start surfaces the server's own words",
+        path=APP,
+        old='    toast("new chat not started — " +\n'
+            '          (failure.code ? failure.code + ": " : "") + failure.message);',
+        new='    toast("new chat not started");',
+    ),
+    Mutation(
+        name="start-failure-reported-as-success",
+        property="a failed start is never silently treated as a new chat",
+        path=APP,
+        old="async function ifStartSession(body) {\n"
+            "  try {\n"
+            '    await apiIf("/interface/sessions", "POST", body);\n'
+            "    return null;\n"
+            "  } catch (e) { return e; }\n"
+            "}",
+        new="async function ifStartSession(body) {\n"
+            '  try { await apiIf("/interface/sessions", "POST", body); } catch { /* ignored */ }\n'
+            "  return null;\n"
+            "}",
+    ),
+    # ── The composer's action row ─────────────────────────────────────────────
+    Mutation(
+        name="send-button-restored",
+        property="Enter is the SOLE submit affordance",
+        path=APP,
+        old='  const actions = el("div", { className: "if-composer-actions" }, end, fresh);',
+        new='  const actions = el("div", { className: "if-composer-actions" },\n'
+            '    el("button", { className: "act primary", type: "button",'
+            ' textContent: "Send" }), end, fresh);',
+    ),
+    Mutation(
+        name="hint-absent",
+        property="the static 'enter to send' hint renders",
+        path=APP,
+        old='  a.composerEl.append(input, actions, hint, note);',
+        new='  a.composerEl.append(input, actions, note);',
+    ),
+    Mutation(
+        name="hint-tracks-gate-state",
+        property=(
+            "the hint is STATIC — U2's note is the single state surface, so a "
+            "hint that moves with gate state can contradict it"
+        ),
+        path=APP,
+        old="  const row = ifComposerGate(a);\n  let text = \"\";",
+        new="  const row = ifComposerGate(a);\n"
+            "  a.composerEl.children[2].textContent = row.outcome === \"BLOCKED\"\n"
+            "    ? \"cannot send\" : \"enter to send\";\n  let text = \"\";",
+    ),
+    Mutation(
+        name="end-label-reverted",
+        property='End reads "End", not "End chat"',
+        path=APP,
+        old='className: "act bad if-end-chat", type: "button", textContent: "End",',
+        new='className: "act bad if-end-chat", type: "button", textContent: "End chat",',
+    ),
+    Mutation(
+        name="end-leaves-the-red-family",
+        property="End keeps the red act-bad styling family",
+        path=APP,
+        old='className: "act bad if-end-chat", type: "button", textContent: "End",',
+        new='className: "act", type: "button", textContent: "End",',
+    ),
+    Mutation(
+        name="new-chat-button-absent",
+        property="+Chat exists on the occupied composer",
+        path=APP,
+        old="  const actions = el(\"div\", { className: \"if-composer-actions\" }, end, fresh);",
+        new="  const actions = el(\"div\", { className: \"if-composer-actions\" }, end);",
+    ),
+    # ── Double activation ────────────────────────────────────────────────────
+    Mutation(
+        name="actions-not-disabled-during-chain",
+        property="both actions are held for the chain's whole duration",
+        path=APP,
+        old="  a.composerActionsBusy = true;\n  a.paint();",
+        new="  a.paint();",
+    ),
+    # ── End's own contract, which U7 must not disturb ────────────────────────
+    Mutation(
+        name="end-swallows-unrelated-failure",
+        property="End reports a non-recovery failure instead of going quiet",
+        path=APP,
+        old='    else return { kind: "failed", note: "end chat failed: " + e.message };',
+        new='    else return { kind: "recovery" };',
+    ),
+    # ── The hint's CSS hook, which the rendered suite reads ──────────────────
+    Mutation(
+        name="hint-css-hook-renamed",
+        property="the hint's class is the one the rendered suite locates",
+        path=CSS,
+        old=".if-composer .if-composer-hint {",
+        new=".if-composer .if-composer-hint-x {",
+    ),
+]
+
+
+# The suites run in ~2s. The timeout exists because a mutation can HANG rather
+# than fail — widening the old retry loop's guard spun node forever instead of
+# reddening — and an un-timed driver then hangs with the source still mutated.
+SUITE_TIMEOUT_S = 120
+
+
+def run_suites() -> tuple[bool, bool]:
+    """(passed, timed_out). A timeout is a failure: a suite that cannot finish
+    has not demonstrated the property."""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", *SUITES],
+            cwd=ROOT, capture_output=True, text=True, check=False,
+            timeout=SUITE_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        return False, True
+    return result.returncode == 0, False
+
+
+def apply(mutation: Mutation) -> str:
+    original = mutation.path.read_text()
+    count = original.count(mutation.old)
+    if count != 1:
+        raise SystemExit(
+            f"{mutation.name}: anchor matched {count} times in "
+            f"{mutation.path.name}, expected exactly 1 — the driver is stale")
+    mutation.path.write_text(original.replace(mutation.old, mutation.new))
+    return original
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--list", action="store_true")
+    parser.add_argument("--only", default=None,
+                        help="run one mutation by name")
+    args = parser.parse_args()
+
+    selected = [m for m in MUTATIONS
+                if args.only is None or m.name == args.only]
+    if args.list:
+        for m in selected:
+            print(f"{m.name:38s} {m.property}")
+        return 0
+    if not selected:
+        raise SystemExit(f"no mutation named {args.only!r}")
+
+    print("baseline: ", end="", flush=True)
+    passed, timed_out = run_suites()
+    if not passed:
+        print("TIMED OUT" if timed_out else "RED", "— fix the tree before mutating")
+        return 1
+    print("green")
+
+    failures = []
+    for m in selected:
+        print(f"{m.name:38s} ", end="", flush=True)
+        original = apply(m)
+        try:
+            passed, timed_out = run_suites()
+            red = not passed
+            print("hung " if timed_out else ("red " if red else "GREEN "),
+                  end="", flush=True)
+        finally:
+            m.path.write_text(original)     # restored even on Ctrl-C / SIGTERM
+        green, _ = run_suites()
+        print("-> revert -> " + ("green" if green else "STILL RED"))
+        # A hang is not an acceptable red: the suite never demonstrated the
+        # property, it merely failed to answer.
+        if not (red and green) or timed_out:
+            failures.append((m, "hung" if timed_out else "did not round-trip"))
+
+    print()
+    if failures:
+        print(f"{len(failures)} of {len(selected)} mutations FAILED:")
+        for m, why in failures:
+            print(f"  - {m.name} ({why}): {m.property}")
+        return 1
+    print(f"{len(selected)}/{len(selected)} mutations red -> revert -> green")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_interface_composer_actions.py
+++ b/tests/test_interface_composer_actions.py
@@ -25,6 +25,10 @@ ROOT = Path(__file__).resolve().parents[1]
 APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
 
 EL = APP[APP.index("const el ="):APP.index("const esc =")]
+# Sliced, not restated: the lifecycle gate the composer buttons obey has to be
+# the app's own set, or a test would keep passing against a stale copy of it.
+LIFECYCLES = APP[APP.index("const IF_ATTACHABLE_LIFECYCLES"):
+                 APP.index("function ifModelLabel")]
 MODEL_LABEL = APP[APP.index("function ifModelLabel"):
                   APP.index("// What the surface may say")]
 COMPOSER = APP[APP.index("function ifSizeComposer"):APP.index("// End chat")]
@@ -133,14 +137,14 @@ def test_occupied_composer_has_no_send_button_and_a_static_hint():
     surface able to contradict it. Pinned as two properties — the hint never
     changes, AND the note demonstrably does (otherwise an inert composer would
     satisfy the first assertion by doing nothing at all)."""
-    script = EL + FAKE_DOM + r"""
+    script = EL + LIFECYCLES + FAKE_DOM + r"""
 let synced = [];
 function ifSyncBrowserComposer(a, state) { synced.push(state); }
 """ + COMPOSER + r"""
 const a = {
   composerEl: new FakeElement("div"),
   sel: {}, pane: new FakeElement("div"),
-  st: { note: "" },
+  st: { note: "", lifecycle: "idle" },
   awaiting: false, halted: false, outBuf: "", role: "writer",
   legalActions: new Set(["send_input"]),
   stateReason: "",
@@ -208,6 +212,71 @@ invariant(hintTexts.size === 1 && hintTexts.has("enter to send"),
   `the hint tracked gate state: ${JSON.stringify([...hintTexts])}`);
 invariant(notes.size > 1,
   `the note never moved, so hint-invariance proves nothing: ${JSON.stringify([...notes])}`);
+"""
+    run_node(script)
+
+
+def test_both_composer_actions_share_one_lifecycle_and_busy_gate():
+    """SC-167: +Chat used to outlive the lifecycle gate End obeyed, because the
+    two halves of that state had two writers in two paint functions. Both
+    buttons terminate the session — +Chat's own chain begins with an End — so
+    both are asserted through both gates, and against EACH other: an inactive
+    lifecycle hides and disables them, an in-flight chain disables them while
+    they stay visible, and a live lifecycle restores them. Painting is what is
+    exercised, not the flag: the chain tests pin the flag, and it was the paint
+    half that shipped unpinned."""
+    script = EL + LIFECYCLES + FAKE_DOM + r"""
+function ifSyncBrowserComposer() {}
+""" + COMPOSER + r"""
+const a = {
+  composerEl: new FakeElement("div"),
+  sel: {}, pane: new FakeElement("div"),
+  st: { note: "", lifecycle: "idle" },
+  awaiting: false, halted: false, outBuf: "", role: "writer",
+  legalActions: new Set(["send_input"]),
+  stateReason: "",
+  composerPendingSeq: null, composerSubmitLatched: false,
+  browserComposerState: "clean", browserComposerWanted: "clean",
+  browserComposerSyncing: false, browserComposerError: "",
+  composerActionsBusy: false,
+  paint() {},
+};
+ifBuildComposer(a);
+const both = () => [
+  { name: "End", el: a.composerEnd },
+  { name: "+Chat", el: a.composerNewChat },
+];
+const check = (expect, why) => {
+  for (const { name, el } of both()) {
+    invariant(el.hidden === expect.hidden,
+      `${name} hidden=${el.hidden}, expected ${expect.hidden} ${why}`);
+    invariant(el.disabled === expect.disabled,
+      `${name} disabled=${el.disabled}, expected ${expect.disabled} ${why}`);
+  }
+};
+
+ifPaintComposer(a);
+check({ hidden: false, disabled: false }, "on a live lifecycle");
+
+// Every non-attachable lifecycle, not just one: the gate is the app's set, and
+// `ended` alone would leave `lost` / `error` free to regress.
+for (const lifecycle of ["ended", "lost", "error", "unreconciled", "available"]) {
+  a.st.lifecycle = lifecycle;
+  ifPaintComposer(a);
+  check({ hidden: true, disabled: true }, `on lifecycle ${lifecycle}`);
+}
+
+// A chain in flight holds BOTH buttons — and leaves them visible, because the
+// operator has to see the action they already pressed.
+a.st.lifecycle = "busy";
+a.composerActionsBusy = true;
+ifPaintComposer(a);
+check({ hidden: false, disabled: true }, "while a chain is in flight");
+
+// The gate releases; neither button is left stuck off.
+a.composerActionsBusy = false;
+ifPaintComposer(a);
+check({ hidden: false, disabled: false }, "after the chain finished");
 """
     run_node(script)
 
@@ -455,21 +524,33 @@ def test_declining_the_chain_confirm_touches_nothing():
 def test_end_chat_keeps_its_own_contract_through_the_shared_path():
     """End's flow is unchanged by U7 (text-only). It now shares the termination
     sequence with +Chat, so assert End still detaches and re-renders on success
-    and still reports an unrelated failure rather than swallowing it."""
+    and still reports an unrelated failure rather than swallowing it.
+
+    It also shares the busy flag, so the guard is asserted the way +Chat's is —
+    held at call time, and RELEASED on the one leg that stays on this pane. A
+    guard that never releases is the same bug in the other direction: an End
+    that failed for an unrelated reason would leave both actions dead."""
     run_node(chain_script(r"""
   const a = attach();
   confirm = () => true;
   apiIf = recorder(() => ({ terminated: true }), a);
-  await ifEndChat(a, SEL, pane(), null);
+  await ifEndChat(a, SEL, pane());
   invariant(detached === 1 && rendered === 1 && starts().length === 0,
     `End did not terminate cleanly: ${detached}/${rendered}`);
+  // The guard covers End's chain too, so +Chat cannot be fired underneath it.
+  invariant(calls.every((c) => c.busy === true),
+    "End left the composer actions live for the duration of its own chain");
 
   reset();
   const b = attach();
   apiIf = recorder(() => { throw fail(500, "internal", "boom"); }, b);
-  await ifEndChat(b, SEL, pane(), null);
+  await ifEndChat(b, SEL, pane());
   invariant(detached === 0 && rendered === 0,
     "an unrelated failure was treated as recovery");
-  invariant(b.st.note.includes("end chat failed") && b.painted === 1,
+  invariant(b.st.note.includes("end chat failed"),
     `End swallowed an unrelated failure: ${b.st.note}`);
+  // Two paints: the guard going on, and the release that also shows the note.
+  invariant(b.composerActionsBusy === false && b.painted === 2,
+    `a failed End did not release the actions onto the pane: ` +
+    `busy=${b.composerActionsBusy} painted=${b.painted}`);
 """))

--- a/tests/test_interface_composer_actions.py
+++ b/tests/test_interface_composer_actions.py
@@ -1,0 +1,475 @@
+"""Composer actions (spec #43 U7): Enter as the sole submit, red End, +Chat.
+
+The unit's value is one property — the +Chat chain is FAIL-CLOSED: it starts a
+new session on an explicit ``terminated`` and on nothing else. Every
+recovery-shaped outcome must both land on the recovery pane AND make no start
+attempt, so each fail-closed test asserts BOTH. Pinning only "landed on
+recovery" would stay green while the chain fired a start it must never fire,
+which is exactly the partially-pinned shape sprint 38 kept shipping (flag: five
+findings across five units).
+
+Driven through node against the real app.js regions rather than the browser, so
+the chain's branches are reachable without a live session; the rendered suite
+covers the pixels.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
+
+EL = APP[APP.index("const el ="):APP.index("const esc =")]
+MODEL_LABEL = APP[APP.index("function ifModelLabel"):
+                  APP.index("// What the surface may say")]
+COMPOSER = APP[APP.index("function ifSizeComposer"):APP.index("// End chat")]
+ACTIONS = APP[APP.index("// End chat (spec Workflow 9)"):
+              APP.index("// Take-over:")]
+
+HAS_NODE = shutil.which("node") is not None
+
+pytestmark = pytest.mark.skipif(not HAS_NODE, reason="node is required")
+
+
+FAKE_DOM = r"""
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag; this.nodeType = 1; this.children = [];
+    this.textContent = ""; this.disabled = false; this.style = {};
+  }
+  append(...nodes) { this.children.push(...nodes); }
+  closest() { return this; }
+}
+globalThis.document = {
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({ nodeType: 3, textContent: String(text ?? "") }),
+};
+function invariant(ok, message) { if (!ok) throw new Error(message); }
+"""
+
+# The chain's collaborators. Every one is observable so a test can assert what
+# the chain did NOT do, which is where fail-closed actually lives.
+CHAIN_HARNESS = r"""
+let apiIf, confirm;
+let detached = 0;
+let rendered = 0;
+let toasts = [];
+let calls = [];
+let confirms = [];
+let sleeps = [];
+function ifDetach() { detached += 1; }
+async function renderInterface() { rendered += 1; }
+function toast(msg) { toasts.push(String(msg)); }
+const realSetTimeout = globalThis.setTimeout;
+// The retry's 2s wait is asserted, not endured: record the delay and run the
+// continuation at once, so a regression that drops the wait is still visible.
+globalThis.setTimeout = (fn, ms) => { sleeps.push(ms); return realSetTimeout(fn, 0); };
+
+function reset() {
+  detached = 0; rendered = 0; toasts = []; calls = []; confirms = []; sleeps = [];
+}
+function attach(over) {
+  const a = {
+    sessionId: 7,
+    st: { harness: "codex", modelRoute: "gpt-5.6-terra", launchEffort: "high",
+          note: "" },
+    composerActionsBusy: false,
+    painted: 0,
+    paint() { this.painted += 1; },
+  };
+  return Object.assign(a, over || {});
+}
+const SEL = { shell_id: 3, shortname: "DEV3", display_name: "Code-01" };
+function pane() { return new FakeElement("div"); }
+// Two 409 shapes, because the server really does emit both and the client
+// branches on them differently (ifError: `code` comes from an error envelope,
+// `reason` from a bare terminated/reason body).
+function fail(status, code, message) {
+  const e = new Error(message);
+  e.status = status; e.code = code;
+  e.body = { error: { code, message } };
+  return e;
+}
+function failReason(status, reason) {
+  const e = new Error(reason);
+  e.status = status; e.code = undefined;
+  e.body = { terminated: false, reason };
+  return e;
+}
+// Records every call WITH the busy flag as it stood at call time — the only way
+// to prove the double-activation guard held for the chain's whole duration
+// rather than merely at its start and end.
+function recorder(handlers, a) {
+  return async (path, method, body) => {
+    calls.push({ path, method, body, busy: a.composerActionsBusy });
+    return handlers(path, method, body, calls.length);
+  };
+}
+function starts() { return calls.filter((c) => c.path === "/interface/sessions"); }
+"""
+
+
+def run_node(script: str) -> None:
+    result = subprocess.run(["node", "-e", script], text=True,
+                            capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+def chain_script(body: str) -> str:
+    return (EL + MODEL_LABEL + FAKE_DOM + CHAIN_HARNESS + ACTIONS
+            + "\n(async () => {\n" + body
+            + "\n})().catch((error) => { console.error(error.stack || error);"
+              " process.exit(1); });\n")
+
+
+def test_occupied_composer_has_no_send_button_and_a_static_hint():
+    """U7's first bullet, and the reason the hint is static: U2's note is the
+    single state surface, so a hint that moved with gate state would be a second
+    surface able to contradict it. Pinned as two properties — the hint never
+    changes, AND the note demonstrably does (otherwise an inert composer would
+    satisfy the first assertion by doing nothing at all)."""
+    script = EL + FAKE_DOM + r"""
+let synced = [];
+function ifSyncBrowserComposer(a, state) { synced.push(state); }
+""" + COMPOSER + r"""
+const a = {
+  composerEl: new FakeElement("div"),
+  sel: {}, pane: new FakeElement("div"),
+  st: { note: "" },
+  awaiting: false, halted: false, outBuf: "", role: "writer",
+  legalActions: new Set(["send_input"]),
+  stateReason: "",
+  composerPendingSeq: null, composerSubmitLatched: false,
+  browserComposerState: "clean", browserComposerWanted: "clean",
+  browserComposerSyncing: false, browserComposerError: "",
+  composerActionsBusy: false,
+  paint() {},
+};
+ifBuildComposer(a);
+const buttons = [];
+const walk = (node) => {
+  for (const kid of node.children || []) {
+    if (kid.tagName === "button") buttons.push(kid);
+    walk(kid);
+  }
+};
+walk(a.composerEl);
+const labels = buttons.map((b) => b.textContent);
+invariant(!labels.includes("Send"),
+  `the Send button survived U7: ${JSON.stringify(labels)}`);
+invariant(JSON.stringify(labels) === JSON.stringify(["End", "+Chat"]),
+  `composer actions are not [End, +Chat]: ${JSON.stringify(labels)}`);
+// End keeps the red styling family and the whole termination contract.
+const end = buttons[0];
+invariant(end.className.includes("act bad") &&
+  end.className.includes("if-end-chat"),
+  `End left the red act-bad family: ${end.className}`);
+
+const hints = [];
+const findHint = (node) => {
+  for (const kid of node.children || []) {
+    if (kid.className === "if-composer-hint") hints.push(kid);
+    findHint(kid);
+  }
+};
+findHint(a.composerEl);
+invariant(hints.length === 1 && hints[0].textContent === "enter to send",
+  `static submit hint is missing: ${JSON.stringify(hints.map((h) => h.textContent))}`);
+
+// Enter is wired as a submit; there is no click path left to reach it.
+let sent = 0;
+globalThis.ifComposerSend = () => { sent += 1; };
+a.composerInput.value = "x";
+a.composerInput.onkeydown({ key: "Enter", shiftKey: false, preventDefault() {} });
+invariant(sent === 1, "Enter is no longer the submit affordance");
+a.composerInput.onkeydown({ key: "Enter", shiftKey: true, preventDefault() {} });
+invariant(sent === 1, "Shift+Enter stopped inserting a newline");
+
+// The hint is static ACROSS gate states, while the note moves.
+const notes = new Set();
+const hintTexts = new Set();
+for (const state of [
+  () => { a.halted = false; a.role = "writer"; a.legalActions = new Set(["send_input"]); },
+  () => { a.halted = true; },
+  () => { a.halted = false; a.role = "viewer"; },
+  () => { a.role = "writer"; a.legalActions = new Set(); a.stateReason = "generation has ended"; },
+]) {
+  state();
+  ifPaintComposer(a);
+  notes.add(a.composerNote.textContent);
+  hintTexts.add(hints[0].textContent);
+}
+invariant(hintTexts.size === 1 && hintTexts.has("enter to send"),
+  `the hint tracked gate state: ${JSON.stringify([...hintTexts])}`);
+invariant(notes.size > 1,
+  `the note never moved, so hint-invariance proves nothing: ${JSON.stringify([...notes])}`);
+"""
+    run_node(script)
+
+
+def test_new_chat_reuses_the_ended_session_launch_triple_verbatim():
+    """+Chat's whole point: harness, model route and effort go back unchanged.
+    The body is asserted as a closed world — an extra or renamed field is a
+    different launch, which is the one thing this must not do."""
+    run_node(chain_script(r"""
+  const a = attach();
+  confirm = (msg) => { confirms.push(msg); return true; };
+  apiIf = recorder((path) => {
+    if (path === "/interface/termination-requests") return { terminated: true };
+    return { session_id: 9 };
+  }, a);
+  await ifNewChatSameRoute(a, SEL, pane());
+
+  invariant(calls.length === 2, `chain made ${calls.length} calls, expected 2`);
+  invariant(calls[0].path === "/interface/termination-requests" &&
+    calls[0].body.force === false && calls[0].body.session_id === 7,
+    `graceful termination was not first: ${JSON.stringify(calls[0])}`);
+  const start = calls[1];
+  invariant(start.path === "/interface/sessions" && start.method === "POST",
+    `start POST missing: ${JSON.stringify(start)}`);
+  invariant(JSON.stringify(start.body) === JSON.stringify(
+    { shell_id: 3, harness: "codex", model: "gpt-5.6-terra", effort: "high" }),
+    `launch triple was not reused verbatim: ${JSON.stringify(start.body)}`);
+  invariant(detached === 1 && rendered === 1,
+    `chain did not detach and re-render once: ${detached}/${rendered}`);
+  // Double activation: the guard held across BOTH legs, not just at the edges.
+  invariant(calls.every((c) => c.busy === true),
+    "actions were re-enabled mid-chain");
+
+  // The confirm names both effects and the exact route being reused.
+  invariant(confirms.length === 1, `expected one confirm: ${confirms.length}`);
+  const text = confirms[0];
+  invariant(text.includes("End session #7") && text.includes("start a new chat") &&
+    text.includes("codex") && text.includes("GPT 5.6 TERRA") &&
+    text.includes("draft is discarded"),
+    `confirm did not name both effects and the route: ${text}`);
+"""))
+
+
+def test_null_legs_of_the_triple_relaunch_as_harness_default():
+    """A NULL model or effort is a real value meaning "harness default" — for
+    pre-migration rows and for launches that named none. It must be OMITTED,
+    because an absent field is how the API spells that, and a null would be a
+    validation error rather than the same launch."""
+    run_node(chain_script(r"""
+  const a = attach({ st: { harness: "claude", modelRoute: null,
+                           launchEffort: null, note: "" } });
+  confirm = (msg) => { confirms.push(msg); return true; };
+  apiIf = recorder((path) => {
+    if (path === "/interface/termination-requests") return { terminated: true };
+    return {};
+  }, a);
+  await ifNewChatSameRoute(a, SEL, pane());
+
+  const start = starts()[0];
+  invariant(JSON.stringify(start.body) === JSON.stringify(
+    { shell_id: 3, harness: "claude" }),
+    `NULL legs were not omitted: ${JSON.stringify(start.body)}`);
+  invariant(confirms[0].includes("HARNESS DEFAULT"),
+    `confirm hid the harness-default route: ${confirms[0]}`);
+"""))
+
+
+@pytest.mark.parametrize("leg,handler", [
+    # The non-throwing 409: the server answers 200/409 with a reason body.
+    ("identity_mismatch",
+     'return { terminated: false, reason: "identity_mismatch" };'),
+    ("not_running",
+     'throw failReason(409, "not_running");'),
+    # The thrown 409 legs End already treats as recovery-shaped.
+    ("not_occupied",
+     'throw fail(409, "not_occupied", "session 7 is unreconciled");'),
+    ("identity_unverified",
+     'throw fail(409, "identity_unverified", "identity not verified");'),
+])
+def test_recovery_shaped_termination_never_starts_a_session(leg, handler):
+    """THE unit's load-bearing property. Two assertions per leg, deliberately:
+    the chain lands on recovery AND makes no start attempt. The spec's mutation
+    proof targets exactly this — make identity_mismatch fall through to the
+    start POST and this test must go red."""
+    body = r"""
+  const a = attach();
+  confirm = () => true;
+  apiIf = recorder((path) => {
+    if (path === "/interface/termination-requests") { __HANDLER__ }
+    return {};
+  }, a);
+  await ifNewChatSameRoute(a, SEL, pane());
+
+  invariant(starts().length === 0,
+    `FAIL-CLOSED VIOLATED: __LEG__ started a session over an unreconciled ` +
+    `shell: ${JSON.stringify(starts())}`);
+  invariant(rendered === 1,
+    `__LEG__ did not land on the recovery pane: rendered=${rendered}`);
+  invariant(a.st.note === "",
+    `__LEG__ left a terminal error on a recoverable shell: ${a.st.note}`);
+"""
+    body = body.replace("__HANDLER__", handler).replace("__LEG__", leg)
+    run_node(chain_script(body))
+
+
+def test_declined_force_kill_ends_with_a_note_and_starts_nothing():
+    """Spec step 4's declined branch: stop with the existing note, nothing
+    started — and give the operator the buttons back, since the session is
+    still alive and the chain is over."""
+    run_node(chain_script(r"""
+  const a = attach();
+  // First confirm = the chain's own; second = the force-kill gate, declined.
+  confirm = (msg) => { confirms.push(msg); return confirms.length === 1; };
+  apiIf = recorder((path) => {
+    if (path === "/interface/termination-requests")
+      return { terminated: false, reason: "graceful_timeout", pid: 4321,
+               generation: 9 };
+    return {};
+  }, a);
+  await ifNewChatSameRoute(a, SEL, pane());
+
+  invariant(starts().length === 0,
+    `a declined force kill still started a session: ${JSON.stringify(starts())}`);
+  invariant(rendered === 0 && detached === 0,
+    `a declined force kill tore down a live session: ${rendered}/${detached}`);
+  invariant(a.st.note.includes("graceful stop timed out"),
+    `declined force kill said nothing: ${a.st.note}`);
+  invariant(a.composerActionsBusy === false,
+    "actions stayed disabled after the chain stopped");
+  invariant(confirms[1].includes("PID 4321") && confirms[1].includes("generation 9"),
+    `force confirm did not name the exact identity: ${confirms[1]}`);
+"""))
+
+
+def test_confirmed_force_kill_continues_into_the_start():
+    """Spec step 4's other half: confirmed and terminated → continue to step 3."""
+    run_node(chain_script(r"""
+  const a = attach();
+  confirm = () => true;
+  apiIf = recorder((path, method, body) => {
+    if (path === "/interface/termination-requests")
+      return body.force
+        ? { terminated: true }
+        : { terminated: false, reason: "graceful_timeout", pid: 1, generation: 1 };
+    return {};
+  }, a);
+  await ifNewChatSameRoute(a, SEL, pane());
+
+  invariant(starts().length === 1,
+    `force-then-start did not reach the start: ${JSON.stringify(calls)}`);
+  invariant(starts()[0].body.model === "gpt-5.6-terra",
+    "the forced path lost the launch route");
+"""))
+
+
+def test_shell_occupied_race_is_retried_exactly_once_after_two_seconds():
+    """Spec step 6: the occupancy flip can lag the termination we just made, so
+    one retry — bounded. The delay is asserted so dropping the wait is visible,
+    and the attempt count is asserted so the bound cannot drift upward."""
+    run_node(chain_script(r"""
+  const a = attach();
+  confirm = () => true;
+  apiIf = recorder((path) => {
+    if (path === "/interface/termination-requests") return { terminated: true };
+    if (starts().length === 1) throw fail(409, "shell_occupied", "still occupied");
+    return {};
+  }, a);
+  await ifNewChatSameRoute(a, SEL, pane());
+
+  invariant(starts().length === 2,
+    `the occupancy race was not retried exactly once: ${starts().length}`);
+  invariant(sleeps.includes(2000),
+    `the retry did not wait 2s: ${JSON.stringify(sleeps)}`);
+  invariant(rendered === 1 && toasts.length === 0,
+    `a recovered race still reported failure: ${JSON.stringify(toasts)}`);
+"""))
+
+
+def test_second_shell_occupied_surfaces_the_server_message_and_stops():
+    """Bounded retry: a second failure hands the shell to the normal New-chat
+    path with the server's own words, and does NOT try a third time."""
+    run_node(chain_script(r"""
+  const a = attach();
+  confirm = () => true;
+  apiIf = recorder((path) => {
+    if (path === "/interface/termination-requests") return { terminated: true };
+    throw fail(409, "shell_occupied", "a live harness process holds this shell");
+  }, a);
+  await ifNewChatSameRoute(a, SEL, pane());
+
+  invariant(starts().length === 2,
+    `retry bound drifted: ${starts().length} start attempts`);
+  invariant(toasts.length === 1 &&
+    toasts[0].includes("shell_occupied") &&
+    toasts[0].includes("a live harness process holds this shell"),
+    `the server's message did not reach the operator: ${JSON.stringify(toasts)}`);
+  invariant(rendered === 1,
+    "the shell was not returned to the normal New-chat path");
+"""))
+
+
+def test_unavailable_model_route_is_surfaced_not_downgraded():
+    """Declared judgement call, spec-silent: POST /interface/sessions preflights
+    the route and 422s invalid_model_route when a once-valid route has since
+    gone away. This is NOT the occupancy race, so it is not retried — and it is
+    emphatically not downgraded to a harness-default launch, because silently
+    changing the triple is the one failure this unit cannot have."""
+    run_node(chain_script(r"""
+  const a = attach();
+  confirm = () => true;
+  apiIf = recorder((path) => {
+    if (path === "/interface/termination-requests") return { terminated: true };
+    throw fail(422, "invalid_model_route",
+      "stored or requested model route 'gpt-5.6-terra' is not currently available");
+  }, a);
+  await ifNewChatSameRoute(a, SEL, pane());
+
+  invariant(starts().length === 1,
+    `a 422 was retried like an occupancy race: ${starts().length} attempts`);
+  invariant(starts()[0].body.model === "gpt-5.6-terra",
+    "the start silently dropped the model route");
+  invariant(toasts.length === 1 && toasts[0].includes("invalid_model_route"),
+    `the 422 was swallowed: ${JSON.stringify(toasts)}`);
+  invariant(rendered === 1,
+    "the shell was not returned to the normal New-chat path");
+"""))
+
+
+def test_declining_the_chain_confirm_touches_nothing():
+    """One confirm gates the whole chain; declining it must not terminate, not
+    disable the actions, and not leave a note."""
+    run_node(chain_script(r"""
+  const a = attach();
+  confirm = () => false;
+  apiIf = recorder(() => ({}), a);
+  await ifNewChatSameRoute(a, SEL, pane());
+  invariant(calls.length === 0,
+    `a declined +Chat still called the API: ${JSON.stringify(calls)}`);
+  invariant(a.composerActionsBusy === false && a.st.note === "" &&
+    detached === 0 && rendered === 0,
+    "a declined +Chat left state behind");
+"""))
+
+
+def test_end_chat_keeps_its_own_contract_through_the_shared_path():
+    """End's flow is unchanged by U7 (text-only). It now shares the termination
+    sequence with +Chat, so assert End still detaches and re-renders on success
+    and still reports an unrelated failure rather than swallowing it."""
+    run_node(chain_script(r"""
+  const a = attach();
+  confirm = () => true;
+  apiIf = recorder(() => ({ terminated: true }), a);
+  await ifEndChat(a, SEL, pane(), null);
+  invariant(detached === 1 && rendered === 1 && starts().length === 0,
+    `End did not terminate cleanly: ${detached}/${rendered}`);
+
+  reset();
+  const b = attach();
+  apiIf = recorder(() => { throw fail(500, "internal", "boom"); }, b);
+  await ifEndChat(b, SEL, pane(), null);
+  invariant(detached === 0 && rendered === 0,
+    "an unrelated failure was treated as recovery");
+  invariant(b.st.note.includes("end chat failed") && b.painted === 1,
+    `End swallowed an unrelated failure: ${b.st.note}`);
+"""))

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -742,13 +742,21 @@ async function renderInterface(root) {
   if (root !== view) throw new Error("End chat refreshed the wrong view");
   rendered += 1;
 }
-async function apiIf() { throw response; }
+// Ordering, not a blanket ban: End paints ONCE before it calls the API, to put
+// its busy guard up. What must never happen is a paint AFTER the transition —
+// that one writes stale state onto a pane already re-rendered into recovery.
+let terminating = false;
+async function apiIf() { terminating = true; throw response; }
 const view = {};
 const pane = { closest: (selector) => selector === ".view" ? view : null };
 const a = {
   sessionId: 7,
   st: { note: "" },
-  paint() { throw new Error("a recovery transition painted stale state"); },
+  painted: 0,
+  paint() {
+    if (terminating) throw new Error("a recovery transition painted stale state");
+    this.painted += 1;
+  },
 };
 const sel = { shortname: "DEV3", display_name: "Code-01" };
 
@@ -756,7 +764,13 @@ async function exercise(error, label) {
   response = error;
   detached = 0;
   rendered = 0;
-  await ifEndChat(a, sel, pane, { disabled: false });
+  terminating = false;
+  a.painted = 0;
+  await ifEndChat(a, sel, pane);
+  if (a.painted !== 1) {
+    throw new Error(`${label} did not raise the busy guard exactly once: ` +
+      `${a.painted}`);
+  }
   if (detached !== 1 || rendered !== 1) {
     throw new Error(`${label} kept the dead attachment: ` +
       `${JSON.stringify({ detached, rendered })}`);
@@ -1535,7 +1549,7 @@ confirm = () => true;
     throw fail(409, "not_occupied",
       "session 4 is unreconciled — termination needs a verified identity");
   };
-  await ifEndChat(a, { shortname: "S3" }, new FakeElement("div"), null);
+  await ifEndChat(a, { shortname: "S3" }, new FakeElement("div"));
   invariant(detached === 1, `unreconciled End chat did not detach: ${detached}`);
   invariant(rendered === 1,
     `unreconciled End chat did not re-render onto recovery: ${rendered}`);
@@ -1544,11 +1558,12 @@ confirm = () => true;
 
   const b = attach();
   apiIf = async () => { throw fail(500, "internal", "boom"); };
-  await ifEndChat(b, { shortname: "S3" }, new FakeElement("div"), null);
+  await ifEndChat(b, { shortname: "S3" }, new FakeElement("div"));
   invariant(detached === 1 && rendered === 1,
     "an unrelated failure was swallowed as a recovery re-render");
-  invariant(b.st.note.includes("end chat failed") && b.painted === 1,
-    `unrelated failure was not reported: ${b.st.note}`);
+  // Two paints: End's busy guard going on, then the release carrying the note.
+  invariant(b.st.note.includes("end chat failed") && b.painted === 2,
+    `unrelated failure was not reported: ${b.st.note} (painted ${b.painted})`);
 })().catch((error) => {
   console.error(error.stack || error);
   process.exit(1);

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -615,7 +615,12 @@ a.paint();
   a.composerInput.onkeydown({
     key: "Enter", shiftKey: false, preventDefault() { prevented = true; },
   });
-  a.composerSend.onclick();
+  // Enter is the SOLE submit affordance (spec #43 U7 removed the Send button),
+  // so the convergence property is now two Enters, not Enter plus a click:
+  // a second attempt must join the existing latch rather than open a new one.
+  a.composerInput.onkeydown({
+    key: "Enter", shiftKey: false, preventDefault() { prevented = true; },
+  });
   invariant(prevented && frames.length === 0 && a.composerSubmitLatched,
     "send during dirty-state sync was not latched exactly once");
   invariant(a.composerInput.disabled,
@@ -636,7 +641,7 @@ a.paint();
     apiCalls[0].body.state === "dirty",
     `draft state did not reach the server: ${JSON.stringify(apiCalls)}`);
   invariant(prevented && frames.length === 1,
-    "latched Enter and Send did not converge on exactly one broker frame");
+    "two latched Enters did not converge on exactly one broker frame");
   const payload = new TextDecoder().decode(frames[0].subarray(9));
   invariant(payload === "hello\nworld\r",
     `composer bytes bypassed terminal Enter semantics: ${JSON.stringify(payload)}`);
@@ -671,9 +676,11 @@ a.paint();
   a.composerInput.value = "retain on reject";
   a.composerInput.oninput();
   await a.browserComposerChain;
-  a.composerSend.onclick();
+  a.composerInput.onkeydown({
+    key: "Enter", shiftKey: false, preventDefault() {},
+  });
   invariant(frames.length === 2 && a.composerPendingSeq === 5,
-    "visible Send did not use the same broker path");
+    "an unlatched Enter did not use the same broker path");
   ifControl(a, { type: "input_reject", seq: 5, reason: "stale_generation" });
   invariant(a.composerInput.value === "retain on reject" &&
     a.composerPendingSeq === null &&
@@ -1317,6 +1324,15 @@ def test_empty_header_note_does_not_reserve_a_flex_row():
     reserved line (it has min-height to stop a jump), so the rule is scoped."""
     assert ".if-head > .if-note:empty { display: none; }" in CSS
     assert ".if-composer .if-note" in CSS and "min-height: 1.2em" in CSS
+
+
+def test_static_submit_hint_has_a_styled_hook():
+    """#43 U7 replaced the Send button with a static "enter to send" hint, so
+    the class the markup emits and the class the stylesheet dresses must be the
+    same one. Cheap text assertion by necessity — the rendered suite is what
+    proves it is actually visible and dim; this catches the rename that would
+    ship an unstyled hint while every node-driven test stayed green."""
+    assert ".if-composer .if-composer-hint {" in CSS
 
 
 def test_recovery_partial_result_keeps_exact_remediation_until_refresh():

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -553,11 +553,16 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
         page.evaluate(
             "ifControl(ifAttach, { type: 'lifecycle', lifecycle: 'ended' })"
         )
+        # SC-167: both actions terminate the session, so an ended pane hides
+        # both. +Chat used to survive here, offering to end a chat that was
+        # already over.
         assert page.get_by_role("button", name="End", exact=True).is_hidden()
+        assert page.get_by_role("button", name="+Chat", exact=True).is_hidden()
         page.evaluate(
             "ifControl(ifAttach, { type: 'lifecycle', lifecycle: 'idle' })"
         )
         assert page.get_by_role("button", name="End", exact=True).is_visible()
+        assert page.get_by_role("button", name="+Chat", exact=True).is_visible()
         page.screenshot(
             path=str(_artifact(tmp_path, "interface-details-desktop.png")),
             full_page=True,

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -52,6 +52,10 @@ SESSION = {
     "identity_verified": True,
     "harness": "codex",
     "model_route": "gpt-5.6-terra",
+    # The third leg of the launch triple (#43 U4's column, #43 U7's consumer).
+    # Present here so +Chat's relaunch can be asserted against a real payload
+    # rather than against a hand-set client field.
+    "launch_effort": "high",
     "lifecycle": "idle",
     "composer": "clean",
     "browser_composer": "clean",
@@ -531,10 +535,13 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
         ).count() == 1
 
         actions = page.locator(".if-composer-actions")
+        # Spec #43 U7: Send is gone (Enter is the sole submit, with a static
+        # hint), End is the red text-only rename, +Chat is the new action.
         assert actions.locator("button").all_inner_texts() == [
-            "Send",
-            "End chat",
+            "End",
+            "+Chat",
         ]
+        assert page.locator(".if-composer-hint").inner_text() == "enter to send"
         boxes = actions.locator("button").evaluate_all(
             """(buttons) => buttons.map((button) => {
               const box = button.getBoundingClientRect();
@@ -546,11 +553,11 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
         page.evaluate(
             "ifControl(ifAttach, { type: 'lifecycle', lifecycle: 'ended' })"
         )
-        assert page.get_by_role("button", name="End chat").is_hidden()
+        assert page.get_by_role("button", name="End", exact=True).is_hidden()
         page.evaluate(
             "ifControl(ifAttach, { type: 'lifecycle', lifecycle: 'idle' })"
         )
-        assert page.get_by_role("button", name="End chat").is_visible()
+        assert page.get_by_role("button", name="End", exact=True).is_visible()
         page.screenshot(
             path=str(_artifact(tmp_path, "interface-details-desktop.png")),
             full_page=True,
@@ -602,8 +609,8 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
             in options
         )
         assert page.locator(".if-composer-actions button").all_inner_texts() == [
-            "Send",
-            "End chat",
+            "End",
+            "+Chat",
         ]
         page.screenshot(
             path=str(_artifact(tmp_path, "interface-details-mobile.png")),
@@ -613,6 +620,68 @@ def test_compact_details_alerts_and_actions_render_on_desktop_and_mobile(
         mobile.close()
 
 
+def test_new_chat_relaunches_the_same_launch_triple_from_the_session_payload(
+    browser, ui_url
+):
+    """+Chat's acceptance, end to end in the real browser: the relaunch POST
+    carries the ENDED session's harness, model route and effort.
+
+    This exists because the node-driven chain tests set ``st.launchEffort``
+    themselves, so they pin what the chain does with the triple but not that the
+    triple is READ from the session payload at all — a mutation nulling that
+    wiring left every one of them green. Here the effort's only source is
+    SESSION["launch_effort"] served by the mock API, so the wiring is on the
+    path being tested.
+    """
+    state = {"started": None, "terminated": None, "ended": False}
+
+    def relaunch_api(route) -> None:
+        request = route.request
+        path = request.url.split("/api", 1)[-1]
+        if path == "/interface/termination-requests":
+            state["terminated"] = request.post_data_json
+            state["ended"] = True
+            return _json(route, {"terminated": True})
+        if path == "/interface/sessions" and request.method == "POST":
+            state["started"] = request.post_data_json
+            return _json(route, {"session_id": 9}, status=201)
+        if path == "/interface/shells" and state["ended"]:
+            return _json(route, {"shells": [{**SHELL, "availability": "starting",
+                                             "session_id": None}]})
+        return _mock_api(route)
+
+    context, page = _open_interface(
+        browser, ui_url, height=1000, api_handler=relaunch_api
+    )
+    dialogs: list[str] = []
+
+    def accept(dialog):
+        dialogs.append(dialog.message)
+        dialog.accept()
+
+    page.on("dialog", accept)
+    try:
+        page.get_by_role("button", name="+Chat", exact=True).click()
+        # The chain ends in a re-render onto the starting pane, so the occupied
+        # composer going away is the signal that both POSTs have been made.
+        page.wait_for_function("() => !document.querySelector('.if-composer')")
+        assert state["terminated"] == {"session_id": 7, "force": False}
+        # The launch triple, reused verbatim — effort included.
+        assert state["started"] == {
+            "shell_id": 3,
+            "harness": "codex",
+            "model": "gpt-5.6-terra",
+            "effort": "high",
+        }, state["started"]
+        # One confirm, naming both effects and the route being reused.
+        assert len(dialogs) == 1, dialogs
+        assert "End session #7" in dialogs[0]
+        assert "GPT 5.6 TERRA" in dialogs[0]
+        assert "discarded" in dialogs[0]
+    finally:
+        context.close()
+
+
 def test_enter_sends_one_frame_and_open_silent_stream_retains_draft(
     browser, ui_url
 ):
@@ -620,9 +689,13 @@ def test_enter_sends_one_frame_and_open_silent_stream_retains_draft(
     try:
         composer = page.locator(".if-composer-input")
         composer.fill("one composed turn")
-        page.get_by_role("button", name="Send").wait_for(state="visible")
+        page.locator(".if-composer-hint").wait_for(state="visible")
+        # There is no Send button to watch for readiness any more (U7), so wait
+        # on the condition its disabled state actually encoded: the draft's
+        # dirty transition has landed, so Enter yields SENT and not QUEUED.
         page.wait_for_function(
-            "() => !document.querySelector('.if-composer-actions button').disabled"
+            "() => ifAttach && ifAttach.browserComposerState === 'dirty'"
+            " && !ifAttach.browserComposerSyncing"
         )
         page.evaluate("ifAttach.composerAckTimeoutMs = 40")
 
@@ -728,7 +801,7 @@ def test_not_occupied_end_chat_detaches_into_preserving_recovery(
     )
     page.on("dialog", lambda dialog: dialog.accept())
     try:
-        page.get_by_role("button", name="End chat").click()
+        page.get_by_role("button", name="End", exact=True).click()
         preview_button = page.get_by_role("button", name="Preview recovery")
         preview_button.wait_for()
         assert page.evaluate("window.__lastWs.readyState") == 3


### PR DESCRIPTION
Spec #43 U7, sprint 45 unit 6. Follows U2 (#596, squash `5acce0f7`) — same composer region.

## What changed

- **Send button removed.** Enter is the sole submit; a **static** `enter to send` hint renders at the composer's edge. Static on purpose: U2's note is the single state surface, and a hint that tracked gate state would be a second surface able to contradict it. Shift+Enter still newlines.
- **"End chat" → "End".** Label only. The red already came from `.if-composer .if-end-chat`, so **no CSS moved** and the termination flow is untouched.
- **New "+Chat"** ends the current chat and relaunches on the same shell with the **same launch triple** — harness, model route, effort — reused verbatim, NULLs included (a NULL leg is *omitted*, which is how the API spells "harness default"). Effort comes from `interface_sessions.launch_effort` (U4's column) via the session payload; the client's `st` gains `launchEffort`. This is the launch route, deliberately not the live model (decision #55).

## Fail-closed

A new session starts on an explicit `terminated` and on nothing else. The graceful-first sequence is factored into `ifTerminateSession`, shared with End, so the spec's "+Chat lands on the recovery pane **exactly as End does**" is true by construction rather than by two copies staying in step. `identity_mismatch` / `not_occupied` / `identity_unverified` / `not_running` land on recovery with **no start attempt**; a declined force kill stops with its note and starts nothing.

## Two trade-offs I picked, and why

**1. The retry bound is two statements, not a loop.** The occupancy-race retry started life as `for (let attempt = 0; ; attempt += 1)`. The mutation that widened its guard **hung the suite instead of reddening it** — an unbounded browser-side retry against a shell that stays occupied spins forever. Rather than test that hazard I removed it: two straight-line attempts via `ifStartSession`, so unbounded retry is not expressible. The simpler-looking loop was rejected for exactly that reason.

**2. I refactored End, in a unit whose spec calls it "text-only".** Sharing one termination path is a larger diff in End's region than a copy would be, but "exactly as End does" is a *behavioural* requirement, and two copies satisfy it only until they drift. End's observable behaviour is unchanged and pinned (`end-swallows-unrelated-failure` mutation, plus the pre-existing unreconciled-End test).

## Judgement call (ratified)

`POST /interface/sessions` preflights the model route and 422s `invalid_model_route` when a route valid at launch has since gone away — and #593 refit the OOTB routes on main, so this is live, not theoretical. The spec's step 6 covers only 409 `shell_occupied`. **Chosen and ratified by PLN1 (#1800):** treat it as the exhausted-409 leg — surface the server's message verbatim, start nothing, normal New-chat path. Never a silent downgrade to harness-default, which would substitute the exact triple this unit exists to preserve.

## Acceptance evidence — 23/23 mutations red → revert → green

Committed as `tests/mutations/u7_composer_actions.py`, not run from scratch. U2's driver lived in an untracked dir and died with the worktree (REV1's Low L3 on #596); this one is reproducible: `python3 tests/mutations/u7_composer_actions.py`.

| # | mutation | property |
|---|---|---|
| 1 | `identity-mismatch-falls-through` | **the spec's named mutation** — fail-closed |
| 2 | `thrown-recovery-409-falls-through` | fail-closed: not_occupied / identity_unverified / not_running |
| 3 | `declined-force-falls-through` | a declined force kill starts nothing |
| 4 | `start-gated-on-absence-of-error` | fail-closed is an equality test on `terminated`, not "nothing went wrong" |
| 5 | `422-falls-through-to-default-route-start` | an unavailable route is refused, never downgraded (PLN1 #1800) |
| 6-8 | `effort-dropped` / `model-dropped` / `null-effort-sent-as-null` | the triple survives verbatim; a NULL leg is omitted |
| 9 | `launch-effort-not-read-from-session` | the triple is **read from the session payload** |
| 10-13 | `occupancy-retry-absent` / `422-retried-like-a-race` / `retry-wait-dropped` / `server-message-swallowed` | the bounded retry and its message |
| 14 | `start-failure-reported-as-success` | a failed start is never reported as a new chat |
| 15-20 | `send-button-restored` / `hint-absent` / `hint-tracks-gate-state` / `end-label-reverted` / `end-leaves-the-red-family` / `new-chat-button-absent` | the action row and the static hint |
| 21 | `actions-not-disabled-during-chain` | double-activation guard, asserted at call time across both legs |
| 22 | `end-swallows-unrelated-failure` | End's own contract, undisturbed |
| 23 | `hint-css-hook-renamed` | markup class == stylesheet class |

**Two of these were GREEN until the rendered suite joined the gate** — #9 and #23. The node-driven chain tests set `st.launchEffort` themselves, so they pinned what the chain *does* with the triple but not that it is read from the payload at all; a mutation nulling that wiring left all fourteen green. Fixed by a rendered test that drives the real browser with `launch_effort` served only by the mock API. Worth flagging as another instance of the "test constrains the property it names while leaving an adjacent one free" family.

Note for reviewers reproducing locally: the rendered suite needs a working Playwright browser, and the sandbox image ships a layout this Playwright cannot find (flag #169). A skip is silently green, so those two round trips need a real browser to mean anything. I ran it via a constructed `PLAYWRIGHT_BROWSERS_PATH` — 17 passed.

## Verification

- `tests/test_interface_composer_actions.py` (new, 14 tests) + composer-contract + ui-contract: **56 passed**
- rendered + interface-api suites on the rebased head: **115 passed, 22 subtests**
- mutation driver: **23/23**
- rebased onto `f72a68b` (44-U1); empty intersection with my six files, zero hand-resolved hunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)