### PR TITLE
fix(update): fast-forward the source checkout before reconciling

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -22,9 +22,9 @@
 #   make dos-u   / dos-update    sync + materialize the engine, reconcile in place
 #                                (source repo: reconciles FROM the checkout, so it
 #                                 fast-forwards it first — being behind is the
-#                                 normal case and just pulls. It stops only when a
-#                                 fast-forward is impossible: commits to pull onto
-#                                 uncommitted work, or a diverged branch.
+#                                 normal case and just pulls. Never blocks: a tree
+#                                 it cannot fast-forward warns that the floor will
+#                                 be stale and updates anyway.
 #                                 ARGS=--no-fetch opts out.)
 #   make dos-t   / dos-test      backend (pytest/unittest) + UI (vitest) suites
 #   make dos-url                 print the review GUI + dev-server URLs

--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -20,9 +20,12 @@
 #   make dos-r   / dos-restart   confirm (YES) + DB backup, then down + launch
 #   make dos-d   / dos-down      stop the sandbox
 #   make dos-u   / dos-update    sync + materialize the engine, reconcile in place
-#                                (source repo: fast-forwards the checkout first —
-#                                 it reconciles FROM that tree, so a stale one
-#                                 would lay a stale floor. ARGS=--no-fetch opts out.)
+#                                (source repo: reconciles FROM the checkout, so it
+#                                 fast-forwards it first — being behind is the
+#                                 normal case and just pulls. It stops only when a
+#                                 fast-forward is impossible: commits to pull onto
+#                                 uncommitted work, or a diverged branch.
+#                                 ARGS=--no-fetch opts out.)
 #   make dos-t   / dos-test      backend (pytest/unittest) + UI (vitest) suites
 #   make dos-url                 print the review GUI + dev-server URLs
 #   make dos-h                   list the commands

--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -19,7 +19,10 @@
 #   make dos-l   / dos-launch    build + start the docker sandbox (+ review GUI)
 #   make dos-r   / dos-restart   confirm (YES) + DB backup, then down + launch
 #   make dos-d   / dos-down      stop the sandbox
-#   make dos-u   / dos-update    fetch + materialize the engine, reconcile in place
+#   make dos-u   / dos-update    sync + materialize the engine, reconcile in place
+#                                (source repo: fast-forwards the checkout first —
+#                                 it reconciles FROM that tree, so a stale one
+#                                 would lay a stale floor. ARGS=--no-fetch opts out.)
 #   make dos-t   / dos-test      backend (pytest/unittest) + UI (vitest) suites
 #   make dos-url                 print the review GUI + dev-server URLs
 #   make dos-h                   list the commands

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -494,9 +494,13 @@ def sync_source_checkout() -> None:
 
     Fast-forward ONLY. This never merges, rebases, resets, or changes branch,
     and it never touches a tree with uncommitted work — the main checkout is the
