### PR TITLE
Add sprint activity evidence readers

### DIFF
--- a/.super-coder/scripts/activity_readers.py
+++ b/.super-coder/scripts/activity_readers.py
@@ -163,6 +163,8 @@ class ActivityReader:
         except (OSError, sqlite3.Error):
             for name in ("epoch", "session", "durable_write", "result_row"):
                 self._mark(evidence, name)
+            if unit is None:
+                self._mark(evidence, "state_changed_at")
             return None
 
         harness = None
@@ -170,15 +172,39 @@ class ActivityReader:
         planner_session = None
         if unit is None:
             try:
-                row = con.execute(
-                    "SELECT sprint_doc_id FROM sprint_planner_bindings "
-                    "WHERE planner_shell_id=? ORDER BY binding_id DESC LIMIT 1",
+                rows = con.execute(
+                    "SELECT b.sprint_doc_id, b.armed_at "
+                    "FROM sprint_planner_bindings b "
+                    "JOIN documents d ON d.document_id=b.sprint_doc_id "
+                    "WHERE b.binding_id=("
+                    " SELECT MAX(b2.binding_id) FROM sprint_planner_bindings b2"
+                    " WHERE b2.sprint_doc_id=b.sprint_doc_id"
+                    ") AND b.planner_shell_id=? AND d.frozen=0 "
+                    "AND EXISTS (SELECT 1 FROM sprint_units u "
+                    "            WHERE u.sprint_doc_id=b.sprint_doc_id) "
+                    "ORDER BY b.sprint_doc_id",
                     (shell_id,),
-                ).fetchone()
-                sprint_doc_id = row["sprint_doc_id"] if row else None
+                ).fetchall()
+                # U9 can render several live planner roles, but Evidence carries
+                # one sprint scope.  Never collapse several bindings to a
+                # confident answer for whichever row happens to sort newest.
+                if len(rows) == 1:
+                    sprint_doc_id = rows[0]["sprint_doc_id"]
+                    evidence.state_changed_at = _timestamp(rows[0]["armed_at"])
+                    if evidence.state_changed_at is None:
+                        self._mark(evidence, "state_changed_at")
+                else:
+                    sprint_doc_id = None
+                    for name in (
+                        "durable_write",
+                        "result_row",
+                        "state_changed_at",
+                    ):
+                        self._mark(evidence, name)
             except sqlite3.Error:
                 self._mark(evidence, "durable_write")
                 self._mark(evidence, "result_row")
+                self._mark(evidence, "state_changed_at")
 
         try:
             if unit is None:
@@ -280,7 +306,8 @@ class ActivityReader:
         if not seq:
             return False
         return re.search(
-            rf"(?<![A-Za-z0-9_]){re.escape(seq)}(?![A-Za-z0-9_])",
+            rf"(?<![A-Za-z0-9_])(?<![A-Za-z0-9_]\.)"
+            rf"{re.escape(seq)}(?![A-Za-z0-9_]|\.[A-Za-z0-9_])",
             body or "",
         ) is not None
 
@@ -385,15 +412,16 @@ class ActivityReader:
 
         revision = "HEAD" if on_declared_head else f"refs/remotes/origin/{branch}"
         try:
