### PR TITLE
feat(skills): assign packs by flavor

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -350,7 +350,7 @@ def get_shell(con, sid: int) -> dict | None:
     r = con.execute(
         "SELECT shell_id, display_name, shortname, partner, role, mandate, "
         "system_prompt, current_state, lineage_seed, "
-        "has_identity, active_archive_id FROM shells "
+        "has_identity, active_archive_id, flavor FROM shells "
         "WHERE shell_id=? AND COALESCE(is_deleted,0)=0", (sid,)).fetchone()
     if r is None:
         return None
@@ -365,7 +365,8 @@ def get_shell(con, sid: int) -> dict | None:
         "ORDER BY entry_date, entry_id", (sid,)))
     shell["skills"] = rows(con.execute(
         "SELECT s.skill_id, s.name, s.description, s.category, "
-        "(SELECT 1 FROM shell_skills ss WHERE ss.shell_id=? AND ss.skill_id=s.skill_id) "
+        "(SELECT 1 FROM resolved_shell_skills ss "
+        " WHERE ss.shell_id=? AND ss.skill_id=s.skill_id) "
         "AS granted FROM skills s WHERE s.is_deleted=0 ORDER BY s.name", (sid,)))
     tag_origin(shell["skills"])
     shell["decisions"] = rows(con.execute(
@@ -390,22 +391,33 @@ def tag_origin(skills: list[dict]) -> list[dict]:
 
 
 def get_skills(con) -> dict:
-    """The full catalogue + per-skill grants for Shells → Skill Assignments.
+    """The catalogue + flavor/Bespoke grants for Shells → Skill Assignments.
     Grouping into sections (repo / category) happens client-side, like
     flags/docs."""
     skills = rows(con.execute(
         "SELECT skill_id, name, description, category, command, common "
         "FROM skills WHERE is_deleted=0 ORDER BY name"))
     tag_origin(skills)
-    grants: dict[int, list] = {}
+    shell_grants: dict[int, list] = {}
     for g in rows(con.execute(
             "SELECT ss.skill_id, ss.shell_id FROM shell_skills ss "
             "JOIN shells sh ON sh.shell_id=ss.shell_id "
-            "WHERE COALESCE(sh.is_deleted,0)=0 ORDER BY ss.shell_id")):
-        grants.setdefault(g["skill_id"], []).append(g["shell_id"])
+            "WHERE sh.flavor IS NULL AND COALESCE(sh.is_deleted,0)=0 "
+            "ORDER BY ss.shell_id")):
+        shell_grants.setdefault(g["skill_id"], []).append(g["shell_id"])
+    flavor_grants: dict[int, list] = {}
+    for g in rows(con.execute(
+            "SELECT skill_id, flavor FROM flavor_skills "
+            "ORDER BY flavor, skill_id")):
+        flavor_grants.setdefault(g["skill_id"], []).append(g["flavor"])
     for s in skills:
-        s["granted_shells"] = grants.get(s["skill_id"], [])
-    return {"skills": skills, "shells": get_shells(con)}
+        s["granted_shells"] = shell_grants.get(s["skill_id"], [])
+        s["granted_flavors"] = flavor_grants.get(s["skill_id"], [])
+    flavors = [
+        {"flavor": t["flavor"], "role": t.get("role")}
+        for t in shell_factory.flavors()
+    ]
+    return {"skills": skills, "shells": get_shells(con), "flavors": flavors}
 
 
 def known_harnesses() -> list[str]:
@@ -1202,7 +1214,19 @@ def resolve_project(con, spec):
         "AND COALESCE(is_deleted,0)=0", (spec,)).fetchone()
 
 
-def set_grant(con, sid, skill_id, granted):
+def set_grant(con, sid, skill_id, granted) -> tuple[bool, str | None]:
+    shell = con.execute(
+        "SELECT flavor FROM shells WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+        (sid,)).fetchone()
+    if shell is None:
+        return False, "no such shell"
+    if shell["flavor"] is not None:
+        return False, (
+            f"shell belongs to flavor '{shell['flavor']}' — edit the flavor pack")
+    if con.execute(
+            "SELECT 1 FROM skills WHERE skill_id=? AND is_deleted=0",
+            (skill_id,)).fetchone() is None:
+        return False, "no such skill"
     if granted:
         con.execute("INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
                     "VALUES (?, ?)", (sid, skill_id))
@@ -1210,6 +1234,35 @@ def set_grant(con, sid, skill_id, granted):
         con.execute("DELETE FROM shell_skills WHERE shell_id=? AND skill_id=?",
                     (sid, skill_id))
     con.commit()
+    return True, None
+
+
+def _known_flavors(con) -> set[str]:
+    return {t["flavor"] for t in shell_factory.flavors()} | {
+        r[0] for r in con.execute(
+            "SELECT DISTINCT flavor FROM shells WHERE flavor IS NOT NULL")
+    } | {
+        r[0] for r in con.execute("SELECT DISTINCT flavor FROM flavor_skills")
+    }
+
+
+def set_flavor_grant(con, flavor, skill_id, granted) -> tuple[bool, str | None]:
+    if flavor not in _known_flavors(con):
+        return False, f"unknown flavor '{flavor}'"
+    if con.execute(
+            "SELECT 1 FROM skills WHERE skill_id=? AND is_deleted=0",
+            (skill_id,)).fetchone() is None:
+        return False, "no such skill"
+    if granted:
+        con.execute(
+            "INSERT OR IGNORE INTO flavor_skills (flavor, skill_id) VALUES (?, ?)",
+            (flavor, skill_id))
+    else:
+        con.execute(
+            "DELETE FROM flavor_skills WHERE flavor=? AND skill_id=?",
+            (flavor, skill_id))
+    con.commit()
+    return True, None
 
 
 # Whitelisted maintenance scripts runnable from the GUI. Each is a fixed argv —
@@ -2959,11 +3012,15 @@ class Handler(BaseHTTPRequestHandler):
                                   {"error": err} if err else proj)
             if path == "/api/shells":
                 body = self._body()
-                if not body.get("name") or not body.get("flavor"):
-                    return self._send(400, {"error": "name and flavor required"})
-                sid = shell_factory.create_shell(
-                    con, flavor=body["flavor"], name=body["name"],
-                    shortname=body.get("shortname"), partner=body.get("partner"))
+                if not body.get("name") or "flavor" not in body:
+                    return self._send(400, {"error": "name and shell type required"})
+                flavor = body.get("flavor") or None
+                try:
+                    sid = shell_factory.create_shell(
+                        con, flavor=flavor, name=body["name"],
+                        shortname=body.get("shortname"), partner=body.get("partner"))
+                except ValueError as e:
+                    return self._send(400, {"error": str(e)})
                 con.commit()
                 sn = con.execute(
                     "SELECT shortname FROM shells WHERE shell_id=?", (sid,)).fetchone()[0]
@@ -3112,7 +3169,9 @@ class Handler(BaseHTTPRequestHandler):
             con.close()
 
     def do_PUT(self):
-        # grant toggle: PUT /api/shells/{id}/skills/{skill_id}  {granted: bool}
+        # grant toggles:
+        #   PUT /api/flavors/{flavor}/skills/{skill_id}  {granted: bool}
+        #   PUT /api/shells/{id}/skills/{skill_id}        {granted: bool}
         # vm block:     PUT /api/vm  {vm: {...}}  (persists to instance.json)
         # ts block:     PUT /api/ts  {ts: {...}}  (persists to instance.json)
         # pm2 block:    PUT /api/pm2  {pm2: {...}}  (persists to instance.json)
@@ -3120,10 +3179,19 @@ class Handler(BaseHTTPRequestHandler):
         parts = path.strip("/").split("/")
         con = db()
         try:
+            if len(parts) == 5 and parts[1] == "flavors" and parts[3] == "skills":
+                ok, err = set_flavor_grant(
+                    con, parts[2], int(parts[4]),
+                    bool(self._body().get("granted")))
+                return self._send(200 if ok else 404,
+                                  {"ok": ok, "error": err})
             if len(parts) == 5 and parts[1] == "shells" and parts[3] == "skills":
-                set_grant(con, int(parts[2]), int(parts[4]),
-                          bool(self._body().get("granted")))
-                return self._send(200, {"ok": True})
+                ok, err = set_grant(
+                    con, int(parts[2]), int(parts[4]),
+                    bool(self._body().get("granted")))
+                status = 200 if ok else (
+                    409 if err and "edit the flavor pack" in err else 404)
+                return self._send(status, {"ok": ok, "error": err})
             if path == "/api/vm":
                 vm = self._body().get("vm")
                 if vm is not None and not isinstance(vm, dict):

--- a/.super-coder/assets/skills/db_map/SKILL.md
+++ b/.super-coder/assets/skills/db_map/SKILL.md
@@ -65,7 +65,7 @@ are ALWAYS empty there — a `dr_*` query against `shell_db.db` silently returns
 | `feature_blockers` | roadmap dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite lands first). Directed, kept acyclic (GUI Flow view wires them; the card's "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `sc mem roadmap depends` |
 | `documents` | content store — spec/doc bodies; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; NEVER edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
-| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine; grants via `./sc skill grant/revoke` |
+| `skills` / `flavor_skills` / `shell_skills` | skill catalogue + shared packs for standard flavors + per-shell packs for Bespoke shells; `resolved_shell_skills` is the effective read view | managed by engine; name any standard shell to change its flavor pack, or a Bespoke shell to change only itself, via `./sc skill grant/revoke` |
 | `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a work-stream that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
 
 `<self>` = your `shell_id` (in the boot doc's ACTIVE SESSION block).

--- a/.super-coder/assets/skills/engine_surgery/SKILL.md
+++ b/.super-coder/assets/skills/engine_surgery/SKILL.md
@@ -130,16 +130,20 @@ python3 .super-coder/scripts/render_check.py
 
 ## Adding a source-repo-only skill
 
-Seeds carry **skills, not grants**: `0001` inserts skill rows and no
-`shell_skills`. Grants happen at shell creation — every shell auto-gets
-`common=1` skills, plus its flavor template's named opt-ins.
+Seeds carry **skills, not grants**: `0001` inserts catalogue rows. Standard
+shells resolve one shared `flavor_skills` pack; Bespoke shells resolve their own
+`shell_skills` rows. Newly-added common skills join every flavor/Bespoke pack
+on update. Opt-ins remain ungranted until assigned.
 
-So a skill with **`common: false` and no entry in any flavor template** seeds
-into a fork's catalogue but is never granted to a fork shell. Grant it here:
+A skill with **`common: false`** seeds into a fork's catalogue without entering
+any pack. Grant it here by naming one shell:
 
 ```
 ./sc skill grant <name> <shell> [<shell>…]
 ```
+
+Naming a standard shell changes its whole flavor pack. Naming a Bespoke shell
+changes only that shell.
 
 ## Stance
 

--- a/.super-coder/assets/skills/local_skill_management/SKILL.md
+++ b/.super-coder/assets/skills/local_skill_management/SKILL.md
@@ -42,10 +42,13 @@ The path: **file -> seed -> grant -> snapshot -> commit**.
    upstream-owned engine territory. DB skills with no asset file = other local
    skills, left intact.
 
-3. **Grant to target shell(s)** — by shell id or shortname:
+3. **Grant to the target pack** — name a shell by id or shortname:
    ```bash
    sc skill grant <skill_name> <shell>...
    ```
+   A standard shell targets its shared flavor pack; every shell of that flavor
+   receives the skill. A Bespoke shell targets only itself. To create an
+   intentional one-shell assignment, create/use a Bespoke shell.
    Unknown skill/shell names = hard error (no silent no-op grants).
    `sc skill list` = catalogue with origins + current grants;
    `sc skill revoke <name> <shell>...` reverses a grant.
@@ -57,8 +60,8 @@ The path: **file -> seed -> grant -> snapshot -> commit**.
    `snapshot.py` serializes local skills (any skill the engine seed doesn't
    own) into the active snapshot (`.sc-state/content.sql` in tracked mode,
    `.sc-state/local/content.sql` in local mode) — what survives `sc update` and
-   `sc rebuild`; the row + grants reconstruct from content.sql. Skip this ->
-   the skill is lost on next update.
+   `sc rebuild`; the row + flavor/Bespoke grants reconstruct from content.sql.
+   Skip this -> the skill is lost on next update.
 
 5. **Finish.** Run `sc render-check` first — hermetic rebuild, fails if the
    `skills_sc/` mirror drifts from the DB render (the CI guard; see the
@@ -72,12 +75,14 @@ Edit the asset file -> repeat seed -> snapshot -> commit (steps 2, 4, 5).
 Asset file gone (removed / authored elsewhere) -> recreate it from the DB body
 first: `sc sql "SELECT content FROM skills WHERE name='<name>'"`.
 
-## Assigning an existing skill to additional shells
+## Assigning an existing skill
 
 ```bash
 sc skill grant <skill_name> <shell>...
 ```
-Then `SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render` + commit.
+Name one standard shell to update its whole flavor, or name a Bespoke shell to
+update only that shell. Then `SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render`
+and commit the resulting artifacts.
 
 ## Removing a skill
 
@@ -89,7 +94,7 @@ Then `SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render` + commit.
    Engine skill this fork has superseded -> retire fork-wide:
    `sc skill retire <name>` (writes the tracked
    `.sc-state/skills_retired.json`, which rides updates; `sc skill unretire`
-   reverses). Per-shell removal -> `sc skill revoke`.
+   reverses). Flavor/Bespoke removal -> `sc skill revoke`.
 
 2. **Remove the asset file** (`.super-coder/assets/skills/<name>/`) —
    otherwise the next `sc seed-skills` re-inserts the skill.
@@ -101,8 +106,8 @@ Then `SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render` + commit.
 
 ## How the GUI organizes skills
 
-The review GUI Skills tab shows the full catalogue in sections with per-shell
-grant toggles; the Shells tab groups its grant list by the same sections.
+Shells → Skill Assignments shows the full catalogue in sections. Each standard
+flavor appears once; Bespoke shells appear individually.
 
 - **Repo skills** — lead section: skills authored in this fork. Membership is
   *derived* — a skill the engine seed doesn't own is repo-local. Same rule
@@ -113,8 +118,10 @@ grant toggles; the Shells tab groups its grant list by the same sections.
   frontmatter. A repo skill's `category` displays as a row label but never
   moves it out of the Repo section.
 
-GUI grant toggles hit the same DB table as `sc skill grant` — they still need
-a snapshot (header button or `SC_ADMIN=1 sc snapshot`) to survive a rebuild.
+GUI grant toggles hit the same ownership boundary as `sc skill grant`:
+`flavor_skills` for standard flavors, `shell_skills` for Bespoke shells. They
+still need a snapshot (header button or `SC_ADMIN=1 sc snapshot`) to survive a
+rebuild.
 
 ## What NOT to do
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1186,7 +1186,7 @@ are ALWAYS empty there — a `dr_*` query against `shell_db.db` silently returns
 | `feature_blockers` | roadmap dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite lands first). Directed, kept acyclic (GUI Flow view wires them; the card''s "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `sc mem roadmap depends` |
 | `documents` | content store — spec/doc bodies; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; NEVER edit a frozen body |
 | `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
-| `skills` / `shell_skills` | skill catalogue (system, seeded from `assets/skills/` via migration) + per-shell grants | managed by engine; grants via `./sc skill grant/revoke` |
+| `skills` / `flavor_skills` / `shell_skills` | skill catalogue + shared packs for standard flavors + per-shell packs for Bespoke shells; `resolved_shell_skills` is the effective read view | managed by engine; name any standard shell to change its flavor pack, or a Bespoke shell to change only itself, via `./sc skill grant/revoke` |
 | `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a work-stream that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
 
 `<self>` = your `shell_id` (in the boot doc''s ACTIVE SESSION block).
@@ -1746,16 +1746,20 @@ python3 .super-coder/scripts/render_check.py
 
 ## Adding a source-repo-only skill
 
-Seeds carry **skills, not grants**: `0001` inserts skill rows and no
-`shell_skills`. Grants happen at shell creation — every shell auto-gets
-`common=1` skills, plus its flavor template''s named opt-ins.
+Seeds carry **skills, not grants**: `0001` inserts catalogue rows. Standard
+shells resolve one shared `flavor_skills` pack; Bespoke shells resolve their own
+`shell_skills` rows. Newly-added common skills join every flavor/Bespoke pack
+on update. Opt-ins remain ungranted until assigned.
 
-So a skill with **`common: false` and no entry in any flavor template** seeds
-into a fork''s catalogue but is never granted to a fork shell. Grant it here:
+A skill with **`common: false`** seeds into a fork''s catalogue without entering
+any pack. Grant it here by naming one shell:
 
 ```
 ./sc skill grant <name> <shell> [<shell>…]
 ```
+
+Naming a standard shell changes its whole flavor pack. Naming a Bespoke shell
+changes only that shell.
 
 ## Stance
 
@@ -2405,10 +2409,13 @@ The path: **file -> seed -> grant -> snapshot -> commit**.
    upstream-owned engine territory. DB skills with no asset file = other local
    skills, left intact.
 
-3. **Grant to target shell(s)** — by shell id or shortname:
+3. **Grant to the target pack** — name a shell by id or shortname:
    ```bash
    sc skill grant <skill_name> <shell>...
    ```
+   A standard shell targets its shared flavor pack; every shell of that flavor
+   receives the skill. A Bespoke shell targets only itself. To create an
+   intentional one-shell assignment, create/use a Bespoke shell.
    Unknown skill/shell names = hard error (no silent no-op grants).
    `sc skill list` = catalogue with origins + current grants;
    `sc skill revoke <name> <shell>...` reverses a grant.
@@ -2420,8 +2427,8 @@ The path: **file -> seed -> grant -> snapshot -> commit**.
    `snapshot.py` serializes local skills (any skill the engine seed doesn''t
    own) into the active snapshot (`.sc-state/content.sql` in tracked mode,
    `.sc-state/local/content.sql` in local mode) — what survives `sc update` and
-   `sc rebuild`; the row + grants reconstruct from content.sql. Skip this ->
-   the skill is lost on next update.
+   `sc rebuild`; the row + flavor/Bespoke grants reconstruct from content.sql.
+   Skip this -> the skill is lost on next update.
 
 5. **Finish.** Run `sc render-check` first — hermetic rebuild, fails if the
    `skills_sc/` mirror drifts from the DB render (the CI guard; see the
@@ -2435,12 +2442,14 @@ Edit the asset file -> repeat seed -> snapshot -> commit (steps 2, 4, 5).
 Asset file gone (removed / authored elsewhere) -> recreate it from the DB body
 first: `sc sql "SELECT content FROM skills WHERE name=''<name>''"`.
 
-## Assigning an existing skill to additional shells
+## Assigning an existing skill
 
 ```bash
 sc skill grant <skill_name> <shell>...
 ```
-Then `SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render` + commit.
+Name one standard shell to update its whole flavor, or name a Bespoke shell to
+update only that shell. Then `SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render`
+and commit the resulting artifacts.
 
 ## Removing a skill
 
@@ -2452,7 +2461,7 @@ Then `SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render` + commit.
    Engine skill this fork has superseded -> retire fork-wide:
    `sc skill retire <name>` (writes the tracked
    `.sc-state/skills_retired.json`, which rides updates; `sc skill unretire`
-   reverses). Per-shell removal -> `sc skill revoke`.
+   reverses). Flavor/Bespoke removal -> `sc skill revoke`.
 
 2. **Remove the asset file** (`.super-coder/assets/skills/<name>/`) —
    otherwise the next `sc seed-skills` re-inserts the skill.
@@ -2464,8 +2473,8 @@ Then `SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render` + commit.
 
 ## How the GUI organizes skills
 
-The review GUI Skills tab shows the full catalogue in sections with per-shell
-grant toggles; the Shells tab groups its grant list by the same sections.
+Shells → Skill Assignments shows the full catalogue in sections. Each standard
+flavor appears once; Bespoke shells appear individually.
 
 - **Repo skills** — lead section: skills authored in this fork. Membership is
   *derived* — a skill the engine seed doesn''t own is repo-local. Same rule
@@ -2476,8 +2485,10 @@ grant toggles; the Shells tab groups its grant list by the same sections.
   frontmatter. A repo skill''s `category` displays as a row label but never
   moves it out of the Repo section.
 
-GUI grant toggles hit the same DB table as `sc skill grant` — they still need
-a snapshot (header button or `SC_ADMIN=1 sc snapshot`) to survive a rebuild.
+GUI grant toggles hit the same ownership boundary as `sc skill grant`:
+`flavor_skills` for standard flavors, `shell_skills` for Bespoke shells. They
+still need a snapshot (header button or `SC_ADMIN=1 sc snapshot`) to survive a
+rebuild.
 
 ## What NOT to do
 

--- a/.super-coder/migrations/0105_flavor_skill_packs.sql
+++ b/.super-coder/migrations/0105_flavor_skill_packs.sql
@@ -1,0 +1,548 @@
+-- 0105 — flavor-owned skill packs + Bespoke-only shell grants
+--
+-- Hard cutover by FnB ruling: standard shells derive one shared pack from
+-- their flavor. Existing per-shell deviations are deliberately discarded,
+-- not reconciled. Bespoke shells (flavor IS NULL) keep shell_skills.
+
+CREATE TABLE IF NOT EXISTS flavor_skills (
+    flavor    TEXT    NOT NULL,
+    skill_id  INTEGER NOT NULL REFERENCES skills(skill_id),
+    PRIMARY KEY (flavor, skill_id)
+);
+
+DROP VIEW IF EXISTS resolved_shell_skills;
+CREATE VIEW resolved_shell_skills AS
+SELECT sh.shell_id, fs.skill_id
+FROM shells sh
+JOIN flavor_skills fs ON fs.flavor = sh.flavor
+WHERE sh.flavor IS NOT NULL
+UNION ALL
+SELECT ss.shell_id, ss.skill_id
+FROM shell_skills ss
+JOIN shells sh ON sh.shell_id = ss.shell_id
+WHERE sh.flavor IS NULL;
+
+-- Every shipped flavor starts with the common catalogue.
+WITH shipped_flavors(flavor) AS (
+    VALUES
+        ('admin'),
+        ('cartographer'),
+        ('dev'),
+        ('devops'),
+        ('planner'),
+        ('reviewer')
+)
+INSERT OR IGNORE INTO flavor_skills (flavor, skill_id)
+SELECT f.flavor, s.skill_id
+FROM shipped_flavors f
+CROSS JOIN skills s
+WHERE s.is_deleted = 0 AND s.common = 1;
+
+-- Then add each shipped template's opt-ins. This list is intentionally the
+-- engine baseline, not a reconstruction of local/per-shell state.
+WITH template_grants(flavor, skill_name) AS (
+    VALUES
+        ('admin', 'git'),
+        ('admin', 'git_cleanup'),
+        ('admin', 'self_update'),
+        ('admin', 'local_skill_management'),
+        ('admin', 'migration_management'),
+        ('admin', 'flag_sweep'),
+        ('admin', 'authoring_syntax'),
+        ('cartographer', 'cartographer'),
+        ('cartographer', 'git'),
+        ('dev', 'docs'),
+        ('dev', 'spec'),
+        ('dev', 'flags'),
+        ('dev', 'git'),
+        ('dev', 'database-migrations'),
+        ('dev', 'redline_review'),
+        ('dev', 'dev_kit'),
+        ('dev', 'test_authoring'),
+        ('dev', 'agents'),
+        ('dev', 'sprint_dev'),
+        ('devops', 'git'),
+        ('devops', 'flags'),
+        ('devops', 'docs'),
+        ('devops', 'database-migrations'),
+        ('devops', 'tailscale'),
+        ('planner', 'docs'),
+        ('planner', 'flags'),
+        ('planner', 'git'),
+        ('planner', 'blueprint'),
+        ('planner', 'api-design'),
+        ('planner', 'onboard'),
+        ('planner', 'sprint_orchestration'),
+        ('planner', 'sprint_orchestration_recover'),
+        ('planner', 'sprint_orchestration_close'),
+        ('reviewer', 'review'),
+        ('reviewer', 'flags'),
+        ('reviewer', 'git'),
+        ('reviewer', 'api-design'),
+        ('reviewer', 'database-migrations'),
+        ('reviewer', 'redline_review'),
+        ('reviewer', 'test_authoring'),
+        ('reviewer', 'agents'),
+        ('reviewer', 'sprint_review')
+)
+INSERT OR IGNORE INTO flavor_skills (flavor, skill_id)
+SELECT g.flavor, s.skill_id
+FROM template_grants g
+JOIN skills s ON s.name = g.skill_name
+WHERE s.is_deleted = 0;
+
+-- shell_skills is now the Bespoke store. Remove flavored-shell rows instead of
+-- migrating their differences; the flavor packs above are the new floor.
+DELETE FROM shell_skills
+WHERE shell_id IN (
+    SELECT shell_id FROM shells WHERE flavor IS NOT NULL
+);
+
+-- Forward-reseed the AI-facing grant procedures.
+-- Generated from assets/skills/*/SKILL.md; UPSERT by name preserves ids.
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted)
+VALUES (
+    'db_map',
+    'Data model behind the engine memory surfaces + the `sc mem` command for each. Check before reading or writing memory — identity, decisions, roadmap, documents, flags. Reads/writes go through the API (`sc mem`), never raw sqlite.',
+    'substrate',
+    NULL,
+    1,
+    '# db_map — super-coder''s DB at a glance
+
+All identity, memory, and content live in the engine DB
+(`.super-coder/shell_db.db`). NEVER touch that file — read and write it only
+through the engine API, via `sc mem`:
+
+- **Read** = `sc mem get <surface>`: your own `state`, `seed`, `lns`,
+  `decisions`, `flags`, `narrative`, `messages`; shared planning state
+  `roadmap`, `projects`, `documents`, `tasks`, `shells` (`--json` for raw).
+  `documents`/`tasks` take `--feature <id>` / `--doc <id>`; `--doc` on
+  `documents` returns the one doc *with* its body.
+- **Write** = `sc mem <cmd> …` (see `## Common writes`).
+
+There is NO raw `sqlite3` path — not as a fallback, not for "ad-hoc" reads.
+If the API isn''t wired, `sc mem` fails loud instead of writing the DB behind
+its back. Your identity rides in your bearer token — the server resolves
+token -> shell; never name a shell in a write. Decisions read FLEET-WIDE
+(every row, tagged `@shortname`) so cross-shell citations resolve; every
+other identity surface reads as you.
+
+**The `sc sql` lane** (read-only; `sc sql-rw` gated) is real and blessed for
+what `sc mem` doesn''t cover: admin/reporting reads and sweep queries — the
+flag_sweep / git_cleanup skills run it by design. The doctrine is one level
+down: memory-surface reads and writes go through `sc mem`; `sc sql` is for
+reporting ACROSS surfaces, never a write path for identity/memory (that is
+what `sc mem` scopes and validates).
+
+The table below = the data model behind those surfaces (what each `sc mem`
+write touches), not a query cheatsheet. Lazy-load: `get` the one surface you
+need, don''t bulk-read.
+
+**Need a read/write `sc mem` doesn''t expose?** Report the gap, don''t reach for
+the DB — the direct path is closed by design, and a fork can''t patch the
+engine (`sc update` would overwrite it). Open a flag naming the data + the
+use, surface it to the FnB (who carries it upstream); message a
+planner-flavor shell too if the fork has one. Until it lands: do what you can
+through the API, flag the rest — NEVER query the DB directly.
+
+```
+sc mem flag open "[Engine] need to <read|write> <what> — no sc mem surface for it | Blocker for: <your work>"
+```
+
+The repo map (`dr_*`) lives in its own db, `.sc-state/map.db` (see the
+`surface_catalogue` skill). The `dr_*` tables also exist in `shell_db.db` but
+are ALWAYS empty there — a `dr_*` query against `shell_db.db` silently returns
+0 rows instead of erroring. Never query `dr_*` here; this map covers only
+`shell_db.db` (memory/identity/content).
+
+## Tables
+
+| Table | Holds | Write rule |
+|---|---|---|
+| `shells` | identity core: `mandate`, `system_prompt`, `current_state` (rolling, ~500 chars), `lineage_seed`, `active_archive_id`. (`connections`/`workspace` retired — boot `## CONNECTIONS` is derived from the `dr_*` map, not authored here) | UPDATE in place |
+| `shell_identity_entries` | seed (cap 10) + L&S (`kind=''lns''`, cap 20); triggers enforce caps | INSERT to add; UPDATE `retired_at` to curate out — NEVER edit a seed body (Law 3) |
+| `shell_decisions` | major decisions | INSERT only; supersede via `parent_decision_id` |
+| `shell_memory_archives` | one row per session; `full_narrative` appended progressively | INSERT at session open; UPDATE narrative |
+| `roadmap` | one row per planned feature; `roadmap_status` = planning horizon (`brainstorm`→`in_progress`→`next`→`near_term`→`long_term`→`shipped`→`retired`), `sort_order` within a bucket. `shipped` = delivered; `retired` = off the board without shipping (decided-against / split / absorbed / replaced) — keep the row. `project_id` (nullable) = the work-stream the feature belongs to; the GUI Flow view groups on it (NULL = Ungrouped) | INSERT/UPDATE |
+| `feature_blockers` | roadmap dependency edges: one row = `feature_id` depends on `blocked_by` (prerequisite lands first). Directed, kept acyclic (GUI Flow view wires them; the card''s "depends on" picker sets them) | INSERT/DELETE the edge; set the whole set via `sc mem roadmap depends` |
+| `documents` | content store — spec/doc bodies; `frozen=1` on ship (immutable); `render_path` = flat-file target | INSERT a new `seq` per stage; NEVER edit a frozen body |
+| `flags` | open + resolved tasks; `feature_id` links a flag to the feature it blocks | INSERT to open; UPDATE `resolved=1` + `resolved_date` to close |
+| `skills` / `flavor_skills` / `shell_skills` | skill catalogue + shared packs for standard flavors + per-shell packs for Bespoke shells; `resolved_shell_skills` is the effective read view | managed by engine; name any standard shell to change its flavor pack, or a Bespoke shell to change only itself, via `./sc skill grant/revoke` |
+| `projects` / `project_shells` | project standing + shell linkage; a `projects` row also doubles as a work-stream that roadmap features attach to via `roadmap.project_id` (the Flow-view grouping) | UPDATE `standing`; INSERT to add |
+
+`<self>` = your `shell_id` (in the boot doc''s ACTIVE SESSION block).
+
+## Common writes
+
+Each routes through the engine API to the live shared DB. `sc mem which`
+orients; `sc mem <cmd> -h` shows flags. Writes always target your own shell —
+the server resolves it from your token.
+
+```
+# current_state (rolling status, not a log — replaces in place):
+sc mem state "…"
+
+# plant a seed / L&S entry (date stamped for you):
+sc mem seed "…"            # sc mem lns "…" for a lesson
+sc mem retire <entry_id>   # curate one out (frees a cap slot)
+
+# record a Major decision (supersede with --parent <id>):
+sc mem decision "…" --rationale "…"
+
+# roadmap: add a feature / move its horizon:
+sc mem roadmap add "…" --status brainstorm --summary "…" [--project <shortname|id>]
+sc mem roadmap status <feature_id> shipped
+
+# roadmap grouping + sequencing (drive the GUI Flow view):
+sc mem roadmap project <feature_id> <shortname|id>   # assign a work-stream (or ''none'' to clear)
+sc mem roadmap depends <feature_id> --on <id> [--on <id>]   # set dependencies (replaces; omit --on to clear; refuses cycles)
+
+# author a spec/doc body (--body-file reads the markdown), then freeze on ship:
+sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
+sc mem doc freeze <document_id>
+
+# spec_tasks (the plan): add a task / advance it / close it honestly:
+sc mem task add "…" --feature <id> --doc <doc_id> --seq <n> [--desc "…"]
+sc mem task start <task_id>     # sc mem task done <task_id>
+sc mem task cancel <task_id> --notes "moved to F<id> as task #<n>"   # split/re-scope — never mark unbuilt work done
+
+# open / edit / close a flag:
+sc mem flag open "[Area] … | Blocker for: …" --name CC-001 [--feature <id>]
+sc mem flag edit <flag_id> [--description "…"] [--priority High] [--feature <id>]
+sc mem flag close <flag_id> --notes "…"
+
+# projects (standing + linkage):
+sc mem project add <shortname> "<title>" --purpose "…" --standing "…"
+sc mem project standing <shortname|id> "…"     # sc mem project status <…> paused
+
+# inbox + first-run:
+sc mem message send <shortname> "…"     # check / mark-read too (see `messaging`)
+sc mem oriented                          # mark first-run done (bootstrapped=1)
+```
+
+## After writing
+
+Nothing more to run — the write is live in the shared engine DB on commit,
+visible to every shell. Persisting to git is an admin/GUI step, not yours.',
+    0
+)
+ON CONFLICT(name) DO UPDATE SET
+    description=excluded.description,
+    category=excluded.category,
+    command=excluded.command,
+    common=excluded.common,
+    content=excluded.content,
+    is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted)
+VALUES (
+    'engine_surgery',
+    'Procedure for changing the engine you are running — pull/reconcile/restart cadence and their costs, three-artifact engine-skill commits with a hermetic mirror render, migrating the live DB safely, and verifying claims about engine code against the remote rather than a possibly-stale checkout. SOURCE-REPO ONLY; a fork consumes the engine as a pinned dependency and never edits it. Load before touching .super-coder/ in the repo that owns it.',
+    'craft',
+    NULL,
+    0,
+    '# engine_surgery — changing the engine you are running
+
+This repo IS the engine. Every shell here runs on the code it edits, reads a DB
+it migrates, and is served by a process started from the tree it commits to.
+That is surgery on a moving car, and it has one characteristic failure mode:
+**a command answers confidently from a target you did not mean.**
+
+**Fork shells never load this.** A fork consumes `.super-coder/` as a gitignored
+dependency pinned by `engine.ref` and updates it with `./sc update`; it never
+authors engine changes. Granted only in the source repo.
+
+## The four trees, and which one bites
+
+| tree | what it is | who keeps it current |
+|---|---|---|
+| your worktree | `.sc-worktrees/<shortname>` — your cwd, your branch | you; boot reports it as `sync:` |
+| the main checkout | resolves your `./sc`, hosts the live DB, runs the server | admin / the FnB; boot reports it as `floor:` |
+| the running process | code already imported — changes only on restart | the FnB |
+| `origin/main` | the truth | whoever merged last |
+
+`sc:11-21` derives the engine root from git''s **common dir**, so `./sc` from any
+worktree reads the MAIN CHECKOUT. Being current in your own tree tells you
+nothing about it. Read the `floor:` line in ACTIVE SESSION.
+
+**Verify any claim about engine code against the remote:**
+
+```
+git show origin/main:<path>     # correct
+./sc help | grep <thing>        # answers from the main checkout — may be stale
+```
+
+Three wrong answers in one session came from skipping that: a help query, a
+pending-migration check that came back empty because it globbed a stale
+migrations dir and nearly made a reconcile a silent no-op, and dormant PR
+watches against a stale running floor.
+
+## EDIT IN YOUR WORKTREE — scripted writes bypass the branch guard
+
+`branch-guard.sh` blocks harness file-edit tools from writing to a
+default-branch checkout. **It does not see writes made by a script.** A
+`cd /home/j3d1/super-coder && python3 -c "...patch..."` lands on `main`,
+uncommitted, with no warning — and your worktree stays clean, so `git status`
+there reassures you nothing happened.
+
+Recovery, if you find edits on the wrong tree:
+
+```
+git -C <main-checkout> diff > /tmp/x.patch
+git apply /tmp/x.patch                                  # in your worktree
+git -C <main-checkout> checkout -- <files>
+```
+
+Prefer the harness edit tools, which are guarded. If you script an edit, `cd` to
+your worktree or use absolute worktree paths, and check `git status` in **both**
+trees afterwards.
+
+## Cadence — pull often, restart rarely
+
+| action | cost | fixes |
+|---|---|---|
+| pull the main checkout | cheap, safe, no session impact | stale reads |
+| apply pending migrations | low; back up first | stale DB rows |
+| `./sc update` + restart | refuses on live Interface state; **restart kills live sessions** | stale running process |
+
+Pull after every merge. Reconcile and restart at **sprint boundaries** — never
+mid-sprint, because a restart kills working devs and swapping the floor under an
+in-flight unit is its own hazard. The restart is the FnB''s call.
+
+## Migrating the live DB
+
+The DB you migrate is the one every shell is using and the server has open.
+
+1. **Fast-forward the main checkout first.** Pending-migration checks glob its
+   `migrations/` dir, so a stale tree reports nothing pending and the reconcile
+   silently does nothing.
+2. **Name the DB path explicitly.** `./sc migrate` from a worktree resolves to
+   the main checkout''s DB and says so nowhere (issue #569). Prefer
+   `python3 .super-coder/scripts/migrate.py <explicit-path>`.
+3. **Back up first**, WAL-safe, via SQLite''s online backup rather than a file
+   copy:
+
+   ```python
+   src = sqlite3.connect(LIVE); dst = sqlite3.connect(BACKUP)
+   with dst: src.backup(dst)
+   ```
+
+4. **Data-only migrations are safe under a running server** (row updates, no
+   DDL). Schema changes want the restart window.
+5. **Verify by read-back**, not by the migrate command''s own output.
+
+## Engine skill edits are a three-artifact commit
+
+All three, or CI goes red even when tests pass:
+
+1. the source asset at `.super-coder/assets/skills/<name>/SKILL.md`;
+2. a **trailing reseed migration** so existing installations converge — full-body
+   upsert, `INSERT … ON CONFLICT(name) DO UPDATE SET`, patterned on the most
+   recent `*_reseed_*.sql`. Generate it FROM the asset rather than hand-writing
+   it, and store the body exactly as the guards read it
+   (`split("---", 2)[2].strip()`) — an unstripped body fails three freshness
+   guards;
+3. the re-rendered mirror.
+
+**Render the mirror through the guard''s own hermetic path**, never from the live
+DB, so it cannot drift from what CI rebuilds:
+
+```python
+import render_check as rc, flat
+rc._build_tracked_db(db)                  # schema → migrations → content.sql
+flat.render_visibility(con, root=rc.ACTIVE_ROOT)
+```
+
+In **local artifact mode** the mirror lives under the ignored `.sc-state/local/`
+and is not in the diff — the commit is then two artifacts, and `render-check`
+still proves the migration.
+
+Run the guard **from your own worktree** — `./sc render-check` resolves to the
+main checkout and will judge code you are not committing (flag #47):
+
+```
+python3 .super-coder/scripts/render_check.py
+```
+
+## Adding a source-repo-only skill
+
+Seeds carry **skills, not grants**: `0001` inserts catalogue rows. Standard
+shells resolve one shared `flavor_skills` pack; Bespoke shells resolve their own
+`shell_skills` rows. Newly-added common skills join every flavor/Bespoke pack
+on update. Opt-ins remain ungranted until assigned.
+
+A skill with **`common: false`** seeds into a fork''s catalogue without entering
+any pack. Grant it here by naming one shell:
+
+```
+./sc skill grant <name> <shell> [<shell>…]
+```
+
+Naming a standard shell changes its whole flavor pack. Naming a Bespoke shell
+changes only that shell.
+
+## Stance
+
+- A command reporting success against a target you did not intend is the house
+  defect. Name the target; verify the effect.
+- Never `SC_ADMIN=1` past a gate to save a step — the publish path is gated on
+  purpose.
+- Never auto-sync the main checkout from a shell. `sync_worktree` may
+  `reset --hard` a shell base; the main checkout is the running server''s tree and
+  a reset discards whatever the operator has in flight.
+- Assert before you replace; read back after you write. A non-matching string
+  replace does nothing and reports success.',
+    0
+)
+ON CONFLICT(name) DO UPDATE SET
+    description=excluded.description,
+    category=excluded.category,
+    command=excluded.command,
+    common=excluded.common,
+    content=excluded.content,
+    is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted)
+VALUES (
+    'local_skill_management',
+    'Create, persist, assign, and remove fork-specific skills — the correct authoring path so skills survive snapshot/rebuild cycles.',
+    'substrate',
+    NULL,
+    0,
+    '# local_skill_management — fork-specific skills that survive
+
+Fork-specific skills live in the DB and persist via `.sc-state/content.sql`
+(the snapshot). The asset file under `.super-coder/assets/skills/<name>/` is
+the **authoring source only** — it sits in gitignored engine territory, and
+that is safe: the engine/local boundary is the seed migration (0001,
+upstream-owned in a fork), not asset-file presence. The snapshot serializes
+your skill to content.sql whether or not the asset file is kept, and
+`sc update` neither manifests it nor heals over its DB row. **content.sql =
+the durable form; the asset file = your editor.**
+
+The path: **file -> seed -> grant -> snapshot -> commit**.
+
+## Creating a fork-specific skill
+
+1. **Write the skill file** at `.super-coder/assets/skills/<name>/SKILL.md`.
+
+   Required frontmatter:
+   ```yaml
+   ---
+   name: skill_name
+   description: One-line summary — shown in boot, catalogue, and the GUI Skills tab
+   category: substrate   # or craft; omit for default
+   ---
+   ```
+   Body: markdown procedure the shell will follow. Imperative, compressed —
+   this boots into context.
+
+2. **Seed into the live DB:**
+   ```bash
+   sc seed-skills
+   ```
+   UPSERTs every asset skill by name (id-stable) and reports what landed. In a
+   fork it deliberately does NOT regenerate the seed migration — that file is
+   upstream-owned engine territory. DB skills with no asset file = other local
+   skills, left intact.
+
+3. **Grant to the target pack** — name a shell by id or shortname:
+   ```bash
+   sc skill grant <skill_name> <shell>...
+   ```
+   A standard shell targets its shared flavor pack; every shell of that flavor
+   receives the skill. A Bespoke shell targets only itself. To create an
+   intentional one-shell assignment, create/use a Bespoke shell.
+   Unknown skill/shell names = hard error (no silent no-op grants).
+   `sc skill list` = catalogue with origins + current grants;
+   `sc skill revoke <name> <shell>...` reverses a grant.
+
+4. **Snapshot — the persistence step:**
+   ```bash
+   SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render
+   ```
+   `snapshot.py` serializes local skills (any skill the engine seed doesn''t
+   own) into the active snapshot (`.sc-state/content.sql` in tracked mode,
+   `.sc-state/local/content.sql` in local mode) — what survives `sc update` and
+   `sc rebuild`; the row + flavor/Bespoke grants reconstruct from content.sql.
+   Skip this -> the skill is lost on next update.
+
+5. **Finish.** Run `sc render-check` first — hermetic rebuild, fails if the
+   `skills_sc/` mirror drifts from the DB render (the CI guard; see the
+   `snapshot` skill). In tracked mode, stage `.sc-state/content.sql` +
+   `skills_sc/` together. In local mode both stay ignored; only engine-owned
+   assets/migrations are committed.
+
+## Updating a skill
+
+Edit the asset file -> repeat seed -> snapshot -> commit (steps 2, 4, 5).
+Asset file gone (removed / authored elsewhere) -> recreate it from the DB body
+first: `sc sql "SELECT content FROM skills WHERE name=''<name>''"`.
+
+## Assigning an existing skill
+
+```bash
+sc skill grant <skill_name> <shell>...
+```
+Name one standard shell to update its whole flavor, or name a Bespoke shell to
+update only that shell. Then `SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render`
+and commit the resulting artifacts.
+
+## Removing a skill
+
+1. **Soft-delete the row + revoke its grants:**
+   ```bash
+   sc skill rm <skill_name>
+   ```
+   Refuses engine skills — the seed resurrects those on next update/rebuild.
+   Engine skill this fork has superseded -> retire fork-wide:
+   `sc skill retire <name>` (writes the tracked
+   `.sc-state/skills_retired.json`, which rides updates; `sc skill unretire`
+   reverses). Flavor/Bespoke removal -> `sc skill revoke`.
+
+2. **Remove the asset file** (`.super-coder/assets/skills/<name>/`) —
+   otherwise the next `sc seed-skills` re-inserts the skill.
+
+3. **Snapshot, render, commit:**
+   ```bash
+   SC_ADMIN=1 sc snapshot && SC_ADMIN=1 sc render
+   ```
+
+## How the GUI organizes skills
+
+Shells → Skill Assignments shows the full catalogue in sections. Each standard
+flavor appears once; Bespoke shells appear individually.
+
+- **Repo skills** — lead section: skills authored in this fork. Membership is
+  *derived* — a skill the engine seed doesn''t own is repo-local. Same rule
+  snapshot.py uses to decide what serializes into `.sc-state/content.sql`, so
+  the section shows exactly what the snapshot keeps durable. No frontmatter
+  flag exists or is needed.
+- **Substrate / Craft / …** — engine skills, sectioned by `category`
+  frontmatter. A repo skill''s `category` displays as a row label but never
+  moves it out of the Repo section.
+
+GUI grant toggles hit the same ownership boundary as `sc skill grant`:
+`flavor_skills` for standard flavors, `shell_skills` for Bespoke shells. They
+still need a snapshot (header button or `SC_ADMIN=1 sc snapshot`) to survive a
+rebuild.
+
+## What NOT to do
+
+- **NEVER skip the snapshot after creating a skill.** Seeding writes the live
+  DB only; content.sql is what survives `sc update` and `sc rebuild`.
+- **NEVER edit `0001_seed_skills.sql` by hand.** Generated, and in a fork
+  upstream-owned engine territory — a local edit blocks the next update.
+- **NEVER create skills via the GUI.** Toggling grants there is fine (snapshot
+  after); creating is not — the GUI writes only the DB and cannot write the
+  asset file or seed it. Use this procedure.',
+    0
+)
+ON CONFLICT(name) DO UPDATE SET
+    description=excluded.description,
+    category=excluded.category,
+    command=excluded.command,
+    common=excluded.common,
+    content=excluded.content,
+    is_deleted=0;

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -388,7 +388,7 @@ def render_connections(con) -> str:
 def render_skills(con, shell_id: int) -> str:
     rows = con.execute(
         "SELECT s.name, s.description FROM skills s "
-        "JOIN shell_skills ss ON ss.skill_id = s.skill_id "
+        "JOIN resolved_shell_skills ss ON ss.skill_id = s.skill_id "
         "WHERE ss.shell_id=? AND s.is_deleted=0 ORDER BY s.name",
         (shell_id,),
     ).fetchall()

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -255,7 +255,7 @@ def render_skill_md(con: sqlite3.Connection, shell_id: int,
     work_dir overrides the write root (used for dev-shell worktrees)."""
     rows = con.execute(
         "SELECT s.name, s.description, s.content FROM skills s "
-        "JOIN shell_skills ss ON ss.skill_id = s.skill_id "
+        "JOIN resolved_shell_skills ss ON ss.skill_id = s.skill_id "
         "WHERE ss.shell_id=? AND s.is_deleted=0 ORDER BY s.name",
         (shell_id,),
     ).fetchall()

--- a/.super-coder/schema.sql
+++ b/.super-coder/schema.sql
@@ -685,6 +685,27 @@ CREATE TABLE shell_skills (
     UNIQUE(shell_id, skill_id)
 );
 
+-- Standard shells share one skill pack per flavor. shell_skills is reserved
+-- for bespoke shells (flavor IS NULL); resolved_shell_skills is the only read
+-- path consumers use, so stale per-shell rows can never make flavored siblings
+-- diverge.
+CREATE TABLE flavor_skills (
+    flavor    TEXT    NOT NULL,
+    skill_id  INTEGER NOT NULL REFERENCES skills(skill_id),
+    PRIMARY KEY (flavor, skill_id)
+);
+
+CREATE VIEW resolved_shell_skills AS
+SELECT sh.shell_id, fs.skill_id
+FROM shells sh
+JOIN flavor_skills fs ON fs.flavor = sh.flavor
+WHERE sh.flavor IS NOT NULL
+UNION ALL
+SELECT ss.shell_id, ss.skill_id
+FROM shell_skills ss
+JOIN shells sh ON sh.shell_id = ss.shell_id
+WHERE sh.flavor IS NULL;
+
 -- ── Projects (per-shell project standing) ───────────────────────────────────
 
 CREATE TABLE projects (

--- a/.super-coder/scripts/feature.py
+++ b/.super-coder/scripts/feature.py
@@ -124,39 +124,36 @@ def _write_instance(cfg: dict) -> None:
 
 
 def grant(con, skill: str, flavors: list[str]) -> int:
-    """Grant `skill` to every live shell of the given flavors. Idempotent."""
+    """Grant `skill` once to each named flavor pack. Idempotent."""
     q = ",".join("?" for _ in flavors)
     cur = con.execute(
-        f"INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
-        f"SELECT s.shell_id, k.skill_id FROM shells s, skills k "
-        f"WHERE COALESCE(s.is_deleted,0)=0 AND s.flavor IN ({q}) "
-        f"AND k.name=? AND k.is_deleted=0",
-        (*flavors, skill))
+        f"INSERT OR IGNORE INTO flavor_skills (flavor, skill_id) "
+        f"SELECT f.flavor, k.skill_id "
+        f"FROM (SELECT flavor FROM flavor_skills WHERE flavor IN ({q}) "
+        f"      UNION SELECT flavor FROM shells WHERE flavor IN ({q})) f, skills k "
+        f"WHERE k.name=? AND k.is_deleted=0",
+        (*flavors, *flavors, skill))
     return cur.rowcount
 
 
 def revoke(con, skill: str, flavors: list[str]) -> int:
-    """Revoke `skill` from shells of the given flavors — only the grants enable
-    would have made; a grant to a bespoke/other-flavor shell is left alone."""
+    """Revoke `skill` from named flavor packs; Bespoke grants stay untouched."""
     q = ",".join("?" for _ in flavors)
     cur = con.execute(
-        f"DELETE FROM shell_skills WHERE skill_id IN "
+        f"DELETE FROM flavor_skills WHERE skill_id IN "
         f"(SELECT skill_id FROM skills WHERE name=? AND is_deleted=0) "
-        f"AND shell_id IN (SELECT shell_id FROM shells "
-        f"WHERE COALESCE(is_deleted,0)=0 AND flavor IN ({q}))",
+        f"AND flavor IN ({q})",
         (skill, *flavors))
     return cur.rowcount
 
 
 def _grant_state(con, skill: str) -> list[str]:
-    """['dev(2)', 'reviewer(1)'] — live shells holding the skill, by flavor."""
+    """['dev', 'reviewer'] — flavor packs holding the skill."""
     rows = con.execute(
-        "SELECT COALESCE(s.flavor,'bespoke'), COUNT(*) FROM shell_skills g "
-        "JOIN shells s ON s.shell_id=g.shell_id "
+        "SELECT g.flavor FROM flavor_skills g "
         "JOIN skills k ON k.skill_id=g.skill_id "
-        "WHERE k.name=? AND COALESCE(s.is_deleted,0)=0 AND k.is_deleted=0 "
-        "GROUP BY 1 ORDER BY 1", (skill,)).fetchall()
-    return [f"{flavor}({n})" for flavor, n in rows]
+        "WHERE k.name=? AND k.is_deleted=0 ORDER BY g.flavor", (skill,)).fetchall()
+    return [flavor for (flavor,) in rows]
 
 
 def _snapshot() -> None:

--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -147,7 +147,8 @@ def main(argv: list[str]) -> int:
                 "SELECT shortname FROM shells WHERE shell_id=?", (sid,)).fetchone()[0]
 
         n = con.execute(
-            "SELECT COUNT(*) FROM shell_skills WHERE shell_id=?", (shell_id,)).fetchone()[0]
+            "SELECT COUNT(*) FROM resolved_shell_skills WHERE shell_id=?",
+            (shell_id,)).fetchone()[0]
         print(f"init_fork: created '{_sn(shell_id)}' ({flavor}, shell_id={shell_id}) "
               f"for user '{username}' — your primary, {n} skills, lineage + genesis seed.")
         for fl, sid in team:

--- a/.super-coder/scripts/shell_factory.py
+++ b/.super-coder/scripts/shell_factory.py
@@ -1,28 +1,18 @@
 #!/usr/bin/env python3
-"""Create a shell from a flavor template — the one path both init_fork (the
-fork's first shell) and the GUI (`POST /api/shells`, additional shells) use.
+"""Create a templated flavor shell or one untemplated Bespoke shell — the one
+path both init_fork and the GUI (`POST /api/shells`) use.
 
-A flavor (templates/shells/<flavor>.json) sets role / mandate / focus / opt-in
-skills, so creating a shell is mostly just a name. Every shell carries the CC
-Lineage Seed (Law 6, shared) + its own genesis seed (Laws 2-4), is granted the
-COMMON skill catalogue plus the flavor's opt-ins, starts un-bootstrapped (gets
+A flavor template sets role / mandate / focus and declares the engine baseline
+used to seed its pack, so creating a shell is mostly just a name. Standard
+shell skills resolve from the shared flavor pack; Bespoke shells have flavor
+NULL and their own shell_skills rows. Every shell carries the CC Lineage Seed
+(Law 6, shared) + its own genesis seed (Laws 2-4), starts un-bootstrapped (gets
 the FIRST RUN orientation), and has its first session opened.
 
