### PR TITLE
docs(tests): warn in-file that the arithmetic 504 is a failing-state slot

### DIFF
--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -1196,7 +1196,9 @@ def test_header_keeps_controls_left_and_work_data_right(browser, ui_url, tmp_pat
     # makes Liberation the one ruler a local run can trust.
     #
     # The arithmetic, from the 1600px CI run of 3bb3ced (slot=504px, need=550px
-    # at 79 chars, font=13.6px):
+    # at 79 chars, font=13.6px). That 504 is the FAILING run's slot — do not
+    # reconcile it with the 496 cap below: a slot equals the cap only while the
+    # context overflows, so the two are different quantities, not a discrepancy.
     #
     #   px/char under the widest ruler   549.8 / 79     = 6.96px
     #   target                           need <= .75 * slot = 378px


### PR DESCRIPTION
Comment-only follow-up to #617. Three lines of comment in
`tests/test_interface_ui_rendered.py`; no assertion, fixture, CSS or probe
change.

## What

The header-fixture comment holds two 504s with different meanings. #617
corrected the flag-#206 paragraph to the real 496px cap and deliberately left
the arithmetic block's 504 standing, because that block is a labelled reading
from the failing 1600px run of 3bb3ced where the slot genuinely WAS 504px.

That distinction was carried in #617's commit message and in the block's
provenance clause. It was not carried as a warning where the number lives. This
adds it:

```
    # The arithmetic, from the 1600px CI run of 3bb3ced (slot=504px, need=550px
    # at 79 chars, font=13.6px). That 504 is the FAILING run's slot — do not
    # reconcile it with the 496 cap below: a slot equals the cap only while the
    # context overflows, so the two are different quantities, not a discrepancy.
```

## Why this is worth a PR of its own

#617 exists because a wrong number survived its own correction — 504 was fixed
in the arithmetic block and its copy three lines down was missed, inside the
very comment that teaches the reader to distrust failure-state numbers.

Leaving the next reader to *infer* that two 504s differ is the same bet that
just failed. A provenance label mitigates; it does not warn. The reader who
greps `504`, finds two, and helpfully unifies them is the precise failure mode,
and they will be reading the file — the less discoverable surface is the commit
message, so the file is where the warning has to live.

## Trade-off

The cheaper option was to change nothing and rely on the provenance label plus
#617's commit body. Rejected: that is exactly the discoverability assumption
that produced this follow-up. The alternative in the other direction — renaming
or removing one of the two 504s so no collision exists — would make the
arithmetic block lie about which run it came from, which is worse than a
collision that is explicitly flagged.

## Vehicle note

PLN1 authorized this as an amend to #617. #617 merged as ec86e9b seven seconds
after that message was sent, so it lands as its own branch off 02d5977 instead.
Same change, same authorization.

Authorized comment-only follow-up per PLN1 (sprint 59, message #2224).

Shell: DEV6 (Code-04)

🤖 Generated with [Claude Code](https://claude.com/claude-code)