### PR TITLE
feat(api): project active sprint boards

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -86,6 +86,7 @@ import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin ru
 import model_catalog  # noqa: E402  (live model-id suggestions, sibling module)
 import analytics  # noqa: E402  (token & session analytics sweep — doc #11)
 import token_parsers  # noqa: E402  (harness roster + per-parser data dirs)
+from sprint_units import UNIT_COLUMNS as _SPRINT_UNIT_COLUMNS  # noqa: E402
 from sprint_units import UNIT_STATES  # noqa: E402
 from quota_probes import dispatch as quota_dispatch  # noqa: E402  (account quota probes — doc #49)
 import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
@@ -576,14 +577,6 @@ def get_docs(con) -> dict:
         "WHERE d.kind='doc' ORDER BY d.feature_id, d.seq"))}
 
 
-_SPRINT_UNIT_COLUMNS = (
-    "unit_id", "sprint_doc_id", "seq", "unit_title", "dev_shell_id",
-    "reviewer_shell_id", "state", "depends_on", "overlap", "branch",
-    "pr_number", "assigned_at", "state_changed_at", "updated_at",
-    "updated_by_shell_id",
-)
-
-
 def get_active_sprints(con) -> dict:
     """Build the active-sprint board from one consistent read snapshot.
 
@@ -598,7 +591,11 @@ def get_active_sprints(con) -> dict:
         ") "
         "SELECT "
         "d.document_id, d.title AS sprint_title, "
-        "strftime('%Y-%m-%dT%H:%M:%SZ', d.created_at) AS started_at, "
+        # SQLite also parses relative clocks and bare Julian days. The shape
+        # gate keeps those fabricated/non-ISO values out of the response.
+        "CASE WHEN d.created_at LIKE '____-__-__%' "
+        "  THEN strftime('%Y-%m-%dT%H:%M:%SZ', d.created_at) "
+        "  ELSE NULL END AS started_at, "
         "d.feature_id, feature.title AS feature_title, "
         "binding.planner_shell_id, planner.shortname AS planner_shortname, "
         "unit.unit_id AS unit_unit_id, "
@@ -630,8 +627,11 @@ def get_active_sprints(con) -> dict:
         "  ON reviewer.shell_id=unit.reviewer_shell_id "
         "WHERE d.kind='doc' AND d.frozen=0 "
         "  AND d.title LIKE 'SPRINT:%' "
-        "ORDER BY started_at IS NULL, started_at, d.document_id, "
-        "  CASE WHEN unit.unit_id IS NULL THEN 0 ELSE 1 END, "
+        # The parser check is separate from the shape gate: either failure
+        # makes the timestamp corrupt, sorted after every valid instant.
+        "ORDER BY CASE WHEN d.created_at LIKE '____-__-__%' "
+        "    AND strftime('%Y-%m-%dT%H:%M:%SZ', d.created_at) IS NOT NULL "
+        "  THEN 0 ELSE 1 END, started_at, d.document_id, "
         "  LENGTH(unit.seq), unit.seq"
     ))
 
@@ -644,6 +644,8 @@ def get_active_sprints(con) -> dict:
             planner_id = row["planner_shell_id"]
             feature_id = row["feature_id"]
             title = row["sprint_title"]
+            # The active-title predicate guarantees a non-NULL matching title;
+            # the only reachable fallback is an empty/whitespace remainder.
             if not title[len("SPRINT:"):].strip():
                 title = f"Sprint #{document_id}"
             sprint = {
@@ -669,10 +671,7 @@ def get_active_sprints(con) -> dict:
             column: row[f"unit_{column}"]
             for column in _SPRINT_UNIT_COLUMNS
         }
-        if unit["state"] not in UNIT_STATES:
-            raise ValueError(
-                f"unknown sprint unit state {unit['state']!r} "
-                f"for unit {unit['unit_id']}")
+        unit["state_recognized"] = unit["state"] in UNIT_STATES
         unit["dev_shortname"] = row["dev_shortname"]
         unit["reviewer_shortname"] = row["reviewer_shortname"]
         sprint["units"].append(unit)

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -86,6 +86,7 @@ import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin ru
 import model_catalog  # noqa: E402  (live model-id suggestions, sibling module)
 import analytics  # noqa: E402  (token & session analytics sweep — doc #11)
 import token_parsers  # noqa: E402  (harness roster + per-parser data dirs)
+from sprint_units import UNIT_STATES  # noqa: E402
 from quota_probes import dispatch as quota_dispatch  # noqa: E402  (account quota probes — doc #49)
 import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
 import ts as ts_mod  # noqa: E402  (tailnet — config + live checks)
@@ -573,6 +574,110 @@ def get_docs(con) -> dict:
         "d.frozen_date, r.title AS feature_title FROM documents d "
         "LEFT JOIN roadmap r ON r.feature_id = d.feature_id "
         "WHERE d.kind='doc' ORDER BY d.feature_id, d.seq"))}
+
+
+_SPRINT_UNIT_COLUMNS = (
+    "unit_id", "sprint_doc_id", "seq", "unit_title", "dev_shell_id",
+    "reviewer_shell_id", "state", "depends_on", "overlap", "branch",
+    "pr_number", "assigned_at", "state_changed_at", "updated_at",
+    "updated_by_shell_id",
+)
+
+
+def get_active_sprints(con) -> dict:
+    """Build the active-sprint board from one consistent read snapshot.
+
+    One SELECT reads active documents, latest planner bindings, feature and
+    role labels, and units. The document body is deliberately absent from
+    both the projection and predicate.
+    """
+    result = rows(con.execute(
+        "WITH latest_bindings AS ("
+        "  SELECT sprint_doc_id, MAX(binding_id) AS binding_id "
+        "  FROM sprint_planner_bindings GROUP BY sprint_doc_id"
+        ") "
+        "SELECT "
+        "d.document_id, d.title AS sprint_title, "
+        "strftime('%Y-%m-%dT%H:%M:%SZ', d.created_at) AS started_at, "
+        "d.feature_id, feature.title AS feature_title, "
+        "binding.planner_shell_id, planner.shortname AS planner_shortname, "
+        "unit.unit_id AS unit_unit_id, "
+        "unit.sprint_doc_id AS unit_sprint_doc_id, "
+        "unit.seq AS unit_seq, unit.unit_title AS unit_unit_title, "
+        "unit.dev_shell_id AS unit_dev_shell_id, "
+        "unit.reviewer_shell_id AS unit_reviewer_shell_id, "
+        "unit.state AS unit_state, unit.depends_on AS unit_depends_on, "
+        "unit.overlap AS unit_overlap, unit.branch AS unit_branch, "
+        "unit.pr_number AS unit_pr_number, "
+        "unit.assigned_at AS unit_assigned_at, "
+        "unit.state_changed_at AS unit_state_changed_at, "
+        "unit.updated_at AS unit_updated_at, "
+        "unit.updated_by_shell_id AS unit_updated_by_shell_id, "
+        "dev.shortname AS dev_shortname, "
+        "reviewer.shortname AS reviewer_shortname "
+        "FROM documents d "
+        "LEFT JOIN roadmap feature ON feature.feature_id=d.feature_id "
+        "LEFT JOIN latest_bindings latest "
+        "  ON latest.sprint_doc_id=d.document_id "
+        "LEFT JOIN sprint_planner_bindings binding "
+        "  ON binding.binding_id=latest.binding_id "
+        "LEFT JOIN shells planner "
+        "  ON planner.shell_id=binding.planner_shell_id "
+        "LEFT JOIN sprint_units unit "
+        "  ON unit.sprint_doc_id=d.document_id "
+        "LEFT JOIN shells dev ON dev.shell_id=unit.dev_shell_id "
+        "LEFT JOIN shells reviewer "
+        "  ON reviewer.shell_id=unit.reviewer_shell_id "
+        "WHERE d.kind='doc' AND d.frozen=0 "
+        "  AND d.title LIKE 'SPRINT:%' "
+        "ORDER BY started_at IS NULL, started_at, d.document_id, "
+        "  CASE WHEN unit.unit_id IS NULL THEN 0 ELSE 1 END, "
+        "  LENGTH(unit.seq), unit.seq"
+    ))
+
+    sprints = []
+    by_document = {}
+    for row in result:
+        document_id = row["document_id"]
+        sprint = by_document.get(document_id)
+        if sprint is None:
+            planner_id = row["planner_shell_id"]
+            feature_id = row["feature_id"]
+            title = row["sprint_title"]
+            if not title[len("SPRINT:"):].strip():
+                title = f"Sprint #{document_id}"
+            sprint = {
+                "document_id": document_id,
+                "title": title,
+                "started_at": row["started_at"],
+                "planner": None if planner_id is None else {
+                    "shell_id": planner_id,
+                    "shortname": row["planner_shortname"],
+                },
+                "feature": None if feature_id is None else {
+                    "feature_id": feature_id,
+                    "title": row["feature_title"],
+                },
+                "units": [],
+            }
+            by_document[document_id] = sprint
+            sprints.append(sprint)
+
+        if row["unit_unit_id"] is None:
+            continue
+        unit = {
+            column: row[f"unit_{column}"]
+            for column in _SPRINT_UNIT_COLUMNS
+        }
+        if unit["state"] not in UNIT_STATES:
+            raise ValueError(
+                f"unknown sprint unit state {unit['state']!r} "
+                f"for unit {unit['unit_id']}")
+        unit["dev_shortname"] = row["dev_shortname"]
+        unit["reviewer_shortname"] = row["reviewer_shortname"]
+        sprint["units"].append(unit)
+
+    return {"active_count": len(sprints), "sprints": sprints}
 
 
 _EMPTY_MAP = {"repo": None, "total_files": 0, "by_lang": [],
@@ -2919,6 +3024,12 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, tag_origin([dict(r)])[0])
             if path == "/api/roadmap":
                 return self._send(200, get_roadmap(con))
+            if path == "/api/sprints":
+                q = parse_qs(urlparse(self.path).query)
+                if q.get("status") != ["active"]:
+                    return self._send(
+                        400, {"error": "status=active is required"})
+                return self._send(200, get_active_sprints(con))
             if path == "/api/docs":
                 return self._send(200, get_docs(con))
             if path == "/api/map":

--- a/.super-coder/scripts/sprint_units.py
+++ b/.super-coder/scripts/sprint_units.py
@@ -5,6 +5,13 @@ board with it, the boot renderer decides which assignments remain live with it,
 and the supervised reconciler uses the same terminal set for its tick.
 """
 
