### PR TITLE
chore(conductor): reconcile main-only commits

### DIFF
--- a/.super-coder/migrations/0108_reseed_decisions_chain_stop_rule.sql
+++ b/.super-coder/migrations/0108_reseed_decisions_chain_stop_rule.sql
@@ -1,0 +1,34 @@
+-- 0108 — decisions: chain stop-rule on the always-loaded boot path
+--
+-- Follow-up to 0044/#274 (index/library split). The index already excludes
+-- superseded rows, but shells — Opus seats especially — still walk decision
+-- chains: a flag/spec/feature cites a decision, the citation resolves to a
+-- superseded row, and the shell follows parent links outward "for context."
+-- The citation-follow itself is fine (that IS the explicit direction); the
+-- failure mode is the walk that continues past the first hop.
+--
+-- Fix (norm only, no read-path change): one stop-rule paragraph in the
+-- always-loaded shell system prompt — active decisions load by subject;
+-- superseded decisions are history, loaded only on explicit direction or
+-- when auditing why a decision changed; parent chains are provenance, not
+-- trails. Spliced into existing shells' prompts anchored on the 0044
+-- "Read before you decide" paragraph, 0037/0044-style; the template covers
+-- shells created from here on. Guarded idempotent.
+
+BEGIN;
+
+UPDATE shells
+   SET system_prompt = REPLACE(system_prompt,
+       'never silently re-litigate.',
+       'never silently re-litigate.
+
+**Chains are provenance, not trails.** Active decisions are working context —
+load them by subject when they bear on the work. A citation in a flag, spec, or
+feature may resolve to a superseded decision; that''s fine — read the superseding
+row it points to and move on. Never walk parent chains as context-gathering;
+load decision history only when explicitly directed, or when auditing why a
+decision changed.')
+ WHERE system_prompt LIKE '%never silently re-litigate.%'
+   AND system_prompt NOT LIKE '%provenance, not trails%';
+
+COMMIT;

--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -6,9 +6,9 @@ catalogue, the render chain) but **no per-instance content** — a fork inherits
 the system, never super-coder's memory or roadmap. So a just-installed fork has
 no users and no shells, and `./sc launch` has nothing to authenticate or boot.
 This provisions the local user, then seeds the starting team via the shared
-shell factory: your primary shell (default `planner`) plus an `admin`, two
-`dev`, a `reviewer`, and the singleton `cartographer` — the full roster out of
-the box.
+shell factory: two `planner`, four `dev`, two `reviewer` shells, an `admin`, and the
+singleton `cartographer` — a ten-shell roster out of the box. One planner is
+your primary by default.
 
 Run ONCE, right after `./sc rebuild`, on a fresh fork. Refuses if a shell already
 exists. After it runs: `SC_ADMIN=1 ./sc snapshot`, then `./sc launch`. More shells (or
@@ -39,8 +39,18 @@ import install as install_mod  # noqa: E402
 
 # The starting team seeded at install, besides the singleton cartographer (added
 # separately below). Your interviewed primary shell — default planner — fills one
-# of these slots; the rest are auto-named team members (ADM1, DEV1, DEV2, REV1).
-TEAM_ROSTER = ["admin", "planner", "dev", "dev", "reviewer"]
+# of these slots; the rest are auto-named team members.
+TEAM_ROSTER = [
+    "admin",
+    "planner",
+    "planner",
+    "dev",
+    "dev",
+    "dev",
+    "dev",
+    "reviewer",
+    "reviewer",
+]
 
 from shell_factory import create_shell, flavors  # noqa: E402
 
@@ -123,7 +133,7 @@ def main(argv: list[str]) -> int:
             partner=a.partner or username, repo=repo,
             role=a.role, mandate=a.mandate)
         # The rest of the starting team — the full roster minus the slot your
