### PR TITLE
fix(ui): space sprint board columns

### DIFF
--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -587,7 +587,7 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .sprint-flow-inner { position: relative; min-width: 850px; }
 .sprint-wires { position: absolute; inset: 0 auto auto 0; z-index: 0;
   pointer-events: none; overflow: visible; }
-.sprint-cols { position: relative; z-index: 1; display: flex; gap: 1.35rem;
+.sprint-cols { position: relative; z-index: 1; display: flex; gap: 35px;
   align-items: flex-start; padding: 0 .15rem; }
 .sprint-col { flex: 1 1 0; min-width: 150px; display: flex;
   flex-direction: column; gap: .65rem; }

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -611,6 +611,8 @@ def test_sprints_multi_board_read_only_visual_gate(
               viewWidth: node.getBoundingClientRect().width,
               boards: Array.from(node.querySelectorAll(".sprint-board"))
                 .map((board) => ({
+                  gap: parseFloat(getComputedStyle(
+                    board.querySelector(".sprint-cols")).columnGap),
                   columns: Array.from(board.querySelectorAll(".sprint-col"))
                     .map((column) => column.getBoundingClientRect().width),
                   cards: Array.from(board.querySelectorAll(".sprint-unit"))
@@ -623,6 +625,7 @@ def test_sprints_multi_board_read_only_visual_gate(
         )
         assert geometry["viewWidth"] == 1350
         for board in geometry["boards"]:
+            assert board["gap"] == 35
             assert max(board["columns"]) - min(board["columns"]) < 1
             assert all(
                 abs(card["card"] - card["column"]) < 1

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -918,6 +918,7 @@ def test_flow_styles_clamp_text_and_contain_narrow_viewport_scrolling():
     assert "#view-sprints, .sprint-board { min-width: 0; }" in sprint_css
     assert "#view-sprints { max-width: 1350px; }" in sprint_css
     assert ".sprint-board { overflow: hidden; }" in sprint_css
+    assert "display: flex; gap: 35px;" in sprint_css
     assert ".sprint-col { flex: 1 1 0;" in sprint_css
     assert ".sprint-unit { width: 100%;" in sprint_css
     assert "overflow-x: auto" in sprint_css


### PR DESCRIPTION
## Summary
- set the sprint board inter-column gap to exactly 35px
- preserve the 1350px board cap and equal column/card widths from PR #656
- verify the computed browser layout gap

## Verification
- `python3 -m pytest -q tests/test_sprints_ui_contract.py tests/test_interface_ui_rendered.py::test_sprints_multi_board_read_only_visual_gate`
- `git diff --check`

## Trade-off
Kept the existing flex layout and responsive horizontal overflow; only the requested spacing changed.