### PR TITLE
test(sprint): pin feature-link declaration semantics

### DIFF
--- a/.super-coder/migrations/0107_reseed_sprint_feature_linkage_followup.sql
+++ b/.super-coder/migrations/0107_reseed_sprint_feature_linkage_followup.sql
@@ -1,11 +1,16 @@
----
-name: sprint_orchestration
-description: Run the steady-state planner loop for a multi-shell sprint. Declare the sprint and structured unit board, assign developers and reviewers, arm event-driven wake, dispatch scoped tasks, advance units from durable events, and route merge order. Load sprint_orchestration_recover only when an expected transition stalls or an alert opens. Load sprint_orchestration_close only when every unit is terminal and main is green.
-category: craft
-common: false
----
+-- 0107 — reseed sprint_orchestration review-Low feature-linkage follow-up.
+-- Generated from assets/skills/sprint_orchestration/SKILL.md; the full-body
+-- UPSERT keeps existing installations aligned with the source asset.
 
-# sprint_orchestration
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_orchestration',
+  'Run the steady-state planner loop for a multi-shell sprint. Declare the sprint and structured unit board, assign developers and reviewers, arm event-driven wake, dispatch scoped tasks, advance units from durable events, and route merge order. Load sprint_orchestration_recover only when an expected transition stalls or an alert opens. Load sprint_orchestration_close only when every unit is terminal and main is green.',
+  'craft',
+  NULL,
+  0,
+  '# sprint_orchestration
 
 Coordinate the sprint from durable records. Keep code context in worker shells
 and coordination context here.
@@ -62,7 +67,7 @@ routes, and no silently shared hard resource.
 Define units that one developer can own through merge. Add dependency edges
 only for real code dependencies.
 
-Predict each unit's file surface and compare intersections:
+Predict each unit''s file surface and compare intersections:
 
 - empty intersection: parallel;
 - shared files: sequence the units or record an explicit overlap protocol;
@@ -72,7 +77,7 @@ Assign one developer and one reviewer to every unit. Balance reviewer load
 against the dependency graph.
 
 Reserve the close-time conformance reviewer now, while reviewer independence is
-still available. Record that shell's conflict set: units authored, unit reviews
+still available. Record that shell''s conflict set: units authored, unit reviews
 performed, rulings supplied, and any other reason it would grade its own work.
 Pass only with a named reviewer whose recorded set is disjoint from conformance
 scope, or an explicit FnB disposition for every unavoidable conflict.
@@ -222,7 +227,7 @@ Boot only the actor that owns the next transition:
 
 Run `./sc run` from a durable interactive planner process. It executes the
 harness over its own process, so a timeout, bounded background task, or exiting
-wrapper becomes the worker's lifetime. If a wrapper already owns a live harness,
+wrapper becomes the worker''s lifetime. If a wrapper already owns a live harness,
 load `sprint_orchestration_recover` and unwrap it there.
 
 Dispatch passes when the harness PID is non-zombie at the assigned worktree and
@@ -255,7 +260,7 @@ message is only the push layer and is emitted only when `board_writer` resolves
 a recipient. Open alerts dedupe, resolve when evidence returns, and re-arm after
 resolution.
 
-Read `sc watch list` for the reconciler's own heartbeat. A stale `reconcile`
+Read `sc watch list` for the reconciler''s own heartbeat. A stale `reconcile`
 line means the watchdog may be wedged; no alerts from a stale watchdog do not
 prove a quiet sprint.
 
@@ -287,13 +292,13 @@ Register each PR with the planner at PR open:
 Monitor before interrupting a worker. Send a new task when behavior must change,
 not to request generic progress.
 
-Never use a draft PR as a planner hold. A state the worker's own procedure
+Never use a draft PR as a planner hold. A state the worker''s own procedure
 teaches it to clear cannot carry a stop; record the hold in board state plus a
 scoped task. No reliable interrupt exists today, and flag #321 owns that gap.
 A stop signal indistinguishable from an obstacle is an instruction to proceed;
 this rule does not close flag #321.
 
-When a review ruling changes a unit's file surface, update the overlap record
+When a review ruling changes a unit''s file surface, update the overlap record
 and re-send the surface notice to every affected concurrent planner before the
 next durable action. The ruling that widens the surface triggers the notice.
 
@@ -323,4 +328,12 @@ This procedure is complete when either:
 - the next expected unit transition is dispatched and the binding is healthy;
 - a diagnosed stall triggers `sprint_orchestration_recover`; or
 - every unit is terminal with green `main`, triggering
