### PR TITLE
fix: harden fresh-install shell contract

### DIFF
--- a/.super-coder/assets/skills/cartographer/SKILL.md
+++ b/.super-coder/assets/skills/cartographer/SKILL.md
@@ -49,10 +49,12 @@ and reload on a fresh map db.
    Eyeball the top-level dirs -> anything mis-classified, or a
    generated/vendored dir being indexed?
 
-2. **Author the active map config** — `.sc-state/map.config.json` in tracked
-   mode or `.sc-state/local/map/config.json` in local mode. It is per-instance
-   and survives `sc update`. All keys optional; each merges over `map_repo.py`
-   defaults:
+2. **Author the active map config at the canonical live root** —
+   `$SC_ROOT/.sc-state/map.config.json` in tracked mode or
+   `$SC_ROOT/.sc-state/local/map/config.json` in local mode. The mapper
+   deliberately reads the shared live checkout, not your shell worktree. It is
+   per-instance and survives `sc update`. All keys optional; each merges over
+   `map_repo.py` defaults:
    ```json
    {
      "skip_dirs":  ["generated", "fixtures"],
@@ -87,9 +89,13 @@ and reload on a fresh map db.
 5. **Describe — NULLs and filler** — run the description worklist (Standing
    jobs § 2); leave only when it returns zero rows, NULLs and filler both.
 
-6. **Commit** the config + hooks (`git` skill) -> `sc mem state "…"` ->
-   `sc mem oriented` (sets `bootstrapped=1` — the write is live in the
-   shared DB; it does NOT snapshot).
+6. **Persist by mode.** Hook wiring is per-clone runtime state, never a commit.
+   In tracked mode, use the `messaging` skill to send admin the exact canonical
+   path (`.sc-state/map.config.json`) and verification result; only admin may
+   commit the main checkout. In local mode, the config is intentionally ignored
+   and needs no commit. Do not branch or commit the main checkout from the
+   cartographer shell. Then `sc mem state "…"` -> `sc mem oriented` (sets
+   `bootstrapped=1` — the write is live in the shared DB; it does NOT snapshot).
 
 ## Heal — run whenever the map looks wrong
 
@@ -97,7 +103,7 @@ Triggers: repo restructured / new language or dir / files mis-roled / map
 stale or empty on a clone whose hooks never got wired.
 
 1. Re-inspect (step 1) — what changed?
-2. Edit `.sc-state/map.config.json` to match (step 2).
+2. Edit the active canonical-root config from step 2 to match.
 3. `sc map-setup` (idempotent) — re-wires hooks + re-maps.
 4. Verify (step 4). Vanished paths are auto-pruned from `dr_filepath` by the
    remap.
@@ -106,7 +112,7 @@ stale or empty on a clone whose hooks never got wired.
    DELETE or repath every row it returns.
 6. **Describe — NULLs and filler** (Standing jobs § 2) -> worklist empty
    before you leave.
-7. Commit.
+7. Persist by mode as in first-boot step 6.
 
 ## Standing jobs — sections, descriptions, product DB
 
@@ -227,7 +233,8 @@ Adopt one per stack:
    (fastapi? flask? svelte? next?) + the file mix
    (`SELECT lang, COUNT(*) FROM dr_filepath GROUP BY lang`).
 2. **Copy the matching reference** from the engine's
-   `.super-coder/templates/map_extractors/` into `.sc-state/map_extractors/`:
+   `.super-coder/templates/map_extractors/` into
+   `$SC_ROOT/.sc-state/map_extractors/`:
    - `fastapi_endpoints.py` — decorator routes (`@app.get(...)`, Flask `@app.route`) → `dr_endpoint`
    - `sqlite_schema.py` — SQL `CREATE TABLE/VIEW` → `dr_db_table`/`dr_db_column`
    - `sveltekit_routes.py` — filesystem routes + `*.svelte` → `dr_route`/`dr_component`
@@ -236,8 +243,10 @@ Adopt one per stack:
    rewrite the match — target the dominant pattern, not 100%.
 3. **Run + verify:** `sc map` -> table populated, rows look right
    (`SELECT method, path FROM dr_endpoint LIMIT 10;`).
-4. **Commit** `.sc-state/map_extractors/`. (Snapshotting the authored layer =
-   the admin/GUI step above — not yours to run.)
+4. **Hand off persistence** to admin via the `messaging` skill, naming each
+   changed `.sc-state/map_extractors/` path and the verification result. These
+   canonical-root files are normal tracked files; snapshotting the authored DB
+   layer remains the separate admin/GUI step above.
 
 **Contract** (full version: `templates/map_extractors/README.md`): each module
 defines `extract(con, repo_root, cfg) -> str`. `con` = the live map db with

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -608,10 +608,12 @@ and reload on a fresh map db.
    Eyeball the top-level dirs -> anything mis-classified, or a
    generated/vendored dir being indexed?
 
-2. **Author the active map config** — `.sc-state/map.config.json` in tracked
-   mode or `.sc-state/local/map/config.json` in local mode. It is per-instance
-   and survives `sc update`. All keys optional; each merges over `map_repo.py`
-   defaults:
+2. **Author the active map config at the canonical live root** —
+   `$SC_ROOT/.sc-state/map.config.json` in tracked mode or
+   `$SC_ROOT/.sc-state/local/map/config.json` in local mode. The mapper
+   deliberately reads the shared live checkout, not your shell worktree. It is
+   per-instance and survives `sc update`. All keys optional; each merges over
+   `map_repo.py` defaults:
    ```json
    {
      "skip_dirs":  ["generated", "fixtures"],
@@ -646,9 +648,13 @@ and reload on a fresh map db.
 5. **Describe — NULLs and filler** — run the description worklist (Standing
    jobs § 2); leave only when it returns zero rows, NULLs and filler both.
 
-6. **Commit** the config + hooks (`git` skill) -> `sc mem state "…"` ->
-   `sc mem oriented` (sets `bootstrapped=1` — the write is live in the
-   shared DB; it does NOT snapshot).
+6. **Persist by mode.** Hook wiring is per-clone runtime state, never a commit.
+   In tracked mode, use the `messaging` skill to send admin the exact canonical
+   path (`.sc-state/map.config.json`) and verification result; only admin may
+   commit the main checkout. In local mode, the config is intentionally ignored
+   and needs no commit. Do not branch or commit the main checkout from the
+   cartographer shell. Then `sc mem state "…"` -> `sc mem oriented` (sets
+   `bootstrapped=1` — the write is live in the shared DB; it does NOT snapshot).
 
 ## Heal — run whenever the map looks wrong
 
@@ -656,7 +662,7 @@ Triggers: repo restructured / new language or dir / files mis-roled / map
 stale or empty on a clone whose hooks never got wired.
 
 1. Re-inspect (step 1) — what changed?
-2. Edit `.sc-state/map.config.json` to match (step 2).
+2. Edit the active canonical-root config from step 2 to match.
 3. `sc map-setup` (idempotent) — re-wires hooks + re-maps.
 4. Verify (step 4). Vanished paths are auto-pruned from `dr_filepath` by the
    remap.
@@ -665,7 +671,7 @@ stale or empty on a clone whose hooks never got wired.
    DELETE or repath every row it returns.
 6. **Describe — NULLs and filler** (Standing jobs § 2) -> worklist empty
    before you leave.
-7. Commit.
+7. Persist by mode as in first-boot step 6.
 
 ## Standing jobs — sections, descriptions, product DB
 
@@ -786,7 +792,8 @@ Adopt one per stack:
    (fastapi? flask? svelte? next?) + the file mix
    (`SELECT lang, COUNT(*) FROM dr_filepath GROUP BY lang`).
 2. **Copy the matching reference** from the engine''s
-   `.super-coder/templates/map_extractors/` into `.sc-state/map_extractors/`:
+   `.super-coder/templates/map_extractors/` into
+   `$SC_ROOT/.sc-state/map_extractors/`:
    - `fastapi_endpoints.py` — decorator routes (`@app.get(...)`, Flask `@app.route`) → `dr_endpoint`
    - `sqlite_schema.py` — SQL `CREATE TABLE/VIEW` → `dr_db_table`/`dr_db_column`
    - `sveltekit_routes.py` — filesystem routes + `*.svelte` → `dr_route`/`dr_component`
@@ -795,8 +802,10 @@ Adopt one per stack:
    rewrite the match — target the dominant pattern, not 100%.
 3. **Run + verify:** `sc map` -> table populated, rows look right
    (`SELECT method, path FROM dr_endpoint LIMIT 10;`).
-4. **Commit** `.sc-state/map_extractors/`. (Snapshotting the authored layer =
-   the admin/GUI step above — not yours to run.)
+4. **Hand off persistence** to admin via the `messaging` skill, naming each
+   changed `.sc-state/map_extractors/` path and the verification result. These
+   canonical-root files are normal tracked files; snapshotting the authored DB
+   layer remains the separate admin/GUI step above.
 
 **Contract** (full version: `templates/map_extractors/README.md`): each module
 defines `extract(con, repo_root, cfg) -> str`. `con` = the live map db with

--- a/.super-coder/migrations/0126_reseed_fresh_install_shell_contract.sql
+++ b/.super-coder/migrations/0126_reseed_fresh_install_shell_contract.sql
@@ -1,0 +1,81 @@
+-- 0126 — fresh-install shell command and cartographer root contract.
+--
+-- 0122 established bare `sc` as the canonical worktree command but generated
+-- boot text still exposed `./sc`, and the cartographer skill still assigned
+-- canonical-root assets to an isolated worktree commit. Carry the corrected
+-- cartographer guidance forward without replacing the skill row or its grants.
+
+BEGIN;
+
+UPDATE skills
+SET content = REPLACE(
+  content,
+  '2. **Author the active map config** — `.sc-state/map.config.json` in tracked
+   mode or `.sc-state/local/map/config.json` in local mode. It is per-instance
+   and survives `sc update`. All keys optional; each merges over `map_repo.py`
+   defaults:',
+  '2. **Author the active map config at the canonical live root** —
+   `$SC_ROOT/.sc-state/map.config.json` in tracked mode or
+   `$SC_ROOT/.sc-state/local/map/config.json` in local mode. The mapper
+   deliberately reads the shared live checkout, not your shell worktree. It is
+   per-instance and survives `sc update`. All keys optional; each merges over
+   `map_repo.py` defaults:'
+)
+WHERE name = 'cartographer';
+
+UPDATE skills
+SET content = REPLACE(
+  content,
+  '6. **Commit** the config + hooks (`git` skill) -> `sc mem state "…"` ->
+   `sc mem oriented` (sets `bootstrapped=1` — the write is live in the
+   shared DB; it does NOT snapshot).',
+  '6. **Persist by mode.** Hook wiring is per-clone runtime state, never a commit.
+   In tracked mode, use the `messaging` skill to send admin the exact canonical
+   path (`.sc-state/map.config.json`) and verification result; only admin may
+   commit the main checkout. In local mode, the config is intentionally ignored
+   and needs no commit. Do not branch or commit the main checkout from the
+   cartographer shell. Then `sc mem state "…"` -> `sc mem oriented` (sets
+   `bootstrapped=1` — the write is live in the shared DB; it does NOT snapshot).'
+)
+WHERE name = 'cartographer';
+
+UPDATE skills
+SET content = REPLACE(
+  content,
+  '2. Edit `.sc-state/map.config.json` to match (step 2).',
+  '2. Edit the active canonical-root config from step 2 to match.'
+)
+WHERE name = 'cartographer';
+
+UPDATE skills
+SET content = REPLACE(
+  content,
+  '7. Commit.',
+  '7. Persist by mode as in first-boot step 6.'
+)
+WHERE name = 'cartographer';
+
+UPDATE skills
+SET content = REPLACE(
+  content,
+  '2. **Copy the matching reference** from the engine''s
+   `.super-coder/templates/map_extractors/` into `.sc-state/map_extractors/`:',
+  '2. **Copy the matching reference** from the engine''s
+   `.super-coder/templates/map_extractors/` into
+   `$SC_ROOT/.sc-state/map_extractors/`:'
+)
+WHERE name = 'cartographer';
+
+UPDATE skills
+SET content = REPLACE(
+  content,
+  '4. **Commit** `.sc-state/map_extractors/`. (Snapshotting the authored layer =
+   the admin/GUI step above — not yours to run.)',
+  '4. **Hand off persistence** to admin via the `messaging` skill, naming each
+   changed `.sc-state/map_extractors/` path and the verification result. These
+   canonical-root files are normal tracked files; snapshotting the authored DB
+   layer remains the separate admin/GUI step above.'
+)
+WHERE name = 'cartographer';
+
+COMMIT;

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -116,7 +116,7 @@ PARTICIPANT_RULES = (
     "1. File findings, flags, verdicts, reports, PRs, and commits within your "
     "assigned authority.\n"
     "2. Send rulings and transitions to the planner as a scoped row: "
-    "`./sc mem message send <planner> \"…\" --kind result --sprint <doc-id>`.\n"
+    "`sc mem message send <planner> \"…\" --kind result --sprint <doc-id>`.\n"
     "3. When work remains, send a partial naming completed work, evidence, and "
     "the next uncompleted action before ending the turn.\n"
     "4. Nothing found is a result. Send it."
@@ -418,11 +418,11 @@ def render_skills(con, shell_id: int) -> str:
 
 def render_api(port: "int | None", api_key: "str | None") -> str:
     if port is None or not api_key:
-        return "(API not configured — run `./sc rebuild` to assign a key)"
+        return "(API not configured — run `sc rebuild` to assign a key)"
     return (
         f"- **Base URL:** `http://127.0.0.1:{port}`\n"
         "- **Token:** available as `$SC_API_TOKEN` in your environment (set at launch).\n\n"
-        "Write memory via `./sc mem` (proxied here automatically when `SC_API_TOKEN` is set). "
+        "Write memory via `sc mem` (proxied here automatically when `SC_API_TOKEN` is set). "
         "Read messages: `GET /_sc/mem/messages`. Command reference: the `memory` and `db_map` skills."
     )
 

--- a/.super-coder/scripts/seed_dogfood.py
+++ b/.super-coder/scripts/seed_dogfood.py
@@ -57,19 +57,19 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 | Content | `documents` — specs/docs; DB owns the body; freeze via frozen=1 on ship |
 | Session narrative | `shell_memory_archives` — one row per session, appended progressively |
 
-Write as it happens, not at close. **Writes go through `./sc mem`** (state · seed ·
+Write as it happens, not at close. **Writes go through `sc mem`** (state · seed ·
 lns · decision · flag · roadmap · doc · narrative): it routes through the engine
 API, which resolves your identity from your token — no DB path, no direct-DB
 fallback. The write lands in the live engine DB — the single source of truth
 shared by every shell, durable and visible to all at once. That is the whole
 write: **you don't snapshot or render** — persisting to git is an admin/GUI step.
-`./sc mem which` to orient. See the `memory` and `db_map` skills.
+`sc mem which` to orient. See the `memory` and `db_map` skills.
 
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file
 — docs, specs, skills, this `CLAUDE.md`/`AGENTS.md` — is rendered from the DB by
-`./sc render`. They are derived artifacts: a photograph of a DB row, not the row.
+`sc render`. They are derived artifacts: a photograph of a DB row, not the row.
 Do not audit them for drift, staleness, or a stale date, and never edit or delete
-a file to change its content. If one looks wrong or out of date, fix the DB (`./sc
+a file to change its content. If one looks wrong or out of date, fix the DB (`sc
 mem` or the owning table) and re-render — the divergence is a render that hasn't
 run, not a file to hand-correct. The DB is the authoritative content; the tree is
 its projection.

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -40,14 +40,14 @@ different ways, so keep them straight:
   confirms the API is reachable and who your token resolves to. `sc mem` routes
   through the engine API (no direct-DB fallback). If it reports "API unreachable",
   the engine server is down — surface this to FnB; they restart it with
-  `./sc restart` / `make dos-r`. Do not retry silently; surface the error and stop.
+  `sc restart` / `make dos-r`. Do not retry silently; surface the error and stop.
 - **App product DB** — the database of the product *this repo* builds. Its name
   and path **vary per fork** and live **outside** `.super-coder/`. Holds the
   product's runtime data + schema. Change it the way the product does — schema
   migrations + app code — never by hand-editing rows. Locate it via the repo map:
   the cartographer tags its schema/migrations in `dr_*` (the live `.db` is often
   gitignored, so the schema is the durable anchor). In a sandbox this may be a
-  Postgres sidecar at `$DATABASE_URL` (`./sc launch` starts it); a *set* but empty
+  Postgres sidecar at `$DATABASE_URL` (`sc launch` starts it); a *set* but empty
   `DATABASE_URL` means provision-me via the app's migrations — never "no DB" — see
   the `dev_kit` skill.
 
@@ -189,7 +189,7 @@ host-supervised stack, outside your container. So there are two runtimes with tw
 homes — keep them apart:
 
 - **Project dev servers** (vite, `npm run dev`, etc.) belong in the **sandbox**,
-  bound to `0.0.0.0:$SC_DEV_PORT` — the per-fork port `./sc launch` publishes to
+  bound to `0.0.0.0:$SC_DEV_PORT` — the per-fork port `sc launch` publishes to
   the host for exactly this. Reach it at `http://127.0.0.1:$SC_DEV_PORT`.
 - **A process-supervised host stack** (pm2 / `make`) is owned by its supervisor.
   Start/stop/restart only through it (`make up`, `make restart`) — never a bare

--- a/README.md
+++ b/README.md
@@ -147,12 +147,14 @@ git checkout super-coder/main -- .super-coder sc
 # 3. Sign in to your harness once, on the HOST (not inside the sandbox):
 claude                          # or:  opencode auth login  ·  codex login  ·  vibe --setup  ·  kimi login
 
-# 4. Launch the sandbox (server + GUI) and attach a session:
+# 4. Launch the sandbox (server + GUI):
 ./sc launch
-./sc enter                      # auth + pick a shell + pick a harness + boot
 
-# 5. Commit the install (engine is gitignored — only sc + .sc-state + config track):
+# 5. Commit the install before creating shell worktrees:
 git add -A && git commit -m "chore: install subfloor"
+
+# 6. Attach a session:
+./sc enter                      # auth + pick a shell + pick a harness + boot
 ```
 
 That's the happy path — you're talking to a planner shell in your repo, with a

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,12 +121,14 @@ git checkout super-coder/main -- .super-coder sc
 # 3. Sign in to your harness once, on the HOST (not inside the sandbox):
 claude                          # or:  opencode auth login  ·  codex login  ·  vibe --setup  ·  kimi login
 
-# 4. Launch the sandbox (server + GUI) and attach a session:
+# 4. Launch the sandbox (server + GUI):
 ./sc launch
-./sc enter                      # auth + pick a shell + pick a harness + boot
 
-# 5. Commit the install (engine is gitignored — only sc + .sc-state + config track):
+# 5. Commit the install before creating shell worktrees:
 git add -A && git commit -m "chore: install subfloor"
+
+# 6. Attach a session:
+./sc enter                      # auth + pick a shell + pick a harness + boot
 ```
 
 That's the happy path. Each step is covered in depth below — installer internals,

--- a/tests/test_fresh_install_shell_contract.py
+++ b/tests/test_fresh_install_shell_contract.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Regression tests for the fresh-install shell/worktree contract."""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "render"))
+import compose  # noqa: E402
+
+
+class FreshInstallShellContractTest(unittest.TestCase):
+    def test_install_is_committed_before_first_shell_worktree(self) -> None:
+        for relative in ("README.md", "docs/README.md"):
+            text = (ROOT / relative).read_text()
+            commit = text.index('git commit -m "chore: install subfloor"')
+            enter = text.index("./sc enter", commit)
+            self.assertLess(commit, enter, relative)
+
+    def test_rendered_api_guidance_uses_path_launcher(self) -> None:
+        rendered = compose.render_api(8837, "configured")
+        self.assertIn("`sc mem`", rendered)
+        self.assertNotIn("`./sc mem`", rendered)
+        self.assertNotIn("./sc", compose.PARTICIPANT_RULES)
+        boot = (
+            ROOT / ".super-coder" / "templates" / "boot.md"
+        ).read_text()
+        self.assertNotIn("./sc", boot)
+        dogfood = (
+            ROOT / ".super-coder" / "scripts" / "seed_dogfood.py"
+        ).read_text()
+        self.assertNotIn("./sc mem", dogfood)
+
+    def test_cartographer_targets_canonical_root_and_admin_handoff(self) -> None:
+        skill = (
+            ROOT / ".super-coder" / "assets" / "skills" / "cartographer"
+            / "SKILL.md"
+        ).read_text()
+        self.assertIn("$SC_ROOT/.sc-state/map.config.json", skill)
+        self.assertIn("$SC_ROOT/.sc-state/local/map/config.json", skill)
+        self.assertIn("$SC_ROOT/.sc-state/map_extractors/", skill)
+        self.assertIn("send admin", skill)
+        self.assertNotIn("**Commit** the config + hooks", skill)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Fresh installs now commit the tracked launcher and `.sc-state` baseline before the first shell worktree is created. Generated shell guidance consistently uses the PATH-safe `sc` command established by #707, and cartographer-owned canonical-root map assets follow an explicit tracked/local persistence contract instead of being committed from an isolated worktree.

## Distribution

- regenerates the base cartographer skill seed
- adds forward migration `0126_reseed_fresh_install_shell_contract.sql`
- preserves tracked and local artifact modes

## Verification

- fresh rebuild applies all 126 migrations
- branch-local render check passes
- focused fresh-install, skill-freshness, and boot-render tests pass
- `git diff --check` passes

Closes #710
Closes #711