### PR TITLE
docs(sandbox): harness freshness runbook

### DIFF
--- a/.super-coder/docs/harness-freshness.md
+++ b/.super-coder/docs/harness-freshness.md
@@ -1,0 +1,163 @@
+---
+title: Harness freshness — keeping shells on current CLIs and models
+tags: [super-coder, sandbox, harness, docker, models, runbook]
+date: 2026-07-26
+project: super-coder
+purpose: Why a shell cannot reach a model that exists, and the commands that fix it — the harness epoch, what rolls it, and what a restart does
+---
+
+# Harness freshness — keeping shells on current CLIs and models
+
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/jedbjorn/subfloor/blob/main/.super-coder/docs/harness-freshness.md)
+
+## You are probably here because
+
+A shell cannot select a model that exists — a new Opus, a new GPT — and the
+obvious commands did not fix it. That symptom is almost never the model, the
+account, or the picker. It is the **harness CLI version inside the sandbox**.
+
+Vendors ship new models in new CLI releases. Claude Code 2.1.218 had no idea
+Opus 5 existed; 2.1.219 did. A sandbox baked with 2.1.218 offers an `opus` alias
+that cannot resolve to Opus 5, and nothing in the picker says why — the picker
+shows aliases, never the build behind them.
+
+## Where harnesses actually live
+
+**Baked into the sandbox image, not mounted from the host.** This is the fact
+every wrong guess about this system comes from.
+
+`./sc launch` bind-mounts your harness **creds** — `~/.claude`, `~/.claude.json`,
+`~/.codex`, `~/.vibe`, `~/.kimi-code`, opencode's two dirs — so the container
+reuses the login you already did. It mounts **no binaries**. The CLIs come from
+the image (`.super-coder/Dockerfile`).
+
+Three reasons it must stay that way, each of which has already bitten someone:
+
+- **A darwin binary is fatal in a linux container.** On a macOS host, mounting
+  the host's install shadows the baked one with a Mach-O binary the container
+  cannot execute. The Dockerfile installs kimi to `/usr/local` for exactly this
+  reason — its native home, `~/.kimi-code`, is a mounted cred dir.
+- **vibe is not relocatable.** `~/.local/bin/vibe` is a script whose shebang is
+  an absolute path into a host uv-managed interpreter. Mounting the binary
+  without that interpreter tree gives you a dangling shebang.
+- **libc baselines differ.** We support Arch, Ubuntu and macOS hosts against a
+  Debian container. Auth is portable JSON; native binaries are not.
+
+The cost of baking is that the CLIs are only as new as the image, and docker
+serves those installer layers from cache indefinitely. Hence the epoch.
+
+## The harness epoch
+
+`SC_HARNESS_EPOCH` is the **expiry date on the image's harness layers**. It is
+referenced inside both harness `RUN` instructions, so changing it re-runs the
+vendor installers (which resolve "latest" themselves — the epoch is an expiry,
+never a version pin). It sits below the node/playwright/pip layers, so rolling
+it costs the harness downloads and nothing else.
+
+| | |
+|---|---|
+| Stored at | `${XDG_CONFIG_HOME:-~/.config}/super-coder/harness-epoch` |
+| Scope | **The machine**, not the repo — every fork shares the `super-coder-sandbox` image tag |
+| Value | Today's date, so two forks rolling on the same day produce one build arg and the second cache-hits |
+| Unrolled | `0` — the Dockerfile default, so an untouched machine builds exactly what it always did |
+| Recorded in the image | `LABEL sc.harness_epoch`, which is how `harness-status` knows whether a build is owed |
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `./sc harness-status` / `make dos-harness-status` | Versions **inside the sandbox** + whether the image owes a rebuild |
+| `./sc update-harnesses` / `make dos-update-harnesses` | Roll the epoch, rebuild the image. Says which restart runs it |
+| `./sc build --harnesses` | Same rebuild without the rest of `update-harnesses`' output |
+| `./sc build` | Ordinary rebuild — passes the **stored** epoch, so it stays cache-warm |
+| `./sc update` / `make dos-u` | Rolls the epoch as part of the update; the rebuild rides the relaunch you already owe |
+
+## Routine cadence
+
+Nothing to remember. `dos-u` rolls the epoch, and the restart an update already
+requires bakes fresh CLIs. Between updates, `dos-update-harnesses` + `dos-r`.
+
+```
+make dos-u                 # engine floor + epoch rolled
+make dos-r                 # rebuild bakes fresh harnesses, sandbox comes back current
+make dos-harness-status    # confirm
+```
+
+## Runbook: a shell cannot reach a model that exists
+
+**1. Ask what the sandbox is actually running.**
+
+```
+./sc harness-status
+```
+
+This probes inside the container, which is the only answer that matters. Your
+host's own `claude --version` is irrelevant on the docker path — nothing mounts
+it in.
+
+**2. Confirm the CLI is the cause, not the catalogue.** Grep the binary for the
+model id. Zero hits is proof; it cannot offer what it has never heard of.
+
+```
+docker exec sc-<repo> sh -c 'grep -c "claude-opus-5" "$(readlink -f "$(command -v claude)")"'
+```
+
+**3. Refresh and bounce.**
+
+```
+make dos-update-harnesses   # rolls the epoch + rebuilds the image
+make dos-r                  # the running container keeps the OLD image until this
+make dos-harness-status     # verify the new build is what shells got
+```
+
+**4. If the CLI is current and the model still is not offered**, it is no longer
+a freshness problem — look at the model catalogue (`./sc models list claude`,
+`./sc models refresh`) and then at account entitlements. `model_routes` marks
+CLI-probed routes `available` and models.dev-sourced ones `advisory`.
+
+## Gotchas
+
+- **A rebuilt image is not a refreshed sandbox.** Running containers keep the
+  image they started with until `./sc restart`. `harness-status` tells you when
+  those two disagree.
+- **Restart discards in-container installs.** `launch`/`restart` do
+  `docker rm -f`, destroying the writable layer. Installing a harness inside a
+  running container "works" and then evaporates at the next bounce — which is
+  exactly how a fixed sandbox appears to un-fix itself. Roll the epoch instead.
+- **`update-harnesses` without docker does something different, on purpose.**
+  There the host *is* the runtime, so it runs the vendor installers against
+  `$HOME` as it always did.
+- **An unlabelled image means unknown, not current.** Images built before this
+  seam carry no `sc.harness_epoch`, and `harness-status` reports a rebuild owed
+  rather than assuming the best.
+- **A fork needs the engine change before any of this exists.** Forks get it
+  through their own `./sc update`; that same update rolls their epoch.
+
+## Several forks on one machine
+
+They share the image tag, so harnesses are installed **once for all of them** —
+there is no per-container install to repeat. The first fork to roll the epoch on
+a given day rebuilds; every other fork's build that day cache-hits and picks up
+the same CLIs on its next restart.
+
+To see the fleet's drift at a glance:
+
+```
+for c in $(docker ps --format '{{.Names}}' | grep '^sc-'); do
+  printf '%-18s ' "$c"; docker exec "$c" claude --version 2>/dev/null | head -1
+done
+```
+
+Containers running an older image report older CLIs until each is restarted.
+That is expected, not a fault — restarts are per-fork and kill live sessions, so
+they stay an operator decision.
+
+## Why the regression was invisible
+
+Worth keeping in mind when judging a future report. Before `harness-status`
+existed, **nothing anywhere printed the harness CLI version**. The picker and the
+model catalogue show aliases (`opus`, `sonnet`); the launch banner showed ports.
+A sandbox one release behind a new model looked identical to a current one, and
+three separate commands (`update`, `update-harnesses`, `restart`) each reported
+success while changing nothing a shell could see. `./sc launch` now names the
+claude build in its banner, and `harness-status` answers the rest.

