### PR TITLE
docs: fetch only main during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Drop subfloor into an existing git repo and boot a shell:
 ```bash
 cd your-repo                                                  # an existing git repo
 
-# 1. Pull in the engine + entry script (files only, no history merge):
-git remote add super-coder https://github.com/jedbjorn/subfloor.git
+# 1. Pull in the engine + entry script (files only, main branch only, no history merge):
+git remote add -t main super-coder https://github.com/jedbjorn/subfloor.git
 git fetch super-coder
 git checkout super-coder/main -- .super-coder sc
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,8 +110,8 @@ boot a shell:
 ```bash
 cd your-repo                                                  # an existing git repo
 
-# 1. Pull in the engine + entry script (files only, no history merge):
-git remote add super-coder https://github.com/jedbjorn/subfloor.git
+# 1. Pull in the engine + entry script (files only, main branch only, no history merge):
+git remote add -t main super-coder https://github.com/jedbjorn/subfloor.git
 git fetch super-coder
 git checkout super-coder/main -- .super-coder sc
 
@@ -873,7 +873,7 @@ new floor.
   engine branch. `--ref <tag|sha>` pins the materialize to a specific upstream
   version instead of the branch head — hold a fork at a known-good engine and
   move deliberately.
-- Missing remote? `git remote add super-coder https://github.com/jedbjorn/subfloor.git`
+- Missing remote? `git remote add -t main super-coder https://github.com/jedbjorn/subfloor.git`
 
 > [!class4]
 > **Local engine edits block the update — never silently overwritten.** The


### PR DESCRIPTION
## Summary
- configure the install remote with `-t main`
- keep the landing and full install guides aligned
- apply the same main-only rule to missing-remote recovery

## Verification
- throwaway git repo fetched only `super-coder/main` plus its symbolic HEAD
- 1434 tests passed, 2 known linked-worktree Make assertions deselected, 617 subtests passed
- render-check passed
- verify passed
- git diff --check passed

## Repository cleanup
- audited 191 upstream branches with zero open PRs and only `main` protected
- deleted 188 stale merged/closed/abandoned branches
- retained `main`, `archive/interface-tmux-main-2026-07-29`, and `parked/cc-review-test-doctrine`