### PR TITLE
feat(sprint): explain reconciler silence

### DIFF
--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -50,6 +50,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import activity_readers
+from quota_probes import dispatch as quota_dispatch
 from sprint_units import TERMINAL_UNIT_STATES, board_writer
 
 CONCLUDED = {"SUCCESS", "FAILURE", "ERROR"}   # statusCheckRollup terminal states
@@ -374,6 +375,110 @@ class ReconciliationReading:
     measurement: dict[str, object]
     observed_at: datetime
     explanation: "str | None"
+
+
+def _activity_explanation(evidence: activity_readers.Evidence) -> list[str]:
+    """Render WHY-tier activity facts without classifying either one."""
+    marker = _utc(evidence.marker_at)
+    transcript = (
+        f"transcript mtime as of {marker.isoformat()}"
+        if marker is not None
+        else "transcript mtime unavailable"
+    )
+    shape = evidence.launch_shape or "unavailable"
+    delta = (
+        f"{evidence.cpu_delta:g}"
+        if evidence.cpu_delta is not None
+        else "unavailable"
+    )
+    return [
+        transcript,
+        f"cpu launch_shape={shape} delta_ticks={delta}",
+    ]
+
+
+def _quota_exhausted(row) -> "bool | None":
+    percent = _row(row, "used_percent")
+    if percent is not None:
+        try:
+            return float(percent) >= 100
+        except (TypeError, ValueError):
+            return None
+
+    used = _row(row, "used")
+    limit = _row(row, "limit_value")
+    if used is None or limit is None:
+        return None
+    try:
+        limit_value = float(limit)
+        return limit_value > 0 and float(used) >= limit_value
+    except (TypeError, ValueError):
+        return None
+
+
+def _provider_explanation(con) -> list[str]:
+    """Render durable quota facts beside process-local probe status."""
+    groups: dict[str, list[sqlite3.Row]] = {}
+    durable_available = True
+    try:
+        rows = con.execute(
+            "SELECT a.provider, w.window_kind, w.scope, w.used_percent, "
+            "w.used, w.limit_value, w.resets_at, w.captured_at "
+            "FROM harness_quota_window w "
+            "JOIN harness_quota_account a ON a.account_pk=w.account_pk "
+            "ORDER BY a.provider, w.captured_at, w.window_kind, w.scope"
+        ).fetchall()
+    except sqlite3.Error:
+        rows = []
+        durable_available = False
+    for row in rows:
+        groups.setdefault(_row(row, "provider"), []).append(row)
+
+    latest_statuses = quota_dispatch.latest_statuses()
+    parts: list[str] = []
+    for provider in quota_dispatch.PROVIDERS:
+        windows = groups.get(provider, [])
+        if not durable_available or not windows:
+            parts.append(f"{provider} quota unavailable")
+        else:
+            captured_at = max(_row(row, "captured_at") for row in windows)
+            current = [
+                row
+                for row in windows
+                if _row(row, "captured_at") == captured_at
+            ]
+            for row in current:
+                scope = _row(row, "scope")
+                window = _row(row, "window_kind")
+                if scope:
+                    window += f":{scope}"
+                exhausted = _quota_exhausted(row)
+                if exhausted is None:
+                    parts.append(
+                        f"{provider} quota unavailable window={window} "
+                        f"as of {captured_at}"
+                    )
+                elif exhausted:
+                    reset = _row(row, "resets_at") or "unavailable"
+                    parts.append(
+                        f"{provider} quota exhausted window={window} "
+                        f"resets_at={reset} as of {captured_at}"
+                    )
+                else:
+                    parts.append(
+                        f"{provider} quota not exhausted window={window} "
+                        f"as of {captured_at}"
+                    )
+
+        status = latest_statuses.get(provider)
+        if status is None:
+            parts.append(f"{provider} probe status unavailable")
+        else:
+            value, captured_at = status
+            parts.append(
+                f"{provider} probe status={value} as of {captured_at}"
+            )
+    return parts
 
 
 def _measurement(evidence: activity_readers.Evidence) -> dict[str, object]:
@@ -757,6 +862,7 @@ def reconcile_tick(
 
     source = reader or activity_readers.read
     read_one = source.read if hasattr(source, "read") else source
+    provider_facts = _provider_explanation(con)
     cache: dict[tuple, activity_readers.Evidence] = {}
     readings: list[ReconciliationReading] = []
     seen: set[tuple] = set()
@@ -790,7 +896,9 @@ def reconcile_tick(
                 evidence=evidence,
                 measurement=_measurement(evidence),
                 observed_at=current,
-                explanation=None,
+                explanation=" | ".join(
+                    _activity_explanation(evidence) + provider_facts
+                ),
             )
         )
     state.retain(seen)

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -411,7 +411,9 @@ def _quota_exhausted(row) -> "bool | None":
         return None
     try:
         limit_value = float(limit)
-        return limit_value > 0 and float(used) >= limit_value
+        if limit_value <= 0:
+            return None
+        return float(used) >= limit_value
     except (TypeError, ValueError):
         return None
 

--- a/.super-coder/scripts/quota_probes/dispatch.py
+++ b/.super-coder/scripts/quota_probes/dispatch.py
@@ -9,6 +9,7 @@ it never has to reason about a partial result.
 from __future__ import annotations
 
 import concurrent.futures
+import threading
 import time
 
 from . import PROVIDERS, account, now_iso
@@ -18,6 +19,14 @@ DEFAULT_TIMEOUT = 5.0
 # that wedges somewhere OTHER than the socket, so a hung provider still costs
 # the caller a bounded wait rather than the request.
 WALL_CLOCK_GRACE = 1.0
+_STATUS_LOCK = threading.Lock()
+_LATEST_STATUS: dict[str, tuple[str, str]] = {}
+
+
+def latest_statuses() -> dict[str, tuple[str, str]]:
+    """Return the latest process-local (status, captured_at) per provider."""
+    with _STATUS_LOCK:
+        return dict(_LATEST_STATUS)
 
 
 def _error(provider: str, detail: str) -> dict:
@@ -68,4 +77,17 @@ def probe_all(log, timeout: float = DEFAULT_TIMEOUT,
         # the caller on the exact probe this timeout exists to contain. The
         # abandoned thread ends on its own socket timeout.
         pool.shutdown(wait=False)
-    return [row for name in names for row in results.get(name, [])]
+    rows = [row for name in names for row in results.get(name, [])]
+    observed: dict[str, tuple[str, str]] = {}
+    for row in rows:
+        provider = row.get("provider")
+        status = row.get("status")
+        captured_at = row.get("captured_at")
+        if not provider or not status or not captured_at:
+            continue
+        prior = observed.get(provider)
+        if prior is None or captured_at >= prior[1]:
+            observed[provider] = (status, captured_at)
+    with _STATUS_LOCK:
+        _LATEST_STATUS.update(observed)
+    return rows

--- a/tests/test_quota_probes.py
+++ b/tests/test_quota_probes.py
@@ -46,6 +46,7 @@ Run:
 """
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import sys
@@ -905,6 +906,63 @@ class CredentialSafetyTest(ProbeCase):
 
 
 class DispatchTest(ProbeCase):
+    def test_fresh_process_has_no_probe_status(self):
+        fresh = importlib.reload(dispatch)
+        self.addCleanup(importlib.reload, fresh)
+
+        self.assertEqual({}, fresh.latest_statuses())
+
+    def test_status_accessor_is_timestamped_narrow_and_read_only(self):
+        fresh = importlib.reload(dispatch)
+        self.addCleanup(importlib.reload, fresh)
+        rows = {
+            "anthropic": {
+                "provider": "anthropic",
+                "status": "ok",
+                "captured_at": "2020-01-01T00:59:00Z",
+                "detail": "must not cross the seam",
+                "windows": [{"used_percent": 10}],
+            },
+            "openai": {
+                "provider": "openai",
+                "status": "error",
+                "captured_at": "2020-01-01T00:58:30Z",
+                "detail": "must not cross the seam",
+                "windows": [],
+            },
+        }
+        with mock.patch.object(
+            fresh,
+            "_run",
+            side_effect=lambda name, log, timeout: [rows[name]],
+        ):
+            returned = fresh.probe_all(
+                self.log,
+                timeout=5,
+                providers=["anthropic", "openai"],
+            )
+
+        self.assertEqual(
+            [rows["anthropic"], rows["openai"]],
+            returned,
+        )
+        statuses = fresh.latest_statuses()
+        self.assertEqual(
+            {
+                "anthropic": ("ok", "2020-01-01T00:59:00Z"),
+                "openai": ("error", "2020-01-01T00:58:30Z"),
+            },
+            statuses,
+        )
+        statuses.pop("anthropic")
+        self.assertEqual(
+            {
+                "anthropic": ("ok", "2020-01-01T00:59:00Z"),
+                "openai": ("error", "2020-01-01T00:58:30Z"),
+            },
+            fresh.latest_statuses(),
+        )
+
     def test_one_provider_raising_is_contained(self):
         self.endpoint(p_anthropic, 200, fixture("anthropic_usage.json"))
         self.endpoint(p_moonshot, 200, fixture("moonshot_usages.json"))

--- a/tests/test_reconciler_tick.py
+++ b/tests/test_reconciler_tick.py
@@ -451,6 +451,58 @@ class ExplanationTierTest(unittest.TestCase):
             parts,
         )
 
+    def test_quota_limit_and_scope_branches_render_exactly(self):
+        add_quota_tables(self.con)
+        moonshot_pk = self.con.execute(
+            "INSERT INTO harness_quota_account(provider, account_ref) "
+            "VALUES ('moonshot', 'acct-m')"
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO harness_quota_window "
+            "(account_pk, window_kind, used, limit_value, captured_at) "
+            "VALUES (?, 'weekly', 5, 0, ?)",
+            (moonshot_pk, "2020-01-01T00:55:00Z"),
+        )
+        self.con.execute(
+            "INSERT INTO harness_quota_window "
+            "(account_pk, window_kind, used, limit_value, captured_at) "
+            "VALUES (?, 'five_hour', 5, 10, ?)",
+            (moonshot_pk, "2020-01-01T00:55:00Z"),
+        )
+        openai_pk = self.con.execute(
+            "INSERT INTO harness_quota_account(provider, account_ref) "
+            "VALUES ('openai', 'acct-o')"
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO harness_quota_window "
+            "(account_pk, window_kind, scope, used_percent, captured_at) "
+            "VALUES (?, 'weekly', 'codex', 25, ?)",
+            (openai_pk, "2020-01-01T00:55:00Z"),
+        )
+
+        with mock.patch.object(
+            pr_poller.quota_dispatch,
+            "latest_statuses",
+            return_value={},
+        ):
+            parts = pr_poller._provider_explanation(self.con)
+
+        self.assertEqual(
+            [
+                "anthropic quota unavailable",
+                "anthropic probe status unavailable",
+                "openai quota not exhausted window=weekly:codex "
+                "as of 2020-01-01T00:55:00Z",
+                "openai probe status unavailable",
+                "moonshot quota not exhausted window=five_hour "
+                "as of 2020-01-01T00:55:00Z",
+                "moonshot quota unavailable window=weekly "
+                "as of 2020-01-01T00:55:00Z",
+                "moonshot probe status unavailable",
+            ],
+            parts,
+        )
+
     def test_unreadable_explanation_signals_do_not_change_the_verdict(self):
         add_unit(self.con, reviewer=None)
         before_board = tuple(

--- a/tests/test_reconciler_tick.py
+++ b/tests/test_reconciler_tick.py
@@ -339,7 +339,38 @@ class ExplanationTierTest(unittest.TestCase):
         )
         self.assertNotIn("status=ok", " | ".join(parts))
 
-    def test_persisted_exhaustion_and_ok_probe_both_render_with_their_ages(self):
+    def test_persisted_exhaustion_carries_resets_at(self):
+        add_quota_tables(self.con)
+        account_pk = self.con.execute(
+            "INSERT INTO harness_quota_account(provider, account_ref) "
+            "VALUES ('anthropic', 'acct-a')"
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO harness_quota_window "
+            "(account_pk, window_kind, used_percent, resets_at, captured_at) "
+            "VALUES (?, 'five_hour', 100, ?, ?)",
+            (
+                account_pk,
+                "2020-01-01T02:00:00Z",
+                "2020-01-01T00:55:00Z",
+            ),
+        )
+
+        with mock.patch.object(
+            pr_poller.quota_dispatch,
+            "latest_statuses",
+            return_value={},
+        ):
+            parts = pr_poller._provider_explanation(self.con)
+
+        self.assertEqual(
+            "anthropic quota exhausted window=five_hour "
+            "resets_at=2020-01-01T02:00:00Z "
+            "as of 2020-01-01T00:55:00Z",
+            parts[0],
+        )
+
+    def test_persisted_exhaustion_and_ok_probe_both_render(self):
         add_quota_tables(self.con)
         account_pk = self.con.execute(
             "INSERT INTO harness_quota_account(provider, account_ref) "
@@ -365,18 +396,26 @@ class ExplanationTierTest(unittest.TestCase):
         ):
             parts = pr_poller._provider_explanation(self.con)
 
+        self.assertEqual(6, len(parts))
+        self.assertTrue(
+            parts[0].startswith(
+                "anthropic quota exhausted window=five_hour "
+            ),
+            parts[0],
+        )
+        self.assertTrue(
+            parts[0].endswith("as of 2020-01-01T00:55:00Z"),
+            parts[0],
+        )
         self.assertEqual(
             [
-                "anthropic quota exhausted window=five_hour "
-                "resets_at=2020-01-01T02:00:00Z "
-                "as of 2020-01-01T00:55:00Z",
                 "anthropic probe status=ok as of 2020-01-01T00:59:00Z",
                 "openai quota unavailable",
                 "openai probe status unavailable",
                 "moonshot quota unavailable",
                 "moonshot probe status unavailable",
             ],
-            parts,
+            parts[1:],
         )
 
     def test_unreadable_quota_value_degrades_to_unavailable(self):

--- a/tests/test_reconciler_tick.py
+++ b/tests/test_reconciler_tick.py
@@ -8,10 +8,12 @@ import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import activity_readers as ar  # noqa: E402
@@ -58,6 +60,14 @@ def build_db() -> sqlite3.Connection:
         """
     )
     return con
