### PR TITLE
feat(boot): stamp the sprint directive at boot from the record (S59 U9)

### DIFF
--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -125,25 +125,6 @@ PARTICIPANT_RULES = (
 )
 
 
-def _sprint_doc_live(body: "str | None") -> bool:
-    """A sprint is live while its doc body carries `status: ACTIVE`. Callers
-    pair this with `documents.frozen = 0` in SQL — the same predicate the
-    reconciler's trigger uses, so the two cannot disagree about whether a
-    sprint is live.
-
-    Restated here rather than imported on purpose: this module is the boot
-    render and holds no engine imports by contract (a bare `sqlite3` read,
-    nothing out of `scripts/` or `api/`), and `run.py` puts `render/` on the
-    path before `scripts/`. The siblings are `interface_broker._sprint_active`,
-    `server._sprint_doc_status` and `run._sprint_doc_is_active` — this is the
-    fourth. Move the predicate and you must move all four; grep `status:`.
-    """
-    for line in (body or "").splitlines():
-        if line.startswith("status:"):
-            return line.split(":", 1)[1].strip() == "ACTIVE"
-    return False
-
-
 def resolve_sprint_roles(con, shell_id: int) -> list:
     """Every sprint role `shell_id` holds right now, read fresh from the record
     — never cached, so a role changed since the last boot resolves correctly.
@@ -160,12 +141,23 @@ def resolve_sprint_roles(con, shell_id: int) -> list:
     binding yet, and the previous one is generation-bound and released when
     that generation ends (`interface_recovery`). Under the armed reading the
     directive renders only when recovery lags — a race, not a record. The
-    latest binding names who the sprint's planner IS; the doc predicate below
-    is what retires it, since closing a sprint both releases its bindings and
-    flips the body to CLOSED. Same definition as
-    `interface_routes._board_writer` minus the armed filter, so the two cannot
-    disagree about whose sprint it is. (Reported to the planner as an ambiguity
-    call before build; PLN1 message #2257.)
+    latest binding names who the sprint's planner IS; the LIVE predicate below
+    is what retires it. Same definition as `interface_routes._board_writer`
+    minus the armed filter, so the two cannot disagree about whose sprint it
+    is. (Reported to the planner as an ambiguity call before build; adopted in
+    PLN1 messages #2257 / #2263.)
+
+    A SPRINT IS LIVE ON THE STRUCTURED PAIR ONLY — `documents.frozen = 0` plus
+    at least one non-terminal `sprint_units` row. Deliberately NOT the body's
+    `status: ACTIVE` line: regex-matching liveness out of prose is part of the
+    structural gap this feature exists to close (flag_id 213 removed exactly
+    that from the reconciler's trigger), and reintroducing it here would have
+    the boot render and the reconciler disagreeing the moment someone
+    reformats a line. Same pair on both sides, one definition, no drift.
+
+    Consequence, decided rather than discovered: at a sprint's very first boot
+    no unit rows exist yet, so the planner gets no directive — correct, since
+    the planner is the shell CREATING those rows.
 
     Degrades to `[]` on OperationalError rather than failing a boot: this runs
     against the LIVE db at every launch, and a floor that has not applied
@@ -174,27 +166,29 @@ def resolve_sprint_roles(con, shell_id: int) -> list:
     render is worse than one missing a section.
     """
     entries = []
+    placeholders = ",".join("?" * len(TERMINAL_UNIT_STATES))
     try:
         planner_docs = con.execute(
-            "SELECT b.sprint_doc_id, d.title, d.body FROM sprint_planner_bindings b "
+            "SELECT b.sprint_doc_id, d.title FROM sprint_planner_bindings b "
             "JOIN documents d ON d.document_id = b.sprint_doc_id "
             "WHERE b.binding_id = (SELECT MAX(b2.binding_id) "
             "                      FROM sprint_planner_bindings b2 "
             "                      WHERE b2.sprint_doc_id = b.sprint_doc_id) "
             "  AND b.planner_shell_id = ? AND d.frozen = 0 "
+            "  AND EXISTS (SELECT 1 FROM sprint_units u "
+            "              WHERE u.sprint_doc_id = b.sprint_doc_id "
+            f"                AND u.state NOT IN ({placeholders})) "
             "ORDER BY b.sprint_doc_id",
-            (shell_id,)).fetchall()
+            (shell_id, *TERMINAL_UNIT_STATES)).fetchall()
     except sqlite3.OperationalError:
         planner_docs = []
-    for doc_id, title, body in planner_docs:
-        if _sprint_doc_live(body):
-            entries.append({"doc_id": doc_id, "doc_title": title,
-                            "role": "planner", "units": []})
+    for doc_id, title in planner_docs:
+        entries.append({"doc_id": doc_id, "doc_title": title,
+                        "role": "planner", "units": []})
 
