### PR TITLE
feat(sprint): the assignment change notice — read off the record (S59 U7)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2407,6 +2407,120 @@ def _unit_projection(con, unit_id: int) -> dict:
     return unit
 
 
+# ------------------------------------------------- assignment change notice
+
+# The two role columns, in one order, derived from the single definition
+# above — the counterpart lookup below indexes into this.
+_ROLE_COLS = tuple(_UNIT_ROLES.values())
+
+
+def _counterpart(col: str) -> str:
+    """The other role on the unit. A unit has exactly two roles — the pair IS
+    the unit — so "the counterpart" is total and needs no default."""
+    return _ROLE_COLS[1 - _ROLE_COLS.index(col)]
+
+
+def _assignment_parties(before: dict, after: dict) -> set:
+    """The shells one board write must tell — the spec's rule and nothing
+    wider (doc 58 "Assignment change notice"): for each role that ACTUALLY
+    moved, the shell newly named, the shell it replaced, and the counterpart
+    role on that unit as the board now reads.
+
+    The set is read OFF THE RECORD. There is no subscription and no reader
+    log because the audit that retired feature #29 found the shells who need
+    telling are exactly the shells the record names — so any rule broader
+    than "these columns" is the defect this emitter exists to avoid, not a
+    generalisation of it.
+
+    A role re-asserted to the same shell has not moved and tells nobody: the
+    sprint-52 incident was a column that CHANGED under two workers, and a
+    planner re-typing the value it already holds is not that.
+    """
+    parties = set()
+    for col in _ROLE_COLS:
+        if before.get(col) == after.get(col):
+            continue
+        parties.update({before.get(col), after.get(col),
+                        after.get(_counterpart(col))})
+    parties.discard(None)
+    return parties
+
+
+def _role_phrase(con, before: dict, after: dict) -> str:
+    named = []
+    for role, col in _UNIT_ROLES.items():
+        if before.get(col) != after.get(col):
+            named.append(f"{role} {_shortname(con, before.get(col))} -> "
+                         f"{_shortname(con, after.get(col))}")
+    roster = ", ".join(f"{role} {_shortname(con, after.get(col))}"
+                       for role, col in _UNIT_ROLES.items())
+    return f"{', '.join(named)}. Now: {roster}."
+
+
+def _shortname(con, shell_id) -> str:
+    if shell_id is None:
+        return "unassigned"
+    row = con.execute("SELECT shortname FROM shells WHERE shell_id=?",
+                      (shell_id,)).fetchone()
+    return row[0] if row is not None else f"shell {shell_id}"
+
+
+def _emit_assignment_notice(con, actor, doc_id: int, seq: str,
+                            before: dict, after: dict) -> int:
+    """The remainder of retired feature #29 (spec doc 58, decision #74): at
+    most three rows per assignment change, only on change, only while the
+    sprint is ACTIVE. Returns the number of rows written.
+
+    Called from inside the board write's own transaction, before its commit,
+    so a board write that rolls back tells nobody it happened — and the
+    routes' Idempotency-Key discipline means a replayed request returns its
+    cached response without reaching this at all. That is why there is no
+    dedupe_key here: the write it rides is already idempotent.
+
+    ONE BODY, delivered to each party rather than three phrasings of one
+    fact. Every recipient can locate itself in it, and a per-role restatement
+    is the drift shape this spec keeps closing.
+
+    `kind='shell'` DELIBERATELY. task / result / pr_event are exactly
+    interface_wake.ELIGIBLE_KINDS, so any of them could turn a planner's
+    board edit into a BOOT — narrowly (a wake item forms only when the
+    recipient is the sprint's bound planner) but really, since a planner may
+    hold a role on its own board. This is a notice, not work; `shell` is
+    inert by construction. The sprint scope is still stamped so the rows
+    filter with the rest of the sprint's traffic.
+    """
+    if not interface_broker._sprint_active(con, doc_id):
+        return 0
+    parties = _assignment_parties(before, after)
+    if actor.kind == "shell":
+        # The shell that just wrote the board does not need telling what it
+        # wrote. This can only take the count BELOW the spec's ceiling.
+        parties.discard(actor.shell_id)
+    live = [s for s in sorted(parties) if con.execute(
+        "SELECT 1 FROM shells WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+        (s,)).fetchone() is not None]
+    if not live:
+        return 0
+    body = (f"sprint {doc_id} unit {seq} assignment change: "
+            + _role_phrase(con, before, after))
+    # from_shell_id is NOT NULL and the operator token carries no shell, so
+    # the sender falls back to the sprint's planner (the shell whose belief
+    # this is) and finally to the recipient itself — the same self-addressing
+    # pr_poller.py uses for daemon-emitted rows. No synthetic shell is minted.
+    sender = actor.shell_id if actor.kind == "shell" else None
+    sender = sender if sender is not None else _board_writer(con, doc_id)
+    for shell_id in live:
+        con.execute(
+            "INSERT INTO shell_messages "
+            "(from_shell_id, to_shell_id, body, kind, sprint_doc_id) "
+            "VALUES (?,?,?,'shell',?)",
+            (sender if sender is not None else shell_id, shell_id, body,
+             doc_id))
+    _log(f"sprint board: doc={doc_id} unit={seq} assignment change "
+         f"notified {len(live)} shell(s)")
+    return len(live)
+
+
 def _sprint_units(actor, query: dict):
     """GET /api/sprint-units?sprint_doc_id=N — the board, read. Every
     participant reads it (it is the board they work from); only the planner
@@ -2495,6 +2609,10 @@ def _add_sprint_unit(actor, headers, body):
                     "unit_exists",
                     f"sprint {doc_id} already has unit {seq} — edit it with "
                     "PATCH rather than declaring it twice")
+            # A declaration that names a role IS an assignment change: before
+            # is the empty board this row did not exist on.
+            _emit_assignment_notice(con, actor, doc_id, seq,
+                                    {c: None for c in _ROLE_COLS}, roles)
             con.commit()
             _log(f"sprint board: doc={doc_id} unit={seq} declared "
                  f"by={actor.scope}")
@@ -2593,6 +2711,11 @@ def _patch_sprint_unit(actor, headers, body):
             con.execute(
                 f"UPDATE sprint_units SET {', '.join(sets)} WHERE unit_id=?",
                 (*params, unit_id))
+            # A role omitted from the body is left alone, so `after` is the
+            # row as it now reads — not the request. The counterpart the
+            # notice names has to be the board's, not the caller's subset.
+            _emit_assignment_notice(con, actor, doc_id, seq, was,
+                                    {**was, **resolved})
             con.commit()
             _log(f"sprint board: doc={doc_id} unit={seq} moved "
                  f"by={actor.scope} ({'state ' + state if state else 'fields'})")

--- a/tests/test_sprint_assignment_notice.py
+++ b/tests/test_sprint_assignment_notice.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""The assignment change notice — the retired-feature-#29 emitter (spec doc
+58 "Assignment change notice", feature 27, sprint doc 59 U7).
+
+The unit's whole claim is a SET: when a role on a sprint unit changes, the
+shells told are exactly the shell newly named, the shell it replaced, and the
+counterpart role on that unit — read off the record, with no subscription and
+no reader log, because the audit that retired #29 found those are exactly the
+shells who need telling. So the test that matters asserts the RECIPIENT SET,
+not a row count: "three rows" is satisfied just as happily by the wrong three,
+and any rule broader than the record's own columns is the defect this emitter
+exists to avoid rather than a generalisation of it. The board here therefore
+carries a SECOND unit whose shells must stay silent — a single-unit fixture
+cannot tell "notify the record's parties" from "notify the board".
+
+The other half is what must NOT emit. A field edit, a state move, a role
+re-asserted to the shell already in it, a closed sprint, and every refused or
+rejected write tell nobody — the sprint-52 incident was a column that CHANGED
+under two live workers, and noise on the paths that did not change is exactly
+the cost that retired #29 in the first place.
+
+Run:
+    python3 tests/test_sprint_assignment_notice.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import interface_wake  # noqa: E402
+from test_sprint_board_record import (  # noqa: E402
+    DEV, OP, PLANNER, _BoardCase)
+
+REV1, REV2, DEV5, DEV6, PLN1, PLN2 = 7, 8, 11, 12, 9, 10
+
+
+class AssignmentNoticeTest(_BoardCase):
+    """One ACTIVE sprint, two units. U1 is the unit under test; U2 exists so
+    that a rule reading the BOARD instead of the RECORD has somewhere to leak
+    to."""
+
+    def setUp(self):
+        super().setUp()
+        for sid, short, flavor, key in ((REV1, "REV1", "reviewer", "rev1tok"),
+                                        (DEV6, "DEV6", "dev", "dev6tok")):
+            self.sql(
+                "INSERT INTO shells (shell_id, display_name, shortname, "
+                "flavor, mandate, system_prompt, user_id, api_key, is_shared, "
+                "has_identity, bootstrapped) VALUES (?,?,?,?,'test','sp',1,?,"
+                "0,1,1)", (sid, f"S{sid}", short, flavor, key))
+        self.add(seq="U1", dev=DEV5, reviewer=REV1)
+        self.add(seq="U2", dev=DEV6, reviewer=PLN2)
+        self.clear_messages()
+
+    # -- helpers -------------------------------------------------------------
+
+    def clear_messages(self):
+        self.sql("DELETE FROM shell_messages")
+
+    def notices(self):
+        con = sqlite3.connect(self.db_path)
+        con.row_factory = sqlite3.Row
+        try:
+            return [dict(r) for r in con.execute(
+                "SELECT * FROM shell_messages ORDER BY message_id")]
+        finally:
+            con.close()
+
+    def told(self):
+        return sorted(m["to_shell_id"] for m in self.notices())
+
+    # -- the spec's verification row -----------------------------------------
+
+    def test_reviewer_reassignment_notifies_exactly_three(self):
+        """spec doc 58: "assignment change notifies exactly three | reassign a
+        reviewer | notify by any broader rule -> extra rows, red"."""
+        status, _ = self.patch(seq="U1", reviewer=REV2)
+        self.assertEqual(status, 200)
+        # The newly named, the one it replaced, and the counterpart on THIS
+        # unit. U2's dev and reviewer are on the same board and hear nothing.
+        self.assertEqual(self.told(), [REV1, REV2, DEV5])
+        self.assertEqual(len(self.notices()), 3)
+
+    def test_the_notice_names_the_change_and_the_new_roster(self):
+        self.patch(seq="U1", reviewer=REV2)
+        bodies = {m["body"] for m in self.notices()}
+        # ONE body, delivered to each party — three phrasings of one fact is
+        # the drift this spec keeps closing.
+        self.assertEqual(len(bodies), 1)
+        body = bodies.pop()
+        self.assertIn("unit U1", body)
+        self.assertIn("reviewer REV1 -> REV2", body)
+        self.assertIn("Now: dev DEV5, reviewer REV2", body)
+
+    # -- what must not emit ---------------------------------------------------
+
+    def test_a_role_reasserted_to_the_same_shell_tells_nobody(self):
+        """A planner re-typing the value already in the column is not the
+        sprint-52 incident, and must not spend the noise budget on it."""
+        status, _ = self.patch(seq="U1", reviewer=REV1)
+        self.assertEqual(status, 200)
+        self.assertEqual(self.notices(), [])
+
+    def test_a_field_edit_tells_nobody(self):
+        status, _ = self.patch(seq="U1", branch="feat/x", pr_number=616)
+        self.assertEqual(status, 200)
+        self.assertEqual(self.notices(), [])
+
+    def test_a_state_move_tells_nobody(self):
+        status, _ = self.patch(seq="U1", state="working")
+        self.assertEqual(status, 200)
+        self.assertEqual(self.notices(), [])
+
+    def test_a_closed_sprint_emits_nothing_but_still_writes_the_board(self):
+        """The ACTIVE gate is on the NOTICE, never on the record. A planner
+        must still be able to correct a closed sprint's board."""
+        self.sql("UPDATE documents SET body=? WHERE document_id=1",
+                 ("# SPRINT: test\nstatus: CLOSED\n",))
+        status, _ = self.patch(seq="U1", reviewer=REV2)
+        self.assertEqual(status, 200)
+        self.assertEqual(self.row("U1")["reviewer_shell_id"], REV2)
+        self.assertEqual(self.notices(), [])
+
+    def test_a_refused_write_tells_nobody(self):
+        """A worker cannot move the board (U1's rule), so it cannot make the
+        board TALK either — a 403 that still emitted would tell three shells
+        about a change that did not happen."""
+        status, _ = self.patch((DEV,), seq="U1", reviewer=REV2)
+        self.assertEqual(status, 403)
+        self.assertEqual(self.notices(), [])
+
+    def test_an_edit_to_a_unit_that_does_not_exist_tells_nobody(self):
+        status, _ = self.patch(seq="U9", reviewer=REV2)
+        self.assertEqual(status, 404)
+        self.assertEqual(self.notices(), [])
+
+    def test_a_redeclared_unit_tells_nobody(self):
+        """POST is not an upsert: the 409 leaves the board unchanged, so the
+        notice must not ride the request that was rejected."""
+        status, _ = self.add(seq="U1", dev=DEV6, reviewer=REV2)
+        self.assertEqual(status, 409)
+        self.assertEqual(self.notices(), [])
+
+    # -- the rest of the set ---------------------------------------------------
+
+    def test_declaring_a_unit_notifies_the_roles_it_names(self):
+        """An INSERT that names a role IS an assignment change; the two named
+        shells are each other's counterpart, so it is two rows, not three."""
+        self.add(seq="U3", dev=DEV5, reviewer=REV2)
+        self.assertEqual(self.told(), [REV2, DEV5])
+
+    def test_declaring_an_unassigned_unit_tells_nobody(self):
+        self.add(seq="U3")
+        self.assertEqual(self.notices(), [])
+
+    def test_clearing_a_role_notifies_the_departing_shell(self):
+        """The shell newly named is nobody, which is a real board state — the
+        one it replaced still has to hear that it is off the unit."""
+        status, _ = self.patch(seq="U1", reviewer=None)
+        self.assertEqual(status, 200)
+        self.assertEqual(self.told(), [REV1, DEV5])
+        self.assertIn("reviewer REV1 -> unassigned",
+                      self.notices()[0]["body"])
+
+    def test_both_roles_at_once_tells_each_shell_exactly_once(self):
+        """AMBIGUITY CALL (reported pre-build): the spec's "at most three" is
+        per CHANGED ROLE, and a request that moves both roles is two changes.
+        The union is deduped by recipient, so four shells hear once each and
+        no shell is ever told twice about one write."""
+        status, _ = self.patch(seq="U1", dev=DEV6, reviewer=REV2)
+        self.assertEqual(status, 200)
+        self.assertEqual(self.told(), [REV1, REV2, DEV5, DEV6])
+
+    def test_a_dev_holding_both_roles_hears_once(self):
+        self.patch(seq="U1", reviewer=DEV5)
+        self.assertEqual(self.told(), [REV1, DEV5])
+
+    def test_the_writing_planner_is_not_told_what_it_just_wrote(self):
+        """The board's writer knows what it wrote. Excluding it can only take
+        the count BELOW the ceiling, never above."""
+        self.arm_binding(PLN1)
+        self.patch(seq="U1", reviewer=PLN1)
+        self.clear_messages()
+        status, _ = self.patch((PLANNER,), seq="U1", reviewer=REV2)
+        self.assertEqual(status, 200)
+        self.assertEqual(self.told(), [REV2, DEV5])
+
+    def test_a_soft_deleted_shell_is_not_a_party(self):
+        self.sql("UPDATE shells SET is_deleted=1 WHERE shell_id=?", (REV1,))
+        self.patch(seq="U1", reviewer=REV2)
+        self.assertEqual(self.told(), [REV2, DEV5])
+
+    # -- the row has to be writable at all ------------------------------------
+
+    def test_an_operator_write_on_an_unbound_sprint_still_emits(self):
+        """`from_shell_id` is NOT NULL and the operator token carries no
+        shell, so a sender that resolved to NULL would turn every operator
+        board edit into a 500. With no binding to fall back to, the row is
+        self-addressed — pr_poller.py's convention for daemon-emitted rows."""
+        self.patch(seq="U1", reviewer=REV2)
+        rows = self.notices()
+        self.assertEqual(len(rows), 3)
+        self.assertTrue(all(m["from_shell_id"] == m["to_shell_id"]
+                            for m in rows), rows)
+
+    def test_a_planner_written_notice_is_sent_from_the_planner(self):
+        self.arm_binding(PLN1)
+        status, _ = self.patch((PLANNER,), seq="U1", reviewer=REV2)
+        self.assertEqual(status, 200)
+        self.assertEqual({m["from_shell_id"] for m in self.notices()},
+                         {PLN1})
+
+    def test_the_notice_can_never_boot_a_shell(self):
+        """`kind` is the whole safety argument: task / result / pr_event are
+        exactly the wake-eligible kinds, so any of them would let a planner's
+        board edit turn into a BOOT of whichever party is a bound planner.
+        This is a notice, not work."""
+        self.patch(seq="U1", reviewer=REV2)
+        kinds = {m["kind"] for m in self.notices()}
+        self.assertEqual(kinds, {"shell"})
+        for kind in kinds:
+            self.assertNotIn(kind, interface_wake.ELIGIBLE_KINDS)
+
+    def test_the_notice_is_scoped_to_its_sprint(self):
+        self.patch(seq="U1", reviewer=REV2)
+        self.assertEqual({m["sprint_doc_id"] for m in self.notices()}, {1})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_sprint_assignment_notice.py
+++ b/tests/test_sprint_assignment_notice.py
@@ -13,6 +13,12 @@ exists to avoid rather than a generalisation of it. The board here therefore
 carries a SECOND unit whose shells must stay silent — a single-unit fixture
 cannot tell "notify the record's parties" from "notify the board".
 
+The budget is the planner's enumeration, not the spec's original sentence: no
+shell receives more than one row for one write. "At most three" was a proxy
+that holds for a single-role change and for nothing else — a PATCH moving both
+roles is two changes and four parties — so the invariant is asserted directly,
+over the emitting cases as a set.
+
 The other half is what must NOT emit. A field edit, a state move, a role
 re-asserted to the shell already in it, a closed sprint, and every refused or
 rejected write tell nobody — the sprint-52 incident was a column that CHANGED
@@ -35,8 +41,7 @@ sys.path.insert(0, str(ENGINE / "api"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import interface_wake  # noqa: E402
-from test_sprint_board_record import (  # noqa: E402
-    DEV, OP, PLANNER, _BoardCase)
+from test_sprint_board_record import DEV, PLANNER, _BoardCase  # noqa: E402
 
 REV1, REV2, DEV5, DEV6, PLN1, PLN2 = 7, 8, 11, 12, 9, 10
 
@@ -156,9 +161,36 @@ class AssignmentNoticeTest(_BoardCase):
         self.add(seq="U3", dev=DEV5, reviewer=REV2)
         self.assertEqual(self.told(), [REV2, DEV5])
 
+    def test_declaring_a_unit_with_one_role_notifies_only_that_shell(self):
+        """No counterpart exists yet, so the newly named shell is the whole
+        set — an empty role column is a real board state, not a missing one."""
+        self.add(seq="U3", dev=DEV5)
+        self.assertEqual(self.told(), [DEV5])
+
     def test_declaring_an_unassigned_unit_tells_nobody(self):
         self.add(seq="U3")
         self.assertEqual(self.notices(), [])
+
+    def test_no_shell_receives_more_than_one_row_for_one_write(self):
+        """The invariant the row count was only ever a proxy for (planner
+        ruling on A1). "At most three" holds for a single-role change and
+        nothing else; this holds for every write that emits at all, which is
+        why it is asserted over the emitting cases as a set rather than left
+        implied by each one's expected recipients."""
+        writes = (
+            lambda: self.add(seq="U3", dev=DEV5, reviewer=REV2),
+            lambda: self.patch(seq="U1", reviewer=REV2),
+            lambda: self.patch(seq="U1", dev=DEV6, reviewer=REV2),
+            lambda: self.patch(seq="U1", reviewer=None),
+            lambda: self.patch(seq="U1", reviewer=DEV5),
+        )
+        for i, write in enumerate(writes):
+            with self.subTest(write=i):
+                self.clear_messages()
+                write()
+                told = self.told()
+                self.assertTrue(told, "this case is supposed to emit")
+                self.assertEqual(told, sorted(set(told)), told)
 
     def test_clearing_a_role_notifies_the_departing_shell(self):
         """The shell newly named is nobody, which is a real board state — the

--- a/tests/test_sprint_assignment_notice.py
+++ b/tests/test_sprint_assignment_notice.py
@@ -34,12 +34,14 @@ import sqlite3
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 sys.path.insert(0, str(ENGINE / "scripts"))
 sys.path.insert(0, str(ENGINE / "api"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import interface_routes as routes  # noqa: E402
 import interface_wake  # noqa: E402
 from test_sprint_board_record import DEV, PLANNER, _BoardCase  # noqa: E402
 
@@ -85,24 +87,35 @@ class AssignmentNoticeTest(_BoardCase):
 
     def test_reviewer_reassignment_notifies_exactly_three(self):
         """spec doc 58: "assignment change notifies exactly three | reassign a
-        reviewer | notify by any broader rule -> extra rows, red"."""
+        reviewer | notify by any broader rule -> extra rows, red".
+
+        THE RECIPIENT SET IS NOT SUFFICIENT AND THIS TEST LEARNED IT THE HARD
+        WAY. Taking the counterpart from the REQUEST instead of the row leaves
+        the same three shells in the set by a different route — the omitted
+        role reads as changed-to-None, which drags the counterpart in as a
+        "replaced" shell. Four other tests caught that; this one, the test
+        that NAMES the property, did not, and a reader who breaks the emitter
+        and sees this still green concludes the property holds.
+
+        So it asserts what each party is TOLD as well as who is told. The
+        wrong route cannot reproduce the body: it reports the dev as vacated
+        by a write that never touched the dev column.
+        """
         status, _ = self.patch(seq="U1", reviewer=REV2)
         self.assertEqual(status, 200)
         # The newly named, the one it replaced, and the counterpart on THIS
         # unit. U2's dev and reviewer are on the same board and hear nothing.
         self.assertEqual(self.told(), [REV1, REV2, DEV5])
         self.assertEqual(len(self.notices()), 3)
-
-    def test_the_notice_names_the_change_and_the_new_roster(self):
-        self.patch(seq="U1", reviewer=REV2)
-        bodies = {m["body"] for m in self.notices()}
         # ONE body, delivered to each party — three phrasings of one fact is
         # the drift this spec keeps closing.
+        bodies = {m["body"] for m in self.notices()}
         self.assertEqual(len(bodies), 1)
         body = bodies.pop()
         self.assertIn("unit U1", body)
-        self.assertIn("reviewer REV1 -> REV2", body)
-        self.assertIn("Now: dev DEV5, reviewer REV2", body)
+        # ONE role moved, so the notice names one move and no other.
+        self.assertIn("assignment change: reviewer REV1 -> REV2.", body)
+        self.assertIn("Now: dev DEV5, reviewer REV2.", body)
 
     # -- what must not emit ---------------------------------------------------
 
@@ -145,6 +158,32 @@ class AssignmentNoticeTest(_BoardCase):
         status, _ = self.patch(seq="U9", reviewer=REV2)
         self.assertEqual(status, 404)
         self.assertEqual(self.notices(), [])
+
+    def test_a_write_that_fails_before_commit_tells_nobody(self):
+        """THE ROLLBACK CASE, by fault injection rather than by construction.
+
+        The refusals below all return BEFORE the write, so they only prove the
+        emitter is not reached on a rejected request — none of them is a
+        rolled-back transaction. This one is: the rows are inserted, the
+        emitter finishes, and then the write dies before its commit. The
+        connection is closed without committing, so SQLite's deferred
+        transaction takes the notices AND the board move down together.
+
+        That pairing is the point. A notice that survived a failed board write
+        would tell three shells about a reassignment the board never recorded
+        — belief and its announcement disagreeing, which is precisely the
+        class of defect this whole service exists to detect.
+        """
+        boom = mock.patch.object(
+            routes, "_log",
+            side_effect=lambda msg: (_ for _ in ()).throw(RuntimeError(msg))
+            if "assignment change" in msg else None)
+        boom.start()
+        self.addCleanup(boom.stop)
+        with self.assertRaises(RuntimeError):
+            self.patch(seq="U1", reviewer=REV2)
+        self.assertEqual(self.notices(), [])
+        self.assertEqual(self.row("U1")["reviewer_shell_id"], REV1)
 
     def test_a_redeclared_unit_tells_nobody(self):
         """POST is not an upsert: the 409 leaves the board unchanged, so the


### PR DESCRIPTION
Sprint 59 unit U7 · spec doc 58 "Assignment change notice" · feature 27. Depends on U1, merged as 02d5977.

## What it does

A board write that moves a role now emits one message to each of the shells the record names: the shell newly named, the shell it replaced, and the counterpart role on that unit. The notify set is read **off the record** — no subscription, no reader log, no read tracking — because the audit that retired feature #29 found that in every demonstrated case those are exactly the shells who need telling. The sprint-52 incident is the case: two devs worked for 12 and 27 minutes against a reviewer column that had changed under them.

**No migration.** 0100 stays free. `shell_messages` plus `kind`/`sprint_doc_id` from 0059/0078 is everything this needed.

## The premise correction, first

U1 reported "one write choke point so U7 hooks a single function", and the assignment quoted it back to me. **It is not literally true.** `sprint_units` has exactly **two** writers — `_add_sprint_unit` and `_patch_sprint_unit` — verified against `origin/main` (nothing else in the engine writes the table; `snapshot.py` only names it for the dump). The useful half survives: the writer set is closed and verified, and both writers already sit inside a transaction behind `Idempotency-Key`. So this is one emitter called from two sites, inside each write's own transaction and before its commit. A board write that rolls back tells nobody it happened, and a replayed request returns its cached response without reaching the emitter — which is why there is no `dedupe_key` here.

## Trade-offs taken, all reported pre-build and ruled on

- **`kind='shell'`, deliberately.** `task`/`result`/`pr_event` are exactly `interface_wake.ELIGIBLE_KINDS`, so the natural-reading choice would let a planner's board edit turn into a **boot** of whichever party is a bound planner. This is a notice, not work. Sprint scope is still stamped so the rows filter with the sprint's other traffic.
- **The budget is an invariant, not a count.** The spec said "at most three rows per assignment change"; a PATCH may move both roles in one request, and the union is then four shells. Ruled: the three-party rule is **per changed role**, deduped by recipient, and the invariant to build against is **no shell receives more than one row for one write**. "At most three" was a proxy that holds for a single-role change and nothing else. The rejected alternative — refusing a two-role PATCH the way `state` already refuses to ride along — does not reduce noise, it splits it.
- **Sender chain**, because `from_shell_id` is `NOT NULL` and the operator token carries no shell: `actor.shell_id` → the sprint's bound planner via U1's existing `_board_writer` → the recipient itself, which is `pr_poller.py`'s established convention for daemon-emitted rows. A sender resolving to NULL would turn every operator board edit into a 500.
- **One body**, delivered to each party, rather than three per-role phrasings of one fact.
- **The writing shell is excluded from its own notice.** Can only take the count below the ceiling, never above.
- **No terminal-state gate.** The spec conditions this on the sprint being ACTIVE and nothing else, and no terminal-set constant exists on `main` yet (U4 introduces it), so there is nothing to import and minting a third statement of it would be the drift this spec keeps closing. The ACTIVE gate is on the **notice**, never on the record — a planner can still correct a closed sprint's board, in silence.

## Verification — mutations run, not reported

Spec's row: *assignment change notifies exactly three | reassign a reviewer | notify by any broader rule → extra rows, red.* The test board carries a **second unit** whose shells must stay silent; a single-unit fixture cannot tell "notify the record's parties" from "notify the board". The primary test asserts the recipient **set**, not a count — "three rows" is satisfied just as happily by the wrong three.

All round trips under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` cleared, and the **baseline re-asserted green after every revert** (a same-size same-second revert leaves stale bytecode running; that cost me two false readings in sprint 38).

| # | Mutation | Result |
|---|---|---|
| M1 | notify every shell on the BOARD, not the record | 12 red, incl. `test_reviewer_reassignment_notifies_exactly_three` |
| M2 | drop the actually-moved guard | 3 red (field edit / state move / re-assert now emit) |
| M3 | drop the counterpart from the set | 5 red, incl. the primary |
| M4 | drop the ACTIVE gate | 1 red (`..._closed_sprint_emits_nothing...`) |
| M5 | `kind='task'` — make the notice wake-eligible | 1 red (`test_the_notice_can_never_boot_a_shell`) |
| M6 | drop the self-addressed sender fallback | 17 red (NULL sender → 500) |
| M7 | take the counterpart from the REQUEST, not the row | 4 red — **but not the primary**, see below |
| M8 | emit per changed role instead of per recipient | 6 red, incl. the invariant test |

**M7 is reported against myself.** Passing the request's role subset instead of the merged row leaves the primary test **green** by coincidence: the omitted role then reads as changed-to-None, which puts the same three shells in the set by a different route. Four other tests catch it, so the property is pinned by the suite — but it is *not* pinned by the test that names it. That is the "adjacent property left free" shape, and a reviewer should decide whether it wants a test that fails for the right reason.

**Known limit, stated rather than papered over:** the rollback case is covered by 403 / 404 / 409, all of which return *before* the write. Those prove the emitter is not reached on a rejected request; none of them is a true mid-transaction rollback.

## Suite

`tests/test_sprint_assignment_notice.py` — 22 tests, green. `tests/test_sprint_board_record.py` (U1) — 36, green, no regression.

Full suite via `./sc job`: **1696 passed, 3 failed**. The 3 are `tests/test_harness_epoch.py::ScHarnessCommands` and are **pre-existing and unrelated** — verified by running that file on the main checkout at `d31161a`, where the same 3 fail identically. They assert a stubbed `9.9.9 (Claude Code)` while the real host CLI versions (`claude 2.1.220`, …) leak through the fixture. Not my diff, not patched here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)