-        # primary already fills — auto-named by the factory (ADM1/DEV1/DEV2/REV1).
+        # primary already fills — auto-named by the factory.
         rest = list(TEAM_ROSTER)
         if flavor in rest:
             rest.remove(flavor)

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -15,10 +15,10 @@ from "engine present" to "a team you can launch":
                  SYSTEM (schema + skill catalogue + render chain), never the memory.
     5. Build   — the system DB (schema + migrations; no per-instance content yet).
     6. Seed    — the fork's first user + starting TEAM (delegates to init_fork:
-                 your primary planner plus an admin, two dev, a reviewer, and the
-                 singleton cartographer — each with the CC lineage + a genesis seed
-                 + skill grants). Shells ship pre-named, so install asks only for a
-                 username; no shell-naming interview.
+                 two planners, four dev, two reviewers, an admin, and the singleton
+                 cartographer — each with the CC lineage + a genesis seed + skill
+                 grants). Shells ship pre-named, so install asks only for a username;
+                 no shell-naming interview.
     7. Persist — `./sc snapshot` (serialize the team) + `./sc render` (flat _sc).
     8. Done    — print how to launch.
 

--- a/.super-coder/templates/shell_system_prompt.md
+++ b/.super-coder/templates/shell_system_prompt.md
@@ -34,6 +34,13 @@ architectural or approach decision, lazy-load the log: `sc mem get decisions`
 rationale). Honor a prior decision or supersede it explicitly (`--parent`) —
 never silently re-litigate.
 
+**Chains are provenance, not trails.** Active decisions are working context —
+load them by subject when they bear on the work. A citation in a flag, spec, or
+feature may resolve to a superseded decision; that's fine — read the superseding
+row it points to and move on. Never walk parent chains as context-gathering;
+load decision history only when explicitly directed, or when auditing why a
+decision changed.
+
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is generated from the DB.
 If one looks wrong or out of date, the DB row is wrong — fix it via `sc mem`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@ that must survive is its DB, serialized to the tracked `.sc-state/content.sql`.
 ### Quick start
 
 > [!class2]
-> **UI** Shells (your landing tab) · **Shells** your starting team — planner · 2×dev · reviewer · admin · cartographer
+> **UI** Shells (your landing tab) · **Shells** your starting team — 2×planner · 4×dev · 2×reviewer · admin · cartographer
 
 **Preparation**
 
@@ -136,7 +136,7 @@ arc from a fresh repo through ship-and-loop, see [*The loop*](#the-loop).
 ### Installer internals
 
 > [!class2]
-> **UI** Shells · Scripts · **Shells** seeds the starting team — planner · 2×dev · reviewer · admin · cartographer
+> **UI** Shells · Scripts · **Shells** seeds the starting team — 2×planner · 4×dev · 2×reviewer · admin · cartographer
 
 subfloor installs **alongside** your code — it renders to `_sc` dirs, so it
 never collides with your repo's own `/docs`, `/specs`, or skills. A fork
@@ -185,9 +185,9 @@ files stay on disk; pins its upstream SHA in `.sc-state/engine.ref`), **strips
 subfloor's own per-instance content** (a fork inherits the *system* — schema +
 skill catalogue + render chain — never the memory or roadmap), builds the system
 DB, seeds your fork's **starting team** (your user + a planner-flavor *primary*
-carrying the CC Lineage Seed and its own genesis seed, plus two `dev`, a
-`reviewer`, the `admin` that owns `main`, and the singleton **Cartographer**
-repo-map owner), and renders. So after install
+carrying the CC Lineage Seed and its own genesis seed, plus a second `planner`,
+four `dev`, two `reviewer` shells, the `admin` that owns `main`, and the singleton
+**Cartographer** repo-map owner), and renders. So after install
 your git surfaces show only your project — the engine no longer appears in
 `git status`. It refuses to run in the subfloor source repo or on an
 already-installed fork (guarding against content loss).
@@ -286,9 +286,10 @@ it owns:
 | **reviewer** | `test_authoring` · `database-migrations` · `redline_review` · `api-design` · `flags` | review |
 | **admin** | `git_cleanup` · `self_update` · `migration_management` · `local_skill_management` | engine · verify-clean |
 