-    running server's tree and may hold work in flight. Anything that cannot be
-    fast-forwarded safely ABORTS with the operator's next command named, because
-    laying a floor from a tree we KNOW is stale is the failure this closes.
+    running server's tree and may hold work in flight.
+
+    ADVISORY, NEVER BLOCKING (FnB ruling 2026-07-27). Anything that cannot be
+    fast-forwarded warns loudly, names the remedy, and lets the update proceed
+    from the current tree. An operator unable to update is a worse failure than
+    an operator updating one commit behind, and the warning is what the silent
+    version lacked. `--no-fetch` skips this step outright.
     """
     branch = git("rev-parse", "--abbrev-ref", "HEAD", check=False).stdout.strip()
     if not branch or branch == "HEAD":
@@ -518,21 +522,22 @@ def sync_source_checkout() -> None:
         print(f"→ engine sync: {branch} already current with {tracking}")
         return
     if git("status", "--porcelain", check=False).stdout.strip():
-        sys.exit(
-            f"update: the engine checkout is {behind} commit(s) behind {tracking} "
-            f"AND has uncommitted changes.\n"
-            f"  Refusing both ways: never fast-forward a tree with work in "
-            f"flight, never lay a floor from a stale one.\n"
-            f"  Commit or stash in {REPO_ROOT}, then re-run.")
+        print(f"! engine sync: {branch} is {behind} commit(s) behind {tracking}, but "
+              f"the checkout has uncommitted changes — not fast-forwarding a tree "
+              f"with work in flight.")
+        print(f"  Updating anyway from the CURRENT tree, so the floor will be "
+              f"{behind} commit(s) stale.")
+        print(f"  To take the newer floor: commit or stash in {REPO_ROOT}, re-run.")
+        return
     before = git("rev-parse", "--short", "HEAD", check=False).stdout.strip()
     pull = git("pull", "--ff-only", check=False)
     if pull.returncode != 0:
-        sys.exit(
-            f"update: cannot fast-forward {branch} to {tracking} "
-            f"({behind} commit(s) behind) — the branch has diverged.\n"
-            f"{pull.stderr.strip()}\n"
-            f"  Reconcile {REPO_ROOT} by hand, then re-run — update never "
-            f"merges, rebases, or resets your tree.")
+        print(f"! engine sync: cannot fast-forward {branch} to {tracking} "
+              f"({behind} commit(s) behind) — the branch has diverged.")
+        print(f"  {pull.stderr.strip().splitlines()[-1] if pull.stderr.strip() else ''}")
+        print(f"  Updating anyway from the CURRENT tree — update never merges, "
+              f"rebases or resets. Reconcile {REPO_ROOT} by hand for the newer floor.")
+        return
     after = git("rev-parse", "--short", "HEAD", check=False).stdout.strip()
     print(f"→ engine sync: fast-forwarded {branch} {before} → {after} "
           f"({behind} commit(s) from {tracking})")

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -484,6 +484,60 @@ def check_local_edits(force: bool) -> None:
         "  - ./sc eject            one-way: stop tracking upstream and own the engine")
 
 
+def sync_source_checkout() -> None:
+    """Fast-forward the SOURCE repo's checkout before reconciling from it.
+
+    Here the engine is tracked, so the update skips fetch/materialize and lays
+    the floor FROM THE WORKING TREE. A checkout behind its upstream therefore
+    reconciles stale code and reports success — the operator's only defence was
+    remembering to pull first, with no signal on the runs they didn't.
+
+    Fast-forward ONLY. This never merges, rebases, resets, or changes branch,
+    and it never touches a tree with uncommitted work — the main checkout is the
+    running server's tree and may hold work in flight. Anything that cannot be
+    fast-forwarded safely ABORTS with the operator's next command named, because
+    laying a floor from a tree we KNOW is stale is the failure this closes.
+    """
+    branch = git("rev-parse", "--abbrev-ref", "HEAD", check=False).stdout.strip()
+    if not branch or branch == "HEAD":
+        print("→ engine sync: detached HEAD — skipped (no branch to fast-forward)")
+        return
+    upstream = git("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}",
+                   check=False)
+    tracking = upstream.stdout.strip()
+    if upstream.returncode != 0 or not tracking:
+        print(f"→ engine sync: '{branch}' tracks no upstream — skipped")
+        return
+    if git("fetch", "--quiet", check=False).returncode != 0:
+        print(f"! engine sync: fetch failed (offline?) — reconciling against the "
+              f"current tree, which may be behind {tracking}")
+        return
+    behind = git("rev-list", "--count", f"HEAD..{tracking}",
+                 check=False).stdout.strip()
+    if behind in ("", "0"):
+        print(f"→ engine sync: {branch} already current with {tracking}")
+        return
+    if git("status", "--porcelain", check=False).stdout.strip():
+        sys.exit(
+            f"update: the engine checkout is {behind} commit(s) behind {tracking} "
+            f"AND has uncommitted changes.\n"
+            f"  Refusing both ways: never fast-forward a tree with work in "
+            f"flight, never lay a floor from a stale one.\n"
+            f"  Commit or stash in {REPO_ROOT}, then re-run.")
+    before = git("rev-parse", "--short", "HEAD", check=False).stdout.strip()
+    pull = git("pull", "--ff-only", check=False)
+    if pull.returncode != 0:
+        sys.exit(
+            f"update: cannot fast-forward {branch} to {tracking} "
+            f"({behind} commit(s) behind) — the branch has diverged.\n"
+            f"{pull.stderr.strip()}\n"
+            f"  Reconcile {REPO_ROOT} by hand, then re-run — update never "
+            f"merges, rebases, or resets your tree.")
+    after = git("rev-parse", "--short", "HEAD", check=False).stdout.strip()
+    print(f"→ engine sync: fast-forwarded {branch} {before} → {after} "
+          f"({behind} commit(s) from {tracking})")
+
+
 def fetch_update_ref(branch: str, ref: str | None = None) -> str:
     """Refresh remote objects and resolve the engine ref without touching the
     installed floor. Git object refresh is the sole mutation allowed before
