### PR TITLE
docs(flags): skill text names the verbs that shipped (S84 U11 follow-on)

### DIFF
--- a/.super-coder/migrations/0111_reseed_flags_verbs.sql
+++ b/.super-coder/migrations/0111_reseed_flags_verbs.sql
@@ -1,14 +1,24 @@
----
-name: flags
-description: Track blockers as flags — surface open ones, open new ones, edit long-lived ones, resolve them. Link a flag to the roadmap feature it blocks. Mirrors the GUI Flags tab. Use when something blocks progress or needs follow-up.
-category: substrate
-common: false
----
+-- 0111 — reseed flags: the verbs shipped in S84 U11 (PR #672, squash 7c82dbc).
+-- Generated from assets/skills/flags/SKILL.md; full-body upsert so existing
+-- installations converge on the asset.
+--
+-- Slot re-allocated to this commit by planner ruling (S84 U11): the skill text
+-- follows the code onto main rather than describing verbs still in flight.
+-- Editing the asset without this migration is exactly the drift
+-- tests/test_skills_freshness.py detects.
 
-# flags — blockers & follow-ups
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'flags',
+  'Track blockers as flags — surface open ones, open new ones, edit long-lived ones, resolve them. Link a flag to the roadmap feature it blocks. Mirrors the GUI Flags tab. Use when something blocks progress or needs follow-up.',
+  'substrate',
+  NULL,
+  0,
+  '# flags — blockers & follow-ups
 
 flag = open question / blocker. `--feature <id>` set -> the flag is that
-feature's blocker (joined on the roadmap; shown on the Roadmap card + Flags
+feature''s blocker (joined on the roadmap; shown on the Roadmap card + Flags
 tab). `<self>` = your shell_id. All reads/writes go through `sc mem` (the
 engine API) — there is no `sqlite3` path.
 
@@ -20,7 +30,7 @@ sc mem get flags --json   # same, as JSON
 ```
 
 Each flag carries its `feature_id`; cross-reference `sc mem get roadmap` for
-the blocked feature's title.
+the blocked feature''s title.
 
 Both list forms are **open-only**. One flag by id, resolved rows included:
 
@@ -31,7 +41,7 @@ GET /_sc/mem/flags/{id}   # no CLI verb — `flag close` reads it before it writ
 ## Open
 
 ```
-sc mem flag open "[Area] what's blocked | Blocker for: X" --name SC-001 --priority Medium [--feature <id>]
+sc mem flag open "[Area] what''s blocked | Blocker for: X" --name SC-001 --priority Medium [--feature <id>]
 ```
 
 - `--name` = short id, format `SC-###`.
@@ -53,7 +63,7 @@ Recipient = whoever the flag blocks:
 |---|---|
 | docs pending after ship | the **planner** |
 | a review failure on a diff | the **author dev** |
-| a blocker on another shell's work | **that shell** |
+| a blocker on another shell''s work | **that shell** |
 | an FnB decision / no shell owns it | **surface to the FnB** (no `send`) |
 
 Message pairs with the *open* only: NEVER re-message a flag that is already
@@ -83,7 +93,7 @@ progressively as gates clear).
 sc mem flag close <flag_id> --notes "…"
 ```
 
-`--notes` states *how* it was resolved — that's the trail.
+`--notes` states *how* it was resolved — that''s the trail.
 
 `close` prints the row it holds — id, label, priority, opened date, owner,
 description — BEFORE it writes. **Read that line and confirm it names the flag
@@ -98,7 +108,15 @@ verified the flag.
 
 ## Stance
 
-Open a flag the moment something blocks or needs follow-up — don't hold it in
+Open a flag the moment something blocks or needs follow-up — don''t hold it in
 your head. Open flags on a feature = its blockers; clear them all before
 calling the feature done. An opened flag with no message sent = a dropped
-handoff.
+handoff.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;


### PR DESCRIPTION
S84 U11 follow-on, per PLN2 ruling #3400 (option B). PR #672 merged as `7c82dbc`;
this makes the flags skill describe the verbs that are **on main**, not verbs in
flight — so between the two merges the text and the binary never disagree.

## Scope (exactly the ruling's list)

- `flag edit --name` — set a `display_name` on a flag opened without one.
- `flag edit --append` — grow a description server-side in one statement.
- `flag close` — echo-before-write, and the already-resolved refusal.
- `GET /_sc/mem/flags/{id}` — single flag, resolved rows included.

## Trade-off

The two `close` paragraphs are longer than the verb needs, and I kept them
deliberately: printing the row only helps a reader who knows to **check** it, and
the reason to check — a wrong id resolves a *real* row instead of failing — is not
recoverable from the output alone. Same call on `--append`: the server concatenates
raw, so the caller owns the separator. A one-line "appends to the description"
would have been shorter and would have shipped the footgun.

## Migration 0111

The slot the ruling re-allocated to this commit — `0110 -> 0112` was the gap on
main, and doc 84's table records the reallocation. Generated **from** the asset
via `seed_skills.parse_skill` + `sql_str`, body stored exactly as the guards read
it (`split("---", 2)[2].strip()`), not hand-written.

## Two artifacts, not three

This repo is in **local artifact mode**, so the flat mirror lives under the ignored
`.sc-state/local/renders` and is not in the diff (`engine_surgery`). Asset +
migration is the complete commit.

## Evidence

- `tests/test_skills_freshness.py` — green, 8 tests. This is the gate CI runs for
  this change (`render-check.yml` step 2).
- **Instrument validated before it was trusted.** Appending one line to the asset
  without regenerating the migration turns it **RED**, 3 failures naming `flags`;
  restored -> green. A guard I had not seen fail is not evidence.
- `python3 .super-coder/scripts/render_check.py` run **from this worktree** (not
  `./sc render-check`, which resolves to the main checkout — flag #47): exactly one
  added drift, `skills_sc/flags.md`. The four `sprint_orchestration*` /
  `sprint_review` entries listed beside it are **pre-existing on `7c82dbc`** —
  confirmed by stashing this change and re-running — a stale local mirror, not this
  diff, and not something this PR should sweep in.

## Note for the FnB

The shipped `close` behavior is not live on the running engine yet — I closed
flags #149/#288/#158 through `sc mem flag close` after the merge and it did **not**
echo, because the live instance resolves from `/home/j3d1/super-coder`, whose floor
is behind `origin/main`. Reaches the running shells at the next pull + reconcile +
restart, which is a sprint-boundary call. Closes were done by exact `flag_id` read
back first, so they are correct regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
