### PR TITLE
feat(analytics): Provider Quota — simplification and probe corrections (spec 57)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -792,20 +792,21 @@ def get_analytics_filters(con) -> dict:
             "models": distinct("model"), "shells": shells}
 
 
-# ── Account analytics — harness quota (spec doc #49) ─────────────────────────
+# ── Provider quota (spec doc #57, superseding #49's account panel) ───────────
 # Token analytics answers *what did we spend*; this answers *how much is left*.
 # It calls quota_probes.dispatch.probe_all ONCE and owns nothing that call does:
 # concurrency, the 5s per-probe timeout and one-provider-failure containment all
 # live in the dispatcher, because containment is only checkable from the probe
 # package. A second timeout layer here would be a bug, not defence in depth.
 #
-# The route is `accounts`, never `usage`: /api/analytics/usage already means
-# token spend on this tab, and a second meaning on that word is a defect waiting
-# to happen.
+# The route is `quota`, never `usage` and no longer `accounts`. /analytics/usage
+# already means token spend on this tab, and a second meaning on that word is a
+# defect waiting to happen; `accounts` named the thing this response stopped
+# carrying when decision #75 dropped account identity, and a path that describes
+# a response's old shape misleads exactly the reader who trusts it.
 
 QUOTA_TTL_SECONDS = 60      # toggling the two sections must not hammer three
                             # third-party endpoints; the refresh button bypasses it
-QUOTA_ACTIVITY_DAYS = 7     # the panel's only filter — a filter, never a delete
 
 # The TTL's clock: the last probe ATTEMPT, in this process — never the newest
 # captured_at. A probe that identifies nobody (no credential file → `na`, or a
@@ -861,15 +862,14 @@ def _quota_upsert(con, accounts: list[dict]) -> int:
     An account carrying no account_ref writes NO registry row: that is a
     provider with no credential file (`na` — the absence of a limit is not a
     limit of zero) or one that failed before it could name anyone. Such a row
-    could never be matched again, and it has no card to render."""
+    could never be matched again, and it holds no reading to show.
+
+    There is no is_current pre-clear any more, and no is_current at all: it
+    existed to mark which of a provider's rows the credential file resolves to
+    NOW, which only mattered while cards were per-account. The panel shows the
+    newest reading per provider (see `_latest_readings`), so the question has
+    no reader left (decision #75, migration 0097)."""
     named = [a for a in accounts if a.get("account_ref")]
-    for provider in dict.fromkeys(a["provider"] for a in named):
-        # A credential file resolves to exactly one account, so the provider's
-        # other rows stop being current the moment this probe names one.
-        # Cleared BEFORE the upsert writes its answer — doing it inside the
-        # upsert would leave a switched-away account still flagged current.
-        con.execute("UPDATE harness_quota_account SET is_current=0 WHERE provider=?",
-                    (provider,))
     written = 0
     for acct in named:
         seen = acct["captured_at"]
@@ -878,13 +878,11 @@ def _quota_upsert(con, accounts: list[dict]) -> int:
         # minting a duplicate identity.
         con.execute(
             "INSERT INTO harness_quota_account "
-            "(provider, account_ref, account_label, plan, first_seen, last_seen, is_current) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?) "
+            "(provider, account_ref, plan, first_seen, last_seen) "
+            "VALUES (?, ?, ?, ?, ?) "
             "ON CONFLICT(provider, account_ref) DO UPDATE SET "
-            "account_label=excluded.account_label, plan=excluded.plan, "
-            "last_seen=excluded.last_seen, is_current=excluded.is_current",
-            (acct["provider"], acct["account_ref"], acct.get("account_label"),
-             acct.get("plan"), seen, seen, 1 if acct.get("is_current") else 0))
+            "plan=excluded.plan, last_seen=excluded.last_seen",
+            (acct["provider"], acct["account_ref"], acct.get("plan"), seen, seen))
         pk = con.execute(
             "SELECT account_pk FROM harness_quota_account WHERE provider=? AND account_ref=?",
             (acct["provider"], acct["account_ref"])).fetchone()[0]
@@ -919,33 +917,72 @@ def probe_quota_accounts(con) -> dict:
     return {"providers": providers, "windows_written": written, "notes": notes}
 
 
-def get_analytics_accounts(con, force: bool = False) -> dict:
-    """Registry + windows for the account panel, probing first when the last
-    probe ATTEMPT has aged past the TTL. `force` is POST /probe — the refresh
-    button."""
-    probe = probe_quota_accounts(con) if _quota_claim(force) else None
-    cutoff = (datetime.now(timezone.utc)
-              - timedelta(days=QUOTA_ACTIVITY_DAYS)).strftime("%Y-%m-%dT%H:%M:%SZ")
-    # The 7-day window, plus the account the credential file resolves to NOW.
-    # That account renders even when its last_seen has aged (a failed probe
-    # leaves it un-advanced), because the spec requires the current account
-    # rather than an empty page. Everything else outside the window stops
-    # rendering WITHOUT being deleted — switching back restores it intact.
-    accounts = rows(con.execute(
-        "SELECT * FROM harness_quota_account WHERE last_seen >= ? OR is_current=1 "
-        "ORDER BY provider, is_current DESC, last_seen DESC", (cutoff,)))
-    by_pk: dict = {}
+def _latest_readings(con) -> dict:
+    """provider -> {captured_at, windows[]}: the most recent reading each
+    provider has produced, whichever account produced it.
+
+    KEYED ON THE WINDOW'S captured_at, NOT the registry row's last_seen, and
+    that is load-bearing rather than a detail. A row with no windows has no
+    reading, so it cannot outrank one that has numbers — which is what makes
+    the stale registry rows flag #196 minted from a guessed account_ref both
+    unable to win and impossible to see, without a data migration to hunt them
+    down. It is also literally what spec #57 asks for: the most recent reading
+    by captured_at, regardless of which account produced it.
+
+    Multiple accounts for one provider are not disambiguated. Under a
+    provider-level panel "which account am I looking at" is not a question the
+    surface answers, and decision #68's multi-account problem dissolves with
+    it."""
+    groups: dict = {}
     for w in rows(con.execute(
-            "SELECT * FROM harness_quota_window "
-            "ORDER BY account_pk, window_kind, scope")):
-        by_pk.setdefault(w.pop("account_pk"), []).append(w)
-    for a in accounts:
-        a["windows"] = by_pk.get(a["account_pk"], [])
-    return {"accounts": accounts,
-            "activity_days": QUOTA_ACTIVITY_DAYS,
+            "SELECT a.provider AS provider, w.* FROM harness_quota_window w "
+            "JOIN harness_quota_account a ON a.account_pk = w.account_pk "
+            "ORDER BY w.window_kind, w.scope")):
+        groups.setdefault((w.pop("provider"), w.pop("account_pk")), []).append(w)
+    latest: dict = {}
+    for (provider, _pk), windows in groups.items():
+        captured_at = max(w["captured_at"] for w in windows)
+        if provider not in latest or captured_at > latest[provider]["captured_at"]:
+            latest[provider] = {"captured_at": captured_at, "windows": windows}
+    return latest
+
+
+def get_analytics_quota(con, force: bool = False) -> dict:
+    """One entry per provider — its windows, the age of the reading, and its
+    status — probing first when the last probe ATTEMPT has aged past the TTL.
+    `force` is POST /probe, the refresh button.
+
+    NOTHING IN THIS RESPONSE IDENTIFIES THE OPERATOR: no label, no email, no
+    account ref, no plan, no sign-in state (decision #75). account_ref stays in
+    the DB as the upsert key and stops there.
+
+    The entry list is built from the probe package's PROVIDERS, not from
+    whatever the status list or the registry happens to hold. A provider that
+    has never been probed must still render a card reading "no reading yet" —
+    the operator has to be able to tell "not configured" from "not readable",
+    and a list built from observed rows cannot express the first."""
+    probe = probe_quota_accounts(con) if _quota_claim(force) else None
+    latest = _latest_readings(con)
+    # The per-provider status list KEEPS ITS MEANING and its source: it is what
+    # distinguishes "nothing configured" from "the probe failed", and dropping
+    # identity does not merge those two.
+    status = {p["provider"]: p for p in
+              ((probe or {}).get("providers") or list(_QUOTA_PROBE["providers"]))}
+    providers = []
+    for name in quota_dispatch.PROVIDERS:
+        reading = latest.get(name) or {}
+        providers.append({
+            "provider": name,
+            "status": status.get(name, {}).get("status"),
+            "detail": status.get(name, {}).get("detail"),
+            # The age of the numbers on the card, and it is never omitted: it
+            # is the only thing that tells a stale reading from a fresh one.
+            "captured_at": reading.get("captured_at"),
+            "windows": reading.get("windows") or [],
+        })
+    return {"providers": providers,
             "ttl_seconds": QUOTA_TTL_SECONDS,
             "probed": probe is not None,
-            "providers": (probe or {}).get("providers") or list(_QUOTA_PROBE["providers"]),
             "notes": (probe or {}).get("notes") or []}
 
 
@@ -2788,12 +2825,11 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, get_analytics_usage(con, q))
             if path == "/api/analytics/filters":
                 return self._send(200, get_analytics_filters(con))
-            if path == "/api/analytics/accounts":
-                # Arrival at #analytics-accounts. Probes only when this
-                # process's last probe ATTEMPT is older than the TTL — never
-                # at boot, never on a timer, never from the Token Analytics
-                # section.
-                return self._send(200, get_analytics_accounts(con))
+            if path == "/api/analytics/quota":
+                # Arrival at #analytics-quota. Probes only when this process's
+                # last probe ATTEMPT is older than the TTL — never at boot,
+                # never on a timer, never from the Token Analytics section.
+                return self._send(200, get_analytics_quota(con))
             if path == "/api/scripts":
                 return self._send(200, {"scripts": script_list()})
             if path == "/api/vm":
@@ -2874,9 +2910,9 @@ class Handler(BaseHTTPRequestHandler):
                 # GUI Analytics tab load — incremental, so steady-state is
                 # cheap; sweep opens its own connection.
                 return self._send(200, analytics.sweep(quiet=True))
-            if path == "/api/analytics/accounts/probe":
+            if path == "/api/analytics/quota/probe":
                 # The refresh button — always re-probes, TTL or not.
-                return self._send(200, get_analytics_accounts(con, force=True))
+                return self._send(200, get_analytics_quota(con, force=True))
             if path == "/api/snapshot":
                 try:
                     with _CONTENT_WRITE_LOCK:

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -864,25 +864,26 @@ def _quota_upsert(con, accounts: list[dict]) -> int:
     limit of zero) or one that failed before it could name anyone. Such a row
     could never be matched again, and it holds no reading to show.
 
-    There is no is_current pre-clear any more, and no is_current at all: it
-    existed to mark which of a provider's rows the credential file resolves to
-    NOW, which only mattered while cards were per-account. The panel shows the
-    newest reading per provider (see `_latest_readings`), so the question has
-    no reader left (decision #75, migration 0097)."""
+    THE REGISTRY ROW IS NOW NOTHING BUT A KEY — (account_pk, provider,
+    account_ref) — so the upsert has nothing to update and DOES NOTHING on
+    conflict. Everything it used to carry described WHICH ACCOUNT, which is the
+    question a provider-level panel stops asking: account_label and is_current
+    went with the cards that read them, plan is displayed nowhere and returned
+    nowhere, and first_seen/last_seen lost their last reader when the newest
+    reading came to be selected by the WINDOW's captured_at (see
+    `_latest_readings`) rather than by the row's last_seen.
+
+    Keeping them as cheap provenance would have been the wrong instinct:
+    THESE TABLES ARE PROBE-REBUILDABLE CACHES, and provenance a single probe
+    regenerates is not provenance (decision #75, migration 0097)."""
     named = [a for a in accounts if a.get("account_ref")]
     written = 0
     for acct in named:
         seen = acct["captured_at"]
-        # first_seen is deliberately absent from the SET list: an account that
-        # went quiet and came back keeps its original first_seen rather than
-        # minting a duplicate identity.
         con.execute(
-            "INSERT INTO harness_quota_account "
-            "(provider, account_ref, plan, first_seen, last_seen) "
-            "VALUES (?, ?, ?, ?, ?) "
-            "ON CONFLICT(provider, account_ref) DO UPDATE SET "
-            "plan=excluded.plan, last_seen=excluded.last_seen",
-            (acct["provider"], acct["account_ref"], acct.get("plan"), seen, seen))
+            "INSERT INTO harness_quota_account (provider, account_ref) "
+            "VALUES (?, ?) ON CONFLICT(provider, account_ref) DO NOTHING",
+            (acct["provider"], acct["account_ref"]))
         pk = con.execute(
             "SELECT account_pk FROM harness_quota_account WHERE provider=? AND account_ref=?",
             (acct["provider"], acct["account_ref"])).fetchone()[0]

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -933,7 +933,18 @@ def _latest_readings(con) -> dict:
     Multiple accounts for one provider are not disambiguated. Under a
     provider-level panel "which account am I looking at" is not a question the
     surface answers, and decision #68's multi-account problem dissolves with
