### PR TITLE
feat(sprint): reconcile worker expectations

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -65,6 +65,7 @@ import interface_wake  # noqa: E402
 import live_model  # noqa: E402
 import ports as ports_mod  # noqa: E402
 import shell_liveness  # noqa: E402
+from sprint_units import UNIT_STATES as _UNIT_STATES  # noqa: E402
 
 TICKET_TTL_S = 60
 RESERVATION_TTL_S = 60
@@ -2267,8 +2268,6 @@ _UNIT_FIELDS = {
     "pr_number": (int, True),
 }
 _UNIT_ROLES = {"dev": "dev_shell_id", "reviewer": "reviewer_shell_id"}
-_UNIT_STATES = ("pending", "working", "in_review", "blocked", "merged",
-                "cancelled")
 
 
 def _is_int(value) -> bool:

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -12,10 +12,14 @@ Nothing here touches the harness; nothing here writes the DB.
 from __future__ import annotations
 
 import sqlite3
+import sys
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
 TEMPLATE_PATH = ENGINE / "templates" / "boot.md"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+from sprint_units import TERMINAL_UNIT_STATES  # noqa: E402
 
 # Rendered into ORIENTATION for every shell EXCEPT the cartographer (who owns the
 # map and heals discrepancies directly — telling it to report them to itself is
@@ -102,8 +106,6 @@ MAP_DB_PATH = ENGINE.parent / ".sc-state" / "map.db"
 # harness is guaranteed to read, and this section is a function of `sprint_units`
 # and the planner binding: a task row cannot grant it, and a missing task row
 # cannot withhold it. The planner is removed from the path.
-TERMINAL_UNIT_STATES = ("merged", "cancelled")
-
 # Stated inline rather than referenced, because the failure mode is precisely a
 # skill body that never loads. This renders as prose in a document every harness
 # reads, so it survives a harness with no skill mechanism at all.

--- a/.super-coder/scripts/activity_readers.py
+++ b/.super-coder/scripts/activity_readers.py
@@ -9,6 +9,10 @@ delivery deliberately live elsewhere.
 ``shell_messages`` and ``sprint_units`` carry all three facts needed here: a
 per-write timestamp, shell attribution, and sprint scope.  Date-only or
 unattributed surfaces are excluded rather than guessed.
+
+``read()`` observes integration refs exactly as they currently are.  Ref
+freshness is the caller's responsibility because one reconciler tick reads
+many worktrees but must fetch the shared integration ref only once.
 """
 from __future__ import annotations
 
@@ -23,6 +27,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from sprint_units import TERMINAL_UNIT_STATES
+
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
 DB_PATH = ENGINE / "shell_db.db"
@@ -32,6 +38,7 @@ PROC = Path("/proc")
 CODEX_CANDIDATE_WINDOW = timedelta(minutes=60)
 UNTIMED_DELETE_RENAME = "last_work_at:untimed_delete_rename"
 AMBIGUOUS_PLANNER_BINDING = "planner_binding:ambiguous"
+INTEGRATION_REF_REFRESH = "integration_refs:refresh_failed"
 BOOT_ARTIFACTS = {
     "CLAUDE.md",
     "AGENTS.md",
@@ -45,6 +52,9 @@ UNREADABLE_FIELDS = {
     "epoch": frozenset({"epoch"}),
     "git_state": frozenset(
         {"dirty", "commits_since_epoch", "last_work_at"}
+    ),
+    INTEGRATION_REF_REFRESH: frozenset(
+        {"branch_present", "commits_since_epoch", "last_work_at"}
     ),
     "marker": frozenset({"marker_at"}),
     "newest_mtime": frozenset({"newest_mtime"}),
@@ -120,6 +130,34 @@ def _boot_artifact(path: str) -> bool:
     if path in BOOT_ARTIFACTS:
         return True
     return path.startswith(".claude/skills/") and path.endswith("/SKILL.md")
+
+
+def refresh_integration_refs(
+    worktree: Path, run=subprocess.run
+) -> bool:
+    """Refresh the shared integration ref once for a reconciler tick.
+
+    ``False`` is data, not a swallowed warning: the caller must mark every
+    affected code-unit reading with :data:`INTEGRATION_REF_REFRESH`.
+    """
+    try:
+        result = run(
+            [
+                "git",
+                "fetch",
+                "--quiet",
+                "origin",
+                "+refs/heads/main:refs/remotes/origin/main",
+            ],
+            cwd=Path(worktree),
+            text=True,
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
 
 
 class ActivityReader:
@@ -289,12 +327,20 @@ class ActivityReader:
                     (shell_id, sprint_doc_id),
                 ).fetchall()
                 if unit is not None:
+                    terminal_marks = ",".join(
+                        "?" for _ in TERMINAL_UNIT_STATES
+                    )
                     active_count = con.execute(
                         "SELECT COUNT(*) FROM sprint_units "
                         "WHERE sprint_doc_id=? "
                         "AND (dev_shell_id=? OR reviewer_shell_id=?) "
-                        "AND state NOT IN ('merged','cancelled')",
-                        (sprint_doc_id, shell_id, shell_id),
+                        f"AND state NOT IN ({terminal_marks})",
+                        (
+                            sprint_doc_id,
+                            shell_id,
+                            shell_id,
+                            *TERMINAL_UNIT_STATES,
+                        ),
                     ).fetchone()[0]
                     if active_count != 1:
                         seq = str(_value(unit, "seq", ""))
@@ -422,15 +468,6 @@ class ActivityReader:
 
         revision = "HEAD" if on_declared_head else f"refs/remotes/origin/{branch}"
         try:
-            fetched = self._git(
-                worktree,
-                "fetch",
-                "--quiet",
-                "origin",
-                "+refs/heads/main:refs/remotes/origin/main",
-            )
-            if fetched.returncode != 0:
-                raise OSError(fetched.stderr)
             contribution = f"refs/remotes/origin/main..{revision}"
             log = self._git(worktree, "log", contribution, "--format=%aI")
         except (OSError, subprocess.SubprocessError):

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -365,6 +365,35 @@ class ReconciliationReading:
     signal: str
     confirmed: bool
     evidence: activity_readers.Evidence
+    measurement: dict[str, object]
+    observed_at: datetime
+    explanation: "str | None"
+
+
+def _measurement(evidence: activity_readers.Evidence) -> dict[str, object]:
+    """Copy classification inputs across the U4/U5 boundary in renderable form."""
+
+    def stamp(value):
+        parsed = _utc(value)
+        return parsed.isoformat() if parsed is not None else None
+
+    return {
+        "epoch": stamp(evidence.epoch),
+        "state_changed_at": stamp(evidence.state_changed_at),
+        "last_result_row_at": stamp(evidence.last_result_row_at),
+        "last_work_at": stamp(evidence.last_work_at),
+        "last_durable_write_at": stamp(evidence.last_durable_write_at),
+        "session_ended_at": stamp(evidence.session_ended_at),
+        "process_present": evidence.process_present,
+        "edits_code": evidence.edits_code,
+        "branch_declared": evidence.branch_declared,
+        "branch_present": evidence.branch_present,
+        "dirty": evidence.dirty,
+        "commits_since_epoch": evidence.commits_since_epoch,
+        "unreadable": tuple(evidence.unreadable),
+        "window_seconds": int(NO_PROGRESS_WINDOW.total_seconds()),
+        "grace_seconds": int(START_GRACE.total_seconds()),
+    }
 
 
 class ReconcilerState:
@@ -550,6 +579,9 @@ def reconcile_tick(
                 signal=signal,
                 confirmed=state.observe(expectation.key, signal),
                 evidence=evidence,
+                measurement=_measurement(evidence),
+                observed_at=current,
+                explanation=None,
             )
         )
     state.retain(seen)

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -23,13 +23,16 @@ What lives here:
   and terminal retirement. Per-repo failures back off capped without blocking
   other repos; a repo recovering from failure marks its next observations as
   blind windows (GitHub may have moved unobserved — convergence, not history).
-- `Poller` — the service's scheduler thread: 30s default interval with jitter,
-  only while ACTIVE sprint watches exist, plus one startup pass; explicit
-  reconcile rides `poll_cycle(source='reconcile')` through the API. It beats
-  the 'watch' heartbeat so `sc watch list` liveness keeps telling the truth.
+- `Poller` — the service's scheduler thread. GitHub polling keeps its 30s
+  watch-gated cadence; worker-expectation reconciliation runs every 10 minutes
+  from structured live units even before a PR or watch exists. Explicit PR
+  reconcile still rides `poll_cycle(source='reconcile')` through the API.
+  The GitHub side beats the 'watch' heartbeat so `sc watch list` liveness keeps
+  telling the truth.
 
 It never injects terminal input, never marks a message read, never acts on a
-PR — polling may create an event, nothing more.
+PR, and never mutates the sprint board. PR polling may create an event; the
+worker reconciler returns report-only readings for the alert unit to consume.
 """
 from __future__ import annotations
 
