### PR TITLE
feat(conductor S2): strip interface engine plumbing

### DIFF
--- a/.super-coder/scripts/activity_readers.py
+++ b/.super-coder/scripts/activity_readers.py
@@ -228,8 +228,6 @@ class ActivityReader:
             return None
 
         harness = None
-        archive_id = None
-        planner_session = None
         if unit is None:
             try:
                 rows = con.execute(
@@ -268,55 +266,23 @@ class ActivityReader:
                 self._mark(evidence, "result_row")
                 self._mark(evidence, "state_changed_at")
 
-        # STEP2(conductor): replace the retired Interface-session epoch and
-        # end-state reads with launch/archive truth.
         try:
-            if unit is None:
-                row = con.execute(
-                    "SELECT session_id, created_at, harness FROM interface_sessions "
-                    "WHERE shell_id=? ORDER BY session_id DESC LIMIT 1",
-                    (shell_id,),
-                ).fetchone()
-                evidence.epoch = _timestamp(row["created_at"]) if row else None
-                harness = row["harness"] if row else None
-                planner_session = row["session_id"] if row else None
-            else:
-                row = con.execute(
-                    "SELECT archive_id, started_at, harness "
-                    "FROM shell_memory_archives "
-                    "WHERE shell_id=? AND started_at IS NOT NULL "
-                    "ORDER BY started_at DESC, archive_id DESC LIMIT 1",
-                    (shell_id,),
-                ).fetchone()
-                evidence.epoch = _timestamp(row["started_at"]) if row else None
-                harness = row["harness"] if row else None
-                archive_id = row["archive_id"] if row else None
+            row = con.execute(
+                "SELECT archive_id, started_at, ended_at, harness "
+                "FROM shell_memory_archives "
+                "WHERE shell_id=? AND started_at IS NOT NULL "
+                "ORDER BY started_at DESC, archive_id DESC LIMIT 1",
+                (shell_id,),
+            ).fetchone()
+            evidence.epoch = _timestamp(row["started_at"]) if row else None
+            evidence.session_ended_at = (
+                _timestamp(row["ended_at"]) if row else None
+            )
+            harness = row["harness"] if row else None
             if evidence.epoch is None:
                 self._mark(evidence, "epoch")
         except sqlite3.Error:
             self._mark(evidence, "epoch")
-
-        try:
-            if unit is None and planner_session is not None:
-                row = con.execute(
-                    "SELECT ended_at, end_reason, harness "
-                    "FROM interface_sessions WHERE session_id=?",
-                    (planner_session,),
-                ).fetchone()
-            elif archive_id is not None:
-                row = con.execute(
-                    "SELECT ended_at, end_reason, harness "
-                    "FROM interface_sessions WHERE shell_id=? AND archive_id=? "
-                    "ORDER BY session_id DESC LIMIT 1",
-                    (shell_id, archive_id),
-                ).fetchone()
-            else:
-                row = None
-            if row:
-                evidence.session_ended_at = _timestamp(row["ended_at"])
-                evidence.session_end_reason = row["end_reason"]
-                harness = harness or row["harness"]
-        except sqlite3.Error:
             self._mark(evidence, "session")
 
         if sprint_doc_id is not None:

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -18,9 +18,8 @@ What lives here:
   sprint_doc_id names a LIVE sprint per `sprint_state`; unscoped legacy
   watches stay dormant until rebound). Per cycle: a `pr_poll_runs` audit row
   per repo, durable `pr_poll_observations` for transitions and blind windows,
-  idempotent `pr_event` messages (dedupe_key) plus same-transaction wake items
-  when a live binding owns the (sprint, planner) pair, fingerprint persistence,
-  and terminal retirement. Per-repo failures back off capped without blocking
+  idempotent `pr_event` messages (dedupe_key), fingerprint persistence, and
+  terminal retirement. Per-repo failures back off capped without blocking
   other repos; a repo recovering from failure marks its next observations as
   blind windows (GitHub may have moved unobserved — convergence, not history).
 - `Poller` — the service's scheduler thread. GitHub polling keeps its 30s
@@ -314,8 +313,8 @@ def classify(
     ):
         return "working"
 
-    # Rule 4 — BOOT clock.  Either authoritative Interface end state or an
-    # absent headless process closes the session.
+    # Rule 4 — BOOT clock. Either the archive lifecycle or an absent headless
+    # process closes the session.
     session_over = (
         _utc(evidence.session_ended_at) is not None
         or evidence.process_present is False
@@ -732,24 +731,10 @@ def deliver_reconciliation_readings(
                 f"reconciler-alert|{alert_id}",
             ),
         ).lastrowid
-        # H-8: ONE eligibility ladder. This used to check `released_at IS
-        # NULL` alone and could queue an item no gate would ever pass — it
-        # went straight into a stall, invisibly. The alert still records the
-        # binding it belongs to whether or not a wake can ride it.
-        binding = con.execute(
-            "SELECT binding_id FROM sprint_planner_bindings "
-            "WHERE sprint_doc_id=? AND planner_shell_id=? "
-            "AND released_at IS NULL ORDER BY binding_id DESC LIMIT 1",
-            (sprint_doc_id, planner_shell_id),
-        ).fetchone()
-        binding_id = binding[0] if binding is not None else None
         con.execute(
-            "UPDATE planner_alerts SET message_id=?, binding_id=? "
-            "WHERE alert_id=?",
-            (message_id, binding_id, alert_id),
+            "UPDATE planner_alerts SET message_id=? WHERE alert_id=?",
+            (message_id, alert_id),
         )
-        # STEP2(conductor): Interface wake retired — the alert row is the
-        # record; wake-item emission moves to the sentinel→Conductor path.
         emitted.append(message_id)
     return emitted
 
@@ -1063,12 +1048,12 @@ def surface_unscoped_watches(con) -> int:
 
 
 def _emit_event(con, watch, event: dict, head_sha: str) -> "int | None":
-    """One semantic transition → idempotent pr_event + same-transaction wake
-    item. Dedupe keyed (watch, transition, head SHA, state) via the message's
+    """One semantic transition → an idempotent pr_event message.
+
+    Dedupe keyed (watch, transition, head SHA, state) via the message's
     dedupe_key partial unique index: a repeated key is a no-op, so a replayed
-    poll or a baseline race can never double-wake the planner. Returns the
-    new message_id when the event was emitted (None on dedupe) so the caller
-    can signal the wake coordinator after commit."""
+    poll or a baseline race can never duplicate the event. Returns the new
+    message_id when emitted, or None on dedupe."""
     dedupe_key = f"pr-event|{watch['watch_id']}|{event['key']}|{head_sha}"
     try:
         cur = con.execute(
@@ -1080,8 +1065,6 @@ def _emit_event(con, watch, event: dict, head_sha: str) -> "int | None":
     except sqlite3.IntegrityError:
         return None  # the dedupe index — already emitted
     message_id = cur.lastrowid
-    # STEP2(conductor): Interface wake retired — the pr_event message row is
-    # the record; waking its consumer moves to the sentinel→Conductor path.
     return message_id
 
 
@@ -1196,8 +1179,6 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
             if terminal:
                 summary["retired"] += 1
         con.commit()
-    # STEP2(conductor): Interface wake coordinator retired — emitted rows are
-    # durable; their consumer's wake-up moves to the sentinel→Conductor path.
     return summary
 
 
@@ -1281,7 +1262,7 @@ class Poller(threading.Thread):
                             refresh=self._refresh,
                             state=self.reconciler_state,
                         )
