### PR TITLE
fix(update): resolve engine paths at target ref

### DIFF
--- a/.super-coder/scripts/engine_manifest.py
+++ b/.super-coder/scripts/engine_manifest.py
@@ -51,7 +51,8 @@ FORK_TEMPLATE_PATHS = (
 # pin), shell_db.db* (gitignored), instance.json (gitignored). assets/seed/ is
 # super-coder-only (stripped on install); assets/shells/ is empty/vestigial.
 # Lives here (not update.py) so install.py can write the first manifest without
-# a circular import; update.py re-exports it as update.ENGINE_PATHS.
+# a circular import. update.py re-exports it as the installed fallback while
+# resolving each update or rollback ref's own literal list.
 ENGINE_PATHS = [
     "sc",
     ".super-coder/aliases.mk",

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -80,10 +80,42 @@ def restore_db(src: Path) -> None:
 def restore_engine(prev_sha: str) -> None:
     """Re-materialize the engine at the prior pin. The SHA should already be in
     the object store (it is the ref we updated *from*); fetch as a fallback."""
-    previous_files = set(update_mod._engine_files_at(prev_sha))
+    fallback_used: list[bool] = []
+    previous_paths = update_mod._engine_paths_for(
+        prev_sha,
+        repo_root=REPO_ROOT,
+        fallback_used=fallback_used,
+    )
     current_sha = ENGINE_REF.read_text().strip() if ENGINE_REF.exists() else ""
-    current_files = (set(update_mod._engine_files_at(current_sha))
-                     if current_sha else set())
+    current_paths = (
+        update_mod._engine_paths_for(
+            current_sha,
+            repo_root=REPO_ROOT,
+            fallback_used=fallback_used,
+        )
+        if current_sha
+        else []
+    )
+    if any(fallback_used):
+        previous_paths = current_paths = list(update_mod.ENGINE_PATHS)
+    previous_files = set(
+        update_mod._engine_files_at(
+            prev_sha,
+            repo_root=REPO_ROOT,
+            engine_paths=previous_paths,
+        )
+    )
+    current_files = (
+        set(
+            update_mod._engine_files_at(
+                current_sha,
+                repo_root=REPO_ROOT,
+                engine_paths=current_paths,
+            )
+        )
+        if current_sha
+        else set()
+    )
     # materialize_engine overlays an archive and deliberately leaves upstream-
     # retired files alone during a forward update. Rollback is different: a
     # target-only migration left behind would make the restored old server
@@ -105,7 +137,7 @@ def restore_engine(prev_sha: str) -> None:
     # next update would read every rolled-back file as a "local edit" and block.
     engine_manifest.write_manifest(
         update_mod._engine_paths_for(prev_sha, repo_root=REPO_ROOT),
-        files=update_mod._engine_files_at(prev_sha),
+        files=update_mod._engine_files_at(prev_sha, repo_root=REPO_ROOT),
     )
     print(f"→ engine re-materialized at {prev_sha[:12]} (engine.ref restored)")
 

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -103,8 +103,10 @@ def restore_engine(prev_sha: str) -> None:
     ENGINE_REF.write_text(prev_sha + "\n")
     # Re-baseline the hash manifest at the restored engine — without this, the
     # next update would read every rolled-back file as a "local edit" and block.
-    engine_manifest.write_manifest(update_mod._engine_paths_at(prev_sha),
-                                   files=update_mod._engine_files_at(prev_sha))
+    engine_manifest.write_manifest(
+        update_mod._engine_paths_for(prev_sha, repo_root=REPO_ROOT),
+        files=update_mod._engine_files_at(prev_sha),
+    )
     print(f"→ engine re-materialized at {prev_sha[:12]} (engine.ref restored)")
 
 

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -88,8 +88,13 @@ _VISUAL_QA_MARKER_RE = re.compile(
 )
 
 
-def git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
-    r = subprocess.run(["git", "-C", str(REPO_ROOT), *args],
+def git(
+    *args: str,
+    check: bool = True,
+    repo_root: Path | None = None,
+) -> subprocess.CompletedProcess:
+    root = repo_root if repo_root is not None else REPO_ROOT
+    r = subprocess.run(["git", "-C", str(root), *args],
                        capture_output=True, text=True)
     if check and r.returncode != 0:
         sys.exit(f"update: `git {' '.join(args)}` failed:\n{r.stderr.strip()}")
@@ -245,12 +250,19 @@ def _literal_engine_paths_at(
     return None, f"{source_path} does not define ENGINE_PATHS"
 
 
-def _engine_paths_for(ref: str, repo_root: Path = REPO_ROOT) -> list[str]:
+def _engine_paths_for(
+    ref: str,
+    repo_root: Path = REPO_ROOT,
+    *,
+    fallback_used: list[bool] | None = None,
+) -> list[str]:
     """Resolve the target ref's allow-list, then keep paths present at ``ref``.
 
     New engines declare their list in ``engine_manifest.py``. Refs before that
     module split declare it in ``update.py``. If neither source satisfies the
     literal-list contract, use the installed list as a warned fallback.
+    ``fallback_used`` receives that provenance when a caller must keep two
+    resolutions under the same authority.
 
     `git archive` aborts wholesale if any pathspec matches nothing, so a single
     engine file retired upstream (e.g. a dropped schema variant) would otherwise
@@ -272,7 +284,8 @@ def _engine_paths_for(ref: str, repo_root: Path = REPO_ROOT) -> list[str]:
         if reason is not None:
             reasons.append(reason)
 
-    if resolved is None:
+    used_installed_fallback = resolved is None
+    if used_installed_fallback:
         print(
             f"WARNING: update could not resolve ENGINE_PATHS at {ref}: "
             f"{'; '.join(reasons)}; falling back to installed ENGINE_PATHS.",
@@ -308,10 +321,17 @@ def _engine_paths_for(ref: str, repo_root: Path = REPO_ROOT) -> list[str]:
         )
     if not present:
         sys.exit(f"update: no engine paths exist at {ref} — wrong ref or remote?")
+    if fallback_used is not None:
+        fallback_used.append(used_installed_fallback)
     return present
 
 
-def _engine_files_at(ref: str) -> list[str]:
+def _engine_files_at(
+    ref: str,
+    repo_root: Path | None = None,
+    *,
+    engine_paths: list[str] | None = None,
+) -> list[str]:
     """The exact FILE list upstream ships under the paths resolved for ``ref``.
 
     This is what a materialize writes, so it is what the manifest must cover
@@ -319,13 +339,21 @@ def _engine_files_at(ref: str) -> list[str]:
     skill's SKILL.md) and upstream-retired stragglers on disk stay out of the
     manifest: they are not upstream-owned, so they must never guard — and later
     block — a future update (see engine_manifest.write_manifest)."""
+    if repo_root is None:
+        repo_root = REPO_ROOT
+    paths = (
+        engine_paths
+        if engine_paths is not None
+        else _engine_paths_for(ref, repo_root=repo_root)
+    )
     return git(
         "ls-tree",
         "-r",
         "--name-only",
         ref,
         "--",
-        *_engine_paths_for(ref, repo_root=REPO_ROOT),
+        *paths,
+        repo_root=repo_root,
     ).stdout.splitlines()
 
 

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -50,6 +50,7 @@ Usage:
 """
 from __future__ import annotations
 
+import ast
 import os
 import re
 import shutil
@@ -77,9 +78,9 @@ import seed_skills  # noqa: E402
 
 EJECTED_MARKER = STATE_DIR / "ejected"
 
-# The materialize set — canonical list lives in engine_manifest.py (shared with
-# install.py's first-manifest write); re-exported here as the name every caller
-# and test already knows.
+# The installed materialize set — engine_manifest.py owns the source-repo and
+# fresh-install answer. Updates resolve the target ref's list independently;
+# this export remains the warned fallback and the stable name callers know.
 ENGINE_PATHS = engine_manifest.ENGINE_PATHS
 
 _VISUAL_QA_MARKER_RE = re.compile(
@@ -196,36 +197,136 @@ def super_coder_remote() -> str:
              "  git remote add super-coder https://github.com/jedbjorn/subfloor.git")
 
 
-def _engine_paths_at(ref: str) -> list[str]:
-    """ENGINE_PATHS that actually exist at `ref` (blob or tree).
+def _literal_engine_paths_at(
+    ref: str,
+    source_path: str,
+    *,
+    repo_root: Path,
+) -> tuple[list[str] | None, str | None]:
+    """Read a literal ``ENGINE_PATHS = list[str]`` assignment from ``ref``."""
+    shown = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{ref}:{source_path}"],
+        capture_output=True,
+        text=True,
+    )
+    if shown.returncode != 0:
+        return None, f"{source_path} is unavailable"
+
+    try:
+        tree = ast.parse(shown.stdout, filename=f"{ref}:{source_path}")
+    except SyntaxError:
+        return None, f"{source_path} is not valid Python"
+
+    for node in tree.body:
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "ENGINE_PATHS"
+            for target in node.targets
+        ):
+            value = node.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "ENGINE_PATHS"
+        ):
+            value = node.value
+        if value is None:
+            continue
+        try:
+            paths = ast.literal_eval(value)
+        except (ValueError, TypeError, SyntaxError):
+            return None, f"{source_path} does not assign a literal list[str]"
+        if not isinstance(paths, list) or not all(
+            isinstance(path, str) for path in paths
+        ):
+            return None, f"{source_path} does not assign a literal list[str]"
+        return paths, None
+
+    return None, f"{source_path} does not define ENGINE_PATHS"
+
+
+def _engine_paths_for(ref: str, repo_root: Path = REPO_ROOT) -> list[str]:
+    """Resolve the target ref's allow-list, then keep paths present at ``ref``.
+
+    New engines declare their list in ``engine_manifest.py``. Refs before that
+    module split declare it in ``update.py``. If neither source satisfies the
+    literal-list contract, use the installed list as a warned fallback.
 
     `git archive` aborts wholesale if any pathspec matches nothing, so a single
     engine file retired upstream (e.g. a dropped schema variant) would otherwise
-    break every fork's update the one time it crosses that deletion. Filter to
-    the paths present at `ref` — and report what was dropped, never silently."""
+    break every fork's update the one time it crosses that deletion. The target
+    list is authoritative; the installed export remains the fallback and the
+    comparison baseline for reporting additions and retirements."""
+    sources = (
+        ".super-coder/scripts/engine_manifest.py",
+        ".super-coder/scripts/update.py",
+    )
+    reasons: list[str] = []
+    resolved: list[str] | None = None
+    for source_path in sources:
+        resolved, reason = _literal_engine_paths_at(
+            ref, source_path, repo_root=repo_root
+        )
+        if resolved is not None:
+            break
+        if reason is not None:
+            reasons.append(reason)
+
+    if resolved is None:
+        print(
+            f"WARNING: update could not resolve ENGINE_PATHS at {ref}: "
+            f"{'; '.join(reasons)}; falling back to installed ENGINE_PATHS.",
+            file=sys.stderr,
+        )
+        resolved = list(ENGINE_PATHS)
+
     present, missing = [], []
-    for p in ENGINE_PATHS:
+    for path in resolved:
         exists = subprocess.run(
-            ["git", "-C", str(REPO_ROOT), "cat-file", "-e", f"{ref}:{p}"],
-            capture_output=True).returncode == 0
-        (present if exists else missing).append(p)
-    if missing:
-        print(f"  note: {len(missing)} engine path(s) absent at {ref[:12]} "
-              f"(retired upstream) — skipping: {', '.join(missing)}")
+            ["git", "-C", str(repo_root), "cat-file", "-e", f"{ref}:{path}"],
+            capture_output=True,
+        ).returncode == 0
+        (present if exists else missing).append(path)
+
+    added = [path for path in present if path not in ENGINE_PATHS]
+    retired = [path for path in ENGINE_PATHS if path not in present]
+    if added:
+        print(
+            f"  note: {len(added)} engine path(s) newly materialized at "
+            f"{ref[:12]}: {', '.join(added)}"
+        )
+    if retired:
+        print(
+            f"  note: {len(retired)} installed engine path(s) retired at "
+            f"{ref[:12]} — skipping: {', '.join(retired)}"
+        )
+    target_only_missing = [path for path in missing if path not in ENGINE_PATHS]
+    if target_only_missing:
+        print(
+            f"  note: {len(target_only_missing)} target engine path(s) absent "
+            f"at {ref[:12]} — skipping: {', '.join(target_only_missing)}"
+        )
     if not present:
         sys.exit(f"update: no engine paths exist at {ref} — wrong ref or remote?")
     return present
 
 
 def _engine_files_at(ref: str) -> list[str]:
-    """The exact FILE list upstream ships at `ref` under the engine paths —
-    what a materialize writes, so what the manifest must cover and nothing
-    more. Locally-added files under engine dirs (e.g. a fork-local skill's
-    SKILL.md) and upstream-retired stragglers on disk stay out of the manifest:
-    they are not upstream-owned, so they must never guard — and later block —
-    a future update (see engine_manifest.write_manifest)."""
-    return git("ls-tree", "-r", "--name-only", ref,
-               "--", *_engine_paths_at(ref)).stdout.splitlines()
+    """The exact FILE list upstream ships under the paths resolved for ``ref``.
+
+    This is what a materialize writes, so it is what the manifest must cover
+    and nothing more. Locally-added files under engine dirs (e.g. a fork-local
+    skill's SKILL.md) and upstream-retired stragglers on disk stay out of the
+    manifest: they are not upstream-owned, so they must never guard — and later
+    block — a future update (see engine_manifest.write_manifest)."""
+    return git(
+        "ls-tree",
+        "-r",
+        "--name-only",
+        ref,
+        "--",
+        *_engine_paths_for(ref, repo_root=REPO_ROOT),
+    ).stdout.splitlines()
 
 
 def materialize_engine(ref: str) -> None:
@@ -236,8 +337,17 @@ def materialize_engine(ref: str) -> None:
     in place. (Files deleted upstream linger until a future doctor sweep — same
     gap the old checkout had; acceptable for a wholesale-overwrite dependency.)"""
     archive = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "archive", ref, "--", *_engine_paths_at(ref)],
-        capture_output=True)
+        [
+            "git",
+            "-C",
+            str(REPO_ROOT),
+            "archive",
+            ref,
+            "--",
+            *_engine_paths_for(ref, repo_root=REPO_ROOT),
+        ],
+        capture_output=True,
+    )
     if archive.returncode != 0:
         sys.exit("update: git archive of the engine failed:\n"
                  + archive.stderr.decode(errors="replace").strip())
@@ -303,8 +413,10 @@ def materialize_fetched_engine(sha: str, *, force: bool = False) -> None:
 
     materialize_engine(sha)
     ENGINE_REF.write_text(sha + "\n")
-    n = engine_manifest.write_manifest(_engine_paths_at(sha),
-                                       files=_engine_files_at(sha))
+    n = engine_manifest.write_manifest(
+        _engine_paths_for(sha, repo_root=REPO_ROOT),
+        files=_engine_files_at(sha),
+    )
     print(f"  engine pinned at {sha[:12]} (.sc-state/engine.ref) · manifest over {n} files")
 
 

--- a/tests/test_rollback_half_floor.py
+++ b/tests/test_rollback_half_floor.py
@@ -212,6 +212,73 @@ class HalfFloorRollbackTest(unittest.TestCase):
             )
             self.assertEqual(engine_ref.read_text(), old_sha + "\n")
 
+    def test_restore_engine_fallback_keeps_broader_installed_paths_symmetric(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            root = Path(raw_tmp)
+            engine = root / ".super-coder"
+            scripts = engine / "scripts"
+            fork_area = engine / "fork-area"
+            state = root / ".sc-state"
+            scripts.mkdir(parents=True)
+            fork_area.mkdir()
+            state.mkdir()
+
+            git(root, "init", "-b", "main")
+            git(root, "config", "user.name", "Rollback Test")
+            git(root, "config", "user.email", "rollback@example.invalid")
+            (root / "sc").write_text("old dispatcher\n")
+            (scripts / "floor.txt").write_text("old engine\n")
+            (scripts / "engine_manifest.py").write_text(
+                'ENGINE_PATHS = ["sc", ".super-coder/scripts"]\n'
+            )
+            sentinel = fork_area / "sentinel.txt"
+            sentinel.write_bytes(b"tracked fork bytes\n")
+            git(root, "add", ".")
+            git(root, "commit", "-m", "old exact floor")
+            old_sha = git(root, "rev-parse", "HEAD")
+
+            (root / "sc").write_text("new dispatcher\n")
+            (scripts / "floor.txt").write_text("new engine\n")
+            (scripts / "engine_manifest.py").write_text(
+                "ENGINE_PATHS = load_paths()\n"
+            )
+            git(root, "add", ".")
+            git(root, "commit", "-m", "new unparseable floor")
+            new_sha = git(root, "rev-parse", "HEAD")
+            engine_ref = state / "engine.ref"
+            engine_ref.write_text(new_sha + "\n")
+            sentinel.write_bytes(b"fork sentinel bytes\n")
+
+            installed = [
+                "sc",
+                ".super-coder/scripts",
+                ".super-coder/fork-area",
+            ]
+            with mock.patch.multiple(
+                rollback,
+                REPO_ROOT=root,
+                ENGINE_REF=engine_ref,
+            ), mock.patch.object(
+                rollback.update_mod,
+                "ENGINE_PATHS",
+                installed,
+            ), mock.patch.object(
+                rollback.update_mod,
+                "materialize_engine",
+            ), mock.patch.object(
+                rollback.engine_manifest,
+                "write_manifest",
+            ):
+                rollback.restore_engine(old_sha)
+
+            self.assertEqual(
+                sentinel.read_bytes(),
+                b"fork sentinel bytes\n",
+                "a broader installed fallback must not turn tracked fork "
+                "content into a rollback deletion candidate",
+            )
+            self.assertEqual(engine_ref.read_text(), old_sha + "\n")
+
     def test_engine_only_refuses_previous_floor_with_unrelated_extra(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             root = Path(raw_tmp)

--- a/tests/test_rollback_half_floor.py
+++ b/tests/test_rollback_half_floor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import io
 import sqlite3
 import subprocess
 import sys
@@ -55,6 +56,162 @@ def read_db(path: Path) -> str:
 
 
 class HalfFloorRollbackTest(unittest.TestCase):
+    def test_path_resolution_fallbacks_only_under_delete_rollback_delta(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            root = Path(raw_tmp)
+            scripts = root / ".super-coder" / "scripts"
+            future = root / ".super-coder" / "future"
+            scripts.mkdir(parents=True)
+            future.mkdir()
+
+            git(root, "init", "-b", "main")
+            git(root, "config", "user.name", "Rollback Test")
+            git(root, "config", "user.email", "rollback@example.invalid")
+            (root / "sc").write_text("dispatcher\n")
+            (scripts / "engine_manifest.py").write_text(
+                'ENGINE_PATHS = ["sc", ".super-coder/scripts"]\n'
+            )
+            future_file = future / "newly-owned.txt"
+            future_file.write_text("tracked before engine ownership\n")
+            git(root, "add", ".")
+            git(root, "commit", "-m", "previous exact list")
+            previous_exact_sha = git(root, "rev-parse", "HEAD")
+
+            (scripts / "engine_manifest.py").write_text(
+                "ENGINE_PATHS = load_paths()\n"
+            )
+            git(root, "add", ".")
+            git(root, "commit", "-m", "previous unparseable list")
+            previous_fallback_sha = git(root, "rev-parse", "HEAD")
+
+            current_paths = [
+                "sc",
+                ".super-coder/scripts",
+                ".super-coder/future",
+            ]
+            (scripts / "engine_manifest.py").write_text(
+                "ENGINE_PATHS = " + repr(current_paths) + "\n"
+            )
+            git(root, "add", ".")
+            git(root, "commit", "-m", "current exact list")
+            current_exact_sha = git(root, "rev-parse", "HEAD")
+
+            (scripts / "engine_manifest.py").write_text(
+                "ENGINE_PATHS = load_paths()\n"
+            )
+            git(root, "add", ".")
+            git(root, "commit", "-m", "current unparseable list")
+            current_fallback_sha = git(root, "rev-parse", "HEAD")
+
+            with mock.patch.object(rollback.update_mod, "REPO_ROOT", root):
+                previous_exact = set(
+                    rollback.update_mod._engine_files_at(previous_exact_sha)
+                )
+                current_exact = set(
+                    rollback.update_mod._engine_files_at(current_exact_sha)
+                )
+                exact_delta = current_exact - previous_exact
+
+                warnings = io.StringIO()
+                with mock.patch.object(
+                    rollback.update_mod,
+                    "ENGINE_PATHS",
+                    ["sc", ".super-coder/scripts"],
+                ), contextlib.redirect_stderr(warnings):
+                    current_fallback = set(
+                        rollback.update_mod._engine_files_at(
+                            current_fallback_sha
+                        )
+                    )
+
+                with mock.patch.object(
+                    rollback.update_mod,
+                    "ENGINE_PATHS",
+                    current_paths,
+                ), contextlib.redirect_stderr(warnings):
+                    previous_fallback = set(
+                        rollback.update_mod._engine_files_at(
+                            previous_fallback_sha
+                        )
+                    )
+
+            expected = ".super-coder/future/newly-owned.txt"
+            self.assertIn(expected, exact_delta)
+            current_fallback_delta = current_fallback - previous_exact
+            previous_fallback_delta = current_exact - previous_fallback
+            self.assertLess(current_fallback_delta, exact_delta)
+            self.assertLess(previous_fallback_delta, exact_delta)
+            self.assertEqual(
+                warnings.getvalue().count(
+                    "falling back to installed ENGINE_PATHS"
+                ),
+                2,
+            )
+
+    def test_restore_engine_resolves_each_refs_allow_list(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            root = Path(raw_tmp)
+            engine = root / ".super-coder"
+            scripts = engine / "scripts"
+            state = root / ".sc-state"
+            scripts.mkdir(parents=True)
+            state.mkdir()
+
+            git(root, "init", "-b", "main")
+            git(root, "config", "user.name", "Rollback Test")
+            git(root, "config", "user.email", "rollback@example.invalid")
+            (root / "sc").write_text("old dispatcher\n")
+            (scripts / "floor.txt").write_text("old engine\n")
+            (scripts / "engine_manifest.py").write_text(
+                'ENGINE_PATHS = ["sc", ".super-coder/scripts"]\n'
+            )
+            git(root, "add", ".")
+            git(root, "commit", "-m", "old floor")
+            old_sha = git(root, "rev-parse", "HEAD")
+
+            (root / "sc").write_text("new dispatcher\n")
+            (scripts / "floor.txt").write_text("new engine\n")
+            (scripts / "engine_manifest.py").write_text(
+                'ENGINE_PATHS = ["sc", ".super-coder/scripts", '
+                '".super-coder/new-path"]\n'
+            )
+            new_path = engine / "new-path" / "new-only.txt"
+            new_path.parent.mkdir()
+            new_path.write_text("new upstream file\n")
+            git(root, "add", ".")
+            git(root, "commit", "-m", "new floor")
+            new_sha = git(root, "rev-parse", "HEAD")
+            engine_ref = state / "engine.ref"
+            engine_ref.write_text(new_sha + "\n")
+
+            with mock.patch.multiple(
+                rollback,
+                REPO_ROOT=root,
+                ENGINE=engine,
+                ENGINE_REF=engine_ref,
+            ), mock.patch.multiple(
+                rollback.update_mod,
+                REPO_ROOT=root,
+                ENGINE=engine,
+            ), mock.patch.multiple(
+                rollback.engine_manifest,
+                REPO_ROOT=root,
+                ENGINE=engine,
+                MANIFEST=engine / "engine.manifest",
+            ):
+                rollback.restore_engine(old_sha)
+
+            self.assertFalse(
+                new_path.exists(),
+                "the current ref's newly allow-listed upstream file must be "
+                "part of current_files - previous_files",
+            )
+            self.assertEqual((root / "sc").read_text(), "old dispatcher\n")
+            self.assertEqual(
+                (scripts / "floor.txt").read_text(), "old engine\n"
+            )
+            self.assertEqual(engine_ref.read_text(), old_sha + "\n")
+
     def test_engine_only_refuses_previous_floor_with_unrelated_extra(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             root = Path(raw_tmp)

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -1,27 +1,32 @@
 #!/usr/bin/env python3
-"""Guard: every tracked engine file is materialized to forks on `./sc update`.
+"""Guards for the engine allow-list materialized by ``./sc update``.
 
-The bugs this prevents: a new top-level file under `.super-coder/` (e.g.
-map_schema.sql, added with the map split) or a new tracked SUBDIRECTORY (e.g.
-shadow/, added with the Interface runtime) that isn't in update.py's
-ENGINE_PATHS allowlist never reaches an updating fork — the fork gets the new
-code but not the files, and breaks (shadow/: 'interface_unavailable: shadow
-sidecar exited' on every fresh fork; flag #59). Known subdirs (scripts/,
-templates/, …) are materialized whole, so files inside them are covered; only
-NEW top-level files and NEW subdirs are at risk. The file-level test asserts
-every git-tracked engine file is covered by the allowlist (or is a deliberate
-per-instance / super-coder-only exclusion); the dir-level one keeps the cheap
-top-level signal.
+Two bug classes live here. First, a new tracked top-level file or directory
+missing from ENGINE_PATHS never reaches any fork. Second, an updating fork can
+run an installed ``update.py`` whose list predates the target ref's list,
+silently laying down the new code without its newly declared path for one
+update. The source-repo coverage checks pin the first class; two-commit fixture
+repos pin target-ref resolution across the version gap, including the retired
+path mirror and warned fallback legs.
+
+Known subdirs (scripts/, templates/, …) are materialized whole, so files inside
+them are covered; only new top-level files and subdirs need new allow-list
+entries. Deliberate per-instance and super-coder-only exclusions remain outside
+the list.
 
 Run:
     python3 tests/test_update_materialize.py
 """
 from __future__ import annotations
 
+import contextlib
+import io
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
@@ -52,7 +57,24 @@ def _covered(rel: str) -> bool:
                for entry in update.ENGINE_PATHS)
 
 
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
 class EnginePathsCoverageTest(unittest.TestCase):
+    def test_head_allow_list_is_a_literal_matching_the_export(self):
+        warning = io.StringIO()
+        with contextlib.redirect_stderr(warning):
+            resolved = update._engine_paths_for("HEAD", repo_root=ROOT)
+
+        self.assertEqual(warning.getvalue(), "")
+        self.assertEqual(resolved, update.engine_manifest.ENGINE_PATHS)
+
     def test_every_top_level_engine_file_is_materialized(self):
         listed = set(update.ENGINE_PATHS)
         missing = []
@@ -94,6 +116,162 @@ class EnginePathsCoverageTest(unittest.TestCase):
             f"tracked engine file(s) absent from update.ENGINE_PATHS — forks "
             f"won't receive them on `./sc update` (add the path to ENGINE_PATHS "
             f"or opt out in NOT_MATERIALIZED): {missing}")
+
+
+class EnginePathsAtRefTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.scripts = self.root / ".super-coder" / "scripts"
+        self.scripts.mkdir(parents=True)
+        _git(self.root, "init", "-b", "main")
+        _git(self.root, "config", "user.name", "Update Test")
+        _git(self.root, "config", "user.email", "update@example.invalid")
+
+    def commit(self, message: str) -> str:
+        _git(self.root, "add", ".")
+        _git(self.root, "commit", "-m", message)
+        return _git(self.root, "rev-parse", "HEAD")
+
+    def write_manifest(self, paths: list[str]) -> None:
+        (self.scripts / "engine_manifest.py").write_text(
+            "ENGINE_PATHS = " + repr(paths) + "\n"
+        )
+
+    def test_added_path_resolves_from_target_ref_and_materializes(self):
+        installed = ["sc", ".super-coder/scripts"]
+        (self.root / "sc").write_text("old dispatcher\n")
+        self.write_manifest(installed)
+        (self.scripts / "floor.txt").write_text("old floor\n")
+        old_sha = self.commit("old allow-list")
+
+        target = [*installed, ".super-coder/new-path"]
+        (self.root / "sc").write_text("new dispatcher\n")
+        self.write_manifest(target)
+        (self.scripts / "floor.txt").write_text("new floor\n")
+        new_file = self.root / ".super-coder" / "new-path" / "new.txt"
+        new_file.parent.mkdir()
+        new_file.write_text("new path content\n")
+        new_sha = self.commit("add engine path")
+        _git(self.root, "checkout", old_sha)
+        self.assertFalse(new_file.exists())
+
+        output = io.StringIO()
+        with mock.patch.multiple(
+            update,
+            REPO_ROOT=self.root,
+            ENGINE_PATHS=installed,
+        ), contextlib.redirect_stdout(output):
+            resolved = update._engine_paths_for(
+                new_sha, repo_root=self.root
+            )
+            update.materialize_engine(new_sha)
+
+        self.assertEqual(resolved, target)
+        self.assertEqual(new_file.read_text(), "new path content\n")
+        self.assertEqual((self.root / "sc").read_text(), "new dispatcher\n")
+        self.assertIn(
+            "1 engine path(s) newly materialized at "
+            f"{new_sha[:12]}: .super-coder/new-path",
+            output.getvalue(),
+        )
+
+    def test_retired_path_is_not_materialized_and_is_reported(self):
+        base = ["sc", ".super-coder/scripts"]
+        installed = [*base, ".super-coder/retired-path"]
+        (self.root / "sc").write_text("old dispatcher\n")
+        self.write_manifest(installed)
+        retired_file = (
+            self.root / ".super-coder" / "retired-path" / "retired.txt"
+        )
+        retired_file.parent.mkdir()
+        retired_file.write_text("old upstream content\n")
+        old_sha = self.commit("path still installed")
+
+        (self.root / "sc").write_text("new dispatcher\n")
+        self.write_manifest(base)
+        retired_file.write_text("tracked but no longer engine-owned\n")
+        new_sha = self.commit("retire engine path")
+        _git(self.root, "checkout", old_sha)
+        retired_file.write_text("fork sentinel\n")
+
+        output = io.StringIO()
+        with mock.patch.multiple(
+            update,
+            REPO_ROOT=self.root,
+            ENGINE_PATHS=installed,
+        ), contextlib.redirect_stdout(output):
+            resolved = update._engine_paths_for(
+                new_sha, repo_root=self.root
+            )
+            update.materialize_engine(new_sha)
+
+        self.assertEqual(resolved, base)
+        self.assertNotIn(".super-coder/retired-path", resolved)
+        self.assertEqual(
+            retired_file.read_text(),
+            "fork sentinel\n",
+            "a target-retired path must stay outside the archive",
+        )
+        self.assertIn(
+            "1 installed engine path(s) retired at "
+            f"{new_sha[:12]} — skipping: .super-coder/retired-path",
+            output.getvalue(),
+        )
+
+    def test_ref_before_manifest_module_uses_update_literal(self):
+        (self.root / "README").write_text("precursor\n")
+        self.commit("before engine files")
+
+        legacy = ["sc", ".super-coder/scripts"]
+        (self.root / "sc").write_text("legacy dispatcher\n")
+        (self.scripts / "update.py").write_text(
+            "ENGINE_PATHS = " + repr(legacy) + "\n"
+        )
+        legacy_sha = self.commit("legacy update literal")
+
+        warning = io.StringIO()
+        with mock.patch.object(update, "ENGINE_PATHS", ["sc"]), \
+                contextlib.redirect_stderr(warning):
+            resolved = update._engine_paths_for(
+                legacy_sha, repo_root=self.root
+            )
+
+        self.assertEqual(resolved, legacy)
+        self.assertEqual(warning.getvalue(), "")
+
+    def test_unparseable_target_list_warns_and_uses_installed_list(self):
+        installed = ["sc", ".super-coder/scripts"]
+        (self.root / "sc").write_text("dispatcher\n")
+        self.write_manifest(installed)
+        (self.scripts / "update.py").write_text(
+            "from engine_manifest import ENGINE_PATHS\n"
+        )
+        self.commit("literal allow-list")
+
+        (self.scripts / "engine_manifest.py").write_text(
+            "ENGINE_PATHS = load_paths()\n"
+        )
+        target_sha = self.commit("dynamic allow-list")
+
+        warning = io.StringIO()
+        with mock.patch.object(update, "ENGINE_PATHS", installed), \
+                contextlib.redirect_stderr(warning):
+            resolved = update._engine_paths_for(
+                target_sha, repo_root=self.root
+            )
+
+        self.assertEqual(resolved, installed)
+        self.assertEqual(
+            warning.getvalue(),
+            "WARNING: update could not resolve ENGINE_PATHS at "
+            f"{target_sha}: "
+            ".super-coder/scripts/engine_manifest.py does not assign a "
+            "literal list[str]; "
+            ".super-coder/scripts/update.py does not define ENGINE_PATHS; "
+            "falling back to installed ENGINE_PATHS.\n",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- resolve ENGINE_PATHS from the target ref via a literal AST extractor, with the legacy update.py location and a loud installed-list fallback
- preserve target-retired exclusions and switch materialize, manifest, and rollback consumers to per-ref resolution
- add two-commit fixture coverage for additions, retirements, fallback diagnostics, the HEAD contract, and rollback under-deletion

## Verification
- 45 passed, 2 subtests: update materialize, engine manifest, rollback half-floor, update preflight, Visual QA distribution, eject
- Ruff clean on all changed Python files
- py_compile clean
- independent mutations: installed-list regression, installed+target union, missing legacy fallback, weakened warning, moved manifest source; every anchor matched exactly once and every leg reddened before restoration

## Sprint 71 U1 note
The rollback test file was declared regression-read-only in spec 66, but PLN2 ratified its expansion to preserve the executed proof that either fallback can only under-delete. This deviation will be repeated in the unit report.

Closes #623