@@ -42,12 +45,23 @@ import sqlite3
 import subprocess
 import threading
 import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import activity_readers
+from sprint_units import TERMINAL_UNIT_STATES
 
 CONCLUDED = {"SUCCESS", "FAILURE", "ERROR"}   # statusCheckRollup terminal states
 
 DEFAULT_INTERVAL = int(os.environ.get("SC_PR_POLL_INTERVAL", "30"))
+DEFAULT_RECONCILE_INTERVAL = int(
+    os.environ.get("SC_RECONCILE_INTERVAL", "600")
+)
 JITTER_FRACTION = 0.25          # sleep interval + uniform(0, 25%) — herd spread
 BACKOFF_CAP_S = 900             # per-repo failure backoff ceiling (15 min)
+NO_PROGRESS_WINDOW = timedelta(minutes=20)
+START_GRACE = timedelta(minutes=20)
 
 _STATUS_ACTIVE = re.compile(r"^status:\s*ACTIVE\s*$", re.MULTILINE)
 
@@ -202,6 +216,344 @@ def transitions(prev: "dict | None", cur: dict, repo: str, number: int) -> "tupl
         events.append({"key": "closed:CLOSED",
                        "body": f"pr_event {tag}: closed without merge — watch retired"})
     return events, terminal
+
+
+# ── Worker-expectation classification (spec 58, U4) ─────────────────────────
+
+def _utc(value) -> "datetime | None":
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        stamp = value
+    else:
+        try:
+            stamp = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return stamp.astimezone(timezone.utc)
+
+
+def _invalid_evidence_fields(evidence: activity_readers.Evidence) -> set[str]:
+    """Resolve reader markers through U3's exported mapping, never by treating
+    marker text as an Evidence field name."""
+    invalid: set[str] = set()
+    for marker in evidence.unreadable:
+        fields = activity_readers.UNREADABLE_FIELDS.get(marker)
+        if not fields:
+            invalid.add("__unknown__")
+            continue
+        invalid.update(fields)
+    return invalid
+
+
+def classify(
+    evidence: activity_readers.Evidence,
+    now,
+    *,
+    window: timedelta = NO_PROGRESS_WINDOW,
+    grace: timedelta = START_GRACE,
+) -> str:
+    """Apply spec 58's precedence ladder without side effects.
+
+    The clocks are intentionally explicit:
+    - result evidence compares with the unit/binding state clock;
+    - recent work compares with ``now``;
+    - durable completion and branch grace use the boot epoch;
+    - the no-progress window starts at the newest boot, state, or work event.
+    """
+    current = _utc(now) or datetime.now(timezone.utc)
+    epoch = _utc(evidence.epoch)
+    state_clock = _utc(evidence.state_changed_at)
+    invalid = _invalid_evidence_fields(evidence)
+
+    # Rule 1.  These three inputs fence every reliable walk through the ladder:
+    # without the boot/state clocks timing is undefined, and without the result
+    # read a lower rule could outrank a report.  An unknown marker is an
+    # undeclared U3/U4 interface and therefore indeterminate too.
+    if "__unknown__" in invalid:
+        return "indeterminate"
+    if invalid.intersection(
+        {"epoch", "state_changed_at", "last_result_row_at"}
+    ):
+        return "indeterminate"
+    if epoch is None or state_clock is None:
+        return "indeterminate"
+
+    # A failed once-per-tick refresh invalidates every git-derived decider.
+    # Do not turn stale refs into a confident "working" or "not_started".
+    git_deciders = {
+        "branch_present",
+        "commits_since_epoch",
+        "last_work_at",
+    }
+    if evidence.edits_code and git_deciders.issubset(invalid):
+        return "indeterminate"
+
+    # Rule 2 — STATE clock.  This deliberately precedes recent work.
+    result_at = _utc(evidence.last_result_row_at)
+    if result_at is not None and result_at >= state_clock:
+        return "reported"
+
+    # Rule 3 — WORK-EVENT clock.  ``dirty`` is never consulted: a delete-only
+    # tree may legally be dirty with an untimed last_work_at.
+    last_work = _utc(evidence.last_work_at)
+    if (
+        evidence.edits_code
+        and last_work is not None
+        and last_work >= current - window
+    ):
+        return "working"
+
+    # Rule 4 — BOOT clock.  Either authoritative Interface end state or an
+    # absent headless process closes the session.
+    session_over = (
+        _utc(evidence.session_ended_at) is not None
+        or evidence.process_present is False
+    )
+    durable_at = _utc(evidence.last_durable_write_at)
+    if session_over and durable_at is not None and durable_at >= epoch:
+        return "work_complete_unreported"
+
+    # Rule 5 — BOOT clock and the 20-minute grace floor.
+    if (
+        evidence.branch_declared is not None
+        and evidence.branch_present is False
+        and current > epoch + max(grace, START_GRACE)
+    ):
+        return "not_started"
+
+    # Rule 6 — newest BOOT, STATE, or WORK-EVENT clock.  Explanation-tier
+    # marker/CPU observations never enter this maximum.
+    last_evidence = max(
+        stamp for stamp in (epoch, state_clock, last_work) if stamp is not None
+    )
+    if current > last_evidence + max(window, NO_PROGRESS_WINDOW):
+        return "checkup"
+
+    # Rule 7.
+    return "working"
+
+
+@dataclass(frozen=True)
+class Expectation:
+    sprint_doc_id: int
+    unit_id: "int | None"
+    seq: "str | None"
+    role: str
+    shell_id: int
+    shell: object
+    unit: object
+
+    @property
+    def key(self) -> tuple:
+        return (
+            self.sprint_doc_id,
+            self.unit_id,
+            self.role,
+            self.shell_id,
+        )
+
+
+@dataclass
+class ReconciliationReading:
+    """One report-only comparison.  U5 owns turning confirmed signals into
+    messages and alerts; U4 never writes either surface."""
+
+    expectation: Expectation
+    signal: str
+    confirmed: bool
+    evidence: activity_readers.Evidence
+
+
+class ReconcilerState:
+    """Volatile consecutive-tick confirmation.
+
+    A restart intentionally resets confirmation: one fresh observation is
+    cheaper than emitting from state whose immediately preceding tick the new
+    process did not observe.
+    """
+
+    ACTIONABLE = {
+        "checkup",
+        "not_started",
+        "work_complete_unreported",
+    }
+
+    def __init__(self):
+        self._previous: dict[tuple, str] = {}
+
+    def observe(self, key: tuple, signal: str) -> bool:
+        previous = self._previous.get(key)
+        self._previous[key] = signal
+        return signal in self.ACTIONABLE and previous == signal
+
+    def retain(self, keys: set[tuple]) -> None:
+        self._previous = {
+            key: signal
+            for key, signal in self._previous.items()
+            if key in keys
+        }
+
+
+def live_expectations(con) -> list[Expectation]:
+    """Enumerate the structured board, independent of PR watches and prose."""
+    placeholders = ",".join("?" for _ in TERMINAL_UNIT_STATES)
+    units = con.execute(
+        "SELECT u.* FROM sprint_units u "
+        "JOIN documents d ON d.document_id=u.sprint_doc_id "
+        f"WHERE d.frozen=0 AND u.state NOT IN ({placeholders}) "
+        "ORDER BY u.sprint_doc_id, u.unit_id",
+        TERMINAL_UNIT_STATES,
+    ).fetchall()
+    if not units:
+        return []
+
+    doc_ids = sorted({_row(unit, "sprint_doc_id") for unit in units})
+    shell_ids = {
+        shell_id
+        for unit in units
+        for shell_id in (
+            _row(unit, "dev_shell_id"),
+            _row(unit, "reviewer_shell_id"),
+        )
+        if shell_id is not None
+    }
+    marks = ",".join("?" for _ in doc_ids)
+    bindings = con.execute(
+        "SELECT b.sprint_doc_id, b.planner_shell_id "
+        "FROM sprint_planner_bindings b "
+        "WHERE b.binding_id=("
+        " SELECT MAX(b2.binding_id) FROM sprint_planner_bindings b2 "
+        " WHERE b2.sprint_doc_id=b.sprint_doc_id"
+        f") AND b.sprint_doc_id IN ({marks}) "
+        "ORDER BY b.sprint_doc_id",
+        doc_ids,
+    ).fetchall()
+    shell_ids.update(_row(row, "planner_shell_id") for row in bindings)
+
+    if not shell_ids:
+        return []
+    shell_marks = ",".join("?" for _ in shell_ids)
+    shells = {
+        _row(row, "shell_id"): row
+        for row in con.execute(
+            "SELECT shell_id, shortname, flavor FROM shells "
+            f"WHERE shell_id IN ({shell_marks})",
+            tuple(sorted(shell_ids)),
+        ).fetchall()
+    }
+
+    expectations: list[Expectation] = []
+    for binding in bindings:
+        shell_id = _row(binding, "planner_shell_id")
+        shell = shells.get(shell_id)
+        if shell is None:
+            continue
+        expectations.append(
+            Expectation(
+                sprint_doc_id=_row(binding, "sprint_doc_id"),
+                unit_id=None,
+                seq=None,
+                role="planner",
+                shell_id=shell_id,
+                shell=shell,
+                unit=None,
+            )
+        )
+    for unit in units:
+        for role, column in (
+            ("dev", "dev_shell_id"),
+            ("reviewer", "reviewer_shell_id"),
+        ):
+            shell_id = _row(unit, column)
+            shell = shells.get(shell_id)
+            if shell is None:
+                continue
+            expectations.append(
+                Expectation(
+                    sprint_doc_id=_row(unit, "sprint_doc_id"),
+                    unit_id=_row(unit, "unit_id"),
+                    seq=_row(unit, "seq"),
+                    role=role,
+                    shell_id=shell_id,
+                    shell=shell,
+                    unit=unit,
+                )
+            )
+    return expectations
+
+
+def _row(row, key, default=None):
+    if row is None:
+        return default
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return getattr(row, key, default)
+
+
+def reconcile_tick(
+    con,
+    *,
+    now=None,
+    reader=None,
+    refresh=None,
+    state: "ReconcilerState | None" = None,
+    worktree=None,
+) -> list[ReconciliationReading]:
+    """Read and classify every live sprint expectation without DB mutation."""
+    current = _utc(now) or datetime.now(timezone.utc)
+    state = state if state is not None else ReconcilerState()
+    expectations = live_expectations(con)
+    if not expectations:
+        state.retain(set())
+        return []
+
+    refresh = refresh or activity_readers.refresh_integration_refs
+    try:
+        refs_fresh = bool(refresh(Path(worktree or activity_readers.REPO_ROOT)))
+    except Exception:  # noqa: BLE001 — failure is recorded on each code reading
+        refs_fresh = False
+
+    source = reader or activity_readers.read
+    read_one = source.read if hasattr(source, "read") else source
+    cache: dict[tuple, activity_readers.Evidence] = {}
+    readings: list[ReconciliationReading] = []
+    seen: set[tuple] = set()
+    for expectation in expectations:
+        evidence_key = (expectation.shell_id, expectation.unit_id)
+        evidence = cache.get(evidence_key)
+        if evidence is None:
+            evidence = read_one(
+                expectation.shell,
+                expectation.unit,
+                current,
+            )
+            if (
+                not refs_fresh
+                and evidence.edits_code
+                and activity_readers.INTEGRATION_REF_REFRESH
+                not in evidence.unreadable
+            ):
+                evidence.unreadable.append(
+                    activity_readers.INTEGRATION_REF_REFRESH
+                )
+                evidence.unreadable.sort()
+            cache[evidence_key] = evidence
+        signal = classify(evidence, current)
+        seen.add(expectation.key)
+        readings.append(
+            ReconciliationReading(
+                expectation=expectation,
+                signal=signal,
+                confirmed=state.observe(expectation.key, signal),
+                evidence=evidence,
+            )
+        )
+    state.retain(seen)
+    return readings
 
 
 # ── Sprint scoping ────────────────────────────────────────────────────────────
