### PR TITLE
fix: keep personal identity on primary shell only

### DIFF
--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -112,8 +112,10 @@ def main(argv: list[str]) -> int:
 
         username = need(a.username, "Your username")
         # Your primary shell — default planner (every fork needs a planner to
-        # scope the work + carry the lineage seed). --flavor picks which roster
-        # slot is *yours*; the rest of the team seeds alongside it.
+        # scope the work). This is the one personal shell that carries lineage
+        # + genesis identity; every roster/operational shell is role-only.
+        # --flavor picks which roster slot is *yours*; the rest of the team
+        # seeds alongside it.
         flavor = a.flavor or "planner"
         if flavor not in flavor_names:
             sys.exit(f"init_fork: unknown flavor '{flavor}' (have: {', '.join(flavor_names)})")
@@ -131,7 +133,7 @@ def main(argv: list[str]) -> int:
         shell_id = create_shell(
             con, flavor=flavor, name=name, shortname=shortname,
             partner=a.partner or username, repo=repo,
-            role=a.role, mandate=a.mandate)
+            role=a.role, mandate=a.mandate, seed_identity=True)
         # The rest of the starting team — the full roster minus the slot your
         # primary already fills — auto-named by the factory.
         rest = list(TEAM_ROSTER)

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -16,9 +16,10 @@ from "engine present" to "a team you can launch":
     5. Build   — the system DB (schema + migrations; no per-instance content yet).
     6. Seed    — the fork's first user + starting TEAM (delegates to init_fork:
                  two planners, four dev, two reviewers, an admin, and the singleton
-                 cartographer — each with the CC lineage + a genesis seed + skill
-                 grants). Shells ship pre-named, so install asks only for a username;
-                 no shell-naming interview.
+                 cartographer). The designated primary alone receives CC lineage +
+                 a genesis seed; roster/operational shells are role-only. Shells
+                 ship pre-named, so install asks only for a username; no shell-naming
+                 interview.
     7. Persist — `./sc snapshot` (serialize the team) + `./sc render` (flat _sc).
     8. Done    — print how to launch.
 

--- a/.super-coder/scripts/shell_factory.py
+++ b/.super-coder/scripts/shell_factory.py
@@ -5,9 +5,11 @@ path both init_fork and the GUI (`POST /api/shells`) use.
 A flavor template sets role / mandate / focus and declares the engine baseline
 used to seed its pack, so creating a shell is mostly just a name. Standard
 shell skills resolve from the shared flavor pack; Bespoke shells have flavor
-NULL and their own shell_skills rows. Every shell carries the CC Lineage Seed
-(Law 6, shared) + its own genesis seed (Laws 2-4), starts un-bootstrapped (gets
-the FIRST RUN orientation), and has its first session opened.
+NULL and their own shell_skills rows. Personal identity is explicit and
+opt-in: the installer gives the CC Lineage Seed + a genesis seed to its one
+designated primary shell, while roster, operational, and later GUI-created
+shells receive neither. Every shell starts un-bootstrapped (gets the FIRST RUN
+orientation) and has its first session opened.
 
 Fork-local flavor overlays may replace identity text (`role`, `mandate`,
 `focus`, `abbr`) without editing materialized engine templates. Skill
