### PR TITLE
feat(sprint): the board becomes a record — sprint_units + planner-only verbs (S59 U1)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2257,6 +2257,7 @@ def _retry_binding(actor, headers, body, binding_id: int):
 _UNIT_FIELDS = {
     "unit_title": "unit_title",
     "depends_on": "depends_on",
+    "overlap": "overlap",
     "branch": "branch",
     "pr_number": "pr_number",
 }
@@ -2341,8 +2342,9 @@ class _BadShell(Exception):
 
 _UNIT_COLS = (
     "unit_id", "sprint_doc_id", "seq", "unit_title", "dev_shell_id",
-    "reviewer_shell_id", "state", "depends_on", "branch", "pr_number",
-    "assigned_at", "state_changed_at", "updated_at", "updated_by_shell_id")
+    "reviewer_shell_id", "state", "depends_on", "overlap", "branch",
+    "pr_number", "assigned_at", "state_changed_at", "updated_at",
+    "updated_by_shell_id")
 
 
 def _unit_projection(con, unit_id: int) -> dict:
@@ -2421,13 +2423,13 @@ def _add_sprint_unit(actor, headers, body):
                 cur = con.execute(
                     "INSERT INTO sprint_units "
                     "(sprint_doc_id, seq, unit_title, dev_shell_id, "
-                    " reviewer_shell_id, state, depends_on, branch, "
+                    " reviewer_shell_id, state, depends_on, overlap, branch, "
                     " pr_number, assigned_at, updated_by_shell_id) "
-                    "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                    "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
                     (doc_id, seq, title, roles["dev_shell_id"],
                      roles["reviewer_shell_id"], state,
-                     body.get("depends_on"), body.get("branch"),
-                     body.get("pr_number"),
+                     body.get("depends_on"), body.get("overlap"),
+                     body.get("branch"), body.get("pr_number"),
                      _now(con) if any(roles.values()) else None,
                      actor.shell_id))
             except db_driver.IntegrityError:

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2248,6 +2248,302 @@ def _retry_binding(actor, headers, body, binding_id: int):
         con.close()
 
 
+# ------------------------------------------------------- the board as a record
+
+# The board's columns as the planner edits them, minus `state` — which is
+# deliberately NOT here (see _patch_sprint_unit). Keyed by request field name,
+# valued by column name; the two differ for the role columns because a request
+# names a shell, not a shell_id.
+_UNIT_FIELDS = {
+    "unit_title": "unit_title",
+    "depends_on": "depends_on",
+    "branch": "branch",
+    "pr_number": "pr_number",
+}
+_UNIT_ROLES = {"dev": "dev_shell_id", "reviewer": "reviewer_shell_id"}
+_UNIT_STATES = ("pending", "working", "in_review", "blocked", "merged",
+                "cancelled")
+
+
+def _board_writer(con, sprint_doc_id: int) -> "int | None":
+    """The one shell allowed to move this sprint's board: the planner bound to
+    it. ONE definition — the alert delivery in U5 resolves the same question
+    and must call this rather than restate it.
+
+    The spec's rule reads "the binding's planner_shell_id, else the sprint
+    doc's author". The second clause is not implementable as written:
+    `documents` carries no author column at all (schema.sql:204), so there is
+    nothing to fall back TO. An unbound sprint therefore falls back to flavor
+    instead — see _may_write_board.
+    """
+    row = con.execute(
+        "SELECT planner_shell_id FROM sprint_planner_bindings "
+        "WHERE sprint_doc_id=? AND released_at IS NULL "
+        "ORDER BY binding_id DESC LIMIT 1", (sprint_doc_id,)).fetchone()
+    return row[0] if row is not None else None
+
+
+def _may_write_board(con, actor, sprint_doc_id: int):
+    """Devs and reviewers never write the board (FnB directive). This is not a
+    permission detail — a worker that could mark its own unit done would make
+    the board agree with reality BY CONSTRUCTION, and the reconciler's whole
+    value is the disagreement. Returns an error tuple, or None to allow."""
+    if actor.kind != "shell":
+        return None                       # the operator owns everything
+    bound = _board_writer(con, sprint_doc_id)
+    if bound is not None:
+        if actor.shell_id == bound:
+            return None
+        return _err(403, "not_the_planner",
+                    f"sprint {sprint_doc_id} is bound to planner shell "
+                    f"{bound} — only it writes this board; workers work and "
+                    "message, and the planner moves the board")
+    flavor = con.execute(
+        "SELECT flavor FROM shells WHERE shell_id=?",
+        (actor.shell_id,)).fetchone()
+    if flavor is not None and flavor[0] == "planner":
+        return None
+    return _err(403, "not_the_planner",
+                f"sprint {sprint_doc_id} has no armed binding and shell "
+                f"{actor.shell_id} is not a planner — only a planner writes "
+                "the board")
+
+
+def _resolve_shell(con, value):
+    """A role slot from a request: a shell_id, a shortname, or None to clear.
+    Raises _BadShell so a typo'd shortname is a 422 and never a silently
+    unassigned role — an empty role column is a state the reconciler reads as
+    "nobody is expected here"."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise _BadShell(f"not a shell reference: {value!r}")
+    if isinstance(value, int):
+        row = con.execute(
+            "SELECT shell_id FROM shells WHERE shell_id=? "
+            "AND COALESCE(is_deleted,0)=0", (value,)).fetchone()
+        if row is None:
+            raise _BadShell(f"no such shell: {value}")
+        return row[0]
+    if isinstance(value, str) and value.strip():
+        row = con.execute(
+            "SELECT shell_id FROM shells WHERE shortname=? COLLATE NOCASE "
+            "AND COALESCE(is_deleted,0)=0", (value.strip(),)).fetchone()
+        if row is None:
+            raise _BadShell(f"no such shell: {value.strip()!r}")
+        return row[0]
+    raise _BadShell(f"not a shell reference: {value!r}")
+
+
+class _BadShell(Exception):
+    pass
+
+
+_UNIT_COLS = (
+    "unit_id", "sprint_doc_id", "seq", "unit_title", "dev_shell_id",
+    "reviewer_shell_id", "state", "depends_on", "branch", "pr_number",
+    "assigned_at", "state_changed_at", "updated_at", "updated_by_shell_id")
+
+
+def _unit_projection(con, unit_id: int) -> dict:
+    row = con.execute(
+        f"SELECT {', '.join(_UNIT_COLS)} FROM sprint_units WHERE unit_id=?",
+        (unit_id,)).fetchone()
+    unit = dict(zip(_UNIT_COLS, row))
+    for role, col in _UNIT_ROLES.items():
+        name = None
+        if unit[col] is not None:
+            r = con.execute("SELECT shortname FROM shells WHERE shell_id=?",
+                            (unit[col],)).fetchone()
+            name = r[0] if r else None
+        unit[f"{role}_shortname"] = name
+    return unit
+
+
+def _sprint_units(actor, query: dict):
+    """GET /api/sprint-units?sprint_doc_id=N — the board, read. Every
+    participant reads it (it is the board they work from); only the planner
+    writes it."""
+    doc_id = _qint(query, "sprint_doc_id")
+    sql = "SELECT unit_id FROM sprint_units"
+    params = []
+    if doc_id is not None:
+        sql += " WHERE sprint_doc_id=?"
+        params.append(doc_id)
+    sql += " ORDER BY sprint_doc_id, seq"
+    con = _db()
+    try:
+        units = [_unit_projection(con, r[0])
+                 for r in con.execute(sql, params).fetchall()]
+        return _json(200, {"units": units})
+    finally:
+        con.close()
+
+
+def _add_sprint_unit(actor, headers, body):
+    """POST /api/sprint-units — declare one unit on a sprint's board.
+
+    Deliberately NOT an upsert, and its counterpart PATCH is deliberately not
+    a create: the natural key is (sprint_doc_id, seq) typed by hand, so a
+    typo'd seq on an edit must fail rather than mint a phantom unit that the
+    reconciler then expects a shell to be working on.
+    """
+    doc_id = body.get("sprint_doc_id")
+    seq = (body.get("seq") or "").strip() if isinstance(
+        body.get("seq"), str) else body.get("seq")
+    title = (body.get("unit_title") or "").strip()
+    if not isinstance(doc_id, int) or not isinstance(seq, str) or not seq \
+            or not title:
+        return _err(422, "validation",
+                    "sprint_doc_id (int), seq (non-empty str, e.g. 'U1'), "
+                    "unit_title (non-empty str) required")
+    state = body.get("state", "pending")
+    if state not in _UNIT_STATES:
+        return _err(422, "validation",
+                    f"state must be one of {', '.join(_UNIT_STATES)}")
+    con = _db()
+    try:
+        refusal = _may_write_board(con, actor, doc_id)
+        if refusal is not None:
+            return refusal
+
+        def produce():
+            if con.execute("SELECT 1 FROM documents WHERE document_id=?",
+                           (doc_id,)).fetchone() is None:
+                return 404, _err_obj("no_such_sprint",
+                                     f"no document {doc_id} to hold a board")
+            try:
+                roles = {col: _resolve_shell(con, body.get(role))
+                         for role, col in _UNIT_ROLES.items()}
+            except _BadShell as exc:
+                return 422, _err_obj("no_such_shell", str(exc))
+            try:
+                cur = con.execute(
+                    "INSERT INTO sprint_units "
+                    "(sprint_doc_id, seq, unit_title, dev_shell_id, "
+                    " reviewer_shell_id, state, depends_on, branch, "
+                    " pr_number, assigned_at, updated_by_shell_id) "
+                    "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                    (doc_id, seq, title, roles["dev_shell_id"],
+                     roles["reviewer_shell_id"], state,
+                     body.get("depends_on"), body.get("branch"),
+                     body.get("pr_number"),
+                     _now(con) if any(roles.values()) else None,
+                     actor.shell_id))
+            except db_driver.IntegrityError:
+                return 409, _err_obj(
+                    "unit_exists",
+                    f"sprint {doc_id} already has unit {seq} — edit it with "
+                    "PATCH rather than declaring it twice")
+            con.commit()
+            _log(f"sprint board: doc={doc_id} unit={seq} declared "
+                 f"by={actor.scope}")
+            return 201, _unit_projection(con, cur.lastrowid)
+
+        return _idempotent(con, actor, "sprint_unit_add", headers, body,
+                           produce)
+    finally:
+        con.close()
+
+
+def _now(con) -> str:
+    return con.execute("SELECT datetime('now')").fetchone()[0]
+
+
+def _patch_sprint_unit(actor, headers, body):
+    """PATCH /api/sprint-units — move one unit, addressed by its natural key
+    (sprint_doc_id, seq) in the body rather than a surrogate id in the path.
+    The planner types the key it reads off the board; resolving seq→unit_id
+    in the client would cost a second round trip that another planner edit
+    can interleave with.
+
+    A `state` move may not ride along with field edits. State is the only
+    column the reconciler derives ROLE EXPECTATION from, so it gets its own
+    call and `state_changed_at` gets exactly one writer — a planner can never
+    move what a worker is expected to be doing as a side effect of fixing a
+    branch name. `sc sprint unit state` is that call; the refusal here is
+    what makes the CLI's separation a property rather than a convention.
+    """
+    doc_id = body.get("sprint_doc_id")
+    seq = body.get("seq")
+    if not isinstance(doc_id, int) or not isinstance(seq, str) \
+            or not seq.strip():
+        return _err(422, "validation",
+                    "sprint_doc_id (int) and seq (str) address the unit")
+    seq = seq.strip()
+    edits = {f: body[f] for f in _UNIT_FIELDS if f in body}
+    roles = {r: body[r] for r in _UNIT_ROLES if r in body}
+    state = body.get("state")
+    if state is not None and (edits or roles):
+        return _err(422, "state_moves_alone",
+                    "a state move takes no other edits — move the state in "
+                    "its own call so state_changed_at has one writer")
+    if state is not None and state not in _UNIT_STATES:
+        return _err(422, "validation",
+                    f"state must be one of {', '.join(_UNIT_STATES)}")
+    if state is None and not edits and not roles:
+        return _err(422, "validation", "no fields to change")
+    if "unit_title" in edits and not (edits["unit_title"] or "").strip():
+        return _err(422, "validation", "unit_title cannot be cleared")
+    con = _db()
+    try:
+        refusal = _may_write_board(con, actor, doc_id)
+        if refusal is not None:
+            return refusal
+
+        def produce():
+            row = con.execute(
+                "SELECT unit_id, state, dev_shell_id, reviewer_shell_id "
+                "FROM sprint_units WHERE sprint_doc_id=? AND seq=?",
+                (doc_id, seq)).fetchone()
+            if row is None:
+                return 404, _err_obj(
+                    "no_such_unit",
+                    f"sprint {doc_id} has no unit {seq!r} — declare it with "
+                    "POST; an edit never creates one")
+            unit_id, was_state, was_dev, was_rev = row
+            sets, params = [], []
+            if state is not None:
+                sets.append("state=?")
+                params.append(state)
+                if state != was_state:
+                    # Only a REAL move restamps the clock. The no-progress
+                    # window resets on state change, so a re-assert of the
+                    # same state must not silently grant a stalled worker
+                    # another full window.
+                    sets.append("state_changed_at=datetime('now')")
+            try:
+                resolved = {_UNIT_ROLES[r]: _resolve_shell(con, v)
+                            for r, v in roles.items()}
+            except _BadShell as exc:
+                return 422, _err_obj("no_such_shell", str(exc))
+            for col, val in resolved.items():
+                sets.append(f"{col}=?")
+                params.append(val)
+            was = {"dev_shell_id": was_dev, "reviewer_shell_id": was_rev}
+            if any(was[c] != v for c, v in resolved.items()):
+                sets.append("assigned_at=datetime('now')")
+            for field, col in _UNIT_FIELDS.items():
+                if field in edits:
+                    sets.append(f"{col}=?")
+                    params.append(edits[field])
+            sets.append("updated_at=datetime('now')")
+            sets.append("updated_by_shell_id=?")
+            params.append(actor.shell_id)
+            con.execute(
+                f"UPDATE sprint_units SET {', '.join(sets)} WHERE unit_id=?",
+                (*params, unit_id))
+            con.commit()
+            _log(f"sprint board: doc={doc_id} unit={seq} moved "
+                 f"by={actor.scope} ({'state ' + state if state else 'fields'})")
+            return 200, _unit_projection(con, unit_id)
+
+        return _idempotent(con, actor, "sprint_unit_patch", headers, body,
+                           produce)
+    finally:
+        con.close()
+
+
 # ---------------------------------------------------------- action receipts
 
 def _begin_receipt(actor, headers, body):
@@ -2625,13 +2921,17 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
     # Shell actors (the planner's own API token) reach ONLY the sprint-wake
     # surfaces — bindings + wake ops + action receipts — never
     # session/writer/stop.
+    # sprint-units is in this set for READS by every participant — the board is
+    # what they work from. Its WRITES are fenced a second time, per sprint, in
+    # _may_write_board: reaching the route is not authority to move the board.
     if actor.kind == "shell" and not (
             p.startswith("/api/interface/sprint-bindings")
             or p.startswith("/api/interface/sprint-alerts")
+            or p.startswith("/api/sprint-units")
             or p.startswith("/api/planner-action-receipts")):
         return _err(403, "shell_scope",
                     "a shell token may call only sprint-binding, "
-                    "sprint-alert, and action-receipt routes")
+                    "sprint-alert, sprint-unit, and action-receipt routes")
     if method in ("POST", "DELETE", "PATCH", "PUT"):
         if not actor.csrf_ok:
             return _err(403, "csrf", "browser mutations need the session's "
@@ -2701,6 +3001,12 @@ def handle(method: str, path: str, headers_raw: str, body: bytes) -> tuple:
                 p, "api", "interface", "sprint-bindings", None) \
                 and method == "DELETE":
             return _release_binding(actor, headers, data, _path_id(p))
+        if p == "/api/sprint-units" and method == "GET":
+            return _sprint_units(actor, query)
+        if p == "/api/sprint-units" and method == "POST":
+            return _add_sprint_unit(actor, headers, data)
+        if p == "/api/sprint-units" and method == "PATCH":
+            return _patch_sprint_unit(actor, headers, data)
         if p == "/api/planner-action-receipts" and method == "POST":
             return _begin_receipt(actor, headers, data)
         if _route_shape(

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2251,19 +2251,64 @@ def _retry_binding(actor, headers, body, binding_id: int):
 # ------------------------------------------------------- the board as a record
 
 # The board's columns as the planner edits them, minus `state` — which is
-# deliberately NOT here (see _patch_sprint_unit). Keyed by request field name,
-# valued by column name; the two differ for the role columns because a request
-# names a shell, not a shell_id.
+# deliberately NOT here (see _patch_sprint_unit). Keyed by request field name
+# (identical to the column name), valued by the type the boundary demands and
+# whether an explicit null may clear it.
+#
+# ONE definition, because POST and PATCH both admit these fields and a second
+# statement of their shape would drift: the boundary that existed in `add` and
+# not in `set` is precisely how a numeric title 500'd on one route and a
+# textual pr_number landed in an INTEGER column on the other.
 _UNIT_FIELDS = {
-    "unit_title": "unit_title",
-    "depends_on": "depends_on",
-    "overlap": "overlap",
-    "branch": "branch",
-    "pr_number": "pr_number",
+    "unit_title": (str, False),
+    "depends_on": (str, True),
+    "overlap": (str, True),
+    "branch": (str, True),
+    "pr_number": (int, True),
 }
 _UNIT_ROLES = {"dev": "dev_shell_id", "reviewer": "reviewer_shell_id"}
 _UNIT_STATES = ("pending", "working", "in_review", "blocked", "merged",
                 "cancelled")
+
+
+def _is_int(value) -> bool:
+    """`True` is an `int` in Python, so a plain isinstance check would accept
+    `{"sprint_doc_id": true}` and address the board of document 1."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _bad_unit_field(body):
+    """Type-check every writable board field AT THE EDGE, before any of it can
+    reach a string method or an INTEGER column.
+
+    The board is a record of what a planner declared, and the reconciler acts
+    on what it is handed — so a field that lands holding something no planner
+    could have typed (a PR number that is text, a branch that is a number) is
+    belief corrupted quietly, which is worse than the 500 that the same input
+    produced on the other route. Returns an error response, or None to allow.
+    """
+    for field, (kind, clearable) in _UNIT_FIELDS.items():
+        if field not in body:
+            continue                      # omitted = leave alone, not clear
+        value = body[field]
+        if value is None:
+            if clearable:
+                continue
+            return _err(422, "validation", f"{field} cannot be cleared")
+        if kind is int and not _is_int(value):
+            return _err(422, "validation", f"{field} must be an integer or null")
+        if kind is str and not isinstance(value, str):
+            return _err(422, "validation",
+                        f"{field} must be a string"
+                        + (" or null" if clearable else ""))
+        if kind is str and not value.strip():
+            # A blank is not a value: an empty `branch` reads as a declared
+            # branch that is the empty string, which U3/U4 compare against the
+            # worktree. Retract it with an explicit null instead.
+            return _err(422, "validation",
+                        f"{field} cannot be blank"
+                        + (" — pass null to clear it" if clearable else ""))
+    return None
 
 
 def _board_writer(con, sprint_doc_id: int) -> "int | None":
