### PR TITLE
feat(conductor S4): land orchestration contracts

### DIFF
--- a/.super-coder/api/conductor_routes.py
+++ b/.super-coder/api/conductor_routes.py
@@ -1,0 +1,330 @@
+"""Conductor contract HTTP API.
+
+Routes:
+  GET  /api/directives[?status=&kind=&sprint_doc_id=&limit=]
+  GET  /api/directives/{id}
+  POST /api/directives
+  GET  /api/sentinel-events[?event_kind=&sprint_doc_id=&unit_id=&limit=]
+  GET  /api/sentinel-events/{id}
+
+Directive creation is token-scoped: the bearer token, never request data,
+selects the issuer shell and flavor. Sentinel writes are engine-internal; the
+HTTP surface is read-only until the sentinel lands in Step 5.
+"""
+from __future__ import annotations
+
+import http.client
+import io
+import json
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+ENGINE = Path(__file__).resolve().parents[1]
+DB_PATH = ENGINE / "shell_db.db"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import db_driver  # noqa: E402
+
+_ALLOWED_HOST_SET = frozenset(("127.0.0.1", "localhost", "::1"))
+_STATUSES = frozenset(("pending", "executed", "refused"))
+
+
+def _db():
+    return db_driver.connect(str(DB_PATH))
+
+
+def _json(status: int, obj):
+    return status, [
+        ("Content-Type", "application/json"),
+        ("Cache-Control", "no-store"),
+    ], json.dumps(obj).encode()
+
+
+def _err(status: int, code: str, message: str):
+    return _json(status, {"error": {"code": code, "message": message}})
+
+
+def _headers(raw: str):
+    return http.client.parse_headers(io.BytesIO(raw.encode("latin-1")))
+
+
+def _host_ok(headers) -> bool:
+    host = (headers.get("Host") or "").strip()
+    if host.startswith("["):
+        host = host[1:].split("]", 1)[0]
+    elif ":" in host:
+        host = host.rsplit(":", 1)[0]
+    return host in _ALLOWED_HOST_SET
+
+
+def _shell_for_token(con, headers):
+    authz = headers.get("Authorization") or ""
+    if authz[:7].lower() != "bearer ":
+        return None
+    token = authz[7:].strip()
+    if not token:
+        return None
+    return con.execute(
+        "SELECT shell_id, flavor FROM shells "
+        "WHERE api_key=? AND COALESCE(is_deleted,0)=0",
+        (token,),
+    ).fetchone()
+
+
+def _int(value, name: str):
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{name} must be an integer") from None
+
+
+def _limit(query) -> int:
+    raw = query.get("limit", ["50"])[0]
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError("limit must be an integer") from None
+    if not 1 <= value <= 200:
+        raise ValueError("limit must be between 1 and 200")
+    return value
+
+
+def _decode(row, json_column: str):
+    out = dict(row)
+    out[json_column] = json.loads(out[json_column])
+    return out
+
+
+def _directive(con, directive_id: int):
+    row = con.execute(
+        "SELECT directive_id, issuer_shell_id, issuer_flavor, kind, payload, "
+        "target, sprint_doc_id, unit_id, status, refusal_reason, created_at, "
+        "executed_at FROM directives WHERE directive_id=?",
+        (directive_id,),
+    ).fetchone()
+    return _decode(row, "payload") if row is not None else None
+
+
+def _event(con, event_id: int):
+    row = con.execute(
+        "SELECT event_id, event_kind, shell_id, sprint_doc_id, unit_id, "
+        "directive_id, evidence, observed_at "
+        "FROM sentinel_events WHERE event_id=?",
+        (event_id,),
+    ).fetchone()
+    return _decode(row, "evidence") if row is not None else None
+
+
+def insert_system_directive(con, *, kind: str, target: str,
+                            payload=None, sprint_doc_id=None, unit_id=None):
+    """Engine-internal system directive writer for the Step 5 sentinel."""
+    cur = con.execute(
+        "INSERT INTO directives "
+        "(issuer_shell_id, issuer_flavor, kind, payload, target, "
+        " sprint_doc_id, unit_id) VALUES (NULL,'system',?,?,?,?,?)",
+        (kind, json.dumps(payload or {}, sort_keys=True), target,
+         sprint_doc_id, unit_id),
+    )
+    return cur.lastrowid
+
+
+def append_sentinel_event(con, *, event_kind: str, evidence=None,
+                          shell_id=None, sprint_doc_id=None, unit_id=None,
+                          directive_id=None):
+    """Engine-internal append seam for the Step 5 sentinel."""
+    cur = con.execute(
+        "INSERT INTO sentinel_events "
+        "(event_kind, shell_id, sprint_doc_id, unit_id, directive_id, evidence) "
+        "VALUES (?,?,?,?,?,?)",
+        (event_kind, shell_id, sprint_doc_id, unit_id, directive_id,
+         json.dumps(evidence or {}, sort_keys=True)),
+    )
+    return cur.lastrowid
+
+
+def _list_directives(con, query):
+    clauses, params = [], []
+    status = query.get("status", [None])[0]
+    if status:
+        if status not in _STATUSES:
+            raise ValueError("status must be pending, executed, or refused")
+        clauses.append("status=?")
+        params.append(status)
+    kind = query.get("kind", [None])[0]
+    if kind:
+        clauses.append("kind=?")
+        params.append(kind)
+    sprint = query.get("sprint_doc_id", [None])[0]
+    if sprint not in (None, ""):
+        clauses.append("sprint_doc_id=?")
+        params.append(_int(sprint, "sprint_doc_id"))
+    sql = (
+        "SELECT directive_id, issuer_shell_id, issuer_flavor, kind, payload, "
+        "target, sprint_doc_id, unit_id, status, refusal_reason, created_at, "
+        "executed_at FROM directives"
+    )
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
+    sql += " ORDER BY directive_id DESC LIMIT ?"
+    params.append(_limit(query))
+    return [_decode(r, "payload") for r in con.execute(sql, params)]
+
+
+def _list_events(con, query):
+    clauses, params = [], []
+    kind = query.get("event_kind", [None])[0]
+    if kind:
+        clauses.append("event_kind=?")
+        params.append(kind)
+    for field in ("sprint_doc_id", "unit_id"):
+        raw = query.get(field, [None])[0]
+        if raw not in (None, ""):
+            clauses.append(f"{field}=?")
+            params.append(_int(raw, field))
+    sql = (
+        "SELECT event_id, event_kind, shell_id, sprint_doc_id, unit_id, "
+        "directive_id, evidence, observed_at FROM sentinel_events"
+    )
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
+    sql += " ORDER BY event_id DESC LIMIT ?"
+    params.append(_limit(query))
+    return [_decode(r, "evidence") for r in con.execute(sql, params)]
+
+
+def _create_directive(con, headers, body):
+    allowed_fields = {
+        "issuer_shell_id", "issuer_flavor", "kind", "payload", "target",
+        "sprint_doc_id", "unit_id",
+    }
+    unknown = sorted(set(body) - allowed_fields)
+    if unknown:
+        return _err(
+            422, "validation",
+            "unknown directive field(s): " + ", ".join(unknown),
+        )
+    shell = _shell_for_token(con, headers)
+    if shell is None:
+        return _err(
+            401, "issuer_required",
+            "directive creation requires a valid shell bearer token",
+        )
+    shell_id, flavor = shell
+    if flavor not in ("dev", "reviewer", "planner"):
+        return _err(403, "issuer_flavor_invalid",
+                    f"shell {shell_id} has no directive-issuing flavor")
+    if "issuer_shell_id" in body and body["issuer_shell_id"] != shell_id:
+        return _err(422, "issuer_claim_mismatch",
+                    "issuer_shell_id is derived from the bearer token")
+    if "issuer_flavor" in body and body["issuer_flavor"] != flavor:
+        return _err(422, "issuer_claim_mismatch",
+                    "issuer_flavor is derived from the bearer token")
+    kind = body.get("kind")
+    target = body.get("target")
+    payload = body.get("payload", {})
+    if not isinstance(kind, str) or not kind.strip():
+        return _err(422, "validation", "kind must be a nonblank string")
+    if not isinstance(target, str) or not target.strip():
+        return _err(422, "validation", "target must be a nonblank string")
+    if not isinstance(payload, dict):
+        return _err(422, "validation", "payload must be a JSON object")
+    allowed = con.execute(
+        "SELECT 1 FROM directive_kinds WHERE issuer_flavor=? AND kind=?",
+        (flavor, kind),
+    ).fetchone()
+    if allowed is None:
+        return _err(
+            422, "directive_kind_not_allowed",
+            f"{flavor} may not issue {kind!r}",
+        )
+    try:
+        sprint = (
+            _int(body["sprint_doc_id"], "sprint_doc_id")
+            if body.get("sprint_doc_id") is not None else None
+        )
+        unit = (
+            _int(body["unit_id"], "unit_id")
+            if body.get("unit_id") is not None else None
+        )
+    except ValueError as exc:
+        return _err(422, "validation", str(exc))
+    if unit is not None:
+        linked = con.execute(
+            "SELECT 1 FROM sprint_units "
+            "WHERE unit_id=? AND sprint_doc_id=?",
+            (unit, sprint),
+        ).fetchone()
+        if linked is None:
+            return _err(422, "unit_sprint_mismatch",
+                        "unit_id does not belong to sprint_doc_id")
+    try:
+        cur = con.execute(
+            "INSERT INTO directives "
+            "(issuer_shell_id, issuer_flavor, kind, payload, target, "
+            " sprint_doc_id, unit_id) VALUES (?,?,?,?,?,?,?)",
+            (shell_id, flavor, kind, json.dumps(payload, sort_keys=True),
+             target.strip(), sprint, unit),
+        )
+        con.commit()
+    except db_driver.IntegrityError as exc:
+        con.rollback()
+        return _err(422, "directive_invalid", str(exc))
+    return _json(201, _directive(con, cur.lastrowid))
+
+
+def handle(method: str, path: str, headers_raw: str, body: bytes):
+    headers = _headers(headers_raw)
+    if not _host_ok(headers):
+        return _err(403, "host_not_allowed",
+                    "Conductor API serves 127.0.0.1/localhost only")
+    parsed = urlparse(path)
+    query = parse_qs(parsed.query)
+    parts = parsed.path.strip("/").split("/")
+    con = _db()
+    try:
+        if parts[:2] == ["api", "directives"]:
+            if len(parts) == 2 and method == "GET":
+                try:
+                    return _json(200, {
+                        "directives": _list_directives(con, query)
+                    })
+                except ValueError as exc:
+                    return _err(422, "validation", str(exc))
+            if len(parts) == 2 and method == "POST":
+                try:
+                    data = json.loads(body) if body else {}
+                except ValueError:
+                    return _err(400, "bad_json",
+                                "request body is not valid JSON")
+                if not isinstance(data, dict):
+                    return _err(400, "bad_json",
+                                "request body must be a JSON object")
+                return _create_directive(con, headers, data)
+            if len(parts) == 3 and method == "GET":
+                try:
+                    item = _directive(con, _int(parts[2], "directive_id"))
+                except ValueError as exc:
+                    return _err(422, "validation", str(exc))
+                return _json(200, item) if item else _err(
+                    404, "not_found", "no such directive")
+        if parts[:2] == ["api", "sentinel-events"]:
+            if len(parts) == 2 and method == "GET":
+                try:
+                    return _json(200, {
+                        "events": _list_events(con, query)
+                    })
+                except ValueError as exc:
+                    return _err(422, "validation", str(exc))
+            if len(parts) == 3 and method == "GET":
+                try:
+                    item = _event(con, _int(parts[2], "event_id"))
+                except ValueError as exc:
+                    return _err(422, "validation", str(exc))
+                return _json(200, item) if item else _err(
+                    404, "not_found", "no such sentinel event")
+        return _err(404, "no_such_route",
+                    f"no route: {method} {parsed.path}")
+    finally:
+        con.close()

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -65,6 +65,7 @@ import db_driver  # noqa: E402
 import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import mem_credentials  # noqa: E402  (runtime Admin credential provisioning, spec #30 req 11)
 sys.path.insert(0, str(ENGINE / "api"))
