### PR TITLE
fix(engine): per-request /vendor resolution + honest failure reporting (S45 U11, spec 48)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2482,14 +2482,14 @@ class Handler(BaseHTTPRequestHandler):
         byte-identical to the text path for the current vendor set, so nothing
         re-downloads on rollout.
         """
-        hit, detail = _resolve_vendor(unquote(path[len("/vendor/"):]))
+        hit, ctype_or_reason = _resolve_vendor(unquote(path[len("/vendor/"):]))
         if hit is None:
             # Name the gate. The old two 404 shapes (JSON route-miss vs
             # `not built`) were what made the outage diagnosable at all, and a
             # per-request resolver collapses that distinction — so replace it
             # deliberately rather than losing it. Loopback-only surface: the
             # reason costs nothing and is half of what this route is for.
-            return self._send(404, detail, "text/plain")   # detail = the gate
+            return self._send(404, ctype_or_reason, "text/plain")
         data = hit.read_bytes()
         headers = {
             "Cache-Control": "no-cache",
@@ -2497,7 +2497,7 @@ class Handler(BaseHTTPRequestHandler):
         }
         if self._if_none_match(headers["ETag"]):
             return self._not_modified(headers)
-        return self._send(200, data, detail, headers=headers)  # detail = ctype
+        return self._send(200, data, ctype_or_reason, headers=headers)
 
     def do_HEAD(self):
         """Vendored assets answer HEAD; everything else keeps the 405.

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -38,7 +38,7 @@ import traceback
 from datetime import date, datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs, unquote
 
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
@@ -90,24 +90,74 @@ import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
 import ts as ts_mod  # noqa: E402  (tailnet — config + live checks)
 import pm2 as pm2_mod  # noqa: E402  (host pm2 stack — config + live checks)
 
+# The app SHELL stays a frozen route table (spec #48): four files, a closed set
+# that has not changed in the life of the project, and index.html is where the
+# CSP header hangs. Adding one is a route change its author is already looking
+# at. Vendored assets are the opposite population — see _VENDOR_TYPES below.
 _STATIC = {
     "/": ("index.html", "text/html; charset=utf-8"),
     "/index.html": ("index.html", "text/html; charset=utf-8"),
     "/app.js": ("app.js", "application/javascript; charset=utf-8"),
     "/style.css": ("style.css", "text/css; charset=utf-8"),
-    # vendored markdown pipeline (marked MIT, DOMPurify MPL-2.0/Apache-2.0) —
-    # local copies so the no-build UI renders sanitized GFM without a CDN.
-    "/vendor/marked.umd.js": ("vendor/marked.umd.js", "application/javascript; charset=utf-8"),
-    "/vendor/purify.min.js": ("vendor/purify.min.js", "application/javascript; charset=utf-8"),
-    # vendored browser terminal (xterm.js 6.0.0, MIT — spec #20: a proven
-    # terminal-emulation library, never hand-rolled emulation).
-    "/vendor/xterm/xterm.js": ("vendor/xterm/xterm.js", "application/javascript; charset=utf-8"),
-    "/vendor/xterm/xterm.css": ("vendor/xterm/xterm.css", "text/css; charset=utf-8"),
-    # FitAddon reads the renderer's ACTUAL cell metrics, which is the only way
-    # to size the grid to what the browser will really paint — hardcoded cell
-    # estimates overshoot the row count and clip the bottom rows.
-    "/vendor/xterm/addon-fit.js": ("vendor/xterm/addon-fit.js", "application/javascript; charset=utf-8"),
 }
+
+# Vendored assets resolve PER REQUEST against `ui/vendor/` (spec #48). The
+# frozen table above ages at a different rate than the file bodies it points
+# at: bodies are read from disk every request, so pulling the repo under a
+# running server updated every registered asset instantly while a NEWLY
+# vendored one stayed unreachable until a restart. That shipped a current
+# app.js to a browser against a server that would not serve its dependencies —
+# a state neither version was tested in (the 2026-07-25 GUI outage: xterm's
+# addon-fit.js on disk, 404 from the route table).
+#
+# This mapping is the ALLOWLIST the frozen table used to be — the second job it
+# was quietly doing, and the one any replacement has to keep. Suffix decides the
+# content type; nothing is ever sniffed from bytes. `.map` is deliberately
+# absent (ruled this round): a source map is a debugging affordance this
+# loopback GUI does not need to serve, and widening this dict is a filesystem
+# tenancy decision, not a convenience one.
+_VENDOR_TYPES = {
+    ".js": "application/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".woff2": "font/woff2",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+}
+
+
+def _resolve_vendor(rel: str) -> tuple:
+    """Resolve one `/vendor/` request path to a servable file.
+
+    `rel` is the ALREADY-DECODED remainder of the URL path. Returns
+    `(Path, content-type)` on a hit and `(None, <the gate that said no>)` on a
+    miss — the miss reason is served to the operator, because the SHAPE of a
+    404 was the entire diagnosis in the incident this route comes from.
+
+    Gate order is the security contract, not a style choice: decoding precedes
+    containment (checking first and decoding after is the classic hole), and
+    resolution precedes the bound check (which is what makes a symlink out of
+    the tree fail the same way `..` does).
+    """
+    root = (UI_DIR / "vendor").resolve()
+    try:
+        ctype = _VENDOR_TYPES.get(Path(rel).suffix.lower())
+        if ctype is None:
+            return None, "suffix not allowlisted"
+        candidate = (root / rel).resolve()
+        if not candidate.is_relative_to(root):
+            return None, "outside the vendor root"
+        # Regular files only: no directory listings, no devices, and no bare
+        # `/vendor/` prefix.
+        if not candidate.is_file():
+            return None, "no such file"
+    except (OSError, ValueError):
+        # A path the filesystem itself refuses to interpret — NUL bytes, a
+        # name too long, a symlink loop — is a miss, not a server fault. The
+        # read below stays OUTSIDE this guard on purpose: a file that passed
+        # every gate and still cannot be read is a real fault and must be
+        # loud, not a 404 claiming it was never there.
+        return None, "unresolvable path"
+    return candidate, ctype
 
 # The Interface's own authorities, for the socket sources in the CSP below —
 # the same three `interface_routes._ALLOWED_HOSTS` fences the API to. Spelled
@@ -1413,16 +1463,26 @@ class Handler(BaseHTTPRequestHandler):
     server_version = "super-coder/1.0"
 
     def _send(self, code, payload, ctype="application/json", headers=None):
-        body = (json.dumps(payload, default=_json_default)
-                if ctype.startswith("application/json")
-                else payload).encode()
+        # Bytes pass through untouched. Vendored assets are not all text — a
+        # str-only sender would force the allowlist to exclude fonts and
+        # images, which is a trap for the next person to vendor one.
+        if isinstance(payload, (bytes, bytearray)):
+            body = bytes(payload)
+        else:
+            body = (json.dumps(payload, default=_json_default)
+                    if ctype.startswith("application/json")
+                    else payload).encode()
         self.send_response(code)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(body)))
         for k, v in (headers or {}).items():
             self.send_header(k, v)
         self.end_headers()
-        self.wfile.write(body)
+        # HEAD is the identical response minus the body, Content-Length
+        # included (RFC 9110 9.3.2) — so the answer to "is this served?" is
+        # generated from the same code that serves it and cannot drift.
+        if self.command != "HEAD":
+            self.wfile.write(body)
 
     def _redirect(self, location: str):
         self.send_response(302)
@@ -2414,8 +2474,52 @@ class Handler(BaseHTTPRequestHandler):
         finally:
             con.close()
 
+    def _serve_vendor(self, path: str):
+        """GET/HEAD a vendored asset, resolved against the tree as it is NOW.
+
+        Headers match the shell files': `no-cache` plus a content-derived
+        ETag, and the same 304. The tag is computed over raw bytes, which is
+        byte-identical to the text path for the current vendor set, so nothing
+        re-downloads on rollout.
+        """
+        hit, detail = _resolve_vendor(unquote(path[len("/vendor/"):]))
+        if hit is None:
+            # Name the gate. The old two 404 shapes (JSON route-miss vs
+            # `not built`) were what made the outage diagnosable at all, and a
+            # per-request resolver collapses that distinction — so replace it
+            # deliberately rather than losing it. Loopback-only surface: the
+            # reason costs nothing and is half of what this route is for.
+            return self._send(404, detail, "text/plain")   # detail = the gate
+        data = hit.read_bytes()
+        headers = {
+            "Cache-Control": "no-cache",
+            "ETag": '"%s"' % hashlib.sha256(data).hexdigest()[:32],
+        }
+        if self._if_none_match(headers["ETag"]):
+            return self._not_modified(headers)
+        return self._send(200, data, detail, headers=headers)  # detail = ctype
+
+    def do_HEAD(self):
+        """Vendored assets answer HEAD; everything else keeps the 405.
+
+        The app shell probes its own `<script src="/vendor/…">` tags with HEAD
+        to tell "not executed yet" from "the floor cannot serve this build"
+        (spec #48). Against a server that 405s the method, every healthy
+        script reads as a broken floor — the probe would manufacture exactly
+        the dishonest report it exists to replace. HEAD on the API is not a
+        contract this server offers, so the narrow route is the whole fix.
+        """
+        path = urlparse(self.path).path
+        if not path.startswith("/vendor/"):
+            # Same body the shim's send_error would have produced, sent the
+            # way HEAD requires: headers only, no bytes after them.
+            return self._send(405, {"error": "method not allowed"})
+        return self._serve_vendor(path)
+
     def do_GET(self):
         path = urlparse(self.path).path
