### PR TITLE
fix(sprint): reconciler + liveness truth — role-shaped evidence, launch records (S84 U4)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -599,7 +599,8 @@ def _availability(con, shell_id: int, snap) -> dict:
                 "composer": composer[0] if composer else None,
                 "alerts": _alert_count(con, session_id),
                 **_NO_SPRINT, **client}
-    state = shell_liveness.session_state(_shortname(con, shell_id), snap)
+    shortname = _shortname(con, shell_id)
+    state = shell_liveness.session_state(shortname, snap)
     if state is not None:
         # Only a WORKING shell names a sprint. A remnant must not borrow its
         # dead session's label and read as live work.
@@ -610,6 +611,19 @@ def _availability(con, shell_id: int, snap) -> dict:
                 "model_route": None, "title": None, "launch_effort": None,
                 "alerts": 0,
                 **(_sprint_context(con, shell_id) if working else _NO_SPRINT)}
+    # No process holds the worktree — but absence of a process is not evidence
+    # of availability when a launch RECORD claims this shell (H-25). Both arms
+    # name the sprint, and neither is borrowing a label: the claim is the
+    # shell's own current launch, so `working` says which sprint holds it and
+    # `expected_absent` says which sprint is missing its worker. That second row
+    # is what feature #27's compare consumes; judging whether the absence is a
+    # fault stays with #27, never with this projection.
+    claimed = shell_liveness.record_state(shortname, snap)
+    if claimed is not None:
+        return {"availability": claimed, "session_id": None,
+                "lifecycle": None, "harness": None, "composer": None,
+                "model_route": None, "title": None, "launch_effort": None,
+                "alerts": 0, **_sprint_context(con, shell_id)}
     return {"availability": "available", "session_id": None,
             "lifecycle": None, "harness": None, "model_route": None,
             "title": None, "launch_effort": None,

--- a/.super-coder/migrations/0110_shell_launch_records.sql
+++ b/.super-coder/migrations/0110_shell_launch_records.sql
@@ -1,0 +1,38 @@
+-- Spec #76 H-25 — the liveness verdict must not depend on launcher lineage.
+--
+-- A headless sprint worker runs detached: no controlling TTY, launcher gone
+-- (ppid==1), harness relaunched per work item. The rail's fallback scan
+-- (interface_routes._availability -> shell_liveness) judged such a process by
+-- its PARENTAGE, so classify_orphan read `tty_nr==0 and ppid==1` -> 'detached'
+-- and every live worker projected 'unreconciled'; between relaunches no process
+-- held the worktree at all and the same shell projected 'available'. Both are
+-- wrong, and the true state was unreachable by construction -- 'busy' required
+-- a live parent, which a sprint launch never has.
+--
+-- The record replaces the inference. run.py is the single exec chokepoint for
+-- every harness (it BECOMES the harness via execvpe), so it stamps the pid it
+-- is about to become. One row per shell, upserted: the newest launch is the
+-- only claim, which is what "re-stamped on each relaunch" means.
+--
+-- `start_ticks` is /proc/<pid>/stat field 22 and is not optional: a pid alone
+-- is a reusable integer, so a record naming a dead pid would resurrect as a
+-- false "working" the moment the OS handed that number to an unrelated
+-- process. pid + start_ticks is the same identity pair interface_sessions
+-- already uses for a tmux pane (pane_pid + pane_start_ticks). execvpe does not
+-- reset it -- the value belongs to the PROCESS, not to the program image --
+-- so the launcher may read its own before exec and the harness matches after.
+--
+-- `worktree` is the cwd run.py chdir's into immediately before exec. The scan
+-- tests that the claimed pid still holds it; parentage is never consulted.
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS shell_launch_records (
+    shell_id    INTEGER PRIMARY KEY REFERENCES shells(shell_id) ON DELETE CASCADE,
+    pid         INTEGER NOT NULL,
+    start_ticks INTEGER NOT NULL,
+    worktree    TEXT    NOT NULL,
+    harness     TEXT,
+    launched_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+COMMIT;

--- a/.super-coder/scripts/activity_readers.py
+++ b/.super-coder/scripts/activity_readers.py
@@ -14,6 +14,13 @@ unattributed surfaces are excluded rather than guessed.
 freshness is the caller's responsibility because one reconciler tick reads
 many worktrees but must fetch the shared integration ref only once.
 
+``read()`` takes the expectation's ``role`` because WHICH surfaces are worth
+asking about depends on it (spec #76 H-15/H-16, flag #364).  A reviewer has no
+code surface, so its evidence never includes branch presence; a dev has one
+whether or not the board's ``branch`` column has been filled yet.  Judging every
+role by the dev-shaped git read is what produced alerts a role could not
+possibly clear.
+
 "Which unit is this row about" is answered STRUCTURALLY where a row carries a
 link (``watched_prs.unit_id``, reached through the poller's ``pr-event|``
 dedupe key) and by regex over prose where it does not — see
@@ -480,8 +487,6 @@ class ActivityReader:
             return
         epoch = evidence.epoch
         branch = evidence.branch_declared
-        if branch is None:
-            return
         try:
             status = self._git(
                 worktree, "status", "--porcelain=v1", "-z", "--untracked-files=all"
@@ -519,7 +524,16 @@ class ActivityReader:
             elif "R" in code:
                 self._mark(evidence, UNTIMED_DELETE_RENAME)
 
-        revision = "HEAD" if on_declared_head else f"refs/remotes/origin/{branch}"
+        # H-15: an UNDECLARED branch is not "no code evidence" — a dev who has
+        # branched and is heads-down building has a worktree HEAD that carries
+        # exactly the work, and the board's `branch` column is filled only at
+        # PR-open. Reading HEAD is what stops the 20-minute checkup floor from
+        # firing on a working dev. A DECLARED branch the worktree is not on
+        # still resolves through the remote, unchanged.
+        revision = (
+            "HEAD" if on_declared_head or branch is None
+            else f"refs/remotes/origin/{branch}"
+        )
         try:
             contribution = f"refs/remotes/origin/main..{revision}"
             log = self._git(worktree, "log", contribution, "--format=%aI")
@@ -813,13 +827,26 @@ class ActivityReader:
         if marker is None:
             self._mark(evidence, "marker")
 
-    def read(self, shell: Any, unit: Any, now: Any) -> Evidence:
-        """Return all readable observations; never classify and never raise."""
+    def read(
+        self, shell: Any, unit: Any, now: Any, role: str | None = None
+    ) -> Evidence:
+        """Return all readable observations; never classify and never raise.
+
+        `role` is the expectation's role on the board ("dev" / "reviewer" /
+        "planner"), and it decides which surfaces are even ASKED about — the
+        second half of flag #364's finding, that each role was judged on
+        dev-shaped evidence it cannot produce. It defaults to None, which reads
+        as the historical dev-shaped unit expectation.
+        """
         evidence = Evidence()
         evidence.branch_declared = _value(unit, "branch")
-        evidence.edits_code = (
-            unit is not None and evidence.branch_declared is not None
-        )
+        # H-15/H-16: what makes an expectation a CODE expectation is its role,
+        # not the board's `branch` column. Gating on the column meant a dev
+        # heads-down before PR-open produced no git evidence at all (and fell to
+        # the no-progress floor), while a reviewer inherited the dev's branch and
+        # read `not_started` until the dev pushed. Reviewers are judged on
+        # review-shaped evidence — result rows and durable writes — only.
+        evidence.edits_code = unit is not None and role != "reviewer"
         if unit is not None:
             evidence.state_changed_at = _timestamp(
                 _value(unit, "state_changed_at")
@@ -838,7 +865,7 @@ class ActivityReader:
                 self._mark(evidence, "state_changed_at")
 
         on_declared_head = False
-        if evidence.branch_declared is not None:
+        if evidence.edits_code and evidence.branch_declared is not None:
             try:
                 present, on_declared_head = self._branch_present(
                     evidence, worktree, evidence.branch_declared
@@ -870,6 +897,6 @@ class ActivityReader:
 _DEFAULT_READER = ActivityReader()
 
 
-def read(shell: Any, unit: Any, now: Any) -> Evidence:
-    """Module contract: ``read(shell, unit, now) -> Evidence``."""
-    return _DEFAULT_READER.read(shell, unit, now)
+def read(shell: Any, unit: Any, now: Any, role: str | None = None) -> Evidence:
+    """Module contract: ``read(shell, unit, now, role=None) -> Evidence``."""
+    return _DEFAULT_READER.read(shell, unit, now, role)

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -267,7 +267,9 @@ def classify(
     - result evidence compares with the unit/binding state clock;
     - recent work compares with ``now``;
     - durable completion and branch grace use the boot epoch;
-    - the no-progress window starts at the newest boot, state, or work event.
+    - the no-progress window starts at the newest boot, state, work, or
+      durable-write event — the last of these being the only signal a role
+      with no code surface can produce.
     """
     current = _utc(now) or datetime.now(timezone.utc)
     epoch = _utc(evidence.epoch)
@@ -322,18 +324,36 @@ def classify(
     if session_over and durable_at is not None and durable_at >= epoch:
         return "work_complete_unreported"
 
-    # Rule 5 — BOOT clock and the 20-minute grace floor.
+    # Rule 5 — BOOT clock and the 20-minute grace floor.  `edits_code` is
+    # explicit here: only a code expectation can be `not_started`, so a reviewer
+    # is never graded on whether the dev has pushed yet (H-16).
     if (
-        evidence.branch_declared is not None
+        evidence.edits_code
+        and evidence.branch_declared is not None
         and evidence.branch_present is False
         and current > epoch + max(grace, START_GRACE)
     ):
         return "not_started"
 
-    # Rule 6 — newest BOOT, STATE, or WORK-EVENT clock.  Explanation-tier
-    # marker/CPU observations never enter this maximum.
+    # Rule 6 — newest BOOT, STATE, WORK-EVENT, or DURABLE-WRITE clock.
+    # Explanation-tier marker/CPU observations never enter this maximum.
+    #
+    # The durable write is here — and ONLY here — because this floor measures
+    # SILENCE, and a durable write is not silence (spec #76 H-16, flag #364
+    # defect b).  `last_durable_write_at` was read on every tick and consulted
+    # at exactly one place: Rule 4, behind `session_over`.  A live planner emits
+    # `task` rows and never `result`, and has no branch, so it walked past
+    # Rules 2, 3 and 5 into this floor measured from a boot clock it had long
+    # since spoken past, and stuck at `checkup` for the rest of the sprint where
+    # no healthy signal could resolve it.  A separate "recent durable write is
+    # working" rule above Rule 5 was drafted and DELETED: it decided nothing
+    # this maximum does not already decide, except to convert a dev's
+    # declared-but-absent branch from `not_started` into `working`, which is a
+    # semantic change no requirement here asks for.
     last_evidence = max(
-        stamp for stamp in (epoch, state_clock, last_work) if stamp is not None
+        stamp
+        for stamp in (epoch, state_clock, last_work, durable_at)
+        if stamp is not None
     )
     if current > last_evidence + max(window, NO_PROGRESS_WINDOW):
         return "checkup"
@@ -874,13 +894,21 @@ def reconcile_tick(
     readings: list[ReconciliationReading] = []
     seen: set[tuple] = set()
     for expectation in expectations:
-        evidence_key = (expectation.shell_id, expectation.unit_id)
+        # Role is part of the cache identity, not decoration: a dev and a
+        # reviewer on the same unit are now read differently (H-15/H-16), so
+        # keying on (shell, unit) alone would serve one role the other's answer.
+        evidence_key = (
+            expectation.shell_id,
+            expectation.unit_id,
+            expectation.role,
+        )
         evidence = cache.get(evidence_key)
         if evidence is None:
             evidence = read_one(
                 expectation.shell,
                 expectation.unit,
                 current,
+                role=expectation.role,
             )
             if (
                 not refs_fresh

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -69,6 +69,7 @@ sys.path.insert(0, str(ENGINE / "api"))
 import model_catalog  # noqa: E402  — HARNESS_PROVIDER: one source for harness → provider
 
 ADAPTERS = ENGINE / "adapters"
+PROC_SELF_STAT = Path("/proc/self/stat")   # H-25: our own start ticks, pre-exec
 
 DEFAULT_HEADLESS_PROMPT = "Check your inbox and act on your unread messages."
 SESSION_OPEN_RETRY_DELAYS_S = (0.1, 0.3)
@@ -1647,9 +1648,94 @@ def main() -> None:
     # supported env var alongside SC_PROTECTED_BRANCHES and SC_SHELL_WORKTREE.
     if not headless:
         set_terminal_tab_title(full["display_name"])
+    # H-25: claim the pid we are ABOUT to become for this shell.
+    record_launch(full["shell_id"], work_dir, harness, headless=headless)
     os.chdir(work_dir)
     print(f"→ exec {' '.join(cmd)}\n")
     os.execvpe(cmd[0], cmd, env)
+
+
+def _self_start_ticks() -> "int | None":
+    """This process's start time — /proc/<pid>/stat field 22.
+
+    The discriminator that makes a recorded pid safe to trust later: a pid on
+    its own is a reusable integer, so a record naming a dead worker would
+    resurrect as a false "working" the moment the kernel handed that number to
+    something unrelated. execvpe does not reset the value — it belongs to the
+    PROCESS, not to the program image — so reading it here, before the exec,
+    describes the harness that is about to replace us.
+
+    comm (field 2) may contain spaces and parens, so the split starts after the
+    final ')': rest[0] is state (field 3), rest[19] is starttime (field 22) —
+    the same indexing shell_liveness._stat_fields and activity_readers._stat
+    already use.
+    """
+    try:
+        data = (PROC_SELF_STAT).read_text()
+    except OSError:
+        return None
+    rest = data[data.rfind(")") + 2:].split()
+    try:
+        return int(rest[19])
+    except (IndexError, ValueError):
+        return None
+
+
+def record_launch(shell_id: int, work_dir: Path, harness: "str | None",
+                  *, headless: bool) -> None:
+    """Record the harness pid this launch is about to become (spec #76 H-25).
+
+    HEADLESS ONLY, deliberately — hence the parameter rather than a caller-side
+    `if`: the rule is the requirement, so it is stated and tested here. A sprint
+    worker runs detached — no controlling TTY, launcher gone, ppid==1 — so the
+    lineage scan can only ever call it 'detached' and project 'unreconciled';
+    between relaunches nothing holds the worktree at all and the same shell
+    projects 'available'. The record is what replaces that inference. An
+    INTERACTIVE boot has a live parent, which the lineage scan reads correctly
+    today, and recording one would suppress a TRUE orphan verdict — a closed
+    terminal's survivor would arrive pre-claimed and the operator would never be
+    told to clear it. So the claim covers exactly the launches whose lineage is
+    unreadable, and no others.
+
+    One row per shell, upserted: the newest launch is the only claim, which is
+    what "re-stamped on each relaunch" means. Accepted cost, stated in the spec's
+    own terms: run.py execs and never returns, so nothing clears the row at exit
+    — a worker that has finished for good keeps reading expected-but-absent
+    until its next launch. That is the honest reading ("the record claimed a
+    worker here; it is gone") and it is the evidence row feature #27's compare
+    consumes; deciding whether an absence is a FAULT stays with #27.
+
+    Best-effort: a failed stamp must never block a boot. The only consequence is
+    that this session falls back to the lineage scan — where it was before.
+    """
+    if not headless:
+        return
+    ticks = _self_start_ticks()
+    if ticks is None:
+        return                       # non-Linux / unreadable — no claim to make
+    try:
+        con = open_db()
+    except SystemExit:
+        return
+    try:
+        con.execute(
+            "INSERT INTO shell_launch_records "
+            "(shell_id, pid, start_ticks, worktree, harness, launched_at) "
+            "VALUES (?,?,?,?,?,?) "
+            "ON CONFLICT(shell_id) DO UPDATE SET "
+            " pid=excluded.pid, start_ticks=excluded.start_ticks,"
+            " worktree=excluded.worktree, harness=excluded.harness,"
+            " launched_at=excluded.launched_at",
+            (shell_id, os.getpid(), ticks, str(work_dir), harness,
+             datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")),
+        )
+        con.commit()
+    except (db_driver.OperationalError, db_driver.IntegrityError):
+        # An un-migrated fork (no such table) or a busy writer. Neither is worth
+        # a boot failure; the lineage fallback still answers.
+        con.rollback()
+    finally:
+        con.close()
 
 
 def set_terminal_tab_title(name: str) -> None:

--- a/.super-coder/scripts/shell_liveness.py
+++ b/.super-coder/scripts/shell_liveness.py
@@ -50,6 +50,18 @@ a suite), so nothing here kills anything. The consumer (`sc run`'s guard, the
 operator) verifies idleness first: `ps -o etime=,stat= -p <pid>`, no child
 processes doing work, then `kill <pid>`.
 
+Launch claims (spec #76 H-25): lineage cannot answer for a headless sprint
+worker. It is detached from birth — no controlling TTY, launcher gone — so
+'detached' describes how it was STARTED, not whether it is working, and between
+relaunches no process holds the worktree at all. `run.record_launch` therefore
+records the pid each headless boot is about to become (`shell_launch_records`),
+and this scan tests THAT pid — identity by pid + start ticks, plus its worktree
+hold — never its parentage. A claimed pid is never an orphan; `orphan` now means
+a pid holding a worktree that no launch record claims, i.e. a true remnant. A
+claim whose process is gone is `expected_absent`, which is not `available`:
+the difference between "nobody launched anything here" and "a launch claimed
+this shell and its worker is missing".
+
 Non-Linux: /proc is absent; compute() returns supported=False. Fall back to
 `lsof -a +D <worktree>` / `ps`. The substrate host is Linux.
 
@@ -156,6 +168,17 @@ def _tty_nr(pid: int) -> int | None:
     rest = _stat_fields(pid)
     try:
         return int(rest[4])              # rest[4]=tty_nr; 0 = no controlling TTY
+    except (IndexError, ValueError):
+        return None
+
+
+def _start_ticks(pid: int) -> int | None:
+    """Field 22 of /proc/<pid>/stat — when this process started. Pairs with the
+    pid to form an identity a recycled pid number cannot inherit. None for a
+    pid that is gone, which is the answer a stale claim needs."""
+    rest = _stat_fields(pid)
+    try:
+        return int(rest[19])             # rest[0]=state (field 3) → rest[19]=field 22
     except (IndexError, ValueError):
         return None
 
@@ -284,6 +307,66 @@ def _shell_labels() -> dict[str, dict]:
     return {r["shortname"].lower(): dict(r) for r in rows}
 
 
+def _launch_claims() -> dict[str, dict]:
+    """shortname.lower() → this shell's current launch claim (spec #76 H-25).
+
+    `run.record_launch` writes one row per shell at every HEADLESS boot, naming
+    the pid it is about to become. Best-effort like _shell_labels: no DB, a
+    locked DB, or an un-migrated fork with no such table all mean "no claims",
+    and the scan falls back to lineage exactly as it did before the record
+    existed."""
+    if not DB_PATH.exists() or DB_PATH.stat().st_size == 0:
+        return {}
+    try:
+        con = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True, timeout=2)
+        con.row_factory = sqlite3.Row
+        rows = con.execute(
+            "SELECT s.shortname, r.pid, r.start_ticks, r.worktree, r.launched_at "
+            "FROM shell_launch_records r JOIN shells s ON s.shell_id=r.shell_id "
+            "WHERE s.shortname IS NOT NULL "
+            "AND COALESCE(s.is_deleted,0)=0").fetchall()
+        con.close()
+    except sqlite3.Error:
+        return {}
+    return {r["shortname"].lower(): dict(r) for r in rows}
+
+
+def claim_live(claim: dict) -> bool:
+    """Is the process a launch claim names still the one that was launched, and
+    does it still hold that shell's worktree?
+
+    PARENTAGE IS NEVER ASKED — that is the whole of H-25. A headless sprint
+    worker is reparented to init the moment its launcher exits, so every
+    lineage-shaped question ('detached', 'a NORMAL headless session still has a
+    live parent') answers about the launch style rather than about the work.
+
+    Identity is pid + start ticks, so a recycled pid number cannot inherit a
+    dead worker's claim, and a zombie — which keeps both — is excluded before
+    the question is asked, exactly as the main scan does.
+
+    The worktree hold only REFUTES on a positive mismatch. An unreadable cwd is
+    missing data (foreign user, or the process exiting mid-scan), and turning
+    missing data into "the worker is gone" is the failure direction this
+    requirement exists to remove."""
+    pid = claim.get("pid")
+    if not pid or _is_zombie(pid):
+        return False
+    if _start_ticks(pid) != claim.get("start_ticks"):
+        return False
+    worktree = claim.get("worktree")
+    if not worktree:
+        return True
+    try:
+        cwd = Path(os.readlink(PROC / str(pid) / "cwd")).resolve()
+    except OSError:
+        return True                      # unreadable → no refutation
+    try:
+        cwd.relative_to(Path(worktree).resolve())
+    except ValueError:
+        return False
+    return True
+
+
 def compute() -> dict:
     """Live shell-liveness snapshot. Pure read — never mutates."""
     if not PROC.is_dir():
@@ -297,6 +380,8 @@ def compute() -> dict:
     bins = harness_binaries()
     root = REPO_ROOT.resolve()
     labels = _shell_labels()
+    claims = _launch_claims()
+    live_claims = {name: c for name, c in claims.items() if claim_live(c)}
 
     # First pass: every harness process and its raw pid/comm (cwd resolved next).
     harness_pids: set[int] = set()
@@ -348,13 +433,18 @@ def compute() -> dict:
             "shortname": shortname,
             "display_name": (labels.get(shortname or "", {}).get("display_name")),
             "is_self": pid == self_pid,
+            # H-25: a pid a live launch record claims is not a remnant, whatever
+            # its lineage says. `orphaned` keeps reporting the raw lineage read;
+            # `claimed` is what every verdict below consults alongside it.
+            "claimed": live_claims.get(shortname or "", {}).get("pid") == pid,
             "orphaned": (None if pid == self_pid
                          else _orphan_verdict(pid)),
         })
 
     active_other = sorted(worktree_sessions)
     indeterminate = len(indeterminate_pids)
-    orphaned_pids = [p["pid"] for p in processes if p["orphaned"]]
+    orphaned_pids = [p["pid"] for p in processes
+                     if p["orphaned"] and not p["claimed"]]
     admin_present = self_pid is not None and self_pid in admin_root_pids
     admin_presence = "present" if admin_present else "indeterminate"
     return {
@@ -370,6 +460,11 @@ def compute() -> dict:
         "indeterminate": indeterminate,
         "indeterminate_pids": indeterminate_pids,
         "orphaned_pids": orphaned_pids,
+        # The launch record's two answers (H-25), for consumers that must
+        # distinguish "nobody launched anything here" from "a launch claimed
+        # this shell and its process is gone".
+        "claimed_pids": {name: c["pid"] for name, c in live_claims.items()},
+        "claimed_absent": sorted(set(claims) - set(live_claims)),
         # The gate: Admin is positively present, no other shell is live, and
         # every harness cwd was readable.
         "safe_to_clean_all": admin_present and not active_other and indeterminate == 0,
@@ -385,11 +480,16 @@ def is_active(shortname: str, snap: dict | None = None) -> bool:
 def orphan_split(shortname: str, snap: dict) -> "tuple[list[int], list[int]]":
     """(all pids, orphaned pids) for one shell's worktree sessions — the shape
     the `sc run` guard needs: every-session-orphaned means the slot is held by
-    survivors of closed terminals / dead parents, not by a working session."""
+    survivors of closed terminals / dead parents, not by a working session.
+
+    A CLAIMED pid is never in the orphan half (H-25). The consumer of this list
+    is advice to kill, and a detached sprint worker is the one process that
+    reads as a remnant by lineage while being the healthiest thing on the box."""
     procs = [p for p in snap.get("processes", [])
              if (p.get("shortname") or "").lower() == shortname.lower()]
     return ([p["pid"] for p in procs],
-            [p["pid"] for p in procs if p.get("orphaned")])
+            [p["pid"] for p in procs
+             if p.get("orphaned") and not p.get("claimed")])
 
 
 def session_state(shortname: str, snap: dict) -> "str | None":
@@ -404,6 +504,29 @@ def session_state(shortname: str, snap: dict) -> "str | None":
     if not pids:
         return None
     return "orphan" if len(orphans) == len(pids) else "busy"
+
+
+def record_state(shortname: str, snap: dict) -> "str | None":
+    """The launch RECORD's verdict for one shell (spec #76 H-25) — asked only
+    after session_state() found no process holding the worktree.
+
+    'working'         — the claimed pid is live and still holds the worktree.
+                        Reachable even when the process scan saw nothing: the
+                        claim is comm-blind, so a harness that renames itself
+                        out of the expected set stays visible.
+    'expected_absent' — a launch claimed this shell and that process is gone.
+                        The distinction the rail could not previously draw:
+                        between relaunches a sprint worker's shell held no
+                        process at all and read as a bare 'available'.
+    None              — no claim was ever made, or liveness is unsupported."""
+    if not snap.get("supported"):
+        return None
+    name = shortname.lower()
+    if name in snap.get("claimed_pids", {}):
+        return "working"
+    if name in snap.get("claimed_absent", []):
+        return "expected_absent"
+    return None
 
 
 def _print_text(d: dict) -> None:
@@ -422,7 +545,9 @@ def _print_text(d: dict) -> None:
         tags = []
         if p["is_self"]:
             tags.append("SELF")
-        if p["orphaned"]:
+        if p.get("claimed"):
+            tags.append("CLAIMED")
+        if p["orphaned"] and not p.get("claimed"):
             tags.append(f"ORPHAN:{p['orphaned']}")
         tag = f"  [{', '.join(tags)}]" if tags else ""
         print(f"  pid {p['pid']:<7} {p['comm']:<9} {p['region']:<9} {who}{tag}")
@@ -438,6 +563,12 @@ def _print_text(d: dict) -> None:
               f"(`ps -o etime=,stat= -p <pid>`; no busy children), then "
               f"`kill <pid>`. An orphan can still be mid-work — never kill "
               f"unverified.")
+    if d.get("claimed_absent"):
+        print(f"\n⚠ {len(d['claimed_absent'])} shell(s) EXPECTED BUT ABSENT: "
+              f"{', '.join(d['claimed_absent'])} — a headless launch claimed "
+              f"each one and that process is gone. Not a remnant to kill; the "
+              f"opposite. Whether an absence is a FAULT is the sprint "
+              f"reconciler's call, never this scan's.")
     print("\nVERDICT")
     if d["active_other_shells"]:
         print(f"  Live OTHER shells: {', '.join(d['active_other_shells'])}"

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2516,8 +2516,12 @@ window.addEventListener("pagehide", ifDetach);
 // `working` is amber, not red (flag #94): a live non-orphan harness holds the
 // worktree — someone is genuinely working outside the Interface. Only the
 // orphan verdict (`unreconciled`) is a stranded remnant worth recovering.
+// `expected_absent` (spec #76 H-25) is warn, not bad: a headless launch claimed
+// this shell and its process is gone. That is evidence, not a remnant to
+// recover — whether the absence is a FAULT is the sprint reconciler's call.
 const IF_BADGE = { available: "ok", starting: "warn", occupied: "accent",
-  working: "warn", lost: "bad", error: "bad", unreconciled: "bad" };
+  working: "warn", lost: "bad", error: "bad", unreconciled: "bad",
+  expected_absent: "warn" };
 const IF_ATTACHABLE_LIFECYCLES = new Set(
   ["starting", "idle", "busy", "approval", "user_input"]);
 
@@ -2631,7 +2635,11 @@ async function renderInterface(root) {
     if (shells.length) pane.append(el("div", { className: "card muted" }, "Select a shell on the left."));
     return;
   }
-  if (sel.availability === "available") return ifAvailablePane(pane, sel, root);
+  // `expected_absent` takes the available pane: no process holds the worktree,
+  // so New chat is legal here. The rail badge is what carries the distinction
+  // the record makes; the pane has nothing different to offer.
+  if (sel.availability === "available" || sel.availability === "expected_absent")
+    return ifAvailablePane(pane, sel, root);
   if (sel.availability === "working") {
     ifDetach();
     return ifWorkingPane(pane, sel, root);

--- a/tests/test_activity_readers.py
+++ b/tests/test_activity_readers.py
@@ -440,15 +440,75 @@ class DatabaseContractTest(ReaderCase):
             evidence.last_result_row_at,
         )
 
-    def test_doc_unit_and_rowless_shell_never_claim_code_work(self):
+    def test_undeclared_branch_still_reads_code_work_from_head(self):
+        """Spec #76 H-15: the board's `branch` column is filled at PR-open, so
+        gating code evidence on it blinded the reader to a dev who had branched
+        and was heads-down building — and a blind reader falls to the
+        no-progress floor. An undeclared branch reads the worktree's own HEAD;
+        branch PRESENCE is the only thing there is nothing to say about."""
+        worked = datetime(2020, 1, 3, tzinfo=UTC)
+        source = self.worktree / "source.py"
+        source.write_text("heads-down\n")
+        stamp(source, worked)
+
         doc = dict(self.unit, branch=None)
         evidence = self.reader.read(self.shell, doc, datetime(2020, 1, 10, tzinfo=UTC))
+
+        self.assertTrue(evidence.edits_code)
+        self.assertIsNone(evidence.branch_declared)
+        self.assertIsNone(evidence.branch_present)
+        self.assertTrue(evidence.dirty)
+        self.assertEqual(0, evidence.commits_since_epoch)
+        self.assertEqual(worked, evidence.last_work_at)
+
+    def test_reviewer_role_reads_no_branch_or_git_evidence(self):
+        """Spec #76 H-16: a reviewer inherited the DEV's branch off the unit row
+        and was then graded on whether that branch existed — so it read
+        `not_started` until the dev pushed. The reviewer's own worktree has
+        nothing to do with the dev's branch; every code-shaped field stays
+        unread, while the review-shaped ones (result rows, durable writes) are
+        still observed."""
+        source = self.worktree / "source.py"
+        source.write_text("the reviewer's own tree\n")
+        stamp(source, datetime(2020, 1, 3, tzinfo=UTC))
+
+        evidence = self.reader.read(
+            self.shell, self.unit, datetime(2020, 1, 10, tzinfo=UTC),
+            role="reviewer",
+        )
+
         self.assertFalse(evidence.edits_code)
         self.assertIsNone(evidence.branch_present)
         self.assertIsNone(evidence.dirty)
         self.assertIsNone(evidence.commits_since_epoch)
         self.assertIsNone(evidence.last_work_at)
+        # The board fact is still reported honestly; it just decides nothing.
+        self.assertEqual("feat/test", evidence.branch_declared)
+        self.assertEqual(
+            datetime(2020, 1, 2, tzinfo=UTC), evidence.last_result_row_at
+        )
+        self.assertEqual(
+            datetime(2020, 1, 6, tzinfo=UTC), evidence.last_durable_write_at
+        )
 
+    def test_dev_role_reads_code_work_the_reviewer_does_not(self):
+        """The paired positive control: one unit, one shell, two roles. Without
+        it, `reviewer reads nothing` would also pass on a reader that reads
+        nothing for anyone."""
+        source = self.worktree / "source.py"
+        source.write_text("dev work\n")
+        stamp(source, datetime(2020, 1, 3, tzinfo=UTC))
+        when = datetime(2020, 1, 10, tzinfo=UTC)
+
+        dev = self.reader.read(self.shell, self.unit, when, role="dev")
+        reviewer = self.reader.read(self.shell, self.unit, when, role="reviewer")
+
+        self.assertTrue(dev.edits_code)
+        self.assertEqual(datetime(2020, 1, 3, tzinfo=UTC), dev.last_work_at)
+        self.assertFalse(reviewer.edits_code)
+        self.assertIsNone(reviewer.last_work_at)
+
+    def test_rowless_shell_never_claims_code_work(self):
         con = sqlite3.connect(self.db)
         con.execute(
             "INSERT INTO interface_sessions VALUES "

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -931,6 +931,60 @@ class InterfaceApiTest(unittest.TestCase):
         self.assertEqual(self.rail(1)["availability"], "working")
         self.assertEqual(self.rail(2)["availability"], "available")
 
+    # -- H-25: the launch record, not the launcher's lineage ------------------
+
+    def claimed(self, *, live=None, absent=(), processes=()):
+        """Point the liveness scan at a snapshot carrying launch claims."""
+        self.liveness.stop()
+        self.liveness = mock.patch.object(
+            routes.shell_liveness, "compute",
+            return_value={"supported": True, "processes": list(processes),
+                          "claimed_pids": dict(live or {}),
+                          "claimed_absent": list(absent)})
+        self.liveness.start()
+
+    def _sprint_archive(self):
+        with contextlib.closing(sqlite3.connect(self.db_path)) as con:
+            con.execute(
+                "INSERT INTO documents (document_id, kind, title, body) "
+                "VALUES (38,'doc','SPRINT: Launcher operator surface','x')")
+            con.execute("UPDATE shell_memory_archives SET sprint_ref='38' "
+                        "WHERE archive_id=10")
+            con.execute("UPDATE shells SET active_archive_id=10 "
+                        "WHERE shell_id=1")
+            con.commit()
+
+    def test_detached_worker_the_scan_missed_is_working_from_its_claim(self):
+        """The claim is comm-blind, so a harness that renamed itself out of the
+        expected set — or any process the scan did not match — still projects
+        `working` with its sprint, instead of vanishing into `available`."""
+        self._sprint_archive()
+        self.claimed(live={"s1": 777})
+        shell = self.rail()
+        self.assertEqual(shell["availability"], "working")
+        self.assertEqual(shell["sprint_ref"], "38")
+
+    def test_relaunch_gap_is_expected_absent_never_a_bare_available(self):
+        """Spec #76 H-25's second rail consequence. Between two work items no
+        process holds the worktree at all; the record still claims the shell, so
+        the absence is reported as evidence rather than as idleness. This is the
+        row feature #27's compare consumes."""
+        self._sprint_archive()
+        self.claimed(absent=["s1"])
+        shell = self.rail()
+        self.assertEqual(shell["availability"], "expected_absent")
+        self.assertEqual(shell["sprint_ref"], "38")
+        self.assertIsNone(shell["session_id"])
+
+    def test_a_shell_no_launch_ever_claimed_is_still_available(self):
+        """The positive control: the rule adds a verdict, it does not replace
+        `available` for every dormant shell."""
+        self._sprint_archive()
+        self.claimed()
+        shell = self.rail()
+        self.assertEqual(shell["availability"], "available")
+        self.assertIsNone(shell["sprint_ref"])
+
     def test_shell_occupied_race(self):
         status, _, _ = self.create_session()
         self.assertEqual(status, 201)

--- a/tests/test_interface_ui_contract.py
+++ b/tests/test_interface_ui_contract.py
@@ -1183,6 +1183,21 @@ def test_rail_routes_working_away_from_recovery_and_paints_it_amber():
     assert '"working"' not in recovery_route.split("ifRecoveryPane")[0]
 
 
+def test_rail_paints_expected_absent_warn_and_never_on_the_recovery_route():
+    """Spec #76 H-25: a record-claimed shell whose worker is gone is EVIDENCE,
+    not a stranded remnant — warn, not bad. And New chat stays legal there, so
+    the value must take the available arm rather than falling through the
+    dispatch into a session fetch for a null session_id."""
+    assert 'expected_absent: "warn"' in RENDER_INTERFACE
+    available_route = RENDER_INTERFACE[
+        RENDER_INTERFACE.index('sel.availability === "available"'):
+        RENDER_INTERFACE.index('sel.availability === "lost"')]
+    assert '"expected_absent"' in available_route
+    recovery_route = RENDER_INTERFACE[
+        RENDER_INTERFACE.index('sel.availability === "lost"'):]
+    assert '"expected_absent"' not in recovery_route.split("ifRecoveryPane")[0]
+
+
 RAIL_POLL_SETUP = r"""
 const shellRow = (shortname, availability, extra = {}) => ({
   shell_id: shortname === "S3" ? 3 : 4, shortname,
@@ -1260,6 +1275,39 @@ invariant(rendered === 0,
   "a still-occupied session was re-rendered — the live terminal would drop");
 invariant(badges(root).some((b) => b.includes("2")),
   `the new alert count never reached the rail: ${badges(root)}`);
+ifStopRailPoll();
+""")
+
+
+def test_expected_absent_renders_as_a_warn_badge_over_the_available_pane():
+    """The behavioural half of the H-25 rail consequence: the badge carries the
+    new word (an unknown value would paint an empty tone class), and selecting
+    the shell lands on the available pane — never the recovery pane, which
+    would tell the operator to recover a worker that already finished."""
+    run_recovery_js(RAIL_POLL_SETUP + r"""
+ifSelected = "S3";
+serveShells([shellRow("S3", "expected_absent", { sprint_ref: "84" })]);
+const root = new FakeElement("div");
+await renderInterface(root);
+
+const badge = all(railOf(root), (n) =>
+  String(n.className || "").includes("if-badge"))[0];
+invariant(badge.textContent === "expected_absent",
+  `rail did not paint the record verdict: ${badge.textContent}`);
+// Token compare, not substring: "if-badge" contains "bad".
+const tone = String(badge.className).split(" ");
+invariant(tone.includes("warn"),
+  `expected_absent painted as "${badge.className}" — an unrecognised `
+  + `availability falls through to an empty tone class`);
+invariant(!tone.includes("bad"),
+  "a finished worker was painted as a stranded remnant");
+
+// The dispatch arm: without it the value falls past every branch into
+// ifSessionPane, which fetches /sessions/null. That path is stubbed inert
+// here, so the tell is a pane with no New-chat affordance at all.
+const pane = all(root, (n) => n.className === "if-pane")[0];
+invariant(Boolean(button(pane, "New chat")),
+  `expected_absent did not reach the available pane: ${pane.textContent}`);
 ifStopRailPoll();
 """)
 

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -614,7 +614,7 @@ class CutoverTest(unittest.TestCase):
         refreshes = []
 
         class Reader:
-            def read(self, shell, unit, now):
+            def read(self, shell, unit, now, role=None):
                 reads.append((shell["shell_id"], unit["seq"]))
                 return pr_poller.activity_readers.Evidence(
                     epoch="2020-01-01T00:00:00Z",
@@ -760,7 +760,7 @@ class CutoverTest(unittest.TestCase):
         con.close()
 
         class RaisingReader:
-            def read(self, shell, unit, now):
+            def read(self, shell, unit, now, role=None):
                 raise RuntimeError("mid-tick sentinel")
 
         out = io.StringIO()

--- a/tests/test_reconciler_tick.py
+++ b/tests/test_reconciler_tick.py
@@ -219,6 +219,93 @@ class ClassificationPrecedenceTest(unittest.TestCase):
             ),
         )
 
+    def test_live_durable_write_is_working_for_a_role_with_no_code(self):
+        """Flag #364 defect (b) / spec #76 H-16. A planner emits `task` rows,
+        never `result`, and has no branch — so Rules 2, 3 and 5 all miss it and
+        Rule 6's floor pinned it at `checkup` for the rest of the sprint, where
+        no healthy signal could ever resolve the alert. Its durable writes were
+        read the whole time and consulted only behind `session_over`; counting
+        them as evidence in the floor is what lets the signal come back."""
+        planner = evidence(
+            edits_code=False,
+            branch_declared=None,
+            branch_present=None,
+            last_result_row_at=None,
+            last_durable_write_at=NOW - timedelta(minutes=3),
+        )
+        self.assertEqual("working", pr_poller.classify(planner, NOW))
+
+    def test_a_durable_write_older_than_the_window_is_still_checkup(self):
+        """The paired negative: the rule reads a CURRENT write, not the mere
+        existence of one. Without this, `working` would become unfalsifiable
+        for every role that has ever written a row."""
+        planner = evidence(
+            edits_code=False,
+            branch_declared=None,
+            branch_present=None,
+            last_durable_write_at=NOW - timedelta(minutes=21),
+        )
+        self.assertEqual("checkup", pr_poller.classify(planner, NOW))
+
+    def test_durable_write_never_outranks_a_closed_session_report(self):
+        """The durable write is evidence in Rule 6's floor and NOWHERE above
+        it. Once the session is over, a durable write is a completion report,
+        not a sign of life, and Rule 4 must keep winning."""
+        item = evidence(
+            edits_code=False,
+            branch_declared=None,
+            branch_present=None,
+            process_present=False,
+            last_durable_write_at=NOW - timedelta(minutes=1),
+        )
+        self.assertEqual("work_complete_unreported", pr_poller.classify(item, NOW))
+
+    def test_a_stale_durable_write_still_resets_the_no_progress_floor(self):
+        """Rule 6 counts the durable write for the same reason it already counts
+        a work event: with a tighter-than-default window the write is too old to
+        prove `working` on its own, but it is still the newest thing that
+        happened, and the floor measures SILENCE from the newest event. Without
+        it the floor would be measured from a boot clock the worker has long
+        since spoken past."""
+        item = evidence(
+            edits_code=False,
+            branch_declared=None,
+            branch_present=None,
+            last_durable_write_at=NOW - timedelta(minutes=10),
+        )
+        self.assertEqual(
+            "working",
+            pr_poller.classify(item, NOW, window=timedelta(minutes=5)),
+        )
+
+    def test_reviewer_without_branch_presence_is_never_not_started(self):
+        """Spec #76 H-16: a reviewer inherited the dev's branch and read
+        `not_started` until the dev pushed. With no code surface it is judged on
+        review-shaped evidence — here, none yet, which is `checkup`, not an
+        accusation that it never began."""
+        reviewer = evidence(
+            edits_code=False,
+            branch_declared="feat/test",
+            branch_present=False,
+        )
+        self.assertEqual("checkup", pr_poller.classify(reviewer, NOW))
+        # Positive control: the same missing branch on a DEV still accuses.
+        self.assertEqual(
+            "not_started",
+            pr_poller.classify(evidence(branch_present=False), NOW),
+        )
+
+    def test_building_dev_with_no_declared_branch_is_working(self):
+        """Spec #76 H-15, the classifier half: with the reader no longer gated
+        on the board's `branch` column, a heads-down dev arrives carrying a work
+        event and must not fall to the 20-minute floor."""
+        dev = evidence(
+            branch_declared=None,
+            branch_present=None,
+            last_work_at=NOW - timedelta(minutes=2),
+        )
+        self.assertEqual("working", pr_poller.classify(dev, NOW))
+
     def test_declared_missing_branch_uses_the_boot_grace(self):
         self.assertEqual(
             "not_started",
@@ -518,7 +605,7 @@ class ExplanationTierTest(unittest.TestCase):
             readable = pr_poller.reconcile_tick(
                 self.con,
                 now=NOW,
-                reader=lambda shell, unit, now: evidence(
+                reader=lambda shell, unit, now, role=None: evidence(
                     marker_at=NOW,
                     cpu_delta=7.0,
                     launch_shape="headless",
@@ -528,7 +615,7 @@ class ExplanationTierTest(unittest.TestCase):
             unreadable = pr_poller.reconcile_tick(
                 self.con,
                 now=NOW,
-                reader=lambda shell, unit, now: evidence(
+                reader=lambda shell, unit, now, role=None: evidence(
                     unreadable=["marker", "process_binding"],
                 ),
                 refresh=lambda worktree: True,
@@ -597,7 +684,7 @@ class TickTest(unittest.TestCase):
             readings = pr_poller.reconcile_tick(
                 self.con,
                 now=NOW,
-                reader=lambda shell, unit, now: evidence(
+                reader=lambda shell, unit, now, role=None: evidence(
                     branch_declared=unit["branch"]
                 ),
                 refresh=lambda worktree: True,
@@ -742,7 +829,12 @@ class TickTest(unittest.TestCase):
             ],
         )
 
-    def test_one_refresh_per_tick_and_one_read_for_two_roles(self):
+    def test_one_refresh_per_tick_but_a_read_per_role(self):
+        """Refresh stays once per tick — the shared integration ref is fetched
+        for the whole run. The READ is now per role (spec #76 H-15/H-16): dev
+        and reviewer are observed differently, so one shell holding both roles
+        on one unit must not have the dev's answer cached and served to the
+        reviewer. Caching on (shell, unit) alone is what did exactly that."""
         add_unit(self.con, dev=1, reviewer=1)
         refreshes = []
         reads = []
@@ -750,23 +842,48 @@ class TickTest(unittest.TestCase):
         result = pr_poller.reconcile_tick(
             self.con,
             now=NOW,
-            reader=lambda shell, unit, now: (
-                reads.append((shell["shell_id"], unit["unit_id"]))
+            reader=lambda shell, unit, now, role=None: (
+                reads.append((shell["shell_id"], unit["unit_id"], role))
                 or evidence()
             ),
             refresh=lambda worktree: refreshes.append(worktree) or True,
         )
 
         self.assertEqual(1, len(refreshes))
-        self.assertEqual([(1, 1)], reads)
+        self.assertEqual([(1, 1, "dev"), (1, 1, "reviewer")], reads)
         self.assertEqual(2, len(result))
+
+    def test_repeated_expectations_for_one_role_still_read_once(self):
+        """The cache is not defeated, only re-keyed: the same (shell, unit,
+        role) triple is read once however many times it is reached."""
+        add_unit(self.con, dev=1, reviewer=None)
+        reads = []
+
+        pr_poller.reconcile_tick(
+            self.con,
+            now=NOW,
+            reader=lambda shell, unit, now, role=None: (
+                reads.append(role) or evidence()
+            ),
+            refresh=lambda worktree: True,
+        )
+        pr_poller.reconcile_tick(
+            self.con,
+            now=NOW,
+            reader=lambda shell, unit, now, role=None: (
+                reads.append(role) or evidence()
+            ),
+            refresh=lambda worktree: True,
+        )
+
+        self.assertEqual(["dev", "dev"], reads)   # one per tick, not two
 
     def test_failed_refresh_is_joined_to_each_affected_reading(self):
         add_unit(self.con)
         readings = pr_poller.reconcile_tick(
             self.con,
             now=NOW,
-            reader=lambda shell, unit, now: evidence(),
+            reader=lambda shell, unit, now, role=None: evidence(),
             refresh=lambda worktree: False,
         )
         for reading in readings:
@@ -779,7 +896,7 @@ class TickTest(unittest.TestCase):
     def test_two_consecutive_ticks_confirm_and_recovery_resets(self):
         add_unit(self.con, reviewer=None)
         state = pr_poller.ReconcilerState()
-        stale = lambda shell, unit, now: evidence()
+        stale = lambda shell, unit, now, role=None: evidence()
 
         first = pr_poller.reconcile_tick(
             self.con,
@@ -798,7 +915,7 @@ class TickTest(unittest.TestCase):
         recovered = pr_poller.reconcile_tick(
             self.con,
             now=NOW + timedelta(minutes=11),
-            reader=lambda shell, unit, now: evidence(last_work_at=now),
+            reader=lambda shell, unit, now, role=None: evidence(last_work_at=now),
             refresh=lambda worktree: True,
             state=state,
         )
@@ -825,7 +942,7 @@ class TickTest(unittest.TestCase):
         readings = pr_poller.reconcile_tick(
             self.con,
             now=NOW,
-            reader=lambda shell, unit, now: evidence(
+            reader=lambda shell, unit, now, role=None: evidence(
                 last_result_row_at=(
                     NOW if unit["sprint_doc_id"] == 60 else None
                 )

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -2,6 +2,7 @@
 """Regression tests for atomic, contention-safe launcher session opening."""
 from __future__ import annotations
 
+import os
 import sqlite3
 import sys
 import tempfile
@@ -364,6 +365,99 @@ class HeadlessSessionFailureTest(unittest.TestCase):
         ensure_worktree.assert_not_called()
         atomic_write.assert_not_called()
         execvpe.assert_not_called()
+
+
+LAUNCH_RECORDS = """
+CREATE TABLE shell_launch_records (
+    shell_id    INTEGER PRIMARY KEY,
+    pid         INTEGER NOT NULL,
+    start_ticks INTEGER NOT NULL,
+    worktree    TEXT    NOT NULL,
+    harness     TEXT,
+    launched_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+"""
+
+
+class RecordLaunchTest(unittest.TestCase):
+    """Spec #76 H-25: the launch claims the pid it is about to become."""
+
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.worktree = self.root / ".sc-worktrees" / "dev6"
+        self.worktree.mkdir(parents=True)
+        self.db = self.root / "shell.db"
+        seed = sqlite3.connect(self.db)
+        seed.executescript(LAUNCH_RECORDS)
+        seed.commit()
+        seed.close()
+        # A stat line whose comm carries a space and parens, so the reader
+        # cannot pass by splitting naively.
+        rest = ["0"] * 30
+        rest[19] = "5150"                      # field 22 — starttime
+        self.stat = self.root / "stat"
+        self.stat.write_text("42 (co dex (x)) " + " ".join(rest) + "\n")
+
+    def _rows(self, sql: str = "SELECT shell_id, pid, start_ticks, worktree, "
+                                "harness FROM shell_launch_records"):
+        con = sqlite3.connect(self.db)
+        try:
+            return con.execute(sql).fetchall()
+        finally:
+            con.close()
+
+    def _record(self, *, headless: bool = True):
+        # record_launch owns the connection it opens, so every call gets a fresh one.
+        with mock.patch.object(
+                run, "open_db",
+                side_effect=lambda: sqlite3.connect(self.db)), \
+                mock.patch.object(run, "PROC_SELF_STAT", self.stat):
+            run.record_launch(1, self.worktree, "codex", headless=headless)
+        return self._rows()
+
+    def test_headless_launch_claims_this_pid_and_its_start_ticks(self):
+        rows = self._record()
+        self.assertEqual(
+            [(1, os.getpid(), 5150, str(self.worktree), "codex")], rows)
+
+    def test_an_interactive_boot_makes_no_claim(self):
+        # Recording one would arrive pre-claimed on a closed terminal's
+        # survivor and suppress the orphan verdict the operator needs.
+        self.assertEqual([], self._record(headless=False))
+
+    def test_relaunch_restamps_one_row_rather_than_accumulating(self):
+        con = sqlite3.connect(self.db)
+        con.execute(
+            "INSERT INTO shell_launch_records "
+            "(shell_id, pid, start_ticks, worktree, harness) "
+            "VALUES (1, 999, 1, ?, 'claude')", (str(self.worktree),))
+        con.commit()
+        con.close()
+        rows = self._record()
+        self.assertEqual(1, len(rows))
+        self.assertEqual((os.getpid(), 5150, "codex"), rows[0][1:3] + rows[0][4:])
+
+    def test_an_unmigrated_fork_does_not_fail_the_boot(self):
+        con = sqlite3.connect(self.db)
+        con.execute("DROP TABLE shell_launch_records")
+        con.commit()
+        con.close()
+        with mock.patch.object(
+                run, "open_db",
+                side_effect=lambda: sqlite3.connect(self.db)), \
+                mock.patch.object(run, "PROC_SELF_STAT", self.stat):
+            run.record_launch(1, self.worktree, "codex", headless=True)
+
+    def test_unreadable_start_ticks_makes_no_claim(self):
+        missing = self.root / "absent"
+        with mock.patch.object(
+                run, "open_db",
+                side_effect=lambda: sqlite3.connect(self.db)), \
+                mock.patch.object(run, "PROC_SELF_STAT", missing):
+            run.record_launch(1, self.worktree, "codex", headless=True)
+        self.assertEqual([], self._rows())
 
 
 if __name__ == "__main__":

--- a/tests/test_shell_liveness.py
+++ b/tests/test_shell_liveness.py
@@ -443,6 +443,221 @@ class ZombieHarnessTest(unittest.TestCase):
         self.assertFalse(snap["safe_to_clean_all"])
 
 
+def _stat_line(*, state: str = "S", ppid: int = 1, tty_nr: int = 0,
+               start_ticks: int = 5150) -> str:
+    """A /proc/<pid>/stat line with the four fields this module reads.
+    The comm deliberately carries a space and parens — the parser must survive
+    it, and a fixture that never exercises that is a fixture that agrees with a
+    naive split()."""
+    rest = ["0"] * 30
+    rest[0] = state                    # field 3  — state
+    rest[1] = str(ppid)                # field 4  — ppid
+    rest[4] = str(tty_nr)              # field 7  — tty_nr
+    rest[19] = str(start_ticks)        # field 22 — starttime
+    return "42 (co dex (x)) " + " ".join(rest) + "\n"
+
+
+def _proc_entry(proc: Path, pid: int, *, cwd: "Path | None" = None,
+                comm: str = "codex", **stat) -> Path:
+    entry = proc / str(pid)
+    entry.mkdir()
+    (entry / "comm").write_text(comm + "\n")
+    (entry / "stat").write_text(_stat_line(**stat))
+    if cwd is not None:
+        (entry / "cwd").symlink_to(cwd)
+    return entry
+
+
+class ClaimLiveTest(unittest.TestCase):
+    """H-25: identity is pid + start ticks + worktree hold. Parentage never."""
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.proc = self.root / "proc"
+        self.proc.mkdir()
+        self.worktree = self.root / ".sc-worktrees" / "dev6"
+        self.worktree.mkdir(parents=True)
+        self.claim = {"pid": 700, "start_ticks": 5150,
+                      "worktree": str(self.worktree)}
+        patch = mock.patch.object(shell_liveness, "PROC", self.proc)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def test_detached_worker_reparented_to_init_is_live(self):
+        # The exact process H-25 exists for: tty_nr 0, ppid 1 — 'detached' by
+        # every lineage read, and working.
+        _proc_entry(self.proc, 700, cwd=self.worktree, ppid=1, tty_nr=0)
+        self.assertTrue(shell_liveness.claim_live(self.claim))
+
+    def test_recycled_pid_does_not_inherit_the_claim(self):
+        # Same pid number, different process. Without start_ticks this is a
+        # false "working" that resolves the reconciler's alert on a stranger.
+        _proc_entry(self.proc, 700, cwd=self.worktree, start_ticks=99999)
+        self.assertFalse(shell_liveness.claim_live(self.claim))
+
+    def test_zombie_keeps_its_ticks_but_holds_nothing(self):
+        _proc_entry(self.proc, 700, cwd=self.worktree, state="Z")
+        self.assertFalse(shell_liveness.claim_live(self.claim))
+
+    def test_pid_that_is_simply_gone_is_not_live(self):
+        self.assertFalse(shell_liveness.claim_live(self.claim))
+
+    def test_cwd_outside_the_worktree_refutes_the_hold(self):
+        elsewhere = self.root / "somewhere-else"
+        elsewhere.mkdir()
+        _proc_entry(self.proc, 700, cwd=elsewhere)
+        self.assertFalse(shell_liveness.claim_live(self.claim))
+
+    def test_subdirectory_of_the_worktree_still_holds_it(self):
+        nested = self.worktree / "src"
+        nested.mkdir()
+        _proc_entry(self.proc, 700, cwd=nested)
+        self.assertTrue(shell_liveness.claim_live(self.claim))
+
+    def test_unreadable_cwd_does_not_refute(self):
+        # Missing data must never become "the worker is gone" — that is the
+        # failure direction this requirement removes.
+        _proc_entry(self.proc, 700, cwd=None)
+        self.assertTrue(shell_liveness.claim_live(self.claim))
+
+
+class RecordStateTest(unittest.TestCase):
+    """The launch record's verdict, asked after the process scan found none."""
+
+    SNAP = {
+        "supported": True,
+        "claimed_pids": {"dev6": 700},
+        "claimed_absent": ["dev5"],
+    }
+
+    def test_live_claim_is_working(self):
+        self.assertEqual("working",
+                         shell_liveness.record_state("DEV6", self.SNAP))
+
+    def test_dead_claim_is_expected_absent_not_available(self):
+        self.assertEqual("expected_absent",
+                         shell_liveness.record_state("dev5", self.SNAP))
+
+    def test_unclaimed_shell_has_no_record_verdict(self):
+        self.assertIsNone(shell_liveness.record_state("dev1", self.SNAP))
+
+    def test_unsupported_snapshot_is_none(self):
+        self.assertIsNone(shell_liveness.record_state(
+            "dev5", {**self.SNAP, "supported": False}))
+
+
+class ClaimedOrphanTest(unittest.TestCase):
+    """A claimed pid is never advised for killing, however it was launched."""
+
+    SNAP = {
+        "supported": True,
+        "processes": [
+            {"pid": 700, "shortname": "dev6", "orphaned": "detached",
+             "claimed": True},
+            {"pid": 800, "shortname": "dev5", "orphaned": "detached",
+             "claimed": False},
+        ],
+    }
+
+    def test_claimed_detached_worker_is_not_in_the_orphan_half(self):
+        pids, orphans = shell_liveness.orphan_split("dev6", self.SNAP)
+        self.assertEqual([700], pids)
+        self.assertEqual([], orphans)
+
+    def test_claimed_detached_worker_reads_busy_not_orphan(self):
+        self.assertEqual("busy", shell_liveness.session_state("dev6", self.SNAP))
+
+    def test_unclaimed_detached_remnant_is_still_an_orphan(self):
+        # The positive control: the rule narrows the orphan verdict, it does
+        # not delete it.
+        self.assertEqual([800],
+                         shell_liveness.orphan_split("dev5", self.SNAP)[1])
+        self.assertEqual("orphan",
+                         shell_liveness.session_state("dev5", self.SNAP))
+
+
+class ComputeWithClaimsTest(unittest.TestCase):
+    """compute() end to end over a fake /proc plus a launch record."""
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.proc = self.root / "proc"
+        self.proc.mkdir()
+        self.worktree = self.root / ".sc-worktrees" / "dev6"
+        self.worktree.mkdir(parents=True)
+        for patch in (
+            mock.patch.object(shell_liveness, "PROC", self.proc),
+            mock.patch.object(shell_liveness, "REPO_ROOT", self.root),
+            mock.patch.object(shell_liveness, "harness_binaries",
+                              return_value={"codex"}),
+            mock.patch.object(shell_liveness, "_shell_labels", return_value={}),
+            mock.patch.object(shell_liveness, "_self_harness_pid",
+                              return_value=None),
+        ):
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def _claims(self, claims):
+        patch = mock.patch.object(shell_liveness, "_launch_claims",
+                                  return_value=claims)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def test_claimed_detached_worker_is_working_not_unreconciled(self):
+        _proc_entry(self.proc, 700, cwd=self.worktree, ppid=1, tty_nr=0)
+        self._claims({"dev6": {"pid": 700, "start_ticks": 5150,
+                               "worktree": str(self.worktree)}})
+
+        snap = shell_liveness.compute()
+
+        self.assertEqual({"dev6": 700}, snap["claimed_pids"])
+        self.assertEqual([], snap["claimed_absent"])
+        self.assertEqual([], snap["orphaned_pids"])
+        self.assertTrue(snap["processes"][0]["claimed"])
+        # Lineage is still REPORTED — it is just no longer the verdict.
+        self.assertEqual("detached", snap["processes"][0]["orphaned"])
+        self.assertEqual("busy", shell_liveness.session_state("dev6", snap))
+
+    def test_relaunch_gap_is_expected_absent_not_available(self):
+        # No process at all: the shell between two work items. Before the
+        # record this projected a bare "available" and the fleet read as idle.
+        self._claims({"dev6": {"pid": 700, "start_ticks": 5150,
+                               "worktree": str(self.worktree)}})
+
+        snap = shell_liveness.compute()
+
+        self.assertEqual({}, snap["claimed_pids"])
+        self.assertEqual(["dev6"], snap["claimed_absent"])
+        self.assertIsNone(shell_liveness.session_state("dev6", snap))
+        self.assertEqual("expected_absent",
+                         shell_liveness.record_state("dev6", snap))
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            shell_liveness._print_text(snap)
+        self.assertIn("EXPECTED BUT ABSENT", output.getvalue())
+
+    def test_unclaimed_detached_process_keeps_the_orphan_verdict(self):
+        _proc_entry(self.proc, 800, cwd=self.worktree, ppid=1, tty_nr=0)
+        self._claims({})
+
+        snap = shell_liveness.compute()
+
+        self.assertEqual([800], snap["orphaned_pids"])
+        self.assertFalse(snap["processes"][0]["claimed"])
+        self.assertEqual("orphan", shell_liveness.session_state("dev6", snap))
+
+    def test_a_shell_with_no_record_and_no_process_stays_available(self):
+        self._claims({})
+        snap = shell_liveness.compute()
+        self.assertIsNone(shell_liveness.session_state("dev6", snap))
+        self.assertIsNone(shell_liveness.record_state("dev6", snap))
+
+
 class ComputeSmokeTest(unittest.TestCase):
     """compute() against the real /proc: shape only, no liveness assumptions."""
 


### PR DESCRIPTION
Spec #76 **H-15 / H-16 / H-25**, plus flag #364's two headline defects. Was stacked on U1; U1 merged as `9ae0c91` mid-build, so this is **rebased onto `main`** and targets it directly. The contribution diff is byte-identical across the rebase (`git diff d95c80c..HEAD` before vs `git diff origin/main..HEAD` after — zero delta, no hunk hand-resolved).

## What was wrong

Three separate ways the reconciler and the rail reported things that were not true.

**H-15 — branch evidence gated "working".** `edits_code` required the board's `branch` column, which the chain fills only at PR-open. A dev who had branched and was heads-down building produced *no* git evidence at all and fell to the 20-minute no-progress floor.

**H-16 — reviewers were graded on the dev's push state.** The reviewer expectation inherited the dev's branch off the unit row and read `not_started` until the dev pushed — a branch that has nothing to do with the reviewer's own worktree.

**Flag #364 defect (b) — the checkup family.** `last_durable_write_at` was read on every tick and consulted at exactly one place: Rule 4, behind `session_over`. A live planner emits `task` rows (never `result`) and has no branch, so it walked past Rules 2, 3 and 5 into Rule 6's floor — measured from a boot clock it had long since spoken past — and stuck at `checkup` for the rest of the sprint, where no healthy signal could resolve it.

Reproduced, not theorised: alert **#356** (S84, role=planner, PLN2, binding 12) opened 17:06:11 and stayed open through continuous planner durable writes at 17:04/17:12/17:37/17:46. `SELECT kind, COUNT(*) FROM shell_messages WHERE from_shell_id=10 AND sprint_doc_id=84 GROUP BY kind` → `pr_event 57 | shell 31 | task 62` — **zero `result` rows**, so Rule 2's "reported" is structurally unreachable for the planner role and Rule 6 is the terminus. Resolution-on-evidence was never broken; the signal simply could never return to healthy.

**H-25 — the liveness verdict depended on launcher lineage.** A headless sprint worker is detached from birth (no controlling TTY, launcher gone, `ppid==1`), so `classify_orphan` could only ever call it `detached` and the rail projected `unreconciled`. Between relaunches nothing held the worktree and the same shell projected a bare `available`. Both wrong — and `busy` was unreachable *by construction*, since it required a live parent that a sprint launch never has.

## What changed

- **Role-shaped evidence.** `activity_readers.read()` takes the expectation's role and decides which surfaces are even asked about. A reviewer is asked nothing about branches; a dev has a code surface whether or not the board's column is filled, and an undeclared branch reads the worktree's own HEAD. `not_started` carries an explicit `edits_code` guard so the rule cannot drift back. Evidence caches per `(shell, unit, ROLE)` — one shell holding both roles on one unit was being served the dev's answer for its reviewer expectation.
- **One clock, not a new rule.** The durable write now counts as evidence in Rule 6's floor, because that floor measures *silence* and a durable write is not silence.
- **Launch records (migration 0110).** `run.py` is the single exec chokepoint, so it records the pid it is about to become. The scan tests *that pid*: identity by pid + start ticks, plus its worktree hold — never its parentage. `orphan` narrows to a pid no record claims (a true remnant); a claim whose process is gone projects `expected_absent`.

## Trade-offs taken, stated rather than hidden

- **A "recent durable write is `working`" rule was drafted and then deleted.** The mutation sweep showed it survivable: it decided nothing the Rule 6 floor does not already decide, *except* to convert a dev's declared-but-absent branch from `not_started` into `working` — a semantic change no requirement here asks for.
- **The launch record is headless-only**, which is why it is a parameter of `record_launch` rather than a caller-side `if`. An interactive boot has a live parent the lineage scan already reads correctly, and recording one would arrive pre-claimed on a closed terminal's survivor, suppressing the orphan verdict the operator needs.
- **Nothing clears the record at exit.** `run.py` execs and never returns, so a worker that has finished for good reads `expected_absent` until its next launch. That is the honest reading; deciding whether an absence is a *fault* stays with feature #27, and decision #76 forbids the exit daemon that would clear it.
- **`app.js` joined the file surface under ruling R-U4-1 / decision #101**, for exactly two lines. Residual: the available pane's own copy still reads "Shell &lt;name&gt; is available." for an `expected_absent` shell. The rail badge carries the distinction; changing the pane copy is a third line this unit did not ask for.
- **H-15's other half is not performable by a dev today.** The spec has the dev declare its branch at unit start, but `sc sprint unit set` is planner-fenced — it returns `403 … only it writes this board` for a worker. This change makes that declaration an optimisation rather than a prerequisite, but U5's skill text should not ship an instruction that 403s.

## Migration slot — verified, not assumed (decision #88)

`migrate.py`'s ledger is per-**file**: `schema_migrations.filename` is the PK (`applied_set`, :37-43) and `pending()` is a set-membership test with no ordering comparison anywhere (:46-49). A file named 0110 appearing after 0113 is stamped is simply "not in done" and applies on the next run. **Not** a high-water mark, so the reservation stands and nothing is renumbered. Verified end-to-end by applying the full chain to a fresh `schema.sql` build.

## Verification

- **Full suite green:** 2046 passed (`tests/`). One `spikes/interface-stream` test fails only under full-repo load and passes in isolation; it is pre-existing, outside CI's `pytest tests/` path, and untouched by this diff.
- **Mutation evidence: 22/22 killed**, one operand per row, serial, assert-on-apply (a row whose substitution does not land raises rather than reporting a green instrument). Two instrument defects were found and fixed during the sweep rather than reported around:
  1. Same-length substitutions applied and reverted within one filesystem timestamp tick could leave a stale `.pyc`, silently **under-counting** a red set — a false green. Observed once (1 red on a row that reproduces as 2). Fixed by disabling bytecode and clearing caches per row; confirmed identical across runs afterward.
  2. A killed sweep left a mutation in the working tree, and one such leftover reached a commit before a read-back against the committed tree caught it. Every mutation anchor is now verified present exactly once in `HEAD` (22/22) as a release gate, and the sweep restores on signal.

## Out of scope — filed, not folded in

Two further reconciler defects were verified against live measurements and opened as flags rather than silently widening this unit:

- **#378 `SC-S84-RECONCILER-STATE-CLOCK`** — a planner board write resets the worker's report clock. Alert #391's own measurement: `last_result_row_at=17:46:15`, `state_changed_at=18:00:24` (a planner transition). Rule 2 requires `result_at >= state_clock`, so a satisfied expectation is re-minted as a fault. Not fixed here: Rule 4 still wins on `session_over`.
- **#379 `SC-S84-RECONCILER-EARLY-MINT`** — flag #364 defect (a), reproducing unchanged. `live_expectations` mints both roles for every non-terminal unit, so a reviewer on a `pending` unit with no task ever issued is graded from the moment the row exists (alert #385). H-16 removes the `not_started` family for that reviewer but does not change *when* the expectation is minted.

Co-authored-by: Code-04 (super-coder) &lt;noreply@super-coder.local&gt;
