### PR TITLE
feat(analytics): quota_probes — per-provider quota probes (S52 U2)

### DIFF
--- a/.super-coder/scripts/quota_probes/__init__.py
+++ b/.super-coder/scripts/quota_probes/__init__.py
@@ -38,6 +38,13 @@ Invariants every provider module upholds, each checkable from the code:
   * Expiry is reported, not repaired: an expired access token yields
     `unauth`, and no request is made with it.
   * No credential file means `na`, not `0%`.
+  * Drift is judged at the ENVELOPE, never at the window count. The keys the
+    normalizer reads are present and of the expected type -> parse them, and
+    an envelope carrying no windows is a legitimate `ok`. The envelope is
+    absent or the wrong shape -> `error` with no rows (see `drift`). The two
+    states are different and must not collapse: reporting drift as a measured
+    zero hides a broken probe behind a healthy card, and reporting an idle
+    account as drift teaches the operator to ignore the error state.
 """
 from __future__ import annotations
 
@@ -226,6 +233,29 @@ def window(*, window_kind: "str | None", probe_version: str, captured_at: str,
         "resets_at": resets_at, "captured_at": captured_at,
         "status": status, "probe_version": probe_version,
     }
+
+
+def drift(provider: str, what: str, log) -> str:
+    """Log a shape drift loudly and return it as the account's `detail`.
+
+    Drift is the response having lost the STRUCTURE the normalizer reads —
+    never the count of windows inside it. A well-formed envelope carrying no
+    windows is a real answer (a fresh account, a plan with no metered limit)
+    and stays `ok` with zero windows; a missing or wrong-typed envelope is
+    `error` with no rows, because a drifted probe must never report a zero as
+    if it had been measured (spec #49, Overview + Edge Cases)."""
+    log(f"{provider}: shape drift — {what}")
+    return what
+
+
+def response_detail(code: int, payload, provider: str, log) -> str:
+    """`detail` for a response the normalizer never gets to read: the HTTP
+    status, the transport's reason when the request never landed, or — for a
+    200 whose body is not a JSON object at all — shape drift, said plainly
+    rather than as a bare 'HTTP 200'."""
+    if code == 200:
+        return drift(provider, "response was not a JSON object", log)
+    return f"HTTP {code}" if code else f"unreachable: {payload}"
 
 
 def status_for_http(code: int) -> str:

--- a/.super-coder/scripts/quota_probes/__init__.py
+++ b/.super-coder/scripts/quota_probes/__init__.py
@@ -1,0 +1,233 @@
+"""Per-provider quota probes — the plugin seam of account analytics.
+
+Sibling of `scripts/token_parsers/`, deliberately shaped like it: one module
+per PROVIDER (not per harness — quota is an account property, five shells on
+Claude share one bucket), each a plugin over a private third-party endpoint we
+don't control. Version drift is accepted: a drifted probe reports `error` with
+its HTTP status and never a zero as if measured (spec doc #49).
+
+Contract — every provider module exposes:
+
+    HARNESS_PROVIDER = "<provider>"
+    PROBE_VERSION    = "<pin>"      # bumped when the expected shape changes
+    def probe(log, timeout) -> list[dict]
+
+  log      callable(str) — probe-level notices (shape drift, unreadable
+           credential file). Loud by design. NEVER receives a token.
+  timeout  seconds, per HTTP request.
+
+Each returned dict is one ACCOUNT, carrying its own windows:
+
+    provider, account_ref, account_label, plan, is_current, status,
+    detail, probe_version, captured_at, windows[]
+
+`status` is `ok` / `unauth` / `na` / `error` and is the account's own — one
+provider's failure never touches another's (see dispatch.probe_all). A
+provider with no credential file returns exactly ONE dict with
+`account_ref=None, status='na', windows=[]`: the caller can tell
+not-configured (`na`) from configured-but-broken (`error`), writes no registry
+row for a null ref, and so renders no card — never a card reading 0%.
+
+Invariants every provider module upholds, each checkable from the code:
+
+  * READ-ONLY on credentials. The probe opens the harness's credential file
+    and never writes it. Refresh tokens rotate; refreshing out-of-band can
+    invalidate the copy the harness holds and break the operator's login.
+  * Tokens are never stored, logged, or returned. They exist only in the
+    request header — nothing in a returned dict or a log line carries one.
+  * Expiry is reported, not repaired: an expired access token yields
+    `unauth`, and no request is made with it.
+  * No credential file means `na`, not `0%`.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROVIDERS = ["anthropic", "openai", "moonshot"]
+
+# Window kind is derived from the OBSERVED DURATION, never from the provider's
+# label: labels are marketing text and change, while a 604800-second window is
+# a week in any vocabulary. Providers that expose no duration (Anthropic's
+# `limits[].kind`, Moonshot's top-level `usage`) are mapped in their own module
+# against the table in spec #49's Normalization section.
+KIND_BY_SECONDS = {18000: "five_hour", 604800: "weekly"}
+SHORT_MAX_SECONDS = 3600
+
+TIME_UNIT_SECONDS = {  # Moonshot's window.timeUnit vocabulary
+    "SECOND": 1, "MINUTE": 60, "HOUR": 3600, "DAY": 86400, "WEEK": 604800,
+}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def iso_from_epoch(epoch: "float | None") -> "str | None":
+    """Epoch seconds (or milliseconds) → ISO UTC. None stays None — a reset
+    time we don't have is never invented."""
+    if epoch is None:
+        return None
+    try:
+        secs = float(epoch)
+    except (TypeError, ValueError):
+        return None
+    if secs > 1e11:  # milliseconds, as both claude and kimi store expiry
+        secs /= 1000.0
+    return datetime.fromtimestamp(secs, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def norm_iso(ts: "str | None") -> "str | None":
+    """Provider ISO timestamp → ISO UTC at second precision. Unparseable
+    input returns None — never a fake time."""
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def epoch_now() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+def is_expired(expires_at: "float | None") -> bool:
+    """True only when the credential file states an expiry that has passed.
+    An absent or unparseable expiry is NOT treated as expired — the request
+    is made and the provider's 401 is authoritative."""
+    if expires_at is None:
+        return False
+    try:
+        secs = float(expires_at)
+    except (TypeError, ValueError):
+        return False
+    if secs > 1e11:
+        secs /= 1000.0
+    return secs <= epoch_now()
+
+
+def kind_for_seconds(seconds: "float | None") -> "str | None":
+    """Observed window duration → normalized kind. None = unrecognized; the
+    caller stores the duration in `scope` and renders the window under its own
+    row rather than dropping it."""
+    if seconds is None:
+        return None
+    try:
+        secs = int(float(seconds))
+    except (TypeError, ValueError):
+        return None
+    if secs in KIND_BY_SECONDS:
+        return KIND_BY_SECONDS[secs]
+    if 0 < secs <= SHORT_MAX_SECONDS:
+        return "short"
+    return None
+
+
+def percent_from(used, limit) -> "float | None":
+    """Absolute counts → percent. A zero (or absent) limit yields None, never
+    a division by zero and never a 0%. A percent is NEVER back-computed into a
+    count — that direction has no inverse."""
+    try:
+        used_n, limit_n = float(used), float(limit)
+    except (TypeError, ValueError):
+        return None
+    if limit_n <= 0:
+        return None
+    return round(used_n / limit_n * 100, 2)
+
+
+def as_percent(value) -> "float | None":
+    if value is None:
+        return None
+    try:
+        return round(float(value), 2)
+    except (TypeError, ValueError):
+        return None
+
+
+def as_count(value) -> "int | None":
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def read_json(path: Path, log, label: str) -> "dict | None":
+    """Read a credential/profile file. Read-only, always: nothing in this
+    package opens a credential file for writing. None = absent or unreadable;
+    the error text names the path, never the contents."""
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        log(f"{label}: unreadable {path}: {e.strerror or e}")
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        log(f"{label}: malformed JSON in {path}: line {e.lineno} col {e.colno}")
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def get_json(url: str, headers: dict, timeout: float) -> "tuple[int, object]":
+    """GET → (http_status, payload). Never raises for a reachable-but-unhappy
+    endpoint; a transport failure is status 0 with the reason as the payload.
+    `headers` carries the bearer token and is never logged or returned."""
+    req = urllib.request.Request(url, method="GET", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read()
+            try:
+                return resp.status, json.loads(body)
+            except json.JSONDecodeError:
+                return resp.status, None
+    except urllib.error.HTTPError as e:
+        return e.code, None
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        return 0, str(getattr(e, "reason", e))
+
+
+def account(*, provider: str, probe_version: str, captured_at: str,
+            account_ref=None, account_label=None, plan=None, is_current=1,
+            status="ok", detail=None, windows=None) -> dict:
+    return {
+        "provider": provider, "account_ref": account_ref,
+        "account_label": account_label, "plan": plan,
+        "is_current": 1 if is_current else 0, "status": status,
+        "detail": detail, "probe_version": probe_version,
+        "captured_at": captured_at, "windows": list(windows or []),
+    }
+
+
+def window(*, window_kind: "str | None", probe_version: str, captured_at: str,
+           scope=None, used_percent=None, used=None, limit=None,
+           resets_at=None, status="ok") -> dict:
+    """One window row. An unrecognized duration keeps its raw duration in
+    `scope` (done by the caller) and window_kind 'unknown' — rendered under
+    its own row rather than dropped."""
+    return {
+        "window_kind": window_kind or "unknown", "scope": scope,
+        "used_percent": used_percent, "used": used, "limit": limit,
+        "resets_at": resets_at, "captured_at": captured_at,
+        "status": status, "probe_version": probe_version,
+    }
+
+
+def status_for_http(code: int) -> str:
+    """HTTP status → account status. 401/403 is the provider telling us the
+    token is dead: report it as `unauth` and leave the last known values
+    standing. Everything else non-200 is `error` — never a measured zero."""
+    if code in (401, 403):
+        return "unauth"
+    return "error"

--- a/.super-coder/scripts/quota_probes/__init__.py
+++ b/.super-coder/scripts/quota_probes/__init__.py
@@ -211,14 +211,18 @@ def account(*, provider: str, probe_version: str, captured_at: str,
 
 
 def window(*, window_kind: "str | None", probe_version: str, captured_at: str,
-           scope=None, used_percent=None, used=None, limit=None,
+           scope=None, used_percent=None, used=None, limit_value=None,
            resets_at=None, status="ok") -> dict:
     """One window row. An unrecognized duration keeps its raw duration in
     `scope` (done by the caller) and window_kind 'unknown' — rendered under
-    its own row rather than dropped."""
+    its own row rather than dropped.
+
+    `limit_value`, not `limit`: the column it feeds cannot be called `limit`
+    because that is a SQLite reserved word (found by U1's premise check,
+    ruled in message #1899). The pair is used/limit_value everywhere."""
     return {
         "window_kind": window_kind or "unknown", "scope": scope,
-        "used_percent": used_percent, "used": used, "limit": limit,
+        "used_percent": used_percent, "used": used, "limit_value": limit_value,
         "resets_at": resets_at, "captured_at": captured_at,
         "status": status, "probe_version": probe_version,
     }

--- a/.super-coder/scripts/quota_probes/anthropic.py
+++ b/.super-coder/scripts/quota_probes/anthropic.py
@@ -1,0 +1,130 @@
+"""Anthropic probe — GET api.anthropic.com/api/oauth/usage.
+
+Two files, and only the first is the credential file:
+
+  ~/.claude/.credentials.json   claudeAiOauth.accessToken + expiresAt — the
+                                token, read and never written.
+  ~/.claude.json                oauthAccount.accountUuid — the account
+                                identifier.
+
+Spec #49 and decisions #65/#67 both say `account_ref` comes from "the
+credential file's account uuid". It is NOT there: that file holds only
+accessToken / refreshToken / expiresAt / refreshTokenExpiresAt / scopes /
+subscriptionType / rateLimitTier. The uuid lives in ~/.claude.json under
+`oauthAccount`, which also carries `emailAddress` in full — so the spec's
+label ladder ("Anthropic: credential-file account uuid, first 8", written on
+the premise that Anthropic returns no email) is reachable but not forced.
+Both gaps were reported to the planner before this module was written; the
+label below follows the spec AS WRITTEN and is the one line a ruling flips.
+
+The usage payload itself returns no account identifier at all, which is why
+the uuid is load-bearing. Whether it survives a re-login is unverified —
+confirming it needs an operator re-login (flag against feature 17).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import (account, as_percent, get_json, is_expired, norm_iso, now_iso,
+               read_json, status_for_http, window)
+
+HARNESS_PROVIDER = "anthropic"
+PROBE_VERSION = "1"
+
+CREDENTIALS = Path.home() / ".claude/.credentials.json"
+PROFILE = Path.home() / ".claude.json"
+URL = "https://api.anthropic.com/api/oauth/usage"
+BETA_HEADER = "oauth-2025-04-20"
+
+# No duration is exposed by this endpoint, so these three labels are the only
+# signal available and are pinned against spec #49's Normalization table.
+KIND_MAP = {"session": "session", "weekly_all": "weekly",
+            "weekly_scoped": "weekly_scoped"}
+
+
+def _account_uuid(log) -> "str | None":
+    profile = read_json(PROFILE, log, HARNESS_PROVIDER)
+    oauth = (profile or {}).get("oauthAccount")
+    if not isinstance(oauth, dict):
+        return None
+    uuid = oauth.get("accountUuid")
+    return str(uuid) if uuid else None
+
+
+def _label(uuid: str) -> str:
+    """Spec #49's ladder: the account uuid, first 8. ~/.claude.json also holds
+    `oauthAccount.emailAddress` in full, so a planner ruling to label Anthropic
+    by email changes this function and nothing else."""
+    return uuid[:8]
+
+
+def _windows(limits, captured_at: str, log) -> list[dict]:
+    rows = []
+    for item in limits:
+        if not isinstance(item, dict):
+            continue
+        raw_kind = item.get("kind")
+        kind = KIND_MAP.get(raw_kind)
+        scope = None
+        if kind == "weekly_scoped":
+            model = ((item.get("scope") or {}).get("model") or {})
+            scope = model.get("display_name")
+        elif kind is None:
+            log(f"{HARNESS_PROVIDER}: unrecognized limit kind {raw_kind!r} — "
+                "kept under its own row")
+            scope = str(raw_kind) if raw_kind else None
+        rows.append(window(
+            window_kind=kind, scope=scope,
+            used_percent=as_percent(item.get("percent")),
+            resets_at=norm_iso(item.get("resets_at")),
+            captured_at=captured_at, probe_version=PROBE_VERSION))
+    return rows
+
+
+def probe(log, timeout) -> list[dict]:
+    captured_at = now_iso()
+
+    def result(**kw):
+        return [account(provider=HARNESS_PROVIDER, probe_version=PROBE_VERSION,
+                        captured_at=captured_at, **kw)]
+
+    creds = read_json(CREDENTIALS, log, HARNESS_PROVIDER)
+    oauth = (creds or {}).get("claudeAiOauth") if creds else None
+    token = (oauth or {}).get("accessToken")
+    if not token:
+        # No credential file (or no token in it): this host has no Claude
+        # subscription session. Absence of a limit is not a limit of zero.
+        return result(status="na", is_current=0)
+
+    uuid = _account_uuid(log)
+    if not uuid:
+        log(f"{HARNESS_PROVIDER}: no oauthAccount.accountUuid in {PROFILE} — "
+            "the usage payload carries no account id, so this account cannot "
+            "be identified")
+        return result(status="error", detail="no account identifier")
+
+    common = dict(account_ref=uuid, account_label=_label(uuid))
+    if is_expired((oauth or {}).get("expiresAt")):
+        # Reported, not repaired: refreshing out-of-band rotates the refresh
+        # token and can break the operator's own login.
+        return result(status="unauth", detail="access token expired", **common)
+
+    code, payload = get_json(URL, {
+        "Authorization": f"Bearer {token}",
+        "anthropic-beta": BETA_HEADER,
+        "Accept": "application/json",
+    }, timeout)
+    if code != 200 or not isinstance(payload, dict):
+        detail = f"HTTP {code}" if code else f"unreachable: {payload}"
+        if code == 200:
+            detail = "response was not a JSON object"
+            log(f"{HARNESS_PROVIDER}: shape drift — {detail}")
+        return result(status=status_for_http(code), detail=detail, **common)
+
+    limits = payload.get("limits")
+    if not isinstance(limits, list):
+        log(f"{HARNESS_PROVIDER}: shape drift — no limits[] in the usage payload")
+        return result(status="error", detail="no limits[] in response", **common)
+
+    return result(plan=payload.get("subscriptionType"),
+                  windows=_windows(limits, captured_at, log), **common)

--- a/.super-coder/scripts/quota_probes/anthropic.py
+++ b/.super-coder/scripts/quota_probes/anthropic.py
@@ -7,15 +7,16 @@ Two files, and only the first is the credential file:
   ~/.claude.json                oauthAccount.accountUuid — the account
                                 identifier.
 
-Spec #49 and decisions #65/#67 both say `account_ref` comes from "the
+Spec #49 and decisions #65/#67 both said `account_ref` comes from "the
 credential file's account uuid". It is NOT there: that file holds only
 accessToken / refreshToken / expiresAt / refreshTokenExpiresAt / scopes /
 subscriptionType / rateLimitTier. The uuid lives in ~/.claude.json under
-`oauthAccount`, which also carries `emailAddress` in full — so the spec's
-label ladder ("Anthropic: credential-file account uuid, first 8", written on
-the premise that Anthropic returns no email) is reachable but not forced.
-Both gaps were reported to the planner before this module was written; the
-label below follows the spec AS WRITTEN and is the one line a ruling flips.
+`oauthAccount`, which also carries `emailAddress` in full — so decision #67's
+premise that neither Anthropic nor Moonshot returns an email, true of the
+usage RESPONSE, is false at the file level. Both gaps were reported to the
+planner before this module was written and ruled on in decision #69: the
+label is the full email, the uuid stays the ref, and reading two files here
+is ratified rather than scope creep.
 
 The usage payload itself returns no account identifier at all, which is why
 the uuid is load-bearing. Whether it survives a re-login is unverified —
@@ -42,20 +43,25 @@ KIND_MAP = {"session": "session", "weekly_all": "weekly",
             "weekly_scoped": "weekly_scoped"}
 
 
-def _account_uuid(log) -> "str | None":
+def _identity(log) -> "tuple[str | None, str | None]":
+    """(account uuid, full email) — both from ~/.claude.json's oauthAccount,
+    which is the only place either exists. The usage response carries neither."""
     profile = read_json(PROFILE, log, HARNESS_PROVIDER)
     oauth = (profile or {}).get("oauthAccount")
     if not isinstance(oauth, dict):
-        return None
-    uuid = oauth.get("accountUuid")
-    return str(uuid) if uuid else None
+        return None, None
+    uuid, email = oauth.get("accountUuid"), oauth.get("emailAddress")
+    return (str(uuid) if uuid else None), (str(email) if email else None)
 
 
-def _label(uuid: str) -> str:
-    """Spec #49's ladder: the account uuid, first 8. ~/.claude.json also holds
-    `oauthAccount.emailAddress` in full, so a planner ruling to label Anthropic
-    by email changes this function and nothing else."""
-    return uuid[:8]
+def _label(uuid: str, email: "str | None") -> str:
+    """The full email, falling back to the uuid's first 8 only when the profile
+    carries no address (decision #69). A card reading 'a3f2b1c8' beside an
+    OpenAI card reading a full address does not tell the operator which account
+    they are looking at, and the address is safe to store for the same reason
+    OpenAI's already is: the engine DB is gitignored and both tables are
+    excluded from content.sql (decision #67)."""
+    return email or uuid[:8]
 
 
 def _windows(limits, captured_at: str, log) -> list[dict]:
@@ -96,14 +102,14 @@ def probe(log, timeout) -> list[dict]:
         # subscription session. Absence of a limit is not a limit of zero.
         return result(status="na", is_current=0)
 
-    uuid = _account_uuid(log)
+    uuid, email = _identity(log)
     if not uuid:
         log(f"{HARNESS_PROVIDER}: no oauthAccount.accountUuid in {PROFILE} — "
             "the usage payload carries no account id, so this account cannot "
             "be identified")
         return result(status="error", detail="no account identifier")
 
-    common = dict(account_ref=uuid, account_label=_label(uuid))
+    common = dict(account_ref=uuid, account_label=_label(uuid, email))
     if is_expired((oauth or {}).get("expiresAt")):
         # Reported, not repaired: refreshing out-of-band rotates the refresh
         # token and can break the operator's own login.

--- a/.super-coder/scripts/quota_probes/anthropic.py
+++ b/.super-coder/scripts/quota_probes/anthropic.py
@@ -26,8 +26,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from . import (account, as_percent, get_json, is_expired, norm_iso, now_iso,
-               read_json, status_for_http, window)
+from . import (account, as_percent, drift, get_json, is_expired, norm_iso,
+               now_iso, read_json, response_detail, status_for_http, window)
 
 HARNESS_PROVIDER = "anthropic"
 PROBE_VERSION = "1"
@@ -121,16 +121,15 @@ def probe(log, timeout) -> list[dict]:
         "Accept": "application/json",
     }, timeout)
     if code != 200 or not isinstance(payload, dict):
-        detail = f"HTTP {code}" if code else f"unreachable: {payload}"
-        if code == 200:
-            detail = "response was not a JSON object"
-            log(f"{HARNESS_PROVIDER}: shape drift — {detail}")
-        return result(status=status_for_http(code), detail=detail, **common)
+        return result(status=status_for_http(code), **common,
+                      detail=response_detail(code, payload, HARNESS_PROVIDER, log))
 
     limits = payload.get("limits")
     if not isinstance(limits, list):
-        log(f"{HARNESS_PROVIDER}: shape drift — no limits[] in the usage payload")
-        return result(status="error", detail="no limits[] in response", **common)
+        # The envelope, not its length: `limits: []` is an account with no
+        # window to report and stays `ok`.
+        return result(status="error", **common, detail=drift(
+            HARNESS_PROVIDER, "no limits[] in the usage payload", log))
 
     return result(plan=payload.get("subscriptionType"),
                   windows=_windows(limits, captured_at, log), **common)

--- a/.super-coder/scripts/quota_probes/dispatch.py
+++ b/.super-coder/scripts/quota_probes/dispatch.py
@@ -1,0 +1,66 @@
+"""Quota probe dispatcher — every provider probed concurrently, contained.
+
+`probe_all` is the package's entry point and the home of the Probe Contract's
+containment invariant: one provider's failure — a raised exception, an import
+error, a wedged connection — becomes that provider's own `error` account and
+touches nothing else. The caller (the API layer) owns the TTL and the upsert;
+it never has to reason about a partial result.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import time
+
+from . import PROVIDERS, account, now_iso
+
+DEFAULT_TIMEOUT = 5.0
+# The probes pass `timeout` to their own HTTP calls; this grace covers a probe
+# that wedges somewhere OTHER than the socket, so a hung provider still costs
+# the caller a bounded wait rather than the request.
+WALL_CLOCK_GRACE = 1.0
+
+
+def _error(provider: str, detail: str) -> dict:
+    return account(provider=provider, probe_version="0", captured_at=now_iso(),
+                   status="error", detail=detail, is_current=0)
+
+
+def _run(name: str, log, timeout: float) -> list[dict]:
+    try:
+        mod = __import__(f"quota_probes.{name}", fromlist=[name])
+    except ImportError as e:
+        log(f"quota_probes: no probe for '{name}' ({e}) — skipped")
+        return [_error(name, f"probe module unavailable: {e}")]
+    try:
+        return list(mod.probe(log, timeout))
+    except Exception as e:  # plugin stance: loud, never fatal to the sweep
+        log(f"quota_probes: {name} probe failed: {e!r}")
+        return [_error(name, f"probe raised {type(e).__name__}")]
+
+
+def probe_all(log, timeout: float = DEFAULT_TIMEOUT,
+              providers: "list[str] | None" = None) -> list[dict]:
+    """Probe every provider concurrently; return their accounts in a stable
+    provider order. Never raises."""
+    names = list(providers or PROVIDERS)
+    results: dict[str, list[dict]] = {}
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=len(names) or 1)
+    try:
+        futures = {name: pool.submit(_run, name, log, timeout) for name in names}
+        # ONE deadline for the whole fan-out, not one per future: waiting on
+        # each in turn with its own timeout would let three slow providers cost
+        # three timeouts, when they have been running concurrently all along.
+        deadline = time.monotonic() + timeout + WALL_CLOCK_GRACE
+        for name, future in futures.items():
+            try:
+                results[name] = future.result(
+                    timeout=max(0.0, deadline - time.monotonic()))
+            except concurrent.futures.TimeoutError:
+                log(f"quota_probes: {name} probe timed out after {timeout}s")
+                results[name] = [_error(name, f"timed out after {timeout}s")]
+    finally:
+        # NOT a `with` block: its exit joins every worker, which would re-block
+        # the caller on the exact probe this timeout exists to contain. The
+        # abandoned thread ends on its own socket timeout.
+        pool.shutdown(wait=False)
+    return [row for name in names for row in results.get(name, [])]

--- a/.super-coder/scripts/quota_probes/moonshot.py
+++ b/.super-coder/scripts/quota_probes/moonshot.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from . import (TIME_UNIT_SECONDS, account, as_count, get_json, is_expired,
-               kind_for_seconds, norm_iso, now_iso, percent_from, read_json,
-               status_for_http, window)
+from . import (TIME_UNIT_SECONDS, account, as_count, drift, get_json,
+               is_expired, kind_for_seconds, norm_iso, now_iso, percent_from,
+               read_json, response_detail, status_for_http, window)
 
 HARNESS_PROVIDER = "moonshot"
 PROBE_VERSION = "1"
@@ -45,6 +45,25 @@ def _counts_window(entry: dict, captured_at: str, kind, scope) -> dict:
                   captured_at=captured_at, probe_version=PROBE_VERSION)
 
 
+def _drift(payload: dict) -> "str | None":
+    """What the normalizer cannot find, or None when the envelope is intact.
+
+    The two keys are not symmetrical, and collapsing them would be the bug.
+    `usage` is a BLOCK — the account-wide weekly figure every payload carries;
+    an account with nothing spent reports `used: 0`, it does not drop the key,
+    so its absence is the shape having changed. `limits` is a COLLECTION —
+    absent or `[]` is a real answer (a plan with no metered sub-window), and
+    calling that drift would cry wolf at an idle account. A `limits` that is
+    present but not a list has no such reading: that is drift.
+    """
+    if not isinstance(payload.get("usage"), dict):
+        return "no usage{} in the usages payload"
+    limits = payload.get("limits")
+    if limits is not None and not isinstance(limits, list):
+        return f"limits is {type(limits).__name__}, not a list"
+    return None
+
+
 def _windows(payload: dict, captured_at: str, log) -> list[dict]:
     rows = []
     usage = payload.get("usage")
@@ -52,8 +71,7 @@ def _windows(payload: dict, captured_at: str, log) -> list[dict]:
         # Pinned by spec #49's Normalization table: the top-level usage block
         # carries no window spec, and it is the account-wide weekly figure.
         rows.append(_counts_window(usage, captured_at, "weekly", None))
-    limits = payload.get("limits")
-    for entry in limits if isinstance(limits, list) else []:
+    for entry in payload.get("limits") or []:
         if not isinstance(entry, dict):
             continue
         seconds = _window_seconds(entry.get("window"))
@@ -88,8 +106,8 @@ def probe(log, timeout) -> list[dict]:
         "Authorization": f"Bearer {token}", "Accept": "application/json",
     }, timeout)
     if code != 200 or not isinstance(payload, dict):
-        detail = f"HTTP {code}" if code else f"unreachable: {payload}"
-        return result(status=status_for_http(code), detail=detail)
+        return result(status=status_for_http(code),
+                      detail=response_detail(code, payload, HARNESS_PROVIDER, log))
 
     user_id = ((payload.get("user") or {}) if isinstance(payload.get("user"), dict)
                else {}).get("userId")
@@ -99,7 +117,13 @@ def probe(log, timeout) -> list[dict]:
             "account cannot be identified")
         return result(status="error", detail="no account identifier")
 
+    common = dict(account_ref=ref, account_label=ref)
+    missing = _drift(payload)
+    if missing:
+        return result(status="error", **common,
+                      detail=drift(HARNESS_PROVIDER, missing, log))
+
     membership = payload.get("membership")
     plan = membership.get("level") if isinstance(membership, dict) else None
-    return result(account_ref=ref, account_label=ref, plan=plan,
+    return result(plan=plan, **common,
                   windows=_windows(payload, captured_at, log))

--- a/.super-coder/scripts/quota_probes/moonshot.py
+++ b/.super-coder/scripts/quota_probes/moonshot.py
@@ -39,7 +39,7 @@ def _window_seconds(spec) -> "float | None":
 
 def _counts_window(entry: dict, captured_at: str, kind, scope) -> dict:
     used, limit = as_count(entry.get("used")), as_count(entry.get("limit"))
-    return window(window_kind=kind, scope=scope, used=used, limit=limit,
+    return window(window_kind=kind, scope=scope, used=used, limit_value=limit,
                   used_percent=percent_from(used, limit),
                   resets_at=norm_iso(entry.get("resetTime")),
                   captured_at=captured_at, probe_version=PROBE_VERSION)

--- a/.super-coder/scripts/quota_probes/moonshot.py
+++ b/.super-coder/scripts/quota_probes/moonshot.py
@@ -1,0 +1,105 @@
+"""Moonshot probe — GET api.kimi.com/coding/v1/usages.
+
+Credential: ~/.kimi-code/credentials/kimi-code.json → access_token, with
+expires_at for the pre-flight expiry check. Read and never written.
+
+The only provider that reports ABSOLUTE counts (used / limit / remaining), so
+its percent is derived rather than given — and derived only when the limit is
+a positive number. Identity is `user.userId`; nothing on disk identifies the
+account, so a failed probe leaves the account unidentified rather than
+guessing at a ref.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import (TIME_UNIT_SECONDS, account, as_count, get_json, is_expired,
+               kind_for_seconds, norm_iso, now_iso, percent_from, read_json,
+               status_for_http, window)
+
+HARNESS_PROVIDER = "moonshot"
+PROBE_VERSION = "1"
+
+CREDENTIALS = Path.home() / ".kimi-code/credentials/kimi-code.json"
+URL = "https://api.kimi.com/coding/v1/usages"
+
+
+def _window_seconds(spec) -> "float | None":
+    """`{"duration": 300, "timeUnit": "MINUTE"}` → 18000. An unknown time unit
+    yields None and the window keeps its raw duration in scope."""
+    if not isinstance(spec, dict):
+        return None
+    unit = TIME_UNIT_SECONDS.get(str(spec.get("timeUnit") or "").upper())
+    try:
+        duration = float(spec.get("duration"))
+    except (TypeError, ValueError):
+        return None
+    return duration * unit if unit else None
+
+
+def _counts_window(entry: dict, captured_at: str, kind, scope) -> dict:
+    used, limit = as_count(entry.get("used")), as_count(entry.get("limit"))
+    return window(window_kind=kind, scope=scope, used=used, limit=limit,
+                  used_percent=percent_from(used, limit),
+                  resets_at=norm_iso(entry.get("resetTime")),
+                  captured_at=captured_at, probe_version=PROBE_VERSION)
+
+
+def _windows(payload: dict, captured_at: str, log) -> list[dict]:
+    rows = []
+    usage = payload.get("usage")
+    if isinstance(usage, dict):
+        # Pinned by spec #49's Normalization table: the top-level usage block
+        # carries no window spec, and it is the account-wide weekly figure.
+        rows.append(_counts_window(usage, captured_at, "weekly", None))
+    limits = payload.get("limits")
+    for entry in limits if isinstance(limits, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        seconds = _window_seconds(entry.get("window"))
+        kind = kind_for_seconds(seconds)
+        scope = entry.get("name") or entry.get("scope")
+        if kind is None:
+            raw = entry.get("window")
+            log(f"{HARNESS_PROVIDER}: unrecognized window {raw!r} — kept under "
+                "its own row")
+            duration = f"{int(seconds)}s" if seconds else str(raw)
+            scope = f"{scope} {duration}" if scope else duration
+        rows.append(_counts_window(entry, captured_at, kind, scope))
+    return rows
+
+
+def probe(log, timeout) -> list[dict]:
+    captured_at = now_iso()
+
+    def result(**kw):
+        return [account(provider=HARNESS_PROVIDER, probe_version=PROBE_VERSION,
+                        captured_at=captured_at, **kw)]
+
+    creds = read_json(CREDENTIALS, log, HARNESS_PROVIDER)
+    token = (creds or {}).get("access_token")
+    if not token:
+        return result(status="na", is_current=0)
+    if is_expired((creds or {}).get("expires_at")):
+        # Reported, not repaired — this package never refreshes a token.
+        return result(status="unauth", detail="access token expired")
+
+    code, payload = get_json(URL, {
+        "Authorization": f"Bearer {token}", "Accept": "application/json",
+    }, timeout)
+    if code != 200 or not isinstance(payload, dict):
+        detail = f"HTTP {code}" if code else f"unreachable: {payload}"
+        return result(status=status_for_http(code), detail=detail)
+
+    user_id = ((payload.get("user") or {}) if isinstance(payload.get("user"), dict)
+               else {}).get("userId")
+    ref = str(user_id) if user_id else None
+    if not ref:
+        log(f"{HARNESS_PROVIDER}: no user.userId in the usages payload — this "
+            "account cannot be identified")
+        return result(status="error", detail="no account identifier")
+
+    membership = payload.get("membership")
+    plan = membership.get("level") if isinstance(membership, dict) else None
+    return result(account_ref=ref, account_label=ref, plan=plan,
+                  windows=_windows(payload, captured_at, log))

--- a/.super-coder/scripts/quota_probes/openai.py
+++ b/.super-coder/scripts/quota_probes/openai.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from . import (account, as_percent, get_json, iso_from_epoch, kind_for_seconds,
-               now_iso, read_json, status_for_http, window)
+from . import (account, as_percent, drift, get_json, iso_from_epoch,
+               kind_for_seconds, now_iso, read_json, response_detail,
+               status_for_http, window)
 
 HARNESS_PROVIDER = "openai"
 PROBE_VERSION = "1"
@@ -49,9 +50,7 @@ def _window_row(entry, captured_at: str, log, scope=None,
                   captured_at=captured_at, probe_version=PROBE_VERSION)
 
 
-def _windows(payload: dict, captured_at: str, log) -> list[dict]:
-    rate_limit = payload.get("rate_limit")
-    rate_limit = rate_limit if isinstance(rate_limit, dict) else {}
+def _windows(rate_limit: dict, payload: dict, captured_at: str, log) -> list[dict]:
     rows = []
     for key in ("primary_window", "secondary_window"):
         row = _window_row(rate_limit.get(key), captured_at, log)
@@ -93,9 +92,9 @@ def probe(log, timeout) -> list[dict]:
     code, payload = get_json(URL, headers, timeout)
     ref = str(file_account_id) if file_account_id else None
     if code != 200 or not isinstance(payload, dict):
-        detail = f"HTTP {code}" if code else f"unreachable: {payload}"
-        return result(status=status_for_http(code), detail=detail,
-                      account_ref=ref, account_label=ref)
+        return result(status=status_for_http(code), account_ref=ref,
+                      account_label=ref,
+                      detail=response_detail(code, payload, HARNESS_PROVIDER, log))
 
     ref = str(payload.get("account_id") or file_account_id or "") or None
     if not ref:
@@ -103,7 +102,14 @@ def probe(log, timeout) -> list[dict]:
             "payload — this account cannot be identified")
         return result(status="error", detail="no account identifier")
 
-    return result(account_ref=ref,
-                  account_label=payload.get("email") or ref,
-                  plan=payload.get("plan_type"),
-                  windows=_windows(payload, captured_at, log))
+    common = dict(account_ref=ref, account_label=payload.get("email") or ref)
+    rate_limit = payload.get("rate_limit")
+    if not isinstance(rate_limit, dict):
+        # The envelope, not its contents: `rate_limit: {}` is an account with
+        # no window to report and stays `ok`; no `rate_limit` at all is the
+        # response having changed shape under us.
+        return result(status="error", **common, detail=drift(
+            HARNESS_PROVIDER, "no rate_limit{} in the usage payload", log))
+
+    return result(plan=payload.get("plan_type"), **common,
+                  windows=_windows(rate_limit, payload, captured_at, log))

--- a/.super-coder/scripts/quota_probes/openai.py
+++ b/.super-coder/scripts/quota_probes/openai.py
@@ -50,6 +50,23 @@ def _window_row(entry, captured_at: str, log, scope=None,
                   captured_at=captured_at, probe_version=PROBE_VERSION)
 
 
+def _drift(rate_limit: dict, payload: dict) -> "str | None":
+    """What the normalizer cannot trust, or None when the envelope is intact.
+
+    `additional_rate_limits` is a COLLECTION, and moonshot's asymmetry applies
+    unchanged: absent or `[]` is a real answer (a plan with no scoped window),
+    so erroring on it would cry wolf at an idle account. A present-but-wrong
+    TYPE has no such reading — the type is part of the envelope (spec #49), and
+    silently skipping it would vanish every scoped window while reporting `ok`.
+    Both containers are checked because the reader coalesces across them.
+    """
+    for container in (rate_limit, payload):
+        extra = container.get("additional_rate_limits")
+        if extra is not None and not isinstance(extra, list):
+            return f"additional_rate_limits is {type(extra).__name__}, not a list"
+    return None
+
+
 def _windows(rate_limit: dict, payload: dict, captured_at: str, log) -> list[dict]:
     rows = []
     for key in ("primary_window", "secondary_window"):
@@ -110,6 +127,11 @@ def probe(log, timeout) -> list[dict]:
         # response having changed shape under us.
         return result(status="error", **common, detail=drift(
             HARNESS_PROVIDER, "no rate_limit{} in the usage payload", log))
+
+    missing = _drift(rate_limit, payload)
+    if missing:
+        return result(status="error", **common,
+                      detail=drift(HARNESS_PROVIDER, missing, log))
 
     return result(plan=payload.get("plan_type"), **common,
                   windows=_windows(rate_limit, payload, captured_at, log))

--- a/.super-coder/scripts/quota_probes/openai.py
+++ b/.super-coder/scripts/quota_probes/openai.py
@@ -75,6 +75,14 @@ def _windows(rate_limit: dict, payload: dict, captured_at: str, log) -> list[dic
             rows.append(row)
     extra = rate_limit.get("additional_rate_limits") \
         or payload.get("additional_rate_limits") or []
+    # Unreachable-as-false in intact code: `_drift` rejects every
+    # present-but-non-list before this runs, and a falsy wrong type coalesces
+    # to []. RETAINED DELIBERATELY — mutation leg
+    # `openai-wrong-typed-collection-swallowed` disables that drift check, and
+    # this guard is what makes the probe then degrade to the historical defect
+    # (scoped windows silently skipped, status `ok`) instead of raising on a
+    # non-iterable. Delete it and the leg still reds, but via TypeError — red
+    # for the wrong reason, no longer testing the failure shape it names.
     if isinstance(extra, list):
         for entry in extra:
             row = _window_row(entry, captured_at, log,

--- a/.super-coder/scripts/quota_probes/openai.py
+++ b/.super-coder/scripts/quota_probes/openai.py
@@ -1,0 +1,109 @@
+"""OpenAI probe — GET chatgpt.com/backend-api/codex/usage.
+
+Credential: ~/.codex/auth.json → tokens.access_token, plus tokens.account_id
+for the `chatgpt-account-id` header. Read and never written.
+
+That file records no expiry (its keys are id_token / access_token /
+refresh_token / account_id / last_refresh), so expiry cannot be pre-checked
+here as it is for the other two providers — the endpoint's 401 is the
+authoritative signal and maps to `unauth`.
+
+The only provider that returns an email, so the only one whose card carries a
+real address; `account_id` is the stable ref either way.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import (account, as_percent, get_json, iso_from_epoch, kind_for_seconds,
+               now_iso, read_json, status_for_http, window)
+
+HARNESS_PROVIDER = "openai"
+PROBE_VERSION = "1"
+
+CREDENTIALS = Path.home() / ".codex/auth.json"
+URL = "https://chatgpt.com/backend-api/codex/usage"
+
+
+def _window_row(entry, captured_at: str, log, scope=None,
+                fallback_kind=None) -> "dict | None":
+    """One rate-limit window. The kind comes from the observed duration;
+    `fallback_kind` covers only the entries spec #49 pins by name because no
+    duration is exposed for them."""
+    if not isinstance(entry, dict):
+        return None
+    seconds = entry.get("limit_window_seconds")
+    kind = kind_for_seconds(seconds)
+    if kind is None:
+        kind = fallback_kind
+    if kind is None:
+        # Unrecognized duration: keep the window under its own row with the
+        # duration in scope rather than dropping a real limit on the floor.
+        log(f"{HARNESS_PROVIDER}: unrecognized window duration {seconds!r} — "
+            "kept under its own row")
+        duration = f"{seconds}s" if seconds is not None else "no duration"
+        scope = f"{scope} {duration}" if scope else duration
+    return window(window_kind=kind, scope=scope,
+                  used_percent=as_percent(entry.get("used_percent")),
+                  resets_at=iso_from_epoch(entry.get("reset_at")),
+                  captured_at=captured_at, probe_version=PROBE_VERSION)
+
+
+def _windows(payload: dict, captured_at: str, log) -> list[dict]:
+    rate_limit = payload.get("rate_limit")
+    rate_limit = rate_limit if isinstance(rate_limit, dict) else {}
+    rows = []
+    for key in ("primary_window", "secondary_window"):
+        row = _window_row(rate_limit.get(key), captured_at, log)
+        if row:
+            rows.append(row)
+    extra = rate_limit.get("additional_rate_limits") \
+        or payload.get("additional_rate_limits") or []
+    if isinstance(extra, list):
+        for entry in extra:
+            row = _window_row(entry, captured_at, log,
+                              scope=(entry or {}).get("limit_name")
+                              if isinstance(entry, dict) else None,
+                              fallback_kind="weekly")
+            if row:
+                rows.append(row)
+    return rows
+
+
+def probe(log, timeout) -> list[dict]:
+    captured_at = now_iso()
+
+    def result(**kw):
+        return [account(provider=HARNESS_PROVIDER, probe_version=PROBE_VERSION,
+                        captured_at=captured_at, **kw)]
+
+    creds = read_json(CREDENTIALS, log, HARNESS_PROVIDER)
+    tokens = (creds or {}).get("tokens") if creds else None
+    token = (tokens or {}).get("access_token")
+    if not token:
+        # An API-key shell (auth_mode=apikey, OPENAI_API_KEY set) lands here
+        # too: it has no subscription window, and no window is `na`, not 0%.
+        return result(status="na", is_current=0)
+
+    file_account_id = (tokens or {}).get("account_id")
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    if file_account_id:
+        headers["chatgpt-account-id"] = str(file_account_id)
+
+    code, payload = get_json(URL, headers, timeout)
+    ref = str(file_account_id) if file_account_id else None
+    if code != 200 or not isinstance(payload, dict):
+        detail = f"HTTP {code}" if code else f"unreachable: {payload}"
+        return result(status=status_for_http(code), detail=detail,
+                      account_ref=ref, account_label=ref)
+
+    ref = str(payload.get("account_id") or file_account_id or "") or None
+    if not ref:
+        log(f"{HARNESS_PROVIDER}: no account_id in {CREDENTIALS} or the usage "
+            "payload — this account cannot be identified")
+        return result(status="error", detail="no account identifier")
+
+    return result(account_ref=ref,
+                  account_label=payload.get("email") or ref,
+                  plan=payload.get("plan_type"),
+                  windows=_windows(payload, captured_at, log))

--- a/tests/fixtures/quota_probes/README.md
+++ b/tests/fixtures/quota_probes/README.md
@@ -1,0 +1,32 @@
+# quota_probes fixtures
+
+Recorded payload shapes for the three provider quota endpoints, used by
+`tests/test_quota_probes.py`. **No test in this suite performs a live call** —
+`urlopen` is stubbed to fail loudly if one is attempted.
+
+## Provenance — read this before trusting a field
+
+These files are transcribed from the **observed field tables in spec doc #49**
+(`## Proven Endpoints`), which record what the three endpoints returned when
+PLN2 called them live against this host's credentials on 2026-07-25 (decision
+#65). They are not raw captures: the live calls were made before this unit
+existed and their bodies were not vendored, and the sprint task explicitly
+scoped unit 2 to "capture fixtures from the spec's documented response shapes"
+rather than re-probe.
+
+So: every field the probes *depend on* is a recorded observation, but the
+surrounding envelope (nesting of `additional_rate_limits`, the exact value
+formats) is a faithful reconstruction. Values are placeholders — no real
+account label, id, or token appears here.
+
+The consequence, stated plainly so it is not discovered as a surprise: these
+fixtures pin the probes against the spec's reading of the payloads, not against
+the wire. A drift between the two shows up as an `error` status from a live
+probe, never as a wrong number — which is the stance spec #49 adopts for all
+three endpoints.
+
+| File | Endpoint |
+|---|---|
+| `anthropic_usage.json` | `GET api.anthropic.com/api/oauth/usage` |
+| `openai_usage.json` | `GET chatgpt.com/backend-api/codex/usage` |
+| `moonshot_usages.json` | `GET api.kimi.com/coding/v1/usages` |

--- a/tests/fixtures/quota_probes/anthropic_usage.json
+++ b/tests/fixtures/quota_probes/anthropic_usage.json
@@ -1,0 +1,28 @@
+{
+  "subscriptionType": "max",
+  "limits": [
+    {
+      "kind": "session",
+      "percent": 22,
+      "resets_at": "2026-07-25T21:00:00+00:00",
+      "severity": "normal"
+    },
+    {
+      "kind": "weekly_all",
+      "percent": 41,
+      "resets_at": "2026-07-28T09:00:00Z",
+      "severity": "normal"
+    },
+    {
+      "kind": "weekly_scoped",
+      "percent": 63,
+      "resets_at": "2026-07-28T09:00:00Z",
+      "severity": "normal",
+      "scope": {
+        "model": {
+          "display_name": "Claude Opus 5"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/quota_probes/moonshot_usages.json
+++ b/tests/fixtures/quota_probes/moonshot_usages.json
@@ -1,0 +1,26 @@
+{
+  "user": {
+    "userId": "placeholder-user-0001"
+  },
+  "membership": {
+    "level": "LEVEL_ADVANCED"
+  },
+  "usage": {
+    "used": 128000,
+    "limit": 500000,
+    "remaining": 372000,
+    "resetTime": "2026-07-31T00:00:00Z"
+  },
+  "limits": [
+    {
+      "window": {
+        "duration": 300,
+        "timeUnit": "MINUTE"
+      },
+      "used": 42,
+      "limit": 200,
+      "remaining": 158,
+      "resetTime": "2026-07-25T20:00:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/quota_probes/openai_usage.json
+++ b/tests/fixtures/quota_probes/openai_usage.json
@@ -1,0 +1,24 @@
+{
+  "email": "placeholder@example.com",
+  "account_id": "acct_placeholder_0001",
+  "plan_type": "prolite",
+  "rate_limit": {
+    "primary_window": {
+      "used_percent": 12.5,
+      "limit_window_seconds": 18000,
+      "reset_at": 1785016800
+    },
+    "secondary_window": {
+      "used_percent": 47.0,
+      "limit_window_seconds": 604800,
+      "reset_at": 1785412800
+    },
+    "additional_rate_limits": [
+      {
+        "limit_name": "premium",
+        "used_percent": 3.0,
+        "reset_at": 1785412800
+      }
+    ]
+  }
+}

--- a/tests/mutations/u2_quota_probes.py
+++ b/tests/mutations/u2_quota_probes.py
@@ -224,11 +224,32 @@ MUTATIONS = [
         new="    if not rate_limit or not isinstance(rate_limit, dict):",
     ),
     Mutation(
+        name="openai-wrong-typed-collection-swallowed",
+        property="a present-but-non-list additional_rate_limits is drift",
+        path=OPENAI,
+        old="    missing = _drift(rate_limit, payload)\n    if missing:",
+        new="    missing = _drift(rate_limit, payload)\n    if False:",
+    ),
+    Mutation(
+        name="openai-empty-collection-cried-as-drift",
+        property="an absent or empty additional_rate_limits is data, not drift",
+        path=OPENAI,
+        old="        if extra is not None and not isinstance(extra, list):",
+        new="        if not isinstance(extra, list):",
+    ),
+    Mutation(
         name="moonshot-lost-usage-parsed-as-zero",
         property="a 200 with no usage{} is error, not an ok reading zero",
         path=MOONSHOT,
         old='    if not isinstance(payload.get("usage"), dict):',
         new="    if False:",
+    ),
+    Mutation(
+        name="moonshot-empty-usage-cried-as-drift",
+        property="an intact but empty usage{} is data, never a false alarm",
+        path=MOONSHOT,
+        old='    if not isinstance(payload.get("usage"), dict):',
+        new='    if not payload.get("usage"):',
     ),
     Mutation(
         name="moonshot-absent-limits-cried-as-drift",

--- a/tests/mutations/u2_quota_probes.py
+++ b/tests/mutations/u2_quota_probes.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Mutation driver for spec #49 U2 (quota probe package).
+
+The unit's value is five invariants a reviewer is told to check FROM CODE
+(spec #49, Probe Contract) plus one normalization rule. Reading the code
+proves none of them, and green CI proves only that the suite ran — so each
+mutation below breaks exactly one property in the real source, runs the suite,
+and demands red; the driver reverts and demands green again. A mutation that
+stays GREEN is a finding about the test, not a success.
+
+Same shape and the same reason as tests/mutations/u7_composer_actions.py: the
+round trips live in the repo so they survive the session that made them.
+
+Deliberately absent: a "the wall-clock deadline is dropped" mutation that
+HANGS. The containment test bounds its assertion between the contained cost
+(~1.2s) and the stub's 3s sleep, so removing the deadline reddens it in 3s
+instead of spinning — a suite that never answers demonstrates nothing (the
+u7 driver learned this the hard way).
+
+Usage:
+    python3 tests/mutations/u2_quota_probes.py          # all mutations
+    python3 tests/mutations/u2_quota_probes.py --list
+    python3 tests/mutations/u2_quota_probes.py --only <name>
+
+Exit 0 = every mutation reproduced red->revert->green.
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PKG = ROOT / ".super-coder" / "scripts" / "quota_probes"
+INIT = PKG / "__init__.py"
+ANTHROPIC = PKG / "anthropic.py"
+OPENAI = PKG / "openai.py"
+MOONSHOT = PKG / "moonshot.py"
+DISPATCH = PKG / "dispatch.py"
+
+SUITES = ["tests/test_quota_probes.py"]
+
+
+@dataclass
+class Mutation:
+    name: str
+    property: str
+    path: Path
+    old: str
+    new: str
+
+
+MUTATIONS = [
+    # ── Invariant: expiry is REPORTED, not repaired ──────────────────────────
+    Mutation(
+        name="expiry-never-detected",
+        property="an expired access token is never sent to the provider",
+        path=INIT,
+        old="    return secs <= epoch_now()",
+        new="    return False",
+    ),
+    Mutation(
+        name="moonshot-skips-its-expiry-check",
+        property="each provider checks expiry itself, not just the helper",
+        path=MOONSHOT,
+        old='    if is_expired((creds or {}).get("expires_at")):',
+        new="    if False:",
+    ),
+    # ── Invariant: no credential file means `na`, not 0% ─────────────────────
+    Mutation(
+        name="absent-credentials-report-zero",
+        property="the absence of a limit is not a limit of zero",
+        path=ANTHROPIC,
+        old='        return result(status="na", is_current=0)',
+        new='        return result(status="ok", is_current=0, windows=[window(\n'
+            '            window_kind="session", used_percent=0,\n'
+            "            captured_at=captured_at, probe_version=PROBE_VERSION)])",
+    ),
+    # ── Invariant: tokens are never stored, logged, or returned ──────────────
+    Mutation(
+        name="token-reaches-the-log",
+        property="no log line carries a token (the classic debug-line leak)",
+        path=ANTHROPIC,
+        old="    code, payload = get_json(URL, {",
+        new='    log(f"{HARNESS_PROVIDER}: GET {URL} bearer {token}")\n'
+            "    code, payload = get_json(URL, {",
+    ),
+    Mutation(
+        name="token-reaches-a-returned-row",
+        property="no returned row carries a token",
+        path=MOONSHOT,
+        old="    return result(account_ref=ref, account_label=ref, plan=plan,",
+        new="    return result(account_ref=ref, account_label=token, plan=plan,",
+    ),
+    # ── Invariant: read-only on credentials ──────────────────────────────────
+    Mutation(
+        name="credential-file-rewritten",
+        property="a probe never writes the harness's credential file",
+        path=ANTHROPIC,
+        old="    uuid = _account_uuid(log)",
+        new="    CREDENTIALS.write_text(CREDENTIALS.read_text())\n"
+            "    uuid = _account_uuid(log)",
+    ),
+    # ── Invariant: one provider's failure is contained ───────────────────────
+    Mutation(
+        name="probe-exception-escapes",
+        property="a raising provider degrades to its own error row",
+        path=DISPATCH,
+        old='        return [_error(name, f"probe raised {type(e).__name__}")]',
+        new="        raise",
+    ),
+    Mutation(
+        name="dead-provider-module-is-fatal",
+        property="an unimportable probe is one error row, not a dead sweep",
+        path=DISPATCH,
+        old='        return [_error(name, f"probe module unavailable: {e}")]',
+        new="        raise",
+    ),
+    # ── Normalization: kind comes from the observed DURATION ─────────────────
+    Mutation(
+        name="kind-read-from-the-window-name",
+        property="window kind is derived from duration, never from the label",
+        path=OPENAI,
+        old='    for key in ("primary_window", "secondary_window"):\n'
+            "        row = _window_row(rate_limit.get(key), captured_at, log)",
+        new='    for key, named in (("primary_window", "five_hour"),\n'
+            '                       ("secondary_window", "weekly")):\n'
+            "        entry = rate_limit.get(key)\n"
+            "        entry = {**entry, \"limit_window_seconds\": None} \\\n"
+            "            if isinstance(entry, dict) else entry\n"
+            "        row = _window_row(entry, captured_at, log, fallback_kind=named)",
+    ),
+    Mutation(
+        name="unmapped-duration-guessed-as-weekly",
+        property="an unrecognized duration is kept as unknown, never guessed",
+        path=INIT,
+        old="    if 0 < secs <= SHORT_MAX_SECONDS:\n"
+            '        return "short"\n'
+            "    return None",
+        new="    if 0 < secs <= SHORT_MAX_SECONDS:\n"
+            '        return "short"\n'
+            '    return "weekly"',
+    ),
+    Mutation(
+        name="unknown-kind-dropped",
+        property="a window under an unrecognized kind is rendered, not dropped",
+        path=ANTHROPIC,
+        old="        elif kind is None:\n"
+            '            log(f"{HARNESS_PROVIDER}: unrecognized limit kind {raw_kind!r} — "\n'
+            '                "kept under its own row")\n'
+            "            scope = str(raw_kind) if raw_kind else None",
+        new="        elif kind is None:\n            continue",
+    ),
+    # ── Numbers: never invented, never divided by zero ───────────────────────
+    Mutation(
+        name="zero-limit-divides",
+        property="limit = 0 yields NULL, never a division",
+        path=INIT,
+        old="    if limit_n <= 0:",
+        new="    if limit_n < 0:",
+    ),
+    Mutation(
+        name="counts-back-computed-from-percent",
+        property="a count is never invented from a percent",
+        path=ANTHROPIC,
+        old='            used_percent=as_percent(item.get("percent")),',
+        new='            used_percent=as_percent(item.get("percent")),\n'
+            '            used=as_percent(item.get("percent")), limit=100,',
+    ),
+    # ── Status vocabulary ────────────────────────────────────────────────────
+    Mutation(
+        name="rejection-reported-as-error",
+        property="401/403 is unauth (last values stand), not a generic error",
+        path=INIT,
+        old="    if code in (401, 403):",
+        new="    if code in (403,):",
+    ),
+    Mutation(
+        name="drift-writes-partial-rows",
+        property="a drifted response is an error, never a partial write",
+        path=ANTHROPIC,
+        old='    limits = payload.get("limits")\n'
+            "    if not isinstance(limits, list):\n"
+            '        log(f"{HARNESS_PROVIDER}: shape drift — no limits[] in the usage payload")\n'
+            '        return result(status="error", detail="no limits[] in response", **common)',
+        new='    limits = payload.get("limits") or []',
+    ),
+]
+
+
+# The suite runs in ~5s (one mutation deliberately costs a 3s sleep). The
+# timeout is the backstop for a mutation that hangs rather than answers.
+SUITE_TIMEOUT_S = 120
+
+
+def run_suites() -> tuple[bool, bool]:
+    """(passed, timed_out). A timeout is a failure: a suite that cannot finish
+    has not demonstrated the property."""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", *SUITES],
+            cwd=ROOT, capture_output=True, text=True, check=False,
+            timeout=SUITE_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        return False, True
+    return result.returncode == 0, False
+
+
+def apply(mutation: Mutation) -> str:
+    original = mutation.path.read_text()
+    count = original.count(mutation.old)
+    if count != 1:
+        raise SystemExit(
+            f"{mutation.name}: anchor matched {count} times in "
+            f"{mutation.path.name}, expected exactly 1 — the driver is stale")
+    mutation.path.write_text(original.replace(mutation.old, mutation.new))
+    return original
+
+
+def _die(signum, frame):
+    """SIGTERM must unwind so the `finally` that reverts the source runs —
+    a killed driver otherwise leaves the package MUTATED in the worktree."""
+    raise SystemExit(f"interrupted by signal {signum}")
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, _die)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--list", action="store_true")
+    parser.add_argument("--only", default=None, help="run one mutation by name")
+    args = parser.parse_args()
+
+    selected = [m for m in MUTATIONS if args.only is None or m.name == args.only]
+    if args.list:
+        for m in selected:
+            print(f"{m.name:36s} {m.property}")
+        return 0
+    if not selected:
+        raise SystemExit(f"no mutation named {args.only!r}")
+
+    print("baseline: ", end="", flush=True)
+    passed, timed_out = run_suites()
+    if not passed:
+        print("TIMED OUT" if timed_out else "RED", "— fix the tree before mutating")
+        return 1
+    print("green")
+
+    failures = []
+    for m in selected:
+        print(f"{m.name:36s} ", end="", flush=True)
+        original = apply(m)
+        try:
+            passed, timed_out = run_suites()
+            red = not passed
+            print("hung " if timed_out else ("red " if red else "GREEN "),
+                  end="", flush=True)
+        finally:
+            m.path.write_text(original)     # restored even on Ctrl-C / SIGTERM
+        green, _ = run_suites()
+        print("-> revert -> " + ("green" if green else "STILL RED"))
+        if not (red and green) or timed_out:
+            failures.append((m, "hung" if timed_out else "did not round-trip"))
+
+    print()
+    if failures:
+        print(f"{len(failures)} of {len(selected)} mutations FAILED:")
+        for m, why in failures:
+            print(f"  - {m.name} ({why}): {m.property}")
+        return 1
+    print(f"{len(selected)}/{len(selected)} mutations red -> revert -> green")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/mutations/u2_quota_probes.py
+++ b/tests/mutations/u2_quota_probes.py
@@ -101,9 +101,24 @@ MUTATIONS = [
         name="credential-file-rewritten",
         property="a probe never writes the harness's credential file",
         path=ANTHROPIC,
-        old="    uuid = _account_uuid(log)",
+        old="    uuid, email = _identity(log)",
         new="    CREDENTIALS.write_text(CREDENTIALS.read_text())\n"
-            "    uuid = _account_uuid(log)",
+            "    uuid, email = _identity(log)",
+    ),
+    # ── The label ruled in decision #69 ──────────────────────────────────────
+    Mutation(
+        name="anthropic-labelled-by-uuid",
+        property="Anthropic's card carries the full email, not the uuid stub",
+        path=ANTHROPIC,
+        old="    return email or uuid[:8]",
+        new="    return uuid[:8]",
+    ),
+    Mutation(
+        name="label-has-no-fallback",
+        property="a profile with no address still labels the card",
+        path=ANTHROPIC,
+        old="    return email or uuid[:8]",
+        new="    return email",
     ),
     # ── Invariant: one provider's failure is contained ───────────────────────
     Mutation(
@@ -169,7 +184,7 @@ MUTATIONS = [
         path=ANTHROPIC,
         old='            used_percent=as_percent(item.get("percent")),',
         new='            used_percent=as_percent(item.get("percent")),\n'
-            '            used=as_percent(item.get("percent")), limit=100,',
+            '            used=as_percent(item.get("percent")), limit_value=100,',
     ),
     # ── Status vocabulary ────────────────────────────────────────────────────
     Mutation(

--- a/tests/mutations/u2_quota_probes.py
+++ b/tests/mutations/u2_quota_probes.py
@@ -93,8 +93,8 @@ MUTATIONS = [
         name="token-reaches-a-returned-row",
         property="no returned row carries a token",
         path=MOONSHOT,
-        old="    return result(account_ref=ref, account_label=ref, plan=plan,",
-        new="    return result(account_ref=ref, account_label=token, plan=plan,",
+        old="    common = dict(account_ref=ref, account_label=ref)",
+        new="    common = dict(account_ref=ref, account_label=token)",
     ),
     # ── Invariant: read-only on credentials ──────────────────────────────────
     Mutation(
@@ -199,10 +199,50 @@ MUTATIONS = [
         property="a drifted response is an error, never a partial write",
         path=ANTHROPIC,
         old='    limits = payload.get("limits")\n'
-            "    if not isinstance(limits, list):\n"
-            '        log(f"{HARNESS_PROVIDER}: shape drift — no limits[] in the usage payload")\n'
-            '        return result(status="error", detail="no limits[] in response", **common)',
-        new='    limits = payload.get("limits") or []',
+            "    if not isinstance(limits, list):",
+        new='    limits = payload.get("limits") or []\n'
+            "    if False:",
+    ),
+    # ── Drift vs legitimately-empty: the two must not collapse ───────────────
+    # Each provider gets the round trip in BOTH directions — a probe that
+    # swallows a lost envelope as zero windows, and a probe that cries drift
+    # at an intact envelope reporting none. Only the pair pins the boundary;
+    # either alone is satisfied by a probe that gets the other case wrong.
+    Mutation(
+        name="openai-lost-envelope-parsed-as-zero",
+        property="a 200 with no rate_limit{} is error, not an ok reading zero",
+        path=OPENAI,
+        old="    if not isinstance(rate_limit, dict):",
+        new="    rate_limit = rate_limit if isinstance(rate_limit, dict) else {}\n"
+            "    if False:",
+    ),
+    Mutation(
+        name="openai-empty-envelope-cried-as-drift",
+        property="an intact rate_limit{} reporting no window stays ok",
+        path=OPENAI,
+        old="    if not isinstance(rate_limit, dict):",
+        new="    if not rate_limit or not isinstance(rate_limit, dict):",
+    ),
+    Mutation(
+        name="moonshot-lost-usage-parsed-as-zero",
+        property="a 200 with no usage{} is error, not an ok reading zero",
+        path=MOONSHOT,
+        old='    if not isinstance(payload.get("usage"), dict):',
+        new="    if False:",
+    ),
+    Mutation(
+        name="moonshot-absent-limits-cried-as-drift",
+        property="an absent `limits` collection is data, never a false alarm",
+        path=MOONSHOT,
+        old="    if limits is not None and not isinstance(limits, list):",
+        new="    if not isinstance(limits, list):",
+    ),
+    Mutation(
+        name="unreadable-200-reported-as-http-200",
+        property="a 200 that is not a JSON object says so, not 'HTTP 200'",
+        path=INIT,
+        old='        return drift(provider, "response was not a JSON object", log)',
+        new='        return f"HTTP {code}"',
     ),
 ]
 

--- a/tests/test_quota_probes.py
+++ b/tests/test_quota_probes.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Tests for the quota probe package — spec doc #49, sprint 52 unit 2.
+
+Every test drives the probes against the recorded fixtures in
+tests/fixtures/quota_probes/ (see that dir's README for provenance). NO TEST
+PERFORMS A LIVE CALL, and that is enforced rather than promised: `urlopen` is
+replaced for the duration of every test with a stub that fails the test if it
+is ever reached.
+
+The five Probe Contract invariants each get a test that a realistic bug turns
+red:
+  • read-only on credentials — the files' bytes AND mtimes are compared
+    across a full probe_all, so an accidental rewrite-with-same-content is
+    caught too;
+  • tokens never stored, logged, or returned — a sentinel token must appear in
+    the Authorization header (proving the probe actually authenticates) and
+    NOWHERE in the returned rows or the log;
+  • expiry reported, not repaired — an expired token yields `unauth` AND
+    makes no request at all;
+  • absent credential file yields `na` and never a 0% anywhere in the result;
+  • one provider's failure is contained — a raiser and a hang each degrade to
+    their own `error` row while the other providers' rows stand.
+
+Plus normalization: window kind is derived from the OBSERVED DURATION, pinned
+by swapping two windows' durations and asserting their kinds swap — a probe
+that read position or label instead would not move.
+
+Run:
+    python3 tests/test_quota_probes.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+FIXTURES = ROOT / "tests" / "fixtures" / "quota_probes"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import quota_probes as qp  # noqa: E402
+from quota_probes import anthropic as p_anthropic  # noqa: E402
+from quota_probes import dispatch  # noqa: E402
+from quota_probes import moonshot as p_moonshot  # noqa: E402
+from quota_probes import openai as p_openai  # noqa: E402
+
+TOKEN = "sentinel-access-token-must-never-leak"
+HOUR_MS = 3600 * 1000
+
+
+def fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+class Endpoint:
+    """Stand-in for quota_probes.get_json — records what it was called with."""
+
+    def __init__(self, code=200, payload=None, delay=0.0):
+        self.code, self.payload, self.delay = code, payload, delay
+        self.calls: list[tuple] = []
+
+    def __call__(self, url, headers, timeout):
+        self.calls.append((url, dict(headers), timeout))
+        if self.delay:
+            time.sleep(self.delay)
+        return self.code, self.payload
+
+
+class ProbeCase(unittest.TestCase):
+    """Writes credential files into a temp HOME and points each probe at them.
+
+    Every probe module resolves its credential paths at import time, so the
+    constants are patched rather than $HOME — the same thing the real code
+    would read, without touching the operator's own files.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.notes: list[str] = []
+        self.log = self.notes.append
+
+        self.claude_creds = self.tmp / ".claude/.credentials.json"
+        self.claude_profile = self.tmp / ".claude.json"
+        self.codex_auth = self.tmp / ".codex/auth.json"
+        self.kimi_creds = self.tmp / ".kimi-code/credentials/kimi-code.json"
+        expires = int((time.time() + 3600) * 1000)
+        self.write(self.claude_creds, {"claudeAiOauth": {
+            "accessToken": TOKEN, "refreshToken": "sentinel-refresh",
+            "expiresAt": expires, "subscriptionType": "max"}})
+        self.write(self.claude_profile, {"oauthAccount": {
+            "accountUuid": "abcd1234-0000-4000-8000-00000000beef",
+            "emailAddress": "placeholder@example.com"}})
+        self.write(self.codex_auth, {"auth_mode": "chatgpt", "tokens": {
+            "access_token": TOKEN, "refresh_token": "sentinel-refresh",
+            "account_id": "acct_placeholder_0001"}})
+        self.write(self.kimi_creds, {
+            "access_token": TOKEN, "refresh_token": "sentinel-refresh",
+            "expires_at": expires})
+
+        self.patch(p_anthropic, CREDENTIALS=self.claude_creds,
+                   PROFILE=self.claude_profile)
+        self.patch(p_openai, CREDENTIALS=self.codex_auth)
+        self.patch(p_moonshot, CREDENTIALS=self.kimi_creds)
+
+        # The no-live-call guard. Reached only if a probe bypasses get_json.
+        guard = mock.patch("urllib.request.urlopen",
+                           side_effect=AssertionError("live HTTP call attempted"))
+        guard.start()
+        self.addCleanup(guard.stop)
+
+    def write(self, path: Path, payload: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload))
+
+    def patch(self, module, **attrs) -> None:
+        for name, value in attrs.items():
+            p = mock.patch.object(module, name, value)
+            p.start()
+            self.addCleanup(p.stop)
+
+    def endpoint(self, module, code=200, payload=None, delay=0.0) -> Endpoint:
+        ep = Endpoint(code, payload, delay)
+        self.patch(module, get_json=ep)
+        return ep
+
+    def one(self, rows: list) -> dict:
+        self.assertEqual(len(rows), 1, f"expected one account, got {rows}")
+        return rows[0]
+
+    def by_kind(self, acct: dict) -> dict:
+        return {(w["window_kind"], w["scope"]): w for w in acct["windows"]}
+
+
+class NormalizerTest(unittest.TestCase):
+    def test_kind_comes_from_the_duration(self):
+        self.assertEqual(qp.kind_for_seconds(18000), "five_hour")
+        self.assertEqual(qp.kind_for_seconds(604800), "weekly")
+        self.assertEqual(qp.kind_for_seconds(900), "short")
+        self.assertEqual(qp.kind_for_seconds("604800"), "weekly")
+
+    def test_unmapped_duration_is_not_guessed(self):
+        self.assertIsNone(qp.kind_for_seconds(7200))
+        self.assertIsNone(qp.kind_for_seconds(None))
+        self.assertIsNone(qp.kind_for_seconds("weekly"))
+
+    def test_percent_is_derived_only_from_a_positive_limit(self):
+        self.assertEqual(qp.percent_from(1, 4), 25.0)
+        self.assertIsNone(qp.percent_from(1, 0), "limit=0 must not divide")
+        self.assertIsNone(qp.percent_from(1, None))
+        self.assertIsNone(qp.percent_from(None, 100))
+
+    def test_epoch_and_iso_normalize_to_utc_seconds(self):
+        self.assertEqual(qp.iso_from_epoch(1785016800), "2026-07-25T22:00:00Z")
+        self.assertEqual(qp.iso_from_epoch(1785016800000), "2026-07-25T22:00:00Z")
+        self.assertEqual(qp.norm_iso("2026-07-25T21:00:00+00:00"),
+                         "2026-07-25T21:00:00Z")
+        self.assertIsNone(qp.norm_iso("not a time"))
+
+
+class AnthropicProbeTest(ProbeCase):
+    def probe(self, code=200, payload=None) -> tuple:
+        ep = self.endpoint(p_anthropic, code,
+                           fixture("anthropic_usage.json") if payload is None
+                           else payload)
+        return self.one(p_anthropic.probe(self.log, 5)), ep
+
+    def test_normalizes_the_three_observed_windows(self):
+        acct, ep = self.probe()
+        self.assertEqual(acct["status"], "ok")
+        self.assertEqual(acct["plan"], "max")
+        self.assertEqual(acct["account_ref"],
+                         "abcd1234-0000-4000-8000-00000000beef")
+        self.assertEqual(acct["account_label"], "abcd1234")
+        windows = self.by_kind(acct)
+        self.assertEqual(set(windows), {("session", None), ("weekly", None),
+                                        ("weekly_scoped", "Claude Opus 5")})
+        self.assertEqual(windows[("session", None)]["used_percent"], 22.0)
+        self.assertEqual(windows[("session", None)]["resets_at"],
+                         "2026-07-25T21:00:00Z")
+        self.assertEqual(ep.calls[0][0], p_anthropic.URL)
+        self.assertEqual(ep.calls[0][1]["anthropic-beta"],
+                         p_anthropic.BETA_HEADER)
+
+    def test_percent_only_provider_leaves_counts_null(self):
+        acct, _ = self.probe()
+        for w in acct["windows"]:
+            self.assertIsNone(w["used"], "a count was invented from a percent")
+            self.assertIsNone(w["limit"])
+
+    def test_expired_token_is_reported_never_used(self):
+        self.write(self.claude_creds, {"claudeAiOauth": {
+            "accessToken": TOKEN, "expiresAt": int((time.time() - 60) * 1000)}})
+        acct, ep = self.probe()
+        self.assertEqual(acct["status"], "unauth")
+        self.assertEqual(ep.calls, [], "an expired token was sent to the provider")
+        self.assertEqual(acct["windows"], [])
+        # The account is still identified, so the card keeps its last values.
+        self.assertEqual(acct["account_ref"],
+                         "abcd1234-0000-4000-8000-00000000beef")
+
+    def test_absent_credential_file_is_na_not_zero(self):
+        self.claude_creds.unlink()
+        acct, ep = self.probe()
+        self.assertEqual(acct["status"], "na")
+        self.assertIsNone(acct["account_ref"], "an na account must key nothing")
+        self.assertEqual(acct["windows"], [])
+        self.assertEqual(ep.calls, [])
+        self.assertNotIn("0", json.dumps([w.get("used_percent")
+                                          for w in acct["windows"]]))
+
+    def test_provider_rejection_is_unauth_other_failures_are_error(self):
+        acct, _ = self.probe(code=401)
+        self.assertEqual(acct["status"], "unauth")
+        acct, _ = self.probe(code=503)
+        self.assertEqual(acct["status"], "error")
+        self.assertIn("503", acct["detail"])
+        self.assertEqual(acct["windows"], [])
+
+    def test_shape_drift_writes_no_partial_rows(self):
+        acct, _ = self.probe(payload={"subscriptionType": "max"})
+        self.assertEqual(acct["status"], "error")
+        self.assertEqual(acct["windows"], [])
+        self.assertTrue(any("shape drift" in n for n in self.notes),
+                        f"drift must be loud; log was {self.notes}")
+
+    def test_unknown_limit_kind_is_kept_not_dropped(self):
+        acct, _ = self.probe(payload={"limits": [
+            {"kind": "monthly_all", "percent": 5, "resets_at": None}]})
+        w = self.one(acct["windows"])
+        self.assertEqual(w["window_kind"], "unknown")
+        self.assertEqual(w["scope"], "monthly_all")
+        self.assertEqual(w["used_percent"], 5.0)
+
+
+class OpenAIProbeTest(ProbeCase):
+    def probe(self, code=200, payload=None) -> tuple:
+        ep = self.endpoint(p_openai, code,
+                           fixture("openai_usage.json") if payload is None
+                           else payload)
+        return self.one(p_openai.probe(self.log, 5)), ep
+
+    def test_normalizes_the_observed_windows(self):
+        acct, ep = self.probe()
+        self.assertEqual(acct["status"], "ok")
+        self.assertEqual(acct["account_label"], "placeholder@example.com",
+                         "the label is the full address, not a local part")
+        self.assertEqual(acct["account_ref"], "acct_placeholder_0001")
+        self.assertEqual(acct["plan"], "prolite")
+        windows = self.by_kind(acct)
+        self.assertEqual(set(windows), {("five_hour", None), ("weekly", None),
+                                        ("weekly", "premium")})
+        self.assertEqual(windows[("five_hour", None)]["used_percent"], 12.5)
+        self.assertEqual(windows[("weekly", None)]["resets_at"],
+                         "2026-07-30T12:00:00Z")
+        self.assertEqual(ep.calls[0][1]["chatgpt-account-id"],
+                         "acct_placeholder_0001")
+
+    def test_kind_follows_the_duration_not_the_window_name(self):
+        """Swap the two windows' durations: their kinds must swap with them.
+
+        A probe that mapped primary→five_hour / secondary→weekly by name or
+        position passes the test above and fails only here.
+        """
+        payload = fixture("openai_usage.json")
+        primary = payload["rate_limit"]["primary_window"]
+        secondary = payload["rate_limit"]["secondary_window"]
+        primary["limit_window_seconds"], secondary["limit_window_seconds"] = \
+            secondary["limit_window_seconds"], primary["limit_window_seconds"]
+        acct, _ = self.probe(payload=payload)
+        kinds = {w["used_percent"]: w["window_kind"] for w in acct["windows"]}
+        self.assertEqual(kinds[12.5], "weekly")
+        self.assertEqual(kinds[47.0], "five_hour")
+
+    def test_unrecognized_duration_keeps_the_window_under_its_own_row(self):
+        payload = {"account_id": "a1", "rate_limit": {"primary_window": {
+            "used_percent": 9, "limit_window_seconds": 7200, "reset_at": 0}}}
+        acct, _ = self.probe(payload=payload)
+        w = self.one(acct["windows"])
+        self.assertEqual(w["window_kind"], "unknown")
+        self.assertEqual(w["scope"], "7200s", "the duration must survive")
+        self.assertEqual(w["used_percent"], 9.0)
+
+    def test_absent_credential_file_is_na_not_zero(self):
+        self.codex_auth.unlink()
+        acct, ep = self.probe()
+        self.assertEqual(acct["status"], "na")
+        self.assertIsNone(acct["account_ref"])
+        self.assertEqual(ep.calls, [])
+
+    def test_rejection_keeps_the_account_identified(self):
+        acct, _ = self.probe(code=401)
+        self.assertEqual(acct["status"], "unauth")
+        self.assertEqual(acct["account_ref"], "acct_placeholder_0001",
+                         "the ref is on disk, so an unauth card still keys")
+
+
+class MoonshotProbeTest(ProbeCase):
+    def probe(self, code=200, payload=None) -> tuple:
+        ep = self.endpoint(p_moonshot, code,
+                           fixture("moonshot_usages.json") if payload is None
+                           else payload)
+        return self.one(p_moonshot.probe(self.log, 5)), ep
+
+    def test_derives_percent_from_absolute_counts(self):
+        acct, _ = self.probe()
+        self.assertEqual(acct["status"], "ok")
+        self.assertEqual(acct["account_ref"], "placeholder-user-0001")
+        self.assertEqual(acct["plan"], "LEVEL_ADVANCED")
+        windows = self.by_kind(acct)
+        weekly = windows[("weekly", None)]
+        self.assertEqual((weekly["used"], weekly["limit"]), (128000, 500000))
+        self.assertEqual(weekly["used_percent"], 25.6)
+        five_hour = windows[("five_hour", None)]
+        self.assertEqual(five_hour["used_percent"], 21.0)
+        self.assertEqual(five_hour["resets_at"], "2026-07-25T20:00:00Z")
+
+    def test_300_minutes_is_five_hours(self):
+        """The kind comes from duration × timeUnit, so changing the unit
+        alone must change the kind."""
+        payload = fixture("moonshot_usages.json")
+        payload["limits"][0]["window"]["timeUnit"] = "SECOND"
+        acct, _ = self.probe(payload=payload)
+        kinds = {w["window_kind"] for w in acct["windows"]}
+        self.assertIn("short", kinds, "300 SECONDS is not five hours")
+        self.assertNotIn("five_hour", kinds)
+
+    def test_zero_limit_reads_na_never_divides(self):
+        payload = fixture("moonshot_usages.json")
+        payload["usage"]["limit"] = 0
+        payload["limits"] = []
+        acct, _ = self.probe(payload=payload)
+        w = self.one(acct["windows"])
+        self.assertIsNone(w["used_percent"])
+        self.assertEqual((w["used"], w["limit"]), (128000, 0),
+                         "the raw counts still stand")
+
+    def test_unknown_time_unit_keeps_the_window(self):
+        payload = fixture("moonshot_usages.json")
+        payload["limits"][0]["window"] = {"duration": 2, "timeUnit": "FORTNIGHT"}
+        acct, _ = self.probe(payload=payload)
+        odd = [w for w in acct["windows"] if w["window_kind"] == "unknown"]
+        self.assertEqual(len(odd), 1)
+        self.assertIn("FORTNIGHT", str(odd[0]["scope"]))
+
+    def test_expired_token_is_reported_never_used(self):
+        self.write(self.kimi_creds, {"access_token": TOKEN,
+                                     "expires_at": int(time.time()) - 60})
+        acct, ep = self.probe()
+        self.assertEqual(acct["status"], "unauth")
+        self.assertEqual(ep.calls, [])
+
+
+class CredentialSafetyTest(ProbeCase):
+    """The two invariants that make this package safe to run on a live host."""
+
+    def endpoints(self) -> list:
+        return [self.endpoint(mod, 200, fixture(name)) for mod, name in (
+            (p_anthropic, "anthropic_usage.json"),
+            (p_openai, "openai_usage.json"),
+            (p_moonshot, "moonshot_usages.json"))]
+
+    def test_token_reaches_the_header_and_nothing_else(self):
+        eps = self.endpoints()
+        rows = dispatch.probe_all(self.log, timeout=5)
+        sent = [call[1].get("Authorization") for ep in eps for call in ep.calls]
+        self.assertEqual(len(sent), 3, "every provider must be probed")
+        for header in sent:
+            self.assertIn(TOKEN, header or "",
+                          "the probe must actually authenticate")
+        self.assertNotIn(TOKEN, json.dumps(rows),
+                         "a token reached a returned row")
+        self.assertNotIn("sentinel-refresh", json.dumps(rows))
+        self.assertNotIn(TOKEN, "\n".join(self.notes), "a token reached the log")
+        self.assertNotIn("sentinel-refresh", "\n".join(self.notes))
+
+    def test_credential_files_are_never_written(self):
+        paths = [self.claude_creds, self.claude_profile, self.codex_auth,
+                 self.kimi_creds]
+        before = {p: (p.read_bytes(), p.stat().st_mtime_ns) for p in paths}
+        self.endpoints()
+        dispatch.probe_all(self.log, timeout=5)
+        for p in paths:
+            self.assertEqual((p.read_bytes(), p.stat().st_mtime_ns), before[p],
+                             f"{p.name} was written by a probe")
+
+    def test_no_probe_module_opens_a_credential_file_for_writing(self):
+        """A second, static check: nothing in the package can write at all."""
+        package = ENGINE / "scripts" / "quota_probes"
+        for path in sorted(package.glob("*.py")):
+            source = path.read_text()
+            for forbidden in ("write_text(", "write_bytes(", "os.replace(",
+                              "unlink(", ".refresh("):
+                self.assertNotIn(forbidden, source,
+                                 f"{path.name} contains a write path")
+
+
+class DispatchTest(ProbeCase):
+    def test_one_provider_raising_is_contained(self):
+        self.endpoint(p_anthropic, 200, fixture("anthropic_usage.json"))
+        self.endpoint(p_moonshot, 200, fixture("moonshot_usages.json"))
+        boom = mock.patch.object(p_openai, "probe",
+                                 side_effect=RuntimeError("provider exploded"))
+        boom.start()
+        self.addCleanup(boom.stop)
+        rows = {r["provider"]: r for r in dispatch.probe_all(self.log, timeout=5)}
+        self.assertEqual(set(rows), {"anthropic", "openai", "moonshot"})
+        self.assertEqual(rows["openai"]["status"], "error")
+        self.assertIn("RuntimeError", rows["openai"]["detail"])
+        self.assertEqual(rows["anthropic"]["status"], "ok")
+        self.assertEqual(rows["moonshot"]["status"], "ok")
+        self.assertTrue(any("provider exploded" in n for n in self.notes))
+
+    def test_a_hung_provider_costs_the_timeout_not_the_request(self):
+        self.endpoint(p_anthropic, 200, fixture("anthropic_usage.json"))
+        self.endpoint(p_moonshot, 200, fixture("moonshot_usages.json"))
+        self.endpoint(p_openai, 200, fixture("openai_usage.json"), delay=3)
+        started = time.monotonic()
+        rows = {r["provider"]: r for r in dispatch.probe_all(self.log, timeout=0.2)}
+        elapsed = time.monotonic() - started
+        # Bound chosen to sit between the contained cost (timeout + grace, so
+        # ~1.2s) and the hang (3s): dropping the deadline reddens here rather
+        # than hanging the suite, which is what makes it a usable mutation.
+        self.assertLess(elapsed, 2, f"the hang was not contained ({elapsed:.1f}s)")
+        self.assertEqual(rows["openai"]["status"], "error")
+        self.assertIn("timed out", rows["openai"]["detail"])
+        self.assertEqual(rows["anthropic"]["status"], "ok")
+        self.assertEqual(rows["moonshot"]["status"], "ok")
+
+    def test_a_missing_probe_module_is_one_error_row(self):
+        """The other containment leg: a provider whose module cannot be
+        imported at all (a rename, a syntax error on a fresh floor) must cost
+        its own row and not the sweep."""
+        self.endpoint(p_anthropic, 200, fixture("anthropic_usage.json"))
+        rows = dispatch.probe_all(self.log, timeout=5,
+                                  providers=["anthropic", "nosuchprovider"])
+        self.assertEqual([r["provider"] for r in rows],
+                         ["anthropic", "nosuchprovider"])
+        self.assertEqual(rows[0]["status"], "ok")
+        self.assertEqual(rows[1]["status"], "error")
+        self.assertIn("unavailable", rows[1]["detail"])
+
+    def test_every_provider_is_probed_in_a_stable_order(self):
+        self.endpoints = None  # not needed; probes run against real modules
+        self.endpoint(p_anthropic, 200, fixture("anthropic_usage.json"))
+        self.endpoint(p_openai, 200, fixture("openai_usage.json"))
+        self.endpoint(p_moonshot, 200, fixture("moonshot_usages.json"))
+        rows = dispatch.probe_all(self.log, timeout=5)
+        self.assertEqual([r["provider"] for r in rows], qp.PROVIDERS)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_quota_probes.py
+++ b/tests/test_quota_probes.py
@@ -176,7 +176,8 @@ class AnthropicProbeTest(ProbeCase):
         self.assertEqual(acct["plan"], "max")
         self.assertEqual(acct["account_ref"],
                          "abcd1234-0000-4000-8000-00000000beef")
-        self.assertEqual(acct["account_label"], "abcd1234")
+        self.assertEqual(acct["account_label"], "placeholder@example.com",
+                         "decision #69: the label is the full email")
         windows = self.by_kind(acct)
         self.assertEqual(set(windows), {("session", None), ("weekly", None),
                                         ("weekly_scoped", "Claude Opus 5")})
@@ -187,11 +188,22 @@ class AnthropicProbeTest(ProbeCase):
         self.assertEqual(ep.calls[0][1]["anthropic-beta"],
                          p_anthropic.BETA_HEADER)
 
+    def test_label_falls_back_to_the_uuid_when_no_address_is_on_file(self):
+        """The ref and the label come from the same object but are not the
+        same field: an older profile without emailAddress must still key AND
+        label the card."""
+        self.write(self.claude_profile, {"oauthAccount": {
+            "accountUuid": "abcd1234-0000-4000-8000-00000000beef"}})
+        acct, _ = self.probe()
+        self.assertEqual(acct["account_label"], "abcd1234")
+        self.assertEqual(acct["account_ref"],
+                         "abcd1234-0000-4000-8000-00000000beef")
+
     def test_percent_only_provider_leaves_counts_null(self):
         acct, _ = self.probe()
         for w in acct["windows"]:
             self.assertIsNone(w["used"], "a count was invented from a percent")
-            self.assertIsNone(w["limit"])
+            self.assertIsNone(w["limit_value"])
 
     def test_expired_token_is_reported_never_used(self):
         self.write(self.claude_creds, {"claudeAiOauth": {
@@ -314,7 +326,7 @@ class MoonshotProbeTest(ProbeCase):
         self.assertEqual(acct["plan"], "LEVEL_ADVANCED")
         windows = self.by_kind(acct)
         weekly = windows[("weekly", None)]
-        self.assertEqual((weekly["used"], weekly["limit"]), (128000, 500000))
+        self.assertEqual((weekly["used"], weekly["limit_value"]), (128000, 500000))
         self.assertEqual(weekly["used_percent"], 25.6)
         five_hour = windows[("five_hour", None)]
         self.assertEqual(five_hour["used_percent"], 21.0)
@@ -337,7 +349,7 @@ class MoonshotProbeTest(ProbeCase):
         acct, _ = self.probe(payload=payload)
         w = self.one(acct["windows"])
         self.assertIsNone(w["used_percent"])
-        self.assertEqual((w["used"], w["limit"]), (128000, 0),
+        self.assertEqual((w["used"], w["limit_value"]), (128000, 0),
                          "the raw counts still stand")
 
     def test_unknown_time_unit_keeps_the_window(self):

--- a/tests/test_quota_probes.py
+++ b/tests/test_quota_probes.py
@@ -335,17 +335,25 @@ class OpenAIProbeTest(ProbeCase):
         """The same rule moonshot's `limits` obeys: no legitimate-empty
         reading exists for the wrong TYPE under a key the normalizer
         iterates. Skipping it silently reports `ok` while every scoped
-        window vanishes — the failure shape SC-167 was blocked for."""
-        payload = fixture("openai_usage.json")
-        payload["rate_limit"]["additional_rate_limits"] = {"premium": {
-            "used_percent": 3.0}}
-        acct, _ = self.probe(payload=payload)
-        self.assertEqual(acct["status"], "error")
-        self.assertEqual(acct["windows"], [],
-                         "no partial rows — the two intact windows must not "
-                         "ship as if they were the whole reading")
-        self.assertTrue(any("shape drift" in n for n in self.notes),
-                        f"drift must be loud; log was {self.notes}")
+        window vanishes — the failure shape SC-167 was blocked for.
+
+        Both an iterable wrong type and a non-iterable one: the drift check
+        is the only thing standing between them and the loop in `_windows`,
+        and only the non-iterable case can tell a working check from a probe
+        that survives on the loop crashing instead."""
+        for value in ({"premium": {"used_percent": 3.0}}, 5):
+            with self.subTest(additional_rate_limits=value):
+                self.notes.clear()
+                payload = fixture("openai_usage.json")
+                payload["rate_limit"]["additional_rate_limits"] = value
+                acct, _ = self.probe(payload=payload)
+                self.assertEqual(acct["status"], "error")
+                self.assertEqual(acct["windows"], [],
+                                 "no partial rows — the two intact windows "
+                                 "must not ship as if they were the whole "
+                                 "reading")
+                self.assertTrue(any("shape drift" in n for n in self.notes),
+                                f"drift must be loud; log was {self.notes}")
 
     def test_an_absent_or_empty_additional_rate_limits_is_data_not_drift(self):
         """The other direction, which the guard must not over-fire on: a plan

--- a/tests/test_quota_probes.py
+++ b/tests/test_quota_probes.py
@@ -331,6 +331,40 @@ class OpenAIProbeTest(ProbeCase):
         self.assertEqual(acct["windows"], [])
         self.assertEqual([n for n in self.notes if "drift" in n], [])
 
+    def test_an_additional_rate_limits_that_is_not_a_list_is_drift(self):
+        """The same rule moonshot's `limits` obeys: no legitimate-empty
+        reading exists for the wrong TYPE under a key the normalizer
+        iterates. Skipping it silently reports `ok` while every scoped
+        window vanishes — the failure shape SC-167 was blocked for."""
+        payload = fixture("openai_usage.json")
+        payload["rate_limit"]["additional_rate_limits"] = {"premium": {
+            "used_percent": 3.0}}
+        acct, _ = self.probe(payload=payload)
+        self.assertEqual(acct["status"], "error")
+        self.assertEqual(acct["windows"], [],
+                         "no partial rows — the two intact windows must not "
+                         "ship as if they were the whole reading")
+        self.assertTrue(any("shape drift" in n for n in self.notes),
+                        f"drift must be loud; log was {self.notes}")
+
+    def test_an_absent_or_empty_additional_rate_limits_is_data_not_drift(self):
+        """The other direction, which the guard must not over-fire on: a plan
+        with no scoped window omits the key or sends `[]`, and both readings
+        are real. The main fixture's two windows still stand."""
+        for value in (None, []):
+            with self.subTest(additional_rate_limits=value):
+                self.notes.clear()
+                payload = fixture("openai_usage.json")
+                if value is None:
+                    del payload["rate_limit"]["additional_rate_limits"]
+                else:
+                    payload["rate_limit"]["additional_rate_limits"] = value
+                acct, _ = self.probe(payload=payload)
+                self.assertEqual(acct["status"], "ok")
+                self.assertEqual({w["window_kind"] for w in acct["windows"]},
+                                 {"five_hour", "weekly"})
+                self.assertEqual([n for n in self.notes if "drift" in n], [])
+
     def test_a_200_that_is_not_a_json_object_says_so(self):
         acct, _ = self.probe(payload=["not", "an", "object"])
         self.assertEqual(acct["status"], "error")
@@ -423,6 +457,22 @@ class MoonshotProbeTest(ProbeCase):
         self.assertEqual(acct["status"], "ok")
         w = self.one(acct["windows"])
         self.assertEqual((w["window_kind"], w["used"]), ("weekly", 128000))
+        self.assertEqual([n for n in self.notes if "drift" in n], [])
+
+    def test_an_empty_usage_block_is_data_not_drift(self):
+        """The block's EMPTY direction, mirroring the absent-`limits` test:
+        `usage: {}` is present and reports nothing, so the row is all-null
+        rather than an error. Crying drift here would false-alarm exactly the
+        idle account the panel exists to reassure."""
+        payload = fixture("moonshot_usages.json")
+        payload["usage"] = {}
+        payload["limits"] = []
+        acct, _ = self.probe(payload=payload)
+        self.assertEqual(acct["status"], "ok")
+        w = self.one(acct["windows"])
+        self.assertEqual((w["window_kind"], w["used"], w["limit_value"],
+                          w["used_percent"]), ("weekly", None, None, None),
+                         "an empty block reports nothing, it does not read 0")
         self.assertEqual([n for n in self.notes if "drift" in n], [])
 
     def test_a_limits_key_that_is_not_a_list_is_drift(self):

--- a/tests/test_quota_probes.py
+++ b/tests/test_quota_probes.py
@@ -241,6 +241,15 @@ class AnthropicProbeTest(ProbeCase):
         self.assertTrue(any("shape drift" in n for n in self.notes),
                         f"drift must be loud; log was {self.notes}")
 
+    def test_an_empty_limits_list_is_data_not_drift(self):
+        """The other half of the rule above: `limits: []` is a well-formed
+        envelope reporting no window — a real answer, kept `ok`."""
+        acct, _ = self.probe(payload={"subscriptionType": "max", "limits": []})
+        self.assertEqual(acct["status"], "ok")
+        self.assertEqual(acct["windows"], [])
+        self.assertEqual([n for n in self.notes if "drift" in n], [],
+                         "an idle account must not be reported as drift")
+
     def test_unknown_limit_kind_is_kept_not_dropped(self):
         acct, _ = self.probe(payload={"limits": [
             {"kind": "monthly_all", "percent": 5, "resets_at": None}]})
@@ -297,6 +306,37 @@ class OpenAIProbeTest(ProbeCase):
         self.assertEqual(w["window_kind"], "unknown")
         self.assertEqual(w["scope"], "7200s", "the duration must survive")
         self.assertEqual(w["used_percent"], 9.0)
+
+    def test_lost_envelope_is_drift_not_a_measured_zero(self):
+        """A 200 that no longer carries `rate_limit` at all. Parsing it as
+        zero windows would render a healthy card with nothing on it —
+        indistinguishable from an account that genuinely has no window."""
+        acct, _ = self.probe(payload={"account_id": "acct_placeholder_0001",
+                                      "email": "placeholder@example.com",
+                                      "plan_type": "prolite"})
+        self.assertEqual(acct["status"], "error")
+        self.assertEqual(acct["windows"], [])
+        self.assertEqual(acct["account_ref"], "acct_placeholder_0001",
+                         "a drifted card still keys to its account")
+        self.assertTrue(any("shape drift" in n for n in self.notes),
+                        f"drift must be loud; log was {self.notes}")
+
+    def test_an_empty_envelope_is_data_not_drift(self):
+        """`rate_limit: {}` — the structure is intact and reports no window.
+        Calling THAT drift would cry wolf at an idle account and train the
+        operator to ignore the error state, which is the worse failure."""
+        acct, _ = self.probe(payload={"account_id": "acct_placeholder_0001",
+                                      "rate_limit": {}})
+        self.assertEqual(acct["status"], "ok")
+        self.assertEqual(acct["windows"], [])
+        self.assertEqual([n for n in self.notes if "drift" in n], [])
+
+    def test_a_200_that_is_not_a_json_object_says_so(self):
+        acct, _ = self.probe(payload=["not", "an", "object"])
+        self.assertEqual(acct["status"], "error")
+        self.assertIn("not a JSON object", acct["detail"],
+                      "'HTTP 200' as a failure detail tells the operator nothing")
+        self.assertTrue(any("shape drift" in n for n in self.notes))
 
     def test_absent_credential_file_is_na_not_zero(self):
         self.codex_auth.unlink()
@@ -359,6 +399,47 @@ class MoonshotProbeTest(ProbeCase):
         odd = [w for w in acct["windows"] if w["window_kind"] == "unknown"]
         self.assertEqual(len(odd), 1)
         self.assertIn("FORTNIGHT", str(odd[0]["scope"]))
+
+    def test_lost_usage_block_is_drift_not_a_measured_zero(self):
+        """`usage` is the account-wide block every payload carries — an
+        account with nothing spent reports `used: 0`, it does not drop the
+        key. Its absence is the shape having changed, not an empty account."""
+        payload = fixture("moonshot_usages.json")
+        del payload["usage"]
+        acct, _ = self.probe(payload=payload)
+        self.assertEqual(acct["status"], "error")
+        self.assertEqual(acct["windows"], [])
+        self.assertEqual(acct["account_ref"], "placeholder-user-0001",
+                         "a drifted card still keys to its account")
+        self.assertTrue(any("shape drift" in n for n in self.notes),
+                        f"drift must be loud; log was {self.notes}")
+
+    def test_an_absent_limits_list_is_data_not_drift(self):
+        """The asymmetry, pinned: `limits` is a collection, so absent is a
+        plan with no metered sub-window and the weekly figure still stands."""
+        payload = fixture("moonshot_usages.json")
+        del payload["limits"]
+        acct, _ = self.probe(payload=payload)
+        self.assertEqual(acct["status"], "ok")
+        w = self.one(acct["windows"])
+        self.assertEqual((w["window_kind"], w["used"]), ("weekly", 128000))
+        self.assertEqual([n for n in self.notes if "drift" in n], [])
+
+    def test_a_limits_key_that_is_not_a_list_is_drift(self):
+        """No legitimate-empty reading exists for the wrong TYPE under a key
+        the normalizer iterates."""
+        payload = fixture("moonshot_usages.json")
+        payload["limits"] = {"weekly": {"used": 1}}
+        acct, _ = self.probe(payload=payload)
+        self.assertEqual(acct["status"], "error")
+        self.assertEqual(acct["windows"], [])
+        self.assertTrue(any("shape drift" in n for n in self.notes))
+
+    def test_a_200_that_is_not_a_json_object_says_so(self):
+        acct, _ = self.probe(payload="<html>maintenance</html>")
+        self.assertEqual(acct["status"], "error")
+        self.assertIn("not a JSON object", acct["detail"])
+        self.assertTrue(any("shape drift" in n for n in self.notes))
 
     def test_expired_token_is_reported_never_used(self):
         self.write(self.kimi_creds, {"access_token": TOKEN,
@@ -458,7 +539,6 @@ class DispatchTest(ProbeCase):
         self.assertIn("unavailable", rows[1]["detail"])
 
     def test_every_provider_is_probed_in_a_stable_order(self):
-        self.endpoints = None  # not needed; probes run against real modules
         self.endpoint(p_anthropic, 200, fixture("anthropic_usage.json"))
         self.endpoint(p_openai, 200, fixture("openai_usage.json"))
         self.endpoint(p_moonshot, 200, fixture("moonshot_usages.json"))


### PR DESCRIPTION
Sprint 52 unit 2 · spec doc #49 · decisions #65 → #66 → #67 → #68 → #69.

`scripts/quota_probes/` — the sibling seam to `scripts/token_parsers/`: one
module per **provider** (quota is an account property; five shells on Claude
share one bucket), a normalizer, and a dispatcher that probes all three
concurrently and contains their failures. Nothing here writes to a DB or a
credential file — U3 owns the TTL, the upsert and the routes, and calls
`dispatch.probe_all(log, timeout)`.

## The five Probe Contract invariants, each with a mutation

The spec says a reviewer checks these *from code*. Reading code proves none of
them and green CI proves only that the suite ran, so each has a round trip in
`tests/mutations/u2_quota_probes.py` — **17/17 red → revert → green** (same
driver shape as U7's, committed for the same reason: round trips that outlive
the session that made them).

| Invariant | How it fails the suite when broken |
|---|---|
| Read-only on credentials | files' bytes **and mtimes** compared across a full `probe_all`, so a rewrite-with-identical-content is caught too; plus a static check that no write path exists in the package at all |
| Tokens never stored, logged, or returned | a sentinel token must reach the `Authorization` header — proving the probe actually authenticates — and appear nowhere in the returned rows or the log |
| Expiry reported, not repaired | an expired token yields `unauth` **and makes no request at all** |
| No credential file → `na`, never `0%` | `na` account keys nothing, so no registry row and no card |
| One provider's failure is contained | a raise, an unimportable module, and a hang each cost their own `error` row while the other two stand |

Normalization derives window kind from the **observed duration**, pinned by a
test that swaps two windows' durations and demands their kinds swap — a probe
reading position or label passes every other test and fails only that one.
Anthropic exposes no duration at all, so its three `limits[].kind` labels are
mapped explicitly against the spec's table; that is the one place a label
decides a kind and it is commented as such.

## Judgement calls (both ratified by PLN2, #1893)

- **A provider with no credential file returns one dict with
  `account_ref=None, status='na', windows=[]`**, not an empty list. The caller
  can then distinguish not-configured from configured-but-broken from a real
  0%, and writes no registry row for a null ref — which is what the spec's
  edge table means by "no card for that provider".
- **Concurrency + the 5s per-probe timeout live here, not in U3's routes.**
  Containment is only checkable from inside the probe package. The board moved
  to match.

## Two spec premises corrected — reported before this code was written

`~/.claude/.credentials.json` holds **no account uuid**: only tokens, expiry,
scopes, `subscriptionType`, `rateLimitTier`. The uuid the registry keys
Anthropic on is in a *different* file, `~/.claude.json → oauthAccount.accountUuid`,
and that same object carries `emailAddress` **in full** — so decision #67's
"neither of those providers returns an email" is true of the usage *response*
and false of the *file*. Ruled as decision #69: the Anthropic card is labelled
by the full email (fallback: uuid first 8), `account_ref` stays the uuid, and
reading two files here is ratified rather than scope creep.

The trade-off I picked, and the simpler option I rejected: I could have shipped
the spec's ladder silently and let the conformance pass find it. Reporting the
premise pre-build cost one message and turned a would-be finding into a ruling.

## Trade-off worth naming: the fixtures

Transcribed from spec #49's observed-field tables, **not** captured from the
wire — the live calls predate this unit, their bodies were not vendored, and
the sprint scoped U2 to the documented shapes rather than re-probing. What that
buys and what it does not is written into `tests/fixtures/quota_probes/README.md`:
a drift between spec and wire surfaces as an `error` status from a live probe,
never as a wrong number.

**No test performs a live call, and that is enforced rather than promised** —
`urlopen` is stubbed to fail any test that reaches it.

## Follow-up carried, not built

Whether the Anthropic uuid survives a re-login is unverified. Decision #68
defers it: a re-login minting a second registry row is an accepted cosmetic
outcome, and no detection/migration/reconciliation machinery is built for it.
Flag SC-171 was closed as withdrawn on that ruling.

Local: `tests/test_quota_probes.py` 29 passed · full suite 1441 passed before
the two ruling commits, re-running on the final head · lint clean on every
file this PR adds.

Shell: DEV4 (Code-02)