### PR TITLE
fix(cli): derive installed API port

### DIFF
--- a/.super-coder/scripts/conductor_contracts.py
+++ b/.super-coder/scripts/conductor_contracts.py
@@ -10,13 +10,25 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-SC_API_BASE = os.environ.get("SC_API_BASE", "http://127.0.0.1:8800")
+import ports as ports_mod
+
+SC_API_BASE = os.environ.get("SC_API_BASE", "")
 SC_API_TOKEN = os.environ.get("SC_API_TOKEN", "")
 _TIMEOUT = 10
 
 
 def _die(msg: str) -> "SystemExit":
     return SystemExit(f"sc conductor: {msg}")
+
+
+def _api_base() -> str:
+    if SC_API_BASE:
+        return SC_API_BASE.rstrip("/")
+    try:
+        port = ports_mod.resolve()["port"]
+    except (KeyError, OSError, TypeError, ValueError) as exc:
+        raise _die(f"could not resolve this install's API URL: {exc}") from exc
+    return f"http://127.0.0.1:{port}"
 
 
 def _api(method: str, path: str, payload=None):
@@ -28,7 +40,7 @@ def _api(method: str, path: str, payload=None):
         data = json.dumps(payload).encode()
         headers["Content-Type"] = "application/json"
     req = urllib.request.Request(
-        SC_API_BASE.rstrip("/") + path,
+        _api_base() + path,
         data=data,
         method=method,
         headers=headers,

--- a/.super-coder/scripts/sprint.py
+++ b/.super-coder/scripts/sprint.py
@@ -53,13 +53,25 @@ import urllib.error
 import urllib.request
 import uuid
 
-SC_API_BASE = os.environ.get("SC_API_BASE", "http://127.0.0.1:8800")
+import ports as ports_mod
+
+SC_API_BASE = os.environ.get("SC_API_BASE", "")
 SC_API_TOKEN = os.environ.get("SC_API_TOKEN", "")
 _TIMEOUT = 10
 
 
 def _die(msg: str) -> "SystemExit":
     return SystemExit(f"sc sprint: {msg}")
+
+
+def _api_base() -> str:
+    if SC_API_BASE:
+        return SC_API_BASE.rstrip("/")
+    try:
+        port = ports_mod.resolve()["port"]
+    except (KeyError, OSError, TypeError, ValueError) as exc:
+        raise _die(f"could not resolve this install's API URL: {exc}") from exc
+    return f"http://127.0.0.1:{port}"
 
 
 def _api(method: str, path: str, payload: "dict | None" = None,
@@ -74,7 +86,7 @@ def _api(method: str, path: str, payload: "dict | None" = None,
     if idem_key:
         headers["Idempotency-Key"] = idem_key
     req = urllib.request.Request(
-        SC_API_BASE.rstrip("/") + path, data=data, method=method,
+        _api_base() + path, data=data, method=method,
         headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:

--- a/tests/test_conductor_contracts.py
+++ b/tests/test_conductor_contracts.py
@@ -19,6 +19,8 @@ STEP4 = MIGRATIONS / "0119_conductor_contracts.sql"
 sys.path.insert(0, str(ENGINE / "api"))
 import conductor_routes  # noqa: E402
 import snapshot as snapshot_mod  # noqa: E402
+sys.path.insert(0, str(ENGINE / "scripts"))
+import conductor_contracts as conductor_cli  # noqa: E402
 
 
 def build_file_db(path: Path, *, include_step4: bool = True) -> sqlite3.Connection:
@@ -36,6 +38,23 @@ def build_file_db(path: Path, *, include_step4: bool = True) -> sqlite3.Connecti
 def response(result):
     status, _headers, body = result
     return status, json.loads(body)
+
+
+class ConductorClientApiBaseTests(unittest.TestCase):
+    def test_uses_the_installed_instance_port_when_launch_did_not_inject_one(self):
+        with mock.patch.object(conductor_cli, "SC_API_BASE", ""), \
+                mock.patch.object(
+                    conductor_cli.ports_mod, "resolve",
+                    return_value={"port": 8842},
+                ):
+            self.assertEqual(
+                conductor_cli._api_base(), "http://127.0.0.1:8842")
+
+    def test_launch_injected_api_base_wins(self):
+        with mock.patch.object(
+                conductor_cli, "SC_API_BASE", "http://127.0.0.1:8899/"):
+            self.assertEqual(
+                conductor_cli._api_base(), "http://127.0.0.1:8899")
 
 
 class ConductorContractTests(unittest.TestCase):

--- a/tests/test_sprint_board_record.py
+++ b/tests/test_sprint_board_record.py
@@ -85,6 +85,23 @@ class SharedStateVocabularyTest(unittest.TestCase):
         )
 
 
+class SprintClientApiBaseTests(unittest.TestCase):
+    def test_uses_the_installed_instance_port_when_launch_did_not_inject_one(self):
+        with mock.patch.object(sprint_cli, "SC_API_BASE", ""), \
+                mock.patch.object(
+                    sprint_cli.ports_mod, "resolve",
+                    return_value={"port": 8842},
+                ):
+            self.assertEqual(
+                sprint_cli._api_base(), "http://127.0.0.1:8842")
+
+    def test_launch_injected_api_base_wins(self):
+        with mock.patch.object(
+                sprint_cli, "SC_API_BASE", "http://127.0.0.1:8899/"):
+            self.assertEqual(
+                sprint_cli._api_base(), "http://127.0.0.1:8899")
+
+
 def build_engine_db(path: Path) -> None:
     con = sqlite3.connect(path)
     con.executescript(SCHEMA.read_text())


### PR DESCRIPTION
## Outcome

- make `sc directives`, `sc events`, and `sc sprint` use the API port persisted for the current install through the existing `ports.resolve()` authority
- retain launch-injected `SC_API_BASE` as the explicit override
- remove the fixed port 8800 fallback
- add regression coverage for installed-port resolution and launch overrides

Addresses #696.

## Verification

- focused: 71 passed, 23 subtests passed
- full: 1416 passed (`MAKEFLAGS=--no-print-directory`; #697 records the unrelated GNU Make 4.4.1 dry-run banner assertion)
- `./sc render-check`
- `./sc verify`
- `git diff --check`
- live subfloor route proof: derived-port events read succeeds; invalid sprint credential reaches port 8801 and returns 401 rather than port-8800 404