-    placeholders = ",".join("?" * len(TERMINAL_UNIT_STATES))
     try:
         rows = con.execute(
-            "SELECT u.sprint_doc_id, d.title, d.body, u.seq, u.unit_title, "
+            "SELECT u.sprint_doc_id, d.title, u.seq, u.unit_title, "
             "       u.dev_shell_id, u.reviewer_shell_id "
             "FROM sprint_units u "
             "JOIN documents d ON d.document_id = u.sprint_doc_id "
@@ -208,9 +202,7 @@ def resolve_sprint_roles(con, shell_id: int) -> list:
     # (doc, role) -> entry, so a shell holding four review units in one sprint
     # gets one line naming all four rather than four sections.
     by_role = {}
-    for doc_id, title, body, seq, unit_title, dev_id, reviewer_id in rows:
-        if not _sprint_doc_live(body):
-            continue
+    for doc_id, title, seq, unit_title, dev_id, reviewer_id in rows:
         for role, holder in (("dev", dev_id), ("reviewer", reviewer_id)):
             if holder != shell_id:
                 continue

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -129,10 +129,13 @@ def resolve_sprint_roles(con, shell_id: int) -> list:
     """Every sprint role `shell_id` holds right now, read fresh from the record
     — never cached, so a role changed since the last boot resolves correctly.
 
-    Returns a list of `{doc_id, doc_title, role, units}`, planner first, then
-    dev, then reviewer; empty means no section renders. A shell with roles in
-    two sprints gets an entry per (sprint, role) — every one is named, because
-    silently choosing one is the failure this unit removes.
+    Returns a list of `{doc_id, doc_title, role, units}` — planner entries
+    first, then the dev/reviewer ones in `unit_id` order (so whichever role's
+    lowest unit_id comes first, NOT dev-before-reviewer); `units` within an
+    entry are in `unit_id` order too, which is the order the planner wrote the
+    board. Empty means no section renders. A shell with roles in two sprints
+    gets an entry per (sprint, role) — every one is named, because silently
+    choosing one is the failure this unit removes.
 
     THE PLANNER IS RESOLVED FROM THE LATEST BINDING, ARMED OR RELEASED. The
     spec said "the armed binding", and that predicate is anti-correlated with
@@ -147,57 +150,78 @@ def resolve_sprint_roles(con, shell_id: int) -> list:
     is. (Reported to the planner as an ambiguity call before build; adopted in
     PLN1 messages #2257 / #2263.)
 
-    A SPRINT IS LIVE ON THE STRUCTURED PAIR ONLY — `documents.frozen = 0` plus
-    at least one non-terminal `sprint_units` row. Deliberately NOT the body's
-    `status: ACTIVE` line: regex-matching liveness out of prose is part of the
-    structural gap this feature exists to close (flag_id 213 removed exactly
-    that from the reconciler's trigger), and reintroducing it here would have
-    the boot render and the reconciler disagreeing the moment someone
-    reformats a line. Same pair on both sides, one definition, no drift.
+    LIVENESS IS STRUCTURED, NEVER THE BODY'S PROSE — `documents.frozen` plus
+    `sprint_units` rows, never the `status: ACTIVE` line. Regex-matching
+    liveness out of prose is part of the structural gap this feature exists to
+    close (flag_id 213 removed exactly that from the reconciler's trigger), and
+    reintroducing it here would have the boot render and the reconciler
+    disagreeing the moment someone reformats a line.
+
+    BUT THE TWO ROLES DO NOT SHARE ONE PREDICATE, and collapsing them was
+    flag_id 231 (my first cut did, on the planner's own instruction; the
+    planner withdrew it):
+
+    - dev / reviewer: `frozen = 0` AND a NON-TERMINAL row of their own. Same
+      pair as the reconciler's trigger, which likewise should not watch a
+      sprint with no live units.
+    - planner: `frozen = 0` AND ANY unit row at all. Every step of close-out —
+      the pre-freeze conformance pass, `status: CLOSED`, the freeze, the
+      participant messages, the watch-retirement sweep, the sprint report, the
+      flag and roadmap bookkeeping — happens AFTER the last unit reaches
+      `merged` and BEFORE the doc is frozen. A non-terminal gate would delete
+      the planner's directive at the exact moment its longest and most
+      procedure-heavy phase begins. So the planner retires on the freeze alone,
+      which is the `sprint` skill's own revocation predicate — the two surfaces
+      cannot disagree about when a sprint ends.
 
     Consequence, decided rather than discovered: at a sprint's very first boot
     no unit rows exist yet, so the planner gets no directive — correct, since
     the planner is the shell CREATING those rows.
 
-    Degrades to `[]` on OperationalError rather than failing a boot: this runs
-    against the LIVE db at every launch, and a floor that has not applied
-    migration 0098 has no `sprint_units` table at all — which is the state of
-    this repo's own running floor as U9 is written. A boot doc that cannot
-    render is worse than one missing a section.
+    Returns `[]` when `sprint_units` DOES NOT EXIST — a floor that has not
+    applied migration 0098 has no such table, which was the state of this
+    repo's own running floor as U9 was written, and compose reads the live db at
+    every boot of every shell. That degrade is gated on the table's ACTUAL
+    ABSENCE and nothing else (flag_id 233): the missing table is temporary, a
+    bare `except OperationalError` would be permanent, and once 0098 is applied
+    the only thing such a catch could still swallow is a genuine fault — a
+    renamed column, a typo — silently reverting the whole fleet to pre-U9
+    behaviour on a section the render itself labels MANDATORY. Faults raise.
     """
     entries = []
+    if not con.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' "
+            "AND name='sprint_units'").fetchone():
+        return []
+    # `sprint_planner_bindings` needs no check of its own: it arrived in
+    # migration 0078 and `sprint_units` in 0098, so units-present implies
+    # bindings-present on any floor that can reach this line.
     placeholders = ",".join("?" * len(TERMINAL_UNIT_STATES))
-    try:
-        planner_docs = con.execute(
-            "SELECT b.sprint_doc_id, d.title FROM sprint_planner_bindings b "
-            "JOIN documents d ON d.document_id = b.sprint_doc_id "
-            "WHERE b.binding_id = (SELECT MAX(b2.binding_id) "
-            "                      FROM sprint_planner_bindings b2 "
-            "                      WHERE b2.sprint_doc_id = b.sprint_doc_id) "
-            "  AND b.planner_shell_id = ? AND d.frozen = 0 "
-            "  AND EXISTS (SELECT 1 FROM sprint_units u "
-            "              WHERE u.sprint_doc_id = b.sprint_doc_id "
-            f"                AND u.state NOT IN ({placeholders})) "
-            "ORDER BY b.sprint_doc_id",
-            (shell_id, *TERMINAL_UNIT_STATES)).fetchall()
-    except sqlite3.OperationalError:
-        planner_docs = []
+    planner_docs = con.execute(
+        "SELECT b.sprint_doc_id, d.title FROM sprint_planner_bindings b "
+        "JOIN documents d ON d.document_id = b.sprint_doc_id "
+        "WHERE b.binding_id = (SELECT MAX(b2.binding_id) "
+        "                      FROM sprint_planner_bindings b2 "
+        "                      WHERE b2.sprint_doc_id = b.sprint_doc_id) "
+        "  AND b.planner_shell_id = ? AND d.frozen = 0 "
+        # ANY row, not a non-terminal one — see the predicate split above.
+        "  AND EXISTS (SELECT 1 FROM sprint_units u "
+        "              WHERE u.sprint_doc_id = b.sprint_doc_id) "
+        "ORDER BY b.sprint_doc_id",
+        (shell_id,)).fetchall()
     for doc_id, title in planner_docs:
         entries.append({"doc_id": doc_id, "doc_title": title,
                         "role": "planner", "units": []})
 
