### PR TITLE
test(ui): re-fixture the rendered wire gate for done-edge suppression (flag #377)

### DIFF
--- a/tests/test_interface_ui_rendered.py
+++ b/tests/test_interface_ui_rendered.py
@@ -304,7 +304,11 @@ SPRINTS = {
                     "dev_shortname": "DEV4",
                     "reviewer_shell_id": 7,
                     "reviewer_shortname": "REV2",
-                    "depends_on": "U2",
+                    # U2 is merged (Done column) and U5 is working: one
+                    # suppressed prerequisite and one live one on a single
+                    # card, so the visual gate sees both halves of the
+                    # done-edge suppression rule.
+                    "depends_on": "U2, U5",
                     "overlap": None,
                     "branch": None,
                     "pr_number": None,
@@ -656,7 +660,28 @@ def test_sprints_multi_board_read_only_visual_gate(
             'nav button[data-tab="sprints"]'
         ).inner_text() == "SPRINTS 2"
         assert boards.nth(0).locator(".sprint-wire").count() == 0
-        assert boards.nth(1).locator(".sprint-wire").count() == 3
+        # Board 2 declares four resolvable edges. Three are sourced in the
+        # Done column (U2 -> U5, U4 -> U5, U2 -> U2f) and one is live at both
+        # ends (U5 -> U2f), so the drawn set pins drawing and suppression
+        # against each other: a broken wire path fails the first assertion,
+        # a lost suppression fails the second.
+        wires = boards.nth(1).locator(".sprint-wire")
+        drawn = {
+            (
+                wires.nth(index).get_attribute("data-from"),
+                wires.nth(index).get_attribute("data-to"),
+            )
+            for index in range(wires.count())
+        }
+        assert ("U5", "U2f") in drawn, (
+            "the live dependency U5 -> U2f must still draw a wire; "
+            f"drawn: {sorted(drawn)}"
+        )
+        assert drawn == {("U5", "U2f")}, (
+            "done-edge suppression: a prerequisite in the Done column draws "
+            "no wire, so U2 -> U5, U4 -> U5 and U2 -> U2f must be absent; "
+            f"drawn: {sorted(drawn)}"
+        )
         unavailable = boards.nth(1).get_by_role(
             "img", name="dependency unavailable: U99", exact=True
         )


### PR DESCRIPTION
Main is red at `f3896c7` (#667), blocking every sprint merge. Test-only repair.

## What broke

#667 stopped drawing dependency wires whose prerequisite sits in the Done column:

```js
if (sprintsColumnKey(bySeq.get(token)) === "done") continue;
```

That suppression is **intended** ("done does not need to be wired" — FnB ruling). What was missed is `test_sprints_multi_board_read_only_visual_gate`, which asserted a flat `boards.nth(1).locator(".sprint-wire").count() == 3`. All four of board 2's resolvable edges were sourced in Done, so the count is now 0.

Bracketing: parent `a06ce84` green (run 30280855791), `f3896c7` red (run 30286481677) — the introducing commit is #667 alone.

## The fix — two walls, not a flip

A bare `3 -> 0` is vacuous: a fully broken wire path also renders 0. Instead the fixture carries both halves on one card — `U2f` now depends on `U2, U5`:

| edge | source column | drawn |
|---|---|---|
| U2 -> U5 | Done (merged) | no |
| U4 -> U5 | Done (merged) | no |
| U2 -> U2f | Done (merged) | no |
| **U5 -> U2f** | Working | **yes** |

The gate reads each wire's `data-from`/`data-to` and asserts (1) the live edge is present — lose the wire path and this reds; (2) the drawn set is *exactly* that edge — lose the suppression filter and this reds. Both messages name the mechanism, so the next #667-shaped change reddens with a readable reason.

Card counts, column membership, and the `dependency unavailable: U99` warning are untouched (only a `depends_on` string changed).

## Verification

- `ui/app.js`, `ui/style.css`, and `tests/test_sprints_ui_contract.py` are not touched.
- The fixture's edge computation was validated by mirroring `sprintsColumnKey` + the edge loop over the fixture: board 1 -> `[]`, board 2 -> `[(U5, U2f)]`, warnings unchanged.
- The rendered suite **skips locally** (flag #204 — playwright/browser skew), so the `interface-rendered` CI job on this PR is the verifier.

Flag #377 · sprint 84 side task (main repair, outside the board) · Code-03 (DEV5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)