-    it."""
+    it.
+
+    A READING IS ONE CAPTURE, NOT EVERY WINDOW EVER SEEN. The window upsert
+    updates and never deletes, so a kind the provider stops reporting keeps its
+    row for good — and returning the accumulated set would file that row under
+    the newest capture's age. That is spec #57's second empty-state wall
+    crossed exactly: an hour-old figure presented as fresh under an "as of 1m
+    ago" stamp. Every window of one probe run carries that run's captured_at
+    (the probes stamp it once), so the newest capture's rows are precisely the
+    rows whose captured_at equals the newest. A probe that failed writes no
+    rows at all, which is why the degraded card still shows its whole last
+    known reading — with that reading's own age."""
     groups: dict = {}
     for w in rows(con.execute(
             "SELECT a.provider AS provider, w.* FROM harness_quota_window w "
@@ -943,8 +954,9 @@ def _latest_readings(con) -> dict:
     latest: dict = {}
     for (provider, _pk), windows in groups.items():
         captured_at = max(w["captured_at"] for w in windows)
+        reading = [w for w in windows if w["captured_at"] == captured_at]
         if provider not in latest or captured_at > latest[provider]["captured_at"]:
-            latest[provider] = {"captured_at": captured_at, "windows": windows}
+            latest[provider] = {"captured_at": captured_at, "windows": reading}
     return latest
 
 

--- a/.super-coder/migrations/0097_quota_drop_account_identity.sql
+++ b/.super-coder/migrations/0097_quota_drop_account_identity.sql
@@ -50,33 +50,64 @@
 -- committed screenshot needing a scrubbed label. With no label rendered there
 -- is nothing in that shot to scrub.
 --
--- ── is_current goes too: no reader AND no writer ─────────────────────────────
+-- ── EVERY OTHER COLUMN GOES TOO: each one answered "WHICH ACCOUNT" ───────────
 --
--- is_current existed to tell one account's card from another's — which account
--- the credential file resolves to NOW — and it had exactly two readers: the
--- API's exemption from the 7-day activity filter, and the UI's muted rendering
--- of a non-current account. Spec 57 removes both, along with the 7-day filter
--- itself and the upsert's pre-clear that maintained the column. A provider-level
--- panel shows the newest reading per provider and never has to answer "which
--- account", so nothing is left that could read it and nothing is left that
--- writes it. A column with neither is a question for the next person.
+-- The registry is left as (account_pk, provider, account_ref) and nothing else.
+-- Each dropped column had its own reason, and they converge on one:
 --
--- idx_hqa_last_seen goes with it: it existed solely to drive the 7-day filter.
--- The COLUMN last_seen stays — the writer still maintains it, and it is the
--- provenance of account_ref, which decision #75 explicitly keeps as an internal
--- upsert key so a repeated probe updates a row instead of duplicating it.
--- account_ref is provider-issued, is never an email, and is never rendered.
+-- is_current told one account's card from another's — which account the
+-- credential file resolves to NOW. Exactly two readers: the API's exemption
+-- from the 7-day activity filter, and the UI's muted rendering of a
+-- non-current account. Spec 57 removes both, plus the 7-day filter itself and
+-- the upsert's pre-clear that maintained the column. Nothing reads it and
+-- nothing writes it; a column with neither is a question for the next person.
 --
--- `plan` also stays. It is not identity (max / prolite / LEVEL_ADVANCED), it is
--- absent from the API response and from the card, and spec 57's verification
--- gate pins where each probe must read it from — which a dropped column could
--- not satisfy. Two of the three were reading it from the wrong place.
+-- first_seen and last_seen lost their last reader to a BUILD DECISION, which is
+-- why they were not in this migration's first draft. Selecting the newest
+-- reading per provider needs an ordering key, and last_seen looks like it. But
+-- the panel selects on the WINDOW's captured_at instead — a row with no windows
+-- then has no reading and cannot outrank one with numbers, which is both what
+-- the spec literally asks for and what makes flag #196's stale guessed-ref rows
+-- unable to win and impossible to see, with no data migration to hunt them
+-- down. That choice removes last_seen's only reader; first_seen never had a
+-- stronger one.
+--
+-- plan is the one that looked harmless enough to keep: not identity in the way
+-- an email is (max / prolite / LEVEL_ADVANCED), and each probe could read it
+-- correctly. But decision #75 displays no plan and the API returns none, so
+-- every read fed a column no one queried — which is precisely why TWO OF THE
+-- THREE PROBES WERE READING IT FROM THE WRONG PLACE, undetected: moonshot from
+-- the top level instead of user.membership, anthropic from a payload key the
+-- wire has never sent. A column nothing queries cannot report that it is wrong.
+--
+-- An earlier draft of spec 57 kept a verification item requiring plan to be
+-- read from user.membership.level. That item was carried over from the defect
+-- list written BEFORE the simplification ruling and contradicted the ruling
+-- itself; it is withdrawn, and the column goes with it.
+--
+-- ── WHY "cheap provenance" DOES NOT SAVE ANY OF THEM ─────────────────────────
+--
+-- The instinct to keep a timestamp because it costs nothing is the one this
+-- migration deliberately refuses. THESE TABLES ARE PROBE-REBUILDABLE CACHES:
+-- provenance that a single probe regenerates is not provenance. If first_seen
+-- is wanted later it is added deliberately and refills on the next probe.
+--
+-- The table is NOT collapsed. account_ref earns its keep as the upsert key that
+-- stops a repeated probe duplicating rows; it is provider-issued, is never an
+-- email, and is never rendered.
+--
+-- idx_hqa_last_seen goes because it existed solely to drive the 7-day filter,
+-- and because SQLite refuses to drop an indexed column — hence the order below:
+-- the index first, then the column it indexed.
 
 BEGIN;
 
+DROP INDEX IF EXISTS idx_hqa_last_seen;
+
 ALTER TABLE harness_quota_account DROP COLUMN account_label;
 ALTER TABLE harness_quota_account DROP COLUMN is_current;
-
-DROP INDEX IF EXISTS idx_hqa_last_seen;
+ALTER TABLE harness_quota_account DROP COLUMN plan;
+ALTER TABLE harness_quota_account DROP COLUMN first_seen;
+ALTER TABLE harness_quota_account DROP COLUMN last_seen;
 
 COMMIT;

--- a/.super-coder/migrations/0097_quota_drop_account_identity.sql
+++ b/.super-coder/migrations/0097_quota_drop_account_identity.sql
@@ -1,0 +1,82 @@
+-- 0097 — Provider Quota: drop account identity from the registry (spec doc 57, feature 17).
+--
+-- Spec 49 built a card per ACCOUNT, labelled with who is signed in. Decision
+-- #75 replaced that with a card per PROVIDER showing its most recent reading
+-- and the age of that reading, and nothing about the operator's session. This
+-- migration removes what the old idea needed and nothing else.
+--
+-- ── Why the label goes, and it is not a redaction ────────────────────────────
+--
+-- The label was never going to be consistent across the three providers, which
+-- is the fact the whole labelling chain (#66 redact → #67 full email → #69 the
+-- Anthropic email path) was missing. Verified by capturing all three payloads
+-- live: only OpenAI returns an email in its usage RESPONSE; Anthropic's comes
+-- from ~/.claude.json, not the API at all; and Moonshot's payload carries no
+-- email anywhere — user{} holds userId, region, membership and businessId, full
+-- stop. So two of three cards always rendered an opaque identifier, and the
+-- operator saw exactly that. A rule reasoned from the one provider that
+-- cooperates is not a rule.
+--
+-- Dropping the column is therefore not a stricter redaction of the same design.
+-- The design is gone: no probe collects an operator label of any kind, so there
+-- is no value to redact, and the exposure class ceases to exist rather than
+-- being defended.
+--
+-- ── CORRECTING 0096's COMMENT, which is why this file says all of the above ──
+--
+-- 0096 is landed and is NOT edited in place. Two things it states are now
+-- wrong, and a future reader has no way to know that from 0096 alone:
+--
+-- 1. It states snapshot exclusion is LOAD-BEARING, on decision #67's ground
+--    that account_label holds the operator's full email and exclusion is "the
+--    ONLY thing between full operator emails and the repository". With no email
+--    ever written, THAT RATIONALE IS RETIRED AT ITS SOURCE.
+--
+--    THE EXCLUSION ITSELF STAYS, AND SO DOES ITS TEST. The rationale simply
+--    reverts to decision #65's original and still-sufficient one: these are
+--    probe-rebuildable caches, exactly like session_token_usage (0071), and a
+--    rebuild re-derives all of it from the next probe. Ordinary hygiene, which
+--    was always reason enough. The test is not weakened — it is cheap, still
+--    correct, and a test deleted because "the risk went away" is how the risk
+--    comes back.
+--
+-- 2. Its account_label comment describes the label ladder as "FULL email
+--    (OpenAI) else user.userId (Moonshot) else credential uuid first 8
+--    (Anthropic)". That was ALREADY WRONG when 0096 landed — conformance SC-C2
+--    found Anthropic's label was the full email under decision #69, not the
+--    uuid's first 8 — and it is doubly wrong now that no ladder exists at all.
+--
+-- Also retired: 0096's second-order note that docs/images/analytics.png is a
+-- committed screenshot needing a scrubbed label. With no label rendered there
+-- is nothing in that shot to scrub.
+--
+-- ── is_current goes too: no reader AND no writer ─────────────────────────────
+--
+-- is_current existed to tell one account's card from another's — which account
+-- the credential file resolves to NOW — and it had exactly two readers: the
+-- API's exemption from the 7-day activity filter, and the UI's muted rendering
+-- of a non-current account. Spec 57 removes both, along with the 7-day filter
+-- itself and the upsert's pre-clear that maintained the column. A provider-level
+-- panel shows the newest reading per provider and never has to answer "which
+-- account", so nothing is left that could read it and nothing is left that
+-- writes it. A column with neither is a question for the next person.
+--
+-- idx_hqa_last_seen goes with it: it existed solely to drive the 7-day filter.
+-- The COLUMN last_seen stays — the writer still maintains it, and it is the
+-- provenance of account_ref, which decision #75 explicitly keeps as an internal
+-- upsert key so a repeated probe updates a row instead of duplicating it.
+-- account_ref is provider-issued, is never an email, and is never rendered.
+--
+-- `plan` also stays. It is not identity (max / prolite / LEVEL_ADVANCED), it is
+-- absent from the API response and from the card, and spec 57's verification
+-- gate pins where each probe must read it from — which a dropped column could
+-- not satisfy. Two of the three were reading it from the wrong place.
+
+BEGIN;
+
+ALTER TABLE harness_quota_account DROP COLUMN account_label;
+ALTER TABLE harness_quota_account DROP COLUMN is_current;
+
+DROP INDEX IF EXISTS idx_hqa_last_seen;
+
+COMMIT;

--- a/.super-coder/scripts/quota_probes/__init__.py
+++ b/.super-coder/scripts/quota_probes/__init__.py
@@ -18,7 +18,7 @@ Contract — every provider module exposes:
 
 Each returned dict is one ACCOUNT, carrying its own windows:
 
-    provider, account_ref, plan, status, detail, probe_version,
+    provider, account_ref, status, detail, probe_version,
     captured_at, windows[]
 
 `account_ref` is an INTERNAL KEY and nothing else: it is what lets a repeated
@@ -247,14 +247,21 @@ def get_json(url: str, headers: dict, timeout: float) -> "tuple[int, object]":
 
 
 def account(*, provider: str, probe_version: str, captured_at: str,
-            account_ref=None, plan=None, status="ok", detail=None,
+            account_ref=None, status="ok", detail=None,
             windows=None) -> dict:
-    """One account's reading. There is no `account_label` and no `is_current`:
-    the first was the operator's identity and is not collected at all any more,
-    and the second existed only to tell one account's card from another's,
-    which a provider-level panel never has to do (decision #75)."""
+    """One account's reading. There is no `account_label`, no `is_current` and
+    no `plan`: the first was the operator's identity and is not collected at
+    all any more, the second existed only to tell one account's card from
+    another's, and the third described WHICH ACCOUNT — the question a
+    provider-level panel stops asking (decision #75, migration 0097).
+
+    `plan` is worth a line because it was the one that looked harmless. It is
+    not identity in the way an email is, and each probe could read it
+    correctly — but nothing displays it and nothing returns it, so every read
+    was feeding a column no one queried. Two of the three were reading it from
+    the wrong place, undetected, for exactly that reason."""
     return {
-        "provider": provider, "account_ref": account_ref, "plan": plan,
+        "provider": provider, "account_ref": account_ref,
         "status": status, "detail": detail, "probe_version": probe_version,
         "captured_at": captured_at, "windows": list(windows or []),
     }

--- a/.super-coder/scripts/quota_probes/__init__.py
+++ b/.super-coder/scripts/quota_probes/__init__.py
@@ -18,8 +18,14 @@ Contract — every provider module exposes:
 
 Each returned dict is one ACCOUNT, carrying its own windows:
 
-    provider, account_ref, account_label, plan, is_current, status,
-    detail, probe_version, captured_at, windows[]
+    provider, account_ref, plan, status, detail, probe_version,
+    captured_at, windows[]
+
+`account_ref` is an INTERNAL KEY and nothing else: it is what lets a repeated
+probe update a row instead of minting a duplicate. It is a provider-issued
+identifier, it is never an email, and it is never rendered — the panel shows
+one card per PROVIDER and says nothing about who is signed in (decision #75).
+No probe in this package collects an operator label of any kind.
 
 `status` is `ok` / `unauth` / `na` / `error` and is the account's own — one
 provider's failure never touches another's (see dispatch.probe_all). A
@@ -137,6 +143,28 @@ def kind_for_seconds(seconds: "float | None") -> "str | None":
     return None
 
 
+def duration_label(seconds) -> str:
+    """Operator-visible text for a window duration we could not map to a kind.
+
+    A CONTAINER IS NEVER INTERPOLATED INTO OPERATOR-VISIBLE TEXT, and this
+    function is where that rule is enforced for every provider. moonshot's
+    fallback used to read `str(raw)` with `raw` the window dict, which put
+    `{'duration': 300, 'timeUnit': 'TIME_UNIT_MINUTE'}` on the card AND
+    persisted it to harness_quota_window.scope (flag #198). openai's read
+    `f"{seconds}s"` straight from the payload, which would do the same thing
+    the day that key nests.
+
+    A repr is not a label. Anything that will not coerce to a number is
+    reported as unrecognized rather than rendered — the row is still kept, so
+    a window we cannot name is visible rather than dropped, which is what spec
+    #49 asks for. It lives here, not in the module that shipped the defect,
+    because it is a class and not a typo."""
+    try:
+        return f"{int(float(seconds))}s"
+    except (TypeError, ValueError):
+        return "unrecognized window"
+
+
 def percent_from(used, limit) -> "float | None":
     """Absolute counts → percent. A zero (or absent) limit yields None, never
     a division by zero and never a 0%. A percent is NEVER back-computed into a
@@ -219,13 +247,15 @@ def get_json(url: str, headers: dict, timeout: float) -> "tuple[int, object]":
 
 
 def account(*, provider: str, probe_version: str, captured_at: str,
-            account_ref=None, account_label=None, plan=None, is_current=1,
-            status="ok", detail=None, windows=None) -> dict:
+            account_ref=None, plan=None, status="ok", detail=None,
+            windows=None) -> dict:
+    """One account's reading. There is no `account_label` and no `is_current`:
+    the first was the operator's identity and is not collected at all any more,
+    and the second existed only to tell one account's card from another's,
+    which a provider-level panel never has to do (decision #75)."""
     return {
-        "provider": provider, "account_ref": account_ref,
-        "account_label": account_label, "plan": plan,
-        "is_current": 1 if is_current else 0, "status": status,
-        "detail": detail, "probe_version": probe_version,
+        "provider": provider, "account_ref": account_ref, "plan": plan,
+        "status": status, "detail": detail, "probe_version": probe_version,
         "captured_at": captured_at, "windows": list(windows or []),
     }
 
@@ -268,13 +298,28 @@ def response_detail(code: int, payload, provider: str, log) -> str:
     rather than as a bare 'HTTP 200'."""
     if code == 200:
         return drift(provider, "response was not a JSON object", log)
+    if code == 403:
+        # Named rather than left as a bare status, because the whole point of
+        # flag #196 is that "HTTP 403" was read as an auth verdict by the layer
+        # above and rendered as a claim about the operator. Say what it is.
+        return ("HTTP 403 — the endpoint rejected this request as an "
+                "unrecognized client, not as a bad credential")
     return f"HTTP {code}" if code else f"unreachable: {payload}"
 
 
 def status_for_http(code: int) -> str:
-    """HTTP status → account status. 401/403 is the provider telling us the
-    token is dead: report it as `unauth` and leave the last known values
-    standing. Everything else non-200 is `error` — never a measured zero."""
-    if code in (401, 403):
-        return "unauth"
-    return "error"
+    """HTTP status → account status.
+
+    401 is the provider's AUTH VERDICT — the token is dead — and is the only
+    code that yields `unauth`.
+
+    403 IS NOT AN AUTH VERDICT, and mapping it to one shipped a defect. These
+    endpoints are private CLI endpoints: they answer 403, with an HTML anti-bot
+    page rather than a JSON auth error, to any request they do not recognize as
+    their own client. Under the old mapping that rendered as "signed out — last
+    known" while the operator was signed in and actively using the harness
+    (flag #196). A 403 is `error` with a diagnosis, so a probe the endpoint has
+    started refusing is visibly broken rather than quietly blamed on the
+    operator's session. Everything else non-200 is `error` too — never a
+    measured zero."""
+    return "unauth" if code == 401 else "error"

--- a/.super-coder/scripts/quota_probes/anthropic.py
+++ b/.super-coder/scripts/quota_probes/anthropic.py
@@ -3,8 +3,7 @@
 Two files, and only the first is the credential file:
 
   ~/.claude/.credentials.json   claudeAiOauth.accessToken + expiresAt — the
-                                token, read and never written. Also
-                                subscriptionType, which is where `plan` lives.
+                                token, read and never written.
   ~/.claude.json                oauthAccount.accountUuid — the internal key.
 
 Spec #49 and decisions #65/#67 both said `account_ref` comes from "the
@@ -21,11 +20,18 @@ identifier of any kind — verified against a live capture, whose top-level keys
 are five_hour / seven_day* / extra_usage / limits / spend /
 member_dashboard_available and nothing else.
 
-`plan` comes from the CREDENTIAL FILE, not the payload: `subscriptionType` is
-a key of that file, and the usage response has never carried it. Reading it
-from the payload — which this module did until the live capture — returned
-None for every account, silently, because the fixture had been transcribed
-with the field invented at the payload's top level.
+NO `plan` IS COLLECTED HERE, and the reason it is worth a note is what finding
+it produced. This module used to read `payload.subscriptionType` — a key the
+usage response has never carried. It returned None for every account,
+silently, forever, because the fixture had been TRANSCRIBED with that field
+invented at the payload's top level, so the test agreed with the bug. The real
+value was in the credential file all along.
+
+The read is gone rather than corrected: decision #75 displays no plan and the
+API returns none, so the column was dropped (migration 0097) and a correct
+read would still have been feeding nothing. Recorded because the same
+read-at-the-wrong-level defect turned up in all three providers, every one of
+them invisible for this identical reason.
 """
 from __future__ import annotations
 
@@ -131,6 +137,4 @@ def probe(log, timeout) -> list[dict]:
         return result(status="error", **common, detail=drift(
             HARNESS_PROVIDER, "no limits[] in the usage payload", log))
 
-    # From the CREDENTIAL FILE, not the payload — see the module docstring.
-    return result(plan=(oauth or {}).get("subscriptionType"),
-                  windows=_windows(limits, captured_at, log), **common)
+    return result(windows=_windows(limits, captured_at, log), **common)

--- a/.super-coder/scripts/quota_probes/anthropic.py
+++ b/.super-coder/scripts/quota_probes/anthropic.py
@@ -16,9 +16,14 @@ That file ALSO carries `emailAddress` in full, and this module used to read
 it: decision #69 made the card's label the operator's full address. Decision
 #75 dropped account identity entirely, so the address is not read here any
 more and the uuid is only ever an upsert key. The payload carries no
-identifier of any kind — verified against a live capture, whose top-level keys
-are five_hour / seven_day* / extra_usage / limits / spend /
-member_dashboard_available and nothing else.
+identifier of any kind — verified against a live capture, which alongside
+five_hour / seven_day* / extra_usage / limits / spend /
+member_dashboard_available carries half a dozen provider-internal keys this
+probe neither reads nor recognizes (`tangelo`, `nimbus_quill`, `cinder_cove`
+and friends). NONE OF THEM NAMES AN ACCOUNT — that is the claim worth making,
+and it is the one the fixture supports. The previous sentence here ended "and
+nothing else", an exhaustive promise about a payload we do not control, and it
+was already false against the capture sitting beside it.
 
 NO `plan` IS COLLECTED HERE, and the reason it is worth a note is what finding
 it produced. This module used to read `payload.subscriptionType` — a key the
@@ -70,10 +75,27 @@ def _account_uuid(log) -> "str | None":
     return str(uuid) if uuid else None
 
 
+def _drift(limits: list) -> "str | None":
+    """What the normalizer cannot read, or None when the envelope is intact.
+
+    `limits: []` is an account with no window to report and stays `ok` — the
+    length is data. An ENTRY that is not an object is not: this list is where
+    every window on the card comes from, so an unreadable entry is a window
+    disappearing while the probe reports `ok` (L-614-1, the same finding as
+    openai's `additional_rate_limits[]` and moonshot's `limits[]`)."""
+    for item in limits:
+        if not isinstance(item, dict):
+            return f"limits[] entry is {type(item).__name__}, not an object"
+    return None
+
+
 def _windows(limits, captured_at: str, log) -> list[dict]:
     rows = []
     for item in limits:
         if not isinstance(item, dict):
+            # Retained guard: `_drift` rejects a non-object entry before this
+            # runs, so a mutation that disables the check degrades to the
+            # historical silent skip instead of raising here.
             continue
         raw_kind = item.get("kind")
         kind = KIND_MAP.get(raw_kind)
@@ -136,5 +158,10 @@ def probe(log, timeout) -> list[dict]:
         # window to report and stays `ok`.
         return result(status="error", **common, detail=drift(
             HARNESS_PROVIDER, "no limits[] in the usage payload", log))
+
+    missing = _drift(limits)
+    if missing:
+        return result(status="error", **common,
+                      detail=drift(HARNESS_PROVIDER, missing, log))
 
     return result(windows=_windows(limits, captured_at, log), **common)

--- a/.super-coder/scripts/quota_probes/anthropic.py
+++ b/.super-coder/scripts/quota_probes/anthropic.py
@@ -3,24 +3,29 @@
 Two files, and only the first is the credential file:
 
   ~/.claude/.credentials.json   claudeAiOauth.accessToken + expiresAt — the
-                                token, read and never written.
-  ~/.claude.json                oauthAccount.accountUuid — the account
-                                identifier.
+                                token, read and never written. Also
+                                subscriptionType, which is where `plan` lives.
+  ~/.claude.json                oauthAccount.accountUuid — the internal key.
 
 Spec #49 and decisions #65/#67 both said `account_ref` comes from "the
 credential file's account uuid". It is NOT there: that file holds only
 accessToken / refreshToken / expiresAt / refreshTokenExpiresAt / scopes /
 subscriptionType / rateLimitTier. The uuid lives in ~/.claude.json under
-`oauthAccount`, which also carries `emailAddress` in full — so decision #67's
-premise that neither Anthropic nor Moonshot returns an email, true of the
-usage RESPONSE, is false at the file level. Both gaps were reported to the
-planner before this module was written and ruled on in decision #69: the
-label is the full email, the uuid stays the ref, and reading two files here
-is ratified rather than scope creep.
+`oauthAccount`.
 
-The usage payload itself returns no account identifier at all, which is why
-the uuid is load-bearing. Whether it survives a re-login is unverified —
-confirming it needs an operator re-login (flag against feature 17).
+That file ALSO carries `emailAddress` in full, and this module used to read
+it: decision #69 made the card's label the operator's full address. Decision
+#75 dropped account identity entirely, so the address is not read here any
+more and the uuid is only ever an upsert key. The payload carries no
+identifier of any kind — verified against a live capture, whose top-level keys
+are five_hour / seven_day* / extra_usage / limits / spend /
+member_dashboard_available and nothing else.
+
+`plan` comes from the CREDENTIAL FILE, not the payload: `subscriptionType` is
+a key of that file, and the usage response has never carried it. Reading it
+from the payload — which this module did until the live capture — returned
+None for every account, silently, because the fixture had been transcribed
+with the field invented at the payload's top level.
 """
 from __future__ import annotations
 
@@ -43,25 +48,20 @@ KIND_MAP = {"session": "session", "weekly_all": "weekly",
             "weekly_scoped": "weekly_scoped"}
 
 
-def _identity(log) -> "tuple[str | None, str | None]":
-    """(account uuid, full email) — both from ~/.claude.json's oauthAccount,
-    which is the only place either exists. The usage response carries neither."""
+def _account_uuid(log) -> "str | None":
+    """The account uuid from ~/.claude.json's oauthAccount — the only place it
+    exists, since the usage response carries no identifier at all.
+
+    `emailAddress` sits in this same block and is deliberately NOT read. It was
+    the card's label under decision #69; decision #75 dropped identity, so the
+    address is no longer collected, stored, or rendered, and the uuid is only
+    ever an upsert key."""
     profile = read_json(PROFILE, log, HARNESS_PROVIDER)
     oauth = (profile or {}).get("oauthAccount")
     if not isinstance(oauth, dict):
-        return None, None
-    uuid, email = oauth.get("accountUuid"), oauth.get("emailAddress")
-    return (str(uuid) if uuid else None), (str(email) if email else None)
-
-
-def _label(uuid: str, email: "str | None") -> str:
-    """The full email, falling back to the uuid's first 8 only when the profile
-    carries no address (decision #69). A card reading 'a3f2b1c8' beside an
-    OpenAI card reading a full address does not tell the operator which account
-    they are looking at, and the address is safe to store for the same reason
-    OpenAI's already is: the engine DB is gitignored and both tables are
-    excluded from content.sql (decision #67)."""
-    return email or uuid[:8]
+        return None
+    uuid = oauth.get("accountUuid")
+    return str(uuid) if uuid else None
 
 
 def _windows(limits, captured_at: str, log) -> list[dict]:
@@ -100,16 +100,16 @@ def probe(log, timeout) -> list[dict]:
     if not token:
         # No credential file (or no token in it): this host has no Claude
         # subscription session. Absence of a limit is not a limit of zero.
-        return result(status="na", is_current=0)
+        return result(status="na")
 
-    uuid, email = _identity(log)
+    uuid = _account_uuid(log)
     if not uuid:
         log(f"{HARNESS_PROVIDER}: no oauthAccount.accountUuid in {PROFILE} — "
-            "the usage payload carries no account id, so this account cannot "
-            "be identified")
+            "the usage payload carries no account id, so this reading cannot "
+            "be keyed to a row")
         return result(status="error", detail="no account identifier")
 
-    common = dict(account_ref=uuid, account_label=_label(uuid, email))
+    common = dict(account_ref=uuid)
     if is_expired((oauth or {}).get("expiresAt")):
         # Reported, not repaired: refreshing out-of-band rotates the refresh
         # token and can break the operator's own login.
@@ -131,5 +131,6 @@ def probe(log, timeout) -> list[dict]:
         return result(status="error", **common, detail=drift(
             HARNESS_PROVIDER, "no limits[] in the usage payload", log))
 
-    return result(plan=payload.get("subscriptionType"),
+    # From the CREDENTIAL FILE, not the payload — see the module docstring.
+    return result(plan=(oauth or {}).get("subscriptionType"),
                   windows=_windows(limits, captured_at, log), **common)

--- a/.super-coder/scripts/quota_probes/dispatch.py
+++ b/.super-coder/scripts/quota_probes/dispatch.py
@@ -22,7 +22,7 @@ WALL_CLOCK_GRACE = 1.0
 
 def _error(provider: str, detail: str) -> dict:
     return account(provider=provider, probe_version="0", captured_at=now_iso(),
-                   status="error", detail=detail, is_current=0)
+                   status="error", detail=detail)
 
 
 def _run(name: str, log, timeout: float) -> list[dict]:

--- a/.super-coder/scripts/quota_probes/moonshot.py
+++ b/.super-coder/scripts/quota_probes/moonshot.py
@@ -13,23 +13,35 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from . import (TIME_UNIT_SECONDS, account, as_count, drift, get_json,
-               is_expired, kind_for_seconds, norm_iso, now_iso, percent_from,
-               read_json, response_detail, status_for_http, window)
+from . import (TIME_UNIT_SECONDS, account, as_count, drift, duration_label,
+               get_json, is_expired, kind_for_seconds, norm_iso, now_iso,
+               percent_from, read_json, response_detail, status_for_http,
+               window)
 
 HARNESS_PROVIDER = "moonshot"
-PROBE_VERSION = "1"
+PROBE_VERSION = "2"
 
 CREDENTIALS = Path.home() / ".kimi-code/credentials/kimi-code.json"
 URL = "https://api.kimi.com/coding/v1/usages"
 
 
 def _window_seconds(spec) -> "float | None":
-    """`{"duration": 300, "timeUnit": "MINUTE"}` → 18000. An unknown time unit
-    yields None and the window keeps its raw duration in scope."""
+    """`{"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"}` → 18000. An unknown
+    time unit yields None and the window is kept under its own row.
+
+    THE ENUM ARRIVES PREFIXED. Spec #49's field table recorded the unit bare
+    (`MINUTE`) and the shipped map was keyed that way, so every live window
+    missed the lookup — including this one, where 300 minutes is 18000 seconds,
+    i.e. `five_hour`, a kind the vocabulary already carries. A recognizable
+    window was filed as unrecognized and rendered as a dict repr.
+
+    The prefix is STRIPPED rather than both spellings enumerated: a second
+    vocabulary is a second thing to keep in sync with a provider we do not
+    control, and the bare form still resolves for free."""
     if not isinstance(spec, dict):
         return None
-    unit = TIME_UNIT_SECONDS.get(str(spec.get("timeUnit") or "").upper())
+    unit_name = str(spec.get("timeUnit") or "").upper().removeprefix("TIME_UNIT_")
+    unit = TIME_UNIT_SECONDS.get(unit_name)
     try:
         duration = float(spec.get("duration"))
     except (TypeError, ValueError):
@@ -38,10 +50,27 @@ def _window_seconds(spec) -> "float | None":
 
 
 def _counts_window(entry: dict, captured_at: str, kind, scope) -> dict:
-    used, limit = as_count(entry.get("used")), as_count(entry.get("limit"))
+    """One row of counts, from either shape this payload uses.
+
+    The top-level `usage` block carries used / limit / remaining directly. A
+    `limits[]` entry nests them one level down under `detail` AND CARRIES NO
+    `used` KEY AT ALL — it gives limit and remaining, so used is derived. The
+    shipped reader looked only at entry level, found nothing, and rendered a
+    structurally empty row as though the account were idle (flag #198).
+
+    One reader for both, because both shapes are in the same payload: unwrap
+    `detail` when it is there, else read the entry itself."""
+    detail = entry.get("detail")
+    source = detail if isinstance(detail, dict) else entry
+    limit = as_count(source.get("limit"))
+    used = as_count(source.get("used"))
+    if used is None:
+        remaining = as_count(source.get("remaining"))
+        if limit is not None and remaining is not None:
+            used = limit - remaining
     return window(window_kind=kind, scope=scope, used=used, limit_value=limit,
                   used_percent=percent_from(used, limit),
-                  resets_at=norm_iso(entry.get("resetTime")),
+                  resets_at=norm_iso(source.get("resetTime")),
                   captured_at=captured_at, probe_version=PROBE_VERSION)
 
 
@@ -78,10 +107,12 @@ def _windows(payload: dict, captured_at: str, log) -> list[dict]:
         kind = kind_for_seconds(seconds)
         scope = entry.get("name") or entry.get("scope")
         if kind is None:
-            raw = entry.get("window")
-            log(f"{HARNESS_PROVIDER}: unrecognized window {raw!r} — kept under "
-                "its own row")
-            duration = f"{int(seconds)}s" if seconds else str(raw)
+            # The LOG may carry the raw window — it is a diagnostic and never
+            # reaches the operator. `scope` may not: it renders on the card and
+            # is persisted. Hence duration_label, which cannot emit a repr.
+            log(f"{HARNESS_PROVIDER}: unrecognized window "
+                f"{entry.get('window')!r} — kept under its own row")
+            duration = duration_label(seconds)
             scope = f"{scope} {duration}" if scope else duration
         rows.append(_counts_window(entry, captured_at, kind, scope))
     return rows
@@ -97,7 +128,7 @@ def probe(log, timeout) -> list[dict]:
     creds = read_json(CREDENTIALS, log, HARNESS_PROVIDER)
     token = (creds or {}).get("access_token")
     if not token:
-        return result(status="na", is_current=0)
+        return result(status="na")
     if is_expired((creds or {}).get("expires_at")):
         # Reported, not repaired — this package never refreshes a token.
         return result(status="unauth", detail="access token expired")
@@ -117,13 +148,17 @@ def probe(log, timeout) -> list[dict]:
             "account cannot be identified")
         return result(status="error", detail="no account identifier")
 
-    common = dict(account_ref=ref, account_label=ref)
+    common = dict(account_ref=ref)
     missing = _drift(payload)
     if missing:
         return result(status="error", **common,
                       detail=drift(HARNESS_PROVIDER, missing, log))
 
-    membership = payload.get("membership")
+    # Nested under `user`, not at the top level — spec #49's field table said
+    # otherwise and `plan` was NULL for every moonshot account as a result,
+    # while LEVEL_ADVANCED sat in the payload the whole time (flag #198).
+    user = payload.get("user")
+    membership = user.get("membership") if isinstance(user, dict) else None
     plan = membership.get("level") if isinstance(membership, dict) else None
     return result(plan=plan, **common,
                   windows=_windows(payload, captured_at, log))

--- a/.super-coder/scripts/quota_probes/moonshot.py
+++ b/.super-coder/scripts/quota_probes/moonshot.py
@@ -84,12 +84,22 @@ def _drift(payload: dict) -> "str | None":
     absent or `[]` is a real answer (a plan with no metered sub-window), and
     calling that drift would cry wolf at an idle account. A `limits` that is
     present but not a list has no such reading: that is drift.
+
+    Neither has an ENTRY inside it that is not an object. The list is a place
+    this reader iterates, so an entry it cannot read is a metered sub-window
+    disappearing from the card while the probe reports `ok` — the same finding
+    as the wrong-typed container, one level down (L-614-1).
     """
     if not isinstance(payload.get("usage"), dict):
         return "no usage{} in the usages payload"
     limits = payload.get("limits")
-    if limits is not None and not isinstance(limits, list):
+    if limits is None:
+        return None
+    if not isinstance(limits, list):
         return f"limits is {type(limits).__name__}, not a list"
+    for entry in limits:
+        if not isinstance(entry, dict):
+            return f"limits[] entry is {type(entry).__name__}, not an object"
     return None
 
 
@@ -102,6 +112,10 @@ def _windows(payload: dict, captured_at: str, log) -> list[dict]:
         rows.append(_counts_window(usage, captured_at, "weekly", None))
     for entry in payload.get("limits") or []:
         if not isinstance(entry, dict):
+            # Retained guard: `_drift` rejects a non-object entry before this
+            # runs, so this is unreachable intact — it is what makes a mutation
+            # that disables the drift check degrade to the historical defect
+            # (the entry silently skipped) instead of raising here.
             continue
         seconds = _window_seconds(entry.get("window"))
         kind = kind_for_seconds(seconds)

--- a/.super-coder/scripts/quota_probes/moonshot.py
+++ b/.super-coder/scripts/quota_probes/moonshot.py
@@ -154,11 +154,4 @@ def probe(log, timeout) -> list[dict]:
         return result(status="error", **common,
                       detail=drift(HARNESS_PROVIDER, missing, log))
 
-    # Nested under `user`, not at the top level — spec #49's field table said
-    # otherwise and `plan` was NULL for every moonshot account as a result,
-    # while LEVEL_ADVANCED sat in the payload the whole time (flag #198).
-    user = payload.get("user")
-    membership = user.get("membership") if isinstance(user, dict) else None
-    plan = membership.get("level") if isinstance(membership, dict) else None
-    return result(plan=plan, **common,
-                  windows=_windows(payload, captured_at, log))
+    return result(**common, windows=_windows(payload, captured_at, log))

--- a/.super-coder/scripts/quota_probes/openai.py
+++ b/.super-coder/scripts/quota_probes/openai.py
@@ -60,7 +60,17 @@ def _client_version() -> "str | None":
 
 
 def _window_row(entry, captured_at: str, log, scope=None) -> "dict | None":
-    """One rate-limit window, from a block carrying its own duration."""
+    """One rate-limit window, from a block carrying its own duration.
+
+    THERE IS NO `fallback_kind` ANY MORE, and its removal is the quiet half of
+    the nested-window fix. The scoped row used to be labelled `weekly` by a
+    fallback rather than by its duration — and it was RIGHT BY ACCIDENT: the
+    reader looked for the duration at entry level, found nothing, and the live
+    window happened to be 604800. A five-hour scoped window would have been
+    labelled weekly just as confidently. Now the duration is read from the
+    block that actually carries it, so the kind is derived; a block that
+    genuinely exposes no duration lands as `unknown` under a formatted
+    duration, which is a visible non-answer instead of a plausible wrong one."""
     if not isinstance(entry, dict):
         return None
     seconds = entry.get("limit_window_seconds")
@@ -218,5 +228,5 @@ def probe(log, timeout) -> list[dict]:
         return result(status="error", **common,
                       detail=drift(HARNESS_PROVIDER, missing, log))
 
-    return result(plan=payload.get("plan_type"), **common,
+    return result(**common,
                   windows=_windows(rate_limit, payload, captured_at, log))

--- a/.super-coder/scripts/quota_probes/openai.py
+++ b/.super-coder/scripts/quota_probes/openai.py
@@ -110,6 +110,11 @@ def _drift(rate_limit: dict, payload: dict) -> "str | None":
     we cannot find is a payload that has moved, not an idle account, and spec
     #49's own rule is that a drifted probe reports `error` rather than a zero
     as if it had been measured.
+
+    An entry that is not an OBJECT is the same finding one type up, and it is
+    checked here for the reason the wrong-typed container is: a list is a place
+    the reader iterates, so anything in it that cannot be read is a scoped
+    window vanishing under status `ok` (L-614-1).
     """
     for container in (rate_limit, payload):
         extra = container.get("additional_rate_limits")
@@ -118,7 +123,10 @@ def _drift(rate_limit: dict, payload: dict) -> "str | None":
         if not isinstance(extra, list):
             return f"additional_rate_limits is {type(extra).__name__}, not a list"
         for entry in extra:
-            if isinstance(entry, dict) and not isinstance(entry.get("rate_limit"), dict):
+            if not isinstance(entry, dict):
+                return (f"additional_rate_limits[] entry is "
+                        f"{type(entry).__name__}, not an object")
+            if not isinstance(entry.get("rate_limit"), dict):
                 return "additional_rate_limits[] entry carries no rate_limit{}"
     return None
 
@@ -142,6 +150,8 @@ def _windows(rate_limit: dict, payload: dict, captured_at: str, log) -> list[dic
     if isinstance(extra, list):
         for entry in extra:
             if not isinstance(entry, dict):
+                # Retained guard, same as the isinstance above and for the same
+                # reason: `_drift` rejects a non-object entry before this runs.
                 continue
             # An entry is NOT itself a window. It carries `limit_name` plus its
             # OWN rate_limit block holding primary/secondary windows, in the

--- a/.super-coder/scripts/quota_probes/openai.py
+++ b/.super-coder/scripts/quota_probes/openai.py
@@ -8,41 +8,72 @@ refresh_token / account_id / last_refresh), so expiry cannot be pre-checked
 here as it is for the other two providers — the endpoint's 401 is the
 authoritative signal and maps to `unauth`.
 
-The only provider that returns an email, so the only one whose card carries a
-real address; `account_id` is the stable ref either way.
+This is the ONLY one of the three whose usage response returns an email, and
+that fact is the reason the account-label design was wrong rather than a
+reason to keep it: a rule reasoned from the one provider that cooperates left
+the other two rendering opaque identifiers. The address is not read here
+(decision #75). `account_id` is the ref, and it is an upsert key only.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
-from . import (account, as_percent, drift, get_json, iso_from_epoch,
-               kind_for_seconds, now_iso, read_json, response_detail,
-               status_for_http, window)
+import harness_versions
+
+from . import (account, as_percent, drift, duration_label, get_json,
+               iso_from_epoch, kind_for_seconds, now_iso, read_json,
+               response_detail, status_for_http, window)
 
 HARNESS_PROVIDER = "openai"
-PROBE_VERSION = "1"
+PROBE_VERSION = "2"
 
 CREDENTIALS = Path.home() / ".codex/auth.json"
 URL = "https://chatgpt.com/backend-api/codex/usage"
 
+# ── Client identity, and why the version is derived rather than pinned ───────
+#
+# This endpoint answers 403 — an HTML anti-bot page, not a JSON auth error — to
+# any request it does not recognize as the codex CLI. Proven by execution twice:
+# the shipped Authorization + Accept + chatgpt-account-id request returns 403,
+# and the identical request plus these three headers returns 200 (flag #196,
+# re-run here against the installed 0.145.0).
+#
+# THE VERSION COMES FROM THE INSTALLED CLI. This fork installs harnesses at
+# --latest on every dos-u, so a baked constant is stale by design — it would
+# start claiming a version this host has not run since the next update.
+#
+# The endpoint accepted a FABRICATED 0.20.0 during diagnosis while 0.145.0 was
+# installed, so as of 2026-07-25 it gates on the SHAPE of the client identity
+# and not on an exact version. That is an observation and not a contract, and
+# nothing here depends on it: we send the version we actually have, and if the
+# endpoint tightens, `status_for_http` makes the 403 loud instead of blaming the
+# operator's session.
+ORIGINATOR = "codex_cli_rs"
 
-def _window_row(entry, captured_at: str, log, scope=None,
-                fallback_kind=None) -> "dict | None":
-    """One rate-limit window. The kind comes from the observed duration;
-    `fallback_kind` covers only the entries spec #49 pins by name because no
-    duration is exposed for them."""
+
+def _client_version() -> "str | None":
+    """The installed codex CLI's dotted version — `codex-cli 0.145.0` →
+    `0.145.0` — or None when there is no codex CLI to ask."""
+    match = re.search(r"\d+\.\d+\.\d+", harness_versions.probe("codex") or "")
+    return match.group(0) if match else None
+
+
+def _window_row(entry, captured_at: str, log, scope=None) -> "dict | None":
+    """One rate-limit window, from a block carrying its own duration."""
     if not isinstance(entry, dict):
         return None
     seconds = entry.get("limit_window_seconds")
     kind = kind_for_seconds(seconds)
     if kind is None:
-        kind = fallback_kind
-    if kind is None:
         # Unrecognized duration: keep the window under its own row with the
         # duration in scope rather than dropping a real limit on the floor.
         log(f"{HARNESS_PROVIDER}: unrecognized window duration {seconds!r} — "
             "kept under its own row")
-        duration = f"{seconds}s" if seconds is not None else "no duration"
+        # duration_label, not an f-string: `limit_window_seconds` is a value
+        # we do not control, and interpolating it raw is the same class of
+        # defect moonshot shipped — a container reaching operator text.
+        duration = duration_label(seconds)
         scope = f"{scope} {duration}" if scope else duration
     return window(window_kind=kind, scope=scope,
                   used_percent=as_percent(entry.get("used_percent")),
@@ -59,11 +90,26 @@ def _drift(rate_limit: dict, payload: dict) -> "str | None":
     TYPE has no such reading — the type is part of the envelope (spec #49), and
     silently skipping it would vanish every scoped window while reporting `ok`.
     Both containers are checked because the reader coalesces across them.
+
+    An ENTRY that carries no `rate_limit{}` is drift for the same reason, one
+    level down. This is the check the envelope rule was missing: the shipped
+    probe read `used_percent` / `limit_window_seconds` / `reset_at` at entry
+    level, found none of them on the live wire, and emitted a row of NULLs
+    under a `weekly` label no duration had confirmed — with `limits` still a
+    list, so status stayed `ok` and nothing was logged. An entry whose numbers
+    we cannot find is a payload that has moved, not an idle account, and spec
+    #49's own rule is that a drifted probe reports `error` rather than a zero
+    as if it had been measured.
     """
     for container in (rate_limit, payload):
         extra = container.get("additional_rate_limits")
-        if extra is not None and not isinstance(extra, list):
+        if extra is None:
+            continue
+        if not isinstance(extra, list):
             return f"additional_rate_limits is {type(extra).__name__}, not a list"
+        for entry in extra:
+            if isinstance(entry, dict) and not isinstance(entry.get("rate_limit"), dict):
+                return "additional_rate_limits[] entry carries no rate_limit{}"
     return None
 
 
@@ -85,12 +131,24 @@ def _windows(rate_limit: dict, payload: dict, captured_at: str, log) -> list[dic
     # case reds via TypeError.
     if isinstance(extra, list):
         for entry in extra:
-            row = _window_row(entry, captured_at, log,
-                              scope=(entry or {}).get("limit_name")
-                              if isinstance(entry, dict) else None,
-                              fallback_kind="weekly")
-            if row:
-                rows.append(row)
+            if not isinstance(entry, dict):
+                continue
+            # An entry is NOT itself a window. It carries `limit_name` plus its
+            # OWN rate_limit block holding primary/secondary windows, in the
+            # same shape as the top-level one — so it is read with the same
+            # reader rather than a second, entry-shaped one.
+            nested = entry.get("rate_limit")
+            if not isinstance(nested, dict):
+                # Same retained-guard shape as the isinstance above: `_drift`
+                # has already rejected this, so it is unreachable intact, and
+                # it is what lets the mutation leg that disables that check
+                # degrade to the historical defect instead of raising.
+                continue
+            for key in ("primary_window", "secondary_window"):
+                row = _window_row(nested.get(key), captured_at, log,
+                                  scope=entry.get("limit_name"))
+                if row:
+                    rows.append(row)
     return rows
 
 
@@ -107,18 +165,37 @@ def probe(log, timeout) -> list[dict]:
     if not token:
         # An API-key shell (auth_mode=apikey, OPENAI_API_KEY set) lands here
         # too: it has no subscription window, and no window is `na`, not 0%.
-        return result(status="na", is_current=0)
+        return result(status="na")
+
+    version = _client_version()
+    if not version:
+        # No fabricated version, and no bare request either: without a client
+        # identity this endpoint answers 403, and a 403 we provoked ourselves
+        # would be indistinguishable from the endpoint tightening. Say which
+        # one it is.
+        return result(status="error", detail=(
+            "no codex CLI installed to derive the client version from — this "
+            "endpoint refuses requests that do not identify as its own client"))
 
     file_account_id = (tokens or {}).get("account_id")
-    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json",
+               "User-Agent": f"{ORIGINATOR}/{version}",
+               "originator": ORIGINATOR, "version": version}
     if file_account_id:
         headers["chatgpt-account-id"] = str(file_account_id)
 
     code, payload = get_json(URL, headers, timeout)
-    ref = str(file_account_id) if file_account_id else None
     if code != 200 or not isinstance(payload, dict):
-        return result(status=status_for_http(code), account_ref=ref,
-                      account_label=ref,
+        # NO account_ref ON A FAILED PROBE — moonshot's rule, applied here for
+        # the reason flag #196 found the hard way. The file's account_id is a
+        # GUESS at who the endpoint will name, and it is a wrong one: the file
+        # says `4747d225-…` while a 200 says `user-0kbAQ…`. Writing the guess
+        # is what put a permanent second registry row under one account, which
+        # then rendered forever as a signed-out card. A failed probe learned
+        # nothing about identity, so it claims none; the last successful
+        # probe's rows stand untouched with their own age, which is exactly
+        # what the card is supposed to show.
+        return result(status=status_for_http(code),
                       detail=response_detail(code, payload, HARNESS_PROVIDER, log))
 
     ref = str(payload.get("account_id") or file_account_id or "") or None
@@ -127,7 +204,7 @@ def probe(log, timeout) -> list[dict]:
             "payload — this account cannot be identified")
         return result(status="error", detail="no account identifier")
 
-    common = dict(account_ref=ref, account_label=payload.get("email") or ref)
+    common = dict(account_ref=ref)
     rate_limit = payload.get("rate_limit")
     if not isinstance(rate_limit, dict):
         # The envelope, not its contents: `rate_limit: {}` is an account with

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2228,7 +2228,7 @@ const AN_STATUS_NOTE = {
   error: "probe failed",
 };
 
-function anProviderCard(prov, onRefresh) {
+function anProviderCard(prov) {
   const status = prov.status;
   const card = el("div", { className: "card an-acct" });
 
@@ -2252,9 +2252,18 @@ function anProviderCard(prov, onRefresh) {
   // difference is the operator's next move. A provider that has never returned
   // anything has nothing to show; one that returned an intact envelope carrying
   // zero windows is genuinely idle and that IS its reading.
+  //
+  // THE SIGNAL IS THE STATUS, NOT captured_at, and the distinction is the whole
+  // reason this branch exists at all. captured_at is derived from window rows,
+  // so a card with no windows never has one — reading it here asked a question
+  // whose answer was fixed, and the idle sentence could not be reached by any
+  // response the API can emit (L-614-2). `ok` with zero windows is the probe
+  // saying it got an intact answer and there was nothing in it; any other
+  // status with zero windows means nothing has ever been read, and the pill
+  // above already says why.
   if (!wins.length)
     card.append(el("div", { className: "muted" },
-      prov.captured_at ? "no windows reported" : "no reading yet"));
+      prov.status === "ok" ? "no windows reported" : "no reading yet"));
   for (const w of wins) card.append(anWindowRow(w));
 
   const foot = el("div", { className: "an-acct-foot" });
@@ -2264,19 +2273,18 @@ function anProviderCard(prov, onRefresh) {
   // how old they are. A card with no age would present stale figures as fresh.
   if (prov.captured_at)
     foot.append(el("span", { className: "muted" }, "as of " + anAge(prov.captured_at)));
+  // NO PER-CARD REFRESH. There was one, and it re-probed all three providers —
+  // one probe run is the only thing the route can do. Per-card refresh made
+  // sense under the ACCOUNT model, where cards differed in whether they could
+  // be refreshed at all; provider cards do not differ that way, so three
+  // buttons doing one thing were three labels under-describing it. The
+  // section's own "refresh all" says what actually happens and is one control
+  // instead of four.
   const actions = el("div", { className: "an-acct-actions" });
   const usageUrl = AN_PROVIDER_USAGE_URL[prov.provider];
   if (usageUrl)
     actions.append(el("a", { className: "act", textContent: "usage page ↗",
       href: usageUrl, target: "_blank", rel: "noopener noreferrer" }));
-  const refresh = el("button", { className: "act", type: "button", textContent: "refresh ⟳" });
-  // Always enabled. The old section disabled this button whenever it judged a
-  // probe could not succeed — but that judgement was made from the registry's
-  // idea of who was signed in, and it was wrong in exactly the case the
-  // operator most wants the button: a lapsed Kimi token that a re-probe fixes
-  // the moment they boot the harness.
-  refresh.onclick = () => onRefresh(refresh);
-  actions.append(refresh);
   foot.append(actions);
   card.append(foot);
   return card;
@@ -2302,13 +2310,16 @@ function anDrawQuota(root, d) {
   // that has never been probed. Nothing is filtered out: hiding a card is how a
   // panel stops lying and starts saying nothing, and the operator cannot tell
   // "not configured" from "not readable" from a card that is not there.
-  for (const prov of providers)
-    root.append(anProviderCard(prov, (btn) => anProbeNow(root, btn)));
+  for (const prov of providers) root.append(anProviderCard(prov));
 }
 
-// The refresh button — POSTs the probe route, which bypasses the 60s TTL. The
+// The refresh control — POSTs the probe route, which bypasses the 60s TTL. The
 // redraw replaces the button along with everything else, so it is only
-// re-enabled on the failure path.
+// re-enabled on the failure path. It is never disabled by a judgement about
+// whether a probe can succeed: the old panel made that judgement from the
+// registry's idea of who was signed in and was wrong in exactly the case the
+// operator most wants it — a lapsed Kimi token that a re-probe fixes the moment
+// they boot the harness.
 async function anProbeNow(root, btn) {
   const label = btn.textContent;
   btn.disabled = true;

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -1709,7 +1709,7 @@ let anSessions = [];      // accumulated cards across "More" pages
 let anNextBefore = null;  // cursor for the next page (null = no older rows)
 let anDaysLoaded = 0;     // window size loaded so far (7 per page)
 let anClass = null;  // selected stat card; null = combined (all classes summed)
-let anView = "tokens";    // 'tokens' | 'accounts' — sub-view, carried in the hash
+let anView = "tokens";    // 'tokens' | 'quota' — sub-view, carried in the hash
 
 const AN_CLASSES = [
   ["input_tokens", "Input"], ["output_tokens", "Output"],
@@ -2106,36 +2106,45 @@ async function anTokenSection(root) {
   }
 }
 
-// ── Account Analytics — harness quota (spec doc #49) ──────────────────────────
+// ── Provider Quota — harness quota (spec doc #57, superseding #49) ────────────
 // Token Analytics answers *what did we spend*; this answers *how much is left*.
-// One card per account, grouped by provider, current accounts first.
+// ONE CARD PER PROVIDER, showing that provider's most recent reading and the
+// age of the reading. Nothing about who is signed in — decision #75.
 //
-// Two rules carry the whole section, and both are about not lying:
+// Three rules carry the whole section, and all three are about not lying:
 //
 // 1. COLOUR IS THRESHOLD-DRIVEN AND PROVIDER-BLIND. It is computed from
 //    used_percent alone, never from a provider's own severity field: anthropic
 //    sends severity=normal at 22%, openai limit_reached=true at 100%, moonshot
 //    nothing at all. Three vocabularies would be three colour rules on one page.
 // 2. A MISSING NUMBER IS NEVER DRAWN AS A ZERO. used_percent NULL renders
-//    "n/a" with no bar — a provider reporting counts against limit_value 0, a
-//    moonshot all-null weekly row, a window whose percent could not be derived.
-//    A 0% meter reads as measured, and "we did not get a number" is not 0%.
+//    "n/a" with no bar — a window whose percent could not be derived, or a
+//    provider that reports counts against limit_value 0. A 0% meter reads as
+//    measured, and "we did not get a number" is not 0%.
+// 3. THE CARD NEVER MAKES A CLAIM ABOUT THE OPERATOR'S SESSION. It has no
+//    label, no account id, no plan and no sign-in language, so the two defects
+//    that shipped as false claims — a 403 rendered "signed out — last known"
+//    while the operator was actively using Codex (#196), and a lapsed 15-minute
+//    Kimi token rendered "no account identified" (#197) — cannot be expressed
+//    here at all. A failed probe leaves the last-known figures standing with
+//    their age, and says nothing else.
 //
-// Provider state comes from the response's per-provider status list, NEVER
-// inferred from the accounts array: an empty array is both "nothing configured"
-// and "every probe failed", and those render differently (na with no registry
-// row = no card, error = a card carrying the HTTP status).
-//
-// 3. WHERE THE REGISTRY AND THE STATUS LIST DISAGREE, THE STATUS GOVERNS WHAT
-//    IS SEEN AND THE REGISTRY KEEPS WHAT IS KNOWN. The registry says what was
-//    true as of the last successful probe; the status says what is true now.
-//    Remove a credential file without switching accounts and the row keeps
-//    is_current — which is exempt from the 7-day filter — so the card would
-//    render forever, unmuted and live-looking, while the same response reports
-//    that provider `na`. The card is muted and its refresh disabled instead;
-//    the row is never filtered out and never mutated, because clearing
-//    is_current on a transiently unreadable file would demote a real account.
+// The per-provider status still comes from the response's status field, never
+// inferred from whether windows arrived: no windows is both "nothing
+// configured" and "the probe failed", and the operator has to be able to tell
+// those apart.
 const AN_PROVIDER_LABEL = { anthropic: "Claude", openai: "Codex", moonshot: "Kimi" };
+// Where the operator goes to manage the account itself. This panel deliberately
+// stops at "how much is left" — the FnB's ruling that retired account identity
+// rests on the provider's own page being one click away, so the link is part of
+// the design and not a convenience. Each URL is taken from the harness CLI's own
+// binary rather than guessed; Kimi's ships no usage page, so its product page is
+// the closest honest destination.
+const AN_PROVIDER_USAGE_URL = {
+  anthropic: "https://claude.ai/settings/usage",
+  openai: "https://chatgpt.com/codex/settings/usage",
+  moonshot: "https://www.kimi.com/code",
+};
 // Display order for a card's windows. Unrecognized kinds sort last rather than
 // being dropped — the probe stores a window it could not map under its raw
 // duration precisely so the panel still shows it.
@@ -2180,14 +2189,6 @@ function anAge(iso) {
   const ms = Date.now() - t;
   return ms <= 0 ? "just now" : anDuration(ms) + " ago";
 }
-// The card's own age: the newest capture across its windows, falling back to
-// last_seen for an account that has none (unauth, or an error after it was
-// identified). Every card renders an age — that is what makes a stale number
-// readable as stale instead of current.
-function anCardAge(acct) {
-  const caps = (acct.windows || []).map((w) => w.captured_at).filter(Boolean).sort();
-  return caps.length ? caps[caps.length - 1] : acct.last_seen;
-}
 
 function anWindowRow(w) {
   const pct = w.used_percent;
@@ -2216,134 +2217,93 @@ function anWindowRow(w) {
   return row;
 }
 
-function anAccountCard(acct, prov, onRefresh) {
-  const current = !!acct.is_current;
-  const status = prov ? prov.status : null;
-  // unauth is the current account with a dead token: last known values, muted,
-  // with their age — the same treatment a signed-out account gets, for the same
-  // reason (the numbers are real, they are just not now). `na` joins them from
-  // a third direction: the row still says is_current, but the credential file
-  // it named is not readable now, so the numbers are equally last-known.
-  const muted = !current || status === "unauth" || status === "na";
-  const card = el("div", { className: "card an-acct" + (muted ? " an-muted" : "") });
+// The status line a card carries under its heading. It describes THE PROBE, never
+// the operator: `unauth` says the token we hold is not usable, which is a fact
+// about a credential file, and stops there. The words "signed out" and "no
+// account identified" are gone from this section on purpose — both were
+// rendered while the operator was signed in and working (#196, #197).
+const AN_STATUS_NOTE = {
+  na: "no readable credential file",
+  unauth: "token not usable — refreshes when you next use this harness",
+  error: "probe failed",
+};
 
+function anProviderCard(prov, onRefresh) {
+  const status = prov.status;
+  const card = el("div", { className: "card an-acct" });
+
+  // No muted styling and no dimming, for any status. Muting existed to mark a
+  // card as "not the current account", a distinction a provider-level panel
+  // does not have — and a dimmed card reads as a lesser truth, when in fact the
+  // numbers on a degraded card are exactly as real as the ones on a fresh card.
+  // The AGE is what distinguishes them, and it is right there in the footer.
   const head = el("div", { className: "an-acct-head" });
-  head.append(el("span", { className: "an-acct-label" }, acct.account_label || acct.account_ref));
-  if (acct.plan) head.append(el("span", { className: "pill" }, acct.plan));
-  if (!current) head.append(el("span", { className: "pill" }, "not signed in"));
-  // What was OBSERVED, not what it implies. "not signed in" would be an
-  // inference about why the file is gone — the operator may be mid-login, or
-  // the file may simply be unreadable — and the engine did not see a sign-out.
-  else if (status === "na") head.append(el("span", { className: "pill warn" },
-    "no readable credential file — last known"));
-  else if (status === "unauth") head.append(el("span", { className: "pill warn" }, "signed out — last known"));
-  else if (status === "error") head.append(el("span", { className: "pill warn" },
-    "error" + (prov.detail ? " · " + prov.detail : "")));
+  head.append(el("h2", {}, AN_PROVIDER_LABEL[prov.provider] || prov.provider));
+  head.append(el("span", { className: "pill" }, prov.provider));
+  if (status && status !== "ok") {
+    const note = AN_STATUS_NOTE[status] || status;
+    head.append(el("span", { className: "pill warn" },
+      note + (prov.detail ? " · " + prov.detail : "")));
+  }
   card.append(head);
 
-  const wins = [...(acct.windows || [])].sort((a, b) => anWindowRank(a) - anWindowRank(b));
-  if (!wins.length) card.append(el("div", { className: "muted" }, "no windows reported"));
+  const wins = [...(prov.windows || [])].sort((a, b) => anWindowRank(a) - anWindowRank(b));
+  // "No reading yet" is not the same sentence as "no windows reported", and the
+  // difference is the operator's next move. A provider that has never returned
+  // anything has nothing to show; one that returned an intact envelope carrying
+  // zero windows is genuinely idle and that IS its reading.
+  if (!wins.length)
+    card.append(el("div", { className: "muted" },
+      prov.captured_at ? "no windows reported" : "no reading yet"));
   for (const w of wins) card.append(anWindowRow(w));
 
   const foot = el("div", { className: "an-acct-foot" });
-  foot.append(el("span", { className: "muted" }, "snapshot " + anAge(anCardAge(acct))));
+  // THE AGE IS NEVER OMITTED AND NEVER SOFTENED. It is the whole of the
+  // empty-state rule: a probe that cannot get fresh numbers leaves the last
+  // known ones standing, and the only thing that keeps that honest is saying
+  // how old they are. A card with no age would present stale figures as fresh.
+  if (prov.captured_at)
+    foot.append(el("span", { className: "muted" }, "as of " + anAge(prov.captured_at)));
+  const actions = el("div", { className: "an-acct-actions" });
+  const usageUrl = AN_PROVIDER_USAGE_URL[prov.provider];
+  if (usageUrl)
+    actions.append(el("a", { className: "act", textContent: "usage page ↗",
+      href: usageUrl, target: "_blank", rel: "noopener noreferrer" }));
   const refresh = el("button", { className: "act", type: "button", textContent: "refresh ⟳" });
-  // A non-current account cannot be re-probed: its token is gone, and the probe
-  // route re-reads whatever the credential files resolve to NOW. The spec grants
-  // Codex an exception — a non-current OpenAI account refreshed from its rollout
-  // files — but no unit implements a rollout reader (verified against U3's head:
-  // zero `rollout` references in quota_probes/ or the routes), so an enabled
-  // button here would fire a probe that provably cannot change this card. A
-  // control that lies is worse than a capability that is missing; declared to
-  // the planner pre-build rather than left to be found.
-  if (!current) {
-    refresh.disabled = true;
-    refresh.title = "signed out — this account's token is gone, so it cannot be re-probed";
-  } else if (status === "na") {
-    // Same inert-button shape, reached from the status side rather than the
-    // registry side: there is no credential file to read, so a probe fired
-    // from here provably cannot change this card either.
-    refresh.disabled = true;
-    refresh.title = "no readable credential file — a probe cannot reach this account now";
-  } else {
-    refresh.onclick = () => onRefresh(refresh);
-  }
-  foot.append(refresh);
+  // Always enabled. The old section disabled this button whenever it judged a
+  // probe could not succeed — but that judgement was made from the registry's
+  // idea of who was signed in, and it was wrong in exactly the case the
+  // operator most wants the button: a lapsed Kimi token that a re-probe fixes
+  // the moment they boot the harness.
+  refresh.onclick = () => onRefresh(refresh);
+  actions.append(refresh);
+  foot.append(actions);
   card.append(foot);
   return card;
 }
 
-// A provider that produced no registry row at all still gets a card when it
-// failed: `error` before the probe could name an account is exactly the case
-// the accounts array cannot express, and silence there would read as "fine".
-function anProviderCard(prov) {
-  const card = el("div", { className: "card an-acct an-muted" });
-  card.append(el("div", { className: "an-acct-head" },
-    el("span", { className: "an-acct-label" }, "no account identified"),
-    el("span", { className: "pill warn" },
-      (prov.status || "error") + (prov.detail ? " · " + prov.detail : ""))));
-  return card;
-}
-
-function anDrawAccounts(root, d) {
+function anDrawQuota(root, d) {
   root.replaceChildren();
-  const accounts = d.accounts || [];
   const providers = d.providers || [];
 
   const head = el("div", { className: "an-acct-bar" });
-  head.append(el("span", { className: "muted" },
-    `accounts active in the last ${d.activity_days || 7} days`));
+  head.append(el("span", { className: "muted" }, "most recent reading per provider"));
   const probeAll = el("button", { className: "act", type: "button", textContent: "refresh all ⟳" });
   probeAll.onclick = () => anProbeNow(root, probeAll);
   head.append(probeAll);
   root.append(head);
 
-  // Provider order follows the status list (the dispatcher's own order), then
-  // any provider present only in the registry.
-  //
-  // `na` — no credential file readable now — is dropped ONLY when the registry
-  // has nothing for it: the absence of a limit is not a limit of zero, so a
-  // provider this host has never seen gets no card. When a registry row DOES
-  // exist the card stays and renders muted (see anAccountCard): the status
-  // governs how the row is drawn, never whether the row is believed. Filtering
-  // it out would throw away the last account this host actually saw.
-  const statusOf = new Map(providers.map((p) => [p.provider, p]));
-  const known = new Set(accounts.map((a) => a.provider));
-  const groups = new Map();
-  for (const name of [...providers.map((p) => p.provider), ...accounts.map((a) => a.provider)]) {
-    if (groups.has(name)) continue;
-    if (statusOf.get(name)?.status === "na" && !known.has(name)) continue;
-    groups.set(name, { name, prov: statusOf.get(name) || null, accounts: [] });
-  }
-  for (const a of accounts) groups.get(a.provider)?.accounts.push(a);
-
-  if (!groups.size) {
-    root.append(el("div", { className: "card muted" }, providers.length
-      ? "No harness credentials found — nothing to probe."
-      : "No probe has run yet."));
+  if (!providers.length) {
+    root.append(el("div", { className: "card muted" }, "No probe has run yet."));
     return;
   }
 
-  // The API exempts is_current from the 7-day filter so the section is never
-  // empty. Say why the page is thin instead of letting it look like the whole
-  // truth about the last week.
-  const cutoff = Date.now() - (d.activity_days || 7) * 864e5;
-  const fresh = (a) => new Date(a.last_seen).getTime() >= cutoff;
-  if (accounts.length && !accounts.some(fresh))
-    root.append(el("div", { className: "an-note" }, `No account has been seen in the last `
-      + `${d.activity_days || 7} days — showing the current account only.`));
-
-  for (const g of groups.values()) {
-    const sec = el("div", { className: "an-prov" });
-    sec.append(el("div", { className: "an-prov-head" },
-      el("h2", {}, AN_PROVIDER_LABEL[g.name] || g.name),
-      el("span", { className: "pill" }, g.name)));
-    if (g.accounts.length)
-      for (const a of g.accounts) sec.append(anAccountCard(a, g.prov, (btn) => anProbeNow(root, btn)));
-    else
-      sec.append(anProviderCard(g.prov || { status: "error" }));
-    root.append(sec);
-  }
+  // EVERY provider gets a card, including one with no credential file and one
+  // that has never been probed. Nothing is filtered out: hiding a card is how a
+  // panel stops lying and starts saying nothing, and the operator cannot tell
+  // "not configured" from "not readable" from a card that is not there.
+  for (const prov of providers)
+    root.append(anProviderCard(prov, (btn) => anProbeNow(root, btn)));
 }
 
 // The refresh button — POSTs the probe route, which bypasses the 60s TTL. The
@@ -2354,7 +2314,7 @@ async function anProbeNow(root, btn) {
   btn.disabled = true;
   btn.textContent = "probing…";
   try {
-    anDrawAccounts(root, await api("/analytics/accounts/probe", "POST"));
+    anDrawQuota(root, await api("/analytics/quota/probe", "POST"));
   } catch (e) {
     toast("probe error: " + e.message);
     btn.disabled = false;
@@ -2365,10 +2325,10 @@ async function anProbeNow(root, btn) {
 // GET is the arrival probe: the route probes for itself when its last attempt
 // has aged past the TTL, so the section fires exactly one probe per minute of
 // toggling and the client asks for nothing extra.
-async function anAccountSection(root) {
-  root.replaceChildren(el("div", { className: "muted" }, "probing accounts…"));
+async function anQuotaSection(root) {
+  root.replaceChildren(el("div", { className: "muted" }, "probing providers…"));
   try {
-    anDrawAccounts(root, await api("/analytics/accounts"));
+    anDrawQuota(root, await api("/analytics/quota"));
   } catch (e) {
     root.replaceChildren(el("div", { className: "card" }, "error: " + e.message));
   }
@@ -2376,8 +2336,13 @@ async function anAccountSection(root) {
 
 // The Analytics tab carries its sub-view in the hash, the convention the
 // roadmap tab already uses for #roadmap / #roadmap-flow: #analytics = Token
-// Analytics, #analytics-accounts = Account Analytics. Both keep `analytics` as
-// the active nav tab; routeFromHash sets anView and re-renders.
+// Analytics, #analytics-quota = Provider Quota. Both keep `analytics` as the
+// active nav tab; routeFromHash sets anView and re-renders.
+//
+// The hash moved with the section's name. #analytics-accounts described a
+// per-account panel that no longer exists, and an operator who lands on a URL
+// naming a surface they cannot find is exactly the confusion the rename exists
+// to prevent — the old hash simply falls through to Token Analytics.
 //
 // Each section renders into its OWN node, so its replaceChildren() cannot wipe
 // the toggle above it — and so arriving at one section never runs the other's
@@ -2385,15 +2350,15 @@ async function anAccountSection(root) {
 // both would mean three third-party calls every time someone reads their spend.
 async function renderAnalytics(root) {
   const seg = el("div", { className: "filters seg an-view" });
-  for (const [mode, label] of [["tokens", "Token Analytics"], ["accounts", "Account Analytics"]]) {
+  for (const [mode, label] of [["tokens", "Token Analytics"], ["quota", "Provider Quota"]]) {
     const b = el("button", { className: "chip" + (anView === mode ? " on" : ""),
       type: "button", textContent: label });
-    b.onclick = () => { location.hash = mode === "accounts" ? "analytics-accounts" : "analytics"; };
+    b.onclick = () => { location.hash = mode === "quota" ? "analytics-quota" : "analytics"; };
     seg.append(b);
   }
   const body = el("div", {});
   root.replaceChildren(el("div", { className: "an-head" }, seg), body);
-  return anView === "accounts" ? anAccountSection(body) : anTokenSection(body);
+  return anView === "quota" ? anQuotaSection(body) : anTokenSection(body);
 }
 
 // ── Interface tab (sprint 25 seq 5) ───────────────────────────────────────────
@@ -4518,7 +4483,7 @@ function show(tab) {
 // put (and re-fetches that tab) instead of snapping back to Shells. Tabs set the
 // hash; hashchange drives show — back/forward and deep links work too. The
 // roadmap tab carries its sub-view in the hash: #roadmap (board) | #roadmap-flow.
-// The analytics tab does the same: #analytics (token) | #analytics-accounts.
+// The analytics tab does the same: #analytics (token) | #analytics-quota.
 // The interface tab carries its selected shell: #interface | #interface/DEV3.
 function routeFromHash() {
   const raw = location.hash.slice(1);
@@ -4528,7 +4493,7 @@ function routeFromHash() {
     return;
   }
   if (raw === "analytics" || raw.startsWith("analytics-")) {
-    anView = raw === "analytics-accounts" ? "accounts" : "tokens";
+    anView = raw === "analytics-quota" ? "quota" : "tokens";
     show("analytics");
     return;
   }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -702,18 +702,19 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .an-view .chip:last-child { border-top-right-radius: 6px; border-bottom-right-radius: 6px; }
 .an-acct-bar { display: flex; align-items: center; gap: .6rem; margin-bottom: .5rem; }
 .an-acct-bar .act { margin-left: auto; }
-.an-note { color: var(--warn); font-size: .85rem; margin-bottom: .5rem; }
-.an-prov { margin-bottom: .8rem; }
-.an-prov-head { display: flex; align-items: center; gap: .5rem; margin-bottom: .3rem; }
-.an-prov-head h2 { margin: 0; font-size: 1rem; }
 .an-acct { margin-bottom: .5rem; }
-/* A signed-out or unauth card keeps its numbers and loses its emphasis: the
-   values are real, they are simply not now. Recessed, never hidden. */
-.an-acct.an-muted { opacity: .62; }
+/* No muted variant. Dimming marked a card as "not the current account", a
+   distinction a provider-level panel does not have — and a degraded card's
+   numbers are exactly as real as a fresh one's. The AGE in the footer is what
+   separates them, so the age carries that job alone. */
 .an-acct-head { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; margin-bottom: .5rem; }
-.an-acct-label { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--ink); }
+.an-acct-head h2 { margin: 0; font-size: 1rem; }
 .an-acct-foot { display: flex; align-items: center; gap: .6rem; margin-top: .5rem; }
-.an-acct-foot .act { margin-left: auto; }
+/* The controls travel as a group so the pair sits right whether or not the age
+   is there to push them — a card with no reading yet has no age, and the
+   buttons must not drift to the left when it doesn't. */
+.an-acct-actions { display: flex; align-items: center; gap: .6rem; margin-left: auto; }
+.an-acct-foot a.act { text-decoration: none; }
 .an-acct-foot .act:disabled { opacity: .45; cursor: not-allowed; }
 .an-win { margin: .45rem 0; }
 .an-win-head { display: flex; align-items: baseline; gap: .5rem; font-size: .85rem; }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -710,12 +710,13 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .an-acct-head { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; margin-bottom: .5rem; }
 .an-acct-head h2 { margin: 0; font-size: 1rem; }
 .an-acct-foot { display: flex; align-items: center; gap: .6rem; margin-top: .5rem; }
-/* The controls travel as a group so the pair sits right whether or not the age
-   is there to push them — a card with no reading yet has no age, and the
-   buttons must not drift to the left when it doesn't. */
+/* The card's actions sit right whether or not the age is there to push them —
+   a card with no reading yet has no age, and the link must not drift left when
+   it doesn't. There is no disabled state to style: the only control here is the
+   usage link, and the refresh button that could be disabled is gone with the
+   per-card refresh it belonged to. */
 .an-acct-actions { display: flex; align-items: center; gap: .6rem; margin-left: auto; }
 .an-acct-foot a.act { text-decoration: none; }
-.an-acct-foot .act:disabled { opacity: .45; cursor: not-allowed; }
 .an-win { margin: .45rem 0; }
 .an-win-head { display: flex; align-items: baseline; gap: .5rem; font-size: .85rem; }
 .an-win-name { color: var(--dim); }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -691,7 +691,7 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   border-radius: 6px; padding: .25rem .5rem; font-size: .78rem;
   pointer-events: none; white-space: nowrap; box-shadow: var(--menu-shadow); }
 
-/* ── Account Analytics: sub-view toggle, account cards, quota meters ──
+/* ── Provider Quota: sub-view toggle, provider cards, quota meters ──
    Colour here is threshold-driven and provider-blind (spec #49): one amber and
    one red, both keyed off used_percent, never off a provider's own severity
    field. A window with no percent gets NEITHER class and draws no bar — an

--- a/tests/fixtures/quota_probes/README.md
+++ b/tests/fixtures/quota_probes/README.md
@@ -54,6 +54,26 @@ must not propagate an address even when the wire offers one, and a fixture with
 the field removed could not tell the difference between a probe that drops it
 and a probe that never saw it.
 
+### One case in the suite is DERIVED, not recorded — and it says so
+
+Every file in this directory is a recording. The suite additionally builds one
+case that is **not**, and it is named here so the distinction never has to be
+rediscovered from the test body.
+
+Moonshot's live five-hour window reads `limit: "100", remaining: "100"`, so the
+derivation under test — `used = limit - remaining` — lands on **zero**. Zero is
+also what every *broken* derivation returns: a missing key coerces to `None` and
+then to 0, and a wrong nesting level finds nothing and yields 0. A test built
+only on the capture would therefore pass against a derivation that never works —
+this sprint's own vacuous-coverage shape, arriving in the fixture layer.
+
+So `test_limits_entry_unwraps_detail_and_derives_used` starts from the capture,
+holds its structure exactly, and moves only the numbers (`400`/`150` → `250`).
+It asserts the capture's entry shape first, so if the wire's shape ever moves the
+derived case fails loudly instead of pinning a structure that no longer exists.
+The capture's own zero is kept as a separate case: an untouched window really
+does read zero, and that is a measured value, not a failure.
+
 ## What drift detection actually covers
 
 An earlier version of this file promised that *"a drift between the two shows up

--- a/tests/fixtures/quota_probes/README.md
+++ b/tests/fixtures/quota_probes/README.md
@@ -4,29 +4,84 @@ Recorded payload shapes for the three provider quota endpoints, used by
 `tests/test_quota_probes.py`. **No test in this suite performs a live call** —
 `urlopen` is stubbed to fail loudly if one is attempted.
 
-## Provenance — read this before trusting a field
-
-These files are transcribed from the **observed field tables in spec doc #49**
-(`## Proven Endpoints`), which record what the three endpoints returned when
-PLN2 called them live against this host's credentials on 2026-07-25 (decision
-#65). They are not raw captures: the live calls were made before this unit
-existed and their bodies were not vendored, and the sprint task explicitly
-scoped unit 2 to "capture fixtures from the spec's documented response shapes"
-rather than re-probe.
-
-So: every field the probes *depend on* is a recorded observation, but the
-surrounding envelope (nesting of `additional_rate_limits`, the exact value
-formats) is a faithful reconstruction. Values are placeholders — no real
-account label, id, or token appears here.
-
-The consequence, stated plainly so it is not discovered as a surprise: these
-fixtures pin the probes against the spec's reading of the payloads, not against
-the wire. A drift between the two shows up as an `error` status from a live
-probe, never as a wrong number — which is the stance spec #49 adopts for all
-three endpoints.
-
 | File | Endpoint |
 |---|---|
 | `anthropic_usage.json` | `GET api.anthropic.com/api/oauth/usage` |
 | `openai_usage.json` | `GET chatgpt.com/backend-api/codex/usage` |
 | `moonshot_usages.json` | `GET api.kimi.com/coding/v1/usages` |
+
+## Provenance — these are real captures
+
+All three were captured live from this host's own credentials on **2026-07-25**
+(spec doc #57), each by issuing exactly the request its probe issues and keeping
+the response body verbatim.
+
+| File | How it was taken |
+|---|---|
+| `anthropic_usage.json` | `GET` with `Authorization: Bearer <accessToken from ~/.claude/.credentials.json>` and `anthropic-beta: oauth-2025-04-20`. |
+| `openai_usage.json` | `GET` with the token and `chatgpt-account-id` from `~/.codex/auth.json`, **plus the codex client identity** (`User-Agent: codex_cli_rs/0.145.0`, `originator: codex_cli_rs`, `version: 0.145.0`). Without those three headers the endpoint answers `403` with an HTML anti-bot page and there is no payload to capture at all — flag #196. |
+| `moonshot_usages.json` | `GET` with the access token from `~/.kimi-code/credentials/kimi-code.json`, captured inside the **900-second** window after the operator booted Kimi. No refresh was performed to obtain it, and none may be: Kimi rotates its refresh token on every refresh, so a refresh by anything other than the Kimi CLI strands the CLI with an invalidated token and signs the operator out of the provider this panel monitors. To re-capture: ask the operator to boot Kimi, then capture within 15 minutes. |
+
+**They replaced transcriptions.** The previous fixtures were written from spec
+doc #49's observed-field tables rather than from the wire, because the sprint
+task scoped that unit to "capture fixtures from the spec's documented response
+shapes" rather than re-probe. Where those tables were wrong the probes were
+built wrong and every test agreed with them (flag #198). Six field-level
+defects — four in moonshot, one in openai, one in anthropic — were found only by
+capturing, and two of them were in the payloads nobody suspected.
+
+### Sanitization
+
+Identifiers are replaced with placeholders. **Nothing else is touched** — no
+tidying, no normalizing, no filling in of "obviously missing" fields:
+
+| File | Replaced |
+|---|---|
+| `anthropic_usage.json` | nothing — this payload carries no identifier of any kind |
+| `openai_usage.json` | `email`, `account_id`, `user_id` |
+| `moonshot_usages.json` | `user.userId`, `parallel.details[]` |
+
+Three properties in particular are **exactly as the wire sent them**, because
+each is something a transcription got wrong:
+
+- **enum prefixes** — `"timeUnit": "TIME_UNIT_MINUTE"`, not `"MINUTE"`
+- **string-typed counts** — `"limit": "100"`, not `100`
+- **nested blocks** — moonshot's `limits[].detail`, openai's
+  `additional_rate_limits[].rate_limit`
+
+`openai_usage.json` keeps its (placeholder) `email` key deliberately. The probe
+must not propagate an address even when the wire offers one, and a fixture with
+the field removed could not tell the difference between a probe that drops it
+and a probe that never saw it.
+
+## What drift detection actually covers
+
+An earlier version of this file promised that *"a drift between the two shows up
+as an `error` status from a live probe, never as a wrong number."* **That claim
+was false and it was disproved in production**: the moonshot probe returned
+status `ok` while the operator's card showed a wrong window kind, an empty row,
+and a Python dict repr.
+
+The reason is structural. Spec #49's drift rule judges the **envelope** — is
+`usage` a dict, is `limits` a list, is `rate_limit` a dict. In that failure every
+one of them held. **The divergence was one level below the envelope, in field
+names and nesting, and an envelope check does not look there.**
+
+Stated accurately, then:
+
+- **Drift detection catches** an envelope that is absent or of the wrong type.
+  That yields `error` with no rows, and it is the case where a probe would
+  otherwise report a zero as though it had been measured.
+- **Drift detection does not catch** a payload whose envelope is intact and
+  whose *contents* have moved — a renamed field, a value that gained a nesting
+  level, an enum that gained a prefix.
+- **What catches those is these fixtures**, and only to the extent that they
+  match the wire. That is why they are captures rather than transcriptions, and
+  why re-capturing is the first move whenever a card looks wrong.
+
+A few specific shapes are pinned directly by the suite — moonshot's `detail`
+unwrap and `TIME_UNIT_` prefix, openai's nested
+`additional_rate_limits[].rate_limit` — because those have already broken once.
+That is a list of known hazards, not a schema. Spec #57 deliberately declined to
+build a general payload validator: it would carry its own failure modes and
+would still only know what a capture had told it.

--- a/tests/fixtures/quota_probes/README.md
+++ b/tests/fixtures/quota_probes/README.md
@@ -89,9 +89,13 @@ names and nesting, and an envelope check does not look there.**
 
 Stated accurately, then:
 
-- **Drift detection catches** an envelope that is absent or of the wrong type.
-  That yields `error` with no rows, and it is the case where a probe would
-  otherwise report a zero as though it had been measured.
+- **Drift detection catches** an envelope that is absent or of the wrong type,
+  and — one level down — an ENTRY of a window collection that the reader cannot
+  open: a non-object, or (openai) one carrying no `rate_limit{}`. Both yield
+  `error` with no rows. The entry-level half exists because the alternative was
+  a silent `continue`: a scoped window vanishing off the card while the status
+  stayed `ok`, which is the same failure as the envelope one and hid the same
+  way.
 - **Drift detection does not catch** a payload whose envelope is intact and
   whose *contents* have moved — a renamed field, a value that gained a nesting
   level, an enum that gained a prefix.

--- a/tests/fixtures/quota_probes/anthropic_usage.json
+++ b/tests/fixtures/quota_probes/anthropic_usage.json
@@ -1,28 +1,95 @@
 {
-  "subscriptionType": "max",
+  "five_hour": {
+    "utilization": 47.0,
+    "resets_at": "2026-07-25T23:10:00.911881+00:00",
+    "limit_dollars": null,
+    "used_dollars": null,
+    "remaining_dollars": null
+  },
+  "seven_day": {
+    "utilization": 36.0,
+    "resets_at": "2026-08-01T06:00:00.911899+00:00",
+    "limit_dollars": null,
+    "used_dollars": null,
+    "remaining_dollars": null
+  },
+  "seven_day_oauth_apps": null,
+  "seven_day_opus": null,
+  "seven_day_sonnet": null,
+  "seven_day_cowork": null,
+  "seven_day_omelette": null,
+  "tangelo": null,
+  "iguana_necktie": null,
+  "omelette_promotional": null,
+  "nimbus_quill": null,
+  "cinder_cove": null,
+  "amber_ladder": null,
+  "extra_usage": {
+    "is_enabled": false,
+    "monthly_limit": null,
+    "used_credits": null,
+    "utilization": null,
+    "currency": null,
+    "decimal_places": null,
+    "disabled_reason": null,
+    "user_disabled": true,
+    "spend_limit_reached": false,
+    "credits_ever_enabled": true,
+    "daily": null,
+    "weekly": null
+  },
   "limits": [
     {
       "kind": "session",
-      "percent": 22,
-      "resets_at": "2026-07-25T21:00:00+00:00",
-      "severity": "normal"
+      "group": "session",
+      "percent": 47,
+      "severity": "normal",
+      "resets_at": "2026-07-25T23:10:00.911881+00:00",
+      "scope": null,
+      "is_active": true
     },
     {
       "kind": "weekly_all",
-      "percent": 41,
-      "resets_at": "2026-07-28T09:00:00Z",
-      "severity": "normal"
+      "group": "weekly",
+      "percent": 36,
+      "severity": "normal",
+      "resets_at": "2026-08-01T06:00:00.911899+00:00",
+      "scope": null,
+      "is_active": false
     },
     {
       "kind": "weekly_scoped",
-      "percent": 63,
-      "resets_at": "2026-07-28T09:00:00Z",
+      "group": "weekly",
+      "percent": 47,
       "severity": "normal",
+      "resets_at": "2026-08-01T05:59:59.912113+00:00",
       "scope": {
         "model": {
-          "display_name": "Claude Opus 5"
-        }
-      }
+          "id": null,
+          "display_name": "Fable"
+        },
+        "surface": null
+      },
+      "is_active": false
     }
-  ]
+  ],
+  "spend": {
+    "used": {
+      "amount_minor": 0,
+      "currency": "USD",
+      "exponent": 2
+    },
+    "limit": null,
+    "percent": 0,
+    "severity": "normal",
+    "enabled": false,
+    "disabled_reason": null,
+    "cap": null,
+    "balance": null,
+    "auto_reload": null,
+    "disclaimer": "Usage credits cover you when you hit your plan limits. [Learn more](https://support.claude.com/articles/12429409)",
+    "can_purchase_credits": false,
+    "can_toggle": false
+  },
+  "member_dashboard_available": false
 }

--- a/tests/fixtures/quota_probes/moonshot_usages.json
+++ b/tests/fixtures/quota_probes/moonshot_usages.json
@@ -1,26 +1,42 @@
 {
   "user": {
-    "userId": "placeholder-user-0001"
-  },
-  "membership": {
-    "level": "LEVEL_ADVANCED"
+    "userId": "placeholderuser000001",
+    "region": "REGION_OVERSEA",
+    "membership": {
+      "level": "LEVEL_ADVANCED"
+    },
+    "businessId": ""
   },
   "usage": {
-    "used": 128000,
-    "limit": 500000,
-    "remaining": 372000,
-    "resetTime": "2026-07-31T00:00:00Z"
+    "limit": "100",
+    "used": "97",
+    "remaining": "3",
+    "resetTime": "2026-07-29T11:38:20.162687Z"
   },
   "limits": [
     {
       "window": {
         "duration": 300,
-        "timeUnit": "MINUTE"
+        "timeUnit": "TIME_UNIT_MINUTE"
       },
-      "used": 42,
-      "limit": 200,
-      "remaining": 158,
-      "resetTime": "2026-07-25T20:00:00Z"
+      "detail": {
+        "limit": "100",
+        "remaining": "100",
+        "resetTime": "2026-07-26T00:38:20.162687Z"
+      }
     }
-  ]
+  ],
+  "parallel": {
+    "limit": "30",
+    "details": [
+      "00000000-0000-0000-0000-000000000000"
+    ]
+  },
+  "totalQuota": {},
+  "authentication": {
+    "method": "METHOD_ACCESS_TOKEN",
+    "scope": "FEATURE_CODING"
+  },
+  "subType": "TYPE_PURCHASE",
+  "domain": "DOMAIN_NEXUS"
 }

--- a/tests/fixtures/quota_probes/openai_usage.json
+++ b/tests/fixtures/quota_probes/openai_usage.json
@@ -1,24 +1,59 @@
 {
+  "user_id": "user-PLACEHOLDER000000000000",
+  "account_id": "user-PLACEHOLDER000000000000",
   "email": "placeholder@example.com",
-  "account_id": "acct_placeholder_0001",
   "plan_type": "prolite",
   "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
     "primary_window": {
-      "used_percent": 12.5,
-      "limit_window_seconds": 18000,
-      "reset_at": 1785016800
-    },
-    "secondary_window": {
-      "used_percent": 47.0,
+      "used_percent": 2,
       "limit_window_seconds": 604800,
-      "reset_at": 1785412800
+      "reset_after_seconds": 602397,
+      "reset_at": 1785622708
     },
-    "additional_rate_limits": [
-      {
-        "limit_name": "premium",
-        "used_percent": 3.0,
-        "reset_at": 1785412800
+    "secondary_window": null
+  },
+  "code_review_rate_limit": null,
+  "additional_rate_limits": [
+    {
+      "limit_name": "GPT-5.3-Codex-Spark",
+      "metered_feature": "codex_bengalfox",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window": {
+          "used_percent": 0,
+          "limit_window_seconds": 604800,
+          "reset_after_seconds": 604800,
+          "reset_at": 1785625111
+        },
+        "secondary_window": null
       }
+    }
+  ],
+  "credits": {
+    "has_credits": false,
+    "unlimited": false,
+    "overage_limit_reached": false,
+    "balance": "0",
+    "approx_local_messages": [
+      0,
+      0
+    ],
+    "approx_cloud_messages": [
+      0,
+      0
     ]
+  },
+  "spend_control": {
+    "reached": false,
+    "individual_limit": null
+  },
+  "rate_limit_reached_type": null,
+  "promo": null,
+  "rate_limit_reset_credits": {
+    "available_count": 0,
+    "applicable_available_count": 0
   }
 }

--- a/tests/test_quota_accounts_api.py
+++ b/tests/test_quota_accounts_api.py
@@ -261,6 +261,62 @@ class QuotaReadTest(QuotaBase):
         self.assertEqual({20.0, 30.0}, {w["used_percent"]
                                         for w in by_provider["openai"]["windows"]})
 
+    def test_a_window_the_provider_stopped_reporting_leaves_the_reading(self):
+        """N-4. The window upsert updates and never deletes, so a kind the
+        provider stops sending keeps its row for good — and the reading used to
+        be the whole accumulated set, filed under the NEWEST capture's age. An
+        hour-old five-hour figure then rendered under "as of 1m ago", which is
+        spec #57's second empty-state wall crossed: stale figures presented as
+        fresh. A reading is one capture.
+
+        Both legs, because the naive fix (delete on write) breaks the second:
+        Leg 1 — the vanished kind is not in the reading.
+        Leg 2 — its ROW is still in the DB, untouched. Nothing is destroyed on
+        a probe's say-so; it is simply not part of this reading, and it comes
+        back the moment the provider sends that window again."""
+        old = iso(minutes_ago=60)
+        with self.stub([acct(windows=[win("weekly", None, 12.0, captured_at=old),
+                                      win("five_hour", None, 80.0, captured_at=old)])],
+                       [acct(windows=[win("weekly", None, 15.0)])]):
+            server.get_analytics_quota(self.con)
+            out = server.get_analytics_quota(self.con, force=True)
+        entry = self.providers(out)["anthropic"]
+        self.assertEqual([("weekly", 15.0)],
+                         [(w["window_kind"], w["used_percent"])
+                          for w in entry["windows"]],
+                         "an hour-old window rode along inside a fresh reading")
+        self.assertNotEqual(old[:16], entry["captured_at"][:16])
+        kept = self.q("SELECT window_kind FROM harness_quota_window "
+                      "WHERE window_kind='five_hour'")
+        self.assertEqual(1, len(kept), "the row was deleted rather than "
+                                       "left out of this reading")
+
+    def test_an_idle_provider_is_distinguishable_from_a_never_probed_one(self):
+        """L-614-2 — the distinction the card's empty state renders, asserted
+        on what this layer can actually EMIT.
+
+        captured_at is derived from window rows, so a provider with no windows
+        never has one and the card cannot read staleness off it. What separates
+        the two is the STATUS: `ok` with zero windows is a probe that got an
+        intact answer carrying nothing (an idle account), while a provider the
+        process has no status for has never produced a reading at all. The card
+        branched on captured_at until this test existed, which made its idle
+        sentence unreachable through any real response."""
+        idle = acct(status="ok", windows=[])
+        with self.stub([idle]):
+            out = server.get_analytics_quota(self.con)
+        by_provider = self.providers(out)
+        self.assertEqual(("ok", [], None),
+                         (by_provider["anthropic"]["status"],
+                          by_provider["anthropic"]["windows"],
+                          by_provider["anthropic"]["captured_at"]))
+        # ...and the provider the probe said nothing about carries no status,
+        # which is the other sentence. Same windows, same captured_at — the
+        # status is the only field that can tell them apart.
+        self.assertIsNone(by_provider["openai"]["status"])
+        self.assertEqual([], by_provider["openai"]["windows"])
+        self.assertIsNone(by_provider["openai"]["captured_at"])
+
     def test_a_degraded_probe_keeps_last_known_figures_and_their_age(self):
         """The empty-state rule, WITH BOTH MIRROR LEGS. A lapsed Kimi token is
         the common case, not an error, and the operator's most useful

--- a/tests/test_quota_accounts_api.py
+++ b/tests/test_quota_accounts_api.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for the Account Analytics API routes (spec doc #49, sprint 52 unit 3).
+"""Tests for the Provider Quota API routes (spec doc #57, superseding #49).
 
 Stdlib `unittest`, matching the sibling suites. Two layers:
 
@@ -29,6 +29,7 @@ import sys
 import tempfile
 import threading
 import unittest
+import urllib.error
 import urllib.request
 from datetime import datetime, timedelta, timezone
 from http.server import ThreadingHTTPServer
@@ -62,12 +63,11 @@ def iso(minutes_ago: float = 0.0, days_ago: float = 0.0) -> str:
     return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def acct(provider="anthropic", ref="uuid-1", label="jed@gmail.com", plan="max",
-         captured_at=None, status="ok", is_current=1, windows=(), detail=None):
+def acct(provider="anthropic", ref="uuid-1", captured_at=None, status="ok",
+         windows=(), detail=None):
     return quota_probes.account(
         provider=provider, probe_version="1", captured_at=captured_at or iso(),
-        account_ref=ref, account_label=label, plan=plan, is_current=is_current,
-        status=status, detail=detail, windows=list(windows))
+        account_ref=ref, status=status, detail=detail, windows=list(windows))
 
 
 def win(kind="session", scope=None, percent=22.0, used=None, limit_value=None,
@@ -113,8 +113,8 @@ class QuotaUpsertTest(QuotaBase):
         first = [acct(windows=[win("session", None, 22.0)])]
         second = [acct(windows=[win("session", None, 44.0)])]
         with self.stub(first, second):
-            server.get_analytics_accounts(self.con)
-            server.get_analytics_accounts(self.con, force=True)
+            server.get_analytics_quota(self.con)
+            server.get_analytics_quota(self.con, force=True)
         rows = self.q("SELECT used_percent FROM harness_quota_window "
                       "WHERE window_kind='session' AND scope IS NULL")
         self.assertEqual(1, len(rows))
@@ -125,39 +125,54 @@ class QuotaUpsertTest(QuotaBase):
         with self.stub([acct(windows=[win("weekly_scoped", "opus", 10.0),
                                       win("weekly_scoped", "sonnet", 20.0),
                                       win("weekly", None, 30.0)])]):
-            server.get_analytics_accounts(self.con)
+            server.get_analytics_quota(self.con)
         self.assertEqual(3, self.q("SELECT COUNT(*) c FROM harness_quota_window")[0]["c"])
 
-    def test_returning_account_keeps_its_original_first_seen(self):
-        old = iso(days_ago=30)
-        with self.stub([acct(captured_at=old)], [acct(captured_at=iso())]):
-            server.get_analytics_accounts(self.con)
-            server.get_analytics_accounts(self.con, force=True)
-        row = self.q("SELECT first_seen, last_seen FROM harness_quota_account")[0]
-        self.assertEqual(old, row["first_seen"])       # never re-minted
-        self.assertGreater(row["last_seen"], old)      # but activity advanced
+    def test_reprobe_reuses_the_registry_row_instead_of_minting_one(self):
+        """What account_ref is FOR, and all it is for after 0097. The row
+        carries no timestamps to advance any more, so the only thing the
+        upsert must still get right is not duplicating."""
+        with self.stub([acct(captured_at=iso(days_ago=30))],
+                       [acct(captured_at=iso())]):
+            server.get_analytics_quota(self.con)
+            server.get_analytics_quota(self.con, force=True)
+        rows = self.q("SELECT account_pk, provider, account_ref "
+                      "FROM harness_quota_account")
+        self.assertEqual(1, len(rows), "a re-probe minted a second row")
+        self.assertEqual("uuid-1", rows[0]["account_ref"])
 
-    def test_switching_account_moves_is_current_off_the_old_row(self):
-        with self.stub([acct(ref="uuid-1", label="a@x.com")],
-                       [acct(ref="uuid-2", label="b@x.com")]):
-            server.get_analytics_accounts(self.con)
-            server.get_analytics_accounts(self.con, force=True)
-        rows = {r["account_ref"]: r["is_current"] for r in
-                self.q("SELECT account_ref, is_current FROM harness_quota_account")}
-        self.assertEqual({"uuid-1": 0, "uuid-2": 1}, rows)
+    def test_a_second_account_on_one_provider_does_not_disambiguate(self):
+        """Two refs under one provider is legal and invisible: the panel shows
+        the NEWEST READING per provider and never asks which account produced
+        it (decision #68's problem dissolving, not being solved)."""
+        with self.stub([acct(ref="uuid-1", captured_at=iso(days_ago=2),
+                             windows=[win("session", None, 10.0,
+                                          captured_at=iso(days_ago=2))])],
+                       [acct(ref="uuid-2", captured_at=iso(),
+                             windows=[win("session", None, 80.0)])]):
+            server.get_analytics_quota(self.con)
+            out = server.get_analytics_quota(self.con, force=True)
+        self.assertEqual(2, self.q("SELECT COUNT(*) c FROM "
+                                   "harness_quota_account")[0]["c"])
+        entry = {p["provider"]: p for p in out["providers"]}["anthropic"]
+        self.assertEqual([80.0], [w["used_percent"] for w in entry["windows"]],
+                         "the newest reading must win outright")
+        self.assertNotIn("account_ref", json.dumps(entry))
 
     def test_account_without_a_ref_writes_no_registry_row(self):
         # No credential file → `na`. The absence of a limit is not a limit of
         # zero, and a row keyed on a null ref could never be matched again.
         na = quota_probes.account(provider="moonshot", probe_version="1",
-                                  captured_at=iso(), status="na", is_current=0)
+                                  captured_at=iso(), status="na")
         with self.stub([na]):
-            out = server.get_analytics_accounts(self.con)
+            out = server.get_analytics_quota(self.con)
         self.assertEqual(0, self.q("SELECT COUNT(*) c FROM harness_quota_account")[0]["c"])
-        # ...but the provider is still REPORTED, or "no accounts" would be
-        # indistinguishable from "every probe failed".
-        self.assertEqual([{"provider": "moonshot", "status": "na", "detail": None}],
-                         out["providers"])
+        # ...but the provider is still REPORTED, or "nothing configured" would
+        # be indistinguishable from "the probe failed".
+        entry = {p["provider"]: p for p in out["providers"]}["moonshot"]
+        self.assertEqual("na", entry["status"])
+        self.assertEqual([], entry["windows"])
+        self.assertIsNone(entry["captured_at"])
 
     def test_unauth_preserves_the_last_known_values(self):
         # "Expiry is reported, not repaired": the card shows what it last knew,
@@ -165,8 +180,8 @@ class QuotaUpsertTest(QuotaBase):
         good = [acct(windows=[win("session", None, 61.0, captured_at=iso(minutes_ago=90))])]
         expired = [acct(status="unauth", windows=[])]
         with self.stub(good, expired):
-            server.get_analytics_accounts(self.con)
-            server.get_analytics_accounts(self.con, force=True)
+            server.get_analytics_quota(self.con)
+            server.get_analytics_quota(self.con, force=True)
         row = self.q("SELECT used_percent, captured_at FROM harness_quota_window")[0]
         self.assertEqual(61.0, row["used_percent"])
         self.assertEqual(iso(minutes_ago=90)[:16], row["captured_at"][:16])
@@ -177,41 +192,111 @@ class QuotaUpsertTest(QuotaBase):
         leaky = acct()
         leaky["access_token"] = "sk-ant-oat01-SHOULD-NEVER-APPEAR"
         with self.stub([leaky]):
-            out = server.get_analytics_accounts(self.con)
+            out = server.get_analytics_quota(self.con)
         self.assertNotIn("SHOULD-NEVER-APPEAR", json.dumps(out))
 
 
 class QuotaReadTest(QuotaBase):
-    """The 7-day activity window — a filter, never a delete."""
+    """The provider-shaped response — one entry per provider, newest reading.
 
-    def test_stale_account_stops_rendering_but_its_row_survives(self):
-        with self.stub([acct(ref="old", label="old@x.com", captured_at=iso(days_ago=30))]):
-            server.get_analytics_accounts(self.con)
-        # Demote it: only the account the credential file resolves to NOW is
-        # exempt from the window.
-        self.con.execute("UPDATE harness_quota_account SET is_current=0")
-        self.con.commit()
+    THE 7-DAY ACTIVITY WINDOW THIS CLASS USED TO PIN IS GONE, along with the
+    is_current exemption that made it survivable. Both existed to decide WHICH
+    ACCOUNT's card to show; a provider-level panel never asks.
+    """
+
+    def providers(self, out) -> dict:
+        return {p["provider"]: p for p in out["providers"]}
+
+    def test_every_provider_gets_an_entry_even_with_nothing_in_the_registry(self):
+        """Built from the PROVIDERS constant, not from what happens to be in
+        the DB — and that is what makes it true BY CONSTRUCTION.
+
+        Built from the status list or the registry, a never-probed provider
+        would render only once something had populated it: a card whose
+        existence depends on the very thing it exists to report the absence
+        of. The operator must be able to tell "not configured" from "not
+        readable", and an absent card says neither."""
         with self.stub([]):
-            out = server.get_analytics_accounts(self.con, force=True)
-        self.assertEqual([], out["accounts"])
-        self.assertEqual(1, self.q("SELECT COUNT(*) c FROM harness_quota_account")[0]["c"])
+            out = server.get_analytics_quota(self.con)
+        self.assertEqual([p["provider"] for p in out["providers"]],
+                         list(server.quota_dispatch.PROVIDERS))
+        for entry in out["providers"]:
+            self.assertEqual(entry["windows"], [])
+            self.assertIsNone(entry["captured_at"], "no reading yet")
 
-    def test_current_account_renders_even_when_its_last_seen_has_aged(self):
-        # A failed probe leaves last_seen un-advanced; the section must still
-        # show the current account rather than an empty page.
-        with self.stub([acct(captured_at=iso(days_ago=30))]):
-            out = server.get_analytics_accounts(self.con)
-        self.assertEqual(["uuid-1"], [a["account_ref"] for a in out["accounts"]])
+    def test_the_newest_reading_wins_by_window_captured_at(self):
+        """Selection keys on the WINDOW's captured_at, not on any registry
+        timestamp — which is why 0097 could drop last_seen at all."""
+        with self.stub([acct(ref="a", windows=[
+                            win("session", None, 10.0,
+                                captured_at=iso(days_ago=3))]),
+                        acct(ref="b", windows=[
+                            win("session", None, 90.0, captured_at=iso())])]):
+            out = server.get_analytics_quota(self.con)
+        entry = self.providers(out)["anthropic"]
+        self.assertEqual([90.0], [w["used_percent"] for w in entry["windows"]])
 
-    def test_windows_attach_to_their_own_account(self):
+    def test_a_reading_with_no_windows_cannot_outrank_one_with_numbers(self):
+        """FLAG #196'S STALE ROWS, PINNED — this is why no data migration was
+        needed. The rows its failure path minted under a guessed account_ref
+        carry no windows, so they hold no reading, so they can never win and
+        can never be seen. Their harmlessness is a property of the selection,
+        not an accident, so it gets a test."""
+        with self.stub([acct(ref="stale-guessed-ref", windows=[]),
+                        acct(ref="real", windows=[
+                            win("session", None, 42.0)])]):
+            out = server.get_analytics_quota(self.con)
+        entry = self.providers(out)["anthropic"]
+        self.assertEqual([42.0], [w["used_percent"] for w in entry["windows"]])
+        self.assertIsNotNone(entry["captured_at"])
+
+    def test_windows_stay_with_their_own_provider(self):
         with self.stub([acct(ref="a", windows=[win("session", None, 10.0)]),
                         acct(provider="openai", ref="b", windows=[
                             win("weekly", None, 20.0), win("five_hour", None, 30.0)])]):
-            out = server.get_analytics_accounts(self.con)
-        by_ref = {a["account_ref"]: a for a in out["accounts"]}
-        self.assertEqual([10.0], [w["used_percent"] for w in by_ref["a"]["windows"]])
-        self.assertEqual({20.0, 30.0},
-                         {w["used_percent"] for w in by_ref["b"]["windows"]})
+            out = server.get_analytics_quota(self.con)
+        by_provider = self.providers(out)
+        self.assertEqual([10.0], [w["used_percent"]
+                                  for w in by_provider["anthropic"]["windows"]])
+        self.assertEqual({20.0, 30.0}, {w["used_percent"]
+                                        for w in by_provider["openai"]["windows"]})
+
+    def test_a_degraded_probe_keeps_last_known_figures_and_their_age(self):
+        """The empty-state rule, WITH BOTH MIRROR LEGS. A lapsed Kimi token is
+        the common case, not an error, and the operator's most useful
+        information in that moment is where they stood 20 minutes ago.
+
+        Leg 1 — it must not BLANK the card: the figures survive.
+        Leg 2 — it must not present stale figures AS FRESH: captured_at still
+        reads the old reading's time, so the age the card renders is true."""
+        old = iso(minutes_ago=90)
+        with self.stub([acct(windows=[win("session", None, 61.0,
+                                          captured_at=old)])],
+                       [acct(status="unauth", windows=[])]):
+            server.get_analytics_quota(self.con)
+            out = server.get_analytics_quota(self.con, force=True)
+        entry = self.providers(out)["anthropic"]
+        self.assertEqual([61.0], [w["used_percent"] for w in entry["windows"]])
+        self.assertEqual("unauth", entry["status"])
+        self.assertEqual(old[:16], entry["captured_at"][:16],
+                         "a stale reading was stamped with a fresh time")
+
+    def test_the_response_carries_no_account_identity_at_all(self):
+        """The gate item, at the API layer, WITH A POSITIVE CONTROL: the probe
+        result really does carry a ref and a leaked address, asserted before
+        the response is checked, so this cannot pass on an empty probe."""
+        leaky = acct(ref="uuid-secret-1", windows=[win()])
+        leaky["account_label"] = "operator@example.com"
+        self.assertIn("operator@example.com", json.dumps(leaky))
+        with self.stub([leaky]):
+            out = server.get_analytics_quota(self.con)
+        blob = json.dumps(out)
+        for banned in ("operator@example.com", "@", "uuid-secret-1",
+                       "account_label", "account_ref", "plan", "is_current"):
+            self.assertNotIn(banned, blob)
+        # ...and the reading itself still arrived, or the sweep proves nothing.
+        self.assertEqual([22.0], [w["used_percent"] for w in
+                                  self.providers(out)["anthropic"]["windows"]])
 
 
 class QuotaTtlTest(QuotaBase):
@@ -220,8 +305,8 @@ class QuotaTtlTest(QuotaBase):
 
     def test_second_arrival_inside_the_ttl_does_not_probe(self):
         with self.stub([acct(windows=[win()])]):
-            server.get_analytics_accounts(self.con)
-            out = server.get_analytics_accounts(self.con)
+            server.get_analytics_quota(self.con)
+            out = server.get_analytics_quota(self.con)
         self.assertEqual(1, len(self.calls))
         self.assertFalse(out["probed"])
 
@@ -230,16 +315,16 @@ class QuotaTtlTest(QuotaBase):
         # (or every provider erroring) writes no captured_at at all, so a
         # captured_at-only TTL would re-probe on every single arrival.
         with self.stub([]):
-            server.get_analytics_accounts(self.con)
-            server.get_analytics_accounts(self.con)
+            server.get_analytics_quota(self.con)
+            server.get_analytics_quota(self.con)
         self.assertEqual(1, len(self.calls))
 
     def test_an_aged_attempt_probes_again(self):
         # The clock is the ATTEMPT, so age the attempt — not the capture.
         with self.stub([acct(windows=[win()])]):
-            server.get_analytics_accounts(self.con)
+            server.get_analytics_quota(self.con)
             server._QUOTA_PROBE["at"] -= server.QUOTA_TTL_SECONDS + 1
-            out = server.get_analytics_accounts(self.con)
+            out = server.get_analytics_quota(self.con)
         self.assertEqual(2, len(self.calls))
         self.assertTrue(out["probed"])
 
@@ -252,20 +337,25 @@ class QuotaTtlTest(QuotaBase):
         # ambiguity that list exists to remove.
         fresh = [acct(windows=[win(captured_at=iso())])]
         with self.stub(fresh):
-            server.get_analytics_accounts(self.con)
+            server.get_analytics_quota(self.con)
             self.assertTrue(self.q("SELECT 1 FROM harness_quota_window"),
                             "positive control: the first probe must have "
                             "written a window row for the DB clock to read")
             server._QUOTA_PROBE.update({"at": None, "providers": []})  # restart
-            out = server.get_analytics_accounts(self.con)
+            out = server.get_analytics_quota(self.con)
         self.assertEqual(2, len(self.calls))
         self.assertTrue(out["probed"])
-        self.assertEqual(["anthropic"], [p["provider"] for p in out["providers"]])
+        # The cards render either way — they are built from PROVIDERS. What a
+        # restart must recover is the STATUS on them: without the re-probe
+        # every entry would carry status None, which is the panel's way of
+        # saying "never probed" and would be a lie about a live account.
+        entry = {p["provider"]: p for p in out["providers"]}["anthropic"]
+        self.assertEqual("ok", entry["status"])
 
     def test_force_bypasses_a_fresh_ttl(self):
         with self.stub([acct(windows=[win()])]):
-            server.get_analytics_accounts(self.con)
-            out = server.get_analytics_accounts(self.con, force=True)
+            server.get_analytics_quota(self.con)
+            out = server.get_analytics_quota(self.con, force=True)
         self.assertEqual(2, len(self.calls))
         self.assertTrue(out["probed"])
 
@@ -279,13 +369,13 @@ class QuotaTtlTest(QuotaBase):
             seen["args"], seen["kwargs"] = a, kw
             return []
         with mock.patch.object(server.quota_dispatch, "probe_all", fake):
-            server.get_analytics_accounts(self.con)
+            server.get_analytics_quota(self.con)
         self.assertEqual((), seen["args"])
         self.assertEqual({}, seen["kwargs"])
 
 
 class QuotaRouteTest(unittest.TestCase):
-    """The two URLs, over real HTTP. `accounts`, never `usage`."""
+    """The two URLs, over real HTTP. `quota`, never `accounts`, never `usage`."""
 
     @classmethod
     def setUpClass(cls):
@@ -328,30 +418,43 @@ class QuotaRouteTest(unittest.TestCase):
             return results
         return mock.patch.object(server.quota_dispatch, "probe_all", fake)
 
-    def test_get_accounts_serves_the_registry(self):
-        with self.stubbed([acct(label="jed@gmail.com", windows=[win()])]):
-            status, body = self.call("/api/analytics/accounts")
+    def test_get_quota_serves_the_provider_entries(self):
+        with self.stubbed([acct(windows=[win()])]):
+            status, body = self.call("/api/analytics/quota")
         self.assertEqual(200, status)
-        self.assertEqual(["jed@gmail.com"],
-                         [a["account_label"] for a in body["accounts"]])
-        self.assertEqual(7, body["activity_days"])
+        self.assertEqual([p["provider"] for p in body["providers"]],
+                         list(server.quota_dispatch.PROVIDERS))
+        entry = {p["provider"]: p for p in body["providers"]}["anthropic"]
+        self.assertEqual([22.0], [w["used_percent"] for w in entry["windows"]])
         self.assertEqual(60, body["ttl_seconds"])
+        self.assertNotIn("activity_days", body,
+                         "the 7-day window is gone, not merely unread")
+        self.assertNotIn("accounts", body)
+
+    def test_the_old_accounts_route_is_gone_with_no_alias(self):
+        """R3: no compatibility alias. An alias would itself be a route naming
+        a mechanism that no longer exists — the exact defect class this unit
+        removes. There is one operator and they are being told directly."""
+        with self.assertRaises(urllib.error.HTTPError) as caught:
+            self.call("/api/analytics/accounts")
+        self.assertEqual(404, caught.exception.code)
 
     def test_post_probe_route_forces_a_probe(self):
         with self.stubbed([acct(windows=[win()])]):
-            self.call("/api/analytics/accounts")        # arms the TTL
-            status, body = self.call("/api/analytics/accounts/probe", method="POST")
+            self.call("/api/analytics/quota")        # arms the TTL
+            status, body = self.call("/api/analytics/quota/probe", method="POST")
         self.assertEqual(200, status)
         self.assertEqual(2, len(self.calls))
         self.assertTrue(body["probed"])
 
     def test_token_analytics_usage_route_still_means_token_spend(self):
-        # The reason the route word is `accounts`: /api/analytics/usage already
-        # has a meaning on this tab and must keep it.
+        # The reason the route word is `quota` and not `usage`:
+        # /api/analytics/usage already has a meaning on this tab — token spend
+        # — and must keep it.
         status, body = self.call("/api/analytics/usage")
         self.assertEqual(200, status)
         self.assertIn("favorite_models", body)
-        self.assertNotIn("accounts", body)
+        self.assertNotIn("providers", body)
 
 
 if __name__ == "__main__":

--- a/tests/test_quota_accounts_ui.py
+++ b/tests/test_quota_accounts_ui.py
@@ -25,13 +25,15 @@ so all three are asked in both directions:
     WITH their age, rather than blanking the card or passing them off as fresh.
 
 WHAT THIS SUITE STOPPED PINNING, AND WHY IT IS NOT A GAP. The 7-day activity
-window, the is_current exemption, muted rendering, the disabled refresh button
-and the full-email label all had tests here and all are gone. They were not
-weakened — the mechanisms were REMOVED (decision #75, migration 0097), and a
-test for a mechanism that no longer exists is the "comment describing a
-mechanism that no longer exists" defect wearing a different hat. What replaces
-them is the property they were each approximating: every provider renders a
-card, and no card says anything about who is signed in.
+window, the is_current exemption, muted rendering, the disabled refresh button,
+the per-card refresh button and the full-email label all had tests here and all
+are gone. They were not weakened — the mechanisms were REMOVED (decision #75,
+migration 0097), and a test for a mechanism that no longer exists is the
+"comment describing a mechanism that no longer exists" defect wearing a
+different hat. What replaces them is the property they were each approximating:
+every provider renders a card, no card says anything about who is signed in,
+and the section has exactly one refresh control because one probe run is all
+the route can do.
 """
 
 from __future__ import annotations
@@ -407,15 +409,28 @@ def test_never_probed_and_idle_say_different_things():
     """Both render zero windows, and collapsing them loses the operator's next
     move. A provider that has never returned anything has nothing to show; one
     that returned an intact envelope carrying zero windows is genuinely idle,
-    and that IS its reading."""
+    and that IS its reading.
+
+    THE SIGNAL IS THE STATUS, and these three payloads are ones the API emits.
+    The card used to branch on captured_at, which the API derives from window
+    rows — so a card with no windows never had one and the idle sentence could
+    not be reached by any real response. This test pinned that branch with a
+    hand-authored payload the producer cannot emit, which is the defect class
+    this whole unit exists to end. `ok` with zero windows is the producible
+    idle reading (pinned at the API layer in the sibling suite); no status is
+    the never-probed one, and a failed probe that has never landed a reading
+    has nothing to show either."""
     r = run_js("""
       const r0 = root(); anDrawQuota(r0, PAYLOAD);
       out({ bodies: byClass(r0, "an-acct").map((c) => c.textContent) });
-    """, payload([provider("anthropic", captured_at=None, windows=[]),
-                  provider("openai", windows=[])]))
-    never, idle = r["bodies"]
+    """, payload([provider("anthropic", status=None, captured_at=None, windows=[]),
+                  provider("openai", status="ok", captured_at=None, windows=[]),
+                  provider("moonshot", status="na", captured_at=None, windows=[])]))
+    never, idle, unconfigured = r["bodies"]
     assert "no reading yet" in never
     assert "no windows reported" in idle
+    assert "no reading yet" in unconfigured
+    assert "no windows reported" not in never + unconfigured
     assert never != idle
 
 
@@ -480,21 +495,31 @@ def test_the_age_is_never_omitted_when_there_is_a_reading():
     assert "as of" not in r["none"]
 
 
-def test_refresh_is_always_available_even_on_a_degraded_card():
-    """The old panel disabled this button whenever it judged a probe could not
-    succeed — a judgement made from the registry's idea of who was signed in,
-    and wrong in exactly the case the operator most wants the button: a lapsed
-    Kimi token that a re-probe fixes the moment they boot the harness."""
+def test_one_refresh_control_for_the_section_and_none_on_the_cards():
+    """ONE PROBE RUN IS ALL THERE IS. Each card used to carry its own
+    "refresh ⟳" that POSTed the same route and re-probed all three providers —
+    a label under-describing what the button does, three times over.
+
+    Per-card refresh made sense under the ACCOUNT model, where cards differed
+    in whether they could be refreshed at all. Provider cards do not differ
+    that way, so the control belongs to the section, and it is never disabled
+    by a judgement about whether a probe can succeed: the old panel made that
+    judgement from the registry's idea of who was signed in, and was wrong in
+    exactly the case the operator most wants it — a lapsed Kimi token that a
+    re-probe fixes the moment they boot the harness. Both statuses below are
+    cases the old panel would have disabled."""
     r = run_js("""
       const r0 = root(); anDrawQuota(r0, PAYLOAD);
-      const cards = byClass(r0, "an-acct");
-      const btn = (c) => buttons(c).filter((b) => b.textContent.startsWith("refresh"))[0];
-      out({ disabled: cards.map((c) => btn(c).disabled),
-            wired: cards.map((c) => btn(c).onclick !== null) });
+      const bar = byClass(r0, "an-acct-bar")[0];
+      out({ all: buttons(r0).map((b) => b.textContent),
+            onCards: byClass(r0, "an-acct").map((c) => buttons(c).length),
+            disabled: buttons(bar)[0].disabled,
+            wired: buttons(bar)[0].onclick !== null });
     """, payload([provider("anthropic", status="unauth", captured_at=iso(hours=-3)),
                   provider("moonshot", status="na", captured_at=None, windows=[])]))
-    assert r["disabled"] == [False, False]
-    assert r["wired"] == [True, True]
+    assert r["all"] == ["refresh all ⟳"], "the section has exactly one control"
+    assert r["onCards"] == [0, 0]
+    assert r["disabled"] is False and r["wired"] is True
 
 
 def test_each_card_links_out_to_its_own_providers_usage_page():
@@ -513,8 +538,7 @@ def test_each_card_links_out_to_its_own_providers_usage_page():
 def test_refresh_forces_a_probe_and_redraws_from_its_response():
     r = run_js("""
       const r0 = root(); anDrawQuota(r0, PAYLOAD);
-      const card = byClass(r0, "an-acct")[0];
-      const btn = buttons(card).filter((b) => b.textContent.startsWith("refresh ⟳"))[0];
+      const btn = buttons(r0).filter((b) => b.textContent.startsWith("refresh all"))[0];
       await btn.onclick();
       out({ calls: calls.map((c) => c.path + " " + c.method),
             cards: byClass(r0, "an-acct").length, toasts });

--- a/tests/test_quota_accounts_ui.py
+++ b/tests/test_quota_accounts_ui.py
@@ -1,12 +1,12 @@
-"""Account Analytics UI (spec #49 U4): toggle, router, cards, thresholds.
+"""Provider Quota UI (spec #57, superseding #49): toggle, router, cards, thresholds.
 
 Driven through node against the REAL app.js regions with a minimal DOM — the
 same idiom as the interface UI contract suite — rather than grepping the source
 for strings. A string assertion passes against a function nobody calls; these
 render the section and read what came out.
 
-The unit's value rests on two properties, and both are about not lying about a
-number, so both are asked in both directions:
+The unit's value rests on three properties, and all three are about not lying,
+so all three are asked in both directions:
 
   * COLOUR IS COMPUTED FROM used_percent ALONE. Asserting "96% is red" leaves a
     reading of a provider's own severity field entirely free, so every colour
@@ -17,10 +17,21 @@ number, so both are asked in both directions:
     0%-wide bar free to be drawn under the label, which is the failure mode the
     spec names: a meter reads as measured. So every n/a test asserts the text
     AND the absence of a fill element.
+  * THE CARD MAKES NO CLAIM ABOUT THE OPERATOR'S SESSION. This is what spec #57
+    replaced the per-account panel WITH, so it is asserted as a property of the
+    rendered output rather than trusted to the absence of the old code: no
+    label, no account id, no plan, no sign-in language, and — the mirror leg
+    that matters most — a degraded probe still shows its last-known figures
+    WITH their age, rather than blanking the card or passing them off as fresh.
 
-The per-provider status list gets the same treatment: `na` and an empty accounts
-array are asserted to render differently, because collapsing them is precisely
-what the status list exists to prevent.
+WHAT THIS SUITE STOPPED PINNING, AND WHY IT IS NOT A GAP. The 7-day activity
+window, the is_current exemption, muted rendering, the disabled refresh button
+and the full-email label all had tests here and all are gone. They were not
+weakened — the mechanisms were REMOVED (decision #75, migration 0097), and a
+test for a mechanism that no longer exists is the "comment describing a
+mechanism that no longer exists" defect wearing a different hat. What replaces
+them is the property they were each approximating: every provider renders a
+card, and no card says anything about who is signed in.
 """
 
 from __future__ import annotations
@@ -41,7 +52,7 @@ EL = APP[APP.index("const el ="):APP.index("const esc =")]
 # fmt / microlabel / statRow — sliced, not restated, so a card's meta row is
 # rendered by the app's own helper.
 HELPERS = APP[APP.index("const fmt = (n)"):APP.index("// On/off switch")]
-ACCOUNTS = APP[APP.index("// ── Account Analytics"):APP.index("// ── Interface tab")]
+QUOTA = APP[APP.index("// ── Provider Quota"):APP.index("// ── Interface tab")]
 _ROUTER_AT = APP.index("function routeFromHash()")
 ROUTER = APP[_ROUTER_AT:
              APP.index('document.querySelectorAll("nav button").forEach', _ROUTER_AT)]
@@ -55,7 +66,7 @@ def iso(**delta) -> str:
 
 
 def window(kind="weekly", pct=10.0, **over) -> dict:
-    """One harness_quota_window row as GET /api/analytics/accounts sends it."""
+    """One harness_quota_window row as GET /api/analytics/quota sends it."""
     row = {"window_pk": 1, "window_kind": kind, "scope": None, "used_percent": pct,
            "used": None, "limit_value": None, "resets_at": iso(hours=3),
            "captured_at": iso(minutes=-2), "status": "ok", "probe_version": "1"}
@@ -63,23 +74,32 @@ def window(kind="weekly", pct=10.0, **over) -> dict:
     return row
 
 
-def account(provider="anthropic", **over) -> dict:
-    row = {"account_pk": 1, "provider": provider, "account_ref": "ref-1",
-           "account_label": "jed@person.com", "plan": "max",
-           "first_seen": iso(days=-30), "last_seen": iso(minutes=-2),
-           "is_current": 1, "windows": [window()]}
-    row.update(over)
-    return row
+_UNSET = object()
 
 
-def payload(accounts=None, providers=None, **over) -> dict:
-    d = {"accounts": [account()] if accounts is None else accounts,
-         "activity_days": 7, "ttl_seconds": 60, "probed": True,
-         "providers": ([{"provider": "anthropic", "status": "ok", "detail": None}]
-                       if providers is None else providers),
-         "notes": []}
+def provider(name="anthropic", status="ok", detail=None, captured_at=_UNSET,
+             windows=None) -> dict:
+    """One entry of the response's `providers` array — the whole response shape
+    now. There is no accounts array and no identity of any kind in it.
+
+    `captured_at` takes a SENTINEL default rather than None, because a null
+    captured_at is the never-probed card — a real and distinct state the tests
+    below have to be able to ask for."""
+    return {"provider": name, "status": status, "detail": detail,
+            "captured_at": iso(minutes=-2) if captured_at is _UNSET else captured_at,
+            "windows": [window()] if windows is None else windows}
+
+
+def payload(providers=None, **over) -> dict:
+    d = {"providers": [provider()] if providers is None else providers,
+         "ttl_seconds": 60, "probed": True, "notes": []}
     d.update(over)
     return d
+
+
+def all_three(**over) -> list:
+    """The real shape of a live response: every provider always present."""
+    return [provider(name, **over) for name in ("anthropic", "openai", "moonshot")]
 
 
 HARNESS = r"""
@@ -113,7 +133,7 @@ async function api(path, method = "GET", body) {
   return PAYLOAD;
 }
 function toast(msg) { toasts.push(String(msg)); }
-// The token section is stubbed so "arriving at accounts never sweeps" is
+// The token section is stubbed so "arriving at quota never sweeps" is
 // observable: a real one would fire /analytics/sweep into the same recorder.
 async function anTokenSection(root) {
   tokenSectionRuns += 1;
@@ -144,7 +164,7 @@ function root() { return new FakeElement("div"); }
 
 def run_js(body: str, data: dict | None = None) -> dict:
     script = ("const PAYLOAD = " + json.dumps(data or payload()) + ";\n"
-              + EL + HELPERS + HARNESS + ACCOUNTS + ROUTER
+              + EL + HELPERS + HARNESS + QUOTA + ROUTER
               + "\n(async () => {\n" + body + "\n})().catch((e) => {"
               " console.error(e.stack || e); process.exit(1); });\n")
     proc = subprocess.run(["node", "-e", script], text=True, capture_output=True)
@@ -154,26 +174,41 @@ def run_js(body: str, data: dict | None = None) -> dict:
 
 # ── router + toggle ──────────────────────────────────────────────────────────
 
-def test_accounts_hash_routes_to_the_analytics_tab_as_a_sub_view():
-    """#analytics-accounts is a URL, and `analytics` stays the active nav tab —
+def test_quota_hash_routes_to_the_analytics_tab_as_a_sub_view():
+    """#analytics-quota is a URL, and `analytics` stays the active nav tab —
     the #roadmap / #roadmap-flow convention. Both halves matter: routing to a
     tab of its own would lose the toggle, and not routing at all would fall
     through to the default view."""
     r = run_js("""
       const seen = [];
-      for (const hash of ["#analytics-accounts", "#analytics", "#analytics-accounts"]) {
+      for (const hash of ["#analytics-quota", "#analytics", "#analytics-quota"]) {
         location.hash = hash; routeFromHash();
         seen.push({ view: anView, tab: shown[shown.length - 1] });
       }
       location.hash = "#roadmap-flow"; routeFromHash();
       out({ seen, roadmapTab: shown[shown.length - 1], roadmapView, viewAfter: anView });
     """)
-    assert r["seen"] == [{"view": "accounts", "tab": "analytics"},
+    assert r["seen"] == [{"view": "quota", "tab": "analytics"},
                          {"view": "tokens", "tab": "analytics"},
-                         {"view": "accounts", "tab": "analytics"}]
+                         {"view": "quota", "tab": "analytics"}]
     # The new branch must not swallow the roadmap sub-view it was modelled on.
     assert r["roadmapTab"] == "roadmap" and r["roadmapView"] == "flow"
-    assert r["viewAfter"] == "accounts"
+    assert r["viewAfter"] == "quota"
+
+
+def test_the_old_accounts_hash_has_no_alias_and_falls_through():
+    """R3: NO COMPATIBILITY ALIAS. #analytics-accounts named a per-account panel
+    this spec deletes, and aliasing it would itself be a route naming a
+    mechanism that no longer exists — the precise defect class being removed.
+
+    It must not silently resolve to the quota view; it falls through to Token
+    Analytics like any other unrecognized analytics hash."""
+    r = run_js("""
+      location.hash = "#analytics-accounts"; routeFromHash();
+      out({ view: anView, tab: shown[shown.length - 1] });
+    """)
+    assert r["view"] == "tokens"
+    assert r["tab"] == "analytics"
 
 
 def test_unknown_hash_still_falls_through_to_the_default_view():
@@ -187,39 +222,40 @@ def test_unknown_hash_still_falls_through_to_the_default_view():
 def test_toggle_navigates_by_hash_so_the_sub_view_is_deep_linkable():
     """Clicking must set the hash, not re-render in place: a toggle that
     re-renders directly leaves the URL behind and the section stops surviving a
-    reload — which is one of the spec's verification checkboxes."""
+    reload — which is one of the spec's verification checkboxes, and it stands
+    against the NEW hash."""
     r = run_js("""
       const a = root(); anView = "tokens"; await renderAnalytics(a);
       const chips = buttons(a).filter((b) => cls(b).includes("chip"));
       const labels = texts(chips);
       const active = texts(chips.filter((b) => cls(b).includes("on")));
       chips[1].onclick();
-      const afterAccounts = location.hash;
-      const b = root(); anView = "accounts"; await renderAnalytics(b);
+      const afterQuota = location.hash;
+      const b = root(); anView = "quota"; await renderAnalytics(b);
       const chips2 = buttons(b).filter((x) => cls(x).includes("chip"));
       const active2 = texts(chips2.filter((x) => cls(x).includes("on")));
       chips2[0].onclick();
-      out({ labels, active, active2, afterAccounts, afterTokens: location.hash });
+      out({ labels, active, active2, afterQuota, afterTokens: location.hash });
     """)
-    assert r["labels"] == ["Token Analytics", "Account Analytics"]
-    assert r["active"] == ["Token Analytics"] and r["active2"] == ["Account Analytics"]
-    assert r["afterAccounts"] == "analytics-accounts"
+    assert r["labels"] == ["Token Analytics", "Provider Quota"]
+    assert r["active"] == ["Token Analytics"] and r["active2"] == ["Provider Quota"]
+    assert r["afterQuota"] == "analytics-quota"
     assert r["afterTokens"] == "analytics"
 
 
 def test_each_section_fires_only_its_own_work_on_arrival():
-    """The token sweep and the account probe both fire on entry. Arriving at one
+    """The token sweep and the quota probe both fire on entry. Arriving at one
     must not run the other: reading token spend would otherwise cost three
     third-party calls, and the probe is specified to fire ONLY here."""
     r = run_js("""
-      anView = "accounts"; await renderAnalytics(root());
-      const onAccounts = { calls: calls.map((c) => c.path + " " + c.method), token: tokenSectionRuns };
+      anView = "quota"; await renderAnalytics(root());
+      const onQuota = { calls: calls.map((c) => c.path + " " + c.method), token: tokenSectionRuns };
       calls = []; tokenSectionRuns = 0;
       anView = "tokens"; await renderAnalytics(root());
-      out({ onAccounts, onTokens: { calls: calls.map((c) => c.path + " " + c.method),
-                                    token: tokenSectionRuns } });
+      out({ onQuota, onTokens: { calls: calls.map((c) => c.path + " " + c.method),
+                                 token: tokenSectionRuns } });
     """)
-    assert r["onAccounts"] == {"calls": ["/analytics/accounts GET"], "token": 0}
+    assert r["onQuota"] == {"calls": ["/analytics/quota GET"], "token": 0}
     assert r["onTokens"] == {"calls": ["/analytics/sweep POST"], "token": 1}
 
 
@@ -228,16 +264,16 @@ def test_arrival_probes_once_and_never_forces_the_ttl():
     has aged out. A client that also POSTs would defeat the TTL outright and
     make "toggling twice inside a minute performs one probe" false."""
     r = run_js("""
-      await anAccountSection(root());
+      await anQuotaSection(root());
       out({ calls: calls.map((c) => c.path + " " + c.method) });
     """)
-    assert r["calls"] == ["/analytics/accounts GET"]
+    assert r["calls"] == ["/analytics/quota GET"]
 
 
 def test_section_reports_a_failed_read_instead_of_rendering_an_empty_panel():
     r = run_js("""
       apiFail = "HTTP 500";
-      const r0 = root(); await anAccountSection(r0);
+      const r0 = root(); await anQuotaSection(r0);
       out({ text: r0.textContent });
     """)
     assert "error: HTTP 500" in r["text"]
@@ -253,12 +289,12 @@ THRESHOLD_CASES = [(0.0, ""), (79.9, ""), (80.0, "amber"), (94.9, "amber"),
 def test_meter_colour_is_threshold_driven(pct, expected):
     r = run_js("""
       const r0 = root();
-      anDrawAccounts(r0, PAYLOAD);
+      anDrawQuota(r0, PAYLOAD);
       const pctNode = byClass(r0, "an-win-pct")[0];
       const fill = byClass(r0, "an-meter-fill")[0];
       out({ pctClasses: cls(pctNode), fillClasses: cls(fill), width: fill.style.width,
             text: pctNode.textContent });
-    """, payload(accounts=[account(windows=[window(pct=pct)])]))
+    """, payload([provider(windows=[window(pct=pct)])]))
     tone = [c for c in r["pctClasses"] if c in ("amber", "red")]
     assert tone == ([expected] if expected else [])
     assert [c for c in r["fillClasses"] if c in ("amber", "red")] == ([expected] if expected else [])
@@ -272,14 +308,12 @@ def test_provider_status_never_decides_colour():
     render red. Colouring off the provider's own vocabulary is exactly what the
     spec forbids — anthropic says severity=normal at 22%, openai says
     limit_reached at 100%, moonshot says nothing."""
-    data = payload(
-        accounts=[account(provider="openai", account_pk=1, windows=[window(pct=22.0)]),
-                  account(provider="anthropic", account_pk=2, account_ref="ref-2",
-                          windows=[window(pct=96.0)])],
-        providers=[{"provider": "openai", "status": "error", "detail": "HTTP 429"},
-                   {"provider": "anthropic", "status": "ok", "detail": None}])
+    data = payload([
+        provider("openai", status="error", detail="HTTP 429",
+                 windows=[window(pct=22.0)]),
+        provider("anthropic", status="ok", windows=[window(pct=96.0)])])
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       out({ tones: byClass(r0, "an-win-pct").map((n) => cls(n).filter((c) => c !== "an-win-pct")),
             texts: texts(byClass(r0, "an-win-pct")) });
     """, data)
@@ -295,12 +329,12 @@ def test_null_percent_reads_na_and_draws_no_bar():
     label itself must carry NO threshold colour, because an absent number is not
     a comfortable one."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       const pctNode = byClass(r0, "an-win-pct")[0];
       out({ text: texts(byClass(r0, "an-win-pct")), fills: byClass(r0, "an-meter-fill").length,
             meters: byClass(r0, "an-meter").length,
             tone: cls(pctNode).filter((c) => c !== "an-win-pct") });
-    """, payload(accounts=[account(windows=[window(pct=None)])]))
+    """, payload([provider(windows=[window(pct=None)])]))
     assert r["text"] == ["n/a"]
     assert r["fills"] == 0
     assert r["tone"] == []
@@ -312,14 +346,12 @@ def test_moonshot_all_null_row_renders_as_na_rather_than_zero_or_nothing():
     none — asymmetric but truthful (U2's reviewer). It must neither be filtered
     out nor drawn as 0%."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       out({ rows: byClass(r0, "an-win").length, pct: texts(byClass(r0, "an-win-pct")),
             fills: byClass(r0, "an-meter-fill").length, name: texts(byClass(r0, "an-win-name")) });
-    """, payload(
-        accounts=[account(provider="moonshot", account_label="usr-9",
-                          windows=[window(kind="weekly", pct=None, used=None,
-                                          limit_value=None, resets_at=None)])],
-        providers=[{"provider": "moonshot", "status": "ok", "detail": None}]))
+    """, payload([provider("moonshot", windows=[
+        window(kind="weekly", pct=None, used=None, limit_value=None,
+               resets_at=None)])]))
     assert r["rows"] == 1 and r["pct"] == ["n/a"] and r["fills"] == 0
     assert r["name"] == ["Weekly"]
 
@@ -328,222 +360,172 @@ def test_zero_limit_renders_na_not_a_division():
     """limit_value = 0 arrives with used_percent NULL (the probe never
     back-computes). The counts still show, so the operator sees WHY it is n/a."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       out({ pct: texts(byClass(r0, "an-win-pct")), fills: byClass(r0, "an-meter-fill").length,
             body: r0.textContent });
-    """, payload(accounts=[account(windows=[window(pct=None, used=0, limit_value=0)])]))
+    """, payload([provider(windows=[window(pct=None, used=0, limit_value=0)])]))
     assert r["pct"] == ["n/a"] and r["fills"] == 0
     assert "0 / 0" in r["body"]
 
 
 def test_a_real_zero_percent_still_draws_a_measured_zero():
     """The mirror of the n/a rule, so the fix cannot be "never draw a bar": a
-    provider that genuinely measured 0% renders 0%, not n/a."""
+    provider that genuinely measured 0% renders 0%, not n/a.
+
+    This is the UI half of moonshot's untouched five-hour window, which really
+    does read 0 used against a limit of 100 — a measured zero, not a failure."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       out({ pct: texts(byClass(r0, "an-win-pct")), width: byClass(r0, "an-meter-fill")[0].style.width });
-    """, payload(accounts=[account(windows=[window(pct=0.0, used=0, limit_value=500)])]))
+    """, payload([provider(windows=[window(pct=0.0, used=0, limit_value=500)])]))
     assert r["pct"] == ["0%"] and r["width"] == "0%"
 
 
-# ── per-provider status list ─────────────────────────────────────────────────
+# ── one card per provider, never hidden ──────────────────────────────────────
 
-def test_na_provider_with_no_registry_row_renders_no_card_at_all():
-    """A missing credential file is not a limit of zero — and with nothing in the
-    registry for that provider there is nothing to show, so it is no card.
-    Asserted against a payload where another provider IS configured, so "renders
-    nothing" cannot pass by the whole section being empty.
+def test_every_provider_renders_a_card_including_the_unconfigured_ones():
+    """Nothing is filtered out, and that is the rule the old panel broke.
 
-    The narrow case: no registry row. When a row DOES exist the card survives —
-    the two tests below are the other half, and neither is safe alone."""
+    Hiding a card is how a panel stops lying and starts saying nothing: the
+    operator cannot tell "not configured" from "not readable" from a card that
+    is not there. Asserted with two of three providers unusable, so a section
+    that renders only what it has data for fails here."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-      out({ groups: texts(byClass(r0, "an-prov-head")), cards: byClass(r0, "an-acct").length,
-            body: r0.textContent });
-    """, payload(
-        accounts=[account(provider="anthropic")],
-        providers=[{"provider": "anthropic", "status": "ok", "detail": None},
-                   {"provider": "openai", "status": "na", "detail": None},
-                   {"provider": "moonshot", "status": "na", "detail": None}]))
-    assert r["groups"] == ["Claudeanthropic"]
-    assert r["cards"] == 1
-    assert "Codex" not in r["body"] and "Kimi" not in r["body"]
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
+      out({ cards: byClass(r0, "an-acct").length,
+            heads: byClass(r0, "an-acct-head").map((n) => n.textContent) });
+    """, payload([
+        provider("anthropic", windows=[window(pct=40.0)]),
+        provider("openai", status="na", captured_at=None, windows=[]),
+        provider("moonshot", status="unauth", captured_at=None, windows=[])]))
+    assert r["cards"] == 3
+    assert [h.split("anthropic")[0].split("openai")[0].split("moonshot")[0]
+            for h in r["heads"]] == ["Claude", "Codex", "Kimi"]
 
 
-def test_na_provider_keeps_its_registry_card_muted_with_refresh_disabled():
-    """The credential file is removed WITHOUT switching accounts (spec 49, "the
-    registry and the status list can disagree"). The row keeps is_current, and
-    is_current is exempt from the 7-day filter, so this card would otherwise
-    render forever — unmuted, looking live, with a refresh that provably cannot
-    change it, while the same response reports the provider `na`.
-
-    Both failure directions are asserted here, because they are each other's
-    cure: filtering the card out (direction 1) throws away the last account this
-    host saw, and rendering it live (direction 2) is the button-that-lies shape
-    this unit already refused on the Codex exception. Passing needs the card to
-    EXIST and to be visibly last-known."""
+def test_never_probed_and_idle_say_different_things():
+    """Both render zero windows, and collapsing them loses the operator's next
+    move. A provider that has never returned anything has nothing to show; one
+    that returned an intact envelope carrying zero windows is genuinely idle,
+    and that IS its reading."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-      const cards = byClass(r0, "an-acct");
-      const btn = buttons(cards[0]).filter((b) => cls(b).includes("act"))[0];
-      out({ cards: cards.length, groups: texts(byClass(r0, "an-prov-head")),
-            muted: cls(cards[0]).includes("an-muted"),
-            disabled: btn.disabled, title: btn.title, onclick: btn.onclick !== null,
-            pct: texts(byClass(cards[0], "an-win-pct")), body: cards[0].textContent });
-    """, payload(
-        accounts=[account(is_current=1,
-                          windows=[window(pct=61.0, captured_at=iso(hours=-3))])],
-        providers=[{"provider": "anthropic", "status": "na", "detail": None}]))
-    # direction 1 — the registry row survives the status disagreeing with it.
-    assert r["cards"] == 1 and r["groups"] == ["Claudeanthropic"]
-    assert r["pct"] == ["61%"]          # last known values kept, not blanked
-    # direction 2 — and it does not present as live.
-    assert r["muted"] is True
-    assert r["disabled"] is True and r["onclick"] is False
-    assert "credential file" in r["title"]
-    assert "snapshot 3h ago" in r["body"]
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
+      out({ bodies: byClass(r0, "an-acct").map((c) => c.textContent) });
+    """, payload([provider("anthropic", captured_at=None, windows=[]),
+                  provider("openai", windows=[])]))
+    never, idle = r["bodies"]
+    assert "no reading yet" in never
+    assert "no windows reported" in idle
+    assert never != idle
 
 
-def test_na_is_reported_as_observed_not_inferred_as_a_sign_out():
-    """`na` means the engine could not read a credential file — which is a
-    different fact from an account the operator switched away from, and from a
-    token the provider rejected. Rendering all three with one string would be an
-    inference about WHY, and the operator may simply be mid-login.
+def test_no_card_makes_any_claim_about_the_operator():
+    """THE PROPERTY THIS WHOLE SPEC EXISTS FOR, asserted on rendered output.
 
-    Asserted by rendering all three and comparing, so reusing one wording for
-    another fails: an assertion that `na` merely "says something" would pass
-    against exactly the collapse this pins."""
-    def body(accounts, providers):
-        return run_js("""
-          const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-          out({ body: byClass(r0, "an-acct")[0].textContent });
-        """, payload(accounts=accounts, providers=providers))["body"]
-
-    na = body([account(is_current=1)],
-              [{"provider": "anthropic", "status": "na", "detail": None}])
-    unauth = body([account(is_current=1)],
-                  [{"provider": "anthropic", "status": "unauth", "detail": "expired"}])
-    switched = body([account(is_current=0, last_seen=iso(days=-2))],
-                    [{"provider": "anthropic", "status": "ok", "detail": None}])
-
-    assert "no readable credential file" in na
-    assert "not signed in" not in na and "signed out" not in na
-    assert na != unauth and na != switched
-
-
-def test_error_before_identification_still_renders_a_card_with_its_status():
-    """The case the accounts array cannot express: the probe failed before it
-    could name anybody, so there is no registry row. Silence here would read as
-    "fine" — the spec requires a card carrying the HTTP status."""
+    Both defects that shipped were false CLAIMS, not wrong numbers: a 403
+    rendered "signed out — last known" while the operator was actively using
+    Codex (#196), and a lapsed 15-minute Kimi token rendered "no account
+    identified" (#197). The response is fed identity-shaped fields it must
+    ignore — a positive control proving the sweep would notice them."""
+    leaky = provider("anthropic", status="unauth", detail="expired",
+                     windows=[window(pct=61.0)])
+    leaky["account_label"] = "operator@example.com"
+    leaky["plan"] = "max"
+    leaky["account_ref"] = "uuid-secret"
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-      out({ cards: byClass(r0, "an-acct").length, body: r0.textContent });
-    """, payload(accounts=[], providers=[
-        {"provider": "openai", "status": "error", "detail": "HTTP 503"}]))
-    assert r["cards"] == 1
-    assert "HTTP 503" in r["body"] and "Codex" in r["body"]
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
+      out({ body: r0.textContent });
+    """, payload([leaky]))
+    body = r["body"]
+    for claim in ("signed out", "not signed in", "no account identified",
+                  "operator@example.com", "@", "uuid-secret", "max"):
+        assert claim not in body, f"the card claimed {claim!r}"
+    # ...and the reading still rendered, or the sweep proves nothing.
+    assert "61%" in body
 
 
-def test_nothing_configured_and_no_probe_yet_say_different_things():
-    """Both arrive as an empty accounts array. Collapsing them is what the
-    per-provider status list exists to prevent."""
-    all_na = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD); out({ body: r0.textContent });
-    """, payload(accounts=[], providers=[
-        {"provider": p, "status": "na", "detail": None}
-        for p in ("anthropic", "openai", "moonshot")]))
-    never = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD); out({ body: r0.textContent });
-    """, payload(accounts=[], providers=[]))
-    assert "No harness credentials found" in all_na["body"]
-    assert "No probe has run yet" in never["body"]
-    assert all_na["body"] != never["body"]
+def test_a_degraded_probe_keeps_its_figures_and_stamps_them_with_their_age():
+    """THE EMPTY-STATE RULE WITH BOTH MIRROR LEGS. A lapsed Kimi token is the
+    common case, not an error, and the operator's most useful information in
+    that moment is where they stood 20 minutes ago.
 
-
-def test_unauth_keeps_last_known_values_muted_with_their_age():
-    """Expiry is reported, not repaired: the numbers stay, the emphasis goes,
-    and the age says how old they are."""
+    Leg 1 — it must not BLANK the card: the figures are still there.
+    Leg 2 — it must not present them AS FRESH: the age is rendered from the
+    reading's own captured_at, so a three-hour-old reading says so."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       const card = byClass(r0, "an-acct")[0];
-      out({ muted: cls(card).includes("an-muted"), pct: texts(byClass(card, "an-win-pct")),
-            body: card.textContent });
-    """, payload(
-        accounts=[account(windows=[window(pct=61.0, captured_at=iso(hours=-3))])],
-        providers=[{"provider": "anthropic", "status": "unauth", "detail": "expired"}]))
-    assert r["muted"] is True
-    assert r["pct"] == ["61%"]
-    assert "signed out — last known" in r["body"]
-    assert "snapshot 3h ago" in r["body"]
+      out({ pct: texts(byClass(card, "an-win-pct")), body: card.textContent });
+    """, payload([provider("anthropic", status="unauth", detail="expired",
+                           captured_at=iso(hours=-3),
+                           windows=[window(pct=61.0)])]))
+    assert r["pct"] == ["61%"]                      # leg 1: not blanked
+    assert "as of 3h ago" in r["body"]              # leg 2: not passed off as fresh
+    assert "token not usable" in r["body"]          # the probe's state, not the operator's
 
 
-# ── the non-current account ──────────────────────────────────────────────────
-
-def test_non_current_account_is_muted_and_cannot_be_refreshed():
-    """Its token is gone, so the probe route cannot re-read it. The button is
-    disabled AND carries the reason — a disabled control with no explanation is
-    its own small lie."""
+def test_the_age_is_never_omitted_when_there_is_a_reading():
+    """The age is the only thing keeping a stale card honest, so its presence is
+    pinned for a FRESH card too — a section that rendered the age only when it
+    judged a reading old would be deciding what counts as stale, which is the
+    operator's call."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
+      out({ fresh: byClass(r0, "an-acct")[0].textContent,
+            none: byClass(r0, "an-acct")[1].textContent });
+    """, payload([provider("anthropic", captured_at=iso(minutes=-2)),
+                  provider("openai", captured_at=None, windows=[])]))
+    assert "as of" in r["fresh"]
+    # ...but a card with no reading has no age to state, and must not invent one.
+    assert "as of" not in r["none"]
+
+
+def test_refresh_is_always_available_even_on_a_degraded_card():
+    """The old panel disabled this button whenever it judged a probe could not
+    succeed — a judgement made from the registry's idea of who was signed in,
+    and wrong in exactly the case the operator most wants the button: a lapsed
+    Kimi token that a re-probe fixes the moment they boot the harness."""
+    r = run_js("""
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       const cards = byClass(r0, "an-acct");
-      const btn = (c) => buttons(c).filter((b) => cls(b).includes("act"))[0];
-      out({ order: byClass(r0, "an-acct-label").map((n) => n.textContent),
-            muted: cards.map((c) => cls(c).includes("an-muted")),
-            disabled: cards.map((c) => btn(c).disabled),
-            titles: cards.map((c) => btn(c).title),
-            notes: cards.map((c) => c.textContent.includes("not signed in")) });
-    """, payload(
-        # The current account's label sorts LAST alphabetically on purpose: with
-        # labels that happen to sort into API order, "the UI preserves the API's
-        # current-first order" is asserted by a fixture that cannot tell the
-        # difference. Caught by mutation M20, which was inert until this changed.
-        accounts=[account(account_pk=1, account_label="zed@person.com", is_current=1),
-                  account(account_pk=2, account_ref="ref-old", account_label="abe@person.com",
-                          is_current=0, last_seen=iso(days=-2))],
-        providers=[{"provider": "anthropic", "status": "ok", "detail": None}]))
-    assert r["order"] == ["zed@person.com", "abe@person.com"]  # API order preserved
-    assert r["muted"] == [False, True]
-    assert r["disabled"] == [False, True]
-    assert r["titles"][0] == "" and "cannot be re-probed" in r["titles"][1]
-    assert r["notes"] == [False, True]
+      const btn = (c) => buttons(c).filter((b) => b.textContent.startsWith("refresh"))[0];
+      out({ disabled: cards.map((c) => btn(c).disabled),
+            wired: cards.map((c) => btn(c).onclick !== null) });
+    """, payload([provider("anthropic", status="unauth", captured_at=iso(hours=-3)),
+                  provider("moonshot", status="na", captured_at=None, windows=[])]))
+    assert r["disabled"] == [False, False]
+    assert r["wired"] == [True, True]
 
 
-def test_non_current_codex_is_disabled_too_because_no_rollout_refresh_exists():
-    """Declared deviation, pinned so it cannot drift silently either way. The
-    spec grants Codex an exception — a non-current OpenAI account refreshed from
-    its rollout files — but no unit implements a rollout reader, so the only
-    action available is the global re-probe, which provably cannot change this
-    card. Enabling it would ship a button that lies. If a rollout path ever
-    lands, this test is the thing that must be changed on purpose."""
+def test_each_card_links_out_to_its_own_providers_usage_page():
+    """The link is part of the design, not a convenience: the ruling that
+    retired account identity rests on the provider's own page being one click
+    away for anything this panel deliberately stops showing."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-      const card = byClass(r0, "an-acct")[0];
-      const btn = buttons(card).filter((b) => cls(b).includes("act"))[0];
-      out({ disabled: btn.disabled, title: btn.title });
-    """, payload(
-        accounts=[account(provider="openai", is_current=0, account_label="old@codex.com",
-                          last_seen=iso(days=-1))],
-        providers=[{"provider": "openai", "status": "ok", "detail": None}]))
-    assert r["disabled"] is True
-    assert "cannot be re-probed" in r["title"]
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
+      out({ hrefs: all(r0, (n) => n.tagName === "a").map((n) => n.href) });
+    """, payload(all_three()))
+    assert r["hrefs"] == ["https://claude.ai/settings/usage",
+                          "https://chatgpt.com/codex/settings/usage",
+                          "https://www.kimi.com/code"]
 
 
 def test_refresh_forces_a_probe_and_redraws_from_its_response():
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       const card = byClass(r0, "an-acct")[0];
-      const btn = buttons(card).filter((b) => cls(b).includes("act"))[0];
+      const btn = buttons(card).filter((b) => b.textContent.startsWith("refresh ⟳"))[0];
       await btn.onclick();
       out({ calls: calls.map((c) => c.path + " " + c.method),
             cards: byClass(r0, "an-acct").length, toasts });
     """)
-    assert r["calls"] == ["/analytics/accounts/probe POST"]
+    assert r["calls"] == ["/analytics/quota/probe POST"]
     assert r["cards"] == 1 and r["toasts"] == []
 
 
 def test_a_failed_refresh_reports_and_re_enables_rather_than_wedging():
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       const btn = buttons(r0).filter((b) => b.textContent.startsWith("refresh all"))[0];
       apiFail = "boom";
       await btn.onclick();
@@ -554,29 +536,15 @@ def test_a_failed_refresh_reports_and_re_enables_rather_than_wedging():
     assert r["label"] == "refresh all ⟳"
 
 
-# ── the seven-day window ─────────────────────────────────────────────────────
-
-def test_every_account_stale_renders_the_current_one_with_a_note():
-    """Never an empty page. The API exempts is_current from the filter so the row
-    arrives; the UI's job is to say why the page is thin instead of letting it
-    read as the whole truth about the week."""
+def test_an_empty_providers_array_says_so_rather_than_rendering_nothing():
+    """Only reachable if the API returns no entries at all — which it cannot,
+    since it builds from the PROVIDERS constant. Kept because "cannot happen"
+    is a claim about another layer, and a blank panel would be the worst way to
+    discover that claim had stopped being true."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-      out({ note: texts(byClass(r0, "an-note")), cards: byClass(r0, "an-acct").length });
-    """, payload(accounts=[account(last_seen=iso(days=-30))]))
-    assert r["cards"] == 1
-    assert r["note"] and "showing the current account only" in r["note"][0]
-    assert "7 days" in r["note"][0]
-
-
-def test_a_fresh_account_carries_no_stale_note():
-    """The other direction — a note on every page is a note nobody reads."""
-    r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-      out({ note: byClass(r0, "an-note").length });
-    """, payload(accounts=[account(last_seen=iso(days=-30)), account(
-        account_pk=2, account_ref="ref-2", last_seen=iso(hours=-1))]))
-    assert r["note"] == 0
+      const r0 = root(); anDrawQuota(r0, PAYLOAD); out({ body: r0.textContent });
+    """, payload([]))
+    assert "No probe has run yet" in r["body"]
 
 
 # ── window rows ──────────────────────────────────────────────────────────────
@@ -585,25 +553,40 @@ def test_unrecognized_window_renders_under_its_raw_kind_and_duration():
     """The probe stores a window it could not map rather than dropping it,
     precisely so the panel can show it. Dropping it here would waste that."""
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       out({ names: texts(byClass(r0, "an-win-name")), rows: byClass(r0, "an-win").length });
-    """, payload(accounts=[account(windows=[
+    """, payload([provider(windows=[
         window(kind="weekly", pct=40.0),
-        window(kind="1209600 SECOND", pct=12.0, scope="1209600s"),
+        window(kind="unknown", pct=12.0, scope="1209600s"),
         window(kind="weekly_scoped", pct=5.0, scope="claude-opus-5"),
         window(kind="session", pct=88.0),
         window(kind="five_hour", pct=3.0)])]))
     # Known kinds in their own order, unrecognized last — never dropped.
     assert r["names"] == ["Session", "5-hour", "Weekly", "Weekly · scoped · claude-opus-5",
-                          "1209600 SECOND · 1209600s"]
+                          "unknown · 1209600s"]
     assert r["rows"] == 5
+
+
+def test_no_container_repr_ever_reaches_a_rendered_card():
+    """The UI end of the container-repr class. The probe is what formats a raw
+    duration, but `scope` is passed through to the card verbatim, so the rule
+    is pinned on BOTH sides of that seam — a defect that reached the database
+    reached the card by the same route."""
+    r = run_js("""
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
+      out({ names: texts(byClass(r0, "an-win-name")), body: r0.textContent });
+    """, payload([provider(windows=[
+        window(kind="unknown", pct=12.0, scope="unrecognized window")])]))
+    assert r["names"] == ["unknown · unrecognized window"]
+    for bad in ("{", "}", "[", "]", "'duration'", "timeUnit"):
+        assert bad not in r["body"], f"a container repr reached the card: {bad}"
 
 
 def test_reset_renders_as_a_countdown_and_never_as_negative_time():
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
       out({ body: r0.textContent });
-    """, payload(accounts=[account(windows=[
+    """, payload([provider(windows=[
         window(kind="session", pct=1.0, resets_at=iso(hours=2, minutes=30)),
         window(kind="weekly", pct=2.0, resets_at=iso(hours=-5)),
         window(kind="short", pct=3.0, resets_at=None)])]))
@@ -612,41 +595,12 @@ def test_reset_renders_as_a_countdown_and_never_as_negative_time():
     assert "-" not in r["body"].split("resets")[2].split("status")[0]
 
 
-def test_an_account_with_no_windows_says_so_rather_than_rendering_blank():
+def test_providers_render_in_the_dispatchers_order():
     r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-      out({ body: r0.textContent, wins: byClass(r0, "an-win").length });
-    """, payload(accounts=[account(windows=[])]))
-    assert r["wins"] == 0
-    assert "no windows reported" in r["body"]
-
-
-def test_providers_render_in_the_dispatchers_order_with_their_accounts():
-    r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-      out({ groups: byClass(r0, "an-prov-head").map((n) => n.textContent),
-            labels: byClass(r0, "an-acct-label").map((n) => n.textContent) });
-    """, payload(
-        accounts=[account(provider="anthropic", account_pk=1, account_label="a@x.com"),
-                  account(provider="openai", account_pk=2, account_ref="r2", account_label="o@x.com"),
-                  account(provider="moonshot", account_pk=3, account_ref="r3", account_label="usr-3")],
-        providers=[{"provider": p, "status": "ok", "detail": None}
-                   for p in ("anthropic", "openai", "moonshot")]))
-    assert r["groups"] == ["Claudeanthropic", "Codexopenai", "Kimimoonshot"]
-    assert r["labels"] == ["a@x.com", "o@x.com", "usr-3"]
-
-
-def test_the_full_account_label_is_rendered_unredacted():
-    """Decision #67: the label is stored and shown in full. Two accounts sharing
-    a local part are indistinguishable truncated, which is the one case this
-    panel exists to show."""
-    r = run_js("""
-      const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-      out({ labels: byClass(r0, "an-acct-label").map((n) => n.textContent) });
-    """, payload(accounts=[
-        account(account_pk=1, account_label="jed@gmail.com"),
-        account(account_pk=2, account_ref="r2", account_label="jed@work.com", is_current=0)]))
-    assert r["labels"] == ["jed@gmail.com", "jed@work.com"]
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
+      out({ pills: texts(byClass(r0, "pill")) });
+    """, payload(all_three()))
+    assert r["pills"] == ["anthropic", "openai", "moonshot"]
 
 
 # ── styles the thresholds depend on ──────────────────────────────────────────
@@ -655,6 +609,13 @@ def test_threshold_classes_have_distinct_styling():
     """The colour rule is only real if the classes differ visibly. Asserted here
     because the JS tests can only see class names."""
     for sel in (".an-win-pct.amber", ".an-win-pct.red",
-                ".an-meter-fill.amber", ".an-meter-fill.red",
-                ".an-acct.an-muted", ".an-acct-foot .act:disabled"):
+                ".an-meter-fill.amber", ".an-meter-fill.red"):
         assert sel in CSS, f"{sel} is not styled"
+
+
+def test_the_muted_card_style_is_gone_not_merely_unused():
+    """Removed, not left inert. Dimming marked a card as "not the current
+    account", a distinction a provider-level panel does not have — and a rule
+    left in the stylesheet is the CSS form of a comment describing a mechanism
+    that no longer exists."""
+    assert "an-muted" not in CSS

--- a/tests/test_quota_gate.py
+++ b/tests/test_quota_gate.py
@@ -1,21 +1,36 @@
 #!/usr/bin/env python3
-"""Spec #49 verification gate — sprint 52, unit 5.
+"""Verification gate — spec #57 (Provider Quota), superseding spec #49's.
 
-The spec's gate is eleven checkboxes. Five are already proven by the units that
-built the code, and this file deliberately does NOT restate them:
+A second copy of a passing check is a second place to drift, so this file holds
+only what nothing else proves. Most of spec #57's gate items belong to the
+layer that owns them and are pinned there:
 
-    1   three probes normalize from fixtures     tests/test_quota_probes.py
-    2   expired token -> unauth, values kept     test_quota_probes / _api / _ui
-    5   two accounts, one refreshable            tests/test_quota_accounts_ui.py
-    6   7-day-stale hidden, row survives         tests/test_quota_accounts_api.py
-    10  neither table in content.sql             test_quota_snapshot_exclusion.py
+    account_label gone from the schema, no email anywhere
+                                             test_quota_schema / _snapshot / _api
+    snapshot exclusion still passes           test_quota_snapshot_exclusion.py
+    openai 200 + version from the CLI         tests/test_quota_probes.py
+    403 -> error, never unauth (+ mirror)     tests/test_quota_probes.py
+    TIME_UNIT_MINUTE at 300 -> five_hour      tests/test_quota_probes.py
+    no container repr reaches scope/card      test_quota_probes / _accounts_ui
+    limits[].detail unwrapped, used derived   tests/test_quota_probes.py
+    plan gone from schema and probes          test_quota_schema / this file
+    fixtures are sanitized real captures      tests/fixtures/.../README.md
+    degraded probe keeps figures + age        test_quota_accounts_api / _ui
+    README drift claim corrected              tests/fixtures/.../README.md
 
-A second copy of a passing check is a second place to drift, so what lives here
-is only what nothing else proves:
+What lives HERE is what no single layer can reach:
 
-  * the CROSS-UNIT checkboxes, which no single unit could reach because they
-    span the probe package, the API and the UI at once (4, 9, 11);
-  * the ones that fell through a seam between units (3, 7, 8).
+  * the CROSS-LAYER items, which span the probe package, the API and the UI at
+    once — token containment, `na` parity across all three providers, a hung
+    provider costing only its own reading, and one probe per toggle;
+  * deep-linking, which needs the router AND the boot IIFE executed;
+  * "every removed mechanism is REMOVED, not left inert", which is a claim
+    about the source of every layer at once and cannot be asked of any one.
+
+SPEC #49'S CHECKBOX 7 IS GONE RATHER THAN UNPROVEN — a hidden account switched
+back with its first_seen intact. The 7-day filter, the is_current exemption and
+first_seen were all dropped by 0097, so there is nothing to hide, switch back
+to, or preserve. `NoInertAccountMachineryTest` is what took its place.
 
 Where a checkbox crosses units, the composition is driven through a real
 artifact rather than an assumption about one: the toggle test replays the
@@ -34,6 +49,7 @@ Run:
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import sqlite3
 import subprocess
@@ -189,7 +205,7 @@ class GateCase(unittest.TestCase):
     def stack(self, force: bool = False) -> dict:
         """The real thing: probe_all -> upsert -> response. Nothing stubbed
         between the probe package and the API's own assembler."""
-        return server.get_analytics_accounts(self.con, force=force)
+        return server.get_analytics_quota(self.con, force=force)
 
     def db_text(self) -> str:
         """Every cell of both quota tables, as text."""
@@ -334,84 +350,136 @@ class MissingCredentialParityTest(GateCase):
         out = self.stack()
         self.assertEqual({"anthropic": "na", "openai": "na", "moonshot": "na"},
                          {p["provider"]: p["status"] for p in out["providers"]})
-        # `na` is not `0%`: no registry row, no card, and no zero anywhere in
-        # the payload that a meter could render as measured.
-        self.assertEqual([], out["accounts"])
+        # `na` is not `0%`: no registry row, and no zero anywhere in the payload
+        # that a meter could render as measured. THE CARDS STILL RENDER — every
+        # provider gets an entry regardless — so the check is that they carry no
+        # numbers, not that they are absent.
         self.assertEqual("", self.db_text())
-        for account in out["accounts"]:
-            for w in account["windows"]:
-                self.assertIsNone(w["used_percent"])
+        for entry in out["providers"]:
+            self.assertEqual([], entry["windows"])
+            self.assertIsNone(entry["captured_at"])
 
 
-# ── Checkbox 7 — hidden, then switched back, with first_seen intact ──────────
+# ── Spec 57 gate — every removed mechanism is REMOVED, not left inert ────────
 
-class HiddenAccountRoundTripTest(GateCase):
-    """U3 proves first_seen is never re-minted, but its account is
-    `is_current=1` for the whole test — and `is_current` is exempt from the
-    7-day filter, so that account is never actually hidden. The round trip the
-    spec names ("switching back to a hidden account restores it with its
-    original first_seen") is therefore unproven: the hide and the restore are
-    the two halves that have to meet."""
+class NoInertAccountMachineryTest(unittest.TestCase):
+    """Spec #57's gate item: "Every removed piece of account machinery is
+    removed, not left inert: no reader remains for anything dropped, and no
+    comment describes a mechanism that no longer exists."
 
-    def probe_returning(self, accounts):
-        return mock.patch.object(server.quota_dispatch, "probe_all",
-                                 lambda log, *a, **kw: accounts)
+    THIS REPLACES SPEC #49'S CHECKBOX 7 (a hidden account switched back with its
+    first_seen intact). That checkbox is not unproven here — its MECHANISM is
+    gone: the 7-day filter, the is_current exemption and first_seen were all
+    dropped by 0097, so there is no hiding, no switching back, and no timestamp
+    to preserve. Testing it would be testing a mechanism that does not exist,
+    which is the same defect this item exists to catch.
 
-    def acct(self, ref, label, captured_at, percent):
-        return qp.account(
-            provider="anthropic", probe_version="1", captured_at=captured_at,
-            account_ref=ref, account_label=label, plan="max", is_current=1,
-            windows=[qp.window(window_kind="weekly", probe_version="1",
-                               captured_at=captured_at, used_percent=percent)])
+    Source-level on purpose, and it is the one gate item where that is the
+    right instrument: "no reader remains" is a claim about the CODE, and a
+    behavioural test cannot distinguish dead code from absent code — which is
+    exactly the distinction the item is about. This feature's documented
+    recurring defect is dead machinery carrying a live comment.
+    """
 
-    def test_a_hidden_account_comes_back_intact_when_it_is_switched_to(self):
-        old = iso(days_ago=30)
-        first = self.acct("uuid-old", "old@person.com", old, 40.0)
-        other = self.acct("uuid-new", "new@person.com", iso(), 10.0)
+    ENGINE_SOURCES = ("api/server.py", "ui/app.js", "ui/style.css",
+                      "scripts/quota_probes/__init__.py",
+                      "scripts/quota_probes/anthropic.py",
+                      "scripts/quota_probes/openai.py",
+                      "scripts/quota_probes/moonshot.py")
+    # Every column 0097 drops, plus the two UI mechanisms that read them.
+    DROPPED = ("account_label", "is_current", "first_seen", "last_seen")
 
-        # 1. seen 30 days ago...
-        with self.probe_returning([first]):
-            self.stack()
-        minted = self.con.execute(
-            "SELECT first_seen FROM harness_quota_account "
-            "WHERE account_ref='uuid-old'").fetchone()["first_seen"]
-        self.assertEqual(old, minted)
+    def quota_region(self, text: str, path: str) -> str:
+        """Only the quota code — these names are common words elsewhere in the
+        engine (watched_prs has its own last_seen, and every tab has a plan)."""
+        if path == "api/server.py":
+            return text[text.index("def _quota_upsert"):text.index("# \u2500\u2500 Mutations")]
+        if path == "ui/app.js":
+            return text[text.index("// \u2500\u2500 Provider Quota"):
+                        text.index("// \u2500\u2500 Interface tab")]
+        if path == "ui/style.css":
+            return text[text.index("/* \u2500\u2500 Provider Quota"):]
+        return text
 
-        # 2. ...operator switches away, so it loses is_current and, being
-        #    outside the window, stops rendering. The row survives.
-        with self.probe_returning([other]):
-            out = self.stack(force=True)
-        self.assertEqual(["uuid-new"], [a["account_ref"] for a in out["accounts"]],
-                         "the aged, non-current account still rendered")
-        self.assertEqual(2, self.con.execute(
-            "SELECT COUNT(*) c FROM harness_quota_account").fetchone()["c"],
-            "the hidden row was deleted rather than filtered")
+    @staticmethod
+    def code_only(text: str, rel: str) -> str:
+        """Executable code with prose stripped out.
 
-        # 3. ...and switches back. It reappears, with its ORIGINAL first_seen
-        #    and no second identity minted for it.
-        back = self.acct("uuid-old", "old@person.com", iso(), 55.0)
-        with self.probe_returning([back]):
-            out = self.stack(force=True)
-        rendered = {a["account_ref"]: a for a in out["accounts"]}
-        self.assertIn("uuid-old", rendered, "the account did not come back")
-        row = self.con.execute(
-            "SELECT * FROM harness_quota_account WHERE account_ref='uuid-old'"
-        ).fetchone()
-        self.assertEqual(old, row["first_seen"], "first_seen was re-minted")
-        self.assertEqual(1, row["is_current"])
-        self.assertEqual(2, self.con.execute(
-            "SELECT COUNT(*) c FROM harness_quota_account").fetchone()["c"],
-            "coming back minted a duplicate account")
-        # Its window came back with it, updated rather than twinned.
-        windows = rendered["uuid-old"]["windows"]
-        self.assertEqual([55.0], [w["used_percent"] for w in windows])
+        The distinction is deliberate and is the whole reason this helper
+        exists. A comment SAYING a column was dropped and why is the opposite
+        of the defect — it is how the next reader learns the mechanism is gone.
+        What the gate forbids is a comment describing a mechanism AS IF IT
+        STILL RAN, and a live reader for a column that is not there. Only the
+        second is decidable by grep, so only the second is asserted."""
+        if rel.endswith(".py"):
+            text = re.sub(r'""".*?"""', "", text, flags=re.S)
+            return "\n".join(line.split("#")[0] for line in text.splitlines())
+        text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+        return "\n".join(line for line in text.splitlines()
+                         if not line.lstrip().startswith("//"))
+
+    def test_no_dropped_column_has_a_reader_left_anywhere(self):
+        for rel in self.ENGINE_SOURCES:
+            region = self.code_only(
+                self.quota_region((ENGINE / rel).read_text(), rel), rel)
+            for name in self.DROPPED:
+                self.assertNotIn(
+                    name, region,
+                    f"{rel} still READS {name} in live code, which 0097 "
+                    "dropped — the column does not exist to be read")
+
+    def test_the_stripper_can_actually_see_a_reader(self):
+        """POSITIVE CONTROL for the test above, and it needs one badly: the
+        assertion is a grep over text that has had prose removed, so an
+        over-eager stripper would return an empty string and pass everything.
+
+        A real reader is planted in each language's code AND in its comments;
+        the code one must be seen and the comment one must not."""
+        cases = [("x.py", 'q = "SELECT last_seen FROM t"  # last_seen in a comment\n'
+                          '"""last_seen in a docstring"""\n'),
+                 ("x.js", "const a = row.last_seen;\n// last_seen in a comment\n"),
+                 ("x.css", ".last_seen { color: red }\n/* last_seen in a comment */\n")]
+        for rel, src in cases:
+            with self.subTest(rel=rel):
+                stripped = self.code_only(src, rel)
+                self.assertIn("last_seen", stripped, "the stripper ate the code")
+                self.assertEqual(1, stripped.count("last_seen"),
+                                 f"prose survived stripping in {rel}: {stripped!r}")
+
+    def test_the_probe_package_no_longer_collects_a_plan(self):
+        """`plan` gets its own leg because it is the one that reads as
+        harmless. It is not identity the way an email is, so "leave it, it
+        costs nothing" is the argument that would have kept it — and it is
+        precisely the argument that let two of three probes read it from the
+        wrong place undetected."""
+        acct = qp.account(provider="anthropic", probe_version="1",
+                          captured_at=iso())
+        self.assertNotIn("plan", acct)
+        # ...and no probe module passes one, which the builder alone cannot say.
+        for rel in ("anthropic", "openai", "moonshot"):
+            src = (ENGINE / f"scripts/quota_probes/{rel}.py").read_text()
+            self.assertNotIn("plan=", src, f"{rel}.py still collects a plan")
+
+    def test_the_ui_carries_no_sign_in_language_at_all(self):
+        """The claims both shipped defects made, gone from the source rather
+        than merely unreachable. A string a card cannot currently render is one
+        refactor away from rendering again."""
+        region = self.quota_region((ENGINE / "ui/app.js").read_text(), "ui/app.js")
+        for claim in ("signed out", "not signed in", "no account identified"):
+            self.assertNotIn(
+                claim.lower(),
+                # The section's own commentary NAMES these strings to explain
+                # why they are gone, so only rendered literals are examined.
+                "".join(line for line in region.splitlines(keepends=True)
+                        if not line.lstrip().startswith("//")).lower(),
+                f"the section can still render {claim!r}")
 
 
 # ── Node-driven halves: checkboxes 8 and 4 ───────────────────────────────────
 
 EL = APP[APP.index("const el ="):APP.index("const esc =")]
 HELPERS = APP[APP.index("const fmt = (n)"):APP.index("// On/off switch")]
-ACCOUNTS = APP[APP.index("// ── Account Analytics"):APP.index("// ── Interface tab")]
+QUOTA = APP[APP.index("// ── Provider Quota"):APP.index("// ── Interface tab")]
 _ROUTER_AT = APP.index("function routeFromHash()")
 # U4's slice stops at the nav-button line; this one deliberately runs PAST it,
 # through `window.addEventListener("hashchange", routeFromHash)` — the wiring
@@ -496,8 +564,8 @@ def run_js(body: str, data: dict | None = None, boot: bool = False,
     has it; setting it afterwards would test a navigation, not a reload."""
     dom = DOM.replace('globalThis.location = { hash: "" };',
                       'globalThis.location = { hash: "%s" };' % hash)
-    script = ("const PAYLOAD = " + json.dumps(data or {"accounts": [], "providers": []})
-              + ";\n" + EL + HELPERS + dom + ACCOUNTS + ROUTER
+    script = ("const PAYLOAD = " + json.dumps(data or {"providers": []})
+              + ";\n" + EL + HELPERS + dom + QUOTA + ROUTER
               + (BOOT if boot else "")
               # The boot IIFE awaits /health before it routes, so the body has
               # to let it settle — reading the view synchronously would see the
@@ -513,7 +581,7 @@ def run_js(body: str, data: dict | None = None, boot: bool = False,
 
 @unittest.skipUnless(HAS_NODE, "node is required")
 class DeepLinkSurvivesReloadTest(unittest.TestCase):
-    """Checkbox 8. U4 proves that routeFromHash MAPS #analytics-accounts to the
+    """Checkbox 8. U4 proves that routeFromHash MAPS #analytics-quota to the
     accounts sub-view, and that the toggle sets the hash. Neither proves the
     hash is ever READ — its ROUTER slice stops before
     `window.addEventListener("hashchange", routeFromHash)`, and the boot-time
@@ -524,11 +592,11 @@ class DeepLinkSurvivesReloadTest(unittest.TestCase):
     were already on the page. That is precisely the half "survives a reload"
     means, so both wirings are executed here rather than read."""
 
-    def test_loading_the_page_on_the_accounts_hash_lands_on_the_section(self):
+    def test_loading_the_page_on_the_quota_hash_lands_on_the_section(self):
         r = run_js("""
           out({ view: anView, tab: shown[shown.length - 1], routed: shown.length });
-        """, boot=True, hash="#analytics-accounts")
-        self.assertEqual("accounts", r["view"])
+        """, boot=True, hash="#analytics-quota")
+        self.assertEqual("quota", r["view"])
         self.assertEqual("analytics", r["tab"])
         self.assertEqual(1, r["routed"], "the load routed more than once")
 
@@ -539,11 +607,11 @@ class DeepLinkSurvivesReloadTest(unittest.TestCase):
         r = run_js("""
           apiFail = "offline";
           out({ view: anView, tab: shown[shown.length - 1] });
-        """, boot=True, hash="#analytics-accounts")
-        self.assertEqual("accounts", r["view"])
+        """, boot=True, hash="#analytics-quota")
+        self.assertEqual("quota", r["view"])
         self.assertEqual("analytics", r["tab"])
 
-    def test_a_reload_on_the_token_hash_does_not_land_on_accounts(self):
+    def test_a_reload_on_the_token_hash_does_not_land_on_quota(self):
         """The other direction, so the test above cannot pass by the sub-view
         happening to default to accounts."""
         r = run_js("""
@@ -561,12 +629,12 @@ class DeepLinkSurvivesReloadTest(unittest.TestCase):
     def test_the_hash_listener_is_registered_so_back_and_forward_route(self):
         r = run_js("""
           const registered = (listeners.hashchange || []).length;
-          location.hash = "#analytics-accounts";
+          location.hash = "#analytics-quota";
           for (const fn of listeners.hashchange || []) fn();
           out({ registered, view: anView, tab: shown[shown.length - 1] });
         """)
         self.assertEqual(1, r["registered"], "nothing listens for a hash change")
-        self.assertEqual("accounts", r["view"])
+        self.assertEqual("quota", r["view"])
         self.assertEqual("analytics", r["tab"])
 
 
@@ -613,7 +681,6 @@ class ProbeCountAcrossToggleTest(unittest.TestCase):
             self.calls.append(True)
             return [qp.account(provider="anthropic", probe_version="1",
                                captured_at=iso(), account_ref="uuid-1",
-                               account_label="jed@gmail.com", plan="max",
                                windows=[qp.window(window_kind="weekly",
                                                   probe_version="1",
                                                   captured_at=iso(),
@@ -631,21 +698,21 @@ class ProbeCountAcrossToggleTest(unittest.TestCase):
                 r.read()
 
     @unittest.skipUnless(HAS_NODE, "node is required")
-    def test_accounts_then_tokens_then_accounts_inside_a_minute_probes_once(self):
+    def test_quota_then_tokens_then_quota_inside_a_minute_probes_once(self):
         emitted = run_js("""
-          anView = "accounts"; await renderAnalytics(root());
-          anView = "tokens";   await renderAnalytics(root());
-          anView = "accounts"; await renderAnalytics(root());
+          anView = "quota";  await renderAnalytics(root());
+          anView = "tokens"; await renderAnalytics(root());
+          anView = "quota";  await renderAnalytics(root());
           out({ emitted: calls });
         """)["emitted"]
         # The UI's real behaviour, stated so a change to it is visible here:
-        # two arrivals at accounts, one at tokens, no POST anywhere.
+        # two arrivals at quota, one at tokens, no POST anywhere.
         self.assertEqual(
-            ["/analytics/accounts GET", "/analytics/sweep POST",
-             "/analytics/accounts GET"],
+            ["/analytics/quota GET", "/analytics/sweep POST",
+             "/analytics/quota GET"],
             [c["path"] + " " + c["method"] for c in emitted])
         with self.probed():
-            self.replay([c for c in emitted if "accounts" in c["path"]])
+            self.replay([c for c in emitted if "quota" in c["path"]])
         self.assertEqual(1, len(self.calls),
                          "the toggle hammered the providers twice inside the TTL")
 
@@ -653,9 +720,9 @@ class ProbeCountAcrossToggleTest(unittest.TestCase):
         """The other side of the same clock: the TTL must absorb a toggle and
         must never absorb the refresh button."""
         with self.probed():
-            self.replay([{"path": "/analytics/accounts", "method": "GET"},
-                         {"path": "/analytics/accounts", "method": "GET"},
-                         {"path": "/analytics/accounts/probe", "method": "POST"}])
+            self.replay([{"path": "/analytics/quota", "method": "GET"},
+                         {"path": "/analytics/quota", "method": "GET"},
+                         {"path": "/analytics/quota/probe", "method": "POST"}])
         self.assertEqual(2, len(self.calls))
 
 
@@ -694,15 +761,18 @@ class TimeoutLeavesOtherCardsTest(GateCase):
         self.assertIn("timed out", by_provider["openai"]["detail"])
 
         rendered = run_js("""
-          const r0 = root(); anDrawAccounts(r0, PAYLOAD);
-          out({ labels: byClass(r0, "an-acct-label").map((n) => n.textContent),
-                cards: byClass(r0, "an-acct").length,
+          const r0 = root(); anDrawQuota(r0, PAYLOAD);
+          out({ cards: byClass(r0, "an-acct").length,
+                withWindows: byClass(r0, "an-acct").filter(
+                  (c) => byClass(c, "an-win").length).length,
                 body: r0.textContent });
         """, data=json.loads(json.dumps(out, default=str)))
-        # The two healthy providers still have their cards...
-        self.assertEqual(2, len([a for a in out["accounts"]]),
-                         "the hang cost another provider its account")
-        self.assertGreaterEqual(rendered["cards"], 2)
+        # Every provider still renders a card, and the two healthy ones still
+        # carry their NUMBERS — the card count alone cannot show that, since
+        # cards render unconditionally now.
+        self.assertEqual(3, rendered["cards"])
+        self.assertEqual(2, rendered["withWindows"],
+                         "the hang cost another provider its reading")
         self.assertIn("Claude", rendered["body"])
         self.assertIn("Kimi", rendered["body"])
         # ...and the hung one says so rather than going quiet or reading 0%.

--- a/tests/test_quota_gate.py
+++ b/tests/test_quota_gate.py
@@ -73,6 +73,7 @@ FIXTURES = ROOT / "tests" / "fixtures" / "quota_probes"
 sys.path.insert(0, str(ENGINE / "scripts"))
 sys.path.insert(0, str(ENGINE / "api"))
 
+import harness_versions  # noqa: E402
 import quota_probes as qp  # noqa: E402
 import server  # noqa: E402
 from quota_probes import anthropic as p_anthropic  # noqa: E402
@@ -153,6 +154,11 @@ class GateCase(unittest.TestCase):
                    PROFILE=self.claude_profile)
         self.patch(p_openai, CREDENTIALS=self.codex_auth)
         self.patch(p_moonshot, CREDENTIALS=self.kimi_creds)
+        # The openai probe's SECOND external dependency: it derives its client
+        # version from the installed codex CLI, so an unstubbed seam makes this
+        # gate answer differently on a runner that has one and a runner that
+        # does not (SC-170). The seam itself is pinned in the probe suite.
+        self.patch(harness_versions, probe=lambda _: "codex-cli 0.145.0")
 
     def write_credentials(self, token: str = CANARY) -> None:
         expires = int((time.time() + 3600) * 1000)

--- a/tests/test_quota_probes.py
+++ b/tests/test_quota_probes.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python3
-"""Tests for the quota probe package — spec doc #49, sprint 52 unit 2.
+"""Tests for the quota probe package — spec doc #57, superseding #49.
+
+THE FIXTURES ARE NOW SANITIZED REAL CAPTURES, and that is the single most
+load-bearing fact about this suite. The originals were TRANSCRIBED from spec
+49's observed-field tables, which were wrong about moonshot in three places —
+so the normalizer was pinned against the planner's reading of the payload and
+every test agreed with it. Six field-level defects lived behind that agreement,
+in all three providers, every one of them invisible because the fixture said
+what the probe said.
+
+Two consequences run through the tests below. Where a live capture's own value
+is too weak to pin an arithmetic (moonshot's five-hour window reads 100/100, so
+`used` derives to zero — and zero is also what a broken derivation returns), a
+second case is DERIVED from the capture with the structure held exactly and
+only the numbers moved. And where the wire does not currently send a shape the
+code must handle (a five-hour SCOPED openai window), it is pinned anyway: a
+test that only covers what the wire sends today is how this feature got here.
 
 Every test drives the probes against the recorded fixtures in
 tests/fixtures/quota_probes/ (see that dir's README for provenance). NO TEST
@@ -173,31 +189,55 @@ class AnthropicProbeTest(ProbeCase):
     def test_normalizes_the_three_observed_windows(self):
         acct, ep = self.probe()
         self.assertEqual(acct["status"], "ok")
-        self.assertEqual(acct["plan"], "max")
         self.assertEqual(acct["account_ref"],
                          "abcd1234-0000-4000-8000-00000000beef")
-        self.assertEqual(acct["account_label"], "placeholder@example.com",
-                         "decision #69: the label is the full email")
         windows = self.by_kind(acct)
         self.assertEqual(set(windows), {("session", None), ("weekly", None),
-                                        ("weekly_scoped", "Claude Opus 5")})
-        self.assertEqual(windows[("session", None)]["used_percent"], 22.0)
+                                        ("weekly_scoped", "Fable")})
+        self.assertEqual(windows[("session", None)]["used_percent"], 47.0)
         self.assertEqual(windows[("session", None)]["resets_at"],
-                         "2026-07-25T21:00:00Z")
+                         "2026-07-25T23:10:00Z")
+        self.assertEqual(windows[("weekly", None)]["used_percent"], 36.0)
+        self.assertEqual(windows[("weekly_scoped", "Fable")]["used_percent"],
+                         47.0)
         self.assertEqual(ep.calls[0][0], p_anthropic.URL)
         self.assertEqual(ep.calls[0][1]["anthropic-beta"],
                          p_anthropic.BETA_HEADER)
 
-    def test_label_falls_back_to_the_uuid_when_no_address_is_on_file(self):
-        """The ref and the label come from the same object but are not the
-        same field: an older profile without emailAddress must still key AND
-        label the card."""
-        self.write(self.claude_profile, {"oauthAccount": {
-            "accountUuid": "abcd1234-0000-4000-8000-00000000beef"}})
+    def test_the_operator_address_on_disk_never_reaches_the_result(self):
+        """THE POSITIVE CONTROL IS THE POINT OF THIS TEST.
+
+        ~/.claude.json really does carry `emailAddress`, and setUp really does
+        write one — asserted present here so the absence assertion below cannot
+        pass merely because nothing was there to find. Decision #69 once made
+        that address the card's label; decision #75 stopped collecting it.
+
+        The uuid from the SAME object must still be read, or this test would
+        also pass against a probe that had stopped reading the file at all."""
+        on_disk = json.loads(self.claude_profile.read_text())
+        self.assertEqual(on_disk["oauthAccount"]["emailAddress"],
+                         "placeholder@example.com")
         acct, _ = self.probe()
-        self.assertEqual(acct["account_label"], "abcd1234")
         self.assertEqual(acct["account_ref"],
                          "abcd1234-0000-4000-8000-00000000beef")
+        self.assertNotIn("placeholder@example.com", json.dumps(acct))
+        self.assertNotIn("@", json.dumps(acct))
+        self.assertNotIn("account_label", acct)
+        self.assertEqual([n for n in self.notes if "@" in n], [])
+
+    def test_no_plan_is_collected_from_either_source(self):
+        """`plan` is dropped (migration 0097), and BOTH candidate sources are
+        pinned because the probe read the wrong one for its whole life.
+
+        `subscriptionType` is a real key of the CREDENTIAL FILE — setUp writes
+        `max` — and was never a key of the payload, which is why reading it
+        from the payload returned None silently and no test noticed. Neither
+        may reach the result now."""
+        self.assertEqual(json.loads(self.claude_creds.read_text())
+                         ["claudeAiOauth"]["subscriptionType"], "max")
+        acct, _ = self.probe()
+        self.assertNotIn("plan", acct)
+        self.assertNotIn("max", json.dumps(acct))
 
     def test_percent_only_provider_leaves_counts_null(self):
         acct, _ = self.probe()
@@ -267,36 +307,86 @@ class OpenAIProbeTest(ProbeCase):
         return self.one(p_openai.probe(self.log, 5)), ep
 
     def test_normalizes_the_observed_windows(self):
+        """Both windows the live capture carries — and the scoped one is the
+        whole of new defect A: it lives inside `additional_rate_limits[0]
+        .rate_limit`, one level below where the shipped probe looked."""
         acct, ep = self.probe()
         self.assertEqual(acct["status"], "ok")
-        self.assertEqual(acct["account_label"], "placeholder@example.com",
-                         "the label is the full address, not a local part")
-        self.assertEqual(acct["account_ref"], "acct_placeholder_0001")
-        self.assertEqual(acct["plan"], "prolite")
         windows = self.by_kind(acct)
-        self.assertEqual(set(windows), {("five_hour", None), ("weekly", None),
-                                        ("weekly", "premium")})
-        self.assertEqual(windows[("five_hour", None)]["used_percent"], 12.5)
+        self.assertEqual(set(windows),
+                         {("weekly", None), ("weekly", "GPT-5.3-Codex-Spark")})
+        self.assertEqual(windows[("weekly", None)]["used_percent"], 2.0)
         self.assertEqual(windows[("weekly", None)]["resets_at"],
-                         "2026-07-30T12:00:00Z")
+                         "2026-08-01T22:18:28Z")
+        scoped = windows[("weekly", "GPT-5.3-Codex-Spark")]
+        self.assertEqual(scoped["used_percent"], 0.0)
+        self.assertEqual(scoped["resets_at"], "2026-08-01T22:58:31Z")
         self.assertEqual(ep.calls[0][1]["chatgpt-account-id"],
                          "acct_placeholder_0001")
 
-    def test_kind_follows_the_duration_not_the_window_name(self):
-        """Swap the two windows' durations: their kinds must swap with them.
+    def test_the_scoped_window_carries_real_numbers_not_an_empty_row(self):
+        """THE REGRESSION PIN FOR DEFECT A, and the reason it needs its own
+        test: the shipped probe read `used_percent` / `limit_window_seconds` /
+        `reset_at` at ENTRY level, where the live payload carries none of them.
+        It produced a row of NULLs, logged NO drift, and returned status `ok`.
 
-        A probe that mapped primary→five_hour / secondary→weekly by name or
-        position passes the test above and fails only here.
-        """
+        `assertIsNotNone` rather than a value match is deliberate — this pins
+        the failure MODE (an empty row shipping as a healthy reading), so it
+        stays meaningful when the capture's numbers are refreshed."""
+        acct, _ = self.probe()
+        scoped = self.by_kind(acct)[("weekly", "GPT-5.3-Codex-Spark")]
+        self.assertIsNotNone(scoped["used_percent"],
+                             "the scoped row shipped with no percent while "
+                             "status stayed ok — defect A, exactly")
+        self.assertIsNotNone(scoped["resets_at"])
+        self.assertEqual(acct["status"], "ok")
+        self.assertEqual([n for n in self.notes if "drift" in n], [])
+
+    def test_a_scoped_five_hour_window_is_not_labelled_weekly(self):
+        """The wire does not currently send this, and that is the point.
+
+        The scoped row's kind used to be right BY ACCIDENT: the duration was
+        unreadable at entry level, so `kind_for_seconds` returned None and a
+        `fallback_kind="weekly"` caught it — while the live window happened to
+        be 604800. Any other duration would have been labelled weekly just as
+        confidently. A test that only covers what the wire sends today is how
+        this feature got here."""
         payload = fixture("openai_usage.json")
-        primary = payload["rate_limit"]["primary_window"]
-        secondary = payload["rate_limit"]["secondary_window"]
-        primary["limit_window_seconds"], secondary["limit_window_seconds"] = \
-            secondary["limit_window_seconds"], primary["limit_window_seconds"]
+        entry = payload["additional_rate_limits"][0]
+        entry["rate_limit"]["primary_window"]["limit_window_seconds"] = 18000
         acct, _ = self.probe(payload=payload)
-        kinds = {w["used_percent"]: w["window_kind"] for w in acct["windows"]}
-        self.assertEqual(kinds[12.5], "weekly")
-        self.assertEqual(kinds[47.0], "five_hour")
+        scoped = self.by_kind(acct)[("five_hour", "GPT-5.3-Codex-Spark")]
+        self.assertEqual(scoped["window_kind"], "five_hour")
+        self.assertNotEqual(scoped["window_kind"], "weekly")
+
+    def test_an_entry_carrying_no_rate_limit_is_drift(self):
+        """One level below the envelope is where defect A lived, so that is
+        where the check has to reach. An entry with no `rate_limit{}` is a
+        payload that has moved, not an idle account — and the shipped probe's
+        answer to it was a silent empty row under status `ok`."""
+        payload = fixture("openai_usage.json")
+        del payload["additional_rate_limits"][0]["rate_limit"]
+        acct, _ = self.probe(payload=payload)
+        self.assertEqual(acct["status"], "error")
+        self.assertEqual(acct["windows"], [],
+                         "no partial rows — the intact top-level window must "
+                         "not ship as if it were the whole reading")
+        self.assertTrue(any("shape drift" in n for n in self.notes),
+                        f"drift must be loud; log was {self.notes}")
+
+    def test_kind_follows_the_duration_not_the_window_name(self):
+        """Give the two windows different durations: their kinds follow the
+        DURATION, not the container they arrived in.
+
+        A probe that mapped top-level→weekly / scoped→weekly by position or by
+        a fallback passes the test above and fails only here. The live capture
+        has both at 604800, which is exactly why it cannot pin this itself."""
+        payload = fixture("openai_usage.json")
+        payload["rate_limit"]["primary_window"]["limit_window_seconds"] = 18000
+        acct, _ = self.probe(payload=payload)
+        kinds = {w["scope"]: w["window_kind"] for w in acct["windows"]}
+        self.assertEqual(kinds[None], "five_hour")
+        self.assertEqual(kinds["GPT-5.3-Codex-Spark"], "weekly")
 
     def test_unrecognized_duration_keeps_the_window_under_its_own_row(self):
         payload = {"account_id": "a1", "rate_limit": {"primary_window": {
@@ -364,13 +454,14 @@ class OpenAIProbeTest(ProbeCase):
                 self.notes.clear()
                 payload = fixture("openai_usage.json")
                 if value is None:
-                    del payload["rate_limit"]["additional_rate_limits"]
+                    del payload["additional_rate_limits"]
                 else:
-                    payload["rate_limit"]["additional_rate_limits"] = value
+                    payload["additional_rate_limits"] = value
                 acct, _ = self.probe(payload=payload)
                 self.assertEqual(acct["status"], "ok")
-                self.assertEqual({w["window_kind"] for w in acct["windows"]},
-                                 {"five_hour", "weekly"})
+                self.assertEqual(self.by_kind(acct).keys(),
+                                 {("weekly", None)},
+                                 "the top-level window still stands alone")
                 self.assertEqual([n for n in self.notes if "drift" in n], [])
 
     def test_a_200_that_is_not_a_json_object_says_so(self):
@@ -387,11 +478,68 @@ class OpenAIProbeTest(ProbeCase):
         self.assertIsNone(acct["account_ref"])
         self.assertEqual(ep.calls, [])
 
-    def test_rejection_keeps_the_account_identified(self):
-        acct, _ = self.probe(code=401)
-        self.assertEqual(acct["status"], "unauth")
-        self.assertEqual(acct["account_ref"], "acct_placeholder_0001",
-                         "the ref is on disk, so an unauth card still keys")
+    def test_a_failed_probe_claims_no_account(self):
+        """INVERTED FROM SPRINT 52, and flag #196 is why.
+
+        This used to assert the opposite — that the file's account_id keeps an
+        unauth card keyed. But the file's id is a GUESS at who the endpoint
+        will name, and a WRONG one: the file says `acct_placeholder_0001`
+        while a 200 says `user-PLACEHOLDER…`. Writing the guess on every
+        failure is what minted a permanent second registry row under one
+        account. A failed probe learned nothing about identity, so it claims
+        none — which is what stops the duplicate at its source rather than
+        reconciling it afterwards.
+
+        The last successful probe's rows are untouched by this and still
+        render with their own age; that is `_latest_readings`' job, pinned in
+        the API suite."""
+        for code in (401, 403, 503):
+            with self.subTest(code=code):
+                acct, _ = self.probe(code=code)
+                self.assertIsNone(acct["account_ref"])
+                self.assertEqual(acct["windows"], [])
+
+    def test_a_403_is_a_loud_client_rejection_never_unauth(self):
+        """Flag #196's half that does not dissolve, with its MIRROR LEGS.
+
+        A 403 from this endpoint is an anti-bot rejection of the CLIENT, not a
+        verdict on the operator's session — it arrived with an HTML body while
+        the token was perfectly valid. Mapping it to `unauth` blamed the
+        operator for being signed out when they were not, and a silently empty
+        card would hide the breakage entirely."""
+        acct, _ = self.probe(code=403)
+        self.assertEqual(acct["status"], "error")
+        self.assertNotEqual(acct["status"], "unauth",
+                            "a 403 here is a client rejection, and telling "
+                            "the operator they are signed out is a claim the "
+                            "probe has not established")
+        self.assertTrue(acct["detail"],
+                        "an empty detail is the silent-empty-card failure — "
+                        "the operator must see WHY the probe broke")
+        self.assertIn("403", acct["detail"])
+
+    def test_the_client_version_comes_from_the_installed_cli(self):
+        """The fork installs harnesses at --latest on every update, so a baked
+        constant goes stale by design. Pinned by moving the installed version
+        and watching every header follow it."""
+        with mock.patch.object(p_openai.harness_versions, "probe",
+                               lambda _: "codex-cli 9.9.9"):
+            _, ep = self.probe()
+        headers = ep.calls[0][1]
+        self.assertEqual(headers["version"], "9.9.9")
+        self.assertEqual(headers["originator"], "codex_cli_rs")
+        self.assertEqual(headers["User-Agent"], "codex_cli_rs/9.9.9")
+
+    def test_no_codex_cli_is_a_named_error_not_a_bare_request(self):
+        """Sending no client identity provokes the very 403 this fix exists to
+        avoid, and a 403 we caused ourselves is indistinguishable from the
+        endpoint tightening. Say which one it is instead."""
+        with mock.patch.object(p_openai.harness_versions, "probe",
+                               lambda _: None):
+            acct, ep = self.probe()
+        self.assertEqual(acct["status"], "error")
+        self.assertEqual(ep.calls, [], "a request went out with no client identity")
+        self.assertIn("client", acct["detail"])
 
 
 class MoonshotProbeTest(ProbeCase):
@@ -402,17 +550,69 @@ class MoonshotProbeTest(ProbeCase):
         return self.one(p_moonshot.probe(self.log, 5)), ep
 
     def test_derives_percent_from_absolute_counts(self):
+        """The account-wide `usage` block, which pins its own arithmetic: the
+        capture reads 97/100 and the counts arrive as STRINGS."""
         acct, _ = self.probe()
         self.assertEqual(acct["status"], "ok")
-        self.assertEqual(acct["account_ref"], "placeholder-user-0001")
-        self.assertEqual(acct["plan"], "LEVEL_ADVANCED")
-        windows = self.by_kind(acct)
-        weekly = windows[("weekly", None)]
-        self.assertEqual((weekly["used"], weekly["limit_value"]), (128000, 500000))
-        self.assertEqual(weekly["used_percent"], 25.6)
-        five_hour = windows[("five_hour", None)]
-        self.assertEqual(five_hour["used_percent"], 21.0)
-        self.assertEqual(five_hour["resets_at"], "2026-07-25T20:00:00Z")
+        self.assertEqual(acct["account_ref"], "placeholderuser000001")
+        weekly = self.by_kind(acct)[("weekly", None)]
+        self.assertEqual((weekly["used"], weekly["limit_value"]), (97, 100))
+        self.assertEqual(weekly["used_percent"], 97.0)
+        self.assertEqual(weekly["resets_at"], "2026-07-29T11:38:20Z")
+
+    def test_limits_entry_unwraps_detail_and_derives_used(self):
+        """Defect 3: entries nest their counts under `detail` and carry NO
+        `used` key at all, so `used` is derived as limit - remaining.
+
+        THIS CASE IS DERIVED FROM THE CAPTURE, NOT RECORDED. The live window
+        reads limit=100 remaining=100, so the real derivation lands on ZERO —
+        and zero is also what every BROKEN derivation returns (missing key →
+        None → 0, wrong nesting → nothing found → 0). A test built only on the
+        capture would pass against a derivation that never works.
+
+        So the structure is the capture's exactly and only the numbers move.
+        The zero case is pinned too, in the test below, because it is what the
+        wire actually sends."""
+        payload = fixture("moonshot_usages.json")
+        detail = payload["limits"][0]["detail"]
+        self.assertEqual(set(payload["limits"][0]), {"window", "detail"},
+                         "the capture's entry shape moved — re-derive this case")
+        self.assertNotIn("used", detail, "defect 3 was that no `used` exists")
+        detail["limit"], detail["remaining"] = "400", "150"
+        acct, _ = self.probe(payload=payload)
+        five_hour = self.by_kind(acct)[("five_hour", None)]
+        self.assertEqual((five_hour["used"], five_hour["limit_value"]),
+                         (250, 400), "used must be limit - remaining")
+        self.assertEqual(five_hour["used_percent"], 62.5)
+        self.assertEqual(five_hour["resets_at"], "2026-07-26T00:38:20Z",
+                         "resetTime is read from `detail`, not entry level")
+
+    def test_an_untouched_five_hour_window_reads_zero_not_nothing(self):
+        """The capture's own numbers, kept as their own case: an unused window
+        is a MEASURED zero with its limit intact. The pair is what separates it
+        from a failed read — a broken derivation returns used=0 too, but it
+        cannot also produce limit_value=100 and a reset time."""
+        acct, _ = self.probe()
+        five_hour = self.by_kind(acct)[("five_hour", None)]
+        self.assertEqual((five_hour["used"], five_hour["limit_value"]), (0, 100))
+        self.assertEqual(five_hour["used_percent"], 0.0)
+        self.assertEqual(five_hour["resets_at"], "2026-07-26T00:38:20Z")
+
+    def test_the_time_unit_prefix_is_stripped_not_enumerated(self):
+        """Defect 1, both spellings. The wire sends `TIME_UNIT_MINUTE`; the
+        shipped map keyed on a bare `MINUTE`, so 300 minutes — a five-hour
+        window, a kind the vocabulary already had — filed as unrecognized.
+
+        Both must work: the prefix is STRIPPED rather than the two spellings
+        enumerated, so a `TIME_UNIT_HOUR` the wire has not sent yet resolves
+        too."""
+        for unit in ("TIME_UNIT_MINUTE", "MINUTE"):
+            with self.subTest(timeUnit=unit):
+                payload = fixture("moonshot_usages.json")
+                payload["limits"][0]["window"]["timeUnit"] = unit
+                acct, _ = self.probe(payload=payload)
+                self.assertIn(("five_hour", None), self.by_kind(acct),
+                              f"300 {unit} is five hours")
 
     def test_300_minutes_is_five_hours(self):
         """The kind comes from duration × timeUnit, so changing the unit
@@ -431,16 +631,59 @@ class MoonshotProbeTest(ProbeCase):
         acct, _ = self.probe(payload=payload)
         w = self.one(acct["windows"])
         self.assertIsNone(w["used_percent"])
-        self.assertEqual((w["used"], w["limit_value"]), (128000, 0),
+        self.assertEqual((w["used"], w["limit_value"]), (97, 0),
                          "the raw counts still stand")
 
     def test_unknown_time_unit_keeps_the_window(self):
+        """A unit the vocabulary cannot convert still yields a ROW — the limit
+        is real and dropping it would hide a real constraint.
+
+        The raw window goes to the LOG, which is a diagnostic the operator
+        never reads, and NOT to `scope`, which renders on the card and is
+        persisted. That split is the whole lesson of defect 2: the place to
+        put an untrusted value is the log."""
         payload = fixture("moonshot_usages.json")
         payload["limits"][0]["window"] = {"duration": 2, "timeUnit": "FORTNIGHT"}
         acct, _ = self.probe(payload=payload)
         odd = [w for w in acct["windows"] if w["window_kind"] == "unknown"]
-        self.assertEqual(len(odd), 1)
-        self.assertIn("FORTNIGHT", str(odd[0]["scope"]))
+        self.assertEqual(len(odd), 1, "an unconvertible window was dropped")
+        self.assertEqual(odd[0]["scope"], "unrecognized window")
+        self.assertNotIn("FORTNIGHT", str(odd[0]["scope"]))
+        self.assertTrue(any("FORTNIGHT" in n for n in self.notes),
+                        f"the raw window must be diagnosable; log was {self.notes}")
+
+    def test_no_container_repr_ever_reaches_operator_visible_text(self):
+        """DEFECT 2, PINNED AS A CLASS RATHER THAN AS THE TYPO IT LOOKED LIKE.
+
+        The shipped probe interpolated the whole window DICT into `scope`, so
+        `{'duration': 300, 'timeUnit': 'TIME_UNIT_MINUTE'}` rendered on the
+        card AND was persisted to the DB. The rule is general — a container is
+        never interpolated into text the operator reads — so this asserts the
+        SHAPE of the output rather than one expected string, and sweeps every
+        field a card renders.
+
+        The unrecognized-window path is the one that reads an uncontrolled
+        value straight from the wire, so each case below is a container
+        arriving where a scalar was assumed. OpenAI carried the identical
+        latent bug on its own duration field, which is why `duration_label` is
+        shared rather than copied — a class needs one implementation."""
+        for bad in ({"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
+                    [300, "MINUTE"],
+                    {"nested": {"duration": 7}}):
+            with self.subTest(window=bad):
+                payload = fixture("moonshot_usages.json")
+                payload["limits"][0]["window"] = bad
+                acct, _ = self.probe(payload=payload)
+                for w in acct["windows"]:
+                    for field in ("scope", "window_kind"):
+                        text = w[field]
+                        if text is None:
+                            continue
+                        self.assertNotRegex(
+                            str(text), r"[{}\[\]]|'\w+':",
+                            f"a container repr reached {field} — the exact "
+                            "defect that put a Python dict on the card and "
+                            "into the database")
 
     def test_lost_usage_block_is_drift_not_a_measured_zero(self):
         """`usage` is the account-wide block every payload carries — an
@@ -451,7 +694,7 @@ class MoonshotProbeTest(ProbeCase):
         acct, _ = self.probe(payload=payload)
         self.assertEqual(acct["status"], "error")
         self.assertEqual(acct["windows"], [])
-        self.assertEqual(acct["account_ref"], "placeholder-user-0001",
+        self.assertEqual(acct["account_ref"], "placeholderuser000001",
                          "a drifted card still keys to its account")
         self.assertTrue(any("shape drift" in n for n in self.notes),
                         f"drift must be loud; log was {self.notes}")
@@ -464,7 +707,7 @@ class MoonshotProbeTest(ProbeCase):
         acct, _ = self.probe(payload=payload)
         self.assertEqual(acct["status"], "ok")
         w = self.one(acct["windows"])
-        self.assertEqual((w["window_kind"], w["used"]), ("weekly", 128000))
+        self.assertEqual((w["window_kind"], w["used"]), ("weekly", 97))
         self.assertEqual([n for n in self.notes if "drift" in n], [])
 
     def test_an_empty_usage_block_is_data_not_drift(self):

--- a/tests/test_quota_probes.py
+++ b/tests/test_quota_probes.py
@@ -47,6 +47,7 @@ Run:
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 import time
@@ -60,6 +61,7 @@ FIXTURES = ROOT / "tests" / "fixtures" / "quota_probes"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 
+import harness_versions  # noqa: E402
 import quota_probes as qp  # noqa: E402
 from quota_probes import anthropic as p_anthropic  # noqa: E402
 from quota_probes import dispatch  # noqa: E402
@@ -68,6 +70,14 @@ from quota_probes import openai as p_openai  # noqa: E402
 
 TOKEN = "sentinel-access-token-must-never-leak"
 HOUR_MS = 3600 * 1000
+
+# The real version probe, captured before any stub replaces the module
+# attribute — the seam test below runs it for real against a scrubbed PATH.
+REAL_VERSION_PROBE = harness_versions.probe
+# What a codex-equipped host answers. Stubbed for every test (see ProbeCase),
+# because `harness_versions.probe` shells out to the installed CLI and the
+# openai probe is the one caller that depends on it.
+STUB_CODEX_VERSION = "codex-cli 0.145.0"
 
 
 def fixture(name: str) -> dict:
@@ -94,6 +104,15 @@ class ProbeCase(unittest.TestCase):
     Every probe module resolves its credential paths at import time, so the
     constants are patched rather than $HOME — the same thing the real code
     would read, without touching the operator's own files.
+
+    HTTP IS NOT THE ONLY EXTERNAL DEPENDENCY, and stubbing only that one is
+    what put 20 failures in CI (SC-170). The openai probe derives its client
+    version from the INSTALLED codex CLI, so on a runner without one it
+    short-circuits to a named error before the get_json seam is ever reached
+    and every openai leg reds — the suite's result depending on the host's
+    toolchain, which is precisely what the fixture work exists to end. Both
+    seams are stubbed here; `test_the_version_seam_is_the_installed_cli` runs
+    the real one against a scrubbed PATH so the coupling itself stays pinned.
     """
 
     def setUp(self):
@@ -123,6 +142,7 @@ class ProbeCase(unittest.TestCase):
                    PROFILE=self.claude_profile)
         self.patch(p_openai, CREDENTIALS=self.codex_auth)
         self.patch(p_moonshot, CREDENTIALS=self.kimi_creds)
+        self.patch(harness_versions, probe=lambda _: STUB_CODEX_VERSION)
 
         # The no-live-call guard. Reached only if a probe bypasses get_json.
         guard = mock.patch("urllib.request.urlopen",
@@ -290,6 +310,23 @@ class AnthropicProbeTest(ProbeCase):
         self.assertEqual([n for n in self.notes if "drift" in n], [],
                          "an idle account must not be reported as drift")
 
+    def test_an_unreadable_limits_entry_is_drift_not_a_silent_skip(self):
+        """L-614-1, this provider's instance. Every window on a Claude card
+        comes out of this list, so an entry the reader cannot open is a window
+        vanishing — and the reader's answer to it was `continue`, under status
+        `ok`, with the account's OTHER windows still rendering as though the
+        card were whole. That is the same failure as the wrong-typed container
+        one level up, which this suite already calls drift."""
+        payload = fixture("anthropic_usage.json")
+        payload["limits"].append("five_hour")
+        acct, _ = self.probe(payload=payload)
+        self.assertEqual(acct["status"], "error")
+        self.assertEqual(acct["windows"], [],
+                         "no partial rows — the readable limits must not ship "
+                         "as if they were the whole reading")
+        self.assertTrue(any("shape drift" in n for n in self.notes),
+                        f"drift must be loud; log was {self.notes}")
+
     def test_unknown_limit_kind_is_kept_not_dropped(self):
         acct, _ = self.probe(payload={"limits": [
             {"kind": "monthly_all", "percent": 5, "resets_at": None}]})
@@ -366,6 +403,26 @@ class OpenAIProbeTest(ProbeCase):
         answer to it was a silent empty row under status `ok`."""
         payload = fixture("openai_usage.json")
         del payload["additional_rate_limits"][0]["rate_limit"]
+        acct, _ = self.probe(payload=payload)
+        self.assertEqual(acct["status"], "error")
+        self.assertEqual(acct["windows"], [],
+                         "no partial rows — the intact top-level window must "
+                         "not ship as if it were the whole reading")
+        self.assertTrue(any("shape drift" in n for n in self.notes),
+                        f"drift must be loud; log was {self.notes}")
+
+    def test_an_entry_that_is_not_an_object_is_drift(self):
+        """L-614-1 — the same finding as the test above, one TYPE up, and it
+        shipped inside the fix for the container-level twin.
+
+        `additional_rate_limits: 5` is drift because a list is where the reader
+        iterates; `additional_rate_limits: [5]` was a silent `continue` under
+        status `ok`, which is the identical scoped-window-vanishes failure with
+        the identical "nothing looks wrong" card. The mirror leg is the test
+        below: `[]` and an absent key stay `ok`, so this cannot be satisfied by
+        erroring on every empty collection."""
+        payload = fixture("openai_usage.json")
+        payload["additional_rate_limits"] = ["gpt-5.3-codex-spark"]
         acct, _ = self.probe(payload=payload)
         self.assertEqual(acct["status"], "error")
         self.assertEqual(acct["windows"], [],
@@ -540,6 +597,42 @@ class OpenAIProbeTest(ProbeCase):
         self.assertEqual(acct["status"], "error")
         self.assertEqual(ep.calls, [], "a request went out with no client identity")
         self.assertIn("client", acct["detail"])
+
+    def test_the_version_seam_is_a_real_subprocess_against_the_hosts_path(self):
+        """SC-170's pin: THE SEAM ITSELF, run for real, both directions.
+
+        Every other test here stubs `harness_versions.probe` — correct
+        isolation, and also where a coupling hides. The seam is a subprocess
+        against the host's PATH, and this suite stubbed only the HTTP one until
+        CI found the second: 20 red legs on every runner without a codex CLI,
+        because the probe short-circuits before `get_json` is reached. So the
+        real seam gets a leg, with PATH pointed at a directory this test owns:
+
+        Leg 1 — a `codex` on PATH: the version reaches every header, through
+        shutil.which and a real `--version` call, with nothing stubbed.
+        Leg 2 — the same PATH with no codex in it: the loud named error, and no
+        request. Without leg 1 this passes for a probe that can never find a
+        CLI at all, which is the failure it is here to detect."""
+        bindir = self.tmp / "bin"
+        bindir.mkdir()
+        fake = bindir / "codex"
+        fake.write_text("#!/bin/sh\necho 'codex-cli 1.2.3'\n")
+        fake.chmod(0o755)
+
+        with mock.patch.object(harness_versions, "probe", REAL_VERSION_PROBE):
+            with mock.patch.dict(os.environ, {"PATH": str(bindir)}):
+                acct, ep = self.probe()
+            self.assertEqual(acct["status"], "ok")
+            self.assertEqual(ep.calls[0][1]["version"], "1.2.3")
+            self.assertEqual(ep.calls[0][1]["User-Agent"], "codex_cli_rs/1.2.3")
+
+            fake.unlink()
+            with mock.patch.dict(os.environ, {"PATH": str(bindir)}):
+                acct, ep = self.probe()
+        self.assertEqual(acct["status"], "error")
+        self.assertIn("codex", acct["detail"])
+        self.assertEqual(ep.calls, [],
+                         "a request went out with no client identity")
 
 
 class MoonshotProbeTest(ProbeCase):
@@ -735,6 +828,23 @@ class MoonshotProbeTest(ProbeCase):
         self.assertEqual(acct["status"], "error")
         self.assertEqual(acct["windows"], [])
         self.assertTrue(any("shape drift" in n for n in self.notes))
+
+    def test_a_limits_entry_that_is_not_an_object_is_drift(self):
+        """L-614-1 here, and this one is not new to the PR — it is the silent
+        skip the wrong-type check above was always sitting on top of. A metered
+        sub-window the reader cannot open disappears from the card while the
+        account-wide weekly figure keeps rendering, so nothing on the card says
+        anything went wrong. The absent/empty legs above are the mirror: this
+        must not fire on an idle account."""
+        payload = fixture("moonshot_usages.json")
+        payload["limits"] = list(payload["limits"]) + ["five_hour"]
+        acct, _ = self.probe(payload=payload)
+        self.assertEqual(acct["status"], "error")
+        self.assertEqual(acct["windows"], [],
+                         "no partial rows — the weekly figure must not ship "
+                         "as if it were the whole reading")
+        self.assertTrue(any("shape drift" in n for n in self.notes),
+                        f"drift must be loud; log was {self.notes}")
 
     def test_a_200_that_is_not_a_json_object_says_so(self):
         acct, _ = self.probe(payload="<html>maintenance</html>")

--- a/tests/test_quota_schema.py
+++ b/tests/test_quota_schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Schema properties of migration 0096 — the quota registry + window tables.
+"""Schema properties of migrations 0096 + 0097 — the quota registry + windows.
 
-Each test here pins a decision the migration makes that a plausible "cleanup"
+Each test here pins a decision the migrations make that a plausible "cleanup"
 would undo:
 
 - the window upsert key really is idempotent for account-wide rows (the reason
@@ -14,7 +14,10 @@ would undo:
   "rendered under its raw duration, not dropped", so a tidy CHECK over the five
   known kinds would be data loss on exactly the endpoint drift this feature
   expects;
-- status IS closed, because those five values are ours.
+- status IS closed, because those five values are ours;
+- 0097 REALLY DROPPED the five identity columns, with a positive control — an
+  assertion that a column is absent is worthless unless it can fail, and this
+  one is the schema half of "no operator email is ever written again".
 
 Run:
     python3 tests/test_quota_schema.py
@@ -49,11 +52,10 @@ class QuotaSchemaTest(unittest.TestCase):
         for p in sorted(MIGRATIONS.glob("*.sql")):
             self.con.executescript(p.read_text())
         self.con.execute("PRAGMA foreign_keys=ON")
+        # Three columns is the whole registry row after 0097.
         self.con.execute(
             "INSERT INTO harness_quota_account (account_pk, provider, "
-            "account_ref, account_label, first_seen, last_seen, is_current) "
-            "VALUES (1, 'anthropic', 'uuid-abc', 'uuid-abc', "
-            "'2026-07-25T00:00:00Z', '2026-07-25T00:00:00Z', 1)")
+            "account_ref) VALUES (1, 'anthropic', 'uuid-abc')")
 
     def tearDown(self):
         self.con.close()
@@ -90,21 +92,50 @@ class QuotaSchemaTest(unittest.TestCase):
             self._windows(), [("weekly", None, 10.0), ("weekly", "opus", 20.0)])
 
     def test_registry_rejects_duplicate_account(self):
-        """A re-probe advances the existing account; it never mints a second
-        row, which is what keeps first_seen intact across a switch-away."""
+        """A re-probe reuses the existing row; it never mints a second one.
+
+        This is the ONLY job account_ref has left after 0097 — it is why the
+        column survived a migration that dropped everything around it."""
         with self.assertRaises(sqlite3.IntegrityError):
             self.con.execute(
-                "INSERT INTO harness_quota_account (provider, account_ref, "
-                "first_seen, last_seen) VALUES ('anthropic', 'uuid-abc', "
-                "'2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z')")
+                "INSERT INTO harness_quota_account (provider, account_ref) "
+                "VALUES ('anthropic', 'uuid-abc')")
 
     def test_same_ref_on_a_different_provider_is_a_different_account(self):
         self.con.execute(
-            "INSERT INTO harness_quota_account (provider, account_ref, "
-            "first_seen, last_seen) VALUES ('openai', 'uuid-abc', 't', 't')")
+            "INSERT INTO harness_quota_account (provider, account_ref) "
+            "VALUES ('openai', 'uuid-abc')")
         self.assertEqual(
             self.con.execute(
                 "SELECT COUNT(*) FROM harness_quota_account").fetchone()[0], 2)
+
+    def test_0097_dropped_every_identity_column(self):
+        """The registry is (account_pk, provider, account_ref) and nothing else.
+
+        POSITIVE CONTROL FIRST, and it is the point of the test: `provider` is
+        asserted PRESENT through the same PRAGMA read that reports the others
+        absent. Without it a typo'd table name, a PRAGMA that returned nothing,
+        or a migration that never ran would all pass this as a clean bill of
+        health — an absence assertion that cannot fail is not evidence."""
+        cols = {r[1] for r in
+                self.con.execute("PRAGMA table_info(harness_quota_account)")}
+        self.assertEqual(cols, {"account_pk", "provider", "account_ref"})
+        for gone in ("account_label", "plan", "first_seen", "last_seen",
+                     "is_current"):
+            self.assertNotIn(gone, cols)
+
+    def test_the_last_seen_index_went_with_its_column(self):
+        """idx_hqa_last_seen drove the 7-day activity filter, which no longer
+        exists. SQLite also refuses to drop an indexed column, so an 0097 that
+        left this behind would not have applied at all — the migration order is
+        load-bearing, not stylistic."""
+        idx = {r[1] for r in
+               self.con.execute("PRAGMA index_list(harness_quota_account)")}
+        self.assertNotIn("idx_hqa_last_seen", idx)
+        # Positive control: the UNIQUE(provider, account_ref) auto-index is
+        # still there, so this PRAGMA does report indexes that exist.
+        self.assertTrue(any(name.startswith("sqlite_autoindex_harness_quota_account")
+                            for name in idx), idx)
 
     def test_unrecognized_window_kind_is_stored_not_rejected(self):
         """Endpoint drift must degrade to a row rendered under its raw duration,

--- a/tests/test_quota_snapshot_exclusion.py
+++ b/tests/test_quota_snapshot_exclusion.py
@@ -1,11 +1,21 @@
 #!/usr/bin/env python3
 """Asserts the quota tables never reach a freshly rendered content.sql.
 
-content.sql is git-tracked. `harness_quota_account.account_label` holds the
-operator's FULL email address — decision #67 withdrew the earlier redaction
-because the address never reaches the repository, which makes snapshot
-exclusion the ONLY thing keeping that true. So the guarantee is asserted here
-rather than assumed from `PER_INSTANCE_TABLES`.
+content.sql is git-tracked, and these are probe-rebuildable caches that do not
+belong in the repository — decision #65's ordinary hygiene, which was always
+reason enough. So the guarantee is asserted here rather than assumed from
+`PER_INSTANCE_TABLES`.
+
+THE RATIONALE CHANGED UNDER THIS TEST AND THE TEST DID NOT MOVE. Decision #67
+had made exclusion LOAD-BEARING: account_label held the operator's full email,
+so exclusion was the only thing between that address and the repository.
+Migration 0097 dropped the column, which retires that rationale AT ITS SOURCE
+— there is no address to leak because none is ever collected.
+
+It would then be easy to argue this test is now redundant. It is not, and it
+is kept at full strength deliberately: a test deleted because "the risk went
+away" is how the risk comes back, and the reason to exclude a rebuildable
+cache from a tracked file never depended on what the cache happened to hold.
 
 The distinction matters. A test that asserts `"harness_quota_account" not in
 snapshot.PER_INSTANCE_TABLES` is just the allowlist read twice: it stays green
@@ -44,11 +54,13 @@ import snapshot  # noqa: E402
 
 QUOTA_TABLES = ("harness_quota_account", "harness_quota_window")
 
-# Full address on purpose: this is the exact value decision #67 accepted into
-# the DB, so it is the exact value that must not appear in a tracked file.
-SENTINEL_EMAIL = "operator.sentinel@must-never-reach-git.test"
-SENTINEL_REF = "acct_sentinel_0123456789"
-SENTINEL_PLAN = "sentinel_plan"
+# account_ref is the ONLY free-text column the registry has left, so it is the
+# only place a sentinel can go — and an EMAIL-SHAPED one is used on purpose.
+# A real account_ref is provider-issued and never an address; writing one that
+# looks like an address is the strongest remaining probe of the renderer,
+# because it fails the same way a genuine leak would. It keeps this suite
+# grepping for CONTENT and not merely for a table name.
+SENTINEL_REF = "operator.sentinel@must-never-reach-git.test"
 
 
 def build_engine_db(path: Path) -> None:
@@ -65,11 +77,8 @@ def build_engine_db(path: Path) -> None:
         "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
         "VALUES (1, 'TC', 'tc', 'test', 'sp', 1, 0, 1, 1)")
     con.execute(
-        "INSERT INTO harness_quota_account (account_pk, provider, account_ref, "
-        "account_label, plan, first_seen, last_seen, is_current) "
-        "VALUES (1, 'openai', ?, ?, ?, '2026-07-25T00:00:00Z', "
-        "'2026-07-25T00:00:00Z', 1)",
-        (SENTINEL_REF, SENTINEL_EMAIL, SENTINEL_PLAN))
+        "INSERT INTO harness_quota_account (account_pk, provider, account_ref) "
+        "VALUES (1, 'openai', ?)", (SENTINEL_REF,))
     con.execute(
         "INSERT INTO harness_quota_window (account_pk, window_kind, scope, "
         "used_percent, captured_at, status, probe_version) "
@@ -118,13 +127,33 @@ class QuotaSnapshotExclusionTest(unittest.TestCase):
                 f"{table} was serialized into content.sql — it holds operator "
                 "account state and content.sql is git-tracked")
 
-    def test_operator_email_absent_from_content_sql(self):
-        """The value, not just the table name. Catches the table reaching the
-        file under an alias, a join, or a future per-column dumper."""
-        self.assertNotIn(SENTINEL_EMAIL, self.rendered)
-        self.assertNotIn(SENTINEL_EMAIL.split("@", 1)[0], self.rendered)
+    def test_registry_content_absent_from_content_sql(self):
+        """The VALUE, not just the table name. Catches the table reaching the
+        file under an alias, a join, or a future per-column dumper — none of
+        which a table-name grep would see."""
         self.assertNotIn(SENTINEL_REF, self.rendered)
-        self.assertNotIn(SENTINEL_PLAN, self.rendered)
+        self.assertNotIn(SENTINEL_REF.split("@", 1)[0], self.rendered)
+
+    def test_no_column_survives_that_could_hold_an_operator_label(self):
+        """The other half of the guarantee, and the half that is now structural.
+
+        Exclusion stops the table reaching a tracked file; THIS stops the value
+        existing at all. After 0097 the registry has one free-text column
+        (account_ref, provider-issued), so there is nowhere for an address to
+        be written even if a future probe tried.
+
+        The positive control is account_ref itself: it is asserted present
+        through the same read that reports the rest absent, so a PRAGMA
+        returning nothing cannot pass this as a clean bill of health."""
+        con = sqlite3.connect(self.db)
+        try:
+            cols = {r[1] for r in
+                    con.execute("PRAGMA table_info(harness_quota_account)")}
+        finally:
+            con.close()
+        self.assertIn("account_ref", cols)
+        self.assertNotIn("account_label", cols)
+        self.assertNotIn("plan", cols)
 
     def test_rows_are_present_in_the_db_that_was_rendered(self):
         """The exclusion must be the renderer's doing, not an empty table. If a


### PR DESCRIPTION
Spec doc #57 (feature 17 seq 4), ruling decision #75, flags #196 / #197 / #198.
One combined unit: probe package, migration 0097, API route, UI, and the six
test suites.

## What changes

The panel becomes **one card per PROVIDER** showing that provider's most recent
reading and the age of the reading. Nothing about who is signed in — not
displayed, not stored. Spec 49's card-per-ACCOUNT idea was built on the one
provider that returns an email, and two of three cards always rendered an opaque
identifier.

## Six defects, not the four the flags listed

The two extra were found by running the SHIPPED normalizers against real
captures instead of reasoning about the payloads. Both were invisible to the
suite for the same reason: **the fixture agreed with the probe.**

- **openai `additional_rate_limits[]` nests its window** under
  `entry.rate_limit`. The shipped reader looked at entry level, produced a row
  of NULLs, logged **no drift**, and returned status `ok` — the
  falsified-safety-claim shape reproduced in a second provider, and it would
  have shipped *inside* the fix for the first one.
- **anthropic read `plan` from `payload.subscriptionType`**, a key the wire has
  never sent. The real value was in the credential file. Recorded but not
  fixed — `plan` is dropped entirely.

That makes the read-at-the-wrong-level defect present in **all three** providers.

## Trade-offs taken deliberately

- **No general schema validator.** The envelope-vs-contents gap is real and
  named in the fixture README, but a validator would need to know that
  `additional_rate_limits[]` changed shape — the same knowledge a real capture
  carries, at a fraction of the failure surface.
- **`fallback_kind` removed rather than narrowed.** The scoped row's kind was
  right *by accident*; a five-hour scoped window would have been labelled weekly
  just as confidently. The kind is now derived from the block that carries the
  duration.
- **The duplicate registry row is prevented at its source, not reconciled.** A
  failed probe now claims no `account_ref` at all, because the credential file's
  id is a *guess* at who the endpoint will name and a wrong one. See the note to
  the planner in the PR discussion — this resolves the spec's "reconcile on
  write" differently than worded.
- **No compatibility alias** for `#analytics-accounts`. An alias would itself be
  a route naming a mechanism that no longer exists.

## Verification

- Migration 0097 verified on a **rebuilt instance**; the live DB is untouched.
  Registry ends as `(account_pk, provider, account_ref)`.
- All three probes run live and return `ok` with correct numbers, including
  moonshot's `five_hour` (the defect-1 window) and openai's scoped window (the
  defect-A window that used to come back empty).
- The API returns three provider-shaped entries carrying **no** email, label,
  ref, plan or sign-in state.
- **144 tests** across the six quota suites. Full suite: 1625 pass; the 3
  failures + 19 errors are pre-existing and in areas this diff does not touch
  (harness epoch, interface UI).
- **No Kimi token refresh was performed at any point** — Kimi rotates its
  refresh token, and a refresh by anything other than the Kimi CLI signs the
  operator out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)