+UNIT_COLUMNS = (
+    "unit_id", "sprint_doc_id", "seq", "unit_title", "dev_shell_id",
+    "reviewer_shell_id", "state", "depends_on", "overlap", "branch",
+    "pr_number", "assigned_at", "state_changed_at", "updated_at",
+    "updated_by_shell_id",
+)
+
 _STATE_VOCABULARY = (
     ("pending", False),
     ("working", False),

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -22,6 +22,7 @@ Run:
 """
 from __future__ import annotations
 
+import json
 import sqlite3
 import sys
 import unittest
@@ -136,6 +137,11 @@ class AssemblerSmokeTest(unittest.TestCase):
         self.assertTrue(any(d["feature_id"] == self.ids["feature_id"]
                             for d in out["docs"]))
 
+    def test_get_active_sprints_empty(self) -> None:
+        self.assertEqual(
+            server.get_active_sprints(self.con),
+            {"active_count": 0, "sprints": []})
+
     def test_get_flags(self) -> None:
         out = server.get_flags(self.con)
         self.assertTrue(out["flags"])
@@ -174,6 +180,255 @@ class AssemblerSmokeTest(unittest.TestCase):
         out = server.get_roadmap(self.con)
         feats = [f for b in out["buckets"] for f in b["features"]]
         self.assertTrue(all(isinstance(f.get("blockers"), list) for f in feats))
+
+
+class ActiveSprintsProjectionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = build_db()
+        self.planner_old = self._shell("PLN-OLD")
+        self.planner_new = self._shell("PLN-NEW")
+        self.dev = self._shell("DEV")
+        self.reviewer = self._shell("REV")
+        self.feature = self.con.execute(
+            "INSERT INTO roadmap (title, roadmap_status) "
+            "VALUES ('Flow Board', 'in_progress')").lastrowid
+        self.con.commit()
+
+    def tearDown(self) -> None:
+        self.con.close()
+
+    def _shell(self, shortname: str) -> int:
+        return self.con.execute(
+            "INSERT INTO shells "
+            "(display_name, shortname, system_prompt, flavor) "
+            "VALUES (?, ?, 'x', 'dev')",
+            (shortname, shortname)).lastrowid
+
+    def _doc(self, title: str, *, frozen=0, body="status: ACTIVE",
+             created_at="2026-07-26 12:00:00", feature_id=None,
+             kind="doc") -> int:
+        seq = self.con.execute(
+            "SELECT COALESCE(MAX(seq),0)+1 FROM documents "
+            "WHERE feature_id IS ? AND kind=?",
+            (feature_id, kind)).fetchone()[0]
+        return self.con.execute(
+            "INSERT INTO documents "
+            "(feature_id, kind, seq, title, frozen, body, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (feature_id, kind, seq, title, frozen, body, created_at)).lastrowid
+
+    def _unit(self, doc_id: int, seq: str, *, state="pending") -> int:
+        return self.con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id, seq, unit_title, dev_shell_id, "
+            "reviewer_shell_id, state, depends_on, overlap, branch, pr_number) "
+            "VALUES (?, ?, ?, ?, ?, ?, 'U0', 'server.py', 'feat/unit', 42)",
+            (doc_id, seq, f"Unit {seq}", self.dev, self.reviewer,
+             state)).lastrowid
+
+    def _binding(self, doc_id: int, planner_id: int, *,
+                 released=False) -> int:
+        generation = self.con.execute(
+            "SELECT COALESCE(MAX(generation),0)+1 FROM interface_generations "
+            "WHERE shell_id=?", (planner_id,)).fetchone()[0]
+        self.con.execute(
+            "INSERT INTO interface_generations (shell_id, generation) "
+            "VALUES (?, ?)", (planner_id, generation))
+        session_id = self.con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation) "
+            "VALUES (?, ?)", (planner_id, generation)).lastrowid
+        return self.con.execute(
+            "INSERT INTO sprint_planner_bindings "
+            "(sprint_doc_id, planner_shell_id, session_id, shell_id, generation, "
+            "released_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (doc_id, planner_id, session_id, planner_id, generation,
+             "2026-07-26 12:30:00" if released else None)).lastrowid
+
+    def _projected_ids(self) -> list[int]:
+        return [
+            sprint["document_id"]
+            for sprint in server.get_active_sprints(self.con)["sprints"]
+        ]
+
+    def test_unfrozen_closed_body_still_projects(self) -> None:
+        doc_id = self._doc(
+            "SPRINT: Closed prose, live record", body="status: CLOSED")
+        self._unit(doc_id, "U1")
+        self.con.commit()
+
+        out = server.get_active_sprints(self.con)
+
+        self.assertEqual(out["active_count"], 1)
+        self.assertEqual(out["sprints"][0]["document_id"], doc_id)
+
+    def test_frozen_sprint_excluded_while_unfrozen_control_projects(self) -> None:
+        active_id = self._doc("SPRINT: Active control")
+        frozen_id = self._doc("SPRINT: Frozen", frozen=1)
+        self._unit(active_id, "U1")
+        self._unit(frozen_id, "U1")
+        self.con.commit()
+
+        ids = self._projected_ids()
+
+        self.assertIn(active_id, ids)
+        self.assertNotIn(frozen_id, ids)
+
+    def test_zero_unit_sprint_still_projects(self) -> None:
+        doc_id = self._doc("SPRINT: No units")
+        self.con.commit()
+
+        out = server.get_active_sprints(self.con)
+
+        self.assertEqual(out["sprints"], [{
+            "document_id": doc_id,
+            "title": "SPRINT: No units",
+            "started_at": "2026-07-26T12:00:00Z",
+            "planner": None,
+            "feature": None,
+            "units": [],
+        }])
+
+    def test_empty_title_remainder_uses_document_id_fallback(self) -> None:
+        doc_id = self._doc("SPRINT:")
+        self._unit(doc_id, "U1")
+        self.con.commit()
+
+        sprint = server.get_active_sprints(self.con)["sprints"][0]
+
+        self.assertEqual(sprint["title"], f"Sprint #{doc_id}")
+
+    def test_kind_and_title_are_structural_predicate_operands(self) -> None:
+        active_id = self._doc("SPRINT: Active")
+        self._unit(active_id, "U1")
+        self._doc("SPRINT: Spec is not a sprint doc", kind="spec")
+        self._doc("Ordinary document")
+        self.con.commit()
+
+        self.assertEqual(self._projected_ids(), [active_id])
+
+    def test_orders_sprints_and_units_and_projects_full_unit_shape(self) -> None:
+        later = self._doc(
+            "SPRINT: Later", created_at="2026-07-26 13:00:00")
+        earlier = self._doc(
+            "SPRINT: Earlier", created_at="2026-07-26 11:00:00",
+            feature_id=self.feature)
+        self._unit(later, "U1")
+        for seq in ("U10", "U-H", "U2", "U1"):
+            self._unit(earlier, seq, state="working")
+        self._binding(earlier, self.planner_old, released=True)
+        self._binding(earlier, self.planner_new, released=True)
+        self.con.commit()
+
+        out = server.get_active_sprints(self.con)
+
+        self.assertEqual(
+            [s["document_id"] for s in out["sprints"]], [earlier, later])
+        sprint = out["sprints"][0]
+        self.assertEqual(sprint["started_at"], "2026-07-26T11:00:00Z")
+        self.assertEqual(sprint["planner"], {
+            "shell_id": self.planner_new, "shortname": "PLN-NEW"})
+        self.assertEqual(sprint["feature"], {
+            "feature_id": self.feature, "title": "Flow Board"})
+        self.assertEqual(
+            [u["seq"] for u in sprint["units"]],
+            ["U1", "U2", "U-H", "U10"])
+        self.assertEqual(set(sprint["units"][0]), {
+            *server._SPRINT_UNIT_COLUMNS,
+            "dev_shortname", "reviewer_shortname",
+        })
+        self.assertEqual(sprint["units"][0]["dev_shortname"], "DEV")
+        self.assertEqual(sprint["units"][0]["reviewer_shortname"], "REV")
+
+    def test_missing_metadata_is_explicit_and_corrupt_time_is_null(self) -> None:
+        valid_id = self._doc(
+            "SPRINT: Valid time", created_at="2026-07-26 13:00:00")
+        self._unit(valid_id, "U1")
+        corrupt_id = self._doc(
+            "SPRINT: Missing metadata", created_at="not-a-time")
+        self._unit(corrupt_id, "U1")
+        self.con.commit()
+
+        out = server.get_active_sprints(self.con)
+        sprint = out["sprints"][1]
+
+        self.assertEqual(
+            [s["document_id"] for s in out["sprints"]],
+            [valid_id, corrupt_id])
+        self.assertIsNone(sprint["started_at"])
+        self.assertIsNone(sprint["planner"])
+        self.assertIsNone(sprint["feature"])
+
+    def test_unassigned_unit_roles_remain_explicit(self) -> None:
+        doc_id = self._doc("SPRINT: Unassigned")
+        self.con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id, seq, unit_title, state) "
+            "VALUES (?, 'U1', 'Unassigned unit', 'pending')", (doc_id,))
+        self.con.commit()
+
+        unit = server.get_active_sprints(self.con)["sprints"][0]["units"][0]
+
+        self.assertIsNone(unit["dev_shell_id"])
+        self.assertIsNone(unit["dev_shortname"])
+        self.assertIsNone(unit["reviewer_shell_id"])
+        self.assertIsNone(unit["reviewer_shortname"])
+
+    def test_unknown_unit_state_fails_the_projection(self) -> None:
+        doc_id = self._doc("SPRINT: Corrupt state")
+        self.con.execute("PRAGMA ignore_check_constraints=ON")
+        self.con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id, seq, unit_title, state) "
+            "VALUES (?, 'U1', 'Corrupt unit', 'mystery')", (doc_id,))
+        self.con.commit()
+
+        with self.assertRaisesRegex(ValueError, "unknown sprint unit state"):
+            server.get_active_sprints(self.con)
+
+    def test_projection_is_one_snapshot_and_never_reads_document_body(self) -> None:
+        doc_id = self._doc("SPRINT: Snapshot", body="status: CLOSED")
+        self._unit(doc_id, "U1")
+        self.con.commit()
+        statements = []
+        self.con.set_trace_callback(statements.append)
+
+        def authorizer(action, table, column, _db_name, _source):
+            if action == sqlite3.SQLITE_READ \
+                    and table == "documents" and column == "body":
+                return sqlite3.SQLITE_DENY
+            return sqlite3.SQLITE_OK
+
+        self.con.set_authorizer(authorizer)
+        try:
+            out = server.get_active_sprints(self.con)
+        finally:
+            self.con.set_authorizer(None)
+            self.con.set_trace_callback(None)
+
+        reads = [
+            statement for statement in statements
+            if statement.lstrip().upper().startswith(("SELECT", "WITH"))
+        ]
+        self.assertEqual(out["active_count"], 1)
+        self.assertEqual(len(reads), 1, reads)
+
+    def test_get_route_requires_active_status(self) -> None:
+        doc_id = self._doc("SPRINT: Routed")
+        self._unit(doc_id, "U1")
+        self.con.commit()
+        proxy = mock.Mock(wraps=self.con)
+        proxy.close.return_value = None
+        with mock.patch.object(server, "db", return_value=proxy):
+            status, _headers, body = server.dispatch_http(
+                "GET", "/api/sprints?status=active", "", b"")
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body)["active_count"], 1)
+
+        with mock.patch.object(server, "db", return_value=proxy):
+            status, _headers, body = server.dispatch_http(
+                "GET", "/api/sprints", "", b"")
+        self.assertEqual(status, 400)
+        self.assertIn("status=active", json.loads(body)["error"])
 
 
 class FeatureBlockerTest(unittest.TestCase):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -35,6 +35,8 @@ MIGRATIONS = ENGINE / "migrations"
 
 sys.path.insert(0, str(ENGINE / "api"))
 import server  # noqa: E402  (server.py adds scripts/ to the path on import)
+import interface_routes  # noqa: E402
+import sprint_units  # noqa: E402
 
 
 def build_db() -> sqlite3.Connection:
@@ -297,14 +299,36 @@ class ActiveSprintsProjectionTest(unittest.TestCase):
 
         self.assertEqual(sprint["title"], f"Sprint #{doc_id}")
 
-    def test_kind_and_title_are_structural_predicate_operands(self) -> None:
+    def test_whitespace_title_remainder_uses_document_id_fallback(self) -> None:
+        doc_id = self._doc("SPRINT:   ")
+        self._unit(doc_id, "U1")
+        self.con.commit()
+
+        sprint = server.get_active_sprints(self.con)["sprints"][0]
+
+        self.assertEqual(sprint["title"], f"Sprint #{doc_id}")
+
+    def test_kind_is_an_independent_structural_predicate_operand(self) -> None:
         active_id = self._doc("SPRINT: Active")
         self._unit(active_id, "U1")
         self._doc("SPRINT: Spec is not a sprint doc", kind="spec")
+        self.con.commit()
+
+        self.assertEqual(self._projected_ids(), [active_id])
+
+    def test_title_is_an_independent_structural_predicate_operand(self) -> None:
+        active_id = self._doc("SPRINT: Active")
+        self._unit(active_id, "U1")
         self._doc("Ordinary document")
         self.con.commit()
 
         self.assertEqual(self._projected_ids(), [active_id])
+
+    def test_sprint_unit_columns_match_interface_projection(self) -> None:
+        self.assertIs(server._SPRINT_UNIT_COLUMNS, sprint_units.UNIT_COLUMNS)
+        self.assertEqual(
+            sprint_units.UNIT_COLUMNS,
+            interface_routes._UNIT_COLS)
 
     def test_orders_sprints_and_units_and_projects_full_unit_shape(self) -> None:
         later = self._doc(
@@ -321,6 +345,7 @@ class ActiveSprintsProjectionTest(unittest.TestCase):
 
         out = server.get_active_sprints(self.con)
 
+        self.assertEqual(out["active_count"], 2)
         self.assertEqual(
             [s["document_id"] for s in out["sprints"]], [earlier, later])
         sprint = out["sprints"][0]
@@ -334,29 +359,53 @@ class ActiveSprintsProjectionTest(unittest.TestCase):
             ["U1", "U2", "U-H", "U10"])
         self.assertEqual(set(sprint["units"][0]), {
             *server._SPRINT_UNIT_COLUMNS,
-            "dev_shortname", "reviewer_shortname",
+            "state_recognized", "dev_shortname", "reviewer_shortname",
         })
+        self.assertTrue(sprint["units"][0]["state_recognized"])
         self.assertEqual(sprint["units"][0]["dev_shortname"], "DEV")
         self.assertEqual(sprint["units"][0]["reviewer_shortname"], "REV")
 
-    def test_missing_metadata_is_explicit_and_corrupt_time_is_null(self) -> None:
+    def test_missing_metadata_is_explicit(self) -> None:
+        doc_id = self._doc("SPRINT: Missing metadata")
+        self._unit(doc_id, "U1")
+        self.con.commit()
+
+        sprint = server.get_active_sprints(self.con)["sprints"][0]
+
+        self.assertIsNone(sprint["planner"])
+        self.assertIsNone(sprint["feature"])
+
+    def test_time_shape_gate_rejects_sqlite_relative_clock(self) -> None:
         valid_id = self._doc(
             "SPRINT: Valid time", created_at="2026-07-26 13:00:00")
         self._unit(valid_id, "U1")
         corrupt_id = self._doc(
-            "SPRINT: Missing metadata", created_at="not-a-time")
+            "SPRINT: Relative clock", created_at="now")
         self._unit(corrupt_id, "U1")
         self.con.commit()
 
         out = server.get_active_sprints(self.con)
-        sprint = out["sprints"][1]
 
         self.assertEqual(
             [s["document_id"] for s in out["sprints"]],
             [valid_id, corrupt_id])
-        self.assertIsNone(sprint["started_at"])
-        self.assertIsNone(sprint["planner"])
-        self.assertIsNone(sprint["feature"])
+        self.assertIsNone(out["sprints"][1]["started_at"])
+
+    def test_time_parser_gate_rejects_shaped_invalid_timestamp(self) -> None:
+        valid_id = self._doc(
+            "SPRINT: Valid time", created_at="2026-07-26 13:00:00")
+        self._unit(valid_id, "U1")
+        corrupt_id = self._doc(
+            "SPRINT: Invalid calendar", created_at="2026-99-99")
+        self._unit(corrupt_id, "U1")
+        self.con.commit()
+
+        out = server.get_active_sprints(self.con)
+
+        self.assertEqual(
+            [s["document_id"] for s in out["sprints"]],
+            [valid_id, corrupt_id])
+        self.assertIsNone(out["sprints"][1]["started_at"])
 
     def test_unassigned_unit_roles_remain_explicit(self) -> None:
         doc_id = self._doc("SPRINT: Unassigned")
@@ -373,17 +422,40 @@ class ActiveSprintsProjectionTest(unittest.TestCase):
         self.assertIsNone(unit["reviewer_shell_id"])
         self.assertIsNone(unit["reviewer_shortname"])
 
-    def test_unknown_unit_state_fails_the_projection(self) -> None:
-        doc_id = self._doc("SPRINT: Corrupt state")
+    def test_unknown_unit_state_degrades_only_its_unit(self) -> None:
+        corrupt_doc_id = self._doc("SPRINT: Corrupt state")
+        healthy_doc_id = self._doc("SPRINT: Healthy board")
+        self._unit(corrupt_doc_id, "U1", state="working")
+        self._unit(healthy_doc_id, "U1", state="in_review")
         self.con.execute("PRAGMA ignore_check_constraints=ON")
         self.con.execute(
             "INSERT INTO sprint_units "
             "(sprint_doc_id, seq, unit_title, state) "
-            "VALUES (?, 'U1', 'Corrupt unit', 'mystery')", (doc_id,))
+            "VALUES (?, 'U2', 'Corrupt unit', 'mystery')",
+            (corrupt_doc_id,))
         self.con.commit()
+        self.con.execute("PRAGMA ignore_check_constraints=OFF")
+        proxy = mock.Mock(wraps=self.con)
+        proxy.close.return_value = None
 
-        with self.assertRaisesRegex(ValueError, "unknown sprint unit state"):
-            server.get_active_sprints(self.con)
+        with mock.patch.object(server, "db", return_value=proxy):
+            status, _headers, body = server.dispatch_http(
+                "GET", "/api/sprints?status=active", "", b"")
+        out = json.loads(body)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(out["active_count"], 2)
+        self.assertEqual(
+            [sprint["document_id"] for sprint in out["sprints"]],
+            [corrupt_doc_id, healthy_doc_id])
+        self.assertEqual(
+            [(unit["state"], unit["state_recognized"])
+             for unit in out["sprints"][0]["units"]],
+            [("working", True), ("mystery", False)])
+        self.assertEqual(
+            [(unit["state"], unit["state_recognized"])
+             for unit in out["sprints"][1]["units"]],
+            [("in_review", True)])
 
     def test_projection_is_one_snapshot_and_never_reads_document_body(self) -> None:
         doc_id = self._doc("SPRINT: Snapshot", body="status: CLOSED")


### PR DESCRIPTION
## Summary
- add GET /api/sprints?status=active as a same-origin read-only aggregate
- use the ruled structural predicate without reading document bodies
- project latest planner, feature, natural-order units, UTC start time, and explicit nullable metadata from one SQL snapshot
- preserve zero-unit sprints and fall back only for a blank SPRINT: title remainder

## Verification
- python3 tests/test_api_endpoints.py — 48 passed
- python3 -m py_compile .super-coder/api/server.py tests/test_api_endpoints.py
- live read-only projection — active_count=2, docs 59 and 77 in started order
- mutation: removing frozen=0 reddens only the frozen-wall test
- mutation: inner-joining units reddens only the zero-unit test

## Judgements
- used one joined SELECT as the SQLite snapshot boundary instead of a multi-query explicit transaction
- valid timestamps sort oldest-first; corrupt timestamps emit null and sort last by document_id
- the unit projection names every sprint_units column and validates state against the shared vocabulary

## Scope
Executed surface: .super-coder/api/server.py and tests/test_api_endpoints.py only. No interface_routes.py or schema changes.