### PR TITLE
feat(analytics): 49-U3 account quota API — GET/POST routes, 60s TTL, upsert (S52 U3)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -807,13 +807,20 @@ QUOTA_TTL_SECONDS = 60      # toggling the two sections must not hammer three
                             # third-party endpoints; the refresh button bypasses it
 QUOTA_ACTIVITY_DAYS = 7     # the panel's only filter — a filter, never a delete
 
-# The TTL's clock. The spec derives it from "the newest captured_at", which is
-# right whenever a probe wrote a row — but a probe that identifies nobody (no
-# credential file → `na`, or a provider erroring before it can name an account)
-# writes NO rows, so that clock never advances and every arrival would re-probe,
-# breaking the spec's own "toggling sections twice inside a minute performs one
-# probe" in exactly the degraded case. Recording the ATTEMPT closes that. The
-# claim is taken under the lock and before the probe runs, so two simultaneous
+# The TTL's clock: the last probe ATTEMPT, in this process — never the newest
+# captured_at. A probe that identifies nobody (no credential file → `na`, or a
+# provider erroring before it can name an account) writes NO rows, so a DB clock
+# never advances and every arrival would re-probe, breaking the spec's own
+# "toggling sections twice inside a minute performs one probe" in exactly the
+# degraded case. The attempt is recorded whether or not it identifies anybody.
+#
+# Living in process, it RESETS ON A SERVER RESTART — the spec declares that
+# ("a restart storm re-probes") and it is load-bearing, not merely tolerated:
+# `providers` below dies with the same process, so the first arrival after a
+# restart MUST probe or the response would carry an EMPTY per-provider status
+# list, and the panel could not tell "nothing configured" from "every probe
+# failed". Mixing a DB clock back in would reopen exactly that window. The claim
+# is taken under the lock and before the probe runs, so two simultaneous
 # arrivals collapse to one probe rather than racing to fire two.
 _QUOTA_LOCK = threading.Lock()
 _QUOTA_PROBE: dict = {"at": None, "providers": []}
