### PR TITLE
feat(sprint): deliver worker expectation alerts

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2007,7 +2007,8 @@ def _alert_projection(row) -> dict:
     cols = (
         "alert_id", "session_id", "binding_id", "message_id", "watch_id",
         "severity", "reason", "opened_at", "resolved_at", "acknowledged_at",
-        "acknowledged_by", "shell_id", "generation",
+        "acknowledged_by", "sprint_doc_id", "seq", "role", "signal",
+        "shell_id", "generation",
     )
     alert = dict(zip(cols, row))
     meaning, action, category = _ALERT_COPY.get(
@@ -2038,13 +2039,19 @@ def _sprint_alerts(actor, query: dict):
     binding_id = _qint(query, "binding_id")
     planner = _qint(query, "planner_shell_id")
     generation = _qint(query, "generation")
+    sprint_doc_id = _qint(query, "sprint_doc_id")
+    if query.get("sprint_doc_id", [None])[0] not in (None, "") \
+            and sprint_doc_id is None:
+        return _err(422, "validation",
+                    "sprint_doc_id filter must be an integer")
     include_resolved = query.get("include_resolved", ["0"])[0] in (
         "1", "true", "yes")
     sql = (
         "SELECT a.alert_id, a.session_id, a.binding_id, a.message_id, "
         "a.watch_id, a.severity, a.reason, a.opened_at, a.resolved_at, "
         "a.acknowledged_at, a.acknowledged_by, "
-        "COALESCE(s.shell_id, b.shell_id), "
+        "a.sprint_doc_id, a.seq, a.role, a.signal, "
+        "COALESCE(a.shell_id, s.shell_id, b.shell_id), "
         "COALESCE(s.generation, b.generation) "
         "FROM planner_alerts a "
         "LEFT JOIN interface_sessions s ON s.session_id=a.session_id "
@@ -2057,8 +2064,14 @@ def _sprint_alerts(actor, query: dict):
             "WHERE shell_id=?) OR a.binding_id IN (SELECT binding_id FROM "
             "sprint_planner_bindings WHERE planner_shell_id=?) OR "
             "a.watch_id IN (SELECT watch_id FROM watched_prs "
-            "WHERE shell_id=?))")
-        params += [actor.shell_id, actor.shell_id, actor.shell_id]
+            "WHERE shell_id=?) OR a.sprint_doc_id IN (SELECT sprint_doc_id "
+            "FROM sprint_planner_bindings WHERE planner_shell_id=?))")
+        params += [
+            actor.shell_id,
+            actor.shell_id,
+            actor.shell_id,
+            actor.shell_id,
+        ]
         planner = actor.shell_id
     elif planner is not None:
         conds.append(
@@ -2066,14 +2079,18 @@ def _sprint_alerts(actor, query: dict):
             "WHERE shell_id=?) OR a.binding_id IN (SELECT binding_id FROM "
             "sprint_planner_bindings WHERE planner_shell_id=?) OR "
             "a.watch_id IN (SELECT watch_id FROM watched_prs "
-            "WHERE shell_id=?))")
-        params += [planner, planner, planner]
+            "WHERE shell_id=?) OR a.sprint_doc_id IN (SELECT sprint_doc_id "
+            "FROM sprint_planner_bindings WHERE planner_shell_id=?))")
+        params += [planner, planner, planner, planner]
     if session_id is not None:
         conds.append("a.session_id=?")
         params.append(session_id)
     if binding_id is not None:
         conds.append("a.binding_id=?")
         params.append(binding_id)
+    if sprint_doc_id is not None:
+        conds.append("a.sprint_doc_id=?")
+        params.append(sprint_doc_id)
     if generation is None and planner is not None and session_id is None \
             and binding_id is None:
         current = None
@@ -2088,13 +2105,17 @@ def _sprint_alerts(actor, query: dict):
         if current is None:
             # Session/binding alerts require a current generation by default,
             # but a dormant watch may be the reason no planner session exists.
-            # Keep that repair signal owner-visible without a live session.
-            conds.append("a.watch_id IS NOT NULL")
+            # Sprint-scoped reconciler alerts likewise remain owner-visible
+            # between planner generations.
+            conds.append(
+                "(a.watch_id IS NOT NULL OR a.sprint_doc_id IS NOT NULL)"
+            )
         else:
             generation = current[0]
     if generation is not None:
         conds.append(
-            "(a.watch_id IS NOT NULL OR COALESCE(s.generation, b.generation)=?)")
+            "(a.watch_id IS NOT NULL OR a.sprint_doc_id IS NOT NULL "
+            "OR COALESCE(s.generation, b.generation)=?)")
         params.append(generation)
     if not include_resolved:
         conds.append("a.resolved_at IS NULL AND a.acknowledged_at IS NULL")

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -66,6 +66,7 @@ import live_model  # noqa: E402
 import ports as ports_mod  # noqa: E402
 import shell_liveness  # noqa: E402
 from sprint_units import UNIT_STATES as _UNIT_STATES  # noqa: E402
+from sprint_units import board_writer as _board_writer  # noqa: E402
 
 TICKET_TTL_S = 60
 RESERVATION_TTL_S = 60
@@ -2318,38 +2319,6 @@ def _bad_unit_field(body):
                         f"{field} cannot be blank"
                         + (" — pass null to clear it" if clearable else ""))
     return None
-
-
-def _board_writer(con, sprint_doc_id: int) -> "int | None":
-    """The one shell allowed to move this sprint's board: the planner bound to
-    it. ONE definition — the alert delivery in U5 resolves the same question
-    and must call this rather than restate it.
-
-    The spec's rule reads "the binding's planner_shell_id, else the sprint
-    doc's author". The second clause is not implementable as written:
-    `documents` carries no author column at all (schema.sql:204), so there is
-    nothing to fall back TO. An unbound sprint therefore falls back to flavor
-    instead — see _may_write_board.
-
-    RELEASED BINDINGS STILL NAME THE WRITER. Filtering on `released_at IS
-    NULL` made the fallback mean "before a binding is armed" OR "after the
-    planner's session ended" (interface_recovery release_binding
-    'shell_recovery') OR "after the sprint was closed or frozen"
-    (_close_sprint_wake) — three engine paths that release with no operator
-    action at all. In that window the fence widened from ONE shell to a CLASS
-    of shells, and a foreign planner could move a unit of a sprint it has no
-    relationship to into `merged` — the terminal state that makes the
-    reconciler stop watching it. The spec's rule names one shell in both of
-    its branches, so this one does too: the most recent planner ever bound to
-    this sprint. Flavor now stands in only for a sprint that never had a
-    binding. The cost is deliberate — a NEW planner taking a sprint over must
-    arm its binding before it can write.
-    """
-    row = con.execute(
-        "SELECT planner_shell_id FROM sprint_planner_bindings "
-        "WHERE sprint_doc_id=? "
-        "ORDER BY binding_id DESC LIMIT 1", (sprint_doc_id,)).fetchone()
-    return row[0] if row is not None else None
 
 
 def _may_write_board(con, actor, sprint_doc_id: int):

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2018,12 +2018,6 @@ _ALERT_COPY = {
         "exists.",
         "warning",
     ),
-    "worker_recovery_blocked": (
-        "A recovery producer reported that its attempt was refused.",
-        "Reassign or escalate the unit. Do not retry a recovery guard that "
-        "keeps refusing.",
-        "warning",
-    ),
     "reconciler_missing_binding": (
         "The reconciler recorded a sprint finding, but the sprint has never "
         "had a planner binding to receive its message.",

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2000,6 +2000,36 @@ _ALERT_COPY = {
         "Rebind the watch with `sc watch pr … --sprint <doc-id>`.",
         "warning",
     ),
+    "worker_checkup": (
+        "The worker has no recent result or work event after its expected "
+        "activity window.",
+        "Read its flags, branch, worktree, messages, and run output before "
+        "deciding whether recovery is needed.",
+        "warning",
+    ),
+    "worker_not_started": (
+        "The unit's declared branch has not appeared after the start grace.",
+        "Confirm the worker's launch evidence before reassigning the unit.",
+        "warning",
+    ),
+    "worker_work_complete_unreported": (
+        "The worker ended after producing durable output but did not report it.",
+        "Read the worker's durable output. Do not restart it; the work already "
+        "exists.",
+        "warning",
+    ),
+    "worker_recovery_blocked": (
+        "A recovery producer reported that its attempt was refused.",
+        "Reassign or escalate the unit. Do not retry a recovery guard that "
+        "keeps refusing.",
+        "warning",
+    ),
+    "reconciler_missing_binding": (
+        "The reconciler recorded a sprint finding, but the sprint has never "
+        "had a planner binding to receive its message.",
+        "Arm the sprint's real planner binding; do not synthesize a recipient.",
+        "warning",
+    ),
 }
 
 

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2007,7 +2007,7 @@ def _alert_projection(row) -> dict:
     cols = (
         "alert_id", "session_id", "binding_id", "message_id", "watch_id",
         "severity", "reason", "opened_at", "resolved_at", "acknowledged_at",
-        "acknowledged_by", "sprint_doc_id", "seq", "role", "signal",
+        "acknowledged_by", "sprint_doc_id", "unit_id", "role", "signal",
         "shell_id", "generation",
     )
     alert = dict(zip(cols, row))
@@ -2050,7 +2050,7 @@ def _sprint_alerts(actor, query: dict):
         "SELECT a.alert_id, a.session_id, a.binding_id, a.message_id, "
         "a.watch_id, a.severity, a.reason, a.opened_at, a.resolved_at, "
         "a.acknowledged_at, a.acknowledged_by, "
-        "a.sprint_doc_id, a.seq, a.role, a.signal, "
+        "a.sprint_doc_id, a.unit_id, a.role, a.signal, "
         "COALESCE(a.shell_id, s.shell_id, b.shell_id), "
         "COALESCE(s.generation, b.generation) "
         "FROM planner_alerts a "

--- a/.super-coder/migrations/0102_reconciler_alert_keys.sql
+++ b/.super-coder/migrations/0102_reconciler_alert_keys.sql
@@ -1,0 +1,25 @@
+-- 0102 — structured worker-reconciliation alert identity.
+--
+-- planner_alerts predates the worker reconciler and is already written by
+-- Interface wake, recovery, snapshot, and PR polling paths.  Keep those rows
+-- valid: every new column is nullable and has no default.  Reconciler alerts
+-- retain dedupe_key for the existing open-row uniqueness guard, but their
+-- identity is queryable without parsing that string.
+
+BEGIN;
+
+ALTER TABLE planner_alerts
+    ADD COLUMN sprint_doc_id INTEGER REFERENCES documents(document_id);
+ALTER TABLE planner_alerts
+    ADD COLUMN seq TEXT;
+ALTER TABLE planner_alerts
+    ADD COLUMN role TEXT CHECK (role IN ('dev', 'reviewer', 'planner'));
+ALTER TABLE planner_alerts
+    ADD COLUMN signal TEXT;
+ALTER TABLE planner_alerts
+    ADD COLUMN shell_id INTEGER REFERENCES shells(shell_id);
+
+CREATE INDEX IF NOT EXISTS idx_planner_alerts_reconciliation
+    ON planner_alerts(sprint_doc_id, seq, role, signal, resolved_at);
+
+COMMIT;

