### PR TITLE
feat(interface): group shell lists by type, bespoke shells last (S45 U12)

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2206,6 +2206,22 @@ const IF_BADGE = { available: "ok", starting: "warn", occupied: "accent",
 const IF_ATTACHABLE_LIFECYCLES = new Set(
   ["starting", "idle", "busy", "approval", "user_input"]);
 
+// Shell type order for every list the Interface renders (FnB request,
+// shared/order.png): the fleet reads as a roster grouped by what a shell IS,
+// not by the order its rows happened to be created in. The type is `flavor`,
+// which the shells payload already carries — `role` is free-text identity and
+// is not it.
+const IF_TYPE_ORDER = ["cartographer", "admin", "planner", "dev",
+  "reviewer", "devops"];
+// Bespoke shells sort last, after every known type. indexOf answers -1 to
+// null, undefined and an unrecognised string alike, which is the bucket: the
+// fork's own CC carries flavor null, a fork that invents a type carries a
+// string this engine has never heard of, and neither outranks a devops.
+function ifTypeRank(s) {
+  const i = IF_TYPE_ORDER.indexOf(s.flavor);
+  return i < 0 ? IF_TYPE_ORDER.length : i;
+}
+
 function ifModelLabel(route) {
   if (!route) return "HARNESS DEFAULT";
   return String(route).replace(/[-_]+/g, " ").trim().toUpperCase();
@@ -2320,7 +2336,11 @@ async function renderInterface(root) {
 function ifBuildRail(rail, picker, shells) {
   rail.replaceChildren();
   picker.replaceChildren(el("option", { value: "" }, "select a shell…"));
-  for (const s of shells) {
+  // Sort a COPY, never the caller's array: the same payload is the poll's
+  // signature input and renderInterface's selection lookup, and both read the
+  // server's order. Array#sort is stable, so within one type the server's
+  // ORDER BY shell_id survives — grouping is the only thing that moves.
+  for (const s of [...shells].sort((a, b) => ifTypeRank(a) - ifTypeRank(b))) {
     // Projection happens SERVER-side (_availability): reserved+starting →
     // starting, occupied+(idle|busy|approval|user_input) → occupied,
     // unreconciled+(lost|error) → lost|error. The rail renders it verbatim;

--- a/tests/mutations/u12_shell_type_order.py
+++ b/tests/mutations/u12_shell_type_order.py
@@ -1,0 +1,176 @@
+"""Mutation round trips for sprint 45 U12 — shell lists grouped by type.
+
+Acceptance evidence, committed rather than run once in a session that dies with
+it (the U5/U7/U11 convention). Each entry breaks ONE property in the real
+source, asserts the test claiming to pin it actually goes RED, restores the
+file, and asserts it goes green again. A property whose mutation stays green is
+not pinned, whatever the suite's colour says.
+
+    python3 tests/mutations/u12_shell_type_order.py [-v]
+
+Two harness conditions, both from flag #182 — a same-size mutation reverted
+inside one second leaves a VALID `.pyc` behind (invalidation is source
+mtime-to-the-second plus size), so the interpreter can keep running mutated
+bytecode after the revert and hand back a reading that is simply false:
+
+  * every child runs with PYTHONDONTWRITEBYTECODE=1, and
+  * every `__pycache__` under the repo is cleared before each run.
+
+The revert is proven, never assumed: the baseline must come back green after
+each round trip, and a failure there is reported as a dirty revert rather than
+folded into the mutation's own result.
+
+Two asserted invariants deliberately have NO entry here, and are named rather
+than left to look covered: the mobile picker agreeing with the rail, and the
+picker's placeholder option staying first. Both hold by CONSTRUCTION — the two
+surfaces are filled by one pass over one sorted array, and the placeholder is
+appended before the loop begins — so there is no single-property mutation that
+can break one without rewriting the loop into something no longer under test.
+The assertions stay as guards against exactly that rewrite.
+
+Not named test_*.py on purpose: pytest must not collect it — it edits tracked
+source. Every file is restored in a `finally`, so an interrupted run still
+leaves the tree clean; `git diff` after a run is the check.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / ".super-coder" / "ui" / "app.js"
+SUITE = "tests/test_interface_ui_contract.py"
+
+TABLE = ('const IF_TYPE_ORDER = ["cartographer", "admin", "planner", "dev",\n'
+         '  "reviewer", "devops"];')
+FALLBACK = "  return i < 0 ? IF_TYPE_ORDER.length : i;"
+COMPARATOR = "(a, b) => ifTypeRank(a) - ifTypeRank(b)"
+
+# (label, -k selector, old, new)
+MUTATIONS = [
+    (
+        "M1 the sort goes entirely — the rail is back to the server's "
+        "shell_id order, which is the state this unit exists to fix",
+        "group_by_type",
+        "[...shells].sort(" + COMPARATOR + ")",
+        "shells",
+    ),
+    (
+        "M2 the comparator is inverted — the roster reads bottom-up",
+        "group_by_type",
+        COMPARATOR,
+        "(a, b) => ifTypeRank(b) - ifTypeRank(a)",
+    ),
+    (
+        "M3 the rank table is permuted (reviewer above dev) — the order is "
+        "the deliverable, so the TABLE has to be pinned, not just the fact "
+        "that some sort ran",
+        "group_by_type",
+        TABLE,
+        'const IF_TYPE_ORDER = ["cartographer", "admin", "planner", '
+        '"reviewer",\n  "dev", "devops"];',
+    ),
+    (
+        "M4 bespoke shells rank FIRST instead of last — indexOf's -1 is used "
+        "raw, which is the natural way to get this wrong",
+        "group_by_type",
+        FALLBACK,
+        "  return i;",
+    ),
+    (
+        "M5 devops is dropped from the table and pools with the unknown "
+        "bucket — this is the ambiguity call PLN1 ratified (devops is a KNOWN "
+        "type at rank 6, above cc), so it is pinned rather than assumed",
+        "group_by_type",
+        TABLE,
+        'const IF_TYPE_ORDER = ["cartographer", "admin", "planner", "dev",\n'
+        '  "reviewer"];',
+    ),
+    (
+        "M6 the sort gains a tie-break of its own — within a type the "
+        "server's order stops surviving, which is the half of the contract a "
+        "grouping assertion alone never sees",
+        "servers_order",
+        COMPARATOR,
+        "(a, b) => ifTypeRank(a) - ifTypeRank(b) || b.shell_id - a.shell_id",
+    ),
+    (
+        "M7 only the NULL half of the bespoke bucket is handled — a type this "
+        "engine has never heard of sorts first (the mutation the cc fixture "
+        "alone CANNOT catch)",
+        "group_by_type",
+        FALLBACK,
+        "  return i < 0 && s.flavor == null ? IF_TYPE_ORDER.length : i;",
+    ),
+    (
+        "M8 only the unknown-STRING half is handled — the fork's own cc, "
+        "whose flavor is literally null, sorts first",
+        "group_by_type",
+        FALLBACK,
+        "  return i < 0 && s.flavor != null ? IF_TYPE_ORDER.length : i;",
+    ),
+    (
+        "M9 the payload is sorted IN PLACE — the same array is the rail "
+        "poll's signature input and renderInterface's selection lookup, and "
+        "both read the server's order",
+        "group_by_type",
+        "[...shells].sort(",
+        "shells.sort(",
+    ),
+]
+
+
+def clear_caches() -> None:
+    for cache in ROOT.rglob("__pycache__"):
+        shutil.rmtree(cache, ignore_errors=True)
+
+
+def run(selector: str) -> bool:
+    """True when the selected tests pass, run on source rather than bytecode."""
+    clear_caches()
+    env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", SUITE, "-q", "-k", selector],
+        cwd=ROOT, capture_output=True, text=True, env=env)
+    return proc.returncode == 0
+
+
+def main() -> int:
+    verbose = "-v" in sys.argv
+    failures = []
+    for label, selector, old, new in MUTATIONS:
+        original = APP.read_text()
+        if original.count(old) != 1:
+            failures.append(f"{label}: anchor found {original.count(old)}x, "
+                            "expected exactly 1 — the driver has drifted from "
+                            "the source")
+            print(f"[FAIL] {label}\n       anchor is not unique")
+            continue
+        try:
+            APP.write_text(original.replace(old, new, 1))
+            red = not run(selector)
+        finally:
+            APP.write_text(original)
+        green = run(selector)
+        ok = red and green
+        if not ok:
+            failures.append(
+                f"{label}: mutated={'RED' if red else 'GREEN (NOT PINNED)'} "
+                f"restored={'green' if green else 'RED (dirty revert)'}")
+        print(f"[{'ok' if ok else 'FAIL'}] {label}\n       {SUITE} "
+              f"-k {selector}: {'red' if red else 'STAYED GREEN'} -> "
+              f"{'green' if green else 'STILL RED'}")
+        if verbose and not ok:
+            print("       ^ this property is not actually pinned")
+    print(f"\n{len(MUTATIONS) - len(failures)}/{len(MUTATIONS)} round trips "
+          "behaved (red under mutation, green on revert)")
+    for line in failures:
+        print("  FAIL " + line)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -1929,6 +1929,76 @@ def test_the_observation_clock_is_kept_out_of_the_rail_signature():
     assert "s.live_model_at" not in sig
 
 
+# A fleet whose SERVER order (ORDER BY shell_id) is deliberately nothing like
+# the ranked order, so an unsorted or half-sorted rail cannot pass by accident.
+# It carries both bespoke shapes: `cc` is the fork's own shell and its flavor is
+# literally NULL in the payload, and `GARD1` is a type this engine has never
+# heard of. Neither is a known type, and both must land after `devops`.
+ORDER_FLEET_SETUP = r"""
+const orderFleet = [
+  ["cc", null], ["REV1", "reviewer"], ["DEV3", "dev"], ["OPS1", "devops"],
+  ["PLN1", "planner"], ["CART1", "cartographer"], ["ADM1", "admin"],
+  ["GARD1", "gardener"], ["DEV4", "dev"], ["PLN2", "planner"],
+].map(([shortname, flavor], i) => ({
+  shell_id: i + 1, shortname, display_name: shortname, flavor,
+  availability: "available", session_id: null }));
+const railNames = (root) =>
+  all(railOf(root), (n) => n.tagName === "b").map((n) => n.textContent);
+const pickerNames = (root) =>
+  all(root, (n) => n.className === "if-picker")[0]
+    .children.slice(1).map((o) => o.value);
+"""
+RANKED = "CART1,ADM1,PLN1,PLN2,DEV3,DEV4,REV1,OPS1,cc,GARD1"
+
+
+def test_both_shell_lists_group_by_type_with_bespoke_shells_last():
+    """The FnB's roster order (shared/order.png): cartographer, admin, planner,
+    dev, reviewer, devops — and anything a fork invented after all of them.
+    Both surfaces are one loop, so both must show it; `devops` is a KNOWN type
+    and outranks the unknown bucket (planner ruling, sprint 45 unit 12)."""
+    run_recovery_js(RAIL_POLL_SETUP + ORDER_FLEET_SETUP + r"""
+serveShells(orderFleet);
+const root = new FakeElement("div");
+await renderInterface(root);
+invariant(railNames(root).join(",") === """ + f'"{RANKED}"' + r""",
+  `the rail is not grouped by type: ${railNames(root)}`);
+invariant(pickerNames(root).join(",") === """ + f'"{RANKED}"' + r""",
+  `the mobile picker disagrees with the rail: ${pickerNames(root)}`);
+
+// The placeholder stays first — the sort must not reach the option that
+// exists to say nothing is selected.
+invariant(all(root, (n) => n.className === "if-picker")[0].children[0].value
+  === "", "the picker lost its placeholder option");
+
+// And the payload itself is untouched: the same array is the poll's signature
+// input and renderInterface's selection lookup, both of which read the
+// server's order.
+invariant(orderFleet.map((s) => s.shortname).join(",")
+  === "cc,REV1,DEV3,OPS1,PLN1,CART1,ADM1,GARD1,DEV4,PLN2",
+  "ifBuildRail reordered the caller's array in place");
+ifStopRailPoll();
+""")
+
+
+def test_shells_of_one_type_keep_the_servers_order():
+    """Grouping is the ONLY thing that moves. Within a type the server's
+    `ORDER BY shell_id` must survive — including inside the bespoke bucket,
+    where `cc` (null) and `GARD1` (unknown string) share a rank and an
+    unstable sort would be free to swap them."""
+    run_recovery_js(RAIL_POLL_SETUP + ORDER_FLEET_SETUP + r"""
+serveShells(orderFleet);
+const root = new FakeElement("div");
+await renderInterface(root);
+const names = railNames(root);
+const before = (a, b) => names.indexOf(a) < names.indexOf(b);
+invariant(before("PLN1", "PLN2"), `planners were reordered: ${names}`);
+invariant(before("DEV3", "DEV4"), `devs were reordered: ${names}`);
+invariant(before("cc", "GARD1"),
+  `the bespoke bucket was reordered — the sort is not stable: ${names}`);
+ifStopRailPoll();
+""")
+
+
 def test_both_rail_display_sites_read_one_model_decision():
     """The desktop row and the mobile picker must never disagree about which
     claim the surface is making — one helper, two consumers. Pinned in source


### PR DESCRIPTION
Sprint 45, unit 12 — the FnB's roster order (`shared/order.png`), the sprint's last unit.

## What changed

The rail and the mobile picker rendered the fleet in the server's `ORDER BY shell_id` — the order rows happened to be created in. One stable sort at the single `ifBuildRail` call site now groups them by type: **cartographer, admin, planner, dev, reviewer, devops**, then everything else.

Both surfaces are filled by that one pass, so they cannot drift apart. `Array#sort` is stable, so **within** a type the server's `shell_id` order survives untouched — grouping is the only thing that moves. The array is copied before sorting: the same payload is the rail poll's signature input and `renderInterface`'s selection lookup, and both read the server's order.

## Premise check, before building (result #1939, ruled in #1940)

- **The type is `flavor`, already exposed.** `_list_shells` selects and returns it, so this is purely front-end and the planner's ratified server-field exception went unused. `role` is a *different* column — free-text, NULL on all 12 shells — and keying on it would sort everything into one bucket.
- **Two surfaces, not three.** `ifBuildRail` fills the rail button and the picker option in one pass; the New-chat control does not enumerate shells at all. The acceptance line was **amended** to two, not missed.
- **Bespoke shells are two shapes, not one.** The fork's own `cc` carries `flavor` *null*; a fork that invents a type carries a string this engine has never heard of. `indexOf` answers -1 to both, so one fallback covers the bucket — and each half gets its own fixture and its own mutation (M7/M8), because the `cc` fixture alone cannot catch the unknown-string bug.

## Rulings honoured

- **devops is a KNOWN type at rank 6** and outranks the unknown bucket — no pooling. Pinned by M5 rather than assumed.
- **The Shells tab is out of scope** (the FnB scoped "drop downs and side panels"). One-line follow-up if wanted.
- **`ifRailSig` untouched.** Stated consequence, accepted at ruling: a flavor change *alone* will not repaint until the next signature change. Flavor is de-facto immutable shell identity.

## Trade-off

Sorting a copy costs one array allocation per repaint (≤ a dozen shells, every 5s) and was chosen over sorting in place, which is shorter: the caller's array is read by two other consumers that want the server's order. M9 pins it.

## Verification

- Two DOM tests through the existing node harness, over a fleet whose server order is deliberately nothing like the ranked order: rail order, picker order, placeholder stays first, the caller's array is left alone, and within-type stability *including inside the bespoke bucket* where `cc` and an unknown type share a rank.
- Mutation driver `tests/mutations/u12_shell_type_order.py` — **9/9 round trips red-under-mutation, green-on-revert**, run with `PYTHONDONTWRITEBYTECODE=1` and every `__pycache__` cleared (flag #182 conditions); tree byte-clean after. Two asserted invariants have no mutation and are *named* in the driver docstring rather than left looking covered: picker-agrees-with-rail and placeholder-first both hold by construction.
- Full local suite: **1458 passed, 1 skipped** (the Playwright module, flag #169).

Co-Authored-By: Code-03 (super-coder) <noreply@super-coder>

🤖 Generated with [Claude Code](https://claude.com/claude-code)