-            merge_base = self._git(
+            fetched = self._git(
                 worktree,
-                "merge-base",
-                "refs/remotes/origin/main",
-                revision,
+                "fetch",
+                "--quiet",
+                "origin",
+                "+refs/heads/main:refs/remotes/origin/main",
             )
-            if merge_base.returncode != 0 or not merge_base.stdout.strip():
-                raise OSError(merge_base.stderr)
-            contribution = f"{merge_base.stdout.strip()}..{revision}"
+            if fetched.returncode != 0:
+                raise OSError(fetched.stderr)
+            contribution = f"refs/remotes/origin/main..{revision}"
             log = self._git(worktree, "log", contribution, "--format=%aI")
         except (OSError, subprocess.SubprocessError):
             log = None
@@ -705,6 +733,8 @@ class ActivityReader:
         except Exception:  # noqa: BLE001 — complete value, never an escape
             for name in ("epoch", "session", "durable_write", "result_row"):
                 self._mark(evidence, name)
+            if unit is None:
+                self._mark(evidence, "state_changed_at")
 
         on_declared_head = False
         if evidence.branch_declared is not None:

--- a/.super-coder/scripts/activity_readers.py
+++ b/.super-coder/scripts/activity_readers.py
@@ -29,6 +29,7 @@ ADAPTERS = ENGINE / "adapters"
 PROC = Path("/proc")
 
 CODEX_CANDIDATE_WINDOW = timedelta(minutes=60)
+UNTIMED_DELETE_RENAME = "last_work_at:untimed_delete_rename"
 BOOT_ARTIFACTS = {
     "CLAUDE.md",
     "AGENTS.md",
@@ -293,16 +294,25 @@ class ActivityReader:
             return
         dirty_times: list[datetime] = []
         for code, rel in entries:
-            if "U" in code or _boot_artifact(rel):
+            if code in {"DD", "AU", "UD", "UA", "DU", "AA", "UU"}:
+                continue
+            if _boot_artifact(rel):
                 continue
             if code != "??" and not any(c in "MADRC" for c in code):
+                continue
+            if "D" in code:
+                self._mark(evidence, UNTIMED_DELETE_RENAME)
                 continue
             try:
                 changed_at = _mtime(worktree / rel)
             except OSError:
+                if "R" in code:
+                    self._mark(evidence, UNTIMED_DELETE_RENAME)
                 continue
             if changed_at >= epoch:
                 dirty_times.append(changed_at)
+            elif "R" in code:
+                self._mark(evidence, UNTIMED_DELETE_RENAME)
 
         revision = "HEAD" if on_declared_head else f"refs/remotes/origin/{branch}"
         try:

--- a/.super-coder/scripts/activity_readers.py
+++ b/.super-coder/scripts/activity_readers.py
@@ -1,0 +1,650 @@
+"""Read worker activity evidence without classifying it.
+
+This is the observation boundary for the worker-expectation reconciler
+(spec 58, U3).  Callers get one complete :class:`Evidence` value even when
+individual inputs are unavailable.  Classification, time windows, and alert
+delivery deliberately live elsewhere.
+
+``last_durable_write_at`` is intentionally a lower bound.  Only
+``shell_messages`` and ``sprint_units`` carry all three facts needed here: a
+per-write timestamp, shell attribution, and sprint scope.  Date-only or
+unattributed surfaces are excluded rather than guessed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+DB_PATH = ENGINE / "shell_db.db"
+ADAPTERS = ENGINE / "adapters"
+PROC = Path("/proc")
+
+CODEX_CANDIDATE_WINDOW = timedelta(minutes=60)
+BOOT_ARTIFACTS = {
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".claude/settings.local.json",
+    ".codex/hooks.json",
+}
+
+
+@dataclass
+class Evidence:
+    last_work_at: datetime | None = None
+    dirty: bool | None = None
+    commits_since_epoch: int | None = None
+    last_durable_write_at: datetime | None = None
+    session_ended_at: datetime | None = None
+    session_end_reason: str | None = None
+    newest_mtime: datetime | None = None
+    epoch: datetime | None = None
+    edits_code: bool = False
+    branch_declared: str | None = None
+    branch_present: bool | None = None
+    marker_at: datetime | None = None
+    cpu_delta: float | None = None
+    launch_shape: str | None = None
+    process_present: bool | None = None
+    unreadable: list[str] = field(default_factory=list)
+
+
+def _value(row: Any, key: str, default=None):
+    if row is None:
+        return default
+    if isinstance(row, Mapping):
+        return row.get(key, default)
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return getattr(row, key, default)
+
+
+def _timestamp(value: Any) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        try:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _mtime(path: Path) -> datetime:
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+
+def _boot_artifact(path: str) -> bool:
+    if path in BOOT_ARTIFACTS:
+        return True
+    return path.startswith(".claude/skills/") and path.endswith("/SKILL.md")
+
+
+class ActivityReader:
+    """Injectable reader used by the scheduler and by hermetic tests."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | None = None,
+        repo_root: Path | None = None,
+        proc: Path | None = None,
+        adapters: Path | None = None,
+        home: Path | None = None,
+        run=subprocess.run,
+    ):
+        self.db_path = Path(db_path or DB_PATH)
+        self.repo_root = Path(repo_root or REPO_ROOT)
+        self.proc = Path(proc or PROC)
+        self.adapters = Path(adapters or ADAPTERS)
+        self.home = Path(home or Path.home())
+        self.run_command = run
+        self._cpu_samples: dict[tuple[tuple[int, int], ...], int] = {}
+
+    @staticmethod
+    def _mark(evidence: Evidence, name: str) -> None:
+        if name not in evidence.unreadable:
+            evidence.unreadable.append(name)
+
+    def _worktree(self, shell: Any) -> Path:
+        explicit = _value(shell, "worktree")
+        if explicit:
+            return Path(explicit)
+        if _value(shell, "flavor") == "admin":
+            return self.repo_root
+        return self.repo_root / ".sc-worktrees" / str(
+            _value(shell, "shortname", "")
+        ).lower()
+
+    def _database_inputs(
+        self, evidence: Evidence, shell: Any, unit: Any
+    ) -> str | None:
+        shell_id = _value(shell, "shell_id")
+        sprint_doc_id = _value(unit, "sprint_doc_id")
+        try:
+            con = sqlite3.connect(
+                f"file:{self.db_path}?mode=ro", uri=True, timeout=2
+            )
+            con.row_factory = sqlite3.Row
+        except (OSError, sqlite3.Error):
+            for name in ("epoch", "session", "durable_write"):
+                self._mark(evidence, name)
+            return None
+
+        harness = None
+        archive_id = None
+        planner_session = None
+        try:
+            if unit is None:
+                row = con.execute(
+                    "SELECT session_id, created_at, harness FROM interface_sessions "
+                    "WHERE shell_id=? ORDER BY session_id DESC LIMIT 1",
+                    (shell_id,),
+                ).fetchone()
+                evidence.epoch = _timestamp(row["created_at"]) if row else None
+                harness = row["harness"] if row else None
+                planner_session = row["session_id"] if row else None
+            else:
+                row = con.execute(
+                    "SELECT archive_id, started_at, harness "
+                    "FROM shell_memory_archives "
+                    "WHERE shell_id=? AND started_at IS NOT NULL "
+                    "ORDER BY started_at DESC, archive_id DESC LIMIT 1",
+                    (shell_id,),
+                ).fetchone()
+                evidence.epoch = _timestamp(row["started_at"]) if row else None
+                harness = row["harness"] if row else None
+                archive_id = row["archive_id"] if row else None
+            if evidence.epoch is None:
+                self._mark(evidence, "epoch")
+        except sqlite3.Error:
+            self._mark(evidence, "epoch")
+
+        try:
+            if unit is None and planner_session is not None:
+                row = con.execute(
+                    "SELECT ended_at, end_reason, harness "
+                    "FROM interface_sessions WHERE session_id=?",
+                    (planner_session,),
+                ).fetchone()
+            elif archive_id is not None:
+                row = con.execute(
+                    "SELECT ended_at, end_reason, harness "
+                    "FROM interface_sessions WHERE shell_id=? AND archive_id=? "
+                    "ORDER BY session_id DESC LIMIT 1",
+                    (shell_id, archive_id),
+                ).fetchone()
+            else:
+                row = None
+            if row:
+                evidence.session_ended_at = _timestamp(row["ended_at"])
+                evidence.session_end_reason = row["end_reason"]
+                harness = harness or row["harness"]
+        except sqlite3.Error:
+            self._mark(evidence, "session")
+
+        if sprint_doc_id is not None:
+            try:
+                row = con.execute(
+                    "SELECT MAX(ts) FROM ("
+                    " SELECT created_at AS ts FROM shell_messages"
+                    "  WHERE from_shell_id=? AND sprint_doc_id=?"
+                    " UNION ALL"
+                    " SELECT updated_at AS ts FROM sprint_units"
+                    "  WHERE updated_by_shell_id=? AND sprint_doc_id=?"
+                    ")",
+                    (shell_id, sprint_doc_id, shell_id, sprint_doc_id),
+                ).fetchone()
+                evidence.last_durable_write_at = _timestamp(row[0] if row else None)
+            except sqlite3.Error:
+                self._mark(evidence, "durable_write")
+        con.close()
+        return harness
+
+    def _git(
+        self, worktree: Path, *args: str
+    ) -> subprocess.CompletedProcess[str]:
+        return self.run_command(
+            ["git", *args],
+            cwd=worktree,
+            text=True,
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+
+    def _branch_present(
+        self, evidence: Evidence, worktree: Path, branch: str
+    ) -> tuple[bool | None, bool]:
+        try:
+            head = self._git(worktree, "symbolic-ref", "--quiet", "--short", "HEAD")
+            on_head = head.returncode == 0 and head.stdout.strip() == branch
+            if on_head:
+                return True, True
+            remote = self._git(
+                worktree,
+                "ls-remote",
+                "--exit-code",
+                "origin",
+                f"refs/heads/{branch}",
+            )
+        except (OSError, subprocess.SubprocessError):
+            self._mark(evidence, "branch")
+            return None, False
+        if remote.returncode == 0:
+            return True, False
+        if remote.returncode == 2:
+            return False, False
+        self._mark(evidence, "branch")
+        return None, False
+
+    @staticmethod
+    def _status_entries(raw: str) -> list[tuple[str, str]]:
+        parts = raw.split("\0")
+        out: list[tuple[str, str]] = []
+        i = 0
+        while i < len(parts):
+            item = parts[i]
+            i += 1
+            if not item:
+                continue
+            code, path = item[:2], item[3:]
+            out.append((code, path))
+            if "R" in code or "C" in code:
+                i += 1  # porcelain -z follows a rename/copy with the old path
+        return out
+
+    def _git_inputs(
+        self, evidence: Evidence, worktree: Path, on_declared_head: bool
+    ) -> None:
+        if not evidence.edits_code:
+            return
+        epoch = evidence.epoch
+        branch = evidence.branch_declared
+        if branch is None:
+            return
+        try:
+            status = self._git(
+                worktree, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+            )
+        except (OSError, subprocess.SubprocessError):
+            self._mark(evidence, "git_state")
+            return
+        if status.returncode != 0:
+            self._mark(evidence, "git_state")
+            return
+
+        entries = self._status_entries(status.stdout)
+        evidence.dirty = bool(entries)
+        if epoch is None:
+            return
+        dirty_times: list[datetime] = []
+        for code, rel in entries:
+            if "U" in code or _boot_artifact(rel):
+                continue
+            if code != "??" and not any(c in "MADRC" for c in code):
+                continue
+            try:
+                changed_at = _mtime(worktree / rel)
+            except OSError:
+                continue
+            if changed_at >= epoch:
+                dirty_times.append(changed_at)
+
+        revision = "HEAD" if on_declared_head else f"refs/remotes/origin/{branch}"
+        try:
+            log = self._git(worktree, "log", revision, "--format=%aI")
+        except (OSError, subprocess.SubprocessError):
+            log = None
+        author_times: list[datetime] = []
+        if log is None or log.returncode != 0:
+            self._mark(evidence, "commits")
+        else:
+            for line in log.stdout.splitlines():
+                authored = _timestamp(line.strip())
+                if authored is not None and authored >= epoch:
+                    author_times.append(authored)
+            evidence.commits_since_epoch = len(author_times)
+
+        try:
+            files = self._git(
+                worktree,
+                "ls-files",
+                "-z",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+            )
+            if files.returncode != 0:
+                raise OSError(files.stderr)
+            mtimes = []
+            for rel in files.stdout.split("\0"):
+                if not rel:
+                    continue
+                try:
+                    mtimes.append(_mtime(worktree / rel))
+                except OSError:
+                    continue
+            evidence.newest_mtime = max(mtimes, default=None)
+        except (OSError, subprocess.SubprocessError):
+            self._mark(evidence, "newest_mtime")
+
+        work_times = dirty_times + author_times
+        evidence.last_work_at = max(work_times, default=None)
+
+    def _adapter_specs(self) -> dict[str, dict]:
+        specs = {}
+        for directory in self.adapters.iterdir():
+            path = directory / "adapter.json"
+            if not path.is_file():
+                continue
+            data = json.loads(path.read_text())
+            harness = data.get("harness")
+            if harness:
+                specs[harness] = data
+        return specs
+
+    @staticmethod
+    def _argv_prefix(argv: Sequence[str], wanted: Sequence[str]) -> bool:
+        if not argv or not wanted:
+            return False
+        actual = [Path(argv[0]).name, *argv[1:]]
+        expected = [Path(wanted[0]).name, *wanted[1:]]
+        return actual[: len(expected)] == expected
+
+    def _shape(self, argv: Sequence[str], spec: dict) -> str | None:
+        headless = spec.get("headless") or {}
+        hlaunch = headless.get("launch") or []
+        launch = spec.get("launch") or []
+        prompt_flag = headless.get("prompt_flag")
+        if self._argv_prefix(argv, hlaunch) and (
+            hlaunch != launch or not prompt_flag or prompt_flag in argv
+        ):
+            return "headless"
+        if prompt_flag and prompt_flag in argv and self._argv_prefix(argv, launch):
+            return "headless"
+        if self._argv_prefix(argv, launch):
+            return "interactive"
+        return None
+
+    @staticmethod
+    def _stat(path: Path) -> tuple[int, int, int, int]:
+        text = path.read_text()
+        rest = text[text.rindex(")") + 2 :].split()
+        return int(rest[1]), int(rest[11]), int(rest[12]), int(rest[19])
+
+    def _process_inputs(
+        self, evidence: Evidence, worktree: Path
+    ) -> str | None:
+        try:
+            specs = self._adapter_specs()
+        except (OSError, ValueError, json.JSONDecodeError):
+            self._mark(evidence, "process")
+            return None
+        if not self.proc.is_dir():
+            self._mark(evidence, "process")
+            return None
+
+        binaries: dict[str, str] = {}
+        for harness, spec in specs.items():
+            launches = [spec.get("launch") or [], (spec.get("headless") or {}).get("launch") or []]
+            for launch in launches:
+                if launch:
+                    binaries[Path(launch[0]).name[:15]] = harness
+            for alias in spec.get("comm_aliases") or []:
+                binaries[Path(alias).name[:15]] = harness
+
+        stats: dict[int, tuple[int, int, int, int]] = {}
+        matches: list[tuple[int, int, str, str, int]] = []
+        unreadable_harness = False
+        unmatched_target = False
+        for entry in self.proc.iterdir():
+            if not entry.name.isdigit():
+                continue
+            pid = int(entry.name)
+            try:
+                stats[pid] = self._stat(entry / "stat")
+                comm = (entry / "comm").read_text().strip()
+            except (OSError, ValueError, IndexError):
+                continue
+            harness = binaries.get(comm)
+            if harness is None:
+                continue
+            try:
+                cwd = Path(os.readlink(entry / "cwd")).resolve()
+                argv = [
+                    item.decode(errors="replace")
+                    for item in (entry / "cmdline").read_bytes().split(b"\0")
+                    if item
+                ]
+            except OSError:
+                unreadable_harness = True
+                continue
+            if cwd != worktree.resolve():
+                continue
+            shape = self._shape(argv, specs[harness])
+            if shape is None:
+                unmatched_target = True
+                continue
+            _ppid, utime, stime, start = stats[pid]
+            matches.append((pid, start, harness, shape, utime + stime))
+
+        if not matches:
+            if unmatched_target:
+                evidence.process_present = True
+                self._mark(evidence, "process_binding")
+                return None
+            if unreadable_harness:
+                self._mark(evidence, "process")
+                return None
+            evidence.process_present = False
+            return None
+        evidence.process_present = True
+        identities = {(m[2], m[3]) for m in matches}
+        if len(matches) != 1 or len(identities) != 1:
+            self._mark(evidence, "process_binding")
+            return None
+
+        root_pid, start, harness, shape, _root_ticks = matches[0]
+        evidence.launch_shape = shape
+        descendants = {root_pid}
+        changed = True
+        while changed:
+            changed = False
+            for pid, (ppid, _u, _s, _start) in stats.items():
+                if pid not in descendants and ppid in descendants:
+                    descendants.add(pid)
+                    changed = True
+        total = sum(stats[pid][1] + stats[pid][2] for pid in descendants)
+        key = tuple(sorted((pid, stats[pid][3]) for pid in descendants))
+        previous = self._cpu_samples.get(key)
+        self._cpu_samples[key] = total
+        if previous is not None:
+            evidence.cpu_delta = float(max(total - previous, 0))
+        return harness
+
+    def _claude_marker(
+        self, worktree: Path, epoch: datetime
+    ) -> datetime | None:
+        root = Path(
+            os.environ.get("CLAUDE_CONFIG_DIR") or self.home / ".claude"
+        ) / "projects"
+        encoded = "".join(c if c.isalnum() else "-" for c in str(worktree))
+        main = root / encoded
+        containers = [main] if main.is_dir() else []
+        if root.is_dir():
+            containers.extend(
+                p
+                for p in root.iterdir()
+                if p.is_dir()
+                and p.name.startswith("-tmp-claude-")
+                and encoded in p.name
+                and p.name.endswith("-scratchpad")
+            )
+        if not containers:
+            return None
+        mtimes = []
+        for container in containers:
+            for path in container.glob("*.jsonl"):
+                stamp = _mtime(path)
+                if stamp >= epoch:
+                    mtimes.append(stamp)
+        return max(mtimes, default=None)
+
+    @staticmethod
+    def _last_turn_cwd(path: Path) -> str | None:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for line in reversed(lines):
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(record, dict) or record.get("type") != "turn_context":
+                continue
+            return (record.get("payload") or {}).get("cwd")
+        return None
+
+    def _codex_marker(
+        self, worktree: Path, epoch: datetime, now: datetime
+    ) -> datetime | None:
+        root = Path(os.environ.get("CODEX_HOME") or self.home / ".codex") / "sessions"
+        cutoff = max(epoch, now - CODEX_CANDIDATE_WINDOW)
+        hits = []
+        for path in root.glob("*/*/*/rollout-*.jsonl"):
+            stamp = _mtime(path)
+            if stamp < cutoff:
+                continue
+            if self._last_turn_cwd(path) == str(worktree):
+                hits.append(stamp)
+        return hits[0] if len(hits) == 1 else None
+
+    def _kimi_marker(
+        self, worktree: Path, epoch: datetime
+    ) -> datetime | None:
+        root = self.home / ".kimi-code" / "sessions"
+        hits = []
+        for session in root.glob("wd_*/session_*"):
+            state = json.loads(
+                (session / "state.json").read_text(
+                    encoding="utf-8", errors="replace"
+                )
+            )
+            if not isinstance(state, dict) or state.get("workDir") != str(worktree):
+                continue
+            stamp = _mtime(session / "agents" / "main" / "wire.jsonl")
+            if stamp >= epoch:
+                hits.append(stamp)
+        return hits[0] if len(hits) == 1 else None
+
+    def _opencode_marker(
+        self, worktree: Path, epoch: datetime
+    ) -> datetime | None:
+        base = Path(os.environ.get("XDG_DATA_HOME") or self.home / ".local/share")
+        path = base / "opencode" / "opencode.db"
+        con = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=2)
+        try:
+            rows = con.execute(
+                "SELECT time_updated FROM session WHERE directory=? "
+                "AND time_updated>=?",
+                (str(worktree), int(epoch.timestamp() * 1000)),
+            ).fetchall()
+        finally:
+            con.close()
+        if len(rows) != 1:
+            return None
+        return datetime.fromtimestamp(rows[0][0] / 1000, tz=timezone.utc)
+
+    def _marker_input(
+        self,
+        evidence: Evidence,
+        harness: str | None,
+        worktree: Path,
+        now: datetime,
+    ) -> None:
+        if harness == "vibe":
+            return
+        if harness is None or evidence.epoch is None:
+            self._mark(evidence, "marker")
+            return
+        try:
+            if harness == "claude":
+                marker = self._claude_marker(worktree, evidence.epoch)
+            elif harness == "codex":
+                marker = self._codex_marker(worktree, evidence.epoch, now)
+            elif harness == "kimi":
+                marker = self._kimi_marker(worktree, evidence.epoch)
+            elif harness == "opencode":
+                marker = self._opencode_marker(worktree, evidence.epoch)
+            else:
+                marker = None
+        except (OSError, ValueError, json.JSONDecodeError, sqlite3.Error):
+            marker = None
+        evidence.marker_at = marker
+        if marker is None:
+            self._mark(evidence, "marker")
+
+    def read(self, shell: Any, unit: Any, now: Any) -> Evidence:
+        """Return all readable observations; never classify and never raise."""
+        evidence = Evidence()
+        evidence.branch_declared = _value(unit, "branch")
+        evidence.edits_code = (
+            unit is not None and evidence.branch_declared is not None
+        )
+        current = _timestamp(now) or datetime.now(timezone.utc)
+        worktree = self._worktree(shell)
+
+        try:
+            self._database_inputs(evidence, shell, unit)
+        except Exception:  # noqa: BLE001 — complete value, never an escape
+            for name in ("epoch", "session", "durable_write"):
+                self._mark(evidence, name)
+
+        on_declared_head = False
+        if evidence.branch_declared is not None:
+            try:
+                present, on_declared_head = self._branch_present(
+                    evidence, worktree, evidence.branch_declared
+                )
+                evidence.branch_present = present
+            except Exception:  # noqa: BLE001 — one unreadable field, not an escape
+                self._mark(evidence, "branch")
+
+        try:
+            self._git_inputs(evidence, worktree, on_declared_head)
+        except Exception:  # noqa: BLE001 — one unreadable field, not an escape
+            self._mark(evidence, "git_state")
+
+        try:
+            process_harness = self._process_inputs(evidence, worktree)
+        except Exception:  # noqa: BLE001 — one unreadable field, not an escape
+            process_harness = None
+            self._mark(evidence, "process")
+
+        # A marker is current-session evidence only when argv bound the live
+        # harness process.  A DB row can corroborate the name, but must never
+        # resurrect a stale transcript after the process has gone.
+        marker_harness = process_harness if evidence.process_present else None
+        self._marker_input(evidence, marker_harness, worktree, current)
+        evidence.unreadable.sort()
+        return evidence
+
+
+_DEFAULT_READER = ActivityReader()
+
+
+def read(shell: Any, unit: Any, now: Any) -> Evidence:
+    """Module contract: ``read(shell, unit, now) -> Evidence``."""
+    return _DEFAULT_READER.read(shell, unit, now)

--- a/.super-coder/scripts/activity_readers.py
+++ b/.super-coder/scripts/activity_readers.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sqlite3
 import subprocess
 from collections.abc import Mapping, Sequence
@@ -36,6 +37,23 @@ BOOT_ARTIFACTS = {
     ".claude/settings.local.json",
     ".codex/hooks.json",
 }
+UNREADABLE_FIELDS = {
+    "branch": frozenset({"branch_present"}),
+    "commits": frozenset({"commits_since_epoch", "last_work_at"}),
+    "durable_write": frozenset({"last_durable_write_at"}),
+    "epoch": frozenset({"epoch"}),
+    "git_state": frozenset(
+        {"dirty", "commits_since_epoch", "last_work_at"}
+    ),
+    "marker": frozenset({"marker_at"}),
+    "newest_mtime": frozenset({"newest_mtime"}),
+    "process": frozenset({"process_present", "launch_shape", "cpu_delta"}),
+    "process_binding": frozenset({"launch_shape", "cpu_delta"}),
+    "result_row": frozenset({"last_result_row_at"}),
+    "session": frozenset({"session_ended_at", "session_end_reason"}),
+    "state_changed_at": frozenset({"state_changed_at"}),
+    UNTIMED_DELETE_RENAME: frozenset({"last_work_at"}),
+}
 
 
 @dataclass
@@ -44,6 +62,8 @@ class Evidence:
     dirty: bool | None = None
     commits_since_epoch: int | None = None
     last_durable_write_at: datetime | None = None
+    last_result_row_at: datetime | None = None
+    state_changed_at: datetime | None = None
     session_ended_at: datetime | None = None
     session_end_reason: str | None = None
     newest_mtime: datetime | None = None
@@ -141,13 +161,25 @@ class ActivityReader:
             )
             con.row_factory = sqlite3.Row
         except (OSError, sqlite3.Error):