-                        emitted = deliver_reconciliation_readings(
+                        deliver_reconciliation_readings(
                             con,
                             self.last_reconciliation,
                         )
@@ -1300,8 +1281,6 @@ class Poller(threading.Thread):
                             # them while leaving the absent beat honest.
                             con.commit()
                             print(f"pr-poller: heartbeat error ({e})", flush=True)
-                        # STEP2(conductor): wake notify retired with the
-                        # Interface; emitted rows are durable records.
                         self._reconcile_due = (
                             monotonic_now + self._reconcile_interval
                         )

--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -25,19 +25,13 @@ SCHEMA_SQLITE = ENGINE / "schema.sql"
 SNAPSHOT_LEGACY = ENGINE / "snapshot" / "content.sql"
 sys.path.insert(0, str(ENGINE / "scripts"))
 import artifact_policy  # noqa: E402
-import db_backup as db_backup_mod  # noqa: E402
-import db_driver    # noqa: E402
-import migrate as migrate_mod  # noqa: E402
-import map_repo     # noqa: E402
 import backfill_shell_api_keys  # noqa: E402  (re-provision api_keys post-rebuild)
-# STEP2(conductor): the Interface stack is retired; the live-state refusal
-# guard's replacement rule lands in Step 2. Until then the guard no-ops when
-# the module is absent.
-try:
-    import interface_reconcile  # noqa: E402  (live-Interface refusal guard)
-except ImportError:
-    interface_reconcile = None
+import db_backup as db_backup_mod  # noqa: E402
+import db_driver  # noqa: E402
+import map_repo  # noqa: E402
+import migrate as migrate_mod  # noqa: E402
 import seed_skills  # noqa: E402  (re-assert the fork retire list post-seed)
+import sprint_state  # noqa: E402
 
 # Compatibility/readability constant: the historical preferred location.
 # Writes resolve dynamically through backup_dir() so a restricted host seat can
@@ -204,7 +198,7 @@ def parse_args(argv: list[str]) -> bool:
     """Return no_backup, print help, or reject — touching NO state.
 
     Spec #67: rebuild used to interpret arguments only after it had read the
-    schema, carried the outgoing keys, probed live Interface state and taken a
+    schema, carried the outgoing keys, probed live sprint state and taken a
     backup, so `./sc rebuild --help` and every typo ran a real rebuild. The
     whole argument contract lives here, ahead of all of it, and this function
     opens no database and touches no path.
@@ -224,6 +218,22 @@ def parse_args(argv: list[str]) -> bool:
     return "--no-backup" in argv
 
 
+def active_sprint_ids(db_path: Path | None = None) -> set[int]:
+    """Read the centralized ACTIVE-sprint predicate from the outgoing DB."""
+    db_path = db_path or DB_PATH
+    if not db_path.exists():
+        return set()
+    con = db_driver.connect(db_path)
+    try:
+        return sprint_state.live_sprint_doc_ids(con)
+    except db_driver.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return set()
+        raise
+    finally:
+        con.close()
+
+
 def main(argv: list[str]) -> int:
     no_backup = parse_args(argv)
 
@@ -232,17 +242,12 @@ def main(argv: list[str]) -> int:
         sys.exit(f"rebuild: missing {schema}")
 
     keys = read_existing_keys()
-    # Spec #20: a rebuild destroys the live DB, so it refuses while any live
-    # Interface state would be lost — non-ended session, unreleased binding,
-    # nonterminal wake batch, or input ambiguity. Same fail-closed shape as
-    # read_existing_keys (#279): abort while the outgoing DB still exists.
-    if interface_reconcile is not None:  # STEP2(conductor): Interface retired
-        reasons = interface_reconcile.live_refusal_reasons(DB_PATH)
-        if reasons:
-            sys.exit(
-                "rebuild: refusing — live Interface state exists; the clean "
-                "operator drain path is required first:\n  - "
-                + "\n  - ".join(reasons))
+    active = active_sprint_ids()
+    if active:
+        ids = ", ".join(str(doc_id) for doc_id in sorted(active))
+        sys.exit(
+            "rebuild: refusing — ACTIVE sprint(s) exist: "
+            f"{ids}. Close or freeze every sprint before rebuilding.")
     if not no_backup:
         backup_existing()
 
@@ -271,17 +276,6 @@ def main(argv: list[str]) -> int:
         else:
             print(f"rebuild: no {SNAPSHOT.relative_to(REPO_ROOT)} — built empty "
                   "(no per-instance content).")
-
-        # content.sql loads after migrations and older snapshots may contain
-        # legacy open alerts for fully ended sessions. Reconcile the completed
-        # candidate, not merely the pre-snapshot schema, so rebuild cannot
-        # reattach actionable state to terminal audit.
-        if interface_reconcile is not None:  # STEP2(conductor)
-            con = db_driver.connect(candidate)
-            try:
-                interface_reconcile.startup_reconcile(con)
-            finally:
-                con.close()
 
         # The migrations above seeded every engine skill live (is_deleted=0) —
         # re-assert the fork retire list so a rebuilt DB doesn't resurrect skills

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -16,14 +16,8 @@ Usage:
     python3 .super-coder/scripts/run.py [shortname] [--first]
     RENDER_ONLY=1 python3 .super-coder/scripts/run.py --first   # render, don't exec
 
-STEP2(conductor): retire this Interface gate and reopen direct interactive
-boot. Interface gate (spec #20): the INTERACTIVE path of main() is no longer
-a public entry — interactive chats start through the Interface API
-(`./sc enter`), which holds the reservation capability, so a direct
-interactive launch refuses before creating an archive (SC_RAW_BOOT=1 is the
-tooling escape hatch). Headless and RENDER_ONLY are unaffected. The
-token-carrying engine path (interface_exec) calls prepare_launch below, never
-main().
+Interactive and headless launches share this direct boot path. `./sc enter`
+dispatches here for a human session; `./sc run` supplies `--headless`.
 
 Headless (`./sc run <shortname> [-p "<prompt>"] [--harness <h>] [-m <model>]
 [--effort <level>]`):
@@ -1259,23 +1253,6 @@ def main() -> None:
     if headless and not requested:
         sys.exit('usage: ./sc run <shortname> [-p "<prompt>"] [--harness <h>] '
                  '[-m <model>] [--effort <level>]')
-
-    # STEP2(conductor): remove this gate when `sc enter` targets direct boot.
-    # Interface gate (spec #20 Tmux Runtime): a public INTERACTIVE launch holds
-    # no reservation capability. Interactive chats start through the Interface
-    # API (`./sc enter` / `sc interface start`), which reserves the generation
-    # BEFORE any archive exists; the token-carrying exec path (interface-exec)
-    # goes through prepare_launch, never main(). Refuse before open_db/
-    # open_session could create an unmanaged archive. Headless (`sc run`) and
-    # RENDER_ONLY (verify) are not interactive launches and stay on this path;
-    # SC_RAW_BOOT=1 is the tooling escape hatch (same standing as
-    # SC_NO_AUTOPRUNE — process scanning stays the backstop either way).
-    if not headless and not os.environ.get("RENDER_ONLY") \
-            and not os.environ.get("SC_RAW_BOOT"):
-        sys.exit("interactive launches go through the Interface (spec #20) — "
-                 "use `./sc enter <shell>` (or `./sc interface start <shell>`). "
-                 "The raw launch path is reserved for the engine's reservation "
-                 "capability (interface-exec).")
 
     # Wordmark banner — interactive boots only; headless/verify logs stay clean.
     if not headless and not os.environ.get("RENDER_ONLY") and sys.stdin.isatty():

--- a/.super-coder/scripts/shell_liveness.py
+++ b/.super-coder/scripts/shell_liveness.py
@@ -204,8 +204,8 @@ def _tty_exists(pid: int, tty_fd: "str | None") -> "bool | None":
     OWN mount namespace, via /proc/<pid>/root<tty_fd>.
 
     Testing the bare path instead asks the SCANNER's namespace, which is a
-    different question whenever the two disagree. A post-TMUX session holds a pty
-    from the container's devpts; scanned from the host, `/dev/pts/3` names the
+    different question whenever the two disagree. A containerized session holds
+    a pty from the container's devpts; scanned from the host, `/dev/pts/3` names the
     HOST's pts 3 — a device that is absent, or worse, belongs to some unrelated
     terminal. The live session then read as `tty-gone`, the rail projected
     `unreconciled` with a recovery affordance instead of `working`, and the

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -78,29 +78,10 @@ PER_INSTANCE_TABLES = [
     # the engine's baseline; content.sql loads AFTER migrations on rebuild, so
     # the fork's edits win — without this the GUI's changes vanish on rebuild.
     "flavor_defaults",
-    # STEP2(conductor): drop the five retired interface_* audit tables from
-    # this serialization surface; Step 4 owns wake-table drain/retirement.
-    # ── Interface (spec #20, 0078) — durable audit only. Live rows are
-    # row-filtered OUT (SNAPSHOT_ROW_FILTERS below): snapshot may run while a
-    # chat is live, and rebuild/update refuse while any live state exists, so
-    # content.sql only ever carries closed/terminal rows. Volatile columns
-    # (tmux socket, PIDs/start ticks, hook token hash) ride SENSITIVE_COLUMNS.
-    # Fully volatile tables (interface_writer_leases, pr_poll_runs) are NOT in
-    # this list — a rebuild rederives them empty. interface_input_state keeps
-    # only terminal delivery-unknown metadata (never terminal bytes).
-    "interface_generations",
-    "interface_sessions",
-    "interface_input_state",
-    # Ordinary mutation idempotency survives rebuild, but credential-producing
-    # responses do not: acquire_lease carries the raw writer bearer and
-    # mint_ticket carries a single-use stream credential. Their backing
-    # runtime state is deliberately not serialized, so replaying either after
-    # rebuild would return a dead credential as well as leak it to git.
-    "interface_idempotency_keys",
-    "sprint_planner_bindings",
-    "planner_wake_batches",
-    "planner_wake_items",
-    "planner_action_receipts",
+    # Retired Interface state and its dependent wake-machine audit remain in
+    # live installed DBs until Step 4 drains them, but are no longer part of a
+    # rebuilt instance. Serializing the dependents without their Interface FK
+    # parents would create an invalid candidate.
     "pr_poll_observations",
     # sprint_units (0098) is the planner's AUTHORED board — the declared belief
     # about who should be doing what — not a derived cache: nothing re-derives
@@ -119,113 +100,15 @@ PER_INSTANCE_TABLES = [
     # .sc-state/map_content.sql by snapshot_map() below, not here.
 ]
 
-# Row-level projection for tables whose LIVE rows must not reach content.sql
-# (spec #20: snapshot preserves closed session/binding audit, terminal/
-# quarantined wake audit, and transition/blind-window observations — and may
-# run while a chat is live). The dump still DELETEs the whole table on load;
-# rows outside the filter simply never existed as far as the rebuild knows.
-def _serialized_session(session_ref: str) -> str:
-    return (
-        "EXISTS (SELECT 1 FROM interface_sessions s "
-        "JOIN interface_generations g "
-        "ON g.shell_id=s.shell_id AND g.generation=s.generation "
-        f"WHERE s.session_id={session_ref} "
-        "AND s.occupancy='ended' AND s.lifecycle='ended' "
-        "AND s.ended_at IS NOT NULL AND g.ended_at IS NOT NULL)"
-    )
-
-
-def _serialized_binding(binding_ref: str) -> str:
-    return (
-        "EXISTS (SELECT 1 FROM sprint_planner_bindings b "
-        "JOIN interface_sessions s ON s.session_id=b.session_id "
-        "JOIN interface_generations sg "
-        "ON sg.shell_id=s.shell_id AND sg.generation=s.generation "
-        "JOIN interface_generations bg "
-        "ON bg.shell_id=b.shell_id AND bg.generation=b.generation "
-        f"WHERE b.binding_id={binding_ref} "
-        "AND (b.released_at IS NOT NULL "
-        "OR EXISTS (SELECT 1 FROM interface_input_state i "
-        "WHERE i.session_id=b.session_id "
-        "AND i.delivery='delivery_unknown') "
-        "OR EXISTS (SELECT 1 FROM planner_wake_batches p "
-        "WHERE p.binding_id=b.binding_id "
-        "AND p.state='delivery_unknown')) "
-        "AND s.occupancy='ended' AND s.lifecycle='ended' "
-        "AND s.ended_at IS NOT NULL "
-        "AND sg.ended_at IS NOT NULL AND bg.ended_at IS NOT NULL)"
-    )
-
-
-def _serialized_batch(
-        batch_ref: str,
-        states: tuple[str, ...] = ("complete", "delivery_unknown")) -> str:
-    state_list = ",".join(f"'{state}'" for state in states)
-    return (
-        "EXISTS (SELECT 1 FROM planner_wake_batches wb "
-        "JOIN sprint_planner_bindings b ON b.binding_id=wb.binding_id "
-        "JOIN interface_sessions s ON s.session_id=b.session_id "
-        "JOIN interface_generations sg "
-        "ON sg.shell_id=s.shell_id AND sg.generation=s.generation "
-        "JOIN interface_generations bg "
-        "ON bg.shell_id=b.shell_id AND bg.generation=b.generation "
-        "JOIN interface_generations wg "
-        "ON wg.shell_id=wb.shell_id AND wg.generation=wb.generation "
-        f"WHERE wb.batch_id={batch_ref} "
-        f"AND wb.state IN ({state_list}) "
-        "AND s.occupancy='ended' AND s.lifecycle='ended' "
-        "AND s.ended_at IS NOT NULL "
-        "AND sg.ended_at IS NOT NULL AND bg.ended_at IS NOT NULL "
-        "AND wg.ended_at IS NOT NULL)"
-    )
-
-
 SNAPSHOT_ROW_FILTERS = {
-    "interface_generations": "WHERE ended_at IS NOT NULL",
-    "interface_sessions":
-        "WHERE occupancy='ended' AND lifecycle='ended' AND ended_at IS NOT NULL "
-        "AND EXISTS (SELECT 1 FROM interface_generations g "
-        "WHERE g.shell_id=interface_sessions.shell_id "
-        "AND g.generation=interface_sessions.generation "
-        "AND g.ended_at IS NOT NULL)",
-    "interface_input_state":
-        "WHERE delivery='delivery_unknown' "
-        "AND " + _serialized_session("interface_input_state.session_id"),
-    "interface_idempotency_keys":
-        "WHERE expires_at > datetime('now') "
-        "AND operation NOT IN ('acquire_lease','mint_ticket')",
-    "sprint_planner_bindings":
-        "WHERE " + _serialized_binding(
-            "sprint_planner_bindings.binding_id"),
-    "planner_wake_batches":
-        "WHERE " + _serialized_batch("planner_wake_batches.batch_id"),
-    # In-flight items are normally volatile. The exception is an item owned
-    # by a serialized delivery_unknown batch: resolve_batch() needs that row
-    # after rebuild to requeue the still-unread message on explicit retry.
-    "planner_wake_items":
-        "WHERE (state IN ('done','reconcile','quarantined','cancelled') "
-        "OR (state IN ('batched','submitting','running') "
-        "AND batch_id IS NOT NULL AND "
-        + _serialized_batch(
-            "planner_wake_items.batch_id", ("delivery_unknown",)) + ")) "
-        "AND " + _serialized_binding("planner_wake_items.binding_id") + " "
-        "AND EXISTS (SELECT 1 FROM shell_messages m "
-        "WHERE m.message_id=planner_wake_items.message_id) "
-        "AND (batch_id IS NULL OR "
-        + _serialized_batch("planner_wake_items.batch_id") + ")",
     "pr_poll_observations":
         "WHERE (transition IS NOT NULL OR blind_window <> 0) "
         "AND EXISTS (SELECT 1 FROM watched_prs w "
         "WHERE w.watch_id=pr_poll_observations.watch_id)",
-    # Alerts are durable only when every referenced parent is in this same
-    # projection. This drops session-scoped alerts for excluded live sessions
-    # and all legacy orphans, preventing integer-ID reuse from reattaching old
-    # generation state (#533).
+    # New poller alerts are plain rows. Legacy rows tied to the retired
+    # Interface/wake machine stay only in the live DB for Step 4's drain.
     "planner_alerts":
-        "WHERE (session_id IS NULL OR "
-        + _serialized_session("planner_alerts.session_id") + ") "
-        "AND (binding_id IS NULL OR "
-        + _serialized_binding("planner_alerts.binding_id") + ") "
+        "WHERE session_id IS NULL AND binding_id IS NULL "
         "AND (message_id IS NULL OR EXISTS ("
         "SELECT 1 FROM shell_messages m "
         "WHERE m.message_id=planner_alerts.message_id)) "
@@ -355,11 +238,6 @@ def dump_local_skills(con) -> list[str]:
 SENSITIVE_COLUMNS = {
     "shells": {"api_key", "api_key_rotated_at"},
     "users": {"password_hash", "password_salt"},
-    # Interface (0078): exact-identity fencing + credential hashes are
-    # volatile runtime state — never serialized even on ended audit rows.
-    "interface_generations": {"hook_token_hash"},
-    "interface_sessions": {"tmux_socket", "pane_pid", "pane_start_ticks",
-                           "harness_pid", "harness_start_ticks"},
 }
 
 
@@ -375,18 +253,9 @@ def dump_table(con, table: str) -> list[str]:
     if not cols:
         return []
     collist = ", ".join(cols)
-    select_cols = list(cols)
-    if table == "planner_alerts" and "resolved_at" in cols:
-        index = cols.index("resolved_at")
-        select_cols[index] = (
-            "CASE WHEN session_id IS NOT NULL THEN COALESCE("
-            "resolved_at, (SELECT s.ended_at FROM interface_sessions s "
-            "WHERE s.session_id=planner_alerts.session_id)) "
-            "ELSE resolved_at END"
-        )
     where = SNAPSHOT_ROW_FILTERS.get(table, "")
     rows = con.execute(
-        f"SELECT {', '.join(select_cols)} FROM {table} "
+        f"SELECT {collist} FROM {table} "
         f"{where} ORDER BY rowid").fetchall()
     lines = [f"DELETE FROM {table};"]
     for row in rows:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -45,7 +45,6 @@ materialize to a specific upstream version instead of the branch head.
 
 Usage:
     ./sc update [--no-fetch] [--branch <name>] [--ref <tag|sha>] [--force]
-                [--discard-live-state]
     python3 .super-coder/scripts/update.py [same flags]
 """
 from __future__ import annotations
@@ -72,17 +71,10 @@ import artifact_policy  # noqa: E402
 import db_driver  # noqa: E402
 import engine_manifest  # noqa: E402
 import install as install_mod  # noqa: E402  (ensure_harnesses)
-# STEP2(conductor): the Interface stack is retired; the live-state refusal
-# guard's replacement rule (an ACTIVE sprint blocks update, read from
-# sprint_state) lands in Step 2. Until then the guard no-ops when the module
-# is absent.
-try:
-    import interface_reconcile  # noqa: E402  (live-Interface refusal guard)
-except ImportError:
-    interface_reconcile = None
 import migrate as migrate_mod  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402
 import seed_skills  # noqa: E402
+import sprint_state  # noqa: E402
 
 EJECTED_MARKER = STATE_DIR / "ejected"
 
@@ -625,69 +617,31 @@ def fetch_and_materialize(branch: str, ref: str | None = None,
     materialize_fetched_engine(sha, force=force)
 
 
-def preflight_live_state(*, allow_discard: bool = False,
-                         discard_requested: bool = False) -> None:
-    """Guard from the current engine before any installed-floor mutation.
-
-    Normal callers fail closed.  ``update.main`` additionally offers an
-    interactive continue-or-roll-back choice, or accepts the explicit
-    ``--discard-live-state`` flag for a headless invocation.  The destructive
-    path is deliberately local-DB only so it still works while the API is down.
-    """
-    if interface_reconcile is None:  # STEP2(conductor): Interface retired
-        return
-    if not allow_discard:
-        reasons = interface_reconcile.live_refusal_reasons(DB_PATH)
-        if not reasons:
-            return
-        details = "\n  - " + "\n  - ".join(reasons)
-        sys.exit(
-            "update: refusing — live Interface state exists; drain/reconcile "
-            "it first:" + details)
-
-    manifest = interface_reconcile.live_loss_manifest(DB_PATH)
-    if manifest.empty():
-        return
-    details = "\n  - " + "\n  - ".join(manifest.loss_lines())
-    print(
-        "WARNING: update detected durable live Interface state.\n"
-        "Continuing will permanently terminalize exactly this loss manifest:"
-        + details,
-        file=sys.stderr,
-    )
-    if not discard_requested:
-        if not sys.stdin.isatty():
-            sys.exit(
-                "update: refusing — no interactive consent is available. "
-                "Drain/reconcile after starting the API, or explicitly accept "
-                "the loss with `./sc update --discard-live-state`.")
-        answer = input(
-            "Choose 'continue' to discard it, or 'rollback' to leave the "
-            "installed floor unchanged [rollback]: "
-        ).strip().lower()
-        if answer != "continue":
-            sys.exit(
-                "update: rolled back — installed engine, pins, and database "
-                "state are unchanged.")
-    else:
-        print(
-            "  --discard-live-state: explicit consent received; discarding.",
-            file=sys.stderr,
-        )
-
+def active_sprint_ids(db_path: Path | None = None) -> set[int]:
+    """Read the centralized ACTIVE-sprint predicate from the live engine DB."""
+    db_path = db_path or DB_PATH
+    if not db_path.exists():
+        return set()
+    con = db_driver.connect(db_path)
     try:
-        counts = interface_reconcile.discard_live_state(DB_PATH, manifest)
-    except interface_reconcile.LiveStateChanged:
-        sys.exit(
-            "update: refusing — live Interface state changed while consent "
-            "was pending; no rows were mutated. Re-run update to review and "
-            "consent to the fresh exact loss manifest.")
-    changed = ", ".join(
-        f"{name.replace('_', ' ')}={value}"
-        for name, value in counts.items()
-        if value
-    ) or "no rows changed"
-    print(f"→ discarded durable Interface state ({changed})")
+        return sprint_state.live_sprint_doc_ids(con)
+    except db_driver.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return set()
+        raise
+    finally:
+        con.close()
+
+
+def preflight_live_state() -> None:
+    """Refuse before mutation while any structurally ACTIVE sprint exists."""
+    active = active_sprint_ids()
+    if not active:
+        return
+    ids = ", ".join(str(doc_id) for doc_id in sorted(active))
+    sys.exit(
+        "update: refusing — ACTIVE sprint(s) exist: "
+        f"{ids}. Close or freeze every sprint before updating.")
 
 
 def migrate_engine_untrack() -> None:
@@ -812,7 +766,6 @@ def expire_sandbox_harnesses() -> str | None:
 def main(argv: list[str]) -> int:
     no_fetch = "--no-fetch" in argv
     force = "--force" in argv
-    discard_live_state = "--discard-live-state" in argv
     branch = "main"
     if "--branch" in argv:
         i = argv.index("--branch")
@@ -842,8 +795,7 @@ def main(argv: list[str]) -> int:
     target_sha = None
     if not source and not no_fetch:
         target_sha = fetch_update_ref(branch, ref=ref)
-    preflight_live_state(
-        allow_discard=True, discard_requested=discard_live_state)
+    preflight_live_state()
 
     if source:
         # The source repo IS the engine — it has no upstream to materialize from

--- a/sc
+++ b/sc
@@ -81,28 +81,14 @@ sc_refuse_linked() {
   exit 1
 }
 
-# Python for the Interface verbs: PREFER an interpreter with `websockets`
-# (baked into the sandbox image's own python and pinned in requirements.txt
-# for the ./sc deps .venv) because attach/view/take-control stream over it.
-# Never a hard gate here (spec #30 req 12, #518): HTTP-only verbs
-# (status/start/stop/reconcile) are stdlib-only and run on any python3 —
-# the stream dependency is checked lazily, inside the verbs that stream,
-# where interface_cli refuses with the exact dependency action.
-ifpy() {
-  if "$PY" -c 'import websockets' >/dev/null 2>&1; then printf '%s\n' "$PY"; return 0; fi
-  if [ -x "$here/.venv/bin/python" ] && "$here/.venv/bin/python" -c 'import websockets' >/dev/null 2>&1; then printf '%s\n' "$here/.venv/bin/python"; return 0; fi
-  printf '%s\n' "$PY"
-}
-
 port() { "$PY" "$S/ports.py" port; }
 devport() { "$PY" "$S/ports.py" devport; }
 
 # The two localhost URLs an operator needs, derived from this fork's ports —
 # never a fixed 8800, because every fork lands on its own offset (ports.py).
-# One printer, three callers (`url`, `enter`, `enter-<shortname>`): the boot
-# summary now paints INSIDE the tmux pane where the harness TUI overdraws it,
-# so `enter` restates the links host-side before attaching and `./sc url` /
-# `make dos-url` is the recall path once they have scrolled away (decision #50).
+# One printer, three callers (`url`, `enter`, `enter-<shortname>`): entry
+# restates the links before handing the terminal to the harness, and `./sc url`
+# / `make dos-url` is the recall path once they have scrolled away.
 sc_urls() {
   # Under `set -e` a failed derivation would abort the caller, so it is a
   # return here and `enter` ignores it: an operator who cannot be told the
@@ -149,7 +135,7 @@ SC_PG_SHM="${SC_PG_SHM:-1g}"
 dcheck() {
   if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
     echo "✗ docker daemon not reachable — the sandbox needs it." >&2
-    echo "  Setup (one-time):  ./sc doctor      No docker:  ./sc serve + ./sc interface enter" >&2
+    echo "  Setup (one-time):  ./sc doctor      No docker:  ./sc boot" >&2
     exit 1
   fi
 }
@@ -1313,16 +1299,6 @@ case "$cmd" in
   pg-down)      sc_pg_down ;;
   boot)         exec "$PY" "$S/run.py" "$@" ;;
   boot-*)       exec "$PY" "$S/run.py" "${cmd#boot-}" "$@" ;;
