### PR TITLE
fix(ui): nest skills navigation under shells

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -390,7 +390,7 @@ def tag_origin(skills: list[dict]) -> list[dict]:
 
 
 def get_skills(con) -> dict:
-    """The full skills catalogue + per-skill grants, for the Skills tab.
+    """The full catalogue + per-skill grants for Shells → Skill Assignments.
     Grouping into sections (repo / category) happens client-side, like
     flags/docs."""
     skills = rows(con.execute(

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -76,10 +76,10 @@ function toast(msg) {
 function setStatus(s) { $("#status").textContent = s; }
 
 // ── Skill sections ──────────────────────────────────────────────────────────
-// One grouping rule for the Skills tab AND the Shells grant list. "Repo skills"
-// are fork-local (origin='repo', derived server-side from the snapshot rule:
-// name not under engine assets/skills) and always lead; engine skills section
-// by their category.
+// One grouping rule for the Shells skill viewer AND Skill Assignments. "Repo
+// skills" are fork-local (origin='repo', derived server-side from the snapshot
+// rule: name not under engine assets/skills) and always lead; engine skills
+// section by their category.
 const SECTION_ORDER = ["repo", "substrate", "craft"];
 const SECTION_LABEL = { repo: "Repo skills", substrate: "Substrate", craft: "Craft", other: "Other" };
 const SECTION_NOTE = {
@@ -102,11 +102,17 @@ function groupSkills(skills, { alwaysRepo = false } = {}) {
 // ── Shells ──────────────────────────────────────────────────────────────────
 // dos-arch-style viewer (ported from dos-arch shell_core/ui /shells): sticky
 // identity sub-header (pill shell picker + role/mandate), then Harness |
-// Skills sub-tabs scoped to the selected shell. Flat panels, accordions,
-// popover pickers, and a unified edit modal.
+// Skills | Skill Assignments | Default Models sub-tabs. Flat panels,
+// accordions, popover pickers, and a unified edit modal.
 let selectedShell = null;
-let shellTab = "harness";     // 'harness' | 'skills' | 'models'
+let shellTab = "harness";     // 'harness' | 'skills' | 'assignments' | 'models'
 let activeSkillId = null;     // skill-viewer selection; reset on shell switch
+const SHELL_TAB_HASH = {
+  harness: "shells",
+  skills: "shells-skills",
+  assignments: "shells-skill-assignments",
+  models: "shells-default-models",
+};
 
 // Rough token estimator — BPE-ish, ~15% off for English; the tilde in the
 // readout makes the approximation explicit. No bundled tokenizer.
@@ -298,21 +304,26 @@ async function renderShells(root) {
   if (shellTab === "models") sub.classList.add("subbar-inert");
   root.append(sub);
 
-  // sub-tabs — Harness / Skills scoped to the selected shell; Default Models
-  // is the fork-global launch matrix (same content from any shell)
+  // Harness / Skills are scoped to the selected shell. Skill Assignments and
+  // Default Models are fork-global views nested here to keep shell setup in
+  // one place. Hash navigation gives every section a reload-safe URL.
   const tabs = el("div", { className: "vtabs" });
   for (const [key, label] of [["harness", "Harness"], ["skills", "Skills"],
+                              ["assignments", "Skill Assignments"],
                               ["models", "Default Models"]]) {
     const b = el("button", { className: shellTab === key ? "active-tab" : "", type: "button", textContent: label });
-    b.onclick = () => { shellTab = key; renderShells(root); };
+    b.onclick = () => { location.hash = SHELL_TAB_HASH[key]; };
     tabs.append(b);
   }
   root.append(tabs);
 
-  const pane = el("div", { className: "shell-pane" });
+  const pane = el("div", {
+    className: "shell-pane" + (shellTab === "assignments" ? " skill-assignments" : ""),
+  });
   root.append(pane);
   if (shellTab === "harness") renderHarness(pane, s);
   else if (shellTab === "models") renderDefaultModels(pane, s);
+  else if (shellTab === "assignments") renderSkillAssignments(pane);
   else renderSkillViewer(pane, s);
 }
 
@@ -654,8 +665,8 @@ function renderSkillViewer(root, s) {
   }).catch((e) => panel.append(el("div", { className: "muted" }, "error: " + e.message)));
 }
 
-// ── Skills (catalogue, sectioned) ────────────────────────────────────────────
-async function renderSkills(root) {
+// ── Skill Assignments (catalogue, sectioned) ─────────────────────────────────
+async function renderSkillAssignments(root) {
   const { skills, shells } = await api("/skills");
   root.replaceChildren();
   root.append(el("div", { className: "muted" },
@@ -692,7 +703,7 @@ function skillRow(s, shells) {
   if (s.command) body.append(el("div", { className: "tag" }, "command: ", el("code", {}, s.command)));
 
   // grants — every available shell as a row with an on/off toggle; same PUT
-  // the Shells tab uses, managed from the skill's side here
+  // the Skills viewer uses, managed from the skill's side here
   const gr = el("div", { className: "grants" });
   gr.append(el("label", { className: "k", textContent: "granted to" }));
   const list = el("div", { className: "grant-list" });
@@ -4455,7 +4466,6 @@ function ifControl(a, m) {
 const VIEWS = {
   interface: ["#view-interface", renderInterface],
   shells: ["#view-shells", renderShells],
-  skills: ["#view-skills", renderSkills],
   roadmap: ["#view-roadmap", renderRoadmap],
   docs: ["#view-docs", renderDocs],
   flags: ["#view-flags", renderFlags],
@@ -4495,9 +4505,17 @@ function show(tab) {
 // hash; hashchange drives show — back/forward and deep links work too. The
 // roadmap tab carries its sub-view in the hash: #roadmap (board) | #roadmap-flow.
 // The analytics tab does the same: #analytics (token) | #analytics-quota.
+// Shells: #shells (Harness) | #shells-skills | #shells-skill-assignments |
+// #shells-default-models.
 // The interface tab carries its selected shell: #interface | #interface/DEV3.
 function routeFromHash() {
   const raw = location.hash.slice(1);
+  if (raw === "" || raw === "shells" || raw.startsWith("shells-")) {
+    shellTab = Object.entries(SHELL_TAB_HASH).find(([, hash]) => hash === raw)?.[0]
+      || "harness";
+    show("shells");
+    return;
+  }
   if (raw === "roadmap" || raw.startsWith("roadmap-")) {
     roadmapView = raw === "roadmap-flow" ? "flow" : "board";
     show("roadmap");
@@ -4513,6 +4531,7 @@ function routeFromHash() {
     show("interface");
     return;
   }
+  if (!VIEWS[raw]) shellTab = "harness";
   show(VIEWS[raw] ? raw : "shells");
 }
 document.querySelectorAll("nav button").forEach((b) => (b.onclick = () => { location.hash = b.dataset.tab; }));
@@ -4574,7 +4593,6 @@ $("#publish").onclick = async (e) => {
     $("#repo").textContent = h.repo;
     forkName = h.repo || "";
     configureArtifactActions(h);
-    setStatus(localArtifactMode ? "local artifacts · port " + h.port : "port " + h.port);
   }
   catch { setStatus("offline"); }
   routeFromHash();   // honor #tab on load (refresh / deep link), else Shells

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -15,7 +15,6 @@
     <nav>
       <button data-tab="interface">Interface</button>
       <button data-tab="shells" class="active">Shells</button>
-      <button data-tab="skills">Skills</button>
       <span class="navsep"></span>
       <button data-tab="roadmap">Roadmap</button>
       <button data-tab="docs">Docs</button>
@@ -35,7 +34,6 @@
   <main>
     <section id="view-interface" class="view" hidden></section>
     <section id="view-shells" class="view"></section>
-    <section id="view-skills" class="view" hidden></section>
     <section id="view-roadmap" class="view" hidden></section>
     <section id="view-docs" class="view" hidden></section>
     <section id="view-flags" class="view" hidden></section>

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -78,7 +78,7 @@ body.interface-view main {
 }
 body.interface-view #view-interface { flex: 1 1 auto; min-height: 0; }
 
-/* ── Tight card rhythm (Skills / Roadmap / Docs / Flags) ────────────────────
+/* ── Tight card rhythm (Skill Assignments / Roadmap / Docs / Flags) ─────────
    Stacked card panels on these tabs sit a small 5px apart. Section headers
    (funnel stages, skill categories) keep enough room to read as group labels;
    only the card-to-card spacing tightens. */
@@ -88,9 +88,9 @@ body.interface-view #view-interface { flex: 1 1 auto; min-height: 0; }
 #view-docs .card + .card, #view-flags .card + .card { margin-top: 5px; }
 #view-flags { gap: 5px; }
 #view-flags .flagbar { margin-bottom: calc(1rem - 5px); }   /* restore bar→cards spacing */
-#view-skills { gap: 5px; }
-#view-skills > .muted:first-child { margin-bottom: calc(1rem - 5px); }  /* intro keeps room */
-#view-skills .bucket > h2 { margin-top: 0; }                 /* header rides on its own card */
+.skill-assignments { gap: 5px; }
+.skill-assignments > .muted:first-child { margin-bottom: calc(1rem - 5px); }  /* intro keeps room */
+.skill-assignments .bucket > h2 { margin-top: 0; }           /* header rides on its own card */
 
 .card {
   background: var(--panel); border: 1px solid var(--line); border-radius: var(--r);
@@ -236,7 +236,7 @@ details.feature.shipped-bar { border-left-color: var(--lock); }
 .link-card .link-v { font-size: .82rem; color: var(--ink); }
 .tag { font-size: .72rem; color: var(--dim); }
 
-/* ── Skills catalogue (Skills tab) — expandable rows, like flags ──────────── */
+/* ── Skill Assignments — expandable rows, like flags ──────────────────────── */
 .card.skills { padding: .3rem 1.1rem; }
 .skill { border-bottom: 1px solid var(--line); }
 .skill:last-of-type { border-bottom: none; }
@@ -319,6 +319,7 @@ a { color: var(--accent); }
   background: var(--accent);
 }
 .shell-pane { display: grid; grid-template-columns: minmax(0, 1fr); gap: .6rem; align-content: start; }
+.shell-pane.skill-assignments { gap: 5px; }
 .viewer-head { display: flex; align-items: center; gap: .9rem; padding: 0 .2rem; margin-top: .2rem; }
 .vpanel { background: var(--panel); border: 1px solid var(--line); border-radius: var(--r); }
 .viewer-panel { padding: 1rem 1.1rem; min-height: 12rem; }

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -383,7 +383,7 @@ def _artifact(tmp_path: Path, name: str) -> Path:
     return directory / name
 
 
-def test_local_artifact_mode_keeps_save_and_disables_publish(browser, ui_url):
+def test_local_artifact_mode_keeps_actions_without_idle_status_noise(browser, ui_url):
     context = browser.new_context(viewport={"width": 1600, "height": 1000})
     page = context.new_page()
     page.route("**/api/**", _mock_api)
@@ -394,7 +394,7 @@ def test_local_artifact_mode_keeps_save_and_disables_publish(browser, ui_url):
         assert snapshot.text_content() == "save locally ⤓"
         assert publish.text_content() == "publish off"
         assert publish.is_disabled()
-        assert "local artifacts" in page.locator("#status").text_content()
+        assert page.locator("#status").text_content() == ""
     finally:
         context.close()
 

--- a/tests/test_quota_accounts_ui.py
+++ b/tests/test_quota_accounts_ui.py
@@ -54,6 +54,8 @@ EL = APP[APP.index("const el ="):APP.index("const esc =")]
 # fmt / microlabel / statRow — sliced, not restated, so a card's meta row is
 # rendered by the app's own helper.
 HELPERS = APP[APP.index("const fmt = (n)"):APP.index("// On/off switch")]
+SHELL_STATE = APP[APP.index("let selectedShell ="):
+                  APP.index("// Rough token estimator")]
 QUOTA = APP[APP.index("// ── Provider Quota"):APP.index("// ── Interface tab")]
 _ROUTER_AT = APP.index("function routeFromHash()")
 ROUTER = APP[_ROUTER_AT:
@@ -166,7 +168,7 @@ function root() { return new FakeElement("div"); }
 
 def run_js(body: str, data: dict | None = None) -> dict:
     script = ("const PAYLOAD = " + json.dumps(data or payload()) + ";\n"
-              + EL + HELPERS + HARNESS + QUOTA + ROUTER
+              + EL + HELPERS + SHELL_STATE + HARNESS + QUOTA + ROUTER
               + "\n(async () => {\n" + body + "\n})().catch((e) => {"
               " console.error(e.stack || e); process.exit(1); });\n")
     proc = subprocess.run(["node", "-e", script], text=True, capture_output=True)

--- a/tests/test_quota_gate.py
+++ b/tests/test_quota_gate.py
@@ -485,6 +485,8 @@ class NoInertAccountMachineryTest(unittest.TestCase):
 
 EL = APP[APP.index("const el ="):APP.index("const esc =")]
 HELPERS = APP[APP.index("const fmt = (n)"):APP.index("// On/off switch")]
+SHELL_STATE = APP[APP.index("let selectedShell ="):
+                  APP.index("// Rough token estimator")]
 QUOTA = APP[APP.index("// ── Provider Quota"):APP.index("// ── Interface tab")]
 _ROUTER_AT = APP.index("function routeFromHash()")
 # U4's slice stops at the nav-button line; this one deliberately runs PAST it,
@@ -571,7 +573,7 @@ def run_js(body: str, data: dict | None = None, boot: bool = False,
     dom = DOM.replace('globalThis.location = { hash: "" };',
                       'globalThis.location = { hash: "%s" };' % hash)
     script = ("const PAYLOAD = " + json.dumps(data or {"providers": []})
-              + ";\n" + EL + HELPERS + dom + QUOTA + ROUTER
+              + ";\n" + EL + HELPERS + SHELL_STATE + dom + QUOTA + ROUTER
               + (BOOT if boot else "")
               # The boot IIFE awaits /health before it routes, so the body has
               # to let it settle — reading the view synchronously would see the

--- a/tests/test_shells_ui_contract.py
+++ b/tests/test_shells_ui_contract.py
@@ -1,0 +1,201 @@
+"""Shells navigation contracts for the build-free review UI."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
+INDEX = (ROOT / ".super-coder" / "ui" / "index.html").read_text()
+SHELL_STATE = APP[APP.index("let selectedShell ="):
+                  APP.index("// Rough token estimator")]
+SHELL_RENDER = APP[APP.index("async function renderShells(root)"):
+                   APP.index("// Default Models — the flavor_defaults")]
+ROUTER_AT = APP.index("function routeFromHash()")
+ROUTER = APP[ROUTER_AT:
+             APP.index('document.querySelectorAll("nav button").forEach',
+                       ROUTER_AT)]
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is required"
+)
+
+
+def run_js(script: str) -> dict:
+    proc = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_skills_is_nested_under_shells_instead_of_global_navigation():
+    nav = INDEX[INDEX.index("<nav>"):INDEX.index("</nav>")]
+    main = INDEX[INDEX.index("<main>"):INDEX.index("</main>")]
+    assert nav.count('data-tab="shells"') == 1
+    assert 'data-tab="skills"' not in nav
+    assert 'id="view-skills"' not in main
+    assert 'id="view-shells"' in main
+
+
+def test_each_shell_section_has_a_distinct_reload_safe_hash():
+    script = SHELL_STATE + r"""
+globalThis.location = { hash: "" };
+let roadmapView = null;
+let anView = "tokens";
+let ifSelected = null;
+const VIEWS = {
+  interface: 1, shells: 1, roadmap: 1, analytics: 1, docs: 1,
+};
+const shown = [];
+function show(tab) { shown.push(tab); }
+""" + ROUTER + r"""
+const seen = [];
+for (const hash of [
+  "", "#shells", "#shells-skills", "#shells-skill-assignments",
+  "#shells-default-models", "#shells-unknown", "#nonsense",
+]) {
+  location.hash = hash;
+  routeFromHash();
+  seen.push({ hash, tab: shown.at(-1), shellTab });
+}
+console.log(JSON.stringify({ seen }));
+"""
+    result = run_js(script)
+    assert result["seen"] == [
+        {"hash": "", "tab": "shells", "shellTab": "harness"},
+        {"hash": "#shells", "tab": "shells", "shellTab": "harness"},
+        {"hash": "#shells-skills", "tab": "shells", "shellTab": "skills"},
+        {
+            "hash": "#shells-skill-assignments",
+            "tab": "shells",
+            "shellTab": "assignments",
+        },
+        {
+            "hash": "#shells-default-models",
+            "tab": "shells",
+            "shellTab": "models",
+        },
+        {"hash": "#shells-unknown", "tab": "shells", "shellTab": "harness"},
+        {"hash": "#nonsense", "tab": "shells", "shellTab": "harness"},
+    ]
+
+
+def test_shell_subtabs_navigate_by_hash_and_dispatch_the_right_panel():
+    script = r"""
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag;
+    this.nodeType = 1;
+    this.children = [];
+    this.className = "";
+    this._text = "";
+    this.classList = {
+      add: (name) => {
+        const names = new Set(this.className.split(" ").filter(Boolean));
+        names.add(name);
+        this.className = [...names].join(" ");
+      },
+    };
+  }
+  append(...nodes) { this.children.push(...nodes); }
+  replaceChildren(...nodes) { this.children = [...nodes]; this._text = ""; }
+  set textContent(value) { this._text = String(value ?? ""); this.children = []; }
+  get textContent() {
+    return this._text + this.children.map(
+      (child) => typeof child === "string" ? child : child.textContent
+    ).join("");
+  }
+}
+globalThis.document = {
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({ nodeType: 3, textContent: String(text ?? "") }),
+};
+globalThis.location = { hash: "" };
+const el = (tag, props = {}, ...kids) => {
+  const node = Object.assign(new FakeElement(tag), props);
+  for (const kid of kids)
+    node.append(kid?.nodeType ? kid : document.createTextNode(kid ?? ""));
+  return node;
+};
+""" + SHELL_STATE + r"""
+const shell = {
+  shell_id: 3, shortname: "DEV3", display_name: "Code-01",
+  flavor: "dev", role: "Dev shell", mandate: "Build", current_state: "",
+  skills: [],
+};
+async function api(path) {
+  if (path === "/shells") return { shells: [shell] };
+  if (path === "/shell-templates") return { templates: [] };
+  if (path === "/shells/3") return shell;
+  throw new Error("unexpected API call: " + path);
+}
+const microlabel = (text) => el("span", {}, text);
+function glassDropdown() { return el("button", {}, "Code-01"); }
+function openNewShellModal() {}
+function setStatus() {}
+function toast() {}
+const rendered = [];
+function renderHarness() { rendered.push("harness"); }
+function renderSkillViewer() { rendered.push("skills"); }
+function renderSkillAssignments() { rendered.push("assignments"); }
+function renderDefaultModels() { rendered.push("models"); }
+""" + SHELL_RENDER + r"""
+function all(root, predicate, found = []) {
+  if (predicate(root)) found.push(root);
+  for (const child of root.children || [])
+    if (child?.nodeType === 1) all(child, predicate, found);
+  return found;
+}
+
+(async () => {
+  const views = [];
+  for (const key of ["harness", "skills", "assignments", "models"]) {
+    shellTab = key;
+    const root = new FakeElement("div");
+    await renderShells(root);
+    const tabs = all(root, (node) => node.className === "vtabs")[0];
+    const buttons = tabs.children;
+    const hashes = [];
+    for (const button of buttons) {
+      button.onclick();
+      hashes.push(location.hash);
+    }
+    views.push({
+      key,
+      labels: buttons.map((button) => button.textContent),
+      active: buttons.filter((button) => button.className === "active-tab")
+        .map((button) => button.textContent),
+      hashes,
+      paneClass: all(root, (node) => node.className.includes("shell-pane"))[0]
+        .className,
+      rendered: rendered.at(-1),
+    });
+  }
+  console.log(JSON.stringify({ views }));
+})().catch((error) => {
+  console.error(error.stack || error);
+  process.exit(1);
+});
+"""
+    result = run_js(script)
+    labels = ["Harness", "Skills", "Skill Assignments", "Default Models"]
+    hashes = [
+        "shells",
+        "shells-skills",
+        "shells-skill-assignments",
+        "shells-default-models",
+    ]
+    for view, label in zip(result["views"], labels, strict=True):
+        assert view["labels"] == labels
+        assert view["active"] == [label]
+        assert view["hashes"] == hashes
+        assert view["rendered"] == view["key"]
+    assert result["views"][2]["paneClass"] == "shell-pane skill-assignments"
+    assert result["views"][0]["paneClass"] == "shell-pane"


### PR DESCRIPTION
## Summary
- remove the global Skills navigation/view and embed the catalogue as Shells → Skill Assignments
- give Harness, Skills, Skill Assignments, and Default Models distinct hash URLs
- remove idle local-artifact/port text while preserving action status feedback

## Trade-off
Uses the existing hash-routing convention instead of introducing path routing, keeping the build-free UI and server unchanged.

## Verification
- 122 tests + 3 subtests across Shells, router, Interface contract, and rendered UI suites
- 60 tests + 7 subtests across UI freshness/vendor/API suites
- node --check .super-coder/ui/app.js
- python3 .super-coder/scripts/render_check.py
- rendered Playwright visual check at #shells-skill-assignments