### PR TITLE
fix(engine): parse rebuild arguments before touching engine state

### DIFF
--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -182,7 +182,45 @@ def validate_foreign_keys(path: Path) -> None:
         con.close()
 
 
+USAGE = "usage: ./sc rebuild [--no-backup]"
+
+HELP = f"""{USAGE}
+
+Rebuild the engine DB from schema.sql + migrations/ + the active snapshot.
+The outgoing DB is backed up first, then atomically replaced by a validated
+candidate.
+
+  --no-backup  skip the pre-rebuild backup of the outgoing DB
+  -h, --help   print this help and exit without reading or writing any state"""
+
+
+def parse_args(argv: list[str]) -> bool:
+    """Return no_backup, print help, or reject — touching NO state.
+
+    Spec #67: rebuild used to interpret arguments only after it had read the
+    schema, carried the outgoing keys, probed live Interface state and taken a
+    backup, so `./sc rebuild --help` and every typo ran a real rebuild. The
+    whole argument contract lives here, ahead of all of it, and this function
+    opens no database and touches no path.
+
+    Help wins over any action flag and over an unknown token (req 7): it
+    asserts nothing about the instance, so there is no state in which it can
+    fail — and nothing it prints can degrade into a rebuild.
+    """
+    if "-h" in argv or "--help" in argv:
+        print(HELP)
+        raise SystemExit(0)
+    unknown = [arg for arg in argv if arg != "--no-backup"]
+    if unknown:
+        print(f"rebuild: unknown argument '{unknown[0]}' ({USAGE})",
+              file=sys.stderr)
+        raise SystemExit(2)
+    return "--no-backup" in argv
+
+
 def main(argv: list[str]) -> int:
+    no_backup = parse_args(argv)
+
     schema = SCHEMA_SQLITE
     if not schema.exists():
         sys.exit(f"rebuild: missing {schema}")
@@ -198,7 +236,7 @@ def main(argv: list[str]) -> int:
             "rebuild: refusing — live Interface state exists; the clean "
             "operator drain path is required first:\n  - "
             + "\n  - ".join(reasons))
-    if "--no-backup" not in argv:
+    if not no_backup:
         backup_existing()
 
     candidate = Path(str(DB_PATH) + ".rebuild")