-    try:
-        rows = con.execute(
-            "SELECT u.sprint_doc_id, d.title, u.seq, u.unit_title, "
-            "       u.dev_shell_id, u.reviewer_shell_id "
-            "FROM sprint_units u "
-            "JOIN documents d ON d.document_id = u.sprint_doc_id "
-            "WHERE (u.dev_shell_id = ? OR u.reviewer_shell_id = ?) "
-            f"  AND u.state NOT IN ({placeholders}) AND d.frozen = 0 "
-            "ORDER BY u.sprint_doc_id, u.unit_id",
-            (shell_id, shell_id, *TERMINAL_UNIT_STATES)).fetchall()
-    except sqlite3.OperationalError:
-        rows = []
+    rows = con.execute(
+        "SELECT u.sprint_doc_id, d.title, u.seq, u.unit_title, "
+        "       u.dev_shell_id, u.reviewer_shell_id "
+        "FROM sprint_units u "
+        "JOIN documents d ON d.document_id = u.sprint_doc_id "
+        "WHERE (u.dev_shell_id = ? OR u.reviewer_shell_id = ?) "
+        f"  AND u.state NOT IN ({placeholders}) AND d.frozen = 0 "
+        "ORDER BY u.sprint_doc_id, u.unit_id",
+        (shell_id, shell_id, *TERMINAL_UNIT_STATES)).fetchall()
 
     # (doc, role) -> entry, so a shell holding four review units in one sprint
     # gets one line naming all four rather than four sections.

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -88,6 +88,172 @@ PROJECT_VS_ENGINE_SOURCE = (
 # The repo catalogue (dr_*) lives in its OWN db, separate from shell_db.db.
 MAP_DB_PATH = ENGINE.parent / ".sc-state" / "map.db"
 
+# ── The sprint directive (spec doc 58, unit U9) ──────────────────────────────
+# A shell holding sprint work is told so BY THE BOOT RENDER, resolved from the
+# record. The directive used to live in a task row the planner hand-wrote; an
+# audit found it in every kickoff row (written from a template) and absent from
+# all six improvised afterwards. A worker booted without it behaved exactly as a
+# shell should in a normal interactive session — it finished a full review pass,
+# filed its flags, then ended its turn on a question. Nothing reads a headless
+# run's stdout, so the planner read the silence as death and re-booted it over
+# eleven minutes of completed work.
+#
+# So the remedy is not a better sentence. The boot doc is the one artifact the
+# harness is guaranteed to read, and this section is a function of `sprint_units`
+# and the planner binding: a task row cannot grant it, and a missing task row
+# cannot withhold it. The planner is removed from the path.
+TERMINAL_UNIT_STATES = ("merged", "cancelled")
+
+# Stated inline rather than referenced, because the failure mode is precisely a
+# skill body that never loads. This renders as prose in a document every harness
+# reads, so it survives a harness with no skill mechanism at all.
+PARTICIPANT_RULES = (
+    "**There may be no one to ask.** A shell booted by `./sc run` gets ONE turn "
+    "and no observer — the planner sees message rows and durable artifacts "
+    "(flags, docs, PRs, commits), never the text you print at the end of a turn. "
+    "Three rules follow, and they are not optional:\n"
+    "\n"
+    "1. **Filing is your own authority.** Findings, flags, verdicts, unit "
+    "reports, PRs — file them. Never ask permission to REPORT something.\n"
+    "2. **A ruling request goes out as a MESSAGE ROW, then the turn ends** — "
+    "`sc mem message send <planner> \"…\" --kind result`. Durable, addressed, "
+    "and it wakes the planner. A question living only in your final stdout "
+    "reaches nobody and is indistinguishable from death.\n"
+    "3. **A turn ending with work unfinished sends a PARTIAL.** \"Items 1-2 "
+    "done, here is what I found, item 3 untouched\" beats silence — silence is "
+    "read as death, and has been."
+)
+
+
+def _sprint_doc_live(body: "str | None") -> bool:
+    """A sprint is live while its doc body carries `status: ACTIVE`. Callers
+    pair this with `documents.frozen = 0` in SQL — the same predicate the
+    reconciler's trigger uses, so the two cannot disagree about whether a
+    sprint is live.
+
+    Restated here rather than imported on purpose: this module is the boot
+    render and holds no engine imports by contract (a bare `sqlite3` read,
+    nothing out of `scripts/` or `api/`), and `run.py` puts `render/` on the
+    path before `scripts/`. The siblings are `interface_broker._sprint_active`,
+    `server._sprint_doc_status` and `run._sprint_doc_is_active` — this is the
+    fourth. Move the predicate and you must move all four; grep `status:`.
+    """
+    for line in (body or "").splitlines():
+        if line.startswith("status:"):
+            return line.split(":", 1)[1].strip() == "ACTIVE"
+    return False
+
+
+def resolve_sprint_roles(con, shell_id: int) -> list:
+    """Every sprint role `shell_id` holds right now, read fresh from the record
+    — never cached, so a role changed since the last boot resolves correctly.
+
+    Returns a list of `{doc_id, doc_title, role, units}`, planner first, then
+    dev, then reviewer; empty means no section renders. A shell with roles in
+    two sprints gets an entry per (sprint, role) — every one is named, because
+    silently choosing one is the failure this unit removes.
+
+    THE PLANNER IS RESOLVED FROM THE LATEST BINDING, ARMED OR RELEASED. The
+    spec said "the armed binding", and that predicate is anti-correlated with
+    the need: `_arm_binding` refuses unless the planner already has an
+    `occupied` Interface session, so the session being booted cannot have a
+    binding yet, and the previous one is generation-bound and released when
+    that generation ends (`interface_recovery`). Under the armed reading the
+    directive renders only when recovery lags — a race, not a record. The
+    latest binding names who the sprint's planner IS; the doc predicate below
+    is what retires it, since closing a sprint both releases its bindings and
+    flips the body to CLOSED. Same definition as
+    `interface_routes._board_writer` minus the armed filter, so the two cannot
+    disagree about whose sprint it is. (Reported to the planner as an ambiguity
+    call before build; PLN1 message #2257.)
+
+    Degrades to `[]` on OperationalError rather than failing a boot: this runs
+    against the LIVE db at every launch, and a floor that has not applied
+    migration 0098 has no `sprint_units` table at all — which is the state of
+    this repo's own running floor as U9 is written. A boot doc that cannot
+    render is worse than one missing a section.
+    """
+    entries = []
+    try:
+        planner_docs = con.execute(
+            "SELECT b.sprint_doc_id, d.title, d.body FROM sprint_planner_bindings b "
+            "JOIN documents d ON d.document_id = b.sprint_doc_id "
+            "WHERE b.binding_id = (SELECT MAX(b2.binding_id) "
+            "                      FROM sprint_planner_bindings b2 "
+            "                      WHERE b2.sprint_doc_id = b.sprint_doc_id) "
+            "  AND b.planner_shell_id = ? AND d.frozen = 0 "
+            "ORDER BY b.sprint_doc_id",
+            (shell_id,)).fetchall()
+    except sqlite3.OperationalError:
+        planner_docs = []
+    for doc_id, title, body in planner_docs:
+        if _sprint_doc_live(body):
+            entries.append({"doc_id": doc_id, "doc_title": title,
+                            "role": "planner", "units": []})
+
+    placeholders = ",".join("?" * len(TERMINAL_UNIT_STATES))
+    try:
+        rows = con.execute(
+            "SELECT u.sprint_doc_id, d.title, d.body, u.seq, u.unit_title, "
+            "       u.dev_shell_id, u.reviewer_shell_id "
+            "FROM sprint_units u "
+            "JOIN documents d ON d.document_id = u.sprint_doc_id "
+            "WHERE (u.dev_shell_id = ? OR u.reviewer_shell_id = ?) "
+            f"  AND u.state NOT IN ({placeholders}) AND d.frozen = 0 "
+            "ORDER BY u.sprint_doc_id, u.unit_id",
+            (shell_id, shell_id, *TERMINAL_UNIT_STATES)).fetchall()
+    except sqlite3.OperationalError:
+        rows = []
+
+    # (doc, role) -> entry, so a shell holding four review units in one sprint
+    # gets one line naming all four rather than four sections.
+    by_role = {}
+    for doc_id, title, body, seq, unit_title, dev_id, reviewer_id in rows:
+        if not _sprint_doc_live(body):
+            continue
+        for role, holder in (("dev", dev_id), ("reviewer", reviewer_id)):
+            if holder != shell_id:
+                continue
+            entry = by_role.get((doc_id, role))
+            if entry is None:
+                entry = {"doc_id": doc_id, "doc_title": title, "role": role,
+                         "units": []}
+                by_role[(doc_id, role)] = entry
+                entries.append(entry)
+            entry["units"].append((seq, unit_title))
+    return entries
+
+
+def render_sprint_directive(con, shell_id: int) -> str:
+    """The `## SPRINT DIRECTIVE` body, or "" when this shell holds no sprint
+    role — no ceremony for a shell with no sprint work."""
+    entries = resolve_sprint_roles(con, shell_id)
+    if not entries:
+        return ""
+    lines = [
+        "You hold sprint work. This section is resolved from the RECORD at "
+        "every boot — the board's `sprint_units` rows and the planner binding "
+        "— never from a message. A task row cannot grant it and a missing task "
+        "row cannot withhold it.",
+        "",
+    ]
+    for e in entries:
+        sprint = f"**Sprint doc {e['doc_id']}**"
+        if e["doc_title"]:
+            sprint += f" — {e['doc_title']}"
+        if e["role"] == "planner":
+            lines.append(f"- {sprint}: you are the **PLANNER**. Invoke the "
+                         "`sprint_orchestration` skill.")
+            continue
+        units = ", ".join(f"`{seq}` ({title})" for seq, title in e["units"])
+        slot = "dev" if e["role"] == "dev" else "reviewer"
+        lines.append(f"- {sprint}: you are the **{slot.upper()}** for {units}. "
+                     f"Invoke the `sprint` skill, {slot} slot.")
+    if len(entries) > 1:
+        lines.append("")
+        lines.append("**Every role you hold is listed above — do not pick one.**")
+    return "\n".join(lines + ["", PARTICIPANT_RULES])
+
 
 def open_map_ro() -> "sqlite3.Connection | None":
     """Read-only handle to the map DB, or None if the repo isn't mapped yet
@@ -378,12 +544,21 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
     if floor_note:
         active_session.append(f"- floor: {floor_note}")
 
+    # Directly after ACTIVE SESSION and ahead of everything else the render
+    # appends: it is this session's standing orders, and the whole unit exists
+    # because a worker missed the context it was operating in. Empty for a
+    # shell with no sprint role — the section is mandatory, never unconditional.
+    sprint_directive = render_sprint_directive(con, shell_id)
+    sprint_block = (["## SPRINT DIRECTIVE — MANDATORY", "", sprint_directive,
+                     "", "---", ""] if sprint_directive else [])
+
     parts = [
         template,
         "",
         "## ACTIVE SESSION", "",
         *active_session,
         "", "---", "",
+        *sprint_block,
         *first_run,
         "## OPERATOR", "", render_operator(user),
         "", "---", "",

--- a/tests/test_boot_sprint_directive.py
+++ b/tests/test_boot_sprint_directive.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""The sprint directive is STAMPED AT BOOT (spec doc 58 U9, feature 27).
+
+The defect this closes: the "load the `sprint` skill" directive lived in a task
+row the planner hand-wrote. It was present in every kickoff row and absent from
+all six improvised afterwards, so a worker booted off an improvised row had no
+participant procedure loaded and behaved like a normal interactive session —
+finished a full review pass, filed its flags, then ended its turn on a question
+nobody could hear. The remedy had to stop being a sentence someone remembers to
+type, so the BOOT RENDER carries it, resolved from the record.
+
+WHY MOST OF THIS FILE ASSERTS ABSENCE. A test that only checks the directive
+APPEARS passes for a renderer that emits the section unconditionally — which
+would be a worse bug than the one being fixed, since it would tell every shell
+in the fork it was in a sprint. So the absences are the real subject here:
+no non-terminal row, only-merged rows, a frozen doc, a CLOSED doc, and the
+tables missing entirely.
+
+AND EVERY ABSENCE CARRIES A POSITIVE CONTROL. An absence asserted against an
+artifact you have not proven populated is trivially true — no-op the emitter
+and every absence test in a naive version of this file still passes. So each
+one flips exactly the fact under test on the SAME db and proves the section
+comes back. That pairing is the point; do not drop the control half.
+
+Run:
+    python3 tests/test_boot_sprint_directive.py
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+
+sys.path.insert(0, str(ENGINE / "render"))
+import compose  # noqa: E402
+
+DEV_SHELL = 11
+REVIEWER_SHELL = 8
+PLANNER_SHELL = 9
+BYSTANDER_SHELL = 6          # holds no sprint role in any test
+
+ACTIVE_BODY = "# SPRINT: test\nstatus: ACTIVE\n\nprose the record never touches\n"
+CLOSED_BODY = "# SPRINT: test\nstatus: CLOSED\n\nprose the record never touches\n"
+
+
+def build_db(path: Path) -> sqlite3.Connection:
+    """Engine db from the tracked baseline. `sprint_units` and
+    `sprint_planner_bindings` are both in schema.sql, so no migration replay is
+    needed to get the shapes this renderer reads."""
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    con.execute("INSERT INTO users (user_id, username) VALUES (1, 'Jed')")
+    for shell_id, shortname, flavor in (
+            (DEV_SHELL, "DEV5", "dev"),
+            (REVIEWER_SHELL, "REV2", "reviewer"),
+            (PLANNER_SHELL, "PLN1", "planner"),
+            (BYSTANDER_SHELL, "DEV4", "dev")):
+        con.execute(
+            "INSERT INTO shells (shell_id, display_name, shortname, flavor, "
+            "role, mandate, system_prompt, current_state) "
+            "VALUES (?,?,?,?,'r','m','sp','cs')",
+            (shell_id, shortname, shortname, flavor))
+    con.commit()
+    return con
+
+
+def add_doc(con, doc_id: int, title: str = "SPRINT: watchdog",
+            body: str = ACTIVE_BODY, frozen: int = 0) -> None:
+    con.execute(
+        "INSERT INTO documents (document_id, title, body, kind, frozen) "
+        "VALUES (?,?,?,'doc',?)", (doc_id, title, body, frozen))
+    con.commit()
+
+
+def add_unit(con, doc_id: int, seq: str, *, dev=None, reviewer=None,
+             state: str = "working", title: str = "the unit") -> None:
+    con.execute(
+        "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title, "
+        "dev_shell_id, reviewer_shell_id, state) VALUES (?,?,?,?,?,?)",
+        (doc_id, seq, title, dev, reviewer, state))
+    con.commit()
+
+
+def arm_binding(con, doc_id: int, planner: int, *, released: bool = False,
+                session_id: int = 1, generation: int = 1) -> int:
+    """A binding row. The FKs to interface_sessions/interface_generations are
+    satisfied by seeding those first; `released` is what the spec's original
+    wording would have filtered on and this unit deliberately does not."""
+    con.execute(
+        "INSERT OR IGNORE INTO interface_generations (shell_id, generation) "
+        "VALUES (?,?)", (planner, generation))
+    con.execute(
+        "INSERT OR IGNORE INTO interface_sessions (session_id, shell_id, "
+        "generation, occupancy, lifecycle) VALUES (?,?,?,'occupied','idle')",
+        (session_id, planner, generation))
+    cur = con.execute(
+        "INSERT INTO sprint_planner_bindings (sprint_doc_id, planner_shell_id, "
+        "session_id, shell_id, generation, released_at) "
+        "VALUES (?,?,?,?,?,?)",
+        (doc_id, planner, session_id, planner, generation,
+         "2026-07-26 01:00:00" if released else None))
+    con.commit()
+    return cur.lastrowid
+
+
+class SprintDirectiveTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "shell_db.db"
+        self.con = build_db(self.path)
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(self.con.close)
+
+    def render(self, shell_id: int) -> str:
+        return compose.render_sprint_directive(self.con, shell_id)
+
+    # ── the roles resolve, and each names its own skill and slot ────────────
+
+    def test_dev_gets_the_dev_slot_and_its_unit(self):
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL, reviewer=REVIEWER_SHELL,
+                 title="boot-stamped directive")
+        out = self.render(DEV_SHELL)
+        self.assertIn("DEV", out)
+        self.assertIn("`sprint` skill, dev slot", out)
+        self.assertIn("`U9`", out)
+        self.assertIn("boot-stamped directive", out)
+        self.assertIn("doc 59", out)
+
+    def test_reviewer_gets_the_reviewer_slot(self):
+        # PLN1's named mutation targets exactly this: make the resolution
+        # ignore reviewer_shell_id and this test must go red. That column's
+        # absence from spec_tasks is what made a dead reviewer undetectable
+        # and justified the whole feature, so it is asserted on its own and
+        # not folded into the dev case.
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U3", dev=DEV_SHELL, reviewer=REVIEWER_SHELL)
+        out = self.render(REVIEWER_SHELL)
+        self.assertIn("REVIEWER", out)
+        self.assertIn("`sprint` skill, reviewer slot", out)
+        self.assertIn("`U3`", out)
+
+    def test_planner_gets_the_orchestration_skill(self):
+        add_doc(self.con, 59)
+        arm_binding(self.con, 59, PLANNER_SHELL)
+        out = self.render(PLANNER_SHELL)
+        self.assertIn("PLANNER", out)
+        self.assertIn("`sprint_orchestration` skill", out)
+
+    def test_planner_resolves_from_a_RELEASED_binding_too(self):
+        # The load-bearing departure from the spec's wording. Arming requires
+        # an already-`occupied` session, so the generation being booted cannot
+        # have a binding yet and the previous one is released when its
+        # generation ends. Filtering on armed would render the planner's
+        # directive only when recovery lagged — the sprint doc is what says
+        # the sprint is live, not the binding.
+        add_doc(self.con, 59)
+        arm_binding(self.con, 59, PLANNER_SHELL, released=True)
+        self.assertIn("PLANNER", self.render(PLANNER_SHELL))
+
+    def test_only_the_latest_binding_names_the_planner(self):
+        # A sprint re-bound to a different planner must not keep telling the
+        # old one it is the planner.
+        add_doc(self.con, 59)
+        arm_binding(self.con, 59, PLANNER_SHELL, released=True,
+                    session_id=1, generation=1)
+        arm_binding(self.con, 59, 10, session_id=2, generation=1)
+        self.assertEqual(self.render(PLANNER_SHELL), "")
+        self.assertIn("PLANNER", self.render(10))   # positive control
+
+    def test_reviewer_of_several_units_gets_one_line_naming_all(self):
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U3", reviewer=REVIEWER_SHELL)
+        add_unit(self.con, 59, "U4", reviewer=REVIEWER_SHELL)
+        out = self.render(REVIEWER_SHELL)
+        self.assertIn("`U3`", out)
+        self.assertIn("`U4`", out)
+        self.assertEqual(out.count("reviewer slot"), 1)
+
+    # ── two roles / two sprints — every one named, never a silent pick ──────
+
+    def test_both_roles_are_named_and_neither_is_picked(self):
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
+        add_unit(self.con, 59, "U3", reviewer=DEV_SHELL)
+        arm_binding(self.con, 59, DEV_SHELL)
+        out = self.render(DEV_SHELL)
+        self.assertIn("dev slot", out)
+        self.assertIn("reviewer slot", out)
+        self.assertIn("`sprint_orchestration` skill", out)
+        self.assertIn("do not pick one", out)
+
+    def test_a_shell_in_two_sprints_sees_both(self):
+        add_doc(self.con, 59, title="SPRINT: watchdog")
+        add_doc(self.con, 61, title="SPRINT: the other one")
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
+        add_unit(self.con, 61, "U2", dev=DEV_SHELL)
+        out = self.render(DEV_SHELL)
+        self.assertIn("doc 59", out)
+        self.assertIn("doc 61", out)
+        self.assertIn("SPRINT: the other one", out)
+        self.assertIn("do not pick one", out)
+
+    def test_the_three_participant_rules_are_in_the_section_itself(self):
+        # They render as prose because the failure mode IS a skill body that
+        # never loads — a pointer to the skill would reproduce the bug.
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
+        out = self.render(DEV_SHELL)
+        self.assertIn("Filing is your own authority", out)
+        self.assertIn("MESSAGE ROW, then the turn ends", out)
+        self.assertIn("sends a PARTIAL", out)
+
+    # ── the absences, each with its positive control ────────────────────────
+
+    def test_no_sprint_row_renders_nothing(self):
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL, reviewer=REVIEWER_SHELL)
+        self.assertEqual(self.render(BYSTANDER_SHELL), "")
+        self.assertNotEqual(self.render(DEV_SHELL), "")     # control
+
+    def test_terminal_units_only_render_nothing(self):
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL, state="merged")
+        add_unit(self.con, 59, "U8", dev=DEV_SHELL, state="cancelled")
+        self.assertEqual(self.render(DEV_SHELL), "")
+        # control: the SAME rows, one moved off a terminal state
+        self.con.execute("UPDATE sprint_units SET state='working' WHERE seq='U9'")
+        self.con.commit()
+        self.assertNotEqual(self.render(DEV_SHELL), "")
+
+    def test_frozen_doc_renders_nothing(self):
+        add_doc(self.con, 59, frozen=1)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
+        arm_binding(self.con, 59, PLANNER_SHELL)
+        self.assertEqual(self.render(DEV_SHELL), "")
+        self.assertEqual(self.render(PLANNER_SHELL), "")
+        # control: same rows, doc unfrozen
+        self.con.execute("UPDATE documents SET frozen=0 WHERE document_id=59")
+        self.con.commit()
+        self.assertNotEqual(self.render(DEV_SHELL), "")
+        self.assertNotEqual(self.render(PLANNER_SHELL), "")
+
+    def test_closed_sprint_renders_nothing(self):
+        add_doc(self.con, 59, body=CLOSED_BODY)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
+        arm_binding(self.con, 59, PLANNER_SHELL)
+        self.assertEqual(self.render(DEV_SHELL), "")
+        self.assertEqual(self.render(PLANNER_SHELL), "")
+        # control: same rows, status flipped back
+        self.con.execute("UPDATE documents SET body=? WHERE document_id=59",
+                         (ACTIVE_BODY,))
+        self.con.commit()
+        self.assertNotEqual(self.render(DEV_SHELL), "")
+        self.assertNotEqual(self.render(PLANNER_SHELL), "")
+
+    def test_missing_tables_render_nothing_instead_of_breaking_the_boot(self):
+        # Not hypothetical: as this unit was written the repo's own running
+        # floor had applied migrations only through 0096, so the live db had
+        # `sprint_planner_bindings` and NO `sprint_units` at all. compose reads
+        # that db at every launch of every shell, so an unguarded SELECT here
+        # is a broken boot for the whole fork, not a missing section.
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
+        arm_binding(self.con, 59, PLANNER_SHELL)
+        self.assertNotEqual(self.render(DEV_SHELL), "")       # control first
+        self.assertNotEqual(self.render(PLANNER_SHELL), "")
+
+        self.con.execute("DROP TABLE sprint_units")
+        self.con.commit()
+        self.assertEqual(self.render(DEV_SHELL), "")
+        self.assertIn("PLANNER", self.render(PLANNER_SHELL))  # still resolves
+
+        self.con.execute("DROP TABLE sprint_planner_bindings")
+        self.con.commit()
+        self.assertEqual(self.render(PLANNER_SHELL), "")
+
+    # ── the terminal set is the schema's, not a private opinion ─────────────
+
+    def test_terminal_states_are_a_subset_of_the_schema_check(self):
+        # A state added to sprint_units that this renderer does not know about
+        # is the silent failure: an unknown state reads as non-terminal, which
+        # errs toward telling a shell it is still in a sprint. Pin the set
+        # against the CHECK so a schema move surfaces here.
+        ddl = self.con.execute(
+            "SELECT sql FROM sqlite_master WHERE name='sprint_units'"
+        ).fetchone()[0]
+        allowed = set(re.findall(r"'(\w+)'", ddl.split("CHECK (state IN")[1]))
+        self.assertTrue(set(compose.TERMINAL_UNIT_STATES) <= allowed)
+        self.assertIn("merged", allowed)
+        self.assertIn("cancelled", allowed)
+
+
+class BootDocIntegrationTest(unittest.TestCase):
+    """The section has to reach the rendered document, in the right place."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "shell_db.db"
+        self.con = build_db(self.path)
+        self.con.row_factory = sqlite3.Row
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(self.con.close)
+
+    def boot(self, shell_id: int) -> str:
+        shell = self.con.execute(
+            "SELECT * FROM shells WHERE shell_id=?", (shell_id,)).fetchone()
+        user = self.con.execute(
+            "SELECT * FROM users WHERE user_id=1").fetchone()
+        return compose.compose_boot(self.con, shell, user, "0001", 1)
+
+    def test_the_section_lands_in_the_boot_doc_under_active_session(self):
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
+        doc = self.boot(DEV_SHELL)
+        self.assertIn("## SPRINT DIRECTIVE — MANDATORY", doc)
+        # ahead of everything the render appends after ACTIVE SESSION — this
+        # is standing orders, not an appendix
+        self.assertLess(doc.index("## ACTIVE SESSION"),
+                        doc.index("## SPRINT DIRECTIVE"))
+        self.assertLess(doc.index("## SPRINT DIRECTIVE"),
+                        doc.index("## IDENTITY"))
+
+    def test_a_shell_with_no_sprint_work_gets_no_section_at_all(self):
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
+        doc = self.boot(BYSTANDER_SHELL)
+        self.assertNotIn("SPRINT DIRECTIVE", doc)
+        self.assertIn("## IDENTITY", doc)                  # control: it rendered
+        self.assertIn("## SPRINT DIRECTIVE", self.boot(DEV_SHELL))
+
+    def test_a_boot_still_renders_when_the_board_table_is_absent(self):
+        self.con.execute("DROP TABLE sprint_units")
+        self.con.commit()
+        doc = self.boot(DEV_SHELL)
+        self.assertNotIn("SPRINT DIRECTIVE", doc)
+        self.assertIn("## IDENTITY", doc)
+        self.assertIn("## STATUS", doc)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_boot_sprint_directive.py
+++ b/tests/test_boot_sprint_directive.py
@@ -149,10 +149,22 @@ class SprintDirectiveTest(unittest.TestCase):
 
     def test_planner_gets_the_orchestration_skill(self):
         add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
         arm_binding(self.con, 59, PLANNER_SHELL)
         out = self.render(PLANNER_SHELL)
         self.assertIn("PLANNER", out)
         self.assertIn("`sprint_orchestration` skill", out)
+
+    def test_planner_gets_nothing_before_the_board_has_rows(self):
+        # A sprint's very first boot: the binding exists, no unit rows do.
+        # Correct — the planner is the shell about to CREATE those rows and
+        # does not need to be told what it is doing. Decided, not discovered
+        # (PLN1 #2263).
+        add_doc(self.con, 59)
+        arm_binding(self.con, 59, PLANNER_SHELL)
+        self.assertEqual(self.render(PLANNER_SHELL), "")
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)          # control
+        self.assertIn("PLANNER", self.render(PLANNER_SHELL))
 
     def test_planner_resolves_from_a_RELEASED_binding_too(self):
         # The load-bearing departure from the spec's wording. Arming requires
