### PR TITLE
feat(analytics): 49-U1 quota tables — migration 0096 + snapshot-exclusion test (S52 U1)

### DIFF
--- a/.super-coder/migrations/0096_harness_quota_accounts.sql
+++ b/.super-coder/migrations/0096_harness_quota_accounts.sql
@@ -1,0 +1,134 @@
+-- 0096 — Account Analytics: harness quota registry + window snapshots (spec doc 49, feature 17, sprint doc 52).
+--
+-- Feature #17's collector answers *what did we spend* by parsing what each
+-- harness writes to disk after the fact. It cannot answer *how much is left*:
+-- no harness writes its remaining allotment anywhere, so allotment lives behind
+-- an authenticated endpoint per provider. These two tables are where the probes
+-- in scripts/quota_probes/ land what those endpoints return.
+--
+-- Two parts:
+--   1. harness_quota_account — the durable registry. One row per account ever
+--      seen. A credential file holds exactly ONE account, so "show all known
+--      accounts" is only possible if we remember the ones we have seen; this is
+--      that memory. Not a timeseries — one current row per account.
+--   2. harness_quota_window — last snapshot per window, overwritten every probe.
+--      No history is kept, so the panel stays a glance surface.
+--
+-- ── NEITHER TABLE GOES IN PER_INSTANCE_TABLES (scripts/snapshot.py) ──────────
+--
+-- They are probe-rebuildable caches, exactly like session_token_usage (0071):
+-- nothing here is authored memory, and a rebuild re-derives all of it from the
+-- next probe. That alone would be reason enough to leave them out.
+--
+-- But the consequence of getting it wrong is no longer merely "a cache got
+-- committed". account_label holds the operator's FULL email address. An earlier
+-- ruling redacted it to the local part; decision #67 WITHDREW that redaction,
+-- because redaction was defending a path that does not exist (the engine DB is
+-- gitignored, and session_token_usage — a cache of exactly this class — appears
+-- zero times in the tracked content.sql on origin/main) while costing real
+-- information: jed@gmail.com and jed@work.com both reduce to "jed", making two
+-- cards indistinguishable in precisely the multi-account case this feature
+-- exists to show.
+--
+-- That withdrawal promoted snapshot exclusion from hygiene to load-bearing: it
+-- is now the ONLY thing between full operator emails and the repository. Adding
+-- either table to PER_INSTANCE_TABLES would put operator PII into a git-tracked
+-- file — the same defect shape already recorded as a conformance Medium for the
+-- plaintext lease token.
+--
+-- This comment exists because a future reader has no other way to know the
+-- exclusion is deliberate; an allowlist records what IS in it, never what was
+-- kept out or why. tests/test_quota_snapshot_exclusion.py asserts the property
+-- against a freshly rendered content.sql rather than against the allowlist, so
+-- the guarantee survives a refactor of how the snapshot decides what to dump.
+--
+-- Second-order, and no allowlist can catch it: docs/images/analytics.png is a
+-- committed screenshot of this very tab. Whoever captures a shot of this
+-- section scrubs the label or shoots a placeholder account.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS harness_quota_account (
+    account_pk    INTEGER PRIMARY KEY,
+    provider      TEXT    NOT NULL,       -- anthropic/openai/moonshot (one module per PROVIDER,
+                                          -- not per harness: quota is an account property, and
+                                          -- five shells on Claude share one bucket)
+    account_ref   TEXT    NOT NULL,       -- provider's stable id: OpenAI account_id, Moonshot
+                                          -- user.userId, or the Anthropic credential-file uuid
+    account_label TEXT,                   -- FULL email (OpenAI) else user.userId (Moonshot) else
+                                          -- credential uuid first 8 (Anthropic). Never truncated —
+                                          -- see decision #67 and the exclusion note above.
+    plan          TEXT,                   -- max / prolite / LEVEL_ADVANCED — verbatim from provider
+    first_seen    TEXT    NOT NULL,       -- ISO UTC; survives an account going quiet and coming back
+    last_seen     TEXT    NOT NULL,       -- ISO UTC; drives the fixed 7-day activity window
+    is_current    INTEGER NOT NULL DEFAULT 0,  -- 1 = the account the credential file resolves to now
+    UNIQUE (provider, account_ref)
+);
+
+-- The registry's identity key. The spec states "one row per account ever seen"
+-- but declares no key for it; without this a re-probe mints a duplicate instead
+-- of advancing last_seen, and "switching back restores the original first_seen"
+-- becomes unimplementable. account_ref is NOT NULL so a drifted payload that
+-- carries no identifier fails loudly here rather than accumulating anonymous
+-- rows — a provider we cannot identify has no card to render anyway.
+
+-- Drives the panel's only filter: last_seen inside 7 days. Rows are never
+-- pruned, they simply stop rendering, so this index reads a growing table.
+CREATE INDEX IF NOT EXISTS idx_hqa_last_seen ON harness_quota_account(last_seen);
+
+CREATE TABLE IF NOT EXISTS harness_quota_window (
+    window_pk     INTEGER PRIMARY KEY,
+    account_pk    INTEGER NOT NULL REFERENCES harness_quota_account(account_pk) ON DELETE CASCADE,
+    window_kind   TEXT    NOT NULL,       -- session/five_hour/weekly/weekly_scoped/short — and see below
+    scope         TEXT,                   -- model or feature the window applies to; NULL = account-wide
+    used_percent  REAL,                   -- 0-100, NULL when underivable (never back-computed into a count)
+    used          INTEGER,                -- absolute counts, NULL when the provider gives none
+    limit_value   INTEGER,                -- "limit" is a SQL reserved word — see note below
+    resets_at     TEXT,                   -- ISO UTC
+    captured_at   TEXT    NOT NULL,       -- ISO UTC — the card always renders its age
+    status        TEXT    NOT NULL DEFAULT 'ok'
+                  CHECK (status IN ('ok', 'stale', 'unauth', 'na', 'error')),
+    probe_version TEXT                    -- drift pin, per probe module
+);
+
+-- window_kind is deliberately NOT constrained by a CHECK. The spec requires
+-- that a window mapping to no known duration is "rendered under its raw
+-- duration, not dropped" — a CHECK over the five known kinds would reject that
+-- insert, which drops exactly the row the spec says to keep. These endpoints
+-- are private, undocumented and expected to drift; the constraint would convert
+-- drift into data loss. status IS constrained, because its five values are ours
+-- and closed.
+--
+-- limit_value, not "limit": the spec's Data Model names this column `limit`,
+-- which is a SQL reserved word — `SELECT used, limit FROM harness_quota_window`
+-- is a syntax error, so every reader downstream would have to quote it forever.
+-- Renamed here and declared to the planner rather than quoted at every call
+-- site. Meaning is unchanged: the absolute allotment, NULL when the provider
+-- reports percentage only. limit_value = 0 yields a NULL percent and an "n/a"
+-- card — never a division by zero.
+
+-- ── The upsert key, and why it is an expression index ────────────────────────
+--
+-- The spec declares UNIQUE (account_pk, window_kind, scope) as the idempotency
+-- key AND declares scope NULL = account-wide. Under SQLite those two clauses
+-- contradict each other: NULLs compare DISTINCT in a UNIQUE index, so a plain
+-- UNIQUE(account_pk, window_kind, scope) does not constrain account-wide rows
+-- at all — two probes of the same window insert two rows, no violation raised.
+-- That is the common path, not an edge case: session, weekly and five_hour are
+-- all account-wide, so the panel's principal rows would duplicate on every
+-- probe and the spec's own "concurrent probes: upsert is idempotent on the
+-- UNIQUE key" would be false.
+--
+-- Folding NULL to '' in the index restores the declared behaviour while leaving
+-- scope NULLable, so the shape U3 and U4 read is exactly the one the spec gave
+-- them. The cost is that the upsert must name this expression as its conflict
+-- target verbatim:
+--
+--   INSERT INTO harness_quota_window (...) VALUES (...)
+--   ON CONFLICT(account_pk, window_kind, COALESCE(scope, ''))
+--   DO UPDATE SET used_percent=excluded.used_percent, ...;
+--
+CREATE UNIQUE INDEX IF NOT EXISTS idx_hqw_key
+    ON harness_quota_window(account_pk, window_kind, COALESCE(scope, ''));
+
+COMMIT;