@@ -2367,6 +2412,15 @@ def _sprint_units(actor, query: dict):
     participant reads it (it is the board they work from); only the planner
     writes it."""
     doc_id = _qint(query, "sprint_doc_id")
+    if query.get("sprint_doc_id", [None])[0] not in (None, "") \
+            and doc_id is None:
+        # _qint answers None for both "absent" and "unparseable", and the two
+        # mean opposite things here: absent asks for every board, unparseable
+        # would SILENTLY WIDEN to every board while the caller believes it
+        # asked about one sprint. A filter that fails open is worse than no
+        # filter, because the caller acts on units it never asked about.
+        return _err(422, "validation",
+                    "sprint_doc_id filter must be an integer")
     sql = "SELECT unit_id FROM sprint_units"
     params = []
     if doc_id is not None:
@@ -2391,14 +2445,18 @@ def _add_sprint_unit(actor, headers, body):
     reconciler then expects a shell to be working on.
     """
     doc_id = body.get("sprint_doc_id")
-    seq = (body.get("seq") or "").strip() if isinstance(
-        body.get("seq"), str) else body.get("seq")
-    title = (body.get("unit_title") or "").strip()
-    if not isinstance(doc_id, int) or not isinstance(seq, str) or not seq \
-            or not title:
+    seq = body.get("seq")
+    if not _is_int(doc_id) or not isinstance(seq, str) or not seq.strip():
         return _err(422, "validation",
-                    "sprint_doc_id (int), seq (non-empty str, e.g. 'U1'), "
-                    "unit_title (non-empty str) required")
+                    "sprint_doc_id (int) and seq (non-empty str, e.g. 'U1') "
+                    "required")
+    seq = seq.strip()
+    bad = _bad_unit_field(body)
+    if bad is not None:
+        return bad
+    if "unit_title" not in body:
+        return _err(422, "validation", "unit_title (non-empty str) required")
+    title = body["unit_title"].strip()
     state = body.get("state", "pending")
     if state not in _UNIT_STATES:
         return _err(422, "validation",
@@ -2468,11 +2526,13 @@ def _patch_sprint_unit(actor, headers, body):
     """
     doc_id = body.get("sprint_doc_id")
     seq = body.get("seq")
-    if not isinstance(doc_id, int) or not isinstance(seq, str) \
-            or not seq.strip():
+    if not _is_int(doc_id) or not isinstance(seq, str) or not seq.strip():
         return _err(422, "validation",
                     "sprint_doc_id (int) and seq (str) address the unit")
     seq = seq.strip()
+    bad = _bad_unit_field(body)
+    if bad is not None:
+        return bad
     edits = {f: body[f] for f in _UNIT_FIELDS if f in body}
     roles = {r: body[r] for r in _UNIT_ROLES if r in body}
     state = body.get("state")
@@ -2485,8 +2545,6 @@ def _patch_sprint_unit(actor, headers, body):
                     f"state must be one of {', '.join(_UNIT_STATES)}")
     if state is None and not edits and not roles:
         return _err(422, "validation", "no fields to change")
-    if "unit_title" in edits and not (edits["unit_title"] or "").strip():
-        return _err(422, "validation", "unit_title cannot be cleared")
     con = _db()
     try:
         refusal = _may_write_board(con, actor, doc_id)
@@ -2525,9 +2583,9 @@ def _patch_sprint_unit(actor, headers, body):
             was = {"dev_shell_id": was_dev, "reviewer_shell_id": was_rev}
             if any(was[c] != v for c, v in resolved.items()):
                 sets.append("assigned_at=datetime('now')")
-            for field, col in _UNIT_FIELDS.items():
+            for field in _UNIT_FIELDS:
                 if field in edits:
-                    sets.append(f"{col}=?")
+                    sets.append(f"{field}=?")
                     params.append(edits[field])
             sets.append("updated_at=datetime('now')")
             sets.append("updated_by_shell_id=?")

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -3173,7 +3173,8 @@ def dispatch_http(method: str, path: str, headers_raw: str,
     parsed = urlparse(path)
     if parsed.path.startswith("/api/interface/") or \
             parsed.path.startswith("/_sc/interface/") or \
-            parsed.path.startswith("/api/planner-action-receipts"):
+            parsed.path.startswith("/api/planner-action-receipts") or \
+            parsed.path.startswith("/api/sprint-units"):
         if interface_routes is None:
             return (503, [("Content-Type", "application/json")],
                     json.dumps({"error": {

--- a/.super-coder/migrations/0098_sprint_units.sql
+++ b/.super-coder/migrations/0098_sprint_units.sql
@@ -1,0 +1,80 @@
+-- 0098 — the sprint board becomes a record (spec doc 58 "The board becomes a
+-- record", feature 27, sprint doc 59 U1).
+--
+-- The worker expectation reconciler compares a declared belief about who
+-- should be doing what against machine-observable activity. Today it cannot,
+-- because the belief is a markdown table inside a `documents` body. Two
+-- consequences, both load-bearing:
+--
+--   1. There is no structured assignment surface that carries a REVIEWER.
+--      `spec_tasks` has exactly one `shell_id` and no reviewer column, so a
+--      reviewer assignment is not representable at all — which is why flag
+--      #185's instance 4 (a reviewer dead while the dev believed it was
+--      re-reviewing) is invisible to any comparator built on today's data.
+--      This is structural, not a data accident: no amount of task rows fixes
+--      a missing column.
+--   2. Unit state lives in a prose cell a planner edits by hand, so it can
+--      silently no-op the way a drifted string replace did.
+--
+-- So the unit table moves into the DB and the document keeps its prose. The
+-- record is the source; the rendered table is a view (`sc sprint board`),
+-- printed on demand and deliberately NOT written back into the body — a
+-- materialised copy would state the board twice, which is the drift this
+-- table exists to delete.
+--
+-- ── The planner is the only writer ──────────────────────────────────────────
+--
+-- FnB directive, and it is the whole point rather than a permission detail:
+-- devs and reviewers work and message, and the planner moves the board as
+-- their messages arrive. If a worker could mark its own unit done, the board
+-- would agree with reality BY CONSTRUCTION and the comparison this service is
+-- would have nothing to compare. Enforcement is at the API (the sprint's
+-- binding planner_shell_id, else the sprint document's author); this table
+-- records WHO moved belief in updated_by_shell_id so the write is attributable
+-- either way.
+--
+-- ── CURRENT STATE ONLY ──────────────────────────────────────────────────────
+--
+-- FnB ruling 2026-07-25: no state-change log. The board tells the story; a
+-- per-move audit trail is a table nobody would read. The cost is accepted
+-- knowingly and is recorded here so a later reader does not "fix" it: "when
+-- did belief and reality first diverge" is answerable only back to
+-- state_changed_at, and the alert rows carry the rest.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS sprint_units (
+    unit_id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_doc_id     INTEGER NOT NULL REFERENCES documents(document_id),
+    -- TEXT, not INTEGER: every message, board and task row in a sprint names
+    -- its unit "U1". An integer column would force a lossy strip at each of
+    -- them, and the reconciler keys on what the planner typed.
+    seq               TEXT    NOT NULL,
+    unit_title        TEXT    NOT NULL,
+    -- BOTH roles, as records. dev_shell_id alone is what today's surface
+    -- already has; reviewer_shell_id is the gap that blocked everything.
+    -- Both are nullable because an unassigned slot is a real board state
+    -- (the planner declares the units, then fills the roles).
+    dev_shell_id      INTEGER REFERENCES shells(shell_id),
+    reviewer_shell_id INTEGER REFERENCES shells(shell_id),
+    state             TEXT    NOT NULL DEFAULT 'pending'
+                      CHECK (state IN ('pending','working','in_review',
+                                       'blocked','merged','cancelled')),
+    -- The units this one waits on, as the board writes them ("U1,U3"). A join
+    -- table would buy graph traversal that nothing in this service performs.
+    depends_on        TEXT,
+    branch            TEXT,
+    pr_number         INTEGER,
+    assigned_at       TEXT,
+    state_changed_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at        TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_by_shell_id INTEGER REFERENCES shells(shell_id),
+    UNIQUE (sprint_doc_id, seq)
+);
+
+-- The reconciler's per-tick read is "the non-terminal units of an ACTIVE
+-- sprint" — its trigger condition, and the one query it runs every 60s.
+CREATE INDEX IF NOT EXISTS idx_sprint_units_live
+    ON sprint_units(sprint_doc_id, state);
+
+COMMIT;

--- a/.super-coder/migrations/0098_sprint_units.sql
+++ b/.super-coder/migrations/0098_sprint_units.sql
@@ -63,6 +63,16 @@ CREATE TABLE IF NOT EXISTS sprint_units (
     -- The units this one waits on, as the board writes them ("U1,U3"). A join
     -- table would buy graph traversal that nothing in this service performs.
     depends_on        TEXT,
+    -- The merge-surface annotation the markdown board carries in the SAME cell
+    -- as the dependency — "owns migration 0098; schema.sql + scripts/sprint.py",
+    -- "shares SKILL.md with U8 — MUST rebase onto merged U2". It is load-bearing
+    -- prose, not decoration: the merge protocol turns on whether a unit's head
+    -- can stand or must rebase, and that is the only place the answer is
+    -- written. Storing the comma list alone would make this table hold LESS than
+    -- the markdown it replaces — a lossy migration rather than a fix. Free text
+    -- deliberately: nothing parses it, a planner writes it for a human to read,
+    -- and `sc sprint board` renders it beside depends_on in one cell.
+    overlap           TEXT,
     branch            TEXT,
     pr_number         INTEGER,
     assigned_at       TEXT,

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -568,6 +568,7 @@ CREATE TABLE sprint_units (
                       CHECK (state IN ('pending','working','in_review',
                                        'blocked','merged','cancelled')),
     depends_on        TEXT,               -- "U1,U3" as the board writes it
+    overlap           TEXT,               -- the merge-surface annotation sharing that cell ("shares X with U8 — MUST rebase"); load-bearing prose, rendered beside depends_on
     branch            TEXT,
     pr_number         INTEGER,
     assigned_at       TEXT,

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -545,6 +545,38 @@ CREATE TABLE planner_alerts (
     resolved_at TEXT
 );
 
+-- ── The sprint board, as a record (spec doc 58; migrations/0098_sprint_units) ─
+-- The planner's declared belief about who should be doing what. It was a
+-- markdown table inside a documents body, which carried no reviewer at all
+-- (spec_tasks has one shell_id) — so a dead REVIEWER was invisible to any
+-- comparator. The document keeps its prose; this table is the source and the
+-- table `sc sprint board` prints is a view of it, never a copy stored back.
+--
+-- THE PLANNER IS THE ONLY WRITER (API-enforced: the sprint's binding
+-- planner_shell_id, else the doc author). A worker marking its own unit done
+-- would make the board agree with reality by construction and destroy the
+-- comparison the reconciler is. CURRENT STATE ONLY — no change log, FnB ruling.
+
+CREATE TABLE sprint_units (
+    unit_id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_doc_id     INTEGER NOT NULL REFERENCES documents(document_id),
+    seq               TEXT    NOT NULL,   -- "U1" verbatim, as every message names it
+    unit_title        TEXT    NOT NULL,
+    dev_shell_id      INTEGER REFERENCES shells(shell_id),
+    reviewer_shell_id INTEGER REFERENCES shells(shell_id),
+    state             TEXT    NOT NULL DEFAULT 'pending'
+                      CHECK (state IN ('pending','working','in_review',
+                                       'blocked','merged','cancelled')),
+    depends_on        TEXT,               -- "U1,U3" as the board writes it
+    branch            TEXT,
+    pr_number         INTEGER,
+    assigned_at       TEXT,
+    state_changed_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at        TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_by_shell_id INTEGER REFERENCES shells(shell_id),
+    UNIQUE (sprint_doc_id, seq)
+);
+
 -- Transition validators — the DB backstop (app pre-checks for friendly
 -- errors via scripts/interface_state.py; keep the edge sets in sync).
 
@@ -776,3 +808,8 @@ CREATE INDEX idx_ppo_watch
     ON pr_poll_observations(watch_id, observed_at);
 CREATE UNIQUE INDEX idx_planner_alerts_open
     ON planner_alerts(dedupe_key) WHERE resolved_at IS NULL;
+
+-- The board record (0098) — the reconciler's per-tick read is "the
+-- non-terminal units of an ACTIVE sprint".
+CREATE INDEX idx_sprint_units_live
+    ON sprint_units(sprint_doc_id, state);

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -95,6 +95,14 @@ PER_INSTANCE_TABLES = [
     "planner_action_receipts",
     "pr_poll_observations",
     "planner_alerts",
+    # sprint_units (0098) is the planner's AUTHORED board — the declared belief
+    # about who should be doing what — not a derived cache: nothing re-derives
+    # it, so a mid-sprint rebuild without it drops the whole sprint's state and
+    # leaves the reconciler with nothing to compare against. Same class as
+    # watched_prs/flags, and unlike the quota tables (0096) which a probe
+    # rebuilds. Loads after `shells` and `documents`, both its FK targets. No
+    # row filter: every unit row is durable planner content, terminal or not.
+    "sprint_units",
     # NOTE: dr_section is authored navigation but lives in the MAP DB now
     # (.sc-state/map.db), not shell_db.db — it is serialized separately to
     # .sc-state/map_content.sql by snapshot_map() below, not here.

--- a/.super-coder/scripts/sprint.py
+++ b/.super-coder/scripts/sprint.py
@@ -153,6 +153,8 @@ def _unit_body(args, *, creating: bool) -> dict:
             body[name] = _role(getattr(args, name))
     if args.depends_on is not None:
         body["depends_on"] = _field(args.depends_on)
+    if args.overlap is not None:
+        body["overlap"] = _field(args.overlap)
     if args.branch is not None:
         body["branch"] = _field(args.branch)
     if args.pr is not None:
@@ -160,12 +162,24 @@ def _unit_body(args, *, creating: bool) -> dict:
     return body
 
 
+def _depends_cell(u: dict) -> str:
+    """The board's "depends on" cell — the machine-readable dependency and the
+    human-readable merge-surface annotation share it, exactly as the markdown
+    board writes it today ("— · owns migration 0098; schema.sql"). Two columns,
+    one cell: the annotation is how a dev knows whether its head can stand or
+    must rebase, so dropping it from the render would lose what the record was
+    widened to keep."""
+    dep = u.get("depends_on") or "—"
+    return f"{dep} · {u['overlap']}" if u.get("overlap") else dep
+
+
 def _print_unit(u: dict) -> None:
     roles = (f"dev={u.get('dev_shortname') or '—'} "
              f"rev={u.get('reviewer_shortname') or '—'}")
     extra = " ".join(
         p for p in (
-            f"depends={u['depends_on']}" if u.get("depends_on") else "",
+            f"depends={_depends_cell(u)}"
+            if (u.get("depends_on") or u.get("overlap")) else "",
             f"branch={u['branch']}" if u.get("branch") else "",
             f"pr=#{u['pr_number']}" if u.get("pr_number") else "")
         if p)
@@ -240,7 +254,7 @@ def cmd_board(args) -> int:
                   seq=u["seq"], title=u["unit_title"],
                   dev=u.get("dev_shortname") or "—",
                   rev=u.get("reviewer_shortname") or "—",
-                  dep=u.get("depends_on") or "—",
+                  dep=_depends_cell(u),
                   branch=u.get("branch") or "—",
                   pr=f"#{u['pr_number']}" if u.get("pr_number") else "—",
                   state=u["state"]))
@@ -378,6 +392,11 @@ def main(argv: "list[str] | None" = None) -> int:
                                  "unit ('none' to clear the slot)")
         sp.add_argument("--depends-on", dest="depends_on", default=None,
                         help="units this one waits on, e.g. U1,U3 "
+                             "('none' to clear)")
+        sp.add_argument("--overlap", default=None,
+                        help="the merge-surface annotation sharing the "
+                             "'depends on' cell, e.g. 'shares schema.sql with "
+                             "U5 — MUST rebase onto merged U2' "
                              "('none' to clear)")
         sp.add_argument("--branch", default=None, help="('none' to clear)")
         sp.add_argument("--pr", type=int, default=None,

--- a/.super-coder/scripts/sprint.py
+++ b/.super-coder/scripts/sprint.py
@@ -6,9 +6,30 @@ sprint 25 seq 8 task #84; wake ops seq 10 task #86).
     ./sc sprint action complete  <receipt_id> [--detail "…"]
     ./sc sprint action unknown   <receipt_id> [--detail "…"]
     ./sc sprint action reconcile <receipt_id> [--detail "…"]
+    ./sc sprint unit add   --sprint <doc-id> --seq U1 --title "…" [roles/fields]
+    ./sc sprint unit set   --sprint <doc-id> --seq U1 [roles/fields]
+    ./sc sprint unit state --sprint <doc-id> --seq U1 <state>
+    ./sc sprint unit list  [--sprint <doc-id>]
+    ./sc sprint board      --sprint <doc-id>
     ./sc sprint status  [--sprint <doc-id>] [--all]
     ./sc sprint alerts  [--all]
     ./sc sprint retry   --binding <id> [--outcome delivered|not_delivered]
+
+The BOARD is a record, not a markdown table a planner edits by hand (spec
+doc 58). The planner is its only writer — devs and reviewers work and
+message, and the planner moves the board as their messages arrive; a worker
+that could mark its own unit done would make the board agree with reality by
+construction and leave the reconciler nothing to compare. Workers read it
+freely (`unit list` / `board`); their writes are refused per sprint.
+
+`unit state` is a separate verb from `unit set` on purpose: state is the only
+column role expectation derives from, so it moves in its own call and
+`state_changed_at` has exactly one writer. The API refuses a state move that
+carries other edits — the separation is a property, not a convention.
+
+`board` RENDERS the unit table from the record and prints it. It does not
+write it back into the document: the document keeps its prose, the record is
+the source, and a stored copy would state the board twice.
 
 Before a planner performs an engine-owned or external side effect for a
 message it records action INTENT (begin) under a key derived from
@@ -102,6 +123,127 @@ def _cmd_update(args, state: str) -> int:
              {"state": state, "result_detail": args.detail},
              f"action-update|{args.receipt_id}|{state}")
     print(f"sc sprint: receipt #{r['receipt_id']} → {r['state']}")
+    return 0
+
+
+# ── the board as a record (spec doc 58 U1): unit add/set/state/list, board ──
+
+_STATES = ("pending", "working", "in_review", "blocked", "merged",
+           "cancelled")
+
+
+def _role(value: "str | None"):
+    """A --dev/--reviewer argument: a shortname, or the literal 'none' to
+    clear the slot. Absent (None) leaves the slot untouched — the API
+    distinguishes an omitted field from an explicit null, so clearing a role
+    must be said out loud."""
+    return None if value is not None and value.lower() == "none" else value
+
+
+def _field(value: "str | None"):
+    return None if value is not None and value.lower() == "none" else value
+
+
+def _unit_body(args, *, creating: bool) -> dict:
+    body = {"sprint_doc_id": args.sprint, "seq": args.seq}
+    if creating or args.title is not None:
+        body["unit_title"] = args.title
+    for name in ("dev", "reviewer"):
+        if getattr(args, name) is not None:
+            body[name] = _role(getattr(args, name))
+    if args.depends_on is not None:
+        body["depends_on"] = _field(args.depends_on)
+    if args.branch is not None:
+        body["branch"] = _field(args.branch)
+    if args.pr is not None:
+        body["pr_number"] = None if args.pr < 0 else args.pr
+    return body
+
+
+def _print_unit(u: dict) -> None:
+    roles = (f"dev={u.get('dev_shortname') or '—'} "
+             f"rev={u.get('reviewer_shortname') or '—'}")
+    extra = " ".join(
+        p for p in (
+            f"depends={u['depends_on']}" if u.get("depends_on") else "",
+            f"branch={u['branch']}" if u.get("branch") else "",
+            f"pr=#{u['pr_number']}" if u.get("pr_number") else "")
+        if p)
+    print(f"{u['seq']:<5} [{u['state']}] {u['unit_title']} · {roles}"
+          + (f" · {extra}" if extra else ""))
+
+
+def cmd_unit_add(args) -> int:
+    body = _unit_body(args, creating=True)
+    if args.state:
+        body["state"] = args.state
+    r = _api("POST", "/api/sprint-units", body,
+             f"unit-add|{args.sprint}|{args.seq}")
+    print(f"sc sprint: unit {r['seq']} declared on sprint "
+          f"{r['sprint_doc_id']}")
+    _print_unit(r)
+    return 0
+
+
+def cmd_unit_set(args) -> int:
+    body = _unit_body(args, creating=False)
+    if len(body) == 2:
+        raise _die("nothing to set — pass at least one of --title, --dev, "
+                   "--reviewer, --depends-on, --branch, --pr "
+                   "(state moves with `unit state`)")
+    r = _api("PATCH", "/api/sprint-units", body,
+             f"unit-set|{args.sprint}|{args.seq}|{uuid.uuid4()}")
+    _print_unit(r)
+    return 0
+
+
+def cmd_unit_state(args) -> int:
+    r = _api("PATCH", "/api/sprint-units",
+             {"sprint_doc_id": args.sprint, "seq": args.seq,
+              "state": args.state},
+             f"unit-state|{args.sprint}|{args.seq}|{args.state}|"
+             f"{uuid.uuid4()}")
+    _print_unit(r)
+    return 0
+
+
+def _units(sprint: "int | None") -> list:
+    path = "/api/sprint-units"
+    if sprint is not None:
+        path += f"?sprint_doc_id={sprint}"
+    return _api("GET", path).get("units", [])
+
+
+def cmd_unit_list(args) -> int:
+    units = _units(args.sprint)
+    if not units:
+        print("sc sprint: no units on the board"
+              + (f" for sprint {args.sprint}" if args.sprint else ""))
+        return 0
+    for u in units:
+        _print_unit(u)
+    return 0
+
+
+def cmd_board(args) -> int:
+    """Render the board from the record. A VIEW — printed, never stored back
+    into the document body."""
+    units = _units(args.sprint)
+    if not units:
+        print(f"sc sprint: sprint {args.sprint} has no units on record")
+        return 0
+    print("| seq | unit | dev | reviewer | depends on | branch | pr | state |")
+    print("|---|---|---|---|---|---|---|---|")
+    for u in units:
+        print("| {seq} | {title} | {dev} | {rev} | {dep} | {branch} | {pr} "
+              "| {state} |".format(
+                  seq=u["seq"], title=u["unit_title"],
+                  dev=u.get("dev_shortname") or "—",
+                  rev=u.get("reviewer_shortname") or "—",
+                  dep=u.get("depends_on") or "—",
+                  branch=u.get("branch") or "—",
+                  pr=f"#{u['pr_number']}" if u.get("pr_number") else "—",
+                  state=u["state"]))
     return 0
 
 
@@ -218,6 +360,52 @@ def main(argv: "list[str] | None" = None) -> int:
         sp.add_argument("receipt_id", type=int)
         sp.add_argument("--detail", default=None)
         sp.set_defaults(_state=state)
+    un = sub.add_parser("unit", help="the sprint board record — declare, "
+                                     "reassign, and move units (planner "
+                                     "writes; anyone reads)")
+    usub = un.add_subparsers(dest="unit_cmd", required=True)
+
+    def _roles_and_fields(sp, *, creating: bool):
+        sp.add_argument("--sprint", type=int, required=True,
+                        help="the sprint document id")
+        sp.add_argument("--seq", required=True,
+                        help="the unit, as the board names it (e.g. U1)")
+        sp.add_argument("--title", required=creating, default=None,
+                        help="the unit's one-line name")
+        for role, who in (("dev", "builds"), ("reviewer", "reviews")):
+            sp.add_argument(f"--{role}", default=None,
+                            help=f"shortname of the shell that {who} this "
+                                 "unit ('none' to clear the slot)")
+        sp.add_argument("--depends-on", dest="depends_on", default=None,
+                        help="units this one waits on, e.g. U1,U3 "
+                             "('none' to clear)")
+        sp.add_argument("--branch", default=None, help="('none' to clear)")
+        sp.add_argument("--pr", type=int, default=None,
+                        help="PR number (-1 to clear)")
+
+    ua = usub.add_parser("add", help="declare a unit on the board (never an "
+                                     "upsert — an existing seq is a 409)")
+    _roles_and_fields(ua, creating=True)
+    ua.add_argument("--state", choices=_STATES, default=None,
+                    help="initial state (default pending)")
+    us = usub.add_parser("set", help="edit a unit's roles/fields — NOT its "
+                                     "state (see `unit state`)")
+    _roles_and_fields(us, creating=False)
+    ust = usub.add_parser("state", help="move one unit's state; takes no "
+                                        "other edits, so state_changed_at "
+                                        "has exactly one writer")
+    ust.add_argument("--sprint", type=int, required=True)
+    ust.add_argument("--seq", required=True)
+    ust.add_argument("state", choices=_STATES)
+    ul = usub.add_parser("list", help="the board's units, one line each "
+                                      "(read-only)")
+    ul.add_argument("--sprint", type=int, default=None)
+
+    bd = sub.add_parser("board", help="render the unit table from the record "
+                                      "(a VIEW — never written back into the "
+                                      "document)")
+    bd.add_argument("--sprint", type=int, required=True)
+
     st = sub.add_parser("status", help="wake status: binding, batch, park, "
                                        "last outcome (read-only)")
     st.add_argument("--sprint", type=int, default=None,
@@ -240,6 +428,12 @@ def main(argv: "list[str] | None" = None) -> int:
         if args.action_cmd == "begin":
             return cmd_begin(args)
         return _cmd_update(args, args._state)
+    if args.cmd == "unit":
+        return {"add": cmd_unit_add, "set": cmd_unit_set,
+                "state": cmd_unit_state, "list": cmd_unit_list}[
+                    args.unit_cmd](args)
+    if args.cmd == "board":
+        return cmd_board(args)
     if args.cmd == "status":
         return cmd_status(args)
     if args.cmd == "alerts":

--- a/sc
+++ b/sc
@@ -1510,8 +1510,8 @@ super-coder — forkable shell substrate
   ./sc sprint action <cmd>  planner action receipts over the API: begin (--message/--operation/--target) records
                              intent before a side effect; complete|unknown|reconcile <receipt_id> records the result
   ./sc sprint unit <cmd>   the sprint board, as a record: add declares a unit (--sprint/--seq/--title, plus
-                             --dev/--reviewer/--depends-on/--branch/--pr; an existing seq is a 409, never an
-                             upsert); set edits those fields but NOT state; state <s> moves one unit alone
+                             --dev/--reviewer/--depends-on/--overlap/--branch/--pr; an existing seq is a 409,
+                             never an upsert); set edits those fields but NOT state; state <s> moves one unit alone
                              (pending|working|in_review|blocked|merged|cancelled) and restamps
                              state_changed_at only when the state actually changes; list reads it.
                              WRITES are the planner's: the shell bound to that sprint, or — when no binding

--- a/sc
+++ b/sc
@@ -1509,6 +1509,16 @@ super-coder — forkable shell substrate
                              own credential, so pasting a token by hand is no longer the everyday sign-in
   ./sc sprint action <cmd>  planner action receipts over the API: begin (--message/--operation/--target) records
                              intent before a side effect; complete|unknown|reconcile <receipt_id> records the result
+  ./sc sprint unit <cmd>   the sprint board, as a record: add declares a unit (--sprint/--seq/--title, plus
+                             --dev/--reviewer/--depends-on/--branch/--pr; an existing seq is a 409, never an
+                             upsert); set edits those fields but NOT state; state <s> moves one unit alone
+                             (pending|working|in_review|blocked|merged|cancelled) and restamps
+                             state_changed_at only when the state actually changes; list reads it.
+                             WRITES are the planner's: the shell bound to that sprint, or — when no binding
+                             is armed — any shell of planner flavor; every other shell is refused 403 and
+                             reads freely. 'none' clears a role or field (--pr -1)
+  ./sc sprint board        render the unit table from the record and print it (--sprint <doc-id>) — a VIEW,
+                             never written back into the document body; the doc keeps its prose
   ./sc sprint status       wake status per binding: armed/released, sprint ACTIVE/frozen, batch state,
                              last outcome, park/quarantine reason (--sprint <doc-id>, --all incl. released)
   ./sc sprint alerts       open wake alerts — session-loss, retries-exhausted, quarantine, unmanaged-writer

--- a/tests/test_sprint_board_record.py
+++ b/tests/test_sprint_board_record.py
@@ -390,6 +390,36 @@ class BoardRecordTest(unittest.TestCase):
             con.close()
         self.assertEqual(body, DOC_BODY)
 
+    def test_the_merge_surface_annotation_survives_and_renders(self):
+        """The markdown board's "depends on" cell carries prose beside the
+        dependency — "shares SKILL.md with U8 — MUST rebase onto merged U2" —
+        and the merge protocol turns on it. A record storing only the comma
+        list would hold LESS than the markdown it replaces, which makes this
+        unit a lossy migration rather than a fix."""
+        note = "shares schema.sql + scripts/sprint.py with U5 — MUST rebase"
+        self.add(seq="U5", unit_title="alerts + delivery", depends_on="U4",
+                 overlap=note)
+        self.assertEqual(self.row("U5")["overlap"], note)
+        _s, out = self.call("GET", "/api/sprint-units?sprint_doc_id=1", (OP,))
+        buf = io.StringIO()
+        with mock.patch.object(sprint_cli, "_api", return_value=out), \
+                redirect_stdout(buf):
+            sprint_cli.cmd_board(mock.Mock(sprint=1))
+        self.assertIn(f"| U4 · {note} |", buf.getvalue())
+
+    def test_an_annotation_without_a_dependency_still_renders(self):
+        """Wave 1's units depend on nothing and carry the annotation anyway —
+        doc 59's own U1 row reads "— · owns migration 0098". An empty
+        dependency must not swallow the note."""
+        self.add(seq="U1", overlap="owns migration 0098; schema.sql")
+        _s, out = self.call("GET", "/api/sprint-units?sprint_doc_id=1", (OP,))
+        buf = io.StringIO()
+        with mock.patch.object(sprint_cli, "_api", return_value=out), \
+                redirect_stdout(buf):
+            sprint_cli.cmd_board(mock.Mock(sprint=1))
+        self.assertIn("| — · owns migration 0098; schema.sql |",
+                      buf.getvalue())
+
     def test_rendered_board_reports_the_record_including_the_reviewer(self):
         """`sc sprint board` is a projection of the record. It renders what
         the record says — both roles — not what a document body remembers."""

--- a/tests/test_sprint_board_record.py
+++ b/tests/test_sprint_board_record.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""The sprint board as a record — migration 0098 + /api/sprint-units + the
+`sc sprint unit|board` verbs (spec doc 58 "The board becomes a record",
+feature 27, sprint doc 59 U1).
+
+Every test here pins a decision that a plausible tidy-up would undo, and the
+two that matter most are not about happy-path CRUD:
+
+- THE REVIEWER COLUMN IS THE UNIT. `spec_tasks` carries one `shell_id` and no
+  reviewer, which is why a dead reviewer (flag #185 instance 4) is invisible
+  to any comparator built on today's data. A board that stored only the dev
+  would pass every CRUD test ever written and still ship the original defect.
+- WORKERS DO NOT WRITE THE BOARD. Not a permission nicety: a worker that
+  could mark its own unit done would make the board agree with reality BY
+  CONSTRUCTION, and the reconciler's entire value is the disagreement. So the
+  refusal is asserted together with the row being UNMOVED — a 403 that still
+  wrote would satisfy a status-code-only test.
+
+The rest pin the edges where belief gets corrupted quietly rather than
+loudly: an edit that creates a phantom unit, a declaration that overwrites a
+live one, a typo'd shortname that leaves a role silently empty (which the
+reconciler reads as "nobody is expected here" — a wrong answer that looks
+like a correct one), a state re-assert that hands a stalled worker a fresh
+detection window, and a state move smuggled in beside a branch rename.
+
+Run:
+    python3 tests/test_sprint_board_record.py
+"""
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+import interface_routes as routes  # noqa: E402
+import interface_wake  # noqa: E402
+import sprint as sprint_cli  # noqa: E402
+
+OP = "Authorization: Bearer optok"
+PLANNER = "Authorization: Bearer plntok"      # shell 9, flavor planner
+PLANNER2 = "Authorization: Bearer pln2tok"    # shell 10, flavor planner
+DEV = "Authorization: Bearer devtok"          # shell 11, flavor dev
+REVIEWER = "Authorization: Bearer revtok"     # shell 8, flavor reviewer
+
+DOC_BODY = "# SPRINT: test\nstatus: ACTIVE\n\nprose the record never touches\n"
+
+
+def build_engine_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute(
+        "INSERT INTO users (user_id, username, is_active) VALUES (1,'T',1)")
+    for sid, short, flavor, key in (
+            (8, "REV2", "reviewer", "revtok"),
+            (9, "PLN1", "planner", "plntok"),
+            (10, "PLN2", "planner", "pln2tok"),
+            (11, "DEV5", "dev", "devtok")):
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, flavor, "
+            "mandate, system_prompt, user_id, api_key, is_shared, "
+            "has_identity, bootstrapped) "
+            "VALUES (?,?,?,?,'test','sp',1,?,0,1,1)",
+            (sid, f"S{sid}", short, flavor, key))
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title, body) "
+        "VALUES (1,'doc','SPRINT: test',?)", (DOC_BODY,))
+    con.commit()
+    con.close()
+
+
+def hdrs(*lines) -> str:
+    return "\r\n".join(("Host: 127.0.0.1:8800", *lines))
+
+
+class _NoCoordinator:
+    def notify_binding(self, binding_id):
+        pass
+
+    def notify_message(self, message_id):
+        pass
+
+    def notify_session(self, session_id):
+        pass
+
+
+class BoardRecordTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db_path = self.tmp / "shell_db.db"
+        build_engine_db(self.db_path)
+        run_dir = self.tmp / "run" / "interface"
+        run_dir.mkdir(parents=True)
+        self.patches = [
+            mock.patch.object(routes, "DB_PATH", self.db_path),
+            mock.patch.object(routes, "RUN_DIR", run_dir),
+            mock.patch.object(routes, "OPERATOR_TOKEN_PATH",
+                              run_dir / "operator.token"),
+        ]
+        for p in self.patches:
+            p.start()
+        (run_dir / "operator.token").write_text("optok")
+        interface_wake.bind(_NoCoordinator())
+        self._keys = 0
+
+    def tearDown(self):
+        interface_wake.bind(None)
+        for p in self.patches:
+            p.stop()
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # -- helpers -------------------------------------------------------------
+
+    def call(self, method, path, header_lines=(), body=None):
+        self._keys += 1
+        lines = list(header_lines)
+        if method != "GET":
+            lines.append(f"Idempotency-Key: k{self._keys}")
+        payload = json.dumps(body).encode() if body is not None else b""
+        status, _h, resp = routes.handle(method, path, hdrs(*lines), payload)
+        return status, json.loads(resp or b"{}")
+
+    def add(self, who=(OP,), **body):
+        body.setdefault("sprint_doc_id", 1)
+        body.setdefault("seq", "U1")
+        body.setdefault("unit_title", "board record")
+        return self.call("POST", "/api/sprint-units", who, body)
+
+    def patch(self, who=(OP,), **body):
+        body.setdefault("sprint_doc_id", 1)
+        body.setdefault("seq", "U1")
+        return self.call("PATCH", "/api/sprint-units", who, body)
+
+    def row(self, seq="U1"):
+        con = sqlite3.connect(self.db_path)
+        con.row_factory = sqlite3.Row
+        try:
+            r = con.execute("SELECT * FROM sprint_units WHERE seq=?",
+                            (seq,)).fetchone()
+            return dict(r) if r is not None else None
+        finally:
+            con.close()
+
+    def sql(self, stmt, params=()):
+        con = sqlite3.connect(self.db_path)
+        try:
+            con.execute(stmt, params)
+            con.commit()
+        finally:
+            con.close()
+
+    def arm_binding(self, planner_shell_id=9):
+        """A live binding for that planner. `session_id` is NOT NULL, so the
+        binding needs a generation + session behind it — written directly
+        rather than through the arm route, which additionally demands a
+        hook-capable harness this test has no opinion about."""
+        con = sqlite3.connect(self.db_path)
+        try:
+            con.execute(
+                "INSERT INTO interface_generations (shell_id, generation) "
+                "VALUES (?,1)", (planner_shell_id,))
+            sid = con.execute(
+                "INSERT INTO interface_sessions (shell_id, generation, "
+                "occupancy, lifecycle, harness, cli_version) "
+                "VALUES (?,1,'occupied','idle','kimi','kimi-code 0.27.0')",
+                (planner_shell_id,)).lastrowid
+            con.execute(
+                "INSERT INTO sprint_planner_bindings (sprint_doc_id, "
+                "planner_shell_id, session_id, shell_id, generation) "
+                "VALUES (1,?,?,?,1)",
+                (planner_shell_id, sid, planner_shell_id))
+            con.commit()
+        finally:
+            con.close()
+
+    # -- the reviewer column: the whole point of the unit ---------------------
+
+    def test_both_roles_are_records_and_resolve_to_shells(self):
+        """The gap that blocked everything: a reviewer assignment must be
+        REPRESENTABLE and readable. A board carrying only the dev passes
+        ordinary CRUD tests and still leaves a dead reviewer invisible."""
+        status, unit = self.add(dev="DEV5", reviewer="REV2")
+        self.assertEqual(status, 201, unit)
+        self.assertEqual(unit["dev_shell_id"], 11)
+        self.assertEqual(unit["reviewer_shell_id"], 8)
+        self.assertEqual(unit["dev_shortname"], "DEV5")
+        self.assertEqual(unit["reviewer_shortname"], "REV2")
+        # and durably, not just in the response projection
+        self.assertEqual(self.row()["reviewer_shell_id"], 8)
+
+    def test_reviewer_is_queryable_as_an_expected_role(self):
+        """What U4 will actually run: 'who is expected on this sprint'. The
+        reviewer must come back from a query over the RECORD, which is
+        impossible against spec_tasks' single shell_id."""
+        self.add(seq="U1", dev="DEV5", reviewer="REV2")
+        self.add(seq="U2", dev="DEV5", reviewer="REV2")
+        con = sqlite3.connect(self.db_path)
+        try:
+            found = con.execute(
+                "SELECT COUNT(*) FROM sprint_units "
+                "WHERE reviewer_shell_id=8 AND state NOT IN "
+                "('merged','cancelled')").fetchone()[0]
+        finally:
+            con.close()
+        self.assertEqual(found, 2)
+
+    # -- workers never write the board ---------------------------------------
+
+    def test_dev_cannot_declare_a_unit_and_nothing_is_written(self):
+        self.arm_binding()
+        status, err = self.add((DEV,), seq="U9")
+        self.assertEqual(status, 403)
+        self.assertEqual(err["error"]["code"], "not_the_planner")
+        self.assertIsNone(self.row("U9"), "the refused write still landed")
+
+    def test_dev_cannot_move_its_own_unit_to_merged(self):
+        """The failure this whole service exists to prevent: a worker marking
+        its own unit done makes the board agree with reality by construction.
+        The refusal is worthless unless the state is genuinely unmoved."""
+        self.arm_binding()
+        self.add(dev="DEV5", reviewer="REV2")
+        status, err = self.patch((DEV,), state="merged")
+        self.assertEqual(status, 403)
+        self.assertEqual(err["error"]["code"], "not_the_planner")
+        self.assertEqual(self.row()["state"], "pending")
+
+    def test_reviewer_cannot_write_the_board_either(self):
+        self.arm_binding()
+        self.add(dev="DEV5", reviewer="REV2")
+        status, _ = self.patch((REVIEWER,), state="in_review")
+        self.assertEqual(status, 403)
+        self.assertEqual(self.row()["state"], "pending")
+
+    def test_workers_read_the_board_freely(self):
+        """Read is not the fence. Every participant works from this board;
+        blocking their reads would just push them back to parsing prose."""
+        self.add(dev="DEV5", reviewer="REV2")
+        for who in (DEV, REVIEWER):
+            status, out = self.call("GET", "/api/sprint-units?sprint_doc_id=1",
+                                    (who,))
+            self.assertEqual(status, 200)
+            self.assertEqual(len(out["units"]), 1)
+            self.assertEqual(out["units"][0]["reviewer_shortname"], "REV2")
+
+    def test_bound_planner_writes_and_another_planner_does_not(self):
+        """The binding names ONE planner. A second planner shell — running its
+        own sprint next door — is not an authority on this board."""
+        self.arm_binding(planner_shell_id=9)
+        status, _ = self.add((PLANNER,), dev="DEV5")
+        self.assertEqual(status, 201)
+        status, err = self.patch((PLANNER2,), state="working")
+        self.assertEqual(status, 403)
+        self.assertEqual(err["error"]["code"], "not_the_planner")
+        self.assertEqual(self.row()["state"], "pending")
+
+    def test_unbound_sprint_falls_back_to_planner_flavor_not_to_anyone(self):
+        """The spec's fallback is 'the sprint doc's author', which `documents`
+        has no column for. Flavor is the stand-in — and it must still exclude
+        workers, or the fence is decorative before a binding is armed."""
+        status, _ = self.add((PLANNER2,), dev="DEV5")
+        self.assertEqual(status, 201)
+        status, err = self.patch((DEV,), branch="feat/x")
+        self.assertEqual(status, 403)
+        self.assertIsNone(self.row()["branch"])
+
+    # -- belief must not be corrupted quietly --------------------------------
+
+    def test_patch_never_creates_a_phantom_unit(self):
+        """A typo'd --seq on an edit must fail loudly. A created phantom is
+        worse than an error: the reconciler would expect a shell to be working
+        on a unit that was never declared."""
+        self.add(seq="U1")
+        status, err = self.patch(seq="U7", state="working")
+        self.assertEqual(status, 404)
+        self.assertEqual(err["error"]["code"], "no_such_unit")
+        self.assertIsNone(self.row("U7"))
+
+    def test_add_is_not_an_upsert_and_leaves_the_live_row_intact(self):
+        self.add(dev="DEV5", reviewer="REV2", branch="feat/real")
+        self.patch(state="working")
+        status, err = self.add(unit_title="typo redeclare", dev="PLN2")
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "unit_exists")
+        live = self.row()
+        self.assertEqual(live["state"], "working")
+        self.assertEqual(live["branch"], "feat/real")
+        self.assertEqual(live["dev_shell_id"], 11)
+        self.assertEqual(live["unit_title"], "board record")
+
+    def test_unknown_shortname_is_refused_not_silently_unassigned(self):
+        """An empty role column reads as 'nobody is expected here'. A typo
+        that clears a role therefore produces a CONFIDENTLY WRONG answer
+        rather than a visible failure — the worst outcome for a monitor."""
+        self.add(dev="DEV5", reviewer="REV2")
+        status, err = self.patch(reviewer="REV9")
+        self.assertEqual(status, 422)
+        self.assertEqual(err["error"]["code"], "no_such_shell")
+        self.assertEqual(self.row()["reviewer_shell_id"], 8)
+
+    def test_a_role_is_cleared_only_when_said_explicitly(self):
+        """Omitted field = leave alone; explicit null = clear. Conflating the
+        two makes every partial edit a silent de-assignment."""
+        self.add(dev="DEV5", reviewer="REV2")
+        self.patch(branch="feat/x")
+        self.assertEqual(self.row()["reviewer_shell_id"], 8)
+        self.patch(reviewer=None)
+        self.assertIsNone(self.row()["reviewer_shell_id"])
+
+    # -- state is the expectation surface ------------------------------------
+
+    def test_a_state_move_refuses_to_carry_other_edits(self):
+        """State is the only column role expectation derives from. Bundled
+        with a branch rename, a planner moves what a worker is expected to be
+        doing as a side effect of clerical tidying."""
+        self.add(dev="DEV5")
+        status, err = self.patch(state="working", branch="feat/x")
+        self.assertEqual(status, 422)
+        self.assertEqual(err["error"]["code"], "state_moves_alone")
+        live = self.row()
+        self.assertEqual(live["state"], "pending")
+        self.assertIsNone(live["branch"])
+
+    def test_state_changed_at_moves_only_on_a_real_change(self):
+        """The no-progress window resets on state change. If re-asserting the
+        same state restamped the clock, a planner refreshing its board would
+        hand a stalled worker a fresh detection window every tick — the
+        monitor would go quiet exactly when it should fire."""
+        self.add(dev="DEV5")
+        self.patch(state="working")
+        self.sql("UPDATE sprint_units SET state_changed_at='2020-01-01 00:00:00'"
+                 " WHERE seq='U1'")
+        self.patch(state="working")
+        self.assertEqual(self.row()["state_changed_at"], "2020-01-01 00:00:00",
+                         "re-asserting the same state reset the window")
+        self.patch(state="in_review")
+        self.assertNotEqual(self.row()["state_changed_at"],
+                            "2020-01-01 00:00:00")
+
+    def test_assigned_at_moves_when_a_role_changes(self):
+        """U7's trigger surface: an assignment change is what it notifies on,
+        and a field edit is not one."""
+        self.add(dev="DEV5", reviewer="REV2")
+        self.sql("UPDATE sprint_units SET assigned_at='2020-01-01 00:00:00' "
+                 "WHERE seq='U1'")
+        self.patch(branch="feat/x")
+        self.assertEqual(self.row()["assigned_at"], "2020-01-01 00:00:00",
+                         "a branch edit counted as a reassignment")
+        self.patch(reviewer="PLN2")
+        self.assertNotEqual(self.row()["assigned_at"], "2020-01-01 00:00:00")
+
+    def test_the_db_refuses_a_state_outside_the_declared_set(self):
+        """The API validates, but the CHECK is the backstop for anything that
+        reaches the table another way."""
+        self.add()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.sql("UPDATE sprint_units SET state='done' WHERE seq='U1'")
+
+    def test_who_moved_belief_is_recorded(self):
+        self.arm_binding()
+        self.add((PLANNER,), dev="DEV5")
+        self.assertEqual(self.row()["updated_by_shell_id"], 9)
+
+    # -- the record is the source; the table is a view -----------------------
+
+    def test_board_writes_never_touch_the_document_body(self):
+        """The document keeps its prose and the record holds the units. A
+        write-back would state the board twice — the exact drift this table
+        exists to delete."""
+        self.add(dev="DEV5", reviewer="REV2")
+        self.patch(state="working")
+        con = sqlite3.connect(self.db_path)
+        try:
+            body = con.execute(
+                "SELECT body FROM documents WHERE document_id=1").fetchone()[0]
+        finally:
+            con.close()
+        self.assertEqual(body, DOC_BODY)
+
+    def test_rendered_board_reports_the_record_including_the_reviewer(self):
+        """`sc sprint board` is a projection of the record. It renders what
+        the record says — both roles — not what a document body remembers."""
+        self.add(seq="U1", unit_title="board record", dev="DEV5",
+                 reviewer="REV2", depends_on="U0", branch="feat/b", pr_number=7)
+        self.patch(seq="U1", state="in_review")
+        _s, out = self.call("GET", "/api/sprint-units?sprint_doc_id=1", (OP,))
+        buf = io.StringIO()
+        with mock.patch.object(sprint_cli, "_api", return_value=out), \
+                redirect_stdout(buf):
+            sprint_cli.cmd_board(mock.Mock(sprint=1))
+        text = buf.getvalue()
+        self.assertIn("| U1 | board record | DEV5 | REV2 | U0 | feat/b | #7 "
+                      "| in_review |", text)
+
+    def test_an_unassigned_role_renders_as_empty_not_as_a_shell(self):
+        self.add(seq="U3", unit_title="activity readers")
+        _s, out = self.call("GET", "/api/sprint-units?sprint_doc_id=1", (OP,))
+        buf = io.StringIO()
+        with mock.patch.object(sprint_cli, "_api", return_value=out), \
+                redirect_stdout(buf):
+            sprint_cli.cmd_board(mock.Mock(sprint=1))
+        self.assertIn("| U3 | activity readers | — | — |", buf.getvalue())
+
+    # -- the board survives a rebuild ----------------------------------------
+
+    def test_the_board_is_snapshot_content_not_a_rebuildable_cache(self):
+        """Nothing re-derives a sprint board. Left out of the snapshot
+        allowlist, a mid-sprint rebuild drops every unit and the reconciler
+        has nothing left to compare belief against."""
+        import snapshot
+        self.assertIn("sprint_units", snapshot.PER_INSTANCE_TABLES)
+        self.assertGreater(
+            snapshot.PER_INSTANCE_TABLES.index("sprint_units"),
+            snapshot.PER_INSTANCE_TABLES.index("documents"),
+            "sprint_units must load after its FK target `documents`")
+        self.assertGreater(
+            snapshot.PER_INSTANCE_TABLES.index("sprint_units"),
+            snapshot.PER_INSTANCE_TABLES.index("shells"),
+            "sprint_units must load after its FK target `shells`")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_sprint_board_record.py
+++ b/tests/test_sprint_board_record.py
@@ -41,11 +41,13 @@ from unittest import mock
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 SCHEMA = ENGINE / "schema.sql"
 MIGRATIONS = ENGINE / "migrations"
