### PR TITLE
fix(sandbox): harness epoch — expire the baked harness CLIs so shells get current models

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -145,13 +145,36 @@ RUN printf '%s\n' \
       > /usr/local/bin/sc \
  && chmod 0755 /usr/local/bin/sc
 
+# ── Harness freshness seam ───────────────────────────────────────────────────
+# The harness CLIs are BAKED (here + below), never mounted from the host: their
+# binaries are host-ABI artifacts, not portable config. A darwin binary in a
+# linux container is fatal (see kimi's note below), vibe's entry point is a
+# script with an absolute shebang into a host uv interpreter, and glibc baselines
+# differ across the distros we support. Auth travels; binaries do not.
+#
+# Baking alone froze them, though: docker serves the installer RUNs from layer
+# cache forever, so `./sc launch|restart` — which DO build — could never make a
+# harness newer, and a new model (Opus 5, in claude 2.1.219) stayed invisible to
+# every shell. This ARG is the expiry. Rolling it invalidates the two harness
+# layers and nothing above them (node/playwright/pip stay cached); it is
+# REFERENCED inside each RUN so the bust is guaranteed, not merely implied by
+# docker's arg-cache heuristics.
+#
+# Who rolls it: `./sc update` (dos-u) and `./sc update-harnesses`, to today's
+# date — see sc's harness_epoch()/harness_epoch_roll(). Routine launches reuse
+# the stored value and stay fully cached. Because the value is a DATE and every
+# fork on a machine shares the `super-coder-sandbox` tag, the first fork to
+# update that day refreshes harnesses for all of them; the rest cache-hit.
+ARG SC_HARNESS_EPOCH=0
+
 # Kimi Code — baked HERE (root stage) with its binary DELIBERATELY redirected to
 # /usr/local/bin (root-writable, on every PATH), unlike the $HOME installs below.
 # Its default home, ~/.kimi-code, holds bin/ AND config in one dir, and
 # `./sc launch` bind-mounts the host's ~/.kimi-code for creds — installing there
 # would let the mount shadow the baked binary (fatal on a macOS host: darwin
 # binary, linux container). KIMI_NO_MODIFY_PATH skips its shell-rc edit.
-RUN curl -fsSL https://code.kimi.com/kimi-code/install.sh \
+RUN echo "harness epoch: ${SC_HARNESS_EPOCH}" \
+ && curl -fsSL https://code.kimi.com/kimi-code/install.sh \
       | env KIMI_INSTALL_DIR=/usr/local KIMI_NO_MODIFY_PATH=1 bash
 
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
@@ -173,10 +196,18 @@ ENV PATH=/home/${SC_USER}/.local/bin:/home/${SC_USER}/.opencode/bin:${PATH}
 # codex drops into ~/.local/bin (already on PATH above), same as claude. vibe's
 # installer self-bootstraps uv (astral.sh) then `uv tool install`s into ~/.local/bin.
 # (kimi is baked earlier, in the root stage — see the comment there.)
-RUN curl -fsSL https://claude.ai/install.sh | bash \
+# SC_HARNESS_EPOCH is referenced so a rolled epoch re-runs these installers; they
+# resolve "latest" themselves, so the epoch is an expiry, not a version pin.
+RUN echo "harness epoch: ${SC_HARNESS_EPOCH}" \
+ && curl -fsSL https://claude.ai/install.sh | bash \
  && curl -fsSL https://opencode.ai/install | bash \
  && curl -fsSL https://chatgpt.com/codex/install.sh | sh \
  && curl -LsSf https://mistral.ai/vibe/install.sh | bash
+
+# Stamp the epoch the harness layers were built with, so an image can be asked
+# what it is rather than guessed at: `./sc harness-status` reads this label and
+# says so when the image predates the stored epoch (i.e. a build is owed).
+LABEL sc.harness_epoch="${SC_HARNESS_EPOCH}"
 
 # Safe in-container git auth — structurally prevents a token in a URL. The
 # sandbox has no ssh, so `git@github.com:` remotes (e.g. a fork's default

--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -28,14 +28,14 @@
 #   LONG-ONLY: Interface status/start/view/attach/take-control/stop/reconcile/
 #              recover; models; sprint/watch/job; build/logs/serve/health/ports;
 #              verify/map/render/snapshot/deps/install/rollback/token/
-#              update-harnesses/feature/eject
+#              update-harnesses/harness-status/feature/eject
 #              passthrough: make dos ARGS=health
 #
 SC := ./sc
 .PHONY: dos-e dos-enter dos-l dos-launch dos-r dos-restart dos-d dos-down dos-u dos-update \
         dos-t dos-test dos-h dos-help dos-url dos-build dos-logs dos-serve dos-health dos-ports \
         dos-verify dos-map dos-render dos-snapshot dos-deps dos-install dos-rollback \
-        dos-update-harnesses dos-feat dos-feature dos-eject dos-token dos-status \
+        dos-update-harnesses dos-harness-status dos-feat dos-feature dos-eject dos-token dos-status \
         dos-start dos-view dos-attach dos-take dos-take-control dos-stop \
         dos-reconcile dos-recover dos-models dos-model-refresh dos-model-list \
         dos-model-resolve dos-sprint dos-watch dos-job dos-setup dos
@@ -103,6 +103,11 @@ dos-rollback:         ; $(SC) rollback
 # credential to stdout (never rotates, never logs); exact alias of ./sc token.
 dos-token:            ; $(SC) token
 dos-update-harnesses: ; $(SC) update-harnesses
+# What the shells' harness CLIs actually are, in the sandbox — and whether the
+# image owes a harness rebuild. The picker shows model ALIASES, never the CLI
+# build that decides which models an alias can reach, so this is the only place
+# that answers it.
+dos-harness-status:   ; $(SC) harness-status
 # Opt-in features: make dos-feat (list) · make dos-feat ARGS="enable pg"
 dos-feature:          ; $(SC) feature $(ARGS)
 dos-feat: dos-feature