--- a/.super-coder/migrations/0102_reconciler_alert_keys.sql
+++ b/.super-coder/migrations/0102_reconciler_alert_keys.sql
@@ -11,7 +11,7 @@ BEGIN;
 ALTER TABLE planner_alerts
     ADD COLUMN sprint_doc_id INTEGER REFERENCES documents(document_id);
 ALTER TABLE planner_alerts
-    ADD COLUMN seq TEXT;
+    ADD COLUMN unit_id INTEGER REFERENCES sprint_units(unit_id);
 ALTER TABLE planner_alerts
     ADD COLUMN role TEXT CHECK (role IN ('dev', 'reviewer', 'planner'));
 ALTER TABLE planner_alerts
@@ -20,6 +20,6 @@ ALTER TABLE planner_alerts
     ADD COLUMN shell_id INTEGER REFERENCES shells(shell_id);
 
 CREATE INDEX IF NOT EXISTS idx_planner_alerts_reconciliation
-    ON planner_alerts(sprint_doc_id, seq, role, signal, resolved_at);
+    ON planner_alerts(sprint_doc_id, unit_id, role, signal, resolved_at);
 
 COMMIT;

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -27,8 +27,8 @@ What lives here:
   watch-gated cadence; worker-expectation reconciliation runs every 10 minutes
   from structured live units even before a PR or watch exists. Explicit PR
   reconcile still rides `poll_cycle(source='reconcile')` through the API.
-  A completed worker-reconciliation tick beats the shared 'watch' heartbeat so
-  quiet work and a silent scheduler remain distinguishable.
+  PR polling and worker reconciliation beat separate heartbeat rows, so each
+  subsystem's liveness remains independently observable.
 
 It never injects terminal input, never marks a message read, never acts on a
 PR, and never mutates the sprint board. PR polling may create an event; the
@@ -629,8 +629,7 @@ def live_expectations(con) -> list[Expectation]:
         _row(row, "document_id")
         for row in con.execute(
             "SELECT d.document_id FROM documents d "
-            "WHERE d.frozen=0 AND d.kind='doc' "
-            "AND d.title LIKE 'SPRINT:%' "
+            "WHERE d.frozen=0 "
             "AND EXISTS (SELECT 1 FROM sprint_units u "
             "WHERE u.sprint_doc_id=d.document_id) "
             "ORDER BY d.document_id"
@@ -876,14 +875,16 @@ class PollerState:
         return blind
 
 
-# ── Heartbeat (#359 — same row the legacy daemon beat; liveness UI unchanged) ─
+# ── Heartbeats (#359 — one row per independently observed poller) ────────────
 
-def beat(con, interval: int) -> None:
+def beat(con, interval: int, *, name: str = "watch") -> None:
     con.execute(
         "INSERT INTO daemon_heartbeats (name, beat_at, interval_s) "
-        "VALUES ('watch', datetime('now'), ?) "
+        "VALUES (?, datetime('now'), ?) "
         "ON CONFLICT(name) DO UPDATE SET beat_at=excluded.beat_at, "
-        "interval_s=excluded.interval_s", (interval,))
+        "interval_s=excluded.interval_s",
+        (name, interval),
+    )
     con.commit()
 
 
@@ -1085,6 +1086,17 @@ class Poller(threading.Thread):
                 con = self._db()
                 try:
                     if self._github_enabled:
+                        try:
+                            beat(con, self._interval)
+                        except Exception as e:
+                            # The beat is ancillary liveness; polling is the
+                            # mission (#359). A beat raising into the cycle's
+                            # except would turn a working poller into a
+                            # dead-with-noise one — log and keep polling.
+                            print(
+                                f"pr-poller: heartbeat error ({e})",
+                                flush=True,
+                            )
                         # GitHub's bounded read remains watch-gated.
                         if armed_watches(con) or live_unscoped_watch_ids(con):
                             n = poll_cycle(
@@ -1113,7 +1125,11 @@ class Poller(threading.Thread):
                             # Commit the reconciliation writes and its liveness
                             # proof together. A failure before this point leaves
                             # no fresh beat claiming the tick completed.
-                            beat(con, self._reconcile_interval)
+                            beat(
+                                con,
+                                self._reconcile_interval,
+                                name="reconcile",
+                            )
                         except Exception as e:
                             # Older/malformed floors may lack the heartbeat
                             # surface. Findings remain the mission; preserve

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -50,7 +50,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import activity_readers
-from sprint_units import TERMINAL_UNIT_STATES
+from sprint_units import TERMINAL_UNIT_STATES, board_writer
 
 CONCLUDED = {"SUCCESS", "FAILURE", "ERROR"}   # statusCheckRollup terminal states
 
@@ -424,6 +424,147 @@ class ReconcilerState:
             for key, signal in self._previous.items()
             if key in keys
         }
+
+
+RECONCILER_SEVERITY = {
+    "checkup": "warning",
+    "not_started": "warning",
+    "work_complete_unreported": "info",
+    # No producer exists in the report-only reconciler. Keep the delivery
+    # contract ready for the recovery path that eventually supplies one.
+    "recovery_blocked": "critical",
+}
+
+
+def _open_reconciliation_alert(
+    con,
+    reading: ReconciliationReading,
+    severity: str,
+) -> "int | None":
+    expectation = reading.expectation
+    dedupe_key = (
+        f"reconciler|{expectation.sprint_doc_id}|{expectation.seq or '-'}|"
+        f"{expectation.role}|{reading.signal}"
+    )
+    opened_at = reading.observed_at.isoformat()
+    cursor = con.execute(
+        "INSERT OR IGNORE INTO planner_alerts "
+        "(sprint_doc_id, seq, role, signal, shell_id, severity, reason, "
+        " dedupe_key, opened_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?)",
+        (
+            expectation.sprint_doc_id,
+            expectation.seq,
+            expectation.role,
+            reading.signal,
+            expectation.shell_id,
+            severity,
+            f"worker_{reading.signal}",
+            dedupe_key,
+            opened_at,
+        ),
+    )
+    return cursor.lastrowid if cursor.rowcount == 1 else None
+
+
+def _open_missing_binding_alert(con, sprint_doc_id: int) -> None:
+    con.execute(
+        "INSERT OR IGNORE INTO planner_alerts "
+        "(sprint_doc_id, severity, reason, dedupe_key) "
+        "VALUES (?, 'warning', 'reconciler_missing_binding', ?)",
+        (
+            sprint_doc_id,
+            f"reconciler|{sprint_doc_id}|-|-|missing_binding",
+        ),
+    )
+
+
+def _reconciliation_body(reading: ReconciliationReading) -> str:
+    expectation = reading.expectation
+    shell = _row(expectation.shell, "shortname", expectation.shell_id)
+    measurement = json.dumps(
+        reading.measurement,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    body = (
+        f"reconciler unit={expectation.seq or '-'} role={expectation.role} "
+        f"shell={shell} signal={reading.signal} measurement={measurement} "
+        f"observed_at={reading.observed_at.isoformat()}"
+    )
+    if reading.explanation is not None:
+        body += " explanation=" + json.dumps(
+            reading.explanation,
+            ensure_ascii=False,
+        )
+    return body
+
+
+def deliver_reconciliation_readings(
+    con,
+    readings: "list[ReconciliationReading]",
+) -> list[int]:
+    """Record confirmed findings and push each newly-opened one to its planner.
+
+    The structured alert is the unconditional record. A message is only the
+    push layer and therefore exists only when the sprint has a historical
+    binding whose planner can be addressed. This function consumes U4's
+    rendered fields and never inspects Evidence or classifies a reading.
+
+    The caller owns the transaction. Returning message ids lets it notify the
+    wake coordinator only after the tick and its heartbeat commit together.
+    """
+    emitted: list[int] = []
+    writers: dict[int, "int | None"] = {}
+    for reading in readings:
+        severity = RECONCILER_SEVERITY.get(reading.signal)
+        if not reading.confirmed or severity is None:
+            continue
+
+        sprint_doc_id = reading.expectation.sprint_doc_id
+        if sprint_doc_id not in writers:
+            writers[sprint_doc_id] = board_writer(con, sprint_doc_id)
+        planner_shell_id = writers[sprint_doc_id]
+        if planner_shell_id is None:
+            _open_missing_binding_alert(con, sprint_doc_id)
+
+        alert_id = _open_reconciliation_alert(con, reading, severity)
+        if alert_id is None or planner_shell_id is None:
+            continue
+
+        message_id = con.execute(
+            "INSERT INTO shell_messages "
+            "(from_shell_id, to_shell_id, body, kind, sprint_doc_id, "
+            " dedupe_key) VALUES (?,?,?,'pr_event',?,?)",
+            (
+                planner_shell_id,
+                planner_shell_id,
+                _reconciliation_body(reading),
+                sprint_doc_id,
+                f"reconciler-alert|{alert_id}",
+            ),
+        ).lastrowid
+        binding = con.execute(
+            "SELECT binding_id FROM sprint_planner_bindings "
+            "WHERE sprint_doc_id=? AND planner_shell_id=? "
+            "AND released_at IS NULL ORDER BY binding_id DESC LIMIT 1",
+            (sprint_doc_id, planner_shell_id),
+        ).fetchone()
+        binding_id = binding[0] if binding is not None else None
+        con.execute(
+            "UPDATE planner_alerts SET message_id=?, binding_id=? "
+            "WHERE alert_id=?",
+            (message_id, binding_id, alert_id),
+        )
+        if binding_id is not None:
+            con.execute(
+                "INSERT OR IGNORE INTO planner_wake_items "
+                "(binding_id, message_id) VALUES (?,?)",
+                (binding_id, message_id),
+            )
+        emitted.append(message_id)
+    return emitted
 
 
 def live_expectations(con) -> list[Expectation]:
@@ -903,6 +1044,15 @@ class Poller(threading.Thread):
                             refresh=self._refresh,
                             state=self.reconciler_state,
                         )
+                        emitted = deliver_reconciliation_readings(
+                            con,
+                            self.last_reconciliation,
+                        )
+                        con.commit()
+                        if emitted:
+                            import interface_wake
+                            for message_id in emitted:
+                                interface_wake.notify_message(message_id)
                         self._reconcile_due = (
                             monotonic_now + self._reconcile_interval
                         )

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -27,8 +27,8 @@ What lives here:
   watch-gated cadence; worker-expectation reconciliation runs every 10 minutes
   from structured live units even before a PR or watch exists. Explicit PR
   reconcile still rides `poll_cycle(source='reconcile')` through the API.
-  The GitHub side beats the 'watch' heartbeat so `sc watch list` liveness keeps
-  telling the truth.
+  A completed worker-reconciliation tick beats the shared 'watch' heartbeat so
+  quiet work and a silent scheduler remain distinguishable.
 
 It never injects terminal input, never marks a message read, never acts on a
 PR, and never mutates the sprint board. PR polling may create an event; the
@@ -1062,14 +1062,6 @@ class Poller(threading.Thread):
                 con = self._db()
                 try:
                     if self._github_enabled:
-                        try:
-                            beat(con, self._interval)
-                        except Exception as e:
-                            # The beat is ancillary liveness; polling is the
-                            # mission (#359). A beat raising into the cycle's
-                            # except would turn a working poller into a
-                            # dead-with-noise one — log and keep polling.
-                            print(f"pr-poller: heartbeat error ({e})", flush=True)
                         # GitHub's bounded read remains watch-gated.
                         if armed_watches(con) or live_unscoped_watch_ids(con):
                             n = poll_cycle(
@@ -1094,7 +1086,17 @@ class Poller(threading.Thread):
                             con,
                             self.last_reconciliation,
                         )
-                        con.commit()
+                        try:
+                            # Commit the reconciliation writes and its liveness
+                            # proof together. A failure before this point leaves
+                            # no fresh beat claiming the tick completed.
+                            beat(con, self._reconcile_interval)
+                        except Exception as e:
+                            # Older/malformed floors may lack the heartbeat
+                            # surface. Findings remain the mission; preserve
+                            # them while leaving the absent beat honest.
+                            con.commit()
+                            print(f"pr-poller: heartbeat error ({e})", flush=True)
                         if emitted:
                             import interface_wake
                             for message_id in emitted:

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -443,20 +443,25 @@ def _open_reconciliation_alert(
     severity: str,
 ) -> "int | None":
     expectation = reading.expectation