@@ -445,20 +797,32 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
 # ── The service scheduler ─────────────────────────────────────────────────────
 
 class Poller(threading.Thread):
-    """The service's bounded PR-poll scheduler: 30s + jitter, only while
-    ACTIVE sprint watches exist, plus one startup pass. It polls GitHub and
-    writes the engine DB — it never touches a model, a terminal, or git.
-    A fork without `gh` disables itself exactly like the legacy daemon did."""
+    """The service's bounded scheduler.
+
+    GitHub reads remain watch-gated.  Reconciliation has its own cadence and
+    structured-unit trigger, so it still runs before a sprint has any PR.
+    """
 
     def __init__(self, db_path, interval: int = DEFAULT_INTERVAL, fetch=None,
-                 connect=None):
+                 connect=None,
+                 reconcile_interval: int = DEFAULT_RECONCILE_INTERVAL,
+                 activity_reader=None, refresh=None):
         super().__init__(name="pr-poller", daemon=True)
         self._db_path = str(db_path)
         self._interval = interval
         self._fetch = fetch
         self._connect = connect
+        self._reconcile_interval = reconcile_interval
+        self._activity_reader = activity_reader or activity_readers.ActivityReader(
+            db_path=Path(self._db_path)
+        )
+        self._refresh = refresh
+        self._reconcile_due = 0.0
+        self._github_enabled = fetch is not None or shutil.which("gh") is not None
         self._stop_event = threading.Event()
         self.state = PollerState()