@@ -162,6 +174,7 @@ class SprintDirectiveTest(unittest.TestCase):
         # directive only when recovery lagged — the sprint doc is what says
         # the sprint is live, not the binding.
         add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
         arm_binding(self.con, 59, PLANNER_SHELL, released=True)
         self.assertIn("PLANNER", self.render(PLANNER_SHELL))
 
@@ -169,6 +182,7 @@ class SprintDirectiveTest(unittest.TestCase):
         # A sprint re-bound to a different planner must not keep telling the
         # old one it is the planner.
         add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
         arm_binding(self.con, 59, PLANNER_SHELL, released=True,
                     session_id=1, generation=1)
         arm_binding(self.con, 59, 10, session_id=2, generation=1)
@@ -227,14 +241,20 @@ class SprintDirectiveTest(unittest.TestCase):
         self.assertNotEqual(self.render(DEV_SHELL), "")     # control
 
     def test_terminal_units_only_render_nothing(self):
+        # This is also what retires the PLANNER's directive: a sprint whose
+        # every unit is merged or cancelled is over, and the structured pair
+        # says so without anyone editing prose.
         add_doc(self.con, 59)
         add_unit(self.con, 59, "U9", dev=DEV_SHELL, state="merged")
         add_unit(self.con, 59, "U8", dev=DEV_SHELL, state="cancelled")
