### PR TITLE
chore(make): retire dos-token — the browser attaches its own credential

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -27,7 +27,7 @@
 #
 #   LONG-ONLY: Interface status/start/view/attach/take-control/stop/reconcile/
 #              recover; models; sprint/watch/job; build/logs/serve/health/ports;
-#              verify/map/render/snapshot/deps/install/rollback/token/
+#              verify/map/render/snapshot/deps/install/rollback/
 #              update-harnesses/harness-status/feature/eject
 #              passthrough: make dos ARGS=health
 #
@@ -35,7 +35,7 @@ SC := ./sc
 .PHONY: dos-e dos-enter dos-l dos-launch dos-r dos-restart dos-d dos-down dos-u dos-update \
         dos-t dos-test dos-h dos-help dos-url dos-build dos-logs dos-serve dos-health dos-ports \
         dos-verify dos-map dos-render dos-snapshot dos-deps dos-install dos-rollback \
-        dos-update-harnesses dos-harness-status dos-feat dos-feature dos-eject dos-token dos-status \
+        dos-update-harnesses dos-harness-status dos-feat dos-feature dos-eject dos-status \
         dos-start dos-view dos-attach dos-take dos-take-control dos-stop \
         dos-reconcile dos-recover dos-models dos-model-refresh dos-model-list \
         dos-model-resolve dos-sprint dos-watch dos-job dos-setup dos
@@ -99,9 +99,6 @@ dos-deps:             ; $(SC) deps $(ARGS)
 dos-install:          ; $(SC) install
 dos-setup: dos-install
 dos-rollback:         ; $(SC) rollback
-# Browser sign-in operator token — prints ONLY the owner-only runtime
-# credential to stdout (never rotates, never logs); exact alias of ./sc token.
-dos-token:            ; $(SC) token
 dos-update-harnesses: ; $(SC) update-harnesses
 # What the shells' harness CLIs actually are, in the sandbox — and whether the
 # image owes a harness rebuild. The picker shows model ALIASES, never the CLI
@@ -190,7 +187,6 @@ dos-help:
 	@echo "                                (rolls the harness epoch + rebuilds; dos-r to run them)"
 	@echo "    dos-harness-status          harness CLI versions in the sandbox + is a harness rebuild owed"
 	@echo "    dos-feat / dos-feature      list/enable/disable opt-in features"
-	@echo "    dos-token                   print the browser sign-in token (stdout only)"
 	@echo "    dos-eject                   ONE-WAY: own the engine"
 	@echo ""
 	@echo "    dos ARGS='<cmd>'            generic ./sc passthrough"

--- a/.super-coder/scripts/operator_token.py
+++ b/.super-coder/scripts/operator_token.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Print the browser sign-in operator token (spec doc #30 req 23).
 
-`./sc token` (exact alias `make dos-token`) prints the current Admin runtime
-credential — the token a browser operator pastes into the sign-in prompt — and
-ONLY that token, on stdout. It never rotates the credential, never puts it in
+`./sc token` prints the current Admin runtime credential — the token a browser
+operator pastes into the sign-in prompt — and ONLY that token, on stdout. It is
+now a recovery path rather than the everyday one: the browser attaches its own
+credential, so the paste-it-by-hand flow (and its `make dos-token` alias) is no
+longer part of normal sign-in. It never rotates the credential, never puts it in
 command arguments, and never writes it to a log.
 
 The source of truth is the owner-only runtime artifact the supervised API

--- a/sc
+++ b/sc
@@ -1465,7 +1465,8 @@ super-coder — forkable shell substrate
                              credential from the owner-only artifact .super-coder/run/mem/<shortname>.json, mode 0600)
                              — stdout carries ONLY the token, for paste into the browser sign-in prompt. Never
                              rotates; a missing/unreadable/insecure artifact refuses on stderr with the service