+    unit_key = (
+        expectation.unit_id
+        if expectation.unit_id is not None
+        else "-"
+    )
     dedupe_key = (
-        f"reconciler|{expectation.sprint_doc_id}|{expectation.seq or '-'}|"
+        f"reconciler|{expectation.sprint_doc_id}|{unit_key}|"
         f"{expectation.role}|{reading.signal}"
     )
     opened_at = reading.observed_at.isoformat()
     cursor = con.execute(
         "INSERT INTO planner_alerts "
-        "(sprint_doc_id, seq, role, signal, shell_id, severity, reason, "
+        "(sprint_doc_id, unit_id, role, signal, shell_id, severity, reason, "
         " dedupe_key, opened_at) "
         "VALUES (?,?,?,?,?,?,?,?,?) "
         "ON CONFLICT(dedupe_key) WHERE resolved_at IS NULL DO NOTHING",
         (
             expectation.sprint_doc_id,
-            expectation.seq,
+            expectation.unit_id,
             expectation.role,
             reading.signal,
             expectation.shell_id,
@@ -491,14 +496,14 @@ def _resolve_reconciliation_alerts(
     expectation = reading.expectation
     con.execute(
         "UPDATE planner_alerts SET resolved_at=? "
-        "WHERE sprint_doc_id=? AND seq IS ? AND role=? "
+        "WHERE sprint_doc_id=? AND unit_id IS ? AND role=? "
         "AND signal IN ('checkup','not_started',"
         "'work_complete_unreported','recovery_blocked') "
         "AND resolved_at IS NULL",
         (
             reading.observed_at.isoformat(),
             expectation.sprint_doc_id,
-            expectation.seq,
+            expectation.unit_id,
             expectation.role,
         ),
     )

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -348,6 +348,12 @@ class Expectation:
 
     @property
     def key(self) -> tuple:
+        """Confirmation identity, not planner-alert identity.
+
+        The assignee is intentional here: a reassignment must earn two fresh
+        observations. Alert identity is constructed separately from immutable
+        unit_id and deliberately excludes shell_id.
+        """
         return (
             self.sprint_doc_id,
             self.unit_id,
@@ -430,8 +436,8 @@ RECONCILER_SEVERITY = {
     "checkup": "warning",
     "not_started": "warning",
     "work_complete_unreported": "info",
-    # No producer exists in the report-only reconciler. Keep the delivery
-    # contract ready for the recovery path that eventually supplies one.
+    # Mapping only: reconcile_tick cannot confirm this signal because it is
+    # deliberately absent from ReconcilerState.ACTIONABLE. No producer exists.
     "recovery_blocked": "critical",
 }
 HEALTHY_RECONCILER_SIGNALS = {"reported", "working"}
@@ -505,7 +511,7 @@ def _resolve_reconciliation_alerts(
         "UPDATE planner_alerts SET resolved_at=? "
         "WHERE sprint_doc_id=? AND unit_id IS ? AND role=? "
         "AND signal IN ('checkup','not_started',"
-        "'work_complete_unreported','recovery_blocked') "
+        "'work_complete_unreported') "
         "AND resolved_at IS NULL",
         (
             reading.observed_at.isoformat(),
@@ -569,9 +575,12 @@ def deliver_reconciliation_readings(
             )
 
         _resolve_reconciliation_alerts(con, reading)
-        severity = RECONCILER_SEVERITY.get(reading.signal)
-        if not reading.confirmed or severity is None:
+        if not reading.confirmed:
             continue
+        # ReconcilerState only confirms ACTIONABLE signals, and every one is
+        # required to have an explicit severity. Fail loudly if that contract
+        # ever drifts instead of preserving an unreachable fallback.
+        severity = RECONCILER_SEVERITY[reading.signal]
         if planner_shell_id is None:
             _open_missing_binding_alert(con, sprint_doc_id)
 

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -449,10 +449,11 @@ def _open_reconciliation_alert(
     )
     opened_at = reading.observed_at.isoformat()
     cursor = con.execute(
-        "INSERT OR IGNORE INTO planner_alerts "
+        "INSERT INTO planner_alerts "
         "(sprint_doc_id, seq, role, signal, shell_id, severity, reason, "
         " dedupe_key, opened_at) "
-        "VALUES (?,?,?,?,?,?,?,?,?)",
+        "VALUES (?,?,?,?,?,?,?,?,?) "
+        "ON CONFLICT(dedupe_key) WHERE resolved_at IS NULL DO NOTHING",
         (
             expectation.sprint_doc_id,
             expectation.seq,
@@ -470,9 +471,10 @@ def _open_reconciliation_alert(
 
 def _open_missing_binding_alert(con, sprint_doc_id: int) -> None:
     con.execute(
-        "INSERT OR IGNORE INTO planner_alerts "
+        "INSERT INTO planner_alerts "
         "(sprint_doc_id, severity, reason, dedupe_key) "
-        "VALUES (?, 'warning', 'reconciler_missing_binding', ?)",
+        "VALUES (?, 'warning', 'reconciler_missing_binding', ?) "
+        "ON CONFLICT(dedupe_key) WHERE resolved_at IS NULL DO NOTHING",
         (
             sprint_doc_id,
             f"reconciler|{sprint_doc_id}|-|-|missing_binding",

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -434,6 +434,7 @@ RECONCILER_SEVERITY = {
     # contract ready for the recovery path that eventually supplies one.
     "recovery_blocked": "critical",
 }
+HEALTHY_RECONCILER_SIGNALS = {"reported", "working"}
 
 
 def _open_reconciliation_alert(
@@ -479,6 +480,28 @@ def _open_missing_binding_alert(con, sprint_doc_id: int) -> None:
     )
 
 
+def _resolve_reconciliation_alerts(
+    con,
+    reading: ReconciliationReading,
+) -> None:
+    if reading.signal not in HEALTHY_RECONCILER_SIGNALS:
+        return
+    expectation = reading.expectation
+    con.execute(
+        "UPDATE planner_alerts SET resolved_at=? "
+        "WHERE sprint_doc_id=? AND seq IS ? AND role=? "
+        "AND signal IN ('checkup','not_started',"
+        "'work_complete_unreported','recovery_blocked') "
+        "AND resolved_at IS NULL",
+        (
+            reading.observed_at.isoformat(),
+            expectation.sprint_doc_id,
+            expectation.seq,
+            expectation.role,
+        ),
+    )
+
+
 def _reconciliation_body(reading: ReconciliationReading) -> str:
     expectation = reading.expectation
     shell = _row(expectation.shell, "shortname", expectation.shell_id)
@@ -518,14 +541,23 @@ def deliver_reconciliation_readings(
     emitted: list[int] = []
     writers: dict[int, "int | None"] = {}
     for reading in readings:
-        severity = RECONCILER_SEVERITY.get(reading.signal)
-        if not reading.confirmed or severity is None:
-            continue
-
         sprint_doc_id = reading.expectation.sprint_doc_id
         if sprint_doc_id not in writers:
             writers[sprint_doc_id] = board_writer(con, sprint_doc_id)
         planner_shell_id = writers[sprint_doc_id]
+        if planner_shell_id is not None:
+            con.execute(
+                "UPDATE planner_alerts SET resolved_at=? "
+                "WHERE sprint_doc_id=? "
+                "AND reason='reconciler_missing_binding' "
+                "AND resolved_at IS NULL",
+                (reading.observed_at.isoformat(), sprint_doc_id),
+            )
+
+        _resolve_reconciliation_alerts(con, reading)
+        severity = RECONCILER_SEVERITY.get(reading.signal)
+        if not reading.confirmed or severity is None:
+            continue
         if planner_shell_id is None:
             _open_missing_binding_alert(con, sprint_doc_id)
 
@@ -570,6 +602,17 @@ def deliver_reconciliation_readings(
 def live_expectations(con) -> list[Expectation]:
     """Enumerate the structured board, independent of PR watches and prose."""
     placeholders = ",".join("?" for _ in TERMINAL_UNIT_STATES)
+    planner_doc_ids = [
+        _row(row, "document_id")
+        for row in con.execute(
+            "SELECT d.document_id FROM documents d "
+            "WHERE d.frozen=0 AND d.kind='doc' "
+            "AND d.title LIKE 'SPRINT:%' "
+            "AND EXISTS (SELECT 1 FROM sprint_units u "
+            "WHERE u.sprint_doc_id=d.document_id) "
+            "ORDER BY d.document_id"
+        ).fetchall()
+    ]
     units = con.execute(
         "SELECT u.* FROM sprint_units u "
         "JOIN documents d ON d.document_id=u.sprint_doc_id "
@@ -577,10 +620,13 @@ def live_expectations(con) -> list[Expectation]:
         "ORDER BY u.sprint_doc_id, u.unit_id",
         TERMINAL_UNIT_STATES,
     ).fetchall()
-    if not units:
+    doc_ids = sorted(
+        set(planner_doc_ids)
+        | {_row(unit, "sprint_doc_id") for unit in units}
+    )
+    if not doc_ids:
         return []
 
-    doc_ids = sorted({_row(unit, "sprint_doc_id") for unit in units})
     shell_ids = {
         shell_id
         for unit in units

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -27,8 +27,8 @@ What lives here:
   watch-gated cadence; worker-expectation reconciliation runs every 10 minutes
   from structured live units even before a PR or watch exists. Explicit PR
   reconcile still rides `poll_cycle(source='reconcile')` through the API.
-  PR polling and worker reconciliation beat separate heartbeat rows, so each
-  subsystem's liveness remains independently observable.
+  PR polling beats the status-visible watch heartbeat. Worker reconciliation
+  records tick completion in a separate heartbeat row that has no reader.
 
 It never injects terminal input, never marks a message read, never acts on a
 PR, and never mutates the sprint board. PR polling may create an event; the

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -471,7 +471,14 @@ def _open_reconciliation_alert(
             opened_at,
         ),
     )
-    return cursor.lastrowid if cursor.rowcount == 1 else None
+    if cursor.rowcount == 1:
+        return cursor.lastrowid
+    con.execute(
+        "UPDATE planner_alerts SET shell_id=? "
+        "WHERE dedupe_key=? AND resolved_at IS NULL AND shell_id IS NOT ?",
+        (expectation.shell_id, dedupe_key, expectation.shell_id),
+    )
+    return None
 
 
 def _open_missing_binding_alert(con, sprint_doc_id: int) -> None:

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -100,7 +100,6 @@ PER_INSTANCE_TABLES = [
     "planner_wake_items",
     "planner_action_receipts",
     "pr_poll_observations",
-    "planner_alerts",
     # sprint_units (0098) is the planner's AUTHORED board — the declared belief
     # about who should be doing what — not a derived cache: nothing re-derives
     # it, so a mid-sprint rebuild without it drops the whole sprint's state and
@@ -109,6 +108,10 @@ PER_INSTANCE_TABLES = [
     # rebuilds. Loads after `shells` and `documents`, both its FK targets. No
     # row filter: every unit row is durable planner content, terminal or not.
     "sprint_units",
+    # Reconciler alerts may reference sprint_units.unit_id (0102), so alerts
+    # load after the board record just as they already load after their
+    # session, binding, message, and watch parents.
+    "planner_alerts",
     # NOTE: dr_section is authored navigation but lives in the MAP DB now
     # (.sc-state/map.db), not shell_db.db — it is serialized separately to
     # .sc-state/map_content.sql by snapshot_map() below, not here.

--- a/.super-coder/scripts/sprint_units.py
+++ b/.super-coder/scripts/sprint_units.py
@@ -24,3 +24,25 @@ UNIT_STATES = tuple(state for state, _terminal in _STATE_VOCABULARY)
 TERMINAL_UNIT_STATES = tuple(
     state for state, terminal in _STATE_VOCABULARY if terminal
 )
+
+
+def board_writer(con, sprint_doc_id: int) -> "int | None":
+    """Return the one shell related to this sprint as its board writer.
+
+    Released bindings still name the writer. Filtering on ``released_at``
+    widens the fence after a planner session ends from one related shell to a
+    whole flavor class. The most recent binding therefore remains authoritative
+    until a later binding records an explicit handoff.
+
+    A sprint that has never had a binding returns ``None``. Documents carry no
+    author column, so a "document author" fallback is not representable. Callers
+    must not synthesize an owner from planner flavor: permission to write a
+    never-bound board is not a relationship to that sprint.
+    """
+    row = con.execute(
+        "SELECT planner_shell_id FROM sprint_planner_bindings "
+        "WHERE sprint_doc_id=? "
+        "ORDER BY binding_id DESC LIMIT 1",
+        (sprint_doc_id,),
+    ).fetchone()
+    return row[0] if row is not None else None

--- a/.super-coder/scripts/sprint_units.py
+++ b/.super-coder/scripts/sprint_units.py
@@ -30,9 +30,12 @@ def board_writer(con, sprint_doc_id: int) -> "int | None":
     """Return the one shell related to this sprint as its board writer.
 
     Released bindings still name the writer. Filtering on ``released_at``
-    widens the fence after a planner session ends from one related shell to a
-    whole flavor class. The most recent binding therefore remains authoritative
-    until a later binding records an explicit handoff.
+    widens the fence after any of the engine's three release paths — shell
+    recovery, update discard, or sprint close/freeze — from one related shell
+    to a whole flavor class. A foreign planner could then move a unit into
+    ``merged``, the terminal state that makes the reconciler stop watching it.
+    The most recent binding therefore remains authoritative until a later
+    binding records an explicit handoff.
 
     A sprint that has never had a binding returns ``None``. Documents carry no
     author column, so a "document author" fallback is not representable. Callers

--- a/tests/test_interface_snapshot.py
+++ b/tests/test_interface_snapshot.py
@@ -181,9 +181,23 @@ class InterfaceSnapshotTest(unittest.TestCase):
             " idem_key, request_hash, response_status, response_resource,"
             " expires_at) VALUES ('operator','certify_clean','expired','h',"
             "200,'{}', '2000-01-01')")
+        unit_id = self.con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id, seq, unit_title, state, dev_shell_id) "
+            "VALUES (2, 'U5', 'delivery', 'merged', 2)"
+        ).lastrowid
+        self.reconciler_unit_id = unit_id
         self.con.execute(
             "INSERT INTO planner_alerts (severity, reason, dedupe_key) "
             "VALUES ('critical','crash','-|-|crash')")
+        self.con.execute(
+            "INSERT INTO planner_alerts "
+            "(sprint_doc_id, unit_id, role, signal, shell_id, severity, "
+            " reason, dedupe_key) "
+            "VALUES (2, ?, 'dev', 'checkup', 2, 'warning', "
+            " 'worker_checkup', ?)",
+            (unit_id, f"reconciler|2|{unit_id}|dev|checkup"),
+        )
         self.con.execute(
             "INSERT INTO planner_alerts (session_id, severity, reason, dedupe_key) "
             "VALUES (1,'warning','live-session','1|-|-|-|live')")
@@ -355,6 +369,13 @@ class InterfaceSnapshotTest(unittest.TestCase):
             alerts = set(rebuilt.execute(
                 "SELECT reason FROM planner_alerts "
                 "WHERE session_id=2 OR binding_id=2").fetchall())
+            reconciler_alert = rebuilt.execute(
+                "SELECT a.sprint_doc_id, a.unit_id, a.role, a.signal, "
+                "a.shell_id, u.seq "
+                "FROM planner_alerts a "
+                "JOIN sprint_units u ON u.unit_id=a.unit_id "
+                "WHERE a.reason='worker_checkup'"
+            ).fetchone()
             open_session_alerts = rebuilt.execute(
                 "SELECT alert_id FROM planner_alerts "
                 "WHERE session_id=2 AND resolved_at IS NULL").fetchall()
@@ -370,6 +391,10 @@ class InterfaceSnapshotTest(unittest.TestCase):
         finally:
             rebuilt.close()
         self.assertEqual(violations, [])
+        self.assertEqual(
+            reconciler_alert,
+            (2, self.reconciler_unit_id, "dev", "checkup", 2, "U5"),
+        )
         self.assertEqual(input_park, ("unknown", "delivery_unknown", 9))
         self.assertEqual(binding, (None,))
         self.assertEqual(wake_park, ("delivery_unknown",))

--- a/tests/test_interface_sprint_ops.py
+++ b/tests/test_interface_sprint_ops.py
@@ -320,12 +320,18 @@ class SprintOpsRoutesTest(unittest.TestCase):
     def test_structured_reconciler_alert_is_sprint_scoped_and_filterable(self):
         self.arm()
         con = sqlite3.connect(self.db_path)
+        unit_id = con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id, seq, unit_title, state, dev_shell_id) "
+            "VALUES (1, 'U5', 'delivery', 'working', 2)"
+        ).lastrowid
         con.execute(
             "INSERT INTO planner_alerts "
-            "(sprint_doc_id, seq, role, signal, shell_id, severity, reason, "
+            "(sprint_doc_id, unit_id, role, signal, shell_id, severity, reason, "
             " dedupe_key) "
-            "VALUES (1, 'U5', 'dev', 'checkup', 2, 'warning', "
-            "        'worker_checkup', 'reconciler|1|U5|dev|checkup')"
+            "VALUES (1, ?, 'dev', 'checkup', 2, 'warning', "
+            "        'worker_checkup', ?)",
+            (unit_id, f"reconciler|1|{unit_id}|dev|checkup"),
         )
         con.commit()
         con.close()
@@ -339,10 +345,10 @@ class SprintOpsRoutesTest(unittest.TestCase):
         self.assertEqual(1, len(body["alerts"]))
         alert = body["alerts"][0]
         self.assertEqual(
-            (1, "U5", "dev", "checkup", 2),
+            (1, unit_id, "dev", "checkup", 2),
             (
                 alert["sprint_doc_id"],
-                alert["seq"],
+                alert["unit_id"],
                 alert["role"],
                 alert["signal"],
                 alert["shell_id"],

--- a/tests/test_interface_sprint_ops.py
+++ b/tests/test_interface_sprint_ops.py
@@ -317,6 +317,62 @@ class SprintOpsRoutesTest(unittest.TestCase):
                                  (SHELL2,))
         self.assertEqual(body["alerts"], [])
 
+    def test_structured_reconciler_alert_is_sprint_scoped_and_filterable(self):
+        self.arm()
+        con = sqlite3.connect(self.db_path)
+        con.execute(
+            "INSERT INTO planner_alerts "
+            "(sprint_doc_id, seq, role, signal, shell_id, severity, reason, "
+            " dedupe_key) "
+            "VALUES (1, 'U5', 'dev', 'checkup', 2, 'warning', "
+            "        'worker_checkup', 'reconciler|1|U5|dev|checkup')"
+        )
+        con.commit()
+        con.close()
+
+        status, body = self.call(
+            "GET",
+            "/api/interface/sprint-alerts?sprint_doc_id=1",
+            (SHELL1,),
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(1, len(body["alerts"]))
+        alert = body["alerts"][0]
+        self.assertEqual(
+            (1, "U5", "dev", "checkup", 2),
+            (
+                alert["sprint_doc_id"],
+                alert["seq"],
+                alert["role"],
+                alert["signal"],
+                alert["shell_id"],
+            ),
+        )
+
+        status, body = self.call(
+            "GET",
+            "/api/interface/sprint-alerts?sprint_doc_id=1",
+            (SHELL2,),
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual([], body["alerts"])
+
+        status, body = self.call(
+            "GET",
+            "/api/interface/sprint-alerts?sprint_doc_id=999",
+            (OP,),
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual([], body["alerts"])
+
+        status, body = self.call(
+            "GET",
+            "/api/interface/sprint-alerts?sprint_doc_id=not-an-id",
+            (OP,),
+        )
+        self.assertEqual(status, 422)
+        self.assertEqual("validation", body["error"]["code"])
+
     def test_unscoped_watch_alert_is_visible_only_to_its_owner(self):
         con = sqlite3.connect(self.db_path)
         con.execute("DELETE FROM interface_input_state")

--- a/tests/test_interface_sprint_ops.py
+++ b/tests/test_interface_sprint_ops.py
@@ -379,6 +379,38 @@ class SprintOpsRoutesTest(unittest.TestCase):
         self.assertEqual(status, 422)
         self.assertEqual("validation", body["error"]["code"])
 
+    def test_work_complete_alert_explicitly_forbids_restart(self):
+        con = sqlite3.connect(self.db_path)
+        unit_id = con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id, seq, unit_title, state, dev_shell_id) "
+            "VALUES (1, 'U5', 'delivery', 'working', 2)"
+        ).lastrowid
+        con.execute(
+            "INSERT INTO planner_alerts "
+            "(sprint_doc_id, unit_id, role, signal, shell_id, severity, reason, "
+            " dedupe_key) "
+            "VALUES (1, ?, 'dev', 'work_complete_unreported', 2, 'info', "
+            "        'worker_work_complete_unreported', ?)",
+            (
+                unit_id,
+                f"reconciler|1|{unit_id}|dev|work_complete_unreported",
+            ),
+        )
+        con.commit()
+        con.close()
+
+        status, body = self.call(
+            "GET",
+            "/api/interface/sprint-alerts?sprint_doc_id=1",
+            (OP,),
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(1, len(body["alerts"]))
+        action = body["alerts"][0]["next_action"]
+        self.assertIn("Do not restart", action)
+        self.assertNotIn("start a new", action)
+
     def test_unscoped_watch_alert_is_visible_only_to_its_owner(self):
         con = sqlite3.connect(self.db_path)
         con.execute("DELETE FROM interface_input_state")

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -653,7 +653,7 @@ class CutoverTest(unittest.TestCase):
         finally:
             con.close()
 
-    def test_missing_gh_disables_only_pr_reads_not_reconciliation(self):
+    def test_missing_gh_disables_pr_reads_but_completed_reconciliation_beats(self):
         import shutil
         old = shutil.which
         shutil.which = lambda name: None
@@ -671,8 +671,71 @@ class CutoverTest(unittest.TestCase):
         self.assertFalse(poller.is_alive())
         con = sqlite3.connect(tmp)
         try:
-            self.assertEqual(con.execute(
-                "SELECT COUNT(*) FROM daemon_heartbeats").fetchone()[0], 0)
+            self.assertEqual(
+                ("watch", 600),
+                con.execute(
+                    "SELECT name, interval_s FROM daemon_heartbeats"
+                ).fetchone(),
+            )
+        finally:
+            con.close()
+
+    def test_mid_reconciliation_failure_leaves_no_fresh_heartbeat(self):
+        import contextlib
+        import io
+
+        tmp = Path(tempfile.mkdtemp()) / "shell_db.db"
+        con = build_db(tmp)
+        seed_shells(con)
+        seed_sprint_doc(con, 100)
+        con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id, seq, unit_title, state, dev_shell_id, branch) "
+            "VALUES (100, 'U5', 'delivery', 'working', 2, 'feat/test')"
+        )
+        con.execute(
+            "INSERT INTO daemon_heartbeats (name, beat_at, interval_s) "
+            "VALUES ('watch', '2000-01-01 00:00:00', 600)"
+        )
+        con.commit()
+        con.close()
+
+        class RaisingReader:
+            def read(self, shell, unit, now):
+                raise RuntimeError("mid-tick sentinel")
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            poller = pr_poller.Poller(
+                tmp,
+                interval=30,
+                fetch=fetch_ok(),
+                activity_reader=RaisingReader(),
+                refresh=lambda worktree: True,
+            )
+            poller.start()
+            time.sleep(0.2)
+            poller.stop()
+            poller.join(timeout=5)
+
+        self.assertIn("cycle error (mid-tick sentinel)", out.getvalue())
+        con = sqlite3.connect(tmp)
+        try:
+            self.assertEqual(
+                ("2000-01-01 00:00:00", 600),
+                con.execute(
+                    "SELECT beat_at, interval_s FROM daemon_heartbeats "
+                    "WHERE name='watch'"
+                ).fetchone(),
+            )
+            self.assertEqual(
+                0,
+                con.execute("SELECT COUNT(*) FROM planner_alerts").fetchone()[0],
+            )
+            self.assertEqual(
+                0,
+                con.execute("SELECT COUNT(*) FROM shell_messages").fetchone()[0],
+            )
         finally:
             con.close()
 

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -530,6 +530,13 @@ class CutoverTest(unittest.TestCase):
             self.assertEqual(con.execute(
                 "SELECT COUNT(*) FROM daemon_heartbeats WHERE name='watch'"
             ).fetchone()[0], 1)
+            self.assertEqual(
+                30,
+                con.execute(
+                    "SELECT interval_s FROM daemon_heartbeats "
+                    "WHERE name='watch'"
+                ).fetchone()[0],
+            )
             self.assertIsNotNone(con.execute(
                 "SELECT last_seen FROM watched_prs").fetchone()["last_seen"])
             run = con.execute("SELECT source, status FROM pr_poll_runs").fetchone()
@@ -653,7 +660,7 @@ class CutoverTest(unittest.TestCase):
         finally:
             con.close()
 
-    def test_missing_gh_disables_pr_reads_but_completed_reconciliation_beats(self):
+    def test_missing_gh_keeps_poll_heartbeat_absent_but_reconciliation_beats(self):
         import shutil
         old = shutil.which
         shutil.which = lambda name: None
@@ -672,10 +679,11 @@ class CutoverTest(unittest.TestCase):
         con = sqlite3.connect(tmp)
         try:
             self.assertEqual(
-                ("watch", 600),
+                [("reconcile", 600)],
                 con.execute(
-                    "SELECT name, interval_s FROM daemon_heartbeats"
-                ).fetchone(),
+                    "SELECT name, interval_s FROM daemon_heartbeats "
+                    "ORDER BY name"
+                ).fetchall(),
             )
         finally:
             con.close()
@@ -695,7 +703,7 @@ class CutoverTest(unittest.TestCase):
         )
         con.execute(
             "INSERT INTO daemon_heartbeats (name, beat_at, interval_s) "
-            "VALUES ('watch', '2000-01-01 00:00:00', 600)"
+            "VALUES ('reconcile', '2000-01-01 00:00:00', 600)"
         )
         con.commit()
         con.close()
@@ -725,8 +733,15 @@ class CutoverTest(unittest.TestCase):
                 ("2000-01-01 00:00:00", 600),
                 con.execute(
                     "SELECT beat_at, interval_s FROM daemon_heartbeats "
-                    "WHERE name='watch'"
+                    "WHERE name='reconcile'"
                 ).fetchone(),
+            )
+            self.assertEqual(
+                30,
+                con.execute(
+                    "SELECT interval_s FROM daemon_heartbeats "
+                    "WHERE name='watch'"
+                ).fetchone()[0],
             )
             self.assertEqual(
                 0,

--- a/tests/test_reconciler_delivery.py
+++ b/tests/test_reconciler_delivery.py
@@ -20,11 +20,13 @@ import pr_poller  # noqa: E402
 NOW = datetime(2020, 1, 1, tzinfo=timezone.utc)
 
 
-def build_db() -> sqlite3.Connection:
+def build_db(skip: set[str] | None = None) -> sqlite3.Connection:
     con = sqlite3.connect(":memory:")
     con.row_factory = sqlite3.Row
     con.executescript(SCHEMA.read_text())
     for migration in sorted(MIGRATIONS.glob("*.sql")):
+        if skip and migration.name in skip:
+            continue
         con.executescript(migration.read_text())
     con.executescript(
         """
@@ -577,6 +579,64 @@ class ReconcilerDeliveryTest(unittest.TestCase):
         ).fetchall()
         self.assertEqual(1, len(rows))
         self.assertIsNotNone(rows[0][0])
+
+    def test_migration_expands_a_dirty_legacy_alert_table_without_rewriting_rows(self):
+        migration_name = "0102_reconciler_alert_keys.sql"
+        legacy = build_db(skip={migration_name})
+        self.addCleanup(legacy.close)
+        interface_broker._alert(
+            legacy,
+            severity="warning",
+            reason="legacy_open",
+        )
+        legacy.commit()
+        before = legacy.execute(
+            "SELECT alert_id, severity, reason, dedupe_key, resolved_at "
+            "FROM planner_alerts"
+        ).fetchone()
+
+        legacy.executescript((MIGRATIONS / migration_name).read_text())
+
+        after = legacy.execute(
+            "SELECT alert_id, severity, reason, dedupe_key, resolved_at, "
+            "sprint_doc_id, unit_id, role, signal, shell_id "
+            "FROM planner_alerts"
+        ).fetchone()
+        self.assertEqual(
+            tuple(before) + (None, None, None, None, None),
+            tuple(after),
+        )
+        interface_broker._alert(
+            legacy,
+            severity="warning",
+            reason="legacy_open",
+        )
+        self.assertEqual(
+            1,
+            legacy.execute(
+                "SELECT COUNT(*) FROM planner_alerts "
+                "WHERE reason='legacy_open'"
+            ).fetchone()[0],
+        )
+        legacy.execute(
+            "UPDATE planner_alerts SET resolved_at=datetime('now') "
+            "WHERE reason='legacy_open'"
+        )
+        interface_broker._alert(
+            legacy,
+            severity="warning",
+            reason="legacy_open",
+        )
+        rows = legacy.execute(
+            "SELECT resolved_at, sprint_doc_id, unit_id, role, signal, shell_id "
+            "FROM planner_alerts WHERE reason='legacy_open' ORDER BY alert_id"
+        ).fetchall()
+        self.assertEqual(2, len(rows))
+        self.assertIsNotNone(rows[0]["resolved_at"])
+        self.assertEqual(
+            (None, None, None, None, None, None),
+            tuple(rows[1]),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_reconciler_delivery.py
+++ b/tests/test_reconciler_delivery.py
@@ -419,7 +419,7 @@ class ReconcilerDeliveryTest(unittest.TestCase):
             "WHERE signal='checkup'"
         ).fetchall()
         self.assertEqual(
-            [(self.unit["unit_id"], "dev", "checkup", 2)],
+            [(self.unit["unit_id"], "dev", "checkup", 4)],
             [tuple(row) for row in rows],
         )
 

--- a/tests/test_reconciler_delivery.py
+++ b/tests/test_reconciler_delivery.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Worker-reconciliation alert delivery (spec 58, U5)."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import interface_broker  # noqa: E402
+import pr_poller  # noqa: E402
+
+NOW = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+def build_db() -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.executescript(
+        """
+        INSERT INTO users (user_id, username, is_active) VALUES (1, 'T', 1);
+        INSERT INTO shells
+          (shell_id, display_name, shortname, flavor, system_prompt, user_id)
+        VALUES
+          (1, 'Planner 1', 'PLN1', 'planner', 'x', 1),
+          (2, 'Developer 1', 'DEV1', 'dev', 'x', 1),
+          (3, 'Planner 2', 'PLN2', 'planner', 'x', 1);
+        """
+    )
+    return con
+
+
+def add_sprint(
+    con: sqlite3.Connection,
+    doc_id: int,
+    seq: str,
+    *,
+    state: str = "working",
+) -> sqlite3.Row:
+    con.execute(
+        "INSERT INTO documents (document_id, kind, title, body) "
+        "VALUES (?, 'doc', ?, 'status: ACTIVE')",
+        (doc_id, f"SPRINT: {doc_id}"),
+    )
+    con.execute(
+        "INSERT INTO sprint_units "
+        "(sprint_doc_id, seq, unit_title, state, dev_shell_id) "
+        "VALUES (?, ?, 'delivery', ?, 2)",
+        (doc_id, seq, state),
+    )
+    con.commit()
+    return con.execute(
+        "SELECT * FROM sprint_units WHERE sprint_doc_id=? AND seq=?",
+        (doc_id, seq),
+    ).fetchone()
+
+
+def add_binding(
+    con: sqlite3.Connection,
+    doc_id: int,
+    planner: int,
+    generation: int = 1,
+) -> tuple[int, int]:
+    con.execute(
+        "INSERT INTO interface_generations (shell_id, generation) VALUES (?,?)",
+        (planner, generation),
+    )
+    session_id = con.execute(
+        "INSERT INTO interface_sessions (shell_id, generation) VALUES (?,?)",
+        (planner, generation),
+    ).lastrowid
+    binding_id = con.execute(
+        "INSERT INTO sprint_planner_bindings "
+        "(sprint_doc_id, planner_shell_id, session_id, shell_id, generation) "
+        "VALUES (?,?,?,?,?)",
+        (doc_id, planner, session_id, planner, generation),
+    ).lastrowid
+    con.commit()
+    return session_id, binding_id
+
+
+class ReconcilerDeliveryTest(unittest.TestCase):
+    def setUp(self):
+        self.con = build_db()
+        self.addCleanup(self.con.close)
+        self.unit = add_sprint(self.con, 59, "U5")
+        self.session_id, self.binding_id = add_binding(self.con, 59, 1)
+
+    def expectation(
+        self,
+        *,
+        doc_id: int = 59,
+        seq: str = "U5",
+        unit: sqlite3.Row | None = None,
+    ) -> pr_poller.Expectation:
+        unit = unit if unit is not None else self.unit
+        shell = self.con.execute(
+            "SELECT * FROM shells WHERE shell_id=2"
+        ).fetchone()
+        return pr_poller.Expectation(
+            sprint_doc_id=doc_id,
+            unit_id=unit["unit_id"],
+            seq=seq,
+            role="dev",
+            shell_id=2,
+            shell=shell,
+            unit=unit,
+        )
+
+    def reading(
+        self,
+        signal: str,
+        *,
+        confirmed: bool = True,
+        minute: int = 0,
+        expectation: pr_poller.Expectation | None = None,
+        explanation: str | None = None,
+    ) -> pr_poller.ReconciliationReading:
+        return pr_poller.ReconciliationReading(
+            expectation=expectation or self.expectation(),
+            signal=signal,
+            confirmed=confirmed,
+            # A sentinel with no Evidence fields: any U5 reach-through raises.
+            evidence=object(),
+            measurement={"count": 3},
+            observed_at=NOW + timedelta(minutes=minute),
+            explanation=explanation,
+        )
+
+    def test_confirmed_actionable_reading_writes_exact_alert_message_and_wake(self):
+        before_board = tuple(self.con.execute(
+            "SELECT * FROM sprint_units ORDER BY unit_id"
+        ).fetchall())
+
+        emitted = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [self.reading("checkup")],
+        )
+
+        self.assertEqual(1, len(emitted))
+        alert = self.con.execute(
+            "SELECT sprint_doc_id, seq, role, signal, shell_id, severity, "
+            "reason, opened_at, resolved_at, message_id "
+            "FROM planner_alerts"
+        ).fetchone()
+        self.assertEqual(
+            (
+                59,
+                "U5",
+                "dev",
+                "checkup",
+                2,
+                "warning",
+                "worker_checkup",
+                NOW.isoformat(),
+                None,
+                emitted[0],
+            ),
+            tuple(alert),
+        )
+        message = self.con.execute(
+            "SELECT from_shell_id, to_shell_id, kind, sprint_doc_id, body "
+            "FROM shell_messages"
+        ).fetchone()
+        self.assertEqual((1, 1, "pr_event", 59), tuple(message)[:4])
+        self.assertEqual(
+            "reconciler unit=U5 role=dev shell=DEV1 signal=checkup "
+            'measurement={"count":3} '
+            f"observed_at={NOW.isoformat()}",
+            message["body"],
+        )
+        self.assertEqual(
+            [(self.binding_id, emitted[0])],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT binding_id, message_id FROM planner_wake_items"
+                )
+            ],
+        )
+        self.assertEqual(
+            before_board,
+            tuple(self.con.execute(
+                "SELECT * FROM sprint_units ORDER BY unit_id"
+            ).fetchall()),
+        )
+
+    def test_unconfirmed_actionable_reading_writes_nothing(self):
+        emitted = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [self.reading("checkup", confirmed=False)],
+        )
+        self.assertEqual([], emitted)
+        self.assertEqual(
+            (0, 0, 0),
+            (
+                self.con.execute(
+                    "SELECT COUNT(*) FROM planner_alerts"
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT COUNT(*) FROM shell_messages"
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT COUNT(*) FROM planner_wake_items"
+                ).fetchone()[0],
+            ),
+        )
+
+    def test_confirmed_indeterminate_reading_writes_nothing(self):
+        emitted = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [self.reading("indeterminate")],
+        )
+        self.assertEqual([], emitted)
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM planner_alerts"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM shell_messages"
+            ).fetchone()[0],
+        )
+
+    def test_severity_map_and_recovery_explanation_are_exact(self):
+        readings = [
+            self.reading("checkup"),
+            self.reading("not_started"),
+            self.reading("work_complete_unreported"),
+            self.reading(
+                "recovery_blocked",
+                explanation="boot refused: shell occupied",
+            ),
+        ]
+        emitted = pr_poller.deliver_reconciliation_readings(self.con, readings)
+        self.assertEqual(4, len(emitted))
+        self.assertEqual(
+            [
+                ("checkup", "warning"),
+                ("not_started", "warning"),
+                ("recovery_blocked", "critical"),
+                ("work_complete_unreported", "info"),
+            ],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT signal, severity FROM planner_alerts "
+                    "ORDER BY signal"
+                )
+            ],
+        )
+        body = self.con.execute(
+            "SELECT body FROM shell_messages "
+            "WHERE body LIKE '%signal=recovery_blocked%'"
+        ).fetchone()[0]
+        self.assertIn(
+            'explanation="boot refused: shell occupied"',
+            body,
+        )
+
+    def test_open_dedupe_healthy_resolve_and_rearm_are_one_lifecycle(self):
+        first = self.reading("checkup", minute=0)
+        first_ids = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [first],
+        )
+        replay_ids = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [first],
+        )
+        pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [self.reading("working", confirmed=False, minute=1)],
+        )
+        rearmed_ids = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [self.reading("checkup", minute=2)],
+        )
+
+        self.assertEqual([], replay_ids)
+        self.assertEqual(1, len(first_ids))
+        self.assertEqual(1, len(rearmed_ids))
+        self.assertNotEqual(first_ids[0], rearmed_ids[0])
+        alerts = self.con.execute(
+            "SELECT opened_at, resolved_at, message_id "
+            "FROM planner_alerts WHERE signal='checkup' ORDER BY alert_id"
+        ).fetchall()
+        self.assertEqual(
+            [
+                (
+                    NOW.isoformat(),
+                    (NOW + timedelta(minutes=1)).isoformat(),
+                    first_ids[0],
+                ),
+                (
+                    (NOW + timedelta(minutes=2)).isoformat(),
+                    None,
+                    rearmed_ids[0],
+                ),
+            ],
+            [tuple(row) for row in alerts],
+        )
+        self.assertEqual(
+            2,
+            self.con.execute(
+                "SELECT COUNT(*) FROM shell_messages"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            2,
+            self.con.execute(
+                "SELECT COUNT(*) FROM planner_wake_items"
+            ).fetchone()[0],
+        )
+
+    def test_reported_is_also_a_healthy_auto_resolve_signal(self):
+        pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [self.reading("not_started")],
+        )
+        pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [self.reading("reported", confirmed=False, minute=1)],
+        )
+        self.assertEqual(
+            (NOW + timedelta(minutes=1)).isoformat(),
+            self.con.execute(
+                "SELECT resolved_at FROM planner_alerts "
+                "WHERE signal='not_started'"
+            ).fetchone()[0],
+        )
+
+    def test_never_bound_records_finding_and_condition_without_push(self):
+        unit = add_sprint(self.con, 60, "U6")
+        expectation = self.expectation(doc_id=60, seq="U6", unit=unit)
+        finding = self.reading("checkup", expectation=expectation)
+
+        first = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [finding],
+        )
+        replay = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [finding],
+        )
+
+        self.assertEqual([], first)
+        self.assertEqual([], replay)
+        self.assertEqual(
+            [
+                ("reconciler_missing_binding", None, "warning"),
+                ("worker_checkup", "checkup", "warning"),
+            ],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT reason, signal, severity FROM planner_alerts "
+                    "WHERE sprint_doc_id=60 ORDER BY reason"
+                )
+            ],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM shell_messages WHERE sprint_doc_id=60"
+            ).fetchone()[0],
+        )
+
+        add_binding(self.con, 60, 3)
+        pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [
+                self.reading(
+                    "indeterminate",
+                    confirmed=False,
+                    minute=1,
+                    expectation=expectation,
+                )
+            ],
+        )
+        rows = self.con.execute(
+            "SELECT reason, resolved_at FROM planner_alerts "
+            "WHERE sprint_doc_id=60 ORDER BY reason"
+        ).fetchall()
+        self.assertEqual(
+            [
+                (
+                    "reconciler_missing_binding",
+                    (NOW + timedelta(minutes=1)).isoformat(),
+                ),
+                ("worker_checkup", None),
+            ],
+            [tuple(row) for row in rows],
+        )
+
+    def test_bound_and_never_bound_sprints_are_isolated_in_one_completed_tick(self):
+        unit = add_sprint(self.con, 60, "U6")
+        unbound = self.reading(
+            "checkup",
+            expectation=self.expectation(doc_id=60, seq="U6", unit=unit),
+        )
+        bound = self.reading("checkup")
+        before_board = tuple(self.con.execute(
+            "SELECT * FROM sprint_units ORDER BY unit_id"
+        ).fetchall())
+
+        emitted = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [bound, unbound],
+        )
+        pr_poller.beat(self.con, 600)
+
+        self.assertEqual(1, len(emitted))
+        self.assertEqual(
+            [(59, 1), (60, 0)],
+            [
+                (
+                    doc_id,
+                    self.con.execute(
+                        "SELECT COUNT(*) FROM shell_messages "
+                        "WHERE sprint_doc_id=?",
+                        (doc_id,),
+                    ).fetchone()[0],
+                )
+                for doc_id in (59, 60)
+            ],
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM planner_alerts "
+                "WHERE sprint_doc_id=59 AND signal='checkup'"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            2,
+            self.con.execute(
+                "SELECT COUNT(*) FROM planner_alerts "
+                "WHERE sprint_doc_id=60"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            ("watch", 600),
+            tuple(self.con.execute(
+                "SELECT name, interval_s FROM daemon_heartbeats"
+            ).fetchone()),
+        )
+        self.assertEqual(
+            before_board,
+            tuple(self.con.execute(
+                "SELECT * FROM sprint_units ORDER BY unit_id"
+            ).fetchall()),
+        )
+
+    def test_legacy_interface_alert_opens_dedupes_resolves_with_null_new_columns(self):
+        interface_broker._alert(
+            self.con,
+            severity="critical",
+            reason="turn_failure",
+            session_id=self.session_id,
+        )
+        interface_broker._alert(
+            self.con,
+            severity="critical",
+            reason="turn_failure",
+            session_id=self.session_id,
+        )
+        self.con.commit()
+        row = self.con.execute(
+            "SELECT sprint_doc_id, seq, role, signal, shell_id, resolved_at "
+            "FROM planner_alerts WHERE reason='turn_failure'"
+        ).fetchone()
+        self.assertEqual((None, None, None, None, None, None), tuple(row))
+
+        interface_broker.close_session(
+            self.con,
+            self.session_id,
+            "test_complete",
+        )
+        self.con.commit()
+        rows = self.con.execute(
+            "SELECT resolved_at FROM planner_alerts "
+            "WHERE reason='turn_failure'"
+        ).fetchall()
+        self.assertEqual(1, len(rows))
+        self.assertIsNotNone(rows[0][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reconciler_delivery.py
+++ b/tests/test_reconciler_delivery.py
@@ -467,12 +467,17 @@ class ReconcilerDeliveryTest(unittest.TestCase):
             ],
         )
 
-        self.assertIsNone(
-            self.con.execute(
-                "SELECT resolved_at FROM planner_alerts "
-                "WHERE sprint_doc_id=60 AND unit_id IS NULL "
-                "AND role='planner' AND signal='checkup'"
-            ).fetchone()[0]
+        self.assertEqual(
+            [(59, 1), (60, 0)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT sprint_doc_id, resolved_at IS NOT NULL "
+                    "FROM planner_alerts WHERE sprint_doc_id IN (59, 60) "
+                    "AND unit_id IS NULL AND role='planner' "
+                    "AND signal='checkup' ORDER BY sprint_doc_id"
+                )
+            ],
         )
 
     def test_unitless_expectation_dedupes_on_an_explicit_key_sentinel(self):

--- a/tests/test_reconciler_delivery.py
+++ b/tests/test_reconciler_delivery.py
@@ -221,10 +221,10 @@ class ReconcilerDeliveryTest(unittest.TestCase):
             ),
         )
 