+import conductor_routes  # noqa: E402  (Step 4 directive/event contracts)
 import sprint_routes  # noqa: E402  (sprint board API — /api/sprint-units)
 import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
 import pr_poller  # noqa: E402  (watched-PR polling — the service scheduler)
@@ -1239,16 +1240,6 @@ def patch_document(con, doc_id, body, commit=True):
                          {"body", "title", "render_path"}, commit=commit)
 
 
-# The alert reasons a WATCH carries, as opposed to a binding. Until H-12 these
-# were resolved on exactly one path — a watch being rebound to a sprint — so a
-# sprint that closed with a failing or unscoped watch left them open forever,
-# and `sc sprint alerts` grew a permanent floor of alerts about sprints nobody
-# was running. Enumerated rather than "every alert with a watch_id" so a future
-# reason has to be classified deliberately.
-_WATCH_ALERT_REASONS = ("pr_watch_unscoped", "pr_poll_failure",
-                        "pr_poll_backoff_escalated")
-
-
 def _link_watch_unit(con, watch_id: int, unit_id) -> bool:
     """Point a live watch at a board unit (H-13). True when the row changed.
 
@@ -1321,10 +1312,9 @@ def _freeze_board_refusal(con, doc_id) -> "dict | None":
 def _close_sprint_wake(con, doc_id) -> dict:
     """Sprint close integration (spec #20 Sprint Scope, sprint 25 seq 10;
     spec #76 H-12; H-1): closing a sprint IS freezing its doc, and the freeze
-    retires the sprint's live footprint in the SAME transaction — its live PR
-    watches and the watch-scoped alerts those watches opened. No watch still
-    polling GitHub for a sprint that ended, and no permanently-open alert
-    about one. Messages stay unread.
+    retires the sprint's live PR watches in the SAME transaction. Sentinel
+    observations are append-only evidence and are never "resolved" on close.
+    Messages stay unread.
 
     The Interface wake machine's close hooks (binding release, held wake-item
     cancellation) died with the Interface stack (conductor Step 1); the legacy
@@ -1338,15 +1328,8 @@ def _close_sprint_wake(con, doc_id) -> dict:
     retired = con.execute(
         "UPDATE watched_prs SET closed_at=datetime('now') "
         "WHERE sprint_doc_id=? AND closed_at IS NULL", (doc_id,)).rowcount
-    marks = ",".join("?" for _ in _WATCH_ALERT_REASONS)
-    resolved = con.execute(
-        "UPDATE planner_alerts SET resolved_at=datetime('now') "
-        f"WHERE resolved_at IS NULL AND reason IN ({marks}) "
-        "AND watch_id IN (SELECT watch_id FROM watched_prs "
-        "                 WHERE sprint_doc_id=?)",
-        (*_WATCH_ALERT_REASONS, doc_id)).rowcount
     return {"released_bindings": 0, "retired_watches": retired,
-            "resolved_watch_alerts": resolved,
+            "resolved_watch_alerts": 0,
             "cancelled_held_items": 0}
 
 
@@ -3069,11 +3052,6 @@ class Handler(BaseHTTPRequestHandler):
                     "unit_id=COALESCE(?, unit_id) WHERE watch_id=?",
                     (sprint_doc_id, json.dumps(fp), unit_id,
                      unscoped["watch_id"]))
