### PR TITLE
fix(test): make four pre-existing tests measure what they claim

### DIFF
--- a/spikes/interface-stream/tests/helpers.py
+++ b/spikes/interface-stream/tests/helpers.py
@@ -127,13 +127,47 @@ class WSClient:
         with self.lock:
             return len(self.out)
 
-    def wait_len(self, n: int, timeout: float = 30.0) -> bytes:
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if self.out_len() >= n:
+    def wait_len(self, n: int, stall_timeout: float = 30.0) -> bytes:
+        """Wait for `n` bytes, failing only on a genuine STALL.
+
+        Flag #67: the previous form was `while monotonic() < deadline` over a
+        total-duration budget, and it produced the flake's two DIFFERENT shapes
+        from one line each.
+
+        Shape 2 — "timed out AFTER the broker had pumped all 5,065,000 bytes" —
+        was this loop's exit race, not contention: the predicate was tested
+        BEFORE `sleep(0.05)` and never again, so bytes that completed during
+        that final sleep were never seen. The loop re-read `monotonic()`, found
+        the deadline gone, and raised while the buffer already held everything
+        asked of it. Reading a fresh length before every failure decision, as
+        below, makes that shape unreachable rather than unlikely.
+
+        Shape 1 — "stalled at 5,007,670 / 5,065,000", i.e. 98.9% delivered —
+        was a real but load-induced slowdown, and no total-duration budget can
+        separate that from a hang: the same 120s is generous on an idle host and
+        tight under five concurrent shells, which is the self-inflicted
+        parallelism the flag describes. So the budget now measures the wrong
+        thing deliberately no longer — it bounds time WITHOUT PROGRESS. A host
+        ten times slower still passes while bytes keep arriving; a pump that
+        genuinely wedges still fails, and reports where it stopped. This is the
+        flag's preferred remedy (make it load-independent) and specifically not
+        its rejected one (raise the timeout, hiding the sensitivity).
+        """
+        last_len = -1
+        last_progress = time.monotonic()
+        while True:
+            have = self.out_len()
+            if have >= n:
                 return self.output()
+            if have != last_len:
+                last_len = have
+                last_progress = time.monotonic()
+            elif time.monotonic() - last_progress > stall_timeout:
+                raise TimeoutError(
+                    f"stream stalled at {have}/{n} bytes — no progress for "
+                    f"{stall_timeout:g}s"
+                )
             time.sleep(0.05)
-        raise TimeoutError(f"length predicate not met (have {self.out_len()} bytes)")
 
     def wait_redraw(self, timeout: float = 10.0) -> bytes:
         deadline = time.monotonic() + timeout

--- a/spikes/interface-stream/tests/test_bounded_buffers.py
+++ b/spikes/interface-stream/tests/test_bounded_buffers.py
@@ -54,7 +54,10 @@ def test_bounded_buffers(spike, make_session, writer, ws_factory, tmp_path):
     t0 = time.monotonic()
     go.touch()
     try:
-        out = good.wait_len(len(corpus), timeout=120)
+        # Flag #67: a no-progress budget, not a total-duration one — the pump is
+        # allowed to take as long as the host makes it take, provided it is
+        # still moving bytes. 30s of complete silence mid-burst is a wedge.
+        out = good.wait_len(len(corpus), stall_timeout=30)
     except TimeoutError:
         st, info = spike.api("GET", f"/api/interface/sessions/{sid}")
         raise TimeoutError(

--- a/tests/test_interface_runtime.py
+++ b/tests/test_interface_runtime.py
@@ -342,14 +342,23 @@ class ShadowSidecarTest(unittest.TestCase):
             "require('readline').createInterface"
             "({input: process.stdin}).on('line', () => {});\n")
 
+        # Same flag #106 correction as its dead-sidecar sibling below, applied
+        # to the whole class rather than only the instance that reddened: the
+        # `elapsed < 5` line was a wall-clock budget with a quiet-machine
+        # assumption baked in. The property is that an unanswering sidecar
+        # RAISES rather than hanging a caller forever, and the injected 0.5s
+        # timeout — not the wall clock — is what bounds this test's runtime.
+        # Asserting the timeout's own message proves the raise came from
+        # wait_for expiring, which is the path this test exists to cover.
         async def flow():
             sidecar = interface_runtime.ShadowSidecar(script)