-    def test_confirmed_indeterminate_reading_writes_nothing(self):
+    def test_unconfirmed_indeterminate_reading_writes_nothing(self):
         emitted = pr_poller.deliver_reconciliation_readings(
             self.con,
-            [self.reading("indeterminate")],
+            [self.reading("indeterminate", confirmed=False)],
         )
         self.assertEqual([], emitted)
         self.assertEqual(
@@ -271,7 +271,11 @@ class ReconcilerDeliveryTest(unittest.TestCase):
             body,
         )
 
-    def test_recovery_blocked_is_mapped_but_has_no_reconciler_producer(self):
+    def test_severity_contract_has_one_documented_producerless_mapping(self):
+        self.assertEqual(
+            pr_poller.ReconcilerState.ACTIONABLE | {"recovery_blocked"},
+            set(pr_poller.RECONCILER_SEVERITY),
+        )
         self.assertEqual(
             "critical",
             pr_poller.RECONCILER_SEVERITY["recovery_blocked"],

--- a/tests/test_reconciler_delivery.py
+++ b/tests/test_reconciler_delivery.py
@@ -105,6 +105,7 @@ class ReconcilerDeliveryTest(unittest.TestCase):
         doc_id: int = 59,
         seq: str = "U5",
         unit: sqlite3.Row | None = None,
+        role: str = "dev",
         shell_id: int = 2,
     ) -> pr_poller.Expectation:
         unit = unit if unit is not None else self.unit
