### PR TITLE
fix(devkit): probe .venv runnability — existence is not importability (flag #53)

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -115,12 +115,17 @@ RUN pip install --no-cache-dir "playwright==1.60.0" \
  && playwright install --with-deps chromium \
  && chmod -R a+rX /opt/ms-playwright
 
-# Dev-kit fallback tools. `./sc lint` / `./sc typecheck` prefer the fork's .venv
-# copy (its pins + config), but a host-managed .venv (pinned out-of-tree
-# interpreter mounted by launch) is pip-skipped in the sandbox — so bake the
-# PATH fallback here or the tools are unobtainable from inside the box
-# (dos-arch QAQC-02). _sc_devtool in ./sc resolves .venv → PATH in that order.
-RUN pip install --no-cache-dir ruff mypy
+# Dev-kit fallback tools. `./sc lint` / `./sc typecheck` / `./sc test` prefer
+# the fork's .venv copy (its pins + config), but a host-managed .venv (pinned
+# out-of-tree interpreter mounted by launch) is pip-skipped in the sandbox, and
+# a .venv built by a python minor that differs from the one resolving in here
+# is present-but-unimportable — so bake the PATH fallback here or the tools are
+# unobtainable from inside the box (dos-arch QAQC-02). _sc_devtool and sc_test
+# in ./sc resolve .venv → PATH in that order, gated on _sc_venv_runnable.
+# pytest belongs in this set: sc_test's fallback lands on it, and it was
+# previously present in the running image only by accident (pip-installed, in
+# no Dockerfile layer), so a clean rebuild would have taken it away.
+RUN pip install --no-cache-dir ruff mypy pytest
 
 # Durable bare `sc` on PATH for EVERY harness. run.py prepends the repo root to
 # PATH at exec, but that only survives into a harness that hands its env verbatim

--- a/sc
+++ b/sc
@@ -226,16 +226,37 @@ _sc_find_manifests() {  # $1 = filename glob, e.g. 'requirements*.txt'
     -name "$1" -type f -print
 }
 
+# Is the repo .venv's tooling runnable BY THE INTERPRETER THAT RESOLVES HERE?
+# Existence is not runnability. A .venv is bind-mounted into the sandbox from
+# the host, and `python -m venv` records its interpreter as an UNVERSIONED
+# symlink (.venv/bin/python3 -> /usr/bin/python3). That path exists in both
+# places and resolves to a DIFFERENT minor version in each whenever the host's
+# python3 and the image's python3 disagree. The venv's packages live in
+# lib/python<X.Y>/site-packages for the host's X.Y, so under the image's
+# interpreter every .venv/bin/* shim is still present and executable and
+# imports NOTHING — `ModuleNotFoundError: No module named '_pytest'`, which
+# reads as a broken tool or a failing suite rather than as the version skew it
+# is. Probe the interpreter against its own site-packages before trusting the
+# shims. (The launch-time py_mount passthrough solves this properly for a venv
+# built from an out-of-tree interpreter under $HOME; it deliberately declines
+# to shadow /usr, so a system-python venv lands here instead.)
+_sc_venv_runnable() {
+  venv="$here/.venv"
+  [ -x "$venv/bin/python" ] || return 1
+  vv="$("$venv/bin/python" -c 'import sys;print("%d.%d"%sys.version_info[:2])' 2>/dev/null)" || return 1
+  [ -n "$vv" ] && [ -d "$venv/lib/python$vv/site-packages" ]
+}
+
 # Resolve a dev-kit tool (ruff / mypy): the fork's .venv copy wins (its pins +
-# config), else the image/PATH copy (baked into the sandbox for exactly this
-# case), else fail with the honest fix. A host-managed .venv (pinned out-of-tree
-# interpreter mounted by launch) is pip-skipped in the sandbox BY DESIGN, so
-# "run ./sc deps first" was a closed loop there — the tool was unobtainable from
-# inside the box (dos-arch QAQC-02). Say what is actually wrong and where the
-# fix runs instead.
+# config) WHEN IT RUNS HERE, else the image/PATH copy (baked into the sandbox
+# for exactly this case), else fail with the honest fix. A host-managed .venv
+# (pinned out-of-tree interpreter mounted by launch) is pip-skipped in the
+# sandbox BY DESIGN, so "run ./sc deps first" was a closed loop there — the
+# tool was unobtainable from inside the box (dos-arch QAQC-02). Say what is
+# actually wrong and where the fix runs instead.
 _sc_devtool() {  # $1 = tool name → prints the executable path, or fails
   venv="$here/.venv"
-  if [ -x "$venv/bin/$1" ]; then printf '%s\n' "$venv/bin/$1"; return 0; fi
+  if [ -x "$venv/bin/$1" ] && _sc_venv_runnable; then printf '%s\n' "$venv/bin/$1"; return 0; fi
   if command -v "$1" >/dev/null 2>&1; then command -v "$1"; return 0; fi
   hostmanaged=""
   if [ -n "${SC_SANDBOX:-}" ] && [ -e "$venv/bin/python" ]; then
@@ -244,7 +265,11 @@ _sc_devtool() {  # $1 = tool name → prints the executable path, or fails
       *) hostmanaged=1 ;;                   # pinned host interpreter — pip skipped here
     esac
   fi
-  if [ -n "$hostmanaged" ]; then
+  if [ -x "$venv/bin/$1" ] && ! _sc_venv_runnable; then
+    # Present but unimportable: name the skew, not a phantom missing package.
+    echo "✗ $1: $venv/bin/$1 exists but its interpreter cannot import it — this .venv was built by a different python minor than the one resolving here ($("$venv/bin/python" -V 2>&1), packages under $(ls -d "$venv"/lib/python* 2>/dev/null | tr '\n' ' '))." >&2
+    echo "  Fix: \`./sc build\` to bake $1 into the image as the PATH fallback — or on the HOST rebuild .venv from an interpreter launch can mount (a uv-managed one under \$HOME), which carries the SAME binary into the sandbox." >&2
+  elif [ -n "$hostmanaged" ]; then
     echo "✗ $1: unavailable, and this .venv is host-managed (pinned out-of-tree interpreter) — in-sandbox pip is skipped by design, so \`./sc deps\` cannot provision it here." >&2
     echo "  Fix on the HOST: install $1 into the pinned venv (e.g. uv pip install $1) — or \`./sc build\` to refresh the sandbox image, which bakes $1 as the PATH fallback." >&2
   else
@@ -394,10 +419,25 @@ sc_test() {
     echo "→ test: $venv/bin/pytest missing — provisioning first (./sc deps)"
     sc_deps || echo "→ test: provisioning incomplete — continuing" >&2
   fi
+  # Which pytest can we actually RUN? The .venv copy wins (fork pins + config)
+  # only when its interpreter can import it — see _sc_venv_runnable. Running a
+  # present-but-unimportable shim anyway fails the ENTIRE suite with
+  # ModuleNotFoundError, which reads as a real test failure and sends whoever
+  # sees it hunting a bug that is not there. The image bakes pytest as the
+  # fallback for exactly this case; it is a real pytest, not the stdlib
+  # downgrade the branch below guards against, so a fork's own missing deps
+  # still fail loudly rather than passing green.
+  pytest_bin=""
+  if [ -x "$venv/bin/pytest" ] && _sc_venv_runnable; then
+    pytest_bin="$venv/bin/pytest"
+  elif command -v pytest >/dev/null 2>&1; then
+    pytest_bin="$(command -v pytest)"
+    [ -x "$venv/bin/pytest" ] && echo "→ test: $venv/bin/pytest is not importable by its interpreter ($("$venv/bin/python" -V 2>&1)) — using $pytest_bin" >&2
+  fi
   rc=0
-  if [ -x "$venv/bin/pytest" ]; then
-    echo "→ test: $venv/bin/pytest"
-    ( cd "$here" && "$venv/bin/pytest" "$@" )
+  if [ -n "$pytest_bin" ]; then
+    echo "→ test: $pytest_bin"
+    ( cd "$here" && "$pytest_bin" "$@" )
     prc=$?
     if [ "$prc" -eq 5 ] && [ $# -eq 0 ]; then
       # pytest exit 5 = collected nothing. On a bare `./sc test` in a fork with
@@ -415,7 +455,7 @@ sc_test() {
     # pytest must not be green-washed through stdlib unittest — fail loud with the
     # fix. Only a fork with no pytest config keeps the legacy stdlib fallback.
     if _sc_wants_pytest; then
-      echo "✗ test: pytest required (pytest config present) but unavailable in $venv — run ./sc deps to provision it" >&2
+      echo "✗ test: pytest required (pytest config present) but unavailable — neither $venv nor PATH has a runnable copy; run ./sc deps to provision it (or ./sc build to bake the image fallback)" >&2
       rc=1
     else
       echo "→ test: python3 -m unittest discover (stdlib)"

--- a/tests/test_devkit_sc.py
+++ b/tests/test_devkit_sc.py
@@ -84,6 +84,103 @@ class ImageFallbackTest(unittest.TestCase):
                          "the sandbox image must bake ruff + mypy — the PATH "
                          "fallback for host-managed-.venv forks")
 
+    def test_image_bakes_pytest(self):
+        """sc_test's fallback lands on the PATH pytest. It sat in the running
+        image by accident (pip-installed, in no layer), so a clean rebuild
+        would have removed the thing the fallback depends on."""
+        self.assertRegex(DOCKERFILE, r"pip install[^\n]*pytest",
+                         "the sandbox image must bake pytest — sc_test falls "
+                         "back to it when the .venv is not runnable here")
+
+
+def _extract(fn: str) -> str:
+    """One sh function body out of `sc`, for a live run in a scratch tree."""
+    m = re.search(fn + r"\(\) \{.*?\n\}", SC, re.S)
+    assert m, f"{fn} not found in sc"
+    return m.group(0)
+
+
+class VenvRunnableTest(unittest.TestCase):
+    """A bind-mounted .venv records its interpreter as an UNVERSIONED symlink,
+    so the same path resolves to a different python minor on the host and in
+    the sandbox. The shims then exist, are executable, and import nothing.
+    `-x` cannot see that; _sc_venv_runnable must."""
+
+    def _probe(self, interpreter_version: str, packages_for: str | None):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            venv = root / ".venv"
+            (venv / "bin").mkdir(parents=True)
+            # A stand-in interpreter: the probe only asks it its version.
+            python = venv / "bin" / "python"
+            python.write_text(f"#!/bin/sh\necho {interpreter_version}\n")
+            python.chmod(0o755)
+            if packages_for:
+                (venv / "lib" / f"python{packages_for}"
+                 / "site-packages").mkdir(parents=True)
+            script = (f'here="{root}"\n{_extract("_sc_venv_runnable")}\n'
+                      "_sc_venv_runnable && echo RUNNABLE || echo NOT\n")
+            return subprocess.run(["sh", "-c", script], capture_output=True,
+                                  text=True).stdout.strip()
+
+    def test_matching_interpreter_and_site_packages_is_runnable(self):
+        self.assertEqual(self._probe("3.12", "3.12"), "RUNNABLE")
+
+    def test_minor_version_skew_is_not_runnable(self):
+        """The live defect: venv built by host py3.14, resolved here as py3.13.
+        Every .venv/bin/* shim is -x and every import fails."""
+        self.assertEqual(self._probe("3.13", "3.14"), "NOT")
+
+    def test_missing_interpreter_is_not_runnable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = (f'here="{tmp}"\n{_extract("_sc_venv_runnable")}\n'
+                      "_sc_venv_runnable && echo RUNNABLE || echo NOT\n")
+            out = subprocess.run(["sh", "-c", script], capture_output=True,
+                                 text=True).stdout.strip()
+        self.assertEqual(out, "NOT")
+
+
+class VenvRunnabilityGateTest(unittest.TestCase):
+    """Both tool-resolution paths must consult the probe. Existence checks
+    alone put an unimportable shim ahead of a working PATH copy — for sc_test
+    that fails the ENTIRE suite with ModuleNotFoundError, which reads as a
+    real test failure."""
+
+    def test_devtool_gates_the_venv_copy_on_runnability(self):
+        # Anchor on the line that RETURNS the venv copy, not on the body: the
+        # probe is also named in the error branch, so a body-wide assertIn
+        # passes vacuously when the gate itself is stripped.
+        body = _extract("_sc_devtool")
+        gate = [ln for ln in body.splitlines()
+                if "printf" in ln and '"$venv/bin/$1"' in ln]
+        self.assertEqual(len(gate), 1, "expected one venv-resolution line")
+        self.assertIn("_sc_venv_runnable", gate[0],
+                      "the venv copy is returned without probing that it runs")
+        # It must still WIN when it does run — fork pins + config ride it.
+        self.assertLess(body.index('"$venv/bin/$1"'), body.index("command -v"))
+
+    def test_sc_test_gates_the_venv_pytest_on_runnability(self):
+        body = _extract("sc_test")
+        self.assertLess(body.index('pytest_bin="$venv/bin/pytest"'),
+                        body.index("command -v pytest"),
+                        "the .venv pytest must be preferred when runnable and "
+                        "only then fall through to the baked PATH copy")
+
+    def test_sc_test_never_runs_an_unprobed_venv_pytest(self):
+        """The regression this closes: `[ -x $venv/bin/pytest ]` deciding on
+        its own what to EXECUTE. Existence may still gate the self-heal
+        (provision when absent) and a diagnostic line — only execution is
+        pinned, and it must go through the probed resolution."""
+        body = _extract("sc_test")
+        self.assertIn('"$pytest_bin" "$@"', body)
+        self.assertNotIn('"$venv/bin/pytest" "$@"', body,
+                         "the suite must run the PROBED pytest, never the raw "
+                         "venv path")
+        # Every selection of the venv copy is guarded by the probe.
+        for m in re.finditer(r'pytest_bin="\$venv/bin/pytest"', body):
+            self.assertIn("_sc_venv_runnable", body[max(0, m.start() - 200):m.start()],
+                          "the venv pytest was selected without the probe")
+
 
 class DepsHostManagedVerifyTest(unittest.TestCase):
     """#314/#324/#339 — the sandbox pip-skip must never green-lie: declared


### PR DESCRIPTION
Closes flag **#53** ("main checkout .venv pytest broken").

## It was never broken — it's a python minor-version skew across a bind mount

```
$ /home/j3d1/super-coder/.venv/bin/pytest --version
ModuleNotFoundError: No module named '_pytest'
```

`python -m venv` records its interpreter as an **unversioned** symlink:

```
.venv/bin/python3 -> /usr/bin/python3
```

That path exists on both sides of the bind mount and resolves to a **different version on each**:

| | interpreter | packages live in |
|---|---|---|
| host (built the venv) | `/usr/bin/python3` = **3.14.5** | `.venv/lib/python3.14/site-packages` ✅ |
| sandbox (uses it) | `/usr/bin/python3` = **3.13.5** | `.venv/lib/python3.13/site-packages` ❌ absent |

So every `.venv/bin/*` shim is present, executable, and imports nothing. Nothing is corrupt — on the host this venv is fine.

**Why it bit so hard:** `_sc_devtool` (`sc:183`) and `sc_test` (`sc:338,343`) both gate on `[ -x … ]` and therefore *prefer* the unimportable shim over the working `/usr/local/bin/pytest` sitting right there on PATH. For `./sc test` that means the whole suite dies on `ModuleNotFoundError` — which reads as a real test failure and sends you hunting a bug that doesn't exist.

The launch-time `py_mount` passthrough already solves this properly for a venv built from an out-of-tree interpreter under `$HOME` (it mounts the identical binary into the container), but it deliberately declines to shadow `/usr` — so a system-python venv lands exactly here.

## Changes

- **`_sc_venv_runnable()`** — probes the interpreter against its own `site-packages` dir. `_sc_devtool` and `sc_test` consult it before preferring the venv copy. The venv still **wins when it runs**, so fork pins and `[tool.*]` config are untouched on a healthy tree.
- **Honest diagnostics** — names the skew (both versions, where the packages actually are) instead of reporting a phantom missing package, and points at the two real fixes: `./sc build`, or rebuild `.venv` from an interpreter `launch` can mount.
- **Dockerfile bakes `pytest`** alongside ruff + mypy. `sc_test`'s fallback lands on it — and it was in the running image **only by accident** (pip-installed, `Required-by:` empty, present in no Dockerfile layer). A clean `./sc build` would have removed the thing the fallback depends on.

## Verified against the real trees, not just fixtures

Running the actual resolution block out of `sc` with `here` pointed at each tree:

```
== here=…/.sc-worktrees/dev6          (sandbox-built venv, py3.12, matching)
RESOLVED: …/.sc-worktrees/dev6/.venv/bin/pytest          ← unchanged

== here=/home/j3d1/super-coder        (host-built py3.14, resolving as py3.13)
→ test: …/.venv/bin/pytest is not importable by its interpreter (Python 3.13.5) — using /usr/local/bin/pytest
RESOLVED: /usr/local/bin/pytest                          ← and it runs that tree's suite green
```

`./sc test tests/test_devkit_sc.py` on the healthy worktree still resolves to the worktree venv — no behavior change where nothing was wrong.

## Tests

A live `sh` probe over version-skew fixtures (match / skew / no interpreter), plus gate pins.

**One thing worth flagging:** my first version of two gate tests asserted `_sc_venv_runnable` appeared *in the function body* — and passed **vacuously** under mutation, because the probe is also named in the error-message branch. They proved nothing. Rewritten to anchor on the **resolution line** itself. Mutation results now: stripping both gates → 2 red; executing the raw venv path → 1 red.

Full backend suite: **1597 pass**.

## Not fixed here

This routes around the skew using the image's tools. It does **not** make the host venv's *packages* importable in the sandbox — for that, the host would rebuild `.venv` from a uv-managed interpreter under `$HOME`, which `sc launch`'s existing `py_mount` then carries into the container. That's a host action, and only matters for app code that needs those pins; the engine suite is stdlib + SQLite and runs fine on the image's pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)