### PR TITLE
fix(engine): classify command targets instead of resolving one root (S84 U10, spec #68)

### DIFF
--- a/.super-coder/scripts/migrate.py
+++ b/.super-coder/scripts/migrate.py
@@ -89,22 +89,59 @@ def apply(con, path: Path) -> None:
 
 
 def migrate(db_path: str) -> int:
+    # Spec #68 req 5: name the two targets — WHICH database, and WHICH migration
+    # source — before opening either, and again on the outcome. `./sc migrate`
+    # run from a linked worktree used to maintain the main checkout's live DB and
+    # print "nothing pending" without ever saying whose DB was current. The
+    # disclosure goes first because a crash mid-chain must still leave the
+    # operator knowing what was being changed.
+    target = Path(db_path).resolve()
+    print(f"migrate: db         {target}")
+    print(f"migrate: migrations {MIGRATIONS_DIR}")
     con = db_driver.connect(db_path)
     try:
         todo = pending(con)
         if not todo:
-            print("migrate: nothing pending — DB is current.")
+            print(f"migrate: nothing pending — {target} is current.")
             return 0
         for path in todo:
             apply(con, path)  # each file self-commits atomically with its stamp
             print(f"migrate: applied {path.name}")
-        print(f"migrate: {len(todo)} migration(s) applied.")
+        print(f"migrate: {len(todo)} migration(s) applied to {target}.")
     finally:
         con.close()
     return 0
 
 
+USAGE = "usage: ./sc migrate  ·  python3 .super-coder/scripts/migrate.py <path-to-db>"
+
+HELP = f"""{USAGE}
+
+Apply every unstamped migration in {MIGRATIONS_DIR.name}/ to the named DB, in
+filename order, recording each in the schema_migrations ledger. Reports the
+absolute DB path and migration source directory before touching either.
+
+Takes exactly one argument: the path to the database.
+"""
+
+
+def parse_args(argv: list[str]) -> str:
+    """Return the DB path, print help, or reject — WITHOUT connecting.
+
+    Help wins over every other token, including a bad one, so no help form can
+    reach a database (`./sc migrate --help` used to run the real migration
+    against the shared live DB). Same shape as rebuild's preflight (spec #67) —
+    the argument contract is settled before any state is opened.
+    """
+    if "-h" in argv or "--help" in argv:
+        print(HELP)
+        raise SystemExit(0)
+    if len(argv) != 1:
+        subject = f"unknown argument '{argv[1]}'" if len(argv) > 1 else "needs a DB path"
+        print(f"migrate: {subject} ({USAGE})", file=sys.stderr)
+        raise SystemExit(2)
+    return argv[0]
+
+
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        sys.exit(f"usage: {Path(sys.argv[0]).name} <path-to-db>")
-    sys.exit(migrate(sys.argv[1]))
+    sys.exit(migrate(parse_args(sys.argv[1:])))

--- a/.super-coder/scripts/render_check.py
+++ b/.super-coder/scripts/render_check.py
@@ -61,6 +61,27 @@ def _build_tracked_db(path: Path) -> None:
         con.close()
 
 
+def _active_content() -> Path:
+    """The content file `_build_tracked_db` will actually read."""
+    return CONTENT if CONTENT.exists() else CONTENT_LEGACY
+
+
+def _target_lines() -> list[str]:
+    """The paths this verdict is ABOUT (spec #68 req 1).
+
+    `./sc render-check` runs the CALLER's engine, so "✓ matches" is a claim about
+    one specific checkout — and it used to be the main one, whichever worktree
+    you typed it in. Printed BEFORE the work, so a crash mid-render leaves the
+    same attribution a success or a drift report does.
+    """
+    return [
+        f"  source root : {REPO_ROOT}",
+        f"  engine      : {ENGINE}",
+        f"  content     : {_active_content()}",
+        f"  mirror      : {ACTIVE_ROOT}",
+    ]
+
+
 def _rel_files(base: Path) -> set[str]:
     """Tracked-mirror files present under `base`, as repo-relative paths."""
     found: set[str] = set()
@@ -74,6 +95,9 @@ def _rel_files(base: Path) -> set[str]:
 
 
 def main() -> int:
+    print("render-check: verifying the tracked sources of this checkout")
+    for line in _target_lines():
+        print(line)
     artifact_policy.prepare_local_state()
     if not artifact_policy.tracks_local_artifacts() and not ACTIVE_ROOT.exists():
         print("✓ render-check: local artifact mode has no rendered instance state yet")
@@ -105,7 +129,9 @@ def main() -> int:
                 "✗ render drift: the active flat _sc mirror does not match the\n"
                 "  mirror rendered from the active sources (schema + migrations +\n"
                 f"  {CONTENT.relative_to(REPO_ROOT)}). A source edit was made without\n"
-                "  re-rendering the mirror.\n\n  drifted:\n"
+                "  re-rendering the mirror.\n\n"
+                + "".join(f"{line}\n" for line in _target_lines())
+                + "\n  drifted:\n"
                 + "".join(f"    {p}\n" for p in drifted)
                 + "\n  fix:  ./sc rebuild && ./sc render flat"
                 + (" && git add " + " ".join(RENDERED)

--- a/sc
+++ b/sc
@@ -8,22 +8,78 @@ set -e
 here="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 cd "$here"
 
-# The engine (`.super-coder/`) and its gitignored live DB sit at the MAIN worktree
-# root. A linked worktree (a shell's `.sc-worktrees/<name>/`) has a tracked copy of
-# THIS script — and, in the canonical repo where `.super-coder/` is tracked, even a
-# DB-less engine copy — but never the live DB. So always resolve the engine at the
-# main root via git's common dir (its parent is the main worktree), so `./sc` works
-# from any worktree. We do NOT cd there: cwd stays the caller's worktree so git ops
-# + shell inference see it. Fall back to $here outside a git checkout.
-ROOT="$here"
-_root="$(cd "$here" 2>/dev/null && cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd || true)"
-[ -n "$_root" ] && [ -d "$_root/.super-coder" ] && ROOT="$_root"
+# FOUR identities, never one ROOT (spec #68). The CALLER is the checkout holding
+# the `sc` that was invoked; the LIVE instance is the MAIN worktree root, which
+# owns `.super-coder/` and its gitignored DB. A linked worktree (a shell's
+# `.sc-worktrees/<name>/`) has a tracked copy of THIS script — and, in the
+# canonical repo where `.super-coder/` is tracked, even a DB-less engine copy —
+# but never the live DB, map or runtime identity. Resolving the live root via
+# git's common dir (its parent is the main worktree) is what makes `./sc mem`
+# work from any worktree; it is ALSO what used to make `./sc migrate` silently
+# maintain the shared instance from a worktree. So both values are kept, commands
+# are CLASSIFIED against them below, and neither is a default for the other.
+#
+# We do NOT cd to the live root: cwd stays the caller's worktree so git ops +
+# shell inference see it. `pwd -P` on both sides so a symlinked or relatively
+# invoked caller compares as itself rather than as a second identity. If the
+# git-common-dir resolution fails (no checkout, no engine there), the caller is a
+# STANDALONE root — one identity, and we never guess a second target.
+CALLER_ROOT="$(CDPATH= cd -- "$here" && pwd -P)"
+CALLER_ENGINE="$CALLER_ROOT/.super-coder"
+LIVE_ROOT="$CALLER_ROOT"
+_root="$(cd "$here" 2>/dev/null && cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd -P || true)"
+[ -n "$_root" ] && [ -d "$_root/.super-coder" ] && LIVE_ROOT="$_root"
 
+# LINKED=1 means caller != live: this invocation can reach shared state it does
+# not own. Compared as normalized paths — never a branch name, never the
+# `.sc-worktrees` spelling (req 7), so a fork that keeps worktrees anywhere (or
+# none at all) is judged by the same test.
+LINKED=0
+[ "$CALLER_ROOT" != "$LIVE_ROOT" ] && LINKED=1
+
+ROOT="$LIVE_ROOT"          # every path below this line is the LIVE instance's
 ENGINE="$ROOT/.super-coder"
 PY="${SC_PYTHON:-python3}"
 DB="$ENGINE/shell_db.db"
 S="$ENGINE/scripts"
 MAPDB="$("$PY" "$S/artifact_policy.py" path map-db)"
+
+# --- linked-worktree target safety (spec #68, decision #81) -------------------
+# A command whose subject is the SHARED live instance refuses from a linked
+# worktree, BEFORE it opens or deletes anything. The worktree has no DB, map,
+# instance config or runtime identity of its own, so there is nothing local to
+# act on instead: decision #81 declined a worktree-local runtime mode, because a
+# partial instance replaces one ambiguity with another. A named refusal is the
+# whole fix — `./sc migrate` from a worktree used to maintain the main
+# checkout's live DB and say nothing about which DB it meant.
+#
+# `-h`/`--help` is not an action and must work from any checkout (sprint ruling
+# R1): parse first, refuse second, act third. Only the commands whose target
+# actually implements help consult sc_help_form; for the rest every form is an
+# action form and refuses.
+sc_help_form() {
+  for _a in "$@"; do
+    case "$_a" in -h|--help) return 0 ;; esac
+  done
+  return 1
+}
+
+# $1 = the command as the operator typed it · $2 = the live target declined.
+# stderr + exit 1: nothing ran, so nothing may read as having run.
+sc_refuse_linked() {
+  [ "$LINKED" -eq 1 ] || return 0
+  {
+    echo "✗ ./sc $1 refused: this is a linked worktree, not the live instance."
+    echo "    caller worktree : $CALLER_ROOT"
+    echo "    live instance   : $LIVE_ROOT"
+    echo "    declined target : $2"
+    echo "  ./sc $1 acts on the shared live instance above, which this worktree"
+    echo "  does not own. Nothing was opened, written or deleted."
+    echo "  For live maintenance, run it from the main checkout:"
+    echo "      cd $LIVE_ROOT && ./sc $1"
+  } >&2
+  exit 1
+}
 
 # Python for the Interface verbs: PREFER an interpreter with `websockets`
 # (baked into the sandbox image's own python and pinned in requirements.txt
@@ -1131,9 +1187,21 @@ case "$cmd" in
   artifact-mode) exec "$PY" "$S/artifact_policy.py" "$@" ;;
   eject)        exec "$PY" "$S/eject.py" "$@" ;;
   init)         exec "$PY" "$S/init_fork.py" "$@" ;;