+        self.reconciler_state = ReconcilerState()
+        self.last_reconciliation: list[ReconciliationReading] = []
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -470,30 +834,46 @@ class Poller(threading.Thread):
         return db_driver.connect(self._db_path)
 
     def run(self) -> None:  # pragma: no cover — thread loop; scheduler tests drive it
-        if self._fetch is None and shutil.which("gh") is None:
+        if not self._github_enabled:
             print("pr-poller: gh CLI not found — PR polling disabled "
-                  "(install gh + login to enable)", flush=True)
-            return
+                  "(worker reconciliation remains enabled)", flush=True)
         source = "startup"
         while not self._stop_event.is_set():
             try:
                 con = self._db()
                 try:
-                    try:
-                        beat(con, self._interval)
-                    except Exception as e:
-                        # The beat is ancillary liveness; polling is the
-                        # mission (#359). A beat raising into the cycle's
-                        # except would turn a working poller into a
-                        # dead-with-noise one — log and keep polling.
-                        print(f"pr-poller: heartbeat error ({e})", flush=True)
-                    # The DB read is cheap and local; the bounded GitHub poll
-                    # happens only while ACTIVE sprint watches exist.
-                    if armed_watches(con) or live_unscoped_watch_ids(con):
-                        n = poll_cycle(con, fetch=self._fetch, source=source,
-                                       state=self.state, interval=self._interval)
-                        if n["events"] or n["errors"]:
-                            print(f"pr-poller: {n}", flush=True)
+                    if self._github_enabled:
+                        try:
+                            beat(con, self._interval)
+                        except Exception as e:
+                            # The beat is ancillary liveness; polling is the
+                            # mission (#359). A beat raising into the cycle's
+                            # except would turn a working poller into a
+                            # dead-with-noise one — log and keep polling.
+                            print(f"pr-poller: heartbeat error ({e})", flush=True)
+                        # GitHub's bounded read remains watch-gated.
+                        if armed_watches(con) or live_unscoped_watch_ids(con):
+                            n = poll_cycle(
+                                con,
+                                fetch=self._fetch,
+                                source=source,
+                                state=self.state,
+                                interval=self._interval,
+                            )
+                            if n["events"] or n["errors"]:
+                                print(f"pr-poller: {n}", flush=True)
+
+                    monotonic_now = time.monotonic()
+                    if monotonic_now >= self._reconcile_due:
+                        self.last_reconciliation = reconcile_tick(
+                            con,
+                            reader=self._activity_reader,
+                            refresh=self._refresh,
+                            state=self.reconciler_state,
+                        )
+                        self._reconcile_due = (
+                            monotonic_now + self._reconcile_interval
+                        )
                 finally:
                     con.close()
             except Exception as e:

--- a/.super-coder/scripts/sprint_units.py
+++ b/.super-coder/scripts/sprint_units.py
@@ -1,0 +1,19 @@
+"""Shared sprint-unit state vocabulary.
+
+This module is deliberately dependency-free.  The Interface API validates the
+board with it, the boot renderer decides which assignments remain live with it,
+and the supervised reconciler uses the same terminal set for its tick.
+"""
+
+_STATE_VOCABULARY = (
+    ("pending", False),
+    ("working", False),
+    ("in_review", False),
+    ("blocked", False),
+    ("merged", True),
+    ("cancelled", True),
+)
+UNIT_STATES = tuple(state for state, _terminal in _STATE_VOCABULARY)
+TERMINAL_UNIT_STATES = tuple(
+    state for state, terminal in _STATE_VOCABULARY if terminal
+)

--- a/tests/test_activity_readers.py
+++ b/tests/test_activity_readers.py
@@ -526,6 +526,13 @@ class DatabaseContractTest(ReaderCase):
                 "git_state": frozenset(
                     {"dirty", "commits_since_epoch", "last_work_at"}
                 ),
