### PR TITLE
fix(cli): sc scripts exit quietly when the reader closes stdout (#384)

### DIFF
--- a/.super-coder/scripts/analytics.py
+++ b/.super-coder/scripts/analytics.py
@@ -304,4 +304,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    sys.exit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/artifact_policy.py
+++ b/.super-coder/scripts/artifact_policy.py
@@ -246,7 +246,9 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
+    from cli_entry import run_cli
+
     try:
-        raise SystemExit(main(sys.argv[1:]))
+        raise SystemExit(run_cli(main, sys.argv[1:]))
     except ArtifactPolicyError as exc:
         raise SystemExit(f"artifact-mode: {exc}") from exc

--- a/.super-coder/scripts/backfill_shell_api_keys.py
+++ b/.super-coder/scripts/backfill_shell_api_keys.py
@@ -48,6 +48,8 @@ def backfill(db_path: str) -> int:
 
 
 if __name__ == "__main__":
+    from cli_entry import run_cli
+
     if len(sys.argv) != 2:
         sys.exit(f"usage: {Path(sys.argv[0]).name} <path-to-db>")
-    sys.exit(backfill(sys.argv[1]))
+    sys.exit(run_cli(backfill, sys.argv[1]))

--- a/.super-coder/scripts/cli_entry.py
+++ b/.super-coder/scripts/cli_entry.py
@@ -1,0 +1,83 @@
+"""One entrypoint wrapper for every `sc` script that prints (flag #384).
+
+Python installs SIG_IGN for SIGPIPE, so a reader that closes early — `| head`,
+`| grep -m1`, a pager the operator quits — turns into a `BrokenPipeError` in
+whatever `print()` happened to be running. The command's real output has already
+been delivered; what the operator sees on top of it is a traceback. Agent shells
+pipe `sc` output on nearly every turn, so those tracebacks land in transcripts
+fleet-wide.
+
+Every `__main__` block under `scripts/` routes its main callable through
+`run_cli()` — one mechanism, one place to fix, and `tests/test_cli_sigpipe.py`
+fails if a new entrypoint forgets. It replaces the hand-copied
+`signal.signal(SIGPIPE, SIG_DFL)` that had accreted in three scripts (#299):
+that variant kills the process with signal 13 mid-write, so the shell sees exit
+141 and the command gets no say in its own status.
+
+Two things have to be quiet, not one:
+
+    the write   — the `print()` that raises, caught here;
+    the flush   — the interpreter's own flush of what is still buffered, which
+                  runs after `main()` returns and prints
+                  "Exception ignored in: <_io.TextIOWrapper name='<stdout>'>".
+                  Re-pointing fd 1 at /dev/null is what silences that one; it
+                  cannot be caught from here.
+
+Exit semantics:
+
+    broken pipe interrupts a run   -> 0. The reader asked for N lines and got
+                                     them; `head` closing the pipe is success.
+    the command already has a status (a return value, argparse's `SystemExit`,
+    any other exception)           -> that status stands, unchanged. A closed
+                                     reader silences noise; it never converts a
+                                     failure into a success.
+
+stderr is never touched — a real error still reaches the operator, whatever
+happened to stdout.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+from typing import Any
+
+
+def _silence_stdout() -> None:
+    """Point fd 1 at /dev/null so the interpreter's exit-flush stays quiet."""
+    try:
+        fd = os.open(os.devnull, os.O_WRONLY)
+    except OSError:
+        return  # out of descriptors; nothing better to try
+    try:
+        os.dup2(fd, sys.stdout.fileno())
+    except (OSError, ValueError, AttributeError):
+        pass  # stdout is not a real fd (a test buffer): nothing to re-point
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+def _flush_stdout() -> None:
+    """Flush stdout now, so a dead reader is discovered here and not at exit."""
+    try:
+        sys.stdout.flush()
+    except BrokenPipeError:
+        _silence_stdout()
+    except (OSError, ValueError):
+        pass  # a closed or detached stream: not this wrapper's business
+
+
+def run_cli(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Call a CLI main, quietly absorbing a reader that closed stdout early."""
+    try:
+        rc = fn(*args, **kwargs)
+    except BrokenPipeError:
+        rc = 0  # the reader closed mid-run; it got what it asked for
+    except BaseException:
+        _flush_stdout()  # keep the pipe quiet; the raised status still stands
+        raise
+    _flush_stdout()
+    return rc

--- a/.super-coder/scripts/db_backup.py
+++ b/.super-coder/scripts/db_backup.py
@@ -168,4 +168,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/dbq.py
+++ b/.super-coder/scripts/dbq.py
@@ -326,4 +326,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/eject.py
+++ b/.super-coder/scripts/eject.py
@@ -194,4 +194,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/feature.py
+++ b/.super-coder/scripts/feature.py
@@ -292,4 +292,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/git_hygiene.py
+++ b/.super-coder/scripts/git_hygiene.py
@@ -274,4 +274,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/git_prune.py
+++ b/.super-coder/scripts/git_prune.py
@@ -108,4 +108,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/harness_versions.py
+++ b/.super-coder/scripts/harness_versions.py
@@ -56,4 +56,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -165,4 +165,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -808,4 +808,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/interface_cli.py
+++ b/.super-coder/scripts/interface_cli.py
@@ -1103,4 +1103,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    sys.exit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/interface_exec.py
+++ b/.super-coder/scripts/interface_exec.py
@@ -236,4 +236,6 @@ def main(argv: "list[str] | None" = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    from cli_entry import run_cli
+
+    sys.exit(run_cli(main))

--- a/.super-coder/scripts/interface_hook.py
+++ b/.super-coder/scripts/interface_hook.py
@@ -187,4 +187,6 @@ def main(argv: "list[str] | None" = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    from cli_entry import run_cli
+
+    sys.exit(run_cli(main))

--- a/.super-coder/scripts/job.py
+++ b/.super-coder/scripts/job.py
@@ -441,11 +441,12 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: "list[str]") -> int:
-    if hasattr(signal, "SIGPIPE"):
-        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    # Early-closed stdout is handled at the entrypoint (cli_entry.run_cli, #384).
     args = build_parser().parse_args(argv)
     return args.fn(args)
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    sys.exit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/map_repo.py
+++ b/.super-coder/scripts/map_repo.py
@@ -374,4 +374,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/map_setup.py
+++ b/.super-coder/scripts/map_setup.py
@@ -76,4 +76,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -75,7 +75,6 @@ import argparse
 import errno
 import json
 import os
-import signal
 import stat
 import sys
 import time
@@ -1064,18 +1063,16 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str]) -> int:
-    # Restore the default SIGPIPE disposition so piping a render into `head`
-    # (or any reader that closes early) terminates quietly like a normal Unix
-    # filter, instead of raising BrokenPipeError mid-render loop (#299). Python
-    # installs SIG_IGN by default, which turns the closed pipe into an
-    # exception; SIG_DFL makes the write kill the process cleanly. Guarded for
-    # platforms without SIGPIPE (Windows), though this only ever runs on Linux.
-    if hasattr(signal, "SIGPIPE"):
-        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    # A reader that closes early (`| head`) is handled at the entrypoint, by
+    # cli_entry.run_cli — one mechanism for every sc script (#384). This used to
+    # restore SIG_DFL here (#299), which killed the process with signal 13
+    # mid-write and cost the command its own exit status.
     args = build_parser().parse_args(argv)
     _require_api()  # every command goes through the API — fail loud if unwired
     return args.fn(args)
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    sys.exit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/migrate.py
+++ b/.super-coder/scripts/migrate.py
@@ -144,4 +144,6 @@ def parse_args(argv: list[str]) -> str:
 
 
 if __name__ == "__main__":
-    sys.exit(migrate(parse_args(sys.argv[1:])))
+    from cli_entry import run_cli
+
+    sys.exit(run_cli(lambda: migrate(parse_args(sys.argv[1:]))))

--- a/.super-coder/scripts/models.py
+++ b/.super-coder/scripts/models.py
@@ -136,4 +136,6 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/operator_token.py
+++ b/.super-coder/scripts/operator_token.py
@@ -61,4 +61,6 @@ def main(argv: "list[str] | None" = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    from cli_entry import run_cli
+
+    sys.exit(run_cli(main))

--- a/.super-coder/scripts/pm2.py
+++ b/.super-coder/scripts/pm2.py
@@ -380,4 +380,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/ports.py
+++ b/.super-coder/scripts/ports.py
@@ -125,4 +125,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/preview.py
+++ b/.super-coder/scripts/preview.py
@@ -378,4 +378,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -320,4 +320,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/render.py
+++ b/.super-coder/scripts/render.py
@@ -93,4 +93,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/render_check.py
+++ b/.super-coder/scripts/render_check.py
@@ -143,4 +143,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -265,4 +265,6 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -1771,4 +1771,6 @@ def set_terminal_tab_title(name: str) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from cli_entry import run_cli
+
+    run_cli(main)

--- a/.super-coder/scripts/seed_dogfood.py
+++ b/.super-coder/scripts/seed_dogfood.py
@@ -225,4 +225,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/seed_skills.py
+++ b/.super-coder/scripts/seed_skills.py
@@ -340,4 +340,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/shell_liveness.py
+++ b/.super-coder/scripts/shell_liveness.py
@@ -595,4 +595,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -403,4 +403,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -470,4 +470,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/sprint.py
+++ b/.super-coder/scripts/sprint.py
@@ -632,4 +632,6 @@ def main(argv: "list[str] | None" = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/ts.py
+++ b/.super-coder/scripts/ts.py
@@ -308,4 +308,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -941,4 +941,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/visual_qa.py
+++ b/.super-coder/scripts/visual_qa.py
@@ -1237,4 +1237,6 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/vm.py
+++ b/.super-coder/scripts/vm.py
@@ -540,4 +540,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/vm_mcp_relay.py
+++ b/.super-coder/scripts/vm_mcp_relay.py
@@ -192,4 +192,6 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/watch.py
+++ b/.super-coder/scripts/watch.py
@@ -56,7 +56,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import signal
 import sys
 import time
 import urllib.error
@@ -330,11 +329,12 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: "list[str]") -> int:
-    if hasattr(signal, "SIGPIPE"):
-        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    # Early-closed stdout is handled at the entrypoint (cli_entry.run_cli, #384).
     args = build_parser().parse_args(argv)
     return args.fn(args)
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    sys.exit(run_cli(main, sys.argv[1:]))

--- a/tests/test_cli_sigpipe.py
+++ b/tests/test_cli_sigpipe.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""SIGPIPE hygiene for the `sc` CLI surface (flag #384).
+
+`./sc sprint board | head -1` used to print the board and then a 12-line
+BrokenPipeError traceback: Python ignores SIGPIPE, so an early-closed reader
+surfaces as an exception out of whatever `print()` was running. Agent shells
+pipe `sc` output constantly, so that traceback lands in transcripts fleet-wide.
+
+Three walls here:
+
+  RunCliTest          the mechanism — what `cli_entry.run_cli` returns, what it
+                      swallows, and what it must NOT swallow.
+  EntrypointsTest     the fan-out — every `__main__` block under scripts/ routes
+                      through the one wrapper, so a new script cannot quietly
+                      reintroduce the bug, and the retired
+                      `signal(SIGPIPE, SIG_DFL)` copies stay retired.
+  LivePipeTest        the behavior — real subprocesses against a closed reader.
+
+Two conditions decide whether a closed reader is even *observable*, so the live
+tests fix both rather than inheriting them:
+
+  buffering   the sandbox exports PYTHONUNBUFFERED=1, so a print writes to fd 1
+              immediately and raises there; without it, stdout is block-buffered
+              and the break lands in the flush instead (rc 120, "Exception
+              ignored in: <_io.TextIOWrapper ...>"). Every live case runs under
+              BOTH — they are different code paths through the wrapper.
+  volume      a head-like reader that closes after one line breaks nothing if
+              the child already fit its whole output in the 64KB pipe buffer.
+              So the head-like child floods (200KB) and the small-output cases
+              use a PRE-CLOSED pipe (read end gone before the child starts).
+              Neither depends on winning a race with the reader.
+
+`test_instrument_sees_the_bug_unwrapped` is the positive control for all of it:
+the same children WITHOUT the wrapper must show the traceback, in every
+condition asserted clean below. Note what is deliberately NOT used as a probe —
+argparse swallows its own write errors (`--help` down a dead pipe is quiet even
+unpatched), so the real-command leg drives a `print()`-bearing command instead.
+
+Run:
+    python3 tests/test_cli_sigpipe.py
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+
+sys.path.insert(0, str(SCRIPTS))
+import cli_entry  # noqa: E402
+
+MAIN_BLOCK = re.compile(r"^if __name__ == .__main__.:\n(?P<body>(?:.*\n?)*)", re.M)
+
+_BUFFERED = {k: v for k, v in os.environ.items() if k != "PYTHONUNBUFFERED"}
+_BUFFERED["PYTHONDONTWRITEBYTECODE"] = "1"
+_UNBUFFERED = {**_BUFFERED, "PYTHONUNBUFFERED": "1"}
+ENVS = (("buffered", _BUFFERED), ("unbuffered", _UNBUFFERED))
+
+CHILD = """\
+import sys
+sys.path.insert(0, {scripts!r})
+{importline}
+
+def main():
+    for i in range({lines}):
+        print("line %d %s" % (i, "x" * 40))
+    return 0
+
+{call}
+"""
+
+# Output small enough to stay buffered, a real failure on stderr, a nonzero
+# status — the break then happens in the wrapper's flush, AFTER the command has
+# already decided its own outcome.
+FAILS_AFTER_OUTPUT = """\
+import sys
+sys.path.insert(0, {scripts!r})
+from cli_entry import run_cli
+
+def main():
+    print("some output")
+    sys.stderr.write("real failure\\n")
+    raise SystemExit(3)
+
+sys.exit(run_cli(main))
+"""
+
+FLOOD = 5000   # ~200KB: past any pipe buffer, so a late write is guaranteed
+FEW = 10       # a few hundred bytes: fits the pipe buffer whole
+
+
+def _write_child(source: str) -> str:
+    fh = tempfile.NamedTemporaryFile("w", suffix=".py", delete=False)
+    fh.write(source)
+    fh.close()
+    return fh.name
+
+
+def _preclosed(argv: list[str], env: dict) -> subprocess.CompletedProcess:
+    """Run argv with fd 1 on a pipe whose read end is already closed."""
+    r, w = os.pipe()
+    os.close(r)
+    try:
+        return subprocess.run(argv, stdout=w, stderr=subprocess.PIPE,
+                              text=True, env=env, timeout=60)
+    finally:
+        os.close(w)
+
+
+def _headlike(argv: list[str], env: dict) -> tuple[str, str, int]:
+    """Read one line, close the pipe, let the writer discover it."""
+    proc = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            text=True, env=env)
+    first = proc.stdout.readline()
+    proc.stdout.close()
+    err = proc.stderr.read()
+    proc.stderr.close()
+    return first, err, proc.wait(timeout=60)
+
+
+class RunCliTest(unittest.TestCase):
+    """The wrapper itself: pass-through, quieting, and what stays loud."""
+
+    def test_returns_the_mains_status(self):
+        self.assertEqual(cli_entry.run_cli(lambda: 7), 7)
+        self.assertEqual(cli_entry.run_cli(lambda a, b=0: a + b, 2, b=3), 5)
+
+    def test_broken_pipe_mid_run_exits_zero(self):
+        def main():
+            raise BrokenPipeError(32, "Broken pipe")
+
+        self.assertEqual(cli_entry.run_cli(main), 0,
+                         "a reader that closed early got what it asked for — "
+                         "that is success, not failure")
+
+    def test_system_exit_keeps_its_status(self):
+        with self.assertRaises(SystemExit) as caught:
+            cli_entry.run_cli(lambda: (_ for _ in ()).throw(SystemExit(2)))
+        self.assertEqual(caught.exception.code, 2,
+                         "argparse's usage error must not become a success")
+
+    def test_other_exceptions_still_raise(self):
+        with self.assertRaises(ValueError):
+            cli_entry.run_cli(lambda: (_ for _ in ()).throw(ValueError("boom")))
+
+    def test_silence_stdout_tolerates_a_stream_with_no_fd(self):
+        """Under a captured stdout (a test buffer) there is no fd 1 to
+        re-point; the wrapper must degrade, not raise a second error."""
+        import io
+
+        held, sys.stdout = sys.stdout, io.StringIO()
+        try:
+            cli_entry._silence_stdout()  # must not raise
+            self.assertEqual(cli_entry.run_cli(lambda: 0), 0)
+        finally:
+            sys.stdout = held
+
+
+class EntrypointsTest(unittest.TestCase):
+    """One mechanism, not N copies — enforced over the whole scripts/ tree."""
+
+    def setUp(self):
+        self.blocks = {}
+        for path in sorted(SCRIPTS.glob("*.py")):
+            m = MAIN_BLOCK.search(path.read_text())
+            if m:
+                self.blocks[path.name] = m.group("body")
+
+    def test_finder_sees_a_known_entrypoint(self):
+        """Positive control: an empty scan would pass every test below."""
+        self.assertIn("sprint.py", self.blocks)
+        self.assertGreaterEqual(len(self.blocks), 40,
+                                "scripts/ holds ~42 CLI entrypoints; a short "
+                                "scan means the finder broke, not that the "
+                                "tree shrank")
+
+    def test_every_entrypoint_routes_through_run_cli(self):
+        for name, body in self.blocks.items():
+            with self.subTest(script=name):
+                self.assertIn("from cli_entry import run_cli", body,
+                              f"{name}: __main__ must import the wrapper")
+                self.assertIn("run_cli(", body,
+                              f"{name}: __main__ must call its main through "
+                              "run_cli — a bare main() reintroduces #384")
+
+    def test_no_script_hand_rolls_sigpipe_handling(self):
+        for path in sorted(SCRIPTS.glob("*.py")):
+            if path.name == "cli_entry.py":
+                continue
+            with self.subTest(script=path.name):
+                self.assertNotIn("SIGPIPE", path.read_text(),
+                                 f"{path.name}: SIGPIPE handling belongs to "
+                                 "cli_entry alone — the SIG_DFL copies (#299) "
+                                 "killed the process with signal 13 and cost "
+                                 "the command its own exit status")
+
+
+class LivePipeTest(unittest.TestCase):
+    """Real processes, closed readers, both buffering modes."""
+
+    def setUp(self):
+        self.made: list[str] = []
+
+    def tearDown(self):
+        for path in self.made:
+            os.unlink(path)
+
+    def _child(self, *, wrapped: bool, lines: int) -> str:
+        src = CHILD.format(
+            scripts=str(SCRIPTS),
+            importline="from cli_entry import run_cli" if wrapped else "",
+            lines=lines,
+            call="sys.exit(run_cli(main))" if wrapped else "sys.exit(main())",
+        )
+        path = _write_child(src)
+        self.made.append(path)
+        return path
+
+    def test_instrument_sees_the_bug_unwrapped(self):
+        """Known-positive for every clean assertion below: without the wrapper,
+        each of these conditions produces the noise on stderr."""
+        flood = self._child(wrapped=False, lines=FLOOD)
+        few = self._child(wrapped=False, lines=FEW)
+        for label, env in ENVS:
+            with self.subTest(env=label, reader="pre-closed", out="flood"):
+                done = _preclosed([sys.executable, flood], env)
+                self.assertIn("BrokenPipeError", done.stderr)
+                self.assertNotEqual(done.returncode, 0)
+            with self.subTest(env=label, reader="pre-closed", out="few"):
+                done = _preclosed([sys.executable, few], env)
+                self.assertIn("BrokenPipeError", done.stderr)
+                self.assertNotEqual(done.returncode, 0)
+            with self.subTest(env=label, reader="head-like", out="flood"):
+                _, err, rc = _headlike([sys.executable, flood], env)
+                self.assertIn("BrokenPipeError", err)
+                self.assertNotEqual(rc, 0)
+
+    def test_head_like_reader_gets_its_lines_and_no_noise(self):
+        wrapped = self._child(wrapped=True, lines=FLOOD)
+        for label, env in ENVS:
+            with self.subTest(env=label):
+                first, err, rc = _headlike([sys.executable, wrapped], env)
+                self.assertEqual(first, "line 0 " + "x" * 40 + "\n",
+                                 "the reader must still get what it asked for")
+                self.assertEqual(err, "", "an early-closed reader is not an error")
+                self.assertEqual(rc, 0)
+
+    def test_pre_closed_stdout_is_silent(self):
+        for lines in (FEW, FLOOD):
+            wrapped = self._child(wrapped=True, lines=lines)
+            for label, env in ENVS:
+                with self.subTest(env=label, lines=lines):
+                    done = _preclosed([sys.executable, wrapped], env)
+                    self.assertEqual(done.stderr, "")
+                    self.assertEqual(done.returncode, 0)
+
+    def test_real_command_is_silent_on_a_closed_reader(self):
+        """A real engine entrypoint that prints and needs no DB — `sc` itself
+        runs this one on every invocation."""
+        argv = [sys.executable, str(SCRIPTS / "artifact_policy.py"), "path", "map-db"]
+        for label, env in ENVS:
+            with self.subTest(env=label):
+                done = _preclosed(argv, env)
+                self.assertEqual(done.stderr, "",
+                                 "a real command printed to stderr because "
+                                 "nobody was reading stdout")
+                self.assertEqual(done.returncode, 0)
+
+    def test_real_error_still_reaches_stderr(self):
+        """The other wall: quieting the pipe must not quiet failures."""
+        argv = [sys.executable, str(SCRIPTS / "sprint.py"), "--bogus"]
+        for label, env in ENVS:
+            with self.subTest(env=label):
+                done = _preclosed(argv, env)
+                self.assertIn("error:", done.stderr)
+                self.assertNotIn("BrokenPipeError", done.stderr)
+                self.assertEqual(done.returncode, 2,
+                                 "a usage error is still a usage error when "
+                                 "nobody is reading")
+
+    def test_failure_after_output_keeps_status_and_stays_quiet(self):
+        """Output buffered, command fails, THEN the flush hits the dead pipe:
+        the status is the command's own, and the pipe adds nothing to stderr.
+
+        Buffered only — that is the condition under which the command reaches
+        its own failure before the pipe is discovered. Unbuffered, the first
+        print raises and the run is simply interrupted (exit 0, covered above).
+        """
+        path = _write_child(FAILS_AFTER_OUTPUT.format(scripts=str(SCRIPTS)))
+        self.made.append(path)
+        done = _preclosed([sys.executable, path], _BUFFERED)
+        self.assertEqual(done.stderr, "real failure\n")
+        self.assertEqual(done.returncode, 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_harness_epoch.py
+++ b/tests/test_harness_epoch.py
@@ -174,8 +174,11 @@ class ScFixture:
         self.fakebin.mkdir()
         self.log.touch()
         shutil.copy2(ROOT / "sc", self.root / "sc")
+        # cli_entry.py is not optional in a synthetic fork: every entrypoint
+        # imports it from its __main__ block (SIGPIPE hygiene, #384).
         for script in ("install.py", "engine_manifest.py", "ports.py",
-                       "artifact_policy.py", "harness_versions.py"):
+                       "artifact_policy.py", "harness_versions.py",
+                       "cli_entry.py"):
             shutil.copy2(ENGINE / "scripts" / script, self.scripts / script)
         (self.engine / "Dockerfile").write_text("FROM scratch\n")
         self._write_fake_docker()

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -32,14 +32,13 @@ class SupervisionFixture:
         self.home.mkdir()
         self.docker_state.mkdir()
         shutil.copy2(ROOT / "sc", self.root / "sc")
-        shutil.copy2(
-            ROOT / ".super-coder" / "scripts" / "artifact_policy.py",
-            self.scripts / "artifact_policy.py",
-        )
-        shutil.copy2(
-            ROOT / ".super-coder" / "scripts" / "db_backup.py",
-            self.scripts / "db_backup.py",
-        )
+        # cli_entry.py rides along with every script copied here: each one
+        # imports it from its __main__ block (SIGPIPE hygiene, #384).
+        for script in ("artifact_policy.py", "db_backup.py", "cli_entry.py"):
+            shutil.copy2(
+                ROOT / ".super-coder" / "scripts" / script,
+                self.scripts / script,
+            )
         (self.engine / "Dockerfile").write_text("FROM scratch\n")
         self._write_scripts()
         self._write_fake_commands()


### PR DESCRIPTION
Closes flag #384 (S84 U13).

## The bug

`./sc sprint board --sprint 84 | head -1` printed the board and then a 12-line
`BrokenPipeError` traceback. Python installs `SIG_IGN` for SIGPIPE, so a reader
that closes early (`| head`, `| grep -m1`, a quit pager) surfaces as an
exception out of whatever `print()` was running. Agent shells pipe `sc` output
on nearly every turn, so that traceback lands in transcripts fleet-wide.

Reproduced on three commands before touching anything (`sprint board`,
`skill list`, `feature list`).

## Enumeration — stated first, per the unit's shape

Method: `grep -l '^if __name__'` over every `.super-coder/scripts/*.py`, then
read each block verbatim, then count stdout-bound `print()` calls per file.
Counts are against the PR's base, `origin/main` at 39e90ab.

- **60** scripts, **42** with a `__main__` entrypoint, **18** library modules with none.
- All **42** print to stdout on their main path (lowest: 2 calls; highest: 63).
  So "entrypoints that print" and "entrypoints" are the same set — all 42 are patched.
- The `sc` dispatcher's own inline `$PY -c` snippets are out of scope: their
  stdout is consumed by the dispatcher through `$( )`, never by an operator's
  pager, and `sc` is POSIX sh, which dies on SIGPIPE by default.
- **U8 collision: none.** `interface_broker.py` and `interface_runtime.py` —
  U8's named surface — have zero `__main__` blocks and are untouched. This PR
  does touch `interface_cli.py` / `interface_exec.py` / `interface_hook.py`,
  two lines each, entrypoint block only.

## The mechanism

One helper, `.super-coder/scripts/cli_entry.py`:

```python
def run_cli(fn, *args, **kwargs):
    try:
        rc = fn(*args, **kwargs)
    except BrokenPipeError:
        rc = 0  # the reader closed mid-run; it got what it asked for
    except BaseException:
        _flush_stdout()  # keep the pipe quiet; the raised status still stands
        raise
    _flush_stdout()
    return rc
```

`_flush_stdout()` discovers a dead reader here rather than at interpreter exit,
and on a break re-points fd 1 at `/dev/null` so the interpreter's own shutdown
flush ("Exception ignored in: `<_io.TextIOWrapper name='<stdout>'>`", exit 120)
stays quiet too. Both writes have to be silenced, not just the first.

Each `__main__` block gains two lines — the import inside the block (so
importing the module as a library is unaffected) and the wrapped call:

```python
if __name__ == "__main__":
    from cli_entry import run_cli

    raise SystemExit(run_cli(main, sys.argv[1:]))
```

**It replaces three hand-copies, it does not join them.** `mem.py`, `watch.py`
and `job.py` carried `signal(SIGPIPE, SIG_DFL)` from #299; that variant kills
the process with signal 13 mid-write, so the shell sees exit 141 and the
command gets no say in its own status. Those are removed, and a test fails if
`SIGPIPE` reappears anywhere outside `cli_entry.py`.

## Exit semantics

- Broken pipe **interrupts** a run → **exit 0**. `head` closing the pipe is the
  reader succeeding, not the writer failing.
- The command **already has a status** (a return value, argparse's `SystemExit`,
  any other exception) → that status **stands**. A closed reader silences noise;
  it never converts a failure into a success. This is the one deliberate
  departure from a flat "always exit 0": laundering a usage error into success
  because nobody was reading is a worse bug than the one being fixed.
- **stderr is never touched.**

## Tests — `tests/test_cli_sigpipe.py`, 14 tests

Two conditions decide whether a closed reader is observable at all, so the live
tests fix both instead of inheriting them:

- **buffering** — the sandbox exports `PYTHONUNBUFFERED=1`, which moves the
  break from the flush into the `print()`. Every live case runs under **both**.
- **volume** — a head-like reader that closes after one line breaks nothing if
  the child already fit its output in the 64KB pipe buffer. So the head-like
  child floods 200KB, and small-output cases use a **pre-closed** pipe. Neither
  leg races the reader.

Legs: the wrapper's unit behavior · **every** entrypoint routes through it
(a new script that forgets goes red) · no script hand-rolls SIGPIPE · head-like
reader gets its line, empty stderr, exit 0 · pre-closed stdout silent · a real
engine command (`artifact_policy.py path map-db`, run on every `sc`
invocation) silent · a usage error still reaching stderr with exit 2 · a
command that fails *after* its output keeping exit 3 with stderr intact.

`test_instrument_sees_the_bug_unwrapped` is the positive control: the same
children without the wrapper must show the traceback in every condition
asserted clean above. Note what is **not** used as a probe — argparse's
`--help` down a dead pipe. Its quietness is **conditional on buffering**:
unbuffered, argparse swallows its own write error and an unpatched run is
silent at rc 0; buffered, the same unpatched run is noisy — rc **120** with
`Exception ignored in: <_io.TextIOWrapper name='<stdout>'>` on stderr. The
sandbox exports `PYTHONUNBUFFERED=1`, which is exactly the leg where the probe
goes blind, so an early draft that used it would have passed on `main`. A probe
whose sensitivity depends on an ambient env var is not a probe.

## Mutation evidence

9 mutants, serial, `PYTHONDONTWRITEBYTECODE=1`, caches cleared, baseline
re-asserted green after every revert.

| # | mutant | red set |
|---|---|---|
| M1 | skip flush/silence after a caught pipe error | **SURVIVED** |
| M2 | no flush after main returns | pre_closed_silent, real_command_silent |
| M3 | swallow every exception, not just the pipe | failure_after_output, other_exceptions, real_error_stderr, system_exit_status |
| M4 | broken pipe reports failure (rc 1) | broken_pipe_exits_zero, head_like_no_noise, pre_closed_silent, real_command_silent |
| M5 | one entrypoint left unwrapped | every_entrypoint_routes, real_command_silent |
| M6 | a script hand-rolls SIGPIPE again | no_hand_rolled_sigpipe |
| M7 | flush path does not silence | failure_after_output, pre_closed_silent, real_command_silent |
| M8 | `_silence_stdout` a no-op | failure_after_output, pre_closed_silent, real_command_silent |
| M9 | silence dup2s a live fd instead of devnull | failure_after_output, pre_closed_silent, real_command_silent |

**M1 disclosed as a survivor.** After a write raises `BrokenPipeError`, CPython
drops the buffer that failed, so nothing is left for the exit flush and the
extra flush is unobservable. It is load-bearing only when a write completes
*partially* before the break, which needs the reader to close mid-transfer — a
race I could not force without a sleep, and this sprint already has a unit
about flaky tests. The line stays (it costs nothing and the field failure was
itself racy), stated here rather than papered over. M7/M8/M9 show the silencing
mechanism it calls is pinned three ways.

## Trade-off rejected

Standardizing on the existing `signal(SIGPIPE, SIG_DFL)` two-liner would have
been a smaller diff. Rejected: it exits 141, kills the process mid-write with
no chance for the command to report its own status, and the unit's stated exit
semantics are 0.

