### PR TITLE
fix(sprint): render reconciler heartbeat

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2733,9 +2733,11 @@ class Handler(BaseHTTPRequestHandler):
     def _daemon_state(self, con) -> "dict | None":
         """Poller + reconciler liveness (#359): heartbeat rows → age + verdict.
         Stale = beat older than 3× the daemon's own interval (one slow gh
-        call + the sleep fit comfortably inside). None = never run (or a
-        pre-0068 DB with no heartbeat table yet) — the client renders both
-        None and stale as "watches are NOT being polled"."""
+        call + the sleep fit comfortably inside). None means neither daemon
+        has run (or a pre-0068 DB has no heartbeat table); a reconcile-only
+        result is truthy but has no top-level beat_at. Reconciliation stays
+        nested so older clients ignore it while their own beat_at guard still
+        renders a never-run poller."""
         try:
             rs = con.execute(
                 "SELECT name, beat_at, interval_s, CAST((julianday('now') - "

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2731,22 +2731,29 @@ class Handler(BaseHTTPRequestHandler):
     # /_sc/watches/reconcile is the operator's explicit one-shot poll.
 
     def _daemon_state(self, con) -> "dict | None":
-        """Poller liveness (#359): the heartbeat row → age + verdict.
-        Stale = beat older than 3× the poller's own interval (one slow gh
+        """Poller + reconciler liveness (#359): heartbeat rows → age + verdict.
+        Stale = beat older than 3× the daemon's own interval (one slow gh
         call + the sleep fit comfortably inside). None = never run (or a
         pre-0068 DB with no heartbeat table yet) — the client renders both
         None and stale as "watches are NOT being polled"."""
         try:
-            r = con.execute(
-                "SELECT beat_at, interval_s, CAST((julianday('now') - "
+            rs = con.execute(
+                "SELECT name, beat_at, interval_s, CAST((julianday('now') - "
                 "julianday(beat_at)) * 86400 AS INTEGER) AS age_s "
-                "FROM daemon_heartbeats WHERE name='watch'").fetchone()
+                "FROM daemon_heartbeats WHERE name IN ('watch','reconcile')").fetchall()
         except Exception:
             return None
-        if r is None:
+        states = {
+            r["name"]: {"beat_at": r["beat_at"], "interval_s": r["interval_s"],
+                        "age_s": r["age_s"],
+                        "stale": r["age_s"] > 3 * r["interval_s"]}
+            for r in rs
+        }
+        if not states:
             return None
-        return {"beat_at": r["beat_at"], "interval_s": r["interval_s"],
-                "age_s": r["age_s"], "stale": r["age_s"] > 3 * r["interval_s"]}
+        watch = states.get("watch", {})
+        watch["reconcile"] = states.get("reconcile")
+        return watch
 
     def _watches_get(self):
         sid = self._require_shell_auth()

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -28,7 +28,7 @@ What lives here:
   from structured live units even before a PR or watch exists. Explicit PR
   reconcile still rides `poll_cycle(source='reconcile')` through the API.
   PR polling beats the status-visible watch heartbeat. Worker reconciliation
-  records tick completion in a separate heartbeat row that has no reader.
+  records tick completion in a separate row rendered alongside it by `sc watch list`.
 
 It never injects terminal input, never marks a message read, never acts on a
 PR, and never mutates the sprint board. PR polling may create an event; the

--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -124,18 +124,27 @@ def _age_str(seconds: int) -> str:
     return f"{seconds // 3600}h"
 
 
+def _heartbeat_line(d: "dict | None", label: str, event: str, dead: str) -> str:
+    if not d or not d.get("beat_at"):
+        return f"  {label}: never run — {dead}"
+    age = _age_str(int(d.get("age_s") or 0))
+    if d.get("stale"):
+        return f"  {label}: STALE — last {event} {age} ago ({d['beat_at']}Z); {dead}"
+    return f"  {label}: live — last {event} {age} ago (interval {d.get('interval_s')}s)"
+
+
 def daemon_line(d: "dict | None") -> str:
-    """Render the /_sc/watches `daemon` block as the liveness line (#359):
+    """Render the /_sc/watches `daemon` block as liveness lines (#359):
     a watch is only as live as its poller, and `list` saying "live" while the
     poller is dead was the lying half of the dos-arch incident. The poller is
     the engine service's scheduler thread since the cutover (decision #19)."""
-    dead = "watches are NOT being polled (engine service poller down — restart: ./sc restart)"
-    if not d or not d.get("beat_at"):
-        return f"  poller: never run — {dead}"
-    age = _age_str(int(d.get("age_s") or 0))
-    if d.get("stale"):
-        return f"  poller: STALE — last poll {age} ago ({d['beat_at']}Z); {dead}"
-    return f"  poller: live — last poll {age} ago (interval {d.get('interval_s')}s)"
+    poller_dead = "watches are NOT being polled (engine service poller down — restart: ./sc restart)"
+    reconcile_dead = "worker reconciliation is NOT running (restart: ./sc restart)"
+    return "\n".join((
+        _heartbeat_line(d, "poller", "poll", poller_dead),
+        _heartbeat_line((d or {}).get("reconcile"), "reconciler",
+                        "reconciliation", reconcile_dead),
+    ))
 
 
 def cmd_pr(args) -> int:

--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -134,10 +134,13 @@ def _heartbeat_line(d: "dict | None", label: str, event: str, dead: str) -> str:
 
 
 def daemon_line(d: "dict | None") -> str:
-    """Render the /_sc/watches `daemon` block as liveness lines (#359):
+    """Render the /_sc/watches `daemon` block as poller + reconciler lines.
+
     a watch is only as live as its poller, and `list` saying "live" while the
     poller is dead was the lying half of the dos-arch incident. The poller is
-    the engine service's scheduler thread since the cutover (decision #19)."""
+    the engine service's scheduler thread since the cutover (decision #19).
+    The nested reconciler row renders independently; an absent row means it
+    never ran, including on engine versions that predate reconciliation."""
     poller_dead = "watches are NOT being polled (engine service poller down — restart: ./sc restart)"
     reconcile_dead = "worker reconciliation is NOT running (restart: ./sc restart)"
     return "\n".join((

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -471,6 +471,23 @@ class DaemonLineTest(unittest.TestCase):
         self.assertIn("4h ago", line)
         self.assertIn("NOT being polled", line)
 
+    def test_stale_reconciler_is_rendered_while_poller_is_fresh(self):
+        con = build_db()
+        self.addCleanup(con.close)
+        con.executescript(
+            "INSERT INTO daemon_heartbeats (name, beat_at, interval_s) "
+            "VALUES ('watch', datetime('now'), 30);"
+            "INSERT INTO daemon_heartbeats (name, beat_at, interval_s) "
+            "VALUES ('reconcile', datetime('now', '-3600 seconds'), 600);"
+        )
+
+        line = watch.daemon_line(server.Handler._daemon_state(None, con))
+
+        self.assertIn("poller: live", line)
+        self.assertNotIn("poller: STALE", line)
+        self.assertIn("reconciler: STALE", line)
+        self.assertIn("worker reconciliation is NOT running", line)
+
 
 # ── API: /_sc/watches + message kinds, over the real server ─────────────────
 

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -488,6 +488,16 @@ class DaemonLineTest(unittest.TestCase):
         self.assertIn("reconciler: STALE", line)
         self.assertIn("worker reconciliation is NOT running", line)
 
+        con.execute(
+            "UPDATE daemon_heartbeats SET beat_at = datetime('now', '-200 seconds') "
+            "WHERE name = 'reconcile'")
+        line = watch.daemon_line(server.Handler._daemon_state(None, con))
+        self.assertIn("reconciler: live", line)
+
+        con.execute("DELETE FROM daemon_heartbeats WHERE name = 'watch'")
+        line = watch.daemon_line(server.Handler._daemon_state(None, con))
+        self.assertIn("poller: never run", line)
+
 
 # ── API: /_sc/watches + message kinds, over the real server ─────────────────
 


### PR DESCRIPTION
Closes flag 302 / S59-U5f.

Summary:
- return the reconcile heartbeat beside the existing watch heartbeat without breaking the flat watch API fields
- render a dedicated reconciler liveness line with the same age > 3 * interval stale rule
- pin a fresh watch plus 3600-second-stale reconcile scenario through the real DB reader and CLI renderer

Verification:
- 122 tests green: test_sprint_eventing, test_pr_poller, test_reconciler_delivery
- watch-only reader mutant: new scenario red
- dropped reconciler rendering mutant: new scenario red

Trade-off: retain the existing watch fields at daemon top level and nest only reconcile, preserving current clients while adding the smallest read-side surface.