-            with mock.patch.object(interface_runtime,
-                                   "SHADOW_REQUEST_TIMEOUT_S", 0.5):
-                t0 = time.monotonic()
-                with self.assertRaises(RuntimeError):
-                    await sidecar.start()   # the boot probe times out
-                self.assertLess(time.monotonic() - t0, 5)
+            with (
+                mock.patch.object(
+                    interface_runtime, "SHADOW_REQUEST_TIMEOUT_S", 0.5),
+                self.assertRaises(RuntimeError) as caught,
+            ):
+                await sidecar.start()   # the boot probe times out
+            self.assertIn("timed out", str(caught.exception))
             await sidecar.stop()
         asyncio.run(flow())
 
@@ -357,14 +366,33 @@ class ShadowSidecarTest(unittest.TestCase):
         # Dies instantly (what a missing @xterm/headless require does).
         script = self._script("process.exit(1)\n")
 
+        # Flag #106: this test used to inject a 5s timeout and assert the probe
+        # returned in under 5s — the budget and the timeout were the SAME
+        # number, so it carried no headroom and reddened twice under sprint
+        # load at 5.027s while the code was correct. "Fast" here does not mean
+        # "under N seconds on a quiet machine"; it means the failure comes from
+        # NOTICING THE PROCESS DIED rather than from waiting the request out.
+        # Those are two different code paths raising two different messages, so
+        # the discriminator is the message, and no clock enters the assertion:
+        #   dead     -> _reader hits EOF -> "shadow sidecar exited"
+        #   wedged   -> asyncio.wait_for -> "... timed out after Ns ..."
+        # The injected timeout is deliberately far LARGER than any plausible
+        # death-detection time, which is what makes the two outcomes
+        # unmistakable: correct code never reaches it under any load, and a
+        # regression that waits it out is reported as a wrong-path failure
+        # rather than a slow pass.
         async def flow():
             sidecar = interface_runtime.ShadowSidecar(script)
-            with mock.patch.object(interface_runtime,
-                                   "SHADOW_REQUEST_TIMEOUT_S", 5):
-                t0 = time.monotonic()
-                with self.assertRaises(RuntimeError):
-                    await sidecar.start()
-                self.assertLess(time.monotonic() - t0, 5)
+            with (
+                mock.patch.object(
+                    interface_runtime, "SHADOW_REQUEST_TIMEOUT_S", 30),
+                self.assertRaises(RuntimeError) as caught,
+            ):
+                await sidecar.start()
+            self.assertIn("exited", str(caught.exception))
+            self.assertNotIn("timed out", str(caught.exception),
+                             "the probe waited out the request timeout instead "
+                             "of failing on the sidecar's death")
             await sidecar.stop()
         asyncio.run(flow())
 

--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -7,16 +7,62 @@ pinned browser stack as visual QA and uploads the tall/short screenshots.
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import os
+import sys
 import threading