+MIGRATION = MIGRATIONS / "0098_sprint_units.sql"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 sys.path.insert(0, str(ENGINE / "api"))
 import interface_routes as routes  # noqa: E402
 import interface_wake  # noqa: E402
+import migrate  # noqa: E402
 import sprint as sprint_cli  # noqa: E402
 
 OP = "Authorization: Bearer optok"
@@ -62,6 +64,31 @@ def build_engine_db(path: Path) -> None:
     con.executescript(SCHEMA.read_text())
     for p in sorted(MIGRATIONS.glob("*.sql")):
         con.executescript(p.read_text())
+    seed_fixtures(con)
+    con.close()
+
+
+def build_pre_migration_db(path: Path) -> None:
+    """The DB this migration actually meets in the field: a fork's live engine
+    DB the moment before it pulls 0098 — everything else in place, no board.
+
+    `schema.sql` is the CURRENT baseline and therefore already carries
+    `sprint_units`, so the fixture drops it. That drop is the whole point:
+    build from the baseline and 0098 could be DELETED with every behavioural
+    test still green, because a fresh install would keep working while every
+    fork that UPGRADES would be left with no board at all.
+    """
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        if p != MIGRATION:
+            con.executescript(p.read_text())
+    con.execute("DROP TABLE IF EXISTS sprint_units")   # drops its index too
+    seed_fixtures(con)
+    con.close()
+
+
+def seed_fixtures(con) -> None:
     con.execute(
         "INSERT INTO users (user_id, username, is_active) VALUES (1,'T',1)")
     for sid, short, flavor, key in (
@@ -79,7 +106,6 @@ def build_engine_db(path: Path) -> None:
         "INSERT INTO documents (document_id, kind, title, body) "
         "VALUES (1,'doc','SPRINT: test',?)", (DOC_BODY,))
     con.commit()
