### PR TITLE
feat(interface): deterministic submit — mode-aware two-phase delivery + submit watch (S84 U8)

### DIFF
--- a/.super-coder/api/interface_routes.py
+++ b/.super-coder/api/interface_routes.py
@@ -2127,6 +2127,15 @@ _ALERT_COPY = {
         "Waiting does not clear it — the declaration is what is wrong.",
         "capability",
     ),
+    "submit_unconfirmed": (
+        "A composer message was delivered to the pane and the harness never "
+        "reported submitting it, including after the engine pressed Enter "
+        "again; `detail` names the harness and how many retries were spent.",
+        "Open the terminal for that session and look: the text is on screen "
+        "unsent, so pressing Enter there completes it. If this repeats on one "
+        "seat, its hook config is the thing to check.",
+        "warning",
+    ),
     "binding_released_live_sprint": (
         "The planner binding was released while this sprint still has "
         "non-terminal units, so nothing is listening for its wake events.",
@@ -3237,6 +3246,13 @@ def _hook_callback(headers, body):
             # (turn_stop → idle, provider session_start → ready+quiet
             # baseline). Signal after commit; a no-op when nothing is queued.
             interface_wake.notify_session(session_id)
+            # spec #62 D2: this hook is the ONLY proof a submit happened, so
+            # it is also what satisfies the runtime's submit watch and stops
+            # its bare-CR retries. Same post-commit, in-process shape as the
+            # wake notify above — the runtime is the one bound here by
+            # bind_runtime, which is the same process that armed the watch.
+            if event == "prompt_submit" and _runtime is not None:
+                _runtime.notify_submit(session_id)
             return _json(200, result)
         except interface_broker.BrokerError as exc:
             # Flag #51 (decision #31): EVERY rejection is audited — a silent

--- a/.super-coder/api/interface_ws.py
+++ b/.super-coder/api/interface_ws.py
@@ -14,6 +14,13 @@ Wire protocol (subprotocol sc-term.v1):
   text JSON control both ways: input_ack, input_reject, writer, lifecycle,
   resync, heartbeat, error. There is NO client "wake" frame — production
   wake submissions are the coordinator's (seq 8).
+  Server->client only (spec #62 D2): submit_confirmed{seq} and
+  submit_pending{seq}. input_ack means "bytes committed to tmux" and never
+  meant more; these two carry what it cannot — whether the harness actually
+  SUBMITTED the frame. `seq` is null for a wake submission, which is nobody's
+  frame. A confirmation may never arrive on a seat whose harness delivers no
+  prompt_submit hook (vibe, opencode): there the watch is not armed at all,
+  and delivery-only semantics are the honest contract.
 
 Upgrade contract: GET /api/interface/session-streams/<session_id>?ticket=T
 with subprotocol sc-term.v1; the ticket is single-use, minted via

--- a/.super-coder/scripts/interface_broker.py
+++ b/.super-coder/scripts/interface_broker.py
@@ -55,6 +55,14 @@ WAKE_BATCH_STALL_S = 300.0
 # keystroke. A minute is two orders of magnitude past the hook's own round
 # trip.
 #
+# It is also the OUTER of two thresholds on one condition (decision #107):
+# interface_runtime's submit watch retries Enter within ~6s of the original,
+# and its budget (SUBMIT_RETRIES x SUBMIT_CONFIRM_S) must stay strictly under
+# this value so the repair finishes before the backstop reports. Changing this
+# number downward without changing those reverses that order and makes the two
+# report the same fault twice — the ordering is pinned by
+# test_deterministic_submit.py::ConstantOrderingTest.
+#
 # Both bound INVISIBILITY, not delivery — nothing here hurries a hook, and
 # neither threshold is evaluated for a seat that has already been observed.
 HOOKS_READY_SILENT_S = 180.0
@@ -983,6 +991,84 @@ def _silence_detail(harness, cli_version, unobserved: str,
             f"declares {unobserved!r} — {measured}")
 
 
+def _submit_silent_alert(con, *, session_id, harness, cli_version, batch_id,
+                         sprint_doc_id, measured: str) -> None:
+    """THE row for "the engine pressed Enter and no prompt_submit answered".
+
+    That is ONE condition, and this sprint gave it TWO measurements at two
+    timescales (decision #107):
+
+      * the submit watch (spec #62 D2, `interface_runtime`) — per delivered
+        frame, ~6s, and it is the REPAIR: it presses Enter again;
+      * H-27's batch silence (below) — per submitting wake batch, 60s, and it
+        is the BACKSTOP: it reports that nothing worked.
+
+    Both raise through here so they produce the SAME reason with the SAME
+    refs, hence the same dedupe key: whichever observes first opens the row
+    and the other REFRESHES its detail. Never inline this `_alert` call at
+    either site — two literal call shapes are two dedupe keys the moment one
+    of them is edited, and the operator then sees one fault reported twice
+    (the double-alerting class decision #106 forbids)."""
+    _alert(con, severity="warning", reason="hooks_declared_but_silent",
+           session_id=session_id, batch_id=batch_id,
+           sprint_doc_id=sprint_doc_id,
+           detail=_silence_detail(harness, cli_version, "prompt_submit",
+                                  measured))
+
+
+def record_submit_unconfirmed(con, session_id: int, attempts: int) -> str:
+    """The submit watch spent every bare-CR retry and the frame never
+    submitted (spec #62 D2 exhaustion). Records the observation; returns the
+    disposition taken, for the caller's log.
+
+    Two dispositions, because the condition has two scopes:
+
+    * **A wake batch is in flight** — this IS H-27's condition, observed
+      early. It feeds H-27's own row (`_submit_silent_alert`) carrying the
+      retry evidence, so the operator gets one row that says the repair was
+      attempted and failed, not one alert now and a second at 60s.
+    * **No batch** — a human composer frame. H-27 scopes to an armed
+      binding's submitting batch and never measures human input, so there is
+      no row of its to feed. It gets its own reason, which also keeps it from
+      colliding with the batch-less READINESS row that `record_hook` resolves
+      on session_start — that row means a different thing and is cleared by a
+      different event.
+
+    Never parks the session and never revokes the writer: the bytes are on
+    screen and the operator can act on them, which is the whole difference
+    between this and a delivery failure.
+    """
+    sess = con.execute(
+        "SELECT harness, cli_version FROM interface_sessions "
+        "WHERE session_id=?", (session_id,)).fetchone()
+    if sess is None:
+        return "no_session"
+    harness, cli_version = sess[0], sess[1]
+    measured = (f"the submit CR was delivered and {attempts} bare-CR "
+                f"{'retry' if attempts == 1 else 'retries'} did not produce "
+                f"a submit hook")
+
+    batch = con.execute(
+        "SELECT b.batch_id, k.sprint_doc_id "
+        "FROM planner_wake_batches b "
+        "JOIN sprint_planner_bindings k ON k.binding_id = b.binding_id "
+        "WHERE b.state='submitting' AND k.session_id=? "
+        "AND k.released_at IS NULL", (session_id,)).fetchone()
+    if batch is not None:
+        _submit_silent_alert(con, session_id=session_id, harness=harness,
+                             cli_version=cli_version, batch_id=batch[0],
+                             sprint_doc_id=batch[1], measured=measured)
+        con.commit()
+        return "fed_h27_batch_row"
+
+    _alert(con, severity="info", reason="submit_unconfirmed",
+           session_id=session_id,
+           detail=_silence_detail(harness, cli_version, "prompt_submit",
+                                  measured))
+    con.commit()
+    return "own_row"
+
+
 def hooks_silence_alert(con, binding_id: int, ready_s=None,
                         submit_s=None) -> "float | None":
     """Check a declared hook chain against what has ACTUALLY arrived, for the
@@ -1018,6 +1104,19 @@ def hooks_silence_alert(con, binding_id: int, ready_s=None,
        a dead chain no longer parks in `starting` where the arming gate could
        see it — it parks HERE, where `_drain_sync` returns early and nothing
        in flight ever looks again.
+
+       POST-D2 THIS CLAUSE IS STRICTLY STRONGER, and it now means something
+       different from what it meant when it shipped (decision #107). Spec #62
+       D2 put a submit watch on every delivered frame: within ~6s of the
+       original Enter it has pressed Enter up to SUBMIT_RETRIES more times.
+       Those retries are ordered to complete well inside HOOKS_SUBMIT_SILENT_S
+       (pinned by test_deterministic_submit.py::ConstantOrderingTest), so by
+       the time this threshold falls due, the cheap repair has ALREADY BEEN
+       TRIED AND FAILED. Reaching here no longer reads "the submit hook is
+       late"; it reads "Enter was pressed several times and this chain
+       answered none of them" — which is why waiting still does not clear it.
+       This is the BACKSTOP; the watch is the repair. Both report through
+       `_submit_silent_alert` so one condition keeps one row.
 
     NOT MEASURED: H-27's literal "a completed human turn produced no
     turn_stop". In band, the only evidence that a turn completed IS
@@ -1075,13 +1174,13 @@ def hooks_silence_alert(con, binding_id: int, ready_s=None,
     # batch submitted zero seconds ago: unmeasured, never reported as silent.
     if batch is not None and batch[1] is not None:
         if batch[1] >= submit_s:
-            _alert(con, severity="warning",
-                   reason="hooks_declared_but_silent", session_id=session_id,
-                   batch_id=batch[0], sprint_doc_id=doc_id,
-                   detail=_silence_detail(
-                       harness, cli_version, "prompt_submit",
-                       f"batch {batch[0]} submitted {batch[1]:.0f}s ago and "
-                       f"the submit hook has not answered"))
+            _submit_silent_alert(
+                con, session_id=session_id, harness=harness,
+                cli_version=cli_version, batch_id=batch[0],
+                sprint_doc_id=doc_id,
+                measured=(f"batch {batch[0]} submitted {batch[1]:.0f}s ago "
+                          f"and the submit hook has not answered, after the "
+                          f"submit watch's bare-CR retries"))
         else:
             pending.append(submit_s - batch[1])
 

--- a/.super-coder/scripts/interface_runtime.py
+++ b/.super-coder/scripts/interface_runtime.py
@@ -45,6 +45,7 @@ from pathlib import Path
 
 import db_driver
 import interface_broker
+import interface_hooks
 import interface_wake
 
 ENGINE = Path(__file__).resolve().parents[1]
@@ -64,6 +65,43 @@ TMUX_SYNC_TIMEOUT_S = 10.0   # a wedged-but-alive tmux must never hang the
                              # broker worker thread (SC-013)
 
 TMUX_SESSION = "sc-interface"
+
+# ── Deterministic submit (spec #62 D1/D2) ───────────────────────────────────
+#
+# A TUI decides whether a `\r` SUBMITS or inserts a newline by whether it
+# classified the surrounding input as a paste, and paste-classified input
+# bypasses keybinding resolution entirely (claude-code #15553, #74238). Sent as
+# one rapid burst, `body + \r` is therefore a coin-flip. These three constants
+# are the whole accommodation:
+#
+# SUBMIT_SETTLE_MS — how long the body is left alone before the submit CR goes
+# out as its own send-keys call, so the TUI's re-arming paste timer (50ms base,
+# 500ms in paste mode) has expired and the CR resolves as a keybinding.
+#
+# SUBMIT_CONFIRM_S / SUBMIT_RETRIES — the submit watch: how long to wait for the
+# `prompt_submit` hook that PROVES a submit, and how many bare-CR retries to
+# spend before reporting the frame delivered-but-not-submitted. A bare CR at an
+# already-submitted (empty) prompt is a no-op on all three verified TUIs, which
+# is what makes a retry safe against a late hook.
+#
+# Env-tunable because they are accommodations of someone else's heuristic, not
+# protocol constants — U5's live-TUI matrix is expected to revise the settle.
+# Read as module globals at CALL time, never bound into a default argument: a
+# default would freeze the value at import and leave these attributes decoys
+# that read correctly and change nothing.
+#
+# ORDERING IS LOAD-BEARING (decision #107). SUBMIT_RETRIES x SUBMIT_CONFIRM_S
+# must stay strictly under interface_broker.HOOKS_SUBMIT_SILENT_S: the watch is
+# the REPAIR and H-27's batch-silence alert is the BACKSTOP, so the repair has
+# to have finished trying before the backstop reports. Pinned by
+# test_deterministic_submit.py::ConstantOrderingTest.
+SUBMIT_SETTLE_MS = float(os.environ.get("SC_SUBMIT_SETTLE_MS", "250"))
+SUBMIT_CONFIRM_S = float(os.environ.get("SC_SUBMIT_CONFIRM_S", "3"))
+SUBMIT_RETRIES = int(os.environ.get("SC_SUBMIT_RETRIES", "2"))
+
+CR = b"\r"
+PASTE_START = b"\x1b[200~"
+PASTE_END = b"\x1b[201~"
 
 
 def _log(tag: str, msg: str) -> None:
@@ -146,6 +184,22 @@ class HumanInput:
 class Resize:
     def __init__(self, rows: int, cols: int):
         self.rows, self.cols = rows, cols
+
+
+class SubmitWatch:
+    """One delivered frame's wait for PROOF that it actually submitted.
+
+    `input_ack` has only ever meant "bytes committed to tmux". This is the
+    other half: the `prompt_submit` hook is the only thing in the system that
+    proves the TUI accepted the Enter, and it arrives over HTTP rather than
+    through the pane, so the wait is an Event the hook route sets — never a
+    scrape of terminal output."""
+
+    def __init__(self, seq: "int | None"):
+        self.seq = seq
+        self.attempts = 0
+        self.confirmed = asyncio.Event()
+        self.task: "asyncio.Task | None" = None
 
 
 # ---------------------------------------------------------------- shadow sidecar
@@ -237,6 +291,25 @@ class ShadowSidecar:
             raise RuntimeError(f"shadow snapshot failed: {msg.get('error')}")
         return base64.b64decode(msg["redraw"])
 
+    async def bracketed_paste(self, gen: str) -> str:
+        """The pane's DECSET 2004 state: 'on', 'off', or 'unknown'.
+
+        UNLIKE every other request here, this one never raises. Its caller is
+        the writer deciding whether to wrap a body in paste markers, and the
+        wrap is an optimization of INTERPRETATION, not correctness of delivery
+        — a sidecar that is dead, restarting, or behind must degrade that
+        caller to no-wrap, not fail the send. Every failure mode (exited
+        sidecar, request timeout, unknown generation, a reply from an older
+        sidecar with no such field) therefore reads 'unknown'."""
+        try:
+            msg = await self._request({"op": "modes", "gen": gen})
+        except Exception:  # noqa: BLE001 — see docstring: no failure may raise
+            return "unknown"
+        if not msg.get("ok"):
+            return "unknown"
+        value = msg.get("bracketed_paste")
+        return value if value in ("on", "off") else "unknown"
+
     async def stop(self) -> None:
         if self._proc and self._proc.returncode is None:
             self._proc.terminate()
@@ -264,6 +337,11 @@ class Generation:
         self.clients: set = set()
         self.queue: asyncio.Queue = asyncio.Queue()
         self.continuity_broken = False
+
+        # Submit determinism (spec #62 D2). `submit_confirmable` caches the
+        # capability answer for this generation's seat: None = not yet asked.
+        self.submit_watch: "SubmitWatch | None" = None
+        self.submit_confirmable: "bool | None" = None
 
         self._bridge: collections.deque[bytes] = collections.deque()
         self._bridge_bytes = 0
@@ -406,6 +484,14 @@ class Generation:
         _log(self.sid, "tearing down generation")
         for task in self._tasks:
             task.cancel()
+        # The submit watch is per-frame, so it is deliberately NOT in _tasks
+        # (a long session would accumulate one dead entry per message there).
+        # It still has to die with the generation: a pane that is going away
+        # cannot submit, and a retry into a killed window is a tmux error
+        # nobody asked for.
+        if self.submit_watch is not None and self.submit_watch.task is not None:
+            self.submit_watch.task.cancel()
+            self.submit_watch = None
         if kill_window:
             for client in list(self.clients):
                 client.send_control({"type": "error", "code": "terminated"})
@@ -569,7 +655,9 @@ class InterfaceRuntime:
                 raise interface_broker.PreSendError(
                     f"wake preflight failed for {gen.pane_id}: "
                     f"{exc!r}") from exc
-            self._send_keys_sync(gen.pane_id, payload)
+            # No seq: a wake frame is not any client's frame, so its
+            # confirmation carries no sequence to match against a draft.
+            self._deliver_frame_sync(gen, payload)
 
         return writer
 
@@ -670,13 +758,53 @@ class InterfaceRuntime:
                 f"{err.decode(errors='replace').strip()}")
         return out
 
+    async def _pin_server_options(self) -> None:
+        """Pin the private tmux server's key encoding, at server creation.
+
+        `extended-keys on` makes tmux re-encode keys in CSI-u form, which
+        rewrites 0x0D inside paste content (claude-code #43169) — and this
+        writer's entire determinism argument (spec #62 D4) is that the 0x0D it
+        sends as a separate submit reaches the pane AS 0x0D. `off` is tmux
+        3.5a's default, so this pins a default rather than changing behaviour;
+        it exists because a default is not a guarantee and nothing else in the
+        runtime states the requirement.
+
+        ASSERTED, NOT ASSUMED: tmux accepts `set` and can still report a
+        different effective value (a version whose default differs, a
+        `-f`-loaded config we do not own). Both the set and the readback are
+        advisory — a refusal is LOGGED and the spawn continues, because a
+        server option we could not pin is not a reason to deny the operator a
+        chat session. Server-scoped (`-s`), so it belongs on the two paths
+        that CREATE the server and nowhere else."""
+        try:
+            await self.tmux("set", "-s", "extended-keys", "off")
+        except RuntimeError as exc:
+            _log("boot", f"tmux extended-keys off REFUSED: {exc!r} — a CR sent "
+                         "as a separate submit may be CSI-u re-encoded")
+            return
+        try:
+            out = await self.tmux("show", "-sv", "extended-keys")
+        except RuntimeError as exc:
+            _log("boot", f"tmux extended-keys readback failed: {exc!r} — "
+                         "the pin is unverified")
+            return
+        effective = out.decode(errors="replace").strip()
+        if effective != "off":
+            _log("boot", f"tmux extended-keys is {effective!r} after setting "
+                         "it off — CSI-u re-encoding is still possible")
+
     def _send_keys_sync(self, pane_id: str, payload: bytes) -> None:
         """The injected broker writer: chunked send-keys -H, ≤512 bytes per
         invocation, called exactly once per accepted frame (as many tmux
         calls as chunks). Runs in the broker worker thread. Every call is
         timeout-bounded: a wedged server raises (TimeoutExpired — ambiguous,
         the caller parks delivery_unknown) instead of hanging the thread
-        (SC-013)."""
+        (SC-013).
+
+        Bytes only — no splitting, no wrapping, no settle. The two-phase
+        delivery protocol lives in `_deliver_frame_sync`, which calls this
+        primitive once per phase; keep this the single audited `-H` byte path
+        the broker contract measures."""
         for off in range(0, len(payload), SENDKEYS_CHUNK):
             chunk = payload[off:off + SENDKEYS_CHUNK]
             subprocess.run(
@@ -684,6 +812,230 @@ class InterfaceRuntime:
                  *[f"{b:02x}" for b in chunk]],
                 capture_output=True, check=True,
                 timeout=TMUX_SYNC_TIMEOUT_S)
+
+    def _bracketed_paste_sync(self, gen: "Generation") -> str:
+        """The pane's DECSET 2004 state — 'on', 'off', or 'unknown'.
+
+        Runs in the writer's worker thread, so the sidecar request rides the
+        runtime loop. Safe from both writer call sites because each is already
+        inside an `asyncio.to_thread` the loop is awaiting — the loop is free
+        to service this. NEVER call it from the loop thread: that self-deadlocks.
+
+        `bracketed_paste` already answers 'unknown' rather than raising for
+        every sidecar-side failure; the outer guard here is for the loop
+        itself being gone or wedged, which its own timeout cannot cover."""
+        try:
+            return asyncio.run_coroutine_threadsafe(
+                self.shadow.bracketed_paste(gen.sid), self.loop
+            ).result(timeout=SHADOW_REQUEST_TIMEOUT_S + 1)
+        except Exception:  # noqa: BLE001 — a mode read may never fail a send
+            return "unknown"
+
+    def _deliver_frame_sync(self, gen: "Generation", payload: bytes, *,
+                            seq: "int | None" = None) -> None:
+        """Deliver ONE accepted frame as mode-aware two-phase bytes (D1).
+
+        This is the injected broker writer both call sites pass down, so it
+        runs once per accepted frame in a worker thread. It may make several
+        tmux calls — the chunker always has, and the broker's "writer called
+        exactly once per frame" contract counts frames, not tmux invocations.
+        What it must never do is put a frame's body and its submit CR in one
+        rapid burst, because the TUI then classifies the CR as pasted content
+        and inserts a newline instead of submitting.
+
+        Three shapes; only the third is split:
+
+        * **no trailing CR** — a raw terminal keystroke forwarded verbatim.
+          Not ours to interpret, and splitting it would change what the
+          operator typed.
+        * **exactly CR** — the operator tapping Enter to answer a TUI dialog.
+          There is no body to settle after and nothing to wrap, and there is
+          no submit of ours to confirm, so no watch is armed.
+        * **body + trailing CR** — a composer or wake frame. Wrap the body
+          when 2004 is active, settle, then send the CR as its own call.
+
+        Delivery failure is left to the caller exactly as before: an exception
+        from any phase propagates, and a frame whose body reached tmux before
+        the failure is genuinely ambiguous — which is the delivery_unknown park
+        the broker already performs. Nothing here catches it into a lie."""
+        if not payload.endswith(CR) or payload == CR:
+            self._send_keys_sync(gen.pane_id, payload)
+            return
+
+        body = payload[:-1]
+        if self._bracketed_paste_sync(gen) == "on":
+            # Protocol-correct: we stand exactly where a terminal emulator
+            # stands, and this is what one does with a paste. It makes every
+            # byte of the body DATA — embedded newlines included, which is
+            # what also fixes multiline composer messages — so nothing inside
+            # the body can submit early. When 2004 is off or unknown the raw
+            # body is delivered instead: the separate-CR phase alone is
+            # already strictly better than today's single burst, never worse.
+            body = PASTE_START + body + PASTE_END
+        self._send_keys_sync(gen.pane_id, body)
+        time.sleep(SUBMIT_SETTLE_MS / 1000.0)
+        self._send_keys_sync(gen.pane_id, CR)
+        self._arm_submit_watch(gen, seq)
+
+    # -- submit watch (D2) ---------------------------------------------------
+
+    def _read_submit_capability(self, session_id: int) -> bool:
+        con = db_driver.connect(self.db_path)
+        try:
+            row = con.execute(
+                "SELECT harness, cli_version FROM interface_sessions "
+                "WHERE session_id=?", (session_id,)).fetchone()
+        finally:
+            con.close()
+        if row is None:
+            return False
+        cap = interface_hooks.capability(row[0], row[1])
+        return cap["events"].get("prompt_submit", False)
+
+    def _submit_confirmable(self, gen: "Generation") -> bool:
+        """Can a `prompt_submit` hook EVER arrive for this seat? (D2 gating)
+
+        vibe and opencode have no hook adapter at all, so no contract event is
+        ever delivered for them. Arming a watch there would press Enter twice
+        into a perfectly healthy pane and then report every correct send as
+        delivered-not-submitted — a monitor that lies on the happy path, which
+        decision #76 forbids. Those seats keep today's delivery-only semantics.
+
+        Note this keys on the EVENT, not on `mandatory_ok`: a seat whose
+        cli_version is unparseable is a metadata-capture miss, not a harness
+        that cannot deliver the hook, and its watch should still arm.
+
+        Resolved once per generation. `harness` and `cli_version` are stamped
+        when the entrypoint promotes the reservation — before any frame can be
+        accepted — and neither changes under a live generation, so re-reading
+        them per frame would only put a DB round trip inside the writer."""
+        if gen.submit_confirmable is None:
+            gen.submit_confirmable = self._read_submit_capability(
+                gen.session_id)
+        return gen.submit_confirmable
+
+    def _arm_submit_watch(self, gen: "Generation", seq: "int | None") -> None:
+        """Arm the delivered frame's submit watch, from the writer thread.
+
+        A hop, not the watch: the watch is loop state (a task and an Event the
+        hook route sets), and this runs in the broker's worker thread.
+
+        NOTHING HERE MAY RAISE. By the time this is called the frame's bytes —
+        body, settle, and submit CR — have all reached tmux successfully. An
+        exception escaping into the writer would propagate out of the broker's
+        two-phase commit, which reads any writer exception as an AMBIGUOUS
+        WRITE and parks the session `delivery_unknown`. That would take a frame
+        that demonstrably delivered and record it as maybe-delivered, over a
+        capability lookup. Confirmation is an observability layer on top of
+        delivery; it is never allowed to damage the delivery beneath it."""
+        try:
+            if not self._submit_confirmable(gen):
+                return
+            loop = getattr(self, "loop", None)
+            if loop is None:
+                return
+            loop.call_soon_threadsafe(self._start_submit_watch, gen, seq)
+        except Exception as exc:  # noqa: BLE001 — see docstring
+            # Degrades to today's delivery-only semantics for this frame: no
+            # confirmation, no retries, and no client message claiming either.
+            _log(gen.sid, f"submit watch NOT armed ({exc!r}) — frame "
+                          "delivered, confirmation unavailable")
+
+    def _start_submit_watch(self, gen: "Generation",
+                            seq: "int | None") -> None:
+        previous = gen.submit_watch
+        if previous is not None and previous.task is not None:
+            # A live previous watch means its frame was superseded before it
+            # resolved (the ack that frees the next frame fires at DELIVERY,
+            # so a second frame can legitimately arrive mid-watch). Drop it:
+            # reporting submit_pending for a frame the operator has already
+            # followed with another is noise, not news.
+            previous.task.cancel()
+        watch = SubmitWatch(seq)
+        gen.submit_watch = watch
+        watch.task = asyncio.create_task(self._submit_watch_loop(gen, watch))
+
+    async def _submit_watch_loop(self, gen: "Generation",
+                                 watch: SubmitWatch) -> None:
+        """Wait for the submit hook; press Enter again a bounded number of
+        times; then report honestly (D2).
+
+        Never parks the session and never revokes the writer. The bytes ARE on
+        the screen — that is the whole difference between this and a delivery
+        failure, and it is why the operator gets a message telling them to look
+        rather than a lock telling them they cannot."""
+        try:
+            while True:
+                confirmed = True
+                try:
+                    await asyncio.wait_for(watch.confirmed.wait(),
+                                           SUBMIT_CONFIRM_S)
+                except asyncio.TimeoutError:
+                    confirmed = False
+                if confirmed:
+                    gen.broadcast_control({"type": "submit_confirmed",
+                                           "seq": watch.seq})
+                    return
+                if watch.attempts >= SUBMIT_RETRIES:
+                    break
+                watch.attempts += 1
+                _log(gen.sid,
+                     f"submit unconfirmed after {SUBMIT_CONFIRM_S}s — bare-CR "
+                     f"retry {watch.attempts}/{SUBMIT_RETRIES}")
+                try:
+                    await asyncio.to_thread(self._send_keys_sync,
+                                            gen.pane_id, CR)
+                except Exception as exc:  # noqa: BLE001 — see below
+                    # A failed retry is a failed ATTEMPT, not a new fault: the
+                    # frame's own bytes already landed, so the honest end state
+                    # is still delivered-not-submitted. Log it and let the
+                    # budget run out into the one report below, rather than
+                    # inventing a second failure surface for it.
+                    _log(gen.sid, f"submit retry {watch.attempts} write "
+                                  f"failed: {exc!r}")
+
+            gen.broadcast_control({"type": "submit_pending", "seq": watch.seq})
+            disposition = await asyncio.to_thread(
+                self._record_submit_unconfirmed, gen.session_id,
+                watch.attempts)
+            _log(gen.sid,
+                 f"submit UNCONFIRMED after {watch.attempts} retries — "
+                 f"delivered but not submitted ({disposition})")
+        finally:
+            if gen.submit_watch is watch:
+                gen.submit_watch = None
+
+    def _record_submit_unconfirmed(self, session_id: int,
+                                   attempts: int) -> str:
+        con = db_driver.connect(self.db_path)
+        try:
+            return interface_broker.record_submit_unconfirmed(
+                con, session_id, attempts)
+        finally:
+            con.close()
+
+    def notify_submit(self, session_id: int) -> None:
+        """The `prompt_submit` hook landed for this session — satisfy an armed
+        submit watch (D2 confirmation).
+
+        Called from the hook route's request thread, in this same process,
+        AFTER its commit: the same in-process pattern (and the same
+        `bind_runtime` reference) as `interface_wake.notify_session`, for the
+        same reason — the hook is the only proof of submit the system has, and
+        it arrives over HTTP, not through the pane."""
+        loop = getattr(self, "loop", None)
+        if loop is None:
+            return
+        try:
+            loop.call_soon_threadsafe(self._confirm_submit, session_id)
+        except RuntimeError:
+            pass   # loop closed: the service is going down
+
+    def _confirm_submit(self, session_id: int) -> None:
+        gen = self.generations.get(session_id)
+        if gen is None or gen.submit_watch is None:
+            return
+        gen.submit_watch.confirmed.set()
 
     async def send_keys(self, pane_id: str, payload: bytes) -> None:
         for off in range(0, len(payload), SENDKEYS_CHUNK):
@@ -826,6 +1178,7 @@ class InterfaceRuntime:
                                 "-n", window, "-x", str(cols), "-y", str(rows),
                                 shell_line)
                 self._tmux_session_started = True
+                await self._pin_server_options()
             else:
                 try:
                     await self.tmux("new-window", "-d", "-t", f"{TMUX_SESSION}:",
@@ -839,6 +1192,9 @@ class InterfaceRuntime:
                                     "-n", window, "-x", str(cols), "-y",
                                     str(rows), shell_line)
                     self._tmux_session_started = True
+                    # A re-created server is a NEW server: its options are
+                    # back at defaults, so the pin has to happen here too.
+                    await self._pin_server_options()
                 else:
                     await self.tmux("resize-window", "-t",
                                     f"{TMUX_SESSION}:{window}",
@@ -1147,7 +1503,7 @@ class InterfaceRuntime:
 
             def writer(n):
                 assert n == len(payload)
-                self._send_keys_sync(gen.pane_id, payload)
+                self._deliver_frame_sync(gen, payload, seq=seq)
 
             result = interface_broker.accept_human_input(
                 con, gen.session_id, seq, len(payload), writer)

--- a/.super-coder/shadow/sidecar.js
+++ b/.super-coder/shadow/sidecar.js
@@ -7,6 +7,7 @@
 //   feed     {gen, data: base64}        (synchronous-ordered per gen)
 //   resize   {gen, rows, cols}
 //   snapshot {gen}  -> {id, ok, gen, redraw: base64}
+//   modes    {gen}  -> {id, ok, gen, bracketed_paste: 'on'|'off'}
 //   dispose  {gen}
 // Ops without id are fire-and-forget (no reply).
 
@@ -68,6 +69,23 @@ rl.on('line', (line) => {
         return Buffer.from(buildRedraw(g.term, g.st), 'utf8').toString('base64');
       }).then(
         (redraw) => reply({ id, ok: true, gen, redraw }),
+        (e) => reply({ id, ok: false, gen, error: String(e) }),
+      );
+      break;
+    case 'modes':
+      // Bracketed-paste (DECSET 2004) as the pane's harness has left it. The
+      // injected writer asks before delivering a body so it can wrap in real
+      // paste markers; a throw here (no such generation) answers ok:false and
+      // the runtime reads that as 'unknown', which degrades to no-wrap.
+      // Rides the same per-gen chain as feed, so the answer reflects every
+      // byte fed before the ask — never a mode read that raced the redraw
+      // that changed it.
+      run(gen, async () => {
+        const g = gens.get(gen);
+        if (!g) throw new Error('no such generation');
+        return g.term.modes.bracketedPasteMode ? 'on' : 'off';
+      }).then(
+        (bp) => reply({ id, ok: true, gen, bracketed_paste: bp }),
         (e) => reply({ id, ok: false, gen, error: String(e) }),
       );
       break;

--- a/tests/test_deterministic_submit.py
+++ b/tests/test_deterministic_submit.py
@@ -1,0 +1,790 @@
+#!/usr/bin/env python3
+"""Deterministic submit — spec #62 Stage 0, units U1 (delivery) + U2 (watch).
+
+The defect under test is a coin-flip, not a crash: `body + \\r` sent as one
+rapid tmux burst is classified as a PASTE by the harness TUI, and
+paste-classified input bypasses keybinding resolution — so the `\\r` inserts a
+newline instead of submitting, and the engine's `input_ack` ("bytes committed
+to tmux") cannot tell the difference. Every test here therefore asserts on the
+SHAPE OF THE DELIVERY (what bytes went out, in how many calls, in what order,
+with what between them) rather than on a return value, because the return value
+was never wrong.
+
+Layout:
+  DeliveryShapeTest      — the three frame shapes, wrap/no-wrap, settle ordering
+  SubmitWatchTest        — arm, confirm, bounded retries, exhaustion surface
+  CapabilityGateTest     — seats that can never confirm never get a watch
+  ConstantOrderingTest   — the load-bearing constant order (decision #107)
+
+Run:
+    python3 -m pytest tests/test_deterministic_submit.py
+"""
+from __future__ import annotations
+
+import asyncio
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+TESTS = Path(__file__).resolve().parent
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(TESTS))
+import interface_broker  # noqa: E402
+import interface_runtime  # noqa: E402
+from test_interface_crash_window import build_engine_db  # noqa: E402
+
+
+class _Recorder:
+    """Interleaved log of what the writer did, in the order it did it.
+
+    Records the tmux byte-sends AND the settle sleeps into ONE list, because
+    every property in DeliveryShapeTest is about their relative order: "the CR
+    left in its own call, after a wait" is a statement about interleaving. A
+    test that recorded only the sends could not tell a settled submit from a
+    burst, which is precisely the bug.
+    """
+
+    def __init__(self):
+        self.log: list[tuple] = []
+
+    def send(self, pane_id: str, payload: bytes) -> None:
+        self.log.append(("send", payload))
+
+    def sleep(self, seconds: float) -> None:
+        self.log.append(("sleep", seconds))
+
+    @property
+    def sends(self) -> list[bytes]:
+        return [p for kind, p in self.log if kind == "send"]
+
+    @property
+    def kinds(self) -> list[str]:
+        return [kind for kind, _ in self.log]
+
+
+def _runtime(tmp: Path):
+    """A runtime with no tmux, no sidecar and no DB rows — this file's unit
+    tests inject at `_send_keys_sync` and at the mode read, which is every
+    external edge `_deliver_frame_sync` touches."""
+    return interface_runtime.InterfaceRuntime(
+        str(tmp / "shell_db.db"), run_dir=str(tmp / "run"))
+
+
+class DeliveryShapeTest(unittest.TestCase):
+    """D1: mode-aware two-phase delivery."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.rt = _runtime(self.tmp)
+        self.gen = interface_runtime.Generation(self.rt, 1, 1, 1, 24, 80)
+        self.gen.pane_id = "%0"
+        # Capability is pre-resolved so these tests are about DELIVERY SHAPE
+        # only; the gate itself is CapabilityGateTest's subject. There is no
+        # loop here either, so arming is a no-op — deliberately, since the
+        # shape must not depend on whether a watch could be armed.
+        self.gen.submit_confirmable = True
+        self.rec = _Recorder()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _deliver(self, payload: bytes, mode: str = "off"):
+        with (
+            mock.patch.object(self.rt, "_send_keys_sync", self.rec.send),
+            mock.patch.object(self.rt, "_bracketed_paste_sync",
+                              return_value=mode),
+            mock.patch.object(interface_runtime.time, "sleep", self.rec.sleep),
+        ):
+            self.rt._deliver_frame_sync(self.gen, payload)
+
+    # -- the split itself ---------------------------------------------------
+
+    def test_body_and_submit_are_separate_calls_with_a_settle_between(self):
+        self._deliver(b"hello\r")
+        self.assertEqual(self.rec.kinds, ["send", "sleep", "send"],
+                         "body and submit must not ride one burst")
+        self.assertEqual(self.rec.sends, [b"hello", b"\r"])
+
+    def test_settle_uses_the_configured_delay(self):
+        with mock.patch.object(interface_runtime, "SUBMIT_SETTLE_MS", 400):
+            self._deliver(b"hello\r")
+        self.assertEqual(
+            [s for k, s in self.rec.log if k == "sleep"], [0.4],
+            "SUBMIT_SETTLE_MS must be read at call time, not bound at import")
+
+    def test_no_trailing_cr_is_forwarded_verbatim(self):
+        # A raw terminal keystroke. Splitting or wrapping it would change what
+        # the operator typed, and there is no submit of ours to settle for.
+        self._deliver(b"abc")
+        self.assertEqual(self.rec.kinds, ["send"])
+        self.assertEqual(self.rec.sends, [b"abc"])
+
+    def test_bare_cr_is_forwarded_verbatim(self):
+        # The operator tapping Enter to answer a TUI dialog: body is empty, so
+        # there is nothing to wrap and nothing to wait for. Wrapping an empty
+        # body would send paste markers around nothing, and settling would
+        # delay a keystroke the operator is watching for.
+        self._deliver(b"\r")
+        self.assertEqual(self.rec.kinds, ["send"])
+        self.assertEqual(self.rec.sends, [b"\r"])
+
+    def test_bare_cr_never_reads_the_mode(self):
+        # Guards the shape, not just the output: an implementation that asked
+        # the sidecar first and then discarded the answer would pass the test
+        # above while putting a blocking round-trip in front of every dialog
+        # keystroke.
+        with (
+            mock.patch.object(self.rt, "_send_keys_sync", self.rec.send),
+            mock.patch.object(self.rt, "_bracketed_paste_sync") as mode,
+            mock.patch.object(interface_runtime.time, "sleep", self.rec.sleep),
+        ):
+            self.rt._deliver_frame_sync(self.gen, b"\r")
+            self.rt._deliver_frame_sync(self.gen, b"abc")
+        mode.assert_not_called()
+
+    def test_empty_payload_sends_nothing_new(self):
+        # Not a shape the composer produces, but the verbatim branch must not
+        # invent bytes for it either.
+        self._deliver(b"")
+        self.assertEqual(self.rec.sends, [b""])
+
+    # -- the wrap -----------------------------------------------------------
+
+    def test_wraps_body_when_bracketed_paste_is_active(self):
+        self._deliver(b"hello\r", mode="on")
+        self.assertEqual(
+            self.rec.sends,
+            [b"\x1b[200~hello\x1b[201~", b"\r"],
+            "an active 2004 pane must receive real paste markers")
+
+    def test_does_not_wrap_when_inactive(self):
+        self._deliver(b"hello\r", mode="off")
+        self.assertEqual(self.rec.sends, [b"hello", b"\r"])
+
+    def test_unknown_mode_degrades_to_no_wrap(self):
+        # A shadow that is dead, restarting, or behind reads 'unknown'. The
+        # separate-CR phase alone is still strictly better than today's single
+        # burst, so 'unknown' must deliver — never refuse, never guess 'on'
+        # (wrapping a pane that is NOT in paste mode would put literal
+        # `ESC[200~` into the prompt).
+        self._deliver(b"hello\r", mode="unknown")
+        self.assertEqual(self.rec.sends, [b"hello", b"\r"])
+
+    def test_multiline_body_keeps_its_newlines_inside_the_wrap(self):
+        # The multiline-composer fix: under a wrap every byte of the body is
+        # DATA, so the interior newlines cannot submit early. Exactly one CR
+        # leaves the writer, and it leaves alone.
+        self._deliver(b"line one\nline two\nline three\r", mode="on")
+        body, submit = self.rec.sends
+        self.assertEqual(
+            body, b"\x1b[200~line one\nline two\nline three\x1b[201~")
+        self.assertEqual(submit, b"\r")
+        self.assertEqual(self.rec.sends.count(b"\r"), 1,
+                         "interior newlines must not become extra submits")
+
+    def test_only_the_trailing_cr_is_split_off(self):
+        # A body that itself ends in CRLF-ish content: exactly one byte comes
+        # off the end, and the rest is delivered untouched.
+        self._deliver(b"keep\r\r", mode="off")
+        self.assertEqual(self.rec.sends, [b"keep\r", b"\r"])
+
+
+class _WriterWiringTest(unittest.TestCase):
+    """Both injected writers route through the two-phase path.
+
+    The point is coverage of the ROUTE, not of the split: a fix applied to one
+    writer and not the other leaves the wake path — the path this sprint's
+    success criterion is about — on the old burst delivery, and every
+    delivery-shape test above would still pass.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        con = sqlite3.connect(self.db)
+        con.execute("INSERT INTO interface_generations (shell_id, generation) "
+                    "VALUES (1,1)")
+        self.sid = con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle) VALUES (1,1,'occupied','idle')").lastrowid
+        con.execute("INSERT INTO interface_input_state (session_id, shell_id,"
+                    " generation, composer) VALUES (?,1,1,'clean')",
+                    (self.sid,))
+        con.commit()
+        self.lease_id = interface_broker.acquire_writer(
+            con, self.sid, "tab-1", "tok-1")
+        con.commit()
+        con.close()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_human_writer_delivers_in_two_phases(self):
+        async def flow():
+            rt = _runtime(self.tmp)
+            rt.loop = asyncio.get_running_loop()
+            gen = interface_runtime.Generation(rt, self.sid, 1, 1, 24, 80)
+            gen.pane_id = "%0"
+            rt.generations[self.sid] = gen
+            rec = _Recorder()
+
+            client = mock.Mock(session_id=self.sid, role="writer",
+                              client_id="tab-1", lease_id=self.lease_id,
+                              lease_token="tok-1")
+            with (
+                mock.patch.object(rt, "_send_keys_sync", rec.send),
+                mock.patch.object(rt, "_bracketed_paste_sync",
+                                  return_value="off"),
+                mock.patch.object(interface_runtime.time, "sleep", rec.sleep),
+            ):
+                await rt._do_human_input(
+                    gen, interface_runtime.HumanInput(
+                        client, 1, b"composed\r"))
+            # The real broker accepted it (ack sent), and the bytes left in
+            # two phases rather than one.
+            self.assertEqual(rec.kinds, ["send", "sleep", "send"])
+            self.assertEqual(rec.sends, [b"composed", b"\r"])
+        asyncio.run(flow())
+
+    def test_wake_writer_delivers_in_two_phases(self):
+        async def flow():
+            rt = _runtime(self.tmp)
+            rt.loop = asyncio.get_running_loop()
+            gen = interface_runtime.Generation(rt, self.sid, 1, 1, 24, 80)
+            gen.pane_id = "%0"
+            rt.generations[self.sid] = gen
+            rec = _Recorder()
+
+            payload = interface_broker.WAKE_PROMPT.encode() + b"\r"
+            writer = rt.wake_writer(self.sid)
+            with (
+                mock.patch.object(rt, "_send_keys_sync", rec.send),
+                mock.patch.object(rt, "_bracketed_paste_sync",
+                                  return_value="on"),
+                mock.patch.object(interface_runtime.time, "sleep", rec.sleep),
+                # The wake writer's own preflight shells out to tmux; this
+                # test is about delivery shape, not about the preflight.
+                mock.patch.object(interface_runtime.subprocess, "run"),
+            ):
+                await asyncio.to_thread(writer, len(payload))
+            self.assertEqual(rec.kinds, ["send", "sleep", "send"])
+            self.assertEqual(
+                rec.sends,
+                [interface_runtime.PASTE_START
+                 + interface_broker.WAKE_PROMPT.encode()
+                 + interface_runtime.PASTE_END,
+                 b"\r"],
+                "the wake writer must adopt the identical delivery")
+        asyncio.run(flow())
+
+
+class _WatchFixture(unittest.TestCase):
+    """A live runtime + generation on a real loop, with tmux stubbed.
+
+    The watch is loop state driven by a hook that arrives from another thread,
+    so these run the real task against a real event loop and a real
+    asyncio.Event. Time is compressed by patching the thresholds rather than
+    by sleeping through 3s waits — the property is the SEQUENCE of what
+    happens per elapsed window, never the wall-clock size of the window.
+    """
+
+    HARNESS = "claude"
+    CLI_VERSION = "2.1.217"
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        build_engine_db(self.db)
+        con = sqlite3.connect(self.db)
+        con.execute("INSERT INTO interface_generations (shell_id, generation) "
+                    "VALUES (1,1)")
+        self.sid = con.execute(
+            "INSERT INTO interface_sessions (shell_id, generation, occupancy,"
+            " lifecycle, harness, cli_version) "
+            "VALUES (1,1,'occupied','idle',?,?)",
+            (self.HARNESS, self.CLI_VERSION)).lastrowid
+        con.execute("INSERT INTO interface_input_state (session_id, shell_id,"
+                    " generation, composer) VALUES (?,1,1,'clean')",
+                    (self.sid,))
+        con.commit()
+        con.close()
+        self.rec = _Recorder()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _make(self):
+        rt = _runtime(self.tmp)
+        rt.db_path = str(self.db)
+        rt.loop = asyncio.get_running_loop()
+        gen = interface_runtime.Generation(rt, self.sid, 1, 1, 24, 80)
+        gen.pane_id = "%0"
+        rt.generations[self.sid] = gen
+        client = mock.Mock()
+        client.controls = []
+        client.send_control = client.controls.append
+        gen.clients.add(client)
+
+        # Started here and stopped at CLEANUP, not scoped to the delivery
+        # call: the watch is a task that OUTLIVES the send, and its retries
+        # fire seconds later. A `with` block around delivery alone expires
+        # before then and the retries reach the real tmux — which is how this
+        # fixture was wrong the first time, quietly shelling out per retry.
+        for patcher in (
+            mock.patch.object(rt, "_send_keys_sync", self.rec.send),
+            mock.patch.object(rt, "_bracketed_paste_sync",
+                              return_value="off"),
+            mock.patch.object(interface_runtime.time, "sleep", self.rec.sleep),
+        ):
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        return rt, gen, client
+
+    async def _deliver(self, rt, gen, payload=b"hello\r", seq=1):
+        """Deliver a frame through the real writer path, off the loop thread
+        exactly as the broker does."""
+        await asyncio.to_thread(rt._deliver_frame_sync, gen, payload, seq=seq)
+
+    @staticmethod
+    def _types(client):
+        return [c.get("type") for c in client.controls]
+
+
+class SubmitWatchTest(_WatchFixture):
+    """D2: the watch, its bounded retries, and the two outcomes."""
+
+    def test_confirmation_ends_the_watch_with_one_message(self):
+        async def flow():
+            rt, gen, client = self._make()
+            with mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S", 5):
+                await self._deliver(rt, gen)
+                watch = gen.submit_watch
+                self.assertIsNotNone(watch, "watch must be armed")
+                # Held in a local: a resolving watch clears gen.submit_watch
+                # in its own `finally`, so re-reading it here would race the
+                # very completion this test is waiting on.
+                # The hook route's notify, from a non-loop thread as in life.
+                await asyncio.to_thread(rt.notify_submit, self.sid)
+                await asyncio.wait_for(watch.task, timeout=5)
+            self.assertEqual(self._types(client), ["submit_confirmed"])
+            self.assertEqual(client.controls[0]["seq"], 1)
+            self.assertEqual(
+                self.rec.sends, [b"hello", b"\r"],
+                "a confirmed submit must not press Enter again")
+        asyncio.run(flow())
+
+    def test_retries_then_reports_pending_when_no_hook_arrives(self):
+        async def flow():
+            rt, gen, client = self._make()
+            with (
+                mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S", 0.05),
+                mock.patch.object(interface_runtime, "SUBMIT_RETRIES", 2),
+            ):
+                await self._deliver(rt, gen)
+                watch = gen.submit_watch
+                await asyncio.wait_for(watch.task, timeout=5)
+            # Exactly the budget: the frame's own CR, then two bare-CR
+            # retries, and no more.
+            self.assertEqual(self.rec.sends, [b"hello", b"\r", b"\r", b"\r"])
+            self.assertEqual(self._types(client), ["submit_pending"])
+            self.assertEqual(client.controls[0]["seq"], 1)
+        asyncio.run(flow())
+
+    def test_retry_budget_is_honoured_exactly(self):
+        # Distinguishes "bounded" from "bounded at the number we meant": a
+        # loop with an off-by-one still terminates and still reports pending.
+        for budget in (0, 1, 3):
+            with self.subTest(retries=budget):
+                self.rec = _Recorder()
+
+                async def flow():
+                    rt, gen, client = self._make()
+                    with (
+                        mock.patch.object(
+                            interface_runtime, "SUBMIT_CONFIRM_S", 0.05),
+                        mock.patch.object(
+                            interface_runtime, "SUBMIT_RETRIES", budget),
+                    ):
+                        await self._deliver(rt, gen)
+                        watch = gen.submit_watch
+                        await asyncio.wait_for(watch.task, timeout=5)
+                    bare = self.rec.sends[1:]
+                    self.assertEqual(bare, [b"\r"] * (budget + 1),
+                                     "one submit CR plus exactly `budget` "
+                                     "retries")
+                asyncio.run(flow())
+
+    def test_late_hook_during_the_retry_window_still_confirms(self):
+        # The spec's "retry lands after a real-but-late hook" case, from the
+        # other side: a hook that arrives mid-budget must stop the retries and
+        # confirm — not be ignored because retrying had already begun.
+        async def flow():
+            rt, gen, client = self._make()
+            with (
+                mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S", 0.2),
+                mock.patch.object(interface_runtime, "SUBMIT_RETRIES", 5),
+            ):
+                await self._deliver(rt, gen)
+                watch = gen.submit_watch
+                await asyncio.sleep(0.3)     # at least one retry has fired
+                self.assertGreaterEqual(watch.attempts, 1,
+                                        "test did not reach the retry window")
+                await asyncio.to_thread(rt.notify_submit, self.sid)
+                await asyncio.wait_for(watch.task, timeout=5)
+            self.assertEqual(self._types(client), ["submit_confirmed"])
+            self.assertLess(self.rec.sends.count(b"\r"), 6,
+                            "retries must stop at the hook, not run the "
+                            "budget out anyway")
+        asyncio.run(flow())
+
+    def test_exhaustion_records_its_own_row_for_a_human_frame(self):
+        # No wake batch is in flight, so this is NOT H-27's condition and must
+        # not be written into H-27's reason (decision #107's second half).
+        async def flow():
+            rt, gen, _ = self._make()
+            with (
+                mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S", 0.05),
+                mock.patch.object(interface_runtime, "SUBMIT_RETRIES", 1),
+            ):
+                await self._deliver(rt, gen)
+                watch = gen.submit_watch
+                await asyncio.wait_for(watch.task, timeout=5)
+        asyncio.run(flow())
+        con = sqlite3.connect(self.db)
+        rows = con.execute(
+            "SELECT reason, severity, detail FROM planner_alerts "
+            "WHERE session_id=? AND resolved_at IS NULL", (self.sid,)
+        ).fetchall()
+        con.close()
+        self.assertEqual([r[0] for r in rows], ["submit_unconfirmed"])
+        self.assertEqual(rows[0][1], "info")
+        self.assertIn("prompt_submit", rows[0][2])
+        self.assertIn("retry", rows[0][2])
+
+    def test_a_delivered_frame_is_never_parked_by_the_watch(self):
+        # The whole point of submit_pending over a halt: the bytes ARE on
+        # screen. Nothing about exhausting the retries may park the session or
+        # revoke the writer.
+        async def flow():
+            rt, gen, _ = self._make()
+            with (
+                mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S", 0.05),
+                mock.patch.object(interface_runtime, "SUBMIT_RETRIES", 1),
+            ):
+                await self._deliver(rt, gen)
+                watch = gen.submit_watch
+                await asyncio.wait_for(watch.task, timeout=5)
+        asyncio.run(flow())
+        con = sqlite3.connect(self.db)
+        lifecycle, = con.execute(
+            "SELECT lifecycle FROM interface_sessions WHERE session_id=?",
+            (self.sid,)).fetchone()
+        revoked = con.execute(
+            "SELECT COUNT(*) FROM interface_writer_leases "
+            "WHERE session_id=? AND revoked_at IS NOT NULL",
+            (self.sid,)).fetchone()[0]
+        con.close()
+        self.assertNotEqual(lifecycle, "lost")
+        self.assertEqual(revoked, 0)
+
+    def test_a_failed_retry_write_does_not_raise_or_add_a_surface(self):
+        # tmux refuses the retry (a window killed mid-watch, say). The frame's
+        # own bytes already landed, so the honest end state is unchanged:
+        # one submit_pending, no exception escaping the task.
+        async def flow():
+            rt, gen, client = self._make()
+
+            def refuse(pane_id, payload):
+                raise RuntimeError("no such window")
+
+            with (
+                mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S", 0.05),
+                mock.patch.object(interface_runtime, "SUBMIT_RETRIES", 2),
+            ):
+                await self._deliver(rt, gen)
+                # Only the RETRIES refuse; the frame's own bytes already
+                # landed above, which is the state this test is about.
+                watch = gen.submit_watch
+                with mock.patch.object(rt, "_send_keys_sync", refuse):
+                    await asyncio.wait_for(watch.task, timeout=5)
+            self.assertEqual(self._types(client), ["submit_pending"])
+        asyncio.run(flow())
+
+    def test_a_superseded_frame_does_not_report_pending(self):
+        # A second frame arrives while the first is still unconfirmed. Only
+        # the live frame's outcome is reported; the abandoned watch must go
+        # quietly rather than emit a submit_pending the operator has already
+        # moved past.
+        async def flow():
+            rt, gen, client = self._make()
+            with (
+                mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S", 10),
+                mock.patch.object(interface_runtime, "SUBMIT_RETRIES", 0),
+            ):
+                await self._deliver(rt, gen, b"first\r", seq=1)
+                first = gen.submit_watch
+                await self._deliver(rt, gen, b"second\r", seq=2)
+                second = gen.submit_watch
+                self.assertIsNot(first, second)
+                await asyncio.sleep(0)
+                self.assertTrue(first.task.cancelled()
+                                or first.task.done())
+                await asyncio.to_thread(rt.notify_submit, self.sid)
+                await asyncio.wait_for(second.task, timeout=5)
+            self.assertEqual(self._types(client), ["submit_confirmed"])
+            self.assertEqual(client.controls[0]["seq"], 2)
+        asyncio.run(flow())
+
+    def test_teardown_cancels_a_live_watch(self):
+        # A pane that is going away cannot submit, and a retry into a killed
+        # window is a tmux error nobody asked for.
+        async def flow():
+            rt, gen, _ = self._make()
+            # teardown also disposes the shadow generation; there is no
+            # sidecar process here and that is not this test's subject.
+            rt.shadow = mock.Mock()
+            with mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S", 10):
+                await self._deliver(rt, gen)
+                task = gen.submit_watch.task
+                await gen.teardown(kill_window=False)
+                await asyncio.sleep(0)
+                self.assertTrue(task.cancelled() or task.done())
+                self.assertIsNone(gen.submit_watch)
+        asyncio.run(flow())
+
+
+class WakeBatchExhaustionTest(_WatchFixture):
+    """Decision #107: exhaustion under a live wake batch feeds H-27's ROW.
+
+    One condition must not produce two alerts. The watch observes it at ~6s
+    and H-27 at 60s, so if these two wrote different reasons — or the same
+    reason with different refs — the operator would see the same fault
+    reported twice, which is exactly the class decision #106 forbids.
+    """
+
+    def _arm_batch(self) -> int:
+        con = sqlite3.connect(self.db)
+        doc_id = con.execute(
+            "INSERT INTO documents (title, kind, body) "
+            "VALUES ('sprint','spec','x')").lastrowid
+        binding_id = con.execute(
+            "INSERT INTO sprint_planner_bindings "
+            "(sprint_doc_id, planner_shell_id, session_id, shell_id, "
+            " generation) VALUES (?,1,?,1,1)",
+            (doc_id, self.sid)).lastrowid
+        # submitting_at, NOT submitted_at: H-27 measures the wait that STARTS
+        # at the submitting commit (migration 0117), and treats a NULL there
+        # as unmeasured rather than as zero seconds ago. Seeding the wrong
+        # column makes H-27 silently skip the batch, which reads exactly like
+        # "it deduped correctly".
+        batch_id = con.execute(
+            "INSERT INTO planner_wake_batches "
+            "(binding_id, shell_id, generation, state, submitting_at) "
+            "VALUES (?,1,1,'submitting',datetime('now'))",
+            (binding_id,)).lastrowid
+        con.commit()
+        con.close()
+        return batch_id
+
+    def _open_alerts(self):
+        con = sqlite3.connect(self.db)
+        rows = con.execute(
+            "SELECT reason, batch_id, dedupe_key, detail FROM planner_alerts "
+            "WHERE resolved_at IS NULL ORDER BY alert_id").fetchall()
+        con.close()
+        return rows
+
+    def _exhaust(self):
+        async def flow():
+            rt, gen, client = self._make()
+            with (
+                mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S", 0.05),
+                mock.patch.object(interface_runtime, "SUBMIT_RETRIES", 2),
+            ):
+                await self._deliver(rt, gen)
+                watch = gen.submit_watch
+                await asyncio.wait_for(watch.task, timeout=5)
+            return client
+        return asyncio.run(flow())
+
+    def test_exhaustion_opens_h27s_reason_on_h27s_batch(self):
+        batch_id = self._arm_batch()
+        self._exhaust()
+        rows = self._open_alerts()
+        self.assertEqual(len(rows), 1, f"expected one row, got {rows}")
+        reason, row_batch, _, detail = rows[0]
+        self.assertEqual(reason, "hooks_declared_but_silent")
+        self.assertEqual(row_batch, batch_id,
+                         "the row must be scoped to the batch, so H-27's own "
+                         "later observation lands on it")
+        self.assertIn("retries", detail)
+
+    def test_h27_running_afterwards_refreshes_rather_than_duplicates(self):
+        # The real sequence in a dead-hook seat: the watch exhausts at ~6s,
+        # then H-27's 60s threshold falls due on the same batch. The second
+        # observation must find the first row — one condition, one row.
+        batch_id = self._arm_batch()
+        self._exhaust()
+        con = sqlite3.connect(self.db)
+        binding_id, = con.execute(
+            "SELECT binding_id FROM planner_wake_batches WHERE batch_id=?",
+            (batch_id,)).fetchone()
+        interface_broker.hooks_silence_alert(con, binding_id, submit_s=0.0)
+        con.commit()
+        con.close()
+
+        rows = self._open_alerts()
+        self.assertEqual(
+            len(rows), 1,
+            f"H-27 minted a second row for one condition: {rows}")
+        self.assertIn("submitted", rows[0][3],
+                      "the surviving row's detail should have refreshed to "
+                      "H-27's later measurement")
+
+    def test_the_two_measurements_agree_on_the_dedupe_key(self):
+        # The structural version of the test above: if these keys ever differ,
+        # the dedupe index cannot collapse them no matter what order they run
+        # in. Asserted directly so a refactor that inlines one of the two
+        # _alert calls fails here rather than in production.
+        batch_id = self._arm_batch()
+        self._exhaust()
+        watch_key = self._open_alerts()[0][2]
+
+        con = sqlite3.connect(self.db)
+        con.execute("UPDATE planner_alerts SET resolved_at=datetime('now')")
+        binding_id, = con.execute(
+            "SELECT binding_id FROM planner_wake_batches WHERE batch_id=?",
+            (batch_id,)).fetchone()
+        con.commit()
+        interface_broker.hooks_silence_alert(con, binding_id, submit_s=0.0)
+        con.commit()
+        con.close()
+
+        h27_key = self._open_alerts()[0][2]
+        self.assertEqual(watch_key, h27_key,
+                         "the repair and the backstop must key the same row")
+
+
+class CapabilityGateTest(_WatchFixture):
+    """D2 gating: a seat that can never confirm never gets a watch.
+
+    vibe and opencode have no hook adapter at all. Arming there would press
+    Enter twice into a healthy pane and then report every correct send as
+    delivered-not-submitted — a monitor that lies on the happy path.
+    """
+
+    HARNESS = "vibe"
+    CLI_VERSION = None
+
+    def test_no_watch_is_armed_without_a_prompt_submit_hook(self):
+        async def flow():
+            rt, gen, client = self._make()
+            with (
+                mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S", 0.05),
+                mock.patch.object(interface_runtime, "SUBMIT_RETRIES", 2),
+            ):
+                await self._deliver(rt, gen)
+                self.assertIsNone(gen.submit_watch)
+                await asyncio.sleep(0.3)   # past the whole retry budget
+            # Delivery is unchanged; nothing pressed Enter again and no
+            # message claimed anything about submission either way.
+            self.assertEqual(self.rec.sends, [b"hello", b"\r"])
+            self.assertEqual(self._types(client), [])
+        asyncio.run(flow())
+
+    def test_unconfirmable_seat_raises_no_alert(self):
+        async def flow():
+            rt, gen, _ = self._make()
+            with mock.patch.object(interface_runtime, "SUBMIT_CONFIRM_S",
+                                   0.05):
+                await self._deliver(rt, gen)
+                await asyncio.sleep(0.3)
+        asyncio.run(flow())
+        con = sqlite3.connect(self.db)
+        count = con.execute("SELECT COUNT(*) FROM planner_alerts").fetchone()[0]
+        con.close()
+        self.assertEqual(count, 0,
+                         "a seat with no hook adapter is not a fault")
+
+    def test_capability_is_resolved_once_per_generation(self):
+        # The read sits inside the writer, between the submit CR and the
+        # caller's ack. Doing it per frame would put a DB round trip on every
+        # message for an answer that cannot change under a live generation.
+        async def flow():
+            rt, gen, _ = self._make()
+            with mock.patch.object(
+                    rt, "_read_submit_capability",
+                    wraps=rt._read_submit_capability) as read:
+                await self._deliver(rt, gen, seq=1)
+                await self._deliver(rt, gen, seq=2)
+                await self._deliver(rt, gen, seq=3)
+            self.assertEqual(read.call_count, 1)
+        asyncio.run(flow())
+
+
+class ArmingIsNeverFatalTest(_WatchFixture):
+    """Arming runs AFTER the frame's bytes are all on the wire.
+
+    An exception escaping it would propagate through the broker's two-phase
+    commit, which reads any writer exception as an ambiguous write and parks
+    the session `delivery_unknown` — recording a frame that demonstrably
+    delivered as maybe-delivered, over an observability lookup.
+    """
+
+    def test_capability_lookup_failure_does_not_fail_the_frame(self):
+        async def flow():
+            rt, gen, client = self._make()
+
+            def boom(session_id):
+                raise sqlite3.OperationalError("no such table")
+
+            with mock.patch.object(rt, "_read_submit_capability", boom):
+                # Must not raise: the bytes below already went out.
+                await self._deliver(rt, gen)
+            self.assertEqual(self.rec.sends, [b"hello", b"\r"])
+            self.assertIsNone(gen.submit_watch)
+            self.assertEqual(self._types(client), [])
+        asyncio.run(flow())
+
+
+class ConstantOrderingTest(unittest.TestCase):
+    """Decision #107: the submit watch is the REPAIR, H-27 is the BACKSTOP.
+
+    Two measurements of ONE condition ("the engine pressed Enter and no
+    prompt_submit answered") at two timescales. The order is load-bearing: the
+    watch must have spent all its retries BEFORE H-27's batch-silence
+    threshold falls due, or the backstop reports a condition the repair is
+    still working on and the operator sees one fault twice.
+
+    This is a pin, not a calculation — it fails on a config that reorders them,
+    which is the only way that invariant can break.
+    """
+
+    def test_retries_finish_before_the_backstop_reports(self):
+        watch_window = (interface_runtime.SUBMIT_RETRIES
+                        * interface_runtime.SUBMIT_CONFIRM_S)
+        self.assertLess(
+            watch_window, interface_broker.HOOKS_SUBMIT_SILENT_S,
+            f"the submit watch spends up to {watch_window}s but H-27 reports "
+            f"batch silence at {interface_broker.HOOKS_SUBMIT_SILENT_S}s — the "
+            "backstop would alert on a condition the repair has not finished "
+            "attempting (decision #107)")
+
+    def test_shipped_defaults_are_the_ruled_ones(self):
+        # The FnB's QAQC ruling (spec #62 open question 1) settled these
+        # numbers explicitly: ON by default, 2 retries x 3s. A silent change
+        # to the defaults is a change to a ruled decision.
+        self.assertEqual(interface_runtime.SUBMIT_RETRIES, 2)
+        self.assertEqual(interface_runtime.SUBMIT_CONFIRM_S, 3.0)
+        self.assertEqual(interface_runtime.SUBMIT_SETTLE_MS, 250.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interface_api.py
+++ b/tests/test_interface_api.py
@@ -81,6 +81,12 @@ class FakeRuntime:
         self.abandoned = []
         self.absence_proved = True
         self.terminate_result = {"terminated": True}
+        # spec #62 D2: the hook route satisfies an armed submit watch through
+        # this call. Part of the facade contract, so it belongs here.
+        self.submit_notifications = []
+
+    def notify_submit(self, session_id):
+        self.submit_notifications.append(session_id)
 
     def call(self, coro):
         return asyncio.run(coro)
@@ -1127,6 +1133,61 @@ class InterfaceApiTest(unittest.TestCase):
                           "WHERE session_id=1").fetchone()[0]
         con.close()
         self.assertEqual(occ, "reserved")
