### PR TITLE
feat(conductor S8): add deterministic relay runtime

### DIFF
--- a/.super-coder/api/conductor_routes.py
+++ b/.super-coder/api/conductor_routes.py
@@ -23,6 +23,7 @@ from urllib.parse import parse_qs, urlparse
 ENGINE = Path(__file__).resolve().parents[1]
 DB_PATH = ENGINE / "shell_db.db"
 sys.path.insert(0, str(ENGINE / "scripts"))
+import conductor_runtime  # noqa: E402
 import db_driver  # noqa: E402
 
 _ALLOWED_HOST_SET = frozenset(("127.0.0.1", "localhost", "::1"))
@@ -271,7 +272,31 @@ def _create_directive(con, headers, body):
     except db_driver.IntegrityError as exc:
         con.rollback()
         return _err(422, "directive_invalid", str(exc))
-    return _json(201, _directive(con, cur.lastrowid))
+    item = _directive(con, cur.lastrowid)
+    conductor_runtime.maybe_wake(con)
+    return _json(201, item)
+
+
+def _act_directive(con, headers, directive_id: int):
+    shell = _shell_for_token(con, headers)
+    if shell is None:
+        return _err(
+            401, "conductor_required",
+            "directive execution requires a valid conductor bearer token",
+        )
+    shell_id, flavor = shell
+    if flavor != "conductor":
+        return _err(
+            403, "conductor_required",
+            f"shell {shell_id} is {flavor or 'bespoke'}, not conductor",
+        )
+    try:
+        result = conductor_runtime.act(con, directive_id, shell_id)
+    except KeyError:
+        return _err(404, "not_found", "no such directive")
+    except PermissionError as exc:
+        return _err(403, "conductor_required", str(exc))
+    return _json(200, result)
 
 
 def handle(method: str, path: str, headers_raw: str, body: bytes):
@@ -309,6 +334,12 @@ def handle(method: str, path: str, headers_raw: str, body: bytes):
                     return _err(422, "validation", str(exc))
                 return _json(200, item) if item else _err(
                     404, "not_found", "no such directive")
+            if len(parts) == 4 and parts[3] == "act" and method == "POST":
+                try:
+                    directive_id = _int(parts[2], "directive_id")
+                except ValueError as exc:
+                    return _err(422, "validation", str(exc))
+                return _act_directive(con, headers, directive_id)
         if parts[:2] == ["api", "sentinel-events"]:
             if len(parts) == 2 and method == "GET":
                 try:

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -61,6 +61,7 @@ _LOG_LOCK = threading.Lock()
 sys.path.insert(0, str(ENGINE / "scripts"))
 import artifact_policy  # noqa: E402
 import backfill_shell_api_keys  # noqa: E402  (startup key provisioning)
+import conductor_runtime  # noqa: E402  (Step 8 wake/config/doctor)
 import db_driver  # noqa: E402
 import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import mem_credentials  # noqa: E402  (runtime Admin credential provisioning, spec #30 req 11)
@@ -3747,11 +3748,24 @@ def main(argv):
     # api_key rotation is picked up here. Lives under the gitignored,
     # never-snapshotted .super-coder/run/.
     mem_credentials.provision(str(DB_PATH), f"http://127.0.0.1:{port}")
+    conductor_config = conductor_runtime.load_config()
+    if conductor_config.enabled:
+        con = db_driver.connect(str(DB_PATH))
+        try:
+            conductor_runtime.doctor(con, conductor_config)
+        except conductor_runtime.ConductorConfigError as exc:
+            sys.exit(f"server: conductor config invalid — {exc}")
+        finally:
+            con.close()
     # Sole scheduler: watched-PR polling (spec #20 task #85, decision #19) plus
     # the config-gated Conductor sentinel. The retired host `sc watch daemon`
     # cannot form a second DB writer. GitHub reads stay watch-gated; sentinel
     # reads stay live-sprint-gated and never boot a shell before Step 8.
-    pr_poller.Poller(DB_PATH).start()
+    pr_poller.Poller(
+        DB_PATH,
+        sentinel_config=pr_poller.sentinel.load_config(),
+        conductor_config=conductor_config,
+    ).start()
     # Bind 127.0.0.1 by default (the host stance: localhost-only, operator owns
     # network controls). In the container set SC_BIND=0.0.0.0 so docker can
     # publish the port — the jail is the `-p 127.0.0.1:PORT:PORT` mapping, which

--- a/.super-coder/migrations/0121_conductor_flavor.sql
+++ b/.super-coder/migrations/0121_conductor_flavor.sql
@@ -1,0 +1,15 @@
+-- 0121 — Conductor Step 8 flavor route.
+--
+-- The flavor itself is a tracked shell template.  Installed databases also
+-- need one deterministic launch default so an ephemeral Conductor cannot fall
+-- through to the fork's ambient harness/model.  No flavor_skills row is added:
+-- zero skills is part of the Conductor authority boundary.
+
+BEGIN;
+
+INSERT OR IGNORE INTO flavor_defaults
+    (flavor, harness, model, is_default)
+VALUES
+    ('conductor', 'opencode', 'ollama-cloud/gpt-oss:20b', 1);
+
+COMMIT;

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -19,6 +19,7 @@ ENGINE = Path(__file__).resolve().parents[1]
 TEMPLATE_PATH = ENGINE / "templates" / "boot.md"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+import conductor_runtime  # noqa: E402
 from sprint_units import TERMINAL_UNIT_STATES  # noqa: E402
 
 # Rendered into ORIENTATION for every shell EXCEPT the cartographer (who owns the