-  `sprint_orchestration_close`.
+  `sprint_orchestration_close`.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -15,6 +15,7 @@ Run:
 from __future__ import annotations
 
 import json
+import shlex
 import sqlite3
 import sys
 import tempfile
@@ -129,17 +130,68 @@ class SchemaTest(unittest.TestCase):
         body = self.con.execute(
             "SELECT content FROM skills WHERE name='sprint_orchestration'").fetchone()[0]
         self.assertEqual(body, asset)
-        declaration = body.split("## 3. Declare the sprint", 1)[1].split(
-            "## 4. Arm event-driven wake", 1)[0]
-        self.assertEqual([
-            line.strip() for line in declaration.splitlines()
-            if "./sc mem doc add" in line
-        ], [
-            './sc mem doc add "SPRINT: <title>" --kind doc '
-            '--feature <feature-id> \\'
-        ])
+
+    def _sprint_orchestration_declaration(self) -> str:
+        body = self.con.execute(
+            "SELECT content FROM skills WHERE name='sprint_orchestration'").fetchone()[0]
+        start = "## 3. Declare the sprint"
+        end = "## 4. Arm event-driven wake"
+        self.assertEqual(body.count(start), 1)
+        self.assertEqual(body.count(end), 1)
+        return body.split(start, 1)[1].split(end, 1)[0]
+
+    def test_sprint_declaration_normatively_requires_feature_link(self):
+        declaration = " ".join(self._sprint_orchestration_declaration().split())
         self.assertIn(
-            "./sc mem get documents --doc <doc-id>",
+            "linked to its governing roadmap feature with "
+            "`--feature <feature-id>`",
+            declaration,
+        )
+
+    def test_sprint_declaration_doc_add_carries_feature_link(self):
+        declaration = self._sprint_orchestration_declaration()
+        lines = declaration.splitlines()
+        invocations = []
+        for index, line in enumerate(lines):
+            if not line.strip().startswith("./sc mem doc add"):
+                continue
+            invocation = line.strip()
+            while invocation.endswith("\\"):
+                index += 1
+                invocation = f"{invocation[:-1]} {lines[index].strip()}"
+            invocations.append(shlex.split(invocation))
+
+        self.assertEqual(len(invocations), 1)
+        tokens = invocations[0]
+        self.assertEqual(
+            tokens[:5],
+            ["./sc", "mem", "doc", "add", "SPRINT: <title>"],
+        )
+        for option, value in (
+            ("--kind", "doc"),
+            ("--feature", "<feature-id>"),
+            ("--body-file", "<draft.md>"),
+        ):
+            with self.subTest(option=option):
+                self.assertEqual(tokens.count(option), 1)
+                self.assertEqual(tokens[tokens.index(option) + 1], value)
+
+    def test_sprint_declaration_readback_resolves_feature_link(self):
+        declaration = self._sprint_orchestration_declaration()
+        invocations = [
+            shlex.split(line.strip())
+            for line in declaration.splitlines()
+            if line.strip().startswith("./sc mem get documents")
+        ]
+        self.assertEqual(invocations, [[
+            "./sc", "mem", "get", "documents", "--feature", "<feature-id>",
+        ]])
+
+    def test_sprint_declaration_pass_condition_requires_resolved_link(self):
+        declaration = " ".join(self._sprint_orchestration_declaration().split())
+        self.assertIn(
+            "**Pass condition:** the `<feature-id>` document read-back names "
+            "the sprint document, and",
             declaration,
         )
 


### PR DESCRIPTION
## S77-U2f

Closes the three review-Low follow-ups from U2:

- Pins the normative feature-link clause and resolved-link pass condition.
- Replaces raw wrapped-line equality with meaning-bearing command-token assertions.
- Reads sprint documents back through `--feature <feature-id>` so the intended roadmap relationship resolves.
- Reseeds `sprint_orchestration` through allocator-confirmed migration 0107.

Verification:

- `tests/test_sprint_eventing.py`: 78/78
- `tests/test_skills_freshness.py`: 8/8
- `python3 .super-coder/scripts/render_check.py`: green
- One-line reflow of the `doc add` invocation: all five declaration tests stay green
- Four operand-only mutations: normative prose, `doc add --feature`, feature-filtered read-back, and pass condition each red exactly its own detector while the seed-consistency control stays green

Trade-off: the command test parses shell tokens instead of comparing rendered lines. This adds a small helper loop but keeps the contract on invocation meaning and permits harmless markdown reflow.