+        arm_binding(self.con, 59, PLANNER_SHELL)
         self.assertEqual(self.render(DEV_SHELL), "")
+        self.assertEqual(self.render(PLANNER_SHELL), "")
         # control: the SAME rows, one moved off a terminal state
         self.con.execute("UPDATE sprint_units SET state='working' WHERE seq='U9'")
         self.con.commit()
         self.assertNotEqual(self.render(DEV_SHELL), "")
+        self.assertNotEqual(self.render(PLANNER_SHELL), "")
 
     def test_frozen_doc_renders_nothing(self):
         add_doc(self.con, 59, frozen=1)
@@ -248,18 +268,25 @@ class SprintDirectiveTest(unittest.TestCase):
         self.assertNotEqual(self.render(DEV_SHELL), "")
         self.assertNotEqual(self.render(PLANNER_SHELL), "")
 
-    def test_closed_sprint_renders_nothing(self):
+    def test_liveness_is_structured_and_the_body_prose_is_never_read(self):
+        # The inverse of an absence test, and it pins a ruling rather than a
+        # behaviour: liveness is `frozen = 0` + a non-terminal unit row, NOT
+        # the body's `status:` line. Regex-matching ACTIVE-ness out of prose is
+        # part of the structural gap this feature closes (flag_id 213 removed
+        # exactly that from the reconciler's trigger), and reintroducing it
+        # here would let the boot render and the reconciler disagree about
+        # whether a sprint is live the moment someone reformats a line.
+        # So: prose says CLOSED, the record says otherwise, and the RECORD wins.
         add_doc(self.con, 59, body=CLOSED_BODY)
         add_unit(self.con, 59, "U9", dev=DEV_SHELL)
         arm_binding(self.con, 59, PLANNER_SHELL)