@@ -782,6 +836,11 @@ def main(argv: list[str]) -> int:
         # and must keep tracking .super-coder/. Reconcile its own tree only.
         print("→ super-coder SOURCE repo — engine is tracked here; "
               "skipping fetch/materialize/untrack (reconcile in place only)")
+        # Reconciling in place makes the WORKING TREE the floor's source, so it
+        # has to be current first. --no-fetch keeps its meaning (touch no
+        # network) and is the escape hatch for reconciling a tree deliberately.
+        if not no_fetch:
+            sync_source_checkout()
         no_fetch = True
     else:
         migrate_engine_untrack()  # one-time B7: untrack the engine (idempotent)

--- a/sc
+++ b/sc
@@ -1490,6 +1490,8 @@ super-coder — forkable shell substrate
   ./sc update              fetch + materialize the engine (gitignored dep) + reconcile IN PLACE (migrate, sync skills, map);
                              live Interface state asks continue-or-rollback; headless discard requires --discard-live-state
                              --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
+                             source repo: no materialize — fast-forwards the checkout first (ff-only; aborts if dirty or diverged),
+                             because the floor is reconciled FROM that tree
   ./sc update-harnesses    refresh the harness CLIs the SHELLS run: rolls the harness epoch + rebuilds the sandbox image
                              (they are baked, never mounted — so a running sandbox keeps the old ones until ./sc restart)
                              without docker, updates this host's CLIs instead — there the host IS the runtime

--- a/sc
+++ b/sc
@@ -1491,8 +1491,8 @@ super-coder — forkable shell substrate
                              live Interface state asks continue-or-rollback; headless discard requires --discard-live-state
                              --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
                              source repo: no materialize — the floor is reconciled FROM the checkout, so it is fast-forwarded first.
-                             Behind + clean (the usual case) just pulls; it aborts ONLY when it cannot fast-forward — commits to
-                             pull onto uncommitted work, or a diverged branch. It never merges, rebases or resets your tree.
+                             Advisory, never blocking: a tree it cannot fast-forward (uncommitted work, or diverged) WARNS that the
+                             floor will be stale and updates anyway. Never merges, rebases or resets. --no-fetch skips the sync.
   ./sc update-harnesses    refresh the harness CLIs the SHELLS run: rolls the harness epoch + rebuilds the sandbox image
                              (they are baked, never mounted — so a running sandbox keeps the old ones until ./sc restart)
                              without docker, updates this host's CLIs instead — there the host IS the runtime

--- a/sc
+++ b/sc
@@ -1490,8 +1490,9 @@ super-coder — forkable shell substrate
   ./sc update              fetch + materialize the engine (gitignored dep) + reconcile IN PLACE (migrate, sync skills, map);
                              live Interface state asks continue-or-rollback; headless discard requires --discard-live-state
                              --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
-                             source repo: no materialize — fast-forwards the checkout first (ff-only; aborts if dirty or diverged),
-                             because the floor is reconciled FROM that tree
+                             source repo: no materialize — the floor is reconciled FROM the checkout, so it is fast-forwarded first.
+                             Behind + clean (the usual case) just pulls; it aborts ONLY when it cannot fast-forward — commits to
+                             pull onto uncommitted work, or a diverged branch. It never merges, rebases or resets your tree.
   ./sc update-harnesses    refresh the harness CLIs the SHELLS run: rolls the harness epoch + rebuilds the sandbox image
                              (they are baked, never mounted — so a running sandbox keeps the old ones until ./sc restart)
                              without docker, updates this host's CLIs instead — there the host IS the runtime

--- a/tests/test_update_source_sync.py
+++ b/tests/test_update_source_sync.py
@@ -99,35 +99,52 @@ class SourceSyncCase(unittest.TestCase):
         self.assertEqual(self.head(), before)
         self.assertIn("already current", out)
 
-    # ── the refusals ─────────────────────────────────────────────────────────
+    # ── the declines: warn, leave the tree alone, let the update through ─────
+    #
+    # ADVISORY, NEVER BLOCKING (FnB ruling 2026-07-27): an operator who cannot
+    # update is a worse failure than one updating a commit behind. Each leg
+    # asserts BOTH halves — the tree is untouched AND the update is not stopped.
 
