### PR TITLE
fix(ui): strengthen navigation dividers

### DIFF
--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -22,6 +22,7 @@
       <span class="navsep"></span>
       <button data-tab="worktrees">Worktrees</button>
       <button data-tab="map">Repo Map</button>
+      <span class="navsep"></span>
       <button data-tab="analytics">Analytics</button>
       <button data-tab="scripts">Scripts</button>
     </nav>

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -40,7 +40,7 @@ h1 { font-size: 1.05rem; margin: 0; font-weight: 650; letter-spacing: .2px; flex
 h1 span { color: var(--dim); font-weight: 400; }
 h1 span::before { content: " / "; color: var(--line); }
 nav { display: flex; gap: 1.1rem; align-items: center; align-self: stretch; }
-.navsep { width: 1px; height: 1.1rem; background: var(--line); margin: 0 .2rem; }
+.navsep { width: 2px; height: 1.75rem; background: var(--line); margin: 0 .2rem; }
 nav button {
   background: none; border: none; color: rgba(255,255,255,.40); position: relative;
   padding: 0 .15rem; cursor: pointer; font: inherit; font-size: 11px;


### PR DESCRIPTION
## Summary
- add a navigation divider between Repo Map and Analytics
- make all navigation dividers taller and thicker while preserving `var(--line)`

## Verification
- `python -m pytest -q tests/test_shells_ui_contract.py tests/test_interface_ui_contract.py` (49 passed)
- rendered the header at 1920×1000 with Playwright and visually checked all three group boundaries