+                "integration_refs:refresh_failed": frozenset(
+                    {
+                        "branch_present",
+                        "commits_since_epoch",
+                        "last_work_at",
+                    }
+                ),
                 "last_work_at:untimed_delete_rename": frozenset(
                     {"last_work_at"}
                 ),
@@ -713,6 +720,7 @@ class GitEvidenceTest(ReaderCase):
         )
         command(self.worktree, "git", "checkout", "feat/test")
         command(self.worktree, "git", "rebase", "main")
+        self.assertTrue(ar.refresh_integration_refs(self.worktree))
 
         rebased = self.read()
 
@@ -740,6 +748,45 @@ class GitEvidenceTest(ReaderCase):
         self.assertEqual(
             datetime(2020, 1, 6, tzinfo=UTC),
             contributed.last_work_at,
+        )
+
+    def test_read_is_fetch_free_and_refresh_is_the_callers_seam(self):
+        calls = []
+
+        def fake(args, **kwargs):
+            calls.append(args)
+            if args[1:3] == ["symbolic-ref", "--quiet"]:
+                return subprocess.CompletedProcess(
+                    args, 0, "feat/test\n", ""
+                )
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        reader = ar.ActivityReader(
+            db_path=self.db,
+            repo_root=self.root,
+            proc=self.proc,
+            adapters=self.adapters,
+            home=self.home,
+            run=fake,
+        )
+        reader.read(
+            self.shell,
+            self.unit,
+            datetime(2020, 1, 10, tzinfo=UTC),
+        )
+        self.assertNotIn("fetch", [arg for call in calls for arg in call])
+
+        self.assertTrue(ar.refresh_integration_refs(self.worktree, run=fake))
+        self.assertEqual(
+            1,
+            sum("fetch" in call for call in calls),
+        )
+
+        def failed(args, **kwargs):
+            return subprocess.CompletedProcess(args, 1, "", "no network")
+
+        self.assertFalse(
+            ar.refresh_integration_refs(self.worktree, run=failed)
         )
 
     def test_criss_cross_history_excludes_every_integration_commit(self):

--- a/tests/test_boot_sprint_directive.py
+++ b/tests/test_boot_sprint_directive.py
@@ -35,6 +35,7 @@ SCHEMA = ENGINE / "schema.sql"
 
 sys.path.insert(0, str(ENGINE / "render"))
 import compose  # noqa: E402
+import sprint_units  # noqa: E402
 
 DEV_SHELL = 11
 REVIEWER_SHELL = 8
@@ -385,12 +386,17 @@ class SprintDirectiveTest(unittest.TestCase):
         self.assertIsNotNone(clause, "the state CHECK clause moved — re-anchor")
         allowed = set(re.findall(r"'(\w+)'", clause.group(1)))
         self.assertNotIn("now", allowed)        # the parse stayed in the clause
+        self.assertEqual(set(sprint_units.UNIT_STATES), allowed)
         self.assertEqual(set(compose.TERMINAL_UNIT_STATES),
                          {"merged", "cancelled"})
         # the complement is the live half, named in full: a new schema state
         # lands HERE and turns this red, which is the addition case.
         self.assertEqual(allowed - set(compose.TERMINAL_UNIT_STATES),
                          {"pending", "working", "in_review", "blocked"})
+        self.assertIs(
+            compose.TERMINAL_UNIT_STATES,
+            sprint_units.TERMINAL_UNIT_STATES,
+        )
 
 
 class BootDocIntegrationTest(unittest.TestCase):

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -2,7 +2,8 @@
 """Tests for the watched-PR polling cutover (spec #20 task #85, decision
 #19): pr_poller's sprint scoping, registration baselines, bounded poll cycle
 (runs/observations/dedupe/backoff/blind windows), wake-item creation, the
-watched_prs uniqueness rebuild (migration 0080), and the service scheduler.
+watched_prs uniqueness rebuild (migration 0080), and the service scheduler's
+watch-independent worker-reconciliation cadence.
 
 Stdlib `unittest`, matching the sibling suites. The GitHub seam is injectable
 (`poll_cycle(con, fetch=...)` / `baseline_read(..., fetch=...)`), so every
@@ -537,6 +538,63 @@ class CutoverTest(unittest.TestCase):
         finally:
             con.close()
 
+    def test_scheduler_reconciles_live_units_without_a_watch(self):
+        tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
+        con = build_db(tmp)
+        seed_shells(con)
+        seed_sprint_doc(con, 100, status="CLOSED")
+        con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id, seq, unit_title, state, dev_shell_id, "
+            " branch, state_changed_at) "
+            "VALUES (100, 'U4', 'tick', 'working', 2, 'feat/test', "
+            "        '2020-01-01T00:00:00Z')"
+        )
+        con.commit()
+        con.close()
+        reads = []
+        refreshes = []
+
+        class Reader:
+            def read(self, shell, unit, now):
+                reads.append((shell["shell_id"], unit["seq"]))
+                return pr_poller.activity_readers.Evidence(
+                    epoch="2020-01-01T00:00:00Z",
+                    state_changed_at="2020-01-01T00:00:00Z",
+                    edits_code=True,
+                    branch_declared="feat/test",
+                    branch_present=True,
+                    process_present=True,
+                )
+
+        poller = pr_poller.Poller(
+            tmp,
+            interval=30,
+            fetch=fetch_ok(),
+            activity_reader=Reader(),
+            refresh=lambda worktree: refreshes.append(worktree) or True,
+        )
+        poller.start()
+        time.sleep(0.5)
+        poller.stop()
+        poller.join(timeout=5)
+
+        self.assertEqual([(2, "U4")], reads)
+        self.assertEqual(1, len(refreshes))
+        self.assertEqual(1, len(poller.last_reconciliation))
+        con = sqlite3.connect(tmp)
+        try:
+            self.assertEqual(
+                0,
+                con.execute("SELECT COUNT(*) FROM watched_prs").fetchone()[0],
+            )
+            self.assertEqual(
+                0,
+                con.execute("SELECT COUNT(*) FROM pr_poll_runs").fetchone()[0],
+            )
+        finally:
+            con.close()
+
     def test_scheduler_surfaces_unscoped_watch_without_fetching_it(self):
         tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
         con = build_db(tmp)
@@ -595,7 +653,7 @@ class CutoverTest(unittest.TestCase):
         finally:
             con.close()
 
-    def test_scheduler_self_disables_without_gh(self):
+    def test_missing_gh_disables_only_pr_reads_not_reconciliation(self):
         import shutil
         old = shutil.which
         shutil.which = lambda name: None
@@ -604,6 +662,9 @@ class CutoverTest(unittest.TestCase):
         try:
             poller = pr_poller.Poller(tmp, interval=30)   # no injected fetch
             poller.start()
+            time.sleep(0.2)
+            self.assertTrue(poller.is_alive())
+            poller.stop()
             poller.join(timeout=5)
         finally:
             shutil.which = old

--- a/tests/test_reconciler_tick.py
+++ b/tests/test_reconciler_tick.py
@@ -53,7 +53,8 @@ def build_db() -> sqlite3.Connection:
         VALUES
           (1, 'Dev', 'DEV1', 'dev', 'x', 1),
           (2, 'Reviewer', 'REV1', 'reviewer', 'x', 1),
-          (3, 'Planner', 'PLN1', 'planner', 'x', 1);
+          (3, 'Planner', 'PLN1', 'planner', 'x', 1),
+          (4, 'Planner 2', 'PLN2', 'planner', 'x', 1);
         """
     )
     return con
