### PR TITLE
fix(update): verify materialized engine completeness

### DIFF
--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -51,6 +51,7 @@ Usage:
 from __future__ import annotations
 
 import ast
+import importlib.util
 import os
 import re
 import shutil
@@ -250,6 +251,13 @@ def _literal_engine_paths_at(
     return None, f"{source_path} does not define ENGINE_PATHS"
 
 
+def _engine_path_exists_at(ref: str, path: str, *, repo_root: Path) -> bool:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), "cat-file", "-e", f"{ref}:{path}"],
+        capture_output=True,
+    ).returncode == 0
+
+
 def _engine_paths_for(
     ref: str,
     repo_root: Path = REPO_ROOT,
@@ -275,11 +283,13 @@ def _engine_paths_for(
     )
     reasons: list[str] = []
     resolved: list[str] | None = None
+    resolution_source = ""
     for source_path in sources:
         resolved, reason = _literal_engine_paths_at(
             ref, source_path, repo_root=repo_root
         )
         if resolved is not None:
+            resolution_source = f"{source_path} at target ref"
             break
         if reason is not None:
             reasons.append(reason)
@@ -292,13 +302,11 @@ def _engine_paths_for(
             file=sys.stderr,
         )
         resolved = list(ENGINE_PATHS)
+        resolution_source = "installed ENGINE_PATHS fallback"
 
     present, missing = [], []
     for path in resolved:
-        exists = subprocess.run(
-            ["git", "-C", str(repo_root), "cat-file", "-e", f"{ref}:{path}"],
-            capture_output=True,
-        ).returncode == 0
+        exists = _engine_path_exists_at(ref, path, repo_root=repo_root)
         (present if exists else missing).append(path)
 
     added = [path for path in present if path not in ENGINE_PATHS]
@@ -321,6 +329,10 @@ def _engine_paths_for(
         )
     if not present:
         sys.exit(f"update: no engine paths exist at {ref} — wrong ref or remote?")
+    print(
+        f"  resolved {len(present)} engine path(s) for {ref[:12]} from "
+        f"{resolution_source}"
+    )
     if fallback_used is not None:
         fallback_used.append(used_installed_fallback)
     return present
@@ -357,13 +369,69 @@ def _engine_files_at(
     ).stdout.splitlines()
 
 
-def materialize_engine(ref: str) -> None:
+def _materialized_engine_paths(repo_root: Path = REPO_ROOT) -> list[str]:
+    """Load ENGINE_PATHS from the engine manifest that is currently on disk."""
+    manifest_path = repo_root / ".super-coder" / "scripts" / "engine_manifest.py"
+    spec = importlib.util.spec_from_file_location(
+        "_sc_materialized_engine_manifest",
+        manifest_path,
+    )
+    if spec is None or spec.loader is None:
+        sys.exit(
+            "update: could not load the materialized engine manifest at "
+            f"{manifest_path}"
+        )
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        sys.exit(
+            "update: reloading the materialized engine manifest failed: "
+            f"{exc}"
+        )
+    paths = getattr(module, "ENGINE_PATHS", None)
+    if not isinstance(paths, list) or not all(
+        isinstance(path, str) for path in paths
+    ):
+        sys.exit(
+            "update: materialized engine manifest does not expose "
+            "ENGINE_PATHS as list[str]"
+        )
+    return list(paths)
+
+
+def _assert_materialized_engine_paths(
+    engine_paths: list[str],
+    repo_root: Path = REPO_ROOT,
+) -> None:
+    """Refuse to record a successful update over a short engine tree."""
+    missing = [path for path in engine_paths if not (repo_root / path).exists()]
+    if not missing:
+        return
+    sys.exit(
+        "update: materialized engine is incomplete; missing declared path(s): "
+        f"{', '.join(missing)}\n"
+        "  remedy: rerun `./sc update --force`; if the paths remain missing, "
+        "report the target engine ref"
+    )
+
+
+def materialize_engine(
+    ref: str,
+    *,
+    engine_paths: list[str] | None = None,
+) -> None:
     """Write the engine paths at `ref` into the working tree WITHOUT touching the
     git index — the engine is gitignored, so a `git checkout -- <paths>` (which
     stages) is wrong. `git archive | tar -x` copies the fetched tree over the
     top, leaving the gitignored per-instance files (shell_db.db*, instance.json)
     in place. (Files deleted upstream linger until a future doctor sweep — same
     gap the old checkout had; acceptable for a wholesale-overwrite dependency.)"""
+    paths = (
+        engine_paths
+        if engine_paths is not None
+        else _engine_paths_for(ref, repo_root=REPO_ROOT)
+    )
     archive = subprocess.run(
         [
             "git",
@@ -372,7 +440,7 @@ def materialize_engine(ref: str) -> None:
             "archive",
             ref,
             "--",
-            *_engine_paths_for(ref, repo_root=REPO_ROOT),
+            *paths,
         ],
         capture_output=True,
     )
@@ -439,11 +507,33 @@ def materialize_fetched_engine(sha: str, *, force: bool = False) -> None:
         # engine ref if discoverable; else leave prev absent (rollback will warn).
         ENGINE_REF_PREV.unlink(missing_ok=True)
 
-    materialize_engine(sha)
+    resolved_paths = _engine_paths_for(sha, repo_root=REPO_ROOT)
+    materialize_engine(sha, engine_paths=resolved_paths)
+    materialized_paths = _materialized_engine_paths(REPO_ROOT)
+    delta = [path for path in materialized_paths if path not in resolved_paths]
+    materializable_delta = [
+        path
+        for path in delta
+        if _engine_path_exists_at(sha, path, repo_root=REPO_ROOT)
+    ]
+    if materializable_delta:
+        print(
+            "WARNING: materialized engine manifest declares "
+            f"{len(materializable_delta)} path(s) missed by target-ref "
+            "resolution; materializing the delta: "
+            f"{', '.join(materializable_delta)}",
+            file=sys.stderr,
+        )
+        materialize_engine(sha, engine_paths=materializable_delta)
+    _assert_materialized_engine_paths(materialized_paths, REPO_ROOT)
     ENGINE_REF.write_text(sha + "\n")
     n = engine_manifest.write_manifest(
-        _engine_paths_for(sha, repo_root=REPO_ROOT),
-        files=_engine_files_at(sha),
+        materialized_paths,
+        files=_engine_files_at(
+            sha,
+            repo_root=REPO_ROOT,
+            engine_paths=materialized_paths,
+        ),
     )
     print(f"  engine pinned at {sha[:12]} (.sc-state/engine.ref) · manifest over {n} files")
 

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -525,7 +525,10 @@ def materialize_fetched_engine(sha: str, *, force: bool = False) -> None:
             file=sys.stderr,
         )
         materialize_engine(sha, engine_paths=materializable_delta)
