### PR TITLE
fix(mem): flag close names its target, edit can name and append (S84 U11)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import hashlib
 import http.client
+import ipaddress
 import json
 import os
 import secrets
@@ -192,19 +193,41 @@ def _authority_host(authority: str) -> str:
     hardening rather than a live exploit — but the fence's whole job is that
     an authority which is not exactly an allowed one is refused, and
     tightening the IPv6 branch while leaving that in place is just the next
-    finding."""
+    finding.
+
+    Flag #158 asked for the malformed cases to be enumerated rather than
+    patched one at a time, and two survived the SC-150 pass:
+
+    * Brackets were accepted around ANYTHING, so `[127.0.0.1]` and
+      `[localhost]` reached the allowlist as bare `127.0.0.1` / `localhost`
+      and passed. Brackets are legal only around an IP-literal (RFC 3986
+      §3.2.2), so the content is now parsed as one — a bracketed reg-name is
+      malformed, and malformed fails closed.
+    * `str.isdigit()` is true for the Latin-1 superscripts `¹²³`, which the
+      header decode admits, so `127.0.0.1:80²` was a trailing-junk authority
+      that parsed clean. The port test is ASCII digits only.
+
+    An empty port (`127.0.0.1:`) stays accepted: RFC 3986 `port = *DIGIT`
+    permits it, and the host is still exactly an allowed one. Authority length
+    is not capped here — the header line is already bounded by the HTTP
+    server's own limit, and an oversized authority fails the allowlist
+    anyway."""
     authority = (authority or "").strip()
     if authority.startswith("["):
         end = authority.find("]")
         if end < 0:
             return ""
         host, rest = authority[1:end], authority[end + 1:]
+        try:
+            ipaddress.IPv6Address(host)
+        except ValueError:
+            return ""
         if rest and not rest.startswith(":"):
             return ""
         port = rest[1:]
     else:
         host, _, port = authority.partition(":")
-    if port and not port.isdigit():
+    if port and not (port.isascii() and port.isdigit()):
         return ""
     return host.lower()
 

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -265,7 +265,12 @@ def read_log() -> list[dict]:
 # deliberately ABSENT — the law says the shell curates them, so there is no door.
 # display_name is operator-set at creation, so the operator may also correct it.
 SHELL_EDITABLE = {"current_state", "display_name"}  # workspace + connections both retired (B5); "where things live" is the derived dr_* map
-FLAG_EDITABLE = {"resolved", "resolution_notes", "description", "feature_id", "priority"}
+# display_name is editable (#288): it was settable exactly once, at open, so a
+# flag opened without a name could never be given one — and an unnamed flag is
+# the one referred to by bare integer, which is the precondition for #149's
+# id/name collision. Same reasoning as SHELL_EDITABLE above.
+FLAG_EDITABLE = {"resolved", "resolution_notes", "description", "display_name",
+                 "feature_id", "priority"}
 ROADMAP_EDITABLE = {"title", "roadmap_status", "summary", "sort_order", "project_id"}
 
 # Typed traffic on the shell_messages bus (migration 0059). Shells send the
@@ -2202,6 +2207,27 @@ class Handler(BaseHTTPRequestHandler):
                     "ORDER BY f.created_date, f.flag_id"))
                 return self._send(200, {"flags": fs})
 