+
+
+def add_quota_tables(con: sqlite3.Connection) -> None:
+    for name in (
+        "0096_harness_quota_accounts.sql",
+        "0097_quota_drop_account_identity.sql",
+    ):
+        con.executescript((MIGRATIONS / name).read_text())
 
 
 def add_unit(
@@ -244,6 +254,231 @@ class ClassificationPrecedenceTest(unittest.TestCase):
         self.assertEqual("reported", pr_poller.classify(item, NOW))
 
 
+class ExplanationTierTest(unittest.TestCase):
+    def setUp(self):
+        self.con = build_db()
+        self.addCleanup(self.con.close)
+
+    def test_transcript_explanation_carries_the_current_marker_time(self):
+        marker = datetime(2020, 1, 1, 0, 59, tzinfo=UTC)
+        parts = pr_poller._activity_explanation(evidence(marker_at=marker))
+
+        self.assertEqual(
+            "transcript mtime as of 2020-01-01T00:59:00+00:00",
+            parts[0],
+        )
+
+    def test_cpu_preserves_the_raw_launch_shape_pair(self):
+        interactive = pr_poller._activity_explanation(
+            evidence(
+                cpu_delta=12.5,
+                launch_shape="interactive",
+            )
+        )
+        headless = pr_poller._activity_explanation(
+            evidence(
+                cpu_delta=12.5,
+                launch_shape="headless",
+            )
+        )
+
+        self.assertEqual(
+            "cpu launch_shape=interactive delta_ticks=12.5",
+            interactive[1],
+        )
+        self.assertEqual(
+            "cpu launch_shape=headless delta_ticks=12.5",
+            headless[1],
+        )
+        self.assertNotEqual(
+            interactive[1],
+            headless[1],
+            "the measured interactive/headless inversion was collapsed",
+        )
+
+    def test_probe_fault_carries_the_probe_timestamp(self):
+        with mock.patch.object(
+            pr_poller.quota_dispatch,
+            "latest_statuses",
+            return_value={
+                "openai": ("error", "2020-01-01T00:58:30Z"),
+            },
+        ):
+            parts = pr_poller._provider_explanation(self.con)
+
+        self.assertEqual(
+            [
+                "anthropic quota unavailable",
+                "anthropic probe status unavailable",
+                "openai quota unavailable",
+                "openai probe status=error as of 2020-01-01T00:58:30Z",
+                "moonshot quota unavailable",
+                "moonshot probe status unavailable",
+            ],
+            parts,
+        )
+
+    def test_fresh_process_probe_source_is_unavailable_never_ok(self):
+        with mock.patch.object(
+            pr_poller.quota_dispatch,
+            "latest_statuses",
+            return_value={},
+        ):
+            parts = pr_poller._provider_explanation(self.con)
+
+        self.assertEqual(
+            [
+                "anthropic quota unavailable",
+                "anthropic probe status unavailable",
+                "openai quota unavailable",
+                "openai probe status unavailable",
+                "moonshot quota unavailable",
+                "moonshot probe status unavailable",
+            ],
+            parts,
+        )
+        self.assertNotIn("status=ok", " | ".join(parts))
+
+    def test_persisted_exhaustion_and_ok_probe_both_render_with_their_ages(self):
+        add_quota_tables(self.con)
+        account_pk = self.con.execute(
+            "INSERT INTO harness_quota_account(provider, account_ref) "
+            "VALUES ('anthropic', 'acct-a')"
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO harness_quota_window "
+            "(account_pk, window_kind, used_percent, resets_at, captured_at) "
+            "VALUES (?, 'five_hour', 100, ?, ?)",
+            (
+                account_pk,
+                "2020-01-01T02:00:00Z",
+                "2020-01-01T00:55:00Z",
+            ),
+        )
+
+        with mock.patch.object(
+            pr_poller.quota_dispatch,
+            "latest_statuses",
+            return_value={
+                "anthropic": ("ok", "2020-01-01T00:59:00Z"),
+            },
+        ):
+            parts = pr_poller._provider_explanation(self.con)
+
+        self.assertEqual(
+            [
+                "anthropic quota exhausted window=five_hour "
+                "resets_at=2020-01-01T02:00:00Z "
+                "as of 2020-01-01T00:55:00Z",
+                "anthropic probe status=ok as of 2020-01-01T00:59:00Z",
+                "openai quota unavailable",
+                "openai probe status unavailable",
+                "moonshot quota unavailable",
+                "moonshot probe status unavailable",
+            ],
+            parts,
+        )
+
+    def test_unreadable_quota_value_degrades_to_unavailable(self):
+        add_quota_tables(self.con)
+        account_pk = self.con.execute(
+            "INSERT INTO harness_quota_account(provider, account_ref) "
+            "VALUES ('anthropic', 'acct-a')"
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO harness_quota_window "
+            "(account_pk, window_kind, used_percent, captured_at) "
+            "VALUES (?, 'weekly', 'not-a-number', ?)",
+            (account_pk, "2020-01-01T00:55:00Z"),
+        )
+
+        with mock.patch.object(
+            pr_poller.quota_dispatch,
+            "latest_statuses",
+            return_value={},
+        ):
+            parts = pr_poller._provider_explanation(self.con)
+
+        self.assertEqual(
+            [
+                "anthropic quota unavailable window=weekly "
+                "as of 2020-01-01T00:55:00Z",
+                "anthropic probe status unavailable",
+                "openai quota unavailable",
+                "openai probe status unavailable",
+                "moonshot quota unavailable",
+                "moonshot probe status unavailable",
+            ],
+            parts,
+        )
+
+    def test_unreadable_explanation_signals_do_not_change_the_verdict(self):
+        add_unit(self.con, reviewer=None)
+        before_board = tuple(
+            self.con.execute(
+                "SELECT * FROM sprint_units ORDER BY unit_id"
+            ).fetchall()
+        )
+        with mock.patch.object(
+            pr_poller.quota_dispatch,
+            "latest_statuses",
+            return_value={},
+        ):
+            readable = pr_poller.reconcile_tick(
+                self.con,
+                now=NOW,
+                reader=lambda shell, unit, now: evidence(
+                    marker_at=NOW,
+                    cpu_delta=7.0,
+                    launch_shape="headless",
+                ),
+                refresh=lambda worktree: True,
+            )[0]
+            unreadable = pr_poller.reconcile_tick(
+                self.con,
+                now=NOW,
+                reader=lambda shell, unit, now: evidence(
+                    unreadable=["marker", "process_binding"],
+                ),
+                refresh=lambda worktree: True,
+            )[0]
+
+        self.assertEqual(
+            ("checkup", NOW, 7.0, "headless", []),
+            (
+                readable.signal,
+                readable.evidence.marker_at,
+                readable.evidence.cpu_delta,
+                readable.evidence.launch_shape,
+                readable.evidence.unreadable,
+            ),
+        )
+        self.assertEqual(
+            (
+                "checkup",
+                None,
+                None,
+                None,
+                ["marker", "process_binding"],
+            ),
+            (
+                unreadable.signal,
+                unreadable.evidence.marker_at,
+                unreadable.evidence.cpu_delta,
+                unreadable.evidence.launch_shape,
+                unreadable.evidence.unreadable,
+            ),
+        )
+        self.assertEqual(
+            before_board,
+            tuple(
+                self.con.execute(
+                    "SELECT * FROM sprint_units ORDER BY unit_id"
+                ).fetchall()
+            ),
+        )
+
+
 class TickTest(unittest.TestCase):
     def setUp(self):
         self.con = build_db()
@@ -263,21 +498,32 @@ class TickTest(unittest.TestCase):
             ).fetchall()
         )
 