-  # STEP2(conductor): delete the retired interface dispatches after enter is
-  # repointed at direct boot.
-  # Interface pane entrypoint (internal; spec #20) — consumes the single-use
-  # launch token the API wrote, then becomes the shell's harness TUI.
-  interface-exec)  exec "$PY" "$S/interface_exec.py" "$@" ;;
-  # Interface CLI parity (spec #20 seq 6) — status/start/view/attach/
-  # take-control/stop/reconcile, and the in-container half of `sc enter`.
-  # API-backed only. ifpy prefers a websockets-capable interpreter for the
-  # stream verbs but never blocks the stdlib-only HTTP verbs (spec #30).
-  interface)    exec "$(ifpy)" "$S/interface_cli.py" "$@" ;;
   # Headless boot (sprint eventing): same render-then-exec path as boot, minus
   # the picker and the TTY. In-container primitive like boot — the planner
   # calls it to stand up an ephemeral worker; also the no-docker host path.
@@ -1469,12 +1445,8 @@ case "$cmd" in
     # no host watch-daemon is started here anymore.
     # Start the PG sidecar when configured — self-skips otherwise.
     sc_pg_up || true ;;
-  # STEP2(conductor): repoint enter/enter-* at direct `sc boot`.
-  # Interactive entry goes through the Interface API (spec #20): the in-container
-  # target resolves occupancy, starts a New chat (picker + reservation) for an
-  # available shell, or reattaches the occupied generation. Never a raw boot.
-  enter)        sc_urls || true; exec docker exec -it "$CNAME" ./sc interface enter "$@" ;;
-  enter-*)      sc_urls || true; exec docker exec -it "$CNAME" ./sc interface enter "${cmd#enter-}" "$@" ;;
+  enter)        sc_urls || true; exec docker exec -it "$CNAME" ./sc boot "$@" ;;
+  enter-*)      sc_urls || true; exec docker exec -it "$CNAME" ./sc boot "${cmd#enter-}" "$@" ;;
   down)         docker rm -f "$CNAME" >/dev/null 2>&1 && echo "→ sandbox stopped" || echo "→ not running"
                 sc_vm_broker_down
                 sc_ts_broker_down