-        self.assertEqual(self.render(DEV_SHELL), "")
-        self.assertEqual(self.render(PLANNER_SHELL), "")
-        # control: same rows, status flipped back
-        self.con.execute("UPDATE documents SET body=? WHERE document_id=59",
-                         (ACTIVE_BODY,))
+        self.assertIn("DEV", self.render(DEV_SHELL))
+        self.assertIn("PLANNER", self.render(PLANNER_SHELL))
+        # and a body with no status line at all changes nothing either
+        self.con.execute("UPDATE documents SET body='' WHERE document_id=59")
         self.con.commit()
-        self.assertNotEqual(self.render(DEV_SHELL), "")
-        self.assertNotEqual(self.render(PLANNER_SHELL), "")
+        self.assertIn("DEV", self.render(DEV_SHELL))
+        self.assertIn("PLANNER", self.render(PLANNER_SHELL))
 
     def test_missing_tables_render_nothing_instead_of_breaking_the_boot(self):
         # Not hypothetical: as this unit was written the repo's own running
@@ -276,11 +303,14 @@ class SprintDirectiveTest(unittest.TestCase):
         self.con.execute("DROP TABLE sprint_units")
         self.con.commit()
         self.assertEqual(self.render(DEV_SHELL), "")
-        self.assertIn("PLANNER", self.render(PLANNER_SHELL))  # still resolves
+        # the planner goes quiet too: liveness is the structured pair, and
+        # half of that pair is the table that just vanished
+        self.assertEqual(self.render(PLANNER_SHELL), "")
 
         self.con.execute("DROP TABLE sprint_planner_bindings")
         self.con.commit()
         self.assertEqual(self.render(PLANNER_SHELL), "")