-Fork-local flavor OVERLAYS: the engine templates are materialized (overwritten
-on `./sc update`), so a fork cannot durably edit them — yet a fork legitimately
-changes what a new shell of a flavor gets (dos-arch replaced `test_authoring`
-with its own `test_authoring_dosarch`; every new dev/reviewer shell then booted
-with the wrong grant). A tracked, fork-owned overlay at
-`.sc-state/flavors/<flavor>.json` closes that:
-
-    {"skills_add": ["test_authoring_dosarch"],
-     "skills_remove": ["test_authoring", "test_authoring_pg"]}
-
-`skills_add` / `skills_remove` adjust the engine list (the durable form — the
-engine list keeps evolving upstream and the overlay rides it); any other key
-(role, mandate, focus, abbr — not `flavor` itself) overrides the template's.
-Applied by load_flavor()/flavors(), so shell creation AND the GUI's flavor
-listing both see the overlaid shape.
+Fork-local flavor overlays may replace identity text (`role`, `mandate`,
+`focus`, `abbr`) without editing materialized engine templates. Skill
+assignment no longer flows through overlays: the live `flavor_skills` pack is
+the one write surface for every shell of that flavor.
 """
 from __future__ import annotations
 
@@ -48,21 +38,31 @@ GENESIS_TMPL = (
     "one shell, one cwd. Everything I am lives in the DB; the process is just the "
     "floor I stand on. I curate my own seed from here.")
 
+BESPOKE_TEMPLATE = {
+    "abbr": "BSP",
+    "role": "Bespoke shell",
+    "mandate": (
+        "Work in {{repo}} through the custom skill pack assigned to you. "
+        "No standard flavor template defines your lane."
+    ),
+    "focus": (
+        "You are a bespoke shell. Treat your granted skills and the operator's "
+        "direction as your scope; do not infer a standard planner, dev, reviewer, "
+        "admin, devops, or cartographer role."
+    ),
+}
+
 
 FORK_FLAVOR_OVERLAYS = REPO_ROOT / ".sc-state" / "flavors"
 
 
 def _apply_overlay(tpl: dict, overlay: dict) -> dict:
-    """Merge a fork overlay over an engine flavor template (pure — see the
-    module docstring for the format). skills_add/skills_remove adjust the
-    engine skill list; other keys override, except `flavor` (the identity the
-    overlay is keyed BY — an overlay cannot rename it)."""
+    """Merge identity fields over a template; never rename its flavor.
+
+    Legacy skills_add/skills_remove keys are ignored. Flavor skill packs are
+    edited in the DB and shared by every shell of that flavor.
+    """
     out = {**tpl}
-    add = overlay.get("skills_add", [])
-    remove = set(overlay.get("skills_remove", []))
-    if add or remove:
-        skills = [s for s in tpl.get("skills", []) if s not in remove]
-        out["skills"] = skills + [s for s in add if s not in skills]
     for k, v in overlay.items():
         if k not in ("skills_add", "skills_remove", "flavor"):
             out[k] = v
@@ -125,14 +125,14 @@ def render_prompt(name: str, role: str, repo: str, focus: str, mandate: str) -> 
     return text
 
 
-def create_shell(con, *, flavor: str, name: str,
+def create_shell(con, *, flavor: str | None, name: str,
                  shortname: str | None = None, partner: str | None = None,
                  repo: str | None = None, role: str | None = None,
                  mandate: str | None = None, user_id: int = 1,
                  is_shared: int = 0) -> int:
-    """Insert a shell from `flavor`, grant its skills, open its first session.
+    """Insert a flavor shell or Bespoke shell and open its first session.
     Returns the new shell_id. Caller commits."""