@@ -181,7 +186,9 @@ dos-help:
 	@echo "    dos-setup / dos-install     first-launch bootstrap: reqs, harness, first shell"
 	@echo "    dos-rollback                undo a bad update — restore the DB + engine pair"
 	@echo "                                (without engine.ref.prev: DB only, with a warning)"
-	@echo "    dos-update-harnesses        update claude + opencode + codex + vibe + kimi"
+	@echo "    dos-update-harnesses        refresh claude + opencode + codex + vibe + kimi in the sandbox image"
+	@echo "                                (rolls the harness epoch + rebuilds; dos-r to run them)"
+	@echo "    dos-harness-status          harness CLI versions in the sandbox + is a harness rebuild owed"
 	@echo "    dos-feat / dos-feature      list/enable/disable opt-in features"
 	@echo "    dos-token                   print the browser sign-in token (stdout only)"
 	@echo "    dos-eject                   ONE-WAY: own the engine"

--- a/.super-coder/scripts/harness_versions.py
+++ b/.super-coder/scripts/harness_versions.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Report the harness CLI versions of the runtime this runs in.
+
+Nothing else surfaces these, and that is how a regression hid: the model picker
+and the catalogue show ALIASES (`opus`, `sonnet`), never the CLI build behind
+them, so a sandbox baked with claude 2.1.218 — one release before Opus 5 landed
+in 2.1.219 — silently offered an `opus` that could not resolve to Opus 5. Nobody
+could see the version that decided it.
+
+Run inside the sandbox (`./sc harness-status` docker-execs it there) so the
+answer is the version SHELLS run, not the host's own copy. The host's CLIs are
+irrelevant on the docker path: the container mounts creds, never binaries.
+
+Each probe is capped by a timeout — a harness that hangs on `--version` must not
+be able to hang a launch banner — and a missing harness is reported, not fatal.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+
+# Probe order = the order the harness picker lists them.
+HARNESSES = ("claude", "codex", "opencode", "vibe", "kimi")
+TIMEOUT = 8
+
+
+def probe(name: str) -> str | None:
+    """First line of `<harness> --version`, or None when absent/unusable.
+    Absent, hung, and crashed all collapse to None on purpose: the caller is a
+    status line, and every one of those means "cannot tell you a version"."""
+    if not shutil.which(name):
+        return None
+    try:
+        proc = subprocess.run([name, "--version"], capture_output=True, text=True,
+                              timeout=TIMEOUT)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    out = (proc.stdout or proc.stderr or "").strip().splitlines()
+    return out[0].strip() if out else None
+
+
+def versions() -> dict[str, str | None]:
+    return {name: probe(name) for name in HARNESSES}
+
+
+def main(argv: list[str]) -> int:
+    found = versions()
+    if "--json" in argv:
+        print(json.dumps(found, indent=2))
+        return 0
+    for name, version in found.items():
+        print(f"  {name:9} {version or '— not installed'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -214,6 +214,66 @@ def _harness_installed(name: str) -> bool:
     return bool(shutil.which(name)) or HARNESS_BIN.get(name, Path("/nonexistent")).exists()
 
 
+# ── Harness epoch (sandbox harness freshness) ────────────────────────────────
+# The functions above install harnesses on THIS machine's $HOME. That is the
+# right thing on the no-docker path, where the host IS the runtime — and a no-op
+# for shells on the docker path, where the harness binaries are baked into the
+# `super-coder-sandbox` image and the container mounts only creds (~/.claude,
+# ~/.codex, …), never binaries. Binaries cannot be mounted in: they are host-ABI
+# artifacts (a darwin binary is fatal in a linux container, vibe's entry point
+# carries an absolute shebang into a host uv interpreter, glibc baselines differ
+# across the distros we support), which is why the Dockerfile bakes them.
+#
+# Baking froze them: docker serves the installer RUNs from layer cache forever,
+# so `./sc launch|restart` — which DO run `docker build` — could never make a
+# harness newer, and `docker rm -f` on every launch discards any in-container
+# update. A claude one release behind Opus 5 therefore stayed one release behind
+# through an update, a harness update, and a restart.
+#
+# The epoch is that layer's expiry. `./sc update` and `./sc update-harnesses`
+# roll it to today; `./sc build` passes it as SC_HARNESS_EPOCH; the Dockerfile
+# references it inside both harness RUNs, so a changed value re-runs the
+# installers (which resolve "latest" themselves — the epoch is an expiry, never
+# a version pin).
+#
+# MACHINE-scoped, not per-repo: every fork on a host shares the image tag, so
+# the harness layer is a machine fact and a per-repo file would let one fork
+# roll an epoch its neighbours never see. Because the value is a DATE, two forks
+# updating the same day produce the same build arg and the second cache-hits.
+# The path follows the engine's existing host-state idiom (XDG_CONFIG_HOME).
+HARNESS_EPOCH_UNSET = "0"  # the Dockerfile's default — "never rolled here"
+
+
+def harness_epoch_path() -> Path:
+    """Where the rolled epoch is stored. SC_HARNESS_EPOCH_FILE overrides (tests)."""
+    override = os.environ.get("SC_HARNESS_EPOCH_FILE")
+    if override:
+        return Path(override)
+    base = os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config")
+    return Path(base) / "super-coder" / "harness-epoch"
+
+
+def harness_epoch() -> str:
+    """The stored epoch, or "0" when never rolled — so an untouched machine
+    builds exactly the image an un-instrumented build would have produced."""
+    try:
+        value = harness_epoch_path().read_text().strip()
+    except OSError:
+        return HARNESS_EPOCH_UNSET
+    return value or HARNESS_EPOCH_UNSET
+
+
+def roll_harness_epoch() -> str:
+    """Expire the image's harness layers as of today, and return the value.
+    Idempotent within a day: rolling twice writes the same string, so a second
+    fork's build on the same day still cache-hits instead of re-downloading."""
+    value = date.today().isoformat()
+    path = harness_epoch_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value + "\n")
+    return value
+
+
 # ── Harness install progress ─────────────────────────────────────────────────
 # A real %-bar isn't possible: the work is third-party installer scripts
 # (curl | bash) whose duration + byte counts we don't know. Instead, run each