@@ -116,10 +117,30 @@ class ReconcilerDeliveryTest(unittest.TestCase):
             sprint_doc_id=doc_id,
             unit_id=unit["unit_id"],
             seq=seq,
-            role="dev",
+            role=role,
             shell_id=shell_id,
             shell=shell,
             unit=unit,
+        )
+
+    def planner_expectation(
+        self,
+        *,
+        doc_id: int = 59,
+        shell_id: int = 1,
+    ) -> pr_poller.Expectation:
+        shell = self.con.execute(
+            "SELECT * FROM shells WHERE shell_id=?",
+            (shell_id,),
+        ).fetchone()
+        return pr_poller.Expectation(
+            sprint_doc_id=doc_id,
+            unit_id=None,
+            seq=None,
+            role="planner",
+            shell_id=shell_id,
+            shell=shell,
+            unit=None,
         )
 
     def reading(
@@ -357,19 +378,105 @@ class ReconcilerDeliveryTest(unittest.TestCase):
             ).fetchone()[0],
         )
 
-    def test_unitless_expectation_dedupes_on_an_explicit_key_sentinel(self):
-        planner = self.con.execute(
-            "SELECT * FROM shells WHERE shell_id=1"
-        ).fetchone()
-        expectation = pr_poller.Expectation(
-            sprint_doc_id=59,
-            unit_id=None,
-            seq=None,
-            role="planner",
-            shell_id=1,
-            shell=planner,
-            unit=None,
+    def test_unitless_planner_alert_resolves_on_recovery(self):
+        expectation = self.planner_expectation()
+        pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [self.reading("checkup", expectation=expectation)],
         )