+        if path.startswith("/vendor/"):
+            return self._serve_vendor(path)
         if path in _STATIC:
             fname, ctype = _STATIC[path]
             f = UI_DIR / fname

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3913,13 +3913,27 @@ async function ifDiagnoseVendor(a, ticket, attempt, missing) {
 // Open the sc-term.v1 stream: 0x00 output → write, 0x04 snapshot → reset+write;
 // keystrokes go out as 0x01 ‖ seq:u64be ‖ payload, one unacked frame at a time.
 function ifOpenStream(a, ticket, attempt = 0) {
+  // Named because it is both written and RETRACTED below: a note nobody can
+  // identify is a note nobody can safely clear.
+  const IF_VENDOR_WAIT_NOTE =
+    "terminal library not ready — checking the vendored scripts…";
   const missing = ["Terminal", "FitAddon"]
     .filter((g) => typeof globalThis[g] === "undefined");
   if (missing.length) {
-    a.st.note = "terminal library not ready — checking the vendored scripts…";
+    a.st.note = IF_VENDOR_WAIT_NOTE;
     a.paint();
     ifDiagnoseVendor(a, ticket, attempt, missing);
     return;
+  }
+  // The race the note describes is over — and nothing downstream repaints on a
+  // successful mount, so left standing it is permanent: a working terminal
+  // under a banner saying the library is missing, whose standing remedy is a
+  // floor restart that kills live sessions. Retract only OUR note (compare, do
+  // not blank), because between the wait and here an unrelated writer — the
+  // read-only take-over notice, a control frame — may own the line.
+  if (a.st.note === IF_VENDOR_WAIT_NOTE) {
+    a.st.note = "";
+    a.paint();
   }
   const term = new Terminal({ convertEol: false, cursorBlink: true,
     fontFamily: "ui-monospace, monospace" });

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2185,6 +2185,7 @@ function ifDetach() {
   if (!a) return;
   ifAttach = null;
   clearInterval(a.heartbeat);
+  clearTimeout(a.vendorRetry);   // a pending vendor re-attempt dies with the attach
   ifClearComposerAckTimer(a);
   a.resizeObs?.disconnect();
   try { a.ws?.close(); } catch { /* already closed */ }
@@ -3215,7 +3216,7 @@ async function ifSessionPane(pane, sel) {
     stateReason: sess.state_reason || "",
     ws: null, term: null, leaseId: null, leaseToken: null, role: "viewer",
     seq: 1, inflight: 0, lastAck: 0, outBuf: "", awaiting: false, halted: false,
-    heartbeat: 0, resizeObs: null, paint: null,
+    heartbeat: 0, resizeObs: null, paint: null, vendorRetry: null,
     composerInput: null, composerEnd: null, composerNewChat: null,
     composerNote: null, composerActionsBusy: false,
     composerPendingSeq: null, composerPendingText: null,
@@ -3849,12 +3850,75 @@ async function ifTakeover(a) {
   } catch (e) { a.st.note = "take-over failed: " + e.message; a.paint(); }
 }
 
+// The terminal globals are undefined in two entirely different worlds, and the
+// attach guard cannot tell them apart by looking: the vendor scripts are
+// `defer`red in <head> while app.js is a plain script at the end of <body>, so
+// during the genuine load race they really are absent — and they are equally
+// absent when the running server never served the file at all. The old guard
+// picked one world (still loading, refresh the page) and prescribed a
+// remedy that cannot work in the other: no refresh will ever define a global
+// whose script 404s. So observe instead of asserting (spec #48). ~8 attempts
+// across ~2s: long enough for the defer race, short enough that a corrupt
+// vendor file becomes a sentence rather than a permanent spinner.
+const IF_VENDOR_RETRY_MS = 250;
+const IF_VENDOR_RETRY_MAX = 8;
+
+// A probe outlives the attach that started it whenever the operator moves on
+// mid-flight, so every note it produces re-checks the generation first — a
+// finding about a session you already left must never repaint a newer one.
+function ifVendorNote(a, note) {
+  if (ifAttach !== a) return;
+  a.st.note = note;
+  a.paint();
+}
+
+// Ask the server what it is actually serving for the scripts THIS page
+// declares — enumerated off the DOM rather than from a second hardcoded list,
+// because a restatement of index.html here is exactly the thing that drifts.
+async function ifDiagnoseVendor(a, ticket, attempt, missing) {
+  const srcs = Array.from(document.querySelectorAll('script[src^="/vendor/"]'))
+    .map((s) => s.getAttribute("src"));
+  if (!srcs.length)
+    return ifVendorNote(a, "terminal unavailable — " + missing.join(" and ") +
+      " undefined and this page declares no /vendor/ scripts to check");
+  let probes;
+  try {
+    probes = await Promise.all(srcs.map(async (src) => ({
+      src, status: (await fetch(src, { method: "HEAD", cache: "no-store" })).status,
+    })));
+  } catch (e) {
+    // Cannot determine — say that and claim nothing else.
+    return ifVendorNote(a, "terminal unavailable — could not check the " +
+      "vendored scripts: " + e.message);
+  }
+  if (ifAttach !== a) return;
+  const failed = probes.filter((p) => p.status !== 200);
+  if (failed.length)
+    return ifVendorNote(a, "terminal unavailable — " +
+      failed.map((p) => p.src + " returned " + p.status).join(", ") +
+      ". The running server is older than this page; the engine floor needs a restart.");
+  if (attempt + 1 >= IF_VENDOR_RETRY_MAX)
+    return ifVendorNote(a, "terminal unavailable — " + srcs.join(", ") +
+      " served but did not define " + missing.join(" and ") + " after " +
+      (attempt + 1) + " attempts (a corrupt or empty vendored file)");
+  // Served and simply not executed yet: retrying is the whole remedy, so do it
+  // here rather than delegating it to the human.
+  a.vendorRetry = setTimeout(() => {
+    a.vendorRetry = null;
+    if (ifAttach !== a) return;
+    ifOpenStream(a, ticket, attempt + 1);
+  }, IF_VENDOR_RETRY_MS);
+}
+
 // Open the sc-term.v1 stream: 0x00 output → write, 0x04 snapshot → reset+write;
 // keystrokes go out as 0x01 ‖ seq:u64be ‖ payload, one unacked frame at a time.
-function ifOpenStream(a, ticket) {
-  if (typeof Terminal === "undefined" || typeof FitAddon === "undefined") {
-    a.st.note = "terminal library still loading — refresh the page";  // deferred vendor scripts
+function ifOpenStream(a, ticket, attempt = 0) {
+  const missing = ["Terminal", "FitAddon"]
+    .filter((g) => typeof globalThis[g] === "undefined");
+  if (missing.length) {
+    a.st.note = "terminal library not ready — checking the vendored scripts…";
     a.paint();
+    ifDiagnoseVendor(a, ticket, attempt, missing);
     return;
   }
   const term = new Terminal({ convertEol: false, cursorBlink: true,

--- a/tests/mutations/u11_vendor_resolution.py
+++ b/tests/mutations/u11_vendor_resolution.py
@@ -1,0 +1,289 @@
+"""Mutation round trips for spec #48 / sprint 45 U11 — per-request /vendor
+resolution and the honest failure report.
+
+Acceptance evidence, committed rather than run once in a session that dies
+with it (the U5/U7 convention). Each entry breaks ONE property in the real
+source, asserts the test claiming to pin it actually goes RED, restores the
+file, and asserts it goes green again. A property whose mutation stays green
+is not pinned, whatever the suite's colour says.
+
+    python3 tests/mutations/u11_vendor_resolution.py [-v]
+
+Two harness conditions, both from flag #182 — a same-size mutation reverted
+inside one second leaves a VALID `.pyc` behind (invalidation is source
+mtime-to-the-second plus size), so the interpreter can keep running mutated
+bytecode after the revert and hand back a reading that is simply false:
+
+  * every child runs with PYTHONDONTWRITEBYTECODE=1, and
+  * every `__pycache__` under the repo is cleared before each run.
+
+The revert is proven, never assumed: the baseline must come back green after
+each round trip, and a failure there is reported as a dirty revert rather than
+folded into the mutation's own result.
+
+Not named test_*.py on purpose: pytest must not collect it — it edits tracked
+source. Every file is restored in a `finally`, so an interrupted run still
+leaves the tree clean; `git diff` after a run is the check.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVER = ROOT / ".super-coder" / "api" / "server.py"
+APP = ROOT / ".super-coder" / "ui" / "app.js"
+SERVER_SUITE = "tests/test_vendor_assets.py"
+UI_SUITE = "tests/test_ui_vendor_probe.py"
+
+FROZEN_TABLE = """def _resolve_vendor(rel: str) -> tuple:"""
+
+# (label, suite, -k selector, file, old, new)
+MUTATIONS = [
+    (
+        "M1 the vendor table is frozen at import again — the defect itself, "
+        "restored by hand",
+        SERVER_SUITE, "vendored_after_the_server_started", SERVER,
+        '        candidate = (root / rel).resolve()',
+        '        if rel not in _FROZEN_AT_IMPORT:\n'
+        '            return None, "no such file"\n'
+        '        candidate = (root / rel).resolve()',
+    ),
+    (
+        "M2 containment is dropped — every traversal spelling reaches the "
+        "file, and the test has to see the BYTES, not just a status",
+        SERVER_SUITE, "traversal or symlink or absolute_path", SERVER,
+        '        if not candidate.is_relative_to(root):\n'
+        '            return None, "outside the vendor root"\n',
+        '',
+    ),
+    (
+        "M3 the decode goes entirely (the half of decode-then-contain a "
+        "traversal battery cannot see — every `..` spelling still 404s, just "
+        "at a different gate, so only an encoded NAME shows it)",
+        SERVER_SUITE, "percent_encoded", SERVER,
+        'unquote(path[len("/vendor/"):])',
+        'path[len("/vendor/"):]',
+    ),
+    (
+        "M4 the suffix allowlist is dropped and the type is guessed from the "
+        "name — anything under vendor/ becomes readable",
+        SERVER_SUITE, "allowlisted or source_maps", SERVER,
+        '        ctype = _VENDOR_TYPES.get(Path(rel).suffix.lower())\n'
+        '        if ctype is None:\n'
+        '            return None, "suffix not allowlisted"',
+        '        ctype = _VENDOR_TYPES.get(Path(rel).suffix.lower(),\n'
+        '                                  "text/plain; charset=utf-8")',
+    ),
+    (
+        "M5 .map is quietly allowlisted (the ruling this round was to leave "
+        "it off)",
+        SERVER_SUITE, "source_maps", SERVER,
+        '    ".css": "text/css; charset=utf-8",',
+        '    ".css": "text/css; charset=utf-8",\n    ".map": "application/json",',
+    ),
+    (
+        "M6 the regular-file gate goes, so a directory answers 200",
+        SERVER_SUITE, "directories or directory_named", SERVER,
+        '        if not candidate.is_file():\n'
+        '            return None, "no such file"',
+        '        if not candidate.exists():\n'
+        '            return None, "no such file"',
+    ),
+    (
+        "M7 the sender is str-only again — a vendored font stops round "
+        "tripping",
+        SERVER_SUITE, "binary", SERVER,
+        '        if isinstance(payload, (bytes, bytearray)):\n'
+        '            body = bytes(payload)\n'
+        '        else:\n'
+        '            body = (json.dumps(payload, default=_json_default)\n'
+        '                    if ctype.startswith("application/json")\n'
+        '                    else payload).encode()',
+        '        body = (json.dumps(payload, default=_json_default)\n'
+        '                if ctype.startswith("application/json")\n'
+        '                else payload).encode()',
+    ),
+    (
+        "M8 every rejection answers with one generic reason, so the 404 stops "
+        "naming the gate",
+        SERVER_SUITE, "names_the_gate", SERVER,
+        '            return self._send(404, detail, "text/plain")   # detail = the gate',
+        '            return self._send(404, "not found", "text/plain")',
+    ),
+    (
+        "M9 the unresolvable-path guard goes, so a NUL byte raises into a 500 "
+        "instead of missing",
+        SERVER_SUITE, "unresolvable", SERVER,
+        '    except (OSError, ValueError):',
+        '    except NotADirectoryError:',
+    ),
+    (
+        "M10 HEAD stops answering for vendored assets — the probe reads 405 "
+        "for every healthy script",
+        SERVER_SUITE, "head", SERVER,
+        '        if not path.startswith("/vendor/"):',
+        '        if True:',
+    ),
+    (
+        "M11 HEAD writes the body it says it is not sending",
+        SERVER_SUITE, "head_with_headers", SERVER,
+        '        if self.command != "HEAD":\n            self.wfile.write(body)',
+        '        self.wfile.write(body)',
+    ),
+    (
+        "M12 the shell files become dynamic too — the spec's deliberate limit "
+        "widens filesystem tenancy silently",
+        SERVER_SUITE, "frozen", SERVER,
+        '        if path in _STATIC:\n'
+        '            fname, ctype = _STATIC[path]',
+        '        if path in _STATIC or (UI_DIR / path.lstrip("/")).is_file():\n'
+        '            fname, ctype = _STATIC.get(\n'
+        '                path, (path.lstrip("/"), "application/javascript"))',
+    ),
+    # -- the app shell ------------------------------------------------------
+    (
+        "M13 the old assertion comes back: a 404 is reported as a load race "
+        "with a refresh remedy",
+        UI_SUITE, "named_with_its_status or old_remedy", APP,
+        '    a.st.note = "terminal library not ready — checking the vendored scripts…";\n'
+        '    a.paint();\n'
+        '    ifDiagnoseVendor(a, ticket, attempt, missing);\n'
+        '    return;',
+        '    a.st.note = "terminal library still loading — refresh the page";\n'
+        '    a.paint();\n'
+        '    return;',
+    ),
+    (
+        "M14 the probe reports only the first failed script",
+        UI_SUITE, "every_failed_script", APP,
+        '      failed.map((p) => p.src + " returned " + p.status).join(", ") +',
+        '      failed[0].src + " returned " + failed[0].status +',
+    ),
+    (
+        "M15 the probe reads the cache instead of the server, so a stale 200 "
+        "can mask the miss",
+        UI_SUITE, "rather_than_the_cache", APP,
+        '{ method: "HEAD", cache: "no-store" }',
+        '{ method: "HEAD" }',
+    ),
+    (
+        "M16 the retry bound is removed — a corrupt vendor file becomes a "
+        "permanent spinner (the same lie in another costume)",
+        UI_SUITE, "terminates_within_the_bound", APP,
+        '  if (attempt + 1 >= IF_VENDOR_RETRY_MAX)',
+        '  if (false)',
+    ),
+    (
+        "M17 the retry itself goes, so the genuine defer race is reported as "
+        "a fault the operator has to act on",
+        UI_SUITE, "resolves_itself", APP,
+        '  a.vendorRetry = setTimeout(() => {\n'
+        '    a.vendorRetry = null;\n'
+        '    if (ifAttach !== a) return;\n'
+        '    ifOpenStream(a, ticket, attempt + 1);\n'
+        '  }, IF_VENDOR_RETRY_MS);',
+        '  ifVendorNote(a, "terminal library still loading");',
+    ),
+    (
+        "M18 the generation check goes, so a probe that lands after the "
+        "operator moved on repaints a pane they already left",
+        UI_SUITE, "throws_after_the_operator", APP,
+        'function ifVendorNote(a, note) {\n  if (ifAttach !== a) return;',
+        'function ifVendorNote(a, note) {',
+    ),
+    (
+        "M19 the post-await generation check goes, so a dead attach still "
+        "schedules its next attempt",
+        UI_SUITE, "moved_on", APP,
+        '  if (ifAttach !== a) return;\n  const failed = probes.filter',
+        '  const failed = probes.filter',
+    ),
+    (
+        "M22 a queued attempt survives the attachment it belongs to, and "
+        "opens a stream against a pane the operator already left",
+        UI_SUITE, "queued_attempt", APP,
+        '    a.vendorRetry = null;\n    if (ifAttach !== a) return;\n',
+        '    a.vendorRetry = null;\n',
+    ),
+    (
+        "M20 a probe that threw is reported as a diagnosis rather than as an "
+        "unknown",
+        UI_SUITE, "throws", APP,
+        '    return ifVendorNote(a, "terminal unavailable — could not check the " +\n'
+        '      "vendored scripts: " + e.message);',
+        '    return ifVendorNote(a, "terminal unavailable — the vendored "\n'
+        '      + "scripts returned an error; the engine floor needs a restart");',
+    ),
+    (
+        "M21 the enumeration is replaced by a hardcoded list — it agrees with "
+        "index.html today and cannot be made to disagree by the page",
+        UI_SUITE, "rather_than_the_cache", APP,
+        '  const srcs = Array.from(document.querySelectorAll(\'script[src^="/vendor/"]\'))\n'
+        '    .map((s) => s.getAttribute("src"));',
+        '  const srcs = ["/vendor/xterm/xterm.js", "/vendor/xterm/addon-fit.js"];',
+    ),
+]
+
+# M1 needs a name to exist for the frozen-table mutation to be syntactically
+# real; injected alongside it and removed with it.
+FROZEN_SHIM = ('_FROZEN_AT_IMPORT = {"xterm/xterm.js"}\n\n\n' + FROZEN_TABLE)
+
+
+def clear_caches() -> None:
+    for cache in ROOT.rglob("__pycache__"):
+        shutil.rmtree(cache, ignore_errors=True)
+
+
+def run(suite: str, selector: str) -> bool:
+    """True when the selected tests pass, run on source rather than bytecode."""
+    clear_caches()
+    env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", suite, "-q", "-k", selector],
+        cwd=ROOT, capture_output=True, text=True, env=env)
+    return proc.returncode == 0
+
+
+def main() -> int:
+    verbose = "-v" in sys.argv
+    failures = []
+    for label, suite, selector, path, old, new in MUTATIONS:
+        original = path.read_text()
+        if original.count(old) != 1:
+            failures.append(f"{label}: anchor found {original.count(old)}x, "
+                            "expected exactly 1 — the driver has drifted from "
+                            "the source")
+            print(f"[FAIL] {label}\n       anchor is not unique")
+            continue
+        try:
+            mutated = original.replace(old, new, 1)
+            if label.startswith("M1 "):
+                mutated = mutated.replace(FROZEN_TABLE, FROZEN_SHIM, 1)
+            path.write_text(mutated)
+            red = not run(suite, selector)
+        finally:
+            path.write_text(original)
+        green = run(suite, selector)
+        ok = red and green
+        if not ok:
+            failures.append(
+                f"{label}: mutated={'RED' if red else 'GREEN (NOT PINNED)'} "
+                f"restored={'green' if green else 'RED (dirty revert)'}")
+        print(f"[{'ok' if ok else 'FAIL'}] {label}\n       {suite} "
+              f"-k {selector}: {'red' if red else 'STAYED GREEN'} -> "
+              f"{'green' if green else 'STILL RED'}")
+        if verbose and not ok:
+            print("       ^ this property is not actually pinned")
+    print(f"\n{len(MUTATIONS) - len(failures)}/{len(MUTATIONS)} round trips "
+          "behaved (red under mutation, green on revert)")
+    for line in failures:
+        print("  FAIL " + line)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/mutations/u11_vendor_resolution.py
+++ b/tests/mutations/u11_vendor_resolution.py
@@ -111,7 +111,7 @@ MUTATIONS = [
         "M8 every rejection answers with one generic reason, so the 404 stops "
         "naming the gate",
         SERVER_SUITE, "names_the_gate", SERVER,
-        '            return self._send(404, detail, "text/plain")   # detail = the gate',
+        '            return self._send(404, ctype_or_reason, "text/plain")',
         '            return self._send(404, "not found", "text/plain")',
     ),
     (
@@ -149,7 +149,7 @@ MUTATIONS = [
         "M13 the old assertion comes back: a 404 is reported as a load race "
         "with a refresh remedy",
         UI_SUITE, "named_with_its_status or old_remedy", APP,
-        '    a.st.note = "terminal library not ready — checking the vendored scripts…";\n'
+        '    a.st.note = IF_VENDOR_WAIT_NOTE;\n'
         '    a.paint();\n'
         '    ifDiagnoseVendor(a, ticket, attempt, missing);\n'
         '    return;',
@@ -233,6 +233,33 @@ MUTATIONS = [
         '  const srcs = Array.from(document.querySelectorAll(\'script[src^="/vendor/"]\'))\n'
         '    .map((s) => s.getAttribute("src"));',
         '  const srcs = ["/vendor/xterm/xterm.js", "/vendor/xterm/addon-fit.js"];',
+    ),
+    (
+        "M24 the wait banner is never retracted — SC-168 itself: a race that "
+        "healed itself still reads `terminal library not ready` over a working "
+        "terminal, indefinitely",
+        UI_SUITE, "retracts_its_own_banner", APP,
+        '  if (a.st.note === IF_VENDOR_WAIT_NOTE) {\n'
+        '    a.st.note = "";\n'
+        '    a.paint();\n'
+        '  }\n',
+        '',
+    ),
+    (
+        "M25 the note is cleared without a repaint — st.note and the pane "
+        "disagree, and since a mount repaints nothing the operator keeps "
+        "reading the stale banner",
+        UI_SUITE, "retracts_its_own_banner", APP,
+        '    a.st.note = "";\n'
+        '    a.paint();',
+        '    a.st.note = "";',
+    ),
+    (
+        "M26 the retraction blanks unconditionally — it stops being ours to "
+        "retract and swallows whatever another writer put on the line",
+        UI_SUITE, "not_ours_survives", APP,
+        '  if (a.st.note === IF_VENDOR_WAIT_NOTE) {',
+        '  if (true) {',
     ),
 ]
 

--- a/tests/mutations/u11_vendor_resolution.py
+++ b/tests/mutations/u11_vendor_resolution.py
@@ -158,6 +158,14 @@ MUTATIONS = [
         '    return;',
     ),
     (
+        "M23 a 405 from a floor with no HEAD route is softened into a load "
+        "race, so the one honest reading of an old floor is lost (PLN1's "
+        "ratification of result #1873 asked for this to be pinned)",
+        UI_SUITE, "old_floor", APP,
+        '  const failed = probes.filter((p) => p.status !== 200);',
+        '  const failed = probes.filter((p) => p.status !== 200 && p.status !== 405);',
+    ),
+    (
         "M14 the probe reports only the first failed script",
         UI_SUITE, "every_failed_script", APP,
         '      failed.map((p) => p.src + " returned " + p.status).join(", ") +',

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -1151,3 +1151,70 @@ def test_long_identity_truncates_without_wrapping_the_header(browser, ui_url):
         )
     finally:
         context.close()
+
+
+def _vendor_fault_pane(browser, ui_url, *, routes):
+    """The attach pane with the vendored terminal scripts broken as `routes`
+    says — no Terminal stub, because the point is what the page does when the
+    real ones do not arrive."""
+    context = browser.new_context(viewport={"width": 1600, "height": 1000})
+    page = context.new_page()
+    page.route("**/api/**", _mock_api)
+    for pattern, handler in routes:
+        page.route(pattern, handler)
+    page.goto(f"{ui_url}/#interface/DEV3", wait_until="networkidle")
+    return context, page
+
+
+def test_a_vendor_script_the_server_cannot_serve_is_named_with_its_status(
+    browser, ui_url
+):
+    """Spec #48, in the real browser: the incident was a vendored asset the
+    running server had no route for, and the pane answered with a refresh the
+    operator dutifully performed several times.
+
+    This is the one place the DOM enumeration is proven — the node-driven
+    contract (tests/test_ui_vendor_probe.py) has to stub querySelectorAll, so
+    only a real page can show that the selector matches the tags index.html
+    actually declares.
+    """
+    context, page = _vendor_fault_pane(
+        browser, ui_url,
+        routes=[("**/vendor/xterm/addon-fit.js", lambda route: route.fulfill(
+            status=404, content_type="text/plain", body="no such file"))],
+    )
+    try:
+        # The pane holds several .if-note boxes (alerts, composer); the
+        # terminal's is the one this unit writes.
+        note = page.locator(".if-note").filter(has_text="terminal unavailable")
+        note.wait_for(timeout=10_000)
+        text = note.inner_text()
+        assert "/vendor/xterm/addon-fit.js returned 404" in text, text
+        assert "restart" in text, text
+        assert "refresh" not in text.lower(), (
+            f"the pane still prescribes a refresh for a 404: {text}"
+        )
+    finally:
+        context.close()
+
+
+def test_a_vendor_script_that_defines_nothing_ends_in_a_sentence_not_a_spinner(
+    browser, ui_url
+):
+    """Served, 200, and empty: the retry has to run out and say so. An
+    unbounded retry would leave the operator watching a pane that never
+    resolves and never lies either — the same silence in a nicer costume."""
+    context, page = _vendor_fault_pane(
+        browser, ui_url,
+        routes=[(f"**/vendor/xterm/{asset}", lambda route: route.fulfill(
+            status=200, content_type="application/javascript", body=""))
+            for asset in ("xterm.js", "addon-fit.js")],
+    )
+    try:
+        note = page.locator(".if-note").filter(has_text="did not define")
+        note.wait_for(timeout=15_000)
+        text = note.inner_text()
+        assert "Terminal and FitAddon" in text, text
+        assert "refresh" not in text.lower(), text
+    finally:
+        context.close()

--- a/tests/test_ui_freshness.py
+++ b/tests/test_ui_freshness.py
@@ -31,9 +31,15 @@ import server  # noqa: E402
 import transport as transport_mod  # noqa: E402
 
 
-class ServedAssetFreshnessTest(unittest.TestCase):
-    """A throwaway UI dir, so the tests can rewrite an asset the way an
-    engine update does without touching the shipped one."""
+class ServedAssetTestCase(unittest.TestCase):
+    """A throwaway UI dir served by the real transport, so the tests can
+    rewrite an asset the way an engine update does without touching the
+    shipped one.
+
+    Shared with tests/test_vendor_assets.py (spec #48): both suites need the
+    same "a real socket, the real dispatcher, a disposable tree" apparatus,
+    and a second copy of it is a fixture that drifts from this one.
+    """
 
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -73,14 +79,21 @@ class ServedAssetFreshnessTest(unittest.TestCase):
         self.thread.join(timeout=10)
         self.loop.close()
 
-    def get(self, path, headers=None):
+    def request(self, method, path, headers=None):
         con = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
         try:
-            con.request("GET", path, headers=headers or {})
+            con.request(method, path, headers=headers or {})
             resp = con.getresponse()
             return resp.status, dict(resp.getheaders()), resp.read()
         finally:
             con.close()
+
+    def get(self, path, headers=None):
+        return self.request("GET", path, headers)
+
+
+class ServedAssetFreshnessTest(ServedAssetTestCase):
+    """Spec #43 U3 — cache directives and the revalidation round trip."""
 
     # -- the validator exists at all -----------------------------------------
 

--- a/tests/test_ui_vendor_probe.py
+++ b/tests/test_ui_vendor_probe.py
@@ -269,6 +269,61 @@ class VendorProbeTest(unittest.TestCase):
           "reported a fault after recovering: " + a.st.note);
         """)
 
+    def test_the_resolved_race_retracts_its_own_banner(self):
+        """SC-168. The wait note is painted before every probe round and the
+        mount is the only thing that ends the wait — so if nothing retracts it,
+        the operator reads `terminal library not ready` over a terminal that is
+        working, forever. Worse than useless mid-incident: its standing remedy
+        is a floor restart, which kills live sessions.
+
+        Separate from the race test above because that one asserts the absence
+        of a FAULT report (`returned` / `did not define`), and the stale banner
+        is neither — it stayed green through the whole defect."""
+        run_js(r"""
+        const a = attach();
+        respond = async () => {
+          if (rounds() >= 2) defineGlobals();     // the deferred scripts execute
+          return { status: 200 };
+        };
+        ifOpenStream(a, "ticket-1");
+        const deadline = Date.now() + 4000;
+        while (!sockets.length && Date.now() < deadline) await sleep(20);
+        invariant(sockets.length === 1, "the attach never recovered on its own");
+        // The banner was really shown — otherwise this test proves nothing.
+        invariant(a.notes.some((n) => /checking the vendored scripts/.test(n)),
+          "the wait note was never painted, so its retraction is untested");
+        invariant(a.st.note === "",
+          "left a note standing over a working terminal: " +
+          JSON.stringify(a.st.note));
+        // The pane has to be told, not just the state: statusNoteEl is written
+        // from st.note on repaint, and a mount repaints nothing by itself.
+        invariant(a.notes[a.notes.length - 1] === "",
+          "cleared the note without repainting, so the banner stays on screen: " +
+          JSON.stringify(a.notes));
+        """)
+
+    def test_a_note_that_is_not_ours_survives_the_mount(self):
+        """The retraction compares before it clears. A blanket blanking would
+        swallow whatever the read-only/take-over path put on the line between
+        the wait and the mount — trading a false banner for a missing one."""
+        run_js(r"""
+        const a = attach();
+        respond = async () => {
+          if (rounds() >= 2) {
+            defineGlobals();
+            // Another writer owns the line by the time the retry lands.
+            a.st.note = "control was taken by another client — you are now read-only";
+          }
+          return { status: 200 };
+        };
+        ifOpenStream(a, "ticket-1");
+        const deadline = Date.now() + 4000;
+        while (!sockets.length && Date.now() < deadline) await sleep(20);
+        invariant(sockets.length === 1, "the attach never recovered on its own");
+        invariant(/read-only/.test(a.st.note),
+          "the mount blanked a note it did not write: " + JSON.stringify(a.st.note));
+        """)
+
     def test_a_probe_landing_after_the_operator_moved_on_does_nothing(self):
         """The attach can end while the HEADs are in flight, and what the dead
         attachment must not do is CONTINUE — no repaint of a pane nobody is

--- a/tests/test_ui_vendor_probe.py
+++ b/tests/test_ui_vendor_probe.py
@@ -203,6 +203,30 @@ class VendorProbeTest(unittest.TestCase):
           "only part of the failure was reported: " + note);
         """)
 
+    def test_an_old_floor_that_cannot_answer_the_probe_is_reported_honestly(self):
+        """The degradation this design has to survive (PLN1's ruling on
+        result #1873): the probe runs in a browser talking to whatever server
+        is RUNNING, and a server predating this unit has no HEAD route for
+        /vendor/ — it answers 405 for scripts it serves perfectly over GET.
+
+        The report is still true there, which is the whole point: a floor that
+        405s the probe IS older than the page that made it, and the remedy it
+        names — restart the floor — is exactly the one that fixes it. Nothing
+        here may soften a 405 into "still loading".
+        """
+        run_js(r"""
+        respond = async () => ({ status: 405 });   // a floor without do_HEAD
+        const a = attach();
+        ifOpenStream(a, "ticket-1");
+        const note = await settle(a, /returned/);
+        invariant(note.includes("/vendor/xterm/xterm.js returned 405"),
+          "an old floor's 405 was not reported: " + note);
+        invariant(/older than this page/.test(note) && /restart/.test(note),
+          "the note did not point at the floor: " + note);
+        invariant(!/refresh/i.test(note), "prescribed a refresh: " + note);
+        invariant(rounds() === 1, "retried against a floor that cannot answer");
+        """)
+
     def test_a_script_that_serves_but_defines_nothing_terminates_within_the_bound(self):
         """A corrupt or empty vendor file is 200 forever, so the retry has to
         end by itself. An unbounded retry is the same lie in another costume:

--- a/tests/test_ui_vendor_probe.py
+++ b/tests/test_ui_vendor_probe.py
@@ -36,6 +36,7 @@ ENGINE = ROOT / ".super-coder"
 APP = (ENGINE / "ui" / "app.js").read_text()
 INDEX = (ENGINE / "ui" / "index.html").read_text()
 EL = APP[APP.index("const el ="):APP.index("const esc =")]
+DETACH = APP[APP.index("function ifDetach()"):APP.index("window.addEventListener(\"pagehide\"")]
 VENDOR = APP[APP.index("// The terminal globals are undefined in two"):
              APP.index("function ifSendInput")]
 
@@ -244,10 +245,16 @@ class VendorProbeTest(unittest.TestCase):
           "reported a fault after recovering: " + a.st.note);
         """)
 
-    def test_a_probe_landing_after_the_operator_moved_on_repaints_nothing(self):
-        """The attach can end while the HEADs are in flight. A finding about
-        the session you left must never overwrite the one you are looking
-        at."""
+    def test_a_probe_landing_after_the_operator_moved_on_does_nothing(self):
+        """The attach can end while the HEADs are in flight, and what the dead
+        attachment must not do is CONTINUE — no repaint of a pane nobody is
+        looking at, and above all no next attempt queued against it.
+
+        Split from the throwing case below on purpose: the guard before the
+        paint and the guard after the await are independently sufficient for a
+        note, so a single test kept BOTH mutations green. The retry is what
+        only the post-await guard prevents.
+        """
         run_js(r"""
         const held = [];
         respond = () => new Promise((resolve) => held.push(resolve));
@@ -259,14 +266,53 @@ class VendorProbeTest(unittest.TestCase):
         // The operator selects another shell: a newer attachment is current.
         const current = attach();
         current.st.note = "attached";
-        held.forEach((resolve) => resolve({ status: 404 }));
-        await sleep(200);
+        held.forEach((resolve) => resolve({ status: 200 }));
+        await sleep(80);
+        invariant(stale.vendorRetry === null,
+          "a probe queued another attempt against an attachment already gone");
         invariant(stale.st.note === staleNote,
           "a probe repainted an attachment that was already gone: " + stale.st.note);
         invariant(stale.notes.length === staleNotes, "repainted the stale pane");
         invariant(current.st.note === "attached",
           "the stale probe overwrote the live pane: " + current.st.note);
-        invariant(stale.vendorRetry === null, "the dead attach scheduled a retry");
+        """)
+
+    def test_a_probe_that_throws_after_the_operator_moved_on_repaints_nothing(self):
+        """The failure path reaches the note without passing the post-await
+        check, so this is the one the paint's own guard has to catch."""
+        run_js(r"""
+        let reject;
+        respond = () => new Promise((_, no) => { reject = no; });
+        const stale = attach();
+        ifOpenStream(stale, "ticket-1");
+        await sleep(50);
+        const staleNote = stale.st.note;
+        const current = attach();
+        current.st.note = "attached";
+        reject(new Error("Failed to fetch"));
+        await sleep(150);
+        invariant(stale.st.note === staleNote,
+          "a failed probe repainted an attachment already gone: " + stale.st.note);
+        invariant(current.st.note === "attached",
+          "the stale probe overwrote the live pane: " + current.st.note);
+        """)
+
+    def test_a_queued_attempt_dies_with_the_attachment(self):
+        """The attach can also end BETWEEN attempts, with the timer already
+        armed — spec #48's "cancelled on detach". The armed callback is the
+        last thing standing between a dropped pane and a stream opened against
+        a session the operator left."""
+        run_js(r"""
+        const a = attach();
+        ifOpenStream(a, "ticket-1");
+        await sleep(80);
+        invariant(a.vendorRetry !== null, "no attempt was queued to cancel");
+        const probed = probes.length;
+        ifAttach = null;                    // the operator navigates away
+        await sleep(500);                   // past two retry intervals
+        invariant(probes.length === probed,
+          "a detached attachment kept probing: " + probes.length + " > " + probed);
+        invariant(sockets.length === 0, "opened a stream for a dead attachment");
         """)
 
     def test_a_probe_that_throws_names_the_error_and_claims_nothing_else(self):
@@ -305,6 +351,14 @@ class VendorEnumerationTest(unittest.TestCase):
         self.assertGreaterEqual(len(vendored), 2, srcs)
         self.assertIn("/vendor/xterm/xterm.js", vendored)
         self.assertIn("/vendor/xterm/addon-fit.js", vendored)
+
+    def test_detach_clears_a_queued_attempt(self):
+        """Belt to the armed callback's braces: teardown drops the timer the
+        way it drops the heartbeat, so nothing is left pending on a pane the
+        operator closed. Asserted against the source because ifDetach's other
+        work (lease DELETE, terminal dispose) is out of this harness's
+        reach."""
+        self.assertIn("clearTimeout(a.vendorRetry)", DETACH)
 
     def test_the_old_remedy_is_gone_from_the_shell(self):
         """It said `refresh the page` for a route-table miss no refresh can

--- a/tests/test_ui_vendor_probe.py
+++ b/tests/test_ui_vendor_probe.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Honest failure reporting when the terminal globals are missing — spec #48
+(sprint 45, unit 11).
+
+The guard this replaces knew one fact ("Terminal is not defined") and asserted
+a different one ("still loading — refresh the page"). Both worlds produce the
+same undefined global: the genuine defer race, where a refresh is beside the
+point because waiting works, and a vendor script the running server never
+served, where no number of refreshes will ever define it. The operator in the
+2026-07-25 outage was handed the refresh remedy for the second world and spent
+the incident acting on it.
+
+So the properties here are about what the operator is TOLD, not about whether
+the terminal mounts — the code did the right thing and said the wrong thing,
+which is the failure mode a "did it survive" assertion cannot see.
+
+Driven through node against the real `ifOpenStream`/`ifDiagnoseVendor` source
+sliced out of ui/app.js, with fetch, the DOM enumeration and the terminal
+globals as the injected seams. The bound is exercised in real time (~2s) with
+a watchdog, so removing it fails the run instead of hanging it.
+
+Run:
+    python3 -m pytest tests/test_ui_vendor_probe.py
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+
+APP = (ENGINE / "ui" / "app.js").read_text()
+INDEX = (ENGINE / "ui" / "index.html").read_text()
+EL = APP[APP.index("const el ="):APP.index("const esc =")]
+VENDOR = APP[APP.index("// The terminal globals are undefined in two"):
+             APP.index("function ifSendInput")]
+
+HAS_NODE = shutil.which("node") is not None
+
+HARNESS = r"""
+globalThis.ifAttach = null;
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag; this.nodeType = 1; this.children = []; this.style = {};
+    this._text = "";
+  }
+  append(...nodes) { this.children.push(...nodes); }
+  replaceChildren(...nodes) { this.children = nodes; }
+  set textContent(value) { this._text = String(value ?? ""); }
+  get textContent() { return this._text; }
+}
+
+// The four vendor scripts index.html declares, in its order.
+let scriptSrcs = ["/vendor/xterm/xterm.js", "/vendor/xterm/addon-fit.js",
+                  "/vendor/marked.umd.js", "/vendor/purify.min.js"];
+let selectorsAsked = [];
+globalThis.document = {
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({ nodeType: 3, textContent: String(text ?? "") }),
+  querySelectorAll: (selector) => {
+    selectorsAsked.push(selector);
+    return scriptSrcs.map((src) => ({
+      getAttribute: (name) => (name === "src" ? src : null) }));
+  },
+};
+
+// Every probe the code makes, with the options it made it with.
+let probes = [];
+let respond = async () => ({ status: 200 });
+globalThis.fetch = (src, options) => {
+  probes.push({ src, ...options });
+  return respond(src, options);
+};
+
+const sockets = [];
+globalThis.WebSocket = class {
+  constructor(url, protocol) { this.url = url; this.protocol = protocol;
+    this.readyState = 0; sockets.push(this); }
+  send() {} close() { this.readyState = 3; }
+};
+globalThis.WebSocket.OPEN = 1;
+globalThis.ResizeObserver = class { observe() {} disconnect() {} };
+globalThis.location = { protocol: "http:", host: "sc.test" };
+
+const TERMINAL = class {
+  constructor() { this.cols = 80; this.rows = 24; }
+  loadAddon() {} open() {} write() {} reset() {} dispose() {}
+  resize() {} onData() {} onResize() {}
+};
+const FIT = { FitAddon: class { proposeDimensions() { return { cols: 80, rows: 24 }; } } };
+function defineGlobals() { globalThis.Terminal = TERMINAL; globalThis.FitAddon = FIT; }
+function undefineGlobals() { delete globalThis.Terminal; delete globalThis.FitAddon; }
+
+function invariant(ok, message) { if (!ok) throw new Error(message); }
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms));
+
+// A fresh attachment, current by construction.
+function attach() {
+  const a = {
+    sessionId: 7, role: "viewer", ws: null, term: null, heartbeat: 0,
+    resizeObs: null, vendorRetry: null, seq: 1, inflight: 0, awaiting: false,
+    halted: false, outBuf: "", composerPendingSeq: null,
+    st: { note: "", writer: "active" },
+    termEl: new FakeElement("div"),
+    notes: [],
+  };
+  a.paint = () => a.notes.push(a.st.note);
+  ifAttach = a;
+  return a;
+}
+
+// The terminal notes are the assertion surface, so wait on the note rather
+// than on a timer — and give up loudly, because "it never settled" is a
+// result this suite has to be able to report rather than hang on.
+async function settle(a, pattern, budgetMs = 6000) {
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    if (pattern.test(a.st.note)) return a.st.note;
+    await sleep(20);
+  }
+  throw new Error("no note matching " + pattern + " within " + budgetMs +
+    "ms — last note was " + JSON.stringify(a.st.note));
+}
+
+function rounds() { return probes.length / scriptSrcs.length; }
+
+function reset() {
+  probes = []; selectorsAsked = []; sockets.length = 0;
+  scriptSrcs = ["/vendor/xterm/xterm.js", "/vendor/xterm/addon-fit.js",
+                "/vendor/marked.umd.js", "/vendor/purify.min.js"];
+  respond = async () => ({ status: 200 });
+  undefineGlobals();
+  ifAttach = null;
+}
+"""
+
+
+def run_js(body: str, timeout: int = 60) -> str:
+    script = (EL + VENDOR + HARNESS +
+              "(async () => {\nreset();\n" + body + "\n})().then(() => "
+              "process.exit(0), (error) => {\n"
+              "  console.error(error.stack || error);\n"
+              "  process.exit(1);\n});\n")
+    result = subprocess.run(["node", "-e", script], text=True,
+                            capture_output=True, check=False, timeout=timeout)
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+@unittest.skipUnless(HAS_NODE, "node is required for the browser contract")
+class VendorProbeTest(unittest.TestCase):
+
+    def test_a_missing_vendor_script_is_named_with_its_status(self):
+        """The outage, reported honestly: the note carries the src and the
+        status the server actually gave, and sends the operator at the floor
+        rather than at the browser."""
+        run_js(r"""
+        respond = async (src) => ({ status: src.endsWith("addon-fit.js") ? 404 : 200 });
+        const a = attach();
+        ifOpenStream(a, "ticket-1");
+        const note = await settle(a, /returned/);
+        invariant(note.includes("/vendor/xterm/addon-fit.js returned 404"),
+          "the note did not name the failed script and its status: " + note);
+        invariant(/restart/.test(note), "the note never says what would help: " + note);
+        invariant(!/refresh/i.test(note),
+          "prescribed a refresh for a fault no refresh can fix: " + note);
+        invariant(sockets.length === 0, "opened a stream with no terminal");
+        invariant(a.vendorRetry === null, "kept retrying a 404");
+        invariant(rounds() === 1, "waited out the bound before reporting a 404");
+        """)
+
+    def test_the_probe_asks_the_server_rather_than_the_cache(self):
+        """A cached answer would describe the page load, not the floor — and
+        HEAD is what keeps the diagnosis from re-downloading 1.2MB of xterm."""
+        run_js(r"""
+        respond = async () => ({ status: 404 });
+        const a = attach();
+        ifOpenStream(a, "ticket-1");
+        await settle(a, /returned/);
+        invariant(probes.length === 4, "probed " + probes.length + " of 4 scripts");
+        for (const probe of probes) {
+          invariant(probe.method === "HEAD", "probe was not a HEAD: " + probe.method);
+          invariant(probe.cache === "no-store", "probe read the cache: " + probe.cache);
+        }
+        invariant(selectorsAsked.every((s) => s === 'script[src^="/vendor/"]'),
+          "enumerated something other than the page's vendor scripts: " + selectorsAsked);
+        """)
+
+    def test_every_failed_script_is_named_not_just_the_first(self):
+        run_js(r"""
+        respond = async (src) => ({ status: src.includes("xterm") ? 503 : 200 });
+        const a = attach();
+        ifOpenStream(a, "ticket-1");
+        const note = await settle(a, /returned/);
+        invariant(note.includes("/vendor/xterm/xterm.js returned 503") &&
+                  note.includes("/vendor/xterm/addon-fit.js returned 503"),
+          "only part of the failure was reported: " + note);
+        """)
+
+    def test_a_script_that_serves_but_defines_nothing_terminates_within_the_bound(self):
+        """A corrupt or empty vendor file is 200 forever, so the retry has to
+        end by itself. An unbounded retry is the same lie in another costume:
+        a permanent spinner that never says anything false and never says
+        anything at all."""
+        run_js(r"""
+        const a = attach();
+        const started = Date.now();
+        ifOpenStream(a, "ticket-1");
+        const note = await settle(a, /did not define/);
+        const elapsed = Date.now() - started;
+        invariant(note.includes("served but did not define Terminal and FitAddon"),
+          "the note did not say what was served or what stayed undefined: " + note);
+        invariant(!/refresh/i.test(note), "prescribed a refresh: " + note);
+        invariant(rounds() === 8, "bound was " + rounds() + " attempts, not 8");
+        invariant(elapsed < 5000, "the bound took " + elapsed + "ms");
+        // Terminal means terminal: nothing keeps running after the verdict.
+        const settled = probes.length;
+        await sleep(600);
+        invariant(probes.length === settled, "kept probing after reporting");
+        invariant(a.vendorRetry === null, "left a retry armed");
+        """, timeout=90)
+
+    def test_the_load_race_resolves_itself_without_asking_the_operator(self):
+        """The world the old message was right about — and it still should not
+        delegate to a human, because waiting is the entire remedy."""
+        run_js(r"""
+        const a = attach();
+        respond = async () => {
+          if (rounds() >= 2) defineGlobals();     // the deferred scripts execute
+          return { status: 200 };
+        };
+        ifOpenStream(a, "ticket-1");
+        const deadline = Date.now() + 4000;
+        while (!sockets.length && Date.now() < deadline) await sleep(20);
+        invariant(sockets.length === 1, "the attach never recovered on its own");
+        invariant(!/refresh/i.test(a.notes.join(" | ")),
+          "asked the operator to refresh during a race that fixed itself: " + a.notes);
+        invariant(!/returned|did not define/.test(a.st.note),
+          "reported a fault after recovering: " + a.st.note);
+        """)
+
+    def test_a_probe_landing_after_the_operator_moved_on_repaints_nothing(self):
+        """The attach can end while the HEADs are in flight. A finding about
+        the session you left must never overwrite the one you are looking
+        at."""
+        run_js(r"""
+        const held = [];
+        respond = () => new Promise((resolve) => held.push(resolve));
+        const stale = attach();
+        ifOpenStream(stale, "ticket-1");
+        await sleep(50);
+        const staleNote = stale.st.note;
+        const staleNotes = stale.notes.length;
+        // The operator selects another shell: a newer attachment is current.
+        const current = attach();
+        current.st.note = "attached";
+        held.forEach((resolve) => resolve({ status: 404 }));
+        await sleep(200);
+        invariant(stale.st.note === staleNote,
+          "a probe repainted an attachment that was already gone: " + stale.st.note);
+        invariant(stale.notes.length === staleNotes, "repainted the stale pane");
+        invariant(current.st.note === "attached",
+          "the stale probe overwrote the live pane: " + current.st.note);
+        invariant(stale.vendorRetry === null, "the dead attach scheduled a retry");
+        """)
+
+    def test_a_probe_that_throws_names_the_error_and_claims_nothing_else(self):
+        run_js(r"""
+        respond = async () => { throw new Error("Failed to fetch"); };
+        const a = attach();
+        ifOpenStream(a, "ticket-1");
+        const note = await settle(a, /could not check/);
+        invariant(note.includes("Failed to fetch"), "swallowed the error: " + note);
+        invariant(!/refresh/i.test(note), "prescribed a refresh: " + note);
+        invariant(!/returned|did not define|restart/.test(note),
+          "claimed a diagnosis it could not make: " + note);
+        """)
+
+    def test_a_page_with_no_vendor_scripts_says_exactly_that(self):
+        run_js(r"""
+        scriptSrcs = [];
+        const a = attach();
+        ifOpenStream(a, "ticket-1");
+        const note = await settle(a, /declares no/);
+        invariant(probes.length === 0, "probed a script list it does not have");
+        invariant(!/refresh/i.test(note), "prescribed a refresh: " + note);
+        """)
+
+
+class VendorEnumerationTest(unittest.TestCase):
+    """The probe reads the page instead of a second list — so the check that
+    matters is that the page and the selector still describe each other. (The
+    real DOM match is proven in the browser by
+    tests/test_interface_ui_rendered.py.)"""
+
+    def test_the_selector_matches_the_script_tags_the_shell_declares(self):
+        self.assertIn('script[src^="/vendor/"]', APP)
+        srcs = re.findall(r'<script src="([^"]+)"', INDEX)
+        vendored = [s for s in srcs if s.startswith("/vendor/")]
+        self.assertGreaterEqual(len(vendored), 2, srcs)
+        self.assertIn("/vendor/xterm/xterm.js", vendored)
+        self.assertIn("/vendor/xterm/addon-fit.js", vendored)
+
+    def test_the_old_remedy_is_gone_from_the_shell(self):
+        """It said `refresh the page` for a route-table miss no refresh can
+        clear. Nothing in the attach path may say it again."""
+        self.assertNotIn("still loading — refresh the page", APP)
+        # No note this path can paint may carry it either — the word survives
+        # in the comments, which is where the reasoning belongs.
+        self.assertEqual(re.findall(r'"[^"]*refresh[^"]*"', VENDOR, re.I), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vendor_assets.py
+++ b/tests/test_vendor_assets.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Vendored assets resolve against the tree as it is NOW — spec #48
+(sprint 45, unit 11).
+
+The defect these pin is a rate mismatch, not a wrong line: the route table was
+built once at import while file BODIES were read per request, so pulling the
+repo under a running server served a current `app.js` to a browser whose newly
+vendored dependency the same server would not serve. Nothing in the units that
+vendored it was wrong; the split was in the server, which is why the fix has
+to be a resolution rule rather than another registration.
+
+Everything here runs over a real socket through the real `dispatch_http`
+against a disposable UI tree (the fixture is shared with
+tests/test_ui_freshness.py), because half the properties — containment, the
+404's shape, HEAD carrying no body — are about what crosses the wire and are
+invisible to a test that calls the resolver directly.
+
+Containment is asserted on the BODY, never on the status alone: a 404 that
+still leaked the file's bytes would pass a status-only check.
+
+Run:
+    python3 -m pytest tests/test_vendor_assets.py
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(TESTS))
+
+from test_ui_freshness import ServedAssetTestCase  # noqa: E402
+
+SECRET = "SECRET-OUTSIDE-THE-VENDOR-ROOT\n"
+
+
+class VendoredAssetTest(ServedAssetTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.vendor = self.ui / "vendor"
+        (self.vendor / "xterm").mkdir(parents=True)
+        (self.vendor / "xterm" / "xterm.js").write_text("globalThis.Terminal = 1;\n")
+        # The bytes containment must never hand back. Inside UI_DIR but above
+        # the vendor root, which is the reach the old frozen table denied by
+        # having no route at all.
+        (self.ui / "secret.js").write_text(SECRET)
+
+    # -- the incident itself --------------------------------------------------
+
+    def test_an_asset_vendored_after_the_server_started_is_reachable(self):
+        """The whole unit, in one test: the server is already running when the
+        file appears — exactly what a `git pull` under a live engine does."""
+        self.assertEqual(self.get("/vendor/xterm/addon-fit.js")[0], 404)
+        (self.vendor / "xterm" / "addon-fit.js").write_text(
+            "globalThis.FitAddon = 1;\n")
+        status, headers, body = self.get("/vendor/xterm/addon-fit.js")
+        self.assertEqual(status, 200, "an asset vendored under a running "
+                                      "server stayed unreachable")
+        self.assertEqual(body, b"globalThis.FitAddon = 1;\n")
+        self.assertEqual(headers.get("Content-Type"),
+                         "application/javascript; charset=utf-8")
+
+    def test_a_vendored_file_rewritten_under_the_server_serves_the_new_bytes(self):
+        first = self.get("/vendor/xterm/xterm.js")[2]
+        (self.vendor / "xterm" / "xterm.js").write_text("globalThis.Terminal = 2;\n")
+        self.assertNotEqual(self.get("/vendor/xterm/xterm.js")[2], first)
+
+    # -- containment ----------------------------------------------------------
+
+    def test_traversal_is_contained_and_no_variant_leaks_a_byte(self):
+        """Decoding has to happen BEFORE containment: `%2e%2e` is the spelling
+        that survives a check applied to the raw path."""
+        for path in ("/vendor/../secret.js",
+                     "/vendor/%2e%2e/secret.js",
+                     "/vendor/xterm/../../secret.js",
+                     "/vendor/xterm/%2e%2e/%2e%2e/secret.js",
+                     "/vendor/..%2fsecret.js",
+                     "/vendor/./../secret.js"):
+            with self.subTest(path=path):
+                status, _, body = self.get(path)
+                self.assertEqual(status, 404)
+                self.assertNotIn(b"SECRET", body,
+                                 f"{path} answered 404 and served the file anyway")
+
+    def test_a_symlink_out_of_the_tree_is_bounded_like_dot_dot(self):
+        """Resolution precedes the bound check, which is the only ordering
+        that catches this — a symlink's own path is squeaky clean."""
+        outside = Path(self.tmp.name) / "outside"
+        outside.mkdir()
+        (outside / "escape.js").write_text(SECRET)
+        (self.vendor / "escape.js").symlink_to(outside / "escape.js")
+        status, _, body = self.get("/vendor/escape.js")
+        self.assertEqual(status, 404)
+        self.assertNotIn(b"SECRET", body)
+
+    def test_an_absolute_path_does_not_escape_the_join(self):
+        """`root / "/etc/hosts"` is `/etc/hosts` in pathlib — the join itself
+        is an escape hatch, so the bound check is what has to catch it."""
+        status, _, body = self.get("/vendor//" + str(self.ui / "secret.js"))
+        self.assertEqual(status, 404)
+        self.assertNotIn(b"SECRET", body)
+
+    # -- the allowlist --------------------------------------------------------
+
+    def test_only_allowlisted_suffixes_are_served_from_the_vendor_root(self):
+        """The planted files are real, readable, and inside the root: the
+        suffix is the only thing standing between them and the operator."""
+        for name, content in (("planted.py", "print('reachable')\n"),
+                              ("planted.sql", "SELECT 1;\n"),
+                              ("planted.env", "TOKEN=x\n"),
+                              ("planted.map", '{"version":3}\n')):
+            (self.vendor / name).write_text(content)
+            with self.subTest(name=name):
+                status, _, body = self.get("/vendor/" + name)
+                self.assertEqual(status, 404)
+                self.assertNotIn(content.encode(), body)
+        # Sanity: the same directory serves an allowlisted file happily, so
+        # the 404s above are the suffix gate and not a broken fixture.
+        (self.vendor / "planted.js").write_text("ok\n")
+        self.assertEqual(self.get("/vendor/planted.js")[0], 200)
+
+    def test_source_maps_are_off_the_allowlist_deliberately(self):
+        """`.map` was ruled out this round (spec #48 open question 3). Pinned
+        so re-adding it is a decision someone makes, not a diff someone
+        overlooks."""
+        (self.vendor / "xterm" / "xterm.js.map").write_text('{"version":3}\n')
+        self.assertEqual(self.get("/vendor/xterm/xterm.js.map")[0], 404)
+
+    def test_a_binary_asset_round_trips_byte_identical(self):
+        """Every byte value, including the ones no text codec survives — the
+        sender was str-only before this unit, so an allowlist with fonts in it
+        forces the bytes path."""
+        blob = bytes(range(256)) * 4
+        (self.vendor / "iosevka.woff2").write_bytes(blob)
+        status, headers, body = self.get("/vendor/iosevka.woff2")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, blob)
+        self.assertEqual(headers.get("Content-Type"), "font/woff2")
+        self.assertEqual(headers.get("Content-Length"), str(len(blob)))
+
+    # -- what is NOT a file ---------------------------------------------------
+
+    def test_directories_are_never_listed_or_served(self):
+        for path in ("/vendor/", "/vendor/xterm/", "/vendor/xterm"):
+            with self.subTest(path=path):
+                status, _, body = self.get(path)
+                self.assertEqual(status, 404)
+                self.assertNotIn(b"xterm.js", body,
+                                 f"{path} enumerated the directory")
+
+    def test_a_directory_named_like_an_asset_is_still_not_a_file(self):
+        (self.vendor / "trap.js").mkdir()
+        self.assertEqual(self.get("/vendor/trap.js")[0], 404)
+
+    def test_an_unresolvable_path_is_a_miss_not_a_server_error(self):
+        """A NUL byte makes the filesystem itself refuse the name. That is a
+        404, not the 500 an unguarded `resolve()` would raise into."""
+        status, _, _ = self.get("/vendor/x%00y.js")
+        self.assertEqual(status, 404)
+
+    # -- the 404 says which gate said no --------------------------------------
+
+    def test_each_rejection_names_the_gate_that_made_it(self):
+        """The SHAPE of a 404 was the entire diagnosis in the outage this spec
+        came from (a JSON route-miss vs a text `not built`). A per-request
+        resolver collapses that distinction, so the reason is spelled out
+        instead — one loopback operator's only reading material."""
+        (self.vendor / "planted.py").write_text("x\n")
+        cases = {
+            "/vendor/planted.py": b"suffix not allowlisted",
+            "/vendor/../secret.js": b"outside the vendor root",
+            "/vendor/xterm/missing.js": b"no such file",
+        }
+        for path, reason in cases.items():
+            with self.subTest(path=path):
+                status, headers, body = self.get(path)
+                self.assertEqual(status, 404)
+                self.assertEqual(body, reason)
+                self.assertTrue(headers.get("Content-Type", "")
+                                .startswith("text/plain"))
+
+    # -- freshness, unchanged from the shell files -----------------------------
+
+    def test_an_unchanged_vendored_asset_answers_304(self):
+        _, headers, _ = self.get("/vendor/xterm/xterm.js")
+        self.assertEqual(headers.get("Cache-Control"), "no-cache")
+        status, _, body = self.get("/vendor/xterm/xterm.js",
+                                   {"If-None-Match": headers["ETag"]})
+        self.assertEqual(status, 304)
+        self.assertEqual(body, b"")
+
+    def test_changed_bytes_answer_200_with_a_new_tag(self):
+        _, first, _ = self.get("/vendor/xterm/xterm.js")
+        (self.vendor / "xterm" / "xterm.js").write_text("globalThis.Terminal = 3;\n")
+        status, headers, body = self.get("/vendor/xterm/xterm.js",
+                                         {"If-None-Match": first["ETag"]})
+        self.assertEqual(status, 200)
+        self.assertIn(b"= 3", body)
+        self.assertNotEqual(headers.get("ETag"), first["ETag"])
+
+    # -- HEAD, because the app shell's honest-failure probe uses it ------------
+
+    def test_a_vendored_asset_answers_head_with_headers_and_no_body(self):
+        """Without this the probe in ui/app.js reads 405 for every HEALTHY
+        script and reports a floor that cannot serve the build — the exact
+        dishonest message the other half of this unit removes."""
+        get_status, get_headers, get_body = self.get("/vendor/xterm/xterm.js")
+        status, headers, body = self.request("HEAD", "/vendor/xterm/xterm.js")
+        self.assertEqual((get_status, status), (200, 200))
+        self.assertEqual(body, b"")
+        self.assertEqual(headers.get("Content-Length"), str(len(get_body)))
+        self.assertEqual(headers.get("Content-Type"),
+                         get_headers.get("Content-Type"))
+        self.assertEqual(headers.get("ETag"), get_headers.get("ETag"))
+
+    def test_head_reports_a_missing_vendored_asset_as_404(self):
+        """The probe's whole job: tell "served" from "not served"."""
+        self.assertEqual(self.request("HEAD", "/vendor/xterm/addon-fit.js")[0], 404)
+        (self.vendor / "xterm" / "addon-fit.js").write_text("x\n")
+        self.assertEqual(self.request("HEAD", "/vendor/xterm/addon-fit.js")[0], 200)
+
+    def test_head_stays_unavailable_off_the_vendor_route(self):
+        """Narrow on purpose: HEAD on the API is not a contract this server
+        offers, and this unit is not the place to start offering it."""
+        for path in ("/app.js", "/", "/api/health"):
+            with self.subTest(path=path):
+                self.assertEqual(self.request("HEAD", path)[0], 405)
+
+    # -- the deliberate limit --------------------------------------------------
+
+    def test_new_top_level_shell_files_stay_frozen(self):
+        """Spec #48 keeps the four shell files on the frozen table — a route
+        change its author is looking at. Opening UI_DIR itself would widen
+        filesystem tenancy for no observed benefit, so a new top-level file
+        still needs a restart, and that is a judgement rather than an
+        oversight."""
+        (self.ui / "extra.js").write_text("console.log('new');\n")
+        self.assertEqual(self.get("/extra.js")[0], 404)
+        self.assertEqual(self.get("/app.js")[0], 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vendor_assets.py
+++ b/tests/test_vendor_assets.py
@@ -252,6 +252,13 @@ class VendoredAssetTest(ServedAssetTestCase):
         self.assertEqual(headers.get("Content-Type"),
                          get_headers.get("Content-Type"))
         self.assertEqual(headers.get("ETag"), get_headers.get("ETag"))
+        # HEAD rides the GET path, conditional branch included — so the branch
+        # gets walked here rather than left to inference. (The shell's own probe
+        # fetches `no-store` and never sends the tag, but a client that holds
+        # one must not fall off the route into a 405 or a 500.)
+        conditional = self.request("HEAD", "/vendor/xterm/xterm.js",
+                                   {"If-None-Match": get_headers["ETag"]})
+        self.assertEqual((conditional[0], conditional[2]), (304, b""))
 
     def test_head_reports_a_missing_vendored_asset_as_404(self):
         """The probe's whole job: tell "served" from "not served"."""

--- a/tests/test_vendor_assets.py
+++ b/tests/test_vendor_assets.py
@@ -33,7 +33,10 @@ sys.path.insert(0, str(TESTS))
 
 from test_ui_freshness import ServedAssetTestCase  # noqa: E402
 
-SECRET = "SECRET-OUTSIDE-THE-VENDOR-ROOT\n"
+# The bytes containment must never hand back. Named for what it is — a
+# canary, not a credential: CodeQL reads a fixture called SECRET as stored
+# sensitive data and files a high-severity alert against the test.
+CANARY = "CANARY-OUTSIDE-THE-VENDOR-ROOT\n"
 
 
 class VendoredAssetTest(ServedAssetTestCase):
@@ -56,10 +59,9 @@ class VendoredAssetTest(ServedAssetTestCase):
         self.vendor = self.ui / "vendor"
         (self.vendor / "xterm").mkdir(parents=True)
         (self.vendor / "xterm" / "xterm.js").write_text("globalThis.Terminal = 1;\n")
-        # The bytes containment must never hand back. Inside UI_DIR but above
-        # the vendor root, which is the reach the old frozen table denied by
-        # having no route at all.
-        (self.ui / "secret.js").write_text(SECRET)
+        # Inside UI_DIR but above the vendor root — the reach the old frozen
+        # table denied by having no route at all.
+        (self.ui / "offlimits.js").write_text(CANARY)
 
     # -- the incident itself --------------------------------------------------
 
@@ -86,16 +88,16 @@ class VendoredAssetTest(ServedAssetTestCase):
     def test_traversal_is_contained_and_no_variant_leaks_a_byte(self):
         """Decoding has to happen BEFORE containment: `%2e%2e` is the spelling
         that survives a check applied to the raw path."""
-        for path in ("/vendor/../secret.js",
-                     "/vendor/%2e%2e/secret.js",
-                     "/vendor/xterm/../../secret.js",
-                     "/vendor/xterm/%2e%2e/%2e%2e/secret.js",
-                     "/vendor/..%2fsecret.js",
-                     "/vendor/./../secret.js"):
+        for path in ("/vendor/../offlimits.js",
+                     "/vendor/%2e%2e/offlimits.js",
+                     "/vendor/xterm/../../offlimits.js",
+                     "/vendor/xterm/%2e%2e/%2e%2e/offlimits.js",
+                     "/vendor/..%2fofflimits.js",
+                     "/vendor/./../offlimits.js"):
             with self.subTest(path=path):
                 status, _, body = self.get(path)
                 self.assertEqual(status, 404)
-                self.assertNotIn(b"SECRET", body,
+                self.assertNotIn(b"CANARY", body,
                                  f"{path} answered 404 and served the file anyway")
 
     def test_a_percent_encoded_name_is_decoded_before_it_is_resolved(self):
@@ -113,18 +115,18 @@ class VendoredAssetTest(ServedAssetTestCase):
         that catches this — a symlink's own path is squeaky clean."""
         outside = Path(self.tmp.name) / "outside"
         outside.mkdir()
-        (outside / "escape.js").write_text(SECRET)
+        (outside / "escape.js").write_text(CANARY)
         (self.vendor / "escape.js").symlink_to(outside / "escape.js")
         status, _, body = self.get("/vendor/escape.js")
         self.assertEqual(status, 404)
-        self.assertNotIn(b"SECRET", body)
+        self.assertNotIn(b"CANARY", body)
 
     def test_an_absolute_path_does_not_escape_the_join(self):
         """`root / "/etc/hosts"` is `/etc/hosts` in pathlib — the join itself
         is an escape hatch, so the bound check is what has to catch it."""
-        status, _, body = self.get("/vendor//" + str(self.ui / "secret.js"))
+        status, _, body = self.get("/vendor//" + str(self.ui / "offlimits.js"))
         self.assertEqual(status, 404)
-        self.assertNotIn(b"SECRET", body)
+        self.assertNotIn(b"CANARY", body)
 
     # -- the allowlist --------------------------------------------------------
 
@@ -194,7 +196,7 @@ class VendoredAssetTest(ServedAssetTestCase):
         (self.vendor / "planted.py").write_text("x\n")
         cases = {
             "/vendor/planted.py": b"suffix not allowlisted",
-            "/vendor/../secret.js": b"outside the vendor root",
+            "/vendor/../offlimits.js": b"outside the vendor root",
             "/vendor/xterm/missing.js": b"no such file",
         }
         for path, reason in cases.items():

--- a/tests/test_vendor_assets.py
+++ b/tests/test_vendor_assets.py
@@ -23,6 +23,7 @@ Run:
 """
 from __future__ import annotations
 
+import socket
 import sys
 import unittest
 from pathlib import Path
@@ -36,6 +37,19 @@ SECRET = "SECRET-OUTSIDE-THE-VENDOR-ROOT\n"
 
 
 class VendoredAssetTest(ServedAssetTestCase):
+
+    def raw(self, method, path):
+        """Everything the server actually wrote, headers and all. The
+        transport closes the connection per response, so EOF is the end."""
+        with socket.create_connection(("127.0.0.1", self.port), timeout=10) as s:
+            s.sendall(f"{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+                      "Connection: close\r\n\r\n".encode())
+            chunks = []
+            while True:
+                chunk = s.recv(65536)
+                if not chunk:
+                    return b"".join(chunks)
+                chunks.append(chunk)
 
     def setUp(self):
         super().setUp()
@@ -83,6 +97,16 @@ class VendoredAssetTest(ServedAssetTestCase):
                 self.assertEqual(status, 404)
                 self.assertNotIn(b"SECRET", body,
                                  f"{path} answered 404 and served the file anyway")
+
+    def test_a_percent_encoded_name_is_decoded_before_it_is_resolved(self):
+        """The other half of decode-then-contain, and the half a traversal
+        battery cannot see: with the decode removed every `..` spelling still
+        404s (on a path that simply does not exist), so only a legitimate
+        encoded name shows whether decoding happens at all."""
+        (self.vendor / "space name.js").write_text("encoded\n")
+        status, _, body = self.get("/vendor/space%20name.js")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b"encoded\n")
 
     def test_a_symlink_out_of_the_tree_is_bounded_like_dot_dot(self):
         """Resolution precedes the bound check, which is the only ordering
@@ -205,10 +229,22 @@ class VendoredAssetTest(ServedAssetTestCase):
     def test_a_vendored_asset_answers_head_with_headers_and_no_body(self):
         """Without this the probe in ui/app.js reads 405 for every HEALTHY
         script and reports a floor that cannot serve the build — the exact
-        dishonest message the other half of this unit removes."""
+        dishonest message the other half of this unit removes.
+
+        The empty body is read off a RAW socket, because http.client declines
+        to read a body after a HEAD whatever the server sent: asserting on the
+        parsed response proves the client's manners, not the server's. (Made
+        the mutation that writes the body anyway go green, which is how this
+        apparatus got replaced.)
+        """
         get_status, get_headers, get_body = self.get("/vendor/xterm/xterm.js")
         status, headers, body = self.request("HEAD", "/vendor/xterm/xterm.js")
         self.assertEqual((get_status, status), (200, 200))
+        raw = self.raw("HEAD", "/vendor/xterm/xterm.js")
+        head, _, after_headers = raw.partition(b"\r\n\r\n")
+        self.assertEqual(after_headers, b"",
+                         "HEAD sent a body after its headers")
+        self.assertIn(b"Content-Length: %d" % len(get_body), head)
         self.assertEqual(body, b"")
         self.assertEqual(headers.get("Content-Length"), str(len(get_body)))
         self.assertEqual(headers.get("Content-Type"),


### PR DESCRIPTION
Sprint 45, unit 11 — spec doc 48 (PLN3's, authored from the 2026-07-25 GUI outage). Both halves in scope per PLN1's ruling; `.map` off the allowlist per the same ruling.

## What was wrong

`_STATIC` was built once at module import; file bodies were read from disk on every request. Pull the repo under a running server and every *registered* asset updates instantly while a *newly vendored* one stays unreachable — a current `app.js` served to a browser whose dependency the same server has no route for. The incident: `addon-fit.js` on disk, `{"error":"not found"}` on the wire, two live planner sessions unwatchable, and the prescribed remedy (restart) unavailable because the server is PID 1 in the sandbox that hosts the sprint. Nothing the vendoring commit did was wrong — the split is in the server, so no discipline in the units can prevent the next one.

Second fault, one symptom: the attach guard knew `Terminal is not defined` and asserted `still loading — refresh the page`. Correct for the genuine defer race; actively misleading for a 404, where no refresh will ever define the global. The operator acted on it.

## Server — `/vendor/**` resolves per request

The four shell files stay a frozen table (closed set; `index.html` carries the CSP). Everything under `/vendor/` resolves against `ui/vendor/` at request time through four gates in a fixed order: **decode then contain** (decoding after is the classic hole), **suffix allowlist** (`.js .css .woff2 .png .svg` — never sniffed; the table is the allowlist the frozen dict was quietly also being), **resolve then bound** (which is what catches a symlink escape as well as `..`), **regular file only** (no listings, ever). `_send` passes bytes through so the allowlist can include fonts without becoming a trap.

404 bodies name the gate that rejected the request. The *shape* of the old 404 was the entire diagnosis in this incident and a per-request resolver otherwise collapses that distinction, so it is replaced deliberately rather than lost. Headers are unchanged: `no-cache` + content-derived ETag + the existing 304.

## App shell — probe, then report what was observed

When a required global is missing, the page enumerates its own `script[src^="/vendor/"]` tags (off the DOM — no second list to drift from `index.html`) and HEADs each with `cache: "no-store"`:

| probe | told |
|---|---|
| any non-200 | `<src> returned <status>` + the floor is older than this page and needs a restart |
| all 200, within bound | nothing to act on — **the attach retries itself** (~8 attempts / ~2s) |
| all 200, bound exhausted | `<srcs> served but did not define Terminal and FitAddon` |
| probe threw | the error, and nothing else |

Bounded (an unbounded retry is the same lie in a spinner's costume), cancelled on detach, and every note re-checks the generation first so a late probe cannot repaint a newer pane. The word "refresh" appears in no note this path can paint.

## The one premise that was wrong (reported pre-build, result #1873, ratified #1874)

The spec's probe HEADs each script — and this server had **no `do_HEAD`**. Verified against `origin/main` and against the live floor: `curl -I /vendor/xterm/xterm.js` → 405 while GET → 200. Built as specced, the probe would have reported every *healthy* script as a floor that cannot serve the build: the same dishonest message one layer along.

So HEAD is answered for `/vendor/**` only, through the same `_serve_vendor` that answers GET — the body is suppressed at the single `_send` write, so HEAD's header contract cannot drift from GET's. HEAD elsewhere keeps its 405; offering it on the API is not this unit's call. Rejected alternative: downgrade the probe to GET, which means re-downloading 1.2MB of xterm.js to read a status code.

Note the degradation is honest, and is pinned (M23): against an *old* floor every probe reads 405 → "older than this page, restart the floor", which is true there.

## Tests

`tests/test_vendor_assets.py` (25) — post-start vendoring reachable; traversal battery over `..`, `%2e%2e`, mixed, `..%2f`, symlink escape and absolute-path join, each asserting the **body never leaks** rather than only the status; percent-decoding; allowlist incl. `.map`; binary round trip over all 256 byte values; directories and directory-named-`.js`; NUL-byte path; gate-named 404s; ETag/304; HEAD parity read off a raw socket; and the deliberate shell-file limit. `tests/test_ui_vendor_probe.py` (14, node-driven against the real source). Two real-browser tests in `test_interface_ui_rendered.py` — the only place the DOM selector is proven against `index.html` rather than a stub. The freshness fixture is now shared with `test_ui_freshness.py` rather than copied.

**Mutation evidence: `tests/mutations/u11_vendor_resolution.py`, 23/23 red-under-mutation → green-on-revert**, run with `PYTHONDONTWRITEBYTECODE=1` and every `__pycache__` cleared (flag #182 — a same-size mutation reverted within one second leaves a valid `.pyc` and the suite then reports on bytecode that is not the file).

The first pass came back **17/22**, and all four gaps were the tests, not the code: removing `unquote` left the traversal battery green (every `..` spelling still 404s, just at a different gate — only a legitimately encoded *name* shows decoding happens at all); `http.client` never reads a body after HEAD whatever the server wrote, so that assertion was about the client's manners; and the two generation guards are each *sufficient* for a note, so one test kept both mutations green. Splitting them turned up a property nobody had listed — an attach that dies **between** attempts with the timer already armed.

## Known gaps

- The node-driven suite **skips in the `tests` CI job** (no node there — same as U2's composer contract). The two headline UI properties are covered end-to-end by the `interface-rendered` job, which does run. Whether to add `setup-node` to the shared gate is a planner call, not this unit's.
- The composer's second banner ("Connecting to the generation-fenced input broker…") still renders alongside the terminal note, since the guard returns before the WebSocket exists. Spec 48 describes it; its requirements table does not ask for it. Left alone, reported as a follow-up.
- `_CSP` has the same frozen-at-import shape. Ruled out of scope (flag #146's territory).

Full suite green locally: 1447 passed, 403 subtests.