--- a/docs/README.md
+++ b/docs/README.md
@@ -431,6 +431,26 @@ loop, and the only role the inbox watcher (`./sc watch inbox`, claude-only)
 fully serves. Any harness *works* in the planner seat — wake latency and
 ergonomics degrade, correctness doesn't.
 
+### Keeping harnesses (and therefore models) current
+
+A new model arrives in a new harness **CLI release** — so a shell can only reach
+the models its CLI knows about. The CLIs are baked into the sandbox image (creds
+are mounted, binaries never are: a darwin binary is fatal in a linux container,
+and vibe's entry point carries an absolute shebang into a host interpreter), and
+docker caches those layers indefinitely. `SC_HARNESS_EPOCH` is their expiry:
+`./sc update` and `./sc update-harnesses` roll it, and the next image build
+reinstalls every harness at latest.
+
+```
+./sc harness-status      # what the sandbox actually runs + is a rebuild owed
+./sc update-harnesses    # roll the epoch + rebuild (then ./sc restart to run it)
+```
+
+If a model that exists is not offered to a shell, start there — it is nearly
+always the CLI build, not the picker or the account. Full runbook, including the
+multi-fork case and why the regression was invisible:
+[`.super-coder/docs/harness-freshness.md`](../.super-coder/docs/harness-freshness.md).
+
 ## Shells & worktrees
 
 > [!class2]

--- a/sc
+++ b/sc
@@ -1450,6 +1450,7 @@ super-coder — forkable shell substrate
                              (they are baked, never mounted — so a running sandbox keeps the old ones until ./sc restart)
                              without docker, updates this host's CLIs instead — there the host IS the runtime
   ./sc harness-status      report the harness CLI versions inside the sandbox + whether the image owes a harness rebuild
+                             (a model the shells cannot reach is nearly always this — see .super-coder/docs/harness-freshness.md)
   ./sc rollback            sound undo of a bad update — restore the DB + engine (engine.ref.prev) together
                              --engine-only repairs a new-engine / unchanged-old-DB half floor without restoring a DB backup
   ./sc feature             list the opt-in features (pg · windows · tailnet · pm2 · app-deploy) and the state of both halves (config block + skill grants)


### PR DESCRIPTION
#609 gave the fleet a way to stay current. This is the operator-facing half: what to run when a shell cannot reach a model that exists, and why that symptom is almost never the model, the picker, or the account.

## `.super-coder/docs/harness-freshness.md`

- **Where harnesses actually live** — baked into the image, creds mounted, binaries never — and the three reasons that cannot change (darwin binary in a linux container; vibe's absolute shebang into a host interpreter; libc baselines across Arch/Ubuntu/macOS).
- **What the epoch is**: machine-scoped, date-valued, referenced inside the harness `RUN`s, stamped into the image as a label.
- **A four-step diagnosis** that ends in proof rather than inference — grep the CLI binary for the model id; zero hits means it has never heard of it.
- **The gotchas that make this look self-un-fixing**: a rebuilt image is not a refreshed sandbox, and `restart` discards in-container installs (which is exactly how a fixed sandbox appears to un-fix itself).
- **The multi-fork case**: one image tag, so harnesses install once for every container on the machine — plus a one-liner to see fleet drift.
- **Why the regression was invisible**, which is worth knowing when judging the next report of this shape: nothing printed the CLI version, and three commands reported success while changing nothing a shell could see.

## Also

- A short section in `docs/README.md` under **Harnesses & models** — that is where someone reads about choosing a model and forms the belief that the picker decides what is reachable.
- A pointer from `./sc harness-status` help, the same pattern `db-broker.md` already uses.

Every command in the runbook was run against the live sandbox before being written down. Full suite: 1586 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)