### PR TITLE
docs(sprint): close skill treats the board as a record, not a source (S84 U6)

### DIFF
--- a/.super-coder/migrations/0112_reseed_sprint_close_board_record.sql
+++ b/.super-coder/migrations/0112_reseed_sprint_close_board_record.sql
@@ -1,11 +1,21 @@
----
-name: sprint_orchestration_close
-description: Close a sprint after every unit is terminal and main is green. Run an independent spec-to-main conformance pass, route findings while authority remains active, close and freeze the sprint document, verify wake and PR-watch cleanup, synthesize the report, and settle flags and roadmap state. Load only at the close trigger.
-category: craft
-common: false
----
+-- 0112 — reseed sprint_orchestration_close: the board is a record, not a source.
+-- Sprint 84 U6 (spec #76, H-23/H-24). Generated from
+-- assets/skills/sprint_orchestration_close/SKILL.md; full-body upsert so
+-- existing installations converge on the asset.
+--
+-- Single-skill reseed by planner ruling: U5's full-chain reseed (0114) is
+-- authored later and is idempotent over this one. Editing the asset without
+-- this migration is exactly the drift tests/test_skills_freshness.py detects.
 
-# sprint_orchestration_close
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_orchestration_close',
+  'Close a sprint after every unit is terminal and main is green. Run an independent spec-to-main conformance pass, route findings while authority remains active, close and freeze the sprint document, verify wake and PR-watch cleanup, synthesize the report, and settle flags and roadmap state. Load only at the close trigger.',
+  'craft',
+  NULL,
+  0,
+  '# sprint_orchestration_close
 
 Close from integrated evidence. Keep the sprint ACTIVE until conformance
 findings are ruled.
@@ -103,7 +113,7 @@ Closing a sprint **is** freezing its doc. Freeze it, and edit nothing:
 ```
 
 NEVER close a sprint by editing its body to `status: CLOSED`. A sprint is live
-iff its `documents` row has `kind='doc'`, a `SPRINT:%` title, `frozen = 0`, and
+iff its `documents` row has `kind=''doc''`, a `SPRINT:%` title, `frozen = 0`, and
 at least one `sprint_units` row — the `status:` line is display prose that no
 liveness reader consults. A body edit therefore releases no binding, cancels no
 wake queue and retires no watch, while reading to a human as a closed sprint.
@@ -145,7 +155,7 @@ Build `Final Board` from the `sprint_units` rows, one row per unit, columns
 board file exists on disk, so the frozen report is the only durable copy of the
 board -> a unit missing from this table has no record anywhere.
 
-NEVER assemble that table from a board render, a draft report or a unit report's
+NEVER assemble that table from a board render, a draft report or a unit report''s
 prose. Those are display; the rows are the record, and the two diverge exactly
 when a late board write lands after someone copied the display.
 
@@ -159,7 +169,7 @@ Persist the report:
 ./sc mem doc add "SPRINT REPORT: <title>" --kind doc --body-file <report.md>
 ```
 
-Add a shared copy only when the fork's artifact policy or FnB requests one.
+Add a shared copy only when the fork''s artifact policy or FnB requests one.
 
 ## Settle bookkeeping
 
@@ -178,4 +188,11 @@ Add a shared copy only when the fork's artifact policy or FnB requests one.
 
 **Close completion:** the sprint doc is frozen, bindings are released, watches
 are retired, the report exists, and every finding or follow-up has an owner or
-explicit disposition.
+explicit disposition.',
+  0)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/tests/test_sprint_close_record.py
+++ b/tests/test_sprint_close_record.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""H-23/H-24 on the skill layer: the close skill treats the board as a RECORD.
+
+Guards the text of `assets/skills/sprint_orchestration_close/SKILL.md` — the
+asset, which is the source; `.claude/skills/` is a per-boot render (decision
+#71) and is never read here.
+
+Why text assertions earn their brittleness: sprint 84 U5 rewrites this exact
+body wholesale through migration 0112 (the three-artifact reseed). A reseed
+that drops the freeze rule or restores `status: CLOSED` ships a close procedure
+that RELEASES NOTHING — under H-1 a sprint is live iff its doc row is unfrozen
+with units, so the `status:` line is display prose no liveness reader consults.
+That regression is silent at every other layer: the skill still reads correctly
+to a human, the close still "succeeds", and the binding stays armed. These are
+the assertions that turn red on it.
+
+Each method pins ONE property. Every section lookup asserts it found a
+non-empty section first, so a renamed heading fails loudly instead of passing
+vacuously against an empty string.
+
+Run:
+    python3 tests/test_sprint_close_record.py
+"""
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+SKILL = ENGINE / "assets" / "skills" / "sprint_orchestration_close" / "SKILL.md"
+
+# every column H-23 requires the frozen report to carry
+BOARD_COLUMNS = ("seq", "title", "dev", "reviewer", "terminal state", "PR",
+                 "review head")
+
+
+class CloseSkillRecordTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.body = SKILL.read_text()
+
+    def section(self, heading: str) -> str:
+        """Text under `## <heading>`, up to the next `## ` heading.
+
+        Fence-aware on purpose: the report skeleton is a fenced block whose
+        lines are themselves `## …`, and a naive splitter ends the section at
+        the first of them — truncating the very content under test.
+
+        Raises rather than returns "" when the heading is gone: an absent
+        section must fail the test that reads it, never satisfy an
+        assertNotIn by vacuum.
+        """
+        collected, fenced, started = [], False, False
+        for line in self.body.splitlines():
+            if line.startswith("```"):
+                fenced = not fenced
+            elif not fenced and line.startswith("## "):
+                if started:
+                    break
+                if line == f"## {heading}":
+                    started = True
+                    continue
+            if started:
+                collected.append(line)
+        self.assertTrue(
+            started,
+            f"section '## {heading}' is gone — a reseed renamed or dropped "
+            f"it, and every assertion below it would pass vacuously")
+        text = "\n".join(collected).strip()
+        self.assertTrue(text, f"section '## {heading}' is empty")
+        return text
+
+    def test_close_is_a_freeze(self):
+        """The close mechanism is `doc freeze`, stated as the whole action."""
+        revoke = self.section("Revoke sprint authority")
+        self.assertIn("./sc mem doc freeze <doc-id>", revoke)
+        self.assertIn("is** freezing its doc", revoke)
+
+    def test_close_never_instructs_a_body_edit(self):
+        """The no-op close must not come back — the U1 consequence.
+
+        Two independent detectors, because the regression has two shapes: the
+        COMMAND returning (`doc edit` on the sprint doc) and the INSTRUCTION
+        returning (`status: CLOSED` written as a step rather than a
+        prohibition).
+        """
+        revoke = self.section("Revoke sprint authority")
+        with self.subTest("no doc-edit command anywhere in the skill"):
+            self.assertNotIn("mem doc edit", self.body)
+        with self.subTest("status: CLOSED survives only under a prohibition"):
+            self.assertIn("NEVER close a sprint by editing its body", revoke)
+            for line in revoke.splitlines():
+                if "status: CLOSED" in line:
+                    self.assertIn(
+                        "NEVER", line,
+                        "`status: CLOSED` appears outside a prohibition — as "
+                        "an instruction it is a close that releases nothing")
+
+    def test_close_says_why_the_status_line_is_not_the_mechanism(self):
+        """Bare 'freeze instead' is followed the first time and reasoned around
+        the second. The H-1 definition is what makes the rule stick."""
+        revoke = self.section("Revoke sprint authority")
+        for token in ("frozen = 0", "sprint_units", "display prose"):
+            with self.subTest(token=token):
+                self.assertIn(token, revoke)
+
+    def test_report_skeleton_carries_the_final_board(self):
+        """H-23: the frozen report is the board's only durable copy."""
+        report = self.section("Write the sprint report")
+        self.assertIn("## Final Board", report)
+
+    def test_final_board_is_built_from_structured_rows(self):
+        """H-23: read `sprint_units`, not a render — with every column named.
+
+        The columns are the point. A 'Final Board' section carrying seq+title
+        only is a table that satisfies the heading and loses the record.
+        """
+        report = self.section("Write the sprint report")
+        self.assertIn("`sprint_units` rows", report)
+        for column in BOARD_COLUMNS:
+            with self.subTest(column=column):
+                self.assertIn(column, report)
+
+    def test_final_board_forbids_copying_a_render(self):
+        """H-24 at the point of use: the table is assembled from rows."""
+        report = self.section("Write the sprint report")
+        self.assertRegex(report, r"NEVER assemble that table from")
+
+    def test_structural_read_rule_is_stated_once_up_front(self):
+        """H-24: the rule a reseed is most likely to drop, because it directs
+        no single command — it governs every read in the file."""
+        preamble = self.body.split("## Confirm the close trigger")[0]
+        self.assertIn("Take every fact from structure", preamble)
+        self.assertIn("NEVER read a fact out of a persisted render", preamble)
+
+    def test_live_board_is_named_as_a_live_read(self):
+        """The rule must not read as 'never look at a board'. `sc sprint board`
+        renders rows at call time and stays legal; without this the next author
+        resolves the apparent contradiction by deleting the rule."""
+        preamble = self.body.split("## Confirm the close trigger")[0]
+        self.assertIn("sc sprint board", preamble)
+        self.assertIn("render the rows at call time", preamble)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sprint_no_render_read.py
+++ b/tests/test_sprint_no_render_read.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""H-24, code half: no engine read path resolves a rendered sprint artifact.
+
+Roadmap #30 / decisions #71-#72 policy, applied to the sprint envelope: the DB
+is the source of truth, the flat `_sc` mirror is a record for FnB review. Spec
+#76 pins it by test, the same method as the #30 audit — pin the audited surface,
+force a human to classify anything new.
+
+The regression this catches is cheap to write and expensive to own: reading
+`docs_sc/SPRINT-*.md` back is the single most convenient way to answer "what did
+that sprint do", and it silently reintroduces prose as a data source — the same
+family as the five `status:` parsers this sprint removed. A render is stale the
+moment a row moves, and unlike the row it has no writer discipline.
+
+Audited baseline, 2026-07-27, sprint 84 U6 (verified by hand, then pinned):
+every engine reference to the mirror trees is a WRITE, a DRIFT-CHECK, an
+EXCLUSION, or a docstring citation. Not one is a read of a render as input.
+
+Run:
+    python3 tests/test_sprint_no_render_read.py
+"""
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+
+# the rendered flat mirror — never an engine input
+MIRROR_TOKENS = ("docs_sc", "specs_sc", "skills_sc", "roadmap_sc")
+
+# reading the mirror IS the job of exactly these two, by design
+MIRROR_OWNERS = {
+    "render/flat.py",          # writes the mirror
+    "scripts/render_check.py",  # reads it back only to diff against the DB
+}
+
+# every other module that may NAME a mirror path, with the role that makes it
+# legal. Naming is fine; resolving one as input is not.
+AUDITED_REFERENCES = {
+    "api/server.py": "render orchestration, help text, render-target list",
+    "scripts/map_repo.py": "excludes the mirror from the repo map",
+    "api/db_broker.py": "docstring spec citation",
+    "scripts/dbq.py": "docstring spec citation",
+    "scripts/job.py": "docstring spec citation",
+    "scripts/run.py": "docstring spec citation",
+    "scripts/watch.py": "docstring spec citation",
+    "scripts/seed_dogfood.py": "stores render_path as a WRITE destination",
+}
+
+# filesystem reads. `open` is a bare Name call; the rest are attribute calls.
+READ_ATTRS = ("read_text", "read_bytes", "glob", "rglob", "iterdir",
+              "listdir", "scandir", "open")
+
+# a realistic violation, in the shape it would actually be written: resolve the
+# rendered sprint report by path and parse it back. The detector must see this.
+INJECTED_VIOLATION = '''
+from pathlib import Path
+ROOT = Path("/tmp")
+def summarize(doc_id):
+    return (ROOT / "docs_sc" / f"SPRINT-{doc_id}.md").read_text()
+'''
+
+
+def engine_sources():
+    for path in sorted(ENGINE.rglob("*.py")):
+        yield path.relative_to(ENGINE).as_posix(), path.read_text(errors="ignore")
+
+
+def render_reads(rel: str, text: str) -> list:
+    """Reads whose TARGET EXPRESSION names a mirror tree.
+
+    AST, not line matching, and deliberately: `SPEC.read_text(),
+    "specs_sc/…"` puts a read and a mirror token on one line while reading an
+    asset and merely recording a render_path. Line matching calls that a
+    violation. Only the receiver of the read call decides.
+    """
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:                      # not ours to police
+        return []
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Attribute) and node.func.attr in READ_ATTRS:
+            target = ast.get_source_segment(text, node.func.value) or ""
+        elif isinstance(node.func, ast.Name) and node.func.id == "open":
+            target = " ".join(ast.get_source_segment(text, a) or ""
+                              for a in node.args[:1])
+        else:
+            continue
+        if any(tok in target for tok in MIRROR_TOKENS):
+            out.append(f"{rel}:{node.lineno}: {target.strip()}")
+    return out
+
+
+class NoRenderReadPathTest(unittest.TestCase):
+    def test_the_detector_catches_an_injected_violation(self):
+        """Validate the instrument against a known positive before trusting a
+        single empty result from it.
+
+        Every assertion below is an ABSENCE claim, and an absence claim from a
+        detector that cannot see its target is unmeasured, not clean. The
+        control is a synthetic violation in the shape one would really be
+        written, because that is what the detector must catch — not the mirror
+        writer, whose own path composition it is not built to follow.
+        """
+        found = render_reads("<injected>", INJECTED_VIOLATION)
+        self.assertEqual(len(found), 1, f"detector blind to a real violation: {found}")
+        self.assertIn("docs_sc", found[0])
+
+    def test_the_detector_does_not_fire_on_a_recorded_render_path(self):
+        """The other half of a trustworthy instrument: storing a render_path as
+        a WRITE destination is legal, and a detector that reds on it would be
+        removed within a sprint for crying wolf."""
+        legal = ('from pathlib import Path\n'
+                 'SPEC = Path("assets/seed/x.md")\n'
+                 'row = (SPEC.read_text(), "specs_sc/x.md")\n')
+        self.assertEqual(render_reads("<legal>", legal), [])
+
+    def test_no_module_resolves_a_render_as_input(self):
+        """The property itself: outside the mirror's two owners, no engine
+        module reads a rendered artifact off disk."""
+        offenders = []
+        for rel, text in engine_sources():
+            if rel in MIRROR_OWNERS:
+                continue
+            offenders.extend(render_reads(rel, text))
+        self.assertEqual(
+            offenders, [],
+            "an engine module resolves a rendered artifact as INPUT. The DB is "
+            "the read path; the mirror is a record for FnB review (roadmap #30, "
+            "decision #71). Read the row, not the render.")
+
+    def test_reference_surface_is_the_audited_one(self):
+        """Coarser net, and the one that catches a read this file's primitive
+        list has not learned yet: a NEW module naming the mirror at all must be
+        classified by a human, not absorbed silently."""
+        referencing = {
+            rel for rel, text in engine_sources()
+            if any(tok in text for tok in MIRROR_TOKENS)
+        } - MIRROR_OWNERS
+        self.assertEqual(
+            referencing, set(AUDITED_REFERENCES),
+            "the set of engine modules naming the rendered mirror changed. "
+            "Classify the new reference: if it WRITES or CITES, add it to "
+            "AUDITED_REFERENCES with its role; if it READS, it violates H-24.")
+
+    def test_no_sprint_render_path_is_composed(self):
+        """Sprint-specific, because sprint docs and SPRINT REPORTs are what
+        H-24 names: nothing in the engine builds a path to one."""
+        offenders = []
+        for rel, text in engine_sources():
+            if rel in MIRROR_OWNERS:
+                continue
+            for n, line in enumerate(text.splitlines(), 1):
+                if any(tok in line for tok in MIRROR_TOKENS) and "SPRINT" in line:
+                    offenders.append(f"{rel}:{n}: {line.strip()}")
+        self.assertEqual(offenders, [],
+                         "a rendered SPRINT artifact is being addressed by path")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sprint 84 · U6 · H-23/H-24 of spec #76. Reviewer: REV2. Depends on U3 (merged, `caf49fe`).

## What changed

**The close skill** (`assets/skills/sprint_orchestration_close/SKILL.md` — the ASSET; `.claude/skills/` is a per-boot render, decision #71):

- **H-23** — the SPRINT REPORT skeleton gains `## Final Board`, built from the `sprint_units` rows with all seven columns (`seq · title · dev · reviewer · terminal state · PR · review head`), plus a named prohibition on assembling it from a render, a draft, or a unit report's prose. No live board file exists on disk, so the frozen report is the board's only durable copy — a unit missing from that table has no record anywhere. All seven columns exist on the row; `review_head` is the one U3 added in migration 0108, so the skill names no field the record lacks.
- **H-24** — a structural-read rule stated once up front, because it governs every read in the file rather than any one command: rows are the record, a persisted render (a report body, a `status:` line, a board pasted into a document) is display, and NEVER read a fact out of one.
- **The U1 consequence** — `## Revoke sprint authority` no longer instructs a body edit. The `./sc mem doc edit` call is gone; close is `./sc mem doc freeze` alone, with the why in the text: a sprint is live iff its `documents` row is `kind='doc'`, `SPRINT:%`, `frozen = 0`, with ≥1 `sprint_units` row, so the `status:` line is display prose no liveness reader consults, and a body edit releases no binding, cancels no wake queue and retires no watch while reading to a human as a closed sprint.

**Migration 0112** — single-skill reseed, generated FROM the asset, body stored as the guards read it (`split("---", 2)[2].strip()`).

**Two test files** — the skill text, and H-24's code half.

## Trade-offs and judgement calls, stated

**The unit was scoped asset-only; that is not shippable, and the scope changed by ruling.** An engine skill's body is seeded by migrations, so editing the asset alone IS the drift `tests/test_skills_freshness.py` exists to catch — 3 of its 8 tests red. Control-proved rather than argued: `git stash push` of the single asset file → 8/8 OK; `git stash pop` → 3 red. The planner ruled the migration in (U5 moves to 0114 — 0113 is U7's, in flight on #661). U5's later full-chain reseed is idempotent over this single-skill one.

**The carve-out in the H-24 rule is deliberate.** `sc sprint board` and the read-only GUI are named as legal live reads that render rows at call time. A rule that reads as "never look at a board" gets deleted by the next author resolving the apparent contradiction, so the exception is stated where the rule is.

**Detection is AST on the read call's receiver, not line matching.** The simpler line matcher was written first and rejected on evidence: it fires on `SPEC.read_text(), "specs_sc/…"` — a read of an *asset* that merely records a `render_path` — and it could not see its own positive control. Both failure modes are now themselves pinned by tests (`test_the_detector_does_not_fire_on_a_recorded_render_path`, `test_the_detector_catches_an_injected_violation`).

**H-24's code half was added on ruling, not on my own initiative.** I reported the hand audit and asked; the planner ruled it in as spec #76's own U6 gate row ("no-read test"). Not folded in unasked.

## Evidence

**Skill text — 13 mutations, 13 red, 0 survivors**, each hitting its intended detector, asset restored byte-identical after every run:

| mutation | detector |
|---|---|
| M1 restore `status: CLOSED` body-edit close | close_is_a_freeze + never_instructs_a_body_edit |
| M2 drop the NEVER prohibition, keep freeze | never_instructs_a_body_edit |
| M3 drop `## Final Board` | report_skeleton_carries_the_final_board |
| M4 drop the `review head` column | final_board_is_built_from_structured_rows |
| M5 build the board from a render | final_board_is_built_from_structured_rows |
| M6 drop the copy-a-render prohibition | final_board_forbids_copying_a_render |
| M7 drop the structural-read rule | structural_read_rule_is_stated_once |
| M8 soften "NEVER read a fact out of a persisted render" | structural_read_rule_is_stated_once |
| M9 drop the live-board carve-out | live_board_is_named_as_a_live_read |
| M10 drop the H-1 why | close_says_why_the_status_line_is_not_the_mechanism |
| M11 rename `## Revoke sprint authority` | 3 tests |
| M12 rename `## Write the sprint report` | 3 tests |
| M13 remove the freeze command | close_is_a_freeze |

M11/M12 are the ones that matter most: the section reader ASSERTS it found a non-empty section before reading it, so a reseed that renames a heading fails loudly instead of passing every `assertNotIn` against an empty string. That is the vacuity mode this test family dies of.

**No-read audit — 5 mutations, 5 red, 0 survivors:** a render read added to an already-audited module; a brand-new module naming the mirror; a composed `docs_sc/SPRINT-*.md` path; the detector blinded (`READ_ATTRS` emptied); the detector reverted to line matching. The last two red the instrument-validation tests specifically, which is the point of having them.

**Disclosure — one instrument bug found in the writing.** My first section splitter ended a section at the first `## ` it saw, which for `## Write the sprint report` is a line INSIDE the fenced report skeleton, so it truncated the content under test and two assertions failed against a fragment. The splitter is now fence-aware. It failed loudly rather than passing on a truncated string, which is the only reason I caught it.

**Audited baseline pinned by the test:** every engine reference to the mirror trees is a write, a drift-check, an exclusion, or a docstring citation. Not one reads a render as input. A new module naming the mirror reds until a human classifies it.

**render-check:** passes, run as `python3 .super-coder/scripts/render_check.py` from the worktree — `./sc render-check` judges the main checkout (flag #47). Local artifact mode, so the mirror is ignored and this is a two-artifact commit; it was re-rendered through `render_check`'s own hermetic path, never the live DB.

**Full suite:** running as job `201-u6-gate`; gate statement per ruling #3270 follows in the unit report. CI on the exact head is authoritative.