+        pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [
+                self.reading(
+                    "working",
+                    confirmed=False,
+                    minute=1,
+                    expectation=expectation,
+                )
+            ],
+        )
+
+        self.assertEqual(
+            (NOW + timedelta(minutes=1)).isoformat(),
+            self.con.execute(
+                "SELECT resolved_at FROM planner_alerts "
+                "WHERE sprint_doc_id=59 AND unit_id IS NULL "
+                "AND role='planner' AND signal='checkup'"
+            ).fetchone()[0],
+        )
+
+    def test_one_role_recovery_does_not_resolve_the_other_role(self):
+        dev = self.expectation(role="dev", shell_id=2)
+        reviewer = self.expectation(role="reviewer", shell_id=4)
+        pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [
+                self.reading("checkup", expectation=dev),
+                self.reading("checkup", expectation=reviewer),
+            ],
+        )
+        pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [
+                self.reading(
+                    "working",
+                    confirmed=False,
+                    minute=1,
+                    expectation=dev,
+                )
+            ],
+        )
+
+        self.assertEqual(
+            [
+                ("dev", (NOW + timedelta(minutes=1)).isoformat()),
+                ("reviewer", None),
+            ],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT role, resolved_at FROM planner_alerts "
+                    "WHERE sprint_doc_id=59 AND unit_id=? "
+                    "AND signal='checkup' ORDER BY role",
+                    (self.unit["unit_id"],),
+                )
+            ],
+        )
+
+    def test_planner_recovery_does_not_resolve_another_sprint(self):
+        add_sprint(self.con, 60, "U6")
+        add_binding(self.con, 60, 3)
+        sprint_59 = self.planner_expectation()
+        sprint_60 = self.planner_expectation(doc_id=60, shell_id=3)
+        pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [
+                self.reading("checkup", expectation=sprint_59),
+                self.reading("checkup", expectation=sprint_60),
+            ],
+        )
+        pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [
+                self.reading(
+                    "working",
+                    confirmed=False,
+                    minute=1,
+                    expectation=sprint_59,
+                )
+            ],
+        )
+
+        self.assertIsNone(
+            self.con.execute(
+                "SELECT resolved_at FROM planner_alerts "
+                "WHERE sprint_doc_id=60 AND unit_id IS NULL "
+                "AND role='planner' AND signal='checkup'"
+            ).fetchone()[0]
+        )
+
+    def test_unitless_expectation_dedupes_on_an_explicit_key_sentinel(self):
+        expectation = self.planner_expectation()
         reading = self.reading("checkup", expectation=expectation)
 
         first = pr_poller.deliver_reconciliation_readings(
@@ -493,63 +600,100 @@ class ReconcilerDeliveryTest(unittest.TestCase):
         )
 
     def test_bound_and_never_bound_sprints_are_isolated_in_one_completed_tick(self):