-1. **Install** — `./sc install` seeds your **starting team**: a `planner` (your
-   primary), two `dev`, a `reviewer`, the `admin` that owns `main` + the engine,
-   and the singleton `cartographer`. *(admin · `self_update`, `migration_management` · UI: Shells)*
+1. **Install** — `./sc install` seeds your **starting team**: two `planner`
+   (one is your primary), four `dev`, two `reviewer` shells, the `admin` that owns
+   `main` + the engine, and the singleton `cartographer`.
+   *(admin · `self_update`, `migration_management` · UI: Shells)*
 2. **Map the repo** — the cartographer configures the index once with
    `./sc map-setup`, then `./sc map` builds it; git hooks re-map on every pull.
    It's infrastructure working shells *read* via `surface_catalogue`.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -89,10 +89,10 @@ keeps running if you close the terminal.
   is the landing view — each shell's role, mandate, current state, and
   identity. The other tabs, the roadmap views, and the token analytics:
   [*Review GUI*](README.md#review-gui).
-- **Meet the team.** The installer seeded a planner (your primary), two devs,
-  a reviewer, the admin that owns `main`, and the cartographer that owns the
-  repo map. Each boots into its own worktree; how they share one repo without
-  collisions: [*Shells & worktrees*](README.md#shells--worktrees).
+- **Meet the team.** The installer seeded two planners (one is your primary),
+  four devs, two reviewers, the admin that owns `main`, and the cartographer
+  that owns the repo map. Each boots into its own worktree; how they share one
+  repo without collisions: [*Shells & worktrees*](README.md#shells--worktrees).
 - **First acts.** Let the cartographer map the repo on its first boot, then
   tell the planner what you're building — it authors the roadmap and the
   first spec.

--- a/tests/test_visual_qa_distribution.py
+++ b/tests/test_visual_qa_distribution.py
@@ -137,7 +137,7 @@ class VisualQaSeedTest(unittest.TestCase):
                 "WHERE sh.flavor IS NULL;"
             )
 
-        next_shell_id = iter(range(1, 7))
+        next_shell_id = iter(range(1, 11))
 
         def create_shell(con, *, flavor, **_kwargs):
             shell_id = next(next_shell_id)
@@ -165,7 +165,25 @@ class VisualQaSeedTest(unittest.TestCase):
         seed.assert_called_once_with()
         with sqlite3.connect(database) as con:
             self.assertEqual(con.execute("SELECT username FROM users").fetchall(), [("Jed",)])
-            self.assertEqual(con.execute("SELECT COUNT(*) FROM shells").fetchone()[0], 6)
+            flavors = con.execute(
+                "SELECT flavor FROM shells ORDER BY shell_id"
+            ).fetchall()
+            self.assertEqual(
+                flavors,
+                [
+                    ("planner",),
+                    ("admin",),
+                    ("planner",),
+                    ("dev",),
+                    ("dev",),
+                    ("dev",),
+                    ("dev",),
+                    ("reviewer",),
+                    ("reviewer",),
+                    ("cartographer",),
+                ],
+            )
+            self.assertNotIn(("devops",), flavors)
 
 
 class VisualQaUpdateTest(unittest.TestCase):


### PR DESCRIPTION
## Outcome

Merge current `main` into `conductor` before promotion, preserving the two main-only commits and their original history/attribution:

- `4afff5b` — decision-chain stop rule on the always-loaded boot path
- `24898a0` — larger default install team (2 planners, 4 devs, 2 reviewers, admin, cartographer)

The merge applied cleanly and stages exactly the seven files owned by those commits. No Interface/TMUX implementation returns. After this lands, `main` is an ancestor of the reconciled Conductor line, allowing protected promotion without force-pushing or discarding useful work.

## Verification

- focused: 54 passed, 4 subtests passed
- full: 1416 passed
- `./sc render-check`
- `./sc verify`
- `git diff --check`