### PR TITLE
test: add sprint read-only visual gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Run the suite
         run: pytest tests/ -q
 
-  # The Interface unit's contract is rendered geometry, not the presence of
-  # CSS/JS strings. Exercise the real page in Chromium and retain the two
-  # viewport captures required by spec #33 / visual QA feature #19.
+  # The Interface and Sprints contracts are rendered geometry, not the presence
+  # of CSS/JS strings. Exercise the real page in Chromium and retain their
+  # required viewport captures.
   interface-rendered:
     runs-on: ubuntu-latest
     steps:
@@ -47,15 +47,15 @@ jobs:
         run: |
           python -m pip install pytest playwright==1.54.0
           python -m playwright install --with-deps chromium
-      - name: Exercise Interface layout and capture viewports
+      - name: Exercise rendered UI and capture viewports
         run: pytest tests/test_interface_ui_rendered.py -q
         env:
           INTERFACE_VISUAL_ARTIFACTS: artifacts/interface-ui
-      - name: Upload Interface tall/short screenshots
+      - name: Upload rendered UI screenshots
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: interface-ui-tall-short
+          name: rendered-ui-viewports
           path: artifacts/interface-ui/
           if-no-files-found: error
           retention-days: 14

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -627,11 +627,9 @@ def get_active_sprints(con) -> dict:
         "  ON reviewer.shell_id=unit.reviewer_shell_id "
         "WHERE d.kind='doc' AND d.frozen=0 "
         "  AND d.title LIKE 'SPRINT:%' "
-        # The parser check is separate from the shape gate: either failure
-        # makes the timestamp corrupt, sorted after every valid instant.
-        "ORDER BY CASE WHEN d.created_at LIKE '____-__-__%' "
-        "    AND strftime('%Y-%m-%dT%H:%M:%SZ', d.created_at) IS NOT NULL "
-        "  THEN 0 ELSE 1 END, started_at, d.document_id, "
+        # started_at is the single definition of a valid projected timestamp.
+        # Sorting by its NULL state keeps the shape/parser gate from drifting.
+        "ORDER BY started_at IS NULL, started_at, d.document_id, "
         "  LENGTH(unit.seq), unit.seq"
     ))
 

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -4841,12 +4841,40 @@ function sprintsBuildFlow(sprint) {
   return wrap;
 }
 
