### PR TITLE
fix(ui): widen sprint board columns

### DIFF
--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -577,6 +577,7 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 
 /* Active sprint flow boards — one self-contained, read-only graph per sprint. */
 #view-sprints, .sprint-board { min-width: 0; }
+#view-sprints { max-width: 1350px; }
 .sprint-board { overflow: hidden; }
 .sprint-header { display: flex; align-items: baseline; gap: .5rem; min-width: 0; }
 .sprint-header h2 { min-width: 0; overflow: hidden; text-overflow: ellipsis;
@@ -588,7 +589,7 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
   pointer-events: none; overflow: visible; }
 .sprint-cols { position: relative; z-index: 1; display: flex; gap: 1.35rem;
   align-items: flex-start; padding: 0 .15rem; }
-.sprint-col { flex: 1 0 150px; min-width: 150px; display: flex;
+.sprint-col { flex: 1 1 0; min-width: 150px; display: flex;
   flex-direction: column; gap: .65rem; }
 .sprint-col-head { display: flex; align-items: center; gap: .35rem;
   min-height: 1.6rem; padding-bottom: .3rem; border-bottom: 1px solid var(--line-soft);
@@ -597,7 +598,7 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .sprint-col-head .count { min-width: 1.3rem; padding: 0 .32rem;
   border: 1px solid var(--line); border-radius: 999px; color: var(--ink);
   font-size: .65rem; line-height: 1.25rem; text-align: center; }
-.sprint-unit { min-width: 0; padding: .55rem .6rem; border: 1px solid var(--line);
+.sprint-unit { width: 100%; min-width: 0; padding: .55rem .6rem; border: 1px solid var(--line);
   border-left: 3px solid var(--line); border-radius: 9px; background: var(--panel2);
   cursor: pointer; transition: opacity .12s, border-color .12s, box-shadow .12s; }
 .sprint-unit:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -606,6 +606,29 @@ def test_sprints_multi_board_read_only_visual_gate(
         cards = view.locator('.sprint-unit[role="button"]')
         assert cards.count() == view.locator(".sprint-unit").count() == 7
 
+        geometry = view.evaluate(
+            """(node) => ({
+              viewWidth: node.getBoundingClientRect().width,
+              boards: Array.from(node.querySelectorAll(".sprint-board"))
+                .map((board) => ({
+                  columns: Array.from(board.querySelectorAll(".sprint-col"))
+                    .map((column) => column.getBoundingClientRect().width),
+                  cards: Array.from(board.querySelectorAll(".sprint-unit"))
+                    .map((card) => ({
+                      card: card.getBoundingClientRect().width,
+                      column: card.parentElement.getBoundingClientRect().width,
+                    })),
+                })),
+            })"""
+        )
+        assert geometry["viewWidth"] == 1350
+        for board in geometry["boards"]:
+            assert max(board["columns"]) - min(board["columns"]) < 1
+            assert all(
+                abs(card["card"] - card["column"]) < 1
+                for card in board["cards"]
+            )
+
         for index in range(cards.count()):
             card = cards.nth(index)
             card.click()

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -916,7 +916,10 @@ def test_flow_styles_clamp_text_and_contain_narrow_viewport_scrolling():
     sprint_css = STYLE[STYLE.index("/* Active sprint flow boards"):
                        STYLE.index("/* Roadmap Flow view")]
     assert "#view-sprints, .sprint-board { min-width: 0; }" in sprint_css
+    assert "#view-sprints { max-width: 1350px; }" in sprint_css
     assert ".sprint-board { overflow: hidden; }" in sprint_css
+    assert ".sprint-col { flex: 1 1 0;" in sprint_css
+    assert ".sprint-unit { width: 100%;" in sprint_css
     assert "overflow-x: auto" in sprint_css
     assert "text-overflow: ellipsis" in sprint_css
     assert "white-space: nowrap" in sprint_css


### PR DESCRIPTION
## Summary
- cap the Sprints view at 1350px
- distribute sprint columns evenly across the available width
- keep unit cards full-width within their columns

## Verification
- `python3 -m pytest -q tests/test_sprints_ui_contract.py tests/test_interface_ui_rendered.py::test_sprints_multi_board_read_only_visual_gate`
- `git diff --check`

## Trade-off
Kept the existing flex layout and narrow-screen horizontal scrolling; only the sizing rules changed.