### PR TITLE
Fix missing Interface sidecar diagnosis

### DIFF
--- a/.super-coder/scripts/interface_runtime.py
+++ b/.super-coder/scripts/interface_runtime.py
@@ -72,7 +72,7 @@ def _log(tag: str, msg: str) -> None:
 
 
 class InterfaceUnavailable(RuntimeError):
-    """tmux/node stack missing or too old — review UI keeps working."""
+    """tmux/node/sidecar stack missing or too old — review UI keeps working."""
 
 
 class SpawnAborted(RuntimeError):
@@ -464,11 +464,15 @@ class InterfaceRuntime:
     # -- availability -----------------------------------------------------------
 
     def _check_available(self) -> str | None:
-        """None if the tmux/node stack is usable, else the reason string."""
+        """None if the tmux/node/sidecar stack is usable, else its reason."""
         if shutil.which("tmux") is None:
             return "tmux not found on PATH"
         if shutil.which("node") is None:
             return "node not found on PATH (shadow sidecar)"
+        sidecar = Path(self.shadow._script)
+        if not sidecar.is_file():
+            return (f"shadow sidecar file missing: {sidecar} — "
+                    "engine materialize is incomplete")
         version = _tmux_version()
         if version is None:
             return "could not parse `tmux -V`"

--- a/tests/test_interface_runtime.py
+++ b/tests/test_interface_runtime.py
@@ -171,9 +171,10 @@ class AvailabilityTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def _runtime(self):
+    def _runtime(self, shadow_script=None):
         return interface_runtime.InterfaceRuntime(
-            str(self.db), run_dir=str(self.tmp / "run"))
+            str(self.db), run_dir=str(self.tmp / "run"),
+            shadow_script=shadow_script)
 
     def test_late_runtime_alert_keeps_ended_session_audit_resolved(self):
         con = sqlite3.connect(self.db)
@@ -231,7 +232,9 @@ class AvailabilityTest(unittest.TestCase):
             asyncio.run(flow())
 
     def test_old_tmux_rejected(self):
-        rt = self._runtime()
+        sidecar = self.tmp / "sidecar.js"
+        sidecar.touch()
+        rt = self._runtime(shadow_script=str(sidecar))
         with mock.patch.object(interface_runtime.shutil, "which",
                                return_value="/usr/bin/x"), \
                 mock.patch.object(interface_runtime, "_tmux_version",
@@ -239,6 +242,25 @@ class AvailabilityTest(unittest.TestCase):
             reason = rt._check_available()
         self.assertIsNotNone(reason)
         self.assertIn("3.3", reason)
+
+    def test_missing_sidecar_names_incomplete_materialize(self):
+        sidecar = self.tmp / "missing-sidecar.js"
+        rt = self._runtime(shadow_script=str(sidecar))
+        with mock.patch.object(interface_runtime.shutil, "which",
+                               return_value="/usr/bin/x"):
+            reason = rt._check_available()
+        self.assertIn(str(sidecar), reason)
+        self.assertIn("engine materialize is incomplete", reason)
+
+    def test_present_sidecar_keeps_runtime_available(self):
+        sidecar = self.tmp / "sidecar.js"
+        sidecar.touch()
+        rt = self._runtime(shadow_script=str(sidecar))
+        with mock.patch.object(interface_runtime.shutil, "which",
+                               return_value="/usr/bin/x"), \
+                mock.patch.object(interface_runtime, "_tmux_version",
+                                  return_value=(3, 4)):
+            self.assertIsNone(rt._check_available())
 
     def test_tmux_version_parse(self):
         cases = [("tmux 3.5a\n", (3, 5)), ("tmux 3.4\n", (3, 4)),


### PR DESCRIPTION
## Summary
- check the configured shadow sidecar file during Interface availability preflight
- name the missing path and identify an incomplete engine materialize
- preserve the existing tmux/node/version path when the sidecar exists

## Verification
- `python -m py_compile .super-coder/scripts/interface_runtime.py`
- `/usr/local/bin/pytest -q tests/test_interface_runtime.py` (34 passed)
- fixture checks: absent path named + materialize diagnosis; present path remains available
- independent mutation legs: disabled guard, opaque wording, reversed present-file condition; each anchor matched exactly once and each assertion failed before restoration

Sprint 71, U3. No ambiguity calls.