@@ -1583,7 +1555,7 @@ super-coder — forkable shell substrate
   ./sc ensure-harness      install claude + opencode + codex + vibe + kimi if missing (official native installers, no npm)
   ./sc doctor              sandbox readiness: docker (rootless/rootful) + harness login
   ./sc update              fetch + materialize the engine (gitignored dep) + reconcile IN PLACE (migrate, sync skills, map);
-                             live Interface state asks continue-or-rollback; headless discard requires --discard-live-state
+                             refuses while any sprint is ACTIVE
                              --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
                              source repo: no materialize — the floor is reconciled FROM the checkout, so it is fast-forwarded first.
                              Advisory, never blocking: a tree it cannot fast-forward (uncommitted work, or diverged) WARNS that the
@@ -1672,19 +1644,11 @@ super-coder — forkable shell substrate
   container only sees this repo + your harness creds):
   ./sc launch              build + start the sandbox container (server + GUI), 127.0.0.1 only
                              --no-build reuses the existing image and refuses before runtime changes when absent
-  ./sc enter               enter a shell through the Interface API: pick a shell, then
-                             New chat (harness picker) if available, else reattach the live session
+  ./sc enter               boot an interactive shell directly (picker when omitted)
   ./sc enter-<shortname>   enter that shell directly (skip the shell picker)
                              harness: --harness <name> or HARNESS=<name> forces it; else when
                              >1 harness is on PATH you're prompted (per-launch, not persisted)
