### PR TITLE
feat(sprint): board transition machine, close cleanup, PR-unit linkage, review_head (S84 U3)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -65,6 +65,7 @@ import interface_wake  # noqa: E402
 import live_model  # noqa: E402
 import ports as ports_mod  # noqa: E402
 import shell_liveness  # noqa: E402
+from sprint_units import TERMINAL_UNIT_STATES as _TERMINAL_UNIT_STATES  # noqa: E402,E501
 from sprint_units import UNIT_STATES as _UNIT_STATES  # noqa: E402
 from sprint_units import board_writer as _board_writer  # noqa: E402
 
@@ -2322,6 +2323,12 @@ _UNIT_FIELDS = {
     "overlap": (str, True),
     "branch": (str, True),
     "pr_number": (int, True),
+    # The reviewer's `review-clean head=<sha>` verdict, as the planner records
+    # it when moving a unit out of in_review (H-14). Free text on purpose:
+    # close checks PRESENCE, never correctness — judging whether that SHA is
+    # the head that was reviewed is the planner's call (decision #76), and a
+    # format check here would only teach a planner to type past it.
+    "review_head": (str, True),
 }
 _UNIT_ROLES = {"dev": "dev_shell_id", "reviewer": "reviewer_shell_id"}
 
@@ -2364,6 +2371,49 @@ def _bad_unit_field(body):
                         f"{field} cannot be blank"
                         + (" — pass null to clear it" if clearable else ""))
     return None
+
+
+def _no_such_move(doc_id, seq: str, was: str, now: str) -> str:
+    """The refusal a planner reads when it asks the board for a move the
+    machine does not have (H-11). Terminal gets its own sentence because the
+    remedy is different in kind: every other illegal move is a typo to retype,
+    while a wrong `merged`/`cancelled` is a declaration that has to be
+    superseded rather than undone."""
+    if was in _TERMINAL_UNIT_STATES:
+        return (f"sprint {doc_id} unit {seq} is {was} — terminal, and terminal "
+                f"has no exits. The row is the record of what was declared, so "
+                f"a mis-declared {was} is corrected by declaring a SUCCESSOR "
+                f"UNIT at a new seq that redoes or disposes of the work, not "
+                f"by re-opening this one")
+    legal = sorted(interface_state.SPRINT_UNIT_EDGES.get(was, ()))
+    return (f"sprint {doc_id} unit {seq} cannot go {was} -> {now}; from {was} "
+            f"the board admits {', '.join(legal)}")
+
+
+def _pr_claimed_by(con, doc_id, pr_number, seq: str):
+    """The partial unique index idx_sprint_units_pr_claim (0109) fires as a
+    bare IntegrityError, which reads to a planner as "the write failed" and
+    names neither the PR nor the unit already holding it. Translate it: return
+    an error object when some OTHER unit on this board already claims
+    `pr_number`, else None so the caller reports its own conflict.
+
+    Re-derived by query rather than parsed out of the driver's message —
+    every driver phrases a constraint violation differently, and the answer a
+    planner needs (WHICH unit) is not in that string on any of them.
+    """
+    if pr_number is None:
+        return None
+    row = con.execute(
+        "SELECT seq FROM sprint_units "
+        "WHERE sprint_doc_id=? AND pr_number=? AND seq<>?",
+        (doc_id, pr_number, seq)).fetchone()
+    if row is None:
+        return None
+    return _err_obj(
+        "pr_already_claimed",
+        f"PR #{pr_number} is already unit {row[0]}'s on sprint {doc_id} — one "
+        f"PR belongs to one unit, and pointing {seq} at it too would leave "
+        "the reconciler resolving its events to whichever row it read first")
 
 
 def _may_write_board(con, actor, sprint_doc_id: int):
@@ -2425,8 +2475,8 @@ class _BadShell(Exception):
 _UNIT_COLS = (
     "unit_id", "sprint_doc_id", "seq", "unit_title", "dev_shell_id",
     "reviewer_shell_id", "state", "depends_on", "overlap", "branch",
-    "pr_number", "assigned_at", "state_changed_at", "updated_at",
-    "updated_by_shell_id")
+    "pr_number", "review_head", "assigned_at", "state_changed_at",
+    "updated_at", "updated_by_shell_id")
 
 
 def _unit_projection(con, unit_id: int) -> dict:
@@ -2669,15 +2719,21 @@ def _add_sprint_unit(actor, headers, body):
                     "INSERT INTO sprint_units "
                     "(sprint_doc_id, seq, unit_title, dev_shell_id, "
                     " reviewer_shell_id, state, depends_on, overlap, branch, "
-                    " pr_number, assigned_at, updated_by_shell_id) "
-                    "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                    " pr_number, review_head, assigned_at, "
+                    " updated_by_shell_id) "
+                    "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
                     (doc_id, seq, title, roles["dev_shell_id"],
                      roles["reviewer_shell_id"], state,
                      body.get("depends_on"), body.get("overlap"),
                      body.get("branch"), body.get("pr_number"),
+                     body.get("review_head"),
                      _now(con) if any(roles.values()) else None,
                      actor.shell_id))
             except db_driver.IntegrityError:
+                claimed = _pr_claimed_by(con, doc_id, body.get("pr_number"),
+                                         seq)
+                if claimed is not None:
+                    return 409, claimed
                 return 409, _err_obj(
                     "unit_exists",
                     f"sprint {doc_id} already has unit {seq} — edit it with "
@@ -2755,6 +2811,13 @@ def _patch_sprint_unit(actor, headers, body):
             unit_id, was_state, was_dev, was_rev = row
             sets, params = [], []
             if state is not None:
+                try:
+                    interface_state.check(
+                        interface_state.SPRINT_UNIT_EDGES, was_state, state)
+                except interface_state.InterfaceTransitionError:
+                    return 409, _err_obj(
+                        "illegal_unit_transition", _no_such_move(
+                            doc_id, seq, was_state, state))
                 sets.append("state=?")
                 params.append(state)
                 if state != was_state:
@@ -2781,9 +2844,16 @@ def _patch_sprint_unit(actor, headers, body):
             sets.append("updated_at=datetime('now')")
             sets.append("updated_by_shell_id=?")
             params.append(actor.shell_id)
-            con.execute(
-                f"UPDATE sprint_units SET {', '.join(sets)} WHERE unit_id=?",
-                (*params, unit_id))
+            try:
+                con.execute(
+                    f"UPDATE sprint_units SET {', '.join(sets)} "
+                    "WHERE unit_id=?", (*params, unit_id))
+            except db_driver.IntegrityError:
+                claimed = _pr_claimed_by(con, doc_id, edits.get("pr_number"),
+                                         seq)
+                if claimed is not None:
+                    return 409, claimed
+                raise
             # A role omitted from the body is left alone, so `after` is the
             # row as it now reads — not the request. The counterpart the
             # notice names has to be the board's, not the caller's subset.

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -87,6 +87,7 @@ import model_catalog  # noqa: E402  (live model-id suggestions, sibling module)
 import analytics  # noqa: E402  (token & session analytics sweep — doc #11)
 import token_parsers  # noqa: E402  (harness roster + per-parser data dirs)
 from sprint_units import UNIT_COLUMNS as _SPRINT_UNIT_COLUMNS  # noqa: E402
+from sprint_units import TERMINAL_UNIT_STATES  # noqa: E402
 from sprint_units import UNIT_STATES  # noqa: E402
 from quota_probes import dispatch as quota_dispatch  # noqa: E402  (account quota probes — doc #49)
 import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
@@ -606,6 +607,7 @@ def get_active_sprints(con) -> dict:
         "unit.state AS unit_state, unit.depends_on AS unit_depends_on, "
         "unit.overlap AS unit_overlap, unit.branch AS unit_branch, "
         "unit.pr_number AS unit_pr_number, "
+        "unit.review_head AS unit_review_head, "
         "unit.assigned_at AS unit_assigned_at, "
         "unit.state_changed_at AS unit_state_changed_at, "
         "unit.updated_at AS unit_updated_at, "
@@ -1243,21 +1245,119 @@ def _sprint_doc_status(con, doc_id) -> "str | None":
     return None
 
 
-def _close_sprint_wake(con, doc_id) -> int:
-    """Sprint close integration (spec #20 Sprint Scope, sprint 25 seq 10):
-    closing (status: CLOSED) or freezing a sprint doc releases its wake
-    bindings and cancels their queued wake work in the SAME transaction —
-    no orphan armed binding or stranded queued batch survives the close
-    (the frozen-CANCEL in the submit gate is the in-flight backstop, not
-    the cleanup). Messages stay unread; the Interface chat is untouched.
-    Returns the number of bindings released."""
+# The alert reasons a WATCH carries, as opposed to a binding. Until H-12 these
+# were resolved on exactly one path — a watch being rebound to a sprint — so a
+# sprint that closed with a failing or unscoped watch left them open forever,
+# and `sc sprint alerts` grew a permanent floor of alerts about sprints nobody
+# was running. Enumerated rather than "every alert with a watch_id" so a future
+# reason has to be classified deliberately.
+_WATCH_ALERT_REASONS = ("pr_watch_unscoped", "pr_poll_failure",
+                        "pr_poll_backoff_escalated")
+
+
+def _link_watch_unit(con, watch_id: int, unit_id) -> bool:
+    """Point a live watch at a board unit (H-13). True when the row changed.
+
+    Called on the idempotent re-registration paths, where the watch already
+    exists: `sc watch pr … --unit U3` on an unlinked watch has to LINK it, not
+    report "already watched" and drop the flag. Re-pointing an already-linked
+    watch is allowed — a PR moving between units is a planner decision, and
+    the alternative is an operator with no way to correct a typo'd --unit.
+    Caller owns the commit.
+    """
+    if unit_id is None:
+        return False
+    return con.execute(
+        "UPDATE watched_prs SET unit_id=? "
+        "WHERE watch_id=? AND (unit_id IS NULL OR unit_id<>?)",
+        (unit_id, watch_id, unit_id)).rowcount > 0
+
+
+def _freeze_board_refusal(con, doc_id) -> "dict | None":
+    """Refuse to freeze a sprint whose own board says it is not finished
+    (spec #76 H-12, H-14). Returns an error body, or None to let the freeze
+    proceed.
+
+    Two conditions, reported TOGETHER rather than one per attempt: a planner
+    fixing a freeze wants the whole list, and refusing serially would make it
+    re-run the close to discover the second reason.
+
+    - every unit terminal (merged or cancelled). A non-terminal unit under a
+      frozen doc is a worker directive with nothing left to move it.
+    - every MERGED unit carries a review_head. Cancelled units are exempt by
+      construction: they never had a clean review, so requiring a head for one
+      would ask the planner to invent a SHA.
+
+    PRESENCE, not correctness — nothing here judges whether the SHA is the one
+    the reviewer read (decision #76). A board with no units at all freezes
+    freely; that is a sprint declared and abandoned before any unit existed,
+    and it has no worker to strand.
+    """
+    marks = ",".join("?" for _ in TERMINAL_UNIT_STATES)
+    live = [
+        (r["seq"], r["state"]) for r in con.execute(
+            "SELECT seq, state FROM sprint_units WHERE sprint_doc_id=? "
+            f"AND state NOT IN ({marks}) ORDER BY LENGTH(seq), seq",
+            (doc_id, *TERMINAL_UNIT_STATES)).fetchall()]
+    headless = [
+        r["seq"] for r in con.execute(
+            "SELECT seq FROM sprint_units WHERE sprint_doc_id=? "
+            "AND state='merged' AND (review_head IS NULL OR "
+            "TRIM(review_head)='') ORDER BY LENGTH(seq), seq",
+            (doc_id,)).fetchall()]
+    if not live and not headless:
+        return None
+    parts = []
+    if live:
+        parts.append("non-terminal: "
+                     + ", ".join(f"{seq} ({state})" for seq, state in live))
+    if headless:
+        parts.append("merged with no review_head: " + ", ".join(headless))
+    return {
+        "error": f"sprint {doc_id} is not finished — {'; '.join(parts)}. "
+                 "Freeze records that the sprint is over; move each unit to "
+                 "merged or cancelled first, and set --review-head on every "
+                 "merged unit from its reviewer's review-clean verdict.",
+        "code": "sprint_not_finished",
+        "non_terminal_units": [seq for seq, _ in live],
+        "units_without_review_head": headless,
+    }
+
+
+def _close_sprint_wake(con, doc_id) -> dict:
+    """Sprint close integration (spec #20 Sprint Scope, sprint 25 seq 10;
+    spec #76 H-12): closing (status: CLOSED) or freezing a sprint doc retires
+    the sprint's WHOLE live footprint in the SAME transaction — its wake
+    bindings and their queued wake work, its live PR watches, and the
+    watch-scoped alerts those watches opened. No orphan armed binding, no
+    stranded queued batch, no watch still polling GitHub for a sprint that
+    ended, and no permanently-open alert about either (the frozen-CANCEL in
+    the submit gate is the in-flight backstop, not the cleanup). Messages stay
+    unread; the Interface chat is untouched.
+
+    Returns the three counts, because a cleanup nobody can see is
+    indistinguishable from one that did not run — the close response reports
+    what it retired.
+    """
+    retired = con.execute(
+        "UPDATE watched_prs SET closed_at=datetime('now') "
+        "WHERE sprint_doc_id=? AND closed_at IS NULL", (doc_id,)).rowcount
+    marks = ",".join("?" for _ in _WATCH_ALERT_REASONS)
+    resolved = con.execute(
+        "UPDATE planner_alerts SET resolved_at=datetime('now') "
+        f"WHERE resolved_at IS NULL AND reason IN ({marks}) "
+        "AND watch_id IN (SELECT watch_id FROM watched_prs "
+        "                 WHERE sprint_doc_id=?)",
+        (*_WATCH_ALERT_REASONS, doc_id)).rowcount
+    released = 0
     if con.execute(
             "SELECT 1 FROM sprint_planner_bindings "
             "WHERE sprint_doc_id=? AND released_at IS NULL LIMIT 1",
-            (doc_id,)).fetchone() is None:
-        return 0
-    return len(interface_broker.release_bindings_for_sprint(
-        con, doc_id, "sprint closed"))
+            (doc_id,)).fetchone() is not None:
+        released = len(interface_broker.release_bindings_for_sprint(
+            con, doc_id, "sprint closed"))
+    return {"released_bindings": released, "retired_watches": retired,
+            "resolved_watch_alerts": resolved}
 
 
 def create_flag(con, body):