+import warnings
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
 
 
-sync_api = pytest.importorskip("playwright.sync_api")
+def _browser_stack_note() -> str:
+    """What this interpreter has, for a skip or launch failure to name.
+
+    Flag #169's cost was never the missing browser — it was that the reader
+    could not tell WHICH of the two halves had drifted. So report both: the
+    playwright the interpreter imports, and the builds actually on disk.
+    """
+    try:
+        version = importlib.metadata.version("playwright")
+    except importlib.metadata.PackageNotFoundError:
+        version = "not installed"
+    root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "")
+    if root and Path(root).is_dir():
+        builds = ", ".join(sorted(p.name for p in Path(root).iterdir())) or "empty"
+    else:
+        builds = f"{root or '<unset>'} is not a directory"
+    return (
+        f"playwright={version} under {sys.executable}\n"
+        f"    PLAYWRIGHT_BROWSERS_PATH={root or '<unset>'} carries: {builds}"
+    )
+
+
+# Flag #169: this module used to be guarded by a bare `importorskip`, which in a
+# sandbox whose .venv has no playwright reports the whole file as "1 skipped" —
+# twenty rendered assertions silently not running, reading exactly like a green
+# run with coverage. A skip is the right OUTCOME for a dependency-light suite;
+# a skip nobody can see is not. So the reason names the stack and the remedy,
+# and it is raised as a warning too, because a warning survives `-q` in the
+# run summary where a skip count does not.
+try:
+    from playwright import sync_api
+except ImportError:  # pragma: no cover - depends on the interpreter
+    _RENDERED_SKIP = (
+        "playwright is not importable, so the 20 rendered assertions in this "
+        "module DID NOT RUN — this is zero rendered coverage, not a pass.\n"
+        f"    {_browser_stack_note()}\n"
+        "    Run this file under an interpreter that has playwright and a "
+        "matching browser build (in the super-coder sandbox that is the system "
+        "`python3`, not .venv/bin/python), or install a playwright whose build "
+        "number matches PLAYWRIGHT_BROWSERS_PATH."
+    )
+    warnings.warn(f"rendered UI suite skipped — {_RENDERED_SKIP}", stacklevel=1)
+    pytest.skip(_RENDERED_SKIP, allow_module_level=True)
+
 sync_playwright = sync_api.sync_playwright
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -293,7 +339,26 @@ def ui_url():
 @pytest.fixture(scope="module")
 def browser():
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(headless=True)
+        # Flag #169's other half: playwright imports but the build it wants is
+        # not the build the image carries, and a raw launch failure reports that
+        # as twenty identical errors about an executable path — which reads as a
+        # broken suite rather than a mismatched environment. Convert it into one
+        # skip that names both sides. Deliberately NOT a blanket guard around
+        # the test body: only the launch is environmental, and a failure inside
+        # a test must stay a failure.
+        try:
+            browser = playwright.chromium.launch(headless=True)
+        except Exception as exc:  # noqa: BLE001 - reported, then re-raised as skip
+            reason = (
+                "playwright is installed but cannot launch chromium, so the 20 "
+                "rendered assertions DID NOT RUN — zero rendered coverage, not "
+                f"a pass.\n    {_browser_stack_note()}\n"
+                f"    launch error: {type(exc).__name__}: {exc}\n"
+                "    The package and the baked browsers have drifted apart; "
+                "align the two in one place rather than shimming a path."
+            )
+            warnings.warn(f"rendered UI suite skipped — {reason}", stacklevel=1)
+            pytest.skip(reason)
         try:
             yield browser
         finally:
@@ -1382,6 +1447,19 @@ HEADER_LINES = """() => {
                     / 10;
   }
   const width = (node) => Math.round(node.getBoundingClientRect().width);
+  // The identity's own content width, measured under the identity's OWN
+  // computed font. This is the reference the no-overgrowth assert needs and
+  // the one `scrollWidth` cannot supply: scrollWidth clamps up to clientWidth,
+  // so an identity that has absorbed 341px of free space reports
+  // scrollWidth 341 and compares equal to itself. Measuring the text instead
+  // keeps the comparison SELF-RELATIVE — layout box against the same string
+  // under the same resolved family — so it carries across hosts that resolve
+  // the generic stack differently, unlike any px budget in the table above.
+  const identityStyle = getComputedStyle(identity);
+  pen.font = `${identityStyle.fontStyle} ${identityStyle.fontWeight} ` +
+             `${identityStyle.fontSize} ${identityStyle.fontFamily}`;
+  const identityNatural =
+    Math.round(pen.measureText(identity.textContent).width * 10) / 10;
   return {
     lines: new Set([dataBox, ...controls].map(centre)).size,
     truncated: context.scrollWidth > context.clientWidth,
@@ -1408,6 +1486,8 @@ HEADER_LINES = """() => {
       data: Math.round(dataBox.width),
       badge: width(badge),
       identity: width(identity),
+      identityBox: Math.round(identity.getBoundingClientRect().width * 10) / 10,
+      identityNatural: identityNatural,
       controls: controls.reduce((sum, rect) => sum + rect.width, 0),
       fontSize: style.fontSize,
       fontFamily: style.fontFamily,
@@ -1428,7 +1508,8 @@ def _header_report(label: str, metrics: dict) -> str:
         f"({metrics['cap'] - metrics['need']:+}px spare) slot={metrics['slot']}px · "
         f"head={metrics['head']}px controls={round(metrics['controls'])}px "
         f"data={metrics['data']}px badge={metrics['badge']}px "
-        f"identity={metrics['identity']}px · font={metrics['fontSize']} "
+        f"identity={metrics['identityBox']}px "
+        f"(content {metrics['identityNatural']}px) · font={metrics['fontSize']} "
         f"{metrics['fontFamily']} · rulers {rulers}"
     )
 