+        self.assertEqual(self.render(DEV_SHELL), "")
 
     # ── the terminal set is the schema's, not a private opinion ─────────────
 

--- a/tests/test_boot_sprint_directive.py
+++ b/tests/test_boot_sprint_directive.py
@@ -240,21 +240,40 @@ class SprintDirectiveTest(unittest.TestCase):
         self.assertEqual(self.render(BYSTANDER_SHELL), "")
         self.assertNotEqual(self.render(DEV_SHELL), "")     # control
 
-    def test_terminal_units_only_render_nothing(self):
-        # This is also what retires the PLANNER's directive: a sprint whose
-        # every unit is merged or cancelled is over, and the structured pair
-        # says so without anyone editing prose.
+    def test_terminal_units_retire_the_WORKERS_but_not_the_planner(self):
+        # The predicate split (flag_id 231, spec doc 58 "The boot directive").
+        # A dev whose every unit is merged or cancelled is done. THE PLANNER IS
+        # NOT: every step of close-out — the conformance pass, `status: CLOSED`,
+        # the freeze, the participant messages, the watch sweep, the sprint
+        # report, the flag and roadmap bookkeeping — happens in exactly this
+        # state, all units merged and the doc not yet frozen. The first cut of
+        # this test asserted the planner rendered "" here and called the sprint
+        # "over"; it is not over, and the assertion pinned the defect.
         add_doc(self.con, 59)
         add_unit(self.con, 59, "U9", dev=DEV_SHELL, state="merged")
         add_unit(self.con, 59, "U8", dev=DEV_SHELL, state="cancelled")
         arm_binding(self.con, 59, PLANNER_SHELL)
         self.assertEqual(self.render(DEV_SHELL), "")
-        self.assertEqual(self.render(PLANNER_SHELL), "")
-        # control: the SAME rows, one moved off a terminal state
+        self.assertIn("PLANNER", self.render(PLANNER_SHELL))
+        # control: the SAME rows, one moved off a terminal state — the dev's
+        # directive comes back, so the absence above was about the state and
+        # not about an empty board
         self.con.execute("UPDATE sprint_units SET state='working' WHERE seq='U9'")
         self.con.commit()
         self.assertNotEqual(self.render(DEV_SHELL), "")
-        self.assertNotEqual(self.render(PLANNER_SHELL), "")
+        self.assertIn("PLANNER", self.render(PLANNER_SHELL))
+
+    def test_the_freeze_alone_retires_the_planner(self):
+        # The other half of the split: what DOES end the planner's directive is
+        # the freeze, which is the `sprint` skill's own revocation predicate.
+        # Terminal units + frozen doc, one field apart from the test above.
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL, state="merged")
+        arm_binding(self.con, 59, PLANNER_SHELL)
+        self.assertIn("PLANNER", self.render(PLANNER_SHELL))   # control first
+        self.con.execute("UPDATE documents SET frozen=1 WHERE document_id=59")
+        self.con.commit()
+        self.assertEqual(self.render(PLANNER_SHELL), "")
 
     def test_frozen_doc_renders_nothing(self):
         add_doc(self.con, 59, frozen=1)
@@ -303,8 +322,8 @@ class SprintDirectiveTest(unittest.TestCase):
         self.con.execute("DROP TABLE sprint_units")
         self.con.commit()
         self.assertEqual(self.render(DEV_SHELL), "")
-        # the planner goes quiet too: liveness is the structured pair, and
-        # half of that pair is the table that just vanished
+        # the planner goes quiet too — its predicate needs a unit ROW, and the
+        # table those rows live in is the one that just vanished
         self.assertEqual(self.render(PLANNER_SHELL), "")
 
         self.con.execute("DROP TABLE sprint_planner_bindings")
@@ -312,20 +331,58 @@ class SprintDirectiveTest(unittest.TestCase):
         self.assertEqual(self.render(PLANNER_SHELL), "")
         self.assertEqual(self.render(DEV_SHELL), "")
 
+    def test_a_BROKEN_query_raises_where_a_missing_table_degrades(self):
+        # flag_id 233. The degrade above is load-bearing but its justification
+        # is TEMPORARY — it evaporates the moment the floor applies 0098 —
+        # whereas a bare `except OperationalError` would be PERMANENT. Past
+        # that point the only thing such a catch could still swallow is a
+        # genuine fault: a later migration renaming a column, a typo. It would
+        # revert the whole fleet to pre-U9 behaviour on a section the render
+        # itself labels MANDATORY, with no error, no stderr and no failing
+        # test — which is the same shape as the bug this unit exists to close,
+        # one layer down.
+        #
+        # No test above this one can tell the two cases apart: DROPping the
+        # table satisfies "absent" and "broken" alike. This one separates them.
+        add_doc(self.con, 59)
+        add_unit(self.con, 59, "U9", dev=DEV_SHELL)
+        self.assertNotEqual(self.render(DEV_SHELL), "")        # control first
+        # the table is PRESENT and a column the query reads is gone — exactly
+        # what a later migration or a typo leaves behind
+        self.con.execute(
+            "ALTER TABLE sprint_units RENAME COLUMN state TO unit_state")
+        self.con.commit()
+        with self.assertRaises(sqlite3.OperationalError):
+            self.render(DEV_SHELL)
+
     # ── the terminal set is the schema's, not a private opinion ─────────────
 