-            for name in ("epoch", "session", "durable_write"):
+            for name in ("epoch", "session", "durable_write", "result_row"):
                 self._mark(evidence, name)
             return None
 
         harness = None
         archive_id = None
         planner_session = None
+        if unit is None:
+            try:
+                row = con.execute(
+                    "SELECT sprint_doc_id FROM sprint_planner_bindings "
+                    "WHERE planner_shell_id=? ORDER BY binding_id DESC LIMIT 1",
+                    (shell_id,),
+                ).fetchone()
+                sprint_doc_id = row["sprint_doc_id"] if row else None
+            except sqlite3.Error:
+                self._mark(evidence, "durable_write")
+                self._mark(evidence, "result_row")
+
         try:
             if unit is None:
                 row = con.execute(
@@ -212,8 +244,45 @@ class ActivityReader:
                 evidence.last_durable_write_at = _timestamp(row[0] if row else None)
             except sqlite3.Error:
                 self._mark(evidence, "durable_write")
+
+            try:
+                rows = con.execute(
+                    "SELECT body, created_at FROM shell_messages "
+                    "WHERE from_shell_id=? AND sprint_doc_id=? AND kind='result' "
+                    "ORDER BY created_at DESC, message_id DESC",
+                    (shell_id, sprint_doc_id),
+                ).fetchall()
+                if unit is not None:
+                    active_count = con.execute(
+                        "SELECT COUNT(*) FROM sprint_units "
+                        "WHERE sprint_doc_id=? "
+                        "AND (dev_shell_id=? OR reviewer_shell_id=?) "
+                        "AND state NOT IN ('merged','cancelled')",
+                        (sprint_doc_id, shell_id, shell_id),
+                    ).fetchone()[0]
+                    if active_count != 1:
+                        seq = str(_value(unit, "seq", ""))
+                        rows = [
+                            row
+                            for row in rows
+                            if self._names_unit(row["body"], seq)
+                        ]
+                evidence.last_result_row_at = _timestamp(
+                    rows[0]["created_at"] if rows else None
+                )
+            except sqlite3.Error:
+                self._mark(evidence, "result_row")
         con.close()
         return harness
+
+    @staticmethod
+    def _names_unit(body: str, seq: str) -> bool:
+        if not seq:
+            return False
+        return re.search(
+            rf"(?<![A-Za-z0-9_]){re.escape(seq)}(?![A-Za-z0-9_])",
+            body or "",
+        ) is not None
 
     def _git(
         self, worktree: Path, *args: str
@@ -316,7 +385,16 @@ class ActivityReader:
 
         revision = "HEAD" if on_declared_head else f"refs/remotes/origin/{branch}"
         try:
-            log = self._git(worktree, "log", revision, "--format=%aI")
+            merge_base = self._git(
+                worktree,
+                "merge-base",
+                "refs/remotes/origin/main",
+                revision,
+            )
+            if merge_base.returncode != 0 or not merge_base.stdout.strip():
+                raise OSError(merge_base.stderr)
+            contribution = f"{merge_base.stdout.strip()}..{revision}"
+            log = self._git(worktree, "log", contribution, "--format=%aI")
         except (OSError, subprocess.SubprocessError):
             log = None
         author_times: list[datetime] = []
@@ -613,13 +691,19 @@ class ActivityReader:
         evidence.edits_code = (
             unit is not None and evidence.branch_declared is not None
         )
+        if unit is not None:
+            evidence.state_changed_at = _timestamp(
+                _value(unit, "state_changed_at")
+            )
+            if evidence.state_changed_at is None:
+                self._mark(evidence, "state_changed_at")
         current = _timestamp(now) or datetime.now(timezone.utc)
         worktree = self._worktree(shell)
 
         try:
             self._database_inputs(evidence, shell, unit)
         except Exception:  # noqa: BLE001 — complete value, never an escape
-            for name in ("epoch", "session", "durable_write"):
+            for name in ("epoch", "session", "durable_write", "result_row"):
                 self._mark(evidence, name)
 
         on_declared_head = False

--- a/.super-coder/scripts/activity_readers.py
+++ b/.super-coder/scripts/activity_readers.py
@@ -31,6 +31,7 @@ PROC = Path("/proc")
 
 CODEX_CANDIDATE_WINDOW = timedelta(minutes=60)
 UNTIMED_DELETE_RENAME = "last_work_at:untimed_delete_rename"
+AMBIGUOUS_PLANNER_BINDING = "planner_binding:ambiguous"
 BOOT_ARTIFACTS = {
     "CLAUDE.md",
     "AGENTS.md",
@@ -49,6 +50,13 @@ UNREADABLE_FIELDS = {
     "newest_mtime": frozenset({"newest_mtime"}),
     "process": frozenset({"process_present", "launch_shape", "cpu_delta"}),
     "process_binding": frozenset({"launch_shape", "cpu_delta"}),
+    AMBIGUOUS_PLANNER_BINDING: frozenset(
+        {
+            "last_durable_write_at",
+            "last_result_row_at",
+            "state_changed_at",
+        }
+    ),
     "result_row": frozenset({"last_result_row_at"}),
     "session": frozenset({"session_ended_at", "session_end_reason"}),
     "state_changed_at": frozenset({"state_changed_at"}),
@@ -195,6 +203,8 @@ class ActivityReader:
                         self._mark(evidence, "state_changed_at")
                 else:
                     sprint_doc_id = None
+                    if len(rows) > 1:
+                        self._mark(evidence, AMBIGUOUS_PLANNER_BINDING)
                     for name in (
                         "durable_write",
                         "result_row",
@@ -606,9 +616,10 @@ class ActivityReader:
                 p
                 for p in root.iterdir()
                 if p.is_dir()
-                and p.name.startswith("-tmp-claude-")
-                and encoded in p.name
-                and p.name.endswith("-scratchpad")
+                and re.fullmatch(
+                    rf"-tmp-claude-\d+-{re.escape(encoded)}-[^-].*-scratchpad",
+                    p.name,
+                )
             )
         if not containers:
             return None

--- a/tests/test_activity_readers.py
+++ b/tests/test_activity_readers.py
@@ -450,6 +450,9 @@ class DatabaseContractTest(ReaderCase):
                     {"durable_write", "result_row", "state_changed_at"}
                     <= set(evidence.unreadable)
                 )
+                self.assertNotIn(
+                    ar.AMBIGUOUS_PLANNER_BINDING, evidence.unreadable
+                )
 
     def test_rowless_shell_does_not_collapse_two_live_sprints(self):
         con = sqlite3.connect(self.db)
@@ -477,6 +480,7 @@ class DatabaseContractTest(ReaderCase):
             {"durable_write", "result_row", "state_changed_at"}
             <= set(evidence.unreadable)
         )
+        self.assertIn(ar.AMBIGUOUS_PLANNER_BINDING, evidence.unreadable)
 
     def test_each_unreadable_input_is_nullable_and_read_never_raises(self):
         broken = ar.ActivityReader(
@@ -532,6 +536,13 @@ class DatabaseContractTest(ReaderCase):
                 ),
                 "process_binding": frozenset(
                     {"launch_shape", "cpu_delta"}
+                ),
+                "planner_binding:ambiguous": frozenset(
+                    {
+                        "last_durable_write_at",
+                        "last_result_row_at",
+                        "state_changed_at",
+                    }
                 ),
                 "result_row": frozenset({"last_result_row_at"}),
                 "session": frozenset(
@@ -1057,7 +1068,10 @@ class HarnessMarkerTest(ReaderCase):
         main = projects / expected_container
         scratch = (
             projects
-            / f"-tmp-claude-0-{expected_container}-session-scratchpad"
+            / (
+                f"-tmp-claude-0-{expected_container}-"
+                "a925d37b-9782-4674-9922-af0b7452ec3f-scratchpad"
+            )
         )
         foreign = projects / "-tmp-claude-0--foreign-session-scratchpad"
         for path in (main, scratch, foreign):
@@ -1075,6 +1089,29 @@ class HarnessMarkerTest(ReaderCase):
             datetime(2020, 1, 3, tzinfo=UTC),
             self.reader._claude_marker(dotted_worktree, EPOCH),
         )
+
+    def test_claude_root_worktree_rejects_nested_worker_scratchpad(self):
+        fixture_root = Path("/tmp") / f"scactivity-root{os.getpid()}"
+        self.addCleanup(shutil.rmtree, fixture_root, True)
+        projects = self.home / ".claude/projects"
+        root_encoded = "".join(
+            c if c.isalnum() else "-" for c in str(fixture_root)
+        )
+        worker_encoded = "".join(
+            c if c.isalnum() else "-"
+            for c in str(fixture_root / ".sc-worktrees" / "pln2")
+        )
+        (projects / root_encoded).mkdir(parents=True)
+        foreign = projects / (
+            f"-tmp-claude-0-{worker_encoded}-"
+            "a925d37b-9782-4674-9922-af0b7452ec3f-scratchpad"
+        )
+        foreign.mkdir()
+        transcript = foreign / "foreign.jsonl"
+        transcript.write_text("{}\n")
+        stamp(transcript, datetime(2020, 1, 9, tzinfo=UTC))
+
+        self.assertIsNone(self.reader._claude_marker(fixture_root, EPOCH))
 
     def _rollout(self, name: str, records: list[dict], when: datetime) -> Path:
         directory = self.home / ".codex/sessions/2019/01/01"

--- a/tests/test_activity_readers.py
+++ b/tests/test_activity_readers.py
@@ -303,6 +303,41 @@ class GitEvidenceTest(ReaderCase):
         self.assertEqual(0, evidence.commits_since_epoch)
         self.assertIsNone(evidence.last_work_at)
 
+    def test_staged_delete_is_dirty_but_untimed(self):
+        (self.worktree / "base.txt").unlink()
+        command(self.worktree, "git", "add", "-u")
+
+        evidence = self.read()
+
+        self.assertTrue(evidence.dirty)
+        self.assertEqual(0, evidence.commits_since_epoch)
+        self.assertIsNone(evidence.last_work_at)
+        self.assertIn(ar.UNTIMED_DELETE_RENAME, evidence.unreadable)
+
+    def test_staged_rename_with_pre_epoch_mtime_is_dirty_but_untimed(self):
+        old = datetime(2019, 12, 31, 23, 59, tzinfo=UTC)
+        stamp(self.worktree / "base.txt", old)
+        command(self.worktree, "git", "mv", "base.txt", "renamed.txt")
+
+        evidence = self.read()
+
+        self.assertTrue(evidence.dirty)
+        self.assertEqual(0, evidence.commits_since_epoch)
+        self.assertIsNone(evidence.last_work_at)
+        self.assertIn(ar.UNTIMED_DELETE_RENAME, evidence.unreadable)
+
+    def test_staged_rename_with_current_epoch_mtime_is_work(self):
+        command(self.worktree, "git", "mv", "base.txt", "renamed.txt")
+        renamed_at = datetime(2020, 1, 3, tzinfo=UTC)
+        stamp(self.worktree / "renamed.txt", renamed_at)
+
+        evidence = self.read()
+
+        self.assertTrue(evidence.dirty)
+        self.assertEqual(0, evidence.commits_since_epoch)
+        self.assertEqual(renamed_at, evidence.last_work_at)
+        self.assertNotIn(ar.UNTIMED_DELETE_RENAME, evidence.unreadable)
+
     def test_author_date_counts_and_rebase_committer_date_does_not(self):
         old_author = self.worktree / "old-author.py"
         old_author.write_text("old\n")

--- a/tests/test_activity_readers.py
+++ b/tests/test_activity_readers.py
@@ -1,0 +1,636 @@
+"""Evidence-reader proofs for spec 58, sprint 59 U3.
+
+The tests stay below classification: they pin observations, nullable failure
+isolation, epoch boundaries, true-route session selection, and CPU sampling.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import activity_readers as ar
+
+UTC = timezone.utc
+EPOCH = datetime(2020, 1, 1, tzinfo=UTC)
+
+
+def stamp(path: Path, when: datetime) -> None:
+    seconds = when.timestamp()
+    os.utime(path, (seconds, seconds))
+
+
+def command(cwd: Path, *args: str, env=None, check=True):
+    merged = os.environ.copy()
+    merged.update(env or {})
+    return subprocess.run(
+        args, cwd=cwd, env=merged, text=True, capture_output=True, check=check
+    )
+
+
+def make_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(
+        """
+        CREATE TABLE shell_memory_archives (
+          archive_id INTEGER PRIMARY KEY, shell_id INTEGER, started_at TEXT,
+          harness TEXT
+        );
+        CREATE TABLE interface_sessions (
+          session_id INTEGER PRIMARY KEY, shell_id INTEGER, archive_id INTEGER,
+          created_at TEXT, ended_at TEXT, end_reason TEXT, harness TEXT
+        );
+        CREATE TABLE shell_messages (
+          message_id INTEGER PRIMARY KEY, from_shell_id INTEGER,
+          sprint_doc_id INTEGER, created_at TEXT
+        );
+        CREATE TABLE sprint_units (
+          unit_id INTEGER PRIMARY KEY, sprint_doc_id INTEGER, seq TEXT,
+          branch TEXT, updated_at TEXT, updated_by_shell_id INTEGER
+        );
+        CREATE TABLE spec_tasks (
+          task_id INTEGER PRIMARY KEY, status TEXT
+        );
+        """
+    )
+    con.execute(
+        "INSERT INTO shell_memory_archives VALUES (10,1,?,'codex')",
+        ("2020-01-01T00:00:00Z",),
+    )
+    # A stale ended Interface session must not describe the current headless
+    # archive.  The current archive has no Interface row at all.
+    con.execute(
+        "INSERT INTO interface_sessions VALUES "
+        "(8,1,9,'2019-12-01T00:00:00Z','2019-12-01T00:01:00Z',"
+        "'operator_end','codex')"
+    )
+    con.execute(
+        "INSERT INTO shell_messages VALUES "
+        "(1,1,59,'2020-01-02T00:00:00Z')"
+    )
+    con.execute(
+        "INSERT INTO sprint_units VALUES "
+        "(1,59,'U3','feat/test','2020-01-03T00:00:00Z',1)"
+    )
+    con.commit()
+    con.close()
+
+
+def make_adapters(path: Path) -> None:
+    specs = {
+        "claude": {
+            "harness": "claude",
+            "launch": ["claude"],
+            "headless": {"launch": ["claude"], "prompt_flag": "-p"},
+        },
+        "codex": {
+            "harness": "codex",
+            "launch": ["codex"],
+            "headless": {"launch": ["codex", "exec"]},
+        },
+        "kimi": {
+            "harness": "kimi",
+            "launch": ["kimi"],
+            "comm_aliases": ["kimi-code"],
+            "headless": {"launch": ["kimi"], "prompt_flag": "-p"},
+        },
+        "opencode": {
+            "harness": "opencode",
+            "launch": ["opencode"],
+            "headless": {"launch": ["opencode", "run"]},
+        },
+    }
+    for harness, spec in specs.items():
+        directory = path / harness
+        directory.mkdir(parents=True)
+        (directory / "adapter.json").write_text(json.dumps(spec))
+
+
+def proc_row(
+    root: Path,
+    pid: int,
+    *,
+    comm: str,
+    cwd: Path,
+    argv: list[str],
+    ppid: int = 1,
+    utime: int = 1,
+    stime: int = 1,
+    start: int = 100,
+) -> None:
+    directory = root / str(pid)
+    directory.mkdir(parents=True, exist_ok=True)
+    fields = ["S", str(ppid), *("0" for _ in range(18))]
+    fields[11], fields[12], fields[19] = str(utime), str(stime), str(start)
+    (directory / "stat").write_text(f"{pid} ({comm}) {' '.join(fields)}")
+    (directory / "comm").write_text(f"{comm}\n")
+    (directory / "cmdline").write_bytes(b"\0".join(a.encode() for a in argv) + b"\0")
+    (directory / "cwd").unlink(missing_ok=True)
+    (directory / "cwd").symlink_to(cwd)
+
+
+class ReaderCase(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.worktree = self.root / "worktree"
+        self.worktree.mkdir()
+        command(self.worktree, "git", "init", "-b", "feat/test")
+        command(self.worktree, "git", "config", "user.email", "reader@test")
+        command(self.worktree, "git", "config", "user.name", "Reader")
+        (self.worktree / "base.txt").write_text("base\n")
+        command(self.worktree, "git", "add", "base.txt")
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-m",
+            "base",
+            env={
+                "GIT_AUTHOR_DATE": "2019-01-01T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2019-01-01T00:00:00+00:00",
+            },
+        )
+        self.db = self.root / "shell.db"
+        make_db(self.db)
+        self.proc = self.root / "proc"
+        self.proc.mkdir()
+        self.adapters = self.root / "adapters"
+        make_adapters(self.adapters)
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self.reader = ar.ActivityReader(
+            db_path=self.db,
+            repo_root=self.root,
+            proc=self.proc,
+            adapters=self.adapters,
+            home=self.home,
+        )
+        self.shell = {
+            "shell_id": 1,
+            "shortname": "DEV1",
+            "flavor": "dev",
+            "worktree": str(self.worktree),
+        }
+        self.unit = {
+            "sprint_doc_id": 59,
+            "seq": "U3",
+            "branch": "feat/test",
+        }
+
+    def read(self):
+        return self.reader.read(self.shell, self.unit, datetime(2020, 1, 10, tzinfo=UTC))
+
+
+class DatabaseContractTest(ReaderCase):
+    def test_epoch_session_identity_and_durable_lower_bound(self):
+        evidence = self.read()
+        self.assertEqual(EPOCH, evidence.epoch)
+        self.assertIsNone(evidence.session_ended_at)
+        self.assertIsNone(evidence.session_end_reason)
+        self.assertEqual(
+            datetime(2020, 1, 3, tzinfo=UTC), evidence.last_durable_write_at
+        )
+        self.assertTrue(evidence.edits_code)
+        self.assertEqual("feat/test", evidence.branch_declared)
+
+    def test_doc_unit_and_rowless_shell_never_claim_code_work(self):
+        doc = dict(self.unit, branch=None)
+        evidence = self.reader.read(self.shell, doc, datetime(2020, 1, 10, tzinfo=UTC))
+        self.assertFalse(evidence.edits_code)
+        self.assertIsNone(evidence.branch_present)
+        self.assertIsNone(evidence.dirty)
+        self.assertIsNone(evidence.commits_since_epoch)
+        self.assertIsNone(evidence.last_work_at)
+
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO interface_sessions VALUES "
+            "(9,1,NULL,'2020-01-05T00:00:00Z',NULL,NULL,'codex')"
+        )
+        con.commit()
+        con.close()
+        rowless = self.reader.read(
+            self.shell, None, datetime(2020, 1, 10, tzinfo=UTC)
+        )
+        self.assertFalse(rowless.edits_code)
+        self.assertEqual(datetime(2020, 1, 5, tzinfo=UTC), rowless.epoch)
+        self.assertIsNone(rowless.branch_declared)
+
+    def test_each_unreadable_input_is_nullable_and_read_never_raises(self):
+        broken = ar.ActivityReader(
+            db_path=self.root / "missing.db",
+            repo_root=self.root,
+            proc=self.root / "missing-proc",
+            adapters=self.root / "missing-adapters",
+            home=self.home,
+        )
+        evidence = broken.read(
+            dict(self.shell, worktree=str(self.root / "missing-worktree")),
+            self.unit,
+            datetime(2020, 1, 10, tzinfo=UTC),
+        )
+        self.assertIsInstance(evidence, ar.Evidence)
+        self.assertIsNone(evidence.epoch)
+        self.assertIsNone(evidence.branch_present)
+        self.assertIsNone(evidence.process_present)
+        self.assertIsNone(evidence.marker_at)
+        self.assertEqual(
+            ["branch", "durable_write", "epoch", "git_state", "marker", "process", "session"],
+            evidence.unreadable,
+        )
+
+
+class GitEvidenceTest(ReaderCase):
+    def test_ledger_done_over_five_dirty_files_is_still_work(self):
+        con = sqlite3.connect(self.db)
+        con.executemany(
+            "INSERT INTO spec_tasks(task_id,status) VALUES (?,'done')",
+            [(n,) for n in range(1, 7)],
+        )
+        con.commit()
+        con.close()
+        newest = None
+        for n in range(5):
+            path = self.worktree / f"dirty-{n}.py"
+            path.write_text(f"{n}\n")
+            newest = datetime(2020, 1, 2, 0, 0, n, tzinfo=UTC)
+            stamp(path, newest)
+
+        evidence = self.read()
+        self.assertTrue(evidence.dirty)
+        self.assertEqual(0, evidence.commits_since_epoch)
+        self.assertEqual(newest, evidence.last_work_at)
+
+    def test_boot_artifact_churn_is_not_work_with_positive_control(self):
+        artifacts = [
+            self.worktree / "CLAUDE.md",
+            self.worktree / "AGENTS.md",
+            self.worktree / ".claude/settings.local.json",
+            self.worktree / ".claude/skills/x/SKILL.md",
+            self.worktree / ".codex/hooks.json",
+        ]
+        for path in artifacts:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("boot\n")
+            stamp(path, datetime(2020, 1, 2, tzinfo=UTC))
+        evidence = self.read()
+        self.assertTrue(evidence.dirty)
+        self.assertIsNone(evidence.last_work_at)
+
+        source = self.worktree / "source.py"
+        source.write_text("work\n")
+        worked = datetime(2020, 1, 3, tzinfo=UTC)
+        stamp(source, worked)
+        self.assertEqual(worked, self.read().last_work_at)
+
+    def test_dirty_path_from_previous_generation_is_not_current_work(self):
+        stale = self.worktree / "stale.py"
+        stale.write_text("left by the previous launch\n")
+        stamp(stale, datetime(2019, 12, 31, 23, 59, tzinfo=UTC))
+        evidence = self.read()
+        self.assertTrue(evidence.dirty)
+        self.assertEqual(0, evidence.commits_since_epoch)
+        self.assertIsNone(evidence.last_work_at)
+
+    def test_author_date_counts_and_rebase_committer_date_does_not(self):
+        old_author = self.worktree / "old-author.py"
+        old_author.write_text("old\n")
+        command(self.worktree, "git", "add", old_author.name)
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-m",
+            "old author new committer",
+            env={
+                "GIT_AUTHOR_DATE": "2019-06-01T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2020-06-01T00:00:00+00:00",
+            },
+        )
+        self.assertEqual(0, self.read().commits_since_epoch)
+
+        new_author = self.worktree / "new-author.py"
+        new_author.write_text("new\n")
+        command(self.worktree, "git", "add", new_author.name)
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-m",
+            "new author",
+            env={
+                "GIT_AUTHOR_DATE": "2020-02-01T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2020-03-01T00:00:00+00:00",
+            },
+        )
+        evidence = self.read()
+        self.assertEqual(1, evidence.commits_since_epoch)
+        self.assertEqual(datetime(2020, 2, 1, tzinfo=UTC), evidence.last_work_at)
+
+    def test_conflicted_path_is_dirty_but_not_a_work_event(self):
+        path = self.worktree / "conflict.txt"
+        path.write_text("base\n")
+        command(self.worktree, "git", "add", path.name)
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-m",
+            "conflict base",
+            env={
+                "GIT_AUTHOR_DATE": "2019-01-02T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2019-01-02T00:00:00+00:00",
+            },
+        )
+        command(self.worktree, "git", "checkout", "-b", "other")
+        path.write_text("other\n")
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-am",
+            "other",
+            env={
+                "GIT_AUTHOR_DATE": "2019-01-03T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2019-01-03T00:00:00+00:00",
+            },
+        )
+        command(self.worktree, "git", "checkout", "feat/test")
+        path.write_text("ours\n")
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-am",
+            "ours",
+            env={
+                "GIT_AUTHOR_DATE": "2019-01-04T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2019-01-04T00:00:00+00:00",
+            },
+        )
+        command(self.worktree, "git", "merge", "other", check=False)
+        stamp(path, datetime(2020, 1, 4, tzinfo=UTC))
+
+        evidence = self.read()
+        self.assertTrue(evidence.dirty)
+        self.assertEqual(0, evidence.commits_since_epoch)
+        self.assertIsNone(evidence.last_work_at)
+
+    def test_branch_reads_head_then_origin_never_a_local_ref(self):
+        calls = []
+
+        def fake(args, **kwargs):
+            calls.append(args)
+            if "symbolic-ref" in args:
+                return subprocess.CompletedProcess(args, 0, "other\n", "")
+            return subprocess.CompletedProcess(args, 0, "abc\trefs/heads/feat/test\n", "")
+
+        reader = ar.ActivityReader(
+            db_path=self.db,
+            repo_root=self.root,
+            proc=self.proc,
+            adapters=self.adapters,
+            home=self.home,
+            run=fake,
+        )
+        evidence = ar.Evidence()
+        present, on_head = reader._branch_present(
+            evidence, self.worktree, "feat/test"
+        )
+        self.assertTrue(present)
+        self.assertFalse(on_head)
+        self.assertEqual("ls-remote", calls[1][1])
+        self.assertNotIn("show-ref", " ".join(calls[1]))
+
+        def absent(args, **kwargs):
+            if "symbolic-ref" in args:
+                return subprocess.CompletedProcess(args, 0, "other\n", "")
+            return subprocess.CompletedProcess(args, 2, "", "")
+
+        reader.run_command = absent
+        self.assertEqual(
+            (False, False),
+            reader._branch_present(ar.Evidence(), self.worktree, "missing"),
+        )
+
+
+class ProcessReaderTest(ReaderCase):
+    def test_argv_shape_rowless_and_whole_tree_cpu_delta(self):
+        proc_row(
+            self.proc,
+            100,
+            comm="codex",
+            cwd=self.worktree,
+            argv=["codex", "exec", "-m", "gpt-5.6-sol"],
+            utime=10,
+            stime=5,
+            start=111,
+        )
+        proc_row(
+            self.proc,
+            101,
+            comm="python",
+            cwd=self.worktree,
+            argv=["python", "helper.py"],
+            ppid=100,
+            utime=4,
+            stime=1,
+            start=222,
+        )
+        first = ar.Evidence()
+        self.assertEqual("codex", self.reader._process_inputs(first, self.worktree))
+        self.assertTrue(first.process_present)
+        self.assertEqual("headless", first.launch_shape)
+        self.assertIsNone(first.cpu_delta)
+
+        proc_row(
+            self.proc,
+            100,
+            comm="codex",
+            cwd=self.worktree,
+            argv=["codex", "exec"],
+            utime=14,
+            stime=6,
+            start=111,
+        )
+        proc_row(
+            self.proc,
+            101,
+            comm="python",
+            cwd=self.worktree,
+            argv=["python", "helper.py"],
+            ppid=100,
+            utime=8,
+            stime=2,
+            start=222,
+        )
+        second = ar.Evidence()
+        self.reader._process_inputs(second, self.worktree)
+        self.assertEqual(10.0, second.cpu_delta)
+
+        # No unit row is needed to resolve launch shape from argv.
+        rowless = self.reader.read(
+            self.shell, None, datetime(2020, 1, 10, tzinfo=UTC)
+        )
+        self.assertEqual("headless", rowless.launch_shape)
+        self.assertTrue(rowless.process_present)
+
+    def test_same_binary_uses_prompt_flag_to_separate_claude_shapes(self):
+        spec = json.loads(
+            (self.adapters / "claude" / "adapter.json").read_text()
+        )
+        self.assertEqual("interactive", self.reader._shape(["claude"], spec))
+        self.assertEqual(
+            "headless", self.reader._shape(["claude", "-p", "task"], spec)
+        )
+
+    def test_absent_process_is_false_but_unreadable_proc_is_none(self):
+        evidence = ar.Evidence()
+        self.assertIsNone(self.reader._process_inputs(evidence, self.worktree))
+        self.assertFalse(evidence.process_present)
+
+        broken = ar.ActivityReader(
+            db_path=self.db,
+            repo_root=self.root,
+            proc=self.root / "absent",
+            adapters=self.adapters,
+            home=self.home,
+        )
+        unknown = ar.Evidence()
+        broken._process_inputs(unknown, self.worktree)
+        self.assertIsNone(unknown.process_present)
+        self.assertEqual(["process"], unknown.unreadable)
+
+
+class HarnessMarkerTest(ReaderCase):
+    def test_claude_uses_dot_encoding_and_aggregates_own_scratchpad(self):
+        projects = self.home / ".claude/projects"
+        encoded = "".join(
+            c if c.isalnum() else "-" for c in str(self.worktree)
+        )
+        main = projects / encoded
+        scratch = projects / f"-tmp-claude-0-{encoded}-session-scratchpad"
+        foreign = projects / "-tmp-claude-0--foreign-session-scratchpad"
+        for path in (main, scratch, foreign):
+            path.mkdir(parents=True)
+        main_log = main / "main.jsonl"
+        scratch_log = scratch / "sub.jsonl"
+        foreign_log = foreign / "other.jsonl"
+        for path in (main_log, scratch_log, foreign_log):
+            path.write_text("{}\n")
+        stamp(main_log, datetime(2020, 1, 2, tzinfo=UTC))
+        stamp(scratch_log, datetime(2020, 1, 3, tzinfo=UTC))
+        stamp(foreign_log, datetime(2020, 1, 4, tzinfo=UTC))
+
+        self.assertNotIn(".", encoded)
+        self.assertEqual(
+            datetime(2020, 1, 3, tzinfo=UTC),
+            self.reader._claude_marker(self.worktree, EPOCH),
+        )
+
+    def _rollout(self, name: str, records: list[dict], when: datetime) -> Path:
+        directory = self.home / ".codex/sessions/2019/01/01"
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"rollout-{name}.jsonl"
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        stamp(path, when)
+        return path
+
+    def test_codex_binds_last_turn_context_not_meta_or_newest_neighbor(self):
+        mine = datetime(2020, 1, 1, 0, 10, tzinfo=UTC)
+        self._rollout(
+            "mine",
+            [
+                {"type": "session_meta", "payload": {"cwd": "/stale"}},
+                {"type": "turn_context", "payload": {"cwd": str(self.worktree)}},
+            ],
+            mine,
+        )
+        self._rollout(
+            "newer-foreign",
+            [{"type": "turn_context", "payload": {"cwd": "/neighbor"}}],
+            datetime(2020, 1, 1, 0, 20, tzinfo=UTC),
+        )
+        self.assertEqual(
+            mine,
+            self.reader._codex_marker(
+                self.worktree, EPOCH, datetime(2020, 1, 1, 0, 30, tzinfo=UTC)
+            ),
+        )
+
+    def test_codex_no_match_and_multi_match_are_both_ambiguous(self):
+        now = datetime(2020, 1, 1, 0, 50, tzinfo=UTC)
+        self._rollout(
+            "foreign",
+            [{"type": "turn_context", "payload": {"cwd": "/neighbor"}}],
+            datetime(2020, 1, 1, 0, 10, tzinfo=UTC),
+        )
+        self.assertIsNone(self.reader._codex_marker(self.worktree, EPOCH, now))
+        for name, minute in (("mine-a", 20), ("mine-b", 30)):
+            self._rollout(
+                name,
+                [{"type": "turn_context", "payload": {"cwd": str(self.worktree)}}],
+                datetime(2020, 1, 1, 0, minute, tzinfo=UTC),
+            )
+        self.assertIsNone(self.reader._codex_marker(self.worktree, EPOCH, now))
+
+        evidence = ar.Evidence(epoch=EPOCH)
+        self.reader._marker_input(evidence, "codex", self.worktree, now)
+        self.assertIsNone(evidence.marker_at)
+        self.assertEqual(["marker"], evidence.unreadable)
+
+    def test_kimi_uses_workdir_and_wire_never_state_updated_at(self):
+        session = self.home / ".kimi-code/sessions/wd_test_hash/session_1"
+        wire = session / "agents/main/wire.jsonl"
+        wire.parent.mkdir(parents=True)
+        state = session / "state.json"
+        state.write_text(json.dumps({"workDir": str(self.worktree)}))
+        wire.write_text("{}\n")
+        wire_time = datetime(2020, 1, 3, tzinfo=UTC)
+        stamp(wire, wire_time)
+        stamp(state, datetime(2020, 1, 9, tzinfo=UTC))
+        self.assertEqual(
+            wire_time, self.reader._kimi_marker(self.worktree, EPOCH)
+        )
+
+    def test_opencode_binds_exact_directory_and_session_clock(self):
+        db = self.home / ".local/share/opencode/opencode.db"
+        db.parent.mkdir(parents=True)
+        con = sqlite3.connect(db)
+        con.execute(
+            "CREATE TABLE session(id TEXT, directory TEXT, time_updated INTEGER)"
+        )
+        con.executemany(
+            "INSERT INTO session VALUES (?,?,?)",
+            [
+                ("mine", str(self.worktree), int(datetime(2020, 1, 2, tzinfo=UTC).timestamp() * 1000)),
+                ("foreign", f"{self.worktree}-other", 1_578_096_000_000),
+            ],
+        )
+        con.commit()
+        con.close()
+        self.assertEqual(
+            datetime(2020, 1, 2, tzinfo=UTC),
+            self.reader._opencode_marker(self.worktree, EPOCH),
+        )
+
+    def test_marker_never_uses_filesystem_without_live_process_binding(self):
+        evidence = self.read()
+        self.assertFalse(evidence.process_present)
+        self.assertIsNone(evidence.marker_at)
+        self.assertIn("marker", evidence.unreadable)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_activity_readers.py
+++ b/tests/test_activity_readers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -51,11 +52,17 @@ def make_db(path: Path) -> None:
         );
         CREATE TABLE shell_messages (
           message_id INTEGER PRIMARY KEY, from_shell_id INTEGER,
-          sprint_doc_id INTEGER, created_at TEXT
+          sprint_doc_id INTEGER, created_at TEXT, kind TEXT, body TEXT
         );
         CREATE TABLE sprint_units (
           unit_id INTEGER PRIMARY KEY, sprint_doc_id INTEGER, seq TEXT,
-          branch TEXT, updated_at TEXT, updated_by_shell_id INTEGER
+          branch TEXT, state TEXT, state_changed_at TEXT, updated_at TEXT,
+          updated_by_shell_id INTEGER, dev_shell_id INTEGER,
+          reviewer_shell_id INTEGER
+        );
+        CREATE TABLE sprint_planner_bindings (
+          binding_id INTEGER PRIMARY KEY, sprint_doc_id INTEGER,
+          planner_shell_id INTEGER
         );
         CREATE TABLE spec_tasks (
           task_id INTEGER PRIMARY KEY, status TEXT
@@ -75,12 +82,15 @@ def make_db(path: Path) -> None:
     )
     con.execute(
         "INSERT INTO shell_messages VALUES "
-        "(1,1,59,'2020-01-02T00:00:00Z')"
+        "(1,1,59,'2020-01-02T00:00:00Z','result',"
+        "'sprint 59: unit U3 fixing')"
     )
     con.execute(
         "INSERT INTO sprint_units VALUES "
-        "(1,59,'U3','feat/test','2020-01-03T00:00:00Z',1)"
+        "(1,59,'U3','feat/test','working','2020-01-04T00:00:00Z',"
+        "'2020-01-03T00:00:00Z',1,1,2)"
     )
+    con.execute("INSERT INTO sprint_planner_bindings VALUES (1,59,1)")
     con.commit()
     con.close()
 
@@ -161,6 +171,13 @@ class ReaderCase(unittest.TestCase):
                 "GIT_COMMITTER_DATE": "2019-01-01T00:00:00+00:00",
             },
         )
+        command(
+            self.worktree,
+            "git",
+            "update-ref",
+            "refs/remotes/origin/main",
+            "HEAD",
+        )
         self.db = self.root / "shell.db"
         make_db(self.db)
         self.proc = self.root / "proc"
@@ -186,6 +203,7 @@ class ReaderCase(unittest.TestCase):
             "sprint_doc_id": 59,
             "seq": "U3",
             "branch": "feat/test",
+            "state_changed_at": "2020-01-04T00:00:00Z",
         }
 
     def read(self):
@@ -201,8 +219,89 @@ class DatabaseContractTest(ReaderCase):
         self.assertEqual(
             datetime(2020, 1, 3, tzinfo=UTC), evidence.last_durable_write_at
         )
+        self.assertEqual(
+            datetime(2020, 1, 2, tzinfo=UTC), evidence.last_result_row_at
+        )
+        self.assertEqual(
+            datetime(2020, 1, 4, tzinfo=UTC), evidence.state_changed_at
+        )
         self.assertTrue(evidence.edits_code)
         self.assertEqual("feat/test", evidence.branch_declared)
+
+    def test_current_archive_session_end_fields_are_observed(self):
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO interface_sessions VALUES "
+            "(10,1,10,'2020-01-01T00:00:00Z','2020-01-05T00:00:00Z',"
+            "'stop_hook','codex')"
+        )
+        con.commit()
+        con.close()
+
+        evidence = self.read()
+
+        self.assertEqual(
+            datetime(2020, 1, 5, tzinfo=UTC), evidence.session_ended_at
+        )
+        self.assertEqual("stop_hook", evidence.session_end_reason)
+
+    def test_result_row_is_unit_scoped_when_shell_holds_multiple_units(self):
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO sprint_units VALUES "
+            "(2,59,'U4','feat/other','working','2020-01-04T00:00:00Z',"
+            "'2020-01-03T00:00:00Z',1,1,3)"
+        )
+        con.executemany(
+            "INSERT INTO shell_messages VALUES (?,?,?,?,?,?)",
+            [
+                (
+                    2,
+                    1,
+                    59,
+                    "2020-01-05T00:00:00Z",
+                    "result",
+                    "sprint 59: unit U4 ready",
+                ),
+                (
+                    3,
+                    1,
+                    59,
+                    "2020-01-04T12:00:00Z",
+                    "result",
+                    "sprint 59: unit=U3 ready",
+                ),
+            ],
+        )
+        con.commit()
+        con.close()
+
+        evidence = self.read()
+
+        self.assertEqual(
+            datetime(2020, 1, 4, 12, tzinfo=UTC),
+            evidence.last_result_row_at,
+        )
+        self.assertEqual(
+            datetime(2020, 1, 5, tzinfo=UTC),
+            evidence.last_durable_write_at,
+        )
+
+    def test_missing_state_clock_is_independently_unreadable(self):
+        unit = dict(self.unit)
+        unit.pop("state_changed_at")
+
+        evidence = self.reader.read(
+            self.shell, unit, datetime(2020, 1, 10, tzinfo=UTC)
+        )
+
+        self.assertIsNone(evidence.state_changed_at)
+        self.assertIn("state_changed_at", evidence.unreadable)
+        self.assertEqual(EPOCH, evidence.epoch)
+        self.assertEqual(
+            datetime(2020, 1, 2, tzinfo=UTC),
+            evidence.last_result_row_at,
+        )
 
     def test_doc_unit_and_rowless_shell_never_claim_code_work(self):
         doc = dict(self.unit, branch=None)
@@ -226,6 +325,14 @@ class DatabaseContractTest(ReaderCase):
         self.assertFalse(rowless.edits_code)
         self.assertEqual(datetime(2020, 1, 5, tzinfo=UTC), rowless.epoch)
         self.assertIsNone(rowless.branch_declared)
+        self.assertEqual(
+            datetime(2020, 1, 3, tzinfo=UTC),
+            rowless.last_durable_write_at,
+        )
+        self.assertEqual(
+            datetime(2020, 1, 2, tzinfo=UTC),
+            rowless.last_result_row_at,
+        )
 
     def test_each_unreadable_input_is_nullable_and_read_never_raises(self):
         broken = ar.ActivityReader(
@@ -246,9 +353,51 @@ class DatabaseContractTest(ReaderCase):
         self.assertIsNone(evidence.process_present)
         self.assertIsNone(evidence.marker_at)
         self.assertEqual(
-            ["branch", "durable_write", "epoch", "git_state", "marker", "process", "session"],
+            [
+                "branch",
+                "durable_write",
+                "epoch",
+                "git_state",
+                "marker",
+                "process",
+                "result_row",
+                "session",
+            ],
             evidence.unreadable,
         )
+
+    def test_unreadable_marker_mapping_is_literal_exhaustive_and_nonempty(self):
+        self.assertEqual(
+            {
+                "branch": frozenset({"branch_present"}),
+                "commits": frozenset(
+                    {"commits_since_epoch", "last_work_at"}
+                ),
+                "durable_write": frozenset({"last_durable_write_at"}),
+                "epoch": frozenset({"epoch"}),
+                "git_state": frozenset(
+                    {"dirty", "commits_since_epoch", "last_work_at"}
+                ),
+                "last_work_at:untimed_delete_rename": frozenset(
+                    {"last_work_at"}
+                ),
+                "marker": frozenset({"marker_at"}),
+                "newest_mtime": frozenset({"newest_mtime"}),
+                "process": frozenset(
+                    {"process_present", "launch_shape", "cpu_delta"}
+                ),
+                "process_binding": frozenset(
+                    {"launch_shape", "cpu_delta"}
+                ),
+                "result_row": frozenset({"last_result_row_at"}),
+                "session": frozenset(
+                    {"session_ended_at", "session_end_reason"}
+                ),
+                "state_changed_at": frozenset({"state_changed_at"}),
+            },
+            ar.UNREADABLE_FIELDS,
+        )
+        self.assertTrue(all(ar.UNREADABLE_FIELDS.values()))
 
 
 class GitEvidenceTest(ReaderCase):
@@ -372,6 +521,61 @@ class GitEvidenceTest(ReaderCase):
         evidence = self.read()
         self.assertEqual(1, evidence.commits_since_epoch)
         self.assertEqual(datetime(2020, 2, 1, tzinfo=UTC), evidence.last_work_at)
+
+    def test_rebased_in_commits_do_not_count_but_own_commit_does(self):
+        command(self.worktree, "git", "branch", "main")
+        command(self.worktree, "git", "checkout", "main")
+        integration = self.worktree / "integration.py"
+        integration.write_text("another shell\n")
+        command(self.worktree, "git", "add", integration.name)
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-m",
+            "integration work",
+            env={
+                "GIT_AUTHOR_DATE": "2020-01-05T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2020-01-05T00:00:00+00:00",
+            },
+        )
+        command(
+            self.worktree,
+            "git",
+            "update-ref",
+            "refs/remotes/origin/main",
+            "HEAD",
+        )
+        command(self.worktree, "git", "checkout", "feat/test")
+        command(self.worktree, "git", "rebase", "main")
+
+        rebased = self.read()
+
+        self.assertEqual(0, rebased.commits_since_epoch)
+        self.assertIsNone(rebased.last_work_at)
+
+        own = self.worktree / "own.py"
+        own.write_text("mine\n")
+        command(self.worktree, "git", "add", own.name)
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-m",
+            "own work",
+            env={
+                "GIT_AUTHOR_DATE": "2020-01-06T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2020-01-06T00:00:00+00:00",
+            },
+        )
+
+        contributed = self.read()
+
+        self.assertEqual(1, contributed.commits_since_epoch)
+        self.assertEqual(
+            datetime(2020, 1, 6, tzinfo=UTC),
+            contributed.last_work_at,
+        )
 
     def test_conflicted_path_is_dirty_but_not_a_work_event(self):
         path = self.worktree / "conflict.txt"
@@ -547,15 +751,59 @@ class ProcessReaderTest(ReaderCase):
         self.assertIsNone(unknown.process_present)
         self.assertEqual(["process"], unknown.unreadable)
 
+    def test_foreign_worktree_process_does_not_make_worker_present(self):
+        foreign = self.root / "foreign-worktree"
+        foreign.mkdir()
+        proc_row(
+            self.proc,
+            200,
+            comm="codex",
+            cwd=foreign,
+            argv=["codex", "exec"],
+        )
+
+        evidence = ar.Evidence()
+        harness = self.reader._process_inputs(evidence, self.worktree)
+
+        self.assertIsNone(harness)
+        self.assertFalse(evidence.process_present)
+        self.assertEqual([], evidence.unreadable)
+
+    def test_multiple_matching_processes_are_present_but_binding_unreadable(self):
+        for pid in (200, 201):
+            proc_row(
+                self.proc,
+                pid,
+                comm="codex",
+                cwd=self.worktree,
+                argv=["codex", "exec"],
+            )
+
+        evidence = ar.Evidence()
+        harness = self.reader._process_inputs(evidence, self.worktree)
+
+        self.assertIsNone(harness)
+        self.assertTrue(evidence.process_present)
+        self.assertIsNone(evidence.launch_shape)
+        self.assertIsNone(evidence.cpu_delta)
+        self.assertEqual(["process_binding"], evidence.unreadable)
+
 
 class HarnessMarkerTest(ReaderCase):
     def test_claude_uses_dot_encoding_and_aggregates_own_scratchpad(self):
+        fixture_root = Path("/tmp") / f"scactivity{os.getpid()}"
+        self.addCleanup(shutil.rmtree, fixture_root, True)
+        dotted_worktree = fixture_root / ".sc-worktrees" / "dev1"
+        dotted_worktree.mkdir(parents=True)
         projects = self.home / ".claude/projects"
-        encoded = "".join(
-            c if c.isalnum() else "-" for c in str(self.worktree)
+        expected_container = (
+            f"-tmp-scactivity{os.getpid()}--sc-worktrees-dev1"
         )
-        main = projects / encoded
-        scratch = projects / f"-tmp-claude-0-{encoded}-session-scratchpad"
+        main = projects / expected_container
+        scratch = (
+            projects
+            / f"-tmp-claude-0-{expected_container}-session-scratchpad"
+        )
         foreign = projects / "-tmp-claude-0--foreign-session-scratchpad"
         for path in (main, scratch, foreign):
             path.mkdir(parents=True)
@@ -568,10 +816,9 @@ class HarnessMarkerTest(ReaderCase):
         stamp(scratch_log, datetime(2020, 1, 3, tzinfo=UTC))
         stamp(foreign_log, datetime(2020, 1, 4, tzinfo=UTC))
 
-        self.assertNotIn(".", encoded)
         self.assertEqual(
             datetime(2020, 1, 3, tzinfo=UTC),
-            self.reader._claude_marker(self.worktree, EPOCH),
+            self.reader._claude_marker(dotted_worktree, EPOCH),
         )
 
     def _rollout(self, name: str, records: list[dict], when: datetime) -> Path:

--- a/tests/test_activity_readers.py
+++ b/tests/test_activity_readers.py
@@ -62,7 +62,10 @@ def make_db(path: Path) -> None:
         );
         CREATE TABLE sprint_planner_bindings (
           binding_id INTEGER PRIMARY KEY, sprint_doc_id INTEGER,
-          planner_shell_id INTEGER
+          planner_shell_id INTEGER, armed_at TEXT
+        );
+        CREATE TABLE documents (
+          document_id INTEGER PRIMARY KEY, frozen INTEGER
         );
         CREATE TABLE spec_tasks (
           task_id INTEGER PRIMARY KEY, status TEXT
@@ -85,12 +88,48 @@ def make_db(path: Path) -> None:
         "(1,1,59,'2020-01-02T00:00:00Z','result',"
         "'sprint 59: unit U3 fixing')"
     )
+    # Each row violates exactly one result-evidence predicate.  All are newer
+    # than the qualifying row so deleting any one SQL predicate turns the
+    # contract assertion red.
+    con.executemany(
+        "INSERT INTO shell_messages VALUES (?,?,?,?,?,?)",
+        [
+            (
+                2,
+                1,
+                59,
+                "2020-01-06T00:00:00Z",
+                "task",
+                "sprint 59: unit U3 task",
+            ),
+            (
+                3,
+                2,
+                59,
+                "2020-01-05T00:00:00Z",
+                "result",
+                "sprint 59: unit U3 foreign shell",
+            ),
+            (
+                4,
+                1,
+                60,
+                "2020-01-04T00:00:00Z",
+                "result",
+                "sprint 60: unit U3 foreign sprint",
+            ),
+        ],
+    )
     con.execute(
         "INSERT INTO sprint_units VALUES "
         "(1,59,'U3','feat/test','working','2020-01-04T00:00:00Z',"
         "'2020-01-03T00:00:00Z',1,1,2)"
     )
-    con.execute("INSERT INTO sprint_planner_bindings VALUES (1,59,1)")
+    con.execute("INSERT INTO documents VALUES (59,0)")
+    con.execute(
+        "INSERT INTO sprint_planner_bindings VALUES "
+        "(1,59,1,'2020-01-04T00:00:00Z')"
+    )
     con.commit()
     con.close()
 
@@ -174,10 +213,19 @@ class ReaderCase(unittest.TestCase):
         command(
             self.worktree,
             "git",
-            "update-ref",
-            "refs/remotes/origin/main",
-            "HEAD",
+            "init",
+            "--bare",
+            str(self.root / "origin.git"),
         )
+        command(
+            self.worktree,
+            "git",
+            "remote",
+            "add",
+            "origin",
+            str(self.root / "origin.git"),
+        )
+        command(self.worktree, "git", "push", "origin", "HEAD:refs/heads/main")
         self.db = self.root / "shell.db"
         make_db(self.db)
         self.proc = self.root / "proc"
@@ -217,7 +265,7 @@ class DatabaseContractTest(ReaderCase):
         self.assertIsNone(evidence.session_ended_at)
         self.assertIsNone(evidence.session_end_reason)
         self.assertEqual(
-            datetime(2020, 1, 3, tzinfo=UTC), evidence.last_durable_write_at
+            datetime(2020, 1, 6, tzinfo=UTC), evidence.last_durable_write_at
         )
         self.assertEqual(
             datetime(2020, 1, 2, tzinfo=UTC), evidence.last_result_row_at
@@ -256,7 +304,7 @@ class DatabaseContractTest(ReaderCase):
             "INSERT INTO shell_messages VALUES (?,?,?,?,?,?)",
             [
                 (
-                    2,
+                    5,
                     1,
                     59,
                     "2020-01-05T00:00:00Z",
@@ -264,7 +312,7 @@ class DatabaseContractTest(ReaderCase):
                     "sprint 59: unit U4 ready",
                 ),
                 (
-                    3,
+                    6,
                     1,
                     59,
                     "2020-01-04T12:00:00Z",
@@ -283,9 +331,19 @@ class DatabaseContractTest(ReaderCase):
             evidence.last_result_row_at,
         )
         self.assertEqual(
-            datetime(2020, 1, 5, tzinfo=UTC),
+            datetime(2020, 1, 6, tzinfo=UTC),
             evidence.last_durable_write_at,
         )
+
+    def test_unit_name_boundaries_pin_the_real_dotted_family(self):
+        names = ar.ActivityReader._names_unit
+
+        self.assertTrue(names("sprint 59: unit U-H.", "U-H"))
+        self.assertTrue(names("sprint 59: unit U-H.1 ready", "U-H.1"))
+        self.assertTrue(names("sprint 59: unit U-H.2 ready", "U-H.2"))
+        self.assertFalse(names("sprint 59: unit U-H.1 ready", "U-H"))
+        self.assertFalse(names("sprint 59: unit U-H.2 ready", "U-H"))
+        self.assertFalse(names("sprint 59: unit U1f ready", "U1"))
 
     def test_missing_state_clock_is_independently_unreadable(self):
         unit = dict(self.unit)
@@ -326,12 +384,98 @@ class DatabaseContractTest(ReaderCase):
         self.assertEqual(datetime(2020, 1, 5, tzinfo=UTC), rowless.epoch)
         self.assertIsNone(rowless.branch_declared)
         self.assertEqual(
-            datetime(2020, 1, 3, tzinfo=UTC),
+            datetime(2020, 1, 6, tzinfo=UTC),
             rowless.last_durable_write_at,
         )
         self.assertEqual(
             datetime(2020, 1, 2, tzinfo=UTC),
             rowless.last_result_row_at,
+        )
+        self.assertEqual(
+            datetime(2020, 1, 4, tzinfo=UTC),
+            rowless.state_changed_at,
+        )
+
+    def test_rowless_shell_rejects_a_binding_superseded_for_that_sprint(self):
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO sprint_planner_bindings VALUES "
+            "(2,59,2,'2020-01-07T00:00:00Z')"
+        )
+        con.commit()
+        con.close()
+
+        evidence = self.reader.read(
+            self.shell, None, datetime(2020, 1, 10, tzinfo=UTC)
+        )
+
+        self.assertIsNone(evidence.last_durable_write_at)
+        self.assertIsNone(evidence.last_result_row_at)
+        self.assertIsNone(evidence.state_changed_at)
+        self.assertTrue(
+            {"durable_write", "result_row", "state_changed_at"}
+            <= set(evidence.unreadable)
+        )
+
+    def test_rowless_shell_rejects_frozen_or_unitless_binding(self):
+        mutations = (
+            "UPDATE documents SET frozen=1",
+            "DELETE FROM sprint_units",
+            "DELETE FROM sprint_planner_bindings",
+        )
+        for index, mutation in enumerate(mutations):
+            with self.subTest(mutation=mutation):
+                db = self.root / f"binding-{index}.db"
+                make_db(db)
+                con = sqlite3.connect(db)
+                con.execute(mutation)
+                con.commit()
+                con.close()
+                reader = ar.ActivityReader(
+                    db_path=db,
+                    repo_root=self.root,
+                    proc=self.proc,
+                    adapters=self.adapters,
+                    home=self.home,
+                )
+
+                evidence = reader.read(
+                    self.shell, None, datetime(2020, 1, 10, tzinfo=UTC)
+                )
+
+                self.assertIsNone(evidence.last_durable_write_at)
+                self.assertIsNone(evidence.last_result_row_at)
+                self.assertIsNone(evidence.state_changed_at)
+                self.assertTrue(
+                    {"durable_write", "result_row", "state_changed_at"}
+                    <= set(evidence.unreadable)
+                )
+
+    def test_rowless_shell_does_not_collapse_two_live_sprints(self):
+        con = sqlite3.connect(self.db)
+        con.execute("INSERT INTO documents VALUES (60,0)")
+        con.execute(
+            "INSERT INTO sprint_units VALUES "
+            "(2,60,'U1','feat/other','working','2020-01-07T00:00:00Z',"
+            "'2020-01-07T00:00:00Z',1,2,3)"
+        )
+        con.execute(
+            "INSERT INTO sprint_planner_bindings VALUES "
+            "(2,60,1,'2020-01-07T00:00:00Z')"
+        )
+        con.commit()
+        con.close()
+
+        evidence = self.reader.read(
+            self.shell, None, datetime(2020, 1, 10, tzinfo=UTC)
+        )
+
+        self.assertIsNone(evidence.last_durable_write_at)
+        self.assertIsNone(evidence.last_result_row_at)
+        self.assertIsNone(evidence.state_changed_at)
+        self.assertTrue(
+            {"durable_write", "result_row", "state_changed_at"}
+            <= set(evidence.unreadable)
         )
 
     def test_each_unreadable_input_is_nullable_and_read_never_raises(self):
@@ -542,9 +686,19 @@ class GitEvidenceTest(ReaderCase):
         command(
             self.worktree,
             "git",
+            "push",
+            "origin",
+            "main:refs/heads/main",
+        )
+        stale_main = command(
+            self.worktree, "git", "rev-parse", "HEAD^"
+        ).stdout.strip()
+        command(
+            self.worktree,
+            "git",
             "update-ref",
             "refs/remotes/origin/main",
-            "HEAD",
+            stale_main,
         )
         command(self.worktree, "git", "checkout", "feat/test")
         command(self.worktree, "git", "rebase", "main")
@@ -575,6 +729,107 @@ class GitEvidenceTest(ReaderCase):
         self.assertEqual(
             datetime(2020, 1, 6, tzinfo=UTC),
             contributed.last_work_at,
+        )
+
+    def test_criss_cross_history_excludes_every_integration_commit(self):
+        base = command(self.worktree, "git", "rev-parse", "HEAD").stdout.strip()
+        command(self.worktree, "git", "checkout", "-b", "integration", base)
+        (self.worktree / "left.py").write_text("left\n")
+        command(self.worktree, "git", "add", "left.py")
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-m",
+            "left",
+            env={
+                "GIT_AUTHOR_DATE": "2020-01-02T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2020-01-02T00:00:00+00:00",
+            },
+        )
+        left = command(self.worktree, "git", "rev-parse", "HEAD").stdout.strip()
+
+        command(self.worktree, "git", "checkout", "feat/test")
+        (self.worktree / "right.py").write_text("right\n")
+        command(self.worktree, "git", "add", "right.py")
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-m",
+            "right",
+            env={
+                "GIT_AUTHOR_DATE": "2020-01-03T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2020-01-03T00:00:00+00:00",
+            },
+        )
+        right = command(self.worktree, "git", "rev-parse", "HEAD").stdout.strip()
+
+        merge_env = {
+            "GIT_AUTHOR_DATE": "2019-06-01T00:00:00+00:00",
+            "GIT_COMMITTER_DATE": "2019-06-01T00:00:00+00:00",
+        }
+        command(self.worktree, "git", "checkout", "integration")
+        command(
+            self.worktree,
+            "git",
+            "merge",
+            "--no-ff",
+            "-m",
+            "merge right",
+            right,
+            env=merge_env,
+        )
+        command(
+            self.worktree,
+            "git",
+            "push",
+            "--force",
+            "origin",
+            "integration:refs/heads/main",
+        )
+
+        command(self.worktree, "git", "checkout", "feat/test")
+        command(
+            self.worktree,
+            "git",
+            "merge",
+            "--no-ff",
+            "-m",
+            "merge left",
+            left,
+            env=merge_env,
+        )
+        (self.worktree / "mine.py").write_text("mine\n")
+        command(self.worktree, "git", "add", "mine.py")
+        command(
+            self.worktree,
+            "git",
+            "commit",
+            "-m",
+            "own work",
+            env={
+                "GIT_AUTHOR_DATE": "2020-01-04T00:00:00+00:00",
+                "GIT_COMMITTER_DATE": "2020-01-04T00:00:00+00:00",
+            },
+        )
+
+        merge_bases = command(
+            self.worktree,
+            "git",
+            "merge-base",
+            "--all",
+            "refs/remotes/origin/main",
+            "HEAD",
+        ).stdout.splitlines()
+        self.assertEqual(2, len(merge_bases))
+
+        evidence = self.read()
+
+        self.assertEqual(1, evidence.commits_since_epoch)
+        self.assertEqual(
+            datetime(2020, 1, 4, tzinfo=UTC),
+            evidence.last_work_at,
         )
 
     def test_conflicted_path_is_dirty_but_not_a_work_event(self):


### PR DESCRIPTION
## Summary

- add the U3 `activity_readers` observation module and complete `Evidence` contract
- bind work, durable-write, process, launch-shape, and harness marker inputs without classifying them
- represent delete/rename work with the ruled lower bound: dirty remains true, untimed events are marked unreadable, and current-epoch rename mtimes contribute

## Verification

- focused reader suite: 21 passed
- adjacent suite before the final ruling: 105 passed
- full suite before the final ruling: 1791 passed + 432 subtests, with only the 3 predeclared flag #208 container failures and no U3 intersection
- ruff: clean
- mutation round trips: deleting the delete marker, deleting the old-rename marker, and ignoring a usable current-rename mtime each turned its dedicated test red

## Judgements

- Spec 58 rulings seven and eight are implemented as written; no open ambiguity remains.
- `last_durable_write_at` is deliberately documented and implemented as a safe lower bound over attributable timestamped sprint surfaces.