### PR TITLE
fix(interface): right-align chat work context

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3185,6 +3185,15 @@ async function ifSprintPanel(pane, sel, sessionUi = null) {
         renderVersion !== sessionUi.sprintPanelVersion)) ||
       (!sel.session_id && !bindings.length && !alerts.length)) return;
 
+  if (sessionUi) {
+    const active = bindings.find((binding) =>
+      !binding.released_at && binding.session_id === sessionUi.sessionId);
+    sessionUi.st.sprintRef = active ? active.sprint_doc_id : null;
+    sessionUi.st.sprintTitle =
+      active && active.sprint ? active.sprint.title || null : null;
+    sessionUi.paint();
+  }
+
   const detailNodes = [];
   const actionNodes = [];
   const alertNodes = [];
@@ -3498,10 +3507,17 @@ async function ifSessionPane(pane, sel) {
     archive: sess.archive_id ?? null,
     since: sess.occupied_at || sess.created_at || null,
     title: sess.title || null,      // minted once, from the first composer send
+    sprintRef: sel.sprint_ref || null,
+    sprintTitle: sel.sprint_title || null,
     note: "",
   };
   const headEl = el("div", { className: "if-head" });
+  const headDataEl = el("div", { className: "if-head-data" });
+  const workContextEl = el("div", { className: "if-work-context" });
+  const sprintBadgeEl = el("span",
+    { className: "pill if-badge accent if-work-badge" });
   const identityEl = el("div", { className: "if-identity" });