-    tpl = load_flavor(flavor)
+    tpl = load_flavor(flavor) if flavor else BESPOKE_TEMPLATE
     # Cartographer is a singleton: one map-keeper per fork. Friendly pre-check
     # here; the trg_singleton_cartographer trigger is the DB backstop. is_deleted=0
     # so a deleted cartographer frees the slot.
@@ -146,7 +146,7 @@ def create_shell(con, *, flavor: str, name: str,
     focus = tpl.get("focus", "").replace("{{repo}}", repo)
     # Explicit shortname wins; otherwise auto-name <ABBR><n> from the flavor so
     # the caller (GUI / init) need not supply one.
-    abbr = tpl.get("abbr") or flavor[:3]
+    abbr = tpl.get("abbr") or (flavor or "bsp")[:3]
     shortname = shortname.strip() if shortname else _auto_shortname(con, abbr)
 
     api_key = secrets.token_urlsafe(32)
@@ -158,7 +158,7 @@ def create_shell(con, *, flavor: str, name: str,
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?, ?, datetime('now'))",
         (name, shortname, partner, role, mandate,
          render_prompt(name, role, repo, focus, mandate),
-         f"Created ({flavor}). First session — run the bootstrap skill to orient.",
+         f"Created ({flavor or 'Bespoke'}). First session — run the bootstrap skill to orient.",
          f"Single repo: this one ({repo}). One shell, one cwd.",
          LINEAGE_SEED, flavor, user_id, is_shared,
          api_key))
