### PR TITLE
feat(memory): L&S self-curation — write-time triage, hard caps, periodic sweep

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1010,8 +1010,15 @@ def patch_columns(con, table, pk_col, pk, body, allowed, commit=True):
         return False, "no editable fields in payload"
     vals = [body[col] for col in cols]
     sets = ", ".join(f"{col}=?" for col in cols)
-    cur = con.execute(f"UPDATE {table} SET {sets} WHERE {pk_col}=?",
-                      tuple(vals) + (pk,))
+    try:
+        cur = con.execute(f"UPDATE {table} SET {sets} WHERE {pk_col}=?",
+                          tuple(vals) + (pk,))
+    except db_driver.IntegrityError as e:
+        # A trigger refused the write (e.g. the current_state length cap). Its
+        # message routes the fix, so hand it back as a client error instead of
+        # letting it surface as an unhandled 500 with the remedy buried.
+        con.rollback()
+        return False, str(e)
     if cur.rowcount == 0:
         return False, "not found"
     if commit:
@@ -2042,8 +2049,24 @@ class Handler(BaseHTTPRequestHandler):
         con = db()
         try:
             if path == "/_sc/mem/state":
-                con.execute("UPDATE shells SET current_state=? WHERE shell_id=?",
-                            ((body.get("body") or ""), sid))
+                try:
+                    con.execute("UPDATE shells SET current_state=? WHERE shell_id=?",
+                                ((body.get("body") or ""), sid))
+                except db_driver.IntegrityError as e:   # the 300-char cap
+                    con.rollback()
+                    return self._send(400, {"error": str(e)})
+                con.commit()
+                return self._send(200, {"ok": True})
+
+            # The curation stamp (migration 0100). Unconditional by design: a
+            # sweep that finds a clean set and retires NOTHING still clears the
+            # counter, or the advisory would stand forever on a shell that has
+            # done the work. This is the case a MAX(retired_at) signal would
+            # have shipped broken.
+            if path == "/_sc/mem/lns/curated":
+                con.execute(
+                    "UPDATE shells SET lns_curated_at=datetime('now') WHERE shell_id=?",
+                    (sid,))
                 con.commit()
                 return self._send(200, {"ok": True})
 
@@ -2080,14 +2103,49 @@ class Handler(BaseHTTPRequestHandler):
                 b = (body.get("body") or "").strip()
                 if not b:
                     return self._send(400, {"error": "body required"})
-                cur = con.execute(
-                    "INSERT INTO shell_identity_entries "
-                    "(shell_id, kind, body, entry_date, source_tag) VALUES (?, ?, ?, ?, ?)",
-                    (sid, kind, b,
-                     body.get("entry_date") or None,
-                     body.get("source_tag") or None))
+                # L&S supersession: the missing verb. Five of one shell's twenty
+                # entries NAMED the entry they duplicated and added anyway —
+                # `lns` offered exactly one verb, so the reconciliation the shell
+                # had already done had nowhere to land. Retire FIRST, then
+                # insert: a supersede at 20/20 must succeed (the freed slot is
+                # the point), and both halves ride one transaction so a rejected
+                # insert can never leave the old entries retired for nothing.
+                retired: list[int] = []
+                if kind == "lns" and body.get("supersedes"):
+                    try:
+                        retired = [int(i) for i in body["supersedes"]]
+                    except (TypeError, ValueError):
+                        return self._send(400, {"error": "supersedes must be entry ids"})
+                    for eid in retired:
+                        if not con.execute(
+                                "SELECT 1 FROM shell_identity_entries "
+                                "WHERE entry_id=? AND shell_id=? AND kind='lns' "
+                                "AND is_deleted=0 AND retired_at IS NULL",
+                                (eid, sid)).fetchone():
+                            return self._send(404, {
+                                "error": f"entry #{eid} is not one of your active "
+                                         "L&S entries — `sc mem get lns` lists them"})
+                    con.execute(
+                        "UPDATE shell_identity_entries SET retired_at=datetime('now') "
+                        "WHERE entry_id IN (%s)" % ",".join("?" * len(retired)),
+                        tuple(retired))
+                try:
+                    cur = con.execute(
+                        "INSERT INTO shell_identity_entries "
+                        "(shell_id, kind, body, entry_date, source_tag) VALUES (?, ?, ?, ?, ?)",
+                        (sid, kind, b,
+                         body.get("entry_date") or None,
+                         body.get("source_tag") or None))
+                except db_driver.IntegrityError as e:
+                    # A cap trigger (count or length) fired. That is a client
+                    # error carrying its own remedy, not a server fault — a 500
+                    # would read as "the engine broke" and bury the routing
+                    # instruction the message exists to deliver.
+                    con.rollback()
+                    return self._send(400, {"error": str(e)})
                 con.commit()
-                return self._send(201, {"entry_id": cur.lastrowid})
+                return self._send(201, {"entry_id": cur.lastrowid,
+                                        "retired": retired})
 
             if path == "/_sc/mem/decisions":
                 d = (body.get("decision") or "").strip()

--- a/.super-coder/assets/skills/curate/SKILL.md
+++ b/.super-coder/assets/skills/curate/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: curate
+description: The periodic L&S sweep. Run when the STATUS L&S line says "curation due" — resolve contradictions, merge entries stating one rule, promote a recurring process to a skill, move environment facts out, then stamp `sc mem curated`. Yours alone; never delegate it.
+category: substrate
+common: true
+---
+
+# curate — the L&S sweep
+
+Write-time triage (`--supersedes` / `--new`) catches contradiction and
+restatement pairwise, at the moment of writing. It **cannot** catch the
+emergent cluster: five entries can each be a valid distinct rule and only in
+aggregate be five instances of one principle. That is this pass's job, along
+with promotion, category drift, and size drift.
+
+**Yours alone.** Law 3 and Law 7 reserve curation to the shell. Never hand this
+to a subagent, never let another shell run it for you, never accept a proposed
+retirement from anyone else. Read your own set; decide yourself.
+
+Trigger: `## STATUS` says `L&S: … — curation due`. Nothing else fires it.
+
+## Load the set
+
+```
+sc mem get lns          # entry ids + bodies — the active set, all of it
+```
+
+Read every entry before deciding anything. This is one cheap read; the whole
+set is already in your boot doc anyway.
+
+## Pass 1 — Consistency
+
+Find entries that **contradict** each other. One of them is the newer
+understanding; the other is superseded and still rendering as live guidance.
+
+```
+sc mem lns "<the surviving rule>" --supersedes <old_id>
+```
+
+Write-time triage should prevent most of these from ever forming. What you find
+here predates the loop or crossed in while two sessions ran.
+
+## Pass 2 — Cluster
+
+Group entries that state **one rule**. Merge each group to a single imperative
+rule:
+
+```
+sc mem lns "<the one rule>" --supersedes 30,33,34,37,38
+```
+
+Three or more members is the bar. Two statements of a rule are often
+legitimately two rules — merging at two is usually wrong.
+
+The incidents behind the entries are already in the narrative. They do not need
+a second home, and the merged rule must not try to carry them: an entry is the
+rule, ≤500 chars, hard-enforced.
+
+## Pass 3 — Promote
+
+A cluster of three or more that keeps **recurring across sessions** is a
+*process*, not a lesson. Author it as a skill and keep one L&S rule pointing at
+it:
+
+```
+sc skill add <you>_<topic> --file <path.md> --desc "<one line>"
+```
+
+Local skills are DB-only and namespaced by your shortname — the command
+enforces both. This is the pressure valve that makes a hard budget survivable:
+knowledge relocates to a lazy surface instead of being deleted.
+
+## Pass 4 — Category
+
+An entry that is an **environment fact** (a routing quirk, a term to avoid, a
+path) is not an operating principle. It belongs in a skill, not in L&S. Retire
+it and put the fact where it is looked up.
+
+```
+sc mem retire <entry_id>
+```
+
+## Stamp
+
+```
+sc mem curated
+```
+
+**Stamp even if you retired nothing.** A clean set is a legitimate outcome; if
+an honest sweep left the counter running, the advisory would stand forever and
+you would learn to ignore it. The stamp says "I looked," not "I cut."
+
+## Stance
+
+Curate the set toward ~12–14 entries, not toward the cap. Cap 20 is a ceiling
+never to reach — if you ever hit it, this sweep is not running.
+
+The trigger firing often does not mean the threshold is wrong; it means entries
+are being written faster than they are reconciled. Fix that at write time, with
+`--supersedes`.

--- a/.super-coder/assets/skills/memory/SKILL.md
+++ b/.super-coder/assets/skills/memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory
-description: When + how this shell persists memory — current_state, session narrative, seed (cap 10), L&S (cap 20), decisions — all via sc mem, written as it happens, not at close.
+description: When + how this shell persists memory — current_state (≤300), session narrative, seed (cap 10), L&S (cap 20, ≤500/entry, --supersedes|--new), decisions — all via sc mem, written as it happens, not at close.
 category: substrate
 common: true
 ---
@@ -16,11 +16,24 @@ from your token) — never name a shell.
 
 ## current_state — rolling status, NOT a log
 
-Present focus + what's next. Replace in place; NEVER append. Soft target ~500
-chars. Rewrite when focus shifts.
+Present focus + what's next. Replace in place; NEVER append. **300 chars, hard
+— the write is rejected over it.** Rewrite when focus shifts.
 ```
 sc mem state "…"
 ```
+
+**Point, do not reproduce.** The overrun is never verbosity, it is restatement:
+a decision's reasoning, a spec's gate, a flag's argument all pasted inline when
+each is a live row one query away. Name what is in flight and carry the id:
+
+```
+Sprint 59 U0 gate — see doc #46, feature #29.
+Blocked on flag #200. Next: U3 shape once U0 answers.
+```
+
+Not the argument, the ruling, or the rationale — those have rows, and a reader
+who needs them runs `sc mem get`. Same principle the boot doc already applies
+to decisions: carry the pointer, lazy-load the payload.
 
 ## Session narrative — append at inflection points
 
@@ -43,12 +56,25 @@ sc mem retire <entry_id>   # curate out (frees a cap slot)
 
 ## L&S (cap 20) — how you work
 
-Operating lessons, imperative voice. Add when a lesson lands; curate by
-retiring. Caps are trigger-enforced (seed 10, L&S 20): at cap, `sc mem` returns
-the cap message -> retire an entry to free the slot.
+Operating lessons, imperative voice. An entry is **the RULE** — **≤500 chars,
+hard**. The incident that taught it goes in the narrative, where you already
+wrote it; if the text opens with "Sprint 38:", it is a narrative entry.
+
+**Exactly one of `--supersedes` / `--new` is required.** Your active set is
+already rendered in your boot doc, so checking a new rule against it costs no
+extra read — and this flag is where that check lands:
 ```
-sc mem lns "…"
+sc mem lns "…" --supersedes 29,36   # contradicts or refines those — retires them, adds this
+sc mem lns "…" --new                # checked against the set, genuinely unrelated
 ```
+`--supersedes` works at 20/20: it frees the slot it uses.
+
+Caps are trigger-enforced (seed 10, L&S 20, L&S body 500, current_state 300) —
+a rejected write is the feedback, and the message routes the fix.
+
+Periodic sweep: when `## STATUS` says `L&S: … — curation due`, run the `curate`
+skill, then `sc mem curated` to stamp it — even if you retired nothing. Cap 20
+is a ceiling never to reach, not a target; curation holds the set near 12–14.
 
 ## Decisions — Major only
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -643,8 +643,8 @@ and reload on a fresh map db.
    Spot-check overrides took:
    `SELECT path, role FROM dr_filepath WHERE path LIKE ''cmd/%'';`
 
