### PR TITLE
feat(conductor S5): add engine-service sentinel

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -3075,7 +3075,11 @@ class Handler(BaseHTTPRequestHandler):
             return
         con = db()
         try:
-            summary = pr_poller.poll_cycle(con, source="reconcile")
+            summary = pr_poller.poll_cycle(
+                con,
+                source="reconcile",
+                system_signals=pr_poller.sentinel.load_config().enabled,
+            )
             return self._send(200, summary)
         except Exception as e:
             return self._fail(e)
@@ -3743,12 +3747,10 @@ def main(argv):
     # api_key rotation is picked up here. Lives under the gitignored,
     # never-snapshotted .super-coder/run/.
     mem_credentials.provision(str(DB_PATH), f"http://127.0.0.1:{port}")
-    # Watched-PR poller (spec #20 task #85, decision #19): this service is the
-    # fork's SOLE GitHub poller — the legacy host `sc watch daemon` (direct-DB
-    # writer) is retired by the same commit that enables this scheduler, which
-    # is the cutover gate: no second writer can be started by any supervised
-    # path. Bounded interval only while ACTIVE sprint watches exist, plus the
-    # startup pass inside the thread; self-disables when gh is absent.
+    # Sole scheduler: watched-PR polling (spec #20 task #85, decision #19) plus
+    # the config-gated Conductor sentinel. The retired host `sc watch daemon`
+    # cannot form a second DB writer. GitHub reads stay watch-gated; sentinel
+    # reads stay live-sprint-gated and never boot a shell before Step 8.
     pr_poller.Poller(DB_PATH).start()
     # Bind 127.0.0.1 by default (the host stance: localhost-only, operator owns
     # network controls). In the container set SC_BIND=0.0.0.0 so docker can

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -18,20 +18,20 @@ What lives here:
   sprint_doc_id names a LIVE sprint per `sprint_state`; unscoped legacy
   watches stay dormant until rebound). Per cycle: a `pr_poll_runs` audit row
   per repo, durable `pr_poll_observations` for transitions and blind windows,
-  idempotent `pr_event` messages (dedupe_key), fingerprint persistence, and
-  terminal retirement. Per-repo failures back off capped without blocking
-  other repos; a repo recovering from failure marks its next observations as
-  blind windows (GitHub may have moved unobserved — convergence, not history).
+  fingerprint persistence, and terminal retirement. With the per-fork sentinel
+  enabled, semantic transitions become deduplicated system directives plus
+  sentinel events; the disabled rollback path keeps the legacy `pr_event`
+  message behavior. Per-repo failures back off capped without blocking other
+  repos; a repo recovering from failure marks its next observations as blind
+  windows (GitHub may have moved unobserved — convergence, not history).
 - `Poller` — the service's scheduler thread. GitHub polling keeps its 30s
-  watch-gated cadence; worker-expectation reconciliation runs every 10 minutes
-  from structured live units even before a PR or watch exists. Explicit PR
-  reconcile still rides `poll_cycle(source='reconcile')` through the API.
-  PR polling beats the status-visible watch heartbeat. Worker reconciliation
-  records tick completion in a separate row rendered alongside it by `sc watch list`.
+  watch-gated cadence. An enabled sentinel evaluates structured live units on
+  its configured cadence even before a PR or watch exists; when disabled, the
+  previous report-only reconciliation remains the rollback behavior. Explicit
+  PR reconcile still rides `poll_cycle(source='reconcile')` through the API.
 
 It never injects terminal input, never marks a message read, never acts on a
-PR, and never mutates the sprint board. PR polling may create an event; the
-worker reconciler returns report-only readings for the alert unit to consume.
+PR, never mutates the sprint board, and never boots a shell.
 """
 from __future__ import annotations
 
@@ -48,6 +48,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import activity_readers
+import sentinel
 import sprint_state
 from quota_probes import dispatch as quota_dispatch
 from sprint_units import TERMINAL_UNIT_STATES
@@ -879,7 +880,8 @@ def sweep_stranded_runs(con) -> int:
 
 def poll_cycle(con, fetch=None, source: str = "scheduler",
                state: "PollerState | None" = None,
-               interval: int = DEFAULT_INTERVAL, now: "float | None" = None) -> dict:
+               interval: int = DEFAULT_INTERVAL, now: float | None = None,
+               system_signals: bool = False) -> dict:
     """One bounded pass over armed watches. Per repo: one batched read, one
     pr_poll_runs audit row, transition/blind-window observations, idempotent
     events, fingerprint persistence, terminal retirement. A failed repo backs
@@ -892,7 +894,6 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
                "unscoped_alerts": surface_unscoped_watches(con),
                "stranded_runs": (sweep_stranded_runs(con)
                                  if source == "startup" else 0)}
-    emitted_ids: list[int] = []
     watches = armed_watches(con)
     summary["watches"] = len(watches)
     if not watches:
@@ -957,10 +958,15 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
                     (w["watch_id"], run_id, cur.get("sha"), json.dumps(cur),
                      ",".join(e["key"] for e in events) or None, blind))
             for e in events:
-                mid = _emit_event(con, w, e, cur.get("sha") or "")
-                if mid is not None:
+                emitted = (
+                    sentinel.emit_pr_transition(
+                        con, w, e, cur.get("sha") or ""
+                    )
+                    if system_signals
+                    else _emit_event(con, w, e, cur.get("sha") or "")
+                )
+                if emitted is not None:
                     summary["events"] += 1
-                    emitted_ids.append(mid)
             con.execute(
                 "UPDATE watched_prs SET last_seen=?" +
                 (", closed_at=datetime('now')" if terminal else "") +
@@ -977,14 +983,18 @@ def poll_cycle(con, fetch=None, source: str = "scheduler",
 class Poller(threading.Thread):
     """The service's bounded scheduler.
 
-    GitHub reads remain watch-gated.  Reconciliation has its own cadence and
-    structured-unit trigger, so it still runs before a sprint has any PR.
+    GitHub reads remain watch-gated.  The enabled sentinel has its own cadence
+    and structured-unit trigger, so it runs before a sprint has any PR.  The
+    disabled path preserves the preceding report-only reconciler for rollback.
     """
 
     def __init__(self, db_path, interval: int = DEFAULT_INTERVAL, fetch=None,
                  connect=None,
                  reconcile_interval: int = DEFAULT_RECONCILE_INTERVAL,
-                 activity_reader=None, refresh=None):
+                 activity_reader=None, refresh=None,
+                 sentinel_config: sentinel.SentinelConfig | None = None,
+                 sentinel_cycle=None, sentinel_liveness=None,
+                 sentinel_git_probe=None):
         super().__init__(name="pr-poller", daemon=True)
         self._db_path = str(db_path)
         self._interval = interval
@@ -996,11 +1006,17 @@ class Poller(threading.Thread):
         )
         self._refresh = refresh
         self._reconcile_due = 0.0