-  ./sc interface <verb>    Interface CLI parity (spec #20), API-backed (never direct DB/tmux):
-                             status [shell] [--json] · start <shell> [--harness H] [--model M] [--effort E]
-                             view <shell> (read-only) · attach <shell> (writer) · take-control <shell>
-                             stop <shell> [--force] · reconcile <shell> [--close]
-                             recover <shell> [--force] [--discard-worktree] [--yes] — mutations take --json
-                             (the browser opens the Interface with no sign-in step: what that trusts and
-                             what it still defends against is .super-coder/docs/interface-trust-boundary.md)
-  make dos-help            supported operator aliases for lifecycle, Interface, models,
+  make dos-help            supported operator aliases for lifecycle, models,
                              sprint/watch/job, maintenance, browser token, and generic ./sc forwarding
   ./sc run <shortname>     headless boot: render + exec the harness NON-interactively (claude · codex ·
                              opencode · kimi) to drain the shell's inbox and act; -p "<prompt>" overrides the
@@ -1698,8 +1662,7 @@ super-coder — forkable shell substrate
 
   Primitives (run inside the container; also the no-docker host escape hatch):
   ./sc serve               run the review layer (api + static UI) in the foreground
-  ./sc boot [shortname]    raw interactive launch — REFUSES without the Interface reservation
-                             capability (spec #20); use ./sc enter / ./sc interface instead
+  ./sc boot [shortname]    direct interactive launch (host/no-docker primitive)
   ./sc deps                install this fork's python (.venv) + node (node_modules) deps into the bind-mount
                              (plus an only-if-needed dev kit: pytest httpx coverage ruff mypy datasette)
   ./sc test                run backend (.venv pytest or stdlib unittest) + UI (vitest) suites; non-zero on any failure

--- a/tests/test_activity_readers.py
+++ b/tests/test_activity_readers.py
@@ -44,11 +44,7 @@ def make_db(path: Path) -> None:
         """
         CREATE TABLE shell_memory_archives (
           archive_id INTEGER PRIMARY KEY, shell_id INTEGER, started_at TEXT,
-          harness TEXT
-        );
-        CREATE TABLE interface_sessions (
-          session_id INTEGER PRIMARY KEY, shell_id INTEGER, archive_id INTEGER,
-          created_at TEXT, ended_at TEXT, end_reason TEXT, harness TEXT
+          ended_at TEXT, harness TEXT
         );
         CREATE TABLE shell_messages (
           message_id INTEGER PRIMARY KEY, from_shell_id INTEGER,
@@ -80,15 +76,8 @@ def make_db(path: Path) -> None:
         """
     )
     con.execute(
-        "INSERT INTO shell_memory_archives VALUES (10,1,?,'codex')",
+        "INSERT INTO shell_memory_archives VALUES (10,1,?,NULL,'codex')",
         ("2020-01-01T00:00:00Z",),
-    )
-    # A stale ended Interface session must not describe the current headless
-    # archive.  The current archive has no Interface row at all.
-    con.execute(
-        "INSERT INTO interface_sessions VALUES "
-        "(8,1,9,'2019-12-01T00:00:00Z','2019-12-01T00:01:00Z',"
-        "'operator_end','codex')"
     )
     con.execute(
         "INSERT INTO shell_messages (message_id, from_shell_id, sprint_doc_id, created_at, kind, body) VALUES "
@@ -286,9 +275,8 @@ class DatabaseContractTest(ReaderCase):
     def test_current_archive_session_end_fields_are_observed(self):
         con = sqlite3.connect(self.db)
         con.execute(
-            "INSERT INTO interface_sessions VALUES "
-            "(10,1,10,'2020-01-01T00:00:00Z','2020-01-05T00:00:00Z',"
-            "'stop_hook','codex')"
+            "UPDATE shell_memory_archives SET ended_at=? WHERE archive_id=10",
+            ("2020-01-05T00:00:00Z",),
         )
         con.commit()
         con.close()
@@ -298,7 +286,7 @@ class DatabaseContractTest(ReaderCase):
         self.assertEqual(
             datetime(2020, 1, 5, tzinfo=UTC), evidence.session_ended_at
         )
-        self.assertEqual("stop_hook", evidence.session_end_reason)
+        self.assertIsNone(evidence.session_end_reason)
 
     def test_result_row_is_unit_scoped_when_shell_holds_multiple_units(self):
         con = sqlite3.connect(self.db)
@@ -511,8 +499,8 @@ class DatabaseContractTest(ReaderCase):
     def test_rowless_shell_never_claims_code_work(self):
         con = sqlite3.connect(self.db)
         con.execute(
-            "INSERT INTO interface_sessions VALUES "
-            "(9,1,NULL,'2020-01-05T00:00:00Z',NULL,NULL,'codex')"
+            "INSERT INTO shell_memory_archives VALUES "
+            "(11,1,'2020-01-05T00:00:00Z',NULL,'codex')"
         )
         con.commit()
         con.close()

--- a/tests/test_operator_surface.py
+++ b/tests/test_operator_surface.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3
 """The launcher's host-side operator surface — URLs and the command chart.
 
-The review GUI link went missing from `make dos-e` when `enter` started
-routing through `./sc interface enter`: the boot summary moved INSIDE the
-tmux pane, where the harness TUI overdraws it. Nothing was deleted; the
-output moved somewhere the operator cannot read (decisions #50, #52).
-
   - `./sc url` prints this fork's DERIVED ports — a fork whose offset is not
     0 must not be told 8800 (ports.py owns the derivation, nobody restates it)
   - `enter` / `enter-<shortname>` restate the links BEFORE handing the
@@ -13,9 +8,6 @@ output moved somewhere the operator cannot read (decisions #50, #52).
   - every dispatchable verb is charted in `./sc help` — enumerated from the
     dispatcher itself, so a verb added without a help line fails here rather
     than becoming invisible to its operator
-
-The in-session half — the attach line the stream client renders — lives in
-tests/test_interface_cli.py, where the client's own harness is.
 
 Run:
     python3 tests/test_operator_surface.py
@@ -37,9 +29,6 @@ ROOT = Path(__file__).resolve().parents[1]
 # Dispatchable but deliberately absent from the operator chart. Anything else
 # missing is drift, not a decision.
 UNCHARTED_BY_DESIGN = {
-    # The in-pane exec target the runtime spawns — a server-only primitive,
-    # never an operator verb (same line aliases.mk draws for the Make surface).
-    "interface-exec",
     # `./sc help` listing itself is noise.
     "help",
 }
@@ -107,7 +96,12 @@ class EnterPreAttachPrintTest(unittest.TestCase):
     def setUp(self):
         self.bin = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.bin)
-        self._stub("docker", "#!/bin/sh\nexit 0\n")
+        self._stub(
+            "docker",
+            "#!/bin/sh\n"
+            "[ -n \"$SC_DOCKER_LOG\" ] && printf '%s\\n' \"$*\" > \"$SC_DOCKER_LOG\"\n"
+            "exit 0\n",
+        )
         # A python that runs everything except ports.py — the one seam whose
         # failure must not decide whether the operator gets a shell.
         self._stub("no-ports-python",
@@ -131,6 +125,16 @@ class EnterPreAttachPrintTest(unittest.TestCase):
                 self.assertEqual(out.returncode, 0, out.stderr)
                 self.assertIn(f"http://127.0.0.1:{cfg['port']}", out.stdout)
                 self.assertIn(f"http://127.0.0.1:{cfg['dev_port']}", out.stdout)
+
+    def test_enter_dispatches_direct_boot(self):
+        log = self.bin / "docker.log"
+        cases = ((("enter",), "./sc boot"), (("enter-DEV1",), "./sc boot DEV1"))
+        for argv, target in cases:
+            with self.subTest(verb=argv[0]):
+                out = sc(*argv, env=self._env(SC_DOCKER_LOG=str(log)))
+                self.assertEqual(out.returncode, 0, out.stderr)
+                self.assertIn(target, log.read_text())
+                self.assertNotIn("interface", log.read_text().lower())
 
     def test_an_underivable_url_never_costs_the_operator_their_shell(self):
         """`sc` runs under `set -e`, so an unguarded print is a new way for

--- a/tests/test_rebuild_args.py
+++ b/tests/test_rebuild_args.py
@@ -102,11 +102,7 @@ def armed(stack: ExitStack, tmp: Path, **overrides):
         rebuild.db_backup_mod, "select_backup_dir",
         tripwire("db_backup.select_backup_dir")))
     stack.enter_context(mock.patch.object(
-        rebuild.interface_reconcile, "live_refusal_reasons",
-        tripwire("live_refusal_reasons")))
-    stack.enter_context(mock.patch.object(
-        rebuild.interface_reconcile, "startup_reconcile",
-        tripwire("startup_reconcile")))
+        rebuild, "active_sprint_ids", tripwire("active_sprint_ids")))
     stack.enter_context(mock.patch.object(
         rebuild.migrate_mod, "migrate", tripwire("migrate")))
     stack.enter_context(mock.patch.object(
@@ -258,8 +254,7 @@ class RebuildActionFormTest(unittest.TestCase):
                         read_existing_keys=lambda *a, **k: {},
                     )
                     stack.enter_context(mock.patch.object(
-                        rebuild.interface_reconcile, "live_refusal_reasons",
-                        lambda *a, **k: []))
+                        rebuild, "active_sprint_ids", return_value=set()))
                     with self.assertRaises(Tripwire) as ctx:
                         rebuild.main(argv)
                 self.assertEqual(str(ctx.exception), expected)