-  rebuild)      exec "$PY" "$S/rebuild.py" "$@" ;;
-  migrate)      exec "$PY" "$S/migrate.py" "$DB" ;;
-  snapshot)     exec "$PY" "$S/snapshot.py" ;;
+  # rebuild/migrate: the script owns the whole argument contract (help, unknown
+  # tokens), so the dispatcher forwards VERBATIM and only inserts the refusal —
+  # after the help question, before the action.
+  rebuild)      sc_help_form "$@" || sc_refuse_linked rebuild "$DB"
+                exec "$PY" "$S/rebuild.py" "$@" ;;
+  migrate)      sc_help_form "$@" || sc_refuse_linked migrate "$DB"
+                exec "$PY" "$S/migrate.py" "$DB" "$@" ;;
+  # snapshot/render name the artifact they would overwrite as well as the DB
+  # they read; resolving that path costs a subprocess, so only the refusing
+  # branch pays for it.
+  snapshot)     if [ "$LINKED" -eq 1 ]; then
+                  sc_refuse_linked snapshot \
+                    "$DB -> $("$PY" "$S/artifact_policy.py" path content)"
+                fi
+                exec "$PY" "$S/snapshot.py" ;;
   mem)          exec "$PY" "$S/mem.py" "$@" ;;
   token)        exec "$PY" "$S/operator_token.py" "$@" ;;
   sprint)       exec "$PY" "$S/sprint.py" "$@" ;;
