### PR TITLE
feat(analytics): 49-U4 Account Analytics UI — toggle, cards, thresholds (S52 U4)

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2123,8 +2123,18 @@ async function anTokenSection(root) {
 //
 // Provider state comes from the response's per-provider status list, NEVER
 // inferred from the accounts array: an empty array is both "nothing configured"
-// and "every probe failed", and those render differently (na = no card at all,
-// error = a card carrying the HTTP status).
+// and "every probe failed", and those render differently (na with no registry
+// row = no card, error = a card carrying the HTTP status).
+//
+// 3. WHERE THE REGISTRY AND THE STATUS LIST DISAGREE, THE STATUS GOVERNS WHAT
+//    IS SEEN AND THE REGISTRY KEEPS WHAT IS KNOWN. The registry says what was
+//    true as of the last successful probe; the status says what is true now.
+//    Remove a credential file without switching accounts and the row keeps
+//    is_current — which is exempt from the 7-day filter — so the card would
+//    render forever, unmuted and live-looking, while the same response reports
+//    that provider `na`. The card is muted and its refresh disabled instead;
+//    the row is never filtered out and never mutated, because clearing
+//    is_current on a transiently unreadable file would demote a real account.
 const AN_PROVIDER_LABEL = { anthropic: "Claude", openai: "Codex", moonshot: "Kimi" };
 // Display order for a card's windows. Unrecognized kinds sort last rather than
 // being dropped — the probe stores a window it could not map under its raw
@@ -2211,14 +2221,21 @@ function anAccountCard(acct, prov, onRefresh) {
   const status = prov ? prov.status : null;
   // unauth is the current account with a dead token: last known values, muted,
   // with their age — the same treatment a signed-out account gets, for the same
-  // reason (the numbers are real, they are just not now).
-  const muted = !current || status === "unauth";
+  // reason (the numbers are real, they are just not now). `na` joins them from
+  // a third direction: the row still says is_current, but the credential file
+  // it named is not readable now, so the numbers are equally last-known.
+  const muted = !current || status === "unauth" || status === "na";
   const card = el("div", { className: "card an-acct" + (muted ? " an-muted" : "") });
 
   const head = el("div", { className: "an-acct-head" });
   head.append(el("span", { className: "an-acct-label" }, acct.account_label || acct.account_ref));
   if (acct.plan) head.append(el("span", { className: "pill" }, acct.plan));
   if (!current) head.append(el("span", { className: "pill" }, "not signed in"));
+  // What was OBSERVED, not what it implies. "not signed in" would be an
+  // inference about why the file is gone — the operator may be mid-login, or
+  // the file may simply be unreadable — and the engine did not see a sign-out.
+  else if (status === "na") head.append(el("span", { className: "pill warn" },
+    "no readable credential file — last known"));
   else if (status === "unauth") head.append(el("span", { className: "pill warn" }, "signed out — last known"));
   else if (status === "error") head.append(el("span", { className: "pill warn" },
     "error" + (prov.detail ? " · " + prov.detail : "")));
@@ -2242,6 +2259,12 @@ function anAccountCard(acct, prov, onRefresh) {
   if (!current) {
     refresh.disabled = true;
     refresh.title = "signed out — this account's token is gone, so it cannot be re-probed";
+  } else if (status === "na") {
+    // Same inert-button shape, reached from the status side rather than the
+    // registry side: there is no credential file to read, so a probe fired
+    // from here provably cannot change this card either.
+    refresh.disabled = true;
+    refresh.title = "no readable credential file — a probe cannot reach this account now";
   } else {
     refresh.onclick = () => onRefresh(refresh);
   }
@@ -2276,13 +2299,20 @@ function anDrawAccounts(root, d) {
   root.append(head);
 
   // Provider order follows the status list (the dispatcher's own order), then
-  // any provider present only in the registry. `na` — no credential file — is
-  // dropped entirely: the absence of a limit is not a limit of zero, and the
-  // spec's edge table says no card for that provider.
+  // any provider present only in the registry.
+  //
+  // `na` — no credential file readable now — is dropped ONLY when the registry
+  // has nothing for it: the absence of a limit is not a limit of zero, so a
+  // provider this host has never seen gets no card. When a registry row DOES
+  // exist the card stays and renders muted (see anAccountCard): the status
+  // governs how the row is drawn, never whether the row is believed. Filtering
+  // it out would throw away the last account this host actually saw.
   const statusOf = new Map(providers.map((p) => [p.provider, p]));
+  const known = new Set(accounts.map((a) => a.provider));
   const groups = new Map();
   for (const name of [...providers.map((p) => p.provider), ...accounts.map((a) => a.provider)]) {
-    if (groups.has(name) || statusOf.get(name)?.status === "na") continue;
+    if (groups.has(name)) continue;
+    if (statusOf.get(name)?.status === "na" && !known.has(name)) continue;
     groups.set(name, { name, prov: statusOf.get(name) || null, accounts: [] });
   }
   for (const a of accounts) groups.get(a.provider)?.accounts.push(a);

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -1709,6 +1709,7 @@ let anSessions = [];      // accumulated cards across "More" pages
 let anNextBefore = null;  // cursor for the next page (null = no older rows)
 let anDaysLoaded = 0;     // window size loaded so far (7 per page)
 let anClass = null;  // selected stat card; null = combined (all classes summed)
+let anView = "tokens";    // 'tokens' | 'accounts' — sub-view, carried in the hash
 
 const AN_CLASSES = [
   ["input_tokens", "Input"], ["output_tokens", "Output"],
@@ -1934,7 +1935,7 @@ function anSessionCard(c, sprintTitles) {
   return row;
 }
 
-async function renderAnalytics(root) {
+async function anTokenSection(root) {
   root.replaceChildren(el("div", { className: "muted" }, "sweeping harness data…"));
   try { await api("/analytics/sweep", "POST"); } catch { /* sweep is best-effort; show what's stored */ }
   const winDays = anDaysLoaded || anRange;
@@ -1956,7 +1957,7 @@ async function renderAnalytics(root) {
   const reset = (k) => (v) => {
     anFilters[k] = v;
     anSessions = []; anNextBefore = null; anDaysLoaded = 0;
-    renderAnalytics(root);
+    anTokenSection(root);
   };
   const rangeSeg = el("div", { className: "filters seg an-range" });
   for (const [label, days] of AN_RANGES) {
@@ -1965,7 +1966,7 @@ async function renderAnalytics(root) {
     chip.onclick = () => {
       anRange = days;
       anSessions = []; anNextBefore = null; anDaysLoaded = 0;
-      renderAnalytics(root);
+      anTokenSection(root);
     };
     rangeSeg.append(chip);
   }
@@ -2098,11 +2099,271 @@ async function renderAnalytics(root) {
     const more = el("button", { className: "act", type: "button", textContent: "More ↓ (7 more days)" });
     more.onclick = async () => {
       more.disabled = true;
-      try { await anLoadPage(7); renderAnalytics(root); }
+      try { await anLoadPage(7); anTokenSection(root); }
       catch (e) { toast("error: " + e.message); more.disabled = false; }
     };
     list.append(el("div", { className: "an-more" }, more));
   }
+}
+
+// ── Account Analytics — harness quota (spec doc #49) ──────────────────────────
+// Token Analytics answers *what did we spend*; this answers *how much is left*.
+// One card per account, grouped by provider, current accounts first.
+//
+// Two rules carry the whole section, and both are about not lying:
+//
+// 1. COLOUR IS THRESHOLD-DRIVEN AND PROVIDER-BLIND. It is computed from
+//    used_percent alone, never from a provider's own severity field: anthropic
+//    sends severity=normal at 22%, openai limit_reached=true at 100%, moonshot
+//    nothing at all. Three vocabularies would be three colour rules on one page.
+// 2. A MISSING NUMBER IS NEVER DRAWN AS A ZERO. used_percent NULL renders
+//    "n/a" with no bar — a provider reporting counts against limit_value 0, a
+//    moonshot all-null weekly row, a window whose percent could not be derived.
+//    A 0% meter reads as measured, and "we did not get a number" is not 0%.
+//
+// Provider state comes from the response's per-provider status list, NEVER
+// inferred from the accounts array: an empty array is both "nothing configured"
+// and "every probe failed", and those render differently (na = no card at all,
+// error = a card carrying the HTTP status).
+const AN_PROVIDER_LABEL = { anthropic: "Claude", openai: "Codex", moonshot: "Kimi" };
+// Display order for a card's windows. Unrecognized kinds sort last rather than
+// being dropped — the probe stores a window it could not map under its raw
+// duration precisely so the panel still shows it.
+const AN_WINDOW_ORDER = ["session", "five_hour", "weekly", "weekly_scoped", "short"];
+const AN_WINDOW_LABEL = {
+  session: "Session", five_hour: "5-hour", weekly: "Weekly",
+  weekly_scoped: "Weekly · scoped", short: "Short",
+};
+const anWindowRank = (w) => {
+  const i = AN_WINDOW_ORDER.indexOf(w.window_kind);
+  return i < 0 ? AN_WINDOW_ORDER.length : i;
+};
+const anWindowName = (w) => (AN_WINDOW_LABEL[w.window_kind] || w.window_kind)
+  + (w.scope ? " · " + w.scope : "");
+
+// below 80 normal · 80+ amber · 95+ red. NULL has no class: an absent number is
+// not a low one, so it gets no colour rather than the reassuring one.
+const anQuotaClass = (pct) => pct == null ? "" : pct >= 95 ? " red" : pct >= 80 ? " amber" : "";
+const anPct = (pct) => pct == null ? "n/a" : Math.round(pct * 10) / 10 + "%";
+
+function anDuration(ms) {
+  const mins = Math.round(ms / 60000);
+  if (mins < 1) return "<1m";
+  if (mins < 60) return mins + "m";
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return hrs + "h" + (mins % 60 ? " " + (mins % 60) + "m" : "");
+  const days = Math.floor(hrs / 24);
+  return days + "d" + (hrs % 24 ? " " + (hrs % 24) + "h" : "");
+}
+// Reset renders as a countdown, not a timestamp — "in 3h 12m" answers the
+// question the operator actually has. A reset already past reads "due" rather
+// than a negative duration; an absent or unparseable one reads "—", never now.
+function anCountdown(iso) {
+  const t = iso ? new Date(iso).getTime() : NaN;
+  if (!Number.isFinite(t)) return "—";
+  const ms = t - Date.now();
+  return ms <= 0 ? "due" : "in " + anDuration(ms);
+}
+function anAge(iso) {
+  const t = iso ? new Date(iso).getTime() : NaN;
+  if (!Number.isFinite(t)) return "—";
+  const ms = Date.now() - t;
+  return ms <= 0 ? "just now" : anDuration(ms) + " ago";
+}
+// The card's own age: the newest capture across its windows, falling back to
+// last_seen for an account that has none (unauth, or an error after it was
+// identified). Every card renders an age — that is what makes a stale number
+// readable as stale instead of current.
+function anCardAge(acct) {
+  const caps = (acct.windows || []).map((w) => w.captured_at).filter(Boolean).sort();
+  return caps.length ? caps[caps.length - 1] : acct.last_seen;
+}
+
+function anWindowRow(w) {
+  const pct = w.used_percent;
+  const row = el("div", { className: "an-win" });
+  row.append(el("div", { className: "an-win-head" },
+    el("span", { className: "an-win-name" }, anWindowName(w)),
+    el("span", { className: "an-win-pct" + anQuotaClass(pct) }, anPct(pct))));
+  const meter = el("div", { className: "an-meter" });
+  if (pct != null) {
+    // Clamped: a provider reporting over 100 fills the track, it does not
+    // overflow it. NULL draws no fill at all — an empty track is honest.
+    const fill = el("div", { className: "an-meter-fill" + anQuotaClass(pct) });
+    fill.style.width = Math.max(0, Math.min(100, pct)) + "%";
+    meter.append(fill);
+  }
+  row.append(meter);
+  const meta = [];
+  if (w.used != null || w.limit_value != null)
+    meta.push(["used", (w.used == null ? "—" : fmt(w.used))
+      + " / " + (w.limit_value == null ? "—" : fmt(w.limit_value))]);
+  meta.push(["resets", anCountdown(w.resets_at)]);
+  if (w.status && w.status !== "ok") meta.push(["status", w.status]);
+  const line = statRow(meta);
+  if (w.resets_at) line.title = "resets " + w.resets_at;
+  row.append(line);
+  return row;
+}
+
+function anAccountCard(acct, prov, onRefresh) {
+  const current = !!acct.is_current;
+  const status = prov ? prov.status : null;
+  // unauth is the current account with a dead token: last known values, muted,
+  // with their age — the same treatment a signed-out account gets, for the same
+  // reason (the numbers are real, they are just not now).
+  const muted = !current || status === "unauth";
+  const card = el("div", { className: "card an-acct" + (muted ? " an-muted" : "") });
+
+  const head = el("div", { className: "an-acct-head" });
+  head.append(el("span", { className: "an-acct-label" }, acct.account_label || acct.account_ref));
+  if (acct.plan) head.append(el("span", { className: "pill" }, acct.plan));
+  if (!current) head.append(el("span", { className: "pill" }, "not signed in"));
+  else if (status === "unauth") head.append(el("span", { className: "pill warn" }, "signed out — last known"));
+  else if (status === "error") head.append(el("span", { className: "pill warn" },
+    "error" + (prov.detail ? " · " + prov.detail : "")));
+  card.append(head);
+
+  const wins = [...(acct.windows || [])].sort((a, b) => anWindowRank(a) - anWindowRank(b));
+  if (!wins.length) card.append(el("div", { className: "muted" }, "no windows reported"));
+  for (const w of wins) card.append(anWindowRow(w));
+
+  const foot = el("div", { className: "an-acct-foot" });
+  foot.append(el("span", { className: "muted" }, "snapshot " + anAge(anCardAge(acct))));
+  const refresh = el("button", { className: "act", type: "button", textContent: "refresh ⟳" });
+  // A non-current account cannot be re-probed: its token is gone, and the probe
+  // route re-reads whatever the credential files resolve to NOW. The spec grants
+  // Codex an exception — a non-current OpenAI account refreshed from its rollout
+  // files — but no unit implements a rollout reader (verified against U3's head:
+  // zero `rollout` references in quota_probes/ or the routes), so an enabled
+  // button here would fire a probe that provably cannot change this card. A
+  // control that lies is worse than a capability that is missing; declared to
+  // the planner pre-build rather than left to be found.
+  if (!current) {
+    refresh.disabled = true;
+    refresh.title = "signed out — this account's token is gone, so it cannot be re-probed";
+  } else {
+    refresh.onclick = () => onRefresh(refresh);
+  }
+  foot.append(refresh);
+  card.append(foot);
+  return card;
+}
+
+// A provider that produced no registry row at all still gets a card when it
+// failed: `error` before the probe could name an account is exactly the case
+// the accounts array cannot express, and silence there would read as "fine".
+function anProviderCard(prov) {
+  const card = el("div", { className: "card an-acct an-muted" });
+  card.append(el("div", { className: "an-acct-head" },
+    el("span", { className: "an-acct-label" }, "no account identified"),
+    el("span", { className: "pill warn" },
+      (prov.status || "error") + (prov.detail ? " · " + prov.detail : ""))));
+  return card;
+}
+
+function anDrawAccounts(root, d) {
+  root.replaceChildren();
+  const accounts = d.accounts || [];
+  const providers = d.providers || [];
+
+  const head = el("div", { className: "an-acct-bar" });
+  head.append(el("span", { className: "muted" },
+    `accounts active in the last ${d.activity_days || 7} days`));
+  const probeAll = el("button", { className: "act", type: "button", textContent: "refresh all ⟳" });
+  probeAll.onclick = () => anProbeNow(root, probeAll);
+  head.append(probeAll);
+  root.append(head);
+
+  // Provider order follows the status list (the dispatcher's own order), then
+  // any provider present only in the registry. `na` — no credential file — is
+  // dropped entirely: the absence of a limit is not a limit of zero, and the
+  // spec's edge table says no card for that provider.
+  const statusOf = new Map(providers.map((p) => [p.provider, p]));
+  const groups = new Map();
+  for (const name of [...providers.map((p) => p.provider), ...accounts.map((a) => a.provider)]) {
+    if (groups.has(name) || statusOf.get(name)?.status === "na") continue;
+    groups.set(name, { name, prov: statusOf.get(name) || null, accounts: [] });
+  }
+  for (const a of accounts) groups.get(a.provider)?.accounts.push(a);
+
+  if (!groups.size) {
+    root.append(el("div", { className: "card muted" }, providers.length
+      ? "No harness credentials found — nothing to probe."
+      : "No probe has run yet."));
+    return;
+  }
+
+  // The API exempts is_current from the 7-day filter so the section is never
+  // empty. Say why the page is thin instead of letting it look like the whole
+  // truth about the last week.
+  const cutoff = Date.now() - (d.activity_days || 7) * 864e5;
+  const fresh = (a) => new Date(a.last_seen).getTime() >= cutoff;
+  if (accounts.length && !accounts.some(fresh))
+    root.append(el("div", { className: "an-note" }, `No account has been seen in the last `
+      + `${d.activity_days || 7} days — showing the current account only.`));
+
+  for (const g of groups.values()) {
+    const sec = el("div", { className: "an-prov" });
+    sec.append(el("div", { className: "an-prov-head" },
+      el("h2", {}, AN_PROVIDER_LABEL[g.name] || g.name),
+      el("span", { className: "pill" }, g.name)));
+    if (g.accounts.length)
+      for (const a of g.accounts) sec.append(anAccountCard(a, g.prov, (btn) => anProbeNow(root, btn)));
+    else
+      sec.append(anProviderCard(g.prov || { status: "error" }));
+    root.append(sec);
+  }
+}
+
+// The refresh button — POSTs the probe route, which bypasses the 60s TTL. The
+// redraw replaces the button along with everything else, so it is only
+// re-enabled on the failure path.
+async function anProbeNow(root, btn) {
+  const label = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = "probing…";
+  try {
+    anDrawAccounts(root, await api("/analytics/accounts/probe", "POST"));
+  } catch (e) {
+    toast("probe error: " + e.message);
+    btn.disabled = false;
+    btn.textContent = label;
+  }
+}
+
+// GET is the arrival probe: the route probes for itself when its last attempt
+// has aged past the TTL, so the section fires exactly one probe per minute of
+// toggling and the client asks for nothing extra.
+async function anAccountSection(root) {
+  root.replaceChildren(el("div", { className: "muted" }, "probing accounts…"));
+  try {
+    anDrawAccounts(root, await api("/analytics/accounts"));
+  } catch (e) {
+    root.replaceChildren(el("div", { className: "card" }, "error: " + e.message));
+  }
+}
+
+// The Analytics tab carries its sub-view in the hash, the convention the
+// roadmap tab already uses for #roadmap / #roadmap-flow: #analytics = Token
+// Analytics, #analytics-accounts = Account Analytics. Both keep `analytics` as
+// the active nav tab; routeFromHash sets anView and re-renders.
+//
+// Each section renders into its OWN node, so its replaceChildren() cannot wipe
+// the toggle above it — and so arriving at one section never runs the other's
+// work: the token sweep and the account probe both fire on entry, and firing
+// both would mean three third-party calls every time someone reads their spend.
+async function renderAnalytics(root) {
+  const seg = el("div", { className: "filters seg an-view" });
+  for (const [mode, label] of [["tokens", "Token Analytics"], ["accounts", "Account Analytics"]]) {
+    const b = el("button", { className: "chip" + (anView === mode ? " on" : ""),
+      type: "button", textContent: label });
+    b.onclick = () => { location.hash = mode === "accounts" ? "analytics-accounts" : "analytics"; };
+    seg.append(b);
+  }
+  const body = el("div", {});
+  root.replaceChildren(el("div", { className: "an-head" }, seg), body);
+  return anView === "accounts" ? anAccountSection(body) : anTokenSection(body);
 }
 
 // ── Interface tab (sprint 25 seq 5) ───────────────────────────────────────────
@@ -4197,12 +4458,18 @@ function show(tab) {
 // put (and re-fetches that tab) instead of snapping back to Shells. Tabs set the
 // hash; hashchange drives show — back/forward and deep links work too. The
 // roadmap tab carries its sub-view in the hash: #roadmap (board) | #roadmap-flow.
+// The analytics tab does the same: #analytics (token) | #analytics-accounts.
 // The interface tab carries its selected shell: #interface | #interface/DEV3.
 function routeFromHash() {
   const raw = location.hash.slice(1);
   if (raw === "roadmap" || raw.startsWith("roadmap-")) {
     roadmapView = raw === "roadmap-flow" ? "flow" : "board";
     show("roadmap");
+    return;
+  }
+  if (raw === "analytics" || raw.startsWith("analytics-")) {
+    anView = raw === "analytics-accounts" ? "accounts" : "tokens";
+    show("analytics");
     return;
   }
   if (raw === "interface" || raw.startsWith("interface/")) {

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -691,6 +691,42 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   border-radius: 6px; padding: .25rem .5rem; font-size: .78rem;
   pointer-events: none; white-space: nowrap; box-shadow: var(--menu-shadow); }
 
+/* ── Account Analytics: sub-view toggle, account cards, quota meters ──
+   Colour here is threshold-driven and provider-blind (spec #49): one amber and
+   one red, both keyed off used_percent, never off a provider's own severity
+   field. A window with no percent gets NEITHER class and draws no bar — an
+   absent number must not read as a comfortable one. */
+.an-head { display: flex; justify-content: flex-end; margin-bottom: .6rem; }
+.an-view .chip { border-radius: 0; }
+.an-view .chip:first-child { border-top-left-radius: 6px; border-bottom-left-radius: 6px; }
+.an-view .chip:last-child { border-top-right-radius: 6px; border-bottom-right-radius: 6px; }
+.an-acct-bar { display: flex; align-items: center; gap: .6rem; margin-bottom: .5rem; }
+.an-acct-bar .act { margin-left: auto; }
+.an-note { color: var(--warn); font-size: .85rem; margin-bottom: .5rem; }
+.an-prov { margin-bottom: .8rem; }
+.an-prov-head { display: flex; align-items: center; gap: .5rem; margin-bottom: .3rem; }
+.an-prov-head h2 { margin: 0; font-size: 1rem; }
+.an-acct { margin-bottom: .5rem; }
+/* A signed-out or unauth card keeps its numbers and loses its emphasis: the
+   values are real, they are simply not now. Recessed, never hidden. */
+.an-acct.an-muted { opacity: .62; }
+.an-acct-head { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; margin-bottom: .5rem; }
+.an-acct-label { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--ink); }
+.an-acct-foot { display: flex; align-items: center; gap: .6rem; margin-top: .5rem; }
+.an-acct-foot .act { margin-left: auto; }
+.an-acct-foot .act:disabled { opacity: .45; cursor: not-allowed; }
+.an-win { margin: .45rem 0; }
+.an-win-head { display: flex; align-items: baseline; gap: .5rem; font-size: .85rem; }
+.an-win-name { color: var(--dim); }
+.an-win-pct { margin-left: auto; font-weight: 600; color: var(--ink); }
+.an-win-pct.amber { color: var(--warn); }
+.an-win-pct.red { color: #d45a5a; }
+.an-meter { height: 6px; border-radius: 99px; background: var(--panel2);
+  border: 1px solid var(--line-soft); overflow: hidden; margin: .2rem 0; }
+.an-meter-fill { height: 100%; background: var(--accent); border-radius: 99px; }
+.an-meter-fill.amber { background: var(--warn); }
+.an-meter-fill.red { background: #d45a5a; }
+
 /* ── Interface tab ── */
 .if-wrap {
   display: flex; gap: 1rem; align-items: stretch; min-height: 0; height: 100%;

--- a/tests/mutations/u4_quota_accounts_ui.py
+++ b/tests/mutations/u4_quota_accounts_ui.py
@@ -8,7 +8,7 @@ pinned, whatever the suite's colour says.
 
     python3 tests/mutations/u4_quota_accounts_ui.py [-v]
 
-Asked per PROPERTY, not per test. Three of this unit's rules have TWO failure
+Asked per PROPERTY, not per test. Four of this unit's rules have TWO failure
 directions each, and a one-directional leg is satisfied by a fix that merely
 trades the bug for its mirror image — the shape U2's reviewer caught mid-sprint:
 
@@ -18,8 +18,13 @@ trades the bug for its mirror image — the shape U2's reviewer caught mid-sprin
   * the seven-day note: M16 renders it on every page, M17 on none. "Never an
     empty page" and "not a note nobody reads" are different requirements living
     in one condition.
-  * muted: M13 drops the signed-out half, M14 drops the unauth half. One
-    condition, two independent reasons a card is not current.
+  * muted: M13 drops the signed-out half, M14 drops the unauth half, M29 drops
+    the `na` half. One condition, three independent reasons a card is not live.
+  * the registry disagreeing with the status (spec 49): M29/M30 render an `na`
+    card as live, M31 is the mirror that HIDES it. Hiding also stops the card
+    lying, so the pair is what forbids the cheap fix — the registry row is what
+    makes first_seen and account-switch survival work, and dropping it on a
+    permissions blip loses the last account this host actually saw.
 
 M6 is the one that matters most and the one a percent-only suite cannot see: it
 colours from a provider's status rather than from used_percent. Every threshold
@@ -45,7 +50,8 @@ SUITE = "tests/test_quota_accounts_ui.py"
 THRESHOLDS = ('const anQuotaClass = (pct) => pct == null ? "" : '
               'pct >= 95 ? " red" : pct >= 80 ? " amber" : "";')
 FILL_GUARD = "  if (pct != null) {"
-MUTED = '  const muted = !current || status === "unauth";'
+MUTED = '  const muted = !current || status === "unauth" || status === "na";'
+NA_GROUP_GATE = '    if (statusOf.get(name)?.status === "na" && !known.has(name)) continue;'
 WINS = "  const wins = [...(acct.windows || [])].sort((a, b) => anWindowRank(a) - anWindowRank(b));"
 GROUP_ORDER = ("  for (const name of [...providers.map((p) => p.provider), "
                "...accounts.map((a) => a.provider)]) {")
@@ -110,11 +116,12 @@ MUTATIONS = [
         "  for (const name of accounts.map((a) => a.provider)) {",
     ),
     (
-        "M8 `na` stops being skipped — a missing credential file renders a "
-        "card, which is the absence of a limit shown as a limit",
-        "na_provider_renders_no_card",
-        '    if (groups.has(name) || statusOf.get(name)?.status === "na") continue;',
-        "    if (groups.has(name)) continue;",
+        "M8 `na` stops being skipped even with nothing in the registry — a "
+        "provider this host has never seen renders a card, which is the "
+        "absence of a limit shown as a limit",
+        "na_provider_with_no_registry_row",
+        NA_GROUP_GATE,
+        "    if (false) continue;",
     ),
     (
         "M9 a NULL percent draws its bar anyway — labelled n/a, drawn as a "
@@ -149,14 +156,14 @@ MUTATIONS = [
         "full emphasis, reading as live",
         "non_current_account",
         MUTED,
-        '  const muted = status === "unauth";',
+        '  const muted = status === "unauth" || status === "na";',
     ),
     (
         "M14 muted loses the unauth half — an expired token's last-known "
         "numbers render as if they were measured now",
         "unauth_keeps_last_known",
         MUTED,
-        "  const muted = !current;",
+        '  const muted = !current || status === "na";',
     ),
     (
         "M15 the card's age comes from last_seen rather than the newest "
@@ -262,6 +269,42 @@ MUTATIONS = [
         "failed_refresh",
         "    btn.disabled = false;\n    btn.textContent = label;",
         "    void label;",
+    ),
+    # ── the registry/status disagreement (spec 49 §"can disagree") ────────────
+    # Four legs, because the ruling is a BALANCE and every single-leg fix trades
+    # one failure for the other. M29 is the pre-ruling source exactly as it
+    # shipped in the first push of #605 — it is here so the regression cannot
+    # come back quietly.
+    (
+        "M29 muted loses the `na` half — the credential file is gone but the "
+        "card renders at full emphasis, which is the pre-ruling behaviour",
+        "na_provider_keeps_its_registry_card",
+        MUTED,
+        '  const muted = !current || status === "unauth";',
+    ),
+    (
+        "M30 refresh stays enabled on an `na` card — the button-that-lies "
+        "shape arriving from the status side instead of the registry side",
+        "na_provider_keeps_its_registry_card",
+        '  } else if (status === "na") {',
+        "  } else if (false) {",
+    ),
+    (
+        "M31 the `na` group is dropped whenever the provider reports it, not "
+        "only when the registry is empty — the account the host last saw is "
+        "thrown away on a permissions blip. The MIRROR of M29/M30: a fix that "
+        "merely hides the card also stops it lying, and this leg refuses it",
+        "na_provider_keeps_its_registry_card",
+        NA_GROUP_GATE,
+        '    if (statusOf.get(name)?.status === "na") continue;',
+    ),
+    (
+        "M32 `na` reuses the sign-out wording — the panel infers WHY the file "
+        "is missing instead of reporting what was observed, and an operator "
+        "mid-login is told they signed out",
+        "reported_as_observed",
+        '    "no readable credential file — last known"));',
+        '    "signed out — last known"));',
     ),
 ]
 

--- a/tests/mutations/u4_quota_accounts_ui.py
+++ b/tests/mutations/u4_quota_accounts_ui.py
@@ -1,0 +1,319 @@
+"""Mutation round trips for sprint 52 U4 — the Account Analytics UI.
+
+Acceptance evidence, committed rather than run once in a session that dies with
+it (the U1/U2/U3 convention). Each entry breaks ONE property in the real source,
+asserts the test claiming to pin it actually goes RED, restores the file, and
+asserts it goes green again. A property whose mutation stays green is not
+pinned, whatever the suite's colour says.
+
+    python3 tests/mutations/u4_quota_accounts_ui.py [-v]
+
+Asked per PROPERTY, not per test. Three of this unit's rules have TWO failure
+directions each, and a one-directional leg is satisfied by a fix that merely
+trades the bug for its mirror image — the shape U2's reviewer caught mid-sprint:
+
+  * n/a versus a measured zero: M9 draws a bar under an absent number (a meter
+    reads as measured), M11 swallows a REAL 0% into n/a. Either alone blesses
+    the other.
+  * the seven-day note: M16 renders it on every page, M17 on none. "Never an
+    empty page" and "not a note nobody reads" are different requirements living
+    in one condition.
+  * muted: M13 drops the signed-out half, M14 drops the unauth half. One
+    condition, two independent reasons a card is not current.
+
+M6 is the one that matters most and the one a percent-only suite cannot see: it
+colours from a provider's status rather than from used_percent. Every threshold
+test would stay green under it, because they all use consistent fixtures — only
+the deliberately-contradictory card (an `error` provider at 22%) reddens.
+
+Not named test_*.py on purpose: pytest must not collect it — it edits tracked
+source. Every file is restored in a `finally`, so an interrupted run still
+leaves the tree clean; `git diff` after a run is the check.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / ".super-coder" / "ui" / "app.js"
+SUITE = "tests/test_quota_accounts_ui.py"
+
+THRESHOLDS = ('const anQuotaClass = (pct) => pct == null ? "" : '
+              'pct >= 95 ? " red" : pct >= 80 ? " amber" : "";')
+FILL_GUARD = "  if (pct != null) {"
+MUTED = '  const muted = !current || status === "unauth";'
+WINS = "  const wins = [...(acct.windows || [])].sort((a, b) => anWindowRank(a) - anWindowRank(b));"
+GROUP_ORDER = ("  for (const name of [...providers.map((p) => p.provider), "
+               "...accounts.map((a) => a.provider)]) {")
+NOTE_GATE = "  if (accounts.length && !accounts.some(fresh))"
+DISPATCH = "  return anView === \"accounts\" ? anAccountSection(body) : anTokenSection(body);"
+
+# (label, -k selector, old, new)
+MUTATIONS = [
+    (
+        "M1 the amber bar moves to 90 — the threshold TABLE is the deliverable, "
+        "so pinning 'some colour rule ran' is not enough",
+        "threshold_driven",
+        THRESHOLDS,
+        'const anQuotaClass = (pct) => pct == null ? "" : '
+        'pct >= 95 ? " red" : pct >= 90 ? " amber" : "";',
+    ),
+    (
+        "M2 the red bar moves to 90 — an 80-only suite would not notice",
+        "threshold_driven",
+        THRESHOLDS,
+        'const anQuotaClass = (pct) => pct == null ? "" : '
+        'pct >= 90 ? " red" : pct >= 80 ? " amber" : "";',
+    ),
+    (
+        "M3 the bounds go strict — 80.0 and 95.0 exactly, the two values a "
+        "provider reports most often, fall a class short",
+        "threshold_driven",
+        THRESHOLDS,
+        'const anQuotaClass = (pct) => pct == null ? "" : '
+        'pct > 95 ? " red" : pct > 80 ? " amber" : "";',
+    ),
+    (
+        "M4 an ABSENT percent is painted normal-green rather than left "
+        "uncoloured — the reassuring colour is the wrong default for a number "
+        "we do not have",
+        "null_percent_reads_na",
+        THRESHOLDS,
+        'const anQuotaClass = (pct) => pct == null ? " amber" : '
+        'pct >= 95 ? " red" : pct >= 80 ? " amber" : "";',
+    ),
+    (
+        "M5 the meter is unclamped — a provider reporting over 100 overflows "
+        "the track instead of filling it",
+        "threshold_driven",
+        "    fill.style.width = Math.max(0, Math.min(100, pct)) + \"%\";",
+        "    fill.style.width = pct + \"%\";",
+    ),
+    (
+        "M6 COLOUR IS TAKEN FROM THE PROVIDER'S STATUS instead of used_percent "
+        "— openai's limit_reached painted red at 22%. Every consistent fixture "
+        "stays green under this; only the contradictory card reddens",
+        "provider_status_never_decides_colour",
+        "  for (const w of wins) card.append(anWindowRow(w));",
+        "  for (const w of wins) card.append(anWindowRow("
+        "status === \"error\" ? { ...w, used_percent: 100 } : w));",
+    ),
+    (
+        "M7 the accounts array drives provider state — the status list is "
+        "ignored, so a provider that failed before naming anybody vanishes",
+        "error_before_identification",
+        GROUP_ORDER,
+        "  for (const name of accounts.map((a) => a.provider)) {",
+    ),
+    (
+        "M8 `na` stops being skipped — a missing credential file renders a "
+        "card, which is the absence of a limit shown as a limit",
+        "na_provider_renders_no_card",
+        '    if (groups.has(name) || statusOf.get(name)?.status === "na") continue;',
+        "    if (groups.has(name)) continue;",
+    ),
+    (
+        "M9 a NULL percent draws its bar anyway — labelled n/a, drawn as a "
+        "0% meter, which is exactly 'a zero rendered as if measured'",
+        "null_percent_reads_na or moonshot_all_null or zero_limit",
+        FILL_GUARD,
+        "  if (true) {",
+    ),
+    (
+        "M10 a NULL percent reads 0% — the same defect in the text rather "
+        "than the bar",
+        "null_percent_reads_na or moonshot_all_null or zero_limit",
+        'const anPct = (pct) => pct == null ? "n/a" : Math.round(pct * 10) / 10 + "%";',
+        'const anPct = (pct) => pct == null ? "0%" : Math.round(pct * 10) / 10 + "%";',
+    ),
+    (
+        "M11 THE MIRROR TRADE: n/a swallows a genuinely measured 0%. A fix for "
+        "M9/M10 that lands here has moved the bug, not removed it",
+        "real_zero_percent",
+        'const anPct = (pct) => pct == null ? "n/a" : Math.round(pct * 10) / 10 + "%";',
+        'const anPct = (pct) => !pct ? "n/a" : Math.round(pct * 10) / 10 + "%";',
+    ),
+    (
+        "M12 refresh is enabled on a signed-out card — a button that fires a "
+        "probe which provably cannot change the card it sits on",
+        "non_current_account or non_current_codex",
+        "  if (!current) {",
+        "  if (false) {",
+    ),
+    (
+        "M13 muted loses the signed-out half — the non-current card renders at "
+        "full emphasis, reading as live",
+        "non_current_account",
+        MUTED,
+        '  const muted = status === "unauth";',
+    ),
+    (
+        "M14 muted loses the unauth half — an expired token's last-known "
+        "numbers render as if they were measured now",
+        "unauth_keeps_last_known",
+        MUTED,
+        "  const muted = !current;",
+    ),
+    (
+        "M15 the card's age comes from last_seen rather than the newest "
+        "capture — a three-hour-old snapshot reports itself as minutes old, "
+        "which is the one thing the age exists to prevent",
+        "unauth_keeps_last_known",
+        "  return caps.length ? caps[caps.length - 1] : acct.last_seen;",
+        "  return acct.last_seen;",
+    ),
+    (
+        "M16 the seven-day note renders on EVERY page — a warning that is "
+        "always on is a warning nobody reads",
+        "fresh_account_carries_no_stale_note",
+        NOTE_GATE,
+        "  if (accounts.length)",
+    ),
+    (
+        "M17 the note never renders — the all-stale page then reads as the "
+        "whole truth about the last week",
+        "every_account_stale",
+        NOTE_GATE,
+        "  if (false)",
+    ),
+    (
+        "M18 an unrecognized window is FILTERED OUT — the probe stores it "
+        "under its raw duration specifically so the panel can show it",
+        "unrecognized_window",
+        WINS,
+        "  const wins = [...(acct.windows || [])]"
+        ".filter((w) => AN_WINDOW_LABEL[w.window_kind])"
+        ".sort((a, b) => anWindowRank(a) - anWindowRank(b));",
+    ),
+    (
+        "M19 indexOf's -1 is used raw, so an unrecognized window sorts FIRST "
+        "— the natural way to get the rank table wrong",
+        "unrecognized_window",
+        "  return i < 0 ? AN_WINDOW_ORDER.length : i;",
+        "  return i;",
+    ),
+    (
+        "M20 the UI re-sorts the accounts — the API's current-first ordering "
+        "stops surviving, and the current account is what the operator came for",
+        "non_current_account",
+        "  for (const a of accounts) groups.get(a.provider)?.accounts.push(a);",
+        "  for (const a of [...accounts].sort((x, y) => String(x.account_label)"
+        ".localeCompare(String(y.account_label)))) groups.get(a.provider)?.accounts.push(a);",
+    ),
+    (
+        "M21 the label is truncated to its local part — decision #67 withdrew "
+        "exactly this, because jed@gmail.com and jed@work.com both reduce to "
+        "'jed' in the multi-account case the panel exists to show",
+        "full_account_label",
+        '  head.append(el("span", { className: "an-acct-label" }, acct.account_label || acct.account_ref));',
+        '  head.append(el("span", { className: "an-acct-label" }, '
+        'String(acct.account_label || acct.account_ref).split("@")[0]));',
+    ),
+    (
+        "M22 a reset already past renders as negative time rather than 'due'",
+        "countdown",
+        '  return ms <= 0 ? "due" : "in " + anDuration(ms);',
+        '  return "in " + anDuration(ms);',
+    ),
+    (
+        "M23 the router branch goes — #analytics-accounts falls through to the "
+        "default view and the deep link is dead",
+        "hash_routes or unknown_hash",
+        '  if (raw === "analytics" || raw.startsWith("analytics-")) {',
+        "  if (false) {",
+    ),
+    (
+        "M24 the branch matches but ignores which sub-view it matched — the "
+        "deep link lands on Token Analytics",
+        "hash_routes",
+        '    anView = raw === "analytics-accounts" ? "accounts" : "tokens";',
+        '    anView = "tokens";',
+    ),
+    (
+        "M25 the toggle re-renders in place instead of setting the hash — the "
+        "section works but stops surviving a reload, which is a spec checkbox",
+        "deep_linkable",
+        '    b.onclick = () => { location.hash = mode === "accounts" ? "analytics-accounts" : "analytics"; };',
+        "    b.onclick = () => { anView = mode; renderAnalytics(root); };",
+    ),
+    (
+        "M26 arrival POSTs the force-probe — the 60s TTL is defeated from the "
+        "client, so toggling twice inside a minute hits three endpoints twice",
+        "arrival_probes_once",
+        '    anDrawAccounts(root, await api("/analytics/accounts"));',
+        '    anDrawAccounts(root, await api("/analytics/accounts/probe", "POST"));',
+    ),
+    (
+        "M27 both sections run on every arrival — reading token spend now "
+        "costs three third-party calls, which is what the spec's 'probe fires "
+        "ONLY on arrival at this section' forbids",
+        "each_section_fires_only_its_own_work",
+        DISPATCH,
+        "  await anTokenSection(body);\n"
+        "  return anView === \"accounts\" ? anAccountSection(body) : undefined;",
+    ),
+    (
+        "M28 a failed refresh leaves the button wedged in 'probing…' — the "
+        "operator's only retry is a page reload",
+        "failed_refresh",
+        "    btn.disabled = false;\n    btn.textContent = label;",
+        "    void label;",
+    ),
+]
+
+
+def clear_caches() -> None:
+    for cache in ROOT.rglob("__pycache__"):
+        shutil.rmtree(cache, ignore_errors=True)
+
+
+def run(selector: str) -> bool:
+    """True when the selected tests pass, run on source rather than bytecode."""
+    clear_caches()
+    env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", SUITE, "-q", "-k", selector],
+        cwd=ROOT, capture_output=True, text=True, env=env)
+    return proc.returncode == 0
+
+
+def main() -> int:
+    verbose = "-v" in sys.argv
+    failures = []
+    for label, selector, old, new in MUTATIONS:
+        original = APP.read_text()
+        if original.count(old) != 1:
+            failures.append(f"{label}: anchor found {original.count(old)}x, "
+                            "expected exactly 1 — the driver has drifted from "
+                            "the source")
+            print(f"[FAIL] {label}\n       anchor is not unique")
+            continue
+        try:
+            APP.write_text(original.replace(old, new, 1))
+            red = not run(selector)
+        finally:
+            APP.write_text(original)
+        green = run(selector)
+        ok = red and green
+        if not ok:
+            failures.append(
+                f"{label}: mutated={'RED' if red else 'GREEN (NOT PINNED)'} "
+                f"restored={'green' if green else 'RED (dirty revert)'}")
+        print(f"[{'ok' if ok else 'FAIL'}] {label}\n       {SUITE} "
+              f"-k {selector}: {'red' if red else 'STAYED GREEN'} -> "
+              f"{'green' if green else 'STILL RED'}")
+        if verbose and not ok:
+            print("       ^ this property is not actually pinned")
+    print(f"\n{len(MUTATIONS) - len(failures)}/{len(MUTATIONS)} round trips "
+          "behaved (red under mutation, green on revert)")
+    for line in failures:
+        print("  FAIL " + line)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_quota_accounts_ui.py
+++ b/tests/test_quota_accounts_ui.py
@@ -348,10 +348,14 @@ def test_a_real_zero_percent_still_draws_a_measured_zero():
 
 # ── per-provider status list ─────────────────────────────────────────────────
 
-def test_na_provider_renders_no_card_at_all():
-    """A missing credential file is not a limit of zero — it is no card. Asserted
-    against a payload where another provider IS configured, so "renders nothing"
-    cannot pass by the whole section being empty."""
+def test_na_provider_with_no_registry_row_renders_no_card_at_all():
+    """A missing credential file is not a limit of zero — and with nothing in the
+    registry for that provider there is nothing to show, so it is no card.
+    Asserted against a payload where another provider IS configured, so "renders
+    nothing" cannot pass by the whole section being empty.
+
+    The narrow case: no registry row. When a row DOES exist the card survives —
+    the two tests below are the other half, and neither is safe alone."""
     r = run_js("""
       const r0 = root(); anDrawAccounts(r0, PAYLOAD);
       out({ groups: texts(byClass(r0, "an-prov-head")), cards: byClass(r0, "an-acct").length,
@@ -364,6 +368,67 @@ def test_na_provider_renders_no_card_at_all():
     assert r["groups"] == ["Claudeanthropic"]
     assert r["cards"] == 1
     assert "Codex" not in r["body"] and "Kimi" not in r["body"]
+
+
+def test_na_provider_keeps_its_registry_card_muted_with_refresh_disabled():
+    """The credential file is removed WITHOUT switching accounts (spec 49, "the
+    registry and the status list can disagree"). The row keeps is_current, and
+    is_current is exempt from the 7-day filter, so this card would otherwise
+    render forever — unmuted, looking live, with a refresh that provably cannot
+    change it, while the same response reports the provider `na`.
+
+    Both failure directions are asserted here, because they are each other's
+    cure: filtering the card out (direction 1) throws away the last account this
+    host saw, and rendering it live (direction 2) is the button-that-lies shape
+    this unit already refused on the Codex exception. Passing needs the card to
+    EXIST and to be visibly last-known."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const cards = byClass(r0, "an-acct");
+      const btn = buttons(cards[0]).filter((b) => cls(b).includes("act"))[0];
+      out({ cards: cards.length, groups: texts(byClass(r0, "an-prov-head")),
+            muted: cls(cards[0]).includes("an-muted"),
+            disabled: btn.disabled, title: btn.title, onclick: btn.onclick !== null,
+            pct: texts(byClass(cards[0], "an-win-pct")), body: cards[0].textContent });
+    """, payload(
+        accounts=[account(is_current=1,
+                          windows=[window(pct=61.0, captured_at=iso(hours=-3))])],
+        providers=[{"provider": "anthropic", "status": "na", "detail": None}]))
+    # direction 1 — the registry row survives the status disagreeing with it.
+    assert r["cards"] == 1 and r["groups"] == ["Claudeanthropic"]
+    assert r["pct"] == ["61%"]          # last known values kept, not blanked
+    # direction 2 — and it does not present as live.
+    assert r["muted"] is True
+    assert r["disabled"] is True and r["onclick"] is False
+    assert "credential file" in r["title"]
+    assert "snapshot 3h ago" in r["body"]
+
+
+def test_na_is_reported_as_observed_not_inferred_as_a_sign_out():
+    """`na` means the engine could not read a credential file — which is a
+    different fact from an account the operator switched away from, and from a
+    token the provider rejected. Rendering all three with one string would be an
+    inference about WHY, and the operator may simply be mid-login.
+
+    Asserted by rendering all three and comparing, so reusing one wording for
+    another fails: an assertion that `na` merely "says something" would pass
+    against exactly the collapse this pins."""
+    def body(accounts, providers):
+        return run_js("""
+          const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+          out({ body: byClass(r0, "an-acct")[0].textContent });
+        """, payload(accounts=accounts, providers=providers))["body"]
+
+    na = body([account(is_current=1)],
+              [{"provider": "anthropic", "status": "na", "detail": None}])
+    unauth = body([account(is_current=1)],
+                  [{"provider": "anthropic", "status": "unauth", "detail": "expired"}])
+    switched = body([account(is_current=0, last_seen=iso(days=-2))],
+                    [{"provider": "anthropic", "status": "ok", "detail": None}])
+
+    assert "no readable credential file" in na
+    assert "not signed in" not in na and "signed out" not in na
+    assert na != unauth and na != switched
 
 
 def test_error_before_identification_still_renders_a_card_with_its_status():

--- a/tests/test_quota_accounts_ui.py
+++ b/tests/test_quota_accounts_ui.py
@@ -1,0 +1,595 @@
+"""Account Analytics UI (spec #49 U4): toggle, router, cards, thresholds.
+
+Driven through node against the REAL app.js regions with a minimal DOM — the
+same idiom as the interface UI contract suite — rather than grepping the source
+for strings. A string assertion passes against a function nobody calls; these
+render the section and read what came out.
+
+The unit's value rests on two properties, and both are about not lying about a
+number, so both are asked in both directions:
+
+  * COLOUR IS COMPUTED FROM used_percent ALONE. Asserting "96% is red" leaves a
+    reading of a provider's own severity field entirely free, so every colour
+    test also pins a card whose provider status disagrees with its percent —
+    an `error` provider at 22% must still render normal, and an `ok` provider at
+    96% must still render red.
+  * A MISSING NUMBER IS NEVER DRAWN AS ZERO. Asserting "n/a is shown" leaves a
+    0%-wide bar free to be drawn under the label, which is the failure mode the
+    spec names: a meter reads as measured. So every n/a test asserts the text
+    AND the absence of a fill element.
+
+The per-provider status list gets the same treatment: `na` and an empty accounts
+array are asserted to render differently, because collapsing them is precisely
+what the status list exists to prevent.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
+CSS = (ROOT / ".super-coder" / "ui" / "style.css").read_text()
+
+EL = APP[APP.index("const el ="):APP.index("const esc =")]
+# fmt / microlabel / statRow — sliced, not restated, so a card's meta row is
+# rendered by the app's own helper.
+HELPERS = APP[APP.index("const fmt = (n)"):APP.index("// On/off switch")]
+ACCOUNTS = APP[APP.index("// ── Account Analytics"):APP.index("// ── Interface tab")]
+_ROUTER_AT = APP.index("function routeFromHash()")
+ROUTER = APP[_ROUTER_AT:
+             APP.index('document.querySelectorAll("nav button").forEach', _ROUTER_AT)]
+
+HAS_NODE = shutil.which("node") is not None
+pytestmark = pytest.mark.skipif(not HAS_NODE, reason="node is required")
+
+
+def iso(**delta) -> str:
+    return (datetime.now(timezone.utc) + timedelta(**delta)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def window(kind="weekly", pct=10.0, **over) -> dict:
+    """One harness_quota_window row as GET /api/analytics/accounts sends it."""
+    row = {"window_pk": 1, "window_kind": kind, "scope": None, "used_percent": pct,
+           "used": None, "limit_value": None, "resets_at": iso(hours=3),
+           "captured_at": iso(minutes=-2), "status": "ok", "probe_version": "1"}
+    row.update(over)
+    return row
+
+
+def account(provider="anthropic", **over) -> dict:
+    row = {"account_pk": 1, "provider": provider, "account_ref": "ref-1",
+           "account_label": "jed@person.com", "plan": "max",
+           "first_seen": iso(days=-30), "last_seen": iso(minutes=-2),
+           "is_current": 1, "windows": [window()]}
+    row.update(over)
+    return row
+
+
+def payload(accounts=None, providers=None, **over) -> dict:
+    d = {"accounts": [account()] if accounts is None else accounts,
+         "activity_days": 7, "ttl_seconds": 60, "probed": True,
+         "providers": ([{"provider": "anthropic", "status": "ok", "detail": None}]
+                       if providers is None else providers),
+         "notes": []}
+    d.update(over)
+    return d
+
+
+HARNESS = r"""
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag; this.nodeType = 1; this.children = [];
+    this._text = ""; this.className = ""; this.disabled = false;
+    this.title = ""; this.style = {}; this.onclick = null;
+  }
+  append(...nodes) { this.children.push(...nodes); }
+  replaceChildren(...nodes) { this.children = [...nodes]; this._text = ""; }
+  set textContent(value) { this._text = String(value ?? ""); this.children = []; }
+  get textContent() {
+    return this._text + this.children.map(
+      (c) => typeof c === "string" ? c : (c.textContent || "")).join("");
+  }
+}
+globalThis.document = {
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({ nodeType: 3, textContent: String(text ?? "") }),
+};
+globalThis.location = { hash: "" };
+
+let calls = [];
+let toasts = [];
+let tokenSectionRuns = 0;
+let apiFail = null;
+async function api(path, method = "GET", body) {
+  calls.push({ path, method: method || "GET" });
+  if (apiFail) throw new Error(apiFail);
+  return PAYLOAD;
+}
+function toast(msg) { toasts.push(String(msg)); }
+// The token section is stubbed so "arriving at accounts never sweeps" is
+// observable: a real one would fire /analytics/sweep into the same recorder.
+async function anTokenSection(root) {
+  tokenSectionRuns += 1;
+  await api("/analytics/sweep", "POST");
+  root.replaceChildren(new FakeElement("div"));
+}
+let anView = "tokens";
+
+// routeFromHash's collaborators. `show` records rather than renders, so the
+// nav-tab claim is checked as a value and not as a side effect.
+let roadmapView = null, ifSelected = null, shown = [];
+const VIEWS = { analytics: 1, roadmap: 1, interface: 1, shells: 1, docs: 1 };
+function show(tab) { shown.push(tab); }
+
+function all(root, pred, found = []) {
+  if (pred(root)) found.push(root);
+  for (const c of root.children || []) if (c && c.nodeType === 1) all(c, pred, found);
+  return found;
+}
+const cls = (n) => String(n.className || "").split(" ").filter(Boolean);
+const byClass = (root, name) => all(root, (n) => cls(n).includes(name));
+const buttons = (root) => all(root, (n) => n.tagName === "button");
+const texts = (nodes) => nodes.map((n) => n.textContent);
+function out(obj) { console.log(JSON.stringify(obj)); }
+function root() { return new FakeElement("div"); }
+"""
+
+
+def run_js(body: str, data: dict | None = None) -> dict:
+    script = ("const PAYLOAD = " + json.dumps(data or payload()) + ";\n"
+              + EL + HELPERS + HARNESS + ACCOUNTS + ROUTER
+              + "\n(async () => {\n" + body + "\n})().catch((e) => {"
+              " console.error(e.stack || e); process.exit(1); });\n")
+    proc = subprocess.run(["node", "-e", script], text=True, capture_output=True)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+# ── router + toggle ──────────────────────────────────────────────────────────
+
+def test_accounts_hash_routes_to_the_analytics_tab_as_a_sub_view():
+    """#analytics-accounts is a URL, and `analytics` stays the active nav tab —
+    the #roadmap / #roadmap-flow convention. Both halves matter: routing to a
+    tab of its own would lose the toggle, and not routing at all would fall
+    through to the default view."""
+    r = run_js("""
+      const seen = [];
+      for (const hash of ["#analytics-accounts", "#analytics", "#analytics-accounts"]) {
+        location.hash = hash; routeFromHash();
+        seen.push({ view: anView, tab: shown[shown.length - 1] });
+      }
+      location.hash = "#roadmap-flow"; routeFromHash();
+      out({ seen, roadmapTab: shown[shown.length - 1], roadmapView, viewAfter: anView });
+    """)
+    assert r["seen"] == [{"view": "accounts", "tab": "analytics"},
+                         {"view": "tokens", "tab": "analytics"},
+                         {"view": "accounts", "tab": "analytics"}]
+    # The new branch must not swallow the roadmap sub-view it was modelled on.
+    assert r["roadmapTab"] == "roadmap" and r["roadmapView"] == "flow"
+    assert r["viewAfter"] == "accounts"
+
+
+def test_unknown_hash_still_falls_through_to_the_default_view():
+    r = run_js("""
+      location.hash = "#nonsense"; routeFromHash();
+      out({ tab: shown[shown.length - 1] });
+    """)
+    assert r["tab"] == "shells"
+
+
+def test_toggle_navigates_by_hash_so_the_sub_view_is_deep_linkable():
+    """Clicking must set the hash, not re-render in place: a toggle that
+    re-renders directly leaves the URL behind and the section stops surviving a
+    reload — which is one of the spec's verification checkboxes."""
+    r = run_js("""
+      const a = root(); anView = "tokens"; await renderAnalytics(a);
+      const chips = buttons(a).filter((b) => cls(b).includes("chip"));
+      const labels = texts(chips);
+      const active = texts(chips.filter((b) => cls(b).includes("on")));
+      chips[1].onclick();
+      const afterAccounts = location.hash;
+      const b = root(); anView = "accounts"; await renderAnalytics(b);
+      const chips2 = buttons(b).filter((x) => cls(x).includes("chip"));
+      const active2 = texts(chips2.filter((x) => cls(x).includes("on")));
+      chips2[0].onclick();
+      out({ labels, active, active2, afterAccounts, afterTokens: location.hash });
+    """)
+    assert r["labels"] == ["Token Analytics", "Account Analytics"]
+    assert r["active"] == ["Token Analytics"] and r["active2"] == ["Account Analytics"]
+    assert r["afterAccounts"] == "analytics-accounts"
+    assert r["afterTokens"] == "analytics"
+
+
+def test_each_section_fires_only_its_own_work_on_arrival():
+    """The token sweep and the account probe both fire on entry. Arriving at one
+    must not run the other: reading token spend would otherwise cost three
+    third-party calls, and the probe is specified to fire ONLY here."""
+    r = run_js("""
+      anView = "accounts"; await renderAnalytics(root());
+      const onAccounts = { calls: calls.map((c) => c.path + " " + c.method), token: tokenSectionRuns };
+      calls = []; tokenSectionRuns = 0;
+      anView = "tokens"; await renderAnalytics(root());
+      out({ onAccounts, onTokens: { calls: calls.map((c) => c.path + " " + c.method),
+                                    token: tokenSectionRuns } });
+    """)
+    assert r["onAccounts"] == {"calls": ["/analytics/accounts GET"], "token": 0}
+    assert r["onTokens"] == {"calls": ["/analytics/sweep POST"], "token": 1}
+
+
+def test_arrival_probes_once_and_never_forces_the_ttl():
+    """GET is the arrival probe — the route decides for itself whether the TTL
+    has aged out. A client that also POSTs would defeat the TTL outright and
+    make "toggling twice inside a minute performs one probe" false."""
+    r = run_js("""
+      await anAccountSection(root());
+      out({ calls: calls.map((c) => c.path + " " + c.method) });
+    """)
+    assert r["calls"] == ["/analytics/accounts GET"]
+
+
+def test_section_reports_a_failed_read_instead_of_rendering_an_empty_panel():
+    r = run_js("""
+      apiFail = "HTTP 500";
+      const r0 = root(); await anAccountSection(r0);
+      out({ text: r0.textContent });
+    """)
+    assert "error: HTTP 500" in r["text"]
+
+
+# ── thresholds: colour from used_percent alone ───────────────────────────────
+
+THRESHOLD_CASES = [(0.0, ""), (79.9, ""), (80.0, "amber"), (94.9, "amber"),
+                   (95.0, "red"), (100.0, "red"), (140.0, "red")]
+
+
+@pytest.mark.parametrize("pct,expected", THRESHOLD_CASES)
+def test_meter_colour_is_threshold_driven(pct, expected):
+    r = run_js("""
+      const r0 = root();
+      anDrawAccounts(r0, PAYLOAD);
+      const pctNode = byClass(r0, "an-win-pct")[0];
+      const fill = byClass(r0, "an-meter-fill")[0];
+      out({ pctClasses: cls(pctNode), fillClasses: cls(fill), width: fill.style.width,
+            text: pctNode.textContent });
+    """, payload(accounts=[account(windows=[window(pct=pct)])]))
+    tone = [c for c in r["pctClasses"] if c in ("amber", "red")]
+    assert tone == ([expected] if expected else [])
+    assert [c for c in r["fillClasses"] if c in ("amber", "red")] == ([expected] if expected else [])
+    # Over 100 fills the track rather than overflowing it.
+    assert r["width"] == f"{min(100.0, pct):g}%"
+
+
+def test_provider_status_never_decides_colour():
+    """The other direction, and the one a percent-only test leaves free: an
+    `error` provider at 22% must render normal and an `ok` provider at 96% must
+    render red. Colouring off the provider's own vocabulary is exactly what the
+    spec forbids — anthropic says severity=normal at 22%, openai says
+    limit_reached at 100%, moonshot says nothing."""
+    data = payload(
+        accounts=[account(provider="openai", account_pk=1, windows=[window(pct=22.0)]),
+                  account(provider="anthropic", account_pk=2, account_ref="ref-2",
+                          windows=[window(pct=96.0)])],
+        providers=[{"provider": "openai", "status": "error", "detail": "HTTP 429"},
+                   {"provider": "anthropic", "status": "ok", "detail": None}])
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ tones: byClass(r0, "an-win-pct").map((n) => cls(n).filter((c) => c !== "an-win-pct")),
+            texts: texts(byClass(r0, "an-win-pct")) });
+    """, data)
+    assert r["tones"] == [[], ["red"]]
+    assert r["texts"] == ["22%", "96%"]
+
+
+# ── never render a zero as if measured ───────────────────────────────────────
+
+def test_null_percent_reads_na_and_draws_no_bar():
+    """All three halves. The text alone would pass while a 0%-wide fill sat under
+    it, and a meter with a bar reads as measured however it is labelled — and the
+    label itself must carry NO threshold colour, because an absent number is not
+    a comfortable one."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const pctNode = byClass(r0, "an-win-pct")[0];
+      out({ text: texts(byClass(r0, "an-win-pct")), fills: byClass(r0, "an-meter-fill").length,
+            meters: byClass(r0, "an-meter").length,
+            tone: cls(pctNode).filter((c) => c !== "an-win-pct") });
+    """, payload(accounts=[account(windows=[window(pct=None)])]))
+    assert r["text"] == ["n/a"]
+    assert r["fills"] == 0
+    assert r["tone"] == []
+    assert r["meters"] == 1  # the empty track still renders — the row is not dropped
+
+
+def test_moonshot_all_null_row_renders_as_na_rather_than_zero_or_nothing():
+    """Moonshot `usage: {}` emits one all-null weekly row where openai emits
+    none — asymmetric but truthful (U2's reviewer). It must neither be filtered
+    out nor drawn as 0%."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ rows: byClass(r0, "an-win").length, pct: texts(byClass(r0, "an-win-pct")),
+            fills: byClass(r0, "an-meter-fill").length, name: texts(byClass(r0, "an-win-name")) });
+    """, payload(
+        accounts=[account(provider="moonshot", account_label="usr-9",
+                          windows=[window(kind="weekly", pct=None, used=None,
+                                          limit_value=None, resets_at=None)])],
+        providers=[{"provider": "moonshot", "status": "ok", "detail": None}]))
+    assert r["rows"] == 1 and r["pct"] == ["n/a"] and r["fills"] == 0
+    assert r["name"] == ["Weekly"]
+
+
+def test_zero_limit_renders_na_not_a_division():
+    """limit_value = 0 arrives with used_percent NULL (the probe never
+    back-computes). The counts still show, so the operator sees WHY it is n/a."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ pct: texts(byClass(r0, "an-win-pct")), fills: byClass(r0, "an-meter-fill").length,
+            body: r0.textContent });
+    """, payload(accounts=[account(windows=[window(pct=None, used=0, limit_value=0)])]))
+    assert r["pct"] == ["n/a"] and r["fills"] == 0
+    assert "0 / 0" in r["body"]
+
+
+def test_a_real_zero_percent_still_draws_a_measured_zero():
+    """The mirror of the n/a rule, so the fix cannot be "never draw a bar": a
+    provider that genuinely measured 0% renders 0%, not n/a."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ pct: texts(byClass(r0, "an-win-pct")), width: byClass(r0, "an-meter-fill")[0].style.width });
+    """, payload(accounts=[account(windows=[window(pct=0.0, used=0, limit_value=500)])]))
+    assert r["pct"] == ["0%"] and r["width"] == "0%"
+
+
+# ── per-provider status list ─────────────────────────────────────────────────
+
+def test_na_provider_renders_no_card_at_all():
+    """A missing credential file is not a limit of zero — it is no card. Asserted
+    against a payload where another provider IS configured, so "renders nothing"
+    cannot pass by the whole section being empty."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ groups: texts(byClass(r0, "an-prov-head")), cards: byClass(r0, "an-acct").length,
+            body: r0.textContent });
+    """, payload(
+        accounts=[account(provider="anthropic")],
+        providers=[{"provider": "anthropic", "status": "ok", "detail": None},
+                   {"provider": "openai", "status": "na", "detail": None},
+                   {"provider": "moonshot", "status": "na", "detail": None}]))
+    assert r["groups"] == ["Claudeanthropic"]
+    assert r["cards"] == 1
+    assert "Codex" not in r["body"] and "Kimi" not in r["body"]
+
+
+def test_error_before_identification_still_renders_a_card_with_its_status():
+    """The case the accounts array cannot express: the probe failed before it
+    could name anybody, so there is no registry row. Silence here would read as
+    "fine" — the spec requires a card carrying the HTTP status."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ cards: byClass(r0, "an-acct").length, body: r0.textContent });
+    """, payload(accounts=[], providers=[
+        {"provider": "openai", "status": "error", "detail": "HTTP 503"}]))
+    assert r["cards"] == 1
+    assert "HTTP 503" in r["body"] and "Codex" in r["body"]
+
+
+def test_nothing_configured_and_no_probe_yet_say_different_things():
+    """Both arrive as an empty accounts array. Collapsing them is what the
+    per-provider status list exists to prevent."""
+    all_na = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD); out({ body: r0.textContent });
+    """, payload(accounts=[], providers=[
+        {"provider": p, "status": "na", "detail": None}
+        for p in ("anthropic", "openai", "moonshot")]))
+    never = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD); out({ body: r0.textContent });
+    """, payload(accounts=[], providers=[]))
+    assert "No harness credentials found" in all_na["body"]
+    assert "No probe has run yet" in never["body"]
+    assert all_na["body"] != never["body"]
+
+
+def test_unauth_keeps_last_known_values_muted_with_their_age():
+    """Expiry is reported, not repaired: the numbers stay, the emphasis goes,
+    and the age says how old they are."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const card = byClass(r0, "an-acct")[0];
+      out({ muted: cls(card).includes("an-muted"), pct: texts(byClass(card, "an-win-pct")),
+            body: card.textContent });
+    """, payload(
+        accounts=[account(windows=[window(pct=61.0, captured_at=iso(hours=-3))])],
+        providers=[{"provider": "anthropic", "status": "unauth", "detail": "expired"}]))
+    assert r["muted"] is True
+    assert r["pct"] == ["61%"]
+    assert "signed out — last known" in r["body"]
+    assert "snapshot 3h ago" in r["body"]
+
+
+# ── the non-current account ──────────────────────────────────────────────────
+
+def test_non_current_account_is_muted_and_cannot_be_refreshed():
+    """Its token is gone, so the probe route cannot re-read it. The button is
+    disabled AND carries the reason — a disabled control with no explanation is
+    its own small lie."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const cards = byClass(r0, "an-acct");
+      const btn = (c) => buttons(c).filter((b) => cls(b).includes("act"))[0];
+      out({ order: byClass(r0, "an-acct-label").map((n) => n.textContent),
+            muted: cards.map((c) => cls(c).includes("an-muted")),
+            disabled: cards.map((c) => btn(c).disabled),
+            titles: cards.map((c) => btn(c).title),
+            notes: cards.map((c) => c.textContent.includes("not signed in")) });
+    """, payload(
+        # The current account's label sorts LAST alphabetically on purpose: with
+        # labels that happen to sort into API order, "the UI preserves the API's
+        # current-first order" is asserted by a fixture that cannot tell the
+        # difference. Caught by mutation M20, which was inert until this changed.
+        accounts=[account(account_pk=1, account_label="zed@person.com", is_current=1),
+                  account(account_pk=2, account_ref="ref-old", account_label="abe@person.com",
+                          is_current=0, last_seen=iso(days=-2))],
+        providers=[{"provider": "anthropic", "status": "ok", "detail": None}]))
+    assert r["order"] == ["zed@person.com", "abe@person.com"]  # API order preserved
+    assert r["muted"] == [False, True]
+    assert r["disabled"] == [False, True]
+    assert r["titles"][0] == "" and "cannot be re-probed" in r["titles"][1]
+    assert r["notes"] == [False, True]
+
+
+def test_non_current_codex_is_disabled_too_because_no_rollout_refresh_exists():
+    """Declared deviation, pinned so it cannot drift silently either way. The
+    spec grants Codex an exception — a non-current OpenAI account refreshed from
+    its rollout files — but no unit implements a rollout reader, so the only
+    action available is the global re-probe, which provably cannot change this
+    card. Enabling it would ship a button that lies. If a rollout path ever
+    lands, this test is the thing that must be changed on purpose."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const card = byClass(r0, "an-acct")[0];
+      const btn = buttons(card).filter((b) => cls(b).includes("act"))[0];
+      out({ disabled: btn.disabled, title: btn.title });
+    """, payload(
+        accounts=[account(provider="openai", is_current=0, account_label="old@codex.com",
+                          last_seen=iso(days=-1))],
+        providers=[{"provider": "openai", "status": "ok", "detail": None}]))
+    assert r["disabled"] is True
+    assert "cannot be re-probed" in r["title"]
+
+
+def test_refresh_forces_a_probe_and_redraws_from_its_response():
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const card = byClass(r0, "an-acct")[0];
+      const btn = buttons(card).filter((b) => cls(b).includes("act"))[0];
+      await btn.onclick();
+      out({ calls: calls.map((c) => c.path + " " + c.method),
+            cards: byClass(r0, "an-acct").length, toasts });
+    """)
+    assert r["calls"] == ["/analytics/accounts/probe POST"]
+    assert r["cards"] == 1 and r["toasts"] == []
+
+
+def test_a_failed_refresh_reports_and_re_enables_rather_than_wedging():
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const btn = buttons(r0).filter((b) => b.textContent.startsWith("refresh all"))[0];
+      apiFail = "boom";
+      await btn.onclick();
+      out({ toasts, disabled: btn.disabled, label: btn.textContent });
+    """)
+    assert r["toasts"] == ["probe error: boom"]
+    assert r["disabled"] is False
+    assert r["label"] == "refresh all ⟳"
+
+
+# ── the seven-day window ─────────────────────────────────────────────────────
+
+def test_every_account_stale_renders_the_current_one_with_a_note():
+    """Never an empty page. The API exempts is_current from the filter so the row
+    arrives; the UI's job is to say why the page is thin instead of letting it
+    read as the whole truth about the week."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ note: texts(byClass(r0, "an-note")), cards: byClass(r0, "an-acct").length });
+    """, payload(accounts=[account(last_seen=iso(days=-30))]))
+    assert r["cards"] == 1
+    assert r["note"] and "showing the current account only" in r["note"][0]
+    assert "7 days" in r["note"][0]
+
+
+def test_a_fresh_account_carries_no_stale_note():
+    """The other direction — a note on every page is a note nobody reads."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ note: byClass(r0, "an-note").length });
+    """, payload(accounts=[account(last_seen=iso(days=-30)), account(
+        account_pk=2, account_ref="ref-2", last_seen=iso(hours=-1))]))
+    assert r["note"] == 0
+
+
+# ── window rows ──────────────────────────────────────────────────────────────
+
+def test_unrecognized_window_renders_under_its_raw_kind_and_duration():
+    """The probe stores a window it could not map rather than dropping it,
+    precisely so the panel can show it. Dropping it here would waste that."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ names: texts(byClass(r0, "an-win-name")), rows: byClass(r0, "an-win").length });
+    """, payload(accounts=[account(windows=[
+        window(kind="weekly", pct=40.0),
+        window(kind="1209600 SECOND", pct=12.0, scope="1209600s"),
+        window(kind="weekly_scoped", pct=5.0, scope="claude-opus-5"),
+        window(kind="session", pct=88.0),
+        window(kind="five_hour", pct=3.0)])]))
+    # Known kinds in their own order, unrecognized last — never dropped.
+    assert r["names"] == ["Session", "5-hour", "Weekly", "Weekly · scoped · claude-opus-5",
+                          "1209600 SECOND · 1209600s"]
+    assert r["rows"] == 5
+
+
+def test_reset_renders_as_a_countdown_and_never_as_negative_time():
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ body: r0.textContent });
+    """, payload(accounts=[account(windows=[
+        window(kind="session", pct=1.0, resets_at=iso(hours=2, minutes=30)),
+        window(kind="weekly", pct=2.0, resets_at=iso(hours=-5)),
+        window(kind="short", pct=3.0, resets_at=None)])]))
+    assert "resets in 2h 29m" in r["body"] or "resets in 2h 30m" in r["body"]
+    assert "resets due" in r["body"]
+    assert "-" not in r["body"].split("resets")[2].split("status")[0]
+
+
+def test_an_account_with_no_windows_says_so_rather_than_rendering_blank():
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ body: r0.textContent, wins: byClass(r0, "an-win").length });
+    """, payload(accounts=[account(windows=[])]))
+    assert r["wins"] == 0
+    assert "no windows reported" in r["body"]
+
+
+def test_providers_render_in_the_dispatchers_order_with_their_accounts():
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ groups: byClass(r0, "an-prov-head").map((n) => n.textContent),
+            labels: byClass(r0, "an-acct-label").map((n) => n.textContent) });
+    """, payload(
+        accounts=[account(provider="anthropic", account_pk=1, account_label="a@x.com"),
+                  account(provider="openai", account_pk=2, account_ref="r2", account_label="o@x.com"),
+                  account(provider="moonshot", account_pk=3, account_ref="r3", account_label="usr-3")],
+        providers=[{"provider": p, "status": "ok", "detail": None}
+                   for p in ("anthropic", "openai", "moonshot")]))
+    assert r["groups"] == ["Claudeanthropic", "Codexopenai", "Kimimoonshot"]
+    assert r["labels"] == ["a@x.com", "o@x.com", "usr-3"]
+
+
+def test_the_full_account_label_is_rendered_unredacted():
+    """Decision #67: the label is stored and shown in full. Two accounts sharing
+    a local part are indistinguishable truncated, which is the one case this
+    panel exists to show."""
+    r = run_js("""
+      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      out({ labels: byClass(r0, "an-acct-label").map((n) => n.textContent) });
+    """, payload(accounts=[
+        account(account_pk=1, account_label="jed@gmail.com"),
+        account(account_pk=2, account_ref="r2", account_label="jed@work.com", is_current=0)]))
+    assert r["labels"] == ["jed@gmail.com", "jed@work.com"]
+
+
+# ── styles the thresholds depend on ──────────────────────────────────────────
+
+def test_threshold_classes_have_distinct_styling():
+    """The colour rule is only real if the classes differ visibly. Asserted here
+    because the JS tests can only see class names."""
+    for sel in (".an-win-pct.amber", ".an-win-pct.red",
+                ".an-meter-fill.amber", ".an-meter-fill.red",
+                ".an-acct.an-muted", ".an-acct-foot .act:disabled"):
+        assert sel in CSS, f"{sel} is not styled"