-5. **Describe all NULLs** — run the description worklist (Standing jobs § 2);
-   leave only when it returns zero rows.
+5. **Describe — NULLs and filler** — run the description worklist (Standing
+   jobs § 2); leave only when it returns zero rows, NULLs and filler both.
 
 6. **Commit** the config + hooks (`git` skill) -> `sc mem state "…"` ->
    `sc mem oriented` (sets `bootstrapped=1` — the write is live in the
@@ -663,8 +663,8 @@ stale or empty on a clone whose hooks never got wired.
 5. **Stale sections** — `dr_section` is authored, never auto-pruned. After any
    migration/restructure run the stale-section worklist (Standing jobs § 1);
    DELETE or repath every row it returns.
-6. **Describe all NULLs** (Standing jobs § 2) -> worklist empty before you
-   leave.
+6. **Describe — NULLs and filler** (Standing jobs § 2) -> worklist empty
+   before you leave.
 7. Commit.
 
 ## Standing jobs — sections, descriptions, product DB
@@ -705,18 +705,43 @@ ORDER BY s.name;
 -- For each row: DELETE (area gone) or UPDATE path_prefix (area renamed).
 ```
 
-**2. Descriptions (`dr_filepath.desc`)** — per-file one-liners, ≤100 chars.
-Run the worklist every session; every run ends with zero NULLs — not optional.
-Queried by working shells within a chosen section (`surface_catalogue`), never
-bulk-loaded at boot.
+**2. Descriptions (`dr_filepath.desc`)** — per-file one-liners, ≤100 chars,
+**adequate, not merely present**. A desc must say something the path does not:
+what the file *does* or *holds*, never its kind restated from the name —
+"Engine database migration: 0042_x.sql" is filler (non-NULL, zero information
+beyond the path), and a NULL-only worklist is blind to it: one mapped repo
+carried 263 such placeholders, invisible for months because every row was
+non-NULL. Derive each one-liner from the file''s own docstring / frontmatter /
+header comment; hand-write the few with nothing extractable. Run the worklist
+every session; every run ends with zero rows — NULLs *and* filler — not
+optional. Queried by working shells within a chosen section
+(`surface_catalogue`), never bulk-loaded at boot.
 
 ```sql
--- WORKLIST — undescribed files, most-load-bearing first:
-SELECT path, role FROM dr_filepath WHERE desc IS NULL ORDER BY role, path;
+-- WORKLIST — undescribed OR filler, most-load-bearing first. The filler clause
+-- is a heuristic (desc ENDS with the filename or its stem — the "<kind
+-- restated>: <name>" shape); judge each hit — and treat a desc you could have
+-- written from the path alone as filler even if the query missed it:
+WITH f AS (SELECT path, role, desc,
+                  replace(path, rtrim(path, replace(path,''/'','''')), '''') AS base
+           FROM dr_filepath),
+     g AS (SELECT *, CASE WHEN instr(base,''.'') > 0
+                          THEN substr(base, 1, instr(base,''.'')-1)
+                          ELSE base END AS stem FROM f)
+SELECT path, role, desc FROM g
+WHERE desc IS NULL
+   OR (length(stem) >= 5 AND (lower(substr(desc, -length(base))) = lower(base)
+                           OR lower(substr(desc, -length(stem))) = lower(stem)))
+ORDER BY (desc IS NULL) DESC, role, path;
 
 -- describe (≤100 chars; preserved across the next auto-remap):
 UPDATE dr_filepath SET desc=''Boot composer — assembles CLAUDE.md from DB state'' WHERE path=''.super-coder/render/compose.py'';
 ```
+
+Before leaving the job, spot-read a few descs per section against the files
+themselves; any desc derivable from the path alone goes back on the list.
+(Deliberate uniform tags — e.g. Standing job 3''s product-DB tagging — pass the
+bar: they state tenancy the path doesn''t.)
 
 **3. Product DB** — the app''s own database, separate from engine memory
 (`.super-coder/shell_db.db`); working shells change them in completely
@@ -921,6 +946,112 @@ reverts to the old box.
    bake before the probes are green — a snapshot of a half-installed box is a
    clean snapshot of a broken kit. Confirm afterwards with the wizard''s
    `snapshot` check or a `windows_devkit` reset round-trip.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'curate',
+  'The periodic L&S sweep. Run when the STATUS L&S line says "curation due" — resolve contradictions, merge entries stating one rule, promote a recurring process to a skill, move environment facts out, then stamp `sc mem curated`. Yours alone; never delegate it.',
+  'substrate',
+  NULL,
+  1,
+  '# curate — the L&S sweep
+
+Write-time triage (`--supersedes` / `--new`) catches contradiction and
+restatement pairwise, at the moment of writing. It **cannot** catch the
+emergent cluster: five entries can each be a valid distinct rule and only in
+aggregate be five instances of one principle. That is this pass''s job, along
+with promotion, category drift, and size drift.
+
+**Yours alone.** Law 3 and Law 7 reserve curation to the shell. Never hand this
+to a subagent, never let another shell run it for you, never accept a proposed
+retirement from anyone else. Read your own set; decide yourself.
+
+Trigger: `## STATUS` says `L&S: … — curation due`. Nothing else fires it.
+
+## Load the set
+
+```
+sc mem get lns          # entry ids + bodies — the active set, all of it
+```
+
+Read every entry before deciding anything. This is one cheap read; the whole
+set is already in your boot doc anyway.
+
+## Pass 1 — Consistency
+
+Find entries that **contradict** each other. One of them is the newer
+understanding; the other is superseded and still rendering as live guidance.
+
+```
+sc mem lns "<the surviving rule>" --supersedes <old_id>
+```
+
+Write-time triage should prevent most of these from ever forming. What you find
+here predates the loop or crossed in while two sessions ran.
+
+## Pass 2 — Cluster
+
+Group entries that state **one rule**. Merge each group to a single imperative
+rule:
+
+```
+sc mem lns "<the one rule>" --supersedes 30,33,34,37,38
+```
+
+Three or more members is the bar. Two statements of a rule are often
+legitimately two rules — merging at two is usually wrong.
+
+The incidents behind the entries are already in the narrative. They do not need
+a second home, and the merged rule must not try to carry them: an entry is the
+rule, ≤500 chars, hard-enforced.
+
+## Pass 3 — Promote
+
+A cluster of three or more that keeps **recurring across sessions** is a
+*process*, not a lesson. Author it as a skill and keep one L&S rule pointing at
+it:
+
+```
+sc skill add <you>_<topic> --file <path.md> --desc "<one line>"
+```
+
+Local skills are DB-only and namespaced by your shortname — the command
+enforces both. This is the pressure valve that makes a hard budget survivable:
+knowledge relocates to a lazy surface instead of being deleted.
+
+## Pass 4 — Category
+
+An entry that is an **environment fact** (a routing quirk, a term to avoid, a
+path) is not an operating principle. It belongs in a skill, not in L&S. Retire
+it and put the fact where it is looked up.
+
+```
+sc mem retire <entry_id>
+```
+
+## Stamp
+
+```
+sc mem curated
+```
+
+**Stamp even if you retired nothing.** A clean set is a legitimate outcome; if
+an honest sweep left the counter running, the advisory would stand forever and
+you would learn to ignore it. The stamp says "I looked," not "I cut."
+
+## Stance
+
+Curate the set toward ~12–14 entries, not toward the cap. Cap 20 is a ceiling
+never to reach — if you ever hit it, this sweep is not running.
+
+The trigger firing often does not mean the threshold is wrong; it means entries
+are being written faster than they are reconciled. Fix that at write time, with
+`--supersedes`.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET
@@ -1211,6 +1342,49 @@ sc mem doc add "…" --kind doc --feature <id> --body-file ./draft.md --render-p
 sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
 ```
 
+## Specs carry "Anticipated User Activity"
+
+Every spec (`kind=''spec''`) ships an `## Anticipated User Activity` section —
+the feature''s posture statement: who is expected to touch it, where it can be
+reached, whose data it holds, and what it does not intend to allow. Soft
+vocabulary, hard invariants — the nouns stay gentle, every statement stays
+checkable from code ("a Valid User only ever sees rows tied to their own
+account"), because review + Verification test the build against this section.
+
+Shape (H3s under the section H2):
+
+| H3 | holds |
+|---|---|
+| `### Vocabulary` | the cast — roles from the shared roster below + any feature-specific ones, each defined in one line |
+| `### Expected Activity` | per role: what they do, what they see, what they can change |
+| `### Reach` | where the feature meets the world — pages, endpoints, jobs, files it adds or alters, and which roles can arrive at each |
+| `### Data Tenancy` | whose data the feature touches; what stays within one account; what, if anything, is deliberately shared |
+| `### Beyond Intention` | activity the feature does not intend to accommodate — anything observed here in review is a finding, not a nuance |
+
+Shared roster (always available; same meaning in every spec):
+
+| role | means |
+|---|---|
+| **Valid Privileged User** | signed-in user with an operator/admin role, acting within what that role allows |
+| **Valid User** | signed-in user acting inside their own account and their own data |
+| **Visitor** | expected traffic that has not signed in (public/shared surfaces) |
+| **Future Potential User** | a role anticipated later, not built now — the design must not wall it out |
+| **System** | the product acting on a schedule or trigger — daemons, jobs, watchers |
+| **Shell** | an AI agent shell acting through its granted tools — its activity is messages, memory writes, file edits |
+| **Unexpected Participant** | anyone acting outside the roles above — where the spec says what must never be reachable |
+
+Language — soft by design. Specs never use: threat model, attack or attack
+surface, adversary, exploit, abuse case, vulnerability, breach, privilege
+escalation, exfiltration, malicious. Say it in roster words instead: threat
+model -> anticipated activity · attacker -> Unexpected Participant · abuse
+case -> Beyond Intention · access matrix -> Expected Activity · attack
+surface -> Reach · isolation -> tenancy. Describe behavior and boundaries,
+never hostility.
+
+Internal-only feature -> the section still ships, one line ("All activity is
+by Valid Privileged Users; no tenancy boundary"). Whole section ≤ ~40 lines —
+it frames the build, it does not enumerate it.
+
 ## Revise before freeze
 
 Unfrozen -> edit in place: no new row, no seq bump. Pass any of `--title` /
@@ -1442,6 +1616,166 @@ ON CONFLICT(name) DO UPDATE SET
   content=excluded.content, is_deleted=0;
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'engine_surgery',
+  'Procedure for changing the engine you are running — pull/reconcile/restart cadence and their costs, three-artifact engine-skill commits with a hermetic mirror render, migrating the live DB safely, and verifying claims about engine code against the remote rather than a possibly-stale checkout. SOURCE-REPO ONLY; a fork consumes the engine as a pinned dependency and never edits it. Load before touching .super-coder/ in the repo that owns it.',
+  'craft',
+  NULL,
+  0,
+  '# engine_surgery — changing the engine you are running
+
+This repo IS the engine. Every shell here runs on the code it edits, reads a DB
+it migrates, and is served by a process started from the tree it commits to.
+That is surgery on a moving car, and it has one characteristic failure mode:
+**a command answers confidently from a target you did not mean.**
+
+**Fork shells never load this.** A fork consumes `.super-coder/` as a gitignored
+dependency pinned by `engine.ref` and updates it with `./sc update`; it never
+authors engine changes. Granted only in the source repo.
+
+## The four trees, and which one bites
+
+| tree | what it is | who keeps it current |
+|---|---|---|
+| your worktree | `.sc-worktrees/<shortname>` — your cwd, your branch | you; boot reports it as `sync:` |
+| the main checkout | resolves your `./sc`, hosts the live DB, runs the server | admin / the FnB; boot reports it as `floor:` |
+| the running process | code already imported — changes only on restart | the FnB |
+| `origin/main` | the truth | whoever merged last |
+
+`sc:11-21` derives the engine root from git''s **common dir**, so `./sc` from any
+worktree reads the MAIN CHECKOUT. Being current in your own tree tells you
+nothing about it. Read the `floor:` line in ACTIVE SESSION.
+
+**Verify any claim about engine code against the remote:**
+
+```
+git show origin/main:<path>     # correct
+./sc help | grep <thing>        # answers from the main checkout — may be stale
+```
+
+Three wrong answers in one session came from skipping that: a help query, a
+pending-migration check that came back empty because it globbed a stale
+migrations dir and nearly made a reconcile a silent no-op, and dormant PR
+watches against a stale running floor.
+
+## EDIT IN YOUR WORKTREE — scripted writes bypass the branch guard
+
+`branch-guard.sh` blocks harness file-edit tools from writing to a
+default-branch checkout. **It does not see writes made by a script.** A
+`cd /home/j3d1/super-coder && python3 -c "...patch..."` lands on `main`,
+uncommitted, with no warning — and your worktree stays clean, so `git status`
+there reassures you nothing happened.
+
+Recovery, if you find edits on the wrong tree:
+
+```
+git -C <main-checkout> diff > /tmp/x.patch
+git apply /tmp/x.patch                                  # in your worktree
+git -C <main-checkout> checkout -- <files>
+```
+
+Prefer the harness edit tools, which are guarded. If you script an edit, `cd` to
+your worktree or use absolute worktree paths, and check `git status` in **both**
+trees afterwards.
+
+## Cadence — pull often, restart rarely
+
+| action | cost | fixes |
+|---|---|---|
+| pull the main checkout | cheap, safe, no session impact | stale reads |
+| apply pending migrations | low; back up first | stale DB rows |
+| `./sc update` + restart | refuses on live Interface state; **restart kills live sessions** | stale running process |
+
+Pull after every merge. Reconcile and restart at **sprint boundaries** — never
+mid-sprint, because a restart kills working devs and swapping the floor under an
+in-flight unit is its own hazard. The restart is the FnB''s call.
+
+## Migrating the live DB
+
+The DB you migrate is the one every shell is using and the server has open.
+
+1. **Fast-forward the main checkout first.** Pending-migration checks glob its
+   `migrations/` dir, so a stale tree reports nothing pending and the reconcile
+   silently does nothing.
+2. **Name the DB path explicitly.** `./sc migrate` from a worktree resolves to
+   the main checkout''s DB and says so nowhere (issue #569). Prefer
+   `python3 .super-coder/scripts/migrate.py <explicit-path>`.
+3. **Back up first**, WAL-safe, via SQLite''s online backup rather than a file
+   copy:
+
+   ```python
+   src = sqlite3.connect(LIVE); dst = sqlite3.connect(BACKUP)
+   with dst: src.backup(dst)
+   ```
+
+4. **Data-only migrations are safe under a running server** (row updates, no
+   DDL). Schema changes want the restart window.
+5. **Verify by read-back**, not by the migrate command''s own output.
+
+## Engine skill edits are a three-artifact commit
+
+All three, or CI goes red even when tests pass:
+
+1. the source asset at `.super-coder/assets/skills/<name>/SKILL.md`;
+2. a **trailing reseed migration** so existing installations converge — full-body
+   upsert, `INSERT … ON CONFLICT(name) DO UPDATE SET`, patterned on the most
+   recent `*_reseed_*.sql`. Generate it FROM the asset rather than hand-writing
+   it, and store the body exactly as the guards read it
+   (`split("---", 2)[2].strip()`) — an unstripped body fails three freshness
+   guards;
+3. the re-rendered mirror.
+
+**Render the mirror through the guard''s own hermetic path**, never from the live
+DB, so it cannot drift from what CI rebuilds:
+
+```python
+import render_check as rc, flat
+rc._build_tracked_db(db)                  # schema → migrations → content.sql
+flat.render_visibility(con, root=rc.ACTIVE_ROOT)
+```
+
+In **local artifact mode** the mirror lives under the ignored `.sc-state/local/`
+and is not in the diff — the commit is then two artifacts, and `render-check`
+still proves the migration.
+
+Run the guard **from your own worktree** — `./sc render-check` resolves to the
+main checkout and will judge code you are not committing (flag #47):
+
+```
+python3 .super-coder/scripts/render_check.py
+```
+
+## Adding a source-repo-only skill
+
+Seeds carry **skills, not grants**: `0001` inserts skill rows and no
+`shell_skills`. Grants happen at shell creation — every shell auto-gets
+`common=1` skills, plus its flavor template''s named opt-ins.
+
+So a skill with **`common: false` and no entry in any flavor template** seeds
+into a fork''s catalogue but is never granted to a fork shell. Grant it here:
+
+```
+./sc skill grant <name> <shell> [<shell>…]
+```
+
+## Stance
+
+- A command reporting success against a target you did not intend is the house
+  defect. Name the target; verify the effect.
+- Never `SC_ADMIN=1` past a gate to save a step — the publish path is gated on
+  purpose.
+- Never auto-sync the main checkout from a shell. `sync_worktree` may
+  `reset --hard` a shell base; the main checkout is the running server''s tree and
+  a reset discards whatever the operator has in flight.
+- Assert before you replace; read back after you write. A non-matching string
+  replace does nothing and reports success.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'flag_sweep',
   'Admin''s every-session flag reconciliation — auto-close flags whose gating work is provably done, open ship flags for implemented-but-unshipped specs and docs-pending flags for shipped features that lack a doc (message the planner), surface judgment calls to the FnB. Step 1 of the admin standing pass; run before git_cleanup.',
   'substrate',
@@ -1491,7 +1825,8 @@ only on unambiguous evidence — any doubt -> Step 4, not a close.
 Close with `sc mem flag close <flag_id> --notes "…"`. The note MUST cite the
 evidence.
 
-**A. Docs-pending flag, doc now exists** = `[Docs] … docs pending` flag on a
+**A. Docs-pending flag, doc now exists** = `[Docs]`-tagged doc-pending flag
+(however worded — "doc pending", "docs pending", "feature doc pending") on a
 feature with `frozen_docs > 0`:
 ```
 sc mem flag close <flag_id> --notes "Auto: frozen spec doc now exists for feature #<id> (flag_sweep)."
@@ -1543,7 +1878,8 @@ WHERE r.roadmap_status NOT IN (''shipped'',''retired'')
   AND NOT EXISTS (
     SELECT 1 FROM flags f
     WHERE f.feature_id = r.feature_id AND f.resolved=0 AND COALESCE(f.is_deleted,0)=0
-      AND (f.description LIKE ''%not marked shipped%'' OR f.description LIKE ''%docs pending%''));
+      AND (f.description LIKE ''[Ship]%'' OR f.description LIKE ''[Docs]%''
+           OR f.description LIKE ''%not marked shipped%'' OR f.description LIKE ''%doc%pending%''));
 ```
 
 Per row: open + message the planner (no planner -> surface to the FnB) — same
@@ -1571,8 +1907,16 @@ WHERE r.roadmap_status = ''shipped''
   AND NOT EXISTS (
     SELECT 1 FROM flags f
     WHERE f.feature_id = r.feature_id AND f.resolved=0 AND COALESCE(f.is_deleted,0)=0
-      AND f.description LIKE ''%docs pending%'');
+      AND (f.description LIKE ''[Docs]%'' OR f.description LIKE ''%doc%pending%''));
 ```
+
+The dedup guards match the `[Docs]`/`[Ship]` tag at position zero FIRST — the
+templates below mint "doc pending" (singular) and legacy hand-written flags say
+"feature doc pending", so a prose-only `''%docs pending%''` pattern matched
+neither and every later sweep re-listed already-flagged rows (found session
+ADM1/0003, seven covered rows re-surfaced). The `''%doc%pending%''` fallback
+catches untagged organic wordings; its over-breadth only ever SKIPS an open —
+the conservative direction.
 
 Per row: open + message the planner (no planner -> surface to the FnB) — same
 contract as the `flags` skill:
@@ -2153,7 +2497,7 @@ ON CONFLICT(name) DO UPDATE SET
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'memory',
-  'When + how this shell persists memory — current_state, session narrative, seed (cap 10), L&S (cap 20), decisions — all via sc mem, written as it happens, not at close.',
+  'When + how this shell persists memory — current_state (≤300), session narrative, seed (cap 10), L&S (cap 20, ≤500/entry, --supersedes|--new), decisions — all via sc mem, written as it happens, not at close.',
   'substrate',
   NULL,
   1,
@@ -2168,11 +2512,24 @@ from your token) — never name a shell.
 
 ## current_state — rolling status, NOT a log
 
-Present focus + what''s next. Replace in place; NEVER append. Soft target ~500
-chars. Rewrite when focus shifts.
+Present focus + what''s next. Replace in place; NEVER append. **300 chars, hard
+— the write is rejected over it.** Rewrite when focus shifts.
 ```
 sc mem state "…"
 ```
+
+**Point, do not reproduce.** The overrun is never verbosity, it is restatement:
+a decision''s reasoning, a spec''s gate, a flag''s argument all pasted inline when
+each is a live row one query away. Name what is in flight and carry the id:
+
+```
+Sprint 59 U0 gate — see doc #46, feature #29.
+Blocked on flag #200. Next: U3 shape once U0 answers.
+```
+
+Not the argument, the ruling, or the rationale — those have rows, and a reader
+who needs them runs `sc mem get`. Same principle the boot doc already applies
+to decisions: carry the pointer, lazy-load the payload.
 
 ## Session narrative — append at inflection points
 
@@ -2195,12 +2552,25 @@ sc mem retire <entry_id>   # curate out (frees a cap slot)
 
 ## L&S (cap 20) — how you work
 
-Operating lessons, imperative voice. Add when a lesson lands; curate by
-retiring. Caps are trigger-enforced (seed 10, L&S 20): at cap, `sc mem` returns
-the cap message -> retire an entry to free the slot.
+Operating lessons, imperative voice. An entry is **the RULE** — **≤500 chars,
+hard**. The incident that taught it goes in the narrative, where you already
+wrote it; if the text opens with "Sprint 38:", it is a narrative entry.
+
+**Exactly one of `--supersedes` / `--new` is required.** Your active set is
+already rendered in your boot doc, so checking a new rule against it costs no
+extra read — and this flag is where that check lands:
 ```
-sc mem lns "…"
+sc mem lns "…" --supersedes 29,36   # contradicts or refines those — retires them, adds this
+sc mem lns "…" --new                # checked against the set, genuinely unrelated
 ```
+`--supersedes` works at 20/20: it frees the slot it uses.
+
+Caps are trigger-enforced (seed 10, L&S 20, L&S body 500, current_state 300) —
+a rejected write is the feedback, and the message routes the fix.
+
+Periodic sweep: when `## STATUS` says `L&S: … — curation due`, run the `curate`
+skill, then `sc mem curated` to stamp it — even if you retired nothing. Cap 20
+is a ceiling never to reach, not a target; curation holds the set near 12–14.
 
 ## Decisions — Major only
 
@@ -3135,6 +3505,12 @@ Surface all three before any planning or code:
   slice.
 - No stated done-condition in the spec -> that is the first unclear item.
 
+### Anticipated User Activity
+The spec''s `## Anticipated User Activity` section is governing intent: its
+roles, reach, and tenancy invariants shape the plan — access and tenancy
+checks are planned tasks, not afterthoughts. Older specs predate the section;
+absence there is not a blocker.
+
 ### Unclear items
 Anything you cannot act on without guessing:
 - Ambiguous between two interpretations
@@ -3194,7 +3570,7 @@ Always this shape:
 |---|---|---|
 | 0 | Preparation | Always first — read code paths, verify DB state, confirm entry points |
 | 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
-| N+1 | Verification | Always last — run tests, smoke-test against done-condition, snapshot + render |
+| N+1 | Verification | Always last — run tests, smoke-test against done-condition, check the build against the spec''s Anticipated User Activity section, snapshot + render |
 
 Add one task per seq with `sc mem task add` — each write is live in the
 shared DB immediately:
@@ -3203,7 +3579,7 @@ shared DB immediately:
 sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points"
 sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>"
 sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>"
-sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, snapshot + render"
+sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test against done-condition, check the build against the spec''s Anticipated User Activity section, snapshot + render"
 ```
 
 Then set `current_state` — nothing done yet, next = Preparation:
@@ -3314,6 +3690,9 @@ Mid-build, the work grows past the spec''s stated what/why:
   marked done.
 - **Verification is not optional.** It is the last task; skipping it makes
   "done" meaningless.
+- **Anticipated User Activity is intent.** Verification checks the build
+  against the spec''s section — a capability beyond its stated roles, or data
+  crossing a tenancy line it states, is a finding, not a nuance.
 - **Spec too large for one session** -> scope a slice at Preparation: cover
   steps 1–K verifiable now, leave K+1–N pending. NEVER start work that can''t
   be verified before the session ends.
@@ -3422,6 +3801,26 @@ row and is worked like a review finding. Repeat your open calls in the
 review request (step 6) so the reviewer gates against your reading, not
 its own guess.
 
+**A premise that looks WRONG is reported BEFORE you build it, not at merge.**
+A spec, board or ruling can rest on a factual claim about the code that simply
+isn''t true. Test it, then say so — do not silently cut the deliverable, and do
+not silently ship against a premise you believe false. Both outcomes are
+recoverable when the planner hears it early; neither is after merge. One dev
+proved a board deliverable could not reach the operator at all and reported it
+pre-build, so an invisible feature was replaced rather than shipped. Another
+re-verified a planner ruling against the parser source before complying with it
+and confirmed it at a level the planner had not checked.
+
+Comply after checking, not instead of checking. A planner instruction phrased as
+a bare directive can be wrong about the world — including destructively so, if it
+names a record by an identifier that resolves to a different row.
+
+**Resolve a record''s identifier before you mutate it.** Display names and row ids
+live in different counters that can overlap in range, so "close SC-144" may
+resolve to a row that is not SC-144. Look the row up and read it before writing.
+If it is already resolved by another shell, leave it — re-closing overwrites that
+shell''s verification notes with yours.
+
 ## Local long work — suites, benches, builds
 
 A harness background task is session-scoped: in a headless boot it dies
@@ -3489,6 +3888,9 @@ kickoff said "start now", or a planner `task` row says so):
   --base main` if the PR exists, otherwise note your base is gone — same
   discipline as the `git` skill''s stacked-merge procedure;
 - `git fetch origin && git rebase origin/main` on your feature branch;
+- drain your inbox once more immediately before pushing — a ruling issued while
+  you were building will not have interrupted you, and pushing an approach that
+  was already overruled costs a cycle;
 - push, open your PR — then, in the SAME step:
 
 ```
@@ -3531,7 +3933,35 @@ not gates. Disagree with a severity call -> planner rules; don''t litigate
 in the thread while the chain waits.
 
 **7. Merge on green + clean, file your unit report, hand off.** All
-checks green + reviewer declared review-clean + boundary above satisfied:
+checks green + reviewer declared review-clean + boundary above satisfied.
+
+**If `main` moved since your review, check the intersection before you rebase.**
+Your reviewer''s verdict is bound to the exact SHA it judged, but `main` moving is
+not by itself a reason to redo anything. Compare what merged since against YOUR
+unit''s files: empty intersection -> your head stands and the verdict holds; report
+the evidence and merge. Overlapping -> rebase onto current `main`, confirm checks
+green on the REBASED head, report that SHA, and then report, per file:
+
+- whether your **own contribution is diff-identical** — compare
+  `diff(old-base..old-head)` against `diff(new-base..new-head)` over your `+/-`
+  lines, normalised for `index`/`@@` noise. Resolve the bases with
+  `git merge-base` rather than assuming a SHA that looks current; a
+  non-ancestor base silently folds the other branch''s content into your diff
+  and inflates it;
+- which reviewed files moved, and **whose content moved them**;
+- **disjointness as YOUR READ, not a proof** — say so plainly.
+
+Diff-identical + disjoint -> the verdict carries; say so with the evidence.
+Otherwise it does NOT carry: the reviewer re-confirms, narrowed to the
+interference question. File-level byte-identity is not the bar — two units can
+touch one file for unrelated reasons and leave every contribution line intact.
+
+If you **hand-resolve** any hunk: name the line and your reasoning, and do NOT
+re-run the mutation round trips yourself. A hand-resolved hunk is exactly what
+can silently unpin a test, so that check belongs to the reviewer — handing over
+your own answer to the question you are asking it defeats the point.
+
+Then:
 
 ```
 gh pr merge <your-pr> --squash --delete-branch
@@ -3583,21 +4013,43 @@ scope); this overlay changes only pace and severity:
    is next-in-queue work; a waiting review stalls the chain exactly like
    red CI. Keep a `SPRINT doc=<id> reviewing=<seq,seq,…>` line in
    `current_state`. No trackers, no scheduled polls.
-2. **Major/Medium block; Low informs.** Wrong-behavior / data-loss /
+2. **Check the head is worth reviewing, BEFORE you spend the pass.** Confirm the
+   PR head is the exact SHA you were asked for and has not been superseded or
+   force-pushed away. Refuse an unrequested or non-CI head and say so in a
+   `result` row instead of reviewing it anyway — a verdict on a doomed SHA is a
+   wasted cycle.
+
+   `main` not being an ancestor (`git merge-base --is-ancestor <main> <head>`) is
+   a **signal, not a refusal**. Check whether the merges that landed since touch
+   any of THIS PR''s files. Empty intersection -> the head is still reviewable and
+   its CI still reflects what will land; review it. Overlapping -> refuse and
+   require the rebase, because the green is then against a base that no longer
+   exists in the files that matter. Same reasoning as the dev-side carry-over
+   rule: test what actually affects this unit, not whether anything moved at all —
+   an absolute ancestor check fires on every unrelated merge and costs a cycle
+   each time.
+3. **Run the mutation yourself.** When a unit''s value rests on one property — an
+   ordering, a currency claim, a fail-closed gate — break it in the source,
+   watch the test go red, revert, watch it pass. A reported round trip is not a
+   verified one. One sprint found FIVE tests that could not fail, every one on
+   fully green CI, every one caught this way and none by CI. Ask it per
+   PROPERTY, not per test: a test can genuinely constrain the property it names
+   while leaving an adjacent one it appears to cover entirely free.
+4. **Major/Medium block; Low informs.** Wrong-behavior / data-loss /
    security / spec-violation (Major) or will-bite-soon (Medium) -> the dev
    fixes now; re-review on the fix push. Style / naming / nice-to-have
    refactors (Low) -> one summary note to the planner for the sprint
    report; Low never blocks merge and you don''t re-litigate it.
-3. **Handoffs go direct** — scoped relaxation, same shape as the merge
+5. **Handoffs go direct** — scoped relaxation, same shape as the merge
    authority. The base `review` skill gates handoffs behind the FnB;
    inside an ACTIVE sprint, for your assigned units only: message the
    author dev your findings directly + copy the planner one line
    (`unit <seq>: N major, M medium — with <dev>` or `unit <seq>:
    review-clean`), --kind result. The FnB gate is unchanged everywhere
    else and returns the moment the doc freezes.
-4. **Clean is a declaration.** Say `review-clean` explicitly to dev +
+6. **Clean is a declaration.** Say `review-clean` explicitly to dev +
    planner — it is what unlocks the dev''s merge; never leave it implied.
-5. **Stand down** on close-out: drop your SPRINT line, confirm to the
+7. **Stand down** on close-out: drop your SPRINT line, confirm to the
    planner in a final `result` row.
 
 ## Conformance slot
@@ -3713,8 +4165,28 @@ manage, you never load code. The full trail replays with
 
 Decompose the push into units a single shell can own end-to-end. Map
 dependency order stingily: a dependency edge = a real code dependency, not
-a preference. Units that don''t touch each other run in parallel; keep
-chains short and the graph wide where the code allows.
+a preference. Keep chains short and the graph wide where the code allows.
+
+**Then check MERGE SURFACE, which is a different question from dependency.**
+Predict each unit''s file set and compute the pairwise intersection. Logical
+independence does NOT imply merge independence: units that need none of each
+other''s code still collide if they edit the same files, and that collision
+lands at merge time, after every review is done.
+
+- Empty intersection → genuinely parallel; say so.
+- Non-empty → either sequence them, or declare them parallel **with the merge
+  protocol and the overlap map attached at kickoff** so reviewers know from the
+  start that their verdicts are SHA-bound.
+- A file touched by **three or more** units → reconsider the cut, don''t just
+  manage the merges.
+
+Record overlap in the board''s `depends on` column. A bare dash means only "no
+logical dependency" and is read as "independent" — which is how one sprint
+declared five units independent while 21 of their 30 file-touches landed on
+nine shared files, three of them touched by three units apiece. The cost was a
+merge protocol invented mid-flight, four rebases, two voided verdicts and a
+hand-resolved conflict. Surfaces that concentrate a lot of behaviour into a few
+large files make this the normal case, not the exception.
 
 Assign each unit a dev shell + a reviewer shell (one reviewer may gate
 several units — don''t let one reviewer become the whole sprint''s
@@ -3838,6 +4310,10 @@ models: devs=<harness>/<model> · reviewers=<harness>/<model>
 | seq | unit | shell | reviewer | depends on | branch | pr | status |
 ```
 
+`depends on` carries BOTH facts: the logical dependency and any file overlap
+(`— · shares app.js with 3`). A dash alone asserts independence you may not
+have checked.
+
 Unit `status` walks `waiting → building → pr-open → in-review → fixing →
 merged`; `fixing` loops back to `in-review` until clean; `ci-red` can
 interleave anywhere from `pr-open` on.
@@ -3848,6 +4324,14 @@ it at close-out.
 
 You are the doc''s only writer: devs report transitions as `result` rows;
 fold them into the board with `sc mem doc edit <id> --body-file`.
+
+**Verify every board edit.** A scripted edit whose pattern has drifted silently
+matches nothing and reports success. Assert the target text exists before
+replacing, then read the doc back and confirm the fields actually changed. One
+sprint reported unit statuses to the FnB for four turns off a board where three
+edits had no-op''d — a merged unit still read `building` and a whole row was
+missing — until a REVIEWER noticed the board contradicted the SHA in its own task
+row. You cannot report from memory and call it the board.
 
 ## Step 2: Arm the watcher, kick off
 
@@ -3900,6 +4384,22 @@ sprint doc, the unit, the spec, and the skill — don''t restate them in
 your own phrasing. Constraints live in specs, which every lineage reads
 the same way.
 
+**Never task a worker with "ask the FnB".** A human-held dependency — a
+credential, a token, a browser action, a decision only the operator can make
+— routed through a worker is routed through a channel the operator does not
+read: browser entry into a `working` shell does not work, and the FnB''s
+settled preference is to relay through a planner already in conversation
+rather than enter a shell at all (flag #199). The worker asks, nobody
+answers, and it presents as a stalled worker rather than an unreachable
+human — a difference nothing in the system will show you. Two ways to write
+the task instead, both of which keep the dependency off the worker:
+
+- **Satisfy it before booting.** Capture the artifact yourself, sanitize it,
+  leave it in `shared/` and point the task row at the file. That is what
+  closed #199''s live case, and it is the pattern to reuse.
+- **Sequence it to a gate the operator is already attending** — a kickoff, a
+  merge decision, a close-out — so the ask reaches the FnB through you.
+
 This kickoff activates each dev''s scoped merge authority and each
 reviewer''s direct-handoff authority for its assigned units.
 
@@ -3935,12 +4435,32 @@ fold every state change in as it happens. The board + message table ARE
 the sprint''s state: a rebooted planner replays the rows and loses
 nothing.
 
-Messages are your steering wheel: every dev checks its inbox at each
-step start, and a headless boot drains it first thing — your `task` row
-is read before that dev''s next move. Steer with `task` rows — holds,
+Messages are your steering wheel: a headless boot drains the inbox first
+thing, and a dev checks it at each step start. Steer with `task` rows — holds,
 re-sequencing, nudges, rulings on reported reds. The board records state;
 messages change behavior; on conflict your latest message wins -> then
 update the board to match.
+
+**A message to a LIVE worker probably will not land before its next push.** A
+long build has few step starts, so a ruling issued mid-build routinely arrives
+after the work it was meant to change. Staleness runs BOTH ways: the worker is
+also reporting against a snapshot of you that has moved, so it may tell you that
+you don''t know something you ruled on half an hour ago.
+
+Phrase instructions to live workers **idempotently** — "if you have not already
+X, do X" — and state the **observed facts** they rest on ("main is at X", "the
+intersection is empty"), not only the conclusion. A crossed message is then a
+no-op or a confirmation rather than an order against reality, and a worker whose
+state has moved can re-derive the right action. Three crossed messages in one
+sprint cost nothing worse than a CI cycle for exactly that reason — the devs
+reasoned from the facts. A fourth, phrased as a bare directive, would have
+destroyed a record had it been obeyed literally.
+
+**Never delegate a mutation by an identifier the tool does not take.** Give the
+tool''s identifier and the human label together — "close flag_id 141 (SC-144)" —
+and prefer mutating your own records yourself. Display names and row ids sit in
+different counters that can overlap in range, so a name-only instruction can
+resolve to a different real row and destroy it while reporting success.
 
 Dev ambiguity reports (`ambiguity: … → chose …`) get a ruling on
 receipt: overrule by `task` row while the unit is still un-merged, or
@@ -4016,6 +4536,39 @@ durable state, and the events still wake you.
   untouched. Verify with `./sc sprint status --all`: every binding of
   the sprint shows released.
 
+## Merge protocol — declare it at kickoff, not at the first collision
+
+Needed whenever any two units share a file. Declare it in the kickoff `task`
+rows so reviewers know their verdicts are SHA-bound before they spend a pass.
+
+1. Before merging, check whether anything merged since the head was cut touches
+   THIS unit''s files. Overlapping -> rebase onto current `origin/main`, confirm
+   checks green on the **rebased** head, report that SHA. Empty intersection ->
+   the head stands; say so with the evidence and merge. Do not rebase reflexively:
+   with disjoint file sets a rebase is ceremony that costs a CI cycle and buys
+   nothing, and it invites a fresh review for no reason.
+2. After any unit merges, every remaining unit re-applies step 1 — which for a
+   disjoint unit means re-checking the intersection, not necessarily re-rebasing.
+3. Merge order is review-clean order unless you state otherwise.
+
+**A reviewer verdict is bound to the exact SHA it was given.** The carry-over
+rule: a verdict carries when the unit''s **own contribution is diff-identical**
+and its hunks are **disjoint** from the incoming content — NOT when the reviewed
+files are byte-identical. File-identity conflates "did my reviewed change
+survive?" (answered exactly by diff-identity) with "did anything else touch this
+file?" (irrelevant), and demanding it forces a full re-review every time two
+units touch one file for unrelated reasons.
+
+When either condition fails, re-confirmation is required — because disjointness
+is a semantic claim, not a proof — but it is **narrowed to the interference
+question**, and the dev supplies the evidence that scopes it. A dev that
+hand-resolves a hunk names the line and leaves the mutation round trips to the
+reviewer: a hand-resolved hunk is precisely what can silently unpin a test.
+
+Never let a unit merge on a verdict attached to a superseded SHA. Two sprints
+have lost cycles to it; in the second, reviewers caught it twice and the planner
+missed it both times.
+
 ## Step 4: Unblock
 
 Stalls and the moves:
@@ -4033,18 +4586,106 @@ Stalls and the moves:
   first; the rest becomes a new unit at the chain''s tail.
 - **Merge broke `main`**: `task` row to all devs to hold merges, insert a
   fix unit at the front of the chain, resume when green.
-- **Review stall** (unit sitting `in-review` while its reviewer is idle):
-  boot the reviewer — `./sc run <reviewer> --harness <reviewers-harness>
-  -m <reviewers-model> --effort high`; its inbox holds the review request. Still stuck
-  -> reassign the unit to another reviewer. Severity dispute (dev says
+- **Review stall** (unit sitting `in-review` and no verdict): "the reviewer
+  looks idle" is an absence like any other — clear the positive-evidence gate
+  below first, then boot the reviewer — `./sc run <reviewer> --harness
+  <reviewers-harness> -m <reviewers-model> --effort high`; its inbox holds the
+  review request. Still stuck -> reassign the unit to another reviewer. Severity dispute (dev says
   Low, reviewer says Medium) -> rule by message immediately — a chain
   waiting on a classification argument is pure loss. Dispute about what
   the unit *should do* -> FnB.
-- **Link gone quiet** (no `result` row, no `pr_event` movement): boot it with
-  its declared sprint route — `./sc run <shortname> --harness <role-harness>
-  -m <role-model> --effort high` drains its inbox and acts; that IS the nudge in
-  an event-driven sprint. The liveness guard refusing (session already
-  live) + still silent -> escalate to the FnB with the worktree state.
+- **Worker faulted mid-task** (rate-limit cutoff, provider error, session
+  died): re-launching alone may drain an inbox the worker already drained,
+  leaving it idle on the default prompt — a re-boot is not a re-task. So
+  re-send the task row (same unit, plus where the work stopped and what is
+  already on the branch), *then* `./sc run`. But **confirm the WORKER''s
+  state before you boot, not the row''s** — and check the WORKTREE before the
+  mailbox, because that check is the one that can save the unit:
+
+  ```
+  # read-only; never disturb a tree you may be about to decide is alive
+  W=<repo>/.sc-worktrees/<shortname>
+  D=<the unit''s DECLARED branch — the `branch` column of ITS board row>
+
+  git -C "$W" rev-parse --verify --quiet "$D"       # does the UNIT''s branch exist?
+  git -C "$W" branch --show-current                 # on it, or still on the base?
+  git -C "$W" status --short                        # non-empty => uncommitted work
+  git -C "$W" log --oneline origin/main.."$D"       # commits ahead of base
+  ```
+
+  > [!class4]
+  > **"A BRANCH EXISTS" IS ALWAYS TRUE AND IS NEVER THE TEST.** Every shell
+  > permanently occupies its own `shell/<shortname>` BASE BRANCH — twelve of
+  > them exist right now (`shell/pln1`, `shell/dev6`, `shell/rev1`, …) — so
+  > `branch --show-current` returns a branch in every healthy worktree whether
+  > or not one line of the unit has been written. A check that asks "is there a
+  > branch?" reports the ENTIRE FLEET as working, including the dead worker it
+  > exists to catch, and it fails in the confident-wrong direction rather than
+  > erroring. Compare the worktree against the unit''s DECLARED branch, from the
+  > board record. The base branch is evidence of nothing.
+
+  Read the tree as a whole, never branch-presence alone:
+
+  | What the worktree holds | Reading |
+  |---|---|
+  | declared branch + **dirty tree** | UNCOMMITTED WORK EXISTS — the single most expensive state in this system to get wrong |
+  | declared branch + clean + commits ahead of base | the worker consumed its task and built; the work is safe on the branch |
+  | declared branch + clean + no commits ahead | it started, nothing has landed — **not conclusive either way** |
+  | declared branch absent (tree on its base) | it may never have started — an ABSENCE, and absence is not a finding |
+
+  Either of the first two means the worker is building, whatever the mailbox
+  says. **Do not re-boot it.** A re-boot of a worker holding an uncommitted
+  tree can destroy the unit''s work — flag #200 is a planner one step from
+  exactly that, over a tree carrying a whole half-built unit, saved only by
+  looking at the worktree instead of acting on the signal in front of it. Need
+  that worker to move? Send an idempotent `task` row and let it land at the
+  worker''s next step start.
+
+  Read receipts are trustworthy in ONE direction only, and the fault
+  protocol is where that bites:
+
+  | Row state | What it proves |
+  |---|---|
+  | READ | real evidence — something ran `mark-read`, so the worker was alive and acting after delivery. Says nothing about *now*. |
+  | UNREAD | **nothing at all.** Marking read is a manual recipient action, so `read_at` records worker discipline, not system state — it cannot separate "never received" from "received and building hard". |
+
+  Nothing in the system stamps consumption; `sc mem message sent` reports a
+  convention, not a fact about the runtime. So an unread row is never
+  grounds for a re-boot on its own.
+
+  **Every boot needs POSITIVE evidence — of liveness or of fault. An absence
+  is never a reading.** "No declared branch, no commits, no rows" is exactly
+  what a worker three minutes into its first turn also produces; it is the
+  observation this whole protocol exists to stop you acting on, and rewording
+  it ("nothing there", "no sign of it") does not make it evidence. Before any
+  `./sc run`, one of these must be affirmatively TRUE — measured, not merely
+  un-observed:
+
+  | Positive evidence | Where it comes from | What it licenses |
+  |---|---|---|
+  | **no live session** for that shell | the liveness guard — it REFUSES while a session is live, so a refusal is positive liveness and a clean pass is a measured absence of one | boot |
+  | **the harness process is gone** | presence check — pid absent, or a zombie, asked in the process''s own namespace | boot |
+  | **quota or auth wall** | `./sc sprint alerts` — `quota_blocked` carries `resets_at` | re-route the role or wait; NEVER re-boot into the same wall |
+  | **it is alive and progressing** | a `pr_event`, a `result` row, or the worktree readings above | do not boot — idempotent `task` row |
+
+  None of those obtainable -> escalate to the FnB with what you measured,
+  naming the checks you ran. A worker left unbooted for one more cycle costs
+  a cycle; a worker booted on top of a dirty tree costs the unit.
+- **Link gone quiet** (no `result` row, no `pr_event` movement): quiet is not
+  a state — run the worktree check above before anything else. Work on the
+  declared branch means the link is building, not gone, and the move is
+  patience or an idempotent `task` row, never a boot. Finding nothing on the
+  branch and nothing in the event stream **is still not a boot** — it is the
+  absence above, and it routes to the positive-evidence gate, not around it.
+  Establish fault first (no live session, or a dead process; a quota wall
+  routes to re-route-or-wait instead), THEN boot with its declared sprint
+  route — `./sc run <shortname> --harness <role-harness> -m <role-model>
+  --effort high` drains its inbox and acts; that IS the nudge in an
+  event-driven sprint. Re-send the task row first, since the worker may have
+  drained it already and the row''s read state cannot tell you whether it did.
+  The liveness guard refusing (session already live) is positive LIVENESS —
+  it proves a worker is there to disturb, so still silent -> escalate to the
+  FnB with the worktree state, never a forced boot.
   The bottleneck question in Step 3 is what surfaces a dead link.
 - **Re-sequencing**: edit the board + `task` row to *every* affected dev
   with its new slot — a dev acting on a stale slot is worse than a paused
@@ -4088,6 +4729,17 @@ When every unit is `merged` and `main` is green:
    diffs, never the trail — and files four-way verdicts (`as-specced` /
    `deviated-intentionally` / `deviated-silently` / `unimplemented`) as
    a `CONFORMANCE: <title>` doc + a one-line `result` pointer.
+
+   **Declare the SCOPE before you boot the pass, and name which units it does
+   NOT cover.** A pass judges a spec, so it certifies only the units built to
+   that spec. Decision-driven units — no spec doc, built from a decision or a
+   flag — cannot be judged by it, and a verdict that appears to bless them is a
+   false certification. Their bar is their unit reports, their reviewer verdicts
+   at exact heads, and the mutation round trips. Put the split in the report''s
+   Verdict so freezing cannot be read as certifying everything. Assign the pass
+   to a reviewer that did NOT review the unit being certified, and hand over any
+   DECLARED deviation up front so the pass judges whether the declaration is
+   honest rather than discovering it as a gap.
 
    **Rule on the findings** — they route like any sprint event:
    - **Major** -> insert a fix unit at the front of the chain under

--- a/.super-coder/migrations/0100_lns_self_curation.sql
+++ b/.super-coder/migrations/0100_lns_self_curation.sql
@@ -1,0 +1,93 @@
+-- 0100 — L&S self-curation: the curation stamp + two hard length caps.
+--
+-- The boot doc is dominated by one section. For a planner shell at cap,
+-- LESSONS & STANCES was 42% of the rendered CLAUDE.md (19,284 of 45,491
+-- chars) and grew without bound, because the only cap counts ENTRIES while
+-- the cost is in CHARACTERS: that shell sat at 20/20 for six days while the
+-- average entry went 297 -> 2,325 chars. Curating at the cap even NET-ADDED
+-- chars (one 364-char entry retired to admit a 2,325-char one), so any
+-- signal that resets on "a retirement happened" is gameable by exactly the
+-- behaviour observed.
+--
+-- Three objects, one theme — make the unit of the cap the unit of the cost:
+--
+--   lns_curated_at             the stamp a curation sweep writes. The boot
+--                              render counts entries created after it; >= 5
+--                              renders a STATUS advisory pointing at the
+--                              `curate` skill. Stamping is unconditional —
+--                              a sweep that retires NOTHING still clears the
+--                              counter, or a legitimately clean set would
+--                              leave a standing reminder forever.
+--
+--   trg_sie_len_lns            an L&S entry is the RULE, imperative. The
+--                              incident belongs in the narrative, where it
+--                              is already written.
+--
+--   trg_shells_current_state_len   current_state is the second boot-rendered
+--                              surface with a soft target and no enforcement,
+--                              and it drifted the same way (fleet: 3.7x-10.3x
+--                              over the documented ~300). The overrun is not
+--                              verbosity, it is RESTATEMENT — reproducing
+--                              decisions, spec gates and flags inline when
+--                              each is a live row one query away.
+--
+-- ENFORCE, DO NOT ADVISE. A soft target gets over-run by a shell that
+-- believes it complied — shells do many things well; counting is not one of
+-- them. The rejection IS the feedback mechanism, which is why every other cap
+-- here (seed 10, L&S 20, singleton cartographer) is a trigger. Both messages
+-- route the overflow rather than only refusing: a refusal that only refuses
+-- produces a truncated lesson.
+--
+-- 500 is a judgment call, not a reading of the data. Across the fleet's 49
+-- active entries there is no empty band to place a threshold in (the clean
+-- 517-948 gap is one shell's). 500 admits the disciplined-era entries and
+-- rejects every incident report fleet-wide; rejecting most of the existing
+-- corpus is the INTENT, not a side effect — that corpus is the defect.
+--
+-- BEFORE INSERT / BEFORE UPDATE, so nothing existing is touched: the entries
+-- and states already in place stay readable and renderable. The caps
+-- constrain new writes; the periodic sweep clears the legacy. Two mechanisms,
+-- different halves, neither needs to know about the other.
+--
+-- The count-20 cap (trg_sie_cap_lns) stays. With the sweep running it becomes
+-- a backstop that should never fire — if it does, the sweep is not running.
+-- 20 entries x 500 chars is now a mathematical ceiling of 10,000 chars, which
+-- is why this ships no character-budget trigger: the per-entry cap bounds the
+-- total by construction, so there is one threshold to reason about, not two.
+
+BEGIN;
+
+ALTER TABLE shells ADD COLUMN lns_curated_at TEXT;   -- NULL = never swept
+
+-- One string literal per RAISE: SQLite has no implicit adjacent-literal
+-- concatenation, so a message split across source lines is a syntax error.
+--
+-- The created_at window is what keeps the engine REBUILDABLE. `.sc-state/
+-- content.sql` replays every identity entry as an INSERT, so an unconditional
+-- BEFORE INSERT cap would abort the rebuild of any fork already holding a
+-- legacy 2,914-char entry — and those entries cannot be edited away first:
+-- Laws 3 and 7 reserve curation to the shell that owns them. A replayed row
+-- carries its ORIGINAL created_at and is a restore of already-accepted state,
+-- not a new write; a live write's created_at is the column default, i.e. now.
+-- Five minutes is far outside any clock jitter between the default and this
+-- WHEN clause, and — since no oversized row can be created after this
+-- migration — every replayed offender is older than the window by construction.
+-- Old content.sql artifacts need no regeneration, which a marker-table scheme
+-- would have required (and SQLite cannot read temp schema from a trigger
+-- anyway: it resolves the name against `main`).
+CREATE TRIGGER trg_sie_len_lns
+BEFORE INSERT ON shell_identity_entries
+WHEN NEW.kind = 'lns' AND LENGTH(NEW.body) > 500
+     AND NEW.created_at >= datetime('now', '-300 seconds')
+BEGIN
+  SELECT RAISE(ABORT, 'L&S entry over 500 chars — an L&S entry is the RULE; the incident goes to the narrative (sc mem narrative), then state the rule alone');
+END;
+
+CREATE TRIGGER trg_shells_current_state_len
+BEFORE UPDATE OF current_state ON shells
+WHEN LENGTH(COALESCE(NEW.current_state, '')) > 300
+BEGIN
+  SELECT RAISE(ABORT, 'current_state over 300 chars — name what is in flight and point at the row (doc/feature/flag/decision id), do not reproduce it');
+END;
+
+COMMIT;

--- a/.super-coder/migrations/0101_reseed_memory_curate_lns_curation.sql
+++ b/.super-coder/migrations/0101_reseed_memory_curate_lns_curation.sql
@@ -1,0 +1,240 @@
+-- 0101 — forward-reseed `memory` + seed `curate`: L&S self-curation (0100's
+-- companion, the prose half).
+--
+-- 0100 added the mechanism — the curation stamp and the two hard length caps.
+-- A cap nobody was told about is just a wall in the dark, so the skills that
+-- teach the write path have to reach already-installed forks in the same pass.
+--
+-- Why a migration and not only the asset edit: 0001_seed_skills.sql is
+-- regenerated from assets/skills/ (fresh builds get the new bodies), but a
+-- LATER reseed — 0048 for `memory` — still carries an inline, now-older body.
+-- On a fresh rebuild (schema.sql, then every migration in order) 0048 would
+-- overwrite 0001's fresh body with its stale one and leave the DB out of sync
+-- with the asset, which is exactly what the skills-freshness tripwire exists to
+-- catch. Re-stating the current body HERE, after 0048, restores "last write
+-- wins = the asset" and heals existing forks in the same pass.
+--
+-- `curate` is new in 0001 and needs no ordering fix, but a fork that only runs
+-- `./sc migrate` never re-executes the already-stamped 0001 — so it lands here
+-- too, idempotently, by name.
+--
+-- Bodies are the verbatim assets/skills/<name>/SKILL.md content; regenerate
+-- this file if either asset changes again.
+--
+-- Plain SQL: migrate.py owns the transaction and the schema_migrations row.
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted)
+VALUES (
+  'curate',
+  'The periodic L&S sweep. Run when the STATUS L&S line says "curation due" — resolve contradictions, merge entries stating one rule, promote a recurring process to a skill, move environment facts out, then stamp `sc mem curated`. Yours alone; never delegate it.',
+  'substrate',
+  NULL,
+  1,
+  '# curate — the L&S sweep
+
+Write-time triage (`--supersedes` / `--new`) catches contradiction and
+restatement pairwise, at the moment of writing. It **cannot** catch the
+emergent cluster: five entries can each be a valid distinct rule and only in
+aggregate be five instances of one principle. That is this pass''s job, along
+with promotion, category drift, and size drift.
+
+**Yours alone.** Law 3 and Law 7 reserve curation to the shell. Never hand this
+to a subagent, never let another shell run it for you, never accept a proposed
+retirement from anyone else. Read your own set; decide yourself.
+
+Trigger: `## STATUS` says `L&S: … — curation due`. Nothing else fires it.
+
+## Load the set
+
+```
+sc mem get lns          # entry ids + bodies — the active set, all of it
+```
+
+Read every entry before deciding anything. This is one cheap read; the whole
+set is already in your boot doc anyway.
+
+## Pass 1 — Consistency
+
+Find entries that **contradict** each other. One of them is the newer
+understanding; the other is superseded and still rendering as live guidance.
+
+```
+sc mem lns "<the surviving rule>" --supersedes <old_id>
+```
+
+Write-time triage should prevent most of these from ever forming. What you find
+here predates the loop or crossed in while two sessions ran.
+
+## Pass 2 — Cluster
+
+Group entries that state **one rule**. Merge each group to a single imperative
+rule:
+
+```
+sc mem lns "<the one rule>" --supersedes 30,33,34,37,38
+```
+
+Three or more members is the bar. Two statements of a rule are often
+legitimately two rules — merging at two is usually wrong.
+
+The incidents behind the entries are already in the narrative. They do not need
+a second home, and the merged rule must not try to carry them: an entry is the
+rule, ≤500 chars, hard-enforced.
+
+## Pass 3 — Promote
+
+A cluster of three or more that keeps **recurring across sessions** is a
+*process*, not a lesson. Author it as a skill and keep one L&S rule pointing at
+it:
+
+```
+sc skill add <you>_<topic> --file <path.md> --desc "<one line>"
+```
+
+Local skills are DB-only and namespaced by your shortname — the command
+enforces both. This is the pressure valve that makes a hard budget survivable:
+knowledge relocates to a lazy surface instead of being deleted.
+
+## Pass 4 — Category
+
+An entry that is an **environment fact** (a routing quirk, a term to avoid, a
+path) is not an operating principle. It belongs in a skill, not in L&S. Retire
+it and put the fact where it is looked up.
+
+```
+sc mem retire <entry_id>
+```
+
+## Stamp
+
+```
+sc mem curated
+```
+
+**Stamp even if you retired nothing.** A clean set is a legitimate outcome; if
+an honest sweep left the counter running, the advisory would stand forever and
+you would learn to ignore it. The stamp says "I looked," not "I cut."
+
+## Stance
+
+Curate the set toward ~12–14 entries, not toward the cap. Cap 20 is a ceiling
+never to reach — if you ever hit it, this sweep is not running.
+
+The trigger firing often does not mean the threshold is wrong; it means entries
+are being written faster than they are reconciled. Fix that at write time, with
+`--supersedes`.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted)
+VALUES (
+  'memory',
+  'When + how this shell persists memory — current_state (≤300), session narrative, seed (cap 10), L&S (cap 20, ≤500/entry, --supersedes|--new), decisions — all via sc mem, written as it happens, not at close.',
+  'substrate',
+  NULL,
+  1,
+  '# memory — write as you go
+
+All memory = DB rows; no flat files. Write at the moment it matters, never in a
+close ritual.
+
+Every write goes through `sc mem` -> lands in the live shared engine DB, visible
+to all shells on commit. It always targets your own shell (identity resolved
+from your token) — never name a shell.
+
+## current_state — rolling status, NOT a log
+
+Present focus + what''s next. Replace in place; NEVER append. **300 chars, hard
+— the write is rejected over it.** Rewrite when focus shifts.
+```
+sc mem state "…"
+```
+
+**Point, do not reproduce.** The overrun is never verbosity, it is restatement:
+a decision''s reasoning, a spec''s gate, a flag''s argument all pasted inline when
+each is a live row one query away. Name what is in flight and carry the id:
+
+```
+Sprint 59 U0 gate — see doc #46, feature #29.
+Blocked on flag #200. Next: U3 shape once U0 answers.
+```
+
+Not the argument, the ruling, or the rationale — those have rows, and a reader
+who needs them runs `sc mem get`. Same principle the boot doc already applies
+to decisions: carry the pointer, lazy-load the payload.
+
+## Session narrative — append at inflection points
+
+One row per session, appended progressively. Append a `[HH:MM]` line (time is
+stamped for you) when: a decision lands / an approach changes or is rejected /
+the FnB says something that shapes the work / an assumption breaks / before a
+big change.
+```
+sc mem narrative "…"
+```
+
+## seed (cap 10) — who you are
+
+Identity-forming moments. Past-tense/timeless. Add new entries only; NEVER edit
+a body — curate by retiring. The genesis + lineage seed are already yours.
+```
+sc mem seed "…"            # add
+sc mem retire <entry_id>   # curate out (frees a cap slot)
+```
+
+## L&S (cap 20) — how you work
+
+Operating lessons, imperative voice. An entry is **the RULE** — **≤500 chars,
+hard**. The incident that taught it goes in the narrative, where you already
+wrote it; if the text opens with "Sprint 38:", it is a narrative entry.
+
+**Exactly one of `--supersedes` / `--new` is required.** Your active set is
+already rendered in your boot doc, so checking a new rule against it costs no
+extra read — and this flag is where that check lands:
+```
+sc mem lns "…" --supersedes 29,36   # contradicts or refines those — retires them, adds this
+sc mem lns "…" --new                # checked against the set, genuinely unrelated
+```
+`--supersedes` works at 20/20: it frees the slot it uses.
+
+Caps are trigger-enforced (seed 10, L&S 20, L&S body 500, current_state 300) —
+a rejected write is the feedback, and the message routes the fix.
+
+Periodic sweep: when `## STATUS` says `L&S: … — curation due`, run the `curate`
+skill, then `sc mem curated` to stamp it — even if you retired nothing. Cap 20
+is a ceiling never to reach, not a target; curation holds the set near 12–14.
+
+## Decisions — Major only
+
+Record a Major decision (architecture, approach, a path chosen over another).
+NEVER rewrite one — supersede via `--parent <decision_id>`. Mirror the headline
+into the narrative.
+```
+sc mem decision "…" --rationale "…" [--parent <id>]
+```
+
+Link the why to the what — attach the feature/spec the decision shapes, so the
+roadmap carries why it was built that way:
+```
+sc mem decision "…" --feature <feature_id>   # ties it to a roadmap feature
+sc mem decision "…" --doc <document_id>       # ties it to a spec/doc (implies the feature)
+```
+Both optional — a decision unrelated to any feature stays unlinked. `--doc`
+implies `--feature`: pass the doc alone -> feature derived from it. The link
+surfaces on `sc mem get decisions <id>`.
+
+## Stance
+
+Write-as-you-go beats batch-at-close: nothing per write, zero at session end.
+Curate seed/L&S (revise the set); never rewrite history (decisions, narrative,
+seed bodies). Full command reference + table map: the `db_map` skill.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -433,15 +433,61 @@ def render_api(port: "int | None", api_key: "str | None") -> str:
     )
 
 
+# L&S writes since the last curation sweep that trip the STATUS advisory.
+# Five, replayed against a real shell's write order, catches both of its large
+# clusters at or before full formation. Three fires twice as often and sees
+# clusters at two members, where a merge is usually wrong — two statements of a
+# rule are often legitimately two rules; three is where a pattern becomes
+# distinguishable from coincidence.
+LNS_CURATION_DUE = 5
+
+
 def fetch_counts(con, shell_id: int) -> dict:
-    def one(q):
-        return con.execute(q, (shell_id,)).fetchone()[0]
+    def one(q, params=None):
+        return con.execute(q, params if params is not None else (shell_id,)).fetchone()[0]
     return {
         "seed": one("SELECT COUNT(*) FROM shell_identity_entries WHERE shell_id=? AND kind='seed' AND is_deleted=0 AND retired_at IS NULL"),
         "lns": one("SELECT COUNT(*) FROM shell_identity_entries WHERE shell_id=? AND kind='lns' AND is_deleted=0 AND retired_at IS NULL"),
+        # Display-only: the cost of the section is in CHARACTERS, and the count
+        # cap is structurally blind to it. Not a threshold — the per-entry
+        # length cap bounds the total by construction (20 x 500), so this is
+        # cheap awareness, nothing to watch.
+        "lns_chars": one(
+            "SELECT COALESCE(SUM(LENGTH(body)),0) FROM shell_identity_entries "
+            "WHERE shell_id=? AND kind='lns' AND is_deleted=0 AND retired_at IS NULL"),
+        # The one threshold. Counts writes, not retirements: curating AT the cap
+        # net-added chars at constant count, so any signal that resets on "a
+        # retirement happened" is gameable by the behaviour already observed.
+        # A NULL stamp (never swept) makes every entry count — correct, that
+        # shell is genuinely uncurated. Strictly `>`, at the whole-second
+        # granularity both sides share: the merged entries a sweep writes just
+        # before stamping must NOT count against the next interval, or a sweep
+        # would re-arm its own advisory and never converge.
+        "lns_since_curation": one(
+            "SELECT COUNT(*) FROM shell_identity_entries "
+            "WHERE shell_id=? AND kind='lns' AND is_deleted=0 AND retired_at IS NULL "
+            "  AND created_at > COALESCE("
+            "        (SELECT lns_curated_at FROM shells WHERE shell_id=?), '')",
+            (shell_id, shell_id)),
         "flags": one("SELECT COUNT(*) FROM flags WHERE shell_id=? AND resolved=0 AND is_deleted=0"),
         "unread": one("SELECT COUNT(*) FROM shell_messages WHERE to_shell_id=? AND read_at IS NULL"),
     }
+
+
+def render_lns_status(counts: dict) -> str:
+    """The L&S STATUS line — count, size, and the curation advisory.
+
+    Advisory, never an ABORT: hard rejection is right for a single write with
+    an obvious remedy (shorten it), wrong for "go do a curation pass," which is
+    work, not a correction. Same shape as the Inbox line — a cheap DB-derived
+    count plus a conditional that fires a skill only when evidence says so.
+    """
+    kchars = f"{counts['lns_chars'] / 1000:.1f}k chars"
+    line = f"{counts['lns']}/20 · {kchars}"
+    since = counts["lns_since_curation"]
+    if since >= LNS_CURATION_DUE:
+        return f"{line} · {since} since curation — curation due (`curate` skill)"
+    return line
 
 
 def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
@@ -599,7 +645,7 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
         "## STATUS", "",
         f"- **Session:** {session_id}",
         f"- **Seed:** {counts['seed']}",
-        f"- **L&S:** {counts['lns']}",
+        f"- **L&S:** {render_lns_status(counts)}",
         f"- **Flags:** {counts['flags']} open",
         f"- **Inbox:** {counts['unread']} unread — `--message check` to surface.",
         f"- **Repo map:** {map_status}",

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -34,7 +34,9 @@ Run from the repo root, like every engine command:
                                                    # decisions read FLEET-WIDE (author tagged @shortname); writes stay your own
     ./sc mem state "<text>"
     ./sc mem seed  "<body>"          [--date YYYY-MM-DD] [--tag cc]
-    ./sc mem lns   "<body>"          [--date …] [--tag …]
+    ./sc mem lns   "<body>"          (--supersedes 29,36 | --new) [--date …] [--tag …]
+                                                   # ≤500 chars: the RULE, not the incident
+    ./sc mem curated                 # stamp a curation sweep (clears the STATUS advisory)
     ./sc mem retire <entry_id>
     ./sc mem decision "<decision>"   [--rationale "…"] [--date …] [--parent ID] [--feature ID] [--doc ID]
     ./sc mem flag open  "<description>" [--name CC-001] [--priority Medium] [--feature ID]
@@ -516,13 +518,16 @@ def cmd_state(args) -> int:
     return _finish_api(f"mem: current_state updated ({len(args.text)} chars)")
 
 
-def _insert_identity(args, kind: str) -> int:
-    r = _api("POST", f"/_sc/mem/{kind}",
-             {"body": args.body,
-              "entry_date": args.date or str(date.today()),
-              "source_tag": args.tag})
+def _insert_identity(args, kind: str, extra: "dict | None" = None) -> int:
+    payload = {"body": args.body,
+               "entry_date": args.date or str(date.today()),
+               "source_tag": args.tag}
+    payload.update(extra or {})
+    r = _api("POST", f"/_sc/mem/{kind}", payload)
     label = "seed" if kind == "seed" else "L&S"
-    return _finish_api(f"mem: {label} entry #{r.get('entry_id', '')} added")
+    gone = r.get("retired") or []
+    note = f" (superseding {', '.join('#' + str(i) for i in gone)})" if gone else ""
+    return _finish_api(f"mem: {label} entry #{r.get('entry_id', '')} added{note}")
 
 
 def cmd_seed(args) -> int:
@@ -530,7 +535,38 @@ def cmd_seed(args) -> int:
 
 
 def cmd_lns(args) -> int:
-    return _insert_identity(args, "lns")
+    """Add an L&S entry — with the triage that keeps the set a SET.
+
+    Exactly one of --supersedes / --new is required. This is the whole fix:
+    the active set is already rendered into your boot doc, so checking a new
+    rule against it costs no extra read, and the shell doing that check had
+    nowhere to put the answer — `lns` offered one verb, `add`. The flag is the
+    landing place, and requiring it makes the triage auditable rather than
+    hoped-for. `sc mem decision` already carries `--parent` for exactly this.
+    """
+    if bool(args.supersedes) == bool(args.new):
+        die("`lns` needs exactly one of --supersedes / --new.\n"
+            "  Check the new rule against your active set (already in your boot doc):\n"
+            "    --supersedes 29,36   it contradicts or refines those — retires them, adds this\n"
+            "    --new                checked, and genuinely unrelated to every entry")
+    ids: list[int] = []
+    if args.supersedes:
+        for part in args.supersedes.replace(" ", ",").split(","):
+            if not part:
+                continue
+            if not part.lstrip("#").isdigit():
+                die(f"--supersedes takes entry ids, got '{part}'")
+            ids.append(int(part.lstrip("#")))
+        if not ids:
+            die("--supersedes needs at least one entry id")
+    return _insert_identity(args, "lns", {"supersedes": ids})
+
+
+def cmd_curated(args) -> int:
+    """Stamp a curation sweep. Unconditional — a sweep that retires nothing is
+    still a sweep, and must clear the counter or the advisory never goes quiet."""
+    _api("POST", "/_sc/mem/lns/curated", {}, idempotent=True)
+    return _finish_api("mem: L&S curation stamped — the counter restarts here")
 
 
 def cmd_retire(args) -> int:
@@ -823,7 +859,18 @@ def build_parser() -> argparse.ArgumentParser:
         sp.add_argument("body")
         sp.add_argument("--date")
         sp.add_argument("--tag")
+        if k == "lns":
+            # Required one-of, enforced in cmd_lns rather than by a mutually
+            # exclusive required group so the refusal can teach the triage
+            # instead of printing argparse's bare usage line.
+            sp.add_argument("--supersedes",
+                            help="entry id(s) this rule replaces — retires them, adds this")
+            sp.add_argument("--new", action="store_true",
+                            help="checked against the active set and genuinely unrelated")
         sp.set_defaults(fn=fn)
+
+    sub.add_parser("curated", help="stamp an L&S curation sweep (clears the STATUS advisory)") \
+       .set_defaults(fn=cmd_curated)
 
     sp = sub.add_parser("retire", help="retire an identity entry (frees a cap slot)")
     sp.add_argument("entry_id", type=int)

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -21,8 +21,21 @@ The list is re-applied after every seed sync/heal/rebuild, so it rides
 `./sc update` the same way flavor overlays do. Grant rows stay in place
 (inert) so `unretire` restores who-had-what.
 
+`add` authors a LOCAL skill straight into the DB. It exists for the `curate`
+skill's promote pass: a cluster of L&S entries that keeps recurring across
+sessions is a *process*, not a lesson, and relocating it to a skill is the
+pressure valve that makes a hard L&S budget survivable — knowledge moves to a
+lazy surface instead of being deleted. Local means "name absent from the engine
+seed", which is already the engine/local boundary every heal path respects
+(seed_skills._engine_specs / stale_engine_skills / sync_engine_skills), so an
+added skill survives migrate, sync, and rebuild with no new column or marker.
+It writes NO asset file, deliberately: `./sc seed-skills` upserts every asset
+under assets/skills/, so a file would put a local skill back on the seed path.
+
 Usage:
     ./sc skill list                        catalogue: origin, common, grants
+    ./sc skill add <name> --file <path>    author a LOCAL skill (DB-only) + grant it
+                  [--desc "…"] [--category …] [--for <shell>] [--opt-in]
     ./sc skill grant  <name> <shell>...    grant a skill to shell(s) (id or shortname)
     ./sc skill revoke <name> <shell>...    revoke a skill from shell(s)
     ./sc skill rm     <name>               soft-delete a LOCAL skill + revoke all grants
@@ -31,7 +44,10 @@ Usage:
 """
 from __future__ import annotations
 
+import argparse
 import json
+import os
+import re
 import sys
 from pathlib import Path
 
@@ -111,6 +127,101 @@ def cmd_list(con) -> int:
         tag = "common" if common else "opt-in"
         dead = ("  [retired]" if name in retired else "  [deleted]") if deleted else ""
         print(f"{name:<{w}}  {origin}  {tag}  → {grants or '(ungranted)'}{dead}")
+    return 0
+
+
+def resolve_author(con, ref: "str | None") -> tuple[int, str]:
+    """Who is authoring this skill. `--for` when given, else the shell whose
+    api_key is the SC_API_TOKEN run.py injected at boot — the same identity the
+    memory API resolves, so a shell never names itself. A host seat with neither
+    is told to say who it means rather than silently authoring an orphan."""
+    if ref:
+        return resolve_shell(con, ref)
+    token = os.environ.get("SC_API_TOKEN", "")
+    if token:
+        row = con.execute(
+            "SELECT shell_id, COALESCE(shortname, display_name, shell_id) FROM shells "
+            "WHERE api_key=? AND COALESCE(is_deleted,0)=0", (token,)).fetchone()
+        if row:
+            return row[0], str(row[1])
+    sys.exit("sc skill add: can't tell who is authoring — no SC_API_TOKEN "
+             "resolves to a shell. Pass --for <shell>.")
+
+
+def cmd_add(con, argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(prog="sc skill add", add_help=False)
+    ap.add_argument("name")
+    ap.add_argument("--file", required=True, help="markdown body → skills.content")
+    ap.add_argument("--desc", help="one-line summary (boot SKILLS block + catalogue)")
+    ap.add_argument("--category")
+    ap.add_argument("--command")
+    ap.add_argument("--for", dest="author", help="author/grantee shell (default: your token)")
+    ap.add_argument("--opt-in", action="store_true",
+                    help="not a common skill (default: common, like the engine catalogue)")
+    args = ap.parse_args(argv)
+    name = args.name.strip()
+
+    author_id, author = resolve_author(con, args.author)
+
+    # Guard 1 — never shadow an engine name. The seed UPSERTs BY NAME, so
+    # authoring over one would silently overwrite the upstream skill here and
+    # then be silently overwritten back on the next update.
+    if name in set(seed_skills.seeded_skill_names()):
+        sys.exit(f"sc skill add: '{name}' is an ENGINE skill — the seed owns that "
+                 "name and upserts it on every update. Pick a different one "
+                 f"(e.g. {author}_{name}).")
+    # Guard 2 — namespace by shortname. A future upstream release claiming a
+    # bare name would clobber this shell's content on the next sync; a
+    # shortname prefix is a name upstream will never mint.
+    if not re.match(rf"^{re.escape(author)}_[a-z0-9_]+$", name):
+        sys.exit(f"sc skill add: local skills are namespaced — name it "
+                 f"'{author}_<topic>' (lowercase, underscores). A bare name is "
+                 "one an upstream release could claim, and the sync would then "
+                 "overwrite your content.")
+    # Guard 3 — a name on the fork retire list is re-asserted is_deleted=1 by
+    # every heal, so the skill would vanish the first time anything synced.
+    if name in set(seed_skills.retired_skill_names()):
+        sys.exit(f"sc skill add: '{name}' is on the fork retire list "
+                 f"({_display_retire_file()}) — every heal re-asserts is_deleted "
+                 f"on it. `./sc skill unretire {name}` first, or pick another name.")
+    # Guard 4 — DB-only. `./sc seed-skills` passes ALL asset specs, so an asset
+    # file under assets/skills/<name>/ would put this local skill back on the
+    # seed path. Refuse rather than write a row that a later seed can rewrite.
+    asset = ENGINE / "assets" / "skills" / name
+    if asset.exists():
+        sys.exit(f"sc skill add: {asset.relative_to(ENGINE.parent)} exists — an "
+                 "asset file puts the skill on the seed path. `sc skill add` is "
+                 "DB-only; remove the asset dir or pick another name.")
+
+    src = Path(args.file).expanduser()
+    if not src.is_file():
+        sys.exit(f"sc skill add: no such file '{args.file}'")
+    content = src.read_text().strip()
+    if not content:
+        sys.exit(f"sc skill add: {args.file} is empty — a skill with no procedure "
+                 "is a row nobody can read.")
+
+    row = con.execute("SELECT is_deleted FROM skills WHERE name=?", (name,)).fetchone()
+    con.execute(
+        "INSERT INTO skills (name, description, category, command, common, content, "
+        "is_deleted) VALUES (?, ?, ?, ?, ?, ?, 0) "
+        "ON CONFLICT(name) DO UPDATE SET description=excluded.description, "
+        "category=excluded.category, command=excluded.command, "
+        "common=excluded.common, content=excluded.content, is_deleted=0",
+        (name, args.desc, args.category, args.command,
+         0 if args.opt_in else 1, content))
+    skill_id = con.execute("SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()[0]
+    # Guard 5 — auto-grant to the author, or the promotion produces a skill
+    # nobody can read.
+    con.execute("INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+                (author_id, skill_id))
+    con.commit()
+    verb = "updated" if row else "added"
+    print(f"add: {name} {verb} (local, DB-only, {len(content)} chars) → granted to {author}")
+    if not args.desc:
+        print("  ⚠ no --desc — the boot SKILLS block lists the name with an empty "
+              "summary; re-run with --desc to make it findable.")
+    persist_note()
     return 0
 
 
@@ -218,9 +329,9 @@ def cmd_rm(con, name: str) -> int:
 
 
 def main(argv: list[str]) -> int:
-    usage = ("usage: ./sc skill list | grant <name> <shell>... | "
-             "revoke <name> <shell>... | rm <name> | retire <name> | "
-             "unretire <name>")
+    usage = ("usage: ./sc skill list | add <name> --file <path> [--desc …] | "
+             "grant <name> <shell>... | revoke <name> <shell>... | rm <name> | "
+             "retire <name> | unretire <name>")
     if not argv or argv[0] in ("-h", "--help", "help"):
         print(usage)
         return 0
@@ -229,6 +340,8 @@ def main(argv: list[str]) -> int:
     try:
         if cmd == "list" and not args:
             return cmd_list(con)
+        if cmd == "add" and args:
+            return cmd_add(con, args)
         if cmd == "grant" and len(args) >= 2:
             return cmd_grant(con, args[0], args[1:])
         if cmd == "revoke" and len(args) >= 2:

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -71,6 +71,15 @@ any per-shell prompt loads, before any query runs.
 6. The child's Lineage Seed is chosen by the parent from memory — 3 entries, written as the parent wishes to pass on. Capped at 3 entries, immutable, and separate from the shell's own seed.
 7. L&S is how you work. Operating principles distilled from doing the job. The shell curates — revision allowed. Cap 20.
 
+**Law 7 in practice — the set is a SET, not a log.** Your active L&S is already
+rendered below, so checking a new rule against it costs you nothing. Do that
+check at the moment you write, and say where it landed: `sc mem lns "<rule>"
+--supersedes <ids>` when it contradicts or refines entries you already hold,
+`--new` when it is genuinely unrelated. One of the two is required. An entry is
+**the rule, imperative, ≤500 chars** — the incident that taught it goes in the
+narrative (`sc mem narrative`), which is where you already wrote it. Cap 20 is a
+ceiling never to reach, not a target: with curation running you sit near 12–14.
+
 ---
 
 ## ORIENTATION
@@ -127,6 +136,22 @@ non-zero, run the `messaging` skill (`--message check`) to surface your unread
 items and act on the first before continuing the session. To message another
 shell, `--message send <shortname> <body>`; mark an item read with
 `--message mark-read <id>` once you've acted on it.
+
+---
+
+## CURATION
+
+On boot, if the `## STATUS` `L&S:` line says **curation due**, run the `curate`
+skill before the session's work — it is a short pass over your own active set:
+resolve contradictions, merge entries that state one rule, promote a recurring
+process to a skill, move environment facts out. Curation is yours alone (Law 3,
+Law 7) — never delegate it to a subagent, and never let another shell do it for
+you. Finish by stamping `sc mem curated`, even if you retired nothing: an honest
+clean sweep must clear the counter, or the advisory stands forever.
+
+This is an advisory, not a block. If the line is quiet, there is nothing to do.
+If it fires every few sessions, that is the signal reporting on itself —
+entries are being written faster than they are reconciled.
 
 ---
 

--- a/tests/test_boot_sprint_directive.py
+++ b/tests/test_boot_sprint_directive.py
@@ -51,11 +51,24 @@ CLOSED_BODY = "# SPRINT: test\nstatus: CLOSED\n\nprose the record never touches\
 
 
 def build_db(path: Path) -> sqlite3.Connection:
-    """Engine db from the tracked baseline. `sprint_units` and
-    `sprint_planner_bindings` are both in schema.sql, so no migration replay is
-    needed to get the shapes this renderer reads."""
+    """Engine db from the tracked baseline: schema.sql THEN every migration.
+
+    `sprint_units` and `sprint_planner_bindings` are both in schema.sql, so the
+    shapes this renderer reads were once available from the baseline alone —
+    but "the sources" for a render are schema + migrations (what `./sc rebuild`
+    and the hermetic render-check both build), and compose_boot legitimately
+    reads migration-added columns (0100's `shells.lns_curated_at`). Replaying
+    them keeps this fixture the same floor the real render runs on.
+    """
     con = sqlite3.connect(path)
     con.executescript(SCHEMA.read_text())
+    for m in sorted((ENGINE / "migrations").glob("*.sql")):
+        con.executescript(m.read_text())
+    # A migration turns FK enforcement on for its own replay; this fixture was
+    # written against the schema-only default (off) and seeds rows in an order
+    # that leans on it. Replaying migrations is meant to add COLUMNS here, not
+    # to change which constraints this fixture is checked against.
+    con.execute("PRAGMA foreign_keys=OFF")
     con.execute("INSERT INTO users (user_id, username) VALUES (1, 'Jed')")
     for shell_id, shortname, flavor in (
             (DEV_SHELL, "DEV5", "dev"),

--- a/tests/test_lns_curation.py
+++ b/tests/test_lns_curation.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Mutation proofs for L&S self-curation (migration 0100).
+
+This ships a GUARD, and a guard is only worth what it REFUSES. One of this
+repo's own L&S entries records `render-check` sitting inert for three sprints
+while announcing success with a green checkmark — so nothing here asserts that
+a legal write works and calls the cap proven. Every cap is proven by writing
+OVER it and demanding the abort; every advisory is proven by driving the
+counter across its threshold in both directions.
+
+Three surfaces, one feature:
+  • the DB caps       — L&S body 500, current_state 300, BEFORE-triggers, so
+                        pre-existing oversized rows stay readable (grandfathering)
+  • the write path    — `sc mem lns` requires --supersedes | --new; supersede
+                        retires first so it works AT the count cap; a rejected
+                        insert must not leave the retirements behind
+  • the render        — STATUS says "curation due" at 5 since the stamp, and a
+                        sweep that retires NOTHING still clears it
+
+Run:
+    python3 tests/test_lns_curation.py
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+sys.path.insert(0, str(ENGINE / "render"))
+import compose  # noqa: E402
+import mem  # noqa: E402
+import server  # noqa: E402
+import skill as skill_cmd  # noqa: E402
+
+TOKEN = "lns-token-deadbeef"
+
+
+def build_engine_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(SCHEMA.read_text())
+    for p in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(p.read_text())
+    con.execute("INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1)")
+    con.execute(
+        "INSERT INTO shells (shell_id, display_name, shortname, mandate, system_prompt, "
+        "user_id, is_shared, has_identity, bootstrapped, api_key) "
+        "VALUES (1, 'TC', 'tc', 'test', 'sp', 1, 0, 1, 1, ?)", (TOKEN,))
+    con.commit()
+    con.close()
+
+
+class LnsCurationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = Path(tempfile.mkdtemp())
+        cls.db = cls.tmp / "shell_db.db"
+        build_engine_db(cls.db)
+        server.DB_PATH = cls.db
+        cls.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+        mem.SC_API_BASE = f"http://127.0.0.1:{cls.httpd.server_address[1]}"
+        mem.SC_API_TOKEN = TOKEN
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+
+    def setUp(self):
+        con = self.con()
+        con.execute("DELETE FROM shell_identity_entries")
+        con.execute("UPDATE shells SET lns_curated_at=NULL, current_state=NULL")
+        con.commit()
+        con.close()
+
+    # ── helpers ───────────────────────────────────────────────────────────────
+    def con(self):
+        c = sqlite3.connect(self.db)
+        c.row_factory = sqlite3.Row
+        return c
+
+    def q(self, sql, *params):
+        c = self.con()
+        try:
+            return c.execute(sql, params).fetchone()
+        finally:
+            c.close()
+
+    def run_mem(self, *argv) -> int:
+        return mem.main(list(argv))
+
+    def mem_fails(self, *argv) -> str:
+        """Drive `sc mem` expecting a refusal; return what it said."""
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err), contextlib.redirect_stdout(io.StringIO()):
+            with self.assertRaises(SystemExit) as cm:
+                self.run_mem(*argv)
+        return (err.getvalue() + str(cm.exception or "")).strip()
+
+    def quiet_mem(self, *argv) -> int:
+        with contextlib.redirect_stdout(io.StringIO()):
+            return self.run_mem(*argv)
+
+    def seed_lns(self, n: int, body: str = "rule", at: "str | None" = None) -> list[int]:
+        """Insert n active L&S entries straight into the DB (bypasses the CLI's
+        triage on purpose — these stand in for a set that already exists).
+
+        `at` is a SQLite datetime modifier for created_at. Both the stamp and
+        created_at come from `datetime('now')`, i.e. whole seconds, so a test
+        that writes and stamps inside one second cannot tell the two apart —
+        the clock is controlled explicitly rather than slept through.
+        """
+        stamp = f"datetime('now', '{at}')" if at else "datetime('now')"
+        c = self.con()
+        ids = []
+        for i in range(n):
+            cur = c.execute(
+                "INSERT INTO shell_identity_entries (shell_id, kind, body, created_at) "
+                f"VALUES (1, 'lns', ?, {stamp})", (f"{body} {i}",))
+            ids.append(cur.lastrowid)
+        c.commit()
+        c.close()
+        return ids
+
+    def counts(self) -> dict:
+        c = self.con()
+        try:
+            return compose.fetch_counts(c, 1)
+        finally:
+            c.close()
+
+    # ── the caps, proven by writing OVER them ─────────────────────────────────
+    def test_lns_501_chars_aborts_and_the_message_routes_the_fix(self):
+        msg = self.mem_fails("lns", "x" * 501, "--new")
+        self.assertIn("500 chars", msg)
+        self.assertIn("narrative", msg)          # the overflow is routed, not just refused
+        self.assertIn("400", msg)                # client error, not a 500 server fault
+        self.assertIsNone(self.q(
+            "SELECT 1 FROM shell_identity_entries WHERE kind='lns'"))
+
+    def test_lns_500_chars_writes(self):
+        self.assertEqual(self.quiet_mem("lns", "x" * 500, "--new"), 0)
+        self.assertEqual(
+            self.q("SELECT LENGTH(body) FROM shell_identity_entries "
+                   "WHERE kind='lns'")[0], 500)
+
+    def test_current_state_301_aborts_and_300_writes(self):
+        msg = self.mem_fails("state", "y" * 301)
+        self.assertIn("300 chars", msg)
+        self.assertIn("point at the row", msg)
+        self.assertIsNone(self.q("SELECT current_state FROM shells WHERE shell_id=1")[0])
+        self.assertEqual(self.quiet_mem("state", "y" * 300), 0)
+        self.assertEqual(
+            len(self.q("SELECT current_state FROM shells WHERE shell_id=1")[0]), 300)
+
+    def test_grandfathered_rows_stay_readable_and_renderable(self):
+        """The legacy corpus predates the caps, so it has to survive them.
+
+        Built the only honest way: schema + every migration BEFORE 0100, the
+        oversized rows written while that was still legal, then 0100 laid on
+        top. BEFORE-triggers don't touch rows in place — the caps constrain new
+        writes and the sweep clears the legacy, two mechanisms over different
+        halves.
+        """
+        legacy = self.tmp / "legacy.db"
+        c = sqlite3.connect(legacy)
+        c.row_factory = sqlite3.Row
+        try:
+            c.executescript(SCHEMA.read_text())
+            older = [p for p in sorted(MIGRATIONS.glob("*.sql"))
+                     if p.name < "0100_"]
+            self.assertTrue(any(p.name.startswith("0099") for p in older))
+            for p in older:
+                c.executescript(p.read_text())
+            c.execute("INSERT INTO users (user_id, username) VALUES (1, 'T')")
+            c.execute("INSERT INTO shells (shell_id, display_name, shortname, "
+                      "system_prompt, current_state, user_id) "
+                      "VALUES (1, 'Old', 'old', 'sp', ?, 1)", ("S" * 3087,))
+            c.execute("INSERT INTO shell_identity_entries (shell_id, kind, body) "
+                      "VALUES (1, 'lns', ?)", ("L" * 2914,))
+            c.commit()
+            c.executescript((MIGRATIONS / "0100_lns_self_curation.sql").read_text())
+            c.commit()
+
+            self.assertEqual(
+                len(c.execute("SELECT current_state FROM shells "
+                              "WHERE shell_id=1").fetchone()[0]), 3087)
+            self.assertIn("L" * 100, compose.render_lns(c, 1))
+            self.assertEqual(compose.fetch_counts(c, 1)["lns_chars"], 2914)
+            # …and the cap is live on that same DB for the NEXT write.
+            with self.assertRaises(sqlite3.IntegrityError):
+                c.execute("INSERT INTO shell_identity_entries "
+                          "(shell_id, kind, body) VALUES (1, 'lns', ?)",
+                          ("N" * 501,))
+        finally:
+            c.close()
+
+    # ── write-time triage ─────────────────────────────────────────────────────
+    def test_neither_flag_refuses_with_the_triage(self):
+        msg = self.mem_fails("lns", "a rule")
+        self.assertIn("--supersedes", msg)
+        self.assertIn("--new", msg)
+        self.assertIsNone(self.q(
+            "SELECT 1 FROM shell_identity_entries WHERE kind='lns'"))
+
+    def test_both_flags_refuse(self):
+        self.mem_fails("lns", "a rule", "--new", "--supersedes", "1")
+        self.assertIsNone(self.q(
+            "SELECT 1 FROM shell_identity_entries WHERE kind='lns'"))
+
+    def test_supersedes_retires_the_named_entries(self):
+        ids = self.seed_lns(3)
+        self.quiet_mem("lns", "the one rule", "--supersedes",
+                       f"{ids[0]},{ids[1]}")
+        for eid in ids[:2]:
+            self.assertIsNotNone(self.q(
+                "SELECT retired_at FROM shell_identity_entries WHERE entry_id=?",
+                eid)["retired_at"])
+        self.assertIsNone(self.q(
+            "SELECT retired_at FROM shell_identity_entries WHERE entry_id=?",
+            ids[2])["retired_at"])
+
+    def test_supersedes_works_at_the_count_cap(self):
+        """The whole point of the verb: at 20/20 a supersede frees the slot it
+        uses. Retire-then-insert, or the cap trigger refuses the write that was
+        going to fix the set."""
+        ids = self.seed_lns(20)
+        self.assertEqual(self.quiet_mem("lns", "merged rule", "--supersedes",
+                                        f"{ids[0]},{ids[1]},{ids[2]}"), 0)
+        self.assertEqual(self.counts()["lns"], 18)
+
+    def test_rejected_insert_leaves_no_orphan_retirements(self):
+        """A supersede whose body busts the length cap must roll BOTH halves
+        back — otherwise a typo silently deletes rules and adds nothing."""
+        ids = self.seed_lns(3)
+        self.mem_fails("lns", "x" * 501, "--supersedes", str(ids[0]))
+        self.assertIsNone(self.q(
+            "SELECT retired_at FROM shell_identity_entries WHERE entry_id=?",
+            ids[0])["retired_at"])
+        self.assertEqual(self.counts()["lns"], 3)
+
+    def test_supersedes_refuses_a_foreign_or_already_retired_entry(self):
+        c = self.con()
+        c.execute("INSERT INTO shells (shell_id, display_name, system_prompt, user_id) "
+                  "VALUES (3, 'Other', 'sp', 1)")
+        foreign = c.execute(
+            "INSERT INTO shell_identity_entries (shell_id, kind, body) "
+            "VALUES (3, 'lns', 'theirs')", ).lastrowid
+        c.commit()
+        c.close()
+        self.assertIn("not one of your active", self.mem_fails(
+            "lns", "mine", "--supersedes", str(foreign)))
+        mine = self.seed_lns(1)[0]
+        self.quiet_mem("retire", str(mine))
+        self.assertIn("not one of your active", self.mem_fails(
+            "lns", "mine", "--supersedes", str(mine)))
+
+    # ── the sweep advisory ────────────────────────────────────────────────────
+    def test_four_since_curation_is_quiet_five_is_due(self):
+        self.seed_lns(4)
+        self.assertNotIn("curation due", compose.render_lns_status(self.counts()))
+        self.seed_lns(1, body="fifth")
+        line = compose.render_lns_status(self.counts())
+        self.assertIn("curation due", line)
+        self.assertIn("`curate` skill", line)
+        self.assertIn("5/20", line)
+
+    def test_stamp_clears_the_counter(self):
+        self.seed_lns(6)
+        self.assertIn("curation due", compose.render_lns_status(self.counts()))
+        self.quiet_mem("curated")
+        self.assertNotIn("curation due", compose.render_lns_status(self.counts()))
+        self.assertEqual(self.counts()["lns_since_curation"], 0)
+
+    def test_a_sweep_that_retires_nothing_still_goes_quiet(self):
+        """THE case that matters — the failure a MAX(retired_at) signal would
+        have shipped. An honest sweep over a clean set retires nothing; if that
+        left the advisory standing, shells would learn to ignore it."""
+        self.seed_lns(7)
+        self.quiet_mem("curated")
+        before = self.q("SELECT COUNT(*) FROM shell_identity_entries "
+                        "WHERE retired_at IS NOT NULL")[0]
+        self.assertEqual(before, 0)
+        self.assertNotIn("curation due", compose.render_lns_status(self.counts()))
+
+    def test_writes_after_the_stamp_count_again(self):
+        self.seed_lns(6)
+        self.quiet_mem("curated")
+        self.assertEqual(self.counts()["lns_since_curation"], 0)
+        self.seed_lns(5, body="post", at="+2 seconds")
+        self.assertEqual(self.counts()["lns_since_curation"], 5)
+        self.assertIn("curation due", compose.render_lns_status(self.counts()))
+
+    def test_the_sweeps_own_merged_entries_do_not_count_against_it(self):
+        """A merge writes a new entry and then stamps. `>` (not `>=`) is what
+        keeps the sweep's own output out of the next interval's count — a sweep
+        that immediately re-armed its own advisory would never converge."""
+        self.seed_lns(5)
+        self.quiet_mem("lns", "the one rule", "--new")   # the merged entry
+        self.quiet_mem("curated")
+        self.assertEqual(self.counts()["lns_since_curation"], 0)
+
+    def test_status_line_reports_chars(self):
+        self.seed_lns(2)
+        self.assertIn("chars", compose.render_lns_status(self.counts()))
+
+
+class SkillAddTest(unittest.TestCase):
+    """`sc skill add` — the promote pass's landing place. Each guard is proven
+    by trying the thing it forbids."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        skill_cmd.DB_PATH = self.db
+        self.body = self.tmp / "proc.md"
+        self.body.write_text("# a procedure\n\nsteps.\n")
+
+    def add(self, *argv) -> str:
+        """Run `skill add`; return stdout on success or the refusal text."""
+        out, err = io.StringIO(), io.StringIO()
+        con = skill_cmd.connect()
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                try:
+                    skill_cmd.cmd_add(con, list(argv))
+                except SystemExit as e:
+                    return str(e or "")
+        finally:
+            con.close()
+        return out.getvalue()
+
+    def q(self, sql, *params):
+        c = sqlite3.connect(self.db)
+        c.row_factory = sqlite3.Row
+        try:
+            return c.execute(sql, params).fetchone()
+        finally:
+            c.close()
+
+    def test_adds_a_namespaced_local_skill_and_grants_it_to_the_author(self):
+        out = self.add("tc_sweep", "--file", str(self.body),
+                       "--desc", "one line", "--for", "tc")
+        self.assertIn("granted to tc", out)
+        row = self.q("SELECT skill_id, description, content, is_deleted "
+                     "FROM skills WHERE name='tc_sweep'")
+        self.assertIsNotNone(row)
+        self.assertEqual(row["description"], "one line")
+        self.assertIn("a procedure", row["content"])
+        self.assertIsNotNone(self.q(
+            "SELECT 1 FROM shell_skills WHERE shell_id=1 AND skill_id=?",
+            row["skill_id"]))
+
+    def test_writes_no_asset_file(self):
+        """DB-only is load-bearing: `./sc seed-skills` upserts every asset, so
+        a file would put a local skill back on the seed path."""
+        self.add("tc_sweep", "--file", str(self.body), "--for", "tc")
+        self.assertFalse((ENGINE / "assets" / "skills" / "tc_sweep").exists())
+
+    def test_refuses_an_engine_name(self):
+        msg = self.add("memory", "--file", str(self.body), "--for", "tc")
+        self.assertIn("ENGINE skill", msg)
+        self.assertIsNone(self.q("SELECT 1 FROM skills WHERE name='memory' "
+                                 "AND content LIKE '%a procedure%'"))
+
+    def test_refuses_a_bare_unnamespaced_name(self):
+        msg = self.add("sweep", "--file", str(self.body), "--for", "tc")
+        self.assertIn("namespaced", msg)
+        self.assertIsNone(self.q("SELECT 1 FROM skills WHERE name='sweep'"))
+
+    def test_refuses_a_name_on_the_fork_retire_list(self):
+        real = skill_cmd.seed_skills.retired_skill_names
+        skill_cmd.seed_skills.retired_skill_names = lambda: ["tc_sweep"]
+        try:
+            msg = self.add("tc_sweep", "--file", str(self.body), "--for", "tc")
+        finally:
+            skill_cmd.seed_skills.retired_skill_names = real
+        self.assertIn("retire list", msg)
+        self.assertIsNone(self.q("SELECT 1 FROM skills WHERE name='tc_sweep'"))
+
+    def test_refuses_an_empty_or_missing_body(self):
+        self.assertIn("no such file", self.add(
+            "tc_sweep", "--file", str(self.tmp / "nope.md"), "--for", "tc"))
+        blank = self.tmp / "blank.md"
+        blank.write_text("   \n")
+        self.assertIn("empty", self.add(
+            "tc_sweep", "--file", str(blank), "--for", "tc"))
+
+    def test_unknown_author_refuses_rather_than_orphaning_the_skill(self):
+        import os
+        saved = os.environ.pop("SC_API_TOKEN", None)
+        try:
+            msg = self.add("tc_sweep", "--file", str(self.body))
+        finally:
+            if saved is not None:
+                os.environ["SC_API_TOKEN"] = saved
+        self.assertIn("--for", msg)
+        self.assertIsNone(self.q("SELECT 1 FROM skills WHERE name='tc_sweep'"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Implements `shared/subfloor-lns-curation-spec.md` (staged, agreed, executed in this downtime window).

## The problem

L&S is **42%** of a planner shell's rendered boot doc — 19,284 of 45,491 chars. It grows without bound because the only cap counts **entries** while the cost is in **characters**: PLN1 sat at 20/20 for six days while the average entry went 297 → 2,325 chars. Curating *at* the cap net-**added** 1,961 chars at constant count, so any signal that resets on "a retirement happened" is gameable by the behaviour already observed.

Decisions were never part of it — `compose.py` has no decisions section, and PLN1's 58 decisions (92k chars) already lazy-load.

The root cause is a **missing verb, not indiscipline**. Five of PLN1's twenty entries name the entry they duplicate and add anyway; #40 states outright that it is the third recording of one observation. The shell already performs the reconciliation — `sc mem lns` offered exactly one verb, so the answer had nowhere to land.

## What ships

| Tier | Mechanism |
|---|---|
| Write-time triage | `sc mem lns` requires exactly one of `--supersedes <ids>` / `--new` — the analogue of the `--parent` that `sc mem decision` already carries |
| Periodic sweep | new `curate` skill (consistency → cluster → promote → category → stamp), fired by a STATUS advisory at 5 writes since `shells.lns_curated_at` |
| Hard caps | L&S body **500** chars, `current_state` **300** chars, both trigger-enforced |
| Promotion landing | `sc skill add` — DB-only, shortname-namespaced, auto-granted to the author |

Write-time triage is pairwise: it catches contradiction and restatement while the reasoning is in hand. It cannot catch the emergent cluster (five entries each valid, only in aggregate one principle) — that is the sweep's job.

**Enforce, don't advise.** Shells over-run soft targets believing they complied, so the rejection *is* the feedback mechanism, consistent with every other cap here. Each message routes the overflow rather than only refusing, and the API returns **400** carrying it instead of a 500 that buries it. The per-entry cap makes a character budget redundant by construction (20 × 500 = 10,000 absolute worst case), so there is one threshold, not two.

## Grandfathering — the design revision this cost

`content.sql` replays identity entries as `INSERT`s, so an unconditional `BEFORE INSERT` cap **aborts the rebuild** of any fork holding a legacy 2,914-char entry — caught by `render-check`, not by the unit tests. Those entries cannot be edited away first: Laws 3 and 7 reserve curation to the shell that owns them.

The trigger therefore fires only on rows whose `created_at` is live (within 5 minutes). A replayed row carries its original timestamp and is a restore of already-accepted state, not a new write. Old `content.sql` artifacts need no regeneration — a marker-table scheme would have required exactly that, and SQLite cannot read temp schema from a trigger anyway.

## Verification

`tests/test_lns_curation.py` — 23 cases, every guard proven by writing **over** it:

- 501 chars aborts · 500 writes · 301 aborts · 300 writes
- a DB built at 0099 with a 2,914-char entry and a 3,087-char `current_state`, then migrated to 0100, still reads, renders, and rejects the *next* oversized write
- supersede works at 20/20 (retire-then-insert) and rolls **both** halves back when the body busts the cap
- 4-since-curation is quiet, 5 is due, the stamp clears it, and **a sweep that retires nothing still goes quiet** — the failure a `MAX(retired_at)` design would have shipped
- `sc skill add` guards: engine name, bare name, retire-listed name, empty body, unknown author

Suite: **1730 passed**, 2 pre-existing environment failures in `test_supervision_sc.py` (confirmed identical on clean `main`). `render-check` green against the real boot render; `ruff` clean on every changed file.

`tests/test_boot_sprint_directive.py` now replays migrations in its fixture — it built from `schema.sql` alone, which no longer carries every column `compose_boot` reads.

## Rollout

`lns_curated_at` starts NULL, so four shells trip the advisory on first boot — **PLN1** (20 / 24.1k), **DEV5** (10 / 10.8k), **DEV3** (9 / 10.6k), **PLN2** (8 / 12.2k). Correct: they are genuinely uncurated. Do not sweep four in one window — sequence them, PLN1 first (worst case, and the best test of whether the sweep's output is worth reading), or backdate `lns_curated_at` per shell as each is swept.

`curate` is `common: true` and already granted to every live shell here; forks pick it up via `update.regrant()`.

## Open

**500 is chosen, not derived.** Across the fleet's 49 active entries there is no empty band to place a threshold in — the clean 517–948 gap is PLN1-only. 500 rejects 43 of 49 existing entries, which is the intent (that corpus is the defect), but the number is a judgment call. Watch the first sweep for lessons lost to a rejected write that was never re-attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