-        readings = pr_poller.reconcile_tick(
-            self.con,
-            now=NOW,
-            reader=lambda shell, unit, now: evidence(
-                branch_declared=unit["branch"]
-            ),
-            refresh=lambda worktree: True,
-        )
+        with mock.patch.object(
+            pr_poller.quota_dispatch,
+            "latest_statuses",
+            return_value={},
+        ):
+            readings = pr_poller.reconcile_tick(
+                self.con,
+                now=NOW,
+                reader=lambda shell, unit, now: evidence(
+                    branch_declared=unit["branch"]
+                ),
+                refresh=lambda worktree: True,
+            )
 
         self.assertEqual(["dev", "reviewer"], [
             reading.expectation.role for reading in readings
         ])
         for reading in readings:
             self.assertEqual(NOW, reading.observed_at)
-            self.assertIsNone(reading.explanation)
+            self.assertTrue(
+                reading.explanation.startswith(
+                "transcript mtime unavailable"
+                " | cpu launch_shape=unavailable delta_ticks=unavailable"
+                ),
+                reading.explanation,
+            )
             self.assertEqual(EPOCH.isoformat(), reading.measurement["epoch"])
             self.assertEqual(
                 int(pr_poller.NO_PROGRESS_WINDOW.total_seconds()),


### PR DESCRIPTION
## Summary

- fill the reconciler WHY tier with transcript time and the raw argv-derived launch-shape/CPU-delta pair
- read durable quota exhaustion and reset facts while exposing only timestamped process-local probe status
- preserve source disagreement and render restart absence as unavailable

## Trade-off

The CPU explanation reports the raw launch-shape/delta pair instead of thresholds. This keeps the tier non-deciding and avoids encoding calibration from the measured interactive/headless inversion.

## Verification

- focused explanation/quota: 86 green
- adjacent delivery/schema/API/gate: 71 green
- full durable job 131-u6-full-solo: 1782 green in 8m09s
- current-head CI: 8/8 green
- worktree-local render check: green
- lint and diff check: green
- mutation red sets: dropped transcript, wrong launch shape, dropped resets_at, missing fault timestamp, restart-as-ok, reconciled disagreement, mutable accessor, and explanation-decides each reddened exactly one distinct test

Full-suite note: one non-failing unclosed-socket ResourceWarning was emitted after success.