### PR TITLE
docs(tests): correct the sandbox generic ruler and the flag-#206 budget

### DIFF
--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -1177,9 +1177,16 @@ def test_header_keeps_controls_left_and_work_data_right(browser, ui_url, tmp_pat
     # runner do not resolve the same font:
     #
     #   ruler at 13.6px, 79-char context   sandbox    ubuntu-latest
-    #   [ui-sans-serif] / [system-ui]      437.6px    549.8px
+    #   [ui-sans-serif] / [system-ui]      471.5px    549.8px
     #   [Liberation Sans] / [Arial]        480.6px    480.6px
     #   [DejaVu Sans]                      437.6px    549.8px
+    #
+    # The sandbox column has THREE distinct values: this host resolves the
+    # generic stack to none of the three named rulers, so its generic row is
+    # its own measurement and must never be copied from a named one. On the
+    # runner the generic and DejaVu rows genuinely coincide at 549.8px, and
+    # carrying that identity back here is how the sandbox generic row was
+    # first written as 437.6px.
     #
     # The runner resolves the generic stack to DejaVu Sans — the WIDEST
     # candidate — not to the Arial/Liberation metrics the earlier fix assumed.
@@ -1213,7 +1220,7 @@ def test_header_keeps_controls_left_and_work_data_right(browser, ui_url, tmp_pat
     # slot is 0px at that viewport on the runner, so any non-empty string
     # truncates by construction.
     #
-    # This does NOT mean the header is adequate. The runner's slot is 504px and
+    # This does NOT mean the header is adequate. The runner's cap is 496px and
     # a realistic 46-char work context needs 550px there, so a REAL title
     # overflows on CI's font — that is flag #206, a product question, and
     # shortening a test fixture does not touch it. The green below is evidence


### PR DESCRIPTION
Comment-only follow-up to #615, authorized by PLN1 (sprint 59, message #2216). One file, one comment block: no assertion, fixture, CSS or probe change.

### Three edits

1. **Sandbox generic ruler `437.6px` → `471.5px`.** Measured, not remembered: re-ran the rendered test locally against the exact 46-char title from 3bb3ced and read the ruler line off the pass. The sandbox has **three** distinct resolutions — generic 471.5, Liberation/Arial 480.6, DejaVu-fallback 437.6 — while the runner's generic and DejaVu genuinely coincide at 549.8. The old value was that runner-true identity carried back to a host where it does not hold. The current 21-char fixture confirms the split independently (314.6 vs 296.5).
2. **A line in the table saying so** — the sandbox resolves the generic stack to none of the three named rulers, so its generic row must never be copied from a named one.
3. **Flag-#206 paragraph `slot is 504px` → `cap is 496px`.** 504 is the failure-state slot (`.if-identity` is `flex: 0 1 auto`, squeezed to 98px while the context overflows); once the context fits the identity takes its natural 107px and the real budget is 496px, per CI's own instrumented run at #615 @ebcb467 (`need=368 cap=496`). The deficit against a realistic 46-char context is 54px, not 46px. Reworded to `cap` because the file defines `slot` and `cap` as different things a few lines above.

### One 504 stays, deliberately

The arithmetic block's `slot=504px` is explicitly labelled as a reading from the failing 1600px run of 3bb3ced, where the slot *was* 504px. Changing it would make the comment lie about its own provenance. Same for the `-46px` comparison in that block. **Do not unify them.**

### Nothing functional moves

The fixture derivation runs through Liberation, 480.6px on both hosts, which is unchanged and is the only ruler a local run can trust.

### Why this exists

Correcting one instance of a wrong number does not find its copies. Flag #206 was sharpened to 496 and the arithmetic block was rewritten, and the prose paragraph three lines below kept the old value — inside the very comment that teaches the reader to distrust failure-state numbers.

Shell: DEV6 (Code-04)