### PR TITLE
feat(ui): make sprint cards selectable

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -4520,6 +4520,7 @@ const sprintsState = {
   flowCleanups: [],
   renderedRoot: null,
   renderedSignature: null,
+  selectedByDocument: new Map(),
 };
 
 function sprintsDuration(startedAt, now = Date.now()) {
@@ -4608,6 +4609,9 @@ function sprintsUnitCard(unit, columnKey, unavailable) {
   const card = el("article", {
     className: `sprint-unit ${columnKey}`,
     title: `${unit.seq} ${unit.unit_title}`,
+    role: "button",
+    tabIndex: 0,
+    ariaPressed: "false",
   });
   card.dataset.seq = String(unit.seq);
   card.append(
@@ -4637,8 +4641,12 @@ function sprintsUnitCard(unit, columnKey, unavailable) {
     }
     card.append(deps);
   }
+  const details = el("div", {
+    className: "sprint-unit-details",
+    hidden: true,
+  });
   if (unit.overlap) {
-    card.append(el("div", {
+    details.append(el("div", {
       className: "sprint-unit-overlap",
       title: unit.overlap,
     }, unit.overlap));
@@ -4649,8 +4657,9 @@ function sprintsUnitCard(unit, columnKey, unavailable) {
       delivery.append(el("span", { title: unit.branch }, `Branch: ${unit.branch}`));
     if (unit.pr_number != null)
       delivery.append(el("span", {}, `PR #${unit.pr_number}`));
-    card.append(delivery);
+    details.append(delivery);
   }
+  if (details.children.length) card.append(details);
   return card;
 }
 
@@ -4772,28 +4781,64 @@ function sprintsBuildFlow(sprint) {
   sprintsState.flowCleanups.push(
     () => window.removeEventListener("resize", onResize));
 
+  let selectedSeq = sprintsState.selectedByDocument.get(sprint.document_id) || null;
+  if (selectedSeq && !cardOf.has(selectedSeq)) {
+    sprintsState.selectedByDocument.delete(sprint.document_id);
+    selectedSeq = null;
+  }
+
+  const spotlight = (seq) => {
+    const lit = new Set(seq ? [seq] : []);
+    wrap.classList.toggle("sprint-spotlight", Boolean(seq));
+    for (const wire of svg.querySelectorAll(".sprint-wire")) {
+      const incident = seq
+        && (wire.dataset.from === seq || wire.dataset.to === seq);
+      wire.classList.toggle("lit", Boolean(incident));
+      if (incident) {
+        lit.add(wire.dataset.from);
+        lit.add(wire.dataset.to);
+      }
+    }
+    for (const [otherSeq, other] of cardOf)
+      other.classList.toggle("lit", lit.has(otherSeq));
+  };
+
+  const select = (seq) => {
+    selectedSeq = seq;
+    if (seq) sprintsState.selectedByDocument.set(sprint.document_id, seq);
+    else sprintsState.selectedByDocument.delete(sprint.document_id);
+    for (const [otherSeq, other] of cardOf) {
+      const selected = otherSeq === seq;
+      const details = other.querySelectorAll(".sprint-unit-details")[0];
+      other.classList.toggle("selected", selected);
+      other.ariaPressed = String(selected);
+      if (details) {
+        details.hidden = !selected;
+        other.ariaExpanded = String(selected);
+      }
+    }
+    spotlight(seq);
+  };
+
   for (const [seq, card] of cardOf) {
     card.onmouseenter = () => {
-      const lit = new Set([seq]);
-      wrap.classList.add("sprint-hover");
-      for (const wire of svg.querySelectorAll(".sprint-wire")) {
-        const incident = wire.dataset.from === seq || wire.dataset.to === seq;
-        wire.classList.toggle("lit", incident);
-        if (incident) {
-          lit.add(wire.dataset.from);
-          lit.add(wire.dataset.to);
-        }
-      }
-      for (const [otherSeq, other] of cardOf)
-        other.classList.toggle("lit", lit.has(otherSeq));
+      if (!selectedSeq) spotlight(seq);
     };
     card.onmouseleave = () => {
-      wrap.classList.remove("sprint-hover");
-      for (const wire of svg.querySelectorAll(".sprint-wire"))
-        wire.classList.remove("lit");
-      for (const other of cardOf.values()) other.classList.remove("lit");
+      if (!selectedSeq) spotlight(null);
+    };
+    card.onclick = (event) => {
+      event.stopPropagation();
+      select(selectedSeq === seq ? null : seq);
+    };
+    card.onkeydown = (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      select(selectedSeq === seq ? null : seq);
     };
   }
+  wrap.onclick = () => select(null);
+  select(selectedSeq);
   return wrap;
 }
 

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -599,7 +599,8 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   font-size: .65rem; line-height: 1.25rem; text-align: center; }
 .sprint-unit { min-width: 0; padding: .55rem .6rem; border: 1px solid var(--line);
   border-left: 3px solid var(--line); border-radius: 9px; background: var(--panel2);
-  transition: opacity .12s, border-color .12s, box-shadow .12s; }
+  cursor: pointer; transition: opacity .12s, border-color .12s, box-shadow .12s; }
+.sprint-unit:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .sprint-unit.pending { border-left-color: var(--lock); }
 .sprint-unit.working { border-left-color: var(--task-open); }
 .sprint-unit.in_review { border-left-color: var(--accent); }
@@ -624,15 +625,18 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   margin-top: .35rem; color: var(--dim); font-size: .7rem;
 }
 .sprint-dep-warning { margin-left: .25rem; }
+.sprint-unit-details { min-width: 0; }
 .sprint-unit-delivery { display: flex; flex-direction: column; min-width: 0; }
 .sprint-unit-delivery > span { overflow: hidden; text-overflow: ellipsis;
   white-space: nowrap; }
 .sprint-wire { fill: none; stroke: rgba(110,168,254,.42); stroke-width: 1.6px; }
-.sprint-flow.sprint-hover .sprint-unit { opacity: .38; }
-.sprint-flow.sprint-hover .sprint-unit.lit { opacity: 1; border-color: var(--accent);
+.sprint-flow.sprint-spotlight .sprint-unit { opacity: .38; }
+.sprint-flow.sprint-spotlight .sprint-unit.lit { opacity: 1; border-color: var(--accent);
   box-shadow: 0 0 0 1px rgba(110,168,254,.35); }
-.sprint-flow.sprint-hover .sprint-wire { stroke: rgba(110,168,254,.1); }
-.sprint-flow.sprint-hover .sprint-wire.lit { stroke: var(--accent); stroke-width: 2px; }
+.sprint-flow.sprint-spotlight .sprint-unit.selected {
+  box-shadow: 0 0 0 2px rgba(110,168,254,.58); }
+.sprint-flow.sprint-spotlight .sprint-wire { stroke: rgba(110,168,254,.1); }
+.sprint-flow.sprint-spotlight .sprint-wire.lit { stroke: var(--accent); stroke-width: 2px; }
 
 /* Roadmap Flow view — feature dependency graph: cards in stage columns with an
    SVG wire overlay (blocker → blocked). Replaces the old mermaid flowchart. */

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import pytest
 
-
 ROOT = Path(__file__).resolve().parents[1]
 APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
 INDEX = (ROOT / ".super-coder" / "ui" / "index.html").read_text()
@@ -314,6 +313,7 @@ out({
     text: card("U2").textContent,
     title: byClass(card("U2"), "sprint-unit-title")[0].title,
     overlap: byClass(card("U2"), "sprint-unit-overlap")[0].title,
+    detailsHidden: byClass(card("U2"), "sprint-unit-details")[0].hidden,
   },
   u1Roles: roles("U1"),
   u2Roles: roles("U2"),
@@ -332,6 +332,7 @@ out({
     assert long_title in result["u2"]["text"]
     assert result["u2"]["title"] == long_title
     assert result["u2"]["overlap"] == long_overlap
+    assert result["u2"]["detailsHidden"] is True
     assert "Branch: feat/sprints-flow-boards" in result["u2"]["text"]
     assert "PR #640" in result["u2"]["text"]
     assert all("active" not in role["className"] for role in result["u1Roles"])
@@ -510,12 +511,149 @@ out({
         "dependency unavailable: U9, U2, S59-U1, (empty), (empty)"
     ]
     assert result["unavailable"][1] == []
-    assert "sprint-hover" in result["hover"]["flow"]
+    assert "sprint-spotlight" in result["hover"]["flow"]
     assert result["hover"]["cards"] == ["U1", "U2"]
     assert result["hover"]["wires"] == 1
 
 
-def test_identical_refresh_reuses_dom_and_preserves_hover_and_scroll():
+def test_click_expands_details_pins_wires_and_blank_space_clears_selection():
+    result = run_js(
+        """
+const flow = sprintsBuildFlow(DATA.sprints[0]);
+const cards = byClass(flow, "sprint-unit");
+const card = (seq) => cards.find((node) => node.dataset.seq === seq);
+const details = byClass(card("U2"), "sprint-unit-details")[0];
+let stopped = 0;
+card("U2").onclick({ stopPropagation: () => { stopped += 1; } });
+card("U2").onmouseleave();
+const selected = {
+  stopped,
+  flow: flow.className,
+  cards: cards.filter((node) => node.classList.contains("selected"))
+    .map((node) => node.dataset.seq),
+  litCards: cards.filter((node) => node.classList.contains("lit"))
+    .map((node) => node.dataset.seq),
+  litWires: byClass(flow, "sprint-wire")
+    .filter((wire) => wire.classList.contains("lit")).length,
+  detailsHidden: details.hidden,
+  detailsText: details.textContent,
+  pressed: card("U2").ariaPressed,
+  expanded: card("U2").ariaExpanded,
+};
+flow.onclick();
+out({
+  selected,
+  cleared: {
+    flow: flow.className,
+    selectedCards: cards.filter(
+      (node) => node.classList.contains("selected")).length,
+    litCards: cards.filter((node) => node.classList.contains("lit")).length,
+    litWires: byClass(flow, "sprint-wire")
+      .filter((wire) => wire.classList.contains("lit")).length,
+    detailsHidden: details.hidden,
+    pressed: card("U2").ariaPressed,
+    expanded: card("U2").ariaExpanded,
+  },
+});
+""",
+        prelude="const DATA = " + json.dumps(payload(units=[
+            unit("U1", "pending"),
+            unit(
+                "U2", "working", depends_on="U1",
+                overlap="shares scripts/sprint.py",
+                branch="feat/sprint-details", pr=650,
+            ),
+            unit("U3", "blocked"),
+        ])) + ";\n",
+    )
+    assert result["selected"] == {
+        "stopped": 1,
+        "flow": "sprint-flow sprint-spotlight",
+        "cards": ["U2"],
+        "litCards": ["U1", "U2"],
+        "litWires": 1,
+        "detailsHidden": False,
+        "detailsText": (
+            "shares scripts/sprint.py"
+            "Branch: feat/sprint-details"
+            "PR #650"
+        ),
+        "pressed": "true",
+        "expanded": "true",
+    }
+    assert result["cleared"] == {
+        "flow": "sprint-flow",
+        "selectedCards": 0,
+        "litCards": 0,
+        "litWires": 0,
+        "detailsHidden": True,
+        "pressed": "false",
+        "expanded": "false",
+    }
+
+
+def test_keyboard_toggles_selection_without_hijacking_other_keys():
+    result = run_js(
+        """
+const flow = sprintsBuildFlow(DATA.sprints[0]);
+const card = byClass(flow, "sprint-unit")[0];
+const details = byClass(card, "sprint-unit-details")[0];
+let prevented = 0;
+const key = (value) => ({
+  key: value,
+  preventDefault: () => { prevented += 1; },
+});
+card.onkeydown(key("ArrowDown"));
+const ignored = {
+  selected: card.classList.contains("selected"),
+  detailsHidden: details.hidden,
+  prevented,
+};
+card.onkeydown(key("Enter"));
+const selected = {
+  selected: card.classList.contains("selected"),
+  detailsHidden: details.hidden,
+  prevented,
+};
+card.onkeydown(key(" "));
+out({
+  role: card.role,
+  tabIndex: card.tabIndex,
+  ignored,
+  selected,
+  cleared: {
+    selected: card.classList.contains("selected"),
+    detailsHidden: details.hidden,
+    prevented,
+  },
+});
+""",
+        prelude="const DATA = " + json.dumps(payload(units=[
+            unit("U1", "working", overlap="detail"),
+        ])) + ";\n",
+    )
+    assert result == {
+        "role": "button",
+        "tabIndex": 0,
+        "ignored": {
+            "selected": False,
+            "detailsHidden": True,
+            "prevented": 0,
+        },
+        "selected": {
+            "selected": True,
+            "detailsHidden": False,
+            "prevented": 1,
+        },
+        "cleared": {
+            "selected": False,
+            "detailsHidden": True,
+            "prevented": 2,
+        },
+    }
+
+
+def test_identical_refresh_reuses_dom_and_preserves_selection_and_scroll():
     result = run_js(
         """
 apiQueue = [DATA, JSON.parse(JSON.stringify(DATA))];
@@ -526,11 +664,14 @@ const flow = byClass(root, "sprint-flow")[0];
 const card = byClass(root, "sprint-unit")
   .find((node) => node.dataset.seq === "U1");
 flow.scrollLeft = 240;
-card.onmouseenter();
+card.onclick({ stopPropagation: () => {} });
+card.onmouseleave();
 await sprintsRefresh();
 out({
   flowReused: byClass(root, "sprint-flow")[0] === flow,
   scrollLeft: flow.scrollLeft,
+  selectedCards: byClass(root, "sprint-unit")
+    .filter((node) => node.classList.contains("selected")).length,
   litCards: byClass(root, "sprint-unit")
     .filter((node) => node.classList.contains("lit")).length,
   resizeListeners: windowListenerCount("resize"),
@@ -544,15 +685,18 @@ out({
     assert result == {
         "flowReused": True,
         "scrollLeft": 240,
+        "selectedCards": 1,
         "litCards": 2,
         "resizeListeners": 1,
     }
 
 
-def test_changed_refresh_replaces_dom_and_cleans_previous_resize_listener():
-    initial = payload(units=[unit("U1", "working")])
+def test_changed_refresh_replaces_dom_preserves_selection_and_cleans_listener():
+    initial = payload(units=[
+        unit("U1", "working", overlap="initial overlap"),
+    ])
     updated = payload(units=[
-        unit("U1", "working"),
+        unit("U1", "working", overlap="updated overlap"),
         unit("U2", "in_review", depends_on="U1"),
     ])
     result = run_js(
@@ -562,12 +706,20 @@ await sprintsRefresh({ render: false });
 const root = makeRoot();
 await renderSprints(root);
 const firstFlow = byClass(root, "sprint-flow")[0];
+const firstCard = byClass(firstFlow, "sprint-unit")[0];
+firstCard.onclick({ stopPropagation: () => {} });
 const before = windowListenerCount("resize");
 await sprintsRefresh();
+const nextFlow = byClass(root, "sprint-flow")[0];
+const selected = byClass(nextFlow, "sprint-unit")
+  .filter((node) => node.classList.contains("selected"));
 out({
-  flowReused: byClass(root, "sprint-flow")[0] === firstFlow,
+  flowReused: nextFlow === firstFlow,
   before,
   after: windowListenerCount("resize"),
+  selected: selected.map((node) => node.dataset.seq),
+  detailsHidden: byClass(selected[0], "sprint-unit-details")[0].hidden,
+  detailsText: byClass(selected[0], "sprint-unit-details")[0].textContent,
 });
 """,
         prelude=(
@@ -575,7 +727,14 @@ out({
             "const UPDATED = " + json.dumps(updated) + ";\n"
         ),
     )
-    assert result == {"flowReused": False, "before": 1, "after": 1}
+    assert result == {
+        "flowReused": False,
+        "before": 1,
+        "after": 1,
+        "selected": ["U1"],
+        "detailsHidden": False,
+        "detailsText": "updated overlap",
+    }
 
 
 def test_flow_styles_clamp_text_and_contain_narrow_viewport_scrolling():
@@ -586,7 +745,8 @@ def test_flow_styles_clamp_text_and_contain_narrow_viewport_scrolling():
     assert "overflow-x: auto" in sprint_css
     assert "text-overflow: ellipsis" in sprint_css
     assert "white-space: nowrap" in sprint_css
-    assert "cursor: pointer" not in sprint_css
+    assert "cursor: pointer" in sprint_css
+    assert ".sprint-unit:focus-visible" in sprint_css
 
 
 def test_zero_state_and_initial_failure_are_distinct():


### PR DESCRIPTION
## Summary
- collapse overlap, branch, and PR details on sprint cards by default
- click a card to expand its details and pin its direct dependency spotlight
- click the selected card or blank board space to clear; keep hover as an unpinned preview
- preserve selection across the board's 15-second refresh and support Enter/Space keyboard toggling

## Verification
- `./sc lint tests/test_sprints_ui_contract.py`
- `node --check .super-coder/ui/app.js`
- `pytest -q tests/test_sprints_ui_contract.py tests/test_interface_ui_contract.py` — 67 passed
- `./sc test` — 1936 passed, 3 baseline failures in `tests/test_harness_epoch.py`
- reproduced the same 3 failures on pristine `origin/main`; tracked in #645

## Trade-off
The API projection remains unchanged so board/CLI consumers retain every field. Compactness is purely presentational, and the selected card is the only card whose secondary detail rows are laid out.