-    _assert_materialized_engine_paths(materialized_paths, REPO_ROOT)
+    _assert_materialized_engine_paths(
+        resolved_paths + materializable_delta,
+        REPO_ROOT,
+    )
     ENGINE_REF.write_text(sha + "\n")
     n = engine_manifest.write_manifest(
         materialized_paths,

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -411,8 +411,10 @@ def _assert_materialized_engine_paths(
     sys.exit(
         "update: materialized engine is incomplete; missing declared path(s): "
         f"{', '.join(missing)}\n"
-        "  remedy: rerun `./sc update --force`; if the paths remain missing, "
-        "report the target engine ref"
+        "  engine.ref was not advanced; the recorded engine pin remains "
+        "unchanged.\n"
+        "  no automated recovery is available; report the target engine ref "
+        "upstream"
     )
 
 

--- a/tests/test_rollback_half_floor.py
+++ b/tests/test_rollback_half_floor.py
@@ -56,7 +56,7 @@ def read_db(path: Path) -> str:
 
 
 class HalfFloorRollbackTest(unittest.TestCase):
-    def test_path_resolution_fallbacks_only_under_delete_rollback_delta(self):
+    def test_current_subset_and_previous_superset_fallbacks_reduce_delta(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             root = Path(raw_tmp)
             scripts = root / ".super-coder" / "scripts"
@@ -242,6 +242,9 @@ class HalfFloorRollbackTest(unittest.TestCase):
             (scripts / "engine_manifest.py").write_text(
                 "ENGINE_PATHS = load_paths()\n"
             )
+            new_path = engine / "new-path" / "new-only.txt"
+            new_path.parent.mkdir()
+            new_path.write_text("new upstream file\n")
             git(root, "add", ".")
             git(root, "commit", "-m", "new unparseable floor")
             new_sha = git(root, "rev-parse", "HEAD")
@@ -253,6 +256,7 @@ class HalfFloorRollbackTest(unittest.TestCase):
                 "sc",
                 ".super-coder/scripts",
                 ".super-coder/fork-area",
+                ".super-coder/new-path",
             ]
             with mock.patch.multiple(
                 rollback,
@@ -276,6 +280,11 @@ class HalfFloorRollbackTest(unittest.TestCase):
                 b"fork sentinel bytes\n",
                 "a broader installed fallback must not turn tracked fork "
                 "content into a rollback deletion candidate",
+            )
+            self.assertFalse(
+                new_path.exists(),
+                "the installed fallback authority must retain a current-ref "
+                "addition in the rollback deletion candidate set",
             )
             self.assertEqual(engine_ref.read_text(), old_sha + "\n")
 

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -356,6 +356,70 @@ class EnginePathsAtRefTest(unittest.TestCase):
             "ref files",
         )
 
+    def test_delta_heal_that_does_not_land_is_refused(self):
+        installed = ["sc", ".super-coder/scripts"]
+        (self.root / "sc").write_text("old dispatcher\n")
+        self.write_manifest(installed)
+        (self.scripts / "update.py").write_text(
+            "from engine_manifest import ENGINE_PATHS\n"
+        )
+        old_sha = self.commit("installed allow-list")
+
+        target = [*installed, ".super-coder/new-path"]
+        (self.root / "sc").write_text("new dispatcher\n")
+        (self.scripts / "engine_manifest.py").write_text(
+            "def load_paths():\n"
+            f"    return {target!r}\n"
+            "ENGINE_PATHS = load_paths()\n"
+        )
+        new_file = self.root / ".super-coder" / "new-path" / "new.txt"
+        new_file.parent.mkdir()
+        new_file.write_text("new path content\n")
+        target_sha = self.commit("dynamic target allow-list")
+        _git(self.root, "checkout", old_sha)
+
+        state = self.root / ".sc-state"
+        engine = self.root / ".super-coder"
+        real_materialize = update.materialize_engine
+
+        def heal_that_does_not_land(
+            ref: str,
+            *,
+            engine_paths: list[str] | None = None,
+        ) -> None:
+            real_materialize(ref, engine_paths=engine_paths)
+            if engine_paths == [".super-coder/new-path"]:
+                new_file.unlink()
+                new_file.parent.rmdir()
+
+        with mock.patch.multiple(
+            update,
+            REPO_ROOT=self.root,
+            ENGINE=engine,
+            STATE_DIR=state,
+            ENGINE_REF=state / "engine.ref",
+            ENGINE_REF_PREV=state / "engine.ref.prev",
+            ENGINE_PATHS=installed,
+            materialize_engine=heal_that_does_not_land,
+        ), mock.patch.multiple(
+            update.engine_manifest,
+            REPO_ROOT=self.root,
+            ENGINE=engine,
+            MANIFEST=engine / "engine.manifest",
+            local_edits=mock.Mock(return_value={}),
+        ), contextlib.redirect_stderr(
+            io.StringIO()
+        ), contextlib.redirect_stdout(
+            io.StringIO()
+        ), self.assertRaises(SystemExit) as failed:
+            update.materialize_fetched_engine(target_sha)
+
+        self.assertIn(".super-coder/new-path", str(failed.exception))
+        self.assertFalse(
+            (state / "engine.ref").exists(),
+            "a delta heal that did not land must not be recorded as current",
+        )
+
     def test_missing_materialized_path_exits_nonzero_and_names_remedy(self):
         target = ["sc", ".super-coder/scripts", ".super-coder/new-path"]
         (self.root / "sc").write_text("old dispatcher\n")

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 import subprocess
 import sys
 import tempfile
@@ -272,6 +273,236 @@ class EnginePathsAtRefTest(unittest.TestCase):
             ".super-coder/scripts/update.py does not define ENGINE_PATHS; "
             "falling back to installed ENGINE_PATHS.\n",
         )