@@ -1163,8 +1231,24 @@ case "$cmd" in
   map-sql)      exec sqlite3 -readonly "$MAPDB" "$@" ;;
   sql-rw)       exec sqlite3 "$DB" "$@" ;;
   map-sql-rw)   exec sqlite3 "$MAPDB" "$@" ;;
-  render)       [ $# -gt 0 ] && exec "$PY" "$S/render.py" "$@" || exec "$PY" "$S/render.py" flat ;;
-  render-check) exec "$PY" "$S/render_check.py" ;;
+  render)       if [ "$LINKED" -eq 1 ]; then
+                  sc_refuse_linked render \
+                    "$DB -> $("$PY" "$S/artifact_policy.py" path renders)"
+                fi
+                [ $# -gt 0 ] && exec "$PY" "$S/render.py" "$@" || exec "$PY" "$S/render.py" flat ;;
+  # render-check is SOURCE-PURE: it builds a throwaway DB from tracked text and
+  # diffs the mirror, touching no live state. So it runs the CALLER's engine —
+  # that is the source the caller is about to commit, and running the main
+  # checkout's copy verified the wrong tree from every worktree. A missing caller
+  # engine fails naming that path; falling back to live source would answer a
+  # question nobody asked.
+  render-check) if [ ! -f "$CALLER_ENGINE/scripts/render_check.py" ]; then
+                  echo "✗ ./sc render-check: no engine source at $CALLER_ENGINE" >&2
+                  echo "  render-check verifies THIS checkout's tracked sources; it does not" >&2
+                  echo "  fall back to the live instance at $LIVE_ROOT." >&2
+                  exit 1
+                fi
+                exec "$PY" "$CALLER_ENGINE/scripts/render_check.py" ;;
   map)          case "${1:-}" in
                   -h|--help) echo "usage: ./sc map — rescan the host repo into the dr_* catalogue ($MAPDB); takes no arguments"
                              exit 0 ;;
@@ -1453,6 +1537,13 @@ case "$cmd" in
     dbuild ;;
   logs)         exec docker logs -f "$CNAME" ;;
   verify)
+    sc_refuse_linked verify "$DB"
+    # Destructive by design: rebuild.py REPLACES the DB below. Say which DB and
+    # which source before that happens — a footer printed after the fact is a
+    # disclosure a crash can skip, and this is the command that eats unsnapshotted
+    # memory when it is pointed at an instance the caller did not mean.
+    echo "→ verify: about to REBUILD $DB"
+    echo "          from engine source $ENGINE"
     "$PY" "$S/rebuild.py"
     # The engine source intentionally carries no per-instance snapshot in local
     # artifact mode. Exercise the real fresh-fork initialization path before
@@ -1479,7 +1570,8 @@ PY
     SC_ADMIN=1 "$PY" "$S/render.py" flat
     RENDER_ONLY=1 exec "$PY" "$S/run.py" --first ;;
   health)       curl -s "http://127.0.0.1:$(port)/api/health" && echo "" ;;
-  clean-db)     rm -f "$DB" "$DB-wal" "$DB-shm" && echo "removed $DB (rebuild with: ./sc rebuild)" ;;
+  clean-db)     sc_refuse_linked clean-db "$DB"
+                rm -f "$DB" "$DB-wal" "$DB-shm" && echo "removed $DB (rebuild with: ./sc rebuild)" ;;
   help|-h|--help)
     cat <<'EOF'
 super-coder — forkable shell substrate
@@ -1506,6 +1598,10 @@ super-coder — forkable shell substrate
   ./sc rebuild             build the .db from schema + migrations + snapshot
   ./sc migrate             apply pending migrations to an existing .db
   ./sc snapshot            dump per-instance tables under the active artifact policy
