### PR TITLE
feat(ui): render sprint flow boards

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -4506,6 +4506,7 @@ function ifControl(a, m) {
 // retention.
 const SPRINTS_REFRESH_MS = 15000;
 const SPRINTS_DURATION_MS = 60000;
+const SPRINTS_SVG_NS = "http://www.w3.org/2000/svg";
 const sprintsState = {
   payload: null,
   error: null,
@@ -4516,6 +4517,7 @@ const sprintsState = {
   durationTimer: null,
   inFlight: null,
   lastFetchAt: 0,
+  flowCleanups: [],
 };
 
 function sprintsDuration(startedAt, now = Date.now()) {
@@ -4564,9 +4566,230 @@ function sprintsHeader(sprint) {
   return [header, meta];
 }
 
+const SPRINT_FLOW_COLUMNS = [
+  { key: "pending", label: "Waiting" },
+  { key: "working", label: "Dev" },
+  { key: "in_review", label: "Review" },
+  { key: "blocked", label: "Blocked" },
+  { key: "done", label: "Done" },
+];
+const SPRINT_STATE_LABELS = {
+  pending: "Pending",
+  working: "Working",
+  in_review: "In Review",
+  blocked: "Blocked",
+  merged: "Merged",
+  cancelled: "Cancelled",
+};
+
+function sprintsColumnKey(unit) {
+  if (unit.state_recognized === false) return "unrecognized";
+  if (unit.state === "merged" || unit.state === "cancelled") return "done";
+  return SPRINT_FLOW_COLUMNS.some((column) => column.key === unit.state)
+    ? unit.state : "unrecognized";
+}
+
+function sprintsRole(unit, role, emphasized) {
+  const shellId = unit[`${role}_shell_id`];
+  const shortname = unit[`${role}_shortname`];
+  const label = shortname || (shellId == null ? "Unassigned" : `Shell #${shellId}`);
+  const classes = ["sprint-role"];
+  if (emphasized) classes.push("active");
+  if (!shortname) classes.push("warn");
+  return el("span", { className: classes.join(" ") },
+    `${role === "dev" ? "Dev" : "Reviewer"}: ${label}`);
+}
+
+function sprintsUnitCard(unit, columnKey, unavailable) {
+  const card = el("article", {
+    className: `sprint-unit ${columnKey}`,
+    title: `${unit.seq} ${unit.unit_title}`,
+  });
+  card.dataset.seq = String(unit.seq);
+  card.append(
+    el("div", { className: "sprint-unit-title", title: unit.unit_title },
+      el("span", { className: "idnum" }, unit.seq), " ", unit.unit_title),
+    el("div", { className: "sprint-unit-state" },
+      el("span", { className: `pill ${columnKey}` },
+        SPRINT_STATE_LABELS[unit.state] || String(unit.state))));
+
+  const roles = el("div", { className: "sprint-unit-roles" },
+    sprintsRole(unit, "dev", columnKey === "working"),
+    sprintsRole(unit, "reviewer", columnKey === "in_review"));
+  card.append(roles);
+
+  if (unit.depends_on) {
+    card.append(el("div", {
+      className: "sprint-unit-deps",
+      ariaLabel: unavailable.length
+        ? `dependency unavailable: ${unavailable.join(", ")}` : "",
+    }, `Depends: ${unit.depends_on}`));
+  }
+  if (unit.overlap) {
+    card.append(el("div", {
+      className: "sprint-unit-overlap",
+      title: unit.overlap,
+    }, unit.overlap));
+  }
+  if (unit.branch || unit.pr_number != null) {
+    const delivery = el("div", { className: "sprint-unit-delivery" });
+    if (unit.branch)
+      delivery.append(el("span", { title: unit.branch }, `Branch: ${unit.branch}`));
+    if (unit.pr_number != null)
+      delivery.append(el("span", {}, `PR #${unit.pr_number}`));
+    card.append(delivery);
+  }
+  return card;
+}
+
+// One graph per sprint. Resolving dependencies against this function's unit map
+// makes a cross-sprint edge impossible by construction.
+function sprintsBuildFlow(sprint) {
+  const units = sprint.units || [];
+  const wrap = el("div", { className: "sprint-flow" });
+  if (!units.length) {
+    wrap.append(el("div", { className: "muted" }, "No units declared"));
+    return wrap;
+  }
+
+  const bySeq = new Map(units.map((unit) => [String(unit.seq), unit]));
+  const edges = [];
+  const unavailableBySeq = new Map();
+  const seenEdges = new Set();
+  for (const unit of units) {
+    const raw = String(unit.depends_on || "");
+    if (!raw) continue;
+    const unavailable = [];
+    for (const part of raw.split(",")) {
+      const token = part.trim();
+      if (!token || token === String(unit.seq) || !bySeq.has(token)) {
+        unavailable.push(token || "(empty)");
+        continue;
+      }
+      const edgeKey = `${token}\u0000${unit.seq}`;
+      if (!seenEdges.has(edgeKey)) {
+        seenEdges.add(edgeKey);
+        edges.push([token, String(unit.seq)]);
+      }
+    }
+    if (unavailable.length) unavailableBySeq.set(String(unit.seq), unavailable);
+  }
+
+  const inner = el("div", { className: "sprint-flow-inner" });
+  const svg = document.createElementNS(SPRINTS_SVG_NS, "svg");
+  svg.setAttribute("class", "sprint-wires");
+  svg.setAttribute("aria-hidden", "true");
+  const cols = el("div", { className: "sprint-cols" });
+  const cardOf = new Map();
+  const columns = [...SPRINT_FLOW_COLUMNS];
+  if (units.some((unit) => sprintsColumnKey(unit) === "unrecognized"))
+    columns.push({ key: "unrecognized", label: "Unrecognized" });
+
+  for (const column of columns) {
+    const inColumn = units.filter(
+      (unit) => sprintsColumnKey(unit) === column.key);
+    const heading = el("div", { className: "sprint-col-head" }, column.label);
+    if (inColumn.length)
+      heading.append(el("span", { className: "count" }, String(inColumn.length)));
+    const col = el("div", { className: `sprint-col ${column.key}` }, heading);
+    for (const unit of inColumn) {
+      const seq = String(unit.seq);
+      const card = sprintsUnitCard(
+        unit, column.key, unavailableBySeq.get(seq) || []);
+      col.append(card);
+      cardOf.set(seq, card);
+    }
+    cols.append(col);
+  }
+  inner.append(svg, cols);
+  wrap.append(inner);
+
+  const markerId = `sprint-arrow-${sprint.document_id}`;
+  const draw = () => {
+    if (!inner.isConnected) return;
+    const base = inner.getBoundingClientRect();
+    const width = inner.scrollWidth;
+    const height = inner.scrollHeight;
+    svg.setAttribute("width", width);
+    svg.setAttribute("height", height);
+    svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+    const marker = document.createElementNS(SPRINTS_SVG_NS, "marker");
+    marker.setAttribute("id", markerId);
+    marker.setAttribute("viewBox", "0 0 8 8");
+    marker.setAttribute("refX", "7");
+    marker.setAttribute("refY", "4");
+    marker.setAttribute("markerWidth", "6");
+    marker.setAttribute("markerHeight", "6");
+    marker.setAttribute("orient", "auto-start-reverse");
+    const arrow = document.createElementNS(SPRINTS_SVG_NS, "path");
+    arrow.setAttribute("d", "M0 0 L8 4 L0 8 z");
+    arrow.setAttribute("fill", "context-stroke");
+    marker.append(arrow);
+    const defs = document.createElementNS(SPRINTS_SVG_NS, "defs");
+    defs.append(marker);
+    svg.replaceChildren(defs);
+
+    for (const [from, to] of edges) {
+      const source = cardOf.get(from);
+      const target = cardOf.get(to);
+      if (!source || !target) continue;
+      const a = source.getBoundingClientRect();
+      const z = target.getBoundingClientRect();
+      const x1 = a.right - base.left;
+      const y1 = a.top - base.top + a.height / 2;
+      const x2 = z.left - base.left;
+      const y2 = z.top - base.top + z.height / 2;
+      const dx = Math.max(40, Math.abs(x2 - x1) * 0.4);
+      const path = document.createElementNS(SPRINTS_SVG_NS, "path");
+      path.setAttribute(
+        "d", `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`);
+      path.setAttribute("class", "sprint-wire");
+      path.setAttribute("marker-end", `url(#${markerId})`);
+      path.dataset.from = from;
+      path.dataset.to = to;
+      svg.append(path);
+    }
+  };
+  requestAnimationFrame(draw);
+
+  const onResize = () => {
+    if (inner.isConnected) draw();
+    else window.removeEventListener("resize", onResize);
+  };
+  window.addEventListener("resize", onResize);
+  sprintsState.flowCleanups.push(
+    () => window.removeEventListener("resize", onResize));
+
+  for (const [seq, card] of cardOf) {
+    card.onmouseenter = () => {
+      const lit = new Set([seq]);
+      wrap.classList.add("sprint-hover");
+      for (const wire of svg.querySelectorAll(".sprint-wire")) {
+        const incident = wire.dataset.from === seq || wire.dataset.to === seq;
+        wire.classList.toggle("lit", incident);
+        if (incident) {
+          lit.add(wire.dataset.from);
+          lit.add(wire.dataset.to);
+        }
+      }
+      for (const [otherSeq, other] of cardOf)
+        other.classList.toggle("lit", lit.has(otherSeq));
+    };
+    card.onmouseleave = () => {
+      wrap.classList.remove("sprint-hover");
+      for (const wire of svg.querySelectorAll(".sprint-wire"))
+        wire.classList.remove("lit");
+      for (const other of cardOf.values()) other.classList.remove("lit");
+    };
+  }
+  return wrap;
+}
+
 function sprintsPaint() {
   const root = sprintsState.root;
   if (!sprintsState.active || !root || !root.isConnected) return;
+  for (const cleanup of sprintsState.flowCleanups) cleanup();
+  sprintsState.flowCleanups = [];
   if (!sprintsState.payload) {
     const message = sprintsState.lastFetchAt
       ? "error: " + (sprintsState.error || "request failed")
@@ -4584,11 +4807,8 @@ function sprintsPaint() {
   if (!sprints.length)
     nodes.push(el("div", { className: "card" }, "No active sprints."));
   for (const sprint of sprints) {
-    const flow = el("div", { className: "sprint-flow" });
-    if (!(sprint.units || []).length)
-      flow.append(el("div", { className: "muted" }, "No units declared"));
     nodes.push(el("section", { className: "card sprint-board" },
-      ...sprintsHeader(sprint), flow));
+      ...sprintsHeader(sprint), sprintsBuildFlow(sprint)));
   }
   root.replaceChildren(...nodes);
 }
@@ -4648,6 +4868,8 @@ function sprintsStartPoll() {
 function sprintsStopRender() {
   if (sprintsState.durationTimer !== null)
     clearInterval(sprintsState.durationTimer);
+  for (const cleanup of sprintsState.flowCleanups) cleanup();
+  sprintsState.flowCleanups = [];
   sprintsState.active = false;
   sprintsState.root = null;
   sprintsState.durationTimer = null;
@@ -4688,7 +4910,8 @@ async function load(tab) {
 let forkName = "";
 function setDocumentTitle(tab) {
   const label = (tab === "interface" && ifSelected) ? ifSelected
-    : (document.querySelector(`nav button[data-tab="${tab}"]`)?.textContent
+    : (tab === "sprints" ? "Sprints"
+       : document.querySelector(`nav button[data-tab="${tab}"]`)?.textContent
        || tab);
   document.title = forkName ? `${label} · ${forkName}` : label;
 }

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -4518,6 +4518,8 @@ const sprintsState = {
   inFlight: null,
   lastFetchAt: 0,
   flowCleanups: [],
+  renderedRoot: null,
+  renderedSignature: null,
 };
 
 function sprintsDuration(startedAt, now = Date.now()) {
@@ -4557,11 +4559,13 @@ function sprintsHeader(sprint) {
   if (sprint.started_at) {
     const started = new Date(sprint.started_at);
     const duration = sprintsDuration(sprint.started_at);
+    const durationNode = el("span", { className: "sprint-duration" },
+      `Running: ${duration}`);
+    durationNode.dataset.startedAt = sprint.started_at;
     meta.append(
       el("time", { dateTime: sprint.started_at, title: sprint.started_at },
         `Started: ${started.toLocaleString()}`),
-      el("span", { className: "sprint-duration" },
-        `Running: ${duration}`));
+      durationNode);
   }
   return [header, meta];
 }
@@ -4611,7 +4615,8 @@ function sprintsUnitCard(unit, columnKey, unavailable) {
       el("span", { className: "idnum" }, unit.seq), " ", unit.unit_title),
     el("div", { className: "sprint-unit-state" },
       el("span", { className: `pill ${columnKey}` },
-        SPRINT_STATE_LABELS[unit.state] || String(unit.state))));
+        Object.hasOwn(SPRINT_STATE_LABELS, unit.state)
+          ? SPRINT_STATE_LABELS[unit.state] : String(unit.state))));
 
   const roles = el("div", { className: "sprint-unit-roles" },
     sprintsRole(unit, "dev", columnKey === "working"),
@@ -4619,11 +4624,18 @@ function sprintsUnitCard(unit, columnKey, unavailable) {
   card.append(roles);
 
   if (unit.depends_on) {
-    card.append(el("div", {
-      className: "sprint-unit-deps",
-      ariaLabel: unavailable.length
-        ? `dependency unavailable: ${unavailable.join(", ")}` : "",
-    }, `Depends: ${unit.depends_on}`));
+    const deps = el("div", { className: "sprint-unit-deps" },
+      `Depends: ${unit.depends_on}`);
+    if (unavailable.length) {
+      const warning = `dependency unavailable: ${unavailable.join(", ")}`;
+      deps.append(" ", el("span", {
+        className: "pill warn sprint-dep-warning",
+        role: "img",
+        ariaLabel: warning,
+        title: warning,
+      }, "⚠"));
+    }
+    card.append(deps);
   }
   if (unit.overlap) {
     card.append(el("div", {
@@ -4788,6 +4800,14 @@ function sprintsBuildFlow(sprint) {
 function sprintsPaint() {
   const root = sprintsState.root;
   if (!sprintsState.active || !root || !root.isConnected) return;
+  const signature = JSON.stringify({
+    loaded: sprintsState.lastFetchAt !== 0,
+    payload: sprintsState.payload,
+    error: sprintsState.error,
+    stale: sprintsState.stale,
+  });
+  if (root === sprintsState.renderedRoot
+      && signature === sprintsState.renderedSignature) return;
   for (const cleanup of sprintsState.flowCleanups) cleanup();
   sprintsState.flowCleanups = [];
   if (!sprintsState.payload) {
@@ -4795,6 +4815,8 @@ function sprintsPaint() {
       ? "error: " + (sprintsState.error || "request failed")
       : "Loading active sprints…";
     root.replaceChildren(el("div", { className: "card" }, message));
+    sprintsState.renderedRoot = root;
+    sprintsState.renderedSignature = signature;
     return;
   }
 
@@ -4811,6 +4833,17 @@ function sprintsPaint() {
       ...sprintsHeader(sprint), sprintsBuildFlow(sprint)));
   }
   root.replaceChildren(...nodes);
+  sprintsState.renderedRoot = root;
+  sprintsState.renderedSignature = signature;
+}
+
+function sprintsUpdateDurations() {
+  const root = sprintsState.root;
+  if (!sprintsState.active || !root || !root.isConnected) return;
+  for (const duration of root.querySelectorAll(".sprint-duration")) {
+    duration.textContent =
+      `Running: ${sprintsDuration(duration.dataset.startedAt)}`;
+  }
 }
 
 async function sprintsRefresh({ render = true } = {}) {
@@ -4873,6 +4906,8 @@ function sprintsStopRender() {
   sprintsState.active = false;
   sprintsState.root = null;
   sprintsState.durationTimer = null;
+  sprintsState.renderedRoot = null;
+  sprintsState.renderedSignature = null;
 }
 
 async function renderSprints(root) {
@@ -4880,7 +4915,8 @@ async function renderSprints(root) {
   sprintsState.active = true;
   sprintsState.root = root;
   sprintsPaint();
-  sprintsState.durationTimer = setInterval(sprintsPaint, SPRINTS_DURATION_MS);
+  sprintsState.durationTimer =
+    setInterval(sprintsUpdateDurations, SPRINTS_DURATION_MS);
 }
 
 // ── Tabs + boot ────────────────────────────────────────────────────────────────

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -623,6 +623,7 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .sprint-unit-deps, .sprint-unit-overlap, .sprint-unit-delivery {
   margin-top: .35rem; color: var(--dim); font-size: .7rem;
 }
+.sprint-dep-warning { margin-left: .25rem; }
 .sprint-unit-delivery { display: flex; flex-direction: column; min-width: 0; }
 .sprint-unit-delivery > span { overflow: hidden; text-overflow: ellipsis;
   white-space: nowrap; }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -575,6 +575,64 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   background: var(--panel2); border: 1px solid var(--line); border-radius: 6px;
   font: 12px/1.5 ui-monospace, monospace; color: var(--ink); user-select: all; }
 
+/* Active sprint flow boards — one self-contained, read-only graph per sprint. */
+#view-sprints, .sprint-board { min-width: 0; }
+.sprint-board { overflow: hidden; }
+.sprint-header { display: flex; align-items: baseline; gap: .5rem; min-width: 0; }
+.sprint-header h2 { min-width: 0; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; }
+.sprint-meta { color: var(--dim); font-size: .78rem; margin-bottom: .7rem; }
+.sprint-flow { width: 100%; min-width: 0; overflow-x: auto; padding: .2rem 0 .35rem; }
+.sprint-flow-inner { position: relative; min-width: 850px; }
+.sprint-wires { position: absolute; inset: 0 auto auto 0; z-index: 0;
+  pointer-events: none; overflow: visible; }
+.sprint-cols { position: relative; z-index: 1; display: flex; gap: 1.35rem;
+  align-items: flex-start; padding: 0 .15rem; }
+.sprint-col { flex: 1 0 150px; min-width: 150px; display: flex;
+  flex-direction: column; gap: .65rem; }
+.sprint-col-head { display: flex; align-items: center; gap: .35rem;
+  min-height: 1.6rem; padding-bottom: .3rem; border-bottom: 1px solid var(--line-soft);
+  color: var(--dim); font-size: .7rem; font-weight: 650; letter-spacing: .08em;
+  text-transform: uppercase; }
+.sprint-col-head .count { min-width: 1.3rem; padding: 0 .32rem;
+  border: 1px solid var(--line); border-radius: 999px; color: var(--ink);
+  font-size: .65rem; line-height: 1.25rem; text-align: center; }
+.sprint-unit { min-width: 0; padding: .55rem .6rem; border: 1px solid var(--line);
+  border-left: 3px solid var(--line); border-radius: 9px; background: var(--panel2);
+  transition: opacity .12s, border-color .12s, box-shadow .12s; }
+.sprint-unit.pending { border-left-color: var(--lock); }
+.sprint-unit.working { border-left-color: var(--task-open); }
+.sprint-unit.in_review { border-left-color: var(--accent); }
+.sprint-unit.blocked, .sprint-unit.unrecognized { border-left-color: var(--warn); }
+.sprint-unit.done { border-left-color: var(--ok); }
+.sprint-unit-title, .sprint-unit-overlap {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.sprint-unit-title { font-size: .82rem; font-weight: 600; }
+.sprint-unit-title .idnum { color: var(--accent); }
+.sprint-unit-state { margin-top: .35rem; }
+.sprint-unit-state .pill.working { color: var(--task-open); }
+.sprint-unit-state .pill.in_review { color: var(--accent); }
+.sprint-unit-state .pill.blocked,
+.sprint-unit-state .pill.unrecognized { color: var(--warn); }
+.sprint-unit-state .pill.done { color: var(--ok); }
+.sprint-unit-roles { display: flex; flex-direction: column; gap: .05rem;
+  margin-top: .35rem; color: var(--dim); font-size: .72rem; }
+.sprint-role.active { color: var(--accent); font-weight: 650; }
+.sprint-role.warn { color: var(--warn); }
+.sprint-unit-deps, .sprint-unit-overlap, .sprint-unit-delivery {
+  margin-top: .35rem; color: var(--dim); font-size: .7rem;
+}
+.sprint-unit-delivery { display: flex; flex-direction: column; min-width: 0; }
+.sprint-unit-delivery > span { overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; }
+.sprint-wire { fill: none; stroke: rgba(110,168,254,.42); stroke-width: 1.6px; }
+.sprint-flow.sprint-hover .sprint-unit { opacity: .38; }
+.sprint-flow.sprint-hover .sprint-unit.lit { opacity: 1; border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(110,168,254,.35); }
+.sprint-flow.sprint-hover .sprint-wire { stroke: rgba(110,168,254,.1); }
+.sprint-flow.sprint-hover .sprint-wire.lit { stroke: var(--accent); stroke-width: 2px; }
+
 /* Roadmap Flow view — feature dependency graph: cards in stage columns with an
    SVG wire overlay (blocker → blocked). Replaces the old mermaid flowchart. */
 .view-toggle { margin-bottom: .6rem; }

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -1679,7 +1679,10 @@ def test_a_failed_title_mint_never_blocks_the_ack_path():
 def test_tab_titles_name_the_view_and_the_fork():
     script = DOC_TITLE + r"""
 function invariant(ok, message) { if (!ok) throw new Error(message); }
-const NAV = { interface: "Interface", roadmap: "Roadmap", shells: "Shells" };
+const NAV = {
+  interface: "Interface", roadmap: "Roadmap", shells: "Shells",
+  sprints: "Sprints 2",
+};
 globalThis.document = {
   title: "",
   querySelector: (sel) => {
@@ -1700,6 +1703,9 @@ invariant(document.title === "DEV4 · super-coder", document.title);
 setDocumentTitle("shells");
 invariant(document.title === "Shells · super-coder",
   "a selected shell must not leak into another tab's title: " + document.title);
+setDocumentTitle("sprints");
+invariant(document.title === "Sprints · super-coder",
+  "the live count must not leak into the tab title: " + document.title);
 
 // /health has not answered (or failed): name the view, never guess a fork.
 forkName = "";

--- a/tests/test_quota_gate.py
+++ b/tests/test_quota_gate.py
@@ -553,7 +553,8 @@ let sprintsRefreshError = null;
 async function sprintsRefresh() {
   if (sprintsRefreshError) throw sprintsRefreshError;
 }
-function sprintsStartPoll() {}
+let sprintsPollStarted = 0;
+function sprintsStartPoll() { sprintsPollStarted += 1; }
 function all(root, pred, found = []) {
   if (pred(root)) found.push(root);
   for (const c of root.children || []) if (c && c.nodeType === 1) all(c, pred, found);
@@ -608,11 +609,15 @@ class DeepLinkSurvivesReloadTest(unittest.TestCase):
 
     def test_loading_the_page_on_the_quota_hash_lands_on_the_section(self):
         r = run_js("""
-          out({ view: anView, tab: shown[shown.length - 1], routed: shown.length });
+          out({ view: anView, tab: shown[shown.length - 1], routed: shown.length,
+                sprintsPollStarted });
         """, boot=True, hash="#analytics-quota")
         self.assertEqual("quota", r["view"])
         self.assertEqual("analytics", r["tab"])
         self.assertEqual(1, r["routed"], "the load routed more than once")
+        self.assertEqual(
+            1, r["sprintsPollStarted"],
+            "the boot IIFE did not start the document-wide sprint poll")
 
     def test_the_boot_route_runs_even_when_the_health_call_fails(self):
         """`routeFromHash()` sits outside the IIFE's try/catch on purpose: an

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -101,11 +101,18 @@ globalThis.document = {
 };
 const windowListeners = new Map();
 globalThis.window = {
-  addEventListener: (name, fn) => windowListeners.set(name, fn),
+  addEventListener: (name, fn) => {
+    if (!windowListeners.has(name)) windowListeners.set(name, new Set());
+    windowListeners.get(name).add(fn);
+  },
   removeEventListener: (name, fn) => {
-    if (windowListeners.get(name) === fn) windowListeners.delete(name);
+    const handlers = windowListeners.get(name);
+    if (!handlers) return;
+    handlers.delete(fn);
+    if (!handlers.size) windowListeners.delete(name);
   },
 };
+const windowListenerCount = (name) => windowListeners.get(name)?.size || 0;
 globalThis.requestAnimationFrame = (fn) => { fn(); return 1; };
 globalThis.setInterval = (fn, ms) => {
   const id = intervals.length + 1;
@@ -357,6 +364,99 @@ out({ headings: byClass(root, "sprint-col-head").map((node) => node.textContent)
     ]
 
 
+def test_projection_recognition_flag_overrides_known_ui_column_key():
+    result = run_js(
+        """
+const flow = sprintsBuildFlow(DATA.sprints[0]);
+const card = byClass(flow, "sprint-unit")[0];
+out({
+  headings: byClass(flow, "sprint-col-head").map((node) => node.textContent),
+  cardClass: card.className,
+  cardText: card.textContent,
+});
+""",
+        prelude="const DATA = " + json.dumps(
+            payload(units=[unit("U1", "done", recognized=False)])
+        ) + ";\n",
+    )
+    assert result["headings"] == [
+        "Waiting", "Dev", "Review", "Blocked", "Done", "Unrecognized1",
+    ]
+    assert "unrecognized" in result["cardClass"]
+    assert "done" in result["cardText"]
+
+
+def test_unrecognized_state_label_ignores_object_prototype():
+    result = run_js(
+        """
+const flow = sprintsBuildFlow(DATA.sprints[0]);
+const card = byClass(flow, "sprint-unit")[0];
+out({ text: card.textContent });
+""",
+        prelude="const DATA = " + json.dumps(
+            payload(units=[unit("U1", "constructor", recognized=False)])
+        ) + ";\n",
+    )
+    assert "constructor" in result["text"]
+    assert "function Object" not in result["text"]
+
+
+def test_unrecognized_column_does_not_mutate_shared_columns():
+    result = run_js(
+        """
+const unknown = sprintsBuildFlow(UNKNOWN.sprints[0]);
+const known = sprintsBuildFlow(KNOWN.sprints[0]);
+out({
+  unknown: byClass(unknown, "sprint-col-head").map((node) => node.textContent),
+  known: byClass(known, "sprint-col-head").map((node) => node.textContent),
+  shared: SPRINT_FLOW_COLUMNS.map((column) => column.label),
+});
+""",
+        prelude=(
+            "const UNKNOWN = " + json.dumps(payload(
+                units=[unit("U1", "mystery", recognized=False)]
+            )) + ";\n"
+            "const KNOWN = " + json.dumps(payload(
+                units=[unit("U1", "working")]
+            )) + ";\n"
+        ),
+    )
+    assert result["unknown"][-1] == "Unrecognized1"
+    assert result["known"] == ["Waiting", "Dev1", "Review", "Blocked", "Done"]
+    assert result["shared"] == ["Waiting", "Dev", "Review", "Blocked", "Done"]
+
+
+def test_unavailable_dependency_has_visible_warning_marker():
+    result = run_js(
+        """
+const flow = sprintsBuildFlow(DATA.sprints[0]);
+const marker = byClass(flow, "sprint-dep-warning")[0];
+out({ text: marker.textContent, className: marker.className });
+""",
+        prelude="const DATA = " + json.dumps(payload(
+            units=[unit("U1", "working", depends_on="U0")]
+        )) + ";\n",
+    )
+    assert result["text"] == "⚠"
+    assert "warn" in result["className"]
+
+
+def test_unavailable_dependency_warning_is_accessibly_named():
+    result = run_js(
+        """
+const flow = sprintsBuildFlow(DATA.sprints[0]);
+const marker = byClass(flow, "sprint-dep-warning")[0];
+out({ role: marker.role, name: marker.ariaLabel });
+""",
+        prelude="const DATA = " + json.dumps(payload(
+            units=[unit("U1", "working", depends_on="U0")]
+        )) + ";\n",
+    )
+    assert result == {
+        "role": "img", "name": "dependency unavailable: U0",
+    }
+
+
 def test_dependency_wires_are_sprint_scoped_and_bad_tokens_degrade_locally():
     data = payload(units=[
         unit("U1", "pending"),
@@ -371,6 +471,7 @@ def test_dependency_wires_are_sprint_scoped_and_bad_tokens_degrade_locally():
         "units": [
             unit("U1", "pending"),
             unit("U2", "in_review", depends_on="U1"),
+            unit("U9", "blocked"),
         ],
     })
     data["active_count"] = 2
@@ -396,8 +497,8 @@ out({
   wires: boards.map((board) => byClass(board, "sprint-wire").map(
     (wire) => [wire.dataset.from, wire.dataset.to])),
   markers: boards.map((board) => byTag(board, "marker")[0].getAttribute("id")),
-  unavailable: boards.map((board) => byClass(board, "sprint-unit-deps")
-    .map((node) => node.ariaLabel).filter(Boolean)),
+  unavailable: boards.map((board) => byClass(board, "sprint-dep-warning")
+    .map((node) => node.ariaLabel)),
   hover,
 });
 """,
@@ -412,6 +513,69 @@ out({
     assert "sprint-hover" in result["hover"]["flow"]
     assert result["hover"]["cards"] == ["U1", "U2"]
     assert result["hover"]["wires"] == 1
+
+
+def test_identical_refresh_reuses_dom_and_preserves_hover_and_scroll():
+    result = run_js(
+        """
+apiQueue = [DATA, JSON.parse(JSON.stringify(DATA))];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+const flow = byClass(root, "sprint-flow")[0];
+const card = byClass(root, "sprint-unit")
+  .find((node) => node.dataset.seq === "U1");
+flow.scrollLeft = 240;
+card.onmouseenter();
+await sprintsRefresh();
+out({
+  flowReused: byClass(root, "sprint-flow")[0] === flow,
+  scrollLeft: flow.scrollLeft,
+  litCards: byClass(root, "sprint-unit")
+    .filter((node) => node.classList.contains("lit")).length,
+  resizeListeners: windowListenerCount("resize"),
+});
+""",
+        prelude="const DATA = " + json.dumps(payload(units=[
+            unit("U1", "pending"),
+            unit("U2", "working", depends_on="U1"),
+        ])) + ";\n",
+    )
+    assert result == {
+        "flowReused": True,
+        "scrollLeft": 240,
+        "litCards": 2,
+        "resizeListeners": 1,
+    }
+
+
+def test_changed_refresh_replaces_dom_and_cleans_previous_resize_listener():
+    initial = payload(units=[unit("U1", "working")])
+    updated = payload(units=[
+        unit("U1", "working"),
+        unit("U2", "in_review", depends_on="U1"),
+    ])
+    result = run_js(
+        """
+apiQueue = [INITIAL, UPDATED];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+const firstFlow = byClass(root, "sprint-flow")[0];
+const before = windowListenerCount("resize");
+await sprintsRefresh();
+out({
+  flowReused: byClass(root, "sprint-flow")[0] === firstFlow,
+  before,
+  after: windowListenerCount("resize"),
+});
+""",
+        prelude=(
+            "const INITIAL = " + json.dumps(initial) + ";\n"
+            "const UPDATED = " + json.dumps(updated) + ";\n"
+        ),
+    )
+    assert result == {"flowReused": False, "before": 1, "after": 1}
 
 
 def test_flow_styles_clamp_text_and_contain_narrow_viewport_scrolling():

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -35,7 +35,8 @@ class FakeElement {
     this.tagName = tag; this.nodeType = 1; this.children = [];
     this._text = ""; this.className = ""; this.title = "";
     this.dateTime = ""; this.isConnected = true; this.hidden = false;
-    this.dataset = {};
+    this.dataset = {}; this.attributes = {};
+    this.scrollWidth = 1000; this.scrollHeight = 500;
     this.classList = {
       add: (name) => this._setClass(name, true),
       remove: (name) => this._setClass(name, false),
@@ -55,6 +56,23 @@ class FakeElement {
   }
   append(...nodes) { this.children.push(...nodes); }
   replaceChildren(...nodes) { this.children = [...nodes]; this._text = ""; }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+    if (name === "class") this.className = String(value);
+  }
+  getAttribute(name) { return this.attributes[name] ?? null; }
+  querySelectorAll(selector) {
+    if (!selector.startsWith(".")) return [];
+    const name = selector.slice(1);
+    return all(this, (node) =>
+      String(node.className || "").split(" ").filter(Boolean).includes(name));
+  }
+  getBoundingClientRect() {
+    const index = Number(String(this.dataset.seq || "").replace(/\D/g, "")) || 0;
+    const left = index * 170;
+    return { left, right: left + 140, top: index * 25,
+             height: 70, width: 140, bottom: index * 25 + 70 };
+  }
   set textContent(value) { this._text = String(value ?? ""); this.children = []; }
   get textContent() {
     return this._text + this.children.map(
@@ -72,6 +90,7 @@ const cleared = [];
 globalThis.document = {
   hidden: false,
   createElement: (tag) => new FakeElement(tag),
+  createElementNS: (_ns, tag) => new FakeElement(tag),
   createTextNode: (text) => ({ nodeType: 3, textContent: String(text ?? "") }),
   querySelector: (selector) =>
     selector === 'nav button[data-tab="sprints"]' ? navButton : null,
@@ -80,6 +99,14 @@ globalThis.document = {
     if (listeners.get(name) === fn) listeners.delete(name);
   },
 };
+const windowListeners = new Map();
+globalThis.window = {
+  addEventListener: (name, fn) => windowListeners.set(name, fn),
+  removeEventListener: (name, fn) => {
+    if (windowListeners.get(name) === fn) windowListeners.delete(name);
+  },
+};
+globalThis.requestAnimationFrame = (fn) => { fn(); return 1; };
 globalThis.setInterval = (fn, ms) => {
   const id = intervals.length + 1;
   intervals.push({ id, fn, ms });
@@ -117,8 +144,40 @@ def payload(*, count=1, started_at="2026-07-26T20:00:00Z", units=None):
             "started_at": started_at,
             "planner": {"shell_id": 10, "shortname": "PLN2"},
             "feature": {"feature_id": 33, "title": "Active sprint flow board"},
-            "units": [{"seq": "U3"}] if units is None else units,
+            "units": [{
+                "seq": "U3",
+                "unit_title": "Sprints route and nav signal",
+                "state": "merged",
+                "state_recognized": True,
+                "dev_shell_id": 11,
+                "dev_shortname": "DEV5",
+                "reviewer_shell_id": 7,
+                "reviewer_shortname": "REV2",
+                "depends_on": "U1",
+                "overlap": None,
+                "branch": "feat/sprints-page",
+                "pr_number": 639,
+            }] if units is None else units,
         }],
+    }
+
+
+def unit(seq, state, *, title=None, depends_on=None, overlap=None,
+         dev_id=11, dev="DEV5", reviewer_id=7, reviewer="REV2",
+         branch=None, pr=None, recognized=True):
+    return {
+        "seq": seq,
+        "unit_title": title or f"Unit {seq}",
+        "state": state,
+        "state_recognized": recognized,
+        "dev_shell_id": dev_id,
+        "dev_shortname": dev,
+        "reviewer_shell_id": reviewer_id,
+        "reviewer_shortname": reviewer,
+        "depends_on": depends_on,
+        "overlap": overlap,
+        "branch": branch,
+        "pr_number": pr,
     }
 
 
@@ -211,6 +270,159 @@ out({
     assert result["titles"][1].startswith("SPRINT: second board")
     assert result["controls"] == 0
     assert result["utc"] == "2026-07-26T20:00:00Z"
+
+
+def test_flow_columns_cards_and_active_role_emphasis():
+    long_title = "Dependency rendering " + ("with a long title " * 8)
+    long_overlap = "Same-file overlap " + ("must stay on one line " * 8)
+    units = [
+        unit("U1", "pending", dev=None, reviewer=None),
+        unit("U2", "working", title=long_title, overlap=long_overlap,
+             branch="feat/sprints-flow-boards", pr=640),
+        unit("U3", "in_review"),
+        unit("U4", "blocked"),
+        unit("U5", "merged"),
+        unit("U6", "cancelled"),
+        {
+            **unit("U7", "mystery", recognized=False),
+            "task_body": "must not leak task body",
+            "messages": ["must not leak messages"],
+            "checks": "must not leak checks",
+        },
+    ]
+    result = run_js(
+        """
+apiQueue = [DATA];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+const cards = byClass(root, "sprint-unit");
+const card = (seq) => cards.find((node) => node.dataset.seq === seq);
+const roles = (seq) => byClass(card(seq), "sprint-role").map(
+  (role) => ({ text: role.textContent, className: role.className }));
+out({
+  headings: byClass(root, "sprint-col-head").map((node) => node.textContent),
+  cards: cards.length,
+  u2: {
+    text: card("U2").textContent,
+    title: byClass(card("U2"), "sprint-unit-title")[0].title,
+    overlap: byClass(card("U2"), "sprint-unit-overlap")[0].title,
+  },
+  u1Roles: roles("U1"),
+  u2Roles: roles("U2"),
+  u3Roles: roles("U3"),
+  u4Roles: roles("U4"),
+  done: [card("U5").textContent, card("U6").textContent],
+  unknown: card("U7").textContent,
+});
+""",
+        prelude="const DATA = " + json.dumps(payload(units=units)) + ";\n",
+    )
+    assert result["headings"] == [
+        "Waiting1", "Dev1", "Review1", "Blocked1", "Done2", "Unrecognized1",
+    ]
+    assert result["cards"] == 7
+    assert long_title in result["u2"]["text"]
+    assert result["u2"]["title"] == long_title
+    assert result["u2"]["overlap"] == long_overlap
+    assert "Branch: feat/sprints-flow-boards" in result["u2"]["text"]
+    assert "PR #640" in result["u2"]["text"]
+    assert all("active" not in role["className"] for role in result["u1Roles"])
+    assert "active" in result["u2Roles"][0]["className"]
+    assert "active" not in result["u2Roles"][1]["className"]
+    assert "active" not in result["u3Roles"][0]["className"]
+    assert "active" in result["u3Roles"][1]["className"]
+    assert all("active" not in role["className"] for role in result["u4Roles"])
+    assert "Merged" in result["done"][0]
+    assert "Cancelled" in result["done"][1]
+    assert "mystery" in result["unknown"]
+    assert "must not leak" not in result["unknown"]
+
+
+def test_unrecognized_column_is_omitted_when_empty():
+    result = run_js(
+        """
+apiQueue = [DATA];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+out({ headings: byClass(root, "sprint-col-head").map((node) => node.textContent) });
+""",
+        prelude="const DATA = " + json.dumps(
+            payload(units=[unit("U1", "working")])
+        ) + ";\n",
+    )
+    assert result["headings"] == [
+        "Waiting", "Dev1", "Review", "Blocked", "Done",
+    ]
+
+
+def test_dependency_wires_are_sprint_scoped_and_bad_tokens_degrade_locally():
+    data = payload(units=[
+        unit("U1", "pending"),
+        unit("U2", "working", depends_on="U1, U9, U2, S59-U1,,"),
+    ])
+    data["sprints"].append({
+        "document_id": 78,
+        "title": "SPRINT: Other graph",
+        "started_at": "2026-07-26T21:00:00Z",
+        "planner": None,
+        "feature": None,
+        "units": [
+            unit("U1", "pending"),
+            unit("U2", "in_review", depends_on="U1"),
+        ],
+    })
+    data["active_count"] = 2
+    result = run_js(
+        """
+apiQueue = [DATA];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+const boards = byClass(root, "sprint-board");
+const firstCards = byClass(boards[0], "sprint-unit");
+const source = firstCards.find((card) => card.dataset.seq === "U1");
+source.onmouseenter();
+const hover = {
+  flow: byClass(boards[0], "sprint-flow")[0].className,
+  cards: firstCards.filter((card) => card.classList.contains("lit"))
+    .map((card) => card.dataset.seq),
+  wires: byClass(boards[0], "sprint-wire")
+    .filter((wire) => wire.classList.contains("lit")).length,
+};
+source.onmouseleave();
+out({
+  wires: boards.map((board) => byClass(board, "sprint-wire").map(
+    (wire) => [wire.dataset.from, wire.dataset.to])),
+  markers: boards.map((board) => byTag(board, "marker")[0].getAttribute("id")),
+  unavailable: boards.map((board) => byClass(board, "sprint-unit-deps")
+    .map((node) => node.ariaLabel).filter(Boolean)),
+  hover,
+});
+""",
+        prelude="const DATA = " + json.dumps(data) + ";\n",
+    )
+    assert result["wires"] == [[["U1", "U2"]], [["U1", "U2"]]]
+    assert result["markers"] == ["sprint-arrow-77", "sprint-arrow-78"]
+    assert result["unavailable"][0] == [
+        "dependency unavailable: U9, U2, S59-U1, (empty), (empty)"
+    ]
+    assert result["unavailable"][1] == []
+    assert "sprint-hover" in result["hover"]["flow"]
+    assert result["hover"]["cards"] == ["U1", "U2"]
+    assert result["hover"]["wires"] == 1
+
+
+def test_flow_styles_clamp_text_and_contain_narrow_viewport_scrolling():
+    sprint_css = STYLE[STYLE.index("/* Active sprint flow boards"):
+                       STYLE.index("/* Roadmap Flow view")]
+    assert "#view-sprints, .sprint-board { min-width: 0; }" in sprint_css
+    assert ".sprint-board { overflow: hidden; }" in sprint_css
+    assert "overflow-x: auto" in sprint_css
+    assert "text-overflow: ellipsis" in sprint_css
+    assert "white-space: nowrap" in sprint_css
+    assert "cursor: pointer" not in sprint_css
 
 
 def test_zero_state_and_initial_failure_are_distinct():
@@ -362,6 +574,7 @@ const routeExit = {
   refreshTimer: sprintsState.refreshTimer,
   durationTimer: sprintsState.durationTimer,
   listenerPresent: listeners.has("visibilitychange"),
+  resizeListenerPresent: windowListeners.has("resize"),
   cleared: [...cleared],
 };
 await intervals.find((entry) => entry.ms === SPRINTS_REFRESH_MS).fn();
@@ -412,6 +625,7 @@ function load() {}
         "refreshTimer": 1,
         "durationTimer": None,
         "listenerPresent": True,
+        "resizeListenerPresent": False,
         "cleared": [2],
     }
     assert result["afterExitTick"] == result["afterNetworkTick"] + 1


### PR DESCRIPTION
## Outcome
- render one isolated read-only flow board per active sprint
- map all unit states into Waiting, Dev, Review, Blocked, Done, plus non-empty Unrecognized
- show scoped cards, active-role emphasis, column counts, and same-sprint dependency wires
- preserve invalid dependency text with an accessible dependency-unavailable label
- keep board overflow local on narrow viewports
- pin boot-time sprint polling by executing the real boot IIFE (SC-319)
- keep the Sprints document title stable when the live nav count changes

## Verification
- 131 passed, 3 subtests passed: sprints UI, quota boot, Interface UI, and API endpoint contracts
- mutation round trips: terminal-state mapping, unavailable dependencies, and boot poll startup each red; each baseline green after revert
- live read-only DB smoke: 2 boards, 21 cards, 15 wires, zero controls
- full engine run reached 30% before the 15-minute local timeout with only the 3 known stale-runtime test_harness_epoch failures; CI is the full gate

## Trade-off
The wire renderer reuses the Roadmap Flow measured-SVG and hover idiom, but resolves against a per-sprint sequence map so cross-sprint edges are impossible by construction.