@@ -554,8 +614,19 @@ def main(argv: list[str]) -> int:
     force = "--force" in argv
     skip_harness = "--skip-harness-install" in argv
     # super-coder's own flags — strip them so they don't reach init_fork's parser.
-    own = {"--force", "--skip-harness-install", "--ensure-harness", "--update-harnesses", "--check-docker"}
+    own = {"--force", "--skip-harness-install", "--ensure-harness", "--update-harnesses",
+           "--check-docker", "--harness-epoch", "--roll-harness-epoch"}
     fork_args = [a for a in argv if a not in own]
+
+    # Standalone, machine-readable: the sandbox harness epoch. `sc` shells out to
+    # these rather than reimplementing the file format, so there is one owner of
+    # it. Bare values on stdout — no step banner — because callers capture them.
+    if "--harness-epoch" in argv:
+        print(harness_epoch())
+        return 0
+    if "--roll-harness-epoch" in argv:
+        print(roll_harness_epoch())
+        return 0
 
     # Standalone: force-update all harness CLIs to latest and exit.
     if "--update-harnesses" in argv:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -459,6 +459,30 @@ def regrant() -> int:
         con.close()
 
 
+def expire_sandbox_harnesses() -> str | None:
+    """Expire the harness CLIs baked into the sandbox image; return the epoch.
+
+    `ensure_harnesses()` installs into THIS machine's $HOME, which is the whole
+    runtime on the no-docker path and none of it on the docker path: the sandbox
+    mounts creds, never binaries, so the CLIs shells actually run are the ones
+    baked into the image — behind a docker layer cache with no expiry of its own.
+    An update therefore used to lay a new engine floor on top of harness CLIs
+    frozen at whenever the image was first built, with no command able to move
+    them (a claude one release short of Opus 5 survived exactly that).
+
+    Rolling the epoch expires those layers for the next build. Nothing downloads
+    here: the rebuild rides the relaunch an update already requires, so the
+    sandbox comes back current in the bounce the new floor needs anyway.
+
+    Returns None when docker is absent — the roll is harmless (there is no image
+    to expire) but announcing it would describe a runtime this host does not have.
+    """
+    epoch = install_mod.roll_harness_epoch()
+    if install_mod.docker_status().get("state") == "absent":
+        return None
+    return epoch
+
+
 def main(argv: list[str]) -> int:
     no_fetch = "--no-fetch" in argv
     force = "--force" in argv
@@ -534,6 +558,13 @@ def main(argv: list[str]) -> int:
     # Auth/login stays manual; this only ensures the CLI binary is present.
     print("→ ensure harnesses installed (claude + opencode + codex + vibe + kimi)")
     install_mod.ensure_harnesses()
+
+    # …and that covers the HOST only — see expire_sandbox_harnesses() for the
+    # half of the fleet ensure_harnesses() cannot reach.
+    epoch = expire_sandbox_harnesses()
+    if epoch:
+        print(f"→ expire the sandbox's baked harness CLIs (epoch {epoch})")
+        print("  they reinstall on the next image build — `./sc restart` / `make dos-r`")
 
     migrate_or_rebuild(live_preflight_done=True)
 

--- a/sc
+++ b/sc
@@ -129,13 +129,33 @@ dnet() {
     || docker network create "$SC_NET" >/dev/null
 }
 
+# Sandbox harness freshness. The harness CLIs are baked into the image (their
+# binaries are host-ABI artifacts — see install.py's harness-epoch note for why
+# they can never be mounted in like creds), and docker serves those installer
+# layers from cache forever. The epoch is their expiry: rolling it re-runs the
+# installers on the next build, and nothing else in the image is invalidated.
+# install.py owns the value + its file; these are thin readers so there is one
+# implementation of it, not two that can disagree.
+harness_epoch()      { "$PY" "$S/install.py" --harness-epoch; }
+harness_epoch_roll() { "$PY" "$S/install.py" --roll-harness-epoch; }
+
+# What the CURRENT image was actually built with, read back from the label the
+# Dockerfile stamps. Empty for an image built before this seam existed (or none
+# at all) — callers treat that as "unknown", never as "current".
+harness_epoch_built() {
+  docker image inspect "$IMG" --format '{{index .Config.Labels "sc.harness_epoch"}}' 2>/dev/null \
+    | sed 's/^<no value>$//' || true
+}
+
 # Build the env image (the repo is bind-mounted at run time, never baked — see
-# .dockerignore: the build context is empty). Cheap to re-run; layers cache.
+# .dockerignore: the build context is empty). Cheap to re-run; layers cache —
+# including the harness layers, unless the epoch below has been rolled since.
 dbuild() {
   docker build -t "$IMG" -f "$ENGINE/Dockerfile" \
     --build-arg SC_USER="$(id -un)" \
     --build-arg SC_UID="$(id -u)" \
     --build-arg SC_GID="$(id -g)" \
+    --build-arg SC_HARNESS_EPOCH="$(harness_epoch)" \
     "$here"
 }
 