+
+    def test_materialized_manifest_heals_paths_missed_by_resolution(self):
+        installed = ["sc", ".super-coder/scripts"]
+        (self.root / "sc").write_text("old dispatcher\n")
+        self.write_manifest(installed)
+        (self.scripts / "update.py").write_text(
+            "from engine_manifest import ENGINE_PATHS\n"
+        )
+        old_sha = self.commit("installed allow-list")
+
+        target = [*installed, ".super-coder/new-path"]
+        (self.root / "sc").write_text("new dispatcher\n")
+        (self.scripts / "engine_manifest.py").write_text(
+            "def load_paths():\n"
+            f"    return {target!r}\n"
+            "ENGINE_PATHS = load_paths()\n"
+        )
+        new_file = self.root / ".super-coder" / "new-path" / "new.txt"
+        new_file.parent.mkdir()
+        new_file.write_text("new path content\n")
+        target_sha = self.commit("dynamic target allow-list")
+        _git(self.root, "checkout", old_sha)
+        self.assertFalse(new_file.exists())
+
+        state = self.root / ".sc-state"
+        engine = self.root / ".super-coder"
+        warning = io.StringIO()
+        output = io.StringIO()
+        real_resolve = update._engine_paths_for
+        with mock.patch.multiple(
+            update,
+            REPO_ROOT=self.root,
+            ENGINE=engine,
+            STATE_DIR=state,
+            ENGINE_REF=state / "engine.ref",
+            ENGINE_REF_PREV=state / "engine.ref.prev",
+            ENGINE_PATHS=installed,
+        ), mock.patch.multiple(
+            update.engine_manifest,
+            REPO_ROOT=self.root,
+            ENGINE=engine,
+            MANIFEST=engine / "engine.manifest",
+            local_edits=mock.Mock(return_value={}),
+        ), mock.patch.object(
+            update,
+            "_engine_paths_for",
+            wraps=real_resolve,
+        ) as resolve, contextlib.redirect_stderr(
+            warning
+        ), contextlib.redirect_stdout(output):
+            update.materialize_fetched_engine(target_sha)
+
+        self.assertEqual(resolve.call_count, 1)
+        self.assertEqual(
+            output.getvalue().count(
+                f"resolved 2 engine path(s) for {target_sha[:12]} from "
+                "installed ENGINE_PATHS fallback"
+            ),
+            1,
+        )
+        self.assertEqual(new_file.read_text(), "new path content\n")
+        self.assertEqual(
+            warning.getvalue().count("falling back to installed ENGINE_PATHS"),
+            1,
+        )
+        self.assertIn(
+            "materialized engine manifest declares 1 path(s) missed by "
+            "target-ref resolution; materializing the delta: "
+            ".super-coder/new-path",
+            warning.getvalue(),
+        )
+        self.assertEqual(
+            set(json.loads((engine / "engine.manifest").read_text())),
+            {
+                "sc",
+                ".super-coder/scripts/engine_manifest.py",
+                ".super-coder/scripts/update.py",
+                ".super-coder/new-path/new.txt",
+            },
+            "the rewritten manifest must baseline exactly the healed target "
+            "ref files",
+        )
+
+    def test_missing_materialized_path_exits_nonzero_and_names_remedy(self):
+        target = ["sc", ".super-coder/scripts", ".super-coder/new-path"]
+        (self.root / "sc").write_text("old dispatcher\n")
+        self.write_manifest(["sc", ".super-coder/scripts"])
+        (self.scripts / "update.py").write_text(
+            "from engine_manifest import ENGINE_PATHS\n"
+        )
+        old_sha = self.commit("installed allow-list")
+
+        (self.root / "sc").write_text("new dispatcher\n")
+        self.write_manifest(target)
+        new_file = self.root / ".super-coder" / "new-path" / "new.txt"
+        new_file.parent.mkdir()
+        new_file.write_text("new path content\n")
+        target_sha = self.commit("target allow-list")
+        _git(self.root, "checkout", old_sha)
+
+        state = self.root / ".sc-state"
+        engine = self.root / ".super-coder"
+        real_materialize = update.materialize_engine
+
+        def materialize_then_delete(
+            ref: str,
+            *,
+            engine_paths: list[str] | None = None,
+        ) -> None:
+            real_materialize(ref, engine_paths=engine_paths)
+            if engine_paths is not None and ".super-coder/new-path" in engine_paths:
+                new_file.unlink()
+                new_file.parent.rmdir()
+
+        with mock.patch.multiple(
+            update,
+            REPO_ROOT=self.root,
+            ENGINE=engine,
+            STATE_DIR=state,
+            ENGINE_REF=state / "engine.ref",
+            ENGINE_REF_PREV=state / "engine.ref.prev",
+            ENGINE_PATHS=["sc", ".super-coder/scripts"],
+            materialize_engine=materialize_then_delete,
+        ), mock.patch.multiple(
+            update.engine_manifest,
+            REPO_ROOT=self.root,
+            ENGINE=engine,
+            MANIFEST=engine / "engine.manifest",
+            local_edits=mock.Mock(return_value={}),
+        ), self.assertRaises(SystemExit) as failed:
+            update.materialize_fetched_engine(target_sha)
+
+        self.assertEqual(
+            str(failed.exception),
+            "update: materialized engine is incomplete; missing declared "
+            "path(s): .super-coder/new-path\n"
+            "  remedy: rerun `./sc update --force`; if the paths remain "
+            "missing, report the target engine ref",
+        )
+        self.assertFalse(
+            (state / "engine.ref").exists(),
+            "an incomplete tree must not be recorded as the current pin",
+        )
+        self.assertFalse(
+            (engine / "engine.manifest").exists(),
+            "an incomplete tree must not receive a clean hash baseline",
+        )
+
+    def test_complete_materialize_is_quiet(self):
+        target = ["sc", ".super-coder/scripts"]
+        (self.root / "sc").write_text("old dispatcher\n")
+        self.write_manifest(target)
+        (self.scripts / "update.py").write_text(
+            "from engine_manifest import ENGINE_PATHS\n"
+        )
+        old_sha = self.commit("installed floor")
+
+        (self.root / "sc").write_text("new dispatcher\n")
+        (self.scripts / "floor.txt").write_text("complete target floor\n")
+        target_sha = self.commit("complete target floor")
+        _git(self.root, "checkout", old_sha)
+
+        state = self.root / ".sc-state"
+        engine = self.root / ".super-coder"
+        warning = io.StringIO()
+        with mock.patch.multiple(
+            update,
+            REPO_ROOT=self.root,
+            ENGINE=engine,
+            STATE_DIR=state,
+            ENGINE_REF=state / "engine.ref",
+            ENGINE_REF_PREV=state / "engine.ref.prev",
+            ENGINE_PATHS=target,
+        ), mock.patch.multiple(
+            update.engine_manifest,
+            REPO_ROOT=self.root,
+            ENGINE=engine,
+            MANIFEST=engine / "engine.manifest",
+            local_edits=mock.Mock(return_value={}),
+        ), contextlib.redirect_stderr(warning):
+            update.materialize_fetched_engine(target_sha)
+
+        self.assertEqual(warning.getvalue(), "")
+        self.assertEqual((state / "engine.ref").read_text(), target_sha + "\n")
+        self.assertEqual(
+            (self.scripts / "floor.txt").read_text(),
+            "complete target floor\n",
+        )
+        self.assertTrue((engine / "engine.manifest").is_file())
+
+    def test_declared_but_absent_path_gets_completeness_remedy(self):
+        installed = ["sc", ".super-coder/scripts"]
+        (self.root / "sc").write_text("old dispatcher\n")
+        self.write_manifest(installed)
+        (self.scripts / "update.py").write_text(
+            "from engine_manifest import ENGINE_PATHS\n"
+        )
+        old_sha = self.commit("installed floor")
+
+        missing_path = ".super-coder/missing-path"
+        (self.root / "sc").write_text("new dispatcher\n")
+        self.write_manifest([*installed, missing_path])
+        target_sha = self.commit("target declares an absent path")
+        _git(self.root, "checkout", old_sha)
+
+        state = self.root / ".sc-state"
+        engine = self.root / ".super-coder"
+        with mock.patch.multiple(
+            update,
+            REPO_ROOT=self.root,
+            ENGINE=engine,
+            STATE_DIR=state,
+            ENGINE_REF=state / "engine.ref",
+            ENGINE_REF_PREV=state / "engine.ref.prev",
+            ENGINE_PATHS=installed,
+        ), mock.patch.multiple(
+            update.engine_manifest,
+            REPO_ROOT=self.root,
+            ENGINE=engine,
+            MANIFEST=engine / "engine.manifest",
+            local_edits=mock.Mock(return_value={}),
+        ), self.assertRaises(SystemExit) as failed:
+            update.materialize_fetched_engine(target_sha)
+
+        self.assertIn(
+            "materialized engine is incomplete; missing declared path(s): "
+            f"{missing_path}",
+            str(failed.exception),
+        )
+        self.assertIn("remedy: rerun `./sc update --force`", str(failed.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -463,7 +463,7 @@ class EnginePathsAtRefTest(unittest.TestCase):
         )
         self.assertTrue((engine / "engine.manifest").is_file())
 
-    def test_declared_but_absent_path_gets_completeness_remedy(self):
+    def test_declared_but_absent_path_completes_cleanly(self):
         installed = ["sc", ".super-coder/scripts"]
         (self.root / "sc").write_text("old dispatcher\n")
         self.write_manifest(installed)
@@ -480,6 +480,7 @@ class EnginePathsAtRefTest(unittest.TestCase):
 
         state = self.root / ".sc-state"
         engine = self.root / ".super-coder"
+        output = io.StringIO()
         with mock.patch.multiple(
             update,
             REPO_ROOT=self.root,
@@ -494,15 +495,28 @@ class EnginePathsAtRefTest(unittest.TestCase):
             ENGINE=engine,
             MANIFEST=engine / "engine.manifest",
             local_edits=mock.Mock(return_value={}),
-        ), self.assertRaises(SystemExit) as failed:
+        ), contextlib.redirect_stdout(output):
             update.materialize_fetched_engine(target_sha)
 
         self.assertIn(
-            "materialized engine is incomplete; missing declared path(s): "
-            f"{missing_path}",
-            str(failed.exception),
+            f"1 target engine path(s) absent at {target_sha[:12]} — "
+            f"skipping: {missing_path}",
+            output.getvalue(),
         )