-    def test_terminal_states_are_a_subset_of_the_schema_check(self):
-        # A state added to sprint_units that this renderer does not know about
+    def test_the_state_vocabulary_is_pinned_to_the_schema_check_exactly(self):
+        # A state ADDED to sprint_units that this renderer does not know about
         # is the silent failure: an unknown state reads as non-terminal, which
-        # errs toward telling a shell it is still in a sprint. Pin the set
-        # against the CHECK so a schema move surfaces here.
+        # errs toward telling a shell it is still in a sprint.
+        #
+        # So this asserts EQUALITY, both directions (flag_id 232). Its first
+        # cut asserted TERMINAL <= allowed — a subset, which can only fail on a
+        # REMOVAL, i.e. the one direction the comment above says is not the
+        # risk. REV2's M10 mutation (adding 'archived' to the CHECK) survived
+        # it with 19/19 green: one leg of eleven lived, and it was this one.
         ddl = self.con.execute(
             "SELECT sql FROM sqlite_master WHERE name='sprint_units'"
         ).fetchone()[0]
-        allowed = set(re.findall(r"'(\w+)'", ddl.split("CHECK (state IN")[1]))
-        self.assertTrue(set(compose.TERMINAL_UNIT_STATES) <= allowed)
-        self.assertIn("merged", allowed)
-        self.assertIn("cancelled", allowed)
+        # Bounded to the clause. Splitting on "CHECK (state IN" and taking the
+        # REST of the DDL swept up the rest of the column list, so `allowed`
+        # actually contained 'now' — from DEFAULT (datetime('now')).
+        clause = re.search(r"CHECK\s*\(state IN\s*\(([^)]*)\)", ddl)
+        self.assertIsNotNone(clause, "the state CHECK clause moved — re-anchor")
+        allowed = set(re.findall(r"'(\w+)'", clause.group(1)))
+        self.assertNotIn("now", allowed)        # the parse stayed in the clause
+        self.assertEqual(set(compose.TERMINAL_UNIT_STATES),
+                         {"merged", "cancelled"})
+        # the complement is the live half, named in full: a new schema state
+        # lands HERE and turns this red, which is the addition case.
+        self.assertEqual(allowed - set(compose.TERMINAL_UNIT_STATES),
+                         {"pending", "working", "in_review", "blocked"})
 
 
 class BootDocIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
Sprint doc 59, unit U9 · spec doc 58 "Unit U9 — the sprint directive is STAMPED AT BOOT" · feature 27.

## What this closes

The "load the `sprint` skill" directive lived in a task row the planner hand-wrote. The audit found it in every kickoff row (written from a template) and **absent from all six rows improvised afterwards**. A reviewer booted off an improvised row had no participant procedure loaded, so it did what a shell correctly does in an interactive session: finished its pass, filed its flags, and ended the turn on a question. Nothing reads a headless run's stdout, so the silence was read as death and the shell was re-booted over eleven minutes of completed work.

A rule that survives only while the planner copies a template is not a rule. So the boot render carries it — the one artifact the harness is guaranteed to read — resolved from `sprint_units` plus the planner binding. **A task row cannot grant it and a missing task row cannot withhold it.**

The three participant rules render inline as prose rather than as a pointer to the skill, because the failure mode is precisely a skill body that never loads.

## Three departures from the spec's wording

All reported to the planner **before building** (message #2257) and ruled on in #2263.

**1. The planner resolves from the LATEST binding, armed or released.** The spec said "the armed binding". That predicate is anti-correlated with the need:

- `_arm_binding` (`api/interface_routes.py:1648`) refuses with `no_live_session` unless the planner already holds an `occupied` Interface session. The boot render runs at process start, so the generation being booted cannot have a binding yet, by construction.
- The binding is generation-bound (FK to `(shell_id, generation)`) and `interface_recovery.py:2005-2018` releases it when that generation ends.

Under the armed reading the planner's directive renders only when recovery lags — a race, not a record, failing in the same direction as the bug being fixed. This is `interface_routes._board_writer` minus the armed filter, so the two surfaces cannot disagree about whose sprint it is.

*Honest bound:* the recovery release is a code read with no observed instance in the live record; the first point needs no recovery at all. Adopted by the planner on the first point.

**2. Dev and reviewer are not binding-gated.** The spec's condition table read "no armed binding, **or** no non-terminal row → nothing rendered", which taken literally puts the planner's session liveness back in the path — the exact coupling this unit removes. A dev booted at 06:00 is told it is in a sprint whether or not the planner happens to be seated. Ambiguity call, ratified.

**3. Liveness is the STRUCTURED pair, never the body's prose.** *(Planner correction, applied in the second commit.)* The first cut matched `status: ACTIVE` out of the doc body. Regex-matching liveness out of prose is part of the structural gap this feature closes — flag_id 213 removed exactly that from the reconciler's trigger — and keeping it would let the boot render and the reconciler disagree the moment someone reformats a line. Liveness is now `documents.frozen = 0` AND at least one non-terminal `sprint_units` row, the same pair the trigger uses.

Consequence, decided rather than discovered: at a sprint's first boot no unit rows exist, so the planner gets no directive — correct, since the planner is the shell creating those rows. Pinned by its own test.

## The missing-table degrade is load-bearing

Not defensive polish. `compose` reads the **live** db at every launch of every shell, and this repo's own running floor had applied migrations only through `0096` while this was written — `sprint_units` was absent from it entirely. An unguarded `SELECT` there is a broken boot for the whole fork, not a missing section. Follows `run.py:resolve_sprint_ref`'s existing degrade.

Known cost of that choice, flagged for the reviewer: the `except OperationalError` is a catch-all, so a genuine SQL error renders no section rather than failing loudly.

## Tests — the absences are the subject

A test asserting the section *appears* also passes for a renderer that emits unconditionally, which would be worse than the original bug. So the absences are pinned: no non-terminal row, only-merged rows, a frozen doc, no board rows yet, and the tables missing.

**Each absence carries a positive control on the same db**, flipping exactly the fact under test and proving the section comes back — an absence asserted against an unpopulated artifact is trivially true.

One test runs the other way and pins a ruling rather than a behaviour: prose says `CLOSED`, the record says otherwise, and the **record wins**.

Mutations run and reverted on the final code (baseline byte-identical and green after each):

| mutation | result |
|---|---|
| role resolution ignores `reviewer_shell_id` (the one the planner named) | **3 red** |
| section emitted unconditionally | **8 red** |
| prose `status: ACTIVE` predicate restored | **1 red** |
| terminal-state filter removed | **1 red** |

19 tests green. `test_boot_project_vs_engine` (5), `test_sprint_board_record` (36) and `test_style_spinner` (24) unaffected.

## Not fixed here

`tests/test_harness_epoch.py` has 3 failures on clean `origin/main` in this sandbox (verified in a detached worktree at `origin/main`) — a sixth instance of the sprint doc's "the sandbox's local test environment disagrees with CI" family. Untouched by this diff, and green in CI.