+  headDataEl.append(workContextEl, sprintBadgeEl, identityEl);
   const sessionDetailsEl = el("div", { className: "if-diag" });
   const sprintDetailsEl = el("div", { className: "if-diag" });
   const detailsEl = el("details", { className: "if-disclosure if-details" },
@@ -3514,14 +3530,14 @@ async function ifSessionPane(pane, sel) {
   const sessionActionsEl = el("div", { className: "if-inline-actions" });
   const sprintActionsEl = el("div", { className: "if-inline-actions" });
   const statusNoteEl = el("div", { className: "if-note" });
-  headEl.append(identityEl, detailsEl, alertsEl, sessionActionsEl,
-    sprintActionsEl, statusNoteEl);
+  headEl.append(detailsEl, alertsEl, sessionActionsEl, sprintActionsEl,
+    headDataEl, statusNoteEl);
   const termEl = el("div", { className: "if-term" });
   const composerEl = el("div", { className: "if-composer" });
   const a = { sessionId, shortname: sel.shortname, st, headEl, termEl,
     composerEl, pane, sel, sessionDetailsEl, sprintDetailsEl, detailsEl,
     alertsEl, alertsSummary, alertsBody, sessionActionsEl, sprintActionsEl,
-    statusNoteEl, identityEl,
+    statusNoteEl, headDataEl, workContextEl, sprintBadgeEl, identityEl,
     legalActions: new Set(
       Array.isArray(sess.legal_actions) ? sess.legal_actions : []),
     stateReason: sess.state_reason || "",
@@ -3602,14 +3618,28 @@ function ifAge(ts) {
   return Math.floor(s / 86400) + "d";
 }
 
+function ifWorkContext(st) {
+  const sprintTitle = String(st.sprintTitle || "")
+    .replace(/^sprint\s*:\s*/i, "").trim();
+  return [sprintTitle, st.title].filter((value, index, all) =>
+    value && all.indexOf(value) === index).join(" · ");
+}
+
 function ifPaintHeader(a, sel, pane) {
   const st = a.st;
   const controlsActive = IF_ATTACHABLE_LIFECYCLES.has(st.lifecycle);
-  // Whose session this is, on the left of the header (spec #43 U4). A chat
-  // with no title yet — nothing sent from the composer — renders the segment
-  // without one rather than reserving an empty slot for it.
-  const identity = [sel.display_name, sel.shortname, st.title]
-    .filter(Boolean).join(" · ");
+  // Actions stay left; the right-aligned data group answers "what" before
+  // "who". A live sprint binding is the honest scope source for a managed
+  // planner session. Its title leads, with the first-message chat title as
+  // the more specific subject (or the sole fallback for an unbound chat).
+  const work = ifWorkContext(st);
+  a.workContextEl.textContent = work;
+  a.workContextEl.title = work;
+  a.workContextEl.hidden = !work;
+  a.sprintBadgeEl.textContent = st.sprintRef ? "Sprint " + st.sprintRef : "";
+  a.sprintBadgeEl.hidden = !st.sprintRef;
+  const identity = [sel.display_name, sel.shortname]
+    .filter(Boolean).join(" | ");
   a.identityEl.textContent = identity;
   a.identityEl.title = identity;
   const stat = (k, v, title) => el("span",

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -777,20 +777,22 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .if-alerts.warning summary { color: var(--warn); border-color: var(--warn); }
 .if-alerts.critical summary { color: #d45a5a; border-color: #d45a5a; }
 .if-alerts-body { color: var(--ink); }
-/* Who this pane is — "<display name> · <SHORTNAME> · <chat title>" on the
-   header's left. It truncates instead of pushing the controls onto a second
-   header line — but .if-head wraps (the note and an open disclosure claim
-   their own line through flex-basis:100%), and a wrapping flex container
-   breaks the line on an item's CONTENT width before it will shrink that item,
-   so min-width:0 alone never got the chance to engage. A zero flex-basis
-   keeps the segment out of the line-breaking decision entirely; it then grows
-   into whatever room the controls leave, capped at its own content width so a
-   short identity sits exactly where it always did, and ellipsis-truncates
-   once there is no room left (min-width:0 is what lets it shrink that far). */
-.if-identity {
-  flex: 1 1 0; max-width: max-content; min-width: 0;
-  overflow: hidden; text-overflow: ellipsis;
+/* Controls stay on the left; the data group consumes the remaining line and
+   aligns the work context, sprint badge, and shell identity to the right.
+   Both text segments may shrink so long subjects never move the controls. */
+.if-head-data {
+  flex: 1 1 0; min-width: 0; margin-left: auto;
+  display: flex; align-items: center; justify-content: flex-end; gap: .75rem;
+}
+.if-work-context {
+  min-width: 0; overflow: hidden; text-overflow: ellipsis;
   white-space: nowrap; color: var(--ink); font-size: .85rem;
+}
+.if-work-badge { flex: 0 0 auto; color: var(--accent); border-color: var(--accent); }
+.if-identity {
+  flex: 0 1 auto; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; color: var(--ink); font-size: .85rem; text-align: right;
 }
 .if-inline-actions { display: flex; align-items: center; gap: .4rem; }
 .if-stat { color: var(--dim); font-size: .8rem; }

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -1731,19 +1731,49 @@ def test_title_is_not_added_to_the_rail_signature():
     assert "s.launch_effort" not in sig
 
 
-def test_header_identity_segment_is_composed_and_styled_to_truncate():
-    """Composition and the truncation styling only. Whether the header ACTUALLY
-    stays one line is a layout fact no CSS-text assertion can witness — this
-    file once asserted all three properties below while a long title still
-    wrapped the controls onto a second line (SC-156). That property is pinned
-    in a real browser by test_interface_ui_rendered's header-line test.
-    """
+def test_header_keeps_controls_left_and_composes_work_data_on_the_right():
+    """The DOM order pins the two-zone hierarchy; rendered coverage below owns
+    the actual geometry and truncation behavior."""
+    assert 'el("div", { className: "if-head-data" })' in APP
+    assert 'el("div", { className: "if-work-context" })' in APP
     assert 'el("div", { className: "if-identity" })' in APP
-    assert "[sel.display_name, sel.shortname, st.title]" in APP
+    assert "headEl.append(detailsEl, alertsEl, sessionActionsEl, sprintActionsEl," in APP
+    assert "headDataEl, statusNoteEl" in APP
+    assert "[sel.display_name, sel.shortname]" in APP
+    assert '.join(" | ")' in APP
+    data = CSS[CSS.index(".if-head-data {"):CSS.index(".if-inline-actions")]
+    assert "margin-left: auto" in data
+    assert "justify-content: flex-end" in data
+    assert "text-overflow: ellipsis" in data
     identity = CSS[CSS.index(".if-identity {"):CSS.index(".if-inline-actions")]
     assert "min-width: 0" in identity
     assert "text-overflow: ellipsis" in identity
     assert "white-space: nowrap" in identity
+
+
+def test_work_context_prefers_live_sprint_scope_then_chat_title():
+    helper = APP[APP.index("function ifWorkContext"):
+                 APP.index("function ifPaintHeader")]
+    script = helper + r"""
+function invariant(ok, message) { if (!ok) throw new Error(message); }
+invariant(
+  ifWorkContext({
+    sprintTitle: "SPRINT: Account Analytics",
+    title: "Tighten the chat header",
+  }) === "Account Analytics · Tighten the chat header",
+  "bound chat did not render sprint subject then chat title");
+invariant(
+  ifWorkContext({ sprintTitle: null, title: "Standalone fix" }) ===
+    "Standalone fix",
+  "unbound chat did not fall back to its first-message title");
+invariant(
+  ifWorkContext({ sprintTitle: "Account Analytics", title: "Account Analytics" }) ===
+    "Account Analytics",
+  "identical scope and title were repeated");
+"""
+    result = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
 
 
 def test_terminal_card_carries_no_dead_chrome_below_the_last_row():

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -1082,39 +1082,32 @@ def test_terminal_bottom_edge_carries_no_dead_chrome(browser, ui_url):
 
 HEADER_LINES = """() => {
   const head = document.querySelector(".if-head");
+  const data = document.querySelector(".if-head-data");
+  const context = document.querySelector(".if-work-context");
   const identity = document.querySelector(".if-identity");
-  const box = identity.getBoundingClientRect();
-  // .if-head centres its items, so a shared flex line is a shared centre —
-  // the tops differ whenever a button is taller than the identity text.
+  const dataBox = data.getBoundingClientRect();
+  const headBox = head.getBoundingClientRect();
   const controls = Array.from(head.children)
-    .filter((child) => child !== identity)
+    .filter((child) => child !== data)
     .map((child) => child.getBoundingClientRect())
     .filter((rect) => rect.height > 0);
   const centre = (rect) => Math.round(rect.top + rect.height / 2);
-  // The identity holds a bare text node, so a Range over its contents measures
-  // the TEXT — unclipped by the segment's overflow, and independent of the box
-  // sized around it. The distance to the controls cannot see the segment
-  // overgrow its content: the controls are the next flex items along, so they
-  // travel with it and the 16px between them never moves.
-  const range = document.createRange();
-  range.selectNodeContents(identity);
   return {
-    lines: new Set([box, ...controls].map(centre)).size,
-    truncated: identity.scrollWidth > identity.clientWidth,
-    boxWidth: box.width,
-    textWidth: range.getBoundingClientRect().width,
+    lines: new Set([dataBox, ...controls].map(centre)).size,
+    truncated: context.scrollWidth > context.clientWidth,
+    controlsRight: Math.max(...controls.map((rect) => rect.right)),
+    dataLeft: dataBox.left,
+    rightInset: headBox.right - dataBox.right,
+    context: context.textContent,
+    badge: document.querySelector(".if-work-badge").textContent,
+    identity: identity.textContent,
   };
 }"""
 
 
-def test_long_identity_truncates_without_wrapping_the_header(browser, ui_url):
-    """Spec #43 U4: the identity segment "stays one line at any width" and the
-    action controls "keep their placement" (SC-156). .if-head wraps, and a
-    wrapping flex container breaks the line on an item's content width before
-    it shrinks that item — so a segment sized by its content dropped the
-    controls onto a second header line and never reached its own ellipsis.
-    Narrow viewport + a title at the 60-char cap forces the choice.
-    """
+def test_header_keeps_controls_left_and_work_data_right(browser, ui_url):
+    """A long work subject truncates inside the right data zone; it never moves
+    the controls or the shell identity onto a second line."""
     titled = {**SESSION, "title": "Wire the watcher daemon into the planner "
                                   "inbox before freeze"}
     assert len(titled["title"]) == 60
@@ -1134,21 +1127,24 @@ def test_long_identity_truncates_without_wrapping_the_header(browser, ui_url):
             "wrapped the controls instead of truncating"
         )
         assert narrow["truncated"], (
-            "the identity fits at 700px — widen the fixture title, this test "
+            "the work context fits at 700px — widen the fixture title, this test "
             "is not measuring anything"
         )
+        assert narrow["controlsRight"] <= narrow["dataLeft"], (
+            "right-side data crossed over the left-side controls"
+        )
+        assert narrow["rightInset"] <= 14
+        assert narrow["badge"] == "Sprint 31"
+        assert narrow["identity"] == "Code-01 | DEV3"
+        assert narrow["context"].startswith("Interface corrective hardening · ")
 
-        # ...and it is capped at its content width, so a segment with room to
-        # spare does not grow and shove the controls to the far right.
+        # With room to spare the same hierarchy remains one line, right aligned.
         page.set_viewport_size({"width": 1600, "height": 1000})
         wide = page.evaluate(HEADER_LINES)
         assert wide["lines"] == 1
         assert not wide["truncated"]
-        assert wide["boxWidth"] - wide["textWidth"] <= 1, (
-            f"a {wide['boxWidth']:.0f}px segment around "
-            f"{wide['textWidth']:.0f}px of text — it grew past its content and "
-            "shoved the controls to the far right"
-        )
+        assert wide["controlsRight"] <= wide["dataLeft"]
+        assert wide["rightInset"] <= 14
     finally:
         context.close()
 


### PR DESCRIPTION
## Summary
- keep Details, Alerts, and action buttons on the left of the chat header
- right-align sprint subject + first-message title, a Sprint badge, and `Shell Name | SHORTNAME`
- source sprint context only from the live session binding; unbound chats fall back to their minted chat title

## Verification
- `node --check .super-coder/ui/app.js`
- `git diff --check`
- `PYTHONPATH=/usr/local/lib/python3.12/site-packages .venv/bin/python -m pytest -q tests/test_interface_ui_contract.py tests/test_interface_ui_rendered.py` — 65 passed
- broad `tests/` run reached 43% before being stopped; its only 3 failures were pre-existing/unrelated `tests/test_harness_epoch.py` cases

## Trade-off
This reuses the existing truthful sprint-binding projection and chat title instead of adding another mutable work-context field.