+        self._sentinel_config = sentinel_config or sentinel.load_config()
+        self._sentinel_cycle = sentinel_cycle or sentinel.cycle
+        self._sentinel_liveness = sentinel_liveness
+        self._sentinel_git_probe = sentinel_git_probe
+        self._sentinel_due = 0.0
         self._github_enabled = fetch is not None or shutil.which("gh") is not None
         self._stop_event = threading.Event()
         self.state = PollerState()
         self.reconciler_state = ReconcilerState()
         self.last_reconciliation: list[ReconciliationReading] = []
+        self.last_sentinel: dict | None = None
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -1014,7 +1030,7 @@ class Poller(threading.Thread):
     def run(self) -> None:  # pragma: no cover — thread loop; scheduler tests drive it
         if not self._github_enabled:
             print("pr-poller: gh CLI not found — PR polling disabled "
-                  "(worker reconciliation remains enabled)", flush=True)
+                  "(sentinel/reconciliation remains enabled)", flush=True)
         source = "startup"
         while not self._stop_event.is_set():
             try:
@@ -1040,12 +1056,41 @@ class Poller(threading.Thread):
                                 source=source,
                                 state=self.state,
                                 interval=self._interval,
+                                system_signals=self._sentinel_config.enabled,
                             )
                             if n["events"] or n["errors"]:
                                 print(f"pr-poller: {n}", flush=True)
 
                     monotonic_now = time.monotonic()