-                con.execute(
-                    "UPDATE planner_alerts SET resolved_at=datetime('now') "
-                    "WHERE watch_id=? AND reason='pr_watch_unscoped' "
-                    "AND resolved_at IS NULL",
-                    (unscoped["watch_id"],))
                 con.commit()
                 return self._send(200, {"watch_id": unscoped["watch_id"],
                                         "rebound": True, "daemon": daemon})
@@ -3611,9 +3589,13 @@ class _ShimHandler(Handler):
 def dispatch_http(method: str, path: str, headers_raw: str,
                   body: bytes) -> tuple:
     """The transport's HTTP entry: route one request, return
-    (status, [(header, value)], body bytes). Sprint board paths go to the
-    sprint_routes module; everything else runs through the shimmed Handler."""
+    (status, [(header, value)], body bytes). Contract and sprint-board paths
+    go to their focused route modules; everything else runs through the
+    shimmed Handler."""
     parsed = urlparse(path)
+    if parsed.path.startswith(("/api/directives",
+                               "/api/sentinel-events")):
+        return conductor_routes.handle(method, path, headers_raw, body)
     if parsed.path.startswith("/api/sprint-units"):
         return sprint_routes.handle(method, path, headers_raw, body)
     handler = _ShimHandler(method, path, headers_raw, body)

--- a/.super-coder/migrations/0119_conductor_contracts.sql
+++ b/.super-coder/migrations/0119_conductor_contracts.sql
@@ -1,0 +1,265 @@
+-- 0119 — Conductor Step 4 contracts.
+--
+-- New orchestration state is deliberately independent of the retired
+-- Interface wake machine. Installed forks can contain live bindings, so this
+-- migration drains them into closed historical rows and preserves one audit
+-- record per binding instead of dropping evidence.
+
+BEGIN;
+
+CREATE TABLE directive_kinds (
+    issuer_flavor TEXT NOT NULL
+                  CHECK (issuer_flavor IN
+                         ('dev','reviewer','planner','system')),
+    kind          TEXT NOT NULL CHECK (trim(kind) <> ''),
+    PRIMARY KEY (issuer_flavor, kind)
+);
+
+INSERT INTO directive_kinds (issuer_flavor, kind) VALUES
+    ('dev',      'ready-for-review'),
+    ('dev',      'ask-planner'),
+    ('dev',      'merged'),
+    ('dev',      'unit-report'),
+    ('reviewer', 'review-clean'),
+    ('reviewer', 'findings'),
+    ('reviewer', 'ask-planner'),
+    ('planner',  'kickoff'),
+    ('planner',  'hold'),
+    ('planner',  're-scope'),
+    ('planner',  're-task'),
+    ('planner',  'close'),
+    ('planner',  'answer'),
+    ('system',   'pr-green'),
+    ('system',   'pr-red'),
+    ('system',   'pr-merged'),
+    ('system',   'stall'),
+    ('system',   'dead-shell');
+
+CREATE TABLE directives (
+    directive_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    issuer_shell_id INTEGER REFERENCES shells(shell_id),
+    issuer_flavor   TEXT NOT NULL,
+    kind            TEXT NOT NULL,
+    payload         TEXT NOT NULL DEFAULT '{}'
+                    CHECK (json_valid(payload) AND json_type(payload)='object'),
+    target          TEXT NOT NULL CHECK (trim(target) <> ''),
+    sprint_doc_id   INTEGER REFERENCES documents(document_id),
+    unit_id         INTEGER REFERENCES sprint_units(unit_id),
+    status          TEXT NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending','executed','refused')),
+    refusal_reason  TEXT,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    executed_at     TEXT,
+    FOREIGN KEY (issuer_flavor, kind)
+        REFERENCES directive_kinds(issuer_flavor, kind),
+    CHECK (
+      (status='pending' AND executed_at IS NULL AND refusal_reason IS NULL)
+      OR
+      (status='executed' AND executed_at IS NOT NULL
+       AND refusal_reason IS NULL)
+      OR
+      (status='refused' AND executed_at IS NOT NULL
+       AND trim(COALESCE(refusal_reason,'')) <> '')
+    )
+);
+
+CREATE TRIGGER trg_directive_issuer_insert
+BEFORE INSERT ON directives
+WHEN NOT (
+    (NEW.issuer_flavor='system' AND NEW.issuer_shell_id IS NULL)
+    OR
+    (NEW.issuer_flavor<>'system' AND NEW.issuer_shell_id IS NOT NULL
+     AND EXISTS (
+       SELECT 1 FROM shells s
+       WHERE s.shell_id=NEW.issuer_shell_id
+         AND s.flavor=NEW.issuer_flavor
+         AND COALESCE(s.is_deleted,0)=0
+     ))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'directive issuer does not match shell flavor');
+END;
+
+CREATE TRIGGER trg_directive_issuer_update
+BEFORE UPDATE OF issuer_shell_id, issuer_flavor, kind ON directives
+BEGIN
+  SELECT RAISE(ABORT, 'directive issuer and kind are immutable');
+END;
+
+CREATE TRIGGER trg_directive_unit_insert
+BEFORE INSERT ON directives
+WHEN NEW.unit_id IS NOT NULL AND (
+    NEW.sprint_doc_id IS NULL OR NOT EXISTS (
+      SELECT 1 FROM sprint_units u
+      WHERE u.unit_id=NEW.unit_id
+        AND u.sprint_doc_id=NEW.sprint_doc_id
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'directive unit does not belong to sprint');
+END;
+
+CREATE TRIGGER trg_directive_link_update
+BEFORE UPDATE OF sprint_doc_id, unit_id ON directives
+WHEN NEW.unit_id IS NOT NULL AND (
+    NEW.sprint_doc_id IS NULL OR NOT EXISTS (
+      SELECT 1 FROM sprint_units u
+      WHERE u.unit_id=NEW.unit_id
+        AND u.sprint_doc_id=NEW.sprint_doc_id
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'directive unit does not belong to sprint');
+END;
+
+CREATE INDEX idx_directives_pending
+    ON directives(status, created_at, directive_id);
+CREATE INDEX idx_directives_sprint_unit
+    ON directives(sprint_doc_id, unit_id, directive_id);
+
+CREATE TABLE sentinel_events (
+    event_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_kind     TEXT NOT NULL CHECK (trim(event_kind) <> ''),
+    shell_id       INTEGER REFERENCES shells(shell_id),
+    sprint_doc_id  INTEGER REFERENCES documents(document_id),
+    unit_id        INTEGER REFERENCES sprint_units(unit_id),
+    directive_id   INTEGER REFERENCES directives(directive_id),
+    evidence       TEXT NOT NULL DEFAULT '{}'
+                   CHECK (json_valid(evidence) AND json_type(evidence)='object'),
+    observed_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TRIGGER trg_sentinel_events_append_only_update
+BEFORE UPDATE ON sentinel_events
+BEGIN
+  SELECT RAISE(ABORT, 'sentinel_events is append-only');
+END;
+
+CREATE TRIGGER trg_sentinel_events_append_only_delete
+BEFORE DELETE ON sentinel_events
+BEGIN
+  SELECT RAISE(ABORT, 'sentinel_events is append-only');
+END;
+
+CREATE TRIGGER trg_sentinel_events_unit_insert
+BEFORE INSERT ON sentinel_events
+WHEN NEW.unit_id IS NOT NULL AND (
+    NEW.sprint_doc_id IS NULL OR NOT EXISTS (
+      SELECT 1 FROM sprint_units u
+      WHERE u.unit_id=NEW.unit_id
+        AND u.sprint_doc_id=NEW.sprint_doc_id
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'sentinel event unit does not belong to sprint');
+END;
+
+CREATE INDEX idx_sentinel_events_observed
+    ON sentinel_events(observed_at, event_id);
+CREATE INDEX idx_sentinel_events_sprint_unit
+    ON sentinel_events(sprint_doc_id, unit_id, event_id);
+
+CREATE TABLE unit_expectations (
+    unit_state        TEXT PRIMARY KEY
+                      CHECK (unit_state IN
+                             ('pending','working','in_review','blocked',
+                              'merged','cancelled')),
+    expected_signals  TEXT NOT NULL
+                      CHECK (json_valid(expected_signals)
+                             AND json_type(expected_signals)='array'),
+    max_dwell_seconds INTEGER CHECK (max_dwell_seconds > 0),
+    enabled           INTEGER NOT NULL DEFAULT 1
+                      CHECK (enabled IN (0,1)),
+    updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    CHECK (
+      (enabled=1 AND max_dwell_seconds IS NOT NULL)
+      OR
+      (enabled=0 AND max_dwell_seconds IS NULL)
+    )
+);
+
+INSERT INTO unit_expectations
+    (unit_state, expected_signals, max_dwell_seconds, enabled)
+VALUES
+    ('pending',   '["kickoff"]',                             3600, 1),
+    ('working',   '["activity","message","commit","pr"]',    7200, 1),
+    ('in_review', '["activity","message","review"]',         3600, 1),
+    ('blocked',   '["message","planner-directive"]',        14400, 1),
+    ('merged',    '[]',                                      NULL, 0),
+    ('cancelled', '[]',                                      NULL, 0);
+
+CREATE TABLE wake_machine_retirements (
+    retirement_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id          INTEGER NOT NULL UNIQUE,
+    sprint_doc_id       INTEGER NOT NULL,
+    planner_shell_id    INTEGER NOT NULL,
+    session_id          INTEGER NOT NULL,
+    prior_released_at   TEXT,
+    prior_release_reason TEXT,
+    wake_batch_count    INTEGER NOT NULL,
+    wake_item_count     INTEGER NOT NULL,
+    retired_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    retirement_reason   TEXT NOT NULL DEFAULT 'conductor-step4-retired'
+);
+
+INSERT INTO wake_machine_retirements (
+    binding_id, sprint_doc_id, planner_shell_id, session_id,
+    prior_released_at, prior_release_reason, wake_batch_count, wake_item_count
+)
+SELECT b.binding_id, b.sprint_doc_id, b.planner_shell_id, b.session_id,
+       b.released_at, b.release_reason,
+       (SELECT COUNT(*) FROM planner_wake_batches wb
+        WHERE wb.binding_id=b.binding_id),
+       (SELECT COUNT(*) FROM planner_wake_items wi
+        WHERE wi.binding_id=b.binding_id)
+FROM sprint_planner_bindings b;
+
+UPDATE planner_wake_items
+SET state='cancelled',
+    error=COALESCE(error, 'retired by Conductor Step 4'),
+    updated_at=datetime('now')
+WHERE state <> 'done' AND state <> 'cancelled';
+
+UPDATE planner_wake_batches
+SET state='delivery_unknown'
+WHERE state='submitting';
+
+UPDATE planner_wake_batches
+SET state='complete',
+    completed_at=COALESCE(completed_at, datetime('now'))
+WHERE state <> 'complete';
+
+UPDATE planner_action_receipts
+SET state='unknown',
+    result_detail=COALESCE(
+      result_detail, 'retired by Conductor Step 4')
+WHERE state='intent';
+
+UPDATE planner_action_receipts
+SET state='reconciled',
+    result_detail=COALESCE(
+      result_detail, 'retired by Conductor Step 4'),
+    reconciled_at=COALESCE(reconciled_at, datetime('now'))
+WHERE state='unknown';
+
+UPDATE planner_alerts
+SET resolved_at=COALESCE(resolved_at, datetime('now'));
+
+UPDATE sprint_planner_bindings
+SET released_at=datetime('now'),
+    release_reason='conductor-step4-retired'
+WHERE released_at IS NULL;
+
+CREATE TRIGGER trg_wake_machine_retirements_append_only_update
+BEFORE UPDATE ON wake_machine_retirements
+BEGIN
+  SELECT RAISE(ABORT, 'wake_machine_retirements is append-only');
+END;
+
+CREATE TRIGGER trg_wake_machine_retirements_append_only_delete
+BEFORE DELETE ON wake_machine_retirements
+BEGIN
+  SELECT RAISE(ABORT, 'wake_machine_retirements is append-only');
+END;
+
+COMMIT;

--- a/.super-coder/scripts/conductor_contracts.py
+++ b/.super-coder/scripts/conductor_contracts.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Read and emit Conductor Step 4 contract rows through the engine API."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+SC_API_BASE = os.environ.get("SC_API_BASE", "http://127.0.0.1:8800")
+SC_API_TOKEN = os.environ.get("SC_API_TOKEN", "")
+_TIMEOUT = 10
+
+
+def _die(msg: str) -> "SystemExit":
+    return SystemExit(f"sc conductor: {msg}")
+
+
+def _api(method: str, path: str, payload=None):
+    headers = {}
+    if SC_API_TOKEN:
+        headers["Authorization"] = f"Bearer {SC_API_TOKEN}"
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        SC_API_BASE.rstrip("/") + path,
+        data=data,
+        method=method,
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as response:
+            return json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        try:
+            obj = json.loads(exc.read())
+            err = obj.get("error", {})
+            message = err.get("message", str(err))
+        except Exception:  # noqa: BLE001
+            message = exc.reason
+        raise _die(f"{method} {path} → HTTP {exc.code}: {message}")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise _die(f"API unreachable ({getattr(exc, 'reason', exc)})")
+
+
+def _query(path: str, values: dict) -> str:
+    clean = {k: v for k, v in values.items() if v is not None}
+    return path + (f"?{urllib.parse.urlencode(clean)}" if clean else "")
+
+
+def _dump(obj) -> None:
+    print(json.dumps(obj, indent=2, sort_keys=True))
+
+
+def _directive_list(args) -> int:
+    result = _api("GET", _query("/api/directives", {
+        "status": args.status,
+        "kind": args.kind,
+        "sprint_doc_id": args.sprint,
+        "limit": args.limit,
+    }))
+    for item in result["directives"]:
+        print(
+            f"{item['directive_id']:>5} [{item['status']}] "
+            f"{item['issuer_flavor']}:{item['kind']} → {item['target']} "
+            f"sprint={item['sprint_doc_id'] or '—'} "
+            f"unit={item['unit_id'] or '—'}"
+        )
+    return 0
+
+
+def _directive_inspect(args) -> int:
+    _dump(_api("GET", f"/api/directives/{args.directive_id}"))
+    return 0
+
+
+def _directive_emit(args) -> int:
+    try:
+        payload = json.loads(args.payload)
+    except ValueError as exc:
+        raise _die(f"--payload is not valid JSON: {exc}")
+    if not isinstance(payload, dict):
+        raise _die("--payload must decode to a JSON object")
+    body = {"kind": args.kind, "target": args.target, "payload": payload}
+    if args.sprint is not None:
+        body["sprint_doc_id"] = args.sprint
+    if args.unit is not None:
+        body["unit_id"] = args.unit
+    item = _api("POST", "/api/directives", body)
+    print(f"sc directives: emitted {item['directive_id']} "
+          f"{item['issuer_flavor']}:{item['kind']} → {item['target']}")
+    return 0
+
+
+def _event_list(args) -> int:
+    result = _api("GET", _query("/api/sentinel-events", {
+        "event_kind": args.kind,
+        "sprint_doc_id": args.sprint,
+        "unit_id": args.unit,
+        "limit": args.limit,
+    }))
+    for item in result["events"]:
+        print(
+            f"{item['event_id']:>5} {item['event_kind']} "
+            f"shell={item['shell_id'] or '—'} "
+            f"sprint={item['sprint_doc_id'] or '—'} "
+            f"unit={item['unit_id'] or '—'} "
+            f"at={item['observed_at']}"
+        )
+    return 0
+
+
+def _event_inspect(args) -> int:
+    _dump(_api("GET", f"/api/sentinel-events/{args.event_id}"))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="./sc")
+    surfaces = parser.add_subparsers(dest="surface", required=True)
+
+    directives = surfaces.add_parser(
+        "directives", help="emit and read Conductor directives")
+    dsub = directives.add_subparsers(dest="verb", required=True)
+    dl = dsub.add_parser("list")
+    dl.add_argument("--status", choices=("pending", "executed", "refused"))
+    dl.add_argument("--kind")
+    dl.add_argument("--sprint", type=int)
+    dl.add_argument("--limit", type=int, default=50)
+    di = dsub.add_parser("inspect")
+    di.add_argument("directive_id", type=int)
+    de = dsub.add_parser("emit")
+    de.add_argument("kind")
+    de.add_argument("--target", required=True)
+    de.add_argument("--payload", default="{}")
+    de.add_argument("--sprint", type=int)
+    de.add_argument("--unit", type=int)
+
+    events = surfaces.add_parser(
+        "events", help="read append-only sentinel observations")
+    esub = events.add_subparsers(dest="verb", required=True)
+    el = esub.add_parser("list")
+    el.add_argument("--kind")
+    el.add_argument("--sprint", type=int)
+    el.add_argument("--unit", type=int)
+    el.add_argument("--limit", type=int, default=50)
+    ei = esub.add_parser("inspect")
+    ei.add_argument("event_id", type=int)
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    handlers = {
+        ("directives", "list"): _directive_list,
+        ("directives", "inspect"): _directive_inspect,
+        ("directives", "emit"): _directive_emit,
+        ("events", "list"): _event_list,
+        ("events", "inspect"): _event_inspect,
+    }
+    return handlers[(args.surface, args.verb)](args)
+
+
+if __name__ == "__main__":
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -799,18 +799,9 @@ def beat(con, interval: int, *, name: str = "watch") -> None:
 
 # ── The poll cycle ────────────────────────────────────────────────────────────
 
-def _alert(con, *, severity: str, reason: str, watch_id=None) -> None:
-    """Raise an alert, deduplicated while open (partial unique index). Local
-    helper — interface_broker._alert predates watch-scoped alerts.
-
-    The sprint and unit are read off the watch rather than left NULL (H-13):
-    0102 gave planner_alerts structured identity columns, and a watch is the
-    one alert source that KNOWS both. Leaving them NULL forced every reader
-    back to parsing `dedupe_key` or grepping prose for "U3" — the guess this
-    linkage exists to delete. `dedupe_key` is unchanged, so an already-open
-    alert stays the same open alert and no re-alert storm follows.
-    """
-    dedupe = f"-|-|{watch_id or '-'}|-|{reason}"
+def _sentinel_observation(con, *, severity: str, reason: str,
+                          watch_id=None) -> None:
+    """Record poller evidence in the Step 4 append-only observation log."""
     sprint_doc_id = unit_id = None
     if watch_id is not None:
         row = con.execute(
@@ -819,20 +810,26 @@ def _alert(con, *, severity: str, reason: str, watch_id=None) -> None:
         if row is not None:
             sprint_doc_id, unit_id = row["sprint_doc_id"], row["unit_id"]
     con.execute(
-        "INSERT OR IGNORE INTO planner_alerts "
-        "(watch_id, sprint_doc_id, unit_id, severity, reason, dedupe_key) "
-        "VALUES (?,?,?,?,?,?)",
-        (watch_id, sprint_doc_id, unit_id, severity, reason, dedupe))
+        "INSERT INTO sentinel_events "
+        "(event_kind, sprint_doc_id, unit_id, evidence) VALUES (?,?,?,?)",
+        (reason, sprint_doc_id, unit_id,
+         json.dumps({"severity": severity, "watch_id": watch_id},
+                    sort_keys=True)))
 
 
 def surface_unscoped_watches(con) -> int:
-    """Turn dormant legacy state into an operator-visible, deduped alert.
-    Returns the number of affected watches, whether newly alerted or already
-    carrying the same open alert."""
+    """Turn dormant legacy state into a deduped sentinel observation."""
     watch_ids = live_unscoped_watch_ids(con)
     for watch_id in watch_ids:
-        _alert(con, severity="critical", reason="pr_watch_unscoped",
-               watch_id=watch_id)
+        already = con.execute(
+            "SELECT 1 FROM sentinel_events "
+            "WHERE event_kind='pr_watch_unscoped' "
+            "AND json_extract(evidence,'$.watch_id')=? LIMIT 1",
+            (watch_id,)).fetchone()
+        if already is None:
+            _sentinel_observation(
+                con, severity="critical", reason="pr_watch_unscoped",
+                watch_id=watch_id)
     if watch_ids:
         con.commit()
     return len(watch_ids)
@@ -924,14 +921,16 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
                 "UPDATE pr_poll_runs SET finished_at=datetime('now'), status=?, "
                 "error=? WHERE run_id=?",
                 ("rate_limited" if r.rate_limited else "error", r.error, run_id))
-            _alert(con, severity="warning", reason="pr_poll_failure",
-                   watch_id=repo_watches[0]["watch_id"])
+            _sentinel_observation(
+                con, severity="warning", reason="pr_poll_failure",
+                watch_id=repo_watches[0]["watch_id"])
             con.commit()
             summary["errors"] += 1
             if failures >= 3:
-                _alert(con, severity="critical",
-                       reason="pr_poll_backoff_escalated",
-                       watch_id=repo_watches[0]["watch_id"])
+                _sentinel_observation(
+                    con, severity="critical",
+                    reason="pr_poll_backoff_escalated",
+                    watch_id=repo_watches[0]["watch_id"])
                 con.commit()
             continue
 

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -91,10 +91,12 @@ PER_INSTANCE_TABLES = [
     # rebuilds. Loads after `shells` and `documents`, both its FK targets. No
     # row filter: every unit row is durable planner content, terminal or not.
     "sprint_units",
-    # Reconciler alerts may reference sprint_units.unit_id (0102), so alerts
-    # load after the board record just as they already load after their
-    # session, binding, message, and watch parents.
-    "planner_alerts",
+    # Conductor contract rows are durable orchestration truth. Whitelist and
+    # expectation defaults are migration-owned system data; the live queue,
+    # evidence trail, and one-time legacy-drain audit are instance state.
+    "directives",
+    "sentinel_events",
+    "wake_machine_retirements",
     # NOTE: dr_section is authored navigation but lives in the MAP DB now
     # (.sc-state/map.db), not shell_db.db — it is serialized separately to
     # .sc-state/map_content.sql by snapshot_map() below, not here.
@@ -105,16 +107,6 @@ SNAPSHOT_ROW_FILTERS = {
         "WHERE (transition IS NOT NULL OR blind_window <> 0) "
         "AND EXISTS (SELECT 1 FROM watched_prs w "
         "WHERE w.watch_id=pr_poll_observations.watch_id)",
-    # New poller alerts are plain rows. Legacy rows tied to the retired
-    # Interface/wake machine stay only in the live DB for Step 4's drain.
-    "planner_alerts":
-        "WHERE session_id IS NULL AND binding_id IS NULL "
-        "AND (message_id IS NULL OR EXISTS ("
-        "SELECT 1 FROM shell_messages m "
-        "WHERE m.message_id=planner_alerts.message_id)) "
-        "AND (watch_id IS NULL OR EXISTS ("
-        "SELECT 1 FROM watched_prs w "
-        "WHERE w.watch_id=planner_alerts.watch_id))",
 }
 
 

--- a/sc
+++ b/sc
@@ -1191,6 +1191,8 @@ case "$cmd" in
   mem)          exec "$PY" "$S/mem.py" "$@" ;;
   token)        exec "$PY" "$S/operator_token.py" "$@" ;;
   sprint)       exec "$PY" "$S/sprint.py" "$@" ;;
+  directives)   exec "$PY" "$S/conductor_contracts.py" directives "$@" ;;
+  events)       exec "$PY" "$S/conductor_contracts.py" events "$@" ;;
   # ── sprint eventing: PR watches + inbox watcher (shell-side, API) and the
   # GitHub watcher daemon (HOST-side foreground; -up/-down supervise it) ──
   watch)             exec "$PY" "$S/watch.py" "$@" ;;
@@ -1596,6 +1598,9 @@ super-coder — forkable shell substrate
                              never written back into the document body; the doc keeps its prose
                              During Conductor decoupling, boot workers explicitly with plain headless
                              `./sc run <shortname>`; automated sprint coordination arrives with Conductor.
+  ./sc directives <cmd>    Conductor directives: list/inspect read the durable queue; emit validates the
+                             authenticated shell's flavor against the data whitelist before inserting
+  ./sc events <cmd>        sentinel observation log: list/inspect append-only evidence rows
   ./sc watch pr <o/r> <n>  register a PR watch (--shell <name> subscribes another shell, e.g. the planner;
                              --sprint <doc-id> arms it to an ACTIVE sprint); an immediate GitHub baseline
                              is taken at registration, then the engine service poller turns transitions

--- a/tests/test_conductor_contracts.py
+++ b/tests/test_conductor_contracts.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Conductor Step 4 schema, API, CLI-facing route, and drain contracts."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+STEP4 = MIGRATIONS / "0119_conductor_contracts.sql"
+
+sys.path.insert(0, str(ENGINE / "api"))
+import conductor_routes  # noqa: E402
+import snapshot as snapshot_mod  # noqa: E402
+
+
+def build_file_db(path: Path, *, include_step4: bool = True) -> sqlite3.Connection:
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        if migration == STEP4 and not include_step4:
+            continue
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+def response(result):
+    status, _headers, body = result
+    return status, json.loads(body)
+
+
+class ConductorContractTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="sc_conductor_")
+        self.db_path = Path(self.tmp.name) / "contracts.db"
+        self.con = build_file_db(self.db_path)
+        self.dev_id = self.con.execute(
+            "INSERT INTO shells "
+            "(display_name, shortname, flavor, system_prompt, api_key) "
+            "VALUES ('Dev','dev','dev','x','dev-token')"
+        ).lastrowid
+        self.rev_id = self.con.execute(
+            "INSERT INTO shells "
+            "(display_name, shortname, flavor, system_prompt, api_key) "
+            "VALUES ('Rev','rev','reviewer','x','rev-token')"
+        ).lastrowid
+        self.con.commit()
+        self.db_patch = mock.patch.object(
+            conductor_routes, "DB_PATH", self.db_path)
+        self.db_patch.start()
+
+    def tearDown(self):
+        self.db_patch.stop()
+        self.con.close()
+        self.tmp.cleanup()
+
+    @staticmethod
+    def headers(token="dev-token"):
+        return f"Host: 127.0.0.1:8800\r\nAuthorization: Bearer {token}\r\n"
+
+    def post(self, body, token="dev-token"):
+        return response(conductor_routes.handle(
+            "POST", "/api/directives", self.headers(token),
+            json.dumps(body).encode()))
+
+    def test_valid_directive_round_trip_and_read_routes(self):
+        status, item = self.post({
+            "kind": "ready-for-review",
+            "target": "conductor",
+            "payload": {"head": "abc"},
+        })
+        self.assertEqual(status, 201)
+        self.assertEqual(item["issuer_shell_id"], self.dev_id)
+        self.assertEqual(item["issuer_flavor"], "dev")
+        self.assertEqual(item["status"], "pending")
+        self.assertEqual(item["payload"], {"head": "abc"})
+
+        status, listed = response(conductor_routes.handle(
+            "GET", "/api/directives?status=pending",
+            "Host: localhost:8800\r\n", b""))
+        self.assertEqual(status, 200)
+        self.assertEqual([d["directive_id"] for d in listed["directives"]],
+                         [item["directive_id"]])
+        status, inspected = response(conductor_routes.handle(
+            "GET", f"/api/directives/{item['directive_id']}",
+            "Host: localhost:8800\r\n", b""))
+        self.assertEqual(status, 200)
+        self.assertEqual(inspected, item)
+
+    def test_cross_flavor_kind_and_claimed_identity_are_refused(self):
+        status, obj = self.post({
+            "kind": "review-clean", "target": "conductor",
+        })
+        self.assertEqual((status, obj["error"]["code"]),
+                         (422, "directive_kind_not_allowed"))
+
+        status, obj = self.post({
+            "kind": "ready-for-review", "target": "conductor",
+            "issuer_flavor": "reviewer",
+        })
+        self.assertEqual((status, obj["error"]["code"]),
+                         (422, "issuer_claim_mismatch"))
+
+    def test_database_trigger_rejects_issuer_flavor_spoof(self):
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO directives "
+                "(issuer_shell_id, issuer_flavor, kind, target) "
+                "VALUES (?, 'reviewer', 'review-clean', 'conductor')",
+                (self.dev_id,),
+            )
+
+    def test_unit_must_belong_to_linked_sprint(self):
+        status, obj = self.post({
+            "kind": "ready-for-review", "target": "conductor",
+            "sprint_doc_id": 99, "unit_id": 1,
+        })
+        self.assertEqual((status, obj["error"]["code"]),
+                         (422, "unit_sprint_mismatch"))
+
+    def test_float_ids_and_unknown_creation_fields_are_refused(self):
+        status, obj = self.post({
+            "kind": "ready-for-review", "target": "conductor",
+            "sprint_doc_id": 1.5,
+        })
+        self.assertEqual((status, obj["error"]["code"]), (422, "validation"))
+        status, obj = self.post({
+            "kind": "ready-for-review", "target": "conductor",
+            "status": "executed",
+        })
+        self.assertEqual((status, obj["error"]["code"]), (422, "validation"))
+
+    def test_sentinel_events_are_readable_and_append_only(self):
+        event_id = conductor_routes.append_sentinel_event(
+            self.con, event_kind="activity-beat",
+            evidence={"last_commit": "abc"}, shell_id=self.dev_id)
+        self.con.commit()
+        status, listed = response(conductor_routes.handle(
+            "GET", "/api/sentinel-events?event_kind=activity-beat",
+            "Host: 127.0.0.1:8800\r\n", b""))
+        self.assertEqual(status, 200)
+        self.assertEqual(listed["events"][0]["evidence"],
+                         {"last_commit": "abc"})
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "UPDATE sentinel_events SET event_kind='changed' "
+                "WHERE event_id=?", (event_id,))
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "DELETE FROM sentinel_events WHERE event_id=?", (event_id,))
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO sentinel_events "
+                "(event_kind, sprint_doc_id, unit_id) "
+                "VALUES ('activity-beat',99,1)")
+
+    def test_expectations_cover_every_unit_state(self):
+        rows = self.con.execute(
+            "SELECT unit_state, enabled, max_dwell_seconds "
+            "FROM unit_expectations").fetchall()
+        self.assertEqual({r["unit_state"] for r in rows}, {
+            "pending", "working", "in_review", "blocked", "merged",
+            "cancelled",
+        })
+        terminal = {r["unit_state"]: r for r in rows}
+        self.assertEqual(terminal["merged"]["enabled"], 0)
+        self.assertIsNone(terminal["cancelled"]["max_dwell_seconds"])
+
+    def test_instance_contract_trail_is_rebuild_persistent(self):
+        for table in (
+                "directives", "sentinel_events", "wake_machine_retirements"):
+            self.assertIn(table, snapshot_mod.PER_INSTANCE_TABLES)
+        self.assertNotIn("unit_expectations", snapshot_mod.PER_INSTANCE_TABLES)
+        self.assertNotIn("directive_kinds", snapshot_mod.PER_INSTANCE_TABLES)
+
+
+class WakeDrainMigrationTests(unittest.TestCase):
+    def test_live_legacy_rows_are_closed_with_audit(self):
+        with tempfile.TemporaryDirectory(prefix="sc_wake_drain_") as td:
+            path = Path(td) / "legacy.db"
+            con = build_file_db(path, include_step4=False)
+            con.execute("PRAGMA foreign_keys=OFF")
+            con.execute(
+                "INSERT INTO sprint_planner_bindings "
+                "(binding_id,sprint_doc_id,planner_shell_id,session_id,"
+                " shell_id,generation) VALUES (7,70,8,9,8,1)")
+            con.execute(
+                "INSERT INTO sprint_planner_bindings "
+                "(binding_id,sprint_doc_id,planner_shell_id,session_id,"
+                " shell_id,generation,released_at) "
+                "VALUES (8,71,9,10,9,1,'2026-01-01 00:00:00')")
+            con.execute(
+                "INSERT INTO planner_wake_batches "
+                "(batch_id,binding_id,shell_id,generation,state) "
+                "VALUES (10,7,8,1,'submitting')")
+            con.execute(
+                "INSERT INTO planner_wake_items "
+                "(item_id,binding_id,message_id,batch_id,state) "
+                "VALUES (11,7,12,10,'running')")
+            con.execute(
+                "INSERT INTO planner_action_receipts "
+                "(receipt_id,operation,target,idem_key,state) "
+                "VALUES (13,'relay','planner','k','intent')")
+            con.execute(
+                "INSERT INTO planner_alerts "
+                "(alert_id,severity,reason,dedupe_key) "
+                "VALUES (14,'warning','legacy','legacy')")
+            con.commit()
+
+            con.executescript(STEP4.read_text())
+
+            binding = con.execute(
+                "SELECT released_at, release_reason "
+                "FROM sprint_planner_bindings WHERE binding_id=7").fetchone()
+            self.assertIsNotNone(binding["released_at"])
+            self.assertEqual(binding["release_reason"],
+                             "conductor-step4-retired")
+            historical = con.execute(
+                "SELECT released_at, release_reason "
+                "FROM sprint_planner_bindings WHERE binding_id=8").fetchone()
+            self.assertEqual(historical["released_at"],
+                             "2026-01-01 00:00:00")
+            self.assertIsNone(historical["release_reason"])
+            self.assertEqual(con.execute(
+                "SELECT state FROM planner_wake_items WHERE item_id=11"
+            ).fetchone()[0], "cancelled")
+            self.assertEqual(con.execute(
+                "SELECT state FROM planner_wake_batches WHERE batch_id=10"
+            ).fetchone()[0], "complete")
+            self.assertEqual(con.execute(
+                "SELECT state FROM planner_action_receipts WHERE receipt_id=13"
+            ).fetchone()[0], "reconciled")
+            self.assertIsNotNone(con.execute(
+                "SELECT resolved_at FROM planner_alerts WHERE alert_id=14"
+            ).fetchone()[0])
+            audit = con.execute(
+                "SELECT wake_batch_count, wake_item_count "
+                "FROM wake_machine_retirements WHERE binding_id=7").fetchone()
+            self.assertEqual(tuple(audit), (1, 1))
+            con.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -280,13 +280,13 @@ class PollCycleTest(unittest.TestCase):
             self.con,
             fetch_ok(gh_node(checks="PENDING"), gh_node(checks="PENDING")))
 
-        alerts = self.con.execute(
-            "SELECT watch_id, severity, reason, resolved_at "
-            "FROM planner_alerts WHERE reason='pr_watch_unscoped'").fetchall()
-        self.assertEqual(len(alerts), 1)
-        self.assertEqual(alerts[0]["watch_id"], 4)
-        self.assertEqual(alerts[0]["severity"], "critical")
-        self.assertIsNone(alerts[0]["resolved_at"])
+        events = self.con.execute(
+            "SELECT evidence FROM sentinel_events "
+            "WHERE event_kind='pr_watch_unscoped'").fetchall()
+        self.assertEqual(len(events), 1)
+        evidence = json.loads(events[0]["evidence"])
+        self.assertEqual(evidence["watch_id"], 4)
+        self.assertEqual(evidence["severity"], "critical")
 
     def test_transition_fans_out_scoped_and_idempotent(self):
         pr_poller.poll_cycle(self.con, fetch_ok(
@@ -414,10 +414,10 @@ class PollCycleTest(unittest.TestCase):
         self.assertEqual(run["status"], "error")
         self.assertEqual(run["error"], "connect timeout")
         self.assertIsNotNone(run["finished_at"])
-        # Alert raised, deduplicated while open.
+        # Failure is durable sentinel evidence.
         self.assertEqual(self.con.execute(
-            "SELECT COUNT(*) FROM planner_alerts WHERE reason='pr_poll_failure' "
-            "AND resolved_at IS NULL").fetchone()[0], 1)
+            "SELECT COUNT(*) FROM sentinel_events "
+            "WHERE event_kind='pr_poll_failure'").fetchone()[0], 1)
         # In backoff: the next cycle skips the repo without fetching.
         n = pr_poller.poll_cycle(self.con, state=state, now=t + 5,
                                  fetch=lambda q: self.fail("fetched during backoff"))
@@ -778,10 +778,10 @@ class CutoverTest(unittest.TestCase):
         con = sqlite3.connect(tmp)
         try:
             row = con.execute(
-                "SELECT severity, reason, resolved_at FROM planner_alerts "
-                "WHERE watch_id=1").fetchone()
-            self.assertEqual(row[:2], ("critical", "pr_watch_unscoped"))
-            self.assertIsNone(row[2])
+                "SELECT event_kind, evidence FROM sentinel_events "
+                "WHERE json_extract(evidence,'$.watch_id')=1").fetchone()
+            self.assertEqual(row[0], "pr_watch_unscoped")
+            self.assertEqual(json.loads(row[1])["severity"], "critical")
         finally:
             con.close()
 

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -370,13 +370,8 @@ def snap(state="OPEN", sha="abc1234def", checks=None, reviews=0, review_state=No
             "reviews": reviews, "review_state": review_state}
 
 
-class WatchAlertIdentityTest(unittest.TestCase):
-    """H-13's other half: an alert about a watch says WHICH UNIT structurally.
-
-    0102 gave planner_alerts `sprint_doc_id`/`unit_id` and the watch path left
-    both NULL, so every reader was pushed back to parsing `dedupe_key` or
-    grepping prose. The watch is the one alert source that knows the answer.
-    """
+class WatchSentinelIdentityTest(unittest.TestCase):
+    """A poller observation about a watch says which sprint/unit structurally."""
 
     def setUp(self):
         self.con = build_db()
@@ -398,17 +393,19 @@ class WatchAlertIdentityTest(unittest.TestCase):
         self.con.commit()
         return wid
 
-    def _alert_row(self, wid):
+    def _event_row(self, wid):
         return self.con.execute(
-            "SELECT sprint_doc_id, unit_id, dedupe_key FROM planner_alerts "
-            "WHERE watch_id=?", (wid,)).fetchone()
+            "SELECT sprint_doc_id, unit_id, evidence FROM sentinel_events "
+            "WHERE json_extract(evidence,'$.watch_id')=? "
+            "ORDER BY event_id DESC LIMIT 1", (wid,)).fetchone()
 
-    def test_an_alert_on_a_linked_watch_names_the_unit(self):
+    def test_an_observation_on_a_linked_watch_names_the_unit(self):
         wid = self._watch(41, self.unit)
-        pr_poller._alert(self.con, severity="critical",
-                         reason="pr_poll_failure", watch_id=wid)
+        pr_poller._sentinel_observation(
+            self.con, severity="critical",
+            reason="pr_poll_failure", watch_id=wid)
         self.con.commit()
-        row = self._alert_row(wid)
+        row = self._event_row(wid)
         self.assertEqual(row["sprint_doc_id"], 100)
         self.assertEqual(row["unit_id"], self.unit)
 
@@ -416,27 +413,29 @@ class WatchAlertIdentityTest(unittest.TestCase):
         """Partial structure beats none: the sprint is known even when the
         unit is not, and claiming a unit here would be a guess."""
         wid = self._watch(42, None)
-        pr_poller._alert(self.con, severity="critical",
-                         reason="pr_poll_failure", watch_id=wid)
+        pr_poller._sentinel_observation(
+            self.con, severity="critical",
+            reason="pr_poll_failure", watch_id=wid)
         self.con.commit()
-        row = self._alert_row(wid)
+        row = self._event_row(wid)
         self.assertEqual(row["sprint_doc_id"], 100)
         self.assertIsNone(row["unit_id"])
 
-    def test_the_dedupe_identity_did_not_move(self):
-        """The structured columns are ADDITIVE. If dedupe_key changed shape,
-        every alert already open would re-raise as a new row the moment this
-        shipped — a fleet-wide alert storm on upgrade."""
+    def test_repeated_failures_remain_distinct_observations(self):
         wid = self._watch(43, self.unit)
         for _ in range(3):
-            pr_poller._alert(self.con, severity="critical",
-                             reason="pr_poll_failure", watch_id=wid)
+            pr_poller._sentinel_observation(
+                self.con, severity="critical",
+                reason="pr_poll_failure", watch_id=wid)
         self.con.commit()
         rows = self.con.execute(
-            "SELECT dedupe_key FROM planner_alerts WHERE watch_id=?",
+            "SELECT evidence FROM sentinel_events "
+            "WHERE json_extract(evidence,'$.watch_id')=?",
             (wid,)).fetchall()
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["dedupe_key"], f"-|-|{wid}|-|pr_poll_failure")
+        self.assertEqual(len(rows), 3)
+        self.assertTrue(all(
+            json.loads(row["evidence"])["severity"] == "critical"
+            for row in rows))
 
 
 class DiffEventsTest(unittest.TestCase):
@@ -936,16 +935,15 @@ class ApiTest(unittest.TestCase):
         self.assertNotIn(113, armed, "a frozen sprint is never polled")
         self.assertNotIn(114, armed, "an undeclared board is never polled")
 
-    def test_scoped_registration_rebinds_legacy_and_resolves_alert(self):
+    def test_scoped_registration_rebinds_legacy_and_preserves_observation(self):
         con = sqlite3.connect(self.db)
         watch_id = con.execute(
             "INSERT INTO watched_prs (repo, pr_number, shell_id) "
             "VALUES ('own/repo', 21, 1)").lastrowid
         con.execute(
-            "INSERT INTO planner_alerts "
-            "(watch_id, severity, reason, dedupe_key) VALUES "
-            "(?, 'critical', 'pr_watch_unscoped', ?)",
-            (watch_id, f"-|-|{watch_id}|-|pr_watch_unscoped"))
+            "INSERT INTO sentinel_events (event_kind, evidence) VALUES "
+            "('pr_watch_unscoped', ?)",
+            (json.dumps({"severity": "critical", "watch_id": watch_id}),))
         con.commit()
         con.close()
 
@@ -958,10 +956,11 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(rows[0]["watch_id"], watch_id)
         self.assertEqual(rows[0]["sprint_doc_id"], 100)
         self.assertIn('"checks": "PENDING"', rows[0]["last_seen"])
-        alert = self.q(
-            "SELECT resolved_at FROM planner_alerts WHERE watch_id=?",
+        event = self.q(
+            "SELECT evidence FROM sentinel_events "
+            "WHERE json_extract(evidence,'$.watch_id')=?",
             watch_id)[0]
-        self.assertIsNotNone(alert["resolved_at"])
+        self.assertEqual(json.loads(event["evidence"])["severity"], "critical")
 
     def test_legacy_rebind_refuses_scope_unmade_during_baseline(self):
         con = sqlite3.connect(self.db)
@@ -971,10 +970,9 @@ class ApiTest(unittest.TestCase):
             "(repo, pr_number, shell_id, last_seen) "
             "VALUES ('own/repo', 23, 1, '{\"state\":\"OPEN\"}')").lastrowid
         con.execute(
-            "INSERT INTO planner_alerts "
-            "(watch_id, severity, reason, dedupe_key) VALUES "
-            "(?, 'critical', 'pr_watch_unscoped', ?)",
-            (watch_id, f"-|-|{watch_id}|-|pr_watch_unscoped"))
+            "INSERT INTO sentinel_events (event_kind, evidence) VALUES "
+            "('pr_watch_unscoped', ?)",
+            (json.dumps({"severity": "critical", "watch_id": watch_id}),))
         con.commit()
         con.close()
         real = pr_poller.baseline_read
@@ -1006,10 +1004,11 @@ class ApiTest(unittest.TestCase):
             "WHERE watch_id=?", watch_id)[0]
         self.assertIsNone(row["sprint_doc_id"])
         self.assertEqual(row["last_seen"], '{"state":"OPEN"}')
-        alert = self.q(
-            "SELECT resolved_at FROM planner_alerts WHERE watch_id=?",
+        event = self.q(
+            "SELECT evidence FROM sentinel_events "
+            "WHERE json_extract(evidence,'$.watch_id')=?",
             watch_id)[0]
-        self.assertIsNone(alert["resolved_at"])
+        self.assertEqual(json.loads(event["evidence"])["severity"], "critical")
 
     def test_list_shows_live_watches(self):
         watch.main(["pr", "own/repo", "17", "--sprint", "100"])


### PR DESCRIPTION
## Outcome

Lands Conductor Step 4 as one contract boundary:

- authenticated directives with issuer-flavor whitelist stored as data
- append-only sentinel evidence plus rebuild-persistent directive/event audit
- data-driven per-unit expectations
- WAL-safe legacy wake-machine drain with immutable retirement audit
- `./sc directives` list/inspect/emit and `./sc events` list/inspect
- PR-poller observations migrated off dormant `planner_alerts`

Contract spec #27 is frozen after implementation and adversarial repair.

## Migration proof

Applied migration 0119 to a WAL-safe copy of the real dos-arch DB:

- live bindings: 1 → 0
- nonterminal wake items: 34 → 0
- nonterminal wake batches: 1 → 0
- incomplete action receipts: 1 → 0
- open planner alerts: 5 → 0
- retirement audit rows: 2
- SQLite integrity: ok

The untouched pre-migration copy is the rollback artifact.

## Verification

- focused contracts: 9 passed
- full suite: 1,380 passed, 601 subtests, 2 deselected
- deselected: the two pre-existing recursive-Make dry-run assertions reproduced on clean conductor during Step 3
- `./sc render-check`
- `./sc verify`
- `git diff --check`
- Python bytecode compile for new API/CLI modules

Depends on merged Step 3 PR #688.