@@ -146,6 +166,41 @@ dimage_preflight() {
   echo "✗ --no-build: sandbox image '$IMG:latest' is missing; nothing was stopped." >&2
   echo "  Run ./sc build, then retry with --no-build." >&2
   return 1
+}
+
+drunning() { [ "$(docker inspect -f '{{.State.Running}}' "$CNAME" 2>/dev/null || echo false)" = true ]; }
+
+# Which harness CLIs the shells will actually run, and whether the image owes a
+# build. Answers from INSIDE the sandbox when one is up, because that is the
+# runtime shells get — the host's own CLIs are not mounted in and do not decide
+# anything on the docker path. Never fatal: this is a status surface, and a
+# probe that cannot run should say so rather than take a launch down with it.
+sc_harness_status() {
+  # In-container (or no docker at all): this process IS the runtime.
+  if [ -n "${SC_SANDBOX:-}" ] || ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+    echo "harness CLIs (this runtime):"
+    "$PY" "$S/harness_versions.py" || true
+    return 0
+  fi
+  stored="$(harness_epoch)"
+  built="$(harness_epoch_built)"
+  if drunning; then
+    echo "harness CLIs (in the sandbox — what shells run):"
+    # python3, not $PY: the container's interpreter is its own (the image's), and
+    # a host SC_PYTHON pointing at a host venv would not exist in there. $S is a
+    # host absolute path that resolves identically inside — launch bind-mounts
+    # the repo at its own path, which is what makes this exec work at all.
+    docker exec "$CNAME" python3 "$S/harness_versions.py" 2>/dev/null \
+      || echo "  (could not probe $CNAME)"
+  else
+    echo "harness CLIs: sandbox '$CNAME' is not running — ./sc launch to start it."
+  fi
+  echo "harness epoch: image built with ${built:-<none — predates the epoch seam>} · stored ${stored}"
+  # A rolled-but-unbuilt epoch is the actionable state: the operator asked for
+  # fresh harnesses and the image has not caught up yet. Say the command.
+  if [ "$stored" != "0" ] && [ "$stored" != "$built" ]; then
+    echo "  ! the image predates the stored epoch — ./sc restart (or ./sc build) to bake fresh harnesses"
+  fi
 }
 
 # ── dev kit (deps + test) — in-container primitives, like serve/boot ──────────
@@ -1012,7 +1067,25 @@ case "$cmd" in
   ensure-harness)  exec "$PY" "$S/install.py" --ensure-harness ;;
   doctor)          exec "$PY" "$S/install.py" --check-docker ;;
   update)            exec "$PY" "$S/update.py" "$@" ;;
-  update-harnesses) exec "$PY" "$S/install.py" --update-harnesses ;;
+  # Refresh the harness CLIs the SHELLS run — which, on the docker path, means
+  # the image and nothing else. Running the installers on the host here is what
+  # this command used to do, and it reported success while changing nothing: the
+  # container mounts creds (~/.claude, ~/.codex, …), never binaries, and every
+  # launch `docker rm -f`s the writable layer that an in-container install would
+  # land in. So: roll the epoch, rebuild, and name the restart that runs it.
+  # Without docker the host IS the runtime, so the installers are correct there.
+  update-harnesses)
+    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+      echo "→ harness epoch rolled to $(harness_epoch_roll)"
+      dbuild
+      echo "→ image rebuilt with fresh harness CLIs"
+      sc_harness_status || true
+      echo "  running sandboxes keep the OLD image until they restart: ./sc restart"
+    else
+      echo "→ no docker — updating this host's harness CLIs (the no-docker runtime)"
+      "$PY" "$S/install.py" --update-harnesses
+    fi ;;
+  harness-status)  sc_harness_status ;;
   rollback)     exec "$PY" "$S/rollback.py" "$@" ;;
   feature)      exec "$PY" "$S/feature.py" "$@" ;;
   artifact-mode) exec "$PY" "$S/artifact_policy.py" "$@" ;;
@@ -1244,6 +1317,13 @@ case "$cmd" in
     fi
     echo "  dev server:    bind 0.0.0.0:$dp inside (\$SC_DEV_PORT) → http://127.0.0.1:$dp"
     echo "  boot a shell:  ./sc enter   (or ./sc enter-<shortname>)"
+    # One line naming the claude build the shells got. It is the version that
+    # decides which models an alias like `opus` can resolve to, and until this
+    # line existed nothing anywhere reported it — a sandbox stuck one release
+    # behind a new model looked identical to a current one. Best-effort: a probe
+    # that cannot answer must not fail a launch that otherwise succeeded.
+    claude_v="$(docker exec "$CNAME" claude --version 2>/dev/null | head -1 || true)"
+    [ -n "$claude_v" ] && echo "  harnesses:     claude $claude_v   (all: ./sc harness-status)"
     # Bring the VM broker up alongside the sandbox when a VM is linked (self-skips
     # otherwise, and no-ops if systemd already owns it). The shells need it to
     # drive the VM; this keeps it from being a forgotten manual step.
@@ -1317,7 +1397,16 @@ case "$cmd" in
     launch_rc=0
     "$0" launch --no-build || launch_rc=$?
     sc_restart_health_summary "$launch_rc" ;;
-  build)        dcheck; dbuild ;;
+  # --harnesses expires the baked harness CLIs first, so the build re-runs their
+  # installers instead of serving them from a cache that has no expiry of its own.
+  build)
+    dcheck
+    case "${1:-}" in
+      --harnesses) echo "→ harness epoch rolled to $(harness_epoch_roll)"; shift ;;
+      "") : ;;
+      *) echo "sc build: unknown argument '$1' (usage: ./sc build [--harnesses])" >&2; exit 2 ;;
+    esac
+    dbuild ;;
   logs)         exec docker logs -f "$CNAME" ;;
   verify)
     "$PY" "$S/rebuild.py"
@@ -1357,7 +1446,10 @@ super-coder — forkable shell substrate
   ./sc update              fetch + materialize the engine (gitignored dep) + reconcile IN PLACE (migrate, sync skills, map);
                              live Interface state asks continue-or-rollback; headless discard requires --discard-live-state
                              --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
