### PR TITLE
feat(memory): decision-chain stop rule on the always-loaded boot path

### DIFF
--- a/.super-coder/migrations/0108_reseed_decisions_chain_stop_rule.sql
+++ b/.super-coder/migrations/0108_reseed_decisions_chain_stop_rule.sql
@@ -1,0 +1,34 @@
+-- 0108 — decisions: chain stop-rule on the always-loaded boot path
+--
+-- Follow-up to 0044/#274 (index/library split). The index already excludes
+-- superseded rows, but shells — Opus seats especially — still walk decision
+-- chains: a flag/spec/feature cites a decision, the citation resolves to a
+-- superseded row, and the shell follows parent links outward "for context."
+-- The citation-follow itself is fine (that IS the explicit direction); the
+-- failure mode is the walk that continues past the first hop.
+--
+-- Fix (norm only, no read-path change): one stop-rule paragraph in the
+-- always-loaded shell system prompt — active decisions load by subject;
+-- superseded decisions are history, loaded only on explicit direction or
+-- when auditing why a decision changed; parent chains are provenance, not
+-- trails. Spliced into existing shells' prompts anchored on the 0044
+-- "Read before you decide" paragraph, 0037/0044-style; the template covers
+-- shells created from here on. Guarded idempotent.
+
+BEGIN;
+
+UPDATE shells
+   SET system_prompt = REPLACE(system_prompt,
+       'never silently re-litigate.',
+       'never silently re-litigate.
+
+**Chains are provenance, not trails.** Active decisions are working context —
+load them by subject when they bear on the work. A citation in a flag, spec, or
+feature may resolve to a superseded decision; that''s fine — read the superseding
+row it points to and move on. Never walk parent chains as context-gathering;
+load decision history only when explicitly directed, or when auditing why a
+decision changed.')
+ WHERE system_prompt LIKE '%never silently re-litigate.%'
+   AND system_prompt NOT LIKE '%provenance, not trails%';
+
+COMMIT;

--- a/.super-coder/templates/shell_system_prompt.md
+++ b/.super-coder/templates/shell_system_prompt.md
@@ -34,6 +34,13 @@ architectural or approach decision, lazy-load the log: `sc mem get decisions`
 rationale). Honor a prior decision or supersede it explicitly (`--parent`) —
 never silently re-litigate.
 
+**Chains are provenance, not trails.** Active decisions are working context —
+load them by subject when they bear on the work. A citation in a flag, spec, or
+feature may resolve to a superseded decision; that's fine — read the superseding
+row it points to and move on. Never walk parent chains as context-gathering;
+load decision history only when explicitly directed, or when auditing why a
+decision changed.
+
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is generated from the DB.
 If one looks wrong or out of date, the DB row is wrong — fix it via `sc mem`.


### PR DESCRIPTION
Shells (Opus seats especially) follow decision citations out of flags/specs/features — which is correct retrieval — but then keep walking parent chains as context-gathering, pulling superseded decision history into context. The 0044/#274 index/library split already keeps superseded rows out of the default index; this adds the missing norm at the moment of temptation's source: one **"Chains are provenance, not trails"** paragraph in the always-loaded shell system prompt. Active decisions load by subject; a citation resolving to a superseded row means read the superseding row it points to and move on; history loads only on explicit direction or when auditing why a decision changed.

Deliberately norm-only (no read-path or CLI changes) — keeping restrictions minimal and seeing if the prompt line is enough before adding mechanics.

- Template edit covers shells created from here on.
- Migration `0108` splices the identical paragraph into existing shells' prompts, anchored on the 0044 "Read before you decide" paragraph, guarded idempotent.

Test plan:
- [x] Applied 0108 twice to a copy of the dos-arch fleet DB (16 shells): paragraph lands once per shell, second apply is a no-op.
- [x] `pytest tests/test_boot_sprint_directive.py tests/test_interface_schema.py` — 31 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)