### PR TITLE
feat(ui): add active sprints page shell

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -4500,10 +4500,164 @@ function ifControl(a, m) {
   }
 }
 
+// ── Active sprints ───────────────────────────────────────────────────────────
+// This is a read-only status surface. The API owns every displayed value; the
+// browser owns only refresh timing, local duration arithmetic, and stale-state
+// retention.
+const SPRINTS_REFRESH_MS = 15000;
+const SPRINTS_DURATION_MS = 60000;
+const sprintsState = {
+  payload: null,
+  error: null,
+  stale: false,
+  active: false,
+  root: null,
+  refreshTimer: null,
+  durationTimer: null,
+  inFlight: null,
+  lastFetchAt: 0,
+};
+
+function sprintsDuration(startedAt, now = Date.now()) {
+  const started = Date.parse(startedAt);
+  if (!Number.isFinite(started)) return null;
+  const minutes = Math.floor(Math.max(0, now - started) / 60000);
+  if (minutes < 1) return "<1m";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ${minutes % 60}m`;
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+function sprintsUpdateNav(payload) {
+  const button = document.querySelector('nav button[data-tab="sprints"]');
+  if (!button) return;
+  const count = payload.active_count;
+  button.textContent = count > 0 ? `Sprints ${count}` : "Sprints";
+  button.classList.toggle("warn", count > 0);
+  button.title = "";
+  button.hidden = false;
+}
+
+function sprintsHeader(sprint) {
+  const header = el("div", { className: "sprint-header" },
+    el("h2", {}, sprint.title),
+    el("span", { className: "pill" }, `Doc #${sprint.document_id}`));
+  const planner = sprint.planner
+    ? sprint.planner.shortname : "Unbound";
+  const feature = sprint.feature
+    ? `#${sprint.feature.feature_id} ${sprint.feature.title}` : "Unlinked";
+  const meta = el("div", { className: "row sprint-meta" },
+    el("span", {}, `Planner: ${planner}`),
+    el("span", {}, `Feature: ${feature}`));
+  if (sprint.started_at) {
+    const started = new Date(sprint.started_at);
+    const duration = sprintsDuration(sprint.started_at);
+    meta.append(
+      el("time", { dateTime: sprint.started_at, title: sprint.started_at },
+        `Started: ${started.toLocaleString()}`),
+      el("span", { className: "sprint-duration" },
+        `Running: ${duration}`));
+  }
+  return [header, meta];
+}
+
+function sprintsPaint() {
+  const root = sprintsState.root;
+  if (!sprintsState.active || !root || !root.isConnected) return;
+  if (!sprintsState.payload) {
+    const message = sprintsState.error
+      ? "error: " + sprintsState.error : "Loading active sprints…";
+    root.replaceChildren(el("div", { className: "card" }, message));
+    return;
+  }
+
+  const nodes = [];
+  if (sprintsState.stale) {
+    nodes.push(el("div", { className: "card" },
+      "Stale — refresh failed: " + sprintsState.error));
+  }
+  const sprints = sprintsState.payload.sprints || [];
+  if (!sprints.length)
+    nodes.push(el("div", { className: "card" }, "No active sprints."));
+  for (const sprint of sprints) {
+    const flow = el("div", { className: "sprint-flow" });
+    if (!(sprint.units || []).length)
+      flow.append(el("div", { className: "muted" }, "No units declared"));
+    nodes.push(el("section", { className: "card sprint-board" },
+      ...sprintsHeader(sprint), flow));
+  }
+  root.replaceChildren(...nodes);
+}
+
+async function sprintsRefresh({ render = true } = {}) {
+  if (sprintsState.inFlight) return sprintsState.inFlight;
+  const request = (async () => {
+    try {
+      const payload = await api("/sprints?status=active");
+      sprintsState.payload = payload;
+      sprintsState.error = null;
+      sprintsState.stale = false;
+      sprintsUpdateNav(payload);
+    } catch (error) {
+      sprintsState.error = error.message;
+      sprintsState.stale = sprintsState.payload !== null;
+      if (!sprintsState.stale) {
+        const button = document.querySelector(
+          'nav button[data-tab="sprints"]');
+        if (button) {
+          button.title = "Active sprint count unavailable";
+          button.hidden = false;
+        }
+      }
+    } finally {
+      sprintsState.lastFetchAt = Date.now();
+      if (render) sprintsPaint();
+    }
+  })();
+  sprintsState.inFlight = request;
+  try { await request; }
+  finally {
+    if (sprintsState.inFlight === request) sprintsState.inFlight = null;
+  }
+}
+
+function sprintsPoll() {
+  if (!sprintsState.active || document.hidden) return;
+  return sprintsRefresh();
+}
+
+function sprintsStopLifecycle() {
+  if (sprintsState.refreshTimer !== null)
+    clearInterval(sprintsState.refreshTimer);
+  if (sprintsState.durationTimer !== null)
+    clearInterval(sprintsState.durationTimer);
+  document.removeEventListener("visibilitychange", sprintsPoll);
+  sprintsState.active = false;
+  sprintsState.root = null;
+  sprintsState.refreshTimer = null;
+  sprintsState.durationTimer = null;
+}
+
+async function renderSprints(root) {
+  sprintsStopLifecycle();
+  sprintsState.active = true;
+  sprintsState.root = root;
+  sprintsPaint();
+  document.addEventListener("visibilitychange", sprintsPoll);
+  sprintsState.refreshTimer = setInterval(sprintsPoll, SPRINTS_REFRESH_MS);
+  sprintsState.durationTimer = setInterval(sprintsPaint, SPRINTS_DURATION_MS);
+  // Boot already fetched the projection before routing so the nav never
+  // flashes a guessed count. A later route entry refreshes immediately.
+  if (Date.now() - sprintsState.lastFetchAt > 1000 && !document.hidden)
+    await sprintsRefresh();
+}
+
 // ── Tabs + boot ────────────────────────────────────────────────────────────────
 const VIEWS = {
   interface: ["#view-interface", renderInterface],
   shells: ["#view-shells", renderShells],
+  sprints: ["#view-sprints", renderSprints],
   roadmap: ["#view-roadmap", renderRoadmap],
   docs: ["#view-docs", renderDocs],
   flags: ["#view-flags", renderFlags],
@@ -4535,6 +4689,7 @@ function show(tab) {
   for (const k of Object.keys(VIEWS)) $(VIEWS[k][0]).hidden = k !== tab;
   document.body.classList.toggle("interface-view", tab === "interface");
   if (tab !== "interface") { ifDetach(); ifStopRailPoll(); }   // leaving drops stream + lease + poll
+  if (tab !== "sprints") sprintsStopLifecycle();
   setDocumentTitle(tab);
   load(tab);
 }
@@ -4633,5 +4788,8 @@ $("#publish").onclick = async (e) => {
     configureArtifactActions(h);
   }
   catch { setStatus("offline"); }
+  // The active count is global navigation state. Establish it before routing
+  // so the label never paints an assumed zero on initial load.
+  await sprintsRefresh({ render: false });
   routeFromHash();   // honor #tab on load (refresh / deep link), else Shells
 })();

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -4521,7 +4521,9 @@ const sprintsState = {
 function sprintsDuration(startedAt, now = Date.now()) {
   const started = Date.parse(startedAt);
   if (!Number.isFinite(started)) return null;
-  const minutes = Math.floor(Math.max(0, now - started) / 60000);
+  // Negative deltas deliberately share the "<1m" zero bucket; a numeric
+  // clamp would be dead code because the branch below already covers them.
+  const minutes = Math.floor((now - started) / 60000);
   if (minutes < 1) return "<1m";
   if (minutes < 60) return `${minutes}m`;
   const hours = Math.floor(minutes / 60);
@@ -4566,8 +4568,9 @@ function sprintsPaint() {
   const root = sprintsState.root;
   if (!sprintsState.active || !root || !root.isConnected) return;
   if (!sprintsState.payload) {
-    const message = sprintsState.error
-      ? "error: " + sprintsState.error : "Loading active sprints…";
+    const message = sprintsState.lastFetchAt
+      ? "error: " + (sprintsState.error || "request failed")
+      : "Loading active sprints…";
     root.replaceChildren(el("div", { className: "card" }, message));
     return;
   }
@@ -4595,6 +4598,8 @@ async function sprintsRefresh({ render = true } = {}) {
   const request = (async () => {
     try {
       const payload = await api("/sprints?status=active");
+      if (!Number.isFinite(payload?.active_count))
+        throw new Error("invalid active sprint projection");
       sprintsState.payload = payload;
       sprintsState.error = null;
       sprintsState.stale = false;
@@ -4623,34 +4628,37 @@ async function sprintsRefresh({ render = true } = {}) {
 }
 
 function sprintsPoll() {
-  if (!sprintsState.active || document.hidden) return;
+  if (document.hidden) return;
   return sprintsRefresh();
 }
 
-function sprintsStopLifecycle() {
+function sprintsStopPoll() {
   if (sprintsState.refreshTimer !== null)
     clearInterval(sprintsState.refreshTimer);
+  document.removeEventListener("visibilitychange", sprintsPoll);
+  sprintsState.refreshTimer = null;
+}
+
+function sprintsStartPoll() {
+  sprintsStopPoll();
+  document.addEventListener("visibilitychange", sprintsPoll);
+  sprintsState.refreshTimer = setInterval(sprintsPoll, SPRINTS_REFRESH_MS);
+}
+
+function sprintsStopRender() {
   if (sprintsState.durationTimer !== null)
     clearInterval(sprintsState.durationTimer);
-  document.removeEventListener("visibilitychange", sprintsPoll);
   sprintsState.active = false;
   sprintsState.root = null;
-  sprintsState.refreshTimer = null;
   sprintsState.durationTimer = null;
 }
 
 async function renderSprints(root) {
-  sprintsStopLifecycle();
+  sprintsStopRender();
   sprintsState.active = true;
   sprintsState.root = root;
   sprintsPaint();
-  document.addEventListener("visibilitychange", sprintsPoll);
-  sprintsState.refreshTimer = setInterval(sprintsPoll, SPRINTS_REFRESH_MS);
   sprintsState.durationTimer = setInterval(sprintsPaint, SPRINTS_DURATION_MS);
-  // Boot already fetched the projection before routing so the nav never
-  // flashes a guessed count. A later route entry refreshes immediately.
-  if (Date.now() - sprintsState.lastFetchAt > 1000 && !document.hidden)
-    await sprintsRefresh();
 }
 
 // ── Tabs + boot ────────────────────────────────────────────────────────────────
@@ -4689,7 +4697,7 @@ function show(tab) {
   for (const k of Object.keys(VIEWS)) $(VIEWS[k][0]).hidden = k !== tab;
   document.body.classList.toggle("interface-view", tab === "interface");
   if (tab !== "interface") { ifDetach(); ifStopRailPoll(); }   // leaving drops stream + lease + poll
-  if (tab !== "sprints") sprintsStopLifecycle();
+  if (tab !== "sprints") sprintsStopRender();
   setDocumentTitle(tab);
   load(tab);
 }
@@ -4788,8 +4796,11 @@ $("#publish").onclick = async (e) => {
     configureArtifactActions(h);
   }
   catch { setStatus("offline"); }
-  // The active count is global navigation state. Establish it before routing
-  // so the label never paints an assumed zero on initial load.
-  await sprintsRefresh({ render: false });
+  // The active count is live global navigation state. Start its document-wide
+  // poll and establish the first value before routing paints any tab.
+  try {
+    sprintsStartPoll();
+    await sprintsRefresh({ render: false });
+  } catch {}
   routeFromHash();   // honor #tab on load (refresh / deep link), else Shells
 })();

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -16,6 +16,7 @@
       <button data-tab="interface">Interface</button>
       <button data-tab="shells" class="active">Shells</button>
       <span class="navsep"></span>
+      <button data-tab="sprints" hidden>Sprints</button>
       <button data-tab="roadmap">Roadmap</button>
       <button data-tab="docs">Docs</button>
       <button data-tab="flags">Flags</button>
@@ -35,6 +36,7 @@
   <main>
     <section id="view-interface" class="view" hidden></section>
     <section id="view-shells" class="view"></section>
+    <section id="view-sprints" class="view" hidden></section>
     <section id="view-roadmap" class="view" hidden></section>
     <section id="view-docs" class="view" hidden></section>
     <section id="view-flags" class="view" hidden></section>

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -48,6 +48,7 @@ nav button {
 }
 nav button:hover { color: rgba(255,255,255,.70); }
 nav button.active { color: #fff; }
+nav button.warn { color: var(--warn); }
 nav button.active::after {
   content: ""; position: absolute; left: 0; right: 0; bottom: -1px; height: 2px;
   background: var(--accent);

--- a/tests/test_quota_gate.py
+++ b/tests/test_quota_gate.py
@@ -549,7 +549,11 @@ let forkName = "";
 const STUB = new FakeElement("div");
 function $(sel) { return STUB; }
 function setStatus(s) {}
-async function sprintsRefresh() {}
+let sprintsRefreshError = null;
+async function sprintsRefresh() {
+  if (sprintsRefreshError) throw sprintsRefreshError;
+}
+function sprintsStartPoll() {}
 function all(root, pred, found = []) {
   if (pred(root)) found.push(root);
   for (const c of root.children || []) if (c && c.nodeType === 1) all(c, pred, found);
@@ -565,7 +569,7 @@ function root() { return new FakeElement("div"); }
 
 
 def run_js(body: str, data: dict | None = None, boot: bool = False,
-           hash: str = "") -> dict:
+           hash: str = "", preboot: str = "") -> dict:
     """Drive the real app.js regions under a minimal DOM.
 
     `boot` appends the app's own load-time IIFE — what a reload actually runs.
@@ -575,6 +579,7 @@ def run_js(body: str, data: dict | None = None, boot: bool = False,
                       'globalThis.location = { hash: "%s" };' % hash)
     script = ("const PAYLOAD = " + json.dumps(data or {"providers": []})
               + ";\n" + EL + HELPERS + SHELL_STATE + dom + QUOTA + ROUTER
+              + preboot
               + (BOOT if boot else "")
               # The boot IIFE awaits /health before it routes, so the body has
               # to let it settle — reading the view synchronously would see the
@@ -617,6 +622,18 @@ class DeepLinkSurvivesReloadTest(unittest.TestCase):
           apiFail = "offline";
           out({ view: anView, tab: shown[shown.length - 1] });
         """, boot=True, hash="#analytics-quota")
+        self.assertEqual("quota", r["view"])
+        self.assertEqual("analytics", r["tab"])
+
+    def test_the_boot_route_runs_even_when_sprints_refresh_throws(self):
+        r = run_js(
+            """
+              out({ view: anView, tab: shown[shown.length - 1] });
+            """,
+            boot=True,
+            hash="#analytics-quota",
+            preboot='sprintsRefreshError = new Error("offline");\n',
+        )
         self.assertEqual("quota", r["view"])
         self.assertEqual("analytics", r["tab"])
 

--- a/tests/test_quota_gate.py
+++ b/tests/test_quota_gate.py
@@ -549,6 +549,7 @@ let forkName = "";
 const STUB = new FakeElement("div");
 function $(sel) { return STUB; }
 function setStatus(s) {}
+async function sprintsRefresh() {}
 function all(root, pred, found = []) {
   if (pred(root)) found.push(root);
   for (const c of root.children || []) if (c && c.nodeType === 1) all(c, pred, found);

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -301,7 +301,7 @@ out({
 def test_visibility_return_refreshes_and_route_exit_cleans_both_timers():
     result = run_js(
         """
-apiQueue = [DATA, DATA];
+apiQueue = [DATA, DATA, DATA];
 let now = Date.parse("2026-07-26T20:00:00Z");
 Date.now = () => now;
 await sprintsRefresh({ render: false });

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -1,0 +1,349 @@
+"""Sprints route shell and refresh lifecycle, driven through the real app.js."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
+INDEX = (ROOT / ".super-coder" / "ui" / "index.html").read_text()
+EL = APP[APP.index("const el ="):APP.index("const esc =")]
+SPRINTS = APP[APP.index("// ── Active sprints"):
+              APP.index("// ── Tabs + boot")]
+ROUTER_AT = APP.index("function routeFromHash()")
+ROUTER = APP[ROUTER_AT:
+             APP.index('document.querySelectorAll("nav button").forEach',
+                       ROUTER_AT)]
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is required"
+)
+
+
+HARNESS = r"""
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag; this.nodeType = 1; this.children = [];
+    this._text = ""; this.className = ""; this.title = "";
+    this.dateTime = ""; this.isConnected = true; this.hidden = false;
+    this.classList = {
+      add: (name) => this._setClass(name, true),
+      remove: (name) => this._setClass(name, false),
+      toggle: (name, force) => {
+        const has = this.className.split(" ").filter(Boolean).includes(name);
+        const next = force === undefined ? !has : Boolean(force);
+        this._setClass(name, next);
+        return next;
+      },
+      contains: (name) => this.className.split(" ").filter(Boolean).includes(name),
+    };
+  }
+  _setClass(name, on) {
+    const names = new Set(this.className.split(" ").filter(Boolean));
+    if (on) names.add(name); else names.delete(name);
+    this.className = [...names].join(" ");
+  }
+  append(...nodes) { this.children.push(...nodes); }
+  replaceChildren(...nodes) { this.children = [...nodes]; this._text = ""; }
+  set textContent(value) { this._text = String(value ?? ""); this.children = []; }
+  get textContent() {
+    return this._text + this.children.map(
+      (child) => typeof child === "string" ? child : child.textContent
+    ).join("");
+  }
+}
+const navButton = new FakeElement("button");
+navButton.textContent = "Sprints";
+const listeners = new Map();
+const intervals = [];
+const cleared = [];
+globalThis.document = {
+  hidden: false,
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({ nodeType: 3, textContent: String(text ?? "") }),
+  querySelector: (selector) =>
+    selector === 'nav button[data-tab="sprints"]' ? navButton : null,
+  addEventListener: (name, fn) => listeners.set(name, fn),
+  removeEventListener: (name, fn) => {
+    if (listeners.get(name) === fn) listeners.delete(name);
+  },
+};
+globalThis.setInterval = (fn, ms) => {
+  const id = intervals.length + 1;
+  intervals.push({ id, fn, ms });
+  return id;
+};
+globalThis.clearInterval = (id) => cleared.push(id);
+let apiQueue = [];
+let apiCalls = [];
+async function api(path) {
+  apiCalls.push(path);
+  const next = apiQueue.shift();
+  if (next instanceof Error) throw next;
+  return next;
+}
+function all(root, predicate, found = []) {
+  if (predicate(root)) found.push(root);
+  for (const child of root.children || [])
+    if (child?.nodeType === 1) all(child, predicate, found);
+  return found;
+}
+const byClass = (root, name) => all(
+  root, (node) => node.className.split(" ").filter(Boolean).includes(name));
+const byTag = (root, tag) => all(root, (node) => node.tagName === tag);
+const makeRoot = () => new FakeElement("div");
+const out = (value) => console.log(JSON.stringify(value));
+"""
+
+
+def payload(*, count=1, started_at="2026-07-26T20:00:00Z", units=None):
+    return {
+        "active_count": count,
+        "sprints": [] if count == 0 else [{
+            "document_id": 77,
+            "title": "SPRINT: Active sprint flow board",
+            "started_at": started_at,
+            "planner": {"shell_id": 10, "shortname": "PLN2"},
+            "feature": {"feature_id": 33, "title": "Active sprint flow board"},
+            "units": [{"seq": "U3"}] if units is None else units,
+        }],
+    }
+
+
+def run_js(body: str, *, prelude: str = "") -> dict:
+    script = (
+        EL + HARNESS + prelude + SPRINTS
+        + "\n(async () => {\n" + body
+        + "\n})().catch((error) => { console.error(error.stack || error);"
+          " process.exit(1); });\n"
+    )
+    proc = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_nav_order_route_and_section_are_reload_safe():
+    nav = INDEX[INDEX.index("<nav>"):INDEX.index("</nav>")]
+    assert nav.index('data-tab="shells"') < nav.index('data-tab="sprints"')
+    assert nav.index('data-tab="sprints"') < nav.index('data-tab="roadmap"')
+    assert nav.index('data-tab="roadmap"') < nav.index('data-tab="docs"')
+    assert 'data-tab="sprints" hidden' in nav
+    assert INDEX.count('id="view-sprints"') == 1
+
+    script = r"""
+globalThis.location = { hash: "#sprints" };
+let shellTab = "harness", roadmapView = null, anView = "tokens", ifSelected = null;
+const SHELL_TAB_HASH = {};
+const VIEWS = { sprints: 1, shells: 1, roadmap: 1, analytics: 1, interface: 1 };
+const shown = [];
+function show(tab) { shown.push(tab); }
+""" + ROUTER + r"""
+routeFromHash();
+console.log(JSON.stringify({ tab: shown.at(-1) }));
+"""
+    proc = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["tab"] == "sprints"
+
+
+def test_authoritative_count_and_headers_render_without_controls():
+    data = payload(count=3)
+    data["sprints"][0]["title"] = "sprint: rendered verbatim"
+    data["sprints"].append({
+        "document_id": 78,
+        "title": "SPRINT: second board",
+        "started_at": None,
+        "planner": None,
+        "feature": None,
+        "units": [],
+    })
+    result = run_js(
+        """
+apiQueue = [DATA];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+const time = byTag(root, "time")[0];
+out({
+  nav: navButton.textContent,
+  warn: navButton.classList.contains("warn"),
+  hidden: navButton.hidden,
+  text: root.textContent,
+  titles: byClass(root, "sprint-board").map((board) => board.textContent),
+  boards: byClass(root, "sprint-board").length,
+  flows: byClass(root, "sprint-flow").length,
+  controls: byTag(root, "button").length + byTag(root, "input").length
+    + byTag(root, "select").length + byTag(root, "textarea").length,
+  utc: time.title,
+});
+""",
+        prelude="const DATA = " + json.dumps(data) + ";\n",
+    )
+    assert result["nav"] == "Sprints 3"
+    assert result["warn"] is True
+    assert result["hidden"] is False
+    assert "sprint: rendered verbatim" in result["text"]
+    assert "Doc #77" in result["text"]
+    assert "Planner: PLN2" in result["text"]
+    assert "Feature: #33 Active sprint flow board" in result["text"]
+    assert "Started:" in result["text"] and "Running:" in result["text"]
+    assert result["boards"] == result["flows"] == 2
+    assert result["titles"][0].startswith("sprint: rendered verbatim")
+    assert result["titles"][1].startswith("SPRINT: second board")
+    assert result["controls"] == 0
+    assert result["utc"] == "2026-07-26T20:00:00Z"
+
+
+def test_zero_state_and_initial_failure_are_distinct():
+    zero = run_js(
+        """
+apiQueue = [DATA];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+out({ text: root.textContent, nav: navButton.textContent,
+      warn: navButton.classList.contains("warn"), hidden: navButton.hidden });
+""",
+        prelude="const DATA = " + json.dumps(payload(count=0)) + ";\n",
+    )
+    assert zero == {
+        "text": "No active sprints.", "nav": "Sprints", "warn": False,
+        "hidden": False,
+    }
+
+    failed = run_js(
+        """
+apiQueue = [new Error("offline")];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+out({ text: root.textContent, nav: navButton.textContent,
+      warn: navButton.classList.contains("warn"), hidden: navButton.hidden,
+      title: navButton.title });
+"""
+    )
+    assert failed == {
+        "text": "error: offline", "nav": "Sprints", "warn": False,
+        "hidden": False, "title": "Active sprint count unavailable",
+    }
+
+
+def test_refresh_failure_retains_payload_and_marks_it_stale():
+    result = run_js(
+        """
+apiQueue = [DATA, new Error("timeout")];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+await sprintsRefresh();
+out({ text: root.textContent, nav: navButton.textContent,
+      boards: byClass(root, "sprint-board").length });
+""",
+        prelude="const DATA = " + json.dumps(payload()) + ";\n",
+    )
+    assert "Stale — refresh failed: timeout" in result["text"]
+    assert "SPRINT: Active sprint flow board" in result["text"]
+    assert result["boards"] == 1
+    assert result["nav"] == "Sprints 1"
+
+
+def test_null_timestamp_and_zero_units_keep_the_header():
+    result = run_js(
+        """
+apiQueue = [DATA];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+out({ text: root.textContent, times: byTag(root, "time").length,
+      durations: byClass(root, "sprint-duration").length });
+""",
+        prelude="const DATA = " + json.dumps(
+            payload(started_at=None, units=[])
+        ) + ";\n",
+    )
+    assert "SPRINT: Active sprint flow board" in result["text"]
+    assert "No units declared" in result["text"]
+    assert "Started:" not in result["text"] and "Running:" not in result["text"]
+    assert result["times"] == result["durations"] == 0
+
+
+def test_duration_format_and_clock_skew_clamp():
+    result = run_js(
+        """
+const now = Date.parse("2026-07-26T20:00:00Z");
+const at = (minutes) =>
+  new Date(now - minutes * 60000).toISOString();
+out({
+  under: sprintsDuration(at(0), now),
+  minutes: sprintsDuration(at(18), now),
+  hours: sprintsDuration(at(252), now),
+  days: sprintsDuration(at(3120), now),
+  skew: sprintsDuration(new Date(now + 60000).toISOString(), now),
+});
+"""
+    )
+    assert result == {
+        "under": "<1m", "minutes": "18m", "hours": "4h 12m",
+        "days": "2d 4h", "skew": "<1m",
+    }
+
+
+def test_visibility_return_refreshes_and_route_exit_cleans_both_timers():
+    result = run_js(
+        """
+apiQueue = [DATA, DATA];
+let now = Date.parse("2026-07-26T20:00:00Z");
+Date.now = () => now;
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+const before = apiCalls.length;
+document.hidden = true;
+await listeners.get("visibilitychange")();
+const hidden = apiCalls.length;
+document.hidden = false;
+await listeners.get("visibilitychange")();
+const visible = apiCalls.length;
+const beforeLocalTick = apiCalls.length;
+const durationBefore = byClass(root, "sprint-duration")[0].textContent;
+now += 18 * 60000;
+intervals.find((entry) => entry.ms === SPRINTS_DURATION_MS).fn();
+const afterLocalTick = apiCalls.length;
+const durationAfter = byClass(root, "sprint-duration")[0].textContent;
+sprintsStopLifecycle();
+out({
+  before, hidden, visible, beforeLocalTick, afterLocalTick,
+  durationBefore, durationAfter,
+  intervals: intervals.map((entry) => entry.ms),
+  cleared, listenerPresent: listeners.has("visibilitychange"),
+  active: sprintsState.active,
+});
+""",
+        prelude="const DATA = " + json.dumps(payload()) + ";\n",
+    )
+    assert result["hidden"] == result["before"]
+    assert result["visible"] == result["before"] + 1
+    assert result["afterLocalTick"] == result["beforeLocalTick"]
+    assert result["durationBefore"] == "Running: <1m"
+    assert result["durationAfter"] == "Running: 18m"
+    assert result["intervals"] == [15000, 60000]
+    assert result["cleared"] == [1, 2]
+    assert result["listenerPresent"] is False
+    assert result["active"] is False
+
+
+def test_boot_fetches_projection_before_routing():
+    boot = APP[APP.rindex("(async () => {"):]
+    fetch_at = boot.index("await sprintsRefresh({ render: false })")
+    route_at = boot.index("routeFromHash()")
+    assert fetch_at < route_at

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -21,6 +21,8 @@ ROUTER_AT = APP.index("function routeFromHash()")
 ROUTER = APP[ROUTER_AT:
              APP.index('document.querySelectorAll("nav button").forEach',
                        ROUTER_AT)]
+SHOW = APP[APP.index("function show(tab)"):
+           APP.index("// Hash routing:", APP.index("function show(tab)"))]
 
 pytestmark = pytest.mark.skipif(
     shutil.which("node") is None, reason="node is required"
@@ -33,6 +35,7 @@ class FakeElement {
     this.tagName = tag; this.nodeType = 1; this.children = [];
     this._text = ""; this.className = ""; this.title = "";
     this.dateTime = ""; this.isConnected = true; this.hidden = false;
+    this.dataset = {};
     this.classList = {
       add: (name) => this._setClass(name, true),
       remove: (name) => this._setClass(name, false),
@@ -61,6 +64,8 @@ class FakeElement {
 }
 const navButton = new FakeElement("button");
 navButton.textContent = "Sprints";
+navButton.hidden = true;
+navButton.dataset.tab = "sprints";
 const listeners = new Map();
 const intervals = [];
 const cleared = [];
@@ -117,9 +122,9 @@ def payload(*, count=1, started_at="2026-07-26T20:00:00Z", units=None):
     }
 
 
-def run_js(body: str, *, prelude: str = "") -> dict:
+def run_js(body: str, *, prelude: str = "", suffix: str = "") -> dict:
     script = (
-        EL + HARNESS + prelude + SPRINTS
+        EL + HARNESS + prelude + SPRINTS + suffix
         + "\n(async () => {\n" + body
         + "\n})().catch((error) => { console.error(error.stack || error);"
           " process.exit(1); });\n"
@@ -198,6 +203,8 @@ out({
     assert "Doc #77" in result["text"]
     assert "Planner: PLN2" in result["text"]
     assert "Feature: #33 Active sprint flow board" in result["text"]
+    assert "Planner: Unbound" in result["text"]
+    assert "Feature: Unlinked" in result["text"]
     assert "Started:" in result["text"] and "Running:" in result["text"]
     assert result["boards"] == result["flows"] == 2
     assert result["titles"][0].startswith("sprint: rendered verbatim")
@@ -239,6 +246,28 @@ out({ text: root.textContent, nav: navButton.textContent,
         "hidden": False, "title": "Active sprint count unavailable",
     }
 
+    empty_error = run_js(
+        """
+apiQueue = [new Error("")];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+out({ text: root.textContent });
+"""
+    )
+    assert empty_error["text"] == "error: request failed"
+
+    malformed = run_js(
+        """
+apiQueue = [{}];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+out({ text: root.textContent });
+"""
+    )
+    assert malformed["text"] == "error: invalid active sprint projection"
+
 
 def test_refresh_failure_retains_payload_and_marks_it_stale():
     result = run_js(
@@ -279,7 +308,7 @@ out({ text: root.textContent, times: byTag(root, "time").length,
     assert result["times"] == result["durations"] == 0
 
 
-def test_duration_format_and_clock_skew_clamp():
+def test_duration_format_and_negative_delta_uses_zero_bucket():
     result = run_js(
         """
 const now = Date.parse("2026-07-26T20:00:00Z");
@@ -300,12 +329,13 @@ out({
     }
 
 
-def test_visibility_return_refreshes_and_route_exit_cleans_both_timers():
+def test_document_poll_survives_route_exit_while_render_wiring_detaches():
     result = run_js(
         """
-apiQueue = [DATA, DATA, DATA];
+apiQueue = [DATA, DATA, DATA, UPDATED];
 let now = Date.parse("2026-07-26T20:00:00Z");
 Date.now = () => now;
+sprintsStartPoll();
 await sprintsRefresh({ render: false });
 const root = makeRoot();
 await renderSprints(root);
@@ -316,36 +346,84 @@ const hidden = apiCalls.length;
 document.hidden = false;
 await listeners.get("visibilitychange")();
 const visible = apiCalls.length;
+await intervals.find((entry) => entry.ms === SPRINTS_REFRESH_MS).fn();
+const afterNetworkTick = apiCalls.length;
 const beforeLocalTick = apiCalls.length;
 const durationBefore = byClass(root, "sprint-duration")[0].textContent;
 now += 18 * 60000;
 intervals.find((entry) => entry.ms === SPRINTS_DURATION_MS).fn();
 const afterLocalTick = apiCalls.length;
 const durationAfter = byClass(root, "sprint-duration")[0].textContent;
-sprintsStopLifecycle();
+const renderedBeforeExit = root.textContent;
+show("roadmap");
+const routeExit = {
+  active: sprintsState.active,
+  root: sprintsState.root,
+  refreshTimer: sprintsState.refreshTimer,
+  durationTimer: sprintsState.durationTimer,
+  listenerPresent: listeners.has("visibilitychange"),
+  cleared: [...cleared],
+};
+await intervals.find((entry) => entry.ms === SPRINTS_REFRESH_MS).fn();
+const afterExitTick = apiCalls.length;
+const renderedAfterExit = root.textContent;
+const navAfterExit = navButton.textContent;
+sprintsStopPoll();
 out({
-  before, hidden, visible, beforeLocalTick, afterLocalTick,
+  before, hidden, visible, afterNetworkTick, beforeLocalTick, afterLocalTick,
   durationBefore, durationAfter,
   intervals: intervals.map((entry) => entry.ms),
-  cleared, listenerPresent: listeners.has("visibilitychange"),
-  active: sprintsState.active,
+  routeExit, afterExitTick, renderedBeforeExit, renderedAfterExit, navAfterExit,
+  finalCleared: cleared, finalListenerPresent: listeners.has("visibilitychange"),
 });
 """,
-        prelude="const DATA = " + json.dumps(payload()) + ";\n",
+        prelude=(
+            "const DATA = " + json.dumps(payload()) + ";\n"
+            "const UPDATED = " + json.dumps(payload(count=2)) + ";\n"
+        ),
+        suffix="""
+const sprintRoot = makeRoot();
+const roadmapRoot = makeRoot();
+const VIEWS = {
+  sprints: ["#view-sprints", renderSprints],
+  roadmap: ["#view-roadmap", async () => {}],
+};
+const roots = {"#view-sprints": sprintRoot, "#view-roadmap": roadmapRoot};
+function $(selector) { return roots[selector]; }
+document.querySelectorAll = (selector) =>
+  selector === "nav button" ? [navButton] : [];
+document.body = new FakeElement("body");
+function ifDetach() {}
+function ifStopRailPoll() {}
+function setDocumentTitle() {}
+function load() {}
+""" + SHOW,
     )
     assert result["hidden"] == result["before"]
     assert result["visible"] == result["before"] + 1
+    assert result["afterNetworkTick"] == result["visible"] + 1
     assert result["afterLocalTick"] == result["beforeLocalTick"]
     assert result["durationBefore"] == "Running: <1m"
     assert result["durationAfter"] == "Running: 18m"
     assert result["intervals"] == [15000, 60000]
-    assert result["cleared"] == [1, 2]
-    assert result["listenerPresent"] is False
-    assert result["active"] is False
+    assert result["routeExit"] == {
+        "active": False,
+        "root": None,
+        "refreshTimer": 1,
+        "durationTimer": None,
+        "listenerPresent": True,
+        "cleared": [2],
+    }
+    assert result["afterExitTick"] == result["afterNetworkTick"] + 1
+    assert result["renderedAfterExit"] == result["renderedBeforeExit"]
+    assert result["navAfterExit"] == "Sprints 2"
+    assert result["finalCleared"] == [2, 1]
+    assert result["finalListenerPresent"] is False
 
 
 def test_boot_fetches_projection_before_routing():
     boot = APP[APP.rindex("(async () => {"):]
+    poll_at = boot.index("sprintsStartPoll()")
     fetch_at = boot.index("await sprintsRefresh({ render: false })")
     route_at = boot.index("routeFromHash()")
-    assert fetch_at < route_at
+    assert poll_at < fetch_at < route_at

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -13,6 +13,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
 INDEX = (ROOT / ".super-coder" / "ui" / "index.html").read_text()
+STYLE = (ROOT / ".super-coder" / "ui" / "style.css").read_text()
 EL = APP[APP.index("const el ="):APP.index("const esc =")]
 SPRINTS = APP[APP.index("// ── Active sprints"):
               APP.index("// ── Tabs + boot")]
@@ -137,6 +138,7 @@ def test_nav_order_route_and_section_are_reload_safe():
     assert nav.index('data-tab="roadmap"') < nav.index('data-tab="docs"')
     assert 'data-tab="sprints" hidden' in nav
     assert INDEX.count('id="view-sprints"') == 1
+    assert "nav button.warn { color: var(--warn); }" in STYLE
 
     script = r"""
 globalThis.location = { hash: "#sprints" };


### PR DESCRIPTION
## Summary

- add the `#sprints` route and page shell before Roadmap
- fetch the active sprint projection before routing, then refresh only while visible
- retain stale payloads on transient errors and update durations locally
- render the active nav count with the existing warning/amber semantic
- keep the shell read-only, including zero-unit and zero-sprint states

## Executed surface

- `.super-coder/ui/index.html`
- `.super-coder/ui/app.js`
- `.super-coder/ui/style.css`
- `tests/test_sprints_ui_contract.py`
- `tests/test_quota_gate.py`

The stylesheet addition is the planner-ruled growth beyond the original U3 prediction. The quota harness change stubs the new boot collaborator so its existing deep-link tests continue to execute the real boot IIFE.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q tests/test_sprints_ui_contract.py tests/test_quota_gate.py` — 27 passed, 3 subtests passed after rebase
- `node --check .super-coder/ui/app.js` — passed
- full suite — 1888 passed, 3 proven baseline harness-image failures deselected; one disjoint bounded-buffer stress timeout passed immediately on isolated rerun
- CSS contract test proved red before `nav button.warn { color: var(--warn); }` was added

## Notes

- rebased onto `origin/main` at `80c082b3`; intervening reconciler surfaces are disjoint
- no sprint mutation controls or requests are introduced