+            if len(parts) == 4 and parts[2] == "flags":
+                # One flag by id, RESOLVED ONES INCLUDED — the list above is
+                # open-only, so it cannot answer "what am I about to close?"
+                # (#149). `sc mem flag close` reads this before it writes, and
+                # a row that is already resolved carries the notes the closer
+                # would otherwise overwrite.
+                fid = int(parts[3])
+                r = con.execute(
+                    "SELECT f.flag_id, f.display_name, f.priority, f.description, "
+                    "f.feature_id, f.created_date, f.resolved, f.resolved_date, "
+                    "f.resolution_notes, "
+                    "(SELECT s.shortname FROM shells s WHERE s.shell_id=f.shell_id) "
+                    " AS owner, "
+                    "(SELECT title FROM roadmap WHERE feature_id=f.feature_id) "
+                    " AS feature_title "
+                    "FROM flags f WHERE f.flag_id=? "
+                    "AND COALESCE(f.is_deleted,0)=0", (fid,)).fetchone()
+                if r is None:
+                    return self._send(404, {"error": "no such flag"})
+                return self._send(200, {"flag": dict(r)})
+
             if path == "/_sc/mem/roadmap":
                 # The board is shared, not per-shell — return all live features.
                 rm = rows(con.execute(
@@ -2723,6 +2749,20 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(404, {"error": "no such flag"})
                 if body.get("resolved"):
                     body.setdefault("resolved_date", date.today().isoformat())
+                # Append to the description in ONE statement (#288 follow-on).
+                # `description` replaces the whole body, so growing a long-lived
+                # tracker flag meant fetch → concatenate → rewrite in the
+                # client, and two shells doing that concurrently lose one
+                # edit. Server-side `||` has no read to lose.
+                add = body.pop("append_description", None)
+                if add:
+                    con.execute(
+                        "UPDATE flags SET description = "
+                        "COALESCE(description,'') || ? WHERE flag_id=?",
+                        (add, fid))
+                    con.commit()
+                    if not any(c in body for c in FLAG_EDITABLE | {"resolved_date"}):
+                        return self._send(200, {"ok": True})
                 ok, err = patch_columns(con, "flags", "flag_id", fid, body,
                                         FLAG_EDITABLE | {"resolved_date"})
                 return self._send(200 if ok else 400, {"ok": ok, "error": err})

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -41,7 +41,7 @@ Run from the repo root, like every engine command:
     ./sc mem decision "<decision>"   [--rationale "…"] [--date …] [--parent ID] [--feature ID] [--doc ID]
     ./sc mem flag open  "<description>" [--name CC-001] [--priority Medium] [--feature ID]
     ./sc mem flag close <flag_id>    [--notes "…"]
-    ./sc mem flag edit  <flag_id>    [--description "…"] [--priority P] [--feature ID]
+    ./sc mem flag edit  <flag_id>    [--name SC-002] [--description "…"] [--append "…"] [--priority P] [--feature ID]
     ./sc mem roadmap add "<title>"   [--status brainstorm] [--summary "…"] [--project <shortname|id>]
     ./sc mem roadmap status <feature_id> <status>
     ./sc mem roadmap edit <feature_id> [--title "…"] [--summary "…"]   # revise a feature's title/summary
@@ -398,9 +398,15 @@ def _render_get(surface: str, data: dict) -> int:
             print("mem: no open flags")
             return 0
         for f in fs:
-            nm = f.get("display_name") or f"#{f['flag_id']}"
+            # id AND label, always both (#149): a named flag used to print its
+            # name alone, so the id needed to close it had to be guessed — and
+            # SC-### names and flag_ids are drawn from two counters drifting
+            # through the same integer range, so a guess resolves to a real
+            # row rather than failing.
+            nm = f.get("display_name") or "unnamed"
             who = f" @{f['owner']}" if f.get("owner") else ""
-            print(f"[{nm}]{who} ({f.get('priority') or 'Medium'}) {f.get('description') or ''}")
+            print(f"#{f['flag_id']} [{nm}]{who} ({f.get('priority') or 'Medium'}) "
+                  f"{f.get('description') or ''}")
         return 0
     if surface == "roadmap":
         rm = data.get("roadmap", [])
@@ -604,6 +610,12 @@ def cmd_decision(args) -> int:
     return _finish_api(f"mem: decision #{r.get('decision_id', '')} recorded{link}")
 
 
+def _one_line(text: "str | None", limit: int = 240) -> str:
+    """A long body as one readable line — enough of it to recognise the row."""
+    s = " ".join((text or "").split())
+    return s if len(s) <= limit else s[:limit - 1] + "…"
+
+
 def cmd_flag(args) -> int:
     if args.flag_cmd == "open":
         r = _api("POST", "/_sc/mem/flags",
@@ -616,20 +628,48 @@ def cmd_flag(args) -> int:
     if args.flag_cmd == "edit":
         # Long-lived tracker flags update their description progressively
         # (#316) — the API always supported the PATCH; this exposes it.
+        if args.description is not None and args.append is not None:
+            die("--description replaces the body and --append adds to it — pick one")
         payload: dict = {}
+        if args.name is not None:
+            payload["display_name"] = args.name
         if args.description is not None:
             payload["description"] = args.description
+        if args.append is not None:
+            payload["append_description"] = args.append
         if args.priority is not None:
             payload["priority"] = args.priority
         if args.feature is not None:
             payload["feature_id"] = args.feature
         if not payload:
-            die("nothing to edit — pass at least one of --description / --priority / --feature")
+            die("nothing to edit — pass at least one of "
+                "--name / --description / --append / --priority / --feature")
         _api("PATCH", f"/_sc/mem/flags/{args.flag_id}", payload)
         return _finish_api(f"mem: flag #{args.flag_id} edited ({' + '.join(payload)})")
+    # close. Read the row and NAME THE TARGET BEFORE THE WRITE (#149): flag_id
+    # and the SC-### display_name are both small integers drawn from two
+    # counters that drift through the same range, so a stale or mistranscribed
+    # reference does not fail loudly — it resolves to a different real record
+    # and resolves THAT. Printing the row first is what lets a caller see it
+    # holds the wrong record while the record still exists.
+    row = _api("GET", f"/_sc/mem/flags/{args.flag_id}").get("flag") or {}
+    name = row.get("display_name") or ""
+    label = f" ({name})" if name else " (unnamed)"
+    print(f"mem: closing flag #{args.flag_id}{label} "
+          f"[{row.get('priority') or '?'}, opened {row.get('created_date') or '?'}"
+          f" by {row.get('owner') or '?'}]")
+    print(f"    {_one_line(row.get('description'))}")
+    if row.get("resolved"):
+        # Closing an already-closed flag is not a no-op: it OVERWRITES the
+        # resolution notes of whoever verified it with the closer's. Refuse,
+        # and print what that write would have destroyed.
+        die(f"flag #{args.flag_id}{label} is already closed "
+            f"({row.get('resolved_date') or 'no date'}) — closing it again would "
+            f"overwrite its resolution notes: "
+            f"{_one_line(row.get('resolution_notes')) or '(none recorded)'}")
     _api("PATCH", f"/_sc/mem/flags/{args.flag_id}",
          {"resolved": True, "resolution_notes": args.notes})
-    return _finish_api(f"mem: flag #{args.flag_id} closed")
+    return _finish_api(f"mem: flag #{args.flag_id}{label} closed")
 
 
 def cmd_roadmap(args) -> int:
@@ -896,9 +936,11 @@ def build_parser() -> argparse.ArgumentParser:
     fo.add_argument("--name")
     fo.add_argument("--priority", default="Medium", choices=["High", "Medium", "Low"])
     fo.add_argument("--feature", type=int)
-    fe = fsub.add_parser("edit", help="update an open flag's description/priority/feature")
+    fe = fsub.add_parser("edit", help="update an open flag's name/description/priority/feature")
     fe.add_argument("flag_id", type=int)
-    fe.add_argument("--description")
+    fe.add_argument("--name", help="set or correct the display_name (#288)")
+    fe.add_argument("--description", help="REPLACES the whole body — see --append")
+    fe.add_argument("--append", help="append to the description instead of replacing it")
     fe.add_argument("--priority", choices=["High", "Medium", "Low"])
     fe.add_argument("--feature", type=int)
     fc = fsub.add_parser("close")

--- a/tests/test_interface_release_gate.py
+++ b/tests/test_interface_release_gate.py
@@ -420,6 +420,62 @@ class ReleaseGateTest(unittest.TestCase):
                 self.assertEqual(status, 403, body)
                 self.assertEqual(body["error"]["code"], "host_not_allowed")
 
+    # -- flag #158: every malformed-authority class, enumerated --------------
+
+    def test_every_malformed_authority_class_fails_the_host_fence(self):
+        """#158 asked for the malformed cases to be ENUMERATED and pinned
+        rather than for whichever one prompted the work to be patched, because
+        this parser is the outermost fence in `handle()` — every Interface
+        request passes it before any authority model runs.
+
+        Two of these classes were live holes before this test existed:
+        brackets were accepted around anything (`[127.0.0.1]` reached the
+        allowlist as `127.0.0.1`), and `str.isdigit()` accepts the Latin-1
+        superscripts the header decode admits, so `127.0.0.1:PORT²` parsed as
+        a clean allowed authority.
+        """
+        cases = {
+            "empty": "",
+            "bare colon": ":",
+            "port only": f":{self.port}",
+            "unbracketed ipv6": f"::1:{self.port}",
+            "bracketed ipv4": f"[127.0.0.1]:{self.port}",
+            "bracketed reg-name": "[localhost]",
+            "superscript port": f"127.0.0.1:{self.port}²",
+            "superscript port, v6 branch": f"[::1]:{self.port}¹",
+            "userinfo": f"evil@127.0.0.1:{self.port}",
+            "host suffix": f"127.0.0.1.evil.example.com:{self.port}",
+            "double port": f"127.0.0.1:{self.port}:{self.port}",
+            "oversized": ("x" * 8000) + ".127.0.0.1",
+        }
+        for label, host in cases.items():
+            with self.subTest(case=label, host=host[:40]):
+                status, _, body = self.http(
+                    "GET", "/api/interface/shells", {"Host": host})
+                self.assertEqual(status, 403, body)
+                self.assertEqual(body["error"]["code"], "host_not_allowed")
+
+    def test_wellformed_allowed_authorities_still_pass_the_host_fence(self):
+        """The negative sweep above is only evidence if the same probe can see
+        a pass. Each of these is a well-formed allowed authority, so the fence
+        must let it through to the authority model — 401 (no credential), not
+        403 (rejected at the door). It also pins the two acceptances the
+        tightening deliberately kept: an RFC-legal empty port, and a host
+        compared case-insensitively.
+        """
+        for label, host in {
+            "ipv4 with port": f"127.0.0.1:{self.port}",
+            "ipv6 with port": f"[::1]:{self.port}",
+            "empty port": "127.0.0.1:",
+            "empty port, v6 branch": "[::1]:",
+            "no port": "localhost",
+            "uppercase host": f"LOCALHOST:{self.port}",
+        }.items():
+            with self.subTest(case=label, host=host):
+                status, _, body = self.http(
+                    "GET", "/api/interface/shells", {"Host": host})
+                self.assertEqual(status, 401, body)
+
     # -- SC-151: the bootstrap honours the key it demands --------------------
 
     def _boot(self, key, **extra):

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -247,6 +247,66 @@ class ApiMemTest(unittest.TestCase):
         self.run_mem("flag", "close", str(fid), "--notes", "fixed")
         self.assertEqual(self.q("SELECT resolved FROM flags WHERE flag_id=?", fid)[0], 1)
 
+    # ── #149: close names the row it is about to resolve, and never twice ─────
+    def test_flag_close_names_the_target_before_it_writes(self):
+        """flag_id and the SC-### display_name are both small integers from two
+        counters that drift through the same range, so a wrong number resolves
+        to a different real row rather than failing. The one thing that lets a
+        caller SEE it holds the wrong record is the row itself, echoed by the
+        command that is about to resolve it."""
+        self.run_mem("flag", "open", "[x] the wrong one | Blocker for: nothing",
+                     "--name", "SC-149-A", "--priority", "High")
+        fid = self.q("SELECT flag_id FROM flags WHERE display_name='SC-149-A'")[0]
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            self.run_mem("flag", "close", str(fid), "--notes", "done")
+        out = buf.getvalue()
+        self.assertIn("SC-149-A", out)          # the name, not just the number
+        self.assertIn("the wrong one", out)     # and enough body to recognise it
+        self.assertIn("High", out)
+
+    def test_flag_close_refuses_to_overwrite_an_existing_resolution(self):
+        """A redundant close is not a no-op: it replaces the resolution notes
+        of whoever verified the flag with the closer's. The first writer's
+        evidence must survive the second close attempt."""
+        self.run_mem("flag", "open", "[x] verified | Blocker for: y",
+                     "--name", "SC-149-B")
+        fid = self.q("SELECT flag_id FROM flags WHERE display_name='SC-149-B'")[0]
+        self.run_mem("flag", "close", str(fid),
+                     "--notes", "REV1 verified at head f7f687c")
+        with self.assertRaises(SystemExit):
+            self.run_mem("flag", "close", str(fid), "--notes", "closed per sprint")
+        row = self.q("SELECT resolution_notes, resolved FROM flags WHERE flag_id=?",
+                     fid)
+        self.assertEqual(row["resolution_notes"], "REV1 verified at head f7f687c")
+        self.assertEqual(row["resolved"], 1)
+
+    # ── #288: a flag opened unnamed can be given a name; --append never eats ──
+    def test_flag_edit_sets_a_display_name_a_flag_was_opened_without(self):
+        self.run_mem("flag", "open", "[x] unnamed | Blocker for: naming")
+        fid = self.q("SELECT flag_id FROM flags WHERE description LIKE '%unnamed%'")[0]
+        self.assertIsNone(
+            self.q("SELECT display_name FROM flags WHERE flag_id=?", fid)[0])
+        self.run_mem("flag", "edit", str(fid), "--name", "SC-288")
+        self.assertEqual(
+            self.q("SELECT display_name FROM flags WHERE flag_id=?", fid)[0],
+            "SC-288")
+
+    def test_flag_edit_append_extends_the_body_instead_of_replacing_it(self):
+        self.run_mem("flag", "open", "[x] tracker gate 1 | Blocker for: arc",
+                     "--name", "SC-288-B")
+        fid = self.q("SELECT flag_id FROM flags WHERE display_name='SC-288-B'")[0]
+        self.run_mem("flag", "edit", str(fid), "--append", "\n\nGATE 2 CLEARED.")
+        desc = self.q("SELECT description FROM flags WHERE flag_id=?", fid)[0]
+        self.assertIn("tracker gate 1", desc)      # the original body survives
+        self.assertIn("GATE 2 CLEARED.", desc)
+        with self.assertRaises(SystemExit):        # replace and append conflict
+            self.run_mem("flag", "edit", str(fid), "--description", "new",
+                         "--append", "more")
+        self.assertIn("tracker gate 1",
+                      self.q("SELECT description FROM flags WHERE flag_id=?",
+                             fid)[0])
+
     # ── roadmap: add / status / work-stream / deps + cycle ────────────────────
     def test_roadmap_lifecycle_and_cycle(self):
         self.run_mem("project", "add", "ws1", "Work Stream 1")


### PR DESCRIPTION
Sprint 84, unit U11 — flags **#149** (CLI data-loss), **#288** (flag-edit gap), **#158** (`_authority_host` malformed authorities). Base includes U4's merge (`e8730bd`).

## #149 — `flag close` names the row it is about to resolve

`flag_id` and the `SC-###` display_name are small integers drawn from two counters that have drifted through the same range, and every message, review and report refers to the **name** while `flag close` takes the **number**. A stale or mistranscribed reference therefore does not fail loudly — it resolves to a different real record and resolves *that*, reporting success. The flag records two near misses, both caught only because a dev declined to follow an instruction literally.

- `flag close <n>` now GETs the row and prints `#id (name) [priority, opened … by …]` plus the first 240 chars of the body **before** the PATCH. That is the minimum behaviour the flag specifies.
- It **refuses** a flag that is already resolved, printing the notes the write would have destroyed. This is the flag's second instance: even when the identifier resolves correctly, a redundant close replaces the verifying shell's resolution notes with the closer's.
- `get flags` prints id **and** label on every line. The `flags` skill already documents that listing as "(id, name, priority, description)" — a named flag printed its name alone, so the id needed to close it had to be guessed. Code now matches the documented contract.

## #288 — a flag opened unnamed can be given a name

The flag left one thing unverified: whether the API accepted `display_name` even though the CLI did not expose it. **It did not** — `display_name` was absent from `FLAG_EDITABLE`, so the remedy is both halves, not CLI-only.

- `flag edit --name` (CLI) + `display_name` in `FLAG_EDITABLE` (API).
- `flag edit --append` — grows the description **server-side in one statement**. `--description` replaces the whole body, so a long-lived tracker flag was grown by fetch → concatenate → rewrite in the client; two shells doing that concurrently lose an edit. Mutually exclusive with `--description`.
- New route `GET /_sc/mem/flags/{id}`, **resolved rows included** — the list route is open-only, so nothing could answer "what am I about to close?".

## #158 — malformed authorities, enumerated rather than patched

The flag asked for the cases to be enumerated and asked whether a newer caller had put the parser on a trust path. **It has one caller, `_host_ok`, and that is the first gate in `handle()`** — every Interface request passes it before any authority model runs. Two classes survived the SC-150 pass:

| authority | before | now |
|---|---|---|
| `[127.0.0.1]`, `[localhost]` | reached the allowlist as bare `127.0.0.1` / `localhost` → **accepted** | brackets are legal only around an IP-literal (RFC 3986 §3.2.2); content is parsed as one → refused |
| `127.0.0.1:PORT²` | `str.isdigit()` is true for the Latin-1 superscripts the header decode admits → **accepted** | ASCII digits only → refused |

Deliberately kept: an empty port (`127.0.0.1:`) is RFC-legal and the host is still exactly an allowed one. Authority length is **not** capped here — the header line is already bounded by the HTTP server's own limit, and an oversized authority fails the allowlist anyway; the oversized case is pinned as a test, not as new code.

## Evidence

- Full suite: **2096 passed, 621 subtests** (`pytest tests/ -q`, 9m41s, job `211-u11-suite` exit 0).
- **Instrument validated for #158**: the two fixed lines were reverted and the new pins re-run — **4 subtest reds, exactly the four defect classes** (bracketed IPv4, bracketed reg-name, superscript port on both branches), while `test_wellformed_allowed_authorities_still_pass_the_host_fence` stayed green. A negative sweep is only evidence if the same probe can see a pass; that positive control is a test, not a claim.
- `render-check` reports drift in four `skills_sc/sprint_*` renders under the gitignored `.sc-state/local/`. **Pre-existing and not from this diff** — verified by stashing the change and re-running: identical drift on the clean tree. This diff touches no skill asset, migration, or content.
- The full-suite run predates one later one-line change (the `get flags` id+label format); no test asserts that output, and CI is the gate on the final head.

## Trade-offs and what was not done

- **Not taken:** making `flag close` accept the `SC-###` display_name, or refusing ambiguous input by naming both candidate rows. Both are listed in #149 as unranked candidates; both widen the CLI's identifier surface. The flag states its own minimum — echo the target before the write — and the already-closed refusal is what actually prevents the destruction the second instance describes.
- **Judgement call:** `--append` is adjacent to #288 rather than inside it (the flag is specifically about `display_name`). Included because the planner named it in-scope pending this read, it is ~10 lines, and it removes a client-side read-modify-write whose lost-update race is the same data-loss family as #149.
- **Migration:** none. No schema change — `display_name` already exists on `flags`.
- **Open for the planner:** `assets/skills/flags/SKILL.md` documents `flag edit`'s signature and states that `--description` replaces the whole text. That text is now incomplete. Updating it is a three-artifact engine-skill commit needing a **reserved migration slot**, which is the planner's to release — not minted here.

No sprint-route edits: U2's wake/broker/binding-projection surfaces are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