@@ -2660,15 +2760,23 @@ class Handler(BaseHTTPRequestHandler):
                     # heals any drift a lost post-freeze serialize left behind.
                     return self._send(200, {"ok": True, "already_frozen": True,
                                             "serialize": serialize_doc_write()})
+                # H-12/H-14: the close skill already REQUIRES every unit
+                # terminal and every merged unit review-clean at a known head.
+                # Until now that was procedure only — a freeze went through on
+                # a board still showing `working` units, and the record then
+                # said the sprint was over while its own units said otherwise.
+                refusal = _freeze_board_refusal(con, did)
+                if refusal is not None:
+                    return self._send(409, refusal)
                 con.execute(
                     "UPDATE documents SET frozen=1, frozen_date=date('now') WHERE document_id=?",
                     (did,))
                 # Sprint close integration (seq 10): freezing the board
-                # releases its wake bindings + cancels queued wake work.
-                released = _close_sprint_wake(con, did)
+                # releases its wake bindings + cancels queued wake work, and
+                # retires the sprint's watches + watch-scoped alerts (H-12).
+                closed = _close_sprint_wake(con, did)
                 con.commit()
-                return self._send(200, {"ok": True,
-                                        "released_bindings": released,
+                return self._send(200, {"ok": True, **closed,
                                         "serialize": serialize_doc_write()})
 
             # PATCH /_sc/mem/docs/{id}
@@ -2687,12 +2795,12 @@ class Handler(BaseHTTPRequestHandler):
                 ok, err = patch_document(con, did, body, commit=False)
                 if not ok:
                     return self._send(400, {"ok": ok, "error": err})
-                released = 0
+                closed = {"released_bindings": 0, "retired_watches": 0,
+                          "resolved_watch_alerts": 0}
                 if _sprint_doc_status(con, did) == "CLOSED":
-                    released = _close_sprint_wake(con, did)
+                    closed = _close_sprint_wake(con, did)
                 con.commit()
-                return self._send(200, {"ok": ok,
-                                        "released_bindings": released,
+                return self._send(200, {"ok": ok, **closed,
                                         "serialize": serialize_doc_write()})
 
             # PATCH /_sc/mem/messages/{id}/read
@@ -2765,9 +2873,11 @@ class Handler(BaseHTTPRequestHandler):
             include_closed = q.get("all", ["0"])[0] in ("1", "true", "yes")
             active = pr_poller.active_sprint_doc_ids(con)
             sql = ("SELECT w.watch_id, w.repo, w.pr_number, w.shell_id, "
-                   "s.shortname, w.created_at, w.closed_at, w.sprint_doc_id "
+                   "s.shortname, w.created_at, w.closed_at, w.sprint_doc_id, "
+                   "w.unit_id, u.seq AS unit_seq "
                    "FROM watched_prs w "
-                   "JOIN shells s ON s.shell_id = w.shell_id")
+                   "JOIN shells s ON s.shell_id = w.shell_id "
+                   "LEFT JOIN sprint_units u ON u.unit_id = w.unit_id")
             if not include_closed:
                 sql += " WHERE w.closed_at IS NULL"
             sql += " ORDER BY w.repo, w.pr_number, w.watch_id"
@@ -2808,6 +2918,23 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(409, {"error":
                     f"document {sprint_doc_id} is not an ACTIVE, unfrozen "
                     "SPRINT doc — watches arm only to active sprints"})
+            # H-13: the unit this PR belongs to, named the way every message
+            # names it ("U3") and resolved against THIS sprint's board. Two
+            # free integers that nothing joined is what made the reconciler
+            # regex message prose for the answer.
+            unit_id = None
+            if body.get("unit"):
+                seq = str(body["unit"]).strip()
+                r = con.execute(
+                    "SELECT unit_id FROM sprint_units "
+                    "WHERE sprint_doc_id=? AND seq=?",
+                    (sprint_doc_id, seq)).fetchone()
+                if r is None:
+                    return self._send(404, {"error":
+                        f"sprint {sprint_doc_id} has no unit '{seq}' — a watch "
+                        "links to a unit the board already declares; check "
+                        "`sc sprint board --sprint " f"{sprint_doc_id}`"})
+                unit_id = r["unit_id"]
             target = sid
             if body.get("shell"):
                 r = con.execute(
@@ -2829,8 +2956,15 @@ class Handler(BaseHTTPRequestHandler):
                 (repo, pr, target, sprint_doc_id)).fetchone()
             daemon = self._daemon_state(con)
             if existing is not None:
+                # A re-registration that NAMES a unit links the live watch even
+                # though the watch itself already existed. Returning "already
+                # watched" while silently dropping --unit would leave the
+                # operator believing a link they can see no trace of.
+                linked = _link_watch_unit(con, existing["watch_id"], unit_id)
+                con.commit()
                 return self._send(200, {"watch_id": existing["watch_id"],
-                                        "existing": True, "daemon": daemon})
+                                        "existing": True, "linked": linked,
+                                        "daemon": daemon})
             # Registration baseline (spec: an immediate GitHub read, normalized
             # and stored BEFORE arming; a failed baseline creates no armed
             # watch and returns a retryable sanitized error). The gh call
@@ -2856,9 +2990,11 @@ class Handler(BaseHTTPRequestHandler):
                 "AND closed_at IS NULL AND sprint_doc_id=?",
                 (repo, pr, target, sprint_doc_id)).fetchone()
             if existing is not None:
-                con.rollback()
+                linked = _link_watch_unit(con, existing["watch_id"], unit_id)
+                con.commit()
                 return self._send(200, {"watch_id": existing["watch_id"],
-                                        "existing": True, "daemon": daemon})
+                                        "existing": True, "linked": linked,
+                                        "daemon": daemon})
             unscoped = con.execute(
                 "SELECT watch_id FROM watched_prs "
                 "WHERE repo=? AND pr_number=? AND shell_id=? "
@@ -2866,9 +3002,10 @@ class Handler(BaseHTTPRequestHandler):
                 (repo, pr, target)).fetchone()
             if unscoped is not None:
                 con.execute(
-                    "UPDATE watched_prs SET sprint_doc_id=?, last_seen=? "
-                    "WHERE watch_id=?",
-                    (sprint_doc_id, json.dumps(fp), unscoped["watch_id"]))
+                    "UPDATE watched_prs SET sprint_doc_id=?, last_seen=?, "
+                    "unit_id=COALESCE(?, unit_id) WHERE watch_id=?",
+                    (sprint_doc_id, json.dumps(fp), unit_id,
+                     unscoped["watch_id"]))
                 con.execute(
                     "UPDATE planner_alerts SET resolved_at=datetime('now') "
                     "WHERE watch_id=? AND reason='pr_watch_unscoped' "
@@ -2879,8 +3016,8 @@ class Handler(BaseHTTPRequestHandler):
                                         "rebound": True, "daemon": daemon})
             cur = con.execute(
                 "INSERT INTO watched_prs (repo, pr_number, shell_id, last_seen, "
-                "sprint_doc_id) VALUES (?, ?, ?, ?, ?)",
-                (repo, pr, target, json.dumps(fp), sprint_doc_id))
+                "sprint_doc_id, unit_id) VALUES (?, ?, ?, ?, ?, ?)",
+                (repo, pr, target, json.dumps(fp), sprint_doc_id, unit_id))
             con.commit()
             return self._send(201, {"watch_id": cur.lastrowid, "daemon": daemon})
         except Exception as e:

--- a/.super-coder/migrations/0108_sprint_unit_transitions.sql
+++ b/.super-coder/migrations/0108_sprint_unit_transitions.sql
@@ -1,0 +1,64 @@
+-- 0108 — the sprint board gets a real transition machine, and the review
+-- verdict gets a column (spec doc 76, H-11 + H-14; sprint doc 84 U3).
+--
+-- 0098 gave `sprint_units.state` a CHECK vocabulary and nothing else. A
+-- vocabulary answers "is this a word" — it never answers "may this row go
+-- there from where it is". So `merged -> working` and `cancelled -> pending`
+-- are accepted today: the reconciler re-arms on a unit that shipped, and the
+-- boot renderer re-issues a worker directive for work that is over. Every
+-- other lifecycle in this engine (0078) carries a DB trigger PLUS a mirrored
+-- app edge map; the board is the one that did not.
+--
+-- ── merged and cancelled are TERMINAL — no exits, ever ──────────────────────
+--
+-- Deliberately no override flag, no admin escape, no `force` verb. The
+-- immutability IS the feature: a terminal row is the record of what was
+-- declared, and a record that can be walked back is not a record. A
+-- MIS-DECLARED terminal state is corrected the way a mis-frozen document is
+-- (decision #82's shape): by declaring a SUCCESSOR UNIT at a new seq that
+-- redoes or disposes of the work. The predecessor stands untouched, and the
+-- pair reads as what actually happened rather than as a state that quietly
+-- became something else.
+--
+-- The trigger is the backstop; scripts/interface_state.py:SPRINT_UNIT_EDGES
+-- mirrors it so the API answers 409 with a sentence instead of an
+-- IntegrityError. KEEP THE TWO IN SYNC — tests/test_interface_transitions.py
+-- walks every (old, new) pair against BOTH layers and fails on any drift.
+--
+-- A same-state re-assert stays legal (`NEW.state <> OLD.state` guard), exactly
+-- as the 0078 machines do: the PATCH route already declines to restamp
+-- state_changed_at on a no-op move, and making the no-op itself an error would
+-- turn an idempotent retry into a failure.
+--
+-- ── H-14: review_head ──────────────────────────────────────────────────────
+--
+-- Sprint close requires "every assigned review ended review-clean at a known
+-- head". That fact lives only in message prose, so close cannot verify it —
+-- it can only re-read a sentence someone wrote. One column carries it: the
+-- planner sets `review_head` from the reviewer's `review-clean head=<sha>`
+-- verdict when it moves a unit out of `in_review`.
+--
+-- PRESENCE, not correctness. Nothing here checks that the SHA is the head that
+-- was reviewed, or that it is a SHA at all — judgment about a verdict stays
+-- with the planner (decision #76). Nullable, because a unit that has not
+-- reached review has no head to name, and `cancelled` units never had a clean
+-- review at all and are exempt from the close check by construction.
+
+BEGIN;
+
+ALTER TABLE sprint_units ADD COLUMN review_head TEXT;
+
+CREATE TRIGGER IF NOT EXISTS trg_sprint_units_state
+BEFORE UPDATE OF state ON sprint_units
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'pending'   AND NEW.state IN ('working','cancelled')) OR
+    (OLD.state = 'working'   AND NEW.state IN ('in_review','blocked','merged','cancelled')) OR
+    (OLD.state = 'in_review' AND NEW.state IN ('working','blocked','merged','cancelled')) OR
+    (OLD.state = 'blocked'   AND NEW.state IN ('working','cancelled'))
+    -- 'merged' and 'cancelled' appear on no left-hand side: terminal.
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal sprint unit transition');
+END;
+
+COMMIT;

--- a/.super-coder/migrations/0109_sprint_pr_unit_linkage.sql
+++ b/.super-coder/migrations/0109_sprint_pr_unit_linkage.sql
@@ -1,0 +1,49 @@
+-- 0109 — structured PR↔unit linkage (spec doc 76, H-13; sprint doc 84 U3).
+--
+-- `sprint_units.pr_number` and `watched_prs.pr_number` are two free integers
+-- that nothing joins. So when a pr_event arrives, "which unit is this about"
+-- is answered by REGEX OVER MESSAGE PROSE (activity_readers._names_unit) —
+-- the reconciler greps a body for "U3". That works until a body says "U3" for
+-- another reason, and it cannot work at all for a row nobody wrote prose into.
+--
+-- Two columns' worth of structure removes the guess from the path that HAS the
+-- answer, and changes nothing about the planner-advances-the-board design:
+--
+--   * `watched_prs.unit_id` — nullable FK, set at registration
+--     (`sc watch pr … --unit U3`). Nullable because unscoped and legacy
+--     watches are real rows: this link is an improvement to traffic that
+--     carries it, never a new requirement on traffic that does not.
+--
+--   * a partial UNIQUE index on `sprint_units(sprint_doc_id, pr_number)` —
+--     two units cannot claim one PR. On the BOARD, not on the registry: the
+--     registry legitimately holds several rows for one PR (a dev's watch and
+--     the planner's watch are different subscriptions to the same PR), so
+--     uniqueness there would refuse a correct registration. The board is where
+--     "this PR is unit U3's" is declared, and where a second claim is a
+--     planner typo that silently re-points the reconciler.
+--
+-- WHERE pr_number IS NOT NULL, because most of a board's life is units with no
+-- PR yet, and SQLite treats every NULL as distinct in a plain UNIQUE anyway —
+-- the partial index states the intent instead of relying on that.
+--
+-- The regex is NOT deleted. It stays as the fallback for unscoped traffic;
+-- readers PREFER the structured ref where one exists (see
+-- pr_poller._alert callers: a watch-scoped alert now names the unit
+-- structurally instead of leaving `planner_alerts.unit_id` NULL for a later
+-- reader to re-derive from a string).
+
+BEGIN;
+
+ALTER TABLE watched_prs
+    ADD COLUMN unit_id INTEGER REFERENCES sprint_units(unit_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sprint_units_pr_claim
+    ON sprint_units(sprint_doc_id, pr_number)
+    WHERE pr_number IS NOT NULL;
+
+-- The poller resolves watch → unit on every event; the registry is small but
+-- this is the only join it performs.
+CREATE INDEX IF NOT EXISTS idx_watched_prs_unit
+    ON watched_prs(unit_id);
+
+COMMIT;

--- a/.super-coder/scripts/activity_readers.py
+++ b/.super-coder/scripts/activity_readers.py
@@ -13,6 +13,13 @@ unattributed surfaces are excluded rather than guessed.
 ``read()`` observes integration refs exactly as they currently are.  Ref
 freshness is the caller's responsibility because one reconciler tick reads
 many worktrees but must fetch the shared integration ref only once.
+
+"Which unit is this row about" is answered STRUCTURALLY where a row carries a
+link (``watched_prs.unit_id``, reached through the poller's ``pr-event|``
+dedupe key) and by regex over prose where it does not — see
+``_row_names_unit``.  The regex is the fallback for unscoped traffic, not the
+primary answer, and it is deliberately kept: a dev's ``result`` row has no
+link and never will.
 """
 from __future__ import annotations
 
@@ -321,7 +328,7 @@ class ActivityReader:
 
             try:
                 rows = con.execute(
-                    "SELECT body, created_at FROM shell_messages "
+                    "SELECT body, created_at, dedupe_key FROM shell_messages "
                     "WHERE from_shell_id=? AND sprint_doc_id=? AND kind='result' "
                     "ORDER BY created_at DESC, message_id DESC",
                     (shell_id, sprint_doc_id),
@@ -344,10 +351,11 @@ class ActivityReader:
                     ).fetchone()[0]
                     if active_count != 1:
                         seq = str(_value(unit, "seq", ""))
+                        unit_id = _value(unit, "unit_id")
                         rows = [
                             row
                             for row in rows
-                            if self._names_unit(row["body"], seq)
+                            if self._row_names_unit(con, row, seq, unit_id)
                         ]
                 evidence.last_result_row_at = _timestamp(
                     rows[0]["created_at"] if rows else None
@@ -356,6 +364,51 @@ class ActivityReader:
                 self._mark(evidence, "result_row")
         con.close()
         return harness
+
+    @classmethod
+    def _row_names_unit(cls, con, row, seq: str, unit_id=None) -> bool:
+        """Is this message row about `seq`? STRUCTURE FIRST, prose second
+        (spec #76 H-13).
+
+        A row that carries a structured unit ref is answered by that ref alone
+        — including when the ref says NO. Falling through to the regex after a
+        structured mismatch would let a body that happens to mention "U3"
+        override the link that states which unit the row is actually about,
+        which is the inversion this requirement exists to remove.
+
+        Rows with no link (a dev's `result` prose is the whole population
+        today) fall back to the regex, which is why it is kept rather than
+        deleted. `watched_prs.unit_id` is nullable, so an unlinked watch is
+        unscoped traffic too and takes the same fallback.
+        """
+        linked = cls._linked_unit_id(con, _value(row, "dedupe_key"))
+        if linked is not None and unit_id is not None:
+            return linked == unit_id
+        return cls._names_unit(_value(row, "body"), seq)
+
+    @staticmethod
+    def _linked_unit_id(con, dedupe_key) -> "int | None":
+        """The unit a row is bound to through the PR watch that emitted it.
+
+        `pr-event|<watch_id>|<transition>|<sha>` is the poller's dedupe
+        identity (pr_poller._emit_event) and the only structured back-reference
+        a message row carries today. Returns None for every other row, for a
+        malformed key, and for a watch with no unit — all three mean "no
+        structured answer", not "no".
+        """
+        if not dedupe_key or not str(dedupe_key).startswith("pr-event|"):
+            return None
+        parts = str(dedupe_key).split("|")
+        if len(parts) < 2 or not parts[1].isdigit():
+            return None
+        try:
+            row = con.execute(
+                "SELECT unit_id FROM watched_prs WHERE watch_id=?",
+                (int(parts[1]),),
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        return None if row is None else row[0]
 
     @staticmethod
     def _names_unit(body: str, seq: str) -> bool:

--- a/.super-coder/scripts/interface_state.py
+++ b/.super-coder/scripts/interface_state.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 """Interface state machines — app-level transition validation (spec #20).
 
-The DB triggers in migrations/0078_interface_sessions.sql are the backstop
-(RAISE(ABORT)); these maps mirror them so the API/broker can pre-check and
-fail with a friendly error instead of an IntegrityError. KEEP THE TWO IN
-SYNC — tests/test_interface_transitions.py walks every (old, new) pair of
-every machine against BOTH layers and fails on any drift.
+The DB triggers are the backstop (RAISE(ABORT)); these maps mirror them so the
+API/broker can pre-check and fail with a friendly error instead of an
+IntegrityError. KEEP THE TWO IN SYNC — tests/test_interface_transitions.py
+walks every (old, new) pair of every machine against BOTH layers and fails on
+any drift.
+
+Triggers live in migrations/0078_interface_sessions.sql (the Interface
+machines) and migrations/0108_sprint_unit_transitions.sql (the sprint board).
 
 Edge rationales trace to spec #20's Occupancy Model / Input Broker / Wake
 Delivery sections. Two deliberate readings of the spec's edge lists:
@@ -98,7 +101,31 @@ RECEIPT_EDGES = {
     "reconciled": set(),
 }
 
+# The sprint board's own lifecycle (spec #76 H-11, migration 0108). Mirrors
+# trg_sprint_units_state.
+#
+# merged and cancelled map to the empty set and that is the whole point: a
+# terminal unit has no exit. A mis-declared one is corrected by declaring a
+# SUCCESSOR UNIT at a new seq, never by re-opening the row — the terminal row
+# stands as the record of what was declared (decision #82's shape). There is
+# deliberately no override edge, no admin escape and no force verb to add one.
+SPRINT_UNIT_EDGES = {
+    "pending": {"working", "cancelled"},
+    "working": {"in_review", "blocked", "merged", "cancelled"},
+    "in_review": {"working", "blocked", "merged", "cancelled"},
+    "blocked": {"working", "cancelled"},
+    "merged": set(),
+    "cancelled": set(),
+}
+
 # (table, pk column, state column, edge map) — one entry per machine.
+#
+# `sprint_unit` is registered here so the drift walker covers it, but its state
+# is NOT moved through transition(): the board's PATCH route pre-checks with
+# check() and then writes state, state_changed_at, updated_at and
+# updated_by_shell_id in ONE update, so the move stays attributable to the
+# planner that made it. Call check() for that machine, not transition(), or the
+# row loses its provenance columns.
 MACHINES = {
     "occupancy": ("interface_sessions", "session_id", "occupancy", OCCUPANCY_EDGES),
     "lifecycle": ("interface_sessions", "session_id", "lifecycle", LIFECYCLE_EDGES),
@@ -107,6 +134,7 @@ MACHINES = {
     "wake_item": ("planner_wake_items", "item_id", "state", WAKE_ITEM_EDGES),
     "wake_batch": ("planner_wake_batches", "batch_id", "state", WAKE_BATCH_EDGES),
     "receipt": ("planner_action_receipts", "receipt_id", "state", RECEIPT_EDGES),
+    "sprint_unit": ("sprint_units", "unit_id", "state", SPRINT_UNIT_EDGES),
 }
 
 # State tables carrying an updated_at column, touched on every transition.

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -160,7 +160,8 @@ def baseline_read(repo: str, pr_number: int, fetch=None) -> "tuple[dict | None, 
     return fp, None
 
 
-def transitions(prev: "dict | None", cur: dict, repo: str, number: int) -> "tuple[list[dict], bool]":
+def transitions(prev: "dict | None", cur: dict, repo: str, number: int,
+                unit: "str | None" = None) -> "tuple[list[dict], bool]":
     """The poller's core: (events, terminal?) for one PR transition.
 
     Each event is {"key", "body"}: key is the semantic transition key
@@ -187,7 +188,13 @@ def transitions(prev: "dict | None", cur: dict, repo: str, number: int) -> "tupl
     cancelled, no conclusion is coming."""
     events: list[dict] = []
     sha7 = (cur.get("sha") or "")[:7]
-    tag = f"{repo}#{number}"
+    # `unit=U3` in the header is the structured ref made visible (H-13): the
+    # watch knows which unit its PR belongs to, so the planner reading the row
+    # — and the reconciler's prose fallback — both get the answer instead of
+    # inferring it. Omitted entirely when the watch carries no unit, because a
+    # header that says `unit=None` is a claim, and an unlinked watch is making
+    # none.
+    tag = f"{repo}#{number}" + (f" unit={unit}" if unit else "")
 
     merged = cur.get("state") == "MERGED"
     checks = cur.get("checks")
@@ -938,9 +945,16 @@ def armed_watches(con) -> list:
         return []
     marks = ",".join("?" for _ in active)
     return con.execute(
-        "SELECT watch_id, repo, pr_number, shell_id, last_seen, sprint_doc_id "
-        f"FROM watched_prs WHERE closed_at IS NULL AND sprint_doc_id IN ({marks}) "
-        "ORDER BY repo, pr_number, watch_id", tuple(sorted(active))).fetchall()
+        "SELECT w.watch_id, w.repo, w.pr_number, w.shell_id, w.last_seen, "
+        "w.sprint_doc_id, w.unit_id, u.seq AS unit_seq "
+        "FROM watched_prs w "
+        # LEFT, not INNER: an unlinked watch is a first-class row (H-13's link
+        # is nullable), and an inner join would silently stop polling every
+        # watch registered without --unit.
+        "LEFT JOIN sprint_units u ON u.unit_id = w.unit_id "
+        f"WHERE w.closed_at IS NULL AND w.sprint_doc_id IN ({marks}) "
+        "ORDER BY w.repo, w.pr_number, w.watch_id",
+        tuple(sorted(active))).fetchall()
 
 
 def live_unscoped_watch_ids(con) -> list[int]:
@@ -1002,12 +1016,28 @@ def beat(con, interval: int, *, name: str = "watch") -> None:
 
 def _alert(con, *, severity: str, reason: str, watch_id=None) -> None:
     """Raise an alert, deduplicated while open (partial unique index). Local
-    helper — interface_broker._alert predates watch-scoped alerts."""
+    helper — interface_broker._alert predates watch-scoped alerts.
+
+    The sprint and unit are read off the watch rather than left NULL (H-13):
+    0102 gave planner_alerts structured identity columns, and a watch is the
+    one alert source that KNOWS both. Leaving them NULL forced every reader
+    back to parsing `dedupe_key` or grepping prose for "U3" — the guess this
+    linkage exists to delete. `dedupe_key` is unchanged, so an already-open
+    alert stays the same open alert and no re-alert storm follows.
+    """
     dedupe = f"-|-|{watch_id or '-'}|-|{reason}"
+    sprint_doc_id = unit_id = None
+    if watch_id is not None:
+        row = con.execute(
+            "SELECT sprint_doc_id, unit_id FROM watched_prs WHERE watch_id=?",
+            (watch_id,)).fetchone()
+        if row is not None:
+            sprint_doc_id, unit_id = row["sprint_doc_id"], row["unit_id"]
     con.execute(
         "INSERT OR IGNORE INTO planner_alerts "
-        "(watch_id, severity, reason, dedupe_key) VALUES (?,?,?,?)",
-        (watch_id, severity, reason, dedupe))
+        "(watch_id, sprint_doc_id, unit_id, severity, reason, dedupe_key) "
+        "VALUES (?,?,?,?,?,?)",
+        (watch_id, sprint_doc_id, unit_id, severity, reason, dedupe))
 
 
 def surface_unscoped_watches(con) -> int:
@@ -1116,7 +1146,8 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
             if cur is None:
                 continue  # unreadable this poll — keep the watch, try next cycle
             prev = json.loads(w["last_seen"]) if w["last_seen"] else None
-            events, terminal = transitions(prev, cur, w["repo"], w["pr_number"])
+            events, terminal = transitions(prev, cur, w["repo"],
+                                           w["pr_number"], w["unit_seq"])
             # Durable only with a transition or a blind-window marker (the
             # snapshot row filter); a quiet successful poll is noise.
             if events or blind:

--- a/.super-coder/scripts/sprint.py
+++ b/.super-coder/scripts/sprint.py
@@ -27,6 +27,20 @@ column role expectation derives from, so it moves in its own call and
 `state_changed_at` has exactly one writer. The API refuses a state move that
 carries other edits — the separation is a property, not a convention.
 
+The states are a MACHINE, not a vocabulary (migration 0108): pending →
+working → in_review ⇄ working, blocked in and out of working/in_review,
+merged from working/in_review, cancelled from anything not already terminal.
+`merged` and `cancelled` are terminal and have no exits — there is no force
+verb here because there is no such move to force. A unit declared terminal in
+error is corrected by declaring a SUCCESSOR UNIT at a new seq that redoes or
+disposes of the work; the terminal row stands as the record of what was
+declared.
+
+`--review-head` records the head a reviewer returned `review-clean` at, set as
+the planner moves the unit out of `in_review`. Freezing the sprint doc checks
+that every MERGED unit has one — presence only, since judging the verdict is
+the planner's job. Cancelled units never had a clean review and are exempt.
+
 `board` RENDERS the unit table from the record and prints it. It does not
 write it back into the document: the document keeps its prose, the record is
 the source, and a stored copy would state the board twice.
@@ -168,6 +182,8 @@ def _unit_body(args, *, creating: bool) -> dict:
         body["branch"] = _field(args.branch)
     if args.pr is not None:
         body["pr_number"] = None if args.pr < 0 else args.pr
+    if args.review_head is not None:
+        body["review_head"] = _field(args.review_head)
     return body
 
 
@@ -190,7 +206,8 @@ def _print_unit(u: dict) -> None:
             f"depends={_depends_cell(u)}"
             if (u.get("depends_on") or u.get("overlap")) else "",
             f"branch={u['branch']}" if u.get("branch") else "",
-            f"pr=#{u['pr_number']}" if u.get("pr_number") else "")
+            f"pr=#{u['pr_number']}" if u.get("pr_number") else "",
+            f"review_head={u['review_head']}" if u.get("review_head") else "")
         if p)
     print(f"{u['seq']:<5} [{u['state']}] {u['unit_title']} · {roles}"
           + (f" · {extra}" if extra else ""))
@@ -221,7 +238,7 @@ def cmd_unit_set(args) -> int:
     body = _unit_body(args, creating=False)
     if len(body) == 2:
         raise _die("nothing to set — pass at least one of --title, --dev, "
-                   "--reviewer, --depends-on, --branch, --pr "
+                   "--reviewer, --depends-on, --branch, --pr, --review-head "
                    "(state moves with `unit state`)")
     r = _api("PATCH", "/api/sprint-units", body,
              f"unit-set|{args.sprint}|{args.seq}|{uuid.uuid4()}")
@@ -419,6 +436,11 @@ def main(argv: "list[str] | None" = None) -> int:
         sp.add_argument("--branch", default=None, help="('none' to clear)")
         sp.add_argument("--pr", type=int, default=None,
                         help="PR number (-1 to clear)")
+        sp.add_argument("--review-head", default=None, metavar="SHA",
+                        help="the head the reviewer returned review-clean at, "
+                             "recorded as the unit leaves in_review; close "
+                             "checks it is PRESENT on every merged unit "
+                             "('none' to clear)")
 
     ua = usub.add_parser("add", help="declare a unit on the board (never an "
                                      "upsert — an existing seq is a 409)")

--- a/.super-coder/scripts/sprint_units.py
+++ b/.super-coder/scripts/sprint_units.py
@@ -8,8 +8,8 @@ and the supervised reconciler uses the same terminal set for its tick.
 UNIT_COLUMNS = (
     "unit_id", "sprint_doc_id", "seq", "unit_title", "dev_shell_id",
     "reviewer_shell_id", "state", "depends_on", "overlap", "branch",
-    "pr_number", "assigned_at", "state_changed_at", "updated_at",
-    "updated_by_shell_id",
+    "pr_number", "review_head", "assigned_at", "state_changed_at",
+    "updated_at", "updated_by_shell_id",
 )
 
 _STATE_VOCABULARY = (

--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -7,11 +7,13 @@ one vantage — everything shell-side rides the engine API (token identity,
 the `sc mem` doctrine):
 
     ./sc watch pr <owner/repo> <n> [--shell <shortname>] --sprint <doc-id>
-                                                           register a watch
+                                   [--unit U3]             register a watch
                                                            (defaults to the
                                                            calling shell;
                                                            scope is required
-                                                           and must be ACTIVE)
+                                                           and must be ACTIVE;
+                                                           --unit links the PR
+                                                           to a board unit)
     ./sc watch list [--all]                                live watches
     ./sc watch inbox [--interval 30] [--timeout 21600]     block until this
                                                            shell has unread
@@ -36,8 +38,12 @@ ACTIVE sprint. The poller only ever writes message rows + its own registry
 state: it never boots shells, never marks anything read, never touches git,
 never injects terminal input.
 
-A `pr_event` body is one line — repo, PR, what changed, head SHA. Detail
-lives in `gh`; the message is the wake-up, not the payload.
+A `pr_event` body is one line — repo, PR, the unit when the watch names one
+(`unit=U3`), what changed, head SHA. Detail lives in `gh`; the message is the
+wake-up, not the payload. The unit comes from `--unit` at registration and is
+the structured answer to "which unit is this about" — the reconciler's regex
+over message prose stays only as the fallback for traffic that carries no
+link.
 
 `inbox` is the planner-side replacement for scheduled polling: it loops a
 cheap local API read (zero harness turns, zero tokens) and exits the moment
@@ -159,15 +165,21 @@ def cmd_pr(args) -> int:
     if args.shell:
         payload["shell"] = args.shell
     payload["sprint_doc_id"] = args.sprint
+    if args.unit:
+        payload["unit"] = args.unit
     r = _api("POST", "/_sc/watches", payload)
     who = args.shell or "you"
+    unit = f" → unit {args.unit}" if args.unit else ""
     if r.get("existing"):
-        print(f"watch: {repo}#{args.number} already watched for {who} (watch #{r['watch_id']})")
+        linked = f", linked{unit}" if r.get("linked") else ""
+        print(f"watch: {repo}#{args.number} already watched for {who} "
+              f"(watch #{r['watch_id']}{linked})")
     elif r.get("rebound"):
-        print(f"watch: {repo}#{args.number} rebound to sprint doc {args.sprint} for {who} "
-              f"(watch #{r['watch_id']}, baseline armed)")
+        print(f"watch: {repo}#{args.number} rebound to sprint doc {args.sprint}{unit} "
+              f"for {who} (watch #{r['watch_id']}, baseline armed)")
     else:
-        print(f"watch: {repo}#{args.number} registered for {who} (watch #{r['watch_id']}, baseline armed)")
+        print(f"watch: {repo}#{args.number} registered for {who}{unit} "
+              f"(watch #{r['watch_id']}, baseline armed)")
         print("  (pr_event rows land in the shell's inbox as the service poller sees transitions)")
     d = r.get("daemon")
     if not d or not d.get("beat_at") or d.get("stale"):
@@ -199,6 +211,8 @@ def cmd_list(args) -> int:
         if not w.get("closed_at"):
             if w.get("sprint_doc_id"):
                 state += f", sprint #{w['sprint_doc_id']}"
+                if w.get("unit_seq"):
+                    state += f" unit {w['unit_seq']}"
                 state += " (armed)" if w.get("armed") else " (dormant — sprint not ACTIVE)"
             else:
                 state += ", dormant (unscoped — rebind with `sc watch pr … --sprint <doc>`)"
@@ -287,6 +301,10 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--shell", help="subscribe another shell (e.g. the planner) instead of you")
     sp.add_argument("--sprint", type=int, required=True, metavar="DOC_ID",
                     help="required ACTIVE sprint document scope")
+    sp.add_argument("--unit", metavar="SEQ",
+                    help="the sprint unit this PR is for, as the board writes "
+                         "it (U3) — carries onto every pr_event so readers "
+                         "resolve the unit structurally instead of by regex")
     sp.set_defaults(fn=cmd_pr)
 
     sp = sub.add_parser("list", help="live watches (--all includes retired)")

--- a/tests/test_activity_readers.py
+++ b/tests/test_activity_readers.py
@@ -52,7 +52,14 @@ def make_db(path: Path) -> None:
         );
         CREATE TABLE shell_messages (
           message_id INTEGER PRIMARY KEY, from_shell_id INTEGER,
-          sprint_doc_id INTEGER, created_at TEXT, kind TEXT, body TEXT
+          sprint_doc_id INTEGER, created_at TEXT, kind TEXT, body TEXT,
+          -- the poller's `pr-event|<watch_id>|…` identity: the only
+          -- structured back-reference a message row carries (H-13)
+          dedupe_key TEXT
+        );
+        CREATE TABLE watched_prs (
+          watch_id INTEGER PRIMARY KEY, sprint_doc_id INTEGER,
+          unit_id INTEGER
         );
         CREATE TABLE sprint_units (
           unit_id INTEGER PRIMARY KEY, sprint_doc_id INTEGER, seq TEXT,
@@ -84,7 +91,7 @@ def make_db(path: Path) -> None:
         "'operator_end','codex')"
     )
     con.execute(
-        "INSERT INTO shell_messages VALUES "
+        "INSERT INTO shell_messages (message_id, from_shell_id, sprint_doc_id, created_at, kind, body) VALUES "
         "(1,1,59,'2020-01-02T00:00:00Z','result',"
         "'sprint 59: unit U3 fixing')"
     )
@@ -92,7 +99,7 @@ def make_db(path: Path) -> None:
     # than the qualifying row so deleting any one SQL predicate turns the
     # contract assertion red.
     con.executemany(
-        "INSERT INTO shell_messages VALUES (?,?,?,?,?,?)",
+        "INSERT INTO shell_messages (message_id, from_shell_id, sprint_doc_id, created_at, kind, body) VALUES (?,?,?,?,?,?)",
         [
             (
                 2,
@@ -301,7 +308,7 @@ class DatabaseContractTest(ReaderCase):
             "'2020-01-03T00:00:00Z',1,1,3)"
         )
         con.executemany(
-            "INSERT INTO shell_messages VALUES (?,?,?,?,?,?)",
+            "INSERT INTO shell_messages (message_id, from_shell_id, sprint_doc_id, created_at, kind, body) VALUES (?,?,?,?,?,?)",
             [
                 (
                     5,
@@ -334,6 +341,78 @@ class DatabaseContractTest(ReaderCase):
             datetime(2020, 1, 6, tzinfo=UTC),
             evidence.last_durable_write_at,
         )
+
+    def test_a_structured_link_beats_the_prose_that_contradicts_it(self):
+        """H-13: the reconciler stops guessing which unit a row is about when
+        the row carries a link.
+
+        The body deliberately names the WRONG unit. Under the regex alone this
+        row is U3's, because "U3" appears in it; under the link it is U4's,
+        because that is what the watch says. The whole point of the structured
+        ref is that it wins — a reader that consulted prose first would keep
+        the defect and merely add a column nobody reads.
+        """
+        con = sqlite3.connect(self.db)
+        con.execute("INSERT INTO watched_prs VALUES (77,59,404)")
+        con.execute(
+            "INSERT INTO shell_messages (message_id, from_shell_id, "
+            "sprint_doc_id, created_at, kind, body, dedupe_key) VALUES "
+            "(90,1,59,'2020-01-06T00:00:00Z','result',"
+            "'pr_event o/r#7 unit=U3: checks green','pr-event|77|checks|abc')"
+        )
+        con.commit()
+        con.close()
+
+        self.assertFalse(self._names(90, seq="U3", unit_id=303),
+                         "prose overrode the structured link")
+        self.assertTrue(self._names(90, seq="U3", unit_id=404),
+                        "the structured link did not attribute the row")
+
+    def test_rows_with_no_link_still_fall_back_to_the_regex(self):
+        """The fallback is not decoration: a dev's `result` row has no watch
+        and never will, so deleting the regex would make every one of them
+        unattributable."""
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO shell_messages (message_id, from_shell_id, "
+            "sprint_doc_id, created_at, kind, body) VALUES "
+            "(91,1,59,'2020-01-06T00:00:00Z','result','U3 is ready')")
+        con.commit()
+        con.close()
+        self.assertTrue(self._names(91, seq="U3", unit_id=303))
+        self.assertFalse(self._names(91, seq="U4", unit_id=404))
+
+    def test_an_unlinked_or_unreadable_watch_is_not_an_answer(self):
+        """Three ways a structured ref can be ABSENT rather than negative — an
+        unlinked watch, a watch that is gone, and a malformed key. Each must
+        fall through to prose, not silently answer "not this unit" and drop a
+        row of real evidence."""
+        con = sqlite3.connect(self.db)
+        con.execute("INSERT INTO watched_prs VALUES (78,59,NULL)")
+        for mid, key in ((92, "pr-event|78|checks|abc"),
+                         (93, "pr-event|999|checks|abc"),
+                         (94, "pr-event|not-a-number|checks|abc")):
+            con.execute(
+                "INSERT INTO shell_messages (message_id, from_shell_id, "
+                "sprint_doc_id, created_at, kind, body, dedupe_key) VALUES "
+                "(?,1,59,'2020-01-06T00:00:00Z','result','U3 ready',?)",
+                (mid, key))
+        con.commit()
+        con.close()
+        for mid in (92, 93, 94):
+            with self.subTest(message_id=mid):
+                self.assertTrue(self._names(mid, seq="U3", unit_id=303))
+
+    def _names(self, message_id, *, seq, unit_id):
+        con = sqlite3.connect(self.db)
+        con.row_factory = sqlite3.Row
+        try:
+            row = con.execute(
+                "SELECT body, dedupe_key FROM shell_messages "
+                "WHERE message_id=?", (message_id,)).fetchone()
+            return ar.ActivityReader._row_names_unit(con, row, seq, unit_id)
+        finally:
+            con.close()
 
     def test_unit_name_boundaries_pin_the_real_dotted_family(self):
         names = ar.ActivityReader._names_unit

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -187,6 +187,7 @@ class AssemblerSmokeTest(unittest.TestCase):
 class ActiveSprintsProjectionTest(unittest.TestCase):
     def setUp(self) -> None:
         self.con = build_db()
+        self._next_pr = 100
         self.planner_old = self._shell("PLN-OLD")
         self.planner_new = self._shell("PLN-NEW")
         self.dev = self._shell("DEV")
@@ -220,13 +221,17 @@ class ActiveSprintsProjectionTest(unittest.TestCase):
             (feature_id, kind, seq, title, frozen, body, created_at)).lastrowid
 
     def _unit(self, doc_id: int, seq: str, *, state="pending") -> int:
+        # A distinct PR per unit: one PR belongs to one unit (0109's partial
+        # unique index), so a fixture reusing 42 for every row now describes a
+        # board no planner could have declared.
+        self._next_pr += 1
         return self.con.execute(
             "INSERT INTO sprint_units "
             "(sprint_doc_id, seq, unit_title, dev_shell_id, "
             "reviewer_shell_id, state, depends_on, overlap, branch, pr_number) "
-            "VALUES (?, ?, ?, ?, ?, ?, 'U0', 'server.py', 'feat/unit', 42)",
+            "VALUES (?, ?, ?, ?, ?, ?, 'U0', 'server.py', 'feat/unit', ?)",
             (doc_id, seq, f"Unit {seq}", self.dev, self.reviewer,
-             state)).lastrowid
+             state, self._next_pr)).lastrowid
 
     def _binding(self, doc_id: int, planner_id: int, *,
                  released=False) -> int:

--- a/tests/test_boot_sprint_directive.py
+++ b/tests/test_boot_sprint_directive.py
@@ -265,10 +265,15 @@ class SprintDirectiveTest(unittest.TestCase):
         arm_binding(self.con, 59, PLANNER_SHELL)
         self.assertEqual(self.render(DEV_SHELL), "")
         self.assertIn("PLANNER", self.render(PLANNER_SHELL))
-        # control: the SAME rows, one moved off a terminal state — the dev's
-        # directive comes back, so the absence above was about the state and
-        # not about an empty board
-        self.con.execute("UPDATE sprint_units SET state='working' WHERE seq='U9'")
+        # control: the SAME board plus ONE non-terminal unit for the same dev —
+        # the dev's directive comes back, so the absence above was about the
+        # state and not about an empty board.
+        #
+        # This used to walk U9 from merged back to working. Migration 0108 made
+        # that a refused transition (terminal has no exits), so the control is
+        # declared at a non-terminal state instead of reached by an edit no
+        # planner could make either.
+        add_unit(self.con, 59, "U7", dev=DEV_SHELL, state="working")
         self.con.commit()
         self.assertNotEqual(self.render(DEV_SHELL), "")
         self.assertIn("PLANNER", self.render(PLANNER_SHELL))

--- a/tests/test_interface_sprint_ops.py
+++ b/tests/test_interface_sprint_ops.py
@@ -940,6 +940,276 @@ class SprintCloseTest(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(body["released_bindings"], 0)
 
+    # ── H-12: close cleans its WHOLE footprint ──────────────────────────────
+    #
+    # Driven through FREEZE rather than the `status: CLOSED` doc edit. Both
+    # reach the same `_close_sprint_wake` today, but U1 is deleting the
+    # status-line trigger under H-1 (the status line becomes display prose that
+    # nothing executable reads, and closing a sprint IS freezing its doc).
+    # Pinning this behaviour to the path being deleted would hand U1 a set of
+    # failures that look like its own regression.
+
+    def sprint_doc(self, doc_id, status_line="ACTIVE"):
+        """An ACTIVE sprint doc with NO planner binding.
+
+        Deliberate for the H-12 tests: `_close_sprint_wake` used to return
+        early when the sprint had no unreleased binding, so a sprint whose
+        planner had already stood down cleaned up NOTHING. Arming a binding
+        here would route every assertion below around that exact defect.
+        (It also keeps these tests off the one-live-binding-per-planner
+        fixture, which a REFUSED freeze would otherwise leave occupied for
+        whichever test runs next.)
+        """
+        con = sqlite3.connect(self.db)
+        try:
+            con.execute(
+                "INSERT INTO documents (document_id, kind, title, body) "
+                "VALUES (?,'doc','SPRINT: close',?)",
+                (doc_id, f"# SPRINT: close\nstatus: {status_line}"))
+            con.commit()
+        finally:
+            con.close()
+
+    def watch(self, doc_id, pr, *, reasons=(), closed=False):
+        """A live watch on `doc_id` plus the watch-scoped alerts it opened.
+        Returns the watch id."""
+        con = sqlite3.connect(self.db)
+        try:
+            wid = con.execute(
+                "INSERT INTO watched_prs (repo, pr_number, shell_id,"
+                " sprint_doc_id, last_seen, closed_at) "
+                "VALUES ('o/r',?,1,?,'{}',?)",
+                (pr, doc_id, "2026-01-01" if closed else None)).lastrowid
+            for reason in reasons:
+                con.execute(
+                    "INSERT INTO planner_alerts (watch_id, severity, reason,"
+                    " dedupe_key) VALUES (?,'critical',?,?)",
+                    (wid, reason, f"-|-|{wid}|-|{reason}"))
+            con.commit()
+            return wid
+        finally:
+            con.close()
+
+    def open_watch_alerts(self, doc_id):
+        con = sqlite3.connect(self.db)
+        try:
+            return con.execute(
+                "SELECT COUNT(*) FROM planner_alerts a "
+                "JOIN watched_prs w ON w.watch_id=a.watch_id "
+                "WHERE w.sprint_doc_id=? AND a.resolved_at IS NULL",
+                (doc_id,)).fetchone()[0]
+        finally:
+            con.close()
+
+    def live_watches(self, doc_id):
+        con = sqlite3.connect(self.db)
+        try:
+            return con.execute(
+                "SELECT COUNT(*) FROM watched_prs "
+                "WHERE sprint_doc_id=? AND closed_at IS NULL",
+                (doc_id,)).fetchone()[0]
+        finally:
+            con.close()
+
+    def test_close_retires_the_sprints_watches_and_their_alerts(self):
+        """Before H-12 the close path released bindings and stopped. The
+        sprint's watches kept polling GitHub for a sprint that was over, and
+        their alerts — resolved on the REBIND path only — stayed open forever,
+        so `sc sprint alerts` grew a permanent floor of rows about finished
+        sprints."""
+        self.sprint_doc(110)
+        w1 = self.watch(110, 901, reasons=("pr_poll_failure",))
+        w2 = self.watch(110, 902, reasons=("pr_poll_backoff_escalated",
+                                           "pr_watch_unscoped"))
+        self.assertEqual(self.live_watches(110), 2)
+        self.assertEqual(self.open_watch_alerts(110), 3)
+
+        status, body = self.freeze(110)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(body["retired_watches"], 2)
+        self.assertEqual(body["resolved_watch_alerts"], 3)
+        self.assertEqual(self.live_watches(110), 0)
+        self.assertEqual(self.open_watch_alerts(110), 0)
+        for wid in (w1, w2):
+            self.assertIsNotNone(self.q(
+                "SELECT closed_at FROM watched_prs WHERE watch_id=?",
+                (wid,))[0])
+
+    def test_close_leaves_another_sprints_watches_alone(self):
+        """The scope is the SPRINT. A close that retired every live watch
+        would take down a concurrent sprint's eventing, and the symptom —
+        a planner that simply stops being woken — names no cause."""
+        self.sprint_doc(111)
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO documents (document_id, kind, title, body) "
+            "VALUES (112,'doc','SPRINT: other','# S\nstatus: ACTIVE')")
+        con.commit()
+        con.close()
+        mine = self.watch(111, 903, reasons=("pr_poll_failure",))
+        theirs = self.watch(112, 904, reasons=("pr_poll_failure",))
+
+        self.freeze(111)
+
+        self.assertIsNotNone(self.q(
+            "SELECT closed_at FROM watched_prs WHERE watch_id=?", (mine,))[0])
+        self.assertIsNone(self.q(
+            "SELECT closed_at FROM watched_prs WHERE watch_id=?",
+            (theirs,))[0])
+        self.assertEqual(self.open_watch_alerts(112), 1)
+
+    def test_close_does_not_resurrect_an_already_retired_watch(self):
+        """`closed_at` is set once. Re-stamping it on close would rewrite the
+        retirement time of a watch that ended days earlier for another
+        reason, and the counts would over-report what this close did."""
+        self.sprint_doc(113)
+        old = self.watch(113, 905, closed=True)
+        self.watch(113, 906)
+        status, body = self.freeze(113)
+        self.assertEqual(body["retired_watches"], 1)
+        self.assertEqual(
+            self.q("SELECT closed_at FROM watched_prs WHERE watch_id=?",
+                   (old,))[0], "2026-01-01")
+
+    def test_close_leaves_an_unrelated_alert_reason_open(self):
+        """Enumerated reasons, not "every alert with a watch_id": a reason
+        this close does not understand is not a reason it may silently
+        declare handled."""
+        self.sprint_doc(114)
+        self.watch(114, 907, reasons=("pr_poll_failure", "something_else"))
+        self.freeze(114)
+        self.assertEqual(self.open_watch_alerts(114), 1)
+        self.assertEqual(self.q(
+            "SELECT reason FROM planner_alerts a JOIN watched_prs w "
+            "ON w.watch_id=a.watch_id WHERE w.sprint_doc_id=114 "
+            "AND a.resolved_at IS NULL")[0], "something_else")
+
+    # ── H-12/H-14: freeze refuses on a board that is not finished ───────────
+
+    def unit(self, doc_id, seq, state, *, review_head=None, pr=None):
+        con = sqlite3.connect(self.db)
+        try:
+            con.execute(
+                "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title,"
+                " state, review_head, pr_number) VALUES (?,?,?,?,?,?)",
+                (doc_id, seq, f"unit {seq}", state, review_head, pr))
+            con.commit()
+        finally:
+            con.close()
+
+    def freeze(self, doc_id):
+        try:
+            return self.patch(f"/_sc/mem/docs/{doc_id}/freeze", {})
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read())
+
+    def frozen(self, doc_id):
+        return self.q("SELECT frozen FROM documents WHERE document_id=?",
+                      (doc_id,))[0]
+
+    def test_freeze_refuses_while_a_unit_is_non_terminal_and_names_it(self):
+        self.sprint_doc(120)
+        self.unit(120, "U1", "merged", review_head="abc1234")
+        self.unit(120, "U2", "working")
+        self.unit(120, "U10", "blocked")
+
+        status, err = self.freeze(120)
+
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["code"], "sprint_not_finished")
+        # NAMING the units is the requirement: "some unit is not done" sends
+        # the planner to read the whole board to find out which.
+        self.assertEqual(err["non_terminal_units"], ["U2", "U10"])
+        self.assertIn("U2 (working)", err["error"])
+        self.assertIn("U10 (blocked)", err["error"])
+        self.assertNotIn("U1", err["non_terminal_units"])
+        self.assertEqual(self.frozen(120), 0, "the refused freeze still froze")
+
+    def test_freeze_refuses_a_merged_unit_with_no_review_head(self):
+        self.sprint_doc(121)
+        self.unit(121, "U1", "merged", review_head="abc1234")
+        self.unit(121, "U2", "merged")
+        self.unit(121, "U3", "merged", review_head="   ")
+
+        status, err = self.freeze(121)
+
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["code"], "sprint_not_finished")
+        self.assertEqual(err["units_without_review_head"], ["U2", "U3"])
+        self.assertEqual(err["non_terminal_units"], [])
+        self.assertEqual(self.frozen(121), 0)
+
+    def test_a_cancelled_unit_needs_no_review_head(self):
+        """The exemption, alone. A cancelled unit never had a clean review,
+        so requiring a head for one asks the planner to invent a SHA — and a
+        check that demanded it would make cancelling a unit a reason the
+        sprint can never be closed."""
+        self.sprint_doc(122)
+        self.unit(122, "U1", "cancelled")
+        self.unit(122, "U2", "merged", review_head="abc1234")
+
+        status, body = self.freeze(122)
+
+        self.assertEqual(status, 200, body)
+        self.assertEqual(self.frozen(122), 1)
+
+    def test_freeze_reports_both_reasons_at_once(self):
+        """A planner fixing a close wants the whole list. Refusing serially
+        makes it re-run the close to discover the second reason."""
+        self.sprint_doc(123)
+        self.unit(123, "U1", "working")
+        self.unit(123, "U2", "merged")
+
+        status, err = self.freeze(123)
+
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["non_terminal_units"], ["U1"])
+        self.assertEqual(err["units_without_review_head"], ["U2"])
+
+    def test_a_finished_board_freezes_and_the_refusal_is_not_a_wall(self):
+        """The permissive half — and the proof that the two H-12 halves run
+        in the right order: a refused freeze must not have cleaned up, or a
+        planner would repair its board on a sprint whose watches were already
+        retired."""
+        self.sprint_doc(124)
+        self.unit(124, "U1", "working")
+        self.watch(124, 908, reasons=("pr_poll_failure",))
+
+        self.assertEqual(self.freeze(124)[0], 409)
+        self.assertEqual(self.live_watches(124), 1,
+                         "a REFUSED freeze retired the sprint's watches")
+        self.assertEqual(self.open_watch_alerts(124), 1)
+
+        con = sqlite3.connect(self.db)
+        con.execute("UPDATE sprint_units SET state='merged', "
+                    "review_head='abc1234' WHERE sprint_doc_id=124")
+        con.commit()
+        con.close()
+
+        status, body = self.freeze(124)
+        self.assertEqual(status, 200, body)
+        self.assertEqual(self.frozen(124), 1)
+        self.assertEqual(body["retired_watches"], 1)
+        self.assertEqual(self.live_watches(124), 0)
+        self.assertEqual(self.open_watch_alerts(124), 0)
+
+    def test_an_already_frozen_sprint_is_still_idempotent(self):
+        """The retry-after-a-lost-response path predates this gate and must
+        survive it: re-freezing reads as the success it was, and does not
+        re-derive a refusal from a board it already froze."""
+        self.sprint_doc(125)
+        self.unit(125, "U1", "merged", review_head="abc1234")
+        self.assertEqual(self.freeze(125)[0], 200)
+        # Dirty the frozen board by DECLARING a unit on it, not by walking the
+        # merged one back — the transition machine refuses that at the DB, and
+        # a test that tried would be asserting against 0108 rather than
+        # against the idempotent-freeze path it names.
+        self.unit(125, "U2", "working")
+        status, body = self.freeze(125)
+        self.assertEqual(status, 200, body)
+        self.assertTrue(body["already_frozen"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_interface_transitions.py
+++ b/tests/test_interface_transitions.py
@@ -131,6 +131,14 @@ class TransitionMatrixTest(unittest.TestCase):
         self.con.commit()
         return cur.lastrowid
 
+    def _unit_row(self, state, n):
+        self.con.execute("DELETE FROM sprint_units")
+        cur = self.con.execute(
+            "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title, state)"
+            " VALUES (1,?,'unit',?)", (f"U{n}", state))
+        self.con.commit()
+        return cur.lastrowid
+
     def _receipt_row(self, state, n):
         self.con.execute("DELETE FROM planner_action_receipts")
         cur = self.con.execute(
@@ -205,6 +213,55 @@ class TransitionMatrixTest(unittest.TestCase):
             return self._receipt_row(old, n[0])
 
         self._walk("receipt", factory)
+
+    def test_sprint_unit_machine(self):
+        n = [0]
+
+        def factory(old, _new):
+            n[0] += 1
+            return self._unit_row(old, n[0])
+
+        self._walk("sprint_unit", factory)
+
+    def test_the_board_has_no_way_out_of_terminal(self):
+        """The matrix walk above proves merged/cancelled refuse every named
+        move. This asks the narrower question the walk cannot: that the
+        refusal is a property of the SOURCE state rather than a list of
+        destinations someone remembered to enumerate.
+
+        Both layers, independently — a machine whose app map is closed while
+        its trigger is open reads as safe from every test that goes through
+        the API, and the DB is where the board actually lives.
+        """
+        states = set(interface_state.SPRINT_UNIT_EDGES)
+        self.assertEqual({"merged", "cancelled"},
+                         {s for s in states
+                          if not interface_state.SPRINT_UNIT_EDGES[s]},
+                         "the terminal set drifted from merged+cancelled")
+        n = 0
+        for terminal in ("merged", "cancelled"):
+            for target in sorted(states - {terminal}):
+                n += 1
+                with self.subTest(edge=f"{terminal}->{target}"):
+                    row_id = self._unit_row(terminal, n)
+                    with self.assertRaises(
+                            interface_state.InterfaceTransitionError):
+                        interface_state.transition(
+                            self.con, "sprint_unit", row_id, target)
+                    n += 1
+                    row_id = self._unit_row(terminal, n)
+                    with self.assertRaises(sqlite3.IntegrityError):
+                        self.con.execute(
+                            "UPDATE sprint_units SET state=? WHERE unit_id=?",
+                            (target, row_id))
+                        self.con.commit()
+                    self.con.rollback()
+                    self.assertEqual(
+                        self.con.execute(
+                            "SELECT state FROM sprint_units WHERE unit_id=?",
+                            (row_id,)).fetchone()[0], terminal)
+        self.assertEqual(n, 20, "the terminal sweep stopped covering the "
+                                "whole vocabulary")
 
 
 if __name__ == "__main__":

--- a/tests/test_sprint_board_record.py
+++ b/tests/test_sprint_board_record.py
@@ -45,6 +45,17 @@ ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 SCHEMA = ENGINE / "schema.sql"
 MIGRATIONS = ENGINE / "migrations"
 MIGRATION = MIGRATIONS / "0098_sprint_units.sql"
+# 0098 declared the board; later deltas reshape it. A fork upgrading runs the
+# CHAIN, so the fixture below must skip and then re-apply all of it — pinning
+# only 0098 would compare "the board as first declared" against "the baseline
+# plus every delta" and fail on the first ALTER anyone ever adds, while
+# proving nothing about whether the upgrade path reaches the same table.
+# Append to this tuple whenever a migration touches sprint_units.
+BOARD_MIGRATIONS = (
+    MIGRATION,
+    MIGRATIONS / "0108_sprint_unit_transitions.sql",
+    MIGRATIONS / "0109_sprint_pr_unit_linkage.sql",
+)
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 sys.path.insert(0, str(ENGINE / "api"))
@@ -95,7 +106,7 @@ def build_pre_migration_db(path: Path) -> None:
     con = sqlite3.connect(path)
     con.executescript(SCHEMA.read_text())
     for p in sorted(MIGRATIONS.glob("*.sql")):
-        if p != MIGRATION:
+        if p not in BOARD_MIGRATIONS:
             con.executescript(p.read_text())
     con.execute("DROP TABLE IF EXISTS sprint_units")   # drops its index too
     seed_fixtures(con)
@@ -132,7 +143,7 @@ def _unit_args(**over):
     difference between "absent" and "explicitly cleared"."""
     args = dict(sprint=1, seq="U1", title="board record", dev=None,
                 reviewer=None, depends_on=None, overlap=None, branch=None,
-                pr=None, state=None)
+                pr=None, review_head=None, state=None)
     args.update(over)
     return mock.Mock(**args)
 
@@ -646,6 +657,9 @@ class BoardRecordTest(_BoardCase):
         the record says — both roles — not what a document body remembers."""
         self.add(seq="U1", unit_title="board record", dev="DEV5",
                  reviewer="REV2", depends_on="U0", branch="feat/b", pr_number=7)
+        # in_review is reached THROUGH working — the board is a machine, and
+        # pending -> in_review is not one of its edges (0108).
+        self.patch(seq="U1", state="working")
         self.patch(seq="U1", state="in_review")
         _s, out = self.call("GET", "/api/sprint-units?sprint_doc_id=1", (OP,))
         buf = io.StringIO()
@@ -978,6 +992,146 @@ class BoardRecordTest(_BoardCase):
         self.assertEqual([u["sprint_doc_id"] for u in out["units"]], [1])
 
 
+class BoardTransitionRouteTest(_BoardCase):
+    """The transition machine AS THE ROUTE SERVES IT (spec #76 H-11).
+
+    test_interface_transitions.py already walks the whole matrix against both
+    enforcement layers. What it cannot see is the layer a planner actually
+    meets: whether the API answers a refused move with a status and a sentence
+    it can act on, or with a 500 carrying an IntegrityError — and whether the
+    refused move left the row alone.
+    """
+
+    def test_every_legal_edge_is_served(self):
+        """The permissive half. A machine tested only by what it refuses
+        passes just as well when it refuses everything, and a board that
+        cannot reach in_review is worse than one that can be walked back."""
+        for path in (("working", "in_review", "working", "blocked", "working",
+                      "merged"),
+                     ("working", "in_review", "blocked", "working",
+                      "in_review", "merged"),
+                     ("working", "blocked", "cancelled"),
+                     ("cancelled",),
+                     ("working", "in_review", "cancelled")):
+            with self.subTest(path=path):
+                seq = "U" + "".join(s[0] for s in path)
+                self.add(seq=seq)
+                for state in path:
+                    status, out = self.patch(seq=seq, state=state)
+                    self.assertEqual(status, 200, out)
+                    self.assertEqual(out["state"], state)
+                self.assertEqual(self.row(seq)["state"], path[-1])
+
+    def test_an_illegal_move_is_refused_by_name_and_changes_nothing(self):
+        self.add(seq="U1")
+        before = self.row("U1")
+        status, err = self.patch(seq="U1", state="in_review")
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["error"]["code"], "illegal_unit_transition")
+        # The message has to name the move AND what IS reachable — "illegal
+        # transition" alone sends the planner back to the migration to find
+        # out what to type instead.
+        self.assertIn("pending -> in_review", err["error"]["message"])
+        self.assertIn("working", err["error"]["message"])
+        after = self.row("U1")
+        self.assertEqual(after["state"], "pending")
+        self.assertEqual(after["state_changed_at"], before["state_changed_at"])
+        self.assertEqual(after["updated_at"], before["updated_at"])
+
+    def test_terminal_is_terminal_through_the_route(self):
+        """Both terminals, every exit, through the API — and the refusal has
+        to teach the remedy, because "no" without "declare a successor unit"
+        is what makes an operator go looking for a --force flag."""
+        for terminal in ("merged", "cancelled"):
+            seq = f"U{terminal[:3]}"
+            self.add(seq=seq)
+            self.patch(seq=seq, state="working")
+            self.assertEqual(
+                self.patch(seq=seq, state=terminal)[0], 200)
+            for target in ("pending", "working", "in_review", "blocked",
+                           "merged", "cancelled"):
+                if target == terminal:
+                    continue      # a same-state re-assert is a legal no-op
+                with self.subTest(edge=f"{terminal}->{target}"):
+                    status, err = self.patch(seq=seq, state=target)
+                    self.assertEqual(status, 409, err)
+                    self.assertEqual(err["error"]["code"],
+                                     "illegal_unit_transition")
+                    self.assertIn("SUCCESSOR UNIT", err["error"]["message"])
+                    self.assertEqual(self.row(seq)["state"], terminal)
+
+    def test_a_terminal_unit_still_accepts_its_own_state(self):
+        """A re-assert is how an idempotent retry lands after an ambiguous
+        timeout. Refusing it would turn "the response was lost" into "the
+        sprint cannot be closed"."""
+        self.add(seq="U1")
+        self.patch(seq="U1", state="working")
+        self.patch(seq="U1", state="merged")
+        moved = self.row("U1")["state_changed_at"]
+        status, out = self.patch(seq="U1", state="merged")
+        self.assertEqual(status, 200, out)
+        self.assertEqual(self.row("U1")["state"], "merged")
+        self.assertEqual(self.row("U1")["state_changed_at"], moved,
+                         "a no-op re-assert restamped the clock")
+
+    def test_one_pr_belongs_to_one_unit(self):
+        """H-13's board half. Two units claiming one PR makes every structured
+        answer to "which unit is this event about" depend on read order."""
+        self.add(seq="U1", pr_number=658)
+        self.add(seq="U2")
+        status, err = self.patch(seq="U2", pr_number=658)
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["error"]["code"], "pr_already_claimed")
+        self.assertIn("U1", err["error"]["message"])
+        self.assertIsNone(self.row("U2")["pr_number"])
+        # Declaring the collision is refused the same way an edit is — the
+        # constraint is the board's, not one route's.
+        status, err = self.add(seq="U3", pr_number=658)
+        self.assertEqual(status, 409, err)
+        self.assertEqual(err["error"]["code"], "pr_already_claimed")
+        self.assertIsNone(self.row("U3"))
+        # and the claim is releasable, so a mis-typed PR is not permanent
+        self.assertEqual(self.patch(seq="U1", pr_number=None)[0], 200)
+        self.assertEqual(self.patch(seq="U2", pr_number=658)[0], 200)
+        self.assertEqual(self.row("U2")["pr_number"], 658)
+
+    def test_two_units_may_both_have_no_pr(self):
+        """The index is PARTIAL. A board's normal state is many units with no
+        PR yet, and a plain UNIQUE would have refused the second one."""
+        self.assertEqual(self.add(seq="U1")[0], 201)
+        self.assertEqual(self.add(seq="U2")[0], 201)
+        self.assertEqual(self.add(seq="U3")[0], 201)
+
+    def test_review_head_is_recorded_and_projected(self):
+        """H-14: the reviewer's verdict head becomes a column the record
+        carries, not a sentence in a message body."""
+        self.add(seq="U1")
+        self.patch(seq="U1", state="working")
+        self.patch(seq="U1", state="in_review")
+        status, out = self.patch(seq="U1", review_head="963dc8c3")
+        self.assertEqual(status, 200, out)
+        self.assertEqual(out["review_head"], "963dc8c3")
+        self.assertEqual(self.row("U1")["review_head"], "963dc8c3")
+        # PRESENCE, not correctness — the route stores what the planner read
+        # off the verdict and judges none of it (decision #76).
+        self.assertEqual(
+            self.patch(seq="U1", review_head="not-a-sha")[0], 200)
+        # blank is not a value; null retracts
+        self.assertEqual(self.patch(seq="U1", review_head="  ")[0], 422)
+        self.assertEqual(self.patch(seq="U1", review_head=None)[0], 200)
+        self.assertIsNone(self.row("U1")["review_head"])
+
+    def test_review_head_cannot_ride_a_state_move(self):
+        """`state_changed_at` has exactly one writer, and H-14 does not buy a
+        second door into the state column."""
+        self.add(seq="U1")
+        status, err = self.patch(seq="U1", state="working",
+                                 review_head="963dc8c3")
+        self.assertEqual(status, 422, err)
+        self.assertEqual(err["error"]["code"], "state_moves_alone")
+        self.assertEqual(self.row("U1")["state"], "pending")
+
+
 class LiveUpgradeTest(_BoardCase):
     """Migration 0098 as the thing under test, rather than as a file that
     happens to run on the way to a fixture.
@@ -996,7 +1150,8 @@ class LiveUpgradeTest(_BoardCase):
     def upgrade(self):
         con = sqlite3.connect(self.db_path)
         try:
-            migrate.apply(con, MIGRATION)
+            for migration in BOARD_MIGRATIONS:
+                migrate.apply(con, migration)
         finally:
             con.close()
 

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -364,9 +364,114 @@ def snap(state="OPEN", sha="abc1234def", checks=None, reviews=0, review_state=No
             "reviews": reviews, "review_state": review_state}
 
 
+class WatchAlertIdentityTest(unittest.TestCase):
+    """H-13's other half: an alert about a watch says WHICH UNIT structurally.
+
+    0102 gave planner_alerts `sprint_doc_id`/`unit_id` and the watch path left
+    both NULL, so every reader was pushed back to parsing `dedupe_key` or
+    grepping prose. The watch is the one alert source that knows the answer.
+    """
+
+    def setUp(self):
+        self.con = build_db()
+        seed_shells(self.con)
+        seed_sprint_doc(self.con)
+        self.unit = self.con.execute(
+            "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+            "VALUES (100,'U3','unit')").lastrowid
+        self.con.commit()
+
+    def tearDown(self):
+        self.con.close()
+
+    def _watch(self, pr, unit_id, doc_id=100):
+        wid = self.con.execute(
+            "INSERT INTO watched_prs (repo, pr_number, shell_id, "
+            "sprint_doc_id, unit_id) VALUES ('o/r',?,1,?,?)",
+            (pr, doc_id, unit_id)).lastrowid
+        self.con.commit()
+        return wid
+
+    def _alert_row(self, wid):
+        return self.con.execute(
+            "SELECT sprint_doc_id, unit_id, dedupe_key FROM planner_alerts "
+            "WHERE watch_id=?", (wid,)).fetchone()
+
+    def test_an_alert_on_a_linked_watch_names_the_unit(self):
+        wid = self._watch(41, self.unit)
+        pr_poller._alert(self.con, severity="critical",
+                         reason="pr_poll_failure", watch_id=wid)
+        self.con.commit()
+        row = self._alert_row(wid)
+        self.assertEqual(row["sprint_doc_id"], 100)
+        self.assertEqual(row["unit_id"], self.unit)
+
+    def test_an_unlinked_watch_still_scopes_the_sprint(self):
+        """Partial structure beats none: the sprint is known even when the
+        unit is not, and claiming a unit here would be a guess."""
+        wid = self._watch(42, None)
+        pr_poller._alert(self.con, severity="critical",
+                         reason="pr_poll_failure", watch_id=wid)
+        self.con.commit()
+        row = self._alert_row(wid)
+        self.assertEqual(row["sprint_doc_id"], 100)
+        self.assertIsNone(row["unit_id"])
+
+    def test_the_dedupe_identity_did_not_move(self):
+        """The structured columns are ADDITIVE. If dedupe_key changed shape,
+        every alert already open would re-raise as a new row the moment this
+        shipped — a fleet-wide alert storm on upgrade."""
+        wid = self._watch(43, self.unit)
+        for _ in range(3):
+            pr_poller._alert(self.con, severity="critical",
+                             reason="pr_poll_failure", watch_id=wid)
+        self.con.commit()
+        rows = self.con.execute(
+            "SELECT dedupe_key FROM planner_alerts WHERE watch_id=?",
+            (wid,)).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["dedupe_key"], f"-|-|{wid}|-|pr_poll_failure")
+
+
 class DiffEventsTest(unittest.TestCase):
     def diff(self, prev, cur):
         return watch.diff_events(prev, cur, "o/r", 7)
+
+    def test_the_unit_rides_the_event_header_when_the_watch_names_one(self):
+        """H-13: the structured ref made visible. The watch knows the unit, so
+        the row the planner reads says which unit it is about instead of
+        leaving every reader to infer it from the PR number."""
+        events, _ = pr_poller.transitions(
+            snap(checks="PENDING"), snap(checks="SUCCESS"), "o/r", 7, "U3")
+        self.assertEqual(len(events), 1)
+        self.assertIn("o/r#7 unit=U3:", events[0]["body"])
+
+    def test_an_unlinked_watch_makes_no_claim_in_the_header(self):
+        """Omitted, not `unit=None`. A header that names a unit is a claim,
+        and an unlinked watch is not making one — the regex fallback is for
+        exactly this traffic."""
+        events, _ = pr_poller.transitions(
+            snap(checks="PENDING"), snap(checks="SUCCESS"), "o/r", 7)
+        self.assertIn("o/r#7:", events[0]["body"])
+        self.assertNotIn("unit=", events[0]["body"])
+
+    def test_every_event_kind_carries_the_unit(self):
+        """One transition kind carrying the ref while the others drop it is
+        the drift shape: the merge event is the one close reads, and it is
+        built on a different branch from the checks event."""
+        cases = {
+            "checks": (snap(checks="PENDING"), snap(checks="SUCCESS")),
+            "review": (snap(reviews=0), snap(reviews=1,
+                                             review_state="APPROVED")),
+            "merged": (snap(), snap(state="MERGED", checks="SUCCESS")),
+            "closed": (snap(), snap(state="CLOSED")),
+        }
+        for kind, (prev, cur) in cases.items():
+            with self.subTest(kind=kind):
+                events, _ = pr_poller.transitions(prev, cur, "o/r", 7, "U3")
+                self.assertTrue(events, f"{kind} emitted nothing to check")
+                for e in events:
+                    self.assertIn("unit=U3", e["body"])
 
     def test_baseline_pending_is_silent(self):
         events, terminal = self.diff(None, snap(checks="PENDING"))
@@ -612,6 +717,83 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["shell_id"], 1)   # the token shell (plan1)
         self.assertEqual(rows[0]["sprint_doc_id"], 100)
+
+    # ── H-13: structured PR↔unit linkage ────────────────────────────────────
+
+    def unit(self, seq, doc_id=100):
+        con = sqlite3.connect(self.db)
+        try:
+            uid = con.execute(
+                "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+                "VALUES (?,?,?)", (doc_id, seq, f"unit {seq}")).lastrowid
+            con.commit()
+            return uid
+        finally:
+            con.close()
+
+    def test_register_links_the_watch_to_a_board_unit(self):
+        uid = self.unit("U3")
+        self.assertEqual(watch.main(
+            ["pr", "own/repo", "31", "--sprint", "100", "--unit", "U3"]), 0)
+        rows = self.q("SELECT unit_id FROM watched_prs WHERE pr_number=31")
+        self.assertEqual(rows[0]["unit_id"], uid)
+
+    def test_registering_without_a_unit_leaves_the_link_null(self):
+        """The link is NULLABLE and stays that way. Unscoped traffic is what
+        the reconciler's regex fallback exists for; inventing a unit here
+        would make every watch claim one."""
+        watch.main(["pr", "own/repo", "32", "--sprint", "100"])
+        self.assertIsNone(
+            self.q("SELECT unit_id FROM watched_prs WHERE pr_number=32")[0][
+                "unit_id"])
+
+    def test_an_undeclared_unit_is_refused_not_silently_dropped(self):
+        """A typo'd --unit that registered an UNLINKED watch would report
+        success and leave the planner believing in a link that is not there —
+        the reconciler would then answer by regex and nobody would know."""
+        with self.assertRaises(SystemExit):
+            watch.main(["pr", "own/repo", "33", "--sprint", "100",
+                        "--unit", "U99"])
+        self.assertEqual(
+            self.q("SELECT 1 FROM watched_prs WHERE pr_number=33"), [])
+
+    def test_a_unit_on_another_sprints_board_is_not_this_sprints_unit(self):
+        """`seq` is unique per sprint, not globally: U3 exists on most boards.
+        Resolving it without the sprint would link a watch to a stranger."""
+        con = sqlite3.connect(self.db)
+        seed_sprint_doc(con, 200)
+        con.close()
+        self.unit("U7", doc_id=200)
+        with self.assertRaises(SystemExit):
+            watch.main(["pr", "own/repo", "34", "--sprint", "100",
+                        "--unit", "U7"])
+
+    def test_re_registering_with_a_unit_links_the_live_watch(self):
+        """The idempotent path must not swallow --unit: "already watched" plus
+        a dropped flag is a link the operator has no way to see is missing."""
+        watch.main(["pr", "own/repo", "35", "--sprint", "100"])
+        uid = self.unit("U4")
+        watch.main(["pr", "own/repo", "35", "--sprint", "100", "--unit", "U4"])
+        rows = self.q("SELECT unit_id FROM watched_prs WHERE pr_number=35")
+        self.assertEqual(len(rows), 1, "the re-registration minted a row")
+        self.assertEqual(rows[0]["unit_id"], uid)
+
+    def test_the_link_is_correctable(self):
+        """A mis-typed --unit has to be fixable in place. The alternative is
+        retiring the watch and losing its baseline to repair a typo."""
+        watch.main(["pr", "own/repo", "36", "--sprint", "100", "--unit", "U3"])
+        right = self.unit("U5")
+        watch.main(["pr", "own/repo", "36", "--sprint", "100", "--unit", "U5"])
+        self.assertEqual(
+            self.q("SELECT unit_id FROM watched_prs WHERE pr_number=36")[0][
+                "unit_id"], right)
+
+    def test_the_watch_list_reports_the_unit(self):
+        self.unit("U6")
+        watch.main(["pr", "own/repo", "37", "--sprint", "100", "--unit", "U6"])
+        r = watch._api("GET", "/_sc/watches")
+        row = [w for w in r["watches"] if w["pr_number"] == 37][0]
+        self.assertEqual(row["unit_seq"], "U6")
 
     def test_register_for_another_shell(self):
         watch.main(["pr", "own/repo", "12", "--shell", "dev1",


### PR DESCRIPTION
Sprint 84 · U3 · spec #76 H-11..H-14. Reviewer REV1.

Four changes that make the sprint board enforce what the close procedure already required.

## H-11 — a real transition machine for `sprint_units.state`

The board had a CHECK vocabulary and nothing else. A vocabulary answers "is this a word"; it never answers "may this row go there from where it is". So `merged → working` and `cancelled → pending` were both accepted — silently re-arming the reconciler and re-rendering worker boot directives for finished work.

Both layers now, like every other lifecycle in this engine: `trg_sprint_units_state` (migration 0108) backstopping `interface_state.SPRINT_UNIT_EDGES`, registered in `MACHINES` so the existing drift walker in `test_interface_transitions.py` covers it without a bespoke test.

`merged` and `cancelled` are terminal with **no exits** — deliberately no override flag, no admin escape, no force verb. A mis-declared terminal state is corrected by declaring a **successor unit at a new seq**; the terminal row stands as the record of what was declared (decision #82's shape). The 409 says exactly that, because "no" without a remedy is what sends an operator looking for `--force`.

## H-12 — close cleans its whole footprint

`_close_sprint_wake` released bindings and — the part the spec did not capture — **returned EARLY when the sprint had no unreleased binding**, so a sprint whose planner had already stood down cleaned up *nothing at all*. It now retires the sprint's live `watched_prs` and resolves their watch-scoped alerts (`pr_watch_unscoped`, `pr_poll_failure`, `pr_poll_backoff_escalated`), which until now were resolved on the *rebind* path only and therefore survived close as permanently open.

It returns counts and the close response reports them: a cleanup nobody can see is indistinguishable from one that did not run.

Freeze now **refuses** while any unit is non-terminal, naming the offenders and both reasons at once (a planner fixing a close wants the whole list, not one reason per attempt).

## H-13 — structured PR↔unit linkage

`watched_prs.unit_id` (nullable FK) set at registration via `sc watch pr … --unit U3`, carried onto the pr_event body header as `unit=U3`, and **preferred over prose** by the reconciler's reader (`_row_names_unit`) and by watch-scoped alerts, which now populate the `sprint_doc_id`/`unit_id` columns 0102 added and the watch path left NULL.

The regex is kept, not deleted — a dev's `result` row has no link and never will, so it remains the fallback for unscoped traffic. Where a link exists it wins outright, including when it says *no*: falling through to prose after a structured mismatch would let a body that happens to mention "U3" override the link, which is the inversion the requirement exists to remove.

## H-14 — review outcome on the record

`sprint_units.review_head`, writable via `sc sprint unit set --review-head`. Freeze checks **presence for merged units only** — cancelled units never had a clean review and are exempt by construction. Presence, not correctness: judging the verdict stays with the planner (decision #76).

## Trade-offs taken, and the simpler options rejected

**`schema.sql` is deliberately not updated.** Both migrations are `ALTER`/trigger deltas, so carrying the columns in the baseline as well would fail a fresh install on duplicate-column when the delta ran. Same call 0102 made for `planner_alerts`, and the sprint's kickoff gate already recorded that as the baseline-plus-deltas design rather than drift. The baseline-vs-upgrade parity gate in `LiveUpgradeTest` still passes — it now walks a `BOARD_MIGRATIONS` chain instead of pinning 0098 as the last word on the table, which is what made it fail on *any* later delta.

**The partial unique index went on `sprint_units`, not `watched_prs`.** The requirement is "two units cannot claim one PR". On the registry that constraint would refuse a legitimate registration — a dev's watch and the planner's watch on one PR are two rows in one sprint. Only `sprint_units(sprint_doc_id, pr_number) WHERE pr_number IS NOT NULL` enforces the sentence. Ratified by PLN2.

**The route pre-checks with `check()` rather than routing through `interface_state.transition()`**, so the board's `state`, `state_changed_at`, `updated_at` and `updated_by_shell_id` stay in one UPDATE and the move stays attributable to the planner that made it. Noted at the `MACHINES` entry so the next caller does not lose provenance.

**H-12 is tested through freeze, not the `status: CLOSED` doc edit.** Both reach the same code today, but U1 is deleting the status-line trigger under H-1. Pinning this to the path being deleted would hand U1 failures that look like its own regression.

## Two tests were exercising illegal transitions and passing green

Not fixture repairs — findings produced by the machine's introduction:

- `test_rendered_board_reports_the_record…` patched `pending → in_review` directly. That is not an edge. Now walks `pending → working → in_review`.
- `test_terminal_units_retire_the_WORKERS…` used `merged → working` as its control. Now declares a non-terminal unit instead of reaching one by an edit no planner could make.

A test I wrote in this PR tried the same `merged → working` walk and the trigger refused it. The machine caught its author on day one.

## Gate — 16 single-operand mutations, each red set attributed

A composite revert proves nothing about which half is load-bearing, so every guard was mutated **alone** with the rest intact.

| # | mutation | red |
|---|---|---|
| M1 | close stops retiring watches | 4 close tests |
| M2 | close stops resolving watch alerts | 3 |
| M3 | close ignores sprint scope | `…leaves_another_sprints_watches_alone` |
| M4 | freeze stops refusing non-terminal | 3 freeze tests |
| M5 | freeze stops requiring review_head | 2 freeze tests |
| M6 | cancelled no longer exempt | `…cancelled_unit_needs_no_review_head` |
| M7 | registration drops the unit link | 2 registration tests |
| M8 | re-registration silently drops `--unit` | 2 linkage tests |
| M9 | pr_event header drops the unit | 5 (subTest covers all 4 event kinds) |
| M10 | alerts drop structured identity | 2 identity tests |
| M11 | one-PR-one-unit index removed | `…one_pr_belongs_to_one_unit` |
| M12 | app edge map opens `merged → working` | drift test + terminal sweep |
| M13 | trigger opens `cancelled → pending` | drift test + `SUBFAILED(cancelled->pending)` |
| M14 | reader consults prose first | precedence test |
| M15 | regex fallback deleted | fallback test + a pre-existing contract test |
| M16 | absent structured ref treated as "no" | 3 absence subTests |

M12/M13 are the drift halves: each layer reddens **alone**, so trigger-vs-app disagreement is what fails rather than merely "something is wrong".

## Migrations

`0108_sprint_unit_transitions.sql` and `0109_sprint_pr_unit_linkage.sql` — the numbers reserved for U3, read back from `git ls-tree origin/main .super-coder/migrations/` at file creation (head was `0107`). U4's 0110-0111 and U5's 0112 untouched.

## Spec citations corrected

Two of three moved; every behavioural claim held.

- H-11 `interface_routes.py:2720` → the state checks are `:2626-2628` and `:2734-2736`
- H-12 `server.py:2758-2765` → the rebind resolution is `:2870-2876`; `_close_sprint_wake` is `:1246`
- H-13 `activity_readers.py:360-368` → accurate

## Note for U4 (DEV6)

`activity_readers._names_unit` gained a structured-first wrapper, `_row_names_unit`. It is upstream of the expectation model you are rebuilding under decisions #96/#97 — build on it rather than around it.

## Verification

Full suite: 1982 passed, 1 failed; that failure is the `merged → working` control above, fixed, and every affected file re-run green (395 passed across the 11 touched/dependent files). `./sc lint` 25 errors and `./sc typecheck` 358 errors — both byte-identical counts with these changes stashed, so all pre-existing and none in a file this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