-        self.assertIn("remedy: rerun `./sc update --force`", str(failed.exception))
+        self.assertEqual(
+            (state / "engine.ref").read_text(),
+            target_sha + "\n",
+        )
+        self.assertFalse((self.root / missing_path).exists())
+        self.assertFalse(
+            any(
+                path == missing_path
+                or path.startswith(missing_path.rstrip("/") + "/")
+                for path in json.loads((engine / "engine.manifest").read_text())
+            ),
+            "a declared path absent at the target ref must stay out of the "
+            "materialized file manifest",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -409,8 +409,10 @@ class EnginePathsAtRefTest(unittest.TestCase):
             str(failed.exception),
             "update: materialized engine is incomplete; missing declared "
             "path(s): .super-coder/new-path\n"
-            "  remedy: rerun `./sc update --force`; if the paths remain "
-            "missing, report the target engine ref",
+            "  engine.ref was not advanced; the recorded engine pin remains "
+            "unchanged.\n"
+            "  no automated recovery is available; report the target engine "
+            "ref upstream",
         )
         self.assertFalse(
             (state / "engine.ref").exists(),


### PR DESCRIPTION
## Summary

- reload the just-materialized `engine_manifest.py` as the installed authority and archive any path delta missed by target-ref resolution
- assert every declared engine path exists before writing `engine.ref` or the hash manifest, with a named non-zero remedy on short trees
- resolve the target list once per update, thread it through archive/file enumeration, and print provenance once
- rename the retired rollback-fallback universal and pin installed-list authority with a current-ref-added file

The second pass is delta-only. An unconditional full second materialize was rejected by decision #80 because it would make a moved/stale manifest silently authoritative.

## Verification

- `50 passed, 2 subtests passed` across the six spec regression files
- Ruff clean on all three changed files
- hermetic `render_check.py` green
- mutation: remove delta archive → delta fixture red only
- mutation: remove completeness assertion → missing-path fixture red only
- mutation: make guard always fail → quiet mirror red
- mutation: drop resolved-list threading → resolver call count 2, report-once fixture red
- mutation: use `previous_paths` rather than installed authority in rollback → added-path authority assertion red