@@ -837,28 +844,13 @@ ON CONFLICT(account_pk, window_kind, COALESCE(scope, '')) DO UPDATE SET
 """
 
 
-def _iso_epoch(ts: "str | None") -> "float | None":
-    """ISO UTC → epoch seconds. Unparseable input is None, never a fake time —
-    a garbage captured_at must not be able to hold the TTL open."""
-    if not ts:
-        return None
-    try:
-        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
-    except (ValueError, TypeError):
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.timestamp()
-
-
-def _quota_claim(force: bool, newest: "str | None") -> bool:
+def _quota_claim(force: bool) -> bool:
     """True when THIS caller should probe. `force` is the refresh button."""
     now = datetime.now(timezone.utc).timestamp()
     with _QUOTA_LOCK:
-        if not force:
-            seen = [t for t in (_QUOTA_PROBE["at"], _iso_epoch(newest)) if t]
-            if seen and now - max(seen) < QUOTA_TTL_SECONDS:
-                return False
+        last = _QUOTA_PROBE["at"]
+        if not force and last and now - last < QUOTA_TTL_SECONDS:
+            return False
         _QUOTA_PROBE["at"] = now
         return True
 
@@ -928,10 +920,10 @@ def probe_quota_accounts(con) -> dict:
 
 
 def get_analytics_accounts(con, force: bool = False) -> dict:
-    """Registry + windows for the account panel, probing first when the newest
-    capture has aged past the TTL. `force` is POST /probe — the refresh button."""
-    newest = con.execute("SELECT MAX(captured_at) FROM harness_quota_window").fetchone()[0]
-    probe = probe_quota_accounts(con) if _quota_claim(force, newest) else None
+    """Registry + windows for the account panel, probing first when the last
+    probe ATTEMPT has aged past the TTL. `force` is POST /probe — the refresh
+    button."""
+    probe = probe_quota_accounts(con) if _quota_claim(force) else None
     cutoff = (datetime.now(timezone.utc)
               - timedelta(days=QUOTA_ACTIVITY_DAYS)).strftime("%Y-%m-%dT%H:%M:%SZ")
     # The 7-day window, plus the account the credential file resolves to NOW.

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -86,6 +86,7 @@ import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin ru
 import model_catalog  # noqa: E402  (live model-id suggestions, sibling module)
 import analytics  # noqa: E402  (token & session analytics sweep — doc #11)
 import token_parsers  # noqa: E402  (harness roster + per-parser data dirs)
+from quota_probes import dispatch as quota_dispatch  # noqa: E402  (account quota probes — doc #49)
 import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
 import ts as ts_mod  # noqa: E402  (tailnet — config + live checks)
 import pm2 as pm2_mod  # noqa: E402  (host pm2 stack — config + live checks)
@@ -789,6 +790,171 @@ def get_analytics_filters(con) -> dict:
         "JOIN shells s ON s.shell_id=u.shell_id ORDER BY s.shortname"))
     return {"harnesses": distinct("harness"), "providers": distinct("provider"),
             "models": distinct("model"), "shells": shells}
+
+
+# ── Account analytics — harness quota (spec doc #49) ─────────────────────────
+# Token analytics answers *what did we spend*; this answers *how much is left*.
+# It calls quota_probes.dispatch.probe_all ONCE and owns nothing that call does:
+# concurrency, the 5s per-probe timeout and one-provider-failure containment all
+# live in the dispatcher, because containment is only checkable from the probe
+# package. A second timeout layer here would be a bug, not defence in depth.
+#
+# The route is `accounts`, never `usage`: /api/analytics/usage already means
+# token spend on this tab, and a second meaning on that word is a defect waiting
+# to happen.
+
+QUOTA_TTL_SECONDS = 60      # toggling the two sections must not hammer three
+                            # third-party endpoints; the refresh button bypasses it
+QUOTA_ACTIVITY_DAYS = 7     # the panel's only filter — a filter, never a delete
+
+# The TTL's clock. The spec derives it from "the newest captured_at", which is
+# right whenever a probe wrote a row — but a probe that identifies nobody (no
+# credential file → `na`, or a provider erroring before it can name an account)
+# writes NO rows, so that clock never advances and every arrival would re-probe,
+# breaking the spec's own "toggling sections twice inside a minute performs one
+# probe" in exactly the degraded case. Recording the ATTEMPT closes that. The
+# claim is taken under the lock and before the probe runs, so two simultaneous
+# arrivals collapse to one probe rather than racing to fire two.
+_QUOTA_LOCK = threading.Lock()
+_QUOTA_PROBE: dict = {"at": None, "providers": []}
+
+# The conflict target is the EXPRESSION, character for character as migration
+# 0096 declares the index: SQLite matches an upsert target against the index
+# expression, not against a column list. Naming plain `scope` here raises "ON
+# CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint" — so a
+# mismatch fails loud instead of silently duplicating the panel's account-wide
+# rows (session, weekly and five_hour are ALL scope-NULL) on every single probe.
+_QUOTA_WINDOW_UPSERT = """
+INSERT INTO harness_quota_window
+    (account_pk, window_kind, scope, used_percent, used, limit_value,
+     resets_at, captured_at, status, probe_version)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(account_pk, window_kind, COALESCE(scope, '')) DO UPDATE SET
+    used_percent=excluded.used_percent, used=excluded.used,
+    limit_value=excluded.limit_value, resets_at=excluded.resets_at,
+    captured_at=excluded.captured_at, status=excluded.status,
+    probe_version=excluded.probe_version
+"""
+
+
+def _iso_epoch(ts: "str | None") -> "float | None":
+    """ISO UTC → epoch seconds. Unparseable input is None, never a fake time —
+    a garbage captured_at must not be able to hold the TTL open."""
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def _quota_claim(force: bool, newest: "str | None") -> bool:
+    """True when THIS caller should probe. `force` is the refresh button."""
+    now = datetime.now(timezone.utc).timestamp()
+    with _QUOTA_LOCK:
+        if not force:
+            seen = [t for t in (_QUOTA_PROBE["at"], _iso_epoch(newest)) if t]
+            if seen and now - max(seen) < QUOTA_TTL_SECONDS:
+                return False
+        _QUOTA_PROBE["at"] = now
+        return True
+
+
+def _quota_upsert(con, accounts: list[dict]) -> int:
+    """Land one probe_all result. Returns the window rows written.
+
+    An account carrying no account_ref writes NO registry row: that is a
+    provider with no credential file (`na` — the absence of a limit is not a
+    limit of zero) or one that failed before it could name anyone. Such a row
+    could never be matched again, and it has no card to render."""
+    named = [a for a in accounts if a.get("account_ref")]
+    for provider in dict.fromkeys(a["provider"] for a in named):
+        # A credential file resolves to exactly one account, so the provider's
+        # other rows stop being current the moment this probe names one.
+        # Cleared BEFORE the upsert writes its answer — doing it inside the
+        # upsert would leave a switched-away account still flagged current.
+        con.execute("UPDATE harness_quota_account SET is_current=0 WHERE provider=?",
+                    (provider,))
+    written = 0
+    for acct in named:
+        seen = acct["captured_at"]
+        # first_seen is deliberately absent from the SET list: an account that
+        # went quiet and came back keeps its original first_seen rather than
+        # minting a duplicate identity.
+        con.execute(
+            "INSERT INTO harness_quota_account "
+            "(provider, account_ref, account_label, plan, first_seen, last_seen, is_current) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(provider, account_ref) DO UPDATE SET "
+            "account_label=excluded.account_label, plan=excluded.plan, "
+            "last_seen=excluded.last_seen, is_current=excluded.is_current",
+            (acct["provider"], acct["account_ref"], acct.get("account_label"),
+             acct.get("plan"), seen, seen, 1 if acct.get("is_current") else 0))
+        pk = con.execute(
+            "SELECT account_pk FROM harness_quota_account WHERE provider=? AND account_ref=?",
+            (acct["provider"], acct["account_ref"])).fetchone()[0]
+        # An account with no windows (`unauth`, or an error after identification)
+        # writes none, so the last known values stand with their own age — the
+        # card reports staleness rather than a measured zero.
+        for w in acct.get("windows") or []:
+            con.execute(_QUOTA_WINDOW_UPSERT, (
+                pk, w["window_kind"], w.get("scope"), w.get("used_percent"),
+                w.get("used"), w.get("limit_value"), w.get("resets_at"),
+                w.get("captured_at") or seen, w.get("status") or "ok",
+                w.get("probe_version")))
+            written += 1
+    return written
+
+
+def probe_quota_accounts(con) -> dict:
+    """Probe every provider and land the result. One call to probe_all; the
+    dispatcher never raises, so a dead provider costs its own card and nothing
+    else."""
+    notes: list[str] = []
+    accounts = quota_dispatch.probe_all(notes.append)
+    written = _quota_upsert(con, accounts)
+    con.commit()
+    # Per-provider status, including the providers that produced no registry row
+    # at all: without it "no accounts" is indistinguishable from "every probe
+    # failed", and the panel cannot tell the operator which one it is.
+    providers = [{"provider": a["provider"], "status": a.get("status"),
+                  "detail": a.get("detail")} for a in accounts]
+    with _QUOTA_LOCK:
+        _QUOTA_PROBE["providers"] = providers
+    return {"providers": providers, "windows_written": written, "notes": notes}
+
+
+def get_analytics_accounts(con, force: bool = False) -> dict:
+    """Registry + windows for the account panel, probing first when the newest
+    capture has aged past the TTL. `force` is POST /probe — the refresh button."""
+    newest = con.execute("SELECT MAX(captured_at) FROM harness_quota_window").fetchone()[0]
+    probe = probe_quota_accounts(con) if _quota_claim(force, newest) else None
+    cutoff = (datetime.now(timezone.utc)
+              - timedelta(days=QUOTA_ACTIVITY_DAYS)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # The 7-day window, plus the account the credential file resolves to NOW.
+    # That account renders even when its last_seen has aged (a failed probe
+    # leaves it un-advanced), because the spec requires the current account
+    # rather than an empty page. Everything else outside the window stops
+    # rendering WITHOUT being deleted — switching back restores it intact.
+    accounts = rows(con.execute(
+        "SELECT * FROM harness_quota_account WHERE last_seen >= ? OR is_current=1 "
+        "ORDER BY provider, is_current DESC, last_seen DESC", (cutoff,)))
+    by_pk: dict = {}
+    for w in rows(con.execute(
+            "SELECT * FROM harness_quota_window "
+            "ORDER BY account_pk, window_kind, scope")):
+        by_pk.setdefault(w.pop("account_pk"), []).append(w)
+    for a in accounts:
+        a["windows"] = by_pk.get(a["account_pk"], [])
+    return {"accounts": accounts,
+            "activity_days": QUOTA_ACTIVITY_DAYS,
+            "ttl_seconds": QUOTA_TTL_SECONDS,
+            "probed": probe is not None,
+            "providers": (probe or {}).get("providers") or list(_QUOTA_PROBE["providers"]),
+            "notes": (probe or {}).get("notes") or []}
 
 
 # ── Mutations ─────────────────────────────────────────────────────────────────
@@ -2630,6 +2796,11 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, get_analytics_usage(con, q))
             if path == "/api/analytics/filters":
                 return self._send(200, get_analytics_filters(con))
+            if path == "/api/analytics/accounts":
+                # Arrival at #analytics-accounts. Probes only when the newest
+                # capture is older than the TTL — never at boot, never on a
+                # timer, never from the Token Analytics section.
+                return self._send(200, get_analytics_accounts(con))
             if path == "/api/scripts":
                 return self._send(200, {"scripts": script_list()})
             if path == "/api/vm":
@@ -2710,6 +2881,9 @@ class Handler(BaseHTTPRequestHandler):
                 # GUI Analytics tab load — incremental, so steady-state is
                 # cheap; sweep opens its own connection.
                 return self._send(200, analytics.sweep(quiet=True))
+            if path == "/api/analytics/accounts/probe":
+                # The refresh button — always re-probes, TTL or not.
+                return self._send(200, get_analytics_accounts(con, force=True))
             if path == "/api/snapshot":
                 try:
                     with _CONTENT_WRITE_LOCK:

--- a/tests/mutations/u3_quota_api.py
+++ b/tests/mutations/u3_quota_api.py
@@ -13,11 +13,14 @@ an adjacent one entirely free — the upsert's conflict target and its
 first_seen-preservation are different guarantees in the same statement, and so
 are the 7-day filter and the is_current exemption in the same WHERE clause.
 
-Deliberately included, because it is the one place this unit departs from the
-spec's literal mechanism: `ttl-db-clock-only` restores the spec's
-captured_at-only TTL. It must redden exactly ONE test — the degraded case where
-a probe writes no rows at all — which is what makes the departure load-bearing
-rather than decoration.
+Deliberately included, because it is the property most likely to be "restored"
+by a well-meaning later reader: `ttl-hybrid-db-clock-restored` puts the DB's
+newest captured_at back into the claim alongside the in-process attempt. The
+ratified clock is the ATTEMPT, in this process, alone — a hybrid survives a
+restart and then serves a response whose per-provider status list is EMPTY,
+because that cache died with the process. Reintroducing it must redden, or the
+next person reintroduces it and the suite stays green (it did: the hybrid
+shipped once and no test noticed).
 
 Usage:
     python3 tests/mutations/u3_quota_api.py           # all mutations
@@ -49,6 +52,10 @@ class Mutation:
     path: Path
     old: str
     new: str
+    # Extra (old, new) edits applied with the same exactly-one-anchor rule. A
+    # property whose removal spanned several sites has to be restored at ALL of
+    # them — a half-restored clock is a different mutation than the one named.
+    also: tuple[tuple[str, str], ...] = ()
 
 
 MUTATIONS = [
@@ -116,23 +123,54 @@ MUTATIONS = [
         name="ttl-never-suppresses",
         property="a second arrival inside 60s does not re-probe",
         path=SERVER,
-        old="            if seen and now - max(seen) < QUOTA_TTL_SECONDS:\n"
-            "                return False",
-        new="            pass",
+        old="        if not force and last and now - last < QUOTA_TTL_SECONDS:\n"
+            "            return False",
+        new="        pass",
     ),
     Mutation(
-        name="ttl-db-clock-only",
-        property="the TTL still holds when the probe wrote NO rows (the departure)",
+        name="ttl-hybrid-db-clock-restored",
+        property="the clock is the in-process ATTEMPT alone — no DB captured_at",
         path=SERVER,
-        old='            seen = [t for t in (_QUOTA_PROBE["at"], _iso_epoch(newest)) if t]',
-        new="            seen = [t for t in (_iso_epoch(newest),) if t]",
+        old='def _quota_claim(force: bool) -> bool:\n'
+            '    """True when THIS caller should probe. `force` is the refresh button."""\n'
+            "    now = datetime.now(timezone.utc).timestamp()\n"
+            "    with _QUOTA_LOCK:\n"
+            "        last = _QUOTA_PROBE[\"at\"]\n"
+            "        if not force and last and now - last < QUOTA_TTL_SECONDS:\n"
+            "            return False",
+        new='def _iso_epoch(ts: "str | None") -> "float | None":\n'
+            "    if not ts:\n"
+            "        return None\n"
+            "    try:\n"
+            '        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))\n'
+            "    except (ValueError, TypeError):\n"
+            "        return None\n"
+            "    if dt.tzinfo is None:\n"
+            "        dt = dt.replace(tzinfo=timezone.utc)\n"
+            "    return dt.timestamp()\n"
+            "\n"
+            "\n"
+            'def _quota_claim(force: bool, newest: "str | None" = None) -> bool:\n'
+            '    """True when THIS caller should probe. `force` is the refresh button."""\n'
+            "    now = datetime.now(timezone.utc).timestamp()\n"
+            "    with _QUOTA_LOCK:\n"
+            "        seen = [t for t in (_QUOTA_PROBE[\"at\"], _iso_epoch(newest)) if t]\n"
+            "        if not force and seen and now - max(seen) < QUOTA_TTL_SECONDS:\n"
+            "            return False",
+        # The caller has to feed the restored clock, or `newest` stays None and
+        # the mutation is a no-op that passes for the wrong reason.
+        also=(
+            ("    probe = probe_quota_accounts(con) if _quota_claim(force) else None",
+             '    newest = con.execute("SELECT MAX(captured_at) FROM harness_quota_window").fetchone()[0]\n'
+             "    probe = probe_quota_accounts(con) if _quota_claim(force, newest) else None"),
+        ),
     ),
     Mutation(
         name="force-ignored",
         property="the refresh button ALWAYS bypasses the TTL",
         path=SERVER,
-        old="        if not force:",
-        new="        if True:",
+        old="        if not force and last and now - last < QUOTA_TTL_SECONDS:",
+        new="        if last and now - last < QUOTA_TTL_SECONDS:",
     ),
     Mutation(
         name="route-owns-a-timeout",
@@ -209,12 +247,15 @@ def run_suites() -> tuple[bool, bool]:
 
 def apply(mutation: Mutation) -> str:
     original = mutation.path.read_text()
-    count = original.count(mutation.old)
-    if count != 1:
-        raise SystemExit(
-            f"{mutation.name}: anchor matched {count} times in "
-            f"{mutation.path.name}, expected exactly 1 — the driver is stale")
-    mutation.path.write_text(original.replace(mutation.old, mutation.new))
+    text = original
+    for old, new in ((mutation.old, mutation.new), *mutation.also):
+        count = text.count(old)
+        if count != 1:
+            raise SystemExit(
+                f"{mutation.name}: anchor matched {count} times in "
+                f"{mutation.path.name}, expected exactly 1 — the driver is stale")
+        text = text.replace(old, new)
+    mutation.path.write_text(text)
     return original
 
 

--- a/tests/mutations/u3_quota_api.py
+++ b/tests/mutations/u3_quota_api.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Mutation driver for spec #49 U3 (Account Analytics API routes).
+
+Same shape and the same reason as tests/mutations/u2_quota_probes.py: green CI
+proves the suite ran, not that any guarantee is protected. Each mutation below
+breaks exactly ONE property in the real source, runs the suite, and demands
+red; the driver reverts and demands green again. A mutation that stays GREEN is
+a finding about the test, not a success.
+
+Asked PER PROPERTY, not per test. Several of these live in one function and one
+SQL string, and a single test can constrain the property it names while leaving
+an adjacent one entirely free — the upsert's conflict target and its
+first_seen-preservation are different guarantees in the same statement, and so
+are the 7-day filter and the is_current exemption in the same WHERE clause.
+
+Deliberately included, because it is the one place this unit departs from the
+spec's literal mechanism: `ttl-db-clock-only` restores the spec's
+captured_at-only TTL. It must redden exactly ONE test — the degraded case where
+a probe writes no rows at all — which is what makes the departure load-bearing
+rather than decoration.
+
+Usage:
+    python3 tests/mutations/u3_quota_api.py           # all mutations
+    python3 tests/mutations/u3_quota_api.py --list
+    python3 tests/mutations/u3_quota_api.py --only <name>
+
+Exit 0 = every mutation reproduced red->revert->green.
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVER = ROOT / ".super-coder" / "api" / "server.py"
+
+SUITES = ["tests/test_quota_accounts_api.py"]
+
+
+@dataclass
+class Mutation:
+    name: str
+    property: str
+    path: Path
+    old: str
+    new: str
+
+
+MUTATIONS = [
+    # ── The upsert: the conflict target is the EXPRESSION ────────────────────
+    Mutation(
+        name="conflict-target-plain-scope",
+        property="the upsert names migration 0096's expression index verbatim",
+        path=SERVER,
+        old="ON CONFLICT(account_pk, window_kind, COALESCE(scope, '')) DO UPDATE SET",
+        new="ON CONFLICT(account_pk, window_kind, scope) DO UPDATE SET",
+    ),
+    Mutation(
+        name="window-insert-without-upsert",
+        property="a re-probe UPDATES the account-wide row instead of twinning it",
+        path=SERVER,
+        old="""ON CONFLICT(account_pk, window_kind, COALESCE(scope, '')) DO UPDATE SET
+    used_percent=excluded.used_percent, used=excluded.used,
+    limit_value=excluded.limit_value, resets_at=excluded.resets_at,
+    captured_at=excluded.captured_at, status=excluded.status,
+    probe_version=excluded.probe_version
+""",
+        new="",
+    ),
+    Mutation(
+        name="coalesce-folds-real-scopes",
+        property="COALESCE folds only NULL — two real scopes stay distinct rows",
+        path=SERVER,
+        old="pk, w[\"window_kind\"], w.get(\"scope\"), w.get(\"used_percent\"),",
+        new="pk, w[\"window_kind\"], None, w.get(\"used_percent\"),",
+    ),
+    # ── The registry: identity survives an account going quiet ───────────────
+    Mutation(
+        name="first-seen-overwritten",
+        property="a returning account keeps its ORIGINAL first_seen",
+        path=SERVER,
+        old='"account_label=excluded.account_label, plan=excluded.plan, "',
+        new='"first_seen=excluded.first_seen, '
+            'account_label=excluded.account_label, plan=excluded.plan, "',
+    ),
+    Mutation(
+        name="is-current-never-cleared",
+        property="switching accounts moves is_current OFF the old row",
+        path=SERVER,
+        old='        con.execute("UPDATE harness_quota_account SET is_current=0 WHERE provider=?",\n'
+            "                    (provider,))",
+        new="        pass",
+    ),
+    Mutation(
+        name="null-ref-writes-a-row",
+        property="a provider with no credential file writes NO registry row",
+        path=SERVER,
+        old='    named = [a for a in accounts if a.get("account_ref")]',
+        new="    named = list(accounts)",
+    ),
+    Mutation(
+        name="unauth-wipes-last-known",
+        property="an expired token PRESERVES the last known values and their age",
+        path=SERVER,
+        old="        for w in acct.get(\"windows\") or []:",
+        new="        con.execute(\"DELETE FROM harness_quota_window WHERE account_pk=?\", (pk,))\n"
+            "        for w in acct.get(\"windows\") or []:",
+    ),
+    # ── The TTL ──────────────────────────────────────────────────────────────
+    Mutation(
+        name="ttl-never-suppresses",
+        property="a second arrival inside 60s does not re-probe",
+        path=SERVER,
+        old="            if seen and now - max(seen) < QUOTA_TTL_SECONDS:\n"
+            "                return False",
+        new="            pass",
+    ),
+    Mutation(
+        name="ttl-db-clock-only",
+        property="the TTL still holds when the probe wrote NO rows (the departure)",
+        path=SERVER,
+        old='            seen = [t for t in (_QUOTA_PROBE["at"], _iso_epoch(newest)) if t]',
+        new="            seen = [t for t in (_iso_epoch(newest),) if t]",
+    ),
+    Mutation(
+        name="force-ignored",
+        property="the refresh button ALWAYS bypasses the TTL",
+        path=SERVER,
+        old="        if not force:",
+        new="        if True:",
+    ),
+    Mutation(
+        name="route-owns-a-timeout",
+        property="this layer re-implements no timeout — probe_all owns it",
+        path=SERVER,
+        old="    accounts = quota_dispatch.probe_all(notes.append)",
+        new="    accounts = quota_dispatch.probe_all(notes.append, timeout=5.0)",
+    ),
+    # ── The read: the 7-day window, and the account that is exempt from it ───
+    Mutation(
+        name="activity-window-ignored",
+        property="an account outside the 7-day window stops rendering",
+        path=SERVER,
+        old='"SELECT * FROM harness_quota_account WHERE last_seen >= ? OR is_current=1 "',
+        new='"SELECT * FROM harness_quota_account WHERE (last_seen >= ? OR 1=1) "',
+    ),
+    Mutation(
+        name="current-account-not-exempt",
+        property="the CURRENT account renders even when its last_seen has aged",
+        path=SERVER,
+        old='"SELECT * FROM harness_quota_account WHERE last_seen >= ? OR is_current=1 "',
+        new='"SELECT * FROM harness_quota_account WHERE last_seen >= ? "',
+    ),
+    Mutation(
+        name="windows-attached-to-wrong-account",
+        property="each account carries its OWN windows",
+        path=SERVER,
+        old='        a["windows"] = by_pk.get(a["account_pk"], [])',
+        new='        a["windows"] = [w for ws in by_pk.values() for w in ws]',
+    ),
+    # ── The response ─────────────────────────────────────────────────────────
+    Mutation(
+        name="provider-status-splatted",
+        property="the response is built from NAMED keys — no probe-dict splat",
+        path=SERVER,
+        old='    providers = [{"provider": a["provider"], "status": a.get("status"),\n'
+            '                  "detail": a.get("detail")} for a in accounts]',
+        new="    providers = [dict(a) for a in accounts]",
+    ),
+    # ── The routes themselves ────────────────────────────────────────────────
+    Mutation(
+        name="get-route-renamed-to-usage",
+        property="the read route is /api/analytics/accounts, never `usage`",
+        path=SERVER,
+        old='            if path == "/api/analytics/accounts":',
+        new='            if path == "/api/analytics/usage-accounts":',
+    ),
+    Mutation(
+        name="probe-route-unreachable",
+        property="POST /api/analytics/accounts/probe is wired to the refresh path",
+        path=SERVER,
+        old='            if path == "/api/analytics/accounts/probe":',
+        new='            if path == "/api/analytics/accounts/reprobe":',
+    ),
+]
+
+
+# The suite runs in ~1.5s; the timeout is the backstop for a mutation that
+# hangs rather than answers. A suite that never answers demonstrates nothing.
+SUITE_TIMEOUT_S = 120
+
+
+def run_suites() -> tuple[bool, bool]:
+    """(passed, timed_out). A timeout is a failure."""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", *SUITES],
+            cwd=ROOT, capture_output=True, text=True, check=False,
+            timeout=SUITE_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        return False, True
+    return result.returncode == 0, False
+
+
+def apply(mutation: Mutation) -> str:
+    original = mutation.path.read_text()
+    count = original.count(mutation.old)
+    if count != 1:
+        raise SystemExit(
+            f"{mutation.name}: anchor matched {count} times in "
+            f"{mutation.path.name}, expected exactly 1 — the driver is stale")
+    mutation.path.write_text(original.replace(mutation.old, mutation.new))
+    return original
+
+
+def _die(signum, frame):
+    """SIGTERM must unwind so the `finally` that reverts the source runs — a
+    killed driver otherwise leaves server.py MUTATED in the worktree."""
+    raise SystemExit(f"interrupted by signal {signum}")
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, _die)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--list", action="store_true")
+    parser.add_argument("--only", default=None, help="run one mutation by name")
+    args = parser.parse_args()
+
+    selected = [m for m in MUTATIONS if args.only is None or m.name == args.only]
+    if args.list:
+        for m in selected:
+            print(f"{m.name:34s} {m.property}")
+        return 0
+    if not selected:
+        raise SystemExit(f"no mutation named {args.only!r}")
+
+    print("baseline: ", end="", flush=True)
+    passed, timed_out = run_suites()
+    if not passed:
+        print("TIMED OUT" if timed_out else "RED", "— fix the tree before mutating")
+        return 1
+    print("green")
+
+    failures = []
+    for m in selected:
+        print(f"{m.name:34s} ", end="", flush=True)
+        original = apply(m)
+        try:
+            passed, timed_out = run_suites()
+            red = not passed
+            print("hung " if timed_out else ("red " if red else "GREEN "),
+                  end="", flush=True)
+        finally:
+            m.path.write_text(original)     # restored even on Ctrl-C / SIGTERM
+        green, _ = run_suites()
+        print("-> revert -> " + ("green" if green else "STILL RED"))
+        if not (red and green) or timed_out:
+            failures.append((m, "hung" if timed_out else "did not round-trip"))
+
+    print()
+    if failures:
+        print(f"{len(failures)} of {len(selected)} mutations FAILED:")
+        for m, why in failures:
+            print(f"  - {m.name} ({why}): {m.property}")
+        return 1
+    print(f"{len(selected)}/{len(selected)} mutations red -> revert -> green")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_quota_accounts_api.py
+++ b/tests/test_quota_accounts_api.py
@@ -234,13 +234,33 @@ class QuotaTtlTest(QuotaBase):
             server.get_analytics_accounts(self.con)
         self.assertEqual(1, len(self.calls))
 
-    def test_an_aged_capture_probes_again(self):
-        with self.stub([acct(windows=[win(captured_at=iso(minutes_ago=5))])]):
+    def test_an_aged_attempt_probes_again(self):
+        # The clock is the ATTEMPT, so age the attempt — not the capture.
+        with self.stub([acct(windows=[win()])]):
             server.get_analytics_accounts(self.con)
-            server._QUOTA_PROBE["at"] = None      # only the DB clock is left
+            server._QUOTA_PROBE["at"] -= server.QUOTA_TTL_SECONDS + 1
             out = server.get_analytics_accounts(self.con)
         self.assertEqual(2, len(self.calls))
         self.assertTrue(out["probed"])
+
+    def test_a_restart_inside_the_ttl_probes_and_refills_the_status_list(self):
+        # The attempt clock lives in the process and dies with it. A restart
+        # within 60s of a probe that DID write rows must therefore probe again:
+        # _QUOTA_PROBE["providers"] died with the same process, so a clock that
+        # survived in the DB would serve an EMPTY per-provider status list and
+        # hand the panel the "nothing configured vs. every probe failed"
+        # ambiguity that list exists to remove.
+        fresh = [acct(windows=[win(captured_at=iso())])]
+        with self.stub(fresh):
+            server.get_analytics_accounts(self.con)
+            self.assertTrue(self.q("SELECT 1 FROM harness_quota_window"),
+                            "positive control: the first probe must have "
+                            "written a window row for the DB clock to read")
+            server._QUOTA_PROBE.update({"at": None, "providers": []})  # restart
+            out = server.get_analytics_accounts(self.con)
+        self.assertEqual(2, len(self.calls))
+        self.assertTrue(out["probed"])
+        self.assertEqual(["anthropic"], [p["provider"] for p in out["providers"]])
 
     def test_force_bypasses_a_fresh_ttl(self):
         with self.stub([acct(windows=[win()])]):

--- a/tests/test_quota_accounts_api.py
+++ b/tests/test_quota_accounts_api.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Tests for the Account Analytics API routes (spec doc #49, sprint 52 unit 3).
+
+Stdlib `unittest`, matching the sibling suites. Two layers:
+
+  * `QuotaUpsertTest` / `QuotaReadTest` / `QuotaTtlTest` call the assembler
+    directly against a throwaway DB built the way the engine ships it
+    (schema.sql + every migration in filename order), with `probe_all` stubbed.
+  * `QuotaRouteTest` stands up the real `server.Handler` on an ephemeral port
+    (the test_mem harness pattern) and drives the two URLs over HTTP, so the
+    route paths are pinned BEHAVIOURALLY — a source-substring check would pass
+    whether or not the route answers.
+
+Probe results are built with U2's own `quota_probes.account()` / `window()`
+builders rather than hand-authored dicts. A hand-authored fixture proves a
+mechanism against data the producer cannot emit; going through the real
+builders means a change to that seam breaks these tests, which is the point.
+
+No test performs a live call: `probe_all` is stubbed in every case.
+
+Run:
+    python3 tests/test_quota_accounts_api.py
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+import quota_probes  # noqa: E402  (the row builders U2 owns)
+import server  # noqa: E402
+
+
+def build_db(path=":memory:") -> sqlite3.Connection:
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for mig in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(mig.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    con.commit()
+    return con
+
+
+def iso(minutes_ago: float = 0.0, days_ago: float = 0.0) -> str:
+    ts = (datetime.now(timezone.utc)
+          - timedelta(minutes=minutes_ago, days=days_ago))
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def acct(provider="anthropic", ref="uuid-1", label="jed@gmail.com", plan="max",
+         captured_at=None, status="ok", is_current=1, windows=(), detail=None):
+    return quota_probes.account(
+        provider=provider, probe_version="1", captured_at=captured_at or iso(),
+        account_ref=ref, account_label=label, plan=plan, is_current=is_current,
+        status=status, detail=detail, windows=list(windows))
+
+
+def win(kind="session", scope=None, percent=22.0, used=None, limit_value=None,
+        captured_at=None, status="ok"):
+    return quota_probes.window(
+        window_kind=kind, probe_version="1", captured_at=captured_at or iso(),
+        scope=scope, used_percent=percent, used=used, limit_value=limit_value,
+        resets_at=iso(), status=status)
+
+
+class QuotaBase(unittest.TestCase):
+    def setUp(self):
+        self.con = build_db()
+        self.addCleanup(self.con.close)
+        # Module state: the TTL's out-of-band clock. Reset per test so one
+        # test's probe cannot suppress the next test's.
+        saved = dict(server._QUOTA_PROBE)
+        self.addCleanup(lambda: server._QUOTA_PROBE.update(saved))
+        server._QUOTA_PROBE.update({"at": None, "providers": []})
+        self.calls = []
+
+    def stub(self, *results):
+        """Stub probe_all with one result list per successive call; the last
+        result repeats. Records every call so probe COUNT is assertable."""
+        seq = list(results) or [[]]
+
+        def fake(log, *a, **kw):
+            self.calls.append(True)
+            return seq[min(len(self.calls) - 1, len(seq) - 1)]
+        return mock.patch.object(server.quota_dispatch, "probe_all", fake)
+
+    def q(self, sql, *params):
+        return self.con.execute(sql, params).fetchall()
+
+
+class QuotaUpsertTest(QuotaBase):
+    """The upsert — the one thing this unit alone can get right."""
+
+    def test_reprobe_updates_the_null_scope_row_instead_of_twinning_it(self):
+        # session/weekly/five_hour are ALL scope-NULL, so this is the panel's
+        # COMMON path, not an edge case. Under a plain UNIQUE(...scope) SQLite
+        # compares NULLs as distinct and every probe would add a duplicate.
+        first = [acct(windows=[win("session", None, 22.0)])]
+        second = [acct(windows=[win("session", None, 44.0)])]
+        with self.stub(first, second):
+            server.get_analytics_accounts(self.con)
+            server.get_analytics_accounts(self.con, force=True)
+        rows = self.q("SELECT used_percent FROM harness_quota_window "
+                      "WHERE window_kind='session' AND scope IS NULL")
+        self.assertEqual(1, len(rows))
+        self.assertEqual(44.0, rows[0]["used_percent"])
+
+    def test_scoped_windows_stay_distinct(self):
+        # COALESCE folds NULL to '' — it must not fold two REAL scopes together.
+        with self.stub([acct(windows=[win("weekly_scoped", "opus", 10.0),
+                                      win("weekly_scoped", "sonnet", 20.0),
+                                      win("weekly", None, 30.0)])]):
+            server.get_analytics_accounts(self.con)
+        self.assertEqual(3, self.q("SELECT COUNT(*) c FROM harness_quota_window")[0]["c"])
+
+    def test_returning_account_keeps_its_original_first_seen(self):
+        old = iso(days_ago=30)
+        with self.stub([acct(captured_at=old)], [acct(captured_at=iso())]):
+            server.get_analytics_accounts(self.con)
+            server.get_analytics_accounts(self.con, force=True)
+        row = self.q("SELECT first_seen, last_seen FROM harness_quota_account")[0]
+        self.assertEqual(old, row["first_seen"])       # never re-minted
+        self.assertGreater(row["last_seen"], old)      # but activity advanced
+
+    def test_switching_account_moves_is_current_off_the_old_row(self):
+        with self.stub([acct(ref="uuid-1", label="a@x.com")],
+                       [acct(ref="uuid-2", label="b@x.com")]):
+            server.get_analytics_accounts(self.con)
+            server.get_analytics_accounts(self.con, force=True)
+        rows = {r["account_ref"]: r["is_current"] for r in
+                self.q("SELECT account_ref, is_current FROM harness_quota_account")}
+        self.assertEqual({"uuid-1": 0, "uuid-2": 1}, rows)
+
+    def test_account_without_a_ref_writes_no_registry_row(self):
+        # No credential file → `na`. The absence of a limit is not a limit of
+        # zero, and a row keyed on a null ref could never be matched again.
+        na = quota_probes.account(provider="moonshot", probe_version="1",
+                                  captured_at=iso(), status="na", is_current=0)
+        with self.stub([na]):
+            out = server.get_analytics_accounts(self.con)
+        self.assertEqual(0, self.q("SELECT COUNT(*) c FROM harness_quota_account")[0]["c"])
+        # ...but the provider is still REPORTED, or "no accounts" would be
+        # indistinguishable from "every probe failed".
+        self.assertEqual([{"provider": "moonshot", "status": "na", "detail": None}],
+                         out["providers"])
+
+    def test_unauth_preserves_the_last_known_values(self):
+        # "Expiry is reported, not repaired": the card shows what it last knew,
+        # with its age — never a measured zero.
+        good = [acct(windows=[win("session", None, 61.0, captured_at=iso(minutes_ago=90))])]
+        expired = [acct(status="unauth", windows=[])]
+        with self.stub(good, expired):
+            server.get_analytics_accounts(self.con)
+            server.get_analytics_accounts(self.con, force=True)
+        row = self.q("SELECT used_percent, captured_at FROM harness_quota_window")[0]
+        self.assertEqual(61.0, row["used_percent"])
+        self.assertEqual(iso(minutes_ago=90)[:16], row["captured_at"][:16])
+
+    def test_probe_payload_extras_never_reach_the_response(self):
+        # A token must not be able to ride out of the probe seam through this
+        # layer: the response is built from named keys, never a dict splat.
+        leaky = acct()
+        leaky["access_token"] = "sk-ant-oat01-SHOULD-NEVER-APPEAR"
+        with self.stub([leaky]):
+            out = server.get_analytics_accounts(self.con)
+        self.assertNotIn("SHOULD-NEVER-APPEAR", json.dumps(out))
+
+
+class QuotaReadTest(QuotaBase):
+    """The 7-day activity window — a filter, never a delete."""
+
+    def test_stale_account_stops_rendering_but_its_row_survives(self):
+        with self.stub([acct(ref="old", label="old@x.com", captured_at=iso(days_ago=30))]):
+            server.get_analytics_accounts(self.con)
+        # Demote it: only the account the credential file resolves to NOW is
+        # exempt from the window.
+        self.con.execute("UPDATE harness_quota_account SET is_current=0")
+        self.con.commit()
+        with self.stub([]):
+            out = server.get_analytics_accounts(self.con, force=True)
+        self.assertEqual([], out["accounts"])
+        self.assertEqual(1, self.q("SELECT COUNT(*) c FROM harness_quota_account")[0]["c"])
+
+    def test_current_account_renders_even_when_its_last_seen_has_aged(self):
+        # A failed probe leaves last_seen un-advanced; the section must still
+        # show the current account rather than an empty page.
+        with self.stub([acct(captured_at=iso(days_ago=30))]):
+            out = server.get_analytics_accounts(self.con)
+        self.assertEqual(["uuid-1"], [a["account_ref"] for a in out["accounts"]])
+
+    def test_windows_attach_to_their_own_account(self):
+        with self.stub([acct(ref="a", windows=[win("session", None, 10.0)]),
+                        acct(provider="openai", ref="b", windows=[
+                            win("weekly", None, 20.0), win("five_hour", None, 30.0)])]):
+            out = server.get_analytics_accounts(self.con)
+        by_ref = {a["account_ref"]: a for a in out["accounts"]}
+        self.assertEqual([10.0], [w["used_percent"] for w in by_ref["a"]["windows"]])
+        self.assertEqual({20.0, 30.0},
+                         {w["used_percent"] for w in by_ref["b"]["windows"]})
+
+
+class QuotaTtlTest(QuotaBase):
+    """The 60s TTL — toggling the two sections must not hammer three
+    third-party endpoints, and the refresh button must always bypass it."""
+
+    def test_second_arrival_inside_the_ttl_does_not_probe(self):
+        with self.stub([acct(windows=[win()])]):
+            server.get_analytics_accounts(self.con)
+            out = server.get_analytics_accounts(self.con)
+        self.assertEqual(1, len(self.calls))
+        self.assertFalse(out["probed"])
+
+    def test_ttl_holds_when_the_probe_wrote_no_rows(self):
+        # The degraded case the DB-only clock cannot cover: nothing configured
+        # (or every provider erroring) writes no captured_at at all, so a
+        # captured_at-only TTL would re-probe on every single arrival.
+        with self.stub([]):
+            server.get_analytics_accounts(self.con)
+            server.get_analytics_accounts(self.con)
+        self.assertEqual(1, len(self.calls))
+
+    def test_an_aged_capture_probes_again(self):
+        with self.stub([acct(windows=[win(captured_at=iso(minutes_ago=5))])]):
+            server.get_analytics_accounts(self.con)
+            server._QUOTA_PROBE["at"] = None      # only the DB clock is left
+            out = server.get_analytics_accounts(self.con)
+        self.assertEqual(2, len(self.calls))
+        self.assertTrue(out["probed"])
+
+    def test_force_bypasses_a_fresh_ttl(self):
+        with self.stub([acct(windows=[win()])]):
+            server.get_analytics_accounts(self.con)
+            out = server.get_analytics_accounts(self.con, force=True)
+        self.assertEqual(2, len(self.calls))
+        self.assertTrue(out["probed"])
+
+    def test_the_route_owns_no_timeout_of_its_own(self):
+        # Concurrency, the 5s per-probe timeout and one-provider-failure
+        # containment are U2's probe_all, by a ratified ambiguity call. A
+        # second timeout layer here is a finding, not defence in depth.
+        seen = {}
+
+        def fake(log, *a, **kw):
+            seen["args"], seen["kwargs"] = a, kw
+            return []
+        with mock.patch.object(server.quota_dispatch, "probe_all", fake):
+            server.get_analytics_accounts(self.con)
+        self.assertEqual((), seen["args"])
+        self.assertEqual({}, seen["kwargs"])
+
+
+class QuotaRouteTest(unittest.TestCase):
+    """The two URLs, over real HTTP. `accounts`, never `usage`."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = Path(tempfile.mkdtemp())
+        cls.db = cls.tmp / "shell_db.db"
+        build_db(str(cls.db)).close()
+        cls._saved_db = server.DB_PATH
+        server.DB_PATH = cls.db
+        cls.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        cls.base = f"http://127.0.0.1:{cls.httpd.server_address[1]}"
+        threading.Thread(target=cls.httpd.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        server.DB_PATH = cls._saved_db
+
+    def setUp(self):
+        server._QUOTA_PROBE.update({"at": None, "providers": []})
+        # This class shares one on-disk DB across its tests, and a capture left
+        # by an earlier test legitimately holds the TTL closed — clear both
+        # clocks so each test starts cold.
+        con = sqlite3.connect(self.db)
+        con.execute("DELETE FROM harness_quota_window")
+        con.execute("DELETE FROM harness_quota_account")
+        con.commit()
+        con.close()
+        self.calls = []
+
+    def call(self, path, method="GET"):
+        req = urllib.request.Request(self.base + path, method=method,
+                                     data=b"{}" if method == "POST" else None)
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return r.status, json.loads(r.read())
+
+    def stubbed(self, results):
+        def fake(log, *a, **kw):
+            self.calls.append(True)
+            return results
+        return mock.patch.object(server.quota_dispatch, "probe_all", fake)
+
+    def test_get_accounts_serves_the_registry(self):
+        with self.stubbed([acct(label="jed@gmail.com", windows=[win()])]):
+            status, body = self.call("/api/analytics/accounts")
+        self.assertEqual(200, status)
+        self.assertEqual(["jed@gmail.com"],
+                         [a["account_label"] for a in body["accounts"]])
+        self.assertEqual(7, body["activity_days"])
+        self.assertEqual(60, body["ttl_seconds"])
+
+    def test_post_probe_route_forces_a_probe(self):
+        with self.stubbed([acct(windows=[win()])]):
+            self.call("/api/analytics/accounts")        # arms the TTL
+            status, body = self.call("/api/analytics/accounts/probe", method="POST")
+        self.assertEqual(200, status)
+        self.assertEqual(2, len(self.calls))
+        self.assertTrue(body["probed"])
+
+    def test_token_analytics_usage_route_still_means_token_spend(self):
+        # The reason the route word is `accounts`: /api/analytics/usage already
+        # has a meaning on this tab and must keep it.
+        status, body = self.call("/api/analytics/usage")
+        self.assertEqual(200, status)
+        self.assertIn("favorite_models", body)
+        self.assertNotIn("accounts", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Spec #49 unit 3, sprint doc 52. The read+write half of the quota panel: two routes, the TTL that keeps a section toggle from hammering three third-party endpoints, and the upsert that lands what U2's probes return in U1's tables.

- `GET /api/analytics/accounts` — registry + windows + per-provider status; probes first when the last probe attempt has aged past 60s. Fires only on arrival at the section: not at boot, not on a timer, not from Token Analytics.
- `POST /api/analytics/accounts/probe` — the refresh button; always re-probes.

Named `accounts`, never `usage`: `/api/analytics/usage` already means token spend on this tab, and the route test asserts that route still answers with token spend rather than grepping the source for a string.

## The upsert

The conflict target is migration 0096's expression index, character for character — `ON CONFLICT(account_pk, window_kind, COALESCE(scope, ''))`. SQLite matches an upsert target against the index *expression*, not a column list, so naming plain `scope` raises rather than duplicating; it fails loud, but it is not inferable from the schema. `session`, `weekly` and `five_hour` are all scope-NULL, so this is the panel's common path, not an edge case.

`first_seen` is deliberately absent from the registry's SET list: an account that goes quiet and comes back keeps its original identity instead of minting a duplicate.

## Layering

Calls `probe_all` ONCE and owns nothing it does. Concurrency, the 5s per-probe timeout and one-provider-failure containment live in U2's dispatcher by a ratified ambiguity call; a mutation asserts this layer passes no timeout of its own, because a second timeout layer here would be a finding, not defence in depth.

## Two judgement calls, both ratified by the planner

1. **The TTL clock is the last probe ATTEMPT**, not only the newest `captured_at`. A probe that identifies nobody (no credential file → `na`, or a provider erroring before it can name an account) writes NO rows, so the spec's original clock never advanced and every arrival would re-probe — breaking the spec's own *toggling sections twice inside a minute performs one probe* in exactly the degraded case. The `ttl-db-clock-only` mutation restores the literal mechanism and reddens exactly ONE test, which is what makes the departure load-bearing rather than decorative.

   **Where the attempt is recorded:** in-process memory (`_QUOTA_PROBE`, module-level, guarded by `_QUOTA_LOCK`) — *not* a DB row. Consequence, stated rather than hidden: **the TTL resets on server restart**, so a restart storm re-probes. It cannot mint a phantom registry entry, because the registry write path filters to `account_ref`-bearing accounts before any INSERT.

2. **The read returns the current account even when its `last_seen` has aged out of the 7-day window.** The spec's edge table requires the section to render the current account rather than an empty page, and the UI cannot render what the API does not send. Everything else outside the window stops rendering WITHOUT being deleted.

Both are now written into spec doc 49, along with the per-provider status list (a spec gap: without it, *nothing configured* and *every probe failed* both reach the UI as an empty accounts array).

## Verification

17 mutation round trips, asked per PROPERTY rather than per test — the conflict target and `first_seen` preservation are different guarantees inside one SQL statement, as are the 7-day filter and the `is_current` exemption inside one WHERE clause. All 17 red → revert → green (`tests/mutations/u3_quota_api.py`).

Probe results in tests are built with U2's own `account()`/`window()` builders, so no test proves a mechanism against data the producer cannot emit, and no test performs a live call.

## Rebase note

Re-cut fresh from `origin/main` (5f9a260) and cherry-picked rather than rebased, because #602 merged as a squash and its patch-ids changed. Contribution verified diff-identical across the re-cut: every `+`/`-` line of `diff(4156505..c1ee55f)` matches `diff(5f9a260..5ef9d43)`. Clean auto-merge in `server.py`; **no hunk was hand-resolved**. U2's merged commit does not touch `server.py` — that file's movement under me was entirely sprint 45's f8f1e8f. `dispatch.py`, the entry point this unit calls, is byte-identical between what I built against and what merged.

Shell: DEV3 (Code-01) · sprint 52 unit 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)