### PR TITLE
fix(sandbox): reap orphaned processes with Docker init

### DIFF
--- a/sc
+++ b/sc
@@ -1329,7 +1329,11 @@ case "$cmd" in
       esac
     fi
     docker rm -f "$CNAME" >/dev/null 2>&1 || true
-    docker run -d --name "$CNAME" --restart unless-stopped \
+    # Docker's init shim is PID 1 so orphaned harness/worker subprocesses are
+    # reaped. Without it the Python API server becomes PID 1, never wait()s on
+    # reparented children, and a long-running multi-shell sprint exhausts the
+    # container's PID limit with zombies (flag #323).
+    docker run -d --name "$CNAME" --restart unless-stopped --init \
       --network "$SC_NET" \
       --user "$(duser)" \
       -e HOME="$HOME" -e SC_BIND=0.0.0.0 -e SC_PYTHON=python3 -e PYTHONUNBUFFERED=1 \

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -268,7 +268,13 @@ class RestrictedLaunchTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         calls = self.fx.calls()
         self.assertIn("docker image inspect super-coder-sandbox", calls)
-        self.assertTrue(any(line.startswith("docker run -d") for line in calls))
+        sandbox_run = next(
+            line
+            for line in calls
+            if line.startswith("docker run -d")
+            and f"--name sc-{self.fx.root.name}" in line
+        )
+        self.assertIn(" --init ", sandbox_run)
         self.assertFalse(any(line.startswith("docker build ") for line in calls))
 
     def test_launch_no_build_missing_image_refuses_before_runtime_change(self):


### PR DESCRIPTION
## Root cause

The sandbox API server currently runs as PID 1 and does not reap orphaned harness/worker subprocesses. Overnight, 18,036 zombies accumulated against a cgroup PID limit of 18,179, causing container-wide fork failures and lost Interface sessions (flag #323).

## Fix

- launch the sandbox with Docker `--init`, making `docker-init` PID 1 and the API server its child
- pin the launch contract in the supervision test

## Verification

- `sh -n sc`
- `python3 tests/test_supervision_sc.py` — 10/10 pass
- disposable live probe with `--init`: 200 deliberately orphaned children, 0 zombies