### PR TITLE
fix: keep interface credentials out of snapshots

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -394,12 +394,22 @@ def _idempotent(con, actor: _Actor, operation: str, headers, body_obj,
                     "Idempotency-Key header is required for Interface mutations")
     canonical = hashlib.sha256(
         json.dumps(body_obj, sort_keys=True, default=str).encode()).hexdigest()
+    # The schema has always carried a 24-hour expiry, but lookup used to ignore
+    # it and no sweep removed stale rows. Besides growing without bound, that
+    # kept credential-bearing responses replayable forever. Expiry is part of
+    # the contract: remove stale records before lookup so an old key no longer
+    # shadows a fresh mutation.
+    expired = con.execute(
+        "DELETE FROM interface_idempotency_keys "
+        "WHERE expires_at <= datetime('now')").rowcount
     row = con.execute(
         "SELECT request_hash, response_status, response_resource "
         "FROM interface_idempotency_keys "
         "WHERE actor_scope=? AND operation=? AND idem_key=?",
         (actor.scope, operation, key)).fetchone()
     if row is not None:
+        if expired:
+            con.commit()
         if row[0] != canonical:
             return _err(409, "idempotency_conflict",
                         "Idempotency-Key reused with a different request body")

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -88,6 +88,11 @@ PER_INSTANCE_TABLES = [
     "interface_generations",
     "interface_sessions",
     "interface_input_state",
+    # Ordinary mutation idempotency survives rebuild, but credential-producing
+    # responses do not: acquire_lease carries the raw writer bearer and
+    # mint_ticket carries a single-use stream credential. Their backing
+    # runtime state is deliberately not serialized, so replaying either after
+    # rebuild would return a dead credential as well as leak it to git.
     "interface_idempotency_keys",
     "sprint_planner_bindings",
     "planner_wake_batches",
@@ -180,6 +185,9 @@ SNAPSHOT_ROW_FILTERS = {
     "interface_input_state":
         "WHERE delivery='delivery_unknown' "
         "AND " + _serialized_session("interface_input_state.session_id"),
+    "interface_idempotency_keys":
+        "WHERE expires_at > datetime('now') "
+        "AND operation NOT IN ('acquire_lease','mint_ticket')",
     "sprint_planner_bindings":
         "WHERE " + _serialized_binding(
             "sprint_planner_bindings.binding_id"),

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -784,6 +784,33 @@ class InterfaceApiTest(unittest.TestCase):
                                  {"shell_id": 2})
         self.assertEqual(status, 422)
 
+    def test_expired_idempotency_record_is_purged_not_replayed(self):
+        status, _, first = self.create_session(key="expired-create")
+        self.assertEqual(status, 201)
+        con = sqlite3.connect(self.db_path)
+        con.execute(
+            "UPDATE interface_idempotency_keys SET expires_at='2000-01-01' "
+            "WHERE actor_scope='operator' AND operation='create_session' "
+            "AND idem_key='expired-create'")
+        con.commit()
+        con.close()
+
+        # The old 201 must not replay after its guarantee window. Producing the
+        # request again reaches current state and sees the occupied shell.
+        status, _, second = self.create_session(key="expired-create")
+        self.assertEqual(status, 409)
+        self.assertEqual(second["error"]["code"], "shell_occupied")
+
+        con = sqlite3.connect(self.db_path)
+        row = con.execute(
+            "SELECT response_status, expires_at > datetime('now') "
+            "FROM interface_idempotency_keys "
+            "WHERE actor_scope='operator' AND operation='create_session' "
+            "AND idem_key='expired-create'").fetchone()
+        con.close()
+        self.assertEqual(row, (409, 1),
+                         "expired row was not replaced by the fresh outcome")
+
     # -- New chat refusal ---------------------------------------------------------------
 
     def unmanaged(self, orphaned, shortname="s1"):

--- a/tests/test_interface_snapshot.py
+++ b/tests/test_interface_snapshot.py
@@ -38,6 +38,8 @@ import snapshot  # noqa: E402
 
 SECRET_SOCKET = "/run/sc/SECRET-tmux-socket-0700"
 SECRET_HOOK_HASH = "hookhash_SECRET_must_not_ship_to_git_00000000"
+SECRET_LEASE_TOKEN = "lease_SECRET_must_not_ship_to_git_000000000000000"
+SECRET_STREAM_TICKET = "ticket_SECRET_must_not_ship_to_git_1111111111111"
 
 
 def build_engine_db(path: Path) -> None:
@@ -161,6 +163,25 @@ class InterfaceSnapshotTest(unittest.TestCase):
             " idem_key, request_hash, expires_at) "
             "VALUES ('operator','sessions.create','k','h','2030-01-01')")
         self.con.execute(
+            "INSERT INTO interface_idempotency_keys (actor_scope, operation,"
+            " idem_key, request_hash, response_status, response_resource,"
+            " expires_at) VALUES ('browser:one','acquire_lease','lease','h',"
+            "201,?, '2030-01-01')",
+            (json.dumps({"lease_id": 1, "lease_token": SECRET_LEASE_TOKEN,
+                         "next_input_seq": 1}),))
+        self.con.execute(
+            "INSERT INTO interface_idempotency_keys (actor_scope, operation,"
+            " idem_key, request_hash, response_status, response_resource,"
+            " expires_at) VALUES ('browser:one','mint_ticket','ticket','h',"
+            "201,?, '2030-01-01')",
+            (json.dumps({"ticket": SECRET_STREAM_TICKET,
+                         "expires_in": 60}),))
+        self.con.execute(
+            "INSERT INTO interface_idempotency_keys (actor_scope, operation,"
+            " idem_key, request_hash, response_status, response_resource,"
+            " expires_at) VALUES ('operator','certify_clean','expired','h',"
+            "200,'{}', '2000-01-01')")
+        self.con.execute(
             "INSERT INTO planner_alerts (severity, reason, dedupe_key) "
             "VALUES ('critical','crash','-|-|crash')")
         self.con.execute(
@@ -270,6 +291,17 @@ class InterfaceSnapshotTest(unittest.TestCase):
         self.assertIn("'k1'", self._dump("planner_action_receipts"))
         self.assertIn("'operator'", self._dump("interface_idempotency_keys"))
         self.assertIn("'crash'", self._dump("planner_alerts"))
+
+    def test_credential_and_expired_idempotency_rows_are_not_snapshotted(self):
+        out = self._dump("interface_idempotency_keys")
+        self.assertIn("'sessions.create'", out,
+                      "ordinary unexpired retry record was dropped")
+        self.assertNotIn("'acquire_lease'", out)
+        self.assertNotIn("'mint_ticket'", out)
+        self.assertNotIn("'certify_clean'", out,
+                         "expired retry record reached the snapshot")
+        self.assertNotIn(SECRET_LEASE_TOKEN, out)
+        self.assertNotIn(SECRET_STREAM_TICKET, out)
 
     def test_alerts_require_every_referenced_parent_in_projection(self):
         out = self._dump("planner_alerts")


### PR DESCRIPTION
## Summary
- enforce the existing 24-hour idempotency expiry before replay
- retain unexpired ordinary retry records in durable snapshots
- exclude lease-token and stream-ticket responses from tracked snapshots

## Why
`interface_idempotency_keys.response_resource` can contain raw writer lease tokens and stream tickets. Snapshotting those rows writes bearer credentials into `.sc-state/content.sql`, where full-history gitleaks correctly flags them. The underlying runtime credentials are not serialized, so replaying these responses after rebuild is both unsafe and nonfunctional.

## Verification
- `python3 tests/test_interface_api.py` (99 passed)
- `python3 tests/test_interface_snapshot.py` (14 passed)
- `python3 tests/test_snapshot_secrets.py` (3 passed)
- focused new regression tests (2 passed)
- `git diff --check`