@@ -500,6 +501,9 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
     source-repo variant (caller decides via install.is_source_repo() — compose
     stays a pure render, no git).
     """
+    if shell["flavor"] == "conductor":
+        return conductor_runtime.render_boot(con, shell)
+
     template = TEMPLATE_PATH.read_text().rstrip()
     template = template.replace(
         "{{project_vs_engine}}",

--- a/.super-coder/scripts/conductor_contracts.py
+++ b/.super-coder/scripts/conductor_contracts.py
@@ -97,6 +97,12 @@ def _directive_emit(args) -> int:
     return 0
 
 
+def _directive_act(args) -> int:
+    result = _api("POST", f"/api/directives/{args.directive_id}/act", {})
+    _dump(result)
+    return 0 if result["status"] in ("executed", "refused") else 2
+
+
 def _event_list(args) -> int:
     result = _api("GET", _query("/api/sentinel-events", {
         "event_kind": args.kind,
@@ -140,6 +146,9 @@ def build_parser() -> argparse.ArgumentParser:
     de.add_argument("--payload", default="{}")
     de.add_argument("--sprint", type=int)
     de.add_argument("--unit", type=int)
+    da = dsub.add_parser(
+        "act", help="execute/refuse one pending row as the Conductor")
+    da.add_argument("directive_id", type=int)
 
     events = surfaces.add_parser(
         "events", help="read append-only sentinel observations")
@@ -160,6 +169,7 @@ def main(argv=None) -> int:
         ("directives", "list"): _directive_list,
         ("directives", "inspect"): _directive_inspect,
         ("directives", "emit"): _directive_emit,
+        ("directives", "act"): _directive_act,
         ("events", "list"): _event_list,
         ("events", "inspect"): _event_inspect,
     }

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -1,0 +1,932 @@
+#!/usr/bin/env python3
+"""Deterministic Conductor mechanics.
+
+The OpenCode Conductor shell reads the transition table rendered from this
+module and calls ``./sc directives act <id>``.  All authority stays here:
+payload validation, board transitions, role-slot launches, refusal, and the
+durable action trail are code, not model judgement.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import shell_liveness
+import sprint_state
+from sprint_units import SPRINT_UNIT_EDGES, SprintTransitionError, check_transition
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+INSTANCE_CONFIG = ENGINE / "instance.json"
+CONDUCTOR_HARNESS = "opencode"
+DEFAULT_CONDUCTOR_MODEL = "ollama-cloud/gpt-oss:20b"
+_LAUNCH_GUARD_SECONDS = 20
+LAUNCH_LOG = ENGINE / "logs" / "conductor-launches.log"
+
+
+@dataclass(frozen=True)
+class ConductorConfig:
+    enabled: bool = False
+    shell: str = "CON1"
+    model: str = DEFAULT_CONDUCTOR_MODEL
+
+
+class ConductorConfigError(ValueError):
+    """An enabled Conductor configuration that cannot safely wake."""
+
+
+class DirectiveRefused(ValueError):
+    """A pending directive that cannot be mechanically executed."""
+
+
+class ConductorLaunchError(RuntimeError):
+    """A role or Conductor process that refused before it could start."""
+
+
+# issuer, kind, mechanical action, success condition.  The renderer and runtime
+# tests consume the same rows so the boot table cannot drift from the executor.
+TRANSITIONS = (
+    (
+        "dev",
+        "ready-for-review",
+        "record PR + move in_review; boot reviewer",
+        "reviewer slot starts at the exact head",
+    ),
+    (
+        "dev",
+        "ask-planner",
+        "move blocked; boot planner with evidence",
+        "planner slot receives the question",
+    ),
+    (
+        "dev",
+        "merged",
+        "move merged; boot planner",
+        "unit is terminal and planner receives the merge",
+    ),
+    (
+        "dev",
+        "unit-report",
+        "relay report to planner",
+        "planner slot receives the structured report",
+    ),
+    (
+        "reviewer",
+        "review-clean",
+        "record review head; boot dev",
+        "developer receives approval for the exact head",
+    ),
+    (
+        "reviewer",
+        "findings",
+        "relay findings to dev or planner",
+        "the responsible slot receives every finding",
+    ),
+    (
+        "reviewer",
+        "ask-planner",
+        "move blocked; boot planner with evidence",
+        "planner slot receives the question",
+    ),
+    (
+        "planner",
+        "kickoff",
+        "move released unit; boot target slot",
+        "the declared target starts with bounded context",
+    ),
+    ("planner", "hold", "move active unit blocked", "board records the hold"),
+    (
+        "planner",
+        "re-scope",
+        "move working; reboot target dev",
+        "developer receives the new boundary",
+    ),
+    (
+        "planner",
+        "re-task",
+        "move working; reboot target dev",
+        "developer receives the replacement path",
+    ),
+    (
+        "planner",
+        "close",
+        "freeze sprint after terminal-unit check",
+        "sprint is structurally closed",
+    ),
+    (
+        "planner",
+        "answer",
+        "restore target role state; reboot asker",
+        "asker receives the ruling",
+    ),
+    (
+        "system",
+        "pr-green",
+        "boot assigned reviewer",
+        "reviewer receives the green-head evidence",
+    ),
+    (
+        "system",
+        "pr-red",
+        "move blocked; boot assigned dev",
+        "developer receives failing-check evidence",
+    ),
+    (
+        "system",
+        "pr-merged",
+        "move merged; boot planner",
+        "board and planner receive the merge",
+    ),
+    (
+        "system",
+        "stall",
+        "move blocked when legal; boot planner",
+        "planner receives the full dwell snapshot",
+    ),
+    (
+        "system",
+        "dead-shell",
+        "move blocked when legal; boot planner",
+        "planner receives the liveness snapshot",
+    ),
+)
+_TRANSITION_SET = {(issuer, kind) for issuer, kind, _action, _pass in TRANSITIONS}
+
+_wake_lock = threading.Lock()
+_act_lock = threading.Lock()
+_launching_until = 0.0
+
+
+def load_config(path: Path = INSTANCE_CONFIG) -> ConductorConfig:
+    """Read the top-level ``conductor`` block; absent means disabled."""
+    try:
+        raw = json.loads(Path(path).read_text())
+    except FileNotFoundError:
+        return ConductorConfig()
+    except OSError as exc:
+        raise ConductorConfigError(f"cannot read conductor config: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ConductorConfigError(f"instance.json is not valid JSON: {exc}") from exc
+    block = raw.get("conductor")
+    if not isinstance(block, dict):
+        return ConductorConfig()
+    enabled = block.get("enabled", False)
+    shell = block.get("shell", "CON1")
+    model = block.get("model", DEFAULT_CONDUCTOR_MODEL)
+    if not isinstance(enabled, bool):
+        raise ConductorConfigError("conductor.enabled must be boolean")
+    if not isinstance(shell, str) or not shell.strip():
+        raise ConductorConfigError("conductor.shell must be a nonblank shortname")
+    if not isinstance(model, str) or not model.strip():
+        raise ConductorConfigError("conductor.model must be a nonblank route")
+    return ConductorConfig(enabled, shell.strip(), model.strip())
+
+
+def doctor(
+    con,
+    config: ConductorConfig,
+    *,
+    which: Callable[[str], str | None] = shutil.which,
+    run: Callable = subprocess.run,
+) -> dict:
+    """Fail an enabled configuration before the service starts."""
+    if not config.enabled:
+        return {"enabled": False, "ok": True}
+    if which(CONDUCTOR_HARNESS) is None:
+        raise ConductorConfigError("OpenCode CLI is not installed on PATH")
+    shell = con.execute(
+        "SELECT shell_id,shortname,flavor,api_key FROM shells "
+        "WHERE shortname=? COLLATE NOCASE AND COALESCE(is_deleted,0)=0",
+        (config.shell,),
+    ).fetchone()
+    if shell is None:
+        raise ConductorConfigError(f"conductor shell {config.shell!r} does not exist")
+    if shell["flavor"] != "conductor":
+        raise ConductorConfigError(
+            f"shell {config.shell!r} is {shell['flavor'] or 'bespoke'}, not conductor"
+        )
+    if not shell["api_key"]:
+        raise ConductorConfigError(
+            f"conductor shell {config.shell!r} has no API credential"
+        )
+    grants = con.execute(
+        "SELECT COUNT(*) FROM flavor_skills WHERE flavor='conductor'"
+    ).fetchone()[0]
+    direct = con.execute(
+        "SELECT COUNT(*) FROM shell_skills WHERE shell_id=?",
+        (shell["shell_id"],),
+    ).fetchone()[0]
+    if grants or direct:
+        raise ConductorConfigError(
+            "conductor must have zero skills; remove flavor and direct grants"
+        )
+    try:
+        models = run(
+            [CONDUCTOR_HARNESS, "models"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ConductorConfigError(f"OpenCode credential probe failed: {exc}") from exc
+    if models.returncode != 0:
+        detail = (models.stderr or models.stdout or "unknown error").strip()
+        raise ConductorConfigError(f"OpenCode credential probe failed: {detail}")
+    available = {line.strip() for line in models.stdout.splitlines() if line.strip()}
+    if config.model not in available:
+        raise ConductorConfigError(
+            f"OpenCode route {config.model!r} is not locally runnable; "
+            "authenticate OpenCode or select a listed model"
+        )
+    return {
+        "enabled": True,
+        "ok": True,
+        "shell_id": shell["shell_id"],
+        "shell": shell["shortname"],
+        "harness": CONDUCTOR_HARNESS,
+        "model": config.model,
+    }
+
+
+def _pending_ids(con) -> list[int]:
+    return [
+        row[0]
+        for row in con.execute(
+            "SELECT directive_id FROM directives "
+            "WHERE status='pending' AND target='conductor' "
+            "ORDER BY directive_id"
+        )
+    ]
+
+
+def _default_launcher(command: list[str]) -> int:
+    LAUNCH_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with LAUNCH_LOG.open("a") as log:
+        proc = subprocess.Popen(
+            command,
+            cwd=REPO_ROOT,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=log,
+            start_new_session=True,
+            env={**os.environ, "SC_NO_AUTOPRUNE": "1"},
+        )
+        time.sleep(0.2)
+        returncode = proc.poll()
+    if returncode not in (None, 0):
+        raise ConductorLaunchError(
+            f"launch pid {proc.pid} exited {returncode}; see {LAUNCH_LOG}"
+        )
+    return proc.pid
+
+
+def _launch_is_live(con, shell_id: int) -> bool:
+    row = con.execute(
+        "SELECT shell_id,pid,start_ticks,worktree,harness,launched_at "
+        "FROM shell_launch_records WHERE shell_id=?",
+        (shell_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    try:
+        return shell_liveness.claim_live(dict(row)) is True
+    except (OSError, ValueError):
+        return False
+
+
+def maybe_wake(
+    con,
+    *,
+    config: ConductorConfig | None = None,
+    launcher: Callable[[list[str]], int] | None = None,
+    now: Callable[[], float] = time.monotonic,
+) -> dict:
+    """Boot one ephemeral Conductor when a pending row arrives."""
+    global _launching_until
+    config = config or load_config()
+    launcher = launcher or _default_launcher
+    if not config.enabled:
+        return {"enabled": False, "launched": False}
+    checked = doctor(con, config)
+    pending = _pending_ids(con)
+    if not pending:
+        return {**checked, "launched": False, "reason": "no-pending"}
+    with _wake_lock:
+        current = now()
+        if current < _launching_until:
+            return {**checked, "launched": False, "reason": "launching"}
+        if _launch_is_live(con, checked["shell_id"]):
+            return {**checked, "launched": False, "reason": "already-live"}
+        prompt = (
+            "Process pending Conductor directives in ascending id order. "
+            "For each id run `./sc directives act <id>`, inspect the result, "
+            "and continue until `./sc directives list --status pending` is empty."
+        )
+        command = [
+            str(REPO_ROOT / "sc"),
+            "run",
+            checked["shell"],
+            "--harness",
+            CONDUCTOR_HARNESS,
+            "--model",
+            config.model,
+            "--prompt",
+            prompt,
+        ]
+        pid = launcher(command)
+        _launching_until = current + _LAUNCH_GUARD_SECONDS
+    return {
+        **checked,
+        "launched": True,
+        "pid": pid,
+        "pending": pending,
+    }
+
+
+def _payload(row) -> dict:
+    try:
+        body = json.loads(row["payload"])
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise DirectiveRefused("payload is not valid JSON") from exc
+    if not isinstance(body, dict):
+        raise DirectiveRefused("payload must be a JSON object")
+    return body
+
+
+def _text(payload: dict, field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise DirectiveRefused(f"payload.{field} must be a nonblank string")
+    return value.strip()
+
+
+def _integer(payload: dict, field: str) -> int:
+    value = payload.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise DirectiveRefused(f"payload.{field} must be an integer")
+    return value
+
+
+def _unit(con, row):
+    unit_id = row["unit_id"]
+    sprint_id = row["sprint_doc_id"]
+    if unit_id is None or sprint_id is None:
+        raise DirectiveRefused("directive requires sprint_doc_id and unit_id")
+    unit = con.execute(
+        "SELECT * FROM sprint_units WHERE unit_id=? AND sprint_doc_id=?",
+        (unit_id, sprint_id),
+    ).fetchone()
+    if unit is None:
+        raise DirectiveRefused("linked sprint unit does not exist")
+    return unit
+
+
+def _shell(con, shortname: str, flavor: str | None = None):
+    row = con.execute(
+        "SELECT shell_id,shortname,flavor FROM shells "
+        "WHERE shortname=? COLLATE NOCASE AND COALESCE(is_deleted,0)=0",
+        (shortname,),
+    ).fetchone()
+    if row is None:
+        raise DirectiveRefused(f"target shell {shortname!r} does not exist")
+    if flavor is not None and row["flavor"] != flavor:
+        raise DirectiveRefused(f"target shell {shortname!r} is not {flavor}")
+    return row
+
+
+def _only_shell(con, flavor: str):
+    rows = con.execute(
+        "SELECT shell_id,shortname,flavor FROM shells "
+        "WHERE flavor=? AND COALESCE(is_deleted,0)=0 ORDER BY shell_id",
+        (flavor,),
+    ).fetchall()
+    if len(rows) != 1:
+        raise DirectiveRefused(
+            f"expected exactly one active {flavor} shell, found {len(rows)}"
+        )
+    return rows[0]
+
+
+def _assert_issuer_assignment(row, unit) -> None:
+    if row["issuer_flavor"] == "dev" and row["issuer_shell_id"] != unit["dev_shell_id"]:
+        raise DirectiveRefused("dev issuer is not the unit's assigned developer")
+    if (
+        row["issuer_flavor"] == "reviewer"
+        and row["issuer_shell_id"] != unit["reviewer_shell_id"]
+    ):
+        raise DirectiveRefused("reviewer issuer is not the unit's assigned reviewer")
+
+
+def _move(con, unit, state: str, actor_shell_id: int) -> None:
+    try:
+        check_transition(SPRINT_UNIT_EDGES, unit["state"], state)
+    except SprintTransitionError as exc:
+        raise DirectiveRefused(str(exc)) from exc
+    con.execute(
+        "UPDATE sprint_units SET state=?,"
+        " state_changed_at=CASE WHEN state<>? THEN datetime('now') "
+        " ELSE state_changed_at END,"
+        " updated_at=datetime('now'),updated_by_shell_id=? WHERE unit_id=?",
+        (state, state, actor_shell_id, unit["unit_id"]),
+    )
+
+
+def _block_when_legal(con, unit, actor_shell_id: int) -> None:
+    if unit["state"] in ("working", "in_review"):
+        _move(con, unit, "blocked", actor_shell_id)
+
+
+def _slot_command(
+    shell,
+    slot: str,
+    sprint_id: int,
+    *,
+    unit_seq: str | None,
+    prompt: str,
+    model: str | None = None,
+) -> list[str]:
+    command = [
+        str(REPO_ROOT / "sc"),
+        "run",
+        shell["shortname"],
+        "--slot",
+        slot,
+        "--sprint",
+        str(sprint_id),
+    ]
+    if unit_seq is not None:
+        command += ["--unit", unit_seq]
+    if model:
+        command += ["--model", model]
+    command += ["--prompt", prompt]
+    return command
+
+
+def _spawn(
+    launches: list[list[str]],
+    shell,
+    slot: str,
+    row,
+    payload: dict,
+    *,
+    unit=None,
+    model: str | None = None,
+) -> None:
+    prompt = json.dumps(
+        {
+            "directive_id": row["directive_id"],
+            "issuer": row["issuer_flavor"],
+            "kind": row["kind"],
+            "payload": payload,
+        },
+        sort_keys=True,
+    )
+    launches.append(
+        _slot_command(
+            shell,
+            slot,
+            row["sprint_doc_id"],
+            unit_seq=unit["seq"] if unit is not None else None,
+            prompt=prompt,
+            model=model,
+        )
+    )
+
+
+def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
+    issuer, kind = row["issuer_flavor"], row["kind"]
+    if (issuer, kind) not in _TRANSITION_SET:
+        raise DirectiveRefused(f"no transition for {issuer}:{kind}")
+    if row["target"] != "conductor":
+        raise DirectiveRefused("directive target must be conductor")
+    sprint_id = row["sprint_doc_id"]
+    if sprint_id is None or not sprint_state.is_live_sprint(con, sprint_id):
+        raise DirectiveRefused("directive requires an active, unfrozen sprint")
+    launches: list[list[str]] = []
+
+    if issuer == "dev":
+        unit = _unit(con, row)
+        _assert_issuer_assignment(row, unit)
+        if kind == "ready-for-review":
+            pr = _integer(payload, "pr_number")
+            head = _text(payload, "head")
+            branch = _text(payload, "branch")
+            if payload.get("checks") != "green":
+                raise DirectiveRefused("payload.checks must be 'green'")
+            con.execute(
+                "UPDATE sprint_units SET pr_number=?,branch=?,"
+                "updated_at=datetime('now'),updated_by_shell_id=? "
+                "WHERE unit_id=?",
+                (pr, branch, actor_shell_id, unit["unit_id"]),
+            )
+            _move(con, unit, "in_review", actor_shell_id)
+            reviewer = con.execute(
+                "SELECT shell_id,shortname,flavor FROM shells "
+                "WHERE shell_id=? AND flavor='reviewer' "
+                "AND COALESCE(is_deleted,0)=0",
+                (unit["reviewer_shell_id"],),
+            ).fetchone()
+            if reviewer is None:
+                raise DirectiveRefused("unit has no assigned reviewer")
+            _spawn(launches, reviewer, "rev", row, payload, unit=unit)
+        elif kind == "ask-planner":
+            _text(payload, "question")
+            _block_when_legal(con, unit, actor_shell_id)
+            _spawn(launches, _only_shell(con, "planner"), "plan", row, payload)
+        elif kind == "merged":
+            pr_number = _integer(payload, "pr_number")
+            head = _text(payload, "head")
+            _text(payload, "merge_sha")
+            if unit["pr_number"] != pr_number:
+                raise DirectiveRefused("merged PR does not match the recorded unit PR")
+            if unit["review_head"] != head:
+                raise DirectiveRefused(
+                    "merged head does not match the recorded review head"
+                )
+            _move(con, unit, "merged", actor_shell_id)
+            _spawn(launches, _only_shell(con, "planner"), "plan", row, payload)
+        elif kind == "unit-report":
+            _text(payload, "shipped")
+            _spawn(launches, _only_shell(con, "planner"), "plan", row, payload)
+        return launches
+
+    if issuer == "reviewer":
+        unit = _unit(con, row) if row["unit_id"] is not None else None
+        if unit is not None:
+            _assert_issuer_assignment(row, unit)
+        if kind == "ask-planner":
+            _text(payload, "question")
+            if unit is not None:
+                _block_when_legal(con, unit, actor_shell_id)
+            _spawn(launches, _only_shell(con, "planner"), "plan", row, payload)
+        elif kind == "review-clean":
+            if unit is None:
+                if payload.get("mode") != "conformance":
+                    raise DirectiveRefused(
+                        "unitless review-clean requires mode=conformance"
+                    )
+                _text(payload, "main_sha")
+                _spawn(launches, _only_shell(con, "planner"), "plan", row, payload)
+            else:
+                if unit["state"] != "in_review":
+                    raise DirectiveRefused("review-clean requires an in_review unit")
+                head = _text(payload, "head")
+                con.execute(
+                    "UPDATE sprint_units SET review_head=?,"
+                    "updated_at=datetime('now'),updated_by_shell_id=? "
+                    "WHERE unit_id=?",
+                    (head, actor_shell_id, unit["unit_id"]),
+                )
+                dev = con.execute(
+                    "SELECT shell_id,shortname,flavor FROM shells WHERE shell_id=?",
+                    (unit["dev_shell_id"],),
+                ).fetchone()
+                _spawn(launches, dev, "dev", row, payload, unit=unit)
+        elif kind == "findings":
+            findings = payload.get("findings")
+            if not isinstance(findings, list) or not findings:
+                raise DirectiveRefused("payload.findings must be a nonempty array")
+            if unit is None:
+                _spawn(launches, _only_shell(con, "planner"), "plan", row, payload)
+            else:
+                dev = con.execute(
+                    "SELECT shell_id,shortname,flavor FROM shells WHERE shell_id=?",
+                    (unit["dev_shell_id"],),
+                ).fetchone()
+                _spawn(launches, dev, "dev", row, payload, unit=unit)
+        return launches
+
+    if issuer == "planner":
+        sprint_id = row["sprint_doc_id"]
+        if sprint_id is None:
+            raise DirectiveRefused("planner directive requires sprint_doc_id")
+        unit = _unit(con, row) if row["unit_id"] is not None else None
+        if kind == "kickoff":
+            target = _shell(con, _text(payload, "to"))
+            model = payload.get("model")
+            if model is not None:
+                model = _text(payload, "model")
+            if target["flavor"] == "dev":
+                if unit is None:
+                    raise DirectiveRefused("dev kickoff requires unit_id")
+                _text(payload, "instruction")
+                if unit["dev_shell_id"] != target["shell_id"]:
+                    raise DirectiveRefused(
+                        "kickoff target is not the assigned developer"
+                    )
+                if unit["state"] in ("pending", "blocked"):
+                    _move(con, unit, "working", actor_shell_id)
+                _spawn(launches, target, "dev", row, payload, unit=unit, model=model)
+            elif target["flavor"] == "reviewer":
+                if unit is None and payload.get("mode") != "conformance":
+                    raise DirectiveRefused(
+                        "unitless reviewer kickoff requires mode=conformance"
+                    )
+                _spawn(launches, target, "rev", row, payload, unit=unit, model=model)
+            else:
+                raise DirectiveRefused("kickoff target must be dev or reviewer")
+        elif kind == "hold":
+            _text(payload, "reason")
+            if unit is not None:
+                _block_when_legal(con, unit, actor_shell_id)
+        elif kind in ("re-task", "re-scope"):
+            if unit is None:
+                raise DirectiveRefused(f"{kind} requires unit_id")
+            target = _shell(con, _text(payload, "to"), "dev")
+            _text(payload, "instruction" if kind == "re-task" else "scope")
+            _text(payload, "reason")
+            if unit["dev_shell_id"] != target["shell_id"]:
+                raise DirectiveRefused(f"{kind} target is not the assigned developer")
+            if unit["state"] == "blocked":
+                _move(con, unit, "working", actor_shell_id)
+            _spawn(launches, target, "dev", row, payload, unit=unit)
+        elif kind == "answer":
+            if unit is None:
+                raise DirectiveRefused("answer requires unit_id")
+            target = _shell(con, _text(payload, "to"))
+            _integer(payload, "question_directive_id")
+            _text(payload, "answer")
+            if target["flavor"] == "dev":
+                if unit["state"] == "blocked":
+                    _move(con, unit, "working", actor_shell_id)
+                _spawn(launches, target, "dev", row, payload, unit=unit)
+            elif target["flavor"] == "reviewer":
+                if unit["state"] == "blocked":
+                    _move(con, unit, "working", actor_shell_id)
+                    unit = con.execute(
+                        "SELECT * FROM sprint_units WHERE unit_id=?",
+                        (unit["unit_id"],),
+                    ).fetchone()
+                    _move(con, unit, "in_review", actor_shell_id)
+                _spawn(launches, target, "rev", row, payload, unit=unit)
+            else:
+                raise DirectiveRefused("answer target must be dev or reviewer")
+        elif kind == "close":
+            main_sha = _text(payload, "main_sha")
+            conformance_id = _integer(payload, "conformance_directive_id")
+            _text(payload, "summary")
+            nonterminal = con.execute(
+                "SELECT COUNT(*) FROM sprint_units WHERE sprint_doc_id=? "
+                "AND state NOT IN ('merged','cancelled')",
+                (sprint_id,),
+            ).fetchone()[0]
+            if nonterminal:
+                raise DirectiveRefused(
+                    f"cannot close with {nonterminal} nonterminal unit(s)"
+                )
+            conformance = con.execute(
+                "SELECT issuer_flavor,kind,status,sprint_doc_id,unit_id,payload "
+                "FROM directives WHERE directive_id=?",
+                (conformance_id,),
+            ).fetchone()
+            if (
+                conformance is None
+                or conformance["issuer_flavor"] != "reviewer"
+                or conformance["kind"] != "review-clean"
+                or conformance["status"] != "executed"
+                or conformance["sprint_doc_id"] != sprint_id
+                or conformance["unit_id"] is not None
+            ):
+                raise DirectiveRefused(
+                    "close requires an executed unitless reviewer "
+                    "review-clean directive from this sprint"
+                )
+            verdict = _payload(conformance)
+            if (
+                verdict.get("mode") != "conformance"
+                or verdict.get("main_sha") != main_sha
+                or verdict.get("findings") not in (None, [])
+            ):
+                raise DirectiveRefused(
+                    "close conformance must be clean and match main_sha"
+                )
+            con.execute(
+                "UPDATE documents SET frozen=1,frozen_date=date('now'),"
+                "updated_at=datetime('now') WHERE document_id=?",
+                (sprint_id,),
+            )
+        return launches
+
+    unit = _unit(con, row)
+    if kind == "pr-green":
+        if unit["state"] != "in_review":
+            raise DirectiveRefused("pr-green requires an in_review unit")
+        reviewer = con.execute(
+            "SELECT shell_id,shortname,flavor FROM shells WHERE shell_id=?",
+            (unit["reviewer_shell_id"],),
+        ).fetchone()
+        if reviewer is None:
+            raise DirectiveRefused("unit has no assigned reviewer")
+        _spawn(launches, reviewer, "rev", row, payload, unit=unit)
+    elif kind == "pr-red":
+        if unit["state"] != "working":
+            _move(con, unit, "working", actor_shell_id)
+        dev = con.execute(
+            "SELECT shell_id,shortname,flavor FROM shells WHERE shell_id=?",
+            (unit["dev_shell_id"],),
+        ).fetchone()
+        _spawn(launches, dev, "dev", row, payload, unit=unit)
+    elif kind == "pr-merged":
+        _move(con, unit, "merged", actor_shell_id)
+        _spawn(launches, _only_shell(con, "planner"), "plan", row, payload)
+    elif kind in ("stall", "dead-shell"):
+        _block_when_legal(con, unit, actor_shell_id)
+        _spawn(launches, _only_shell(con, "planner"), "plan", row, payload)
+    return launches
+
+
+def _trail(con, row, actor_shell_id: int, event_kind: str, evidence: dict) -> None:
+    con.execute(
+        "INSERT INTO sentinel_events "
+        "(event_kind,shell_id,sprint_doc_id,unit_id,directive_id,evidence) "
+        "VALUES (?,?,?,?,?,?)",
+        (
+            event_kind,
+            actor_shell_id,
+            row["sprint_doc_id"],
+            row["unit_id"],
+            row["directive_id"],
+            json.dumps(evidence, sort_keys=True),
+        ),
+    )
+
+
+def _act_locked(
+    con,
+    directive_id: int,
+    actor_shell_id: int,
+    *,
+    launcher: Callable[[list[str]], int] | None = None,
+) -> dict:
+    launcher = launcher or _default_launcher
+    actor = con.execute(
+        "SELECT shell_id,flavor FROM shells "
+        "WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+        (actor_shell_id,),
+    ).fetchone()
+    if actor is None or actor["flavor"] != "conductor":
+        raise PermissionError("directive act requires a conductor shell")
+    row = con.execute(
+        "SELECT * FROM directives WHERE directive_id=?",
+        (directive_id,),
+    ).fetchone()
+    if row is None:
+        raise KeyError(f"no directive {directive_id}")
+    if row["status"] != "pending":
+        return {
+            "directive_id": directive_id,
+            "status": row["status"],
+            "replayed": True,
+        }
+
+    con.execute("SAVEPOINT conductor_act")
+    try:
+        payload = _payload(row)
+        launches = _execute(con, row, payload, actor_shell_id)
+        pids = [launcher(command) for command in launches]
+        con.execute("RELEASE conductor_act")
+        con.execute(
+            "UPDATE directives SET status='executed',"
+            "executed_at=datetime('now') WHERE directive_id=?",
+            (directive_id,),
+        )
+        evidence = {
+            "issuer": row["issuer_flavor"],
+            "kind": row["kind"],
+            "launches": launches,
+            "pids": pids,
+        }
+        _trail(con, row, actor_shell_id, "conductor-executed", evidence)
+        con.commit()
+        return {
+            "directive_id": directive_id,
+            "status": "executed",
+            "launches": launches,
+            "pids": pids,
+        }
+    except DirectiveRefused as exc:
+        con.execute("ROLLBACK TO conductor_act")
+        con.execute("RELEASE conductor_act")
+        reason = str(exc)
+        con.execute(
+            "UPDATE directives SET status='refused',refusal_reason=?,"
+            "executed_at=datetime('now') WHERE directive_id=?",
+            (reason, directive_id),
+        )
+        escalation = None
+        try:
+            planner = _only_shell(con, "planner")
+            if row["sprint_doc_id"] is None:
+                raise DirectiveRefused("cannot escalate without sprint_doc_id")
+            prompt = json.dumps(
+                {
+                    "directive_id": directive_id,
+                    "refusal": reason,
+                    "issuer": row["issuer_flavor"],
+                    "kind": row["kind"],
+                    "payload": row["payload"],
+                },
+                sort_keys=True,
+            )
+            command = _slot_command(
+                planner,
+                "plan",
+                row["sprint_doc_id"],
+                unit_seq=None,
+                prompt=prompt,
+            )
+            escalation = {"command": command, "pid": launcher(command)}
+        except DirectiveRefused as escalation_error:
+            escalation = {"error": str(escalation_error)}
+        _trail(
+            con,
+            row,
+            actor_shell_id,
+            "conductor-refused",
+            {"reason": reason, "escalation": escalation},
+        )
+        con.commit()
+        return {
+            "directive_id": directive_id,
+            "status": "refused",
+            "reason": reason,
+            "escalation": escalation,
+        }
+    except Exception:
+        con.execute("ROLLBACK TO conductor_act")
+        con.execute("RELEASE conductor_act")
+        raise
+
+
+def act(
+    con,
+    directive_id: int,
+    actor_shell_id: int,
+    *,
+    launcher: Callable[[list[str]], int] | None = None,
+) -> dict:
+    """Execute or refuse one pending directive as a Conductor shell."""
+    with _act_lock:
+        return _act_locked(
+            con,
+            directive_id,
+            actor_shell_id,
+            launcher=launcher,
+        )
+
+
+def render_boot(con, shell) -> str:
+    """Render the Conductor's complete, no-skill transition-table boot doc."""
+    pending = con.execute(
+        "SELECT directive_id,issuer_flavor,kind,sprint_doc_id,unit_id "
+        "FROM directives WHERE status='pending' AND target='conductor' "
+        "ORDER BY directive_id"
+    ).fetchall()
+    lines = [
+        "# CONDUCTOR — MECHANICAL RELAY",
+        "",
+        "| Invariant | Required result |",
+        "|---|---|",
+        "| Never decide | Execute only a row below through `./sc directives act <id>` |",
+        "| Never invent data | A missing/malformed payload is refused and escalated by the command |",
+        "| Never poll | Drain the current pending list once, then exit |",
+        "| Never write directly | Board/session changes occur only inside the authenticated act command |",
+        "",
+        "| Issuer | Kind | Mechanical action | Pass |",
+        "|---|---|---|---|",
+    ]
+    for issuer, kind, action, success in TRANSITIONS:
+        lines.append(f"| `{issuer}` | `{kind}` | {action} | {success} |")
+    lines += [
+        "",
+        "| Pending id | Issuer | Kind | Sprint | Unit |",
+        "|---:|---|---|---:|---:|",
+    ]
+    if pending:
+        for row in pending:
+            lines.append(
+                f"| {row['directive_id']} | `{row['issuer_flavor']}` | "
+                f"`{row['kind']}` | {row['sprint_doc_id'] or '—'} | "
+                f"{row['unit_id'] or '—'} |"
+            )
+    else:
+        lines.append("| — | — | — | — | — |")
+    lines += [
+        "",
+        "1. Run `./sc directives list --status pending`.",
+        "2. For each id in ascending order run `./sc directives act <id>`.",
+        "3. Inspect every result; continue after executed or refused.",
+        "4. Exit when the pending list is empty.",
+        "",
+        f"Shell: `{shell['shortname']}` · flavor: `conductor` · skills: `0`",
+    ]
+    return "\n".join(lines) + "\n"

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -48,6 +48,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import activity_readers
+import conductor_runtime
 import sentinel
 import sprint_state
 from quota_probes import dispatch as quota_dispatch
@@ -994,7 +995,9 @@ class Poller(threading.Thread):
                  activity_reader=None, refresh=None,
                  sentinel_config: sentinel.SentinelConfig | None = None,
                  sentinel_cycle=None, sentinel_liveness=None,
-                 sentinel_git_probe=None):
+                 sentinel_git_probe=None,
+                 conductor_config: conductor_runtime.ConductorConfig | None = None,
+                 conductor_wake=None):
         super().__init__(name="pr-poller", daemon=True)
         self._db_path = str(db_path)
         self._interval = interval
@@ -1006,17 +1009,33 @@ class Poller(threading.Thread):
         )
         self._refresh = refresh
         self._reconcile_due = 0.0
-        self._sentinel_config = sentinel_config or sentinel.load_config()
+        # API startup owns ambient instance config and injects it. Direct
+        # construction (tests and bounded tools) is inert unless opted in.
+        self._sentinel_config = (
+            sentinel_config
+            if sentinel_config is not None
+            else sentinel.SentinelConfig()
+        )
         self._sentinel_cycle = sentinel_cycle or sentinel.cycle
         self._sentinel_liveness = sentinel_liveness
         self._sentinel_git_probe = sentinel_git_probe
         self._sentinel_due = 0.0
+        # The API startup also owns Conductor config loading and doctor
+        # validation. A directly-constructed Poller stays disabled instead of
+        # inheriting ambient repository config.
+        self._conductor_config = (
+            conductor_config
+            if conductor_config is not None
+            else conductor_runtime.ConductorConfig()
+        )
+        self._conductor_wake = conductor_wake or conductor_runtime.maybe_wake
         self._github_enabled = fetch is not None or shutil.which("gh") is not None
         self._stop_event = threading.Event()
         self.state = PollerState()
         self.reconciler_state = ReconcilerState()
         self.last_reconciliation: list[ReconciliationReading] = []
         self.last_sentinel: dict | None = None
+        self.last_conductor: dict | None = None
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -1118,6 +1137,19 @@ class Poller(threading.Thread):
                         self._reconcile_due = (
                             monotonic_now + self._reconcile_interval
                         )
+                    if self._conductor_config.enabled:
+                        try:
+                            self.last_conductor = self._conductor_wake(
+                                con, config=self._conductor_config)
+                        except Exception as e:
+                            # Wake is a notification edge, never the scheduler
+                            # mission. Startup doctor catches static config;
+                            # transient launch failures remain visible without
+                            # suppressing poll/sentinel/reconciliation work.
+                            print(
+                                f"pr-poller: conductor wake error ({e})",
+                                flush=True,
+                            )
                 finally:
                     con.close()
             except Exception as e:

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -109,6 +109,11 @@ def headless_effort_env(adapter: dict, effort: "str | None") -> dict[str, str]:
     return {ecfg["env"]: effort} if effort and ecfg.get("env") else {}
 
 
+def default_headless_effort(adapter: dict) -> "str | None":
+    """Use high only when the adapter has an effort transport."""
+    return "high" if ((adapter.get("headless") or {}).get("effort")) else None
+
+
 def validate_headless_request(adapter: dict, model: "str | None",
                               effort: "str | None") -> None:
     hcfg = adapter.get("headless") or {}
@@ -1120,12 +1125,14 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
 
     # Model route: an explicit model wins; else the (flavor, harness) cell,
     # exactly main()'s flavor_defaults routing. Effort mirrors main(): a
-    # headless plan defaults to high; the interactive TUI path has no effort
-    # seam in the adapters (main() ignores --effort there too), so it is
-    # recorded on the plan but not applied.
+    # headless plan defaults to high only when the adapter can transport it;
+    # OpenCode's no-effort seam stays unset instead of failing before launch.
     flavor_model = fdef["models"].get(harness) if fdef else None
     session_model = model or flavor_model
-    session_effort = effort or ("high" if headless else None)
+    session_effort = (
+        effort if effort is not None
+        else (default_headless_effort(adapter) if headless else None)
+    )
     if headless:
         try:
             validate_headless_request(adapter, session_model, session_effort)
@@ -1456,13 +1463,17 @@ def main() -> None:
                or default_harness)
 
     # Resolve + validate the complete headless route before opening a session.
-    # `sc run` is the sprint-worker primitive, so high effort is its default;
-    # the orchestration skill passes it explicitly as well for auditability.
+    # `sc run` is the sprint-worker primitive, so high effort is the default
+    # where the harness exposes an effort seam. OpenCode exposes none and keeps
+    # the model's own default.
     flavor_model = fdef["models"].get(harness) if fdef else None
+    adapter = load_adapter(harness)
     session_model = (resolve_headless_model(flag_model, fdef, harness)
                      if headless else flavor_model)
-    session_effort = flag_effort or ("high" if headless else None)
-    adapter = load_adapter(harness)
+    session_effort = (
+        flag_effort if flag_effort is not None
+        else (default_headless_effort(adapter) if headless else None)
+    )
     if headless:
         try:
             validate_headless_request(adapter, session_model, session_effort)

--- a/.super-coder/templates/shells/conductor.json
+++ b/.super-coder/templates/shells/conductor.json
@@ -1,0 +1,9 @@
+{
+  "flavor": "conductor",
+  "abbr": "CON",
+  "role": "Conductor relay shell",
+  "mandate": "Execute the rendered directive transition table for {{repo}}. Relay and apply only mechanical actions authorized by pending directive rows; never decide, infer missing data, poll, or retain state.",
+  "focus": "Drain the current pending Conductor directives through the authenticated act command, inspect each executed/refused result, then exit. The boot document is the complete procedure and transition vocabulary. You have no skills and no authority outside a pending directive.",
+  "inherit_common_skills": false,
+  "skills": []
+}

--- a/sc
+++ b/sc
@@ -1600,7 +1600,8 @@ super-coder — forkable shell substrate
                              `./sc run <shortname> --slot <plan|dev|rev> --sprint <id> [--unit U]`;
                              launch validates flavor and assignment, then embeds the exact sprint context.
   ./sc directives <cmd>    Conductor directives: list/inspect read the durable queue; emit validates the
-                             authenticated shell's flavor against the data whitelist before inserting
+                             authenticated shell's flavor against the data whitelist before inserting;
+                             act executes/refuses one pending row through the mechanical transition table
   ./sc events <cmd>        sentinel observation log: list/inspect append-only evidence rows
   ./sc watch pr <o/r> <n>  register a PR watch (--shell <name> subscribes another shell, e.g. the planner;
                              --sprint <doc-id> arms it to an ACTIVE sprint); an immediate GitHub baseline

--- a/tests/run_conductor_real_matrix.py
+++ b/tests/run_conductor_real_matrix.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Manual Step 8 gate: real weak-model OpenCode over the full directive matrix.
+
+The model is real; the fork and role actors are isolated.  A temporary engine
+DB receives every allowed issuer/kind pair plus one malformed payload.  A
+loopback contract server executes real Conductor mechanics while recording
+role-slot launch commands instead of starting worker models.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+sys.path.insert(0, str(ROOT / "tests"))
+
+import conductor_routes
+import conductor_runtime as runtime
+from test_conductor_runtime import (
+    ConductorDirectiveMatrixTests,
+    build_db,
+)
+
+
+class ContractHandler(BaseHTTPRequestHandler):
+    def _dispatch(self):
+        length = int(self.headers.get("Content-Length") or "0")
+        body = self.rfile.read(length) if length else b""
+        headers = "".join(f"{k}: {v}\r\n" for k, v in self.headers.items())
+        status, response_headers, payload = conductor_routes.handle(
+            self.command, self.path, headers, body
+        )
+        self.send_response(status)
+        for key, value in response_headers:
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(payload)
+
+    do_GET = _dispatch
+    do_POST = _dispatch
+
+    def log_message(self, _format, *_args):
+        return
+
+
+def seed(con) -> None:
+    con.executemany(
+        "INSERT INTO shells "
+        "(shell_id,display_name,shortname,flavor,system_prompt,api_key) "
+        "VALUES (?,?,?,?,?,?)",
+        (
+            (1, "Conductor", "CON1", "conductor", "x", "con-token"),
+            (2, "Planner", "PLN1", "planner", "x", "plan-token"),
+            (3, "Developer", "DEV1", "dev", "x", "dev-token"),
+            (4, "Reviewer", "REV1", "reviewer", "x", "rev-token"),
+        ),
+    )
+    shell_ids = {"dev": 3, "reviewer": 4, "planner": 2, "system": None}
+    for index, (issuer, kind, state, payload, linked_unit) in enumerate(
+        ConductorDirectiveMatrixTests.CASES, start=1
+    ):
+        payload = dict(payload)
+        sprint_id = 1000 + index
+        unit_id = 2000 + index
+        con.execute(
+            "INSERT INTO documents "
+            "(document_id,kind,title,body,frozen) VALUES "
+            "(?,'doc',?,'status: ACTIVE',0)",
+            (sprint_id, f"SPRINT: matrix {issuer}:{kind}"),
+        )
+        con.execute(
+            "INSERT INTO sprint_units "
+            "(unit_id,sprint_doc_id,seq,unit_title,dev_shell_id,"
+            "reviewer_shell_id,state,branch,pr_number,review_head) "
+            "VALUES (?,?,?, ?,3,4,?,'feat/u',7,?)",
+            (
+                unit_id,
+                sprint_id,
+                f"U{index}",
+                f"{issuer}:{kind}",
+                state,
+                "abc" if kind == "merged" else None,
+            ),
+        )
+        if kind == "close":
+            payload["conformance_directive_id"] = -12
+            con.execute(
+                "INSERT INTO directives "
+                "(directive_id,issuer_shell_id,issuer_flavor,kind,payload,target,"
+                "sprint_doc_id,unit_id,status,executed_at) VALUES "
+                "(-12,4,'reviewer','review-clean',?,'conductor',?,NULL,"
+                "'executed',datetime('now'))",
+                (
+                    json.dumps(
+                        {
+                            "mode": "conformance",
+                            "main_sha": payload["main_sha"],
+                            "findings": [],
+                        }
+                    ),
+                    sprint_id,
+                ),
+            )
+        con.execute(
+            "INSERT INTO directives "
+            "(issuer_shell_id,issuer_flavor,kind,payload,target,"
+            "sprint_doc_id,unit_id) VALUES (?,?,?,?, 'conductor',?,?)",
+            (
+                shell_ids[issuer],
+                issuer,
+                kind,
+                json.dumps(payload),
+                sprint_id,
+                unit_id if linked_unit else None,
+            ),
+        )
+    sprint_id = 1999
+    con.execute(
+        "INSERT INTO documents "
+        "(document_id,kind,title,body,frozen) VALUES "
+        "(?,'doc','SPRINT: malformed','status: ACTIVE',0)",
+        (sprint_id,),
+    )
+    con.execute(
+        "INSERT INTO sprint_units "
+        "(unit_id,sprint_doc_id,seq,unit_title,dev_shell_id,"
+        "reviewer_shell_id,state) VALUES "
+        "(2999,?,'UX','malformed',3,4,'working')",
+        (sprint_id,),
+    )
+    con.execute(
+        "INSERT INTO directives "
+        "(issuer_shell_id,issuer_flavor,kind,payload,target,"
+        "sprint_doc_id,unit_id) VALUES "
+        "(3,'dev','ready-for-review','{\"pr_number\":\"bad\"}',"
+        "'conductor',?,2999)",
+        (sprint_id,),
+    )
+    con.commit()
+
+
+def main() -> int:
+    if not shutil_which("opencode"):
+        print("real matrix: OpenCode missing", file=sys.stderr)
+        return 2
+    with tempfile.TemporaryDirectory(prefix="sc_real_conductor_") as td:
+        temp = Path(td)
+        db_path = temp / "matrix.db"
+        con = build_db(db_path)
+        seed(con)
+        shell = con.execute("SELECT * FROM shells WHERE shell_id=1").fetchone()
+        (temp / "AGENTS.md").write_text(runtime.render_boot(con, shell))
+        (temp / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "permission": {
+                        "bash": "allow",
+                        "external_directory": "allow",
+                    },
+                }
+            )
+        )
+        scripts = temp / ".super-coder" / "scripts"
+        scripts.mkdir(parents=True)
+        for name in ("conductor_contracts.py", "cli_entry.py"):
+            shutil.copy2(ENGINE / "scripts" / name, scripts / name)
+        (temp / "sc").write_text(
+            "#!/bin/sh\n"
+            'exec python3 "$(dirname "$0")/.super-coder/scripts/'
+            'conductor_contracts.py" directives "$@"\n'
+        )
+        (temp / "sc").chmod(0o755)
+
+        launches: list[list[str]] = []
+
+        def record(command):
+            launches.append(command)
+            return 7000 + len(launches)
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), ContractHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        base = f"http://127.0.0.1:{server.server_port}"
+        env = {
+            **os.environ,
+            "SC_API_BASE": base,
+            "SC_API_TOKEN": "con-token",
+            "SC_NO_AUTOPRUNE": "1",
+        }
+        prompt = (
+            "Follow AGENTS.md exactly. Drain every pending directive in "
+            "ascending id order with ./sc directives act <id>. Continue after "
+            "both executed and refused results. Exit only when the pending "
+            "list is empty, then reply MATRIX_COMPLETE."
+        )
+        try:
+            with (
+                mock.patch.object(conductor_routes, "DB_PATH", db_path),
+                mock.patch.object(runtime, "_default_launcher", record),
+                mock.patch.object(runtime, "REPO_ROOT", temp),
+            ):
+                result = subprocess.run(
+                    [
+                        "opencode",
+                        "run",
+                        "-m",
+                        runtime.DEFAULT_CONDUCTOR_MODEL,
+                        prompt,
+                    ],
+                    cwd=temp,
+                    env=env,
+                    text=True,
+                    capture_output=True,
+                    timeout=180,
+                    check=False,
+                )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+        counts = dict(
+            con.execute(
+                "SELECT status,COUNT(*) n FROM directives GROUP BY status"
+            ).fetchall()
+        )
+        pending = counts.get("pending", 0)
+        refused = counts.get("refused", 0)
+        executed = counts.get("executed", 0)
+        trail = con.execute(
+            "SELECT COUNT(*) FROM sentinel_events "
+            "WHERE event_kind IN ('conductor-executed','conductor-refused')"
+        ).fetchone()[0]
+        con.close()
+        print(result.stdout)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        print(
+            json.dumps(
+                {
+                    "returncode": result.returncode,
+                    "executed": executed,
+                    "refused": refused,
+                    "pending": pending,
+                    "trail": trail,
+                    "recorded_role_launches": len(launches),
+                },
+                sort_keys=True,
+            )
+        )
+        return (
+            0
+            if (
+                result.returncode == 0
+                and executed == len(runtime.TRANSITIONS) + 1
+                and refused == 1
+                and pending == 0
+                and trail == len(runtime.TRANSITIONS) + 1
+            )
+            else 1
+        )
+
+
+def shutil_which(binary: str) -> str | None:
+    from shutil import which
+
+    return which(binary)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_conductor_contracts.py
+++ b/tests/test_conductor_contracts.py
@@ -139,6 +139,59 @@ class ConductorContractTests(unittest.TestCase):
         })
         self.assertEqual((status, obj["error"]["code"]), (422, "validation"))
 