+
+    def test_prompt_submit_hook_notifies_the_runtime_submit_watch(self):
+        """spec #62 D2: the ROUTE half of submit confirmation.
+
+        The runtime's own tests prove that notify_submit resolves an armed
+        watch; nothing there proves anyone CALLS it. That is the whole join —
+        the hook arrives over HTTP and the watch lives in the WS runtime, and
+        they only meet because this route reaches through bind_runtime. With
+        this untested, a watch could arm correctly, retry correctly, and still
+        report every healthy submit as pending forever.
+        """
+        sid = self.occupy()
+        # Measure THIS call's effect. `bind_runtime` writes a module global, so
+        # what the list holds on entry is a property of the whole process, not
+        # of the hook under test; the claim being pinned is "this callback
+        # produced exactly one notify, for this session".
+        self.runtime.submit_notifications.clear()
+        status, _, _ = self.call(
+            "POST", "/api/interface/hook-callbacks",
+            ("Authorization: Bearer " + self.hook_token(sid),),
+            {"shell_id": 1, "generation": 1, "hook_seq": 3,
+             "event": "prompt_submit", "pid": 4321})
+        self.assertEqual(status, 200)
+        self.assertEqual(self.runtime.submit_notifications, [sid])
+
+    def test_non_submit_hooks_do_not_notify_the_submit_watch(self):
+        # The watch is satisfied by PROOF OF SUBMIT specifically. Notifying on
+        # any lifecycle event would confirm a frame that never submitted —
+        # turn_stop in particular fires on every completed turn, so keying on
+        # "a hook arrived" would make the watch unfalsifiable.
+        sid = self.occupy()
+        self.runtime.submit_notifications.clear()   # this call's effect only
+        status, _, _ = self.call(
+            "POST", "/api/interface/hook-callbacks",
+            ("Authorization: Bearer " + self.hook_token(sid),),
+            {"shell_id": 1, "generation": 1, "hook_seq": 3,
+             "event": "turn_stop", "pid": 4321})
+        self.assertEqual(status, 200)
+        self.assertEqual(self.runtime.submit_notifications, [],
+                         "only prompt_submit proves a submit")
+
+    def test_rejected_prompt_submit_hook_does_not_notify(self):
+        # A replayed/stale hook_seq is refused by record_hook and never
+        # commits. Notifying anyway would let a replay confirm a live frame
+        # that has not submitted — the notify must sit after the commit, on
+        # the success path only.
+        sid = self.occupy()
+        self.runtime.submit_notifications.clear()   # this call's effect only
+        status, _, _ = self.call(
+            "POST", "/api/interface/hook-callbacks",
+            ("Authorization: Bearer " + self.hook_token(sid),),
+            {"shell_id": 1, "generation": 1, "hook_seq": 1,   # already used
+             "event": "prompt_submit", "pid": 4321})
+        self.assertEqual(status, 409)
+        self.assertEqual(self.runtime.submit_notifications, [])
 
     def test_hook_session_start_promotes(self):
         self.create_session()