-    con.close()
 
 
 def hdrs(*lines) -> str:
@@ -97,11 +123,18 @@ class _NoCoordinator:
         pass
 
 
-class BoardRecordTest(unittest.TestCase):
+class _BoardCase(unittest.TestCase):
+    """Scaffolding shared by the record tests and the live-upgrade tests: one
+    temp DB with the routes bound to it. `build` is the hook the upgrade class
+    swaps — it is the ONLY difference between a board that was installed and a
+    board that was migrated into place."""
+
+    build = staticmethod(build_engine_db)
+
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp())
         self.db_path = self.tmp / "shell_db.db"
-        build_engine_db(self.db_path)
+        self.build(self.db_path)
         run_dir = self.tmp / "run" / "interface"
         run_dir.mkdir(parents=True)
         self.patches = [
@@ -186,6 +219,9 @@ class BoardRecordTest(unittest.TestCase):
             con.commit()
         finally:
             con.close()
+
+
+class BoardRecordTest(_BoardCase):
 
     # -- the reviewer column: the whole point of the unit ---------------------
 
@@ -549,6 +585,213 @@ class BoardRecordTest(unittest.TestCase):
             snapshot.PER_INSTANCE_TABLES.index("sprint_units"),
             snapshot.PER_INSTANCE_TABLES.index("shells"),
             "sprint_units must load after its FK target `shells`")