@@ -92,6 +93,31 @@ def add_unit(
             branch,
             STATE_CLOCK.isoformat(),
         ),
+    )
+    con.commit()
+
+
+def add_binding(
+    con: sqlite3.Connection,
+    *,
+    doc_id: int = 59,
+    planner: int = 3,
+    generation: int = 1,
+    released_at: str | None = None,
+) -> None:
+    con.execute(
+        "INSERT INTO interface_generations (shell_id, generation) VALUES (?, ?)",
+        (planner, generation),
+    )
+    session_id = con.execute(
+        "INSERT INTO interface_sessions (shell_id, generation) VALUES (?, ?)",
+        (planner, generation),
+    ).lastrowid
+    con.execute(
+        "INSERT INTO sprint_planner_bindings "
+        "(sprint_doc_id, planner_shell_id, session_id, shell_id, generation, "
+        " released_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (doc_id, planner, session_id, planner, generation, released_at),
     )
     con.commit()
 
@@ -135,6 +161,20 @@ class ClassificationPrecedenceTest(unittest.TestCase):
             unreadable=[ar.UNTIMED_DELETE_RENAME],
         )
         self.assertEqual("checkup", pr_poller.classify(item, NOW))
+
+    def test_live_session_with_durable_write_is_not_complete(self):
+        durable = EPOCH + timedelta(minutes=1)
+        self.assertEqual(
+            "checkup",
+            pr_poller.classify(
+                evidence(
+                    process_present=True,
+                    session_ended_at=None,
+                    last_durable_write_at=durable,
+                ),
+                NOW,
+            ),
+        )
 
     def test_session_over_has_two_routes_and_uses_the_boot_clock(self):
         durable = EPOCH + timedelta(minutes=1)
@@ -235,6 +275,14 @@ class TickTest(unittest.TestCase):
         self.assertEqual(["dev", "reviewer"], [
             reading.expectation.role for reading in readings
         ])
+        for reading in readings:
+            self.assertEqual(NOW, reading.observed_at)
+            self.assertIsNone(reading.explanation)
+            self.assertEqual(EPOCH.isoformat(), reading.measurement["epoch"])
+            self.assertEqual(
+                int(pr_poller.NO_PROGRESS_WINDOW.total_seconds()),
+                reading.measurement["window_seconds"],
+            )
         self.assertEqual(
             0,
             self.con.execute("SELECT COUNT(*) FROM watched_prs").fetchone()[0],
@@ -265,6 +313,27 @@ class TickTest(unittest.TestCase):
             state=sprint_units.TERMINAL_UNIT_STATES[0],
         )
         self.assertEqual([], pr_poller.live_expectations(self.con))