-                             action (`./sc restart` / `make dos-r`). Alias: make dos-token
+                             action (`./sc restart` / `make dos-r`). A recovery path — the browser attaches its
+                             own credential, so pasting a token by hand is no longer the everyday sign-in
   ./sc sprint action <cmd>  planner action receipts over the API: begin (--message/--operation/--target) records
                              intent before a side effect; complete|unknown|reconcile <receipt_id> records the result
   ./sc sprint status       wake status per binding: armed/released, sprint ACTIVE/frozen, batch state,

--- a/tests/test_aliases_make.py
+++ b/tests/test_aliases_make.py
@@ -85,6 +85,19 @@ def make(*args: str) -> subprocess.CompletedProcess[str]:
 
 @unittest.skipUnless(shutil.which("make"), "GNU Make is not installed")
 class MakeAliasContractTest(unittest.TestCase):
+    def test_retired_dos_token_alias_stays_gone(self):
+        """`dos-token` existed for one job: paste the sign-in credential into
+        the browser by hand. The browser attaches its own now, so the alias is
+        retired — and a retired alias needs a test, or the next person adding a
+        maintenance target restores it from muscle memory. `./sc token` itself
+        stays: it is still the recovery path when the automatic attach cannot
+        run, so this pins the ALIAS being gone, never the capability."""
+        result = make("-n", "dos-token")
+        self.assertNotEqual(result.returncode, 0,
+                            "dos-token still resolves as a make target")
+        self.assertNotIn("dos-token", make("dos-help").stdout)
+        self.assertNotIn("dos-token", make("dos-h").stdout)
+
     def test_documented_targets_delegate_exactly_to_sc(self):
         cases = [
             (("dos-enter",), "./sc enter"),
@@ -139,7 +152,6 @@ class MakeAliasContractTest(unittest.TestCase):
             (("dos-install",), "./sc install"),
             (("dos-setup",), "./sc install"),
             (("dos-rollback",), "./sc rollback"),
-            (("dos-token",), "./sc token"),
             (("dos-update-harnesses",), "./sc update-harnesses"),
             (("dos-feature", "ARGS=enable pg"), "./sc feature enable pg"),
             (("dos-feat",), "./sc feature"),
@@ -181,17 +193,10 @@ class MakeAliasContractTest(unittest.TestCase):
             result.stderr,
         )
 
-    def test_full_help_covers_token_dispatch_and_operator_groups(self):
+    def test_full_help_covers_operator_groups(self):
         result = make("dos-help")
         self.assertEqual(result.returncode, 0, result.stderr)
         help_text = result.stdout
-        self.assertEqual(
-            help_text.count(
-                "dos-token                   print the browser sign-in token "
-                "(stdout only)"
-            ),
-            1,
-        )
         for heading in ("HOT", "INTERFACE", "MODELS + SPRINT", "MAINTENANCE"):
             self.assertIn(heading, help_text)
         for target in (
@@ -211,7 +216,6 @@ class MakeAliasContractTest(unittest.TestCase):
             "dos-watch",
             "dos-job",
             "dos-setup",
-            "dos-token",
             "dos-url",
             "dos ARGS='<cmd>'",
         ):


### PR DESCRIPTION
`dos-token` existed for one job: print the sign-in credential so an operator could paste it into the browser by hand. The GUI attaches its own credential from code now, so the alias is a stopgap outliving its stopgap.

## Removed
- the `dos-token` target and its `.PHONY` entry (`.super-coder/aliases.mk`)
- its `dos-help` line and the `token/` mention in the LONG-ONLY header
- the `Alias: make dos-token` note in `./sc help`
- the two test assertions that pinned it

## Added
A test that it **stays** gone — `make -n dos-token` must fail and neither help chart may mention it. A retired alias with no test is one muscle-memory commit away from returning.

## Deliberately not removed

`./sc token` itself. It is spec-backed (doc #30 req 23), carries its own refusal contract and test suite (`tests/test_runtime_credentials.py`), and is still the recovery path when the automatic attach cannot run — a missing or insecure runtime artifact, or a browser that cannot reach the API. Its docstring now says that is what it is for, rather than describing the paste flow as the everyday one.

Say the word if you want the capability gone too, not just the alias — that is a bigger change (spec req, refusal contract, trust-boundary doc) and I did not assume it.

Full suite: 1562 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)