### PR TITLE
fix: stamp fourth sprint participant duty

### DIFF
--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -117,7 +117,8 @@ PARTICIPANT_RULES = (
     "2. Send rulings and transitions to the planner as a scoped row: "
     "`./sc mem message send <planner> \"…\" --kind result --sprint <doc-id>`.\n"
     "3. When work remains, send a partial naming completed work, evidence, and "
-    "the next uncompleted action before ending the turn."
+    "the next uncompleted action before ending the turn.\n"
+    "4. Nothing found is a result. Send it."
 )
 
 

--- a/tests/test_boot_sprint_directive.py
+++ b/tests/test_boot_sprint_directive.py
@@ -231,7 +231,7 @@ class SprintDirectiveTest(unittest.TestCase):
         self.assertIn("SPRINT: the other one", out)
         self.assertIn("Act on every role listed above", out)
 
-    def test_the_three_participant_rules_are_in_the_section_itself(self):
+    def test_the_four_participant_rules_are_in_the_section_itself(self):
         # They render as prose because the failure mode IS a skill body that
         # never loads — a pointer to the skill would reproduce the bug.
         add_doc(self.con, 59)
@@ -240,6 +240,7 @@ class SprintDirectiveTest(unittest.TestCase):
         self.assertIn("File findings, flags, verdicts", out)
         self.assertIn("--kind result --sprint <doc-id>", out)
         self.assertIn("send a partial", out)
+        self.assertIn("Nothing found is a result. Send it.", out)
 
     # ── the absences, each with its positive control ────────────────────────
 


### PR DESCRIPTION
## Summary

- render duty 4 in the boot-stamped sprint participant rules
- pin the exact duty-4 sentence in the focused boot-directive test

## Verification

- `python3 tests/test_boot_sprint_directive.py` — 21 tests green on the rebased head
- mutation: removing only duty 4 produced exactly one red test: `SprintDirectiveTest.test_the_four_participant_rules_are_in_the_section_itself`; restored green

## Surface

Exactly `.super-coder/render/compose.py` and `tests/test_boot_sprint_directive.py`; no migrations or skill assets.