--- a/tests/test_rebuild_args.py
+++ b/tests/test_rebuild_args.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Argument preflight for rebuild (spec #67).
+
+`./sc rebuild --help` and every typo used to run a REAL rebuild: main() read the
+schema, carried the outgoing api_keys, probed live Interface state and took a
+backup before it looked at argv at all. These tests pin the inverse — help and
+invalid input decide everything they decide before any of that machinery is
+reachable — so they arm each pre-action seam to raise and then assert the seams
+stayed unfired AND the sentinel tree is byte-identical.
+
+An unfired tripwire only means something if the tripwire can fire, so
+`test_action_forms_reach_the_armed_seams` is the positive control: the same
+patched seams, driven by the two valid forms, must raise.
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack, redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[1]
+ENGINE = REPO / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import rebuild  # noqa: E402
+
+
+class Tripwire(Exception):
+    """Raised by a seam that a non-action form must never reach."""
+
+
+def tripwire(name: str):
+    def fail(*args, **kwargs):
+        raise Tripwire(name)
+    return fail
+
+
+def tree_state(root: Path) -> dict[str, str]:
+    """Every file under root, by content. A created candidate or backup shows up
+    as a new key, a mutated DB as a changed digest — one observation covering
+    both halves of 'byte-for-byte unchanged'."""
+    return {
+        str(path.relative_to(root)): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def sentinel_tree(tmp: Path) -> Path:
+    """An outgoing DB with live WAL/SHM sidecars and a populated backup dir.
+
+    The bytes are not a real database on purpose: any seam that opens or copies
+    them fails loudly rather than quietly succeeding.
+    """
+    (tmp / "shell_db.db").write_bytes(b"outgoing-database")
+    (tmp / "shell_db.db-wal").write_bytes(b"outgoing-wal")
+    (tmp / "shell_db.db-shm").write_bytes(b"outgoing-shm")
+    backups = tmp / "backups"
+    backups.mkdir()
+    (backups / "shell_db.prerebuild.20260101_000000.db").write_bytes(b"old-backup")
+    (tmp / "schema.sql").write_text("-- sentinel schema\n")
+    return tmp / "shell_db.db"
+
+
+def armed(stack: ExitStack, tmp: Path, **overrides):
+    """Point rebuild at the sentinel tree with every post-parse seam armed.
+
+    Seams are armed by NAME so a failure says which one ran. Both database entry
+    points (db_driver.connect, sqlite3.connect) are included: 'no database open'
+    is a claim about opening, not about a particular helper.
+    """
+    patches = {
+        "DB_PATH": tmp / "shell_db.db",
+        "REPO_ROOT": tmp,
+        "ENGINE": tmp,
+        "SCHEMA_SQLITE": tmp / "schema.sql",
+        "SNAPSHOT": tmp / "content.sql",
+        "SNAPSHOT_LEGACY": tmp / "legacy-content.sql",
+        "read_existing_keys": tripwire("read_existing_keys"),
+        "restore_keys": tripwire("restore_keys"),
+        "backup_existing": tripwire("backup_existing"),
+        "backup_dir": tripwire("backup_dir"),
+        "backup_db": tripwire("backup_db"),
+        "prune_backups": tripwire("prune_backups"),
+        "snapshot_path": tripwire("snapshot_path"),
+        "validate_foreign_keys": tripwire("validate_foreign_keys"),
+        "_remove_database": tripwire("_remove_database"),
+    }
+    patches.update(overrides)
+    stack.enter_context(mock.patch.multiple(rebuild, **patches))
+    stack.enter_context(mock.patch.object(
+        rebuild.db_driver, "connect", tripwire("db_driver.connect")))
+    stack.enter_context(mock.patch.object(
+        rebuild.sqlite3, "connect", tripwire("sqlite3.connect")))
+    stack.enter_context(mock.patch.object(
+        rebuild.db_backup_mod, "select_backup_dir",
+        tripwire("db_backup.select_backup_dir")))
+    stack.enter_context(mock.patch.object(
+        rebuild.interface_reconcile, "live_refusal_reasons",
+        tripwire("live_refusal_reasons")))
+    stack.enter_context(mock.patch.object(
+        rebuild.interface_reconcile, "startup_reconcile",
+        tripwire("startup_reconcile")))
+    stack.enter_context(mock.patch.object(
+        rebuild.migrate_mod, "migrate", tripwire("migrate")))
+    stack.enter_context(mock.patch.object(
+        rebuild.map_repo, "main", tripwire("map_repo.main")))
+    stack.enter_context(mock.patch.object(
+        rebuild.backfill_shell_api_keys, "backfill", tripwire("backfill")))
+    stack.enter_context(mock.patch.object(
+        rebuild.seed_skills, "apply_retired", tripwire("apply_retired")))
+
+
+def run_main(argv: list[str]) -> tuple[int, str, str]:
+    """main(argv) -> (exit code, stdout, stderr). A form that neither exits nor
+    raises is itself a failure: every form under test is a terminating one."""
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        try:
+            rebuild.main(argv)
+        except SystemExit as exc:
+            code = exc.code
+        else:
+            raise AssertionError(f"main({argv!r}) returned without exiting")
+    return code, out.getvalue(), err.getvalue()
+
+
+class RebuildHelpTest(unittest.TestCase):
+    def test_help_exits_zero_with_usage_and_touches_no_state(self):
+        for argv in (["-h"], ["--help"]):
+            with self.subTest(argv=argv), tempfile.TemporaryDirectory() as raw:
+                tmp = Path(raw)
+                sentinel_tree(tmp)
+                before = tree_state(tmp)
+                with ExitStack() as stack:
+                    armed(stack, tmp)
+                    code, out, err = run_main(argv)
+                self.assertEqual(code, 0)
+                self.assertIn("usage: ./sc rebuild [--no-backup]", out)
+                self.assertIn("--no-backup", out)
+                self.assertIn("skip the pre-rebuild backup", out)
+                self.assertEqual(err, "")
+                self.assertEqual(tree_state(tmp), before)
+
+    def test_help_exits_zero_when_the_schema_is_missing(self):
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            sentinel_tree(tmp)
+            (tmp / "schema.sql").unlink()
+            before = tree_state(tmp)
+            with ExitStack() as stack:
+                armed(stack, tmp, SCHEMA_SQLITE=tmp / "schema.sql")
+                code, out, err = run_main(["--help"])
+            self.assertEqual(code, 0)
+            self.assertIn("usage: ./sc rebuild", out)
+            self.assertNotIn("missing", err)
+            self.assertEqual(tree_state(tmp), before)
+
+    def test_help_wins_over_action_and_unknown_input_and_performs_no_action(self):
+        for argv in (
+            ["--no-backup", "--help"],
+            ["--help", "--no-backup"],
+            ["-h", "--no-backup"],
+            ["--bogus", "-h"],
+        ):
+            with self.subTest(argv=argv), tempfile.TemporaryDirectory() as raw:
+                tmp = Path(raw)
+                sentinel_tree(tmp)
+                before = tree_state(tmp)
+                with ExitStack() as stack:
+                    armed(stack, tmp)
+                    code, out, err = run_main(argv)
+                self.assertEqual(code, 0)
+                self.assertIn("usage: ./sc rebuild", out)
+                self.assertNotIn("done ->", out)
+                self.assertEqual(err, "")
+                self.assertEqual(tree_state(tmp), before)
+
+
+class RebuildInvalidArgumentTest(unittest.TestCase):
+    def test_unknown_argument_exits_two_naming_the_token_and_touches_no_state(self):
+        for argv, rejected in (
+            (["--dry-run"], "--dry-run"),
+            (["-n"], "-n"),
+            (["oops"], "oops"),
+            (["--no-backup", "--force"], "--force"),
+            (["--force", "--no-backup"], "--force"),
+            (["--no-backup=1"], "--no-backup=1"),
+            ([""], ""),
+        ):
+            with self.subTest(argv=argv), tempfile.TemporaryDirectory() as raw:
+                tmp = Path(raw)
+                sentinel_tree(tmp)
+                before = tree_state(tmp)
+                with ExitStack() as stack:
+                    armed(stack, tmp)
+                    code, out, err = run_main(argv)
+                self.assertEqual(code, 2)
+                self.assertIn(f"unknown argument '{rejected}'", err)
+                self.assertIn("usage: ./sc rebuild [--no-backup]", err)
+                self.assertEqual(out, "")
+                self.assertEqual(tree_state(tmp), before)
+
+    def test_first_unknown_token_is_the_one_named(self):
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            sentinel_tree(tmp)
+            with ExitStack() as stack:
+                armed(stack, tmp)
+                code, _, err = run_main(["--first", "--second"])
+            self.assertEqual(code, 2)
+            self.assertIn("'--first'", err)
+            self.assertNotIn("'--second'", err)
+
+
+class RebuildActionFormTest(unittest.TestCase):
+    """The positive control plus the two valid forms' meaning.
+
+    Each case lets the seams BEFORE the one under test behave, and names the
+    seam that must then be reached. That proves the tripwires in the tests above
+    are live rather than merely unreachable, and pins --no-backup's meaning:
+    the default form must reach backup_existing, and --no-backup must get past
+    it without calling it.
+    """
+
+    def test_action_forms_reach_the_armed_seams(self):
+        for argv, expected in (
+            ([], "read_existing_keys"),
+            (["--no-backup"], "read_existing_keys"),
+        ):
+            with self.subTest(argv=argv), tempfile.TemporaryDirectory() as raw:
+                tmp = Path(raw)
+                sentinel_tree(tmp)
+                with ExitStack() as stack:
+                    armed(stack, tmp)
+                    with self.assertRaises(Tripwire) as ctx:
+                        rebuild.main(argv)
+                self.assertEqual(str(ctx.exception), expected)
+
+    def test_default_form_still_backs_up_and_no_backup_still_skips_it(self):
+        for argv, expected in (
+            ([], "backup_existing"),
+            (["--no-backup"], "_remove_database"),
+            (["--no-backup", "--no-backup"], "_remove_database"),
+        ):
+            with self.subTest(argv=argv), tempfile.TemporaryDirectory() as raw:
+                tmp = Path(raw)
+                sentinel_tree(tmp)
+                with ExitStack() as stack:
+                    armed(
+                        stack, tmp,
+                        read_existing_keys=lambda *a, **k: {},
+                    )
+                    stack.enter_context(mock.patch.object(
+                        rebuild.interface_reconcile, "live_refusal_reasons",
+                        lambda *a, **k: []))
+                    with self.assertRaises(Tripwire) as ctx:
+                        rebuild.main(argv)
+                self.assertEqual(str(ctx.exception), expected)
+
+
+class RebuildDispatchParityTest(unittest.TestCase):
+    """Requirement 1: rebuild.py owns the WHOLE contract, so `./sc rebuild` and
+    a direct script call cannot differ — which holds only while the dispatcher
+    forwards verbatim. Both halves are pinned: the forwarder's text, and the
+    script's own end-to-end behavior in a fresh interpreter."""
+
+    def test_dispatcher_forwards_every_argument_verbatim(self):
+        line = next(
+            ln.strip() for ln in (REPO / "sc").read_text().splitlines()
+            if ln.strip().startswith("rebuild)")
+        )
+        self.assertEqual(
+            line, 'rebuild)      exec "$PY" "$S/rebuild.py" "$@" ;;')
+
+    def test_script_invocation_handles_help_and_rejection_end_to_end(self):
+        # A COPY of the engine scripts, deliberately without schema.sql: this
+        # subprocess is the one place a regression could start a real rebuild,
+        # so the only instance it can reach is a throwaway that rebuild refuses.
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            shutil.copytree(ENGINE / "scripts", tmp / ".super-coder" / "scripts")
+            script = tmp / ".super-coder" / "scripts" / "rebuild.py"
+
+            for argv, code, stream, needle in (
+                (["--help"], 0, "stdout", "usage: ./sc rebuild [--no-backup]"),
+                (["-h"], 0, "stdout", "--no-backup  skip the pre-rebuild backup"),
+                (["--wat"], 2, "stderr", "unknown argument '--wat'"),
+                (["bogus"], 2, "stderr", "unknown argument 'bogus'"),
+            ):
+                with self.subTest(argv=argv):
+                    done = subprocess.run(
+                        [sys.executable, str(script), *argv],
+                        capture_output=True, text=True, cwd=str(tmp),
+                        timeout=120, check=False)
+                    self.assertEqual(done.returncode, code, done.stderr)
+                    self.assertIn(needle, getattr(done, stream))
+                    quiet = "stderr" if stream == "stdout" else "stdout"
+                    self.assertEqual(getattr(done, quiet), "")
+                    self.assertFalse(
+                        (tmp / ".super-coder" / "shell_db.db").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sprint 84 · U9 · spec #67 — rebuild command argument preflight.

## The defect

`rebuild.main()` read the schema, carried the outgoing api_keys, probed live
Interface state and took a backup *before* it interpreted `argv` at all — its
only argument check was `"--no-backup" not in argv`. So `./sc rebuild --help`
and every typo ran a real rebuild. Premise re-verified on this base
(`b0cd2277`, `rebuild.py:185-203` as the spec cited at `679ee461`).

## The change

`parse_args()` at the top of `main()` owns the whole contract and touches no
state — no path, no database, no probe:

- `-h` / `--help` → usage, explains `--no-backup`, exit 0
- unknown positional or option → exit 2 on stderr, naming the rejected token
  plus usage (matching `sc launch`'s existing message shape)
- repeated `--no-backup` → the same flag
- help wins over any action flag *and* over an unknown token: help asserts
  nothing about the instance, so there is no state in which it can fail, and
  nothing it prints can degrade into a rebuild

The dispatcher is untouched — `rebuild)` already forwarded `"$@"` verbatim, and
a test now pins that it keeps doing so, since requirement 1 (identical behavior
from `./sc rebuild` and a direct script call) holds only while it does.

Refusal, candidate integrity, atomic replacement and rollback are unchanged.
No migration.

**Trade-off:** hand-rolled parser over `argparse`. The contract is four tokens
wide, `main(argv)` is called in-process by `update.py` and by tests, and
argparse would impose its own usage text and exit paths on those callers. Four
lines are the smaller thing to delete when the contract changes.

## Tests

`tests/test_rebuild_args.py` arms every post-parse seam to raise —
`read_existing_keys`, `live_refusal_reasons`, `backup_existing`, `backup_dir`,
`backup_db`, `prune_backups`, `snapshot_path`, `_remove_database`,
`validate_foreign_keys`, `migrate`, `startup_reconcile`, `apply_retired`,
`backfill`, `map_repo.main`, and both DB entry points (`db_driver.connect`,
`sqlite3.connect`) — then asserts, for each non-action form, the exit code, the
exact stream the message lands on, the *other* stream being empty, and a
sentinel tree (outgoing DB + `-wal` + `-shm` + a populated backup dir) that is
byte-identical afterwards.

An unfired tripwire is only evidence if it can fire, so
`RebuildActionFormTest` is the positive control: the same armed seams, driven
by the valid forms, must raise — and it pins `--no-backup`'s meaning by naming
which seam each form reaches (`[]` → `backup_existing`, `--no-backup` →
`_remove_database`).

Existing end-to-end valid-path coverage in `test_rebuild_integrity.py` (default
backup, and `--no-backup`) is retained and still green.

## Mutation evidence

Harness conditions: `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared before
every run, and the baseline re-asserted GREEN after every revert (a same-size
mutation reverted inside one second otherwise leaves valid stale bytecode
running). Suites: `tests/test_rebuild_args.py` + `tests/test_rebuild_integrity.py`.
Red sets captured from `-rfE`, matching `SUBFAILED(...)` as well as `FAILED` —
the first pass of this harness matched only `FAILED` and silently under-reported
every subtest red set.

| mutation | outcome | red set |
|---|---|---|
| M1 parser not called (pre-fix behavior) | killed | both help tests, both invalid tests, help-wins, script-invocation |
| M2 help branch removed | killed | help tests + help-wins + script-invocation only |
| M3 unknown-argument branch removed | killed | invalid tests + script-invocation only |
| M4 rejected token misnamed (first → last) | killed | `test_first_unknown_token_is_the_one_named` alone |
| M5 usage dropped from the rejection | killed | `test_unknown_argument_exits_two...` alone |
| M6 help exits nonzero | killed | help tests + script-invocation |
| M7 `--no-backup` meaning inverted | killed | action-form test + `test_orphan_snapshot_refuses...` |
| M8 dispatcher stops forwarding arguments | killed | dispatcher parity test alone |
| M9 non-action form writes a stray file | killed | the four byte-equality tests |

0 survivors. M2/M3 and M4/M5 give the disjoint red sets that show each operand
is detected separately. M9 is synthetic on purpose: every other mutation reds
through a tripwire, which would leave the byte-equality assertion itself
unproven — M9 trips no seam, so only the tree comparison can catch it, and it
reds exactly the four tests that make that claim.

## Suite state

Full `./sc test`: 1947 passed, 1 failed. The failure is
`spikes/interface-stream/tests/test_bounded_buffers.py`, unrelated to this diff,
reproducing deterministically on an idle host and *also* at the pre-U12 commit
`c66264cc` — no CI job runs `spikes/` at all. Filed as flag #369 with the A/B
evidence. Everything under `tests/` — the scope CI gates — is green.