--- a/tests/test_quota_schema.py
+++ b/tests/test_quota_schema.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Schema properties of migration 0096 — the quota registry + window tables.
+
+Each test here pins a decision the migration makes that a plausible "cleanup"
+would undo:
+
+- the window upsert key really is idempotent for account-wide rows (the reason
+  it is an expression index over COALESCE(scope,'') and not the plain UNIQUE
+  the spec's Data Model literally names — SQLite compares NULLs as distinct, so
+  the plain form does not constrain the common path at all);
+- the registry has an identity key, so a re-probe advances an account instead
+  of minting a duplicate;
+- an unrecognized window_kind is STORED, not rejected — the spec requires it be
+  "rendered under its raw duration, not dropped", so a tidy CHECK over the five
+  known kinds would be data loss on exactly the endpoint drift this feature
+  expects;
+- status IS closed, because those five values are ours.
+
+Run:
+    python3 tests/test_quota_schema.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+UPSERT = (
+    "INSERT INTO harness_quota_window "
+    "(account_pk, window_kind, scope, used_percent, captured_at, status) "
+    "VALUES (?, ?, ?, ?, ?, 'ok') "
+    "ON CONFLICT(account_pk, window_kind, COALESCE(scope, '')) "
+    "DO UPDATE SET used_percent=excluded.used_percent, "
+    "captured_at=excluded.captured_at"
+)
+
+
+class QuotaSchemaTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        self.con = sqlite3.connect(self.db)
+        self.con.executescript(SCHEMA.read_text())
+        for p in sorted(MIGRATIONS.glob("*.sql")):
+            self.con.executescript(p.read_text())
+        self.con.execute("PRAGMA foreign_keys=ON")
+        self.con.execute(
+            "INSERT INTO harness_quota_account (account_pk, provider, "
+            "account_ref, account_label, first_seen, last_seen, is_current) "
+            "VALUES (1, 'anthropic', 'uuid-abc', 'uuid-abc', "
+            "'2026-07-25T00:00:00Z', '2026-07-25T00:00:00Z', 1)")
+
+    def tearDown(self):
+        self.con.close()
+        for p in sorted(self.tmp.glob("*")):
+            p.unlink()
+        self.tmp.rmdir()
+
+    def _windows(self):
+        return self.con.execute(
+            "SELECT window_kind, scope, used_percent FROM harness_quota_window "
+            "ORDER BY window_pk").fetchall()
+
+    def test_upsert_is_idempotent_for_account_wide_windows(self):
+        """scope IS NULL is the COMMON path — session, weekly and five_hour are
+        all account-wide. Two probes must leave one row, updated."""
+        for percent in (10.0, 20.0):
+            self.con.execute(
+                UPSERT, (1, "weekly", None, percent, "2026-07-25T00:00:00Z"))
+        self.assertEqual(self._windows(), [("weekly", None, 20.0)])
+
+    def test_upsert_is_idempotent_for_scoped_windows(self):
+        for percent in (10.0, 30.0):
+            self.con.execute(
+                UPSERT, (1, "weekly_scoped", "opus", percent,
+                         "2026-07-25T00:00:00Z"))
+        self.assertEqual(self._windows(), [("weekly_scoped", "opus", 30.0)])
+
+    def test_account_wide_and_scoped_windows_coexist(self):
+        """COALESCE folds NULL to '' for uniqueness only — it must not collide a
+        NULL scope with a genuinely empty or differently-scoped one."""
+        self.con.execute(UPSERT, (1, "weekly", None, 10.0, "t"))
+        self.con.execute(UPSERT, (1, "weekly", "opus", 20.0, "t"))
+        self.assertEqual(
+            self._windows(), [("weekly", None, 10.0), ("weekly", "opus", 20.0)])
+
+    def test_registry_rejects_duplicate_account(self):
+        """A re-probe advances the existing account; it never mints a second
+        row, which is what keeps first_seen intact across a switch-away."""
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO harness_quota_account (provider, account_ref, "
+                "first_seen, last_seen) VALUES ('anthropic', 'uuid-abc', "
+                "'2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z')")
+
+    def test_same_ref_on_a_different_provider_is_a_different_account(self):
+        self.con.execute(
+            "INSERT INTO harness_quota_account (provider, account_ref, "
+            "first_seen, last_seen) VALUES ('openai', 'uuid-abc', 't', 't')")
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM harness_quota_account").fetchone()[0], 2)
+
+    def test_unrecognized_window_kind_is_stored_not_rejected(self):
+        """Endpoint drift must degrade to a row rendered under its raw duration,
+        never to a dropped row. A CHECK over the five known kinds would turn
+        this insert into data loss."""
+        self.con.execute(UPSERT, (1, "900_SECOND", "900 SECOND", 5.0, "t"))
+        self.assertEqual(self._windows(), [("900_SECOND", "900 SECOND", 5.0)])
+
+    def test_status_is_a_closed_set(self):
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO harness_quota_window (account_pk, window_kind, "
+                "captured_at, status) VALUES (1, 'weekly', 't', 'probably_ok')")
+
+    def test_window_requires_a_real_account(self):
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO harness_quota_window (account_pk, window_kind, "
+                "captured_at) VALUES (99, 'weekly', 't')")
+
+    def test_counts_and_percent_are_independently_nullable(self):
+        """Anthropic and OpenAI report percentage only; Moonshot reports counts
+        only. Neither is ever back-computed from the other, so both sides must
+        be storable as NULL."""
+        self.con.execute(UPSERT, (1, "session", None, 22.0, "t"))
+        self.con.execute(
+            "INSERT INTO harness_quota_window (account_pk, window_kind, scope, "
+            "used, limit_value, captured_at) "
+            "VALUES (1, 'five_hour', NULL, 120, 500, 't')")
+        rows = self.con.execute(
+            "SELECT window_kind, used_percent, used, limit_value "
+            "FROM harness_quota_window ORDER BY window_pk").fetchall()
+        self.assertEqual(
+            rows, [("session", 22.0, None, None), ("five_hour", None, 120, 500)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quota_snapshot_exclusion.py
+++ b/tests/test_quota_snapshot_exclusion.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Asserts the quota tables never reach a freshly rendered content.sql.
+
+content.sql is git-tracked. `harness_quota_account.account_label` holds the
+operator's FULL email address — decision #67 withdrew the earlier redaction
+because the address never reaches the repository, which makes snapshot
+exclusion the ONLY thing keeping that true. So the guarantee is asserted here
+rather than assumed from `PER_INSTANCE_TABLES`.
+
+The distinction matters. A test that asserts `"harness_quota_account" not in
+snapshot.PER_INSTANCE_TABLES` is just the allowlist read twice: it stays green
+if the renderer grows a second source of tables, dumps a table the allowlist
+never named, or is refactored to decide inclusion some other way. This builds a
+throwaway engine DB with real rows in both quota tables, runs the REAL
+`snapshot.main()` against it, and greps the file that comes out. Whatever path
+put a table into that file, the assertion sees it.
+
+The paths `main()` writes are redirected into a temp dir (the live DB, the
+output content.sql, the legacy-copy cleanup, and the map serializer, which
+otherwise writes the repo's own map_content.sql). The render loop itself —
+`PER_INSTANCE_TABLES`, `dump_table`, `SENSITIVE_COLUMNS`, the row filters — is
+untouched and real.
+
+Run:
+    python3 tests/test_quota_snapshot_exclusion.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import snapshot  # noqa: E402
+
+QUOTA_TABLES = ("harness_quota_account", "harness_quota_window")
+
+# Full address on purpose: this is the exact value decision #67 accepted into
+# the DB, so it is the exact value that must not appear in a tracked file.
+SENTINEL_EMAIL = "operator.sentinel@must-never-reach-git.test"
+SENTINEL_REF = "acct_sentinel_0123456789"
+SENTINEL_PLAN = "sentinel_plan"
+
+
+def build_engine_db(path: Path) -> None:
+    """Schema + every migration, then rows in the quota tables and one row in a
+    table that IS serialized (the positive control)."""
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1)")
+    con.execute(
+        "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
+        "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
+        "VALUES (1, 'TC', 'tc', 'test', 'sp', 1, 0, 1, 1)")
+    con.execute(
+        "INSERT INTO harness_quota_account (account_pk, provider, account_ref, "
+        "account_label, plan, first_seen, last_seen, is_current) "
+        "VALUES (1, 'openai', ?, ?, ?, '2026-07-25T00:00:00Z', "
+        "'2026-07-25T00:00:00Z', 1)",
+        (SENTINEL_REF, SENTINEL_EMAIL, SENTINEL_PLAN))
+    con.execute(
+        "INSERT INTO harness_quota_window (account_pk, window_kind, scope, "
+        "used_percent, captured_at, status, probe_version) "
+        "VALUES (1, 'weekly', NULL, 42.0, '2026-07-25T00:00:00Z', 'ok', '1')")
+    con.commit()
+    con.close()
+
+
+class QuotaSnapshotExclusionTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        self.out = self.tmp / "state" / "content.sql"
+        build_engine_db(self.db)
+        self.rendered = self._render()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _render(self) -> str:
+        """Run the real snapshot.main() with its write targets redirected."""
+        with mock.patch.multiple(
+            snapshot,
+            DB_PATH=self.db,
+            OUT_PATH=self.out,
+            LEGACY_PATH=self.tmp / "legacy" / "content.sql",
+            REPO_ROOT=self.tmp,          # main() prints OUT_PATH.relative_to(REPO_ROOT)
+            snapshot_map=lambda: None,   # else it serializes the REPO's map db
+        ), mock.patch.object(
+            snapshot.artifact_policy, "prepare_local_state", lambda: []
+        ), mock.patch.dict(os.environ, {"SC_ADMIN": "1"}):
+            self.assertEqual(snapshot.main(), 0)
+        return self.out.read_text()
+
+    def test_render_is_real(self):
+        """Guard the guard: the assertions below are only worth anything if the
+        renderer actually produced a populated content.sql. A silently empty or
+        failed render would make every `assertNotIn` pass for free."""
+        self.assertIn("INSERT INTO shells", self.rendered)
+        self.assertIn("'tc'", self.rendered)
+
+    def test_quota_tables_absent_from_content_sql(self):
+        for table in QUOTA_TABLES:
+            self.assertNotIn(
+                table, self.rendered,
+                f"{table} was serialized into content.sql — it holds operator "
+                "account state and content.sql is git-tracked")
+
+    def test_operator_email_absent_from_content_sql(self):
+        """The value, not just the table name. Catches the table reaching the
+        file under an alias, a join, or a future per-column dumper."""
+        self.assertNotIn(SENTINEL_EMAIL, self.rendered)
+        self.assertNotIn(SENTINEL_EMAIL.split("@", 1)[0], self.rendered)
+        self.assertNotIn(SENTINEL_REF, self.rendered)
+        self.assertNotIn(SENTINEL_PLAN, self.rendered)
+
+    def test_rows_are_present_in_the_db_that_was_rendered(self):
+        """The exclusion must be the renderer's doing, not an empty table. If a
+        future migration edit dropped these rows on the floor, the assertions
+        above would pass while proving nothing."""
+        con = sqlite3.connect(self.db)
+        try:
+            for table in QUOTA_TABLES:
+                count = con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+                self.assertEqual(count, 1, f"{table} had no row to exclude")
+        finally:
+            con.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Spec #49 unit 1 · sprint doc 52 · planner PLN2.

The two tables the quota probes land in, plus the test that keeps operator
emails out of the repository.

## What ships

- **`harness_quota_account`** — the durable registry, one row per account ever
  seen. A credential file holds exactly ONE account, so *show all known
  accounts* is only possible if we remember the ones we have seen. Keyed
  `UNIQUE (provider, account_ref)` so a re-probe advances an account rather than
  minting a duplicate — the spec states "one row per account ever seen" but
  declares no key for it, and without one "switching back restores the original
  `first_seen`" is unimplementable.
- **`harness_quota_window`** — last snapshot per window, overwritten every
  probe. No history; the panel stays a glance surface.
- **The migration comment** recording why neither table belongs in
  `PER_INSTANCE_TABLES`.
- **`tests/test_quota_snapshot_exclusion.py`** — the unit's load-bearing
  deliverable.
- `tests/test_quota_schema.py` — pins the schema decisions a plausible cleanup
  would undo.

## The gate is a test, not a reading of the allowlist

The spec's gate explicitly refuses a reviewer reading `PER_INSTANCE_TABLES` as
satisfaction, and a test asserting `"harness_quota_account" not in
snapshot.PER_INSTANCE_TABLES` would be that same reading written twice — green
if the renderer ever grows a second source of tables, dumps something the
allowlist never named, or is refactored to decide inclusion another way.

So the test builds a throwaway engine DB with real rows in both tables, runs the
**real `snapshot.main()`** with only its write targets redirected (live DB,
output path, legacy-copy cleanup, and the map serializer, which would otherwise
write the repo's own `map_content.sql`), and greps the `content.sql` that comes
out. The render loop — `PER_INSTANCE_TABLES`, `dump_table`, `SENSITIVE_COLUMNS`,
the row filters — is untouched and real. Whatever path put a table into that
file, the assertion sees it. It asserts the table names, the sentinel email, its
local part, the account ref and the plan are all absent.

It also carries a positive control, `test_render_is_real`. An empty or failed
render would make every `assertNotIn` pass for free; emptying the render loop
makes the three exclusion assertions pass vacuously and **only** that control
goes red. Verified by mutation, below.

## Two of the spec's Data Model claims do not hold in SQLite

Both found by running them rather than reading them, both reported to PLN2
before building (msg #1895) and **both ratified** (msg #1898, re-run
independently by the planner on sqlite 3.46.1).

**The declared upsert key is not one.** `UNIQUE (account_pk, window_kind,
scope)` and "scope NULL = account-wide" contradict each other: NULLs compare
DISTINCT in a UNIQUE index, so two probes of an account-wide window insert two
rows with no violation raised. That is the *common* path — `session`, `weekly`
and `five_hour` are all account-wide — so the panel's principal rows would
duplicate on every probe, and the spec's own "concurrent probes: upsert is
idempotent on the UNIQUE key" would be false.

Implemented as a unique **expression index** over `COALESCE(scope,'')`, which
restores the declared behaviour while leaving `scope` NULLable, so the shape U3
and U4 read is exactly the one the spec gave them. Rejected alternative: `scope
NOT NULL DEFAULT ''` makes the plain UNIQUE work but changes the stored
semantics downstream reads. The planner added two arguments I did not have — a
mismatched `ON CONFLICT` target raises `OperationalError` rather than silently
duplicating, and `CREATE UNIQUE INDEX` is the established house pattern while
`NOT NULL DEFAULT ''` has zero precedent here.

The cost is that the upsert must name the expression as its conflict target
verbatim. That literal is in the migration comment, since it is the one thing U3
cannot rediscover from the schema:

```sql
ON CONFLICT(account_pk, window_kind, COALESCE(scope, ''))
```

**`limit` is a SQL reserved word.** `SELECT used, limit FROM
harness_quota_window` is a syntax error, so every downstream reader would have
to quote it forever. Column is `limit_value`, paired with `used`. PLN2 is
correcting the spec's Data Model for both, so it is no longer a deviation, and
telling U2's normalizer to emit `limit_value` — one vocabulary across the seam.

## `window_kind` deliberately carries no CHECK

The spec requires that a window mapping to no known duration is "rendered under
its raw duration, not dropped". A tidy CHECK over the five known kinds would
reject that insert — turning the endpoint drift this feature explicitly expects
into data loss on exactly the row the spec says to keep. `status` **is**
constrained: those five values are ours and closed.

## Verification

Five mutation round trips, each applied in isolation and reverted:

| Mutation | Result |
|---|---|
| Add both tables to `PER_INSTANCE_TABLES` | RED — `test_quota_tables_absent`, `test_operator_email_absent` |
| Expression index → the plain `UNIQUE(…, scope)` the spec literally names | RED — both idempotency tests |
| Add a CHECK on `window_kind` | RED — `test_unrecognized_window_kind_is_stored_not_rejected` |
| Drop `UNIQUE (provider, account_ref)` | RED — `test_registry_rejects_duplicate_account` |
| Empty the render loop | RED — `test_render_is_real` only (the guard-the-guard) |

Applied through the real `migrate.py` against an **explicitly named scratch DB**,
not the dispatcher's default: ledger row written, re-run reports "nothing
pending", and the documented `ON CONFLICT` literal upserts two account-wide
probes into one row. The host live DB still shows **zero** `harness_quota%`
tables — per the board, no migration reaches it and no restart is requested;
sprint 45 has live Interface sessions.

Full suite green: **1426 passed, 384 subtests**, including the playwright-rendered
suite via the flag #169 shim. `ruff` clean on both new files; the one `mypy`
`import-not-found` on the `sys.path.insert` idiom is the established test
pattern here (126 instances across the suite).

Migration numbering re-checked against `origin/main` immediately before push —
0095 is still the highest, 0096 free.

Shell: DEV3 (Code-01) · sprint 52 unit 1