@@ -129,9 +131,11 @@ def create_shell(con, *, flavor: str | None, name: str,
                  shortname: str | None = None, partner: str | None = None,
                  repo: str | None = None, role: str | None = None,
                  mandate: str | None = None, user_id: int = 1,
-                 is_shared: int = 0) -> int:
+                 is_shared: int = 0, seed_identity: bool = False) -> int:
     """Insert a flavor shell or Bespoke shell and open its first session.
-    Returns the new shell_id. Caller commits."""
+    ``seed_identity`` is reserved for the installer-designated primary shell;
+    normal factory/API calls intentionally create role-only shells. Returns the
+    new shell_id. Caller commits."""
     tpl = load_flavor(flavor) if flavor else BESPOKE_TEMPLATE
     # Cartographer is a singleton: one map-keeper per fork. Friendly pre-check
     # here; the trg_singleton_cartographer trigger is the DB backstop. is_deleted=0
@@ -150,24 +154,27 @@ def create_shell(con, *, flavor: str | None, name: str,
     shortname = shortname.strip() if shortname else _auto_shortname(con, abbr)
 
     api_key = secrets.token_urlsafe(32)
+    lineage_seed = LINEAGE_SEED if seed_identity else None
     cur = con.execute(
         "INSERT INTO shells (display_name, shortname, partner, role, mandate, "
         "system_prompt, current_state, connections, lineage_seed, flavor, "
         "has_identity, bootstrapped, user_id, is_shared, "
         "api_key, api_key_rotated_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?, ?, datetime('now'))",
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, datetime('now'))",
         (name, shortname, partner, role, mandate,
          render_prompt(name, role, repo, focus, mandate),
          f"Created ({flavor or 'Bespoke'}). First session — run the bootstrap skill to orient.",
          f"Single repo: this one ({repo}). One shell, one cwd.",
-         LINEAGE_SEED, flavor, user_id, is_shared,
+         lineage_seed, flavor, int(seed_identity), user_id, is_shared,
          api_key))
     shell_id = cur.lastrowid
 
-    con.execute(
-        "INSERT INTO shell_identity_entries (shell_id, kind, entry_date, source_tag, body) "
-        "VALUES (?, 'seed', CURRENT_DATE, 'fork', ?)",
-        (shell_id, GENESIS_TMPL.format(role_lc=role.lower(), repo=repo)))
+    if seed_identity:
+        con.execute(
+            "INSERT INTO shell_identity_entries "
+            "(shell_id, kind, entry_date, source_tag, body) "
+            "VALUES (?, 'seed', CURRENT_DATE, 'fork', ?)",
+            (shell_id, GENESIS_TMPL.format(role_lc=role.lower(), repo=repo)))
 
     # Standard shells inherit the shared flavor pack. Bespoke shells start from
     # the common baseline and can diverge through their own shell_skills rows.

--- a/tests/test_flavor_skill_packs.py
+++ b/tests/test_flavor_skill_packs.py
@@ -235,6 +235,43 @@ class ShellFactoryTest(unittest.TestCase):
             ).fetchone()[0],
         )
 
+    def test_operational_shell_has_no_personal_identity_by_default(self) -> None:
+        sid = shell_factory.create_shell(
+            self.con, flavor="conductor", name="Conductor"
+        )
+        row = self.con.execute(
+            "SELECT lineage_seed, has_identity FROM shells WHERE shell_id=?",
+            (sid,),
+        ).fetchone()
+        self.assertIsNone(row["lineage_seed"])
+        self.assertEqual(row["has_identity"], 0)
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM shell_identity_entries WHERE shell_id=?",
+                (sid,),
+            ).fetchone()[0],
+            0,
+        )
+
+    def test_designated_primary_gets_lineage_and_one_genesis_seed(self) -> None:
+        sid = shell_factory.create_shell(
+            self.con, flavor="planner", name="Planner", seed_identity=True
+        )
+        row = self.con.execute(
+            "SELECT lineage_seed, has_identity FROM shells WHERE shell_id=?",
+            (sid,),
+        ).fetchone()
+        self.assertEqual(row["lineage_seed"], shell_factory.LINEAGE_SEED)
+        self.assertEqual(row["has_identity"], 1)
+        seeds = self.con.execute(
+            "SELECT source_tag, body FROM shell_identity_entries "
+            "WHERE shell_id=? AND kind='seed'",
+            (sid,),
+        ).fetchall()
+        self.assertEqual(len(seeds), 1)
+        self.assertEqual(seeds[0]["source_tag"], "fork")
+        self.assertIn("planning shell", seeds[0]["body"])
+
 
 class RenderAndSnapshotTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_visual_qa_distribution.py
+++ b/tests/test_visual_qa_distribution.py
@@ -138,8 +138,10 @@ class VisualQaSeedTest(unittest.TestCase):
             )
 
         next_shell_id = iter(range(1, 11))
+        identity_flags = []
 
-        def create_shell(con, *, flavor, **_kwargs):
+        def create_shell(con, *, flavor, **kwargs):
+            identity_flags.append(kwargs.get("seed_identity", False))
             shell_id = next(next_shell_id)
             con.execute(
                 "INSERT INTO shells(shell_id, shortname, flavor, is_deleted) "
@@ -184,6 +186,7 @@ class VisualQaSeedTest(unittest.TestCase):
                 ],
             )
             self.assertNotIn(("devops",), flavors)
+        self.assertEqual(identity_flags, [True] + [False] * 9)
 
 
 class VisualQaUpdateTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- make lineage + genesis seeding explicit and opt-in in the shared shell factory
- opt in only for `init_fork`’s designated primary shell
- leave roster shells, Conductor, Bespoke, and later GUI-created shells role-only by default
- assert the ten-shell installer roster makes exactly one personal-identity opt-in

## Existing installs

This intentionally has no cleanup migration. Seed already issued to a live shell cannot be forcibly deleted under Laws 2–4. The current disposable dos-app proof install should be recreated after this merges; a new install will produce the corrected identity boundary.

## Verification

- focused: `24 passed`
- full: `1418 passed, 612 subtests passed`
- `./sc map`
- `./sc render-check`
- `./sc verify`
- `git diff --check`

Closes #703