### PR TITLE
feat(sprint): structural sprint liveness via sprint_state predicates (S84 U1)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -65,6 +65,7 @@ import interface_wake  # noqa: E402
 import live_model  # noqa: E402
 import ports as ports_mod  # noqa: E402
 import shell_liveness  # noqa: E402
+import sprint_state  # noqa: E402
 from sprint_units import TERMINAL_UNIT_STATES as _TERMINAL_UNIT_STATES  # noqa: E402,E501
 from sprint_units import UNIT_STATES as _UNIT_STATES  # noqa: E402
 from sprint_units import board_writer as _board_writer  # noqa: E402
@@ -1659,12 +1660,14 @@ def _err_obj(code: str, message: str, details=None) -> dict:
 
 
 def _arm_binding(actor, headers, body):
-    """POST /api/interface/sprint-bindings — arm one ACTIVE sprint document
+    """POST /api/interface/sprint-bindings — arm one LIVE sprint document
     to one planner generation (spec #20 API Resources / Sprint Scope). A
     shell actor may arm only ITSELF; the operator may arm any planner.
-    Fail-closed refusals: doc missing/frozen/not ACTIVE, no occupied
-    planner session, a mandatory-hook gap (an unverifiable wake must never
-    arm), or a second ACTIVE binding (the partial unique indexes backstop).
+    Fail-closed refusals: the doc is not a live sprint per `sprint_state`
+    (missing, not a sprint doc, frozen, or holding no units — so the board is
+    declared BEFORE the binding is armed), no occupied planner session, a
+    mandatory-hook gap (an unverifiable wake must never arm), or a second
+    ACTIVE binding (the partial unique indexes backstop).
     """
     doc_id = body.get("sprint_doc_id")
     planner = body.get("planner_shell_id")
@@ -1677,14 +1680,11 @@ def _arm_binding(actor, headers, body):
     con = _db()
     try:
         def produce():
-            doc = con.execute(
-                "SELECT frozen FROM documents WHERE document_id=?",
-                (doc_id,)).fetchone()
-            if doc is None or doc[0] or not interface_broker._sprint_active(
-                    con, doc_id):
+            if not sprint_state.is_live_sprint(con, doc_id):
                 return 409, _err_obj(
                     "sprint_not_active",
-                    "sprint document is missing, frozen, or not ACTIVE")
+                    "sprint document is missing, frozen, retitled, or holds "
+                    "no units — declare the board before arming the binding")
             sess = con.execute(
                 "SELECT session_id, shell_id, generation, harness, "
                 "cli_version FROM interface_sessions "
@@ -1814,7 +1814,7 @@ def _project_binding(con, row) -> dict:
             "document_id": doc_id,
             "title": doc[0] if doc else None,
             "frozen": bool(doc[1]) if doc else None,
-            "active": interface_broker._sprint_active(con, doc_id),
+            "active": sprint_state.is_live_sprint(con, doc_id),
         },
         "wake_state": ("disarmed" if released_at is not None else
                        _wake_state(con, planner_shell_id=planner)),
@@ -2556,7 +2556,7 @@ def _emit_assignment_notice(con, actor, doc_id: int, seq: str,
                             before: dict, after: dict) -> int:
     """The remainder of retired feature #29 (spec doc 58, decision #74): one
     row per shell whose relationship to the unit changed, only on change, only
-    while the sprint is ACTIVE. Returns the number of rows written.
+    while the sprint is LIVE. Returns the number of rows written.
 
     THE INVARIANT IS "AT MOST ONE ROW PER SHELL PER WRITE", not a row count.
     The spec's "at most three" was a proxy for it and is wrong at the edge: a
@@ -2582,7 +2582,7 @@ def _emit_assignment_notice(con, actor, doc_id: int, seq: str,
     inert by construction. The sprint scope is still stamped so the rows
     filter with the rest of the sprint's traffic.
     """
-    if not interface_broker._sprint_active(con, doc_id):
+    if not sprint_state.is_live_sprint(con, doc_id):
         return 0
     parties = _assignment_parties(before, after)
     if actor.kind == "shell":
@@ -2683,13 +2683,15 @@ def _add_sprint_unit(actor, headers, body):
             return refusal
 
         def produce():
-            # "A sprint document" already has a definition in this engine —
-            # pr_poller's `kind='doc' AND frozen=0 AND title LIKE 'SPRINT:%'`
-            # — and the same clause is used here rather than a second one that
-            # can drift from it. MINUS `frozen=0`, deliberately: whether a
-            # frozen board stays mutable is a separate parked question, and
-            # folding it in here would decide it as a side effect of a typo
-            # guard.
+            # "A sprint document" has ONE definition in this engine —
+            # `sprint_state` — and this route uses it rather than a second
+            # clause that can drift from it.
+            #
+            # `is_writable_sprint_board`, not `is_live_sprint`: a frozen board
+            # is not mutable (H-1 answers the question this site used to park),
+            # but the unit-count clause cannot appear here, because this is the
+            # route that CREATES the first unit. Declare the board, then arm
+            # the binding.
             #
             # The typo this catches is adjacent-integer, not exotic: a sprint
             # doc and its spec are consecutive ids (59 and 58 for this very
@@ -2697,12 +2699,17 @@ def _add_sprint_unit(actor, headers, body):
             # participant — they read the sprint doc — while the rows exist
             # and the reconciler watches them.
             doc = con.execute(
-                "SELECT title, kind='doc' AND title LIKE 'SPRINT:%' "
-                "FROM documents WHERE document_id=?", (doc_id,)).fetchone()
+                "SELECT title, frozen FROM documents WHERE document_id=?",
+                (doc_id,)).fetchone()
             if doc is None:
                 return 404, _err_obj("no_such_sprint",
                                      f"no document {doc_id} to hold a board")
-            if not doc[1]:
+            if not sprint_state.is_writable_sprint_board(con, doc_id):
+                if doc[1] and sprint_state.is_sprint_doc(con, doc_id):
+                    return 409, _err_obj(
+                        "sprint_frozen",
+                        f"sprint {doc_id} ({doc[0]!r}) is frozen — a frozen "
+                        "sprint is closed, and a closed board takes no writes")
                 return 422, _err_obj(
                     "not_a_sprint_doc",
                     f"document {doc_id} is {doc[0]!r}, not a sprint board — "

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2688,10 +2688,14 @@ def _add_sprint_unit(actor, headers, body):
             # clause that can drift from it.
             #
             # `is_writable_sprint_board`, not `is_live_sprint`: a frozen board
-            # is not mutable (H-1 answers the question this site used to park),
-            # but the unit-count clause cannot appear here, because this is the
-            # route that CREATES the first unit. Declare the board, then arm
-            # the binding.
+            # takes no NEW units (H-1 answers the question this site used to
+            # park), but the unit-count clause cannot appear here, because this
+            # is the route that CREATES the first unit. Declare the board, then
+            # arm the binding.
+            #
+            # "No new units" is narrower than "immutable", deliberately: PATCH
+            # is NOT gated on the freeze, so a planner can still correct a
+            # closed sprint's board. You may correct history, not extend it.
             #
             # The typo this catches is adjacent-integer, not exotic: a sprint
             # doc and its spec are consecutive ids (59 and 58 for this very

--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -1671,7 +1671,7 @@ def _arm_binding(actor, headers, body):
     """
     doc_id = body.get("sprint_doc_id")
     planner = body.get("planner_shell_id")
-    if not isinstance(doc_id, int) or not isinstance(planner, int):
+    if not _is_int(doc_id) or not _is_int(planner):
         return _err(422, "validation",
                     "sprint_doc_id, planner_shell_id (int) required")
     if actor.kind == "shell" and actor.shell_id != planner:

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -80,6 +80,7 @@ except ImportError as _exc:  # websockets/tmux stack absent → review UI still 
     _INTERFACE_IMPORT_ERROR = _exc
 import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
 import pr_poller  # noqa: E402  (watched-PR polling — the service scheduler)
+import sprint_state  # noqa: E402  (the one structural sprint-liveness predicate)
 import ports as ports_mod  # noqa: E402
 import shell_factory  # noqa: E402
 import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin rule)
@@ -268,9 +269,10 @@ FLAG_EDITABLE = {"resolved", "resolution_notes", "description", "feature_id", "p
 ROADMAP_EDITABLE = {"title", "roadmap_status", "summary", "sort_order", "project_id"}
 
 # Typed traffic on the shell_messages bus (migration 0059). Shells send the
-# first three via `sc mem message send --kind`; 'pr_event' is emitted by the
-# GitHub watcher daemon (scripts/watch.py), which writes the DB directly —
-# accepted here too so a replayed/manual event isn't rejected on kind alone.
+# first three via `sc mem message send --kind`; 'pr_event' belongs to the PR
+# poller, which writes the DB directly. It stays in this vocabulary because
+# reads and filters use it, but shell-token ingress REFUSES it (H-3) — see the
+# POST /_sc/mem/messages handler.
 MESSAGE_KINDS = {"shell", "task", "result", "pr_event"}
 # spec_tasks lifecycle — 'cancelled' (#342) closes a task whose work moved in
 # a feature split/re-scope without lying that it was built. Validated here so
@@ -581,9 +583,17 @@ def get_docs(con) -> dict:
 def get_active_sprints(con) -> dict:
     """Build the active-sprint board from one consistent read snapshot.
 
-    One SELECT reads active documents, latest planner bindings, feature and
-    role labels, and units. The document body is deliberately absent from
+    One SELECT reads open sprint documents, latest planner bindings, feature
+    and role labels, and units. The document body is deliberately absent from
     both the projection and predicate.
+
+    The predicate comes from `sprint_state` rather than being inlined here, so
+    it cannot drift from the one the wake path enforces. It is
+    `writable_board_clause`, NOT `live_sprint_clause`: the unit-count operand
+    is deliberately absent, because a sprint declared seconds ago has no units
+    yet and this is the operator's window onto exactly that moment
+    (`test_zero_unit_sprint_still_projects` pins it). Liveness gates what the
+    engine ACTS on; this view shows the operator what exists.
     """
     result = rows(con.execute(
         "WITH latest_bindings AS ("
@@ -627,8 +637,7 @@ def get_active_sprints(con) -> dict:
         "LEFT JOIN shells dev ON dev.shell_id=unit.dev_shell_id "
         "LEFT JOIN shells reviewer "
         "  ON reviewer.shell_id=unit.reviewer_shell_id "
-        "WHERE d.kind='doc' AND d.frozen=0 "
-        "  AND d.title LIKE 'SPRINT:%' "
+        f"WHERE {sprint_state.writable_board_clause('d')} "
         # started_at is the single definition of a valid projected timestamp.
         # Sorting by its NULL state keeps the shape/parser gate from drifting.
         "ORDER BY started_at IS NULL, started_at, d.document_id, "
@@ -1220,29 +1229,35 @@ def patch_shell(con, shell_id, body):
 
 
 def patch_document(con, doc_id, body, commit=True):
-    r = con.execute("SELECT frozen FROM documents WHERE document_id=?",
+    r = con.execute("SELECT frozen, title FROM documents WHERE document_id=?",
                     (doc_id,)).fetchone()
     if r is None:
         return False, "no such document"
     if r["frozen"]:
         return False, "document is frozen — open the next spec, don't edit this one"
+    # The title is part of the liveness predicate (H-1), so it stops being a
+    # mutable prose surface for as long as the doc holds a board: a mid-sprint
+    # retitle would silently drop the sprint out of `SPRINT:%` and turn every
+    # participant deaf, which is the exact defect class the structural
+    # predicate exists to close, moved one field over. Freezing the doc — i.e.
+    # closing the sprint — lifts nothing here: a frozen doc refuses all edits
+    # one branch above.
+    # Compared RAW, exactly as `patch_columns` would write it — a normalized
+    # comparison would wave through the whitespace and NULL forms that break
+    # `LIKE 'SPRINT:%'` just as thoroughly as a rename.
+    if "title" in body and body["title"] != r["title"]:
+        if sprint_state.has_units(con, doc_id):
+            return False, (
+                f"document {doc_id} is the board of sprint {r['title']!r} "
+                f"and its title is load-bearing — a live sprint is identified "
+                f"by 'SPRINT:%', so retitling it would silently disarm the "
+                f"wake path and every watch. Close the sprint (freeze the "
+                f"doc) before any retitle.")
     # render_path is editable (#312): a doc authored without one could never
     # be made publishable — `doc edit --render-path` advertised the option
     # and silently dropped it, and `doc add` always INSERTs a new row.
     return patch_columns(con, "documents", "document_id", doc_id, body,
                          {"body", "title", "render_path"}, commit=commit)
-
-
-def _sprint_doc_status(con, doc_id) -> "str | None":
-    """The sprint board's `status:` line (the planner is its only writer)."""
-    r = con.execute("SELECT body FROM documents WHERE document_id=?",
-                    (doc_id,)).fetchone()
-    if r is None or r[0] is None:
-        return None
-    for line in r[0].splitlines():
-        if line.startswith("status:"):
-            return line.split(":", 1)[1].strip()
-    return None
 
 
 # The alert reasons a WATCH carries, as opposed to a binding. Until H-12 these
@@ -1326,8 +1341,8 @@ def _freeze_board_refusal(con, doc_id) -> "dict | None":
 
 def _close_sprint_wake(con, doc_id) -> dict:
     """Sprint close integration (spec #20 Sprint Scope, sprint 25 seq 10;
-    spec #76 H-12): closing (status: CLOSED) or freezing a sprint doc retires
-    the sprint's WHOLE live footprint in the SAME transaction — its wake
+    spec #76 H-12; H-1): closing a sprint IS freezing its doc, and the freeze
+    retires the sprint's WHOLE live footprint in the SAME transaction — its wake
     bindings and their queued wake work, its live PR watches, and the
     watch-scoped alerts those watches opened. No orphan armed binding, no
     stranded queued batch, no watch still polling GitHub for a sprint that
@@ -2540,6 +2555,44 @@ class Handler(BaseHTTPRequestHandler):
                 kind = (body.get("kind") or "shell").strip()
                 if kind not in MESSAGE_KINDS:
                     return self._send(400, {"error": f"kind must be one of {', '.join(sorted(MESSAGE_KINDS))}"})
+                if kind == "pr_event":
+                    # Kind parity with the CLI (H-3), which has refused
+                    # `--kind pr_event` since 0059. This whole surface is
+                    # shell-token ingress (`_require_shell_auth`), and a shell
+                    # that can mint a PR event can wake a planner with a
+                    # transition GitHub never reported — the wake loop's ground
+                    # truth, forgeable by any holder of any shell key.
+                    #
+                    # The poller is unaffected BECAUSE it emits by direct DB
+                    # insert rather than through this route. That is contract,
+                    # not accident: if the poller is ever moved onto the API it
+                    # needs a system credential, not a carve-out here.
+                    return self._send(403, {"error":
+                        "kind 'pr_event' is emitted by the PR poller, which "
+                        "writes the DB directly — a shell may not mint one. "
+                        "Send --kind result to report a PR transition."})
+                sprint_doc_id = body.get("sprint_doc_id")
+                if sprint_doc_id is not None:
+                    # Scope validation at the write boundary (H-2). This route
+                    # took any integer, so a typo'd --sprint produced a message
+                    # scoped to nothing: it never woke, never filtered with the
+                    # sprint's traffic, and reported success.
+                    #
+                    # SPRINT-DOC IDENTITY ONLY, deliberately — not liveness.
+                    # Declaration-window coordination (board declared, units
+                    # not yet) and post-close result rows are both legal
+                    # traffic; liveness gates the WAKE path, one layer down in
+                    # `interface_wake.maybe_create_wake_item`, and must never
+                    # gate acceptance of the message itself.
+                    if isinstance(sprint_doc_id, bool) or not isinstance(sprint_doc_id, int):
+                        return self._send(400, {"error":
+                            "sprint_doc_id must be an int (a sprint document id)"})
+                    if not sprint_state.is_sprint_doc(con, sprint_doc_id):
+                        return self._send(422, {"error":
+                            f"document {sprint_doc_id} is not a SPRINT doc — "
+                            "a scoped message tagged to anything else is "
+                            "invisible to the sprint and never wakes its "
+                            "planner; check the --sprint id"})
                 to_sid = body.get("to_shell_id")
                 if to_sid is None and body.get("to"):
                     r = con.execute(
@@ -2582,8 +2635,7 @@ class Handler(BaseHTTPRequestHandler):
                     cur = con.execute(
                         "INSERT INTO shell_messages (from_shell_id, to_shell_id, body, kind, sprint_doc_id, dedupe_key) "
                         "VALUES (?, ?, ?, ?, ?, ?)",
-                        (sid, int(to_sid), msg, kind,
-                         body.get("sprint_doc_id"), dk))
+                        (sid, int(to_sid), msg, kind, sprint_doc_id, dk))
                     message_id = cur.lastrowid
                     # Transactional wake ingress (spec #20 Event Ingress, seq
                     # 8): the wake item rides the SAME transaction as the
@@ -2786,21 +2838,24 @@ class Handler(BaseHTTPRequestHandler):
                         "SELECT 1 FROM documents WHERE document_id=?",
                         (did,)).fetchone():
                     return self._send(404, {"error": "no such document"})
-                # Sprint close integration (seq 10): the planner closes the
-                # board by setting status: CLOSED — the doc edit and the wake
-                # close (binding release + queue cancel) land in ONE
-                # transaction, edge-identical to the freeze path above: a
-                # crash mid-close leaves neither a CLOSED doc with an armed
-                # binding nor a released binding under an ACTIVE doc.
+                # NO sprint-close trigger here (H-1). A body edit used to
+                # release bindings when it happened to leave a `status: CLOSED`
+                # line, which made a prose line executable and made the close
+                # depend on formatting. Closing a sprint IS freezing its doc —
+                # the freeze route above owns the release, atomically. The
+                # `status:` line the close skill still writes is display prose
+                # for the human reader and nothing reads it back.
                 ok, err = patch_document(con, did, body, commit=False)
                 if not ok:
                     return self._send(400, {"ok": ok, "error": err})
-                closed = {"released_bindings": 0, "retired_watches": 0,
-                          "resolved_watch_alerts": 0}
-                if _sprint_doc_status(con, did) == "CLOSED":
-                    closed = _close_sprint_wake(con, did)
                 con.commit()
-                return self._send(200, {"ok": ok, **closed,
+                # Zeros, not an absent key: the counts stay in the response
+                # shape the freeze route reports (U3), so a reader parsing a
+                # doc write never has to branch on which route answered.
+                return self._send(200, {"ok": ok,
+                                        "released_bindings": 0,
+                                        "retired_watches": 0,
+                                        "resolved_watch_alerts": 0,
                                         "serialize": serialize_doc_write()})
 
             # PATCH /_sc/mem/messages/{id}/read
@@ -2833,7 +2888,8 @@ class Handler(BaseHTTPRequestHandler):
     # the whole board. Since the polling cutover (spec #20 task #85, decision
     # #19) the service's own scheduler is the sole poller and DB writer:
     # registration takes an immediate GitHub baseline (no baseline, no armed
-    # watch), `--sprint` scopes a watch to an ACTIVE sprint document, and
+    # watch), `--sprint` scopes a watch to a sprint document (validated as a
+    # sprint doc, not for liveness — the poller arms on liveness), and
     # /_sc/watches/reconcile is the operator's explicit one-shot poll.
 
     def _daemon_state(self, con) -> "dict | None":
@@ -2871,7 +2927,7 @@ class Handler(BaseHTTPRequestHandler):
         try:
             q = parse_qs(urlparse(self.path).query)
             include_closed = q.get("all", ["0"])[0] in ("1", "true", "yes")
-            active = pr_poller.active_sprint_doc_ids(con)
+            active = sprint_state.live_sprint_doc_ids(con)
             sql = ("SELECT w.watch_id, w.repo, w.pr_number, w.shell_id, "
                    "s.shortname, w.created_at, w.closed_at, w.sprint_doc_id, "
                    "w.unit_id, u.seq AS unit_seq "
@@ -2914,10 +2970,17 @@ class Handler(BaseHTTPRequestHandler):
                 sprint_doc_id = int(sprint_doc_id)
             except (TypeError, ValueError):
                 return self._send(400, {"error": "sprint_doc_id must be an int"})
-            if not pr_poller.is_active_sprint(con, sprint_doc_id):
+            # Registration validates SPRINT-DOC IDENTITY only, not liveness
+            # (H-2): a watch registered in the declaration window — board
+            # declared, units not yet — must be legal, and liveness is the
+            # poller's arming predicate, not the write boundary. A watch on a
+            # sprint that is not live is inert by construction: `armed_watches`
+            # scopes every poll to `sprint_state.live_sprint_doc_ids`.
+            if not sprint_state.is_sprint_doc(con, sprint_doc_id):
                 return self._send(409, {"error":
-                    f"document {sprint_doc_id} is not an ACTIVE, unfrozen "
-                    "SPRINT doc — watches arm only to active sprints"})
+                    f"document {sprint_doc_id} is not a SPRINT doc — a watch "
+                    "scopes to a sprint board, and one registered anywhere "
+                    "else is never polled; check the --sprint id"})
             # H-13: the unit this PR belongs to, named the way every message
             # names it ("U3") and resolved against THIS sprint's board. Two
             # free integers that nothing joined is what made the reconciler
@@ -2976,14 +3039,16 @@ class Handler(BaseHTTPRequestHandler):
                     "retryable": True, "daemon": daemon})
             # The baseline is an external read and cannot hold a DB writer
             # reservation. Revalidate scope after it, under the same
-            # transaction that arms or rebinds the watch, so sprint closure
-            # cannot land between the ACTIVE decision and its write.
+            # transaction that arms or rebinds the watch, so a doc that stops
+            # being a sprint board cannot land between the decision and its
+            # write.
             con.execute("BEGIN IMMEDIATE")
-            if not pr_poller.is_active_sprint(con, sprint_doc_id):
+            if not sprint_state.is_sprint_doc(con, sprint_doc_id):
                 con.rollback()
                 return self._send(409, {"error":
-                    f"document {sprint_doc_id} is not an ACTIVE, unfrozen "
-                    "SPRINT doc — watches arm only to active sprints"})
+                    f"document {sprint_doc_id} is not a SPRINT doc — a watch "
+                    "scopes to a sprint board, and one registered anywhere "
+                    "else is never polled; check the --sprint id"})
             existing = con.execute(
                 "SELECT watch_id FROM watched_prs "
                 "WHERE repo=? AND pr_number=? AND shell_id=? "

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -23,6 +23,7 @@ import hashlib
 
 import interface_hooks
 import interface_state
+import sprint_state
 
 MAX_INPUT_BYTES = 64 * 1024  # one human frame, per the pinned spike protocol
 WAKE_PROMPT = "Check your inbox and act on unread sprint events."
@@ -897,25 +898,11 @@ def release_bindings_for_sprint(con, sprint_doc_id: int,
     return ids
 
 
-def _sprint_active(con, sprint_doc_id: int) -> bool:
-    """The sprint doc's body contract carries a `status: ACTIVE|CLOSED` line
-    (the planner is its only writer); a wake may submit only while ACTIVE."""
-    row = con.execute(
-        "SELECT body FROM documents WHERE document_id=?",
-        (sprint_doc_id,)).fetchone()
-    if row is None or row[0] is None:
-        return False
-    for line in row[0].splitlines():
-        if line.startswith("status:"):
-            return line.split(":", 1)[1].strip() == "ACTIVE"
-    return False
-
-
 def _cancel_batch(con, batch_id: int) -> None:
     """Close a still-queued batch without sending a byte (the binding was
-    released or the sprint left ACTIVE between form and submit): the batch
-    completes empty and its batched items are cancelled — a wake must never
-    fire for a sprint that is no longer armed."""
+    released or the sprint stopped being live between form and submit): the
+    batch completes empty and its batched items are cancelled — a wake must
+    never fire for a sprint that is no longer armed."""
     interface_state.transition(
         con, "wake_batch", batch_id, "complete",
         extra_sets={"completed_at": _now(con)})
@@ -932,9 +919,9 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
     """Gate + submit one coalesced fixed-prompt batch under the input lock.
 
     Revalidates everything the spec requires before a byte moves: the binding
-    still armed and its sprint still ACTIVE AND unfrozen (a close or freeze
-    between form_batch and submit CANCELS the batch — freeze is how sprint
-    authority is revoked, so a post-freeze wake is exactly what must not
+    still armed and its sprint still LIVE per `sprint_state` (a close, freeze
+    or retitle between form_batch and submit CANCELS the batch — freeze is how
+    sprint authority is revoked, so a post-freeze wake is exactly what must not
     fire), a live occupied session (an ended session gate-fails with an
     ALERT and the batch stays queued for a future generation — End chat
     deliberately does not release the sprint binding, so this gate must
@@ -1007,16 +994,13 @@ def submit_wake_batch(con, batch_id: int, writer, now_iso: str,
             began = False
             return {"submitted": False, "cancelled": True,
                     "reason": "binding released — sprint no longer armed"}
-        frozen = con.execute(
-            "SELECT frozen FROM documents WHERE document_id=?",
-            (binding[0],)).fetchone()
-        if (frozen is None or frozen[0]
-                or not _sprint_active(con, binding[0])):
+        if not sprint_state.is_live_sprint(con, binding[0]):
             _cancel_batch(con, batch_id)
             con.commit()
             began = False
             return {"submitted": False, "cancelled": True,
-                    "reason": "sprint doc is frozen or not ACTIVE"}
+                    "reason": "sprint is no longer live (frozen, retitled, "
+                              "or its board was emptied)"}
 
         sess = con.execute(
             "SELECT session_id, occupancy, lifecycle, occupied_at, "

--- a/.super-coder/scripts/interface_wake.py
+++ b/.super-coder/scripts/interface_wake.py
@@ -28,6 +28,7 @@ import threading
 import db_driver
 import interface_broker
 import interface_hooks
+import sprint_state
 
 ELIGIBLE_KINDS = ("task", "result", "pr_event")
 RETRY_DELAYS_S = (1.0, 5.0, 30.0)  # bounded pre-send retries (spec table)
@@ -42,9 +43,9 @@ def maybe_create_wake_item(con, message_id: int) -> "int | None":
 
     Eligibility, exactly the spec's list: a typed sprint event (task /
     result / pr_event — `shell` and legacy unscoped traffic NEVER wake),
-    carrying a sprint_doc_id whose document exists, is unfrozen, and
-    declares status ACTIVE; an ACTIVE (unreleased) binding for that sprint
-    names this message's recipient as planner; the binding's Interface
+    carrying a sprint_doc_id naming a LIVE sprint (`sprint_state` — a sprint
+    doc, unfrozen, holding a board); an ACTIVE (unreleased) binding for that
+    sprint names this message's recipient as planner; the binding's Interface
     session and generation are still live (not ended/replaced); and the
     harness supports the mandatory lifecycle hooks (a capability gap
     refuses arming AND ingress — the wake would be unverifiable). Message
@@ -56,11 +57,7 @@ def maybe_create_wake_item(con, message_id: int) -> "int | None":
     if msg is None or msg[1] not in ELIGIBLE_KINDS or msg[2] is None:
         return None
     to_shell_id, _, sprint_doc_id = msg
-    doc = con.execute(
-        "SELECT frozen FROM documents WHERE document_id=?",
-        (sprint_doc_id,)).fetchone()
-    if doc is None or doc[0] or not interface_broker._sprint_active(
-            con, sprint_doc_id):
+    if not sprint_state.is_live_sprint(con, sprint_doc_id):
         return None
     binding = con.execute(
         "SELECT binding_id, session_id, shell_id, generation "

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -1004,13 +1004,16 @@ def build_parser() -> argparse.ArgumentParser:
     ms = msub.add_parser("send")
     ms.add_argument("to")
     ms.add_argument("body")
-    # 'pr_event' is deliberately not offered — it is the daemon's kind; a shell
-    # forging PR transitions would poison the wake loop's ground truth.
+    # 'pr_event' is deliberately not offered — it is the poller's kind; a shell
+    # forging PR transitions would poison the wake loop's ground truth. The API
+    # refuses it at shell-token ingress too (H-3), so this is a friendly early
+    # refusal rather than the only fence.
     ms.add_argument("--kind", default="shell", choices=["shell", "task", "result"],
                     help="message kind: shell (default) | task (planner→worker) | result (worker→planner)")
     ms.add_argument("--sprint", type=int, default=None, metavar="DOC_ID",
-                    help="scope a task/result event to an ACTIVE sprint doc — "
-                         "wake-eligible when the recipient is the bound planner")
+                    help="scope a task/result event to a sprint doc (validated "
+                         "server-side) — wake-eligible when the sprint is live "
+                         "and the recipient is its bound planner")
     mm = msub.add_parser("mark-read")
     mm.add_argument("message_id", type=int)
     sp.set_defaults(fn=cmd_message)

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -15,7 +15,7 @@ What lives here:
 - `baseline_read()` — registration's immediate GitHub read: no normalized
   baseline stored, no armed watch (the caller fails retryable).
 - `poll_cycle()` — one bounded pass over ARMED watches only (live rows whose
-  sprint_doc_id names an ACTIVE, unfrozen SPRINT document; unscoped legacy
+  sprint_doc_id names a LIVE sprint per `sprint_state`; unscoped legacy
   watches stay dormant until rebound). Per cycle: a `pr_poll_runs` audit row
   per repo, durable `pr_poll_observations` for transitions and blind windows,
   idempotent `pr_event` messages (dedupe_key) plus same-transaction wake items
@@ -39,7 +39,6 @@ from __future__ import annotations
 import json
 import os
 import random
-import re
 import shutil
 import sqlite3
 import subprocess
@@ -50,6 +49,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import activity_readers
+import sprint_state
 from quota_probes import dispatch as quota_dispatch
 from sprint_units import TERMINAL_UNIT_STATES, board_writer
 
@@ -63,8 +63,6 @@ JITTER_FRACTION = 0.25          # sleep interval + uniform(0, 25%) — herd spre
 BACKOFF_CAP_S = 900             # per-repo failure backoff ceiling (15 min)
 NO_PROGRESS_WINDOW = timedelta(minutes=20)
 START_GRACE = timedelta(minutes=20)
-
-_STATUS_ACTIVE = re.compile(r"^status:\s*ACTIVE\s*$", re.MULTILINE)
 
 
 # ── GitHub read (the only network seam — injectable for tests) ───────────────
@@ -916,31 +914,14 @@ def reconcile_tick(
 
 # ── Sprint scoping ────────────────────────────────────────────────────────────
 
-def active_sprint_doc_ids(con) -> "set[int]":
-    """The unfrozen SPRINT documents declaring `status: ACTIVE` — the only
-    scopes whose watches the poller arms (spec: GitHub polling is limited to
-    active sprint watches)."""
-    ids: set[int] = set()
-    rows = con.execute(
-        "SELECT document_id, body FROM documents "
-        "WHERE kind='doc' AND frozen=0 AND title LIKE 'SPRINT:%'").fetchall()
-    for doc_id, body in rows:
-        if body and _STATUS_ACTIVE.search(body):
-            ids.add(doc_id)
-    return ids
-
-
-def is_active_sprint(con, doc_id: int) -> bool:
-    r = con.execute(
-        "SELECT body FROM documents WHERE document_id=? AND kind='doc' "
-        "AND frozen=0 AND title LIKE 'SPRINT:%'", (doc_id,)).fetchone()
-    return bool(r and r[0] and _STATUS_ACTIVE.search(r[0]))
-
-
 def armed_watches(con) -> list:
-    """Live watches scoped to an ACTIVE sprint — the poller's whole world.
-    Unscoped legacy watches stay dormant until explicitly rebound."""
-    active = active_sprint_doc_ids(con)
+    """Live watches scoped to a LIVE sprint — the poller's whole world.
+    Unscoped legacy watches stay dormant until explicitly rebound.
+
+    Liveness is `sprint_state`'s structural predicate, never the body's prose
+    (H-1): this module's own `status: ACTIVE` regex was one of the two divergent
+    parsers that made a reformatted line silently disarm every watch."""
+    active = sprint_state.live_sprint_doc_ids(con)
     if not active:
         return []
     marks = ",".join("?" for _ in active)

--- a/.super-coder/scripts/sprint.py
+++ b/.super-coder/scripts/sprint.py
@@ -55,7 +55,7 @@ Only then is the message marked read. Informational messages need no
 receipt.
 
 status / alerts are the read-only wake ops surfaces: binding armed/released,
-sprint doc ACTIVE/frozen, batch state, park/quarantine reason, last wake
+sprint doc live/frozen, batch state, park/quarantine reason, last wake
 outcome, and the open wake alerts (session-loss, retry-exhausted,
 quarantine, unmanaged-writer). retry is the operator recovery path for a
 PARKED/stalled batch: the parked batch is NEVER resubmitted — it resolves

--- a/.super-coder/scripts/sprint_state.py
+++ b/.super-coder/scripts/sprint_state.py
@@ -1,0 +1,108 @@
+"""The one structural definition of a live sprint (spec #76, H-1/H-2).
+
+Liveness used to be a `status:` line inside `documents.body`, parsed by two
+divergent implementations across five sites: a reformatted line killed the wake
+path and every armed watch while boot still rendered the sprint live. The
+definition now lives here, in structure, once — and the body's `status:` line is
+display prose that nothing executable reads.
+
+Three predicates, deliberately distinct. Collapsing any pair reintroduces a
+defect this module exists to close:
+
+- `is_sprint_doc` — the identity of a sprint document and nothing more. This is
+  the write boundary for message tagging and watch registration (H-2): a
+  coordination message sent during the declaration window (board declared,
+  units not yet) and a result row sent after close must both stay legal, so
+  neither `frozen` nor the unit count may appear here.
+- `is_writable_sprint_board` — identity plus `frozen = 0`. A frozen sprint doc's
+  board is not mutable. It deliberately omits the unit-count clause, because the
+  route it guards CREATES the first unit: gating that on liveness would make
+  every board undeclarable.
+- `is_live_sprint` / `live_sprint_doc_ids` / `live_sprint_clause` — the full
+  predicate. It gates the wake path, binding arm, the assignment notice, poller
+  scoping and the sprint-activity projection, and nothing else.
+
+Ordering consequence, decided rather than discovered: a sprint doc with zero
+`sprint_units` rows is not live, so the board is declared BEFORE the binding is
+armed.
+
+Closing a sprint IS freezing its doc — atomic with binding release and queue
+cancellation through the freeze route's `_close_sprint_wake`.
+
+The boot renderer's directive predicate (`render/compose.py`) is NOT one of
+these and must not be folded in: it is role-scoped (a dev retires on its last
+non-terminal unit, a planner only on the freeze) and that split is deliberate.
+It already reads structure, so it cannot drift from this module the way the
+prose parsers did.
+
+Dependency-free on purpose — the API, the poller and the broker all import it,
+so no site re-derives a clause that can drift from this one.
+
+Note on the title clause: SQLite's `LIKE` is ASCII-case-insensitive, so
+`'Sprint: x'` matches. That is the behaviour every prose parser already had and
+it is preserved deliberately — a swap to `GLOB` or a case-sensitive compare
+would un-live every mixed-case sprint at once, silently.
+"""
+
+_IS_SPRINT_DOC = "{d}.kind='doc' AND {d}.title LIKE 'SPRINT:%'"
+_UNFROZEN = "{d}.frozen=0"
+_HAS_UNITS = ("EXISTS (SELECT 1 FROM sprint_units u "
+              "WHERE u.sprint_doc_id={d}.document_id)")
+
+
+def sprint_doc_clause(alias: str = "d") -> str:
+    """Sprint-document identity as a SQL fragment over a `documents` alias."""
+    return _IS_SPRINT_DOC.format(d=alias)
+
+
+def writable_board_clause(alias: str = "d") -> str:
+    """Board-mutability as a SQL fragment over a `documents` alias."""
+    return f"{sprint_doc_clause(alias)} AND {_UNFROZEN.format(d=alias)}"
+
+
+def live_sprint_clause(alias: str = "d") -> str:
+    """Liveness as a SQL fragment, for callers that must JOIN the predicate
+    rather than probe one id (the sprint-activity projection reads it this
+    way, so the projection and the probes cannot disagree)."""
+    return f"{writable_board_clause(alias)} AND {_HAS_UNITS.format(d=alias)}"
+
+
+def _probe(con, doc_id, clause: str) -> bool:
+    if not isinstance(doc_id, int) or isinstance(doc_id, bool):
+        return False
+    return con.execute(
+        f"SELECT 1 FROM documents d WHERE d.document_id=? AND {clause}",
+        (doc_id,)).fetchone() is not None
+
+
+def is_sprint_doc(con, doc_id) -> bool:
+    """Does `doc_id` name a sprint document — at any unit count, frozen or not?"""
+    return _probe(con, doc_id, sprint_doc_clause())
+
+
+def is_writable_sprint_board(con, doc_id) -> bool:
+    """May this sprint's board be written — i.e. is its doc unfrozen?"""
+    return _probe(con, doc_id, writable_board_clause())
+
+
+def is_live_sprint(con, doc_id) -> bool:
+    """Is this sprint live: a sprint doc, unfrozen, holding at least one unit?"""
+    return _probe(con, doc_id, live_sprint_clause())
+
+
+def live_sprint_doc_ids(con) -> "set[int]":
+    """Every live sprint's document_id — the poller's whole world."""
+    return {row[0] for row in con.execute(
+        f"SELECT d.document_id FROM documents d WHERE {live_sprint_clause()}")}
+
+
+def has_units(con, doc_id) -> bool:
+    """Does this document hold a board? The title is part of the liveness
+    predicate, so `doc edit` refuses to retitle a doc for which this is true —
+    a mid-sprint retitle would otherwise kill liveness silently, which is this
+    spec's own defect class moved one field over."""
+    if not isinstance(doc_id, int) or isinstance(doc_id, bool):
+        return False
+    return con.execute(
+        "SELECT 1 FROM sprint_units WHERE sprint_doc_id=? LIMIT 1",
+        (doc_id,)).fetchone() is not None

--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -11,9 +11,10 @@ the `sc mem` doctrine):
                                                            (defaults to the
                                                            calling shell;
                                                            scope is required
-                                                           and must be ACTIVE;
-                                                           --unit links the PR
-                                                           to a board unit)
+                                                           and must name a
+                                                           sprint doc; --unit
+                                                           links the PR to a
+                                                           board unit)
     ./sc watch list [--all]                                live watches
     ./sc watch inbox [--interval 30] [--timeout 21600]     block until this
                                                            shell has unread
@@ -27,16 +28,16 @@ direct-DB writer) is RETIRED: the `daemon` verb here now prints the retirement
 notice and exits clean so legacy nohup/systemd supervision stops instead of
 racing the service. Registration performs an immediate GitHub read and stores
 the normalized baseline before arming; the service then polls armed watches
-(live, scoped to an ACTIVE sprint) on a bounded interval, and every semantic
+(live, scoped to a LIVE sprint) on a bounded interval, and every semantic
 transition becomes an idempotent `pr_event` row (+ wake item when a binding is
 armed) addressed to the watch's shell. Events: checks concluded (green or
 red), review submitted, merged, closed. On close — and on merge with no
 checks still running — the final event is emitted and `closed_at` set: the
 watch retires itself. A merge with checks still PENDING retains the watch
-(#375). Unscoped legacy watches stay readable but dormant until rebound to an
-ACTIVE sprint. The poller only ever writes message rows + its own registry
-state: it never boots shells, never marks anything read, never touches git,
-never injects terminal input.
+(#375). Unscoped legacy watches stay readable but dormant until rebound to a
+sprint doc; a scoped watch is polled only while that sprint is LIVE. The poller
+only ever writes message rows + its own registry state: it never boots shells,
+never marks anything read, never touches git, never injects terminal input.
 
 A `pr_event` body is one line — repo, PR, the unit when the watch names one
 (`unit=U3`), what changed, head SHA. Detail lives in `gh`; the message is the
@@ -213,7 +214,8 @@ def cmd_list(args) -> int:
                 state += f", sprint #{w['sprint_doc_id']}"
                 if w.get("unit_seq"):
                     state += f" unit {w['unit_seq']}"
-                state += " (armed)" if w.get("armed") else " (dormant — sprint not ACTIVE)"
+                state += (" (armed)" if w.get("armed")
+                          else " (dormant — sprint not live)")
             else:
                 state += ", dormant (unscoped — rebind with `sc watch pr … --sprint <doc>`)"
         print(f"  #{w['watch_id']} {w['repo']}#{w['pr_number']} → {w['shortname']} "
@@ -300,7 +302,7 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("number", type=int, help="PR number")
     sp.add_argument("--shell", help="subscribe another shell (e.g. the planner) instead of you")
     sp.add_argument("--sprint", type=int, required=True, metavar="DOC_ID",
-                    help="required ACTIVE sprint document scope")
+                    help="required sprint document scope — polled while that sprint is live")
     sp.add_argument("--unit", metavar="SEQ",
                     help="the sprint unit this PR is for, as the board writes "
                          "it (U3) — carries onto every pr_event so readers "

--- a/tests/test_interface_crash_window.py
+++ b/tests/test_interface_crash_window.py
@@ -80,6 +80,15 @@ def build_engine_db(path: Path) -> None:
     con.execute(
         "INSERT INTO documents (document_id, kind, title, body) "
         "VALUES (1,'doc','SPRINT: test','# SPRINT: test\nstatus: ACTIVE')")
+    # A DECLARED BOARD is what makes the sprint live (H-1) — the `status:` line
+    # above is display prose nothing executable reads. Every binding below is
+    # inserted by raw SQL, bypassing the arm route, and that route refuses to
+    # arm a boardless sprint ("declare the board before arming the binding").
+    # Without this row these fixtures build a state the engine cannot produce,
+    # and submit-time revalidation correctly cancels every batch.
+    con.execute(
+        "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+        "VALUES (1,'U1','the unit')")
     con.commit()
     con.close()
 
@@ -777,6 +786,9 @@ class CloseSessionMatrixTest(unittest.TestCase):
             "INSERT INTO documents (kind, title, body) VALUES "
             "('doc','SPRINT: t','# SPRINT: t\nstatus: ACTIVE')")
         doc = self.con.execute("SELECT last_insert_rowid()").fetchone()[0]
+        self.con.execute(                       # its board — see build_engine_db
+            "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+            "VALUES (?,'U1','the unit')", (doc,))
         self.con.execute(
             "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
             " planner_shell_id, session_id, shell_id, generation) "

--- a/tests/test_interface_sprint_ops.py
+++ b/tests/test_interface_sprint_ops.py
@@ -194,6 +194,26 @@ class SprintOpsRoutesTest(unittest.TestCase):
         con.close()
         return batch
 
+    # -- arming ------------------------------------------------------------------
+
+    def test_arm_refuses_a_bool_id_rather_than_arming_against_document_1(self):
+        """`isinstance(True, int)` is True, so a plain int check let a JSON
+        `true` through to `is_live_sprint`, where SQLite binds it as 1 — the
+        route would have armed a binding against document 1's board (which is
+        live here, so nothing downstream would have refused it). Both ids go
+        through `_is_int` for that reason.
+        """
+        for field in ("sprint_doc_id", "planner_shell_id"):
+            with self.subTest(field=field):
+                body = {"sprint_doc_id": 1, "planner_shell_id": 1, field: True}
+                status, resp = self.call(
+                    "POST", "/api/interface/sprint-bindings",
+                    (OP, f"Idempotency-Key: k-bool-{field}"), body)
+                self.assertEqual(status, 422, resp)
+                self.assertEqual("validation", resp["error"]["code"])
+        self.assertIsNone(self.q("SELECT binding_id FROM "
+                                 "sprint_planner_bindings LIMIT 1"))
+
     # -- wake status -------------------------------------------------------------
 
     def test_status_armed_projection(self):

--- a/tests/test_interface_sprint_ops.py
+++ b/tests/test_interface_sprint_ops.py
@@ -68,6 +68,11 @@ def build_engine_db(path: Path) -> None:
     con.execute(
         "INSERT INTO documents (document_id, kind, title, body) "
         "VALUES (1,'doc','SPRINT: test','# SPRINT: test\nstatus: ACTIVE')")
+    # A declared board is what makes the sprint LIVE (H-1); the body's
+    # `status:` line above is display prose that nothing reads.
+    con.execute(
+        "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+        "VALUES (1,'U1','the unit')")
     con.commit()
     con.close()
 
@@ -844,6 +849,11 @@ class SprintCloseTest(unittest.TestCase):
             "INSERT INTO documents (document_id, kind, title, body) "
             "VALUES (?,'doc','SPRINT: close',?)",
             (doc_id, f"# SPRINT: close\nstatus: {status_line}"))
+        # A declared board is what makes the sprint live and the wake item
+        # eligible (H-1). The `status:` line above is display prose.
+        con.execute(
+            "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+            "VALUES (?,'U1','the unit')", (doc_id,))
         binding = con.execute(
             "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
             " planner_shell_id, session_id, shell_id, generation) "
@@ -860,47 +870,52 @@ class SprintCloseTest(unittest.TestCase):
         con.close()
         return binding, mid
 
-    def test_status_closed_releases_binding_and_cancels_queue(self):
+    def test_status_closed_line_alone_closes_nothing(self):
+        """H-1's delivered half at the close seam: closing a sprint IS
+        freezing its doc, so a body edit that writes `status: CLOSED` releases
+        no binding and cancels no wake work. The close skill keeps writing
+        that line for the human reader; nothing executable reads it back.
+
+        Before H-1 this edit performed the close, which made a prose line
+        load-bearing in both directions — reformat it and the close silently
+        did not happen.
+        """
         binding, mid = self.arm_sprint(101)
         status, body = self.patch(
             "/_sc/mem/docs/101",
             {"body": "# SPRINT: close\nstatus: CLOSED"})
         self.assertEqual(status, 200)
-        self.assertEqual(body["released_bindings"], 1)
-        row = self.q("SELECT released_at, release_reason FROM "
-                     "sprint_planner_bindings WHERE binding_id=?", (binding,))
-        self.assertIsNotNone(row[0])
-        self.assertEqual(row[1], "sprint closed")
-        item = self.q("SELECT state, error FROM planner_wake_items "
-                      "WHERE message_id=?", (mid,))
-        self.assertEqual(item[0], "cancelled")
-        self.assertIn("sprint closed", item[1])
-        # Messages stay unread (spec Sprint Scope).
-        self.assertIsNone(self.q("SELECT read_at FROM shell_messages "
-                                 "WHERE message_id=?", (mid,))[0])
-        # The released binding's open alerts resolve — no longer actionable.
+        self.assertEqual(body["released_bindings"], 0)
         self.assertIsNone(self.q(
-            "SELECT 1 FROM planner_alerts WHERE binding_id=? "
-            "AND resolved_at IS NULL", (binding,)))
+            "SELECT released_at FROM sprint_planner_bindings "
+            "WHERE binding_id=?", (binding,))[0])
+        self.assertEqual(self.q("SELECT state FROM planner_wake_items "
+                                "WHERE message_id=?", (mid,))[0], "queued")
+        # Stand down: the binding is still armed, and one live binding per
+        # planner is a structural constraint the sibling close tests need.
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "UPDATE sprint_planner_bindings SET released_at=datetime('now'),"
+            " release_reason='test teardown' WHERE binding_id=?", (binding,))
+        con.commit()
+        con.close()
 
-    def test_closed_close_is_atomic_under_fault(self):
-        """SC-016: a fault between the column patch and the wake close
-        leaves NO partial state — the status: CLOSED edit and the binding
-        release + queue cancel land in ONE transaction, edge-identical to
-        the freeze path."""
+    def test_freeze_close_is_atomic_under_fault(self):
+        """SC-016, now anchored where the close lives: a fault between the
+        freeze column write and the wake close leaves NO partial state — both
+        land in ONE transaction."""
         binding, mid = self.arm_sprint(104)
         with mock.patch.object(server, "_close_sprint_wake",
                                side_effect=RuntimeError("injected fault")):
             try:
-                self.patch("/_sc/mem/docs/104",
-                           {"body": "# SPRINT: close\nstatus: CLOSED"})
+                self.patch("/_sc/mem/docs/104/freeze", {})
                 self.fail("the injected fault should surface as a 500")
             except urllib.error.HTTPError as e:
                 self.assertEqual(e.code, 500)
-        # NEITHER side landed: doc still ACTIVE, binding still armed, wake
-        # item still queued, alert still open.
-        self.assertIn("status: ACTIVE", self.q(
-            "SELECT body FROM documents WHERE document_id=104")[0])
+        # NEITHER side landed: doc still unfrozen (still live), binding still
+        # armed, wake item still queued, alert still open.
+        self.assertEqual(self.q(
+            "SELECT frozen FROM documents WHERE document_id=104")[0], 0)
         self.assertIsNone(self.q(
             "SELECT released_at FROM sprint_planner_bindings "
             "WHERE binding_id=?", (binding,))[0])
@@ -919,15 +934,85 @@ class SprintCloseTest(unittest.TestCase):
         con.close()
 
     def test_freeze_releases_binding_and_cancels_queue(self):
+        """The whole close, at the one route that performs it."""
         binding, mid = self.arm_sprint(102)
         status, body = self.patch("/_sc/mem/docs/102/freeze", {})
         self.assertEqual(status, 200)
         self.assertEqual(body["released_bindings"], 1)
-        self.assertIsNotNone(self.q(
-            "SELECT released_at FROM sprint_planner_bindings "
-            "WHERE binding_id=?", (binding,))[0])
-        self.assertEqual(self.q("SELECT state FROM planner_wake_items "
-                                "WHERE message_id=?", (mid,))[0], "cancelled")
+        row = self.q("SELECT released_at, release_reason FROM "
+                     "sprint_planner_bindings WHERE binding_id=?", (binding,))
+        self.assertIsNotNone(row[0])
+        self.assertEqual(row[1], "sprint closed")
+        item = self.q("SELECT state, error FROM planner_wake_items "
+                      "WHERE message_id=?", (mid,))
+        self.assertEqual(item[0], "cancelled")
+        self.assertIn("sprint closed", item[1])
+        # Messages stay unread (spec Sprint Scope).
+        self.assertIsNone(self.q("SELECT read_at FROM shell_messages "
+                                 "WHERE message_id=?", (mid,))[0])
+        # The released binding's open alerts resolve — no longer actionable.
+        self.assertIsNone(self.q(
+            "SELECT 1 FROM planner_alerts WHERE binding_id=? "
+            "AND resolved_at IS NULL", (binding,)))
+
+    def test_retitle_is_refused_while_the_doc_holds_a_board(self):
+        """H-1 moved liveness onto structure, and the title is one of its
+        operands — so `doc edit` stops treating the title as free prose while
+        the doc holds a board. Without this the defect just moves one field
+        over: a mid-sprint retitle drops the doc out of `SPRINT:%` and every
+        participant goes deaf with nothing said.
+
+        The body stays editable in the same call shape, which is the point —
+        this fences ONE field, not the document.
+        """
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO documents (document_id, kind, title, body) "
+            "VALUES (105,'doc','SPRINT: fenced','# SPRINT: fenced')")
+        con.execute(
+            "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+            "VALUES (105,'U1','the unit')")
+        con.commit()
+        con.close()
+
+        for title in ("Retro notes", None, "  "):
+            with self.subTest(title=title):
+                try:
+                    self.patch("/_sc/mem/docs/105", {"title": title})
+                    self.fail("a retitle on a board doc must be refused")
+                except urllib.error.HTTPError as e:
+                    self.assertEqual(e.code, 400)
+                    detail = json.loads(e.read())["error"]
+                    self.assertIn("SPRINT: fenced", detail)
+                self.assertEqual(
+                    self.q("SELECT title FROM documents WHERE document_id=105")[0],
+                    "SPRINT: fenced")
+
+        # the body is untouched by the fence
+        status, _ = self.patch("/_sc/mem/docs/105", {"body": "# edited"})
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            self.q("SELECT body FROM documents WHERE document_id=105")[0],
+            "# edited")
+        # a no-op title (the same string) is not a change and passes
+        status, _ = self.patch("/_sc/mem/docs/105",
+                               {"title": "SPRINT: fenced"})
+        self.assertEqual(status, 200)
+
+    def test_a_doc_without_a_board_retitles_freely(self):
+        """The fence is scoped to documents that hold units — every other doc
+        in the fork keeps an editable title."""
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO documents (document_id, kind, title, body) "
+            "VALUES (106,'doc','SPRINT: no board','x')")
+        con.commit()
+        con.close()
+        status, _ = self.patch("/_sc/mem/docs/106", {"title": "Renamed"})
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            self.q("SELECT title FROM documents WHERE document_id=106")[0],
+            "Renamed")
 
     def test_close_without_bindings_is_a_noop(self):
         con = sqlite3.connect(self.db)

--- a/tests/test_interface_sprint_ops.py
+++ b/tests/test_interface_sprint_ops.py
@@ -843,31 +843,56 @@ class SprintCloseTest(unittest.TestCase):
         finally:
             con.close()
 
-    def arm_sprint(self, doc_id, status_line="ACTIVE"):
+    def arm_sprint(self, doc_id, status_line="ACTIVE", unit_state="cancelled"):
+        """A live sprint with one armed binding and one queued wake item.
+
+        Two composed rules shape this helper, and getting either wrong makes
+        the whole class order-dependent — the DB is per-CLASS, not per-test.
+
+        H-1: a declared board is what makes the sprint live and the wake item
+        eligible; the `status:` line is display prose. So a unit row is
+        mandatory here.
+
+        U3's freeze machine: freeze refuses while any unit is non-terminal, and
+        the default state is 'pending'. A board whose only unit is 'pending' is
+        live AND unfreezable, so the callers that close the sprint would get
+        409 before reaching the close path they exist to test. 'cancelled' is
+        the terminal state that needs no invented review_head SHA — the freeze
+        refusal itself is pinned by its own tests below, not by this helper.
+
+        The prior active binding is released because the partial unique index
+        allows one per planner shell: a caller that does NOT close its sprint
+        (the prose-close test) leaves its binding armed for whoever runs next.
+        """
         con = sqlite3.connect(self.db)
-        con.execute(
-            "INSERT INTO documents (document_id, kind, title, body) "
-            "VALUES (?,'doc','SPRINT: close',?)",
-            (doc_id, f"# SPRINT: close\nstatus: {status_line}"))
-        # A declared board is what makes the sprint live and the wake item
-        # eligible (H-1). The `status:` line above is display prose.
-        con.execute(
-            "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
-            "VALUES (?,'U1','the unit')", (doc_id,))
-        binding = con.execute(
-            "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
-            " planner_shell_id, session_id, shell_id, generation) "
-            "VALUES (?,1,?,1,1)", (doc_id, self.sid)).lastrowid
-        mid = con.execute(
-            "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
-            " kind, sprint_doc_id) VALUES (2,1,'x','task',?)",
-            (doc_id,)).lastrowid
-        interface_wake.maybe_create_wake_item(con, mid)
-        interface_broker._alert(con, severity="critical",
-                                reason="wake_presend_retries_exhausted",
-                                binding_id=binding)
-        con.commit()
-        con.close()
+        try:
+            con.execute(
+                "UPDATE sprint_planner_bindings SET "
+                "released_at=datetime('now'), "
+                "release_reason='superseded test case' "
+                "WHERE released_at IS NULL")
+            con.execute(
+                "INSERT INTO documents (document_id, kind, title, body) "
+                "VALUES (?,'doc','SPRINT: close',?)",
+                (doc_id, f"# SPRINT: close\nstatus: {status_line}"))
+            con.execute(
+                "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title, "
+                "state) VALUES (?,'U1','the unit',?)", (doc_id, unit_state))
+            binding = con.execute(
+                "INSERT INTO sprint_planner_bindings (sprint_doc_id,"
+                " planner_shell_id, session_id, shell_id, generation) "
+                "VALUES (?,1,?,1,1)", (doc_id, self.sid)).lastrowid
+            mid = con.execute(
+                "INSERT INTO shell_messages (from_shell_id, to_shell_id, body,"
+                " kind, sprint_doc_id) VALUES (2,1,'x','task',?)",
+                (doc_id,)).lastrowid
+            interface_wake.maybe_create_wake_item(con, mid)
+            interface_broker._alert(con, severity="critical",
+                                    reason="wake_presend_retries_exhausted",
+                                    binding_id=binding)
+            con.commit()
+        finally:
+            con.close()
         return binding, mid
 
     def test_status_closed_line_alone_closes_nothing(self):

--- a/tests/test_interface_wake.py
+++ b/tests/test_interface_wake.py
@@ -64,6 +64,11 @@ def build_engine_db(path: Path) -> None:
     con.execute(
         "INSERT INTO documents (document_id, kind, title, body) "
         "VALUES (1,'doc','SPRINT: test','# SPRINT: test\nstatus: ACTIVE')")
+    # A declared board is what makes the sprint LIVE (H-1); the body's
+    # `status:` line above is display prose that nothing reads.
+    con.execute(
+        "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+        "VALUES (1,'U1','the unit')")
     con.commit()
     con.close()
 
@@ -182,12 +187,44 @@ class WakeIngressTest(WakeFixture):
         mid = self.add_message("task", to_shell_id=2)  # not the planner
         self.assertIsNone(interface_wake.maybe_create_wake_item(self.con, mid))
 
-    def test_closed_sprint_never_wakes(self):
+    def test_a_closed_status_line_alone_still_wakes(self):
+        """H-1's delivered half at the ingress gate: the body's `status:` line
+        is display prose. It said CLOSED here and the wake item is created
+        anyway, because closing a sprint is freezing its doc — see
+        test_frozen_sprint_never_wakes for the structural half. Before H-1 a
+        planner who reformatted this one line went silently deaf."""
         self.con.execute(
             "UPDATE documents SET body='# SPRINT: test\nstatus: CLOSED' "
             "WHERE document_id=1")
         mid = self.add_message("task")
+        self.assertIsNotNone(
+            interface_wake.maybe_create_wake_item(self.con, mid))
+
+    def test_undeclared_board_never_wakes(self):
+        """The unit-count operand on its own: unfrozen, correctly titled, and
+        not live because no board has been declared yet."""
+        self.con.execute("DELETE FROM sprint_units WHERE sprint_doc_id=1")
+        mid = self.add_message("task")
         self.assertIsNone(interface_wake.maybe_create_wake_item(self.con, mid))
+
+    def test_retitled_sprint_never_wakes(self):
+        """The title operand on its own — the field `doc edit` now refuses to
+        change on a doc holding a board, for exactly this reason.
+
+        The lower-case case pins that `LIKE` is ASCII-case-insensitive in
+        SQLite, which is the inherited behaviour: swapping the predicate to
+        GLOB or a case-sensitive compare would silently un-live every sprint
+        whose title was typed in mixed case, and nothing else would notice.
+        """
+        for title, wakes in (("Retro notes", False),
+                             ("sprint: test", True)):
+            with self.subTest(title=title):
+                self.con.execute(
+                    "UPDATE documents SET title=? WHERE document_id=1",
+                    (title,))
+                mid = self.add_message("task")
+                item = interface_wake.maybe_create_wake_item(self.con, mid)
+                self.assertIs(item is not None, wakes)
 
     def test_frozen_sprint_never_wakes(self):
         self.con.execute("UPDATE documents SET frozen=1 WHERE document_id=1")
@@ -880,6 +917,9 @@ class WakeRoutesTest(unittest.TestCase):
         for p in self.patches:
             p.start()
         (run_dir / "operator.token").write_text("optok")
+        self._seed()
+
+    def _seed(self):
         con = sqlite3.connect(self.db_path)
         con.execute("UPDATE shells SET api_key='shelltok1' WHERE shell_id=1")
         con.execute("UPDATE shells SET api_key='shelltok2' WHERE shell_id=2")
@@ -895,6 +935,13 @@ class WakeRoutesTest(unittest.TestCase):
             " generation, composer) VALUES (?,1,1,'clean')", (self.sid,))
         con.commit()
         con.close()
+
+    def _rebuild(self):
+        """A fresh DB at the same path, so one test can run several
+        independent gate cases without their mutations composing."""
+        self.db_path.unlink()
+        build_engine_db(self.db_path)
+        self._seed()
 
     def tearDown(self):
         for p in self.patches:
@@ -946,15 +993,36 @@ class WakeRoutesTest(unittest.TestCase):
         self.assertEqual(status, 409)
         self.assertEqual(body["error"]["code"], "already_armed")
 
-    def test_arm_requires_active_unfrozen_sprint(self):
-        con = sqlite3.connect(self.db_path)
-        con.execute("UPDATE documents SET body='# S\nstatus: CLOSED' "
-                    "WHERE document_id=1")
-        con.commit()
-        con.close()
-        status, body = self.arm()
-        self.assertEqual(status, 409)
-        self.assertEqual(body["error"]["code"], "sprint_not_active")
+    def test_arm_requires_a_live_sprint(self):
+        """H-1 at the arm gate: each operand refuses ALONE, and the prose line
+        refuses nothing. The undeclared-board case is the ordering the spec
+        creates — declare the board, then arm — and it was previously armable,
+        which is how a planner ended up bound to a sprint with no units.
+        """
+        cases = (
+            ("frozen", "UPDATE documents SET frozen=1 WHERE document_id=1",
+             False),
+            ("retitled", "UPDATE documents SET title='Retro' "
+                         "WHERE document_id=1", False),
+            ("no board declared", "DELETE FROM sprint_units "
+                                  "WHERE sprint_doc_id=1", False),
+            ("status line says CLOSED",
+             "UPDATE documents SET body='# S\nstatus: CLOSED' "
+             "WHERE document_id=1", True),
+        )
+        for i, (label, mutation, arms) in enumerate(cases):
+            with self.subTest(case=label):
+                self._rebuild()
+                con = sqlite3.connect(self.db_path)
+                con.execute(mutation)
+                con.commit()
+                con.close()
+                status, body = self.arm(key=f"k-live-{i}")
+                if arms:
+                    self.assertEqual(status, 201, body)
+                else:
+                    self.assertEqual(status, 409, body)
+                    self.assertEqual(body["error"]["code"], "sprint_not_active")
 
     def test_arm_requires_mandatory_hooks(self):
         con = sqlite3.connect(self.db_path)

--- a/tests/test_interface_wake_submit.py
+++ b/tests/test_interface_wake_submit.py
@@ -55,11 +55,19 @@ def build_engine_db(path: Path) -> None:
         "VALUES (1,'doc','SPRINT: live',?)",
         (ACTIVE_BODY,),
     )
+    # Doc 2 is the CLOSED sprint, and closing a sprint IS freezing its doc
+    # (H-1). Its body still says `status: CLOSED` for the human reader, and
+    # that line is not what the gate reads — `frozen=1` is. Both docs carry a
+    # unit row, so the freeze is the ONLY difference between them.
     con.execute(
-        "INSERT INTO documents (document_id, kind, title, body) "
-        "VALUES (2,'doc','SPRINT: done',?)",
+        "INSERT INTO documents (document_id, kind, title, body, frozen) "
+        "VALUES (2,'doc','SPRINT: done',?,1)",
         (CLOSED_BODY,),
     )
+    for doc_id in (1, 2):
+        con.execute(
+            "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+            "VALUES (?,'U1','the unit')", (doc_id,))
     con.commit()
     con.close()
 
@@ -169,6 +177,31 @@ class WakeSubmitGateTest(unittest.TestCase):
         self.assertTrue(out["cancelled"])
         self.assertEqual(writes, [])
         self.assertEqual(self._batch_state(batch), "complete")
+
+    def test_a_closed_status_line_alone_does_not_cancel(self):
+        """The delivered half of H-1 at this gate. Doc 1's body is rewritten
+        to say `status: CLOSED` and the sprint stays live, because the gate
+        reads structure. Before H-1 this batch was cancelled by prose alone —
+        so a planner reformatting that line silently killed its own wakes."""
+        self.con.execute(
+            "UPDATE documents SET body=? WHERE document_id=1", (CLOSED_BODY,))
+        self.con.commit()
+        _, _, batch = self._arm()
+        out, writes = self._submit(batch, "2030-01-01 00:00:10")
+        self.assertFalse(out.get("cancelled"), out)
+        self.assertTrue(out["submitted"], out)
+        self.assertEqual(len(writes), 1)
+
+    def test_emptying_the_board_cancels_the_batch(self):
+        """Liveness needs a declared board, so a sprint whose units are gone
+        is not live even unfrozen — the other operand of the predicate."""
+        _, _, batch = self._arm()
+        self.con.execute("DELETE FROM sprint_units WHERE sprint_doc_id=1")
+        self.con.commit()
+        out, writes = self._submit(batch, "2030-01-01 00:00:10")
+        self.assertFalse(out["submitted"])
+        self.assertTrue(out["cancelled"])
+        self.assertEqual(writes, [])
 
     # ── post-restart debounce (flag #37) ────────────────────────────────
     def test_null_last_human_input_still_owes_full_debounce(self):

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -142,6 +142,25 @@ class SprintScopingTest(unittest.TestCase):
         self.con.commit()
         self.assertTrue(sprint_state.is_live_sprint(self.con, 100))
 
+    def test_a_bool_doc_id_never_addresses_document_1s_board(self):
+        """`True` is an `int` in Python and SQLite binds it as 1, so every
+        predicate here would answer for document 1 if the guard were dropped —
+        a caller that fumbles a JSON `true` into a doc id would read some other
+        sprint's liveness as its own. Document 1 is seeded live on purpose:
+        that is the known positive the guard has to refuse anyway, so a False
+        below cannot come from an empty table.
+        """
+        seed_sprint_doc(self.con, 1)
+        probes = (sprint_state.is_sprint_doc,
+                  sprint_state.is_writable_sprint_board,
+                  sprint_state.is_live_sprint,
+                  sprint_state.has_units)
+        for probe in probes:
+            with self.subTest(probe=probe.__name__):
+                self.assertIs(probe(self.con, 1), True)    # known positive
+                self.assertIs(probe(self.con, True), False)
+                self.assertIs(probe(self.con, False), False)
+
     def test_armed_watches_excludes_unscoped_and_inactive(self):
         seed_shells(self.con)
         seed_sprint_doc(self.con, 100)

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -28,6 +28,7 @@ MIGRATIONS = ENGINE / "migrations"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import pr_poller  # noqa: E402
+import sprint_state  # noqa: E402
 import watch  # noqa: E402  (retired daemon verb)
 
 
@@ -54,11 +55,22 @@ def seed_shells(con: sqlite3.Connection) -> None:
 
 
 def seed_sprint_doc(con, doc_id: int, status: str = "ACTIVE", frozen: int = 0,
-                    title: str = "SPRINT: T", kind: str = "doc") -> None:
+                    title: str = "SPRINT: T", kind: str = "doc",
+                    units: int = 1) -> None:
+    """A sprint doc, live by default.
+
+    `units` is what makes it live (H-1) — a doc with a declared board. `status`
+    writes the body's prose line, which nothing executable reads any more; it
+    stays a parameter precisely so a test can prove that.
+    """
     con.execute(
         "INSERT INTO documents (document_id, kind, title, body, frozen) "
         "VALUES (?, ?, ?, ?, ?)",
         (doc_id, kind, title, f"# {title}\nstatus: {status}\ndeclared: today\n", frozen))
+    for i in range(units):
+        con.execute(
+            "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+            "VALUES (?, ?, ?)", (doc_id, f"U{i + 1}", f"unit {i + 1}"))
     con.commit()
 
 
@@ -94,31 +106,51 @@ class SprintScopingTest(unittest.TestCase):
     def tearDown(self):
         self.con.close()
 
-    def test_only_active_unfrozen_sprint_docs_count(self):
-        seed_sprint_doc(self.con, 100)                                # ACTIVE
-        seed_sprint_doc(self.con, 101, status="CLOSED")               # closed
-        seed_sprint_doc(self.con, 102, frozen=1)                      # frozen
+    def test_poller_scope_is_structural_liveness_never_the_status_line(self):
+        """The predicate this module used to parse out of prose (H-1).
+
+        Both halves matter. The DELIVERED half: 101's body says CLOSED and it
+        is live anyway, because the `status:` line is display prose now — that
+        assertion turns red the moment anything reads it back. The PREVENTED
+        half: frozen, not-a-sprint-title, not-a-doc, and no-board-declared are
+        each excluded on their own.
+        """
+        seed_sprint_doc(self.con, 100)                                # live
+        seed_sprint_doc(self.con, 101, status="CLOSED")               # prose lies — still live
+        seed_sprint_doc(self.con, 102, frozen=1)                      # frozen → closed
         seed_sprint_doc(self.con, 103, title="SPRINT REPORT: T")      # not a board
         seed_sprint_doc(self.con, 104, kind="spec")                   # not a doc
-        seed_sprint_doc(self.con, 105, status="active")               # case matters
-        self.assertEqual(pr_poller.active_sprint_doc_ids(self.con), {100})
+        seed_sprint_doc(self.con, 105, units=0)                       # board not declared yet
+        self.assertEqual(sprint_state.live_sprint_doc_ids(self.con), {100, 101})
+        for doc_id, live in ((100, True), (101, True), (102, False),
+                             (103, False), (104, False), (105, False),
+                             (999, False)):
+            with self.subTest(doc_id=doc_id):
+                self.assertIs(sprint_state.is_live_sprint(self.con, doc_id), live)
 
-    def test_is_active_sprint(self):
-        seed_sprint_doc(self.con, 100)
-        seed_sprint_doc(self.con, 101, status="CLOSED")
-        self.assertTrue(pr_poller.is_active_sprint(self.con, 100))
-        self.assertFalse(pr_poller.is_active_sprint(self.con, 101))
-        self.assertFalse(pr_poller.is_active_sprint(self.con, 999))
+    def test_declaring_the_first_unit_is_what_makes_a_sprint_live(self):
+        """The ordering H-1 creates: board first, then arm. A unit-less sprint
+        doc is a real document that simply is not live yet, and the poller must
+        read it that way rather than as a missing one."""
+        seed_sprint_doc(self.con, 100, units=0)
+        self.assertFalse(sprint_state.is_live_sprint(self.con, 100))
+        self.assertTrue(sprint_state.is_sprint_doc(self.con, 100))
+        self.assertTrue(sprint_state.is_writable_sprint_board(self.con, 100))
+        self.con.execute(
+            "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+            "VALUES (100, 'U1', 'first')")
+        self.con.commit()
+        self.assertTrue(sprint_state.is_live_sprint(self.con, 100))
 
     def test_armed_watches_excludes_unscoped_and_inactive(self):
         seed_shells(self.con)
         seed_sprint_doc(self.con, 100)
-        seed_sprint_doc(self.con, 101, status="CLOSED")
+        seed_sprint_doc(self.con, 101, frozen=1)
         self.con.executescript(
             "INSERT INTO watched_prs (repo, pr_number, shell_id, sprint_doc_id) VALUES "
             "('o/r', 1, 1, 100),"     # armed
             "('o/r', 2, 1, NULL),"    # unscoped → dormant
-            "('o/r', 3, 1, 101);"     # closed sprint → dormant
+            "('o/r', 3, 1, 101);"     # frozen sprint → dormant
             "UPDATE watched_prs SET closed_at=datetime('now') WHERE pr_number=3;")
         self.con.execute(
             "INSERT INTO watched_prs (repo, pr_number, shell_id, sprint_doc_id, closed_at) "

--- a/tests/test_sprint_assignment_notice.py
+++ b/tests/test_sprint_assignment_notice.py
@@ -136,14 +136,41 @@ class AssignmentNoticeTest(_BoardCase):
         self.assertEqual(status, 200)
         self.assertEqual(self.notices(), [])
 
-    def test_a_closed_sprint_emits_nothing_but_still_writes_the_board(self):
-        """The ACTIVE gate is on the NOTICE, never on the record. A planner
-        must still be able to correct a closed sprint's board."""
+    def test_a_prose_closed_sprint_still_emits_because_prose_closes_nothing(self):
+        """H-1's ratified consequence, at the notice surface.
+
+        This test used to assert the opposite — that a `status: CLOSED` body
+        silenced the emitter while the board still took the write — and that
+        was the prose-liveness defect stated as a guarantee: liveness read off
+        a formatted line, so reflowing it re-armed a closed sprint's notices.
+
+        Closing a sprint is now freezing its doc. A body edit that writes
+        `status: CLOSED` closes NOTHING, so the sprint is still live and the
+        notice fires. The line remains for the human reader; nothing
+        executable reads it back.
+        """
         self.sql("UPDATE documents SET body=? WHERE document_id=1",
                  ("# SPRINT: test\nstatus: CLOSED\n",))
         status, _ = self.patch(seq="U1", reviewer=REV2)
         self.assertEqual(status, 200)
         self.assertEqual(self.row("U1")["reviewer_shell_id"], REV2)
+        self.assertEqual(self.told(), [REV1, REV2, DEV5])
+
+    def test_a_frozen_sprint_emits_nothing_but_still_writes_the_board(self):
+        """The gate is on the NOTICE, never on the record — the property the
+        old prose test claimed, re-anchored to the structural close.
+
+        A planner must still be able to correct a closed sprint's board, so
+        PATCH is deliberately not gated on the freeze (unlike unit CREATE,
+        which refuses: you may correct history, not extend it). The emitter's
+        own `is_live_sprint` check is what stays silent, and `frozen=1` is the
+        operand that now trips it.
+        """
+        self.sql("UPDATE documents SET frozen=1 WHERE document_id=1")
+        status, _ = self.patch(seq="U1", reviewer=REV2)
+        self.assertEqual(status, 200)
+        self.assertEqual(self.row("U1")["reviewer_shell_id"], REV2,
+                         "the record still takes the correction")
         self.assertEqual(self.notices(), [])
 
     def test_a_refused_write_tells_nobody(self):

--- a/tests/test_sprint_board_record.py
+++ b/tests/test_sprint_board_record.py
@@ -241,6 +241,13 @@ class _BoardCase(unittest.TestCase):
         finally:
             con.close()
 
+    def sql_one(self, stmt, params=()):
+        con = sqlite3.connect(self.db_path)
+        try:
+            return con.execute(stmt, params).fetchone()[0]
+        finally:
+            con.close()
+
     def sql(self, stmt, params=()):
         con = sqlite3.connect(self.db_path)
         try:
@@ -908,10 +915,12 @@ class BoardRecordTest(_BoardCase):
         exist and the reconciler watches them. The seq axis of this same typo
         class is already defended (PATCH never creates); this is the doc axis.
 
-        Deliberately NOT asserted here: whether a FROZEN sprint doc still
-        accepts units. That is a live question parked for the FnB, and the
-        engine's predicate carries a `frozen=0` clause this check omits on
-        purpose — pinning it either way would decide it by side effect."""
+        The frozen case is a SEPARATE refusal now — see
+        test_a_frozen_board_takes_no_writes. This route used to omit the
+        `frozen=0` clause deliberately, with a comment parking "whether a
+        frozen board stays mutable"; H-1 answers it (a frozen sprint doc is
+        not live, so it is closed) and the parked comment went with the
+        clause."""
         self.sql("INSERT INTO documents (document_id, kind, title, body) "
                  "VALUES (2,'spec','Worker expectation reconciler','x')")
         status, err = self.call("POST", "/api/sprint-units", (OP,),
@@ -932,6 +941,38 @@ class BoardRecordTest(_BoardCase):
         self.assertEqual(status, 404)
         self.assertEqual(err["error"]["code"], "no_such_sprint")
         self.assertEqual(self.add()[0], 201, "the real sprint doc was refused")
+
+    def test_a_frozen_board_takes_no_writes(self):
+        """The parked question, answered (H-1 + H-12). Freezing the sprint doc
+        IS closing the sprint, so its board stops being mutable — the unit
+        route and the shared liveness predicate agree instead of the route
+        carrying its own carve-out.
+
+        The refusal is asserted with the row UNWRITTEN: a 409 that still
+        inserted would satisfy a status-code-only test.
+        """
+        self.sql("UPDATE documents SET frozen=1 WHERE document_id=1")
+        status, err = self.call("POST", "/api/sprint-units", (OP,),
+                                {"sprint_doc_id": 1, "seq": "U1",
+                                 "unit_title": "posthumous unit"})
+        self.assertEqual(status, 409)
+        self.assertEqual(err["error"]["code"], "sprint_frozen")
+        self.assertIsNone(self.row("U1"))
+        # and thawing it makes the same call succeed — so the refusal is the
+        # freeze and nothing else about this fixture
+        self.sql("UPDATE documents SET frozen=0 WHERE document_id=1")
+        self.assertEqual(self.add()[0], 201)
+
+    def test_declaring_the_first_unit_is_not_gated_on_liveness(self):
+        """The ordering H-1 creates, from the other side. A sprint is live only
+        once it holds a unit, so gating THIS route on liveness would make the
+        first unit — and therefore every board — undeclarable. Board first,
+        then arm the binding.
+        """
+        self.assertEqual(
+            self.sql_one("SELECT COUNT(*) FROM sprint_units"), 0,
+            "the fixture starts with no board")
+        self.assertEqual(self.add()[0], 201)
 
     def test_the_board_reads_back_in_work_order_not_lexicographic_order(self):
         """`seq` is TEXT, so `ORDER BY seq` puts U10 and U11 between U1 and

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -908,23 +908,31 @@ class ApiTest(unittest.TestCase):
         pr_poller.baseline_read = lambda repo, pr: (
             {"state": "OPEN", "sha": "s", "checks": None, "reviews": 0,
              "review_state": None}, None)
+        # PR numbers unused by any other test in this class: the DB is
+        # per-CLASS, and re-registering a PR under a SECOND sprint takes a new
+        # row rather than rebinding, so a shared number reads back as two rows.
         try:
-            watch.main(["pr", "own/repo", "31", "--sprint", "113"])
-            watch.main(["pr", "own/repo", "32", "--sprint", "114"])
+            watch.main(["pr", "own/repo", "41", "--sprint", "113"])
+            watch.main(["pr", "own/repo", "42", "--sprint", "114"])
         finally:
             pr_poller.baseline_read = real
 
         self.assertEqual(
             [(r["pr_number"], r["sprint_doc_id"]) for r in self.q(
                 "SELECT pr_number, sprint_doc_id FROM watched_prs "
-                "WHERE pr_number IN (31, 32) ORDER BY pr_number")],
-            [(31, 113), (32, 114)], "both registrations were accepted")
+                "WHERE pr_number IN (41, 42) ORDER BY pr_number")],
+            [(41, 113), (42, 114)], "both registrations were accepted")
         con = sqlite3.connect(self.db)
         con.row_factory = sqlite3.Row
         try:
             armed = {w["sprint_doc_id"] for w in pr_poller.armed_watches(con)}
         finally:
             con.close()
+        # POSITIVE CONTROL FIRST: both claims below are absences, and an empty
+        # armed set satisfies them for free. Doc 100 is the class fixture's
+        # live sprint and carries watches, so its presence proves the probe
+        # sees armed watches at all.
+        self.assertIn(100, armed, "the probe sees a live sprint's watches")
         self.assertNotIn(113, armed, "a frozen sprint is never polled")
         self.assertNotIn(114, armed, "an undeclared board is never polled")
 

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -68,11 +68,17 @@ def seed_shells(con: sqlite3.Connection) -> None:
     con.commit()
 
 
-def seed_sprint_doc(con: sqlite3.Connection, doc_id: int = 100) -> None:
+def seed_sprint_doc(con: sqlite3.Connection, doc_id: int = 100,
+                    units: int = 1) -> None:
     con.execute(
         "INSERT INTO documents (document_id, kind, title, body, frozen) "
         "VALUES (?, 'doc', 'SPRINT: T', '# SPRINT: T\nstatus: ACTIVE\n', 0)",
         (doc_id,))
+    # `units` is what makes it live (H-1) — the `status:` line is prose.
+    for i in range(units):
+        con.execute(
+            "INSERT INTO sprint_units (sprint_doc_id, seq, unit_title) "
+            "VALUES (?, ?, ?)", (doc_id, f"U{i + 1}", f"unit {i + 1}"))
     con.commit()
 
 
@@ -850,26 +856,31 @@ class ApiTest(unittest.TestCase):
         self.assertIn('"state": "OPEN"', row["last_seen"])
         self.assertIn('"sha": "abc1234def"', row["last_seen"])
 
-    def test_registration_refuses_scope_closed_during_baseline(self):
+    def test_registration_refuses_scope_unmade_during_baseline(self):
+        """The TOCTOU window the BEGIN IMMEDIATE revalidation exists to close.
+
+        Registration validates SPRINT-DOC IDENTITY (H-2), not liveness, so the
+        mutation that must lose the race is one that stops the target being a
+        sprint board at all — here a retitle mid-baseline."""
         con = sqlite3.connect(self.db)
         seed_sprint_doc(con, 101)
         con.close()
         real = pr_poller.baseline_read
 
-        def close_scope(repo, pr):
+        def unmake_scope(repo, pr):
             con = sqlite3.connect(self.db)
             try:
                 con.execute(
-                    "UPDATE documents SET body="
-                    "'# SPRINT: T\nstatus: CLOSED\n' WHERE document_id=101")
+                    "UPDATE documents SET title='Retro notes' "
+                    "WHERE document_id=101")
                 con.commit()
             finally:
                 con.close()
-            return ({"state": "OPEN", "sha": "closed-during-baseline",
+            return ({"state": "OPEN", "sha": "retitled-during-baseline",
                      "checks": "PENDING", "reviews": 0,
                      "review_state": None}, None)
 
-        pr_poller.baseline_read = close_scope
+        pr_poller.baseline_read = unmake_scope
         try:
             with self.assertRaises(SystemExit) as denied:
                 watch.main(
@@ -878,10 +889,44 @@ class ApiTest(unittest.TestCase):
             pr_poller.baseline_read = real
 
         self.assertIn("HTTP 409", str(denied.exception))
-        self.assertIn("not an ACTIVE, unfrozen SPRINT doc",
-                      str(denied.exception))
+        self.assertIn("not a SPRINT doc", str(denied.exception))
         self.assertEqual(
             self.q("SELECT 1 FROM watched_prs WHERE pr_number=22"), [])
+
+    def test_registration_on_a_frozen_sprint_is_accepted_but_dormant(self):
+        """H-2's deliberate loosening, stated as behaviour rather than left
+        implicit. Registration is an identity check, so a frozen sprint takes
+        the row; the poller then never sees it, because arming reads liveness.
+        Registering during the declaration window rides the same rule."""
+        con = sqlite3.connect(self.db)
+        seed_sprint_doc(con, 113)
+        con.execute("UPDATE documents SET frozen=1 WHERE document_id=113")
+        seed_sprint_doc(con, 114, units=0)          # board not declared yet
+        con.commit()
+        con.close()
+        real = pr_poller.baseline_read
+        pr_poller.baseline_read = lambda repo, pr: (
+            {"state": "OPEN", "sha": "s", "checks": None, "reviews": 0,
+             "review_state": None}, None)
+        try:
+            watch.main(["pr", "own/repo", "31", "--sprint", "113"])
+            watch.main(["pr", "own/repo", "32", "--sprint", "114"])
+        finally:
+            pr_poller.baseline_read = real
+
+        self.assertEqual(
+            [(r["pr_number"], r["sprint_doc_id"]) for r in self.q(
+                "SELECT pr_number, sprint_doc_id FROM watched_prs "
+                "WHERE pr_number IN (31, 32) ORDER BY pr_number")],
+            [(31, 113), (32, 114)], "both registrations were accepted")
+        con = sqlite3.connect(self.db)
+        con.row_factory = sqlite3.Row
+        try:
+            armed = {w["sprint_doc_id"] for w in pr_poller.armed_watches(con)}
+        finally:
+            con.close()
+        self.assertNotIn(113, armed, "a frozen sprint is never polled")
+        self.assertNotIn(114, armed, "an undeclared board is never polled")
 
     def test_scoped_registration_rebinds_legacy_and_resolves_alert(self):
         con = sqlite3.connect(self.db)
@@ -910,7 +955,7 @@ class ApiTest(unittest.TestCase):
             watch_id)[0]
         self.assertIsNotNone(alert["resolved_at"])
 
-    def test_legacy_rebind_refuses_scope_closed_during_baseline(self):
+    def test_legacy_rebind_refuses_scope_unmade_during_baseline(self):
         con = sqlite3.connect(self.db)
         seed_sprint_doc(con, 102)
         watch_id = con.execute(
@@ -926,19 +971,20 @@ class ApiTest(unittest.TestCase):
         con.close()
         real = pr_poller.baseline_read
 
-        def freeze_scope(repo, pr):
+        def unmake_scope(repo, pr):
             con = sqlite3.connect(self.db)
             try:
                 con.execute(
-                    "UPDATE documents SET frozen=1 WHERE document_id=102")
+                    "UPDATE documents SET title='Retro notes' "
+                    "WHERE document_id=102")
                 con.commit()
             finally:
                 con.close()
-            return ({"state": "OPEN", "sha": "frozen-during-baseline",
+            return ({"state": "OPEN", "sha": "retitled-during-baseline",
                      "checks": "SUCCESS", "reviews": 1,
                      "review_state": "APPROVED"}, None)
 
-        pr_poller.baseline_read = freeze_scope
+        pr_poller.baseline_read = unmake_scope
         try:
             with self.assertRaises(SystemExit) as denied:
                 watch.main(
@@ -983,6 +1029,104 @@ class ApiTest(unittest.TestCase):
     def test_cli_refuses_pr_event_kind(self):
         with self.assertRaises(SystemExit):   # argparse: not in choices
             mem.main(["message", "send", "dev1", "forged", "--kind", "pr_event"])
+
+    def test_api_refuses_pr_event_from_a_shell_token(self):
+        """H-3 — kind parity. The CLI's argparse `choices` was the ONLY fence:
+        any holder of any shell key could POST kind='pr_event' straight past it
+        and mint a PR transition GitHub never reported, waking a planner on
+        forged ground truth. The refusal belongs at shell-token ingress, which
+        is what this route is."""
+        before = self.q("SELECT COUNT(*) c FROM shell_messages "
+                        "WHERE kind='pr_event'")[0]["c"]
+        with self.assertRaises(SystemExit) as denied:
+            mem._api("POST", "/_sc/mem/messages",
+                     {"to": "plan1", "body": "own/repo#9 merged (forged)",
+                      "kind": "pr_event", "sprint_doc_id": 100})
+        self.assertIn("HTTP 403", str(denied.exception))
+        self.assertEqual(
+            self.q("SELECT COUNT(*) c FROM shell_messages "
+                   "WHERE kind='pr_event'")[0]["c"], before,
+            "the refused send must leave no row")
+
+    def test_the_poller_still_emits_pr_event_through_its_own_path(self):
+        """The other half of H-3, and the reason it is a 403 and not a schema
+        change: the poller writes `pr_event` by direct DB insert, so the API
+        refusal cannot reach it. If this ever goes red, the poller has been
+        moved onto the API and needs a system credential — not a carve-out in
+        the ingress check.
+
+        Its own DB, not the class fixture: poll_cycle sweeps EVERY armed watch,
+        so the sibling tests' registrations would share the batched read.
+        """
+        con = build_db()
+        try:
+            seed_shells(con)
+            seed_sprint_doc(con)
+            con.execute(
+                "INSERT INTO watched_prs (repo, pr_number, shell_id, "
+                "sprint_doc_id, last_seen) VALUES ('own/repo', 77, 1, 100, ?)",
+                (json.dumps({"state": "OPEN", "sha": "aaa", "checks": "PENDING",
+                             "reviews": 0, "review_state": None}),))
+            con.commit()
+            pr_poller.poll_cycle(con, fetch=lambda q: pr_poller.GhResult(
+                data={"r0": {"pullRequest": {
+                    "state": "MERGED", "headRefOid": "bbb",
+                    "reviews": {"totalCount": 0, "nodes": []},
+                    "commits": {"nodes": [{"commit": {"statusCheckRollup":
+                                                      {"state": "SUCCESS"}}}]},
+                }}}))
+            emitted = con.execute(
+                "SELECT body FROM shell_messages WHERE kind='pr_event'"
+            ).fetchall()
+        finally:
+            con.close()
+        self.assertTrue(emitted, "the poller's own path is unaffected")
+
+    def test_message_scope_must_name_a_sprint_doc(self):
+        """H-2 — validate sprint scope at the write boundary. This route took
+        ANY integer, so a typo'd --sprint produced a message scoped to nothing:
+        never woke, never filtered with the sprint's traffic, reported success.
+        """
+        spec_id = 100 - 1
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO documents (document_id, kind, title, body) "
+            "VALUES (?, 'spec', 'Sprint flow hardening', 'x')", (spec_id,))
+        con.commit()
+        con.close()
+        for scope in (spec_id, 99999):
+            with self.subTest(scope=scope):
+                with self.assertRaises(SystemExit) as denied:
+                    mem._api("POST", "/_sc/mem/messages",
+                             {"to": "dev1", "body": "scoped wrong",
+                              "kind": "task", "sprint_doc_id": scope})
+                self.assertIn("HTTP 422", str(denied.exception))
+        self.assertEqual(
+            self.q("SELECT COUNT(*) c FROM shell_messages "
+                   "WHERE body='scoped wrong'")[0]["c"], 0)
+
+    def test_message_scope_accepts_a_sprint_doc_at_any_liveness(self):
+        """The deliberately distinct half of H-2: tagging validates IDENTITY,
+        never liveness. A coordination message in the declaration window (board
+        declared, units not yet) and a result row sent after close are both
+        legal traffic — gating them on liveness would make the sprint's own
+        open and close unreportable."""
+        con = sqlite3.connect(self.db)
+        seed_sprint_doc(con, 121, units=0)            # declaration window
+        seed_sprint_doc(con, 122)
+        con.execute("UPDATE documents SET frozen=1 WHERE document_id=122")
+        con.commit()
+        con.close()
+        for scope in (121, 122):
+            with self.subTest(scope=scope):
+                out = mem._api("POST", "/_sc/mem/messages",
+                               {"to": "dev1", "body": f"legal {scope}",
+                                "kind": "result", "sprint_doc_id": scope})
+                self.assertIn("message_id", out)
+                self.assertEqual(
+                    self.q("SELECT sprint_doc_id s FROM shell_messages "
+                           "WHERE message_id=?", out["message_id"])[0]["s"],
+                    scope)
 
     def test_messages_read_returns_kind(self):
         mem.main(["message", "send", "plan1", "report done", "--kind", "result"])


### PR DESCRIPTION
## U1 — structural sprint liveness (S84, spec #76 H-1/H-2/H-3)

Sprint liveness was a `status:` line inside `documents.body`, parsed by two
divergent implementations across the codebase. A reformatted line killed the
wake path and every armed watch while boot still rendered the sprint live.

This replaces prose-derived liveness with **three structural predicates** in a
new dependency-free module, `.super-coder/scripts/sprint_state.py`, and routes
every call site through it. The `status:` line stays in the body as display
prose that nothing executable reads.

### The three predicates, and why they are not one

Ratified by the planner (doc 84). Collapsing any pair reintroduces a defect the
module exists to close:

| Predicate | Operands | Gates |
|---|---|---|
| `is_sprint_doc` | kind + title | write boundary: message tagging, watch registration |
| `is_writable_sprint_board` | + `frozen=0` | board mutation (the route that CREATES the first unit) |
| `is_live_sprint` / `live_sprint_clause` | + unit-count | the wake path, binding arm, poller scoping, activity projection |

`is_sprint_doc` deliberately excludes `frozen` and the unit count: a
coordination message sent in the declaration window (board declared, units not
yet) and a result row sent after close must both stay legal.
`is_writable_sprint_board` deliberately excludes the unit count: the route it
guards creates the first unit, so gating it on liveness would make every board
undeclarable.

**Ordering consequence, decided rather than discovered:** a sprint doc with zero
`sprint_units` rows is not live, so the board is declared BEFORE the binding is
armed.

### Caller inventory — 10 sites

Reproduce with (run against the merge base, `caf49fe`):

```
git grep -nE '_sprint_active|active_sprint_doc_ids|is_active_sprint|_sprint_doc_status|_STATUS_ACTIVE' caf49fe -- '.super-coder/'
```

```
interface_routes.py:1683   _sprint_active            submit gate
interface_routes.py:1817   _sprint_active            "active" projection
interface_routes.py:2585   _sprint_active
server.py:2800             _sprint_doc_status=="CLOSED"   site #10 — DELETED
server.py:2874             active_sprint_doc_ids
server.py:2917             is_active_sprint
server.py:2982             is_active_sprint          watch registration
interface_broker.py:1014   _sprint_active
interface_wake.py:62       _sprint_active
pr_poller.py:928/937/943   _STATUS_ACTIVE.search     the prose parser itself
```

Definitions retired alongside them: `interface_broker._sprint_active`,
`pr_poller.active_sprint_doc_ids` / `is_active_sprint` / `_STATUS_ACTIVE`,
`server._sprint_doc_status`. `get_active_sprints`'s inline
`kind='doc' AND frozen=0 AND title LIKE 'SPRINT:%'` clause is a separate,
non-grep-visible re-derivation and is also routed through the module.

### Deviations from the task row

**1. Site #10 — deletion, not redirection (RATIFIED).** The ratified table
routed the doc-close trigger to `is_live_sprint`; there is nothing there to
route. A body edit that happened to leave a `status: CLOSED` line released
bindings — a prose line made executable, with the close depending on
formatting. Closing a sprint IS freezing its doc, and the freeze route already
performs the release atomically. Pinned two ways:
`test_status_closed_line_alone_closes_nothing` proves the removal, and
`test_freeze_close_is_atomic_under_fault` proves the SC-016 atomicity claim
survived the move to the route that actually performs the close.

*Consequence, intended:* anything that closed a sprint by writing
`status: CLOSED` without freezing now closes nothing, silently. H-12 makes
freeze the enforced close.

**2. Watch registration on a FROZEN sprint returns 201 (NOT 4xx).** Restated in
full, as it was previously truncated. Registration validates
`sprint_state.is_sprint_doc` — identity only, per H-2 — and that predicate is
true of a frozen doc. So `sc watch pr … --sprint <closed-sprint>` is **accepted**
where the previous `is_active_sprint` check would have refused it.

This is deliberate, and the reasoning is the same one that makes `is_sprint_doc`
identity-only: liveness is the poller's ARMING predicate, not the write
boundary. The registration is inert by construction — `armed_watches` scopes
every poll to `sprint_state.live_sprint_doc_ids`, so a watch on a frozen sprint
is never polled and emits no event. Refusing at registration instead would also
refuse the declaration-window case (board declared, units not yet), which must
stay legal.

The trade-off I picked, stated explicitly: a typo'd `--sprint` naming a closed
sprint now returns 201 and silently never polls, where before it returned an
error. I judged that acceptable because `sc watch list` renders the watch as
`dormant — sprint not live`, so the state is visible rather than hidden — but
this is the deviation most worth a reviewer's disagreement, and I am flagging it
as such rather than burying it.

**3. Site #5 — `writable_board_clause`, not `is_live_sprint` (RATIFIED).** The
sprint-activity projection (`get_active_sprints`) omits the unit-count operand.
Full liveness would take the FnB's Active-sprints view dark for the entire
declaration window. It is a display surface, not an executable gate, and a
just-declared sprint is exactly what an operator wants to see there. Gating a
human's view on a predicate designed to gate the wake path would be a silent UX
regression shipped as a refactor. `test_zero_unit_sprint_still_projects` pins it.

### Rebase — hand-resolved hunks

Rebased onto `caf49fe` (U3), which touched three files this unit also touches.
Six hunks were resolved by hand; per the merge rule they are named here for the
reviewer:

1. `interface_routes.py:68` — import block. Both imports kept
   (`sprint_state` + U3's `TERMINAL_UNIT_STATES`). Mechanical.
2. `server.py` `_close_sprint_wake` — **U3's implementation wins entirely**
   (dict return, watch retirement + alert resolution). Only my H-1 docstring
   sentence was merged in; my `-> int` variant was discarded.
3. `server.py` `_sprint_doc_status` — deleted (U1 site #10), with U3's
   surrounding additions preserved.
4. `server.py` doc-edit route — trigger removed (site #10). Response now
   reports `released_bindings`/`retired_watches`/`resolved_watch_alerts` as
   **zeros rather than absent keys**, so the response shape matches U3's freeze
   route and no reader has to branch on which route answered. This is the one
   hunk where I wrote something neither side had.
5. `server.py` watch registration — my identity-only error text over U3's
   "not an ACTIVE, unfrozen SPRINT doc"; U3's `--unit` linkage block kept intact.
6. `watch.py` ×3 — docstring, `--sprint` help, and the `sc watch list` state
   string. U3's `--unit` flag and `unit_seq` display kept; my
   `dormant — sprint not live` wording over `dormant — sprint not ACTIVE`.

No mutation operand was hand-resolved (all of them sit in `sprint_state.py` or
in auto-merged regions of `server.py`). The mutation pass is re-running on the
current head as a supervised job; its table is posted as a follow-up. An earlier
revision of this section claimed the re-run had already happened — it had not,
and that claim is withdrawn rather than retro-justified.

### Rebase 2 — onto `e6a94ae`, zero hand-resolved hunks

`origin/main` moved to `e6a94ae` (U9, rebuild arg parsing), whose surface
(`scripts/rebuild.py`, `tests/test_rebuild_args.py`) is disjoint from all 17
files here. Clean replay; this unit's contribution is byte-identical before and
after. The six hunks above are from the U3 rebase and still stand.

### CI fix round — 17 failures, all fixture-level

The first full run of these predicates atop U3's merged transition machine was
red in the seam. All 17 are fixed in the second commit and none required an
engine behaviour change. Four clusters:

1. **`test_interface_crash_window` (10)** — both sprint fixtures declared a doc
   with no `sprint_units` row, then armed a binding by raw SQL. The arm route
   refuses a boardless sprint, so the fixtures built a state the engine cannot
   produce; submit-time revalidation was correctly cancelling a batch that could
   never have been armed. Board row added.
2. **`SprintCloseTest` (5)** — H-1 needs a unit row for liveness; U3's freeze
   refuses while any unit is non-terminal; the default state is `pending`. The
   helper therefore built a sprint that was live *and* unfreezable, so the close
   tests got 409 before reaching the close path they test. The 409 then leaked an
   unclosed connection through a UNIQUE violation on the class-shared DB — that
   is where all three `database is locked` failures came from. Unit seeded
   `cancelled`, prior binding released, connection closed in a `finally`. U3's
   close path refused exactly what it is built to refuse; no defect there.
3. **`test_sprint_assignment_notice` (1)** — the closed-sprint test closed by
   prose, which H-1 ratifies as closing nothing. Re-anchored to `frozen=1`, where
   the original property holds unchanged (the gate is on the NOTICE, never on the
   record), plus a new test pinning the ratified consequence positively.
4. **`test_sprint_eventing` (1)** — my own new test reused PR numbers already
   registered under another sprint in the same class-scoped DB. Moved, and its
   two absence assertions now carry a positive control.

**A correction to my own reasoning, recorded because the diff carries its
result.** Diagnosing (3) I reasoned the emitter's `is_live_sprint` guard was made
dead by H-1 — a PATCH implies the unit exists implies the sprint is live — and
wrote a test asserting a frozen board returns 409. It returns 200: **unit-PATCH
is not gated on the freeze, only unit-CREATE is.** I had inferred the route
rather than read it. The guard is live and is now pinned both ways. The
asymmetry is deliberate and unchanged here — you may correct a closed sprint's
board, not extend it — and I tightened one comment of mine that overstated it as
"a frozen board is not mutable".

**Pre-existing, reported not fixed:** registering a repo+PR already watched under
sprint A, now under sprint B, creates a second open watch row rather than
rebinding or refusing. Verified present on `origin/main`; my diff does not touch
that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