+
+    def test_latest_planner_binding_emits_the_rowless_planner_expectation(self):
+        add_unit(self.con)
+        add_binding(
+            self.con,
+            planner=3,
+            released_at=(NOW - timedelta(minutes=1)).isoformat(),
+        )
+        add_binding(self.con, planner=4)
+
+        planners = [
+            expectation
+            for expectation in pr_poller.live_expectations(self.con)
+            if expectation.role == "planner"
+        ]
+
+        self.assertEqual(1, len(planners))
+        self.assertEqual(4, planners[0].shell_id)
+        self.assertEqual("PLN2", planners[0].shell["shortname"])
+        self.assertIsNone(planners[0].unit_id)
+        self.assertIsNone(planners[0].unit)
 
     def test_every_nonterminal_schema_state_remains_a_live_expectation(self):
         for offset, state in enumerate(

--- a/tests/test_reconciler_tick.py
+++ b/tests/test_reconciler_tick.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Worker-expectation classification and supervised tick (spec 58, U4)."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import activity_readers as ar  # noqa: E402
+import pr_poller  # noqa: E402
+import sprint_units  # noqa: E402
+
+UTC = timezone.utc
+NOW = datetime(2020, 1, 1, 1, 0, tzinfo=UTC)
+EPOCH = NOW - timedelta(minutes=40)
+STATE_CLOCK = NOW - timedelta(minutes=35)
+
+
+def evidence(**changes) -> ar.Evidence:
+    values = {
+        "epoch": EPOCH,
+        "state_changed_at": STATE_CLOCK,
+        "last_result_row_at": None,
+        "last_work_at": None,
+        "last_durable_write_at": None,
+        "session_ended_at": None,
+        "process_present": True,
+        "edits_code": True,
+        "branch_declared": "feat/test",
+        "branch_present": True,
+    }
+    values.update(changes)
+    return ar.Evidence(**values)
+
+
+def build_db() -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    con.executescript(
+        """
+        INSERT INTO users (user_id, username) VALUES (1, 'T');
+        INSERT INTO shells
+          (shell_id, display_name, shortname, flavor, system_prompt, user_id)
+        VALUES
+          (1, 'Dev', 'DEV1', 'dev', 'x', 1),
+          (2, 'Reviewer', 'REV1', 'reviewer', 'x', 1),
+          (3, 'Planner', 'PLN1', 'planner', 'x', 1);
+        """
+    )
+    return con
+
+
+def add_unit(
+    con: sqlite3.Connection,
+    *,
+    doc_id: int = 59,
+    unit_id: int = 1,
+    seq: str = "U4",
+    state: str = "working",
+    dev: int | None = 1,
+    reviewer: int | None = 2,
+    branch: str | None = "feat/test",
+    frozen: int = 0,
+    body: str = "status: CLOSED",
+) -> None:
+    con.execute(
+        "INSERT OR IGNORE INTO documents "
+        "(document_id, kind, title, body, frozen) VALUES (?, 'doc', ?, ?, ?)",
+        (doc_id, f"SPRINT: {doc_id}", body, frozen),
+    )
+    con.execute(
+        "INSERT INTO sprint_units "
+        "(unit_id, sprint_doc_id, seq, unit_title, state, dev_shell_id, "
+        " reviewer_shell_id, branch, state_changed_at) "
+        "VALUES (?, ?, ?, 'tick', ?, ?, ?, ?, ?)",
+        (
+            unit_id,
+            doc_id,
+            seq,
+            state,
+            dev,
+            reviewer,
+            branch,
+            STATE_CLOCK.isoformat(),
+        ),
+    )
+    con.commit()
+
+
+class ClassificationPrecedenceTest(unittest.TestCase):
+    def test_unreadable_result_precedes_every_positive_signal(self):
+        item = evidence(
+            last_result_row_at=NOW,
+            last_work_at=NOW,
+            unreadable=["result_row"],
+        )
+        self.assertEqual("indeterminate", pr_poller.classify(item, NOW))
+
+    def test_reported_outranks_recent_work(self):
+        item = evidence(last_result_row_at=NOW, last_work_at=NOW)
+        self.assertEqual("reported", pr_poller.classify(item, NOW))
+
+    def test_result_before_the_state_clock_does_not_close_the_window(self):
+        item = evidence(
+            last_result_row_at=STATE_CLOCK - timedelta(seconds=1),
+            last_work_at=NOW,
+        )
+        self.assertEqual("working", pr_poller.classify(item, NOW))
+
+    def test_recent_work_event_is_working_but_dirty_alone_never_is(self):
+        self.assertEqual(
+            "working",
+            pr_poller.classify(
+                evidence(last_work_at=NOW - timedelta(minutes=1), dirty=True),
+                NOW,
+            ),
+        )
+        self.assertEqual(
+            "checkup",
+            pr_poller.classify(evidence(last_work_at=None, dirty=True), NOW),
+        )
+
+    def test_untimed_delete_or_rename_falls_safe_to_checkup(self):
+        item = evidence(
+            dirty=True,
+            unreadable=[ar.UNTIMED_DELETE_RENAME],
+        )
+        self.assertEqual("checkup", pr_poller.classify(item, NOW))
+
+    def test_session_over_has_two_routes_and_uses_the_boot_clock(self):
+        durable = EPOCH + timedelta(minutes=1)
+        self.assertEqual(
+            "work_complete_unreported",
+            pr_poller.classify(
+                evidence(
+                    session_ended_at=NOW - timedelta(minutes=1),
+                    last_durable_write_at=durable,
+                ),
+                NOW,
+            ),
+        )
+        self.assertEqual(
+            "work_complete_unreported",
+            pr_poller.classify(
+                evidence(
+                    process_present=False,
+                    last_durable_write_at=durable,
+                ),
+                NOW,
+            ),
+        )
+        self.assertEqual(
+            "checkup",
+            pr_poller.classify(
+                evidence(
+                    process_present=False,
+                    last_durable_write_at=EPOCH - timedelta(seconds=1),
+                ),
+                NOW,
+            ),
+        )
+
+    def test_declared_missing_branch_uses_the_boot_grace(self):
+        self.assertEqual(
+            "not_started",
+            pr_poller.classify(evidence(branch_present=False), NOW),
+        )
+        inside_grace = EPOCH + timedelta(minutes=19)
+        self.assertEqual(
+            "working",
+            pr_poller.classify(evidence(branch_present=False), inside_grace),
+        )
+
+    def test_ledger_done_dirty_tree_stays_work_then_becomes_checkup(self):
+        # The task ledger is deliberately absent from Evidence.  These are the
+        # exact other three legs of the observed adversarial state.
+        item = evidence(
+            dirty=True,
+            commits_since_epoch=0,
+            last_work_at=NOW - timedelta(minutes=1),
+        )
+        self.assertEqual("working", pr_poller.classify(item, NOW))
+        self.assertEqual(
+            "checkup",
+            pr_poller.classify(item, NOW + timedelta(minutes=21)),
+        )
+
+    def test_rowless_planner_is_classified_without_branch_evidence(self):
+        item = evidence(
+            edits_code=False,
+            branch_declared=None,
+            branch_present=None,
+            last_result_row_at=NOW,
+        )
+        self.assertEqual("reported", pr_poller.classify(item, NOW))
+
+
+class TickTest(unittest.TestCase):
+    def setUp(self):
+        self.con = build_db()
+        self.addCleanup(self.con.close)
+
+    def test_structured_live_unit_runs_without_pr_watch_or_active_prose(self):
+        add_unit(self.con, body="status: CLOSED")
+        before_messages = self.con.execute(
+            "SELECT COUNT(*) FROM shell_messages"
+        ).fetchone()[0]
+        before_alerts = self.con.execute(
+            "SELECT COUNT(*) FROM planner_alerts"
+        ).fetchone()[0]
+        before_board = tuple(
+            self.con.execute(
+                "SELECT * FROM sprint_units ORDER BY unit_id"
+            ).fetchall()
+        )
+
+        readings = pr_poller.reconcile_tick(
+            self.con,
+            now=NOW,
+            reader=lambda shell, unit, now: evidence(
+                branch_declared=unit["branch"]
+            ),
+            refresh=lambda worktree: True,
+        )
+
+        self.assertEqual(["dev", "reviewer"], [
+            reading.expectation.role for reading in readings
+        ])
+        self.assertEqual(
+            0,
+            self.con.execute("SELECT COUNT(*) FROM watched_prs").fetchone()[0],
+        )
+        self.assertEqual(
+            before_messages,
+            self.con.execute("SELECT COUNT(*) FROM shell_messages").fetchone()[0],
+        )
+        self.assertEqual(
+            before_alerts,
+            self.con.execute("SELECT COUNT(*) FROM planner_alerts").fetchone()[0],
+        )
+        self.assertEqual(
+            before_board,
+            tuple(
+                self.con.execute(
+                    "SELECT * FROM sprint_units ORDER BY unit_id"
+                ).fetchall()
+            ),
+        )
+
+    def test_frozen_and_terminal_units_are_not_expectations(self):
+        add_unit(self.con, doc_id=59, unit_id=1, frozen=1)
+        add_unit(
+            self.con,
+            doc_id=60,
+            unit_id=2,
+            state=sprint_units.TERMINAL_UNIT_STATES[0],
+        )
+        self.assertEqual([], pr_poller.live_expectations(self.con))
+
+    def test_every_nonterminal_schema_state_remains_a_live_expectation(self):
+        for offset, state in enumerate(
+            ("pending", "working", "in_review", "blocked"),
+            start=1,
+        ):
+            add_unit(
+                self.con,
+                doc_id=100 + offset,
+                unit_id=100 + offset,
+                seq=f"U{offset}",
+                state=state,
+                reviewer=None,
+            )
+        self.assertEqual(
+            ["U1", "U2", "U3", "U4"],
+            [
+                expectation.seq
+                for expectation in pr_poller.live_expectations(self.con)
+            ],
+        )
+
+    def test_one_refresh_per_tick_and_one_read_for_two_roles(self):
+        add_unit(self.con, dev=1, reviewer=1)
+        refreshes = []
+        reads = []
+
+        result = pr_poller.reconcile_tick(
+            self.con,
+            now=NOW,
+            reader=lambda shell, unit, now: (
+                reads.append((shell["shell_id"], unit["unit_id"]))
+                or evidence()
+            ),
+            refresh=lambda worktree: refreshes.append(worktree) or True,
+        )
+
+        self.assertEqual(1, len(refreshes))
+        self.assertEqual([(1, 1)], reads)
+        self.assertEqual(2, len(result))
+
+    def test_failed_refresh_is_joined_to_each_affected_reading(self):
+        add_unit(self.con)
+        readings = pr_poller.reconcile_tick(
+            self.con,
+            now=NOW,
+            reader=lambda shell, unit, now: evidence(),
+            refresh=lambda worktree: False,
+        )
+        for reading in readings:
+            self.assertIn(
+                ar.INTEGRATION_REF_REFRESH,
+                reading.evidence.unreadable,
+            )
+            self.assertEqual("indeterminate", reading.signal)
+
+    def test_two_consecutive_ticks_confirm_and_recovery_resets(self):
+        add_unit(self.con, reviewer=None)
+        state = pr_poller.ReconcilerState()
+        stale = lambda shell, unit, now: evidence()
+
+        first = pr_poller.reconcile_tick(
+            self.con,
+            now=NOW,
+            reader=stale,
+            refresh=lambda worktree: True,
+            state=state,
+        )
+        second = pr_poller.reconcile_tick(
+            self.con,
+            now=NOW + timedelta(minutes=10),
+            reader=stale,
+            refresh=lambda worktree: True,
+            state=state,
+        )
+        recovered = pr_poller.reconcile_tick(
+            self.con,
+            now=NOW + timedelta(minutes=11),
+            reader=lambda shell, unit, now: evidence(last_work_at=now),
+            refresh=lambda worktree: True,
+            state=state,
+        )
+        again = pr_poller.reconcile_tick(
+            self.con,
+            now=NOW + timedelta(minutes=32),
+            reader=stale,
+            refresh=lambda worktree: True,
+            state=state,
+        )
+
+        self.assertEqual(("checkup", False), (first[0].signal, first[0].confirmed))
+        self.assertEqual(("checkup", True), (second[0].signal, second[0].confirmed))
+        self.assertEqual(("working", False), (
+            recovered[0].signal,
+            recovered[0].confirmed,
+        ))
+        self.assertEqual(("checkup", False), (again[0].signal, again[0].confirmed))
+
+    def test_two_sprints_are_evaluated_per_unit(self):
+        add_unit(self.con, doc_id=59, unit_id=1, seq="U4", reviewer=None)
+        add_unit(self.con, doc_id=60, unit_id=2, seq="U7", reviewer=None)
+
+        readings = pr_poller.reconcile_tick(
+            self.con,
+            now=NOW,
+            reader=lambda shell, unit, now: evidence(
+                last_result_row_at=(
+                    NOW if unit["sprint_doc_id"] == 60 else None
+                )
+            ),
+            refresh=lambda worktree: True,
+        )
+
+        self.assertEqual(
+            [(59, "U4", "checkup"), (60, "U7", "reported")],
+            [
+                (
+                    item.expectation.sprint_doc_id,
+                    item.expectation.seq,
+                    item.signal,
+                )
+                for item in readings
+            ],
+        )
+
+    def test_shared_terminal_constant_drives_renderer_reader_api_and_tick(self):
+        self.assertIs(
+            pr_poller.TERMINAL_UNIT_STATES,
+            sprint_units.TERMINAL_UNIT_STATES,
+        )
+        self.assertIs(
+            ar.TERMINAL_UNIT_STATES,
+            sprint_units.TERMINAL_UNIT_STATES,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sprint_board_record.py
+++ b/tests/test_sprint_board_record.py
@@ -53,6 +53,7 @@ import interface_routes as routes  # noqa: E402
 import interface_wake  # noqa: E402
 import migrate  # noqa: E402
 import sprint as sprint_cli  # noqa: E402
+import sprint_units  # noqa: E402
 
 OP = "Authorization: Bearer optok"
 PLANNER = "Authorization: Bearer plntok"      # shell 9, flavor planner
@@ -61,6 +62,15 @@ DEV = "Authorization: Bearer devtok"          # shell 11, flavor dev
 REVIEWER = "Authorization: Bearer revtok"     # shell 8, flavor reviewer
 
 DOC_BODY = "# SPRINT: test\nstatus: ACTIVE\n\nprose the record never touches\n"
+
+
+class SharedStateVocabularyTest(unittest.TestCase):
+    def test_api_uses_the_dependency_free_shared_vocabulary(self):
+        self.assertIs(routes._UNIT_STATES, sprint_units.UNIT_STATES)
+        self.assertEqual(
+            set(sprint_units.TERMINAL_UNIT_STATES),
+            {"merged", "cancelled"},
+        )
 
 
 def build_engine_db(path: Path) -> None:


### PR DESCRIPTION
## Summary
- add the report-only U4 worker-expectation classifier and 10-minute supervised tick, driven by structured live sprint units rather than PR watches
- make activity reads fetch-free, refresh integration refs once per tick, and mark failed refreshes as attributable unreadable evidence
- centralize the sprint-unit state vocabulary for the API, U3 result scoping, U9 boot render, and U4 tick

## Scope and trade-off
The shared vocabulary lives in a dependency-free scripts module because importing the Interface routes module would drag its full stack into the renderer and scheduler. The two merged-unit edits are intentionally narrow: activity_readers.py contains only the ruled refresh seam plus the shared terminal import; compose.py only imports the shared terminal set.

## Verification
- U4 reconciler: 17/17 green
- U3 activity reader: 35/35 green
- scheduler/poller: 31/31 green
- U9 boot directive: 21/21 green
- full suite stable rerun: 1841 passed; three sandbox-only harness_epoch failures are flag #208, and one unrelated bounded-buffer timing red passed immediately in isolation
- mutation round trips: reported-over-working precedence, both session-over operands independently, shared terminal vocabulary across renderer/tick, and fetch-free read seam all reddened their named tests and returned green after restore

Sprint 59 unit U4.