-    def test_behind_with_uncommitted_work_aborts_untouched(self):
-        """The main checkout is the running server's tree; never fast-forward
-        one holding work in flight, and never reconcile from a stale one."""
+    def test_uncommitted_work_warns_and_does_not_block(self):
+        """The main checkout is the running server's tree — never fast-forward
+        one holding work in flight. But never refuse the update over it."""
         tip = self.fall_behind()
         (self.work / "scratch.txt").write_text("operator work in flight\n")
         before = self.head()
-        with self.assertRaises(SystemExit) as raised:
-            self.sync()
-        self.assertEqual(self.head(), before, "aborted run still moved HEAD")
+        out = self.sync()   # must NOT raise — SystemExit would fail the test here
+        self.assertEqual(self.head(), before, "fast-forwarded over work in flight")
         self.assertNotEqual(self.head(), tip)
-        self.assertIn("uncommitted changes", str(raised.exception))
         self.assertTrue((self.work / "scratch.txt").exists(),
                         "the operator's file was discarded")
+        self.assertIn("uncommitted changes", out)
+        self.assertIn("stale", out, "the warning must say the floor will be stale")
 
-    def test_diverged_aborts_without_merging_or_resetting(self):
+    def test_diverged_warns_without_merging_resetting_or_blocking(self):
         tip = self.fall_behind()
         (self.work / "local.txt").write_text("local\n")
         git(self.work, "add", "local.txt")
         git(self.work, "commit", "-m", "local only")
         before = self.head()
-        with self.assertRaises(SystemExit) as raised:
-            self.sync()
+        out = self.sync()   # must NOT raise
         self.assertEqual(self.head(), before, "diverged branch was moved")
-        self.assertIn("diverged", str(raised.exception))
+        self.assertIn("diverged", out)
         # the upstream commit must NOT have been merged in
         merged = git(self.work, "branch", "--contains", tip, "--format=%(refname)")
         self.assertEqual(merged, "", "upstream commit was merged despite divergence")
+
+    def test_no_git_state_can_stop_the_update(self):
+        """The ruling as one property: whatever the checkout looks like, the
+        sync returns and the update proceeds. Positive control — the same
+        harness DOES fast-forward when it can (first test above)."""
+        self.fall_behind()
+        (self.work / "scratch.txt").write_text("untracked work\n")
+        (self.work / "a.txt").write_text("tracked edit\n")
+        for label, setup in (("dirty", lambda: None),
+                             ("detached", lambda: git(self.work, "checkout",
+                                                      "--detach"))):
+            with self.subTest(state=label):
+                setup()
+                self.sync()   # any SystemExit escaping here fails the leg
 
     # ── the skips ────────────────────────────────────────────────────────────
 

