### PR TITLE
feat(ui): declutter the sprints board wires

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -4570,11 +4570,14 @@ function sprintsHeader(sprint) {
   return [header, meta];
 }
 
+// Most-advanced state first: dependency wires run prerequisite → dependent,
+// and a prerequisite is almost always further along the pipeline than what
+// waits on it, so this order makes the dominant wire direction left→right.
 const SPRINT_FLOW_COLUMNS = [
-  { key: "pending", label: "Waiting" },
   { key: "done", label: "Done" },
-  { key: "working", label: "Dev" },
   { key: "in_review", label: "Review" },
+  { key: "working", label: "Dev" },
+  { key: "pending", label: "Waiting" },
   { key: "blocked", label: "Blocked" },
 ];
 const SPRINT_STATE_LABELS = {
@@ -4686,6 +4689,9 @@ function sprintsBuildFlow(sprint) {
         unavailable.push(token || "(empty)");
         continue;
       }
+      // A discharged prerequisite (Done column) no longer constrains anything;
+      // its wire would be pure ink. The card's Depends: line still names it.
+      if (sprintsColumnKey(bySeq.get(token)) === "done") continue;
       const edgeKey = `${token}\u0000${unit.seq}`;
       if (!seenEdges.has(edgeKey)) {
         seenEdges.add(edgeKey);
@@ -4705,9 +4711,39 @@ function sprintsBuildFlow(sprint) {
   if (units.some((unit) => sprintsColumnKey(unit) === "unrecognized"))
     columns.push({ key: "unrecognized", label: "Unrecognized" });
 
+  // Row order inside a column follows the wires, not declaration order: two
+  // barycenter sweeps pull each card level with its graph neighbours, which
+  // removes most wire crossings without changing what any column contains.
+  // Cards with no live dependencies keep their relative declaration order.
+  const columnUnits = new Map(columns.map((column) => [column.key,
+    units.filter((unit) => sprintsColumnKey(unit) === column.key)]));
+  const neighbors = new Map();
+  for (const [from, to] of edges) {
+    if (!neighbors.has(from)) neighbors.set(from, []);
+    if (!neighbors.has(to)) neighbors.set(to, []);
+    neighbors.get(from).push(to);
+    neighbors.get(to).push(from);
+  }
+  const rowOf = new Map();
+  for (const inColumn of columnUnits.values())
+    inColumn.forEach((unit, row) => rowOf.set(String(unit.seq), row));
+  for (let sweep = 0; sweep < 2; sweep += 1) {
+    for (const inColumn of columnUnits.values()) {
+      const keys = new Map(inColumn.map((unit) => {
+        const seq = String(unit.seq);
+        const near = neighbors.get(seq);
+        return [seq, near && near.length
+          ? near.reduce((sum, other) => sum + rowOf.get(other), 0) / near.length
+          : rowOf.get(seq)];
+      }));
+      inColumn.sort((a, b) =>
+        keys.get(String(a.seq)) - keys.get(String(b.seq)));
+      inColumn.forEach((unit, row) => rowOf.set(String(unit.seq), row));
+    }
+  }
+
   for (const column of columns) {
-    const inColumn = units.filter(
-      (unit) => sprintsColumnKey(unit) === column.key);
+    const inColumn = columnUnits.get(column.key);
     const heading = el("div", { className: "sprint-col-head" }, column.label);
     if (inColumn.length)
       heading.append(el("span", { className: "count" }, String(inColumn.length)));
@@ -4755,14 +4791,29 @@ function sprintsBuildFlow(sprint) {
       if (!source || !target) continue;
       const a = source.getBoundingClientRect();
       const z = target.getBoundingClientRect();
-      const x1 = a.right - base.left;
       const y1 = a.top - base.top + a.height / 2;
-      const x2 = z.left - base.left;
       const y2 = z.top - base.top + z.height / 2;
-      const dx = Math.max(40, Math.abs(x2 - x1) * 0.4);
+      // Anchor on the near edges: a backward wire exits left and enters right
+      // instead of looping the full board width, and a same-column wire takes
+      // a short lap through the gutter beside its own column.
+      let d;
+      if (z.left >= a.right) {
+        const x1 = a.right - base.left;
+        const x2 = z.left - base.left;
+        const dx = Math.max(40, (x2 - x1) * 0.4);
+        d = `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`;
+      } else if (z.right <= a.left) {
+        const x1 = a.left - base.left;
+        const x2 = z.right - base.left;
+        const dx = Math.max(40, (x1 - x2) * 0.4);
+        d = `M ${x1} ${y1} C ${x1 - dx} ${y1}, ${x2 + dx} ${y2}, ${x2} ${y2}`;
+      } else {
+        const x1 = a.right - base.left;
+        const x2 = z.right - base.left;
+        d = `M ${x1} ${y1} C ${x1 + 24} ${y1}, ${x2 + 24} ${y2}, ${x2} ${y2}`;
+      }
       const path = document.createElementNS(SPRINTS_SVG_NS, "path");
-      path.setAttribute(
-        "d", `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`);
+      path.setAttribute("d", d);
       path.setAttribute("class", "sprint-wire");
       path.setAttribute("marker-end", `url(#${markerId})`);
       path.dataset.from = from;

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -630,7 +630,10 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .sprint-unit-delivery { display: flex; flex-direction: column; min-width: 0; }
 .sprint-unit-delivery > span { overflow: hidden; text-overflow: ellipsis;
   white-space: nowrap; }
-.sprint-wire { fill: none; stroke: rgba(110,168,254,.42); stroke-width: 1.6px; }
+/* Wires are ink-on-demand: invisible at rest (each card's Depends: line
+   carries the standing signal), revealed by the spotlight rules below when a
+   card is hovered or selected. */
+.sprint-wire { fill: none; stroke: transparent; stroke-width: 1.6px; }
 .sprint-flow.sprint-spotlight .sprint-unit { opacity: .38; }
 .sprint-flow.sprint-spotlight .sprint-unit.lit { opacity: 1; border-color: var(--accent);
   box-shadow: 0 0 0 1px rgba(110,168,254,.35); }

--- a/tests/test_sprints_ui_contract.py
+++ b/tests/test_sprints_ui_contract.py
@@ -330,7 +330,7 @@ out({
         prelude="const DATA = " + json.dumps(payload(units=units)) + ";\n",
     )
     assert result["headings"] == [
-        "Waiting1", "Done2", "Dev1", "Review1", "Blocked1", "Unrecognized1",
+        "Done2", "Review1", "Dev1", "Waiting1", "Blocked1", "Unrecognized1",
     ]
     assert result["cards"] == 7
     assert long_title in result["u2"]["text"]
@@ -387,7 +387,7 @@ out({ headings: byClass(root, "sprint-col-head").map((node) => node.textContent)
         ) + ";\n",
     )
     assert result["headings"] == [
-        "Waiting", "Done", "Dev1", "Review", "Blocked",
+        "Done", "Review", "Dev1", "Waiting", "Blocked",
     ]
 
 
@@ -407,7 +407,7 @@ out({
         ) + ";\n",
     )
     assert result["headings"] == [
-        "Waiting", "Done", "Dev", "Review", "Blocked", "Unrecognized1",
+        "Done", "Review", "Dev", "Waiting", "Blocked", "Unrecognized1",
     ]
     assert "unrecognized" in result["cardClass"]
     assert "done" in result["cardText"]
@@ -449,8 +449,8 @@ out({
         ),
     )
     assert result["unknown"][-1] == "Unrecognized1"
-    assert result["known"] == ["Waiting", "Done", "Dev1", "Review", "Blocked"]
-    assert result["shared"] == ["Waiting", "Done", "Dev", "Review", "Blocked"]
+    assert result["known"] == ["Done", "Review", "Dev1", "Waiting", "Blocked"]
+    assert result["shared"] == ["Done", "Review", "Dev", "Waiting", "Blocked"]
 
 
 def test_unavailable_dependency_has_visible_warning_marker():
@@ -538,8 +538,83 @@ out({
     ]
     assert result["unavailable"][1] == []
     assert "sprint-spotlight" in result["hover"]["flow"]
-    assert result["hover"]["cards"] == ["U1", "U2"]
+    assert result["hover"]["cards"] == ["U2", "U1"]
     assert result["hover"]["wires"] == 1
+
+
+def test_satisfied_dependencies_draw_no_wire_but_stay_named():
+    result = run_js(
+        """
+const flow = sprintsBuildFlow(DATA.sprints[0]);
+const card = byClass(flow, "sprint-unit").find(
+  (node) => node.dataset.seq === "U3");
+out({
+  wires: byClass(flow, "sprint-wire").map(
+    (wire) => [wire.dataset.from, wire.dataset.to]),
+  depends: byClass(card, "sprint-unit-deps")[0].textContent,
+  warnings: byClass(flow, "sprint-dep-warning").length,
+});
+""",
+        prelude="const DATA = " + json.dumps(payload(units=[
+            unit("U1", "merged"),
+            unit("U2", "cancelled"),
+            unit("U4", "pending"),
+            unit("U3", "working", depends_on="U1, U2, U4"),
+        ])) + ";\n",
+    )
+    assert result["wires"] == [["U4", "U3"]]
+    assert result["depends"] == "Depends: U1, U2, U4"
+    assert result["warnings"] == 0
+
+
+def test_rows_follow_wires_to_reduce_crossings():
+    result = run_js(
+        """
+const flow = sprintsBuildFlow(DATA.sprints[0]);
+const cols = byClass(flow, "sprint-col");
+const order = (key) => byClass(
+  cols.find((col) => col.classList.contains(key)), "sprint-unit")
+  .map((node) => node.dataset.seq);
+out({ dev: order("working"), waiting: order("pending") });
+""",
+        prelude="const DATA = " + json.dumps(payload(units=[
+            unit("U1", "pending"),
+            unit("U2", "pending"),
+            unit("U5", "working", depends_on="U2"),
+            unit("U6", "working", depends_on="U1"),
+        ])) + ";\n",
+    )
+    assert result["dev"] == ["U6", "U5"]
+    assert result["waiting"] == ["U1", "U2"]
+
+
+def test_wires_anchor_on_near_edges_by_direction():
+    # The harness derives each card's rect from its seq digits, so U1→U2 is a
+    # forward wire, U5→U2 a backward one, and U3→X3 (equal digits, identical
+    # rects) exercises the same-column gutter branch.
+    result = run_js(
+        """
+const flow = sprintsBuildFlow(DATA.sprints[0]);
+out(byClass(flow, "sprint-wire").map((wire) => (
+  { from: wire.dataset.from, to: wire.dataset.to,
+    d: wire.getAttribute("d") })));
+""",
+        prelude="const DATA = " + json.dumps(payload(units=[
+            unit("U1", "pending"),
+            unit("U5", "in_review"),
+            unit("U2", "working", depends_on="U1, U5"),
+            unit("U3", "pending"),
+            unit("X3", "pending", depends_on="U3"),
+        ])) + ";\n",
+    )
+    assert result == [
+        {"from": "U1", "to": "U2",
+         "d": "M 310 60 C 350 60, 300 85, 340 85"},
+        {"from": "U5", "to": "U2",
+         "d": "M 850 160 C 702 160, 628 85, 480 85"},
+        {"from": "U3", "to": "X3",
+         "d": "M 650 110 C 674 110, 674 110, 650 110"},
+    ]
 
 
 def test_click_expands_details_pins_wires_and_blank_space_clears_selection():
@@ -596,7 +671,7 @@ out({
         "stopped": 1,
         "flow": "sprint-flow sprint-spotlight",
         "cards": ["U2"],
-        "litCards": ["U1", "U2"],
+        "litCards": ["U2", "U1"],
         "litWires": 1,
         "detailsHidden": False,
         "detailsText": (


### PR DESCRIPTION
## What

Three purely front-end changes to the Sprints tab's flow board, whose dependency wires currently run in every direction:

1. **Satisfied dependencies draw no wire.** A prerequisite already in the Done column (merged/cancelled) constrains nothing — its wire was pure ink. The card's `Depends:` line still names it, and the ⚠ unavailable-token marker is untouched. Mid-sprint, most wire clutter was exactly these dead wires.
2. **Smarter routing in the state-column layout.**
   - Columns reorder to **Done | Review | Dev | Waiting | Blocked** — most-advanced state first, so the dominant wire direction (prerequisite → dependent) runs left→right with the layout instead of against it.
   - Side-aware anchors: a backward wire now exits the source's left edge and enters the target's right edge instead of looping the full board width; a same-column wire takes a short lap through the gutter beside its column.
   - Two barycenter sweeps order rows within each column by the average position of their graph neighbours, removing most crossings. Cards with no live wires keep declaration order.
3. **Ink-on-demand.** Wires are invisible at rest and revealed by the existing hover/selection spotlight (incident wires accent-bright, the rest faint for context). The per-card `Depends:` line carries the standing signal.

Rejected in review discussion: a dependency-layered column toggle (option 2 of the proposal) — the FnB opted to keep state columns as the only layout.

## Tests

`tests/test_sprints_ui_contract.py`: four heading-order pins updated, two lit-card enumeration orders follow the new column order, plus three new tests pinning the satisfied-wire filter, barycenter row ordering, and all three anchor branches (forward / backward / same-column gutter). Full file passes (28 tests), as do `test_sprint_board_record.py` and `test_interface_sprint_ops.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)