--- a/tests/test_rebuild_integrity.py
+++ b/tests/test_rebuild_integrity.py
@@ -102,11 +102,10 @@ class RebuildIntegrityTest(unittest.TestCase):
             ).fetchone())
             con.close()
 
-    def test_rebuild_reconciles_open_ended_alert_loaded_after_migrations(self):
+    def test_active_sprint_refuses_before_rebuild_mutation(self):
         with tempfile.TemporaryDirectory() as raw_tmp:
             tmp = Path(raw_tmp)
             outgoing = tmp / "shell_db.db"
-            snapshot = tmp / "content.sql"
             apply_engine_schema(outgoing)
             con = sqlite3.connect(outgoing)
             con.execute(
@@ -116,60 +115,27 @@ class RebuildIntegrityTest(unittest.TestCase):
                 "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
                 "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
                 "VALUES (1,'Before','s1','test','sp',1,0,1,1)")
+            con.execute(
+                "INSERT INTO documents "
+                "(document_id, kind, title, frozen) "
+                "VALUES (59,'doc','SPRINT: rebuild guard',0)")
+            con.execute(
+                "INSERT INTO sprint_units "
+                "(sprint_doc_id, seq, unit_title, state) "
+                "VALUES (59,'U1','guard proof','working')")
             con.commit()
             con.close()