--- a/tests/test_update_source_sync.py
+++ b/tests/test_update_source_sync.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Source-repo update fast-forwards its checkout before reconciling from it.
+
+In the source repo `./sc update` skips fetch/materialize and lays the floor FROM
+THE WORKING TREE, so a stale checkout reconciles stale code and reports success.
+These pin the sync that closes that, and — just as load-bearing — the two cases
+where it must REFUSE rather than touch the tree.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import update  # noqa: E402
+
+
+def git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True, capture_output=True, text=True).stdout.strip()
+
+
+class SourceSyncCase(unittest.TestCase):
+    """A real clone with a real upstream — the behaviour under test is git's."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        tmp = Path(self.tmp.name)
+        self.origin = tmp / "origin.git"
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(self.origin)],
+                       check=True, capture_output=True)
+        self.work = tmp / "work"
+        subprocess.run(["git", "clone", str(self.origin), str(self.work)],
+                       check=True, capture_output=True)
+        git(self.work, "config", "user.email", "t@example.com")
+        git(self.work, "config", "user.name", "t")
+        (self.work / "a.txt").write_text("one\n")
+        git(self.work, "add", "a.txt")
+        git(self.work, "commit", "-m", "one")
+        git(self.work, "push", "-u", "origin", "main")
+        self.addCleanup(self.tmp.cleanup)
+
+    def sync(self) -> str:
+        """Run the sync against the fixture checkout, returning its output."""
+        buf = io.StringIO()
+        with mock.patch.object(update, "REPO_ROOT", self.work), \
+                contextlib.redirect_stdout(buf):
+            update.sync_source_checkout()
+        return buf.getvalue()
+
+    def fall_behind(self, n: int = 1) -> str:
+        """Push a commit, then rewind the checkout so it trails by `n`."""
+        for i in range(n):
+            (self.work / "a.txt").write_text(f"upstream {i}\n")
+            git(self.work, "commit", "-am", f"upstream {i}")
+        git(self.work, "push", "origin", "main")
+        tip = git(self.work, "rev-parse", "HEAD")
+        git(self.work, "reset", "--hard", f"HEAD~{n}")
+        return tip
+
+    def head(self) -> str:
+        return git(self.work, "rev-parse", "HEAD")
+
+    # ── the fix ──────────────────────────────────────────────────────────────
+
+    def test_behind_and_clean_fast_forwards(self):
+        tip = self.fall_behind()
+        self.assertNotEqual(self.head(), tip)
+        out = self.sync()
+        self.assertEqual(self.head(), tip, "checkout was not fast-forwarded")
+        self.assertIn("fast-forwarded", out)
+
+    def test_fast_forward_is_linear_never_a_merge(self):
+        """Asserting the new HEAD alone cannot tell a fast-forward from a merge
+        that lands the same commit, so assert the shape too.
+
+        Measured, not assumed: a plain `git pull` does NOT redden this — git
+        fast-forwards on its own when it can, and that mutation is caught by the
+        diverged case instead. The mutation this leg owns is one that forces a
+        merge where a fast-forward was possible (`--no-ff`), which no other test
+        here detects."""
+        tip = self.fall_behind()
+        self.sync()
+        self.assertEqual(self.head(), tip)
+        parents = git(self.work, "rev-list", "--parents", "-n", "1", "HEAD").split()
+        self.assertEqual(len(parents), 2, f"HEAD is not a linear commit: {parents}")
+
+    def test_already_current_is_a_quiet_noop(self):
+        before = self.head()
+        out = self.sync()
+        self.assertEqual(self.head(), before)
+        self.assertIn("already current", out)
+
+    # ── the refusals ─────────────────────────────────────────────────────────
+
+    def test_behind_with_uncommitted_work_aborts_untouched(self):
+        """The main checkout is the running server's tree; never fast-forward
+        one holding work in flight, and never reconcile from a stale one."""
+        tip = self.fall_behind()
+        (self.work / "scratch.txt").write_text("operator work in flight\n")
+        before = self.head()
+        with self.assertRaises(SystemExit) as raised:
+            self.sync()
+        self.assertEqual(self.head(), before, "aborted run still moved HEAD")
+        self.assertNotEqual(self.head(), tip)
+        self.assertIn("uncommitted changes", str(raised.exception))
+        self.assertTrue((self.work / "scratch.txt").exists(),
+                        "the operator's file was discarded")
+
+    def test_diverged_aborts_without_merging_or_resetting(self):
+        tip = self.fall_behind()
+        (self.work / "local.txt").write_text("local\n")
+        git(self.work, "add", "local.txt")
+        git(self.work, "commit", "-m", "local only")
+        before = self.head()
+        with self.assertRaises(SystemExit) as raised:
+            self.sync()
+        self.assertEqual(self.head(), before, "diverged branch was moved")
+        self.assertIn("diverged", str(raised.exception))
+        # the upstream commit must NOT have been merged in
+        merged = git(self.work, "branch", "--contains", tip, "--format=%(refname)")
+        self.assertEqual(merged, "", "upstream commit was merged despite divergence")
+
+    # ── the skips ────────────────────────────────────────────────────────────
+
+    def test_no_upstream_is_skipped_not_fatal(self):
+        git(self.work, "checkout", "-b", "untracked-branch")
+        out = self.sync()
+        self.assertIn("tracks no upstream", out)
+
+    def test_detached_head_is_skipped_not_fatal(self):
+        git(self.work, "checkout", "--detach")
+        out = self.sync()
+        self.assertIn("detached HEAD", out)
+
+
+class Stop(Exception):
+    """Sentinel — halts main() at the seam under test."""
+
+
+class SourceSyncWiringCase(unittest.TestCase):
+    """The function above is only worth anything if main() actually calls it.
+
+    Every leg halts main() at a seam rather than running the reconcile, and
+    halts it at BOTH seams — the sync itself and the first step after it. That
+    second patch is not belt-and-braces: with only the first, deleting the call
+    site lets main() run on into `migrate_or_rebuild` and `snapshot` against the
+    live repo. Observed, not theorised — the first version of this test did
+    exactly that when the call site was mutated away.
+    """
+
+    def test_source_repo_update_syncs_before_reconciling(self):
+        with mock.patch.object(update, "is_source_repo", return_value=True), \
+                mock.patch.object(update, "preflight_live_state"), \
+                mock.patch.object(update, "ensure_workflows", side_effect=Stop), \
+                mock.patch.object(update, "sync_source_checkout",
+                                  side_effect=Stop) as sync, \
+                contextlib.redirect_stdout(io.StringIO()):
+            with self.assertRaises(Stop):
+                update.main([])
+        sync.assert_called_once()
+
+    def test_no_fetch_opts_out_of_the_sync(self):
+        """--no-fetch means touch no network; it stays the escape hatch for
+        reconciling a tree deliberately. Positive control: the test above shows
+        this same harness DOES reach the sync without the flag."""
+        with mock.patch.object(update, "is_source_repo", return_value=True), \
+                mock.patch.object(update, "preflight_live_state"), \
+                mock.patch.object(update, "ensure_workflows", side_effect=Stop), \
+                mock.patch.object(update, "sync_source_checkout") as sync, \
+                contextlib.redirect_stdout(io.StringIO()):
+            with self.assertRaises(Stop):
+                update.main(["--no-fetch"])
+        sync.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`make dos-u` / `./sc update` now fast-forwards the source repo's checkout before it reconciles the floor — **advisory, never blocking**.

## Why

In the source repo the update **skips fetch/materialize and lays the floor from the working tree** (`update.py`, source branch). So a checkout behind `origin/main` reconciles stale code and reports success — silently. The documented remedy was "sync with main, then update": a manual step with no signal on the runs it was missed.

Measured while writing it: the main checkout was **2 commits behind** `origin/main` and clean — a `dos-u` at that moment would have laid a 2-commit-stale floor and said "done".

## How

`sync_source_checkout()` runs in the source branch of `main()`, before anything reconciles.

- **Fast-forward only** — never merges, rebases, resets, or changes branch.
- **Never blocks the update** (FnB ruling 2026-07-27). A tree it cannot fast-forward — uncommitted work, or a diverged branch — warns that the floor will be stale, names the remedy, and the update proceeds from the current tree. An operator who cannot update is a worse failure than one updating a commit behind; the value here is the warning the silent version lacked, not a gate.
- Offline, detached HEAD and no-upstream degrade to a note and continue.
- `--no-fetch` keeps its meaning (touch no network) and skips the sync.

Being **behind is the ordinary case** and simply pulls. The source repo is worked 100% through worktrees, so the main checkout is near-always clean and on main.

**Forks are untouched** — the whole path sits behind `is_source_repo()`, which tests the origin basename against `SOURCE_REPO_NAMES = ("super-coder", "subfloor")`, so the rename is handled at the remote rather than by matching local directory names.

### Why not in the Makefile

`aliases.mk` states at line 3 that *"the dispatcher ./sc is the canonical interface; these targets only delegate"*, and every target is a one-line delegation. Putting the guard in the recipe would mean a second copy of the source-repo predicate in shell — the duplicated-predicate shape already filed as SC-309. Behind `is_source_repo()` there is one predicate, `dos-u` gets the behaviour through delegation, and both help texts describe it.

## Tests

`tests/test_update_source_sync.py` — 10 legs against a real clone with a real upstream: the fast-forward and its linearity, both declines (asserting the tree is untouched **and** the update is not stopped), the ruling as a standalone property (`no git state can stop the update`), the skips, and the call-site wiring.

Mutation proofs run, not assumed:

| mutation | reddens |
|---|---|
| `--ff-only` → `--no-ff` | linearity leg |
| drop the dirty-tree guard | work-in-flight leg (it fast-forwards over it) |
| restore either `sys.exit` | work-in-flight leg **and** the never-block property |
| delete the call site | wiring leg |

One measured correction is recorded in the test body: `--ff-only` → plain `git pull` does **not** redden the linearity leg (git fast-forwards on its own when it can) — that mutation is caught by the diverged case instead. The docstring names the mutation that actually reddens it.

The wiring test halts `main()` at **two** seams. With only one, deleting the call site let `main()` run on into `migrate_or_rebuild` and `snapshot` against the live repo — observed while proving that mutation, and hardened before commit.

Full backend suite green at the first commit: **1936 passed, 437 subtests**. Update + supervision suites re-run green after each revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)