@@ -1529,6 +1610,19 @@ def test_header_keeps_controls_left_and_work_data_right(browser, ui_url, tmp_pat
         assert narrow["badge"] == "Sprint 31"
         assert narrow["identity"] == "Code-01 | DEV3"
         assert narrow["context"].startswith("Interface corrective hardening · ")
+        # Flag #177: `lines == 1` is satisfied by an identity that never wraps
+        # AND by one that refuses to shrink and squeezes its neighbours to
+        # nothing instead, so it cannot distinguish them. At a viewport this
+        # over-subscribed the identity must be YIELDING — its box narrower than
+        # its own text — which is the half of `.if-identity`'s contract
+        # (`flex: 0 1 auto; min-width: 0`) that shrinking expresses.
+        assert narrow["metrics"]["identityBox"] < narrow["metrics"]["identityNatural"], (
+            "the identity held its full width at 700px instead of truncating: "
+            f"box={narrow['metrics']['identityBox']}px is not under its own "
+            f"content width {narrow['metrics']['identityNatural']}px. The work "
+            "context absorbs the whole shortfall — check `flex-shrink` and "
+            f"`min-width` on .if-identity\n{report[-1]}"
+        )
 
         # With room to spare the same hierarchy remains one line, right aligned.
         page.set_viewport_size({"width": 1600, "height": 1000})
@@ -1547,6 +1641,24 @@ def test_header_keeps_controls_left_and_work_data_right(browser, ui_url, tmp_pat
         )
         assert wide["controlsRight"] <= wide["dataLeft"], report[-1]
         assert wide["rightInset"] <= 14, report[-1]
+        # Flag #177, the property the retired `gapToControls` assert claimed to
+        # pin and did not: with room to spare the identity is sized to its
+        # CONTENT and does not absorb the free space. Every other assert here
+        # survives an identity grown to 3.6x its text — it still occupies one
+        # line, still sits right of the controls, still keeps its inset — so
+        # this is the only one that fails when the cap goes. Compared against
+        # the identity's own measured text rather than a px budget, which is
+        # what makes it host-independent; the 25% allowance covers
+        # measureText-vs-layout subpixel drift, not a second element's width.
+        overgrowth = wide["metrics"]["identityNatural"] * 1.25 + 4
+        assert wide["metrics"]["identityBox"] <= overgrowth, (
+            f"the identity grew to {wide['metrics']['identityBox']}px at 1600px "
+            f"against {wide['metrics']['identityNatural']}px of text "
+            f"(ceiling {round(overgrowth, 1)}px): it is absorbing the header's "
+            "free space instead of staying at its content width, which pushes "
+            "the work context's slot down as the viewport grows"
+            f"\n{report[-1]}"
+        )
     finally:
         # Written on pass as well as failure: an instrumented run that goes
         # green still has to hand back the numbers it measured.


### PR DESCRIPTION
Sprint 84 · U12 · flags #67, #106, #169, #177 — deterministic test hygiene.

Four pre-existing tests that did not measure what they claimed. Each fix is
verified by mutation: break the guarded code, show the test RED, show the
baseline green again after the revert. A green suite alone is not the
deliverable, so every claim below has a red behind it.

## The trap this unit had to avoid

A flaky test is most easily "fixed" by weakening it into a test that cannot
fail — which converts a flake into flag #177's defect and looks like success
on a green board. So each fix below is paired with the mutation that proves it
still catches what it was written to catch, and where one fix added two
assertions, each was reddened by its own ISOLATING mutation — one red does not
prove two operands are live.

## #177 — a property pinned nowhere

The `gapToControls` assertion the flag names is already gone from the tree, but
the property it was supposed to pin is still unpinned. Growing `.if-identity`
to **341px against 94.8px of actual text** ships green through BOTH the
rendered and the static suite. Every existing assertion survives it — still one
line, still right of the controls, still inside its inset — while the work
context's slot is squeezed **38px → 0px**.

Two assertions added, each with an isolating mutation:

| Mutation | Effect | Which assert fires |
|---|---|---|
| `flex: 1 0 auto` | identity refuses to shrink | narrow: identity must yield |
| `flex: 1 1 auto` | identity absorbs free space | wide: no overgrowth |

Both compare the element against its **own measured text** rather than a px
budget, so they hold across hosts that resolve the generic font stack
differently — the failure mode this file has been re-tuned for twice. Note
`scrollWidth` cannot serve as that reference: it clamps up to `clientWidth`, so
an overgrown identity compares equal to itself.

Deliberately NOT asserted: `contextSlot > 0`. The runner's slot is already 0px
at 700px on an unmutated head, so that assert would be red in CI on correct
code.

## #169 — a skip nobody could see

The suite reported `1 skipped` when playwright was absent: twenty assertions
silently not running, indistinguishable from a green run with coverage. A skip
is the right outcome for a dependency-light suite; an invisible one is not.

The skip now names the interpreter, the playwright version, the browser builds
actually on disk, and the remedy — and is raised as a warning, because a
warning survives `-q` where a skip count does not. All three environment states
were exercised directly rather than reasoned about:

| State | Before | After |
|---|---|---|
| playwright + matching browser | 20 passed | 20 passed |
| playwright absent | `1 skipped` | loud skip naming the stack |
| playwright present, build drifted | 20 confusing errors | 1 loud skip |

The guard is scoped to the **launch only** — a failure inside a test stays a
failure. Confirmed: the #177 mutations above still report `1 failed` through
this guard, not a skip.

## #106 — a budget that was its own timeout

`test_dead_sidecar_fails_probe_fast` injected a 5s timeout and asserted the
probe returned in under 5s. The budget and the timeout were the same number, so
it carried zero headroom and reddened at 5.027s with correct code.

"Fast" is re-expressed as what it actually means: the failure arrives via
**death-detection**, not via the request timeout. Two paths, two messages, so
the message discriminates and no clock enters the assertion:

- dead → `_reader` hits EOF → `"shadow sidecar exited"`
- wedged → `asyncio.wait_for` → `"... timed out after Ns ..."`

Mutation (strip death-detection) → `AssertionError: 'exited' not found in
"...timed out after 30s..."`. Applied to the sibling
`test_silent_sidecar_times_out` too — same defect, same class; fixing only the
instance that happened to redden would leave the class in place.

Stability: 10/10 quiet, then 8/8 while a full suite ran concurrently, with
runtimes varying 1.4s–5.1s. That 3.5x spread under load is exactly what the old
assertion died on.

## #67 — the instrument, and what it found

`wait_len` tested its predicate BEFORE `sleep(0.05)` and never again, so a burst
completing during that final sleep raised on a stale reading:

```
TimeoutError: length predicate not met (have 5065000 bytes)
```

A test reporting the **entire corpus** in the same breath as declaring the
predicate unmet. That is the flag's "shape 2", it is deterministic rather than
contention, and it is reproduced here with a synthetic poll sequence. It
survived because nobody read the message — they reran it.

The total-duration budget is replaced with a **no-progress** budget: a slower
host passes while bytes keep arriving; a genuine wedge fails and reports where
it stopped. Mutation (wedge the pump) → fails in 30s with `stream stalled at
0/5065000 — no progress for 30s`, rather than hanging.

**This test now fails intermittently on this host, and that is the unit
working.** The repaired instrument surfaces an unresolved delivery observation
in the spike (flag #362 / PLN2's #363): the broker's counters report a tail as
fanned out that the client has not received. Per PLN2's ruling this PR ships
the instrument only and does not adopt the defect. **No CI impact: CI runs
`pytest tests/`; no job collects `spikes/`.**

Stated precisely, because the rate and the mechanism are supported by different
evidence and only one of them is settled:

- **Established, load-invariantly:** delivery stops mid-burst and does not
  resume within 180 seconds while the connection is open. Contention predicts
  slowness; it does not predict permanent silence.
- **NOT established:** any failure *rate*. Every observation here was taken on a
  box also running other devs' suites, so no quiet-host rate is claimed. An
  isolation measurement is scheduled by PLN2 into a planned fleet-drain window
  and is deliberately not carried by this unit.

## Verification

- Full suite: **1947 passed, 460 subtests passed** (exit 0).
- Lint: parity with `main` on every touched file.
- Mutation round trips run with `PYTHONDONTWRITEBYTECODE=1` and caches cleared,
  each asserting the baseline is green after the revert — a same-second revert
  can otherwise leave stale bytecode running and invert a reading.

## One correction, recorded rather than buried

An earlier report of mine argued from "12 runs in isolation on an idle host".
That claim was false — I never measured the host, and two other devs were
running full suites during the window. The conclusion survived, but only after
being re-established by an experiment that does not depend on host quietness:
raising the no-progress budget to 180s. Outcomes are bimodal five orders of
magnitude apart (~1s pass, or nothing further for 180s) at *identical* measured
load, and one failure sat 180s silent with **12,285 bytes** outstanding. Load
does not discriminate the two modes and cannot be the cause. Details on flag
#362, including the withdrawn inference.