-        unit = add_sprint(self.con, 60, "U6")
-        unbound = self.reading(
-            "checkup",
-            expectation=self.expectation(doc_id=60, seq="U6", unit=unit),
+        cases = (
+            ("bound-first", 59, 60, 1),
+            ("unbound-first", 62, 61, 3),
         )
-        bound = self.reading("checkup")
-        before_board = tuple(self.con.execute(
-            "SELECT * FROM sprint_units ORDER BY unit_id"
-        ).fetchall())
+        for label, bound_doc_id, unbound_doc_id, planner_id in cases:
+            with self.subTest(order=label):
+                if bound_doc_id == 59:
+                    bound_unit = self.unit
+                else:
+                    bound_unit = add_sprint(
+                        self.con,
+                        bound_doc_id,
+                        f"U{bound_doc_id}",
+                    )
+                    add_binding(self.con, bound_doc_id, planner_id)
+                unbound_unit = add_sprint(
+                    self.con,
+                    unbound_doc_id,
+                    f"U{unbound_doc_id}",
+                )
+                bound = self.reading(
+                    "checkup",
+                    expectation=self.expectation(
+                        doc_id=bound_doc_id,
+                        seq=f"U{bound_doc_id}",
+                        unit=bound_unit,
+                    ),
+                )
+                unbound = self.reading(
+                    "checkup",
+                    expectation=self.expectation(
+                        doc_id=unbound_doc_id,
+                        seq=f"U{unbound_doc_id}",
+                        unit=unbound_unit,
+                    ),
+                )
+                readings = sorted(
+                    (bound, unbound),
+                    key=lambda item: item.expectation.sprint_doc_id,
+                )
+                before_board = tuple(self.con.execute(
+                    "SELECT * FROM sprint_units ORDER BY unit_id"
+                ).fetchall())
 
-        emitted = pr_poller.deliver_reconciliation_readings(
-            self.con,
-            [bound, unbound],
-        )
-        pr_poller.beat(self.con, 600)
+                emitted = pr_poller.deliver_reconciliation_readings(
+                    self.con,
+                    readings,
+                )
+                pr_poller.beat(self.con, 600, name="reconcile")
 
-        self.assertEqual(1, len(emitted))
-        self.assertEqual(
-            [(59, 1), (60, 0)],
-            [
-                (
-                    doc_id,
+                self.assertEqual(1, len(emitted))
+                self.assertEqual(
+                    [(bound_doc_id, 1), (unbound_doc_id, 0)],
+                    [
+                        (
+                            doc_id,
+                            self.con.execute(
+                                "SELECT COUNT(*) FROM shell_messages "
+                                "WHERE sprint_doc_id=?",
+                                (doc_id,),
+                            ).fetchone()[0],
+                        )
+                        for doc_id in (bound_doc_id, unbound_doc_id)
+                    ],
+                )
+                self.assertEqual(
+                    1,
                     self.con.execute(
-                        "SELECT COUNT(*) FROM shell_messages "
-                        "WHERE sprint_doc_id=?",
-                        (doc_id,),
+                        "SELECT COUNT(*) FROM planner_alerts "
+                        "WHERE sprint_doc_id=? AND signal='checkup'",
+                        (bound_doc_id,),
                     ).fetchone()[0],
                 )
-                for doc_id in (59, 60)
-            ],
-        )
-        self.assertEqual(
-            1,
-            self.con.execute(
-                "SELECT COUNT(*) FROM planner_alerts "
-                "WHERE sprint_doc_id=59 AND signal='checkup'"
-            ).fetchone()[0],
-        )
-        self.assertEqual(
-            2,
-            self.con.execute(
-                "SELECT COUNT(*) FROM planner_alerts "
-                "WHERE sprint_doc_id=60"
-            ).fetchone()[0],
-        )
-        self.assertEqual(
-            ("watch", 600),
-            tuple(self.con.execute(
-                "SELECT name, interval_s FROM daemon_heartbeats"
-            ).fetchone()),
-        )
-        self.assertEqual(
-            before_board,
-            tuple(self.con.execute(
-                "SELECT * FROM sprint_units ORDER BY unit_id"
-            ).fetchall()),
-        )
+                self.assertEqual(
+                    2,
+                    self.con.execute(
+                        "SELECT COUNT(*) FROM planner_alerts "
+                        "WHERE sprint_doc_id=?",
+                        (unbound_doc_id,),
+                    ).fetchone()[0],
+                )
+                self.assertEqual(
+                    ("reconcile", 600),
+                    tuple(self.con.execute(
+                        "SELECT name, interval_s FROM daemon_heartbeats "
+                        "WHERE name='reconcile'"
+                    ).fetchone()),
+                )
+                self.assertEqual(
+                    before_board,
+                    tuple(self.con.execute(
+                        "SELECT * FROM sprint_units ORDER BY unit_id"
+                    ).fetchall()),
+                )
 
     def test_legacy_interface_alert_opens_dedupes_resolves_with_null_new_columns(self):
         interface_broker._alert(

--- a/tests/test_reconciler_delivery.py
+++ b/tests/test_reconciler_delivery.py
@@ -34,7 +34,8 @@ def build_db() -> sqlite3.Connection:
         VALUES
           (1, 'Planner 1', 'PLN1', 'planner', 'x', 1),
           (2, 'Developer 1', 'DEV1', 'dev', 'x', 1),
-          (3, 'Planner 2', 'PLN2', 'planner', 'x', 1);
+          (3, 'Planner 2', 'PLN2', 'planner', 'x', 1),
+          (4, 'Developer 2', 'DEV2', 'dev', 'x', 1);
         """
     )
     return con
@@ -102,17 +103,19 @@ class ReconcilerDeliveryTest(unittest.TestCase):
         doc_id: int = 59,
         seq: str = "U5",
         unit: sqlite3.Row | None = None,
+        shell_id: int = 2,
     ) -> pr_poller.Expectation:
         unit = unit if unit is not None else self.unit
         shell = self.con.execute(
-            "SELECT * FROM shells WHERE shell_id=2"
+            "SELECT * FROM shells WHERE shell_id=?",
+            (shell_id,),
         ).fetchone()
         return pr_poller.Expectation(
             sprint_doc_id=doc_id,
             unit_id=unit["unit_id"],
             seq=seq,
             role="dev",
-            shell_id=2,
+            shell_id=shell_id,
             shell=shell,
             unit=unit,
         )
@@ -149,14 +152,14 @@ class ReconcilerDeliveryTest(unittest.TestCase):
 
         self.assertEqual(1, len(emitted))
         alert = self.con.execute(
-            "SELECT sprint_doc_id, seq, role, signal, shell_id, severity, "
+            "SELECT sprint_doc_id, unit_id, role, signal, shell_id, severity, "
             "reason, opened_at, resolved_at, message_id "
             "FROM planner_alerts"
         ).fetchone()
         self.assertEqual(
             (
                 59,
-                "U5",
+                self.unit["unit_id"],
                 "dev",
                 "checkup",
                 2,
@@ -235,23 +238,18 @@ class ReconcilerDeliveryTest(unittest.TestCase):
             ).fetchone()[0],
         )
 
-    def test_severity_map_and_recovery_explanation_are_exact(self):
+    def test_emitted_severity_map_and_explanation_are_exact(self):
         readings = [
-            self.reading("checkup"),
+            self.reading("checkup", explanation="quota resets at 01:00Z"),
             self.reading("not_started"),
             self.reading("work_complete_unreported"),
-            self.reading(
-                "recovery_blocked",
-                explanation="boot refused: shell occupied",
-            ),
         ]
         emitted = pr_poller.deliver_reconciliation_readings(self.con, readings)
-        self.assertEqual(4, len(emitted))
+        self.assertEqual(3, len(emitted))
         self.assertEqual(
             [
                 ("checkup", "warning"),
                 ("not_started", "warning"),
-                ("recovery_blocked", "critical"),
                 ("work_complete_unreported", "info"),
             ],
             [
@@ -264,11 +262,21 @@ class ReconcilerDeliveryTest(unittest.TestCase):
         )
         body = self.con.execute(
             "SELECT body FROM shell_messages "
-            "WHERE body LIKE '%signal=recovery_blocked%'"
+            "WHERE body LIKE '%signal=checkup%'"
         ).fetchone()[0]
         self.assertIn(
-            'explanation="boot refused: shell occupied"',
+            'explanation="quota resets at 01:00Z"',
             body,
+        )
+
+    def test_recovery_blocked_is_mapped_but_has_no_reconciler_producer(self):
+        self.assertEqual(
+            "critical",
+            pr_poller.RECONCILER_SEVERITY["recovery_blocked"],
+        )
+        self.assertNotIn(
+            "recovery_blocked",
+            pr_poller.ReconcilerState.ACTIONABLE,
         )
 
     def test_open_dedupe_healthy_resolve_and_rearm_are_one_lifecycle(self):
@@ -341,6 +349,78 @@ class ReconcilerDeliveryTest(unittest.TestCase):
                 "SELECT resolved_at FROM planner_alerts "
                 "WHERE signal='not_started'"
             ).fetchone()[0],
+        )
+
+    def test_unitless_expectation_dedupes_on_an_explicit_key_sentinel(self):
+        planner = self.con.execute(
+            "SELECT * FROM shells WHERE shell_id=1"
+        ).fetchone()
+        expectation = pr_poller.Expectation(
+            sprint_doc_id=59,
+            unit_id=None,
+            seq=None,
+            role="planner",
+            shell_id=1,
+            shell=planner,
+            unit=None,
+        )
+        reading = self.reading("checkup", expectation=expectation)
+
+        first = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [reading],
+        )
+        replay = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [reading],
+        )
+
+        self.assertEqual(1, len(first))
+        self.assertEqual([], replay)
+        row = self.con.execute(
+            "SELECT unit_id, dedupe_key, shell_id FROM planner_alerts "
+            "WHERE role='planner'"
+        ).fetchone()
+        self.assertEqual(
+            (None, "reconciler|59|-|planner|checkup", 1),
+            tuple(row),
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM shell_messages "
+                "WHERE sprint_doc_id=59 AND body LIKE '%role=planner%'"
+            ).fetchone()[0],
+        )
+
+    def test_role_reassignment_does_not_change_the_open_alert_key(self):
+        first = self.reading(
+            "checkup",
+            expectation=self.expectation(shell_id=2),
+        )
+        reassigned = self.reading(
+            "checkup",
+            expectation=self.expectation(shell_id=4),
+        )
+
+        first_ids = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [first],
+        )
+        reassigned_ids = pr_poller.deliver_reconciliation_readings(
+            self.con,
+            [reassigned],
+        )
+
+        self.assertEqual(1, len(first_ids))
+        self.assertEqual([], reassigned_ids)
+        rows = self.con.execute(
+            "SELECT unit_id, role, signal, shell_id FROM planner_alerts "
+            "WHERE signal='checkup'"
+        ).fetchall()
+        self.assertEqual(
+            [(self.unit["unit_id"], "dev", "checkup", 2)],
+            [tuple(row) for row in rows],
         )
 
     def test_never_bound_records_finding_and_condition_without_push(self):
@@ -480,7 +560,7 @@ class ReconcilerDeliveryTest(unittest.TestCase):
         )
         self.con.commit()
         row = self.con.execute(
-            "SELECT sprint_doc_id, seq, role, signal, shell_id, resolved_at "
+            "SELECT sprint_doc_id, unit_id, role, signal, shell_id, resolved_at "
             "FROM planner_alerts WHERE reason='turn_failure'"
         ).fetchone()
         self.assertEqual((None, None, None, None, None, None), tuple(row))

--- a/tests/test_reconciler_tick.py
+++ b/tests/test_reconciler_tick.py
@@ -358,6 +358,32 @@ class TickTest(unittest.TestCase):
             ],
         )
 
+    def test_all_terminal_planner_expectation_never_reads_the_doc_title(self):
+        add_unit(
+            self.con,
+            state=sprint_units.TERMINAL_UNIT_STATES[0],
+        )
+        self.con.execute(
+            "UPDATE documents SET title='Worker expectation reconciler' "
+            "WHERE document_id=59"
+        )
+        self.con.commit()
+        add_binding(self.con, planner=3)
+
+        self.assertEqual(
+            [(59, None, None, "planner", 3)],
+            [
+                (
+                    item.sprint_doc_id,
+                    item.unit_id,
+                    item.seq,
+                    item.role,
+                    item.shell_id,
+                )
+                for item in pr_poller.live_expectations(self.con)
+            ],
+        )
+
     def test_every_nonterminal_schema_state_remains_a_live_expectation(self):
         for offset, state in enumerate(
             ("pending", "working", "in_review", "blocked"),

--- a/tests/test_reconciler_tick.py
+++ b/tests/test_reconciler_tick.py
@@ -335,6 +335,29 @@ class TickTest(unittest.TestCase):
         self.assertIsNone(planners[0].unit_id)
         self.assertIsNone(planners[0].unit)
 
+    def test_all_terminal_live_sprint_still_has_its_planner_expectation(self):
+        add_unit(
+            self.con,
+            state=sprint_units.TERMINAL_UNIT_STATES[0],
+        )
+        add_binding(self.con, planner=3)
+
+        expectations = pr_poller.live_expectations(self.con)
+
+        self.assertEqual(
+            [(59, None, None, "planner", 3)],
+            [
+                (
+                    item.sprint_doc_id,
+                    item.unit_id,
+                    item.seq,
+                    item.role,
+                    item.shell_id,
+                )
+                for item in expectations
+            ],
+        )
+
     def test_every_nonterminal_schema_state_remains_a_live_expectation(self):
         for offset, state in enumerate(
             ("pending", "working", "in_review", "blocked"),


### PR DESCRIPTION
## Summary

- extend `planner_alerts` with structured sprint, immutable unit, role, signal, and assignee fields while preserving the existing open `dedupe_key` invariant
- consume U4 reconciliation readings as report-only output, record confirmed actionable findings, push new findings to the historical board writer, and resolve alerts when healthy readings arrive
- keep never-bound sprints auditable without inventing a recipient, preserve all-terminal planner expectations, and advance liveness only after a successful reconciliation tick
- expose structured alerts through the Interface API and snapshot/rebuild path with explicit recovery guidance

## Verification

- exact-head focused U5 suite: 104 passed
- exact-head GitHub engine suite: 1,843 passed, 11 skipped, 435 subtests passed; all PR checks green
- uncontended local `SC_SANDBOX=` full suite: job `121-u5-full-solo` running; final count pending
- render check: passed
- Ruff: all U5-owned files passed; `tests/test_reconciler_tick.py` retains the same two pre-existing findings present on `origin/main`
- mutation checks pin confirmation, dedupe/re-arm, auto-resolution, heartbeat ordering, nullable migration compatibility, missing-binding behavior, explanation rendering, all-terminal planner presence, unit-less sentinel keys, and assignee-independent identity

## Contract notes

- alert identity is `(sprint_doc_id, unit_id, role, signal)` encoded in the existing `dedupe_key`; `shell_id` is mutable subject data and never part of identity
- NULL `unit_id` uses the `-` sentinel
- no `sprint_units` shape or natural ordering changed
- `recovery_blocked` is mapping-only; the reconciler does not invent a producer
- reachability audit removed an unconstructible confirmed/indeterminate fallback and kept `Expectation.key` separate as shell-sensitive confirmation identity

Sprint doc 59 · U5