+
+    # -- malformed input is refused at the edge -------------------------------
+
+    def test_a_field_of_the_wrong_type_is_refused_not_stored(self):
+        """The board is a record of what a planner DECLARED, and the reconciler
+        acts on what it is handed. A field holding something no planner could
+        have typed — a PR number that is text, a branch that is a number — is
+        belief corrupted quietly; SQLite's affinity will happily keep 'seven'
+        in an INTEGER column. Enumerated as a SET, because a boundary that
+        covers the field a bug was reported on and not its neighbours is the
+        same gap one column over."""
+        self.add()
+        malformed = {"unit_title": 7, "depends_on": ["U1"], "overlap": 3.5,
+                     "branch": 42, "pr_number": "seven"}
+        for field, value in malformed.items():
+            before = self.row()[field]
+            status, err = self.patch(**{field: value})
+            self.assertEqual(status, 422, f"{field}={value!r} was accepted")
+            self.assertEqual(err["error"]["code"], "validation")
+            self.assertEqual(self.row()[field], before,
+                             f"{field} moved on a refused write")
+
+    def test_a_malformed_declaration_is_refused_without_a_500(self):
+        """Same set on the create path. `add` and `set` are two doors to one
+        record: a numeric title reached .strip() here and returned a sanitized
+        500, which tells the planner nothing about what it typed wrong."""
+        for field, value in (("unit_title", 7), ("pr_number", "seven"),
+                             ("branch", 42), ("sprint_doc_id", "1"),
+                             ("sprint_doc_id", True), ("seq", 1)):
+            status, err = self.add(**{"seq": "U8", field: value})
+            self.assertEqual(status, 422, f"{field}={value!r} was accepted")
+            self.assertEqual(err["error"]["code"], "validation")
+            self.assertIsNone(self.row("U8"))
+
+    def test_a_blank_is_not_a_value_and_null_is_the_way_to_clear(self):
+        """An empty `branch` reads as a unit whose declared branch is the empty
+        string — and U3/U4 compare that declaration against what the worktree
+        holds. Retraction has a spelling already (explicit null); a blank must
+        not become a second one that means something subtly different."""
+        self.add(branch="feat/real")
+        status, _ = self.patch(branch="   ")
+        self.assertEqual(status, 422)
+        self.assertEqual(self.row()["branch"], "feat/real")
+        self.patch(branch=None)
+        self.assertIsNone(self.row()["branch"])
+
+    def test_a_malformed_filter_refuses_rather_than_widening(self):
+        """The failure that matters most on the read path: a filter that fails
+        to parse must not fall open to EVERY board. The caller believes it
+        asked about one sprint, and the reconciler acts on what it is handed —
+        so silent widening hands it units from a sprint nobody asked about."""
+        self.add(seq="U1")
+        self.sql("INSERT INTO documents (document_id, kind, title, body) "
+                 "VALUES (2,'doc','SPRINT: other','x')")
+        self.sql("INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+                 "VALUES (2,'U1','another sprint entirely')")
+        status, err = self.call("GET", "/api/sprint-units?sprint_doc_id=abc",
+                                (OP,))
+        self.assertEqual(status, 422, err)
+        self.assertEqual(err["error"]["code"], "validation")
+        # and the honest filter still answers with ONLY that sprint
+        status, out = self.call("GET", "/api/sprint-units?sprint_doc_id=1",
+                                (OP,))
+        self.assertEqual(status, 200)
+        self.assertEqual([u["sprint_doc_id"] for u in out["units"]], [1])
+
+
+class LiveUpgradeTest(_BoardCase):
+    """Migration 0098 as the thing under test, rather than as a file that
+    happens to run on the way to a fixture.
+
+    Every test above builds its DB from `schema.sql` — the current baseline,
+    which already carries `sprint_units`. Under that fixture the migration
+    could be DELETED and all of them would stay green: fresh installs would
+    keep working, and every existing fork — including this repo's own live
+    DB — would upgrade into a board that is not there. So these start from the
+    DB the migration actually meets and drive the REAL runner across it,
+    ledger and outer-transaction stripping included.
+    """
+
+    build = staticmethod(build_pre_migration_db)
+
+    def upgrade(self):
+        con = sqlite3.connect(self.db_path)
+        try:
+            migrate.apply(con, MIGRATION)
+        finally:
+            con.close()
+
+    def shape(self, db_path):
+        """A table's structure as the DB itself reports it — columns with
+        their types, defaults and nullability, the FK targets, and the
+        indexes with their columns and uniqueness."""
+        con = sqlite3.connect(db_path)
+        try:
+            cols = con.execute("PRAGMA table_info(sprint_units)").fetchall()
+            fks = sorted(con.execute(
+                "PRAGMA foreign_key_list(sprint_units)").fetchall())
+            idx = []
+            for _s, name, unique, _o, _p in con.execute(
+                    "PRAGMA index_list(sprint_units)").fetchall():
+                cols_of = [r[2] for r in con.execute(
+                    f"PRAGMA index_info({name})").fetchall()]
+                idx.append((name, unique, cols_of))
+            return {"columns": cols, "fks": fks, "indexes": sorted(idx)}
+        finally:
+            con.close()
+
+    def test_the_migration_lands_the_board_on_a_db_that_had_none(self):
+        """Absence first: a fixture that already held the table would make
+        every assertion below vacuous — which is exactly the defect this test
+        exists to close, one layer down."""
+        con = sqlite3.connect(self.db_path)
+        try:
+            self.assertEqual(
+                con.execute("SELECT COUNT(*) FROM sqlite_master WHERE "
+                            "type='table' AND name='sprint_units'"
+                            ).fetchone()[0], 0,
+                "the fixture already had a board — the upgrade proves nothing")
+        finally:
+            con.close()
+
+        self.upgrade()
+
+        shape = self.shape(self.db_path)
+        names = [c[1] for c in shape["columns"]]
+        # BOTH roles: the reviewer column is the gap that blocked everything,
+        # and an upgrade that landed only the dev would ship the original
+        # defect to every fork while a fresh install stayed correct.
+        self.assertIn("dev_shell_id", names)
+        self.assertIn("reviewer_shell_id", names)
+        self.assertIn("overlap", names)
+        # the reconciler's per-tick read is (sprint_doc_id, state)
+        self.assertIn(("idx_sprint_units_live", 0, ["sprint_doc_id", "state"]),
+                      shape["indexes"])
+        con = sqlite3.connect(self.db_path)
+        try:
+            self.assertEqual(
+                con.execute("SELECT COUNT(*) FROM schema_migrations WHERE "
+                            "filename=?", (MIGRATION.name,)).fetchone()[0], 1,
+                "the runner did not stamp the ledger — it would re-run")
+        finally:
+            con.close()
+
+    def test_the_migrated_board_enforces_the_constraints_it_promises(self):
+        """Structure is not behaviour: a table can arrive with the right
+        columns and no CHECK, and the first thing that notices is a board
+        holding a state nothing can interpret."""
+        self.upgrade()
+        con = sqlite3.connect(self.db_path)
+        try:
+            con.execute("INSERT INTO sprint_units (sprint_doc_id, seq, "
+                        "unit_title) VALUES (1,'U1','board record')")
+            with self.assertRaises(sqlite3.IntegrityError):
+                con.execute("UPDATE sprint_units SET state='done'")
+            with self.assertRaises(sqlite3.IntegrityError):
+                con.execute("INSERT INTO sprint_units (sprint_doc_id, seq, "
+                            "unit_title) VALUES (1,'U1','declared twice')")
+            self.assertEqual(
+                con.execute("SELECT state FROM sprint_units").fetchone()[0],
+                "pending")
+        finally:
+            con.close()
+
+    def test_the_migrated_board_serves_the_api_and_its_fence(self):
+        """The end the operator sees: after the upgrade the board takes a
+        planner's declaration and refuses a worker's — through the same routes,
+        against a table no `schema.sql` in this DB ever created."""
+        self.upgrade()
+        self.arm_binding()
+        status, unit = self.add((PLANNER,), dev="DEV5", reviewer="REV2")
+        self.assertEqual(status, 201, unit)
+        self.assertEqual(unit["reviewer_shortname"], "REV2")
+        status, _ = self.patch((DEV,), state="merged")
+        self.assertEqual(status, 403)
+        self.assertEqual(self.row()["state"], "pending")
+
+    def test_the_upgrade_and_the_baseline_build_the_same_table(self):
+        """Two populations run this code: forks that install from `schema.sql`
+        and forks that upgrade through the migration. If the two definitions
+        drift, the same query answers differently in each — and the drift is
+        invisible to both, because each only ever builds its own way."""
+        self.upgrade()
+        installed = self.tmp / "installed.db"
+        build_engine_db(installed)
+        self.assertEqual(self.shape(self.db_path), self.shape(installed))
+
+    def test_the_migration_is_inert_when_the_board_is_already_there(self):
+        """A fresh build runs `schema.sql` and THEN every migration, so 0098
+        always meets a table that already exists — and `./sc update` can re-run
+        an unstamped file against a DB whose ledger was rebuilt. Neither may
+        error, and neither may disturb what the board already holds."""
+        installed = self.tmp / "installed.db"
+        build_engine_db(installed)
+        con = sqlite3.connect(installed)
+        try:
+            con.execute("INSERT INTO sprint_units (sprint_doc_id, seq, "
+                        "unit_title, state) VALUES (1,'U1','live',"
+                        "'in_review')")
+            con.commit()
+            migrate.apply(con, MIGRATION)
+            con.executescript(MIGRATION.read_text())      # and again, bare
+            self.assertEqual(
+                con.execute("SELECT seq, state FROM sprint_units"
+                            ).fetchall(), [("U1", "in_review")])
+        finally:
+            con.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_sprint_board_record.py
+++ b/tests/test_sprint_board_record.py
@@ -474,6 +474,65 @@ class BoardRecordTest(unittest.TestCase):
             sprint_cli.cmd_board(mock.Mock(sprint=1))
         self.assertIn("| U3 | activity readers | — | — |", buf.getvalue())
 
+    # -- the CLI reaches the routes it claims to ------------------------------
+
+    def test_each_verb_calls_the_method_and_path_it_claims(self):
+        """The route tests prove the handlers; this proves the verbs actually
+        REACH them. A wrong method or path in the CLI would ship invisibly —
+        the handler tests stay green either way, and the live server is on the
+        stale engine floor this sprint, so no end-to-end call can catch it.
+
+        `set` and `state` deliberately share one route: state is refused
+        server-side when it arrives beside other edits, so the separation is
+        enforced where it cannot be bypassed by calling the API directly."""
+        seen = []
+
+        def spy(method, path, payload=None, idem=None):
+            seen.append((method, path, payload))
+            return {"units": [], "seq": "U1", "sprint_doc_id": 1,
+                    "unit_title": "t", "state": "pending"}
+
+        args = mock.Mock(sprint=1, seq="U1", title="t", dev="DEV5",
+                         reviewer="REV2", depends_on="U0", overlap="note",
+                         branch="b", pr=7, state="working")
+        with mock.patch.object(sprint_cli, "_api", spy):
+            sprint_cli.cmd_unit_add(args)
+            sprint_cli.cmd_unit_set(args)
+            sprint_cli.cmd_unit_state(args)
+            sprint_cli.cmd_unit_list(args)
+            sprint_cli.cmd_board(args)
+
+        self.assertEqual([m for m, _p, _b in seen],
+                         ["POST", "PATCH", "PATCH", "GET", "GET"])
+        for _m, path, _b in seen:
+            self.assertTrue(path.startswith("/api/sprint-units"), path)
+        # the state verb sends state ALONE — the CLI must not smuggle the
+        # other parsed arguments along and earn a 422 on every call
+        self.assertEqual(seen[2][2],
+                         {"sprint_doc_id": 1, "seq": "U1", "state": "working"})
+        # and `set` must not send state, which would make every field edit a
+        # refusal
+        self.assertNotIn("state", seen[1][2])
+        self.assertEqual(seen[1][2]["overlap"], "note")
+
+    def test_the_cli_clears_a_slot_only_on_the_literal_none(self):
+        """`--dev none` clears; `--dev DEV5` assigns. Mapping a missing flag
+        to a clear would de-assign a role on every unrelated edit."""
+        seen = []
+        with mock.patch.object(
+                sprint_cli, "_api",
+                lambda m, p, payload=None, idem=None: (
+                    seen.append(payload) or {"seq": "U1", "sprint_doc_id": 1,
+                                             "unit_title": "t",
+                                             "state": "pending"})):
+            sprint_cli.cmd_unit_set(mock.Mock(
+                sprint=1, seq="U1", title=None, dev="none", reviewer=None,
+                depends_on=None, overlap=None, branch=None, pr=-1))
+        self.assertIsNone(seen[0]["dev"], "'none' did not clear the dev slot")
+        self.assertIsNone(seen[0]["pr_number"], "--pr -1 did not clear the PR")
+        self.assertNotIn("reviewer", seen[0],
+                         "an omitted --reviewer was sent as a change")
+
     # -- the board survives a rebuild ----------------------------------------
 
     def test_the_board_is_snapshot_content_not_a_rebuildable_cache(self):

--- a/tests/test_sprint_board_record.py
+++ b/tests/test_sprint_board_record.py
@@ -390,6 +390,36 @@ class BoardRecordTest(unittest.TestCase):
             con.close()
         self.assertEqual(body, DOC_BODY)
 
+    def test_every_editable_field_round_trips_through_set(self):
+        """Enumerated as a SET rather than one field at a time, because a
+        mutation round trip found the gap: dropping `overlap` from the
+        editable map reddened nothing — every test that touched a field
+        asserted some OTHER property (a refusal, a timestamp) and none
+        asserted the value landed. The ruling requires both add and set to
+        carry the annotation; the same hole covered branch, depends_on,
+        pr_number and unit_title, so all five are pinned here."""
+        self.add()
+        edits = {"unit_title": "board record v2", "depends_on": "U0,U3",
+                 "overlap": "shares scripts/sprint.py with U5",
+                 "branch": "feat/sprint-board-record", "pr_number": 613}
+        for field, value in edits.items():
+            status, unit = self.patch(**{field: value})
+            self.assertEqual(status, 200, unit)
+            self.assertEqual(self.row()[field], value,
+                             f"{field} did not survive `set`")
+
+    def test_a_clearable_field_is_cleared_only_when_said_explicitly(self):
+        """Same distinction the roles get: omitted leaves it, explicit null
+        clears it. `sc sprint unit set --overlap none` must be able to retract
+        a stale merge-surface note, and an unrelated edit must not."""
+        self.add(depends_on="U0", overlap="MUST rebase onto merged U2")
+        self.patch(branch="feat/x")
+        self.assertEqual(self.row()["overlap"], "MUST rebase onto merged U2")
+        self.patch(overlap=None)
+        self.assertIsNone(self.row()["overlap"])
+        self.assertEqual(self.row()["depends_on"], "U0",
+                         "clearing one field cleared its neighbour")
+
     def test_the_merge_surface_annotation_survives_and_renders(self):
         """The markdown board's "depends on" cell carries prose beside the
         dependency — "shares SKILL.md with U8 — MUST rebase onto merged U2" —


### PR DESCRIPTION
Sprint 59, unit U1. Spec doc 58, section "The board becomes a record". Reviewer: REV2.

## What this fixes

The reconciler must know who SHOULD be active before it can report that belief and reality disagree. Today it cannot. The board is a markdown table inside a `documents` body, and the only structured assignment surface — `spec_tasks` — has **one** `shell_id` and no reviewer column at all (`schema.sql:244`). A reviewer assignment is not representable, which is exactly why flag #185's instance 4 — a reviewer dead while the dev believed it was re-reviewing — is invisible to any comparator built on today's data. That is structural, not a data accident.

So the unit table becomes a record: migration **0098** `sprint_units`, both roles as columns, maintained by the planner through `sc sprint unit add|set|state|list` over `/api/sprint-units`. The document keeps its prose; `sc sprint board` renders the table on demand.

## The three decisions worth reviewing

**The planner is the only writer** (`_may_write_board`, fenced per sprint). Not a permission detail: a worker that could mark its own unit done would make the board agree with reality *by construction* and leave the reconciler nothing to compare. Workers read freely — reaching the route is not authority to write it. The refusal tests assert the row is **unmoved**, not just the status code; a 403 that still wrote would satisfy a code-only test.

**A state move takes no other edits** (422 `state_moves_alone`). State is the only column role expectation derives from, so it moves alone and `state_changed_at` has exactly one writer — a planner can never move what a worker is expected to be doing as a side effect of fixing a branch name. Enforced server-side, so the CLI's separate `unit state` verb is a property rather than a convention.

**`add` is not an upsert and `patch` never creates.** The natural key is typed by hand. A phantom unit from a mistyped `--seq` is a unit the reconciler then expects a shell to be working on and nobody is — a self-inflicted instance of the exact false expectation this feature exists to detect.

## Trade-offs taken, and one premise that failed

- **No state transition graph**, only the CHECK on the value set. The board is planner *belief*; a planner who cannot correct a wrong entry keeps the false one. A legal-edge table would also state the workflow a second time, in a second place, and drift. Ratified by PLN1.
- **`seq` is TEXT holding `"U1"`** — deliberately unlike `spec_tasks.seq` (INTEGER). Every message and board row says `U1`; an int forces a lossy strip. The difference is a choice, not an inconsistency.
- **`depends_on` + `overlap`, two columns in one rendered cell.** PLN1's amendment: the markdown board's "depends on" cell carries load-bearing prose beside the dependency ("shares SKILL.md with U8 — MUST rebase onto merged U2"), and the merge protocol turns on it. Storing the comma list alone would leave the record holding *less* than the markdown it replaces.
- **The write-authority fallback in the spec does not exist.** The spec (and PLN1's ruling 6b) say "the binding's `planner_shell_id`, else the sprint doc's author". `documents` has no author column. Unbound sprints fall back to `shells.flavor='planner'` instead — workers still refused. Reported pre-merge as an ambiguity call; it lands on U5 too, which uses the same phrase for alert delivery.
- **`sc sprint board` is a read.** It never writes the table back into the document body: a stored copy would state the board twice and go stale silently — the drift this table exists to delete.

`sprint_units` joins `PER_INSTANCE_TABLES`: nothing re-derives a sprint board, so a mid-sprint rebuild without it drops the planner's whole state.

## Verification

27 hermetic tests. **23 mutation round trips, all caught**, run with `PYTHONDONTWRITEBYTECODE=1`, caches cleared, and the baseline re-asserted green after every revert — a same-size revert inside one second otherwise leaves a stale `.pyc` running and can show a dead test as green.

One mutation **survived** on the first pass and is worth the reviewer's note: deleting `overlap` from the editable-field map reddened nothing. The hole was the class, not the instance — every test touching a field through PATCH asserted some *other* property and none asserted the value landed, leaving `depends_on`, `branch`, `pr_number` and `unit_title` equally unpinned. Closed as a set.

**Two inherited reds, neither mine:**
- flag #202 — `test_header_keeps_controls_left_and_work_data_right`, red on main since dba07d2.
- `test_harness_epoch.py` ×3 — reproduced on a clean `origin/main` worktree with none of my diff; they read real harness CLI versions and expect stubbed ones.

Full suite otherwise: 1627 passed, 1 skipped, 416 subtests.

`render-check` is **not** cited as proof — per flag #201 it short-circuits to rc=0 in this repo's local artifact mode and cannot go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)