### PR DESCRIPTION
Sprint 52 unit 4 (board doc 52), spec doc 49. The surface half of the quota panel — the Analytics tab's second section, at its own URL, rendering what U3's routes return.

**MERGE GATE: this must not merge before U3 (#—, `feat/quota-api-routes`).** The section calls `GET /api/analytics/accounts` and `POST /api/analytics/accounts/probe`; merged first it would ship a UI whose routes 404. The diff is file-disjoint from U3 (`ui/*` vs `api/server.py`), so this is a sequencing gate, not a conflict.

## What lands

- `#analytics-accounts` joins `routeFromHash` beside the `#roadmap` / `#roadmap-flow` branch it is modelled on. `analytics` stays the active nav tab for both, and `renderAnalytics` dispatches on the sub-view.
- Each section renders into its **own node**, which is what keeps arrival at one from running the other's work. The token sweep and the account probe both fire on entry; firing both would cost three third-party calls every time someone reads their token spend.
- One card per account, grouped by provider, current first — label in full (decision #67), plan, a meter per window, the reset as a countdown, the snapshot age, and a per-card refresh.

## The two rules that carry the section

**Colour is computed from `used_percent` alone** — below 80 normal, 80+ amber, 95+ red — never from a provider's own severity field. Anthropic sends `severity: normal` at 22%, OpenAI `limit_reached: true` at 100%, Moonshot nothing; three vocabularies would be three colour rules on one page.

**A missing number is never drawn as a zero.** A NULL `used_percent` renders `n/a` with no bar and no threshold class — `limit_value = 0`, a moonshot all-null weekly row, a percent that could not be derived.

Provider state comes from the response's **per-provider status list**, never inferred from the accounts array: `na` renders no card at all, `error` before identification renders a card carrying its HTTP status, `unauth` keeps the last known values muted with their age. An empty accounts array means both *nothing configured* and *every probe failed* — which is why U3 sends that list.

## Trade-offs and declared calls

Two judgement calls, both declared to PLN2 **before** building and both ratified (msg #2011); spec doc 49 was corrected to match in its eighth edit.

1. **Refresh is disabled on every non-current card, Codex included.** The spec granted non-current OpenAI cards a refresh sourced from rollout files. Verified against U3's pushed head and the merged probe package: `git grep -n rollout` over `scripts/quota_probes/` and `api/server.py` returns **zero hits**, and `probe_all` resolves whatever the *current* credential files point at. The simpler-looking option — enable it so the UI matches the sentence — ships a control that provably cannot change the card it sits on. That is this spec's own *never render a zero as if measured*, applied to a button. Deferred, not dropped: the data exists (5,527 sessions, decision #65), the reader is a unit of its own.
2. **Refresh is rendered per card, not once per section.** The spec names "the refresh button" singular and also requires a per-card disabled state; one section-level control cannot express the second.

## Evidence

**28 mutation round trips**, asked per PROPERTY rather than per test — `tests/mutations/u4_quota_accounts_ui.py`. All 28 red → revert → green. Three properties are pinned in **both** directions, because a one-directional leg is satisfied by a fix that trades the bug for its mirror image:

| Property | Direction A | Direction B |
|---|---|---|
| n/a vs a measured zero | M9/M10 draw the absent number as 0% | M11 swallows a genuinely measured 0% into n/a |
| the seven-day note | M16 renders it on every page | M17 on none |
| `muted` | M13 drops the signed-out half | M14 drops the unauth half |

M6 is the one a percent-only suite cannot see: it colours from the provider's status instead of the number. Every consistent fixture stays green under it — only the deliberately contradictory card (an `error` provider at 22%) reddens.

**Two mutations stayed green on the first run, and the tests were wrong, not the source.** M4 (an absent percent painted a colour) was invisible because the n/a test read the text and the bar but never the label's own classes. M20 (the UI re-sorting accounts, losing the API's current-first order) was inert because the fixture's labels happened to sort into API order, so the assertion could not tell the difference. Both tests fixed; the M20 fixture now sorts *against* the API order on purpose and says so in a comment.

34 tests in `tests/test_quota_accounts_ui.py`, driven through node against the real `app.js` regions with a minimal DOM (the interface UI-contract idiom) rather than grepping source for strings — a string assertion passes against a function nobody calls.

**Seam check beyond the suite**, because the node fixtures are ones I wrote by reading U3's source: U3's *real* response — built through U2's own `account()`/`window()` builders and U3's upsert over a scratch DB carrying migration 0096, `probe_all` stubbed, **no live call**, host live DB untouched — fed to this renderer end to end. Two anthropic cards (current first, the second muted with refresh disabled), moonshot `na` with no group at all, openai `error` with HTTP 503 on a card of its own, 96% red / 81.5% amber / 22% normal, `limit_value = 0` reading n/a beside `used 0 / 0`, the unrecognized 1209600-second window under its raw duration, and a past reset reading "due".

Full suite green locally: **1539 passed, 407 subtests**. No migration, no restart request, host live DB untouched — the section is verified by test and locally rebuilt instance, not the host GUI (which is down pending the post-sprint restart, board doc 52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)