+                             live-state commands (rebuild · migrate · verify · snapshot · render · clean-db) act on the SHARED live
+                             instance at the main checkout, so they REFUSE from a linked worktree rather than substitute it, naming
+                             the target declined (decision #81); -h/--help still answers from any checkout. render-check is the
+                             source-pure one: it verifies the CALLER's tracked sources and names the checkout it read.
   ./sc mem <cmd> [args]    a shell's own memory, over the engine API (get/state/seed/lns/decision/flag/roadmap/doc/narrative);
                              identity is the shell's token, server-resolved — no DB path, no direct-DB fallback. `./sc mem which` to orient
   ./sc token               print the browser sign-in operator token (an operator capability: the Admin runtime

--- a/tests/test_rebuild_args.py
+++ b/tests/test_rebuild_args.py
@@ -272,12 +272,19 @@ class RebuildDispatchParityTest(unittest.TestCase):
     script's own end-to-end behavior in a fresh interpreter."""
 
     def test_dispatcher_forwards_every_argument_verbatim(self):
-        line = next(
-            ln.strip() for ln in (REPO / "sc").read_text().splitlines()
-            if ln.strip().startswith("rebuild)")
-        )
+        # Spec #68 (U10) put a linked-worktree refusal in front of the forward,
+        # so the case is two lines now — pinned as two lines, deliberately. The
+        # requirement is unchanged and is what the second line still says: the
+        # dispatcher adds nothing to argv and removes nothing from it. The first
+        # line is pinned too because ORDER is the contract: the help question is
+        # asked before the refusal, which is asked before the exec.
+        lines = [ln.strip() for ln in (REPO / "sc").read_text().splitlines()]
+        start = next(i for i, ln in enumerate(lines) if ln.startswith("rebuild)"))
         self.assertEqual(
-            line, 'rebuild)      exec "$PY" "$S/rebuild.py" "$@" ;;')
+            lines[start],
+            'rebuild)      sc_help_form "$@" || sc_refuse_linked rebuild "$DB"')
+        self.assertEqual(
+            lines[start + 1], 'exec "$PY" "$S/rebuild.py" "$@" ;;')
 
     def test_script_invocation_handles_help_and_rejection_end_to_end(self):
         # A COPY of the engine scripts, deliberately without schema.sql: this

--- a/tests/test_worktree_targets.py
+++ b/tests/test_worktree_targets.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Worktree-safe command targets (spec #68).
+
+`sc` resolved ONE root — the main worktree, via git's common dir — so every
+command typed in a linked worktree silently acted on the shared live instance:
+`./sc migrate --help` maintained the main checkout's DB, `./sc render-check`
+verified the main checkout's sources, and `./sc verify` rebuilt a DB the caller
+never named. These tests drive the REAL dispatcher inside a REAL linked git
+worktree, against sentinel state, and pin the three answers spec #68 allows:
+run the caller's own source, deliberately reach the shared runtime, or refuse
+before touching anything.
+
+The fixture is deliberately a full engine copy rather than stubs. If the guard
+were removed, `rebuild`/`migrate`/`clean-db` would really run and really replace
+the sentinel DB, so the state assertions here can fail — and the message
+assertions fail independently of whether a given command's mutation lands.
+Distinct trees and distinct DBs on the two sides (req 9) mean a substitution in
+either direction shows up as the WRONG path in the output, not as silence.
+
+Run:  python3 tests/test_worktree_targets.py
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack, redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[1]
+ENGINE = REPO / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import migrate as migrate_mod  # noqa: E402
+
+# Copied engine minus caches and anything instance-owned: the fixture's live
+# state is the sentinel this module writes, never a real fork's.
+IGNORE = shutil.ignore_patterns(
+    "__pycache__", "*.pyc", "shell_db.db*", "backups", "node_modules",
+    "logs", "source-policy.json",   # dropped -> fixture runs in TRACKED mode
+)
+
+# A skill row renders to skills_sc/<slug>.md, so a migration only one checkout
+# holds becomes a file only that checkout's render-check can produce.
+SENTINEL_MIGRATION = "9999_worktree_sentinel.sql"
+SENTINEL_SKILL = "wt-sentinel-skill"
+SENTINEL_SQL = (
+    "INSERT INTO skills (name, description, content, common, is_deleted) "
+    f"VALUES ('{SENTINEL_SKILL}', 'present only in the linked worktree', "
+    "'sentinel body', 0, 0);\n"
+)
+
+
+def run_sc(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    """`./sc <args>` from `cwd`, with the dispatcher's own `sc` — the one under
+    test — resolved relative to that checkout."""
+    env = dict(os.environ)
+    env.pop("SC_PYTHON", None)
+    return subprocess.run(
+        [str(cwd / "sc"), *args],
+        cwd=str(cwd), capture_output=True, text=True, timeout=600,
+        check=False, env=env)
+
+
+def state_digest(root: Path) -> dict[str, str]:
+    """The live-state artifacts of an instance, by content: the DB, its WAL/SHM
+    sidecars, and every backup. A replaced DB shows as a changed digest, a new
+    candidate or backup as a new key."""
+    engine = root / ".super-coder"
+    watched = [engine / "shell_db.db", engine / "shell_db.db-wal",
+               engine / "shell_db.db-shm"]
+    watched += sorted((engine / "backups").rglob("*"))
+    return {
+        str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in watched if p.is_file()
+    }
+
+
+def make_live_db(path: Path, engine: Path) -> None:
+    """A REAL database carrying the fixture's schema plus an identifying marker.
+
+    Real because the point is that an unguarded command can destroy it: garbage
+    bytes would make rebuild/migrate fail early and leave the file intact, which
+    is a green test with no guard behind it.
+    """
+    con = sqlite3.connect(path)
+    con.executescript((engine / "schema.sql").read_text())
+    con.execute("CREATE TABLE live_marker (who TEXT)")
+    con.execute("INSERT INTO live_marker VALUES ('LIVE-INSTANCE-DB')")
+    con.commit()
+    con.close()
+
+
+class WorktreeFixture(unittest.TestCase):
+    """One main checkout that owns the live state, one linked worktree that does
+    not, both real git checkouts of the real engine."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.mkdtemp(prefix="sc_wt_")
+        tmp = Path(cls._tmp)
+        cls.main = tmp / "main"
+        cls.main.mkdir()
+        shutil.copytree(ENGINE, cls.main / ".super-coder", ignore=IGNORE)
+        shutil.copy2(REPO / "sc", cls.main / "sc")
+        (cls.main / "sc").chmod(0o755)
+        git = ["git", "-C", str(cls.main)]
+        subprocess.run([*git, "init", "-q", "-b", "main"], check=True)
+        subprocess.run([*git, "config", "user.email", "t@t"], check=True)
+        subprocess.run([*git, "config", "user.name", "t"], check=True)
+        subprocess.run([*git, "add", "-A"], check=True)
+        subprocess.run([*git, "commit", "-qm", "fixture"], check=True)
+        cls.wt = tmp / "linked-worktree"
+        subprocess.run([*git, "worktree", "add", "-q", str(cls.wt)], check=True)
+
+        # The live state exists ONLY under the main checkout — the asymmetry the
+        # whole spec is about.
+        cls.live_db = cls.main / ".super-coder" / "shell_db.db"
+        make_live_db(cls.live_db, cls.main / ".super-coder")
+        backups = cls.main / ".super-coder" / "backups"
+        backups.mkdir(exist_ok=True)
+        (backups / "shell_db.prerebuild.20260101_000000.db").write_bytes(b"old-backup")
+        cls.pristine = tmp / "pristine"
+        cls.pristine.mkdir()
+        shutil.copy2(cls.live_db, cls.pristine / "shell_db.db")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls._tmp, ignore_errors=True)
+
+    def setUp(self):
+        """Restore the live state so each test meets the same instance."""
+        shutil.copy2(self.pristine / "shell_db.db", self.live_db)
+        for side in ("-wal", "-shm"):
+            Path(str(self.live_db) + side).unlink(missing_ok=True)
+        backups = self.main / ".super-coder" / "backups"
+        shutil.rmtree(backups, ignore_errors=True)
+        backups.mkdir()
+        (backups / "shell_db.prerebuild.20260101_000000.db").write_bytes(b"old-backup")
+
+
+class LinkedWorktreeRefusalTest(WorktreeFixture):
+    """Requirements 2 and 3: the live-state commands refuse from a linked
+    worktree, before they open or delete anything."""
+
+    LIVE_STATE_COMMANDS = ("rebuild", "migrate", "verify", "snapshot",
+                           "render", "clean-db")
+
+    def test_live_state_commands_refuse_and_leave_the_instance_untouched(self):
+        for cmd in self.LIVE_STATE_COMMANDS:
+            with self.subTest(cmd=cmd):
+                self.setUp()
+                before = state_digest(self.main)
+                done = run_sc(self.wt, cmd)
+                self.assertEqual(done.returncode, 1, done.stdout + done.stderr)
+                self.assertEqual(done.stdout, "")
+                self.assertIn(f"./sc {cmd} refused", done.stderr)
+                self.assertIn(str(self.wt), done.stderr)      # caller named
+                self.assertIn(str(self.main), done.stderr)    # live target named
+                self.assertIn(str(self.live_db), done.stderr)
+                self.assertIn(f"cd {self.main} && ./sc {cmd}", done.stderr)
+                self.assertEqual(state_digest(self.main), before)
+
+    def artifact_path(self, kind: str) -> str:
+        """The live instance's own answer for an artifact path — asked the way
+        the dispatcher asks it, so the assertion cannot encode one artifact
+        mode's spelling."""
+        return subprocess.run(
+            [sys.executable,
+             str(self.main / ".super-coder" / "scripts" / "artifact_policy.py"),
+             "path", kind],
+            capture_output=True, text=True, check=True).stdout.strip()
+
+    def test_refusal_names_the_artifact_a_command_would_overwrite(self):
+        """snapshot and render do not only read the DB — they replace an
+        instance artifact, so the declined target has to name that too."""
+        for cmd, kind in (("snapshot", "content"), ("render", "renders")):
+            with self.subTest(cmd=cmd):
+                done = run_sc(self.wt, cmd)
+                self.assertEqual(done.returncode, 1)
+                self.assertIn(
+                    f"declined target : {self.live_db} -> {self.artifact_path(kind)}",
+                    done.stderr)
+
+    def test_the_worktree_never_grows_a_partial_instance(self):
+        """Decision #81: refusal, not a worktree-local runtime. Nothing may
+        appear under the caller's engine either."""
+        for cmd in self.LIVE_STATE_COMMANDS:
+            with self.subTest(cmd=cmd):
+                run_sc(self.wt, cmd)
+                self.assertFalse((self.wt / ".super-coder" / "shell_db.db").exists())
+                self.assertEqual(state_digest(self.wt), {})
+
+
+class HelpSurvivesTheRefusalTest(WorktreeFixture):
+    """Sprint ruling R1: -h/--help answers from ANY checkout — parse first,
+    refuse second, act third. Only an ACTION form is refused."""
+
+    def test_help_forms_exit_zero_with_usage_from_the_linked_worktree(self):
+        for cmd, flag, needle in (
+            ("rebuild", "--help", "usage: ./sc rebuild"),
+            ("rebuild", "-h", "usage: ./sc rebuild"),
+            ("migrate", "--help", "usage: ./sc migrate"),
+            ("migrate", "-h", "usage: ./sc migrate"),
+        ):
+            with self.subTest(cmd=cmd, flag=flag):
+                before = state_digest(self.main)
+                done = run_sc(self.wt, cmd, flag)
+                self.assertEqual(done.returncode, 0, done.stderr)
+                self.assertIn(needle, done.stdout)
+                self.assertNotIn("refused", done.stdout + done.stderr)
+                self.assertEqual(state_digest(self.main), before)
+
+    def test_the_same_help_forms_answer_identically_from_the_root(self):
+        """A help form is not a worktree concession — the root prints the same
+        thing, so the two checkouts cannot drift into two contracts."""
+        for cmd in ("rebuild", "migrate"):
+            with self.subTest(cmd=cmd):
+                from_wt = run_sc(self.wt, cmd, "--help")
+                from_root = run_sc(self.main, cmd, "--help")
+                self.assertEqual(from_wt.returncode, 0)
+                self.assertEqual(from_root.returncode, 0)
+                self.assertEqual(from_wt.stdout, from_root.stdout)
+
+    def test_an_action_form_that_merely_looks_like_help_is_still_refused(self):
+        done = run_sc(self.wt, "migrate", "--halp")
+        self.assertEqual(done.returncode, 1)
+        self.assertIn("./sc migrate refused", done.stderr)
+
+
+class RootCheckoutUnchangedTest(WorktreeFixture):
+    """Requirements 5, 6 and 8: the main checkout still acts, and now says what
+    it is acting on."""
+
+    def test_root_migrate_applies_the_chain_and_names_both_targets(self):
+        done = run_sc(self.main, "migrate")
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertIn(f"migrate: db         {self.live_db}", done.stdout)
+        self.assertIn(
+            f"migrate: migrations {self.main / '.super-coder' / 'migrations'}",
+            done.stdout)
+        self.assertIn("migration(s) applied to", done.stdout)
+        self.assertNotEqual(
+            hashlib.sha256(self.live_db.read_bytes()).hexdigest(),
+            hashlib.sha256((self.pristine / "shell_db.db").read_bytes()).hexdigest(),
+            "root migrate must still really migrate")
+
+    def test_root_migrate_names_its_targets_on_the_nothing_pending_outcome(self):
+        run_sc(self.main, "migrate")
+        done = run_sc(self.main, "migrate")
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertIn(f"migrate: db         {self.live_db}", done.stdout)
+        self.assertIn(f"nothing pending — {self.live_db} is current", done.stdout)
+
+    def test_root_verify_discloses_its_target_before_the_rebuild_runs(self):
+        """The ordering IS the requirement, so both events are captured in ONE
+        stream: a disclosure printed after the destruction is no disclosure."""
+        script = self.main / ".super-coder" / "scripts" / "rebuild.py"
+        original = script.read_bytes()
+        script.write_text(
+            "#!/usr/bin/env python3\n"
+            "print('REBUILD-RAN')\n"
+            "raise SystemExit(3)\n")
+        try:
+            done = run_sc(self.main, "verify")
+        finally:
+            script.write_bytes(original)
+        self.assertNotEqual(done.returncode, 0)
+        merged = done.stdout
+        self.assertIn(str(self.live_db), merged)
+        self.assertIn("REBUILD-RAN", merged)
+        self.assertLess(
+            merged.index(str(self.live_db)), merged.index("REBUILD-RAN"),
+            "verify disclosed its target only after rebuild had already run")
+
+
+class RenderCheckRunsCallerSourceTest(WorktreeFixture):
+    """Requirement 1: render-check is source-pure — it verifies the sources of
+    the checkout it was typed in."""
+
+    def setUp(self):
+        super().setUp()
+        self.sentinel = (self.wt / ".super-coder" / "migrations" / SENTINEL_MIGRATION)
+        self.sentinel.write_text(SENTINEL_SQL)
+        self.addCleanup(self.sentinel.unlink, missing_ok=True)
+
+    @staticmethod
+    def drifted(done: subprocess.CompletedProcess) -> set[str]:
+        body = done.stderr.split("drifted:", 1)
+        return set(body[1].split()) if len(body) == 2 else set()
+
+    def test_a_worktree_only_migration_is_visible_to_the_worktree_alone(self):
+        from_wt = run_sc(self.wt, "render-check")
+        from_root = run_sc(self.main, "render-check")
+        wt_files, root_files = self.drifted(from_wt), self.drifted(from_root)
+        sentinel = f"skills_sc/{SENTINEL_SKILL}.md"
+        self.assertIn(sentinel, wt_files,
+                      f"worktree render-check did not read its own migrations\n"
+                      f"{from_wt.stdout}\n{from_wt.stderr}")
+        self.assertNotIn(sentinel, root_files,
+                         "the root checkout has no such migration to see")
+
+    def test_render_check_reports_the_caller_source_root_from_both_checkouts(self):
+        for root in (self.wt, self.main):
+            with self.subTest(root=root.name):
+                done = run_sc(root, "render-check")
+                self.assertIn(f"source root : {root}", done.stdout)
+                other = self.main if root == self.wt else self.wt
+                self.assertNotIn(f"source root : {other}", done.stdout)
+                self.assertIn(f"engine      : {root / '.super-coder'}", done.stdout)
+
+    def test_a_missing_caller_engine_fails_naming_that_path(self):
+        """It must not fall back to the live source: that answers a question
+        about a tree the caller never asked about."""
+        moved = self.wt / ".super-coder" / "scripts" / "render_check.py"
+        stash = moved.with_suffix(".py.stashed")
+        moved.rename(stash)
+        try:
+            done = run_sc(self.wt, "render-check")
+        finally:
+            stash.rename(moved)
+        self.assertEqual(done.returncode, 1)
+        self.assertIn(str(self.wt / ".super-coder"), done.stderr)
+        self.assertIn("does not", done.stderr)
+        self.assertEqual(done.stdout, "")
+
+
+class LiveSurfacesStillResolveTest(WorktreeFixture):
+    """Requirement 4: the shared-runtime surfaces keep reaching the shared
+    runtime. The refusal is for commands that MUTATE live state, and a guard
+    that swallowed `mem`/`sql`/`map-sql` would strand every shell."""
+
+    def test_sql_from_the_worktree_reads_the_live_instance_database(self):
+        done = run_sc(self.wt, "sql", "SELECT who FROM live_marker;")
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertIn("LIVE-INSTANCE-DB", done.stdout)
+
+    def test_map_sql_from_the_worktree_reads_the_live_catalogue(self):
+        mapdb = subprocess.run(
+            [sys.executable,
+             str(self.main / ".super-coder" / "scripts" / "artifact_policy.py"),
+             "path", "map-db"],
+            capture_output=True, text=True, check=True).stdout.strip()
+        Path(mapdb).parent.mkdir(parents=True, exist_ok=True)
+        con = sqlite3.connect(mapdb)
+        con.execute("CREATE TABLE IF NOT EXISTS map_marker (who TEXT)")
+        con.execute("INSERT INTO map_marker VALUES ('LIVE-MAP-DB')")
+        con.commit()
+        con.close()
+        self.addCleanup(Path(mapdb).unlink, missing_ok=True)
+
+        done = run_sc(self.wt, "map-sql", "SELECT who FROM map_marker;")
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertIn("LIVE-MAP-DB", done.stdout)
+
+
+class StandaloneRootTest(unittest.TestCase):
+    """Requirement 8 and the failure mode: with no second target resolvable, the
+    caller IS the instance — a fork without worktrees keeps its current paths,
+    and a non-checkout never guesses."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="sc_solo_"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        shutil.copytree(ENGINE, self.tmp / ".super-coder", ignore=IGNORE)
+        shutil.copy2(REPO / "sc", self.tmp / "sc")
+        (self.tmp / "sc").chmod(0o755)
+        make_live_db(self.tmp / ".super-coder" / "shell_db.db",
+                     self.tmp / ".super-coder")
+
+    def test_a_checkout_less_root_is_not_treated_as_a_linked_worktree(self):
+        done = run_sc(self.tmp, "migrate")
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertNotIn("refused", done.stderr)
+        self.assertIn(f"migrate: db         {self.tmp / '.super-coder' / 'shell_db.db'}",
+                      done.stdout)
+
+    def test_a_symlinked_invocation_is_the_same_root_not_a_second_one(self):
+        """Normalization before comparison: reaching the same tree through a
+        symlink must not read as caller != live."""
+        link = self.tmp.parent / (self.tmp.name + "-link")
+        link.symlink_to(self.tmp)
+        self.addCleanup(link.unlink)
+        done = run_sc(link, "migrate")
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertNotIn("refused", done.stderr)
+
+
+class MigratePreflightTest(unittest.TestCase):
+    """migrate's own argument contract (spec #67's shape, applied to the command
+    whose help form was the live reproduction): the parse decides everything
+    before a database is opened."""
+
+    def run_main(self, argv):
+        out = io.StringIO()
+        with ExitStack() as stack:
+            stack.enter_context(mock.patch.object(
+                migrate_mod.db_driver, "connect",
+                mock.Mock(side_effect=AssertionError("opened a database"))))
+            stack.enter_context(redirect_stdout(out))
+            stack.enter_context(redirect_stderr(io.StringIO()))
+            try:
+                migrate_mod.parse_args(argv)
+            except SystemExit as exc:
+                return exc.code, out.getvalue()
+        raise AssertionError(f"parse_args({argv!r}) returned without exiting")
+
+    def test_help_prints_usage_and_opens_no_database(self):
+        for argv in (["-h"], ["--help"], ["/some/db", "--help"], ["--nope", "-h"]):
+            with self.subTest(argv=argv):
+                code, out = self.run_main(argv)
+                self.assertEqual(code, 0)
+                self.assertIn("usage: ./sc migrate", out)
+
+    def test_an_unknown_token_is_rejected_by_name(self):
+        code, _ = self.run_main(["/some/db", "--dry-run"])
+        self.assertEqual(code, 2)
+
+    def test_a_lone_db_path_is_accepted(self):
+        self.assertEqual(migrate_mod.parse_args(["/some/db"]), "/some/db")
+
+    def test_the_targets_are_reported_before_the_database_is_opened(self):
+        """Disclosure ahead of the work, not in a footer a crash can skip."""
+        out = io.StringIO()
+        boom = mock.Mock(side_effect=RuntimeError("connect failed"))
+        with mock.patch.object(migrate_mod.db_driver, "connect", boom), \
+                redirect_stdout(out):
+            with self.assertRaises(RuntimeError):
+                migrate_mod.migrate("/some/where/shell_db.db")
+        self.assertIn("migrate: db         /some/where/shell_db.db", out.getvalue())
+        self.assertIn(f"migrate: migrations {migrate_mod.MIGRATIONS_DIR}",
+                      out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sprint 84 · U10 · spec #68 · decision #81 · reviewer REV3

## The defect

`sc` resolved **one** `ROOT` — the main worktree, via git's common dir — and
derived the engine, the live DB and every script path from it. That single line
is what makes `./sc mem` work from a linked worktree. It is also why, from a
planning worktree:

- `./sc migrate --help` **executed** against the shared live DB and printed
  "nothing pending" (harmless only because nothing was pending);
- `./sc render-check` verified the **main checkout's** sources, so a shell could
  never check the tree it was about to commit;
- `./sc verify` replaced a live DB the caller never named.

## The change

The dispatcher now carries four identities — caller root, caller engine, live
root, live engine+DB — normalized with `pwd -P` and compared **as paths**, never
by branch name or the `.sc-worktrees` spelling. Commands are **classified**
against them rather than inheriting one global root:

| class | commands | behavior from a linked worktree |
|---|---|---|
| source-pure verification | `render-check` | executes the **caller's** engine; reports source root / engine / content / mirror |
| live API + catalogue | `mem`, `sql`, `map-sql`, `interface` | unchanged — still the shared runtime |
| live-state mutation | `rebuild`, `migrate`, `verify`, `snapshot`, `render`, `clean-db` | **refuses**, exit 1, before anything is opened or deleted |
| root invocation | all of the above | unchanged, plus target disclosure |

The refusal names the caller worktree, the live instance, the exact target
declined (`snapshot`/`render` also name the artifact they would overwrite) and
`cd <live root> && ./sc <cmd>`.

Root-checkout disclosure: `migrate` prints the absolute DB path and migration
source dir **before connecting** and again on both the "current" and "applied"
outcomes; `verify` prints the DB and engine source it is about to replace
**before** `rebuild.py` runs — a footer is a disclosure a crash can skip.

Ruling R1: `-h`/`--help` answers from any checkout, so the guard sits behind the
parse — help, then refusal, then act. `migrate` gained spec #67's preflight shape
to make that true where the reproduction actually lives: help wins over every
token and opens no database; an unknown token now exits 2 instead of being
silently ignored while a migration runs.

## Trade-off

A **refusal**, not a caller-local fallback. Pointing `migrate`/`verify` at a
worktree-local DB would invent an instance nobody asked for — decision #81
declined exactly that, because a worktree has no DB, map, instance config or
runtime identity, and a partial instance replaces one ambiguity with another.
Refusing closes the destructive defect now; a hermetic branch-verification
runtime is a later spec that can name all its artifacts together.

Consequence worth stating: in a **fork**, where `.super-coder/` is materialized
only in the main root, `./sc render-check` from a linked worktree now **fails
naming the missing caller engine** instead of silently verifying main. That is
the spec's stated failure mode (req 1 + "does not fall back to live source"), and
the message says so.

Two things checked rather than assumed: the GUI/API invokes these scripts
**directly** (`server.py:_SCRIPTS`), never through `./sc`, so the admin surface
cannot be broken by the dispatcher guard; and `snapshot`/`render flat` already
had an orthogonal `SC_ADMIN` gate (`_serialize_guard.py`) — the worktree refusal
sits in front of it, on a different axis.

## Verification

Tests drive the **real** dispatcher inside a **real** linked git worktree against
a **real** sentinel DB carrying the schema, so an unguarded command genuinely
replaces it — garbage bytes would fail early and leave a green test with no guard
behind it. Distinct trees and distinct DBs on both sides (req 9) make a
substitution show up as the wrong path in the output, not as silence.

Full suite: **2004 passed, 1 skipped, 0 failed** (job 203, exit 0). The skip is
the playwright rendered-UI module, which warns loudly that it is zero rendered
coverage.

**Mutation matrix (job 202, exit 0)** — each applied alone, baseline re-asserted
green after every revert, red sets captured at subtest granularity:

| mutation | reds |
|---|---|
| M1 one global `ROOT` restored | 9 — all six refusal subtests, both declined-target subtests, the look-alike-help case |
| M2 `render-check` routed at the live engine | 2 — worktree-only-migration visibility, worktree source-root report |
| M3 `verify` guard removed | 1 — refusal(cmd='verify') |
| M4 `migrate` stops disclosing targets | 4 |
| M5 help no longer bypasses the refusal | 3 |
| M6 `verify` discloses after the rebuild | 1 — the ordering pin |

14 of 15 pairs disjoint. The single overlap is **M3 ⊂ M1 by construction** — M1
is the general case, M3 one operand of it — reported as nested rather than
dressed up as disjoint.

## REV3's U9 Low, discharged

This diff moves `sc:1134`, so `test_dispatcher_forwards_every_argument_verbatim`
reds. It is updated in the same commit, deliberately: the case is two lines now
and **both** are pinned, because the ORDER is the contract — help question, then
refusal, then verbatim exec. The verbatim-forwarding assertion itself is
unchanged.

## Follow-ups (not built, out of req list)

1. `./sc snapshot --help` / `render` / `verify` / `clean-db` `--help` still
   perform the action **from the root checkout** — a pre-existing defect on a
   different axis; from a worktree they now refuse. Raised with the planner.
2. `./sc update` reconciles the live instance and calls rebuild in-process
   (`update.py:706`); spec req 2 enumerates six commands and `update` is not one
   of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