-
-            snapshot.write_text(
-                "PRAGMA foreign_keys=OFF;\n"
-                "BEGIN;\n"
-                "DELETE FROM users;\n"
-                "INSERT INTO users (user_id, username, is_active) "
-                "VALUES (1,'after',1);\n"
-                "DELETE FROM shells;\n"
-                "INSERT INTO shells (shell_id, display_name, shortname, mandate, "
-                "system_prompt, user_id, is_shared, has_identity, bootstrapped) "
-                "VALUES (1,'After','s1','test','sp',1,0,1,1);\n"
-                "INSERT INTO interface_generations "
-                "(shell_id, generation, ended_at) "
-                "VALUES (1,1,'2026-07-20 00:00:00');\n"
-                "INSERT INTO interface_sessions "
-                "(session_id, shell_id, generation, occupancy, lifecycle, "
-                "ended_at) VALUES "
-                "(1,1,1,'ended','ended','2026-07-20 00:00:00');\n"
-                "INSERT INTO interface_input_state "
-                "(session_id, shell_id, generation, composer, delivery, "
-                "pending_seq) VALUES "
-                "(1,1,1,'unknown','delivery_unknown',7);\n"
-                "INSERT INTO planner_alerts "
-                "(alert_id, session_id, severity, reason, dedupe_key) "
-                "VALUES (42,1,'critical','crash_window_delivery_unknown',"
-                "'1|-|-|crash_window_delivery_unknown');\n"
-                "COMMIT;\n"
-                "PRAGMA foreign_keys=ON;\n"
-            )
+            before = digest(outgoing)
 
             with mock.patch.multiple(
-                rebuild,
-                ENGINE=tmp / ".super-coder",
-                DB_PATH=outgoing,
-                REPO_ROOT=tmp,
-                SNAPSHOT=snapshot,
-                SNAPSHOT_LEGACY=tmp / "missing-content.sql",
-            ), mock.patch.object(rebuild.map_repo, "main"):
-                self.assertEqual(rebuild.main(["--no-backup"]), 0)
-                self.assertEqual(rebuild.main(["--no-backup"]), 0)
+                rebuild, DB_PATH=outgoing, REPO_ROOT=tmp
+            ), self.assertRaises(SystemExit) as ctx:
+                rebuild.main(["--no-backup"])
 
-            con = sqlite3.connect(outgoing)
-            try:
-                alerts = con.execute(
-                    "SELECT alert_id, reason, resolved_at "
-                    "FROM planner_alerts WHERE session_id=1").fetchall()
-            finally:
-                con.close()
-            self.assertEqual(alerts, [
-                (42, "crash_window_delivery_unknown",
-                 "2026-07-20 00:00:00")
-            ])
+            self.assertIn("ACTIVE sprint", str(ctx.exception))
+            self.assertIn("59", str(ctx.exception))
+            self.assertEqual(before, digest(outgoing))
+            self.assertFalse(Path(str(outgoing) + ".rebuild").exists())
 
     def test_valid_candidate_atomically_replaces_outgoing_db(self):
         with tempfile.TemporaryDirectory() as raw_tmp:

--- a/tests/test_snapshot_secrets.py
+++ b/tests/test_snapshot_secrets.py
@@ -89,6 +89,21 @@ class SnapshotSecretsTest(unittest.TestCase):
             missing = cols - live
             self.assertFalse(missing, f"{table}: SENSITIVE_COLUMNS names not in schema: {missing}")
 
+    def test_retired_interface_and_wake_audit_is_not_snapshotted(self):
+        retired = {
+            "interface_generations",
+            "interface_sessions",
+            "interface_input_state",
+            "interface_idempotency_keys",
+            "interface_writer_leases",
+            "sprint_planner_bindings",
+            "planner_wake_batches",
+            "planner_wake_items",
+            "planner_action_receipts",
+        }
+        self.assertTrue(retired.isdisjoint(snapshot.PER_INSTANCE_TABLES))
+        self.assertTrue(retired.isdisjoint(snapshot.SNAPSHOT_ROW_FILTERS))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_update_preflight.py
+++ b/tests/test_update_preflight.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
-import io
 import sqlite3
 import subprocess
 import sys
@@ -55,12 +54,12 @@ def build_live_db(path: Path) -> None:
             "user_id, is_shared, has_identity, bootstrapped) "
             "VALUES (1,'Admin','AMI','test','test',1,0,1,1)")
         con.execute(
-            "INSERT INTO interface_generations (shell_id, generation) "
-            "VALUES (1,1)")
+            "INSERT INTO documents (document_id, kind, title, frozen) "
+            "VALUES (59,'doc','SPRINT: update guard',0)")
         con.execute(
-            "INSERT INTO interface_sessions "
-            "(shell_id, generation, occupancy, lifecycle) "
-            "VALUES (1,1,'occupied','idle')")
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id, seq, unit_title, state) "
+            "VALUES (59,'U1','guard proof','working')")
         con.commit()
     finally:
         con.close()