-                    if monotonic_now >= self._reconcile_due:
+                    if (
+                        self._sentinel_config.enabled
+                        and monotonic_now >= self._sentinel_due
+                    ):
+                        kwargs = {
+                            "config": self._sentinel_config,
+                            "activity_reader": self._activity_reader,
+                        }
+                        if self._sentinel_liveness is not None:
+                            kwargs["liveness"] = self._sentinel_liveness
+                        if self._sentinel_git_probe is not None:
+                            kwargs["git_probe"] = self._sentinel_git_probe
+                        self.last_sentinel = self._sentinel_cycle(
+                            con, **kwargs
+                        )
+                        if self.last_sentinel["active_units"]:
+                            beat(
+                                con,
+                                self._sentinel_config.interval_seconds,
+                                name="sentinel",
+                            )
+                        self._sentinel_due = (
+                            monotonic_now
+                            + self._sentinel_config.interval_seconds
+                        )
+                    elif (
+                        not self._sentinel_config.enabled
+                        and monotonic_now >= self._reconcile_due
+                    ):
                         self.last_reconciliation = reconcile_tick(
                             con,
                             reader=self._activity_reader,
@@ -1080,5 +1125,14 @@ class Poller(threading.Thread):
                 # fork to the polling world. Log and keep the loop.
                 print(f"pr-poller: cycle error ({e})", flush=True)
             source = "scheduler"
-            self._stop_event.wait(self._interval +
-                            random.uniform(0, self._interval * JITTER_FRACTION))
+            cadence = min(
+                self._interval,
+                (
+                    self._sentinel_config.interval_seconds
+                    if self._sentinel_config.enabled
+                    else self._reconcile_interval
+                ),
+            )
+            self._stop_event.wait(
+                cadence + random.uniform(0, cadence * JITTER_FRACTION)
+            )

--- a/.super-coder/scripts/sentinel.py
+++ b/.super-coder/scripts/sentinel.py
@@ -1,0 +1,679 @@
+#!/usr/bin/env python3
+"""Conductor sentinel — one bounded observation cycle for live sprint units.
+
+The engine service is the only scheduler.  This module performs one injectable
+cycle and owns no thread: ``pr_poller.Poller`` calls it when this fork enables
+the ``sentinel`` block in ``.super-coder/instance.json``.
+
+The sentinel observes and records.  It never changes the sprint board and it
+never boots a shell.  Actionable observations become a system directive
+addressed to the Conductor plus an append-only ``sentinel_events`` row linked
+to that directive.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import activity_readers
+import shell_liveness
+import sprint_state
+from sprint_units import TERMINAL_UNIT_STATES
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+INSTANCE_CONFIG = ENGINE / "instance.json"
+DEFAULT_INTERVAL_SECONDS = 30
+DEFAULT_ACTIVITY_BEAT_SECONDS = 300
+CONDUCTOR_TARGET = "conductor"
+
+
+def _row(row: Any, key: str, default=None):
+    if row is None:
+        return default
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return getattr(row, key, default)
+
+
+def _utc(value) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        stamp = value
+    else:
+        try:
+            stamp = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return stamp.astimezone(timezone.utc)
+
+
+def _stamp(value) -> str | None:
+    parsed = _utc(value)
+    return parsed.isoformat() if parsed is not None else None
+
+
+@dataclass(frozen=True)
+class SentinelConfig:
+    enabled: bool = False
+    interval_seconds: int = DEFAULT_INTERVAL_SECONDS
+    activity_beat_seconds: int = DEFAULT_ACTIVITY_BEAT_SECONDS
+
+
+def load_config(path: Path = INSTANCE_CONFIG) -> SentinelConfig:
+    """Read this fork's feature flag and cadences.
+
+    Missing config means disabled, preserving the pre-Step-5 service behavior.
+    A malformed enabled block fails closed instead of starting a partially
+    configured sentinel.
+    """
+    try:
+        raw = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return SentinelConfig()
+    block = raw.get("sentinel")
+    if not isinstance(block, dict):
+        return SentinelConfig()
+    enabled = block.get("enabled", False)
+    interval = block.get("interval_seconds", DEFAULT_INTERVAL_SECONDS)
+    beat = block.get(
+        "activity_beat_seconds", DEFAULT_ACTIVITY_BEAT_SECONDS
+    )
+    if not isinstance(enabled, bool):
+        return SentinelConfig()
+    if (
+        isinstance(interval, bool)
+        or not isinstance(interval, int)
+        or interval <= 0
+        or isinstance(beat, bool)
+        or not isinstance(beat, int)
+        or beat <= 0
+    ):
+        return SentinelConfig()
+    return SentinelConfig(enabled, interval, beat)
+
+
+def _json(value: dict) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _event_with_key(con, dedupe_key: str):
+    return con.execute(
+        "SELECT event_id, directive_id FROM sentinel_events "
+        "WHERE json_extract(evidence,'$.dedupe_key')=? "
+        "ORDER BY event_id DESC LIMIT 1",
+        (dedupe_key,),
+    ).fetchone()
+
+
+def append_observation(
+    con,
+    *,
+    event_kind: str,
+    evidence: dict,
+    dedupe_key: str,
+    shell_id=None,
+    sprint_doc_id=None,
+    unit_id=None,
+) -> int | None:
+    """Append one idempotent observation inside the caller's transaction."""
+    if _event_with_key(con, dedupe_key) is not None:
+        return None
+    body = dict(evidence)
+    body["dedupe_key"] = dedupe_key
+    return con.execute(
+        "INSERT INTO sentinel_events "
+        "(event_kind,shell_id,sprint_doc_id,unit_id,evidence) "
+        "VALUES (?,?,?,?,?)",
+        (
+            event_kind,
+            shell_id,
+            sprint_doc_id,
+            unit_id,
+            _json(body),
+        ),
+    ).lastrowid
+
+
+def emit_system_signal(
+    con,
+    *,
+    kind: str,
+    evidence: dict,
+    dedupe_key: str,
+    shell_id=None,
+    sprint_doc_id=None,
+    unit_id=None,
+) -> int | None:
+    """Create one system directive and its linked observation atomically."""
+    prior = _event_with_key(con, dedupe_key)
+    if prior is not None:
+        return None
+    directive_id = con.execute(
+        "INSERT INTO directives "
+        "(issuer_shell_id,issuer_flavor,kind,payload,target,"
+        " sprint_doc_id,unit_id) "
+        "VALUES (NULL,'system',?,?,?,?,?)",
+        (
+            kind,
+            _json(evidence),
+            CONDUCTOR_TARGET,
+            sprint_doc_id,
+            unit_id,
+        ),
+    ).lastrowid
+    body = dict(evidence)
+    body["dedupe_key"] = dedupe_key
+    con.execute(
+        "INSERT INTO sentinel_events "
+        "(event_kind,shell_id,sprint_doc_id,unit_id,directive_id,evidence) "
+        "VALUES (?,?,?,?,?,?)",
+        (
+            kind,
+            shell_id,
+            sprint_doc_id,
+            unit_id,
+            directive_id,
+            _json(body),
+        ),
+    )
+    return directive_id
+
+
+def emit_pr_transition(con, watch, event: dict, head_sha: str) -> int | None:
+    """Retarget one semantic PR transition to the Conductor contracts."""
+    key = event["key"]
+    if key == "checks:SUCCESS":
+        kind = "pr-green"
+    elif key in {"checks:FAILURE", "checks:ERROR"}:
+        kind = "pr-red"
+    elif key == "merged:MERGED":
+        kind = "pr-merged"
+    elif key.startswith("review:"):
+        kind = "pr-review"
+    else:
+        kind = "pr-closed"
+
+    sprint_doc_id = _row(watch, "sprint_doc_id")
+    unit_id = _row(watch, "unit_id")
+    identity = unit_id if unit_id is not None else f"watch-{watch['watch_id']}"
+    dedupe_key = (
+        f"pr|{sprint_doc_id}|{identity}|{watch['repo']}|"
+        f"{watch['pr_number']}|{key}|{head_sha}"
+    )
+    evidence = {
+        "watch_id": watch["watch_id"],
+        "repo": watch["repo"],
+        "pr_number": watch["pr_number"],
+        "unit_seq": _row(watch, "unit_seq"),
+        "transition": key,
+        "head_sha": head_sha or None,
+        "summary": event["body"],
+    }
+    if kind in {"pr-green", "pr-red", "pr-merged"}:
+        return emit_system_signal(
+            con,
+            kind=kind,
+            evidence=evidence,
+            dedupe_key=dedupe_key,
+            sprint_doc_id=sprint_doc_id,
+            unit_id=unit_id,
+        )
+    return append_observation(
+        con,
+        event_kind=kind,
+        evidence=evidence,
+        dedupe_key=dedupe_key,
+        sprint_doc_id=sprint_doc_id,
+        unit_id=unit_id,
+    )
+
+
+def _assigned_shell(unit) -> tuple[int | None, str]:
+    if unit["state"] == "in_review":
+        return unit["reviewer_shell_id"], "reviewer"
+    if unit["state"] == "blocked":
+        # Blocked has no active worker role in the board schema: it is reachable
+        # from both working and in_review, and the transition does not retain
+        # which side blocked. Its expectation is deliberately planner-shaped
+        # (message/directive), so attaching either worker's pid would invent an
+        # owner and can turn the inactive peer into a false dead-shell verdict.
+        return None, "planner"
+    return unit["dev_shell_id"], "dev"
+
+
+def active_units(con) -> list[dict]:
+    """Return live, nonterminal units with their state expectation."""
+    sprint_ids = sprint_state.live_sprint_doc_ids(con)
+    if not sprint_ids:
+        return []
+    marks = ",".join("?" for _ in sprint_ids)
+    terminal_marks = ",".join("?" for _ in TERMINAL_UNIT_STATES)
+    rows = con.execute(
+        "SELECT u.*, e.expected_signals, e.max_dwell_seconds "
+        "FROM sprint_units u "
+        "JOIN unit_expectations e ON e.unit_state=u.state AND e.enabled=1 "
+        f"WHERE u.sprint_doc_id IN ({marks}) "
+        f"AND u.state NOT IN ({terminal_marks}) "
+        "ORDER BY u.sprint_doc_id,u.unit_id",
+        (*sorted(sprint_ids), *TERMINAL_UNIT_STATES),
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _shell_and_launch(con, shell_id) -> tuple[dict | None, dict | None]:
+    if shell_id is None:
+        return None, None
+    shell = con.execute(
+        "SELECT shell_id,shortname,flavor FROM shells "
+        "WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+        (shell_id,),
+    ).fetchone()
+    launch = con.execute(
+        "SELECT shell_id,pid,start_ticks,worktree,harness,launched_at "
+        "FROM shell_launch_records WHERE shell_id=?",
+        (shell_id,),
+    ).fetchone()
+    shell_dict = dict(shell) if shell is not None else None
+    launch_dict = dict(launch) if launch is not None else None
+    if shell_dict is not None and launch_dict is not None:
+        shell_dict["worktree"] = launch_dict["worktree"]
+    return shell_dict, launch_dict
+
+
+def _message_snapshot(con, unit, shell_id) -> dict | None:
+    sprint_doc_id = unit["sprint_doc_id"]
+    if shell_id is None:
+        rows = con.execute(
+            "SELECT message_id,from_shell_id,to_shell_id,kind,body,created_at,"
+            " read_at,dedupe_key "
+            "FROM shell_messages WHERE sprint_doc_id=? "
+            "ORDER BY created_at DESC,message_id DESC LIMIT 100",
+            (sprint_doc_id,),
+        ).fetchall()
+        active_count = con.execute(
+            "SELECT COUNT(*) FROM sprint_units WHERE sprint_doc_id=? "
+            f"AND state NOT IN ({','.join('?' for _ in TERMINAL_UNIT_STATES)})",
+            (sprint_doc_id, *TERMINAL_UNIT_STATES),
+        ).fetchone()[0]
+    else:
+        rows = con.execute(
+            "SELECT message_id,from_shell_id,to_shell_id,kind,body,created_at,"
+            " read_at,dedupe_key "
+            "FROM shell_messages WHERE sprint_doc_id=? "
+            "AND (from_shell_id=? OR to_shell_id=?) "
+            "ORDER BY created_at DESC,message_id DESC LIMIT 100",
+            (sprint_doc_id, shell_id, shell_id),
+        ).fetchall()
+        active_count = con.execute(
+            "SELECT COUNT(*) FROM sprint_units WHERE sprint_doc_id=? "
+            "AND (dev_shell_id=? OR reviewer_shell_id=?) "
+            f"AND state NOT IN ({','.join('?' for _ in TERMINAL_UNIT_STATES)})",
+            (sprint_doc_id, shell_id, shell_id, *TERMINAL_UNIT_STATES),
+        ).fetchone()[0]
+    if not rows:
+        return None
+    row = rows[0] if active_count <= 1 else next(
+        (
+            candidate
+            for candidate in rows
+            if _message_unit_id(con, candidate) == unit["unit_id"]
+            or re.search(
+                rf"(?<![A-Za-z0-9_]){re.escape(str(unit['seq']))}"
+                rf"(?![A-Za-z0-9_])",
+                candidate["body"] or "",
+            )
+        ),
+        None,
+    )
+    if row is None:
+        return None
+    return {
+        key: row[key]
+        for key in (
+            "message_id",
+            "from_shell_id",
+            "to_shell_id",
+            "kind",
+            "created_at",
+            "read_at",
+        )
+    }
+
+
+def _message_unit_id(con, row) -> int | None:
+    key = row["dedupe_key"]
+    if not key or not str(key).startswith("pr-event|"):
+        return None
+    parts = str(key).split("|")
+    if len(parts) < 2 or not parts[1].isdigit():
+        return None
+    linked = con.execute(
+        "SELECT unit_id FROM watched_prs WHERE watch_id=?",
+        (int(parts[1]),),
+    ).fetchone()
+    return linked[0] if linked is not None else None
+
+
+def _directive_snapshot(
+    con, sprint_doc_id: int, unit_id: int, *, kind: str | None = None
+) -> dict | None:
+    params: list[Any] = [sprint_doc_id, unit_id]
+    where = (
+        "sprint_doc_id=? AND (unit_id=? OR unit_id IS NULL) "
+        "AND issuer_flavor='planner'"
+    )
+    if kind is not None:
+        where += " AND kind=?"
+        params.append(kind)
+    row = con.execute(
+        "SELECT directive_id,kind,created_at,status FROM directives "
+        f"WHERE {where} ORDER BY created_at DESC,directive_id DESC LIMIT 1",
+        params,
+    ).fetchone()
+    return dict(row) if row is not None else None
+
+
+def _pr_snapshot(con, unit_id: int) -> dict | None:
+    row = con.execute(
+        "SELECT w.watch_id,w.repo,w.pr_number,w.last_seen,"
+        " o.observed_at,o.transition,o.head_sha "
+        "FROM watched_prs w "
+        "LEFT JOIN pr_poll_observations o ON o.observation_id=("
+        " SELECT o2.observation_id FROM pr_poll_observations o2 "
+        " WHERE o2.watch_id=w.watch_id "
+        " ORDER BY o2.observed_at DESC,o2.observation_id DESC LIMIT 1"
+        ") WHERE w.unit_id=? "
+        "ORDER BY COALESCE(o.observed_at,w.created_at) DESC,w.watch_id DESC "
+        "LIMIT 1",
+        (unit_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    item = dict(row)
+    try:
+        item["fingerprint"] = json.loads(item.pop("last_seen") or "null")
+    except json.JSONDecodeError:
+        item["fingerprint"] = None
+    return item
+
+
+def git_snapshot(worktree: Path) -> dict:
+    """Read the current commit identity without mutating or fetching."""
+    out = subprocess.run(
+        ["git", "show", "-s", "--format=%H%n%cI", "HEAD"],
+        cwd=worktree,
+        text=True,
+        capture_output=True,
+        timeout=15,
+        check=False,
+    )
+    if out.returncode != 0:
+        return {"head_sha": None, "committed_at": None}
+    lines = out.stdout.splitlines()
+    return {
+        "head_sha": lines[0] if lines else None,
+        "committed_at": lines[1] if len(lines) > 1 else None,
+    }
+
+
+def _latest(*values) -> datetime | None:
+    parsed = [_utc(value) for value in values]
+    return max((value for value in parsed if value is not None), default=None)
+
+
+def _signal_times(
+    *,
+    activity: activity_readers.Evidence,
+    message,
+    commit,
+    pr,
+    planner,
+    kickoff,
+) -> dict[str, datetime | None]:
+    latest_activity = _latest(
+        activity.newest_mtime,
+        activity.last_work_at,
+        activity.marker_at,
+        activity.last_durable_write_at,
+    )
+    pr_at = _utc(_row(pr, "observed_at"))
+    review_at = (
+        pr_at
+        if str(_row(pr, "transition", "")).startswith("review:")
+        else _utc(activity.last_result_row_at)
+    )
+    return {
+        "activity": latest_activity,
+        "message": _utc(_row(message, "created_at")),
+        "commit": _utc(_row(commit, "committed_at")),
+        "pr": pr_at,
+        "review": review_at,
+        "planner-directive": _utc(_row(planner, "created_at")),
+        "kickoff": _utc(_row(kickoff, "created_at")),
+    }
+
+
+def _activity_beat(
+    con,
+    *,
+    unit,
+    shell_id,
+    signal_at,
+    now,
+    interval_seconds: int,
+    evidence: dict,
+) -> bool:
+    if signal_at is None:
+        return False
+    prior = con.execute(
+        "SELECT evidence,observed_at FROM sentinel_events "
+        "WHERE event_kind='activity-beat' AND unit_id=? AND shell_id IS ? "
+        "ORDER BY event_id DESC LIMIT 1",
+        (unit["unit_id"], shell_id),
+    ).fetchone()
+    if prior is not None:
+        prior_body = json.loads(prior["evidence"])
+        if prior_body.get("activity_at") == signal_at.isoformat():
+            return False
+        observed = _utc(prior["observed_at"])
+        if observed is not None and (now - observed).total_seconds() < interval_seconds:
+            return False
+    dedupe_key = (
+        f"activity|{unit['unit_id']}|{unit['state_changed_at']}|"
+        f"{signal_at.isoformat()}"
+    )
+    body = dict(evidence)
+    body["activity_at"] = signal_at.isoformat()
+    return append_observation(
+        con,
+        event_kind="activity-beat",
+        evidence=body,
+        dedupe_key=dedupe_key,
+        shell_id=shell_id,
+        sprint_doc_id=unit["sprint_doc_id"],
+        unit_id=unit["unit_id"],
+    ) is not None
+
+
+def cycle(
+    con,
+    *,
+    config: SentinelConfig | None = None,
+    now=None,
+    activity_reader=None,
+    liveness: Callable[[dict], bool] = shell_liveness.claim_live,
+    git_probe: Callable[[Path], dict] = git_snapshot,
+) -> dict:
+    """Run one complete sentinel pass.
+
+    Every external seam is injectable so fake clocks, worktrees, launch claims,
+    and git state can exercise the production transaction.
+    """
+    config = config or load_config()
+    summary = {
+        "enabled": config.enabled,
+        "active_units": 0,
+        "activity_beats": 0,
+        "dead_shells": 0,
+        "stalls": 0,
+        "indeterminate": 0,
+    }
+    if not config.enabled:
+        return summary
+    units = active_units(con)
+    summary["active_units"] = len(units)
+    if not units:
+        return summary
+
+    current = _utc(now) or datetime.now(timezone.utc)
+    source = activity_reader or activity_readers.read
+    read_one = source.read if hasattr(source, "read") else source
+
+    for unit in units:
+        shell_id, role = _assigned_shell(unit)
+        shell, launch = _shell_and_launch(con, shell_id)
+        state_clock = _utc(unit["state_changed_at"])
+        if state_clock is None:
+            summary["indeterminate"] += 1
+            continue
+
+        activity = activity_readers.Evidence(
+            state_changed_at=state_clock,
+            edits_code=role == "dev",
+        )
+        if shell is not None:
+            activity = read_one(shell, unit, current, role=role)
+        worktree = Path(
+            _row(launch, "worktree")
+            or (REPO_ROOT / ".sc-worktrees" / str(_row(shell, "shortname", "")))
+        )
+        try:
+            commit = git_probe(worktree) if shell is not None else {}
+        except (OSError, subprocess.SubprocessError):
+            commit = {}
+        message = _message_snapshot(con, unit, shell_id)
+        planner = _directive_snapshot(
+            con, unit["sprint_doc_id"], unit["unit_id"]
+        )
+        kickoff = _directive_snapshot(
+            con, unit["sprint_doc_id"], unit["unit_id"], kind="kickoff"
+        )
+        pr = _pr_snapshot(con, unit["unit_id"])
+        signals = _signal_times(
+            activity=activity,
+            message=message,
+            commit=commit,
+            pr=pr,
+            planner=planner,
+            kickoff=kickoff,
+        )
+        latest_activity = signals["activity"]
+        evidence = {
+            "unit_state": unit["state"],
+            "unit_seq": unit["seq"],
+            "role": role,
+            "state_changed_at": state_clock.isoformat(),
+            "worktree": str(worktree) if shell is not None else None,
+            "last_mtime": _stamp(activity.newest_mtime),
+            "last_activity": _stamp(latest_activity),
+            "last_commit_sha": _row(commit, "head_sha"),
+            "last_commit_at": _stamp(_row(commit, "committed_at")),
+            "last_message_id": _row(message, "message_id"),
+            "last_message_at": _stamp(_row(message, "created_at")),
+            "last_message": message,
+            "pr": pr,
+            "process": {
+                "pid": _row(launch, "pid"),
+                "start_ticks": _row(launch, "start_ticks"),
+                "launched_at": _stamp(_row(launch, "launched_at")),
+            },
+            "expected_signals": json.loads(unit["expected_signals"]),
+        }
+
+        launch_floor = _utc(unit.get("assigned_at")) or state_clock
+        launch_at = _utc(_row(launch, "launched_at"))
+        launch_applies = launch is not None and (
+            launch_at is None or launch_at >= launch_floor
+        )
+        live = None
+        if launch_applies:
+            try:
+                verdict = liveness(launch)
+                live = verdict if isinstance(verdict, bool) else None
+            except (OSError, ValueError):
+                live = None
+        evidence["process"]["live"] = live
+        if launch_applies and live is False:
+            dedupe_key = (
+                f"dead-shell|{unit['unit_id']}|{unit['state_changed_at']}|"
+                f"{launch['pid']}|{launch['start_ticks']}"
+            )
+            if emit_system_signal(
+                con,
+                kind="dead-shell",
+                evidence=evidence,
+                dedupe_key=dedupe_key,
+                shell_id=shell_id,
+                sprint_doc_id=unit["sprint_doc_id"],
+                unit_id=unit["unit_id"],
+            ) is not None:
+                summary["dead_shells"] += 1
+            continue
+
+        if _activity_beat(
+            con,
+            unit=unit,
+            shell_id=shell_id,
+            signal_at=latest_activity,
+            now=current,
+            interval_seconds=config.activity_beat_seconds,
+            evidence=evidence,
+        ):
+            summary["activity_beats"] += 1
+
+        expected = evidence["expected_signals"]
+        signal_clock = max(
+            (
+                signals[name]
+                for name in expected
+                if name in signals and signals[name] is not None
+            ),
+            default=None,
+        )
+        quiet_since = max(
+            value for value in (state_clock, signal_clock) if value is not None
+        )
+        dwell = max(0, int((current - quiet_since).total_seconds()))
+        evidence["last_expected_signal_at"] = _stamp(signal_clock)
+        evidence["dwell_seconds"] = dwell
+        evidence["max_dwell_seconds"] = unit["max_dwell_seconds"]
+        if dwell < unit["max_dwell_seconds"]:
+            continue
+        dedupe_key = (
+            f"stall|{unit['unit_id']}|{unit['state_changed_at']}|"
+            f"{_stamp(signal_clock)}"
+        )
+        if emit_system_signal(
+            con,
+            kind="stall",
+            evidence=evidence,
+            dedupe_key=dedupe_key,
+            shell_id=shell_id,
+            sprint_doc_id=unit["sprint_doc_id"],
+            unit_id=unit["unit_id"],
+        ) is not None:
+            summary["stalls"] += 1
+
+    con.commit()
+    return summary

--- a/tests/test_pr_poller.py
+++ b/tests/test_pr_poller.py
@@ -312,6 +312,52 @@ class PollCycleTest(unittest.TestCase):
             self.assertEqual(o["blind_window"], 0)
             self.assertIsNotNone(o["run_id"])
 
+    def test_enabled_sentinel_retargets_pr_transition_once_to_conductor(self):
+        unit_id = self.con.execute(
+            "SELECT unit_id FROM sprint_units "
+            "WHERE sprint_doc_id=100 ORDER BY unit_id LIMIT 1"
+        ).fetchone()[0]
+        self.con.execute(
+            "UPDATE watched_prs SET unit_id=? WHERE pr_number=1",
+            (unit_id,),
+        )
+        self.con.commit()
+        pr_poller.poll_cycle(
+            self.con,
+            fetch_ok(gh_node(checks="PENDING"), gh_node(checks="PENDING")),
+            system_signals=True,
+        )
+        result = pr_poller.poll_cycle(
+            self.con,
+            fetch_ok(gh_node(checks="SUCCESS"), gh_node(checks="PENDING")),
+            system_signals=True,
+        )
+
+        self.assertEqual(result["events"], 1)
+        self.assertEqual(self.messages(), [])
+        directives = self.con.execute(
+            "SELECT issuer_flavor,kind,target,sprint_doc_id,unit_id,payload "
+            "FROM directives"
+        ).fetchall()
+        self.assertEqual(len(directives), 1)
+        self.assertEqual(
+            tuple(directives[0])[:5],
+            ("system", "pr-green", "conductor", 100, unit_id),
+        )
+        self.assertEqual(
+            json.loads(directives[0]["payload"])["head_sha"],
+            "abc1234def",
+        )
+        event = self.con.execute(
+            "SELECT event_kind,directive_id,evidence FROM sentinel_events "
+            "WHERE event_kind='pr-green'"
+        ).fetchone()
+        self.assertEqual(event["directive_id"], 1)
+        self.assertEqual(
+            json.loads(event["evidence"])["transition"],
+            "checks:SUCCESS",
+        )
+
     def test_semantic_dedupe_survives_a_replayed_transition(self):
         pr_poller.poll_cycle(self.con, fetch_ok(gh_node(checks="PENDING"),
                                                 gh_node(checks="PENDING")))

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Conductor Step 5 sentinel unit and synthetic-cycle coverage."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import activity_readers  # noqa: E402
+import pr_poller  # noqa: E402
+import sentinel  # noqa: E402
+
+
+def build_db(path: Path | None = None) -> sqlite3.Connection:
+    con = sqlite3.connect(path if path else ":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+def seed_floor(con: sqlite3.Connection, *, state="working") -> int:
+    con.executescript(
+        "INSERT INTO users (user_id,username,is_active) VALUES (1,'T',1);"
+        "INSERT INTO shells "
+        "(shell_id,display_name,shortname,flavor,system_prompt,user_id) VALUES "
+        "(1,'Planner','plan1','planner','x',1),"
+        "(2,'Dev','dev1','dev','x',1),"
+        "(3,'Reviewer','rev1','reviewer','x',1);"
+        "INSERT INTO documents "
+        "(document_id,kind,title,body,frozen) "
+        "VALUES (100,'doc','SPRINT: Sentinel','# sprint',0);"
+    )
+    unit_id = con.execute(
+        "INSERT INTO sprint_units "
+        "(sprint_doc_id,seq,unit_title,dev_shell_id,reviewer_shell_id,state,"
+        " assigned_at,state_changed_at) "
+        "VALUES (100,'U1','sentinel slice',2,3,?,"
+        " '2026-01-01T00:00:00Z','2026-01-01T00:00:00Z')",
+        (state,),
+    ).lastrowid
+    con.commit()
+    return unit_id
+
+
+class FakeReader:
+    def __init__(self, evidence=None):
+        self.evidence = evidence or activity_readers.Evidence()
+        self.calls = []
+
+    def read(self, shell, unit, now, role=None):
+        self.calls.append((shell["shell_id"], unit["unit_id"], role))
+        return self.evidence
+
+
+class SentinelConfigTests(unittest.TestCase):
+    def test_missing_and_malformed_config_fail_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "instance.json"
+            self.assertEqual(sentinel.load_config(path), sentinel.SentinelConfig())
+            path.write_text('{"sentinel":{"enabled":"yes","interval_seconds":0}}')
+            self.assertEqual(sentinel.load_config(path), sentinel.SentinelConfig())
+
+    def test_valid_per_fork_config_sets_both_cadences(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "instance.json"
+            path.write_text(json.dumps({
+                "port": 8800,
+                "sentinel": {
+                    "enabled": True,
+                    "interval_seconds": 15,
+                    "activity_beat_seconds": 90,
+                },
+            }))
+            self.assertEqual(
+                sentinel.load_config(path),
+                sentinel.SentinelConfig(True, 15, 90),
+            )
+
+
+class SentinelCycleTests(unittest.TestCase):
+    def setUp(self):
+        self.con = build_db()
+        self.config = sentinel.SentinelConfig(
+            enabled=True, interval_seconds=30, activity_beat_seconds=300
+        )
+
+    def tearDown(self):
+        self.con.close()
+
+    def run_cycle(
+        self,
+        *,
+        now,
+        reader=None,
+        liveness=lambda claim: True,
+        git_probe=None,
+    ):
+        return sentinel.cycle(
+            self.con,
+            config=self.config,
+            now=now,
+            activity_reader=reader or FakeReader(),
+            liveness=liveness,
+            git_probe=git_probe or (
+                lambda worktree: {
+                    "head_sha": None,
+                    "committed_at": None,
+                }
+            ),
+        )
+
+    def test_no_live_sprint_is_a_write_free_noop(self):
+        reader = FakeReader()
+        result = self.run_cycle(
+            now="2026-01-01T03:00:00Z", reader=reader
+        )
+        self.assertEqual(result["active_units"], 0)
+        self.assertEqual(reader.calls, [])
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM sentinel_events"
+            ).fetchone()[0],
+            0,
+        )
+        self.assertEqual(
+            self.con.execute("SELECT COUNT(*) FROM directives").fetchone()[0],
+            0,
+        )
+
+    def test_dead_launch_is_immediate_and_deduped_before_dwell(self):
+        unit_id = seed_floor(self.con)
+        self.con.execute(
+            "INSERT INTO shell_launch_records "
+            "(shell_id,pid,start_ticks,worktree,harness,launched_at) "
+            "VALUES (2,4242,99,'/tmp/dev1','codex','2026-01-01T00:01:00Z')"
+        )
+        self.con.commit()
+
+        first = self.run_cycle(
+            now="2026-01-01T00:02:00Z", liveness=lambda claim: False
+        )
+        second = self.run_cycle(
+            now="2026-01-01T00:03:00Z", liveness=lambda claim: False
+        )
+
+        self.assertEqual(first["dead_shells"], 1)
+        self.assertEqual(first["stalls"], 0)
+        self.assertEqual(second["dead_shells"], 0)
+        directive = self.con.execute(
+            "SELECT * FROM directives WHERE kind='dead-shell'"
+        ).fetchone()
+        self.assertEqual(directive["issuer_flavor"], "system")
+        self.assertEqual(directive["target"], "conductor")
+        self.assertEqual(directive["unit_id"], unit_id)
+        event = self.con.execute(
+            "SELECT directive_id,evidence FROM sentinel_events "
+            "WHERE event_kind='dead-shell'"
+        ).fetchone()
+        self.assertEqual(event["directive_id"], directive["directive_id"])
+        self.assertEqual(json.loads(event["evidence"])["process"]["pid"], 4242)
+
+    def test_indeterminate_launch_verdict_never_becomes_dead(self):
+        seed_floor(self.con)
+        self.con.execute(
+            "INSERT INTO shell_launch_records "
+            "(shell_id,pid,start_ticks,worktree,harness,launched_at) "
+            "VALUES (2,4242,99,'/tmp/dev1','codex','2026-01-01T00:01:00Z')"
+        )
+        self.con.commit()
+        result = self.run_cycle(
+            now="2026-01-01T00:02:00Z", liveness=lambda claim: None
+        )
+        self.assertEqual(result["dead_shells"], 0)
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM directives"
+            ).fetchone()[0],
+            0,
+        )
+
+    def test_disk_activity_emits_a_beat_and_resets_dwell(self):
+        seed_floor(self.con)
+        reader = FakeReader(activity_readers.Evidence(
+            state_changed_at="2026-01-01T00:00:00Z",
+            newest_mtime="2026-01-01T02:30:00Z",
+            last_work_at="2026-01-01T02:30:00Z",
+            process_present=True,
+        ))
+        result = self.run_cycle(
+            now="2026-01-01T03:00:00Z", reader=reader
+        )
+        replay = self.run_cycle(
+            now="2026-01-01T03:10:00Z", reader=reader
+        )
+
+        self.assertEqual(result["activity_beats"], 1)
+        self.assertEqual(result["stalls"], 0)
+        self.assertEqual(replay["activity_beats"], 0)
+        event = self.con.execute(
+            "SELECT evidence FROM sentinel_events "
+            "WHERE event_kind='activity-beat'"
+        ).fetchone()
+        self.assertEqual(
+            json.loads(event["evidence"])["activity_at"],
+            "2026-01-01T02:30:00+00:00",
+        )
+
+    def test_recent_message_is_an_expected_signal(self):
+        seed_floor(self.con)
+        self.con.execute(
+            "INSERT INTO shell_messages "
+            "(from_shell_id,to_shell_id,body,kind,sprint_doc_id,created_at) "
+            "VALUES (2,1,'still working','shell',100,'2026-01-01T02:30:00Z')"
+        )
+        self.con.commit()
+        result = self.run_cycle(now="2026-01-01T03:00:00Z")
+        self.assertEqual(result["stalls"], 0)
+
+    def test_message_for_another_active_unit_does_not_reset_dwell(self):
+        seed_floor(self.con)
+        self.con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id,seq,unit_title,dev_shell_id,state,assigned_at,"
+            " state_changed_at) "
+            "VALUES (100,'U2','other',2,'working','2026-01-01T00:00:00Z',"
+            "'2026-01-01T00:00:00Z')"
+        )
+        self.con.execute(
+            "INSERT INTO shell_messages "
+            "(from_shell_id,to_shell_id,body,kind,sprint_doc_id,created_at) "
+            "VALUES (2,1,'U2 still working','shell',100,"
+            "'2026-01-01T02:30:00Z')"
+        )
+        self.con.commit()
+        result = self.run_cycle(now="2026-01-01T03:00:00Z")
+        self.assertEqual(result["stalls"], 1)
+        stalled = self.con.execute(
+            "SELECT u.seq FROM directives d "
+            "JOIN sprint_units u ON u.unit_id=d.unit_id "
+            "WHERE d.kind='stall'"
+        ).fetchall()
+        self.assertEqual([row[0] for row in stalled], ["U1"])
+
+    def test_recent_commit_is_an_expected_working_signal(self):
+        seed_floor(self.con)
+        result = self.run_cycle(
+            now="2026-01-01T03:00:00Z",
+            git_probe=lambda worktree: {
+                "head_sha": "abc123",
+                "committed_at": "2026-01-01T02:30:00Z",
+            },
+        )
+        self.assertEqual(result["stalls"], 0)
+
+    def test_recent_pr_observation_is_an_expected_working_signal(self):
+        unit_id = seed_floor(self.con)
+        watch_id = self.con.execute(
+            "INSERT INTO watched_prs "
+            "(repo,pr_number,shell_id,sprint_doc_id,unit_id,last_seen) "
+            "VALUES ('o/r',7,2,100,?,?)",
+            (
+                unit_id,
+                json.dumps({
+                    "state": "OPEN",
+                    "sha": "abc123",
+                    "checks": "PENDING",
+                    "reviews": 0,
+                    "review_state": None,
+                }),
+            ),
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO pr_poll_observations "
+            "(watch_id,head_sha,fingerprint,transition,observed_at) "
+            "VALUES (?,'abc123','{}','checks:PENDING',"
+            "'2026-01-01T02:30:00Z')",
+            (watch_id,),
+        )
+        self.con.commit()
+        result = self.run_cycle(now="2026-01-01T03:00:00Z")
+        self.assertEqual(result["stalls"], 0)
+
+    def test_recent_review_is_an_expected_in_review_signal(self):
+        unit_id = seed_floor(self.con, state="in_review")
+        watch_id = self.con.execute(
+            "INSERT INTO watched_prs "
+            "(repo,pr_number,shell_id,sprint_doc_id,unit_id,last_seen) "
+            "VALUES ('o/r',7,3,100,?,'{}')",
+            (unit_id,),
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO pr_poll_observations "
+            "(watch_id,head_sha,fingerprint,transition,observed_at) "
+            "VALUES (?,'abc123','{}','review:APPROVED',"
+            "'2026-01-01T02:30:00Z')",
+            (watch_id,),
+        )
+        self.con.commit()
+        result = self.run_cycle(now="2026-01-01T03:00:00Z")
+        self.assertEqual(result["stalls"], 0)
+
+    def test_recent_kickoff_is_an_expected_pending_signal(self):
+        unit_id = seed_floor(self.con, state="pending")
+        self.con.execute(
+            "INSERT INTO directives "
+            "(issuer_shell_id,issuer_flavor,kind,target,sprint_doc_id,unit_id,"
+            " created_at) "
+            "VALUES (1,'planner','kickoff','conductor',100,?,"
+            "'2026-01-01T02:30:00Z')",
+            (unit_id,),
+        )
+        self.con.commit()
+        result = self.run_cycle(now="2026-01-01T03:00:00Z")
+        self.assertEqual(result["stalls"], 0)
+
+    def test_recent_planner_directive_is_an_expected_blocked_signal(self):
+        unit_id = seed_floor(self.con, state="blocked")
+        reader = FakeReader()
+        self.con.execute(
+            "INSERT INTO directives "
+            "(issuer_shell_id,issuer_flavor,kind,target,sprint_doc_id,unit_id,"
+            " created_at) "
+            "VALUES (1,'planner','hold','conductor',100,?,"
+            "'2026-01-01T02:30:00Z')",
+            (unit_id,),
+        )
+        self.con.commit()
+        result = self.run_cycle(
+            now="2026-01-01T03:00:00Z", reader=reader
+        )
+        self.assertEqual(result["stalls"], 0)
+        self.assertEqual(reader.calls, [])
+
+    def test_expired_dwell_writes_full_evidence_and_one_signal(self):
+        unit_id = seed_floor(self.con)
+        result = self.run_cycle(now="2026-01-01T03:00:00Z")
+        replay = self.run_cycle(now="2026-01-01T03:01:00Z")
+
+        self.assertEqual(result["stalls"], 1)
+        self.assertEqual(replay["stalls"], 0)
+        directive = self.con.execute(
+            "SELECT payload FROM directives WHERE kind='stall'"
+        ).fetchone()
+        payload = json.loads(directive["payload"])
+        self.assertEqual(payload["dwell_seconds"], 10800)
+        self.assertEqual(payload["max_dwell_seconds"], 7200)
+        self.assertEqual(payload["last_commit_sha"], None)
+        self.assertEqual(payload["last_message_id"], None)
+        self.assertEqual(payload["unit_seq"], "U1")
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM sentinel_events "
+                "WHERE unit_id=? AND event_kind='stall'",
+                (unit_id,),
+            ).fetchone()[0],
+            1,
+        )
+
+    def test_in_review_monitors_the_reviewer_not_the_developer(self):
+        seed_floor(self.con, state="in_review")
+        reader = FakeReader(activity_readers.Evidence(
+            state_changed_at="2026-01-01T00:00:00Z",
+            newest_mtime="2026-01-01T00:10:00Z",
+        ))
+        self.run_cycle(now="2026-01-01T00:20:00Z", reader=reader)
+        self.assertEqual(reader.calls, [(3, 1, "reviewer")])
+
+
+class SyntheticServiceCycleTests(unittest.TestCase):
+    def test_enabled_service_runs_one_sentinel_cycle_without_a_pr_watch(self):
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "shell_db.db"
+            con = build_db(db_path)
+            seed_floor(con)
+            con.close()
+            poller = pr_poller.Poller(
+                db_path,
+                interval=30,
+                fetch=lambda query: self.fail("no watch means no GitHub read"),
+                activity_reader=FakeReader(),
+                sentinel_config=sentinel.SentinelConfig(True, 30, 300),
+                sentinel_liveness=lambda claim: True,
+                sentinel_git_probe=lambda worktree: {
+                    "head_sha": None,
+                    "committed_at": None,
+                },
+            )
+            poller.start()
+            time.sleep(0.3)
+            poller.stop()
+            poller.join(timeout=5)
+
+            con = sqlite3.connect(db_path)
+            try:
+                self.assertEqual(
+                    con.execute(
+                        "SELECT COUNT(*) FROM directives WHERE kind='stall'"
+                    ).fetchone()[0],
+                    1,
+                )
+                self.assertEqual(
+                    con.execute(
+                        "SELECT interval_s FROM daemon_heartbeats "
+                        "WHERE name='sentinel'"
+                    ).fetchone()[0],
+                    30,
+                )
+                self.assertEqual(
+                    con.execute(
+                        "SELECT COUNT(*) FROM daemon_heartbeats "
+                        "WHERE name='reconcile'"
+                    ).fetchone()[0],
+                    0,
+                )
+            finally:
+                con.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a per-fork feature-gated sentinel cycle to the sole engine-service scheduler
- observe launch-record liveness, worktree activity, messages, commits, PR state, and data-driven dwell windows
- emit deduplicated system directives plus linked sentinel events for dead shells, stalls, and semantic PR transitions
- preserve the previous report-only reconciliation and pr_event path when the sentinel is disabled

## Verification
- 1399 pytest tests + 602 subtests passed
- focused sentinel/poller/contracts/liveness/activity suite: 163 tests + 22 subtests passed
- ./sc render-check
- ./sc verify
- git diff --check