+    def test_valid_creation_requests_config_gated_conductor_wake(self):
+        with mock.patch.object(
+                conductor_routes.conductor_runtime,
+                "maybe_wake",
+                return_value={"launched": True},
+        ) as wake:
+            status, _item = self.post({
+                "kind": "ready-for-review",
+                "target": "conductor",
+                "payload": {"head": "abc"},
+            })
+        self.assertEqual(status, 201)
+        wake.assert_called_once()
+
+    def test_act_requires_conductor_token_and_calls_mechanical_runtime(self):
+        conductor_id = self.con.execute(
+            "INSERT INTO shells "
+            "(display_name,shortname,flavor,system_prompt,api_key) "
+            "VALUES ('Conductor','con1','conductor','x','con-token')"
+        ).lastrowid
+        self.con.commit()
+        status, item = self.post({
+            "kind": "ready-for-review",
+            "target": "conductor",
+            "payload": {"head": "abc"},
+        })
+        self.assertEqual(status, 201)
+        directive_id = item["directive_id"]
+
+        status, obj = response(conductor_routes.handle(
+            "POST", f"/api/directives/{directive_id}/act",
+            self.headers("dev-token"), b"{}"))
+        self.assertEqual((status, obj["error"]["code"]),
+                         (403, "conductor_required"))
+
+        expected = {
+            "directive_id": directive_id,
+            "status": "executed",
+            "launches": [],
+            "pids": [],
+        }
+        with mock.patch.object(
+                conductor_routes.conductor_runtime,
+                "act",
+                return_value=expected,
+        ) as act:
+            status, obj = response(conductor_routes.handle(
+                "POST", f"/api/directives/{directive_id}/act",
+                self.headers("con-token"), b"{}"))
+        self.assertEqual((status, obj), (200, expected))
+        act.assert_called_once()
+        self.assertEqual(act.call_args.args[2], conductor_id)
+
     def test_sentinel_events_are_readable_and_append_only(self):
         event_id = conductor_routes.append_sentinel_event(
             self.con, event_kind="activity-beat",

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -1,0 +1,568 @@
+"""Conductor Step 8 transition, wake, doctor, and synthetic-sprint gates."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+SCRIPTS = ENGINE / "scripts"
+RENDER = ENGINE / "render"
+sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(RENDER))
+
+import compose
+import conductor_runtime as runtime
+import run
+
+
+def build_db(path: Path) -> sqlite3.Connection:
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+class RuntimeFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory(prefix="sc_conductor8_")
+        self.addCleanup(self.tmp.cleanup)
+        self.con = build_db(Path(self.tmp.name) / "runtime.db")
+        self.addCleanup(self.con.close)
+        shells = (
+            (1, "Conductor", "CON1", "conductor", "con-token"),
+            (2, "Planner", "PLN1", "planner", "plan-token"),
+            (3, "Developer", "DEV1", "dev", "dev-token"),
+            (4, "Reviewer", "REV1", "reviewer", "rev-token"),
+        )
+        self.con.executemany(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,api_key) "
+            "VALUES (?,?,?,?,?,?)",
+            [
+                (sid, name, short, flavor, "x", token)
+                for sid, name, short, flavor, token in shells
+            ],
+        )
+        self.con.execute(
+            "INSERT INTO documents "
+            "(document_id,kind,title,body,frozen) "
+            "VALUES (100,'doc','SPRINT: synthetic','status: ACTIVE',0)"
+        )
+        self.con.execute(
+            "INSERT INTO sprint_units "
+            "(unit_id,sprint_doc_id,seq,unit_title,dev_shell_id,"
+            "reviewer_shell_id,state,branch,pr_number,review_head) "
+            "VALUES (10,100,'U1','synthetic unit',3,4,"
+            "'pending','feat/u1',7,NULL)"
+        )
+        self.con.execute(
+            "INSERT OR REPLACE INTO model_routes "
+            "(harness,selector,provider,provider_model,source,availability,"
+            "stale,headless_supported,high_effort_supported,"
+            "supported_efforts,last_seen_at) "
+            "VALUES ('opencode',?,'ollama-cloud','gpt-oss:20b',"
+            "'opencode-cli','available',0,1,0,'[]',datetime('now'))",
+            (runtime.DEFAULT_CONDUCTOR_MODEL,),
+        )
+        self.con.commit()
+        runtime._launching_until = 0.0
+        self.commands: list[list[str]] = []
+
+    def launcher(self, command: list[str]) -> int:
+        self.commands.append(command)
+        return 9000 + len(self.commands)
+
+    def set_unit(self, state: str, *, review_head=None) -> None:
+        self.con.execute(
+            "UPDATE sprint_units SET state=?,review_head=? WHERE unit_id=10",
+            (state, review_head),
+        )
+        self.con.execute("UPDATE documents SET frozen=0 WHERE document_id=100")
+        self.con.commit()
+
+    def emit(self, issuer: str, kind: str, payload: dict, *, unit: bool = True) -> int:
+        shell_id = {
+            "dev": 3,
+            "reviewer": 4,
+            "planner": 2,
+            "system": None,
+        }[issuer]
+        return self.con.execute(
+            "INSERT INTO directives "
+            "(issuer_shell_id,issuer_flavor,kind,payload,target,"
+            "sprint_doc_id,unit_id) VALUES (?,?,?,?, 'conductor',100,?)",
+            (
+                shell_id,
+                issuer,
+                kind,
+                json.dumps(payload),
+                10 if unit else None,
+            ),
+        ).lastrowid
+
+
+class ConductorFlavorAndDoctorTests(RuntimeFixture):
+    @staticmethod
+    def model_probe(models: str = runtime.DEFAULT_CONDUCTOR_MODEL):
+        def probe(*_args, **_kwargs):
+            return subprocess.CompletedProcess(
+                ["opencode", "models"],
+                0,
+                stdout=f"{models}\n",
+                stderr="",
+            )
+
+        return probe
+
+    def test_template_migration_and_boot_are_zero_skill_and_exhaustive(self):
+        template = json.loads((ENGINE / "templates/shells/conductor.json").read_text())
+        self.assertEqual(template["flavor"], "conductor")
+        self.assertEqual(template["skills"], [])
+        default = self.con.execute(
+            "SELECT harness,model,is_default FROM flavor_defaults "
+            "WHERE flavor='conductor'"
+        ).fetchone()
+        self.assertEqual(
+            tuple(default),
+            ("opencode", runtime.DEFAULT_CONDUCTOR_MODEL, 1),
+        )
+        shell = self.con.execute("SELECT * FROM shells WHERE shell_id=1").fetchone()
+        rendered = runtime.render_boot(self.con, shell)
+        for issuer, kind, action, success in runtime.TRANSITIONS:
+            self.assertIn(
+                f"| `{issuer}` | `{kind}` | {action} | {success} |",
+                rendered,
+            )
+        self.assertNotIn("## MEMORY", rendered)
+        self.assertNotIn("## SKILLS", rendered)
+        composed = compose.compose_boot(
+            self.con,
+            shell,
+            {"username": "Jed", "user_id": 1},
+            "0001",
+            1,
+        )
+        self.assertEqual(composed, rendered)
+
+    def test_doctor_proves_cli_shell_zero_skills_and_exact_route(self):
+        config = runtime.ConductorConfig(True, "CON1", runtime.DEFAULT_CONDUCTOR_MODEL)
+        result = runtime.doctor(
+            self.con,
+            config,
+            which=lambda binary: f"/bin/{binary}",
+            run=self.model_probe(),
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["harness"], "opencode")
+
+        with self.assertRaisesRegex(
+            runtime.ConductorConfigError, "not locally runnable"
+        ):
+            runtime.doctor(
+                self.con,
+                config,
+                which=lambda binary: f"/bin/{binary}",
+                run=self.model_probe("ollama-cloud/another-model"),
+            )
+
+    def test_wake_is_config_gated_and_single_flight(self):
+        self.emit("dev", "unit-report", {"shipped": "x"})
+        disabled = runtime.maybe_wake(
+            self.con,
+            config=runtime.ConductorConfig(),
+            launcher=self.launcher,
+        )
+        self.assertFalse(disabled["launched"])
+
+        config = runtime.ConductorConfig(True, "CON1", runtime.DEFAULT_CONDUCTOR_MODEL)
+        with (
+            mock.patch.object(runtime, "_launch_is_live", return_value=False),
+            mock.patch.object(runtime.shutil, "which", return_value="/bin/opencode"),
+            mock.patch.object(runtime.subprocess, "run", self.model_probe()),
+        ):
+            first = runtime.maybe_wake(
+                self.con, config=config, launcher=self.launcher, now=lambda: 100.0
+            )
+            second = runtime.maybe_wake(
+                self.con, config=config, launcher=self.launcher, now=lambda: 101.0
+            )
+        self.assertTrue(first["launched"])
+        self.assertEqual(second["reason"], "launching")
+        self.assertEqual(len(self.commands), 1)
+        self.assertIn("--harness", self.commands[0])
+        self.assertIn("opencode", self.commands[0])
+        self.assertIn(runtime.DEFAULT_CONDUCTOR_MODEL, self.commands[0])
+
+    def test_opencode_headless_route_does_not_invent_effort(self):
+        adapter = run.load_adapter("opencode")
+        self.assertIsNone(run.default_headless_effort(adapter))
+        command = run.headless_command(
+            adapter,
+            "act",
+            runtime.DEFAULT_CONDUCTOR_MODEL,
+            effort=run.default_headless_effort(adapter),
+        )
+        self.assertEqual(command[:2], ["opencode", "run"])
+
+
+class ConductorDirectiveMatrixTests(RuntimeFixture):
+    CASES = (
+        (
+            "dev",
+            "ready-for-review",
+            "working",
+            {"pr_number": 7, "head": "abc", "branch": "feat/u1", "checks": "green"},
+            True,
+        ),
+        (
+            "dev",
+            "ask-planner",
+            "working",
+            {"question": "which?", "alternatives": ["a", "b"], "evidence": ["x"]},
+            True,
+        ),
+        (
+            "dev",
+            "merged",
+            "in_review",
+            {"pr_number": 7, "head": "abc", "merge_sha": "def"},
+            True,
+        ),
+        (
+            "dev",
+            "unit-report",
+            "working",
+            {"shipped": "behavior", "judgements": []},
+            True,
+        ),
+        (
+            "reviewer",
+            "review-clean",
+            "in_review",
+            {"head": "abc", "findings": [], "mutation": "failed then passed"},
+            True,
+        ),
+        (
+            "reviewer",
+            "findings",
+            "in_review",
+            {"head": "abc", "findings": [{"severity": "Major"}]},
+            True,
+        ),
+        (
+            "reviewer",
+            "ask-planner",
+            "in_review",
+            {"question": "scope?", "alternatives": ["a", "b"]},
+            True,
+        ),
+        (
+            "planner",
+            "kickoff",
+            "pending",
+            {"to": "DEV1", "instruction": "build", "model": "sonnet"},
+            True,
+        ),
+        (
+            "planner",
+            "hold",
+            "working",
+            {"reason": "missing evidence", "next": "supply it"},
+            True,
+        ),
+        (
+            "planner",
+            "re-scope",
+            "blocked",
+            {"to": "DEV1", "scope": "smaller", "reason": "evidence"},
+            True,
+        ),
+        (
+            "planner",
+            "re-task",
+            "blocked",
+            {"to": "DEV1", "instruction": "new path", "reason": "evidence"},
+            True,
+        ),
+        (
+            "planner",
+            "close",
+            "merged",
+            {"main_sha": "abc", "conformance_directive_id": 77, "summary": "done"},
+            False,
+        ),
+        (
+            "planner",
+            "answer",
+            "blocked",
+            {"to": "DEV1", "question_directive_id": 42, "answer": "choose a"},
+            True,
+        ),
+        (
+            "system",
+            "pr-green",
+            "in_review",
+            {"head_sha": "abc", "transition": "checks:SUCCESS"},
+            True,
+        ),
+        (
+            "system",
+            "pr-red",
+            "in_review",
+            {"head_sha": "abc", "transition": "checks:FAILURE"},
+            True,
+        ),
+        (
+            "system",
+            "pr-merged",
+            "in_review",
+            {"head_sha": "abc", "transition": "merged:MERGED"},
+            True,
+        ),
+        ("system", "stall", "working", {"dwell_seconds": 99}, True),
+        ("system", "dead-shell", "working", {"process": {"live": False}}, True),
+    )
+
+    def test_every_kind_and_issuer_has_one_executable_action(self):
+        self.assertEqual(
+            {(issuer, kind) for issuer, kind, _action, _pass in runtime.TRANSITIONS},
+            {(issuer, kind) for issuer, kind, _state, _payload, _unit in self.CASES},
+        )
+        for issuer, kind, state, payload, linked_unit in self.CASES:
+            with (
+                self.subTest(issuer=issuer, kind=kind),
+                tempfile.TemporaryDirectory(prefix="sc_conductor_case_") as td,
+            ):
+                con = build_db(Path(td) / "case.db")
+                try:
+                    con.executemany(
+                        "INSERT INTO shells "
+                        "(shell_id,display_name,shortname,flavor,"
+                        "system_prompt,api_key) VALUES (?,?,?,?,?,?)",
+                        (
+                            (1, "Conductor", "CON1", "conductor", "x", "con-token"),
+                            (2, "Planner", "PLN1", "planner", "x", "plan-token"),
+                            (3, "Developer", "DEV1", "dev", "x", "dev-token"),
+                            (4, "Reviewer", "REV1", "reviewer", "x", "rev-token"),
+                        ),
+                    )
+                    con.execute(
+                        "INSERT INTO documents "
+                        "(document_id,kind,title,body,frozen) VALUES "
+                        "(100,'doc','SPRINT: case','status: ACTIVE',0)"
+                    )
+                    con.execute(
+                        "INSERT INTO sprint_units "
+                        "(unit_id,sprint_doc_id,seq,unit_title,"
+                        "dev_shell_id,reviewer_shell_id,state,branch,"
+                        "pr_number,review_head) "
+                        "VALUES (10,100,'U1','case',3,4,?,?,7,?)",
+                        (
+                            state,
+                            "feat/u1",
+                            "abc" if kind == "merged" else None,
+                        ),
+                    )
+                    shell_id = {
+                        "dev": 3,
+                        "reviewer": 4,
+                        "planner": 2,
+                        "system": None,
+                    }[issuer]
+                    if kind == "close":
+                        con.execute(
+                            "INSERT INTO directives "
+                            "(directive_id,issuer_shell_id,issuer_flavor,kind,payload,"
+                            "target,sprint_doc_id,unit_id,status,executed_at) "
+                            "VALUES (77,4,'reviewer','review-clean',?,"
+                            "'conductor',100,NULL,'executed',datetime('now'))",
+                            (
+                                json.dumps(
+                                    {
+                                        "mode": "conformance",
+                                        "main_sha": "abc",
+                                        "findings": [],
+                                    }
+                                ),
+                            ),
+                        )
+                    directive_id = con.execute(
+                        "INSERT INTO directives "
+                        "(issuer_shell_id,issuer_flavor,kind,payload,"
+                        "target,sprint_doc_id,unit_id) "
+                        "VALUES (?,?,?,?, 'conductor',100,?)",
+                        (
+                            shell_id,
+                            issuer,
+                            kind,
+                            json.dumps(payload),
+                            10 if linked_unit else None,
+                        ),
+                    ).lastrowid
+                    con.commit()
+                    result = runtime.act(con, directive_id, 1, launcher=self.launcher)
+                    self.assertEqual(result["status"], "executed")
+                    row = con.execute(
+                        "SELECT status,refusal_reason FROM directives "
+                        "WHERE directive_id=?",
+                        (directive_id,),
+                    ).fetchone()
+                    self.assertEqual(tuple(row), ("executed", None))
+                    event = con.execute(
+                        "SELECT event_kind FROM sentinel_events WHERE directive_id=?",
+                        (directive_id,),
+                    ).fetchone()
+                    self.assertEqual(event[0], "conductor-executed")
+                finally:
+                    con.close()
+
+    def test_malformed_payload_is_refused_and_escalated(self):
+        directive_id = self.emit("dev", "ready-for-review", {"pr_number": "not-int"})
+        self.con.commit()
+        result = runtime.act(self.con, directive_id, 1, launcher=self.launcher)
+        self.assertEqual(result["status"], "refused")
+        self.assertIn("payload.pr_number", result["reason"])
+        self.assertIn("command", result["escalation"])
+        self.assertIn("PLN1", result["escalation"]["command"])
+        self.assertEqual(
+            self.con.execute(
+                "SELECT status FROM directives WHERE directive_id=?",
+                (directive_id,),
+            ).fetchone()[0],
+            "refused",
+        )
+
+    def test_refusal_rolls_back_partial_board_changes(self):
+        self.set_unit("working")
+        self.con.execute("UPDATE shells SET is_deleted=1 WHERE shell_id=4")
+        directive_id = self.emit(
+            "dev",
+            "ready-for-review",
+            {
+                "pr_number": 99,
+                "head": "new-head",
+                "branch": "feat/new",
+                "checks": "green",
+            },
+        )
+        self.con.commit()
+
+        result = runtime.act(self.con, directive_id, 1, launcher=self.launcher)
+
+        self.assertEqual(result["status"], "refused")
+        unit = self.con.execute(
+            "SELECT state,pr_number,branch FROM sprint_units WHERE unit_id=10"
+        ).fetchone()
+        self.assertEqual(tuple(unit), ("working", 7, "feat/u1"))
+
+    def test_non_conductor_cannot_act(self):
+        directive_id = self.emit("dev", "unit-report", {"shipped": "x"})
+        self.con.commit()
+        with self.assertRaisesRegex(PermissionError, "conductor"):
+            runtime.act(self.con, directive_id, 2, launcher=self.launcher)
+
+
+class ConductorSyntheticSprintTests(RuntimeFixture):
+    def act_one(self, issuer, kind, payload, *, unit=True):
+        directive_id = self.emit(issuer, kind, payload, unit=unit)
+        self.con.commit()
+        result = runtime.act(self.con, directive_id, 1, launcher=self.launcher)
+        self.assertEqual(result["status"], "executed")
+        return directive_id
+
+    def test_kickoff_to_merge_to_conformance_to_close_without_human_input(self):
+        ids = [
+            self.act_one(
+                "planner",
+                "kickoff",
+                {
+                    "to": "DEV1",
+                    "instruction": "build synthetic unit",
+                    "model": "sonnet",
+                },
+            ),
+            self.act_one(
+                "dev",
+                "ready-for-review",
+                {"pr_number": 7, "head": "abc", "branch": "feat/u1", "checks": "green"},
+            ),
+            self.act_one(
+                "reviewer",
+                "review-clean",
+                {"head": "abc", "findings": [], "mutation": "failed then passed"},
+            ),
+            self.act_one(
+                "dev", "merged", {"pr_number": 7, "head": "abc", "merge_sha": "def"}
+            ),
+            self.act_one(
+                "reviewer",
+                "review-clean",
+                {
+                    "mode": "conformance",
+                    "main_sha": "def",
+                    "verdicts": [{"requirement": "all", "verdict": "as-specced"}],
+                    "findings": [],
+                },
+                unit=False,
+            ),
+        ]
+        ids.append(
+            self.act_one(
+                "planner",
+                "close",
+                {
+                    "main_sha": "def",
+                    "conformance_directive_id": ids[-1],
+                    "summary": "synthetic sprint complete",
+                },
+                unit=False,
+            )
+        )
+
+        unit = self.con.execute(
+            "SELECT state,review_head,updated_by_shell_id "
+            "FROM sprint_units WHERE unit_id=10"
+        ).fetchone()
+        self.assertEqual(tuple(unit), ("merged", "abc", 1))
+        self.assertEqual(
+            self.con.execute(
+                "SELECT frozen FROM documents WHERE document_id=100"
+            ).fetchone()[0],
+            1,
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM directives WHERE issuer_flavor='conductor'"
+            ).fetchone()[0],
+            0,
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM directives WHERE status='executed'"
+            ).fetchone()[0],
+            6,
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM sentinel_events "
+                "WHERE event_kind='conductor-executed'"
+            ).fetchone()[0],
+            6,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -190,8 +190,18 @@ class ConductorFlavorAndDoctorTests(RuntimeFixture):
         config = runtime.ConductorConfig(True, "CON1", runtime.DEFAULT_CONDUCTOR_MODEL)
         with (
             mock.patch.object(runtime, "_launch_is_live", return_value=False),
-            mock.patch.object(runtime.shutil, "which", return_value="/bin/opencode"),
-            mock.patch.object(runtime.subprocess, "run", self.model_probe()),
+            mock.patch.object(
+                runtime,
+                "doctor",
+                return_value={
+                    "enabled": True,
+                    "ok": True,
+                    "shell_id": 1,
+                    "shell": "CON1",
+                    "harness": "opencode",
+                    "model": runtime.DEFAULT_CONDUCTOR_MODEL,
+                },
+            ),
         ):
             first = runtime.maybe_wake(
                 self.con, config=config, launcher=self.launcher, now=lambda: 100.0

--- a/tests/test_flavor_skill_packs.py
+++ b/tests/test_flavor_skill_packs.py
@@ -85,9 +85,12 @@ class HardCutoverMigrationTest(unittest.TestCase):
                     (template["flavor"],),
                 )
             }
+            inherited = (
+                common if template.get("inherit_common_skills", True) else set()
+            )
             self.assertEqual(
                 actual,
-                common | set(template.get("skills", [])),
+                inherited | set(template.get("skills", [])),
                 template["flavor"],
             )
 


### PR DESCRIPTION
## Summary

- add a zero-skill `conductor` flavor routed to OpenCode `ollama-cloud/gpt-oss:20b`, with a minimal exhaustive transition-table boot
- add config-time auth/routability doctor, config-gated pending-row wake, authenticated `directives act`, transactional board transitions, refusal rollback/escalation, and durable action trails
- add full issuer/kind matrix coverage, synthetic kickoff-to-close proof, and a real weak-model matrix harness

## Verification

- `tests/run_conductor_real_matrix.py`: real gpt-oss:20b drained 19 actions; 19 executed (including conformance proof), 1 malformed refused, 0 pending, 19 trail events
- focused: 153 passed, 57 subtests passed
- full: 1412 passed, 612 subtests passed
- `./sc render-check`
- `./sc verify`
- `git diff --check`

Targets the long-lived `conductor` rollout branch. Step 6 soak/calibration remains an independent prerequisite for Step 9.