@@ -112,10 +111,7 @@ class UpdatePreflightSentinelTest(unittest.TestCase):
             ), mock.patch.object(
                 update, "fetch_update_ref", return_value="a" * 40
             ) as fetch, mock.patch.object(
-                update.interface_reconcile,
-                "live_loss_manifest",
-                return_value=update.interface_reconcile.LiveLossManifest(
-                    sessions=(7,)),
+                update, "active_sprint_ids", return_value={59}
             ), mock.patch.object(
                 update, "migrate_engine_untrack"
             ) as untrack, mock.patch.object(
@@ -221,7 +217,7 @@ class UpdatePreflightSentinelTest(unittest.TestCase):
                 update.main([])
 
             self.assertIn("refusing", str(ctx.exception))
-            self.assertIn("--discard-live-state", str(ctx.exception))
+            self.assertIn("ACTIVE sprint", str(ctx.exception))
             self.assertEqual(fingerprint(watched), before_files)
             with contextlib.closing(sqlite3.connect(db_path)) as con:
                 self.assertEqual(con.execute(
@@ -233,134 +229,18 @@ class UpdatePreflightSentinelTest(unittest.TestCase):
                     before_schema)
 
 
-class UpdateConsentTest(unittest.TestCase):
-    def _preflight(self, *, interactive: bool, answer: str | None = None,
-                   explicit: bool = False):
-        stderr = io.StringIO()
-        patches = [
-            mock.patch.object(
-                update.interface_reconcile,
-                "live_loss_manifest",
-                return_value=update.interface_reconcile.LiveLossManifest(
-                    generations=((1, 1),), sessions=(7,)),
-            ),
-            mock.patch.object(
-                update.interface_reconcile,
-                "discard_live_state",
-                return_value={"sessions_ended": 1, "batches_completed": 1},
-            ),
-            mock.patch.object(sys.stdin, "isatty", return_value=interactive),
-            contextlib.redirect_stderr(stderr),
-        ]
-        if answer is not None:
-            patches.append(mock.patch("builtins.input", return_value=answer))
-        with contextlib.ExitStack() as stack:
-            entered = [stack.enter_context(patch) for patch in patches]
-            update.preflight_live_state(
-                allow_discard=True, discard_requested=explicit)
-        prompt = entered[-1].call_args.args[0] if answer is not None else None
-        return entered[1], stderr.getvalue(), prompt
-
-    def test_down_api_interactive_continue_warns_then_discards(self):
-        discard, warning, prompt = self._preflight(
-            interactive=True, answer="continue")
-        discard.assert_called_once_with(
-            update.DB_PATH,
-            update.interface_reconcile.LiveLossManifest(
-                generations=((1, 1),), sessions=(7,)),
-        )
-        self.assertIn("Interface generation(s): 1/1", warning)
-        self.assertIn("Interface session ID(s): 7", warning)
-        self.assertIn("'continue'", prompt)
-        self.assertIn("'rollback'", prompt)
-
-    def test_interactive_rollback_mutates_nothing(self):
+class UpdateActiveSprintGuardTest(unittest.TestCase):
+    def test_active_sprint_refuses_without_consent_path(self):
         with mock.patch.object(
-            update.interface_reconcile,
-            "live_loss_manifest",
-            return_value=update.interface_reconcile.LiveLossManifest(
-                sessions=(7,)),
-        ), mock.patch.object(
-            update.interface_reconcile, "discard_live_state"
-        ) as discard, mock.patch.object(
-            sys.stdin, "isatty", return_value=True
-        ), mock.patch(
-            "builtins.input", return_value="rollback"
+            update, "active_sprint_ids", return_value={59, 60}
         ), self.assertRaises(SystemExit) as ctx:
-            update.preflight_live_state(allow_discard=True)
-        self.assertIn("unchanged", str(ctx.exception))
-        discard.assert_not_called()
+            update.preflight_live_state()
+        self.assertIn("59, 60", str(ctx.exception))
+        self.assertIn("Close or freeze", str(ctx.exception))
 
-    def test_headless_without_explicit_flag_fails_closed(self):
-        with mock.patch.object(
-            update.interface_reconcile,
-            "live_loss_manifest",
-            return_value=update.interface_reconcile.LiveLossManifest(
-                sessions=(7,)),
-        ), mock.patch.object(
-            update.interface_reconcile, "discard_live_state"
-        ) as discard, mock.patch.object(
-            sys.stdin, "isatty", return_value=False
-        ), self.assertRaises(SystemExit) as ctx:
-            update.preflight_live_state(allow_discard=True)
-        self.assertIn("--discard-live-state", str(ctx.exception))
-        discard.assert_not_called()
-
-    def test_headless_explicit_flag_discards_and_proceeds(self):
-        discard, warning, prompt = self._preflight(
-            interactive=False, explicit=True)
-        discard.assert_called_once_with(
-            update.DB_PATH,
-            update.interface_reconcile.LiveLossManifest(
-                generations=((1, 1),), sessions=(7,)),
-        )
-        self.assertIn("explicit consent received", warning)
-        self.assertIsNone(prompt)
-
-    def test_post_prompt_insertion_refuses_without_mutating_any_row(self):
-        with tempfile.TemporaryDirectory() as raw_tmp:
-            db_path = Path(raw_tmp) / "shell_db.db"
-            build_live_db(db_path)
-            after_insert = {}
-
-            def insert_new_live_state(_prompt):
-                con = sqlite3.connect(db_path)
-                try:
-                    con.execute(
-                        "INSERT INTO shells "
-                        "(shell_id, display_name, shortname, mandate, "
-                        "system_prompt, user_id, is_shared, has_identity, "
-                        "bootstrapped) "
-                        "VALUES (2,'Worker','WORK','test','test',1,0,1,1)")
-                    con.execute(
-                        "INSERT INTO interface_generations "
-                        "(shell_id, generation) VALUES (2,1)")
-                    con.execute(
-                        "INSERT INTO interface_sessions "
-                        "(shell_id, generation, occupancy, lifecycle) "
-                        "VALUES (2,1,'occupied','idle')")
-                    con.commit()
-                    after_insert["dump"] = list(con.iterdump())
-                finally:
-                    con.close()
-                return "continue"
-
-            with mock.patch.object(
-                update, "DB_PATH", db_path
-            ), mock.patch.object(
-                sys.stdin, "isatty", return_value=True
-            ), mock.patch(
-                "builtins.input", side_effect=insert_new_live_state
-            ), self.assertRaises(SystemExit) as refused:
-                update.preflight_live_state(allow_discard=True)
-
-            self.assertIn("changed while consent was pending",
-                          str(refused.exception))
-            con = sqlite3.connect(db_path)
-            try:
-                self.assertEqual(list(con.iterdump()), after_insert["dump"])
-            finally:
-                con.close()
+    def test_no_active_sprint_proceeds(self):
+        with mock.patch.object(update, "active_sprint_ids", return_value=set()):
+            self.assertIsNone(update.preflight_live_state())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace update/rebuild Interface guards with the centralized structured ACTIVE-sprint predicate
- move activity evidence to archive lifecycle truth and reduce PR-poller output to plain durable rows
- remove retired Interface/wake snapshot audit and reopen direct `sc enter` → `sc boot`

## Verification
- `env -u MAKELEVEL .venv/bin/python -m pytest -q` — 1394 passed, 595 subtests
- `./sc render-check` — green
- `./sc verify` — rebuild/migrations/render-only boot green
- direct headless render-only boot green
- engine service health green on `127.0.0.1:8899`; poller remained clean
- `git grep -i "import interface"` — zero hits
- runtime `tmux` grep — zero hits