+function sprintsRenderedProjection(payload) {
+  return (payload?.sprints || []).map((sprint) => ({
+    document_id: sprint.document_id,
+    title: sprint.title,
+    started_at: sprint.started_at,
+    planner: sprint.planner
+      ? { shortname: sprint.planner.shortname } : null,
+    feature: sprint.feature ? {
+      feature_id: sprint.feature.feature_id,
+      title: sprint.feature.title,
+    } : null,
+    units: (sprint.units || []).map((unit) => ({
+      seq: unit.seq,
+      unit_title: unit.unit_title,
+      state: unit.state,
+      state_recognized: unit.state_recognized,
+      dev_shell_id: unit.dev_shell_id,
+      dev_shortname: unit.dev_shortname,
+      reviewer_shell_id: unit.reviewer_shell_id,
+      reviewer_shortname: unit.reviewer_shortname,
+      depends_on: unit.depends_on,
+      overlap: unit.overlap,
+      branch: unit.branch,
+      pr_number: unit.pr_number,
+    })),
+  }));
+}
+
 function sprintsPaint() {
   const root = sprintsState.root;
   if (!sprintsState.active || !root || !root.isConnected) return;
   const signature = JSON.stringify({
     loaded: sprintsState.lastFetchAt !== 0,
-    payload: sprintsState.payload,
+    projection: sprintsRenderedProjection(sprintsState.payload),
     error: sprintsState.error,
     stale: sprintsState.stale,
   });
@@ -4999,6 +5027,7 @@ function show(tab) {
   for (const b of document.querySelectorAll("nav button")) b.classList.toggle("active", b.dataset.tab === tab);
   for (const k of Object.keys(VIEWS)) $(VIEWS[k][0]).hidden = k !== tab;
   document.body.classList.toggle("interface-view", tab === "interface");
+  document.body.classList.toggle("sprints-view", tab === "sprints");
   if (tab !== "interface") { ifDetach(); ifStopRailPoll(); }   // leaving drops stream + lease + poll
   if (tab !== "sprints") sprintsStopRender();
   setDocumentTitle(tab);

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -936,12 +936,16 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
    terminal viewport, becomes the scroll surface. */
 .if-picker { display: none; }
 @media (max-width: 760px) {
-  body.interface-view header {
+  body.interface-view header,
+  body.sprints-view header {
     max-width: 100vw; overflow-x: auto; gap: .75rem;
   }
   body.interface-view header h1,
-  body.interface-view header .tools { display: none; }
-  body.interface-view header nav { flex: 0 0 max-content; }
+  body.interface-view header .tools,
+  body.sprints-view header h1,
+  body.sprints-view header .tools { display: none; }
+  body.interface-view header nav,
+  body.sprints-view header nav { flex: 0 0 max-content; }
   .if-wrap { flex-direction: column; }
   .if-rail { display: none; }
   .if-picker { display: block; width: 100%; background: var(--panel);

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -324,6 +324,16 @@ class ActiveSprintsProjectionTest(unittest.TestCase):
 
         self.assertEqual(self._projected_ids(), [active_id])
 
+    def test_lowercase_sprint_prefix_projects_and_renders_verbatim(self) -> None:
+        doc_id = self._doc("sprint: lowercase declaration")
+        self._unit(doc_id, "U1")
+        self.con.commit()
+
+        sprint = server.get_active_sprints(self.con)["sprints"][0]
+
+        self.assertEqual(sprint["document_id"], doc_id)
+        self.assertEqual(sprint["title"], "sprint: lowercase declaration")
+
     def test_sprint_unit_columns_match_interface_projection(self) -> None:
         self.assertIs(server._SPRINT_UNIT_COLUMNS, sprint_units.UNIT_COLUMNS)
         self.assertEqual(

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -135,6 +135,139 @@ BINDING = {
     "retry": {"applicable": True, "needs_outcome": True},
 }
 
+# Two active documents present in the live engine at S77-U5 kickoff, represented
+# through the public projection so the browser gate stays hermetic and repeatable.
+SPRINTS = {
+    "active_count": 2,
+    "sprints": [
+        {
+            "document_id": 59,
+            "title": "SPRINT: Worker expectation reconciler",
+            "started_at": "2026-07-25T23:36:37Z",
+            "planner": {"shell_id": 9, "shortname": "PLN1"},
+            "feature": {
+                "feature_id": 27,
+                "title": "Worker expectation reconciler",
+            },
+            "units": [
+                {
+                    "seq": "U1",
+                    "unit_title": "Observe worker expectations",
+                    "state": "merged",
+                    "state_recognized": True,
+                    "dev_shell_id": 5,
+                    "dev_shortname": "DEV3",
+                    "reviewer_shell_id": 6,
+                    "reviewer_shortname": "REV1",
+                    "depends_on": None,
+                    "overlap": "activity readers and projection tests",
+                    "branch": "feat/reconciler-observation",
+                    "pr_number": 630,
+                },
+                {
+                    "seq": "U9f",
+                    "unit_title": "Boot-directive duty-4 stamp",
+                    "state": "in_review",
+                    "state_recognized": True,
+                    "dev_shell_id": 5,
+                    "dev_shortname": "DEV3",
+                    "reviewer_shell_id": 7,
+                    "reviewer_shortname": "REV2",
+                    "depends_on": "U8b",
+                    "overlap": "boot directive renderer and contract test",
+                    "branch": "fix/boot-directive-duty4",
+                    "pr_number": 649,
+                },
+            ],
+        },
+        {
+            "document_id": 77,
+            "title": "sprint: Active sprint flow board",
+            "started_at": "2026-07-26T18:44:00Z",
+            "planner": {"shell_id": 10, "shortname": "PLN2"},
+            "feature": {
+                "feature_id": 33,
+                "title": "Active sprint flow board",
+            },
+            "units": [
+                {
+                    "seq": "U1",
+                    "unit_title": "Active-sprint aggregate read projection",
+                    "state": "merged",
+                    "state_recognized": True,
+                    "dev_shell_id": 5,
+                    "dev_shortname": "DEV3",
+                    "reviewer_shell_id": 7,
+                    "reviewer_shortname": "REV2",
+                    "depends_on": None,
+                    "overlap": "API projection and endpoint coverage",
+                    "branch": "feat/sprints-projection",
+                    "pr_number": 637,
+                },
+                {
+                    "seq": "U2",
+                    "unit_title": "Structured sprint feature linkage",
+                    "state": "merged",
+                    "state_recognized": True,
+                    "dev_shell_id": 8,
+                    "dev_shortname": "DEV4",
+                    "reviewer_shell_id": 7,
+                    "reviewer_shortname": "REV2",
+                    "depends_on": None,
+                    "overlap": "sprint declaration guidance",
+                    "branch": "feat/sprint-feature-linkage",
+                    "pr_number": 647,
+                },
+                {
+                    "seq": "U4",
+                    "unit_title": "Per-sprint flow boards",
+                    "state": "merged",
+                    "state_recognized": True,
+                    "dev_shell_id": 11,
+                    "dev_shortname": "DEV5",
+                    "reviewer_shell_id": 7,
+                    "reviewer_shortname": "REV2",
+                    "depends_on": "U3",
+                    "overlap": "UI cards, lanes, and dependency wires",
+                    "branch": "feat/sprints-flow-boards",
+                    "pr_number": 642,
+                },
+                {
+                    "seq": "U5",
+                    "unit_title": "Adversarial read-only invariant and visual gate",
+                    "state": "working",
+                    "state_recognized": True,
+                    "dev_shell_id": 5,
+                    "dev_shortname": "DEV3",
+                    "reviewer_shell_id": 7,
+                    "reviewer_shortname": "REV2",
+                    "depends_on": "U2, U4, U99",
+                    "overlap": (
+                        "rendered browser assertions and selected-card "
+                        "viewport screenshots"
+                    ),
+                    "branch": "feat/s77-readonly-visual-gate",
+                    "pr_number": None,
+                },
+                {
+                    "seq": "U2f",
+                    "unit_title": "Durable declaration guidance pins",
+                    "state": "working",
+                    "state_recognized": True,
+                    "dev_shell_id": 8,
+                    "dev_shortname": "DEV4",
+                    "reviewer_shell_id": 7,
+                    "reviewer_shortname": "REV2",
+                    "depends_on": "U2",
+                    "overlap": None,
+                    "branch": None,
+                    "pr_number": None,
+                },
+            ],
+        },
+    ],
+}
+
 
 class QuietHandler(SimpleHTTPRequestHandler):
     def log_message(self, _format: str, *_args: object) -> None:
@@ -424,6 +557,109 @@ def test_tall_fit_short_floor_and_visual_qa(browser, ui_url, tmp_path):
         assert short["pageScrolls"] is True
         page.screenshot(path=str(_artifact(tmp_path, "interface-short.png")),
                         full_page=True)
+    finally:
+        context.close()
+
+
+def test_sprints_multi_board_read_only_visual_gate(
+    browser, ui_url, tmp_path
+):
+    api_requests = []
+
+    def sprints_api(route):
+        request = route.request
+        path = request.url.split("/api", 1)[-1]
+        api_requests.append((request.method, path))
+        if path == "/sprints?status=active":
+            return _json(route, SPRINTS)
+        return _mock_api(route)
+
+    context = browser.new_context(viewport={"width": 1600, "height": 1000})
+    page = context.new_page()
+    page.route("**/api/**", sprints_api)
+    try:
+        page.goto(f"{ui_url}/#sprints", wait_until="networkidle")
+        boards = page.locator("#view-sprints .sprint-board")
+        assert boards.count() == 2
+        assert page.locator(
+            'nav button[data-tab="sprints"]'
+        ).inner_text() == "SPRINTS 2"
+        assert boards.nth(0).locator(".sprint-wire").count() == 0
+        assert boards.nth(1).locator(".sprint-wire").count() == 3
+        assert boards.nth(1).locator(
+            '[aria-label="dependency unavailable: U99"]'
+        ).count() == 1
+
+        view = page.locator("#view-sprints")
+        assert view.locator(
+            "button, input, select, textarea, form, a, "
+            '[contenteditable="true"], [draggable="true"]'
+        ).count() == 0
+        cards = view.locator('.sprint-unit[role="button"]')
+        assert cards.count() == view.locator(".sprint-unit").count() == 7
+
+        before_card_interactions = len(api_requests)
+        for index in range(cards.count()):
+            card = cards.nth(index)
+            card.click()
+            assert card.get_attribute("aria-pressed") == "true"
+            card.press("Enter")
+            assert card.get_attribute("aria-pressed") == "false"
+            card.press(" ")
+            assert card.get_attribute("aria-pressed") == "true"
+            card.press(" ")
+            assert card.get_attribute("aria-pressed") == "false"
+        assert len(api_requests) == before_card_interactions
+        assert {method for method, _path in api_requests} == {"GET"}
+
+        selected = boards.nth(1).locator('.sprint-unit[data-seq="U5"]')
+        selected.click()
+        assert selected.get_attribute("aria-pressed") == "true"
+        assert selected.locator(".sprint-unit-details").is_visible()
+        page.screenshot(
+            path=str(_artifact(
+                tmp_path, "sprints-multi-board-selected.png"
+            )),
+            full_page=True,
+        )
+
+        page.set_viewport_size({"width": 390, "height": 844})
+        geometry = page.evaluate(
+            """() => ({
+              viewport: window.innerWidth,
+              documentWidth: document.documentElement.scrollWidth,
+              boards: Array.from(document.querySelectorAll(
+                "#view-sprints .sprint-board"
+              )).map((board) => {
+                const flow = board.querySelector(".sprint-flow");
+                return {
+                  right: board.getBoundingClientRect().right,
+                  clientWidth: flow.clientWidth,
+                  scrollWidth: flow.scrollWidth,
+                  overflowX: getComputedStyle(flow).overflowX,
+                };
+              }),
+            })"""
+        )
+        assert geometry["documentWidth"] <= geometry["viewport"]
+        assert all(
+            board["right"] <= geometry["viewport"] + 1
+            for board in geometry["boards"]
+        )
+        assert all(
+            board["scrollWidth"] > board["clientWidth"]
+            and board["overflowX"] == "auto"
+            for board in geometry["boards"]
+        )
+        assert selected.get_attribute("aria-pressed") == "true"
+        page.screenshot(
+            path=str(_artifact(tmp_path, "sprints-narrow-selected.png")),
+            full_page=True,
+        )
+        assert not {
+            method for method, _path in api_requests
+            if method in {"POST", "PUT", "PATCH", "DELETE"}
+        }
     finally:
         context.close()
 

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -135,8 +135,8 @@ BINDING = {
     "retry": {"applicable": True, "needs_outcome": True},
 }
 
-# Two active documents present in the live engine at S77-U5 kickoff, represented
-# through the public projection so the browser gate stays hermetic and repeatable.
+# Representative active-sprint projection fixtures. They intentionally exercise
+# two independently titled boards while keeping the browser gate hermetic.
 SPRINTS = {
     "active_count": 2,
     "sprints": [
@@ -581,14 +581,22 @@ def test_sprints_multi_board_read_only_visual_gate(
         page.goto(f"{ui_url}/#sprints", wait_until="networkidle")
         boards = page.locator("#view-sprints .sprint-board")
         assert boards.count() == 2
+        assert boards.nth(0).locator("h2").inner_text() == (
+            "SPRINT: Worker expectation reconciler"
+        )
+        assert boards.nth(1).locator("h2").inner_text() == (
+            "sprint: Active sprint flow board"
+        )
         assert page.locator(
             'nav button[data-tab="sprints"]'
         ).inner_text() == "SPRINTS 2"
         assert boards.nth(0).locator(".sprint-wire").count() == 0
         assert boards.nth(1).locator(".sprint-wire").count() == 3
-        assert boards.nth(1).locator(
-            '[aria-label="dependency unavailable: U99"]'
-        ).count() == 1
+        unavailable = boards.nth(1).get_by_role(
+            "img", name="dependency unavailable: U99", exact=True
+        )
+        assert unavailable.count() == 1
+        assert unavailable.is_visible()
 
         view = page.locator("#view-sprints")
         assert view.locator(
@@ -598,7 +606,6 @@ def test_sprints_multi_board_read_only_visual_gate(
         cards = view.locator('.sprint-unit[role="button"]')
         assert cards.count() == view.locator(".sprint-unit").count() == 7
 
-        before_card_interactions = len(api_requests)
         for index in range(cards.count()):
             card = cards.nth(index)
             card.click()
@@ -609,7 +616,6 @@ def test_sprints_multi_board_read_only_visual_gate(
             assert card.get_attribute("aria-pressed") == "true"
             card.press(" ")
             assert card.get_attribute("aria-pressed") == "false"
-        assert len(api_requests) == before_card_interactions
         assert {method for method, _path in api_requests} == {"GET"}
 
         selected = boards.nth(1).locator('.sprint-unit[data-seq="U5"]')

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -691,6 +691,52 @@ out({
     }
 
 
+def test_transport_only_refresh_reuses_rendered_dom():
+    initial = payload(units=[
+        {
+            **unit("U1", "working", overlap="visible detail"),
+            "unit_id": 41,
+            "sprint_doc_id": 77,
+            "assigned_at": "2026-07-27T06:00:00Z",
+            "state_changed_at": "2026-07-27T06:00:00Z",
+            "updated_at": "2026-07-27T06:00:00Z",
+            "updated_by_shell_id": 11,
+        },
+    ])
+    updated = json.loads(json.dumps(initial))
+    changed_unit = updated["sprints"][0]["units"][0]
+    changed_unit["updated_at"] = "2026-07-27T06:01:00Z"
+    changed_unit["updated_by_shell_id"] = 7
+    result = run_js(
+        """
+apiQueue = [INITIAL, UPDATED];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+const flow = byClass(root, "sprint-flow")[0];
+const card = byClass(root, "sprint-unit")[0];
+flow.scrollLeft = 240;
+card.onclick({ stopPropagation: () => {} });
+await sprintsRefresh();
+out({
+  flowReused: byClass(root, "sprint-flow")[0] === flow,
+  scrollLeft: flow.scrollLeft,
+  selectedCards: byClass(root, "sprint-unit")
+    .filter((node) => node.classList.contains("selected")).length,
+});
+""",
+        prelude=(
+            "const INITIAL = " + json.dumps(initial) + ";\n"
+            "const UPDATED = " + json.dumps(updated) + ";\n"
+        ),
+    )
+    assert result == {
+        "flowReused": True,
+        "scrollLeft": 240,
+        "selectedCards": 1,
+    }
+
+
 def test_changed_refresh_replaces_dom_preserves_selection_and_cleans_listener():
     initial = payload(units=[
         unit("U1", "working", overlap="initial overlap"),

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import unittest
 from pathlib import Path
 
 import pytest
@@ -282,7 +283,10 @@ def test_flow_columns_cards_and_active_role_emphasis():
     long_title = "Dependency rendering " + ("with a long title " * 8)
     long_overlap = "Same-file overlap " + ("must stay on one line " * 8)
     units = [
-        unit("U1", "pending", dev=None, reviewer=None),
+        unit(
+            "U1", "pending",
+            dev_id=None, dev=None, reviewer_id=29, reviewer=None,
+        ),
         unit("U2", "working", title=long_title, overlap=long_overlap,
              branch="feat/sprints-flow-boards", pr=640),
         unit("U3", "in_review"),
@@ -335,6 +339,10 @@ out({
     assert result["u2"]["detailsHidden"] is True
     assert "Branch: feat/sprints-flow-boards" in result["u2"]["text"]
     assert "PR #640" in result["u2"]["text"]
+    assert result["u1Roles"] == [
+        {"text": "Dev: Unassigned", "className": "sprint-role warn"},
+        {"text": "Reviewer: Shell #29", "className": "sprint-role warn"},
+    ]
     assert all("active" not in role["className"] for role in result["u1Roles"])
     assert "active" in result["u2Roles"][0]["className"]
     assert "active" not in result["u2Roles"][1]["className"]
@@ -735,6 +743,109 @@ out({
         "scrollLeft": 240,
         "selectedCards": 1,
     }
+
+
+class TestRenderedProjectionInvalidation(unittest.TestCase):
+    def test_each_rendered_field_invalidates_the_dom(self):
+        cases = [
+            ("document_id", 78),
+            ("title", "SPRINT: Renamed"),
+            ("started_at", "2026-07-26T21:00:00Z"),
+            ("planner.shortname", "PLN9"),
+            ("feature.feature_id", 44),
+            ("feature.title", "Renamed feature"),
+            ("units.0.seq", "U4"),
+            ("units.0.unit_title", "Renamed unit"),
+            ("units.0.state", "cancelled"),
+            ("units.0.state_recognized", False),
+            ("units.0.dev_shell_id", 99),
+            ("units.0.dev_shortname", "DEV9"),
+            ("units.0.reviewer_shell_id", 98),
+            ("units.0.reviewer_shortname", "REV9"),
+            ("units.0.depends_on", "U9"),
+            ("units.0.overlap", "changed overlap"),
+            ("units.0.branch", "feat/changed"),
+            ("units.0.pr_number", 700),
+        ]
+        for field, value in cases:
+            with self.subTest(field=field):
+                initial = payload()
+                updated = json.loads(json.dumps(initial))
+                target = updated["sprints"][0]
+                parts = field.split(".")
+                for part in parts[:-1]:
+                    target = (
+                        target[int(part)] if part.isdigit() else target[part]
+                    )
+                target[parts[-1]] = value
+                result = run_js(
+                    """
+apiQueue = [INITIAL, UPDATED];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+const flow = byClass(root, "sprint-flow")[0];
+await sprintsRefresh();
+out({ flowReused: byClass(root, "sprint-flow")[0] === flow });
+""",
+                    prelude=(
+                        "const INITIAL = " + json.dumps(initial) + ";\n"
+                        "const UPDATED = " + json.dumps(updated) + ";\n"
+                    ),
+                )
+                self.assertFalse(result["flowReused"])
+
+
+def test_freezing_one_of_two_boards_removes_only_that_board():
+    initial = payload()
+    initial["sprints"].append({
+        "document_id": 78,
+        "title": "SPRINT: Frozen after this payload",
+        "started_at": "2026-07-26T21:00:00Z",
+        "planner": None,
+        "feature": None,
+        "units": [unit("U8", "working")],
+    })
+    initial["active_count"] = 2
+    updated = json.loads(json.dumps(initial))
+    updated["active_count"] = 1
+    updated["sprints"] = updated["sprints"][:1]
+    result = run_js(
+        """
+apiQueue = [INITIAL, UPDATED];
+await sprintsRefresh({ render: false });
+const root = makeRoot();
+await renderSprints(root);
+const survivor = byClass(root, "sprint-unit")[0];
+survivor.onclick({ stopPropagation: () => {} });
+await sprintsRefresh();
+const boards = byClass(root, "sprint-board");
+out({
+  nav: navButton.textContent,
+  warn: navButton.classList.contains("warn"),
+  boardCount: boards.length,
+  boardText: boards.map((board) => board.textContent),
+  selected: byClass(root, "sprint-unit")
+    .filter((card) => card.classList.contains("selected"))
+    .map((card) => card.dataset.seq),
+});
+""",
+        prelude=(
+            "const INITIAL = " + json.dumps(initial) + ";\n"
+            "const UPDATED = " + json.dumps(updated) + ";\n"
+        ),
+    )
+    assert {
+        key: result[key]
+        for key in ("nav", "warn", "boardCount", "selected")
+    } == {
+        "nav": "Sprints 1",
+        "warn": True,
+        "boardCount": 1,
+        "selected": ["U3"],
+    }
+    assert "SPRINT: Active sprint flow board" in result["boardText"][0]
+    assert "SPRINT: Frozen after this payload" not in result["boardText"][0]
 
 
 def test_changed_refresh_replaces_dom_preserves_selection_and_cleans_listener():

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -355,6 +355,24 @@ out({
     assert "must not leak" not in result["unknown"]
 
 
+def test_roles_resolve_independently_to_their_own_shortnames():
+    result = run_js(
+        """
+const flow = sprintsBuildFlow(DATA.sprints[0]);
+const roles = byClass(flow, "sprint-role").map(
+  (role) => ({ text: role.textContent, className: role.className }));
+out(roles);
+""",
+        prelude="const DATA = " + json.dumps(payload(units=[
+            unit("U1", "pending", dev_id=None, dev=None)
+        ])) + ";\n",
+    )
+    assert result == [
+        {"text": "Dev: Unassigned", "className": "sprint-role warn"},
+        {"text": "Reviewer: REV2", "className": "sprint-role"},
+    ]
+
+
 def test_unrecognized_column_is_omitted_when_empty():
     result = run_js(
         """


### PR DESCRIPTION
## Outcome

- adds a real Chromium read-only gate over two sprint boards, exercising every selectable card by mouse and keyboard and proving no interaction initiates a mutation request
- captures desktop and 390px selected-card screenshots in the rendered-UI CI artifact
- contains each board's horizontal scrolling on narrow viewports instead of widening the document
- compares refreshes by the fields the board actually renders, so transport-only timestamp writes preserve selection and scroll
- resolves carried Lows 300/SC-309, 301/SC-310, and 320/SC-326

## Review fixes

- flag_id 344 / SC-343: table-drives all 18 rendered projection fields as independent subtests; dropping `state` from the whitelist makes its subtest red
- flag_id 345 / SC-344: pins the 2→1 freeze path, nav decrement, survivor selection, and amber state; both the monotonic-badge and retain-shorter-DOM mutants go red
- flag_id 346 / SC-345: renders and pins both `Unassigned` and `Shell #<id>` plus their warn class; both fallback mutants go red
- took Lows flag_id 347 / SC-346, flag_id 348 / SC-347, and flag_id 349 / SC-348: the read-only request assertion is poll-safe, the Chromium warning marker is visible and accessibly named, and representative fixture titles are declared and asserted

## Judgements

- The refresh fix uses an explicit rendered projection rather than scroll/selection restoration machinery. This matches the spec's repaint-skip ruling and keeps invisible transport fields out of the DOM identity.
- Planner-ratified during the U5 REV2 fix round: the `body.sprints-view` narrow-header treatment is in scope because it mirrors `interface-view` and is the minimal fix for the document-level overflow found by this gate.
- PR #650's `app.js` change is disjoint: it only updates the Kimi console URL.
- The post-build rebase onto merged PR #649 was disjoint; `git range-diff` marks the contribution unchanged.

## Verification

- `44 passed, 18 subtests passed` — complete DOM contract + rendered Chromium modules at `5799a15deda6981ea728cada68529f7d82ca4ee1`
- all five fix-reverted controls red: dropped `state`; monotonic badge; retained shorter DOM; deleted role labels; deleted role warn class
- `1930 passed, 437 subtests passed` — full engine suite on the preceding review head; this fix round changes tests only
- desktop and narrow screenshots inspected locally
- `git diff --check`