-  ./sc update-harnesses    update claude + opencode + codex + vibe + kimi to latest (force-reruns official installers)
+  ./sc update-harnesses    refresh the harness CLIs the SHELLS run: rolls the harness epoch + rebuilds the sandbox image
+                             (they are baked, never mounted — so a running sandbox keeps the old ones until ./sc restart)
+                             without docker, updates this host's CLIs instead — there the host IS the runtime
+  ./sc harness-status      report the harness CLI versions inside the sandbox + whether the image owes a harness rebuild
   ./sc rollback            sound undo of a bad update — restore the DB + engine (engine.ref.prev) together
                              --engine-only repairs a new-engine / unchanged-old-DB half floor without restoring a DB backup
   ./sc feature             list the opt-in features (pg · windows · tailnet · pm2 · app-deploy) and the state of both halves (config block + skill grants)
@@ -1443,7 +1535,7 @@ super-coder — forkable shell substrate
   ./sc down                stop + remove the sandbox container
   ./sc restart             confirm + WAL-safe backup, fully bounce, then health-check managed services
                              --yes skips the prompt · --no-build preflights/reuses the existing image
-  ./sc build               (re)build the sandbox image
+  ./sc build               (re)build the sandbox image · --harnesses also expires the baked harness CLIs so they reinstall
   ./sc logs                tail the sandbox server logs
 
   Primitives (run inside the container; also the no-docker host escape hatch):

--- a/tests/test_harness_epoch.py
+++ b/tests/test_harness_epoch.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Coverage for sandbox harness freshness — the harness epoch.
+
+The harness CLIs shells run are BAKED into the sandbox image (their binaries are
+host-ABI artifacts and cannot be mounted in like creds). Docker serves those
+installer layers from cache forever, so before this seam existed there was no
+command anywhere that could make a shell's harness newer: `launch`/`restart` do
+build, but from cache; `update-harnesses` ran the installers against the HOST,
+which the container does not mount; `update` called ensure_harnesses(), which
+skips anything already present; and every launch `docker rm -f`s the writable
+layer an in-container install would land in. A claude one release short of the
+model it needed survived all four.
+
+These tests pin the way out: an epoch that expires those layers, rolled by the
+update paths, passed to the build, and referenced inside the RUNs so the bust is
+guaranteed rather than left to docker's arg-cache heuristics.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+INSTALL_PY = ENGINE / "scripts" / "install.py"
+TODAY = date.today().isoformat()
+
+
+def run_install(*args: str, epoch_file: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["SC_HARNESS_EPOCH_FILE"] = str(epoch_file)
+    return subprocess.run([sys.executable, str(INSTALL_PY), *args],
+                          capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+class HarnessEpochValue(unittest.TestCase):
+    """The stored value, via the CLI seam `sc` actually shells out to."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.epoch_file = Path(self._tmp.name) / "state" / "harness-epoch"
+
+    def test_unrolled_machine_reports_the_dockerfile_default(self):
+        """"0" is the Dockerfile's own default, so a machine that has never
+        rolled builds the exact image an un-instrumented build produced — the
+        seam must not invalidate anyone's cache merely by existing."""
+        result = run_install("--harness-epoch", epoch_file=self.epoch_file)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "0")
+
+    def test_roll_writes_today_and_creates_its_parent_directory(self):
+        result = run_install("--roll-harness-epoch", epoch_file=self.epoch_file)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), TODAY)
+        self.assertEqual(self.epoch_file.read_text().strip(), TODAY)
+
+    def test_roll_is_idempotent_within_a_day(self):
+        """The value is a DATE on purpose: every fork on a machine shares the
+        image tag, so a second fork updating the same day must produce the same
+        build arg and cache-hit instead of re-downloading five installers."""
+        first = run_install("--roll-harness-epoch", epoch_file=self.epoch_file)
+        second = run_install("--roll-harness-epoch", epoch_file=self.epoch_file)
+        self.assertEqual(first.stdout.strip(), second.stdout.strip())
+
+    def test_stored_value_reads_back(self):
+        run_install("--roll-harness-epoch", epoch_file=self.epoch_file)
+        result = run_install("--harness-epoch", epoch_file=self.epoch_file)
+        self.assertEqual(result.stdout.strip(), TODAY)
+
+    def test_unreadable_store_reads_as_unrolled_rather_than_failing(self):
+        """A build must never be blocked by the freshness bookkeeping — an
+        unreadable store means "not rolled here", not "stop"."""
+        self.epoch_file.parent.mkdir(parents=True)
+        self.epoch_file.mkdir()  # a directory where a file belongs
+        result = run_install("--harness-epoch", epoch_file=self.epoch_file)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "0")
+
+
+class HarnessEpochDockerfile(unittest.TestCase):
+    """The image side of the contract, asserted on the Dockerfile text."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = (ENGINE / "Dockerfile").read_text()
+
+    def harness_runs(self) -> list[str]:
+        """The two RUN instructions that install harness CLIs, line
+        continuations folded, so a reference can be found anywhere inside."""
+        folded = self.text.replace("\\\n", " ")
+        return [line for line in folded.splitlines()
+                if line.startswith("RUN ") and "install" in line
+                and ("claude.ai" in line or "code.kimi.com" in line)]
+
+    def test_both_harness_layers_exist(self):
+        self.assertEqual(len(self.harness_runs()), 2,
+                         "expected the kimi RUN and the claude/opencode/codex/vibe RUN")
+
+    def test_every_harness_layer_references_the_epoch(self):
+        """Declaring the ARG near a RUN is not enough — docker only reliably
+        invalidates a layer whose COMMAND changes. Each harness RUN must expand
+        the epoch, or a roll silently buys nothing and the freeze comes back."""
+        for run in self.harness_runs():
+            with self.subTest(run=run[:60]):
+                self.assertIn("SC_HARNESS_EPOCH", run)
+
+    def test_epoch_arg_is_declared_before_the_layers_it_expires(self):
+        arg_at = self.text.index("ARG SC_HARNESS_EPOCH")
+        first_harness_at = self.text.index("code.kimi.com")
+        self.assertLess(arg_at, first_harness_at)
+
+    def test_epoch_arg_defaults_to_unrolled(self):
+        self.assertRegex(self.text, r"ARG SC_HARNESS_EPOCH=0\b")
+
+    def test_image_records_the_epoch_it_was_built_with(self):
+        """`harness-status` compares this label against the stored epoch to say
+        whether a build is owed; without it the answer would be a guess."""
+        self.assertIn('LABEL sc.harness_epoch="${SC_HARNESS_EPOCH}"', self.text)
+
+    def test_epoch_sits_below_the_expensive_layers(self):
+        """Rolling must cost the harness downloads and nothing else — put the
+        ARG above node/playwright/pip and every roll rebuilds the world."""
+        arg_at = self.text.index("ARG SC_HARNESS_EPOCH")
+        for costly in ("playwright", "nodesource", "@xterm/headless"):
+            with self.subTest(layer=costly):
+                self.assertLess(self.text.index(costly), arg_at)
+
+
+class ScFixture:
+    """A throwaway fork tree with a fake docker, enough to drive `sc`'s harness
+    commands and read back exactly what it asked docker to do."""
+
+    def __init__(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name) / "fork"
+        self.engine = self.root / ".super-coder"
+        self.scripts = self.engine / "scripts"
+        self.fakebin = Path(self._tmp.name) / "bin"
+        self.log = Path(self._tmp.name) / "calls.log"
+        self.epoch_file = Path(self._tmp.name) / "state" / "harness-epoch"
+        self.scripts.mkdir(parents=True)
+        self.fakebin.mkdir()
+        self.log.touch()
+        shutil.copy2(ROOT / "sc", self.root / "sc")
+        for script in ("install.py", "engine_manifest.py", "ports.py",
+                       "artifact_policy.py", "harness_versions.py"):
+            shutil.copy2(ENGINE / "scripts" / script, self.scripts / script)
+        (self.engine / "Dockerfile").write_text("FROM scratch\n")
+        self._write_fake_docker()
+        self.env = os.environ.copy()
+        self.env.update({
+            "PATH": f"{self.fakebin}:{self.env['PATH']}",
+            "SC_PYTHON": sys.executable,
+            "SC_HARNESS_EPOCH_FILE": str(self.epoch_file),
+            "SC_TEST_LOG": str(self.log),
+            "SC_TEST_LABEL": "",
+            "SC_TEST_RUNNING": "1",
+            "NO_COLOR": "1",
+        })
+
+    def close(self) -> None:
+        self._tmp.cleanup()
+
+    def _write_fake_docker(self) -> None:
+        path = self.fakebin / "docker"
+        path.write_text(textwrap.dedent(
+            """\
+            #!/bin/sh
+            printf 'docker' >> "$SC_TEST_LOG"
+            printf ' %s' "$@" >> "$SC_TEST_LOG"
+            printf '\\n' >> "$SC_TEST_LOG"
+            case "$1" in
+              info) exit 0 ;;
+              build) exit 0 ;;
+              image) printf '%s\\n' "$SC_TEST_LABEL"; exit 0 ;;
+              inspect) [ -n "$SC_TEST_RUNNING" ] && echo true || echo false; exit 0 ;;
+              exec)
+                # `docker exec <name> claude --version` — the launch banner probe.
+                for a in "$@"; do
+                  if [ "$a" = claude ]; then echo "9.9.9 (Claude Code)"; exit 0; fi
+                done
+                echo "  claude    9.9.9 (Claude Code)"; exit 0 ;;
+            esac
+            exit 0
+            """
+        ))
+        path.chmod(0o755)
+
+    def calls(self) -> list[str]:
+        return [line for line in self.log.read_text().splitlines() if line.strip()]
+
+    def build_args(self) -> dict[str, str]:
+        """SC_* build args from the last `docker build`, as a dict."""
+        build = [c for c in self.calls() if c.startswith("docker build ")][-1]
+        return dict(re.findall(r"--build-arg (\w+)=(\S*)", build))
+
+    def run(self, *args: str, **env: str) -> subprocess.CompletedProcess[str]:
+        environ = {**self.env, **env}
+        return subprocess.run([str(self.root / "sc"), *args], capture_output=True,
+                              text=True, env=environ, cwd=self.root)
+
+
+class ScHarnessCommands(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fx = ScFixture()
+        self.addCleanup(self.fx.close)
+
+    def test_build_passes_the_stored_epoch(self):
+        result = self.fx.run("build")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.fx.build_args().get("SC_HARNESS_EPOCH"), "0")
+
+    def test_build_harnesses_rolls_first_so_the_layers_expire(self):
+        result = self.fx.run("build", "--harnesses")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.fx.build_args().get("SC_HARNESS_EPOCH"), TODAY)
+        self.assertEqual(self.fx.epoch_file.read_text().strip(), TODAY)
+
+    def test_plain_build_does_not_roll(self):
+        """`build` is on the launch/restart path — it must stay a cache-warm
+        no-op, or every restart would re-download five installers."""
+        self.fx.run("build")
+        self.assertFalse(self.fx.epoch_file.exists())
+
+    def test_build_rejects_an_unknown_flag_before_building(self):
+        result = self.fx.run("build", "--harness")  # a plausible typo
+        self.assertEqual(result.returncode, 2)
+        self.assertFalse([c for c in self.fx.calls() if c.startswith("docker build")])
+
+    def test_update_harnesses_rolls_and_rebuilds_on_the_docker_path(self):
+        result = self.fx.run("update-harnesses")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.fx.build_args().get("SC_HARNESS_EPOCH"), TODAY)
+
+    def test_update_harnesses_does_not_install_onto_the_host_when_docker_runs(self):
+        """The old behavior: run the installers here, report success, change
+        nothing a shell can see. The container mounts creds, never binaries."""
+        result = self.fx.run("update-harnesses")
+        self.assertNotIn("claude.ai/install.sh", result.stdout)
+        self.assertNotIn("Updating harness CLIs", result.stdout)
+
+    def test_update_harnesses_names_the_restart_that_runs_them(self):
+        """A rebuilt image is not a refreshed sandbox — the running container
+        keeps the old one until it is bounced. Say so, or the operator reads
+        'rebuilt' as 'done' (which is how this bug was reported)."""
+        result = self.fx.run("update-harnesses")
+        self.assertIn("./sc restart", result.stdout)
+
+    def test_harness_status_reports_the_versions_inside_the_sandbox(self):
+        result = self.fx.run("harness-status")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("9.9.9 (Claude Code)", result.stdout)
+
+    def test_harness_status_flags_an_image_that_owes_a_rebuild(self):
+        self.fx.run("build", "--harnesses")          # epoch rolled to today…
+        result = self.fx.run("harness-status", SC_TEST_LABEL="2020-01-01")
+        self.assertIn("predates the stored epoch", result.stdout)
+
+    def test_harness_status_is_quiet_when_the_image_matches(self):
+        self.fx.run("build", "--harnesses")
+        result = self.fx.run("harness-status", SC_TEST_LABEL=TODAY)
+        self.assertNotIn("predates the stored epoch", result.stdout)
+
+    def test_harness_status_does_not_claim_currency_for_an_unlabelled_image(self):
+        """An image built before the seam existed has no label. Unknown must not
+        read as current — that is precisely the state this bug shipped in."""
+        self.fx.run("build", "--harnesses")
+        result = self.fx.run("harness-status", SC_TEST_LABEL="")
+        self.assertIn("predates the stored epoch", result.stdout)
+
+
+class UpdateExpiresSandboxHarnesses(unittest.TestCase):
+    """`./sc update` (dos-u) must move the harnesses shells run, not just the
+    host's — the gap that let an update ship a new floor on frozen CLIs."""
+
+    def setUp(self) -> None:
+        sys.path.insert(0, str(ENGINE / "scripts"))
+        import update as update_mod  # noqa: PLC0415 — engine scripts are path-loaded
+        self.update_mod = update_mod
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.epoch_file = Path(self._tmp.name) / "harness-epoch"
+        os.environ["SC_HARNESS_EPOCH_FILE"] = str(self.epoch_file)
+        self.addCleanup(os.environ.pop, "SC_HARNESS_EPOCH_FILE", None)
+        self.docker = {"state": "rootless"}
+        real = self.update_mod.install_mod.docker_status
+        self.update_mod.install_mod.docker_status = lambda: self.docker
+        self.addCleanup(setattr, self.update_mod.install_mod, "docker_status", real)
+
+    def test_update_rolls_the_epoch(self):
+        self.assertEqual(self.update_mod.expire_sandbox_harnesses(), TODAY)
+        self.assertEqual(self.epoch_file.read_text().strip(), TODAY)
+
+    def test_no_docker_rolls_silently_instead_of_describing_a_missing_runtime(self):
+        self.docker = {"state": "absent"}
+        self.assertIsNone(self.update_mod.expire_sandbox_harnesses())
+        self.assertEqual(self.epoch_file.read_text().strip(), TODAY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_harness_epoch.py
+++ b/tests/test_harness_epoch.py
@@ -92,18 +92,37 @@ class HarnessEpochDockerfile(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.text = (ENGINE / "Dockerfile").read_text()
+        sys.path.insert(0, str(ENGINE / "scripts"))
+        import install as install_mod  # noqa: PLC0415 — engine scripts are path-loaded
+        # The harness set, from the one place that owns it — the same dict the
+        # Dockerfile's header comment says to keep these installers in sync with.
+        # Selecting by NAME, never by installer hostname: matching a bare domain
+        # substring is the url-sanitization anti-pattern CodeQL flags, and it
+        # would silently stop finding a layer the day a vendor moves its host.
+        cls.harness_names = tuple(install_mod.HARNESS_INSTALL)
+
+    def folded(self) -> str:
+        """The Dockerfile with line continuations joined, so each instruction is
+        one line and a position comparison is a comparison of instructions."""
+        return self.text.replace("\\\n", " ")
 
     def harness_runs(self) -> list[str]:
-        """The two RUN instructions that install harness CLIs, line
-        continuations folded, so a reference can be found anywhere inside."""
-        folded = self.text.replace("\\\n", " ")
-        return [line for line in folded.splitlines()
-                if line.startswith("RUN ") and "install" in line
-                and ("claude.ai" in line or "code.kimi.com" in line)]
+        """The RUN instructions that install harness CLIs — one line each."""
+        return [line for line in self.folded().splitlines()
+                if line.startswith("RUN ") and "curl" in line
+                and any(name in line for name in self.harness_names)]
 
     def test_both_harness_layers_exist(self):
         self.assertEqual(len(self.harness_runs()), 2,
                          "expected the kimi RUN and the claude/opencode/codex/vibe RUN")
+
+    def test_every_harness_the_engine_installs_is_baked(self):
+        """A harness added to HARNESS_INSTALL but not to the image would be
+        absent from every sandbox while `./sc install` reported it present."""
+        baked = " ".join(self.harness_runs())
+        for name in self.harness_names:
+            with self.subTest(harness=name):
+                self.assertIn(name, baked)
 
     def test_every_harness_layer_references_the_epoch(self):
         """Declaring the ARG near a RUN is not enough — docker only reliably
@@ -114,8 +133,11 @@ class HarnessEpochDockerfile(unittest.TestCase):
                 self.assertIn("SC_HARNESS_EPOCH", run)
 
     def test_epoch_arg_is_declared_before_the_layers_it_expires(self):
-        arg_at = self.text.index("ARG SC_HARNESS_EPOCH")
-        first_harness_at = self.text.index("code.kimi.com")
+        """An ARG is in scope from its declaration to the end of the stage — a
+        harness RUN above it would expand the epoch to nothing and never bust."""
+        folded = self.folded()
+        arg_at = folded.index("ARG SC_HARNESS_EPOCH")
+        first_harness_at = min(folded.index(run) for run in self.harness_runs())
         self.assertLess(arg_at, first_harness_at)
 
     def test_epoch_arg_defaults_to_unrolled(self):
@@ -156,6 +178,16 @@ class ScFixture:
             shutil.copy2(ENGINE / "scripts" / script, self.scripts / script)
         (self.engine / "Dockerfile").write_text("FROM scratch\n")
         self._write_fake_docker()
+        # Stub curl too. The no-docker branch of update-harnesses runs the real
+        # vendor installers; a regression that took that branch under docker
+        # would otherwise pipe the live internet into bash on the test machine.
+        self._write_executable("curl", """\
+            #!/bin/sh
+            printf 'curl' >> "$SC_TEST_LOG"
+            printf ' %s' "$@" >> "$SC_TEST_LOG"
+            printf '\\n' >> "$SC_TEST_LOG"
+            exit 0
+            """)
         self.env = os.environ.copy()
         self.env.update({
             "PATH": f"{self.fakebin}:{self.env['PATH']}",
@@ -169,6 +201,11 @@ class ScFixture:
 
     def close(self) -> None:
         self._tmp.cleanup()
+
+    def _write_executable(self, name: str, body: str) -> None:
+        path = self.fakebin / name
+        path.write_text(textwrap.dedent(body))
+        path.chmod(0o755)
 
     def _write_fake_docker(self) -> None:
         path = self.fakebin / "docker"
@@ -243,9 +280,13 @@ class ScHarnessCommands(unittest.TestCase):
 
     def test_update_harnesses_does_not_install_onto_the_host_when_docker_runs(self):
         """The old behavior: run the installers here, report success, change
-        nothing a shell can see. The container mounts creds, never binaries."""
+        nothing a shell can see. The container mounts creds, never binaries.
+        Asserted on the stubbed curl rather than on output text, so a regression
+        is caught by what the command TRIED to do — and cannot reach the network
+        from a test run either way."""
         result = self.fx.run("update-harnesses")
-        self.assertNotIn("claude.ai/install.sh", result.stdout)
+        self.assertEqual([c for c in self.fx.calls() if c.startswith("curl ")], [],
+                         "ran a harness installer against a host no shell can see")
         self.assertNotIn("Updating harness CLIs", result.stdout)
 
     def test_update_harnesses_names_the_restart_that_runs_them(self):


### PR DESCRIPTION
## The bug

A shell in the sandbox could not reach Opus 5, and nothing the operator ran fixed it — not `dos-u`, not `make dos-update-harnesses`, not a restart.

Opus 5 ships in claude CLI **2.1.219**. The sandbox image baked **2.1.218**:

```
grep -c "claude-opus-5" ~/.local/share/claude/versions/2.1.218  →  0
                                                     2.1.219  →  37
docker run --rm super-coder-sandbox:latest claude --version → 2.1.218
```

## Why every escape hatch failed

1. **The harness layer was cache-frozen.** `launch`/`restart` do run `docker build`, but the harness `RUN` had no cache-buster — every rebuild served it from cache. A rebuild could never make a harness newer.
2. **`update-harnesses` updated the wrong machine.** It ran the installers wherever invoked; on the host that updates `~/.local/share/claude`, which the container does not mount. Launch bind-mounts creds (`~/.claude`, `~/.codex`, …) and never binaries. The command reported success and changed nothing a shell could see.
3. **`update` skipped harnesses by design.** `ensure_harnesses()` returns `present` for anything installed.
4. **Restart regressed the version.** `docker rm -f` destroys the writable layer, so an in-container update survives only until the next bounce — which is the before/after the operator observed.

Result: no supported command could put a current harness inside a container, and nothing anywhere reported the CLI version that decides which models an alias like `opus` can resolve to.

## Why not just mount the host's harnesses

Considered and rejected — the engine already rejected it once, in `Dockerfile:148-151`, where kimi is deliberately installed to `/usr/local` *because* its native home is a mounted cred dir and letting the mount shadow the binary is "fatal on a macOS host: darwin binary, linux container". Plus `~/.local/bin/vibe` is a script whose shebang is an absolute path to a host uv interpreter, and glibc baselines differ across Arch/Ubuntu/Mac. Auth is portable JSON; binaries are host-ABI artifacts.

The per-container cost that motivates mounting doesn't exist either: `IMG=super-coder-sandbox` is **one tag shared by every fork** — harnesses are already installed once for all of them.

## The fix

Keep baking; give the layer an expiry.

- **`ARG SC_HARNESS_EPOCH`**, referenced *inside* both harness `RUN`s so a roll genuinely invalidates them rather than relying on docker's arg-cache heuristics, and placed below node/playwright/pip so a roll costs the harness downloads and nothing else. A `LABEL` records what the image was built with.
- **`./sc update` and `./sc update-harnesses` roll it to today**; `./sc build` passes the stored value, so routine launches stay fully cached. The store is **machine-scoped** (every fork shares the tag) and the value is a **date** — the first fork to update that day refreshes harnesses for all of them, the rest cache-hit.
- **`./sc update-harnesses` on the docker path rebuilds** instead of installing onto a host the container cannot see, and names the restart that runs it. Without docker the host *is* the runtime, so the installers still run there.
- **`./sc harness-status`** / `make dos-harness-status` reports the versions inside the sandbox and whether the image owes a rebuild; `launch` names the claude build in its banner. An unlabelled image reads as *unknown*, never as current.

## Verification

- A rebuild lands claude **2.1.220** (39 `opus-5` references vs 0 in 2.1.218); label stamped `2026-07-25`.
- A plain rebuild afterwards is **all-CACHED** — restarts stay fast.
- Full suite: **1585 passed, 11 skipped**. `ruff` clean.
- Mutation-checked: removing the epoch reference from the `RUN` or the `--build-arg` from `dbuild` turns **4 of the new assertions red**.

Note for whoever merges: running sandboxes keep the old image until `./sc restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)