--- a/tests/test_interface_runtime.py
+++ b/tests/test_interface_runtime.py
@@ -411,6 +411,180 @@ class ShadowSidecarTest(unittest.TestCase):
         asyncio.run(flow())
 
 
+@unittest.skipUnless(HAS_SHADOW_STACK,
+                     "needs node + @xterm/headless (shadow sidecar)")
+class ShadowBracketedPasteTest(unittest.TestCase):
+    """The `modes` op (spec #62 D1 step 4): the writer's ONLY route to the
+    pane's DECSET 2004 state, and the one input to whether a body is wrapped
+    in real paste markers.
+
+    Driven against the REAL sidecar, not a stub: the whole point of the op is
+    that @xterm/headless tracks a mode our own code does not model, so a stub
+    that returns what we expect would prove only that we can spell the field
+    name. Every case here feeds actual escape bytes and reads back what the
+    terminal made of them."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.sidecar = interface_runtime.ShadowSidecar(
+            str(interface_runtime.SHADOW_DIR / "sidecar.js"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _run(self, coro_fn):
+        async def flow():
+            await self.sidecar.start()
+            try:
+                return await coro_fn()
+            finally:
+                await self.sidecar.stop()
+        return asyncio.run(flow())
+
+    def test_tracks_mode_set_and_reset(self):
+        # One generation, both transitions, in the order a real harness makes
+        # them: a TUI enables 2004 when it takes the prompt and disables it on
+        # the way out. Asserting 'on' alone would pass against a stub wired to
+        # a constant.
+        async def flow():
+            self.sidecar.create("g1", 24, 80)
+            self.assertEqual(await self.sidecar.bracketed_paste("g1"), "off",
+                             "a fresh terminal has 2004 inactive")
+            self.sidecar.feed("g1", b"\x1b[?2004h")
+            self.assertEqual(await self.sidecar.bracketed_paste("g1"), "on")
+            self.sidecar.feed("g1", b"\x1b[?2004l")
+            self.assertEqual(await self.sidecar.bracketed_paste("g1"), "off")
+        self._run(flow)
+
+    def test_answer_reflects_bytes_fed_before_the_ask(self):
+        # feed is fire-and-forget; the ask must ride the same per-generation
+        # chain. If it did not, this read could answer from the state BEFORE
+        # the mode-setting bytes were parsed — a wrap decision racing the
+        # redraw that justifies it. The mode bytes are deliberately trailed by
+        # a payload large enough that parsing cannot plausibly be instant.
+        async def flow():
+            self.sidecar.create("g2", 24, 80)
+            self.sidecar.feed("g2", b"\x1b[?2004h" + b"x" * 200_000)
+            self.assertEqual(await self.sidecar.bracketed_paste("g2"), "on")
+        self._run(flow)
+
+    def test_isolated_per_generation(self):
+        # The sidecar multiplexes every session in one process; a mode read is
+        # meaningless if it can answer from a neighbour's terminal.
+        async def flow():
+            self.sidecar.create("a", 24, 80)
+            self.sidecar.create("b", 24, 80)
+            self.sidecar.feed("a", b"\x1b[?2004h")
+            self.assertEqual(await self.sidecar.bracketed_paste("a"), "on")
+            self.assertEqual(await self.sidecar.bracketed_paste("b"), "off")
+        self._run(flow)
+
+    def test_unknown_generation_reads_unknown_without_raising(self):
+        # The caller is a writer mid-frame: 'unknown' degrades it to no-wrap,
+        # an exception would fail a send whose bytes are fine.
+        async def flow():
+            self.assertEqual(await self.sidecar.bracketed_paste("nope"),
+                             "unknown")
+        self._run(flow)
+
+    def test_dead_sidecar_reads_unknown_without_raising(self):
+        # Same contract at the harshest failure: the process is gone, so the
+        # request cannot be answered at all. snapshot() RAISES here by design
+        # (attach has a capture-pane fallback to fall into); this one must not.
+        script = self.tmp / "dead.js"
+        script.write_text("process.exit(1)\n")
+        dead = interface_runtime.ShadowSidecar(str(script))
+
+        async def flow():
+            with self.assertRaises(RuntimeError):
+                await dead.start()          # boot probe sees the death
+            self.assertEqual(await dead.bracketed_paste("g1"), "unknown")
+            await dead.stop()
+        asyncio.run(flow())
+
+    def test_silent_sidecar_reads_unknown_without_raising(self):
+        # A wedged-but-alive sidecar: the request times out rather than
+        # failing on EOF. Same degradation, different path — and this is the
+        # one that would otherwise stall a writer thread on a future nothing
+        # resolves.
+        script = self.tmp / "silent.js"
+        script.write_text("require('readline').createInterface"
+                          "({input: process.stdin}).on('line', () => {});\n")
+        silent = interface_runtime.ShadowSidecar(str(script))
+
+        async def flow():
+            with mock.patch.object(
+                    interface_runtime, "SHADOW_REQUEST_TIMEOUT_S", 0.3):
+                with self.assertRaises(RuntimeError):
+                    await silent.start()
+                self.assertEqual(await silent.bracketed_paste("g1"), "unknown")
+            await silent.stop()
+        asyncio.run(flow())
+
+
+class ServerOptionPinTest(unittest.TestCase):
+    """_pin_server_options is ADVISORY at every step (spec #62 D4).
+
+    A server option the runtime could not pin is not a reason to deny the
+    operator a chat session, so each of the three things that can go wrong —
+    the set is refused, the readback fails, the effective value disagrees —
+    must be logged and swallowed. They are three separate code paths, and an
+    `except` that covers the first says nothing about the other two, so each
+    gets its own case."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.rt = interface_runtime.InterfaceRuntime(
+            str(self.tmp / "shell_db.db"), run_dir=str(self.tmp / "run"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _pin_with(self, fake_tmux):
+        calls: list[tuple] = []
+
+        async def tmux(*args):
+            calls.append(args)
+            return fake_tmux(*args)
+
+        with mock.patch.object(self.rt, "tmux", new=tmux):
+            asyncio.run(self.rt._pin_server_options())
+        return calls
+
+    def test_set_refused_does_not_raise(self):
+        def fake(*args):
+            raise RuntimeError("invalid option: extended-keys")
+        calls = self._pin_with(fake)
+        self.assertEqual([c[0] for c in calls], ["set"],
+                         "a refused set must not be followed by a readback")
+
+    def test_readback_failure_does_not_raise(self):
+        def fake(*args):
+            if args[0] == "show":
+                raise RuntimeError("no server running")
+            return b""
+        calls = self._pin_with(fake)
+        self.assertEqual([c[0] for c in calls], ["set", "show"])
+
+    def test_disagreeing_effective_value_does_not_raise(self):
+        # tmux accepted the set and still reports something else. The pin
+        # cannot fix that; it must report it and let the spawn proceed.
+        def fake(*args):
+            return b"on\n" if args[0] == "show" else b""
+        calls = self._pin_with(fake)
+        self.assertEqual([c[0] for c in calls], ["set", "show"])
+
+    def test_pins_the_server_scope_off(self):
+        # The exact argv matters: `-s` is server scope (one server, set at
+        # creation). A session- or window-scoped set would silently not apply
+        # to panes created later, which is every pane we care about.
+        def fake(*args):
+            return b"off\n" if args[0] == "show" else b""
+        calls = self._pin_with(fake)
+        self.assertEqual(calls[0], ("set", "-s", "extended-keys", "off"))
+        self.assertEqual(calls[1], ("show", "-sv", "extended-keys"))
+
+
 class TicketTest(unittest.TestCase):
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp())
@@ -783,6 +957,48 @@ class TmuxIntegrationTest(unittest.TestCase):
         await wait_for(lambda: gen.dbg_fanout_bytes >= 5,
                        what="pane raw-mode READY marker")
         return info
+
+    def test_extended_keys_pinned_at_server_creation(self):
+        """The runtime PINS extended-keys off; it does not inherit the default.
+
+        tmux 3.5a already defaults this off, so asserting `off` after a plain
+        spawn is a test that cannot come back red — it passes with
+        _pin_server_options deleted. So the private server is pre-seeded with
+        `extended-keys on` (exactly what a tmux config we do not own could do)
+        and the spawn has to have flipped it. The seed uses a DIFFERENT session
+        name so the runtime's own `new-session -d -s sc-interface` still
+        succeeds against the now-existing server.
+
+        Why it matters: `on` makes tmux re-encode keys in CSI-u form, which
+        rewrites the 0x0D this writer sends as its separate submit phase
+        (claude-code #43169) — the byte the whole two-phase protocol exists to
+        deliver intact.
+        """
+        async def flow():
+            sock = self.rt.sock
+            subprocess.run(["tmux", "-S", sock, "new-session", "-d",
+                            "-s", "seed-not-ours", "sleep 60"],
+                           check=True, capture_output=True)
+            subprocess.run(["tmux", "-S", sock, "set", "-s",
+                            "extended-keys", "on"],
+                           check=True, capture_output=True)
+            seeded = subprocess.run(
+                ["tmux", "-S", sock, "show", "-sv", "extended-keys"],
+                check=True, capture_output=True, text=True).stdout.strip()
+            self.assertEqual(seeded, "on",
+                             "seeding failed, so the assertion below could "
+                             "not have failed either — test is vacuous")
+
+            await self._spawn_stub()
+            try:
+                out = await self.rt.tmux("show", "-sv", "extended-keys")
+                self.assertEqual(
+                    out.decode().strip(), "off",
+                    "the runtime did not pin extended-keys at server creation "
+                    "— CSI-u re-encoding can still corrupt the submit CR")
+            finally:
+                await self.rt.stop()   # the sidecar is a child process
+        asyncio.run(flow())
 
     def test_input_echo_redraw_terminate(self):
         asyncio.run(self._flow_input_echo_redraw_terminate())


### PR DESCRIPTION
## S84 U8 — Feature 31 Stage 0: deterministic submit (spec #62, U1+U2)

A TUI decides whether a trailing CR submits or inserts a newline by whether it
classified the input as a paste, so `body + \r` sent as one burst is a coin-flip.
This makes the submit deterministic and, where the harness can prove submit,
verified.

Scope is spec #62 **U1 + U2 only** — U3/U4/U5 deferred per decision #108
(ui/app.js budget from decision #101 outlives U4's merge until sprint close;
U5 is spike-grade and blocked on flag #369, since no CI job runs `spikes/`).

### What ships

- **U1a — sidecar `modes` op** surfacing DECSET 2004 as `on`/`off`. Every failure
  mode (dead sidecar, timeout, unknown generation, older sidecar) reads `unknown`
  and degrades the caller to no-wrap rather than failing the send.
- **U1b — `extended-keys off`** pinned on both tmux server-create paths, with a
  readback assertion that logs when the effective value differs. Advisory by
  design: a server option we could not pin never denies the operator a session.
- **U1c — two-phase delivery.** `_deliver_frame_sync` splits body from trailing
  CR, wraps the body in real paste markers when 2004 is active, settles
  `SC_SUBMIT_SETTLE_MS`, then sends the CR as its own `send-keys`. Frames with no
  trailing CR and the exactly-CR frame pass through verbatim. Both writers (wake
  + human) route through it. Frame contract, one-unacked-frame discipline,
  two-phase commit and crash-window parking (decision #16) are unchanged.
- **U2 — submit watch.** Armed per frame after the CR. The `prompt_submit` hook is
  the only proof of submit, so the hook route satisfies it in-process through the
  existing `bind_runtime` reference. No confirmation within `SC_SUBMIT_CONFIRM_S`
  resends a bare CR, up to `SC_SUBMIT_RETRIES`; confirmation broadcasts
  `submit_confirmed{seq}`, exhaustion broadcasts `submit_pending{seq}` and records
  an observation. Never parks the session and never revokes the writer — the bytes
  are on screen. Disabled on seats with no `prompt_submit` hook (vibe, opencode).

### Trade-offs taken

- **Arming may not raise.** An exception in the writer reads as an ambiguous write
  and would park a frame that demonstrably delivered — so arming is failure-tolerant
  by construction, not by a blanket try/except at the call site.
- **`unknown` degrades, never blocks.** The simpler alternative (fail the send when
  the mode can't be read) was rejected: an unreadable sidecar must not cost the
  operator a delivery, and unwrapped-plus-separate-CR is already strictly better
  than today's single burst.
- **D2 and H-27 share one condition, one alert.** Per decision #107, D2 is the
  repair and H-27 the backstop for the same silence. Both raise through
  `_submit_silent_alert` and therefore share a dedupe key — the operator sees one
  row refreshed, never two. H-27's docstring is updated to its strictly-stronger
  post-D2 meaning (silent *even after retries*) in this same diff, and the constant
  ordering `SC_SUBMIT_RETRIES x SC_SUBMIT_CONFIRM_S < HOOKS_SUBMIT_SILENT_S` is
  pinned by a test that reds if the ordering inverts.

### Verification

- Full suite green on this head: **2232 passed, 20 skipped** (`sc job` 214).
- The affected files (`test_deterministic_submit.py`, `test_interface_api.py`,
  `test_interface_runtime.py`) were run **6 times total** — once in each full suite
  plus 5 targeted repeats — hunting a once-seen hook-route flake (stray
  `notify_submit` on a fresh FakeRuntime). It did not reappear in any run.
- `render-check` clean. Note it is vacuous in this checkout's local artifact mode
  ("no rendered instance state yet"); this diff touches no skill or document
  render surface.
- Rebased onto `origin/main` after #674 merged; the contribution diff is byte-identical
  before and after the rebase (surfaces are disjoint — #674 touched CLI entrypoints,
  not `interface_runtime`/`interface_broker`/`interface_routes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