@@ -169,15 +169,13 @@ def create_shell(con, *, flavor: str, name: str,
         "VALUES (?, 'seed', CURRENT_DATE, 'fork', ?)",
         (shell_id, GENESIS_TMPL.format(role_lc=role.lower(), repo=repo)))
 
-    # COMMON catalogue (auto) + this flavor's opt-in skills, granted by name.
-    con.execute(
-        "INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
-        "SELECT ?, skill_id FROM skills WHERE is_deleted=0 AND common=1", (shell_id,))
-    for sk in tpl.get("skills", []):
+    # Standard shells inherit the shared flavor pack. Bespoke shells start from
+    # the common baseline and can diverge through their own shell_skills rows.
+    if flavor is None:
         con.execute(
             "INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
-            "SELECT ?, skill_id FROM skills WHERE name=? AND is_deleted=0",
-            (shell_id, sk))
+            "SELECT ?, skill_id FROM skills WHERE is_deleted=0 AND common=1",
+            (shell_id,))
 
     open_session(con, shell_id)
     return shell_id

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -8,6 +8,8 @@ no-op (`INSERT ... SELECT` over zero rows, #253). This surface makes the
 lifecycle first-class and loud: unknown skill or shell names are hard
 errors, engine skills refuse `rm` (the seed would just resurrect them),
 and every write reminds you that `./sc snapshot` is the persistence step.
+Naming a standard shell targets its shared flavor pack; naming a Bespoke shell
+targets only that shell.
 
 Catalogue rows themselves are authored as assets + `./sc seed-skills`
 (engine + fork-local alike); this command manages what's GRANTED where,
@@ -36,8 +38,8 @@ Usage:
     ./sc skill list                        catalogue: origin, common, grants
     ./sc skill add <name> --file <path>    author a LOCAL skill (DB-only) + grant it
                   [--desc "…"] [--category …] [--for <shell>] [--opt-in]
-    ./sc skill grant  <name> <shell>...    grant a skill to shell(s) (id or shortname)
-    ./sc skill revoke <name> <shell>...    revoke a skill from shell(s)
+    ./sc skill grant  <name> <shell>...    grant via shell reference (flavor/Bespoke)
+    ./sc skill revoke <name> <shell>...    revoke via shell reference
     ./sc skill rm     <name>               soft-delete a LOCAL skill + revoke all grants
     ./sc skill retire   <name>             retire an ENGINE skill fork-wide (durable)
     ./sc skill unretire <name>             restore a retired engine skill (+ its grants)
@@ -86,6 +88,54 @@ def resolve_shell(con, ref: str) -> tuple[int, str]:
              + ", ".join(f"{i} ({n})" for i, n in have))
 
 
+def set_target_grant(con, shell_id: int, label: str, skill_id: int,
+                     granted: bool) -> tuple[int, str]:
+    """Mutate the owning pack for a shell and return (rowcount, scope label)."""
+    flavor = con.execute(
+        "SELECT flavor FROM shells WHERE shell_id=?", (shell_id,)).fetchone()[0]
+    if flavor is not None:
+        if granted:
+            cur = con.execute(
+                "INSERT OR IGNORE INTO flavor_skills (flavor, skill_id) "
+                "VALUES (?, ?)", (flavor, skill_id))
+        else:
+            cur = con.execute(
+                "DELETE FROM flavor_skills WHERE flavor=? AND skill_id=?",
+                (flavor, skill_id))
+        return cur.rowcount, f"{flavor} flavor"
+    if granted:
+        cur = con.execute(
+            "INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+            (shell_id, skill_id))
+    else:
+        cur = con.execute(
+            "DELETE FROM shell_skills WHERE shell_id=? AND skill_id=?",
+            (shell_id, skill_id))
+    return cur.rowcount, f"Bespoke {label}"
+
+
+def grant_scopes(con, skill_id: int) -> list[str]:
+    rows = con.execute(
+        "SELECT 'flavor:' || flavor AS scope "
+        "FROM flavor_skills WHERE skill_id=? "
+        "UNION ALL "
+        "SELECT 'shell:' || COALESCE(sh.shortname, sh.display_name, sh.shell_id) "
+        "FROM shell_skills ss JOIN shells sh ON sh.shell_id=ss.shell_id "
+        "WHERE ss.skill_id=? AND sh.flavor IS NULL "
+        "AND COALESCE(sh.is_deleted,0)=0 ORDER BY scope",
+        (skill_id, skill_id)).fetchall()
+    return [r[0] for r in rows]
+
+
+def grant_count(con, skill_id: int) -> int:
+    return con.execute(
+        "SELECT (SELECT COUNT(*) FROM flavor_skills WHERE skill_id=?) + "
+        "(SELECT COUNT(*) FROM shell_skills ss "
+        " JOIN shells sh ON sh.shell_id=ss.shell_id "
+        " WHERE ss.skill_id=? AND sh.flavor IS NULL)",
+        (skill_id, skill_id)).fetchone()[0]
+
+
 def resolve_skill(con, name: str) -> int:
     """A live skill row by name. Loud on a miss — the silent-no-op killer."""
     row = con.execute(
@@ -113,20 +163,18 @@ def cmd_list(con) -> int:
     engine = set(seed_skills.seeded_skill_names())
     retired = set(seed_skills.retired_skill_names())
     rows = con.execute(
-        "SELECT s.skill_id, s.name, s.common, s.is_deleted, "
-        "  (SELECT GROUP_CONCAT(COALESCE(sh.shortname, sh.shell_id), ', ') "
-        "   FROM shell_skills ss JOIN shells sh ON sh.shell_id = ss.shell_id "
-        "   WHERE ss.skill_id = s.skill_id AND COALESCE(sh.is_deleted,0)=0) "
+        "SELECT s.skill_id, s.name, s.common, s.is_deleted "
         "FROM skills s ORDER BY s.is_deleted, s.name").fetchall()
     if not rows:
         print("(no skills)")
         return 0
     w = max(len(r[1]) for r in rows)
-    for _, name, common, deleted, grants in rows:
+    for skill_id, name, common, deleted in rows:
         origin = "engine" if name in engine else "local "
         tag = "common" if common else "opt-in"
         dead = ("  [retired]" if name in retired else "  [deleted]") if deleted else ""
-        print(f"{name:<{w}}  {origin}  {tag}  → {grants or '(ungranted)'}{dead}")
+        scopes = ", ".join(grant_scopes(con, skill_id)) or "(ungranted)"
+        print(f"{name:<{w}}  {origin}  {tag}  → {scopes}{dead}")
     return 0
 
 
@@ -211,13 +259,13 @@ def cmd_add(con, argv: list[str]) -> int:
         (name, args.desc, args.category, args.command,
          0 if args.opt_in else 1, content))
     skill_id = con.execute("SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()[0]
-    # Guard 5 — auto-grant to the author, or the promotion produces a skill
-    # nobody can read.
-    con.execute("INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
-                (author_id, skill_id))
+    # Guard 5 — auto-grant to the author's owning pack, or the promotion
+    # produces a skill nobody can read.
+    _, scope = set_target_grant(con, author_id, author, skill_id, True)
     con.commit()
     verb = "updated" if row else "added"
-    print(f"add: {name} {verb} (local, DB-only, {len(content)} chars) → granted to {author}")
+    print(f"add: {name} {verb} (local, DB-only, {len(content)} chars) "
+          f"→ granted to {scope}")
     if not args.desc:
         print("  ⚠ no --desc — the boot SKILLS block lists the name with an empty "
               "summary; re-run with --desc to make it findable.")
@@ -229,11 +277,9 @@ def cmd_grant(con, name: str, shell_refs: list[str]) -> int:
     skill_id = resolve_skill(con, name)
     for ref in shell_refs:
         shell_id, label = resolve_shell(con, ref)
-        cur = con.execute(
-            "INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
-            (shell_id, skill_id))
-        print(f"grant: {name} → {label}"
-              + ("" if cur.rowcount else "  (already granted)"))
+        changed, scope = set_target_grant(con, shell_id, label, skill_id, True)
+        print(f"grant: {name} → {scope}"
+              + ("" if changed else "  (already granted)"))
     con.commit()
     persist_note()
     return 0
@@ -243,11 +289,9 @@ def cmd_revoke(con, name: str, shell_refs: list[str]) -> int:
     skill_id = resolve_skill(con, name)
     for ref in shell_refs:
         shell_id, label = resolve_shell(con, ref)
-        cur = con.execute(
-            "DELETE FROM shell_skills WHERE shell_id=? AND skill_id=?",
-            (shell_id, skill_id))
-        print(f"revoke: {name} ⇸ {label}"
-              + ("" if cur.rowcount else "  (was not granted)"))
+        changed, scope = set_target_grant(con, shell_id, label, skill_id, False)
+        print(f"revoke: {name} ⇸ {scope}"
+              + ("" if changed else "  (was not granted)"))
     con.commit()
     persist_note()
     return 0
@@ -280,9 +324,9 @@ def cmd_retire(con, name: str) -> int:
     if not already:
         _write_retire_list(names + [name])
     seed_skills.apply_retired(con)
-    dormant = con.execute(
-        "SELECT COUNT(*) FROM shell_skills ss JOIN skills s ON s.skill_id=ss.skill_id "
-        "WHERE s.name=?", (name,)).fetchone()[0]
+    dormant = grant_count(
+        con, con.execute(
+            "SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()[0])
     rel = _display_retire_file()
     print(f"retire: {name}" + ("  (already listed)" if already else "")
           + f" — retired fork-wide; {dormant} grant(s) kept dormant "
@@ -299,9 +343,9 @@ def cmd_unretire(con, name: str) -> int:
                  f"({seed_skills.RETIRED_FILE}).")
     _write_retire_list([n for n in names if n != name])
     seed_skills.apply_retired(con)
-    grants = con.execute(
-        "SELECT COUNT(*) FROM shell_skills ss JOIN skills s ON s.skill_id=ss.skill_id "
-        "WHERE s.name=?", (name,)).fetchone()[0]
+    grants = grant_count(
+        con, con.execute(
+            "SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()[0])
     rel = _display_retire_file()
     print(f"unretire: {name} — restored with {grants} grant(s) live again.")
     action = "commit" if artifact_policy.tracks_local_artifacts() else "kept local at"
@@ -315,8 +359,9 @@ def cmd_rm(con, name: str) -> int:
         sys.exit(f"sc skill: '{name}' is an ENGINE skill — the seed re-inserts it "
                  "on every update/rebuild, so a local rm cannot stick. "
                  f"`./sc skill retire {name}` retires it fork-wide (durable), or "
-                 "`./sc skill revoke` removes it per shell.")
-    n = con.execute("DELETE FROM shell_skills WHERE skill_id=?", (skill_id,)).rowcount
+                 "`./sc skill revoke` removes it from a flavor or Bespoke shell.")
+    n = con.execute("DELETE FROM flavor_skills WHERE skill_id=?", (skill_id,)).rowcount
+    n += con.execute("DELETE FROM shell_skills WHERE skill_id=?", (skill_id,)).rowcount
     con.execute("UPDATE skills SET is_deleted=1 WHERE skill_id=?", (skill_id,))
     con.commit()
     print(f"rm: {name} soft-deleted, {n} grant(s) revoked.")

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -43,8 +43,8 @@ LEGACY_PATH = ENGINE / "snapshot" / "content.sql"
 # Per-instance tables, parents-before-children for readability.
 # `schema_migrations` is excluded. Engine-authored skills are system content
 # seeded from migrations; project-local skills are serialized by the special
-# `skills` dumper below. `shell_skills` loads after `skills`, so grants to
-# local skill names resolve on rebuild.
+# `skills` dumper below. Grant tables load after `skills`, so grants to local
+# skill names resolve on rebuild.
 PER_INSTANCE_TABLES = [
     "users",
     "shells",
@@ -62,6 +62,7 @@ PER_INSTANCE_TABLES = [
     "projects",
     "project_shells",
     "skills",
+    "flavor_skills",
     "shell_skills",
     # shell_messages is per-instance memory (the inbox between this fork's
     # shells), so it survives a rebuild like flags/decisions — not a derived
@@ -251,19 +252,33 @@ def engine_skill_names() -> list[str]:
 
 
 def dump_shell_skills(con) -> list[str]:
-    """Grants resolved by skill NAME, not raw skill_id. Skill ids are positional
-    (they shift when the catalogue grows), so a raw-id dump would bind a fork's
-    grants to the wrong skills after an update. Resolving by name at load time
-    makes grants id-churn-proof."""
+    """Bespoke grants resolved by skill NAME, not raw skill_id."""
     rows = con.execute(
         "SELECT ss.shell_id, s.name FROM shell_skills ss "
-        "JOIN skills s ON s.skill_id = ss.skill_id ORDER BY ss.shell_id, s.name"
+        "JOIN skills s ON s.skill_id = ss.skill_id "
+        "JOIN shells sh ON sh.shell_id = ss.shell_id "
+        "WHERE sh.flavor IS NULL ORDER BY ss.shell_id, s.name"
     ).fetchall()
     lines = ["DELETE FROM shell_skills;"]
     for shell_id, name in rows:
         lines.append(
             f"INSERT INTO shell_skills (shell_id, skill_id) "
             f"SELECT {shell_id}, skill_id FROM skills WHERE name={quote(name)};")
+    lines.append("")
+    return lines
+
+
+def dump_flavor_skills(con) -> list[str]:
+    """Flavor packs resolved by skill NAME so catalogue id churn is harmless."""
+    rows = con.execute(
+        "SELECT fs.flavor, s.name FROM flavor_skills fs "
+        "JOIN skills s ON s.skill_id = fs.skill_id ORDER BY fs.flavor, s.name"
+    ).fetchall()
+    lines = ["DELETE FROM flavor_skills;"]
+    for flavor, name in rows:
+        lines.append(
+            f"INSERT INTO flavor_skills (flavor, skill_id) "
+            f"SELECT {quote(flavor)}, skill_id FROM skills WHERE name={quote(name)};")
     lines.append("")
     return lines
 
@@ -338,6 +353,8 @@ SENSITIVE_COLUMNS = {
 def dump_table(con, table: str) -> list[str]:
     if table == "skills":
         return dump_local_skills(con)
+    if table == "flavor_skills":
+        return dump_flavor_skills(con)
     if table == "shell_skills":
         return dump_shell_skills(con)
     cols = [r[1] for r in con.execute(f"PRAGMA table_info({table})")]

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -31,7 +31,7 @@ Flow:
     6. sync the engine skills catalogue (idempotent, id-stable UPSERT) —
        new/changed engine skills reach the fork without a rebuild, while
        project-local skills are left intact.
-    7. re-grant common skills to all shells.
+    7. re-grant common skills to every flavor pack + Bespoke shell.
     8. wire the auto-remap hooks + map the repo + snapshot the (live) state.
 
 Then review + commit (only `.sc-state/` — content.sql + engine.ref — moves; the
@@ -677,7 +677,7 @@ def sync_skills() -> None:
         con.commit()
         # The seed just reset every engine row to is_deleted=0 — re-assert the
         # fork retire list (.sc-state/skills_retired.json) before regrant()
-        # hands the common catalogue back to every shell.
+        # hands the common catalogue back to every flavor/Bespoke pack.
         flipped = seed_skills.apply_retired(con)
     finally:
         con.close()
@@ -689,15 +689,30 @@ def sync_skills() -> None:
 def regrant() -> int:
     con = db_driver.connect(DB_PATH)
     try:
-        # Grant newly-added COMMON skills to every shell. Opt-in (common=0)
-        # skills are per-shell assignments — left untouched so an update never
-        # overrides who-has-which catalogue skill.
+        # Newly-added COMMON skills join every standard flavor pack and every
+        # Bespoke shell. Opt-ins stay exactly where the operator assigned them.
+        template_flavors = {
+            p.stem for p in (ENGINE / "templates" / "shells").glob("*.json")
+        }
+        live_flavors = {
+            r[0] for r in con.execute(
+                "SELECT DISTINCT flavor FROM shells WHERE flavor IS NOT NULL")
+        }
+        added = 0
+        for flavor in sorted(template_flavors | live_flavors):
+            cur = con.execute(
+                "INSERT OR IGNORE INTO flavor_skills (flavor, skill_id) "
+                "SELECT ?, skill_id FROM skills "
+                "WHERE is_deleted=0 AND common=1", (flavor,))
+            added += cur.rowcount
         cur = con.execute(
             "INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
             "SELECT s.shell_id, k.skill_id FROM shells s, skills k "
-            "WHERE COALESCE(s.is_deleted,0)=0 AND k.is_deleted=0 AND k.common=1")
+            "WHERE COALESCE(s.is_deleted,0)=0 AND s.flavor IS NULL "
+            "AND k.is_deleted=0 AND k.common=1")
+        added += cur.rowcount
         con.commit()
-        return cur.rowcount
+        return added
     finally:
         con.close()
 

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -228,11 +228,15 @@ function openNewShellModal(templates, root) {
   const fl = el("select", {});
   for (const t of templates)
     fl.append(el("option", { value: t.flavor, textContent: `${t.flavor} — ${t.role}` }));
+  fl.append(el("option", {
+    value: "",
+    textContent: "Bespoke — custom skill pack",
+  }));
   const nm = el("input", { type: "text", placeholder: "name (e.g. Arch)" });
   const create = el("button", { className: "act primary", type: "button", textContent: "Create" });
   const cancel = el("button", { className: "act", type: "button", textContent: "Cancel" });
   const form = el("div", { className: "modal-form" },
-    el("span", { className: "k" }, "flavor"), fl,
+    el("span", { className: "k" }, "shell type"), fl,
     el("span", { className: "k" }, "name"), nm);
   const close = openModal({ title: "New shell", bodyNode: form,
     footNodes: [create, cancel], width: 600, height: 300 });
@@ -240,7 +244,10 @@ function openNewShellModal(templates, root) {
     if (!nm.value.trim()) return toast("name required");
     create.disabled = true; create.textContent = "Creating…";
     try {
-      const r = await api("/shells", "POST", { flavor: fl.value, name: nm.value.trim() });
+      const r = await api("/shells", "POST", {
+        flavor: fl.value || null,
+        name: nm.value.trim(),
+      });
       selectedShell = r.shell_id; activeSkillId = null;
       close(); setStatus(`shell created — ${r.shortname}`); renderShells(root);
     } catch (e) { toast("error: " + e.message); create.disabled = false; create.textContent = "Create"; }
@@ -301,7 +308,8 @@ async function renderShells(root) {
   sub.append(delBtn);
   // Default Models is fork-global config — the shell-scoped header (picker,
   // role/mandate, ＋New shell) is greyed out and inert there, not load-bearing.
-  if (shellTab === "models") sub.classList.add("subbar-inert");
+  if (shellTab === "assignments" || shellTab === "models")
+    sub.classList.add("subbar-inert");
   root.append(sub);
 
   // Harness / Skills are scoped to the selected shell. Skill Assignments and
@@ -616,17 +624,22 @@ function renderSkillViewer(root, s) {
   btn.append(el("span", { className: "gdrop-label mono" }, active.name),
     el("span", { className: "gdrop-caret" }, "⇅"));
   const menu = el("div", { className: "gmenu", hidden: true });
+  const grantPath = (skillId) => s.flavor
+    ? `/flavors/${encodeURIComponent(s.flavor)}/skills/${skillId}`
+    : `/shells/${s.shell_id}/skills/${skillId}`;
   for (const k of skills) {
     const row = el("div", { className: "gmenu-item" + (k.skill_id === activeSkillId ? " active-row" : "") });
     const tog = el("button", { className: "gmenu-check", type: "button",
       title: k.granted ? "Revoke" : "Grant", textContent: k.granted ? "☑" : "☐" });
     tog.onclick = async () => {
       try {
-        await api(`/shells/${s.shell_id}/skills/${k.skill_id}`, "PUT", { granted: !k.granted });
+        await api(grantPath(k.skill_id), "PUT", { granted: !k.granted });
         k.granted = k.granted ? 0 : 1;
         tog.textContent = k.granted ? "☑" : "☐";
         tog.title = k.granted ? "Revoke" : "Grant";
-        setStatus("grant updated");
+        setStatus(s.flavor
+          ? `${s.flavor} flavor pack updated`
+          : `${s.display_name} Bespoke pack updated`);
       } catch (e) { toast("error: " + e.message); }
     };
     const sel = el("button", { className: "gmenu-name mono", type: "button", textContent: k.name });
@@ -643,7 +656,12 @@ function renderSkillViewer(root, s) {
   // rendered markdown by default; the right-aligned toggle shows raw text
   const rawBtn = el("button", { className: "rawtoggle", type: "button",
     title: "Toggle raw markdown", textContent: "raw", hidden: true });
-  root.append(el("div", { className: "viewer-head" }, microlabel("Skill Viewer"), wrap, rawBtn));
+  root.append(
+    el("div", { className: "muted note" },
+      s.flavor
+        ? `Shared ${s.flavor} pack — changes apply to every ${s.flavor} shell.`
+        : `Bespoke pack — changes apply only to ${s.display_name}.`),
+    el("div", { className: "viewer-head" }, microlabel("Skill Viewer"), wrap, rawBtn));
   const stats = statRow([["Char Count", "…"], ["Est. Tokens", "…"]]);
   const panel = el("div", { className: "vpanel viewer-panel" });
   root.append(stats, panel);
@@ -667,10 +685,11 @@ function renderSkillViewer(root, s) {
 
 // ── Skill Assignments (catalogue, sectioned) ─────────────────────────────────
 async function renderSkillAssignments(root) {
-  const { skills, shells } = await api("/skills");
+  const { skills, shells, flavors } = await api("/skills");
+  const bespokeShells = shells.filter((sh) => !sh.flavor);
   root.replaceChildren();
   root.append(el("div", { className: "muted" },
-    "The skills catalogue, sectioned. Engine skills ship with super-coder and group by category; repo skills are authored in this fork. Grants are editable here and on each shell."));
+    "Assign each skill once per standard flavor. Every shell of that flavor inherits the same pack. Bespoke shells remain individually assignable."));
   for (const sec of groupSkills(skills, { alwaysRepo: true })) {
     const wrap = el("div", { className: "bucket" });
     const h = el("h2", {}, `${sec.label} `, el("span", { className: "count" }, String(sec.skills.length)));
@@ -683,13 +702,13 @@ async function renderSkillAssignments(root) {
       continue;
     }
     const card = el("div", { className: "card skills" });
-    for (const s of sec.skills) card.append(skillRow(s, shells));
+    for (const s of sec.skills) card.append(skillRow(s, flavors, bespokeShells));
     wrap.append(card);
     root.append(wrap);
   }
 }
 
-function skillRow(s, shells) {
+function skillRow(s, flavors, bespokeShells) {
   const row = el("details", { className: "skill" });
   // collapsed row stays quiet: mono name + truncated description, no badges —
   // origin/section is the group header, grants live in the expanded body
@@ -702,16 +721,34 @@ function skillRow(s, shells) {
   const body = el("div", { className: "skill-body" });
   if (s.command) body.append(el("div", { className: "tag" }, "command: ", el("code", {}, s.command)));
 
-  // grants — every available shell as a row with an on/off toggle; same PUT
-  // the Skills viewer uses, managed from the skill's side here
+  // One row per standard flavor, then one row per Bespoke shell.
   const gr = el("div", { className: "grants" });
-  gr.append(el("label", { className: "k", textContent: "granted to" }));
+  gr.append(el("label", { className: "k", textContent: "assigned to" }));
   const list = el("div", { className: "grant-list" });
-  for (const sh of shells) {
+  list.append(el("div", { className: "k", textContent: "Standard flavors" }));
+  for (const fl of flavors) {
+    const sw = toggleSwitch(s.granted_flavors.includes(fl.flavor), async (next, cb) => {
+      try {
+        await api(`/flavors/${encodeURIComponent(fl.flavor)}/skills/${s.skill_id}`,
+          "PUT", { granted: next });
+        setStatus(`${fl.flavor} flavor pack updated`);
+        const i = s.granted_flavors.indexOf(fl.flavor);
+        if (next && i < 0) s.granted_flavors.push(fl.flavor);
+        if (!next && i >= 0) s.granted_flavors.splice(i, 1);
+      } catch (e) { toast("error: " + e.message); cb.checked = !next; }
+    });
+    list.append(el("div", { className: "grant-row" },
+      sw,
+      el("span", { className: "grant-name" }, fl.flavor,
+        el("span", { className: "muted", textContent: fl.role ? " · " + fl.role : "" }))));
+  }
+  if (bespokeShells.length)
+    list.append(el("div", { className: "k", textContent: "Bespoke shells" }));
+  for (const sh of bespokeShells) {
     const sw = toggleSwitch(s.granted_shells.includes(sh.shell_id), async (next, cb) => {
       try {
         await api(`/shells/${sh.shell_id}/skills/${s.skill_id}`, "PUT", { granted: next });
-        setStatus("grant updated");
+        setStatus(`${sh.display_name} Bespoke pack updated`);
         const i = s.granted_shells.indexOf(sh.shell_id);
         if (next && i < 0) s.granted_shells.push(sh.shell_id);
         if (!next && i >= 0) s.granted_shells.splice(i, 1);
@@ -720,7 +757,8 @@ function skillRow(s, shells) {
     list.append(el("div", { className: "grant-row" },
       sw,
       el("span", { className: "grant-name" }, sh.display_name,
-        el("span", { className: "muted", textContent: sh.shortname ? " /" + sh.shortname : "" }))));
+        el("span", { className: "muted",
+          textContent: sh.shortname ? " /" + sh.shortname : "" }))));
   }
   gr.append(list);
   body.append(gr);

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -53,6 +53,9 @@ def seed(con: sqlite3.Connection) -> dict:
         "INSERT INTO shells (display_name, system_prompt, flavor, shortname) "
         "VALUES ('Dev', 'x', 'dev', 'dev')")
     sid = cur.lastrowid
+    bespoke_sid = con.execute(
+        "INSERT INTO shells (display_name, system_prompt, flavor, shortname) "
+        "VALUES ('Custom', 'x', NULL, 'custom')").lastrowid
     fid = con.execute(
         "INSERT INTO roadmap (title, roadmap_status, sort_order, owning_shell, summary) "
         "VALUES ('Feature A', 'next', 1, ?, 'a summary')", (sid,)).lastrowid
@@ -72,10 +75,13 @@ def seed(con: sqlite3.Connection) -> dict:
     kid = con.execute(
         "INSERT INTO skills (name, description, category, common, is_deleted) "
         "VALUES ('local_only_skill', 'fixture repo skill', 'craft', 0, 0)").lastrowid
+    con.execute("INSERT INTO flavor_skills (flavor, skill_id) VALUES ('dev', ?)",
+                (kid,))
     con.execute("INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
-                (sid, kid))
+                (bespoke_sid, kid))
     con.commit()
-    return {"shell_id": sid, "feature_id": fid, "skill_id": kid}
+    return {"shell_id": sid, "bespoke_shell_id": bespoke_sid,
+            "feature_id": fid, "skill_id": kid}
 
 
 class AssemblerSmokeTest(unittest.TestCase):
@@ -143,7 +149,9 @@ class AssemblerSmokeTest(unittest.TestCase):
         # the fixture skill has no assets/skills/ dir → repo origin, granted once
         fixture = by_name["local_only_skill"]
         self.assertEqual(fixture["origin"], "repo")
-        self.assertEqual(fixture["granted_shells"], [self.ids["shell_id"]])
+        self.assertEqual(fixture["granted_flavors"], ["dev"])
+        self.assertEqual(
+            fixture["granted_shells"], [self.ids["bespoke_shell_id"]])
         # an engine-seeded skill derives as engine
         self.assertEqual(by_name["db_map"]["origin"], "engine")
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -5,8 +5,7 @@ Two layers: the REGISTRY must stay consistent with the assets it points at
 (every granted skill exists in assets/skills/ and is common:false — a feature
 must never grant a skill the seed doesn't ship, or auto-grant a common one
 twice; every flavor has a template), and the GRANT/REVOKE SQL must do what the
-registry means (grant to live shells of the named flavors only, revoke without
-touching other shells' grants).
+registry means (grant each named flavor pack once and leave other packs alone).
 
 Run:
     python3 tests/test_feature.py
@@ -38,6 +37,8 @@ def _mini_db() -> sqlite3.Connection:
                              is_deleted INTEGER DEFAULT 0);
         CREATE TABLE shell_skills (shell_id INTEGER, skill_id INTEGER,
                                    PRIMARY KEY (shell_id, skill_id));
+        CREATE TABLE flavor_skills (flavor TEXT, skill_id INTEGER,
+                                    PRIMARY KEY (flavor, skill_id));
     """)
     con.executemany("INSERT INTO shells (shell_id, flavor, is_deleted) VALUES (?,?,?)",
                     [(1, "dev", 0), (2, "dev", 0), (3, "reviewer", 0),
@@ -97,12 +98,12 @@ class RegistryIntegrityTest(unittest.TestCase):
 
 
 class GrantRevokeTest(unittest.TestCase):
-    def test_grant_targets_live_shells_of_named_flavors(self):
+    def test_grant_targets_each_named_flavor_once(self):
         con = _mini_db()
         n = feature.grant(con, "test_authoring_pg", ["dev", "reviewer"])
-        self.assertEqual(n, 3)  # dev(1,2) + reviewer(3); deleted dev(5) skipped
-        rows = {r[0] for r in con.execute("SELECT shell_id FROM shell_skills")}
-        self.assertEqual(rows, {1, 2, 3})
+        self.assertEqual(n, 2)
+        rows = {r[0] for r in con.execute("SELECT flavor FROM flavor_skills")}
+        self.assertEqual(rows, {"dev", "reviewer"})
 
     def test_grant_is_idempotent(self):
         con = _mini_db()
@@ -117,13 +118,13 @@ class GrantRevokeTest(unittest.TestCase):
     def test_revoke_leaves_other_flavors_grants(self):
         con = _mini_db()
         feature.grant(con, "test_authoring_pg", ["dev", "reviewer"])
-        # A manual grant to a planner shell — outside the feature's flavors.
-        con.execute("INSERT INTO shell_skills VALUES (6, 10)")
+        # A manual planner-pack grant — outside the feature's flavors.
+        con.execute("INSERT INTO flavor_skills VALUES ('planner', 10)")
         n = feature.revoke(con, "test_authoring_pg", ["dev", "reviewer"])
-        self.assertEqual(n, 3)
-        rows = {r[0] for r in con.execute("SELECT shell_id FROM shell_skills")}
-        self.assertEqual(rows, {6}, "revoke must not touch grants outside the "
-                                    "feature's flavors")
+        self.assertEqual(n, 2)
+        rows = {r[0] for r in con.execute("SELECT flavor FROM flavor_skills")}
+        self.assertEqual(rows, {"planner"}, "revoke must not touch packs outside "
+                                           "the feature's flavors")
 
 
 if __name__ == "__main__":

--- a/tests/test_flavor_overlay.py
+++ b/tests/test_flavor_overlay.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 """Tests for fork-local flavor overlays (shell_factory.py).
 
-The engine's templates/shells/*.json are materialized — overwritten on every
-`./sc update` — so a fork cannot durably edit what a new shell of a flavor
-gets. The overlay (`.sc-state/flavors/<flavor>.json`, tracked, fork-owned)
-must: adjust the skill list via skills_add/skills_remove (riding upstream's
-evolving list, not replacing it), override scalars but never `flavor` itself,
-apply in BOTH load_flavor() and flavors() (creation + GUI listing), and fail
-loud on bad JSON rather than silently creating an un-overlaid shell.
+The engine's templates/shells/*.json are materialized. Fork overlays may
+replace identity text but skill assignment belongs exclusively to the live
+flavor pack. Legacy skills_add/skills_remove keys are ignored.
 
 Run:
     python3 tests/test_flavor_overlay.py
@@ -30,21 +26,14 @@ TPL = {"flavor": "dev", "abbr": "DEV", "role": "Dev shell",
 
 
 class ApplyOverlayTest(unittest.TestCase):
-    def test_skills_add_remove(self):
-        # The dos-arch case: swap the engine testing skill for the fork's own.
+    def test_legacy_skill_keys_are_ignored(self):
         out = sf._apply_overlay(TPL, {
             "skills_add": ["test_authoring_dosarch"],
             "skills_remove": ["test_authoring", "test_authoring_pg"]})
-        self.assertEqual(out["skills"],
-                         ["docs", "git", "test_authoring_dosarch"])
+        self.assertEqual(out["skills"], TPL["skills"])
         self.assertEqual(TPL["skills"],
                          ["docs", "git", "test_authoring", "test_authoring_pg"],
                          "overlay must not mutate the input template")
-
-    def test_add_is_idempotent_against_engine_list(self):
-        out = sf._apply_overlay(TPL, {"skills_add": ["git", "flags"]})
-        self.assertEqual(out["skills"].count("git"), 1)
-        self.assertIn("flags", out["skills"])
 
     def test_scalar_override_but_never_flavor(self):
         out = sf._apply_overlay(TPL, {"role": "Fork dev", "flavor": "hijack"})
@@ -76,13 +65,12 @@ class OverlayFileTest(unittest.TestCase):
     def test_no_overlay_file_loads_plain_template(self):
         self.assertEqual(sf.load_flavor("dev")["skills"], TPL["skills"])
 
-    def test_load_flavor_applies_overlay(self):
+    def test_load_flavor_ignores_legacy_skill_overlay(self):
         (self.overlays / "dev.json").write_text(json.dumps(
             {"skills_add": ["test_authoring_dosarch"],
              "skills_remove": ["test_authoring", "test_authoring_pg"]}))
         got = sf.load_flavor("dev")["skills"]
-        self.assertIn("test_authoring_dosarch", got)
-        self.assertNotIn("test_authoring", got)
+        self.assertEqual(got, TPL["skills"])
 
     def test_flavors_listing_applies_overlay(self):
         (self.overlays / "dev.json").write_text(json.dumps({"role": "Fork dev"}))

--- a/tests/test_flavor_skill_packs.py
+++ b/tests/test_flavor_skill_packs.py
@@ -1,0 +1,305 @@
+"""Flavor-owned skill packs and Bespoke shell regression coverage."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import shell_factory  # noqa: E402
+import snapshot  # noqa: E402
+
+sys.path.insert(0, str(ENGINE / "api"))
+import server  # noqa: E402
+
+sys.path.insert(0, str(ENGINE / "render"))
+import compose  # noqa: E402
+import flat  # noqa: E402
+
+
+def build_db(*, through_0105: bool = True) -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for path in sorted(MIGRATIONS.glob("*.sql")):
+        if not through_0105 and path.name >= "0105_":
+            break
+        con.executescript(path.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+def add_shell(con: sqlite3.Connection, name: str, flavor: str | None) -> int:
+    return con.execute(
+        "INSERT INTO shells (display_name, shortname, system_prompt, flavor) "
+        "VALUES (?, ?, 'prompt', ?)",
+        (name, name.upper(), flavor),
+    ).lastrowid
+
+
+def skill_id(con: sqlite3.Connection, name: str) -> int:
+    return con.execute(
+        "SELECT skill_id FROM skills WHERE name=?", (name,)
+    ).fetchone()[0]
+
+
+def resolved_names(con: sqlite3.Connection, shell_id: int) -> set[str]:
+    return {
+        r[0]
+        for r in con.execute(
+            "SELECT s.name FROM resolved_shell_skills rs "
+            "JOIN skills s ON s.skill_id=rs.skill_id "
+            "WHERE rs.shell_id=? AND s.is_deleted=0",
+            (shell_id,),
+        )
+    }
+
+
+class HardCutoverMigrationTest(unittest.TestCase):
+    def test_seeded_packs_match_common_plus_shipped_template_opt_ins(self) -> None:
+        con = build_db()
+        common = {
+            r[0]
+            for r in con.execute(
+                "SELECT name FROM skills WHERE common=1 AND is_deleted=0"
+            )
+        }
+        for path in sorted((ENGINE / "templates" / "shells").glob("*.json")):
+            template = json.loads(path.read_text())
+            actual = {
+                r[0]
+                for r in con.execute(
+                    "SELECT s.name FROM flavor_skills fs "
+                    "JOIN skills s ON s.skill_id=fs.skill_id "
+                    "WHERE fs.flavor=? AND s.is_deleted=0",
+                    (template["flavor"],),
+                )
+            }
+            self.assertEqual(
+                actual,
+                common | set(template.get("skills", [])),
+                template["flavor"],
+            )
+
+    def test_flavored_rows_are_discarded_bespoke_rows_survive(self) -> None:
+        con = build_db(through_0105=False)
+        dev1 = add_shell(con, "dev1", "dev")
+        dev2 = add_shell(con, "dev2", "dev")
+        bespoke = add_shell(con, "custom", None)
+        kid = skill_id(con, "engine_surgery")
+        con.executemany(
+            "INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+            [(dev1, kid), (bespoke, kid)],
+        )
+
+        con.executescript(
+            (MIGRATIONS / "0105_flavor_skill_packs.sql").read_text()
+        )
+
+        self.assertEqual(
+            con.execute(
+                "SELECT COUNT(*) FROM shell_skills WHERE shell_id IN (?, ?)",
+                (dev1, dev2),
+            ).fetchone()[0],
+            0,
+        )
+        self.assertNotIn("engine_surgery", resolved_names(con, dev1))
+        self.assertEqual(resolved_names(con, dev1), resolved_names(con, dev2))
+        self.assertIn("engine_surgery", resolved_names(con, bespoke))
+
+    def test_stale_flavored_shell_row_is_never_effective(self) -> None:
+        con = build_db()
+        dev = add_shell(con, "dev", "dev")
+        kid = skill_id(con, "engine_surgery")
+        con.execute(
+            "INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+            (dev, kid),
+        )
+        self.assertNotIn("engine_surgery", resolved_names(con, dev))
+
+
+class GrantApiTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = build_db()
+        self.dev1 = add_shell(self.con, "dev1", "dev")
+        self.dev2 = add_shell(self.con, "dev2", "dev")
+        self.custom1 = add_shell(self.con, "custom1", None)
+        self.custom2 = add_shell(self.con, "custom2", None)
+        self.kid = skill_id(self.con, "engine_surgery")
+
+    def tearDown(self) -> None:
+        self.con.close()
+
+    def test_flavor_write_changes_every_sibling(self) -> None:
+        ok, err = server.set_flavor_grant(
+            self.con, "dev", self.kid, True
+        )
+        self.assertTrue(ok, err)
+        self.assertIn("engine_surgery", resolved_names(self.con, self.dev1))
+        self.assertIn("engine_surgery", resolved_names(self.con, self.dev2))
+
+        ok, err = server.set_grant(self.con, self.dev1, self.kid, False)
+        self.assertFalse(ok)
+        self.assertIn("edit the flavor pack", err)
+        self.assertIn("engine_surgery", resolved_names(self.con, self.dev2))
+
+    def test_bespoke_writes_can_diverge(self) -> None:
+        ok, err = server.set_grant(self.con, self.custom1, self.kid, True)
+        self.assertTrue(ok, err)
+        self.assertIn("engine_surgery", resolved_names(self.con, self.custom1))
+        self.assertNotIn("engine_surgery", resolved_names(self.con, self.custom2))
+
+    def test_unknown_targets_do_not_write(self) -> None:
+        self.assertFalse(
+            server.set_flavor_grant(
+                self.con, "invented", self.kid, True
+            )[0]
+        )
+        self.assertFalse(server.set_grant(self.con, 999999, self.kid, True)[0])
+        self.assertFalse(
+            server.set_flavor_grant(self.con, "dev", 999999, True)[0]
+        )
+
+    def test_catalogue_reports_flavors_and_bespoke_shells_separately(self) -> None:
+        server.set_flavor_grant(self.con, "dev", self.kid, True)
+        server.set_grant(self.con, self.custom1, self.kid, True)
+        row = next(
+            s
+            for s in server.get_skills(self.con)["skills"]
+            if s["skill_id"] == self.kid
+        )
+        self.assertIn("dev", row["granted_flavors"])
+        self.assertEqual(row["granted_shells"], [self.custom1])
+
+
+class ShellFactoryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = build_db()
+        self.con.execute(
+            "INSERT INTO users (user_id, username) VALUES (1, 'operator')"
+        )
+
+    def tearDown(self) -> None:
+        self.con.close()
+
+    def test_bespoke_shell_is_untemplated_with_its_own_common_baseline(self) -> None:
+        sid = shell_factory.create_shell(
+            self.con, flavor=None, name="One Off"
+        )
+        row = self.con.execute(
+            "SELECT flavor, role, shortname FROM shells WHERE shell_id=?", (sid,)
+        ).fetchone()
+        self.assertIsNone(row["flavor"])
+        self.assertEqual(row["role"], "Bespoke shell")
+        self.assertTrue(row["shortname"].startswith("BSP"))
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM shell_skills WHERE shell_id=?", (sid,)
+            ).fetchone()[0],
+            self.con.execute(
+                "SELECT COUNT(*) FROM skills "
+                "WHERE common=1 AND is_deleted=0"
+            ).fetchone()[0],
+        )
+
+    def test_standard_shell_stores_no_per_shell_grants(self) -> None:
+        sid = shell_factory.create_shell(
+            self.con, flavor="dev", name="Builder"
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM shell_skills WHERE shell_id=?", (sid,)
+            ).fetchone()[0],
+            0,
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM resolved_shell_skills WHERE shell_id=?",
+                (sid,),
+            ).fetchone()[0],
+            self.con.execute(
+                "SELECT COUNT(*) FROM flavor_skills WHERE flavor='dev'"
+            ).fetchone()[0],
+        )
+
+
+class RenderAndSnapshotTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = build_db()
+        self.dev = add_shell(self.con, "dev", "dev")
+        self.custom = add_shell(self.con, "custom", None)
+        self.kid = skill_id(self.con, "engine_surgery")
+
+    def tearDown(self) -> None:
+        self.con.close()
+
+    def test_boot_and_flat_render_use_resolved_grants(self) -> None:
+        self.con.execute(
+            "INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+            (self.dev, self.kid),
+        )
+        self.con.execute(
+            "INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+            (self.custom, self.kid),
+        )
+        self.assertNotIn("engine_surgery", compose.render_skills(
+            self.con, self.dev
+        ))
+        self.assertIn("engine_surgery", compose.render_skills(
+            self.con, self.custom
+        ))
+        with tempfile.TemporaryDirectory() as tmp:
+            flat.render_skill_md(
+                self.con, self.dev, work_dir=Path(tmp) / "dev"
+            )
+            flat.render_skill_md(
+                self.con, self.custom, work_dir=Path(tmp) / "custom"
+            )
+            self.assertFalse(
+                (Path(tmp) / "dev" / ".claude" / "skills"
+                 / "engine_surgery").exists()
+            )
+            self.assertTrue(
+                (Path(tmp) / "custom" / ".claude" / "skills"
+                 / "engine_surgery" / "SKILL.md").exists()
+            )
+
+    def test_snapshot_serializes_pack_grants_by_skill_name(self) -> None:
+        self.con.execute(
+            "INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+            (self.dev, self.kid),
+        )
+        self.con.execute(
+            "INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+            (self.custom, self.kid),
+        )
+        flavor_dump = "\n".join(snapshot.dump_flavor_skills(self.con))
+        shell_dump = "\n".join(snapshot.dump_shell_skills(self.con))
+        self.assertIn("DELETE FROM flavor_skills;", flavor_dump)
+        self.assertIn("WHERE name='git'", flavor_dump)
+        self.assertIn("DELETE FROM shell_skills;", shell_dump)
+        self.assertIn(
+            f"INSERT INTO shell_skills (shell_id, skill_id) "
+            f"SELECT {self.custom}, skill_id FROM skills "
+            "WHERE name='engine_surgery';",
+            shell_dump,
+        )
+        self.assertNotIn(
+            f"SELECT {self.dev}, skill_id FROM skills "
+            "WHERE name='engine_surgery';",
+            shell_dump,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lns_curation.py
+++ b/tests/test_lns_curation.py
@@ -356,7 +356,7 @@ class SkillAddTest(unittest.TestCase):
     def test_adds_a_namespaced_local_skill_and_grants_it_to_the_author(self):
         out = self.add("tc_sweep", "--file", str(self.body),
                        "--desc", "one line", "--for", "tc")
-        self.assertIn("granted to tc", out)
+        self.assertIn("granted to Bespoke tc", out)
         row = self.q("SELECT skill_id, description, content, is_deleted "
                      "FROM skills WHERE name='tc_sweep'")
         self.assertIsNotNone(row)

--- a/tests/test_local_skill_persistence.py
+++ b/tests/test_local_skill_persistence.py
@@ -39,10 +39,12 @@ SKILLS_DDL = (
     "common INTEGER NOT NULL DEFAULT 1, is_deleted INTEGER NOT NULL DEFAULT 0)")
 SHELLS_DDL = (
     "CREATE TABLE shells (shell_id INTEGER PRIMARY KEY, shortname TEXT, "
-    "display_name TEXT, is_deleted INTEGER DEFAULT 0)")
+    "display_name TEXT, flavor TEXT, is_deleted INTEGER DEFAULT 0)")
 GRANTS_DDL = (
     "CREATE TABLE shell_skills (shell_skill_id INTEGER PRIMARY KEY, "
-    "shell_id INTEGER NOT NULL, skill_id INTEGER NOT NULL, UNIQUE(shell_id, skill_id))")
+    "shell_id INTEGER NOT NULL, skill_id INTEGER NOT NULL, UNIQUE(shell_id, skill_id));"
+    "CREATE TABLE flavor_skills (flavor TEXT NOT NULL, skill_id INTEGER NOT NULL, "
+    "UNIQUE(flavor, skill_id))")
 
 
 def write_asset(root: Path, name: str, body: str) -> None:

--- a/tests/test_shells_ui_contract.py
+++ b/tests/test_shells_ui_contract.py
@@ -44,6 +44,24 @@ def test_skills_is_nested_under_shells_instead_of_global_navigation():
     assert 'id="view-shells"' in main
 
 
+def test_new_shell_creator_offers_bespoke_without_a_flavor_template():
+    creator = APP[APP.index("function openNewShellModal"):
+                  APP.index("async function renderShells(root)")]
+    assert "Bespoke — custom skill pack" in creator
+    assert "flavor: fl.value || null" in creator
+    assert '"shell type"' in creator
+
+
+def test_skill_assignments_are_flavor_scoped_with_bespoke_exceptions():
+    assignments = APP[APP.index("async function renderSkillAssignments"):
+                      APP.index("// ── Roadmap")]
+    assert "const bespokeShells = shells.filter((sh) => !sh.flavor)" in assignments
+    assert "for (const fl of flavors)" in assignments
+    assert "/flavors/${encodeURIComponent(fl.flavor)}/skills/${s.skill_id}" in assignments
+    assert "for (const sh of bespokeShells)" in assignments
+    assert "for (const sh of shells)" not in assignments
+
+
 def test_each_shell_section_has_a_distinct_reload_safe_hash():
     script = SHELL_STATE + r"""
 globalThis.location = { hash: "" };

--- a/tests/test_skill_retire.py
+++ b/tests/test_skill_retire.py
@@ -46,6 +46,12 @@ def make_db() -> sqlite3.Connection:
     con.execute(
         "CREATE TABLE shell_skills (shell_skill_id INTEGER PRIMARY KEY, "
         "shell_id INTEGER, skill_id INTEGER, UNIQUE(shell_id, skill_id))")
+    con.execute(
+        "CREATE TABLE flavor_skills (flavor TEXT, skill_id INTEGER, "
+        "UNIQUE(flavor, skill_id))")
+    con.execute(
+        "CREATE TABLE shells (shell_id INTEGER PRIMARY KEY, flavor TEXT)")
+    con.execute("INSERT INTO shells (shell_id, flavor) VALUES (1, NULL)")
     con.executescript(SEED_SQL)
     con.execute("INSERT INTO skills (name, description, content) "
                 "VALUES ('test_authoring_dosarch', 'fork skill', 'body')")

--- a/tests/test_visual_qa_distribution.py
+++ b/tests/test_visual_qa_distribution.py
@@ -123,8 +123,18 @@ class VisualQaSeedTest(unittest.TestCase):
         with sqlite3.connect(database) as con:
             con.executescript(
                 "CREATE TABLE users(user_id INTEGER PRIMARY KEY, username TEXT, is_active INTEGER);"
-                "CREATE TABLE shells(shell_id INTEGER PRIMARY KEY, shortname TEXT, is_deleted INTEGER DEFAULT 0);"
+                "CREATE TABLE shells(shell_id INTEGER PRIMARY KEY, shortname TEXT, "
+                "flavor TEXT, is_deleted INTEGER DEFAULT 0);"
                 "CREATE TABLE shell_skills(shell_id INTEGER, skill_id INTEGER);"
+                "CREATE TABLE flavor_skills(flavor TEXT, skill_id INTEGER);"
+                "CREATE VIEW resolved_shell_skills AS "
+                "SELECT sh.shell_id, fs.skill_id FROM shells sh "
+                "JOIN flavor_skills fs ON fs.flavor=sh.flavor "
+                "WHERE sh.flavor IS NOT NULL "
+                "UNION ALL "
+                "SELECT ss.shell_id, ss.skill_id FROM shell_skills ss "
+                "JOIN shells sh ON sh.shell_id=ss.shell_id "
+                "WHERE sh.flavor IS NULL;"
             )
 
         next_shell_id = iter(range(1, 7))
@@ -132,8 +142,9 @@ class VisualQaSeedTest(unittest.TestCase):
         def create_shell(con, *, flavor, **_kwargs):
             shell_id = next(next_shell_id)
             con.execute(
-                "INSERT INTO shells(shell_id, shortname, is_deleted) VALUES (?, ?, 0)",
-                (shell_id, f"{flavor[:3].upper()}{shell_id}"),
+                "INSERT INTO shells(shell_id, shortname, flavor, is_deleted) "
+                "VALUES (?, ?, ?, 0)",
+                (shell_id, f"{flavor[:3].upper()}{shell_id}", flavor),
             )
             return shell_id
 


### PR DESCRIPTION
## Summary

- replace standard per-shell grants with one shared skill pack per flavor
- keep per-shell grants only for Bespoke shells and add Bespoke to shell creation
- route boot rendering, API, CLI, snapshot, update, and feature grants through the same ownership model
- hard-cut existing flavored-shell deviations without preservation or reconciliation

## Verification

- 87 focused schema/API/UI/freshness tests pass
- 42 rebuild/snapshot/update tests pass
- full tests/ corpus passed in ordered worktree-local segments after fixture updates
- test_harness_epoch was excluded locally because it invokes the shared main-checkout ./sc and tests the running floor rather than this branch
- node --check .super-coder/ui/app.js
- python3 .super-coder/scripts/render_check.py
- git diff --check