### PR TITLE
fix(conductor): await handoff activation before slot boot

### DIFF
--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -480,6 +480,7 @@ def _slot_command(
         slot,
         "--sprint",
         str(sprint_id),
+        "--await-sprint-active",
         "--harness",
         harness,
         "--model",

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -78,6 +78,8 @@ SLOT_SKILLS = {
     "rev": ("reviewer", "sprint_rev"),
 }
 SESSION_OPEN_RETRY_DELAYS_S = (0.1, 0.3)
+SPRINT_ACTIVATION_WAIT_SECONDS = 30.0
+SPRINT_ACTIVATION_POLL_SECONDS = 0.05
 
 
 def resolve_headless_model(flag_model: "str | None", fdef: "dict | None",
@@ -702,6 +704,40 @@ class SlotRequestError(ValueError):
     """A slot launch that cannot resolve one unambiguous sprint assignment."""
 
 
+def await_sprint_active(
+    con,
+    sprint_ref: int,
+    *,
+    timeout_seconds: float = SPRINT_ACTIVATION_WAIT_SECONDS,
+) -> bool:
+    """Wait for a Conductor handoff transaction to become visible.
+
+    Conductor validates the board, activates the sprint, and releases its
+    ready units in one transaction. Slot children start before that transaction
+    commits so launch failures can still roll it back. A child launched through
+    that boundary must therefore wait on a fresh read instead of rejecting the
+    still-visible ``declared`` state.
+
+    Return False on timeout or when the sprint is absent/in another state;
+    ``resolve_slot_context`` then emits the ordinary fail-closed diagnosis.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        row = con.execute(
+            "SELECT state FROM sprints WHERE sprint_doc_id=?",
+            (sprint_ref,),
+        ).fetchone()
+        state = row["state"] if row is not None else None
+        if state == "active":
+            return True
+        if state != "declared" or time.monotonic() >= deadline:
+            return False
+        # End any read transaction before polling so a separate SQLite
+        # connection's activation commit becomes visible.
+        con.rollback()
+        time.sleep(SPRINT_ACTIVATION_POLL_SECONDS)
+
+
 def resolve_slot_context(con, shell, slot: str, sprint_ref: int,
                          unit_ref: "str | None" = None) -> dict:
     """Validate and load the deterministic context for one ephemeral slot.
@@ -1319,10 +1355,15 @@ def main() -> None:
     slot = None
     slot_sprint = None
     slot_unit = None
+    await_active = False
     positional = []
     i = 0
     while i < len(args):
         a = args[i]
+        if a == "--await-sprint-active":
+            await_active = True
+            i += 1
+            continue
         if a == "--harness":
             flag_harness = args[i + 1] if i + 1 < len(args) else None
             i += 2
@@ -1387,12 +1428,18 @@ def main() -> None:
             sys.exit("sc run: --sprint must be a positive integer")
         if slot_sprint <= 0:
             sys.exit("sc run: --sprint must be a positive integer")
+    if await_active and (not headless or slot is None or slot_sprint is None):
+        sys.exit(
+            "sc run: --await-sprint-active requires a headless sprint slot"
+        )
 
     # Wordmark banner — interactive boots only; headless/verify logs stay clean.
     if not headless and not os.environ.get("RENDER_ONLY") and sys.stdin.isatty():
         print(style.banner(REPO_ROOT.name))
 
     con = open_db()
+    if await_active:
+        await_sprint_active(con, slot_sprint)
     # Self-heal stale engine skills before anything this boot reads them
     # (compose's SKILLS block, render_skill_md). A DB stranded by an in-place
     # `0001` regen repairs itself from assets/skills/ instead of needing a manual

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -499,6 +499,19 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             "refused",
         )
 
+    def test_handoff_slot_waits_for_the_act_transaction_to_commit(self):
+        self.set_declared()
+        directive_id = self.emit("planner", "handoff", {}, unit=False)
+        self.con.commit()
+
+        result = runtime.act(
+            self.con, directive_id, 1, launcher=self.launcher
+        )
+
+        self.assertEqual(result["status"], "executed")
+        self.assertEqual(len(result["launches"]), 1)
+        self.assertIn("--await-sprint-active", result["launches"][0])
+
     def test_refusal_rolls_back_partial_board_changes(self):
         self.set_unit("working")
         self.con.execute("UPDATE shells SET is_deleted=1 WHERE shell_id=4")

--- a/tests/test_run_slots.py
+++ b/tests/test_run_slots.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import sqlite3
 import sys
+import tempfile
+import threading
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -175,6 +178,40 @@ class SlotContextTest(unittest.TestCase):
             run.resolve_slot_context(
                 self.con, self.shell(2), "dev", 25)
 
+    def test_conductor_slot_wait_observes_activation_from_another_connection(
+            self) -> None:
+        with tempfile.TemporaryDirectory(prefix="sc_slot_activation_") as td:
+            path = Path(td) / "runtime.db"
+            setup = sqlite3.connect(path)
+            setup.execute(
+                "CREATE TABLE sprints (sprint_doc_id INTEGER PRIMARY KEY,"
+                " state TEXT NOT NULL)"
+            )
+            setup.execute("INSERT INTO sprints VALUES (25,'declared')")
+            setup.commit()
+            setup.close()
+
+            def activate() -> None:
+                time.sleep(0.05)
+                writer = sqlite3.connect(path)
+                writer.execute(
+                    "UPDATE sprints SET state='active' WHERE sprint_doc_id=25"
+                )
+                writer.commit()
+                writer.close()
+
+            thread = threading.Thread(target=activate)
+            thread.start()
+            reader = sqlite3.connect(path)
+            reader.row_factory = sqlite3.Row
+            try:
+                self.assertTrue(
+                    run.await_sprint_active(reader, 25, timeout_seconds=1.0)
+                )
+            finally:
+                reader.close()
+                thread.join()
+
     def test_slot_boot_section_inlines_context_and_complete_skill(self) -> None:
         ctx = run.resolve_slot_context(
             self.con, self.shell(2), "dev", 25, "U1")
@@ -250,7 +287,8 @@ class SlotLaunchIntegrationTest(unittest.TestCase):
                 mock.patch.object(
                     run.sys, "argv",
                     ["run.py", "--headless", "DEV1", "--harness", "claude",
-                     "--slot", "dev", "--sprint", "25", "--unit", "U1"]), \
+                     "--slot", "dev", "--sprint", "25", "--unit", "U1",
+                     "--await-sprint-active"]), \
                 mock.patch.object(run, "open_db", return_value=con), \
                 mock.patch.object(
                     run, "authenticate", return_value={"user_id": 1}), \


### PR DESCRIPTION
Fixes #714.

## What changed
- add an internal `--await-sprint-active` barrier to Conductor slot launches
- poll through the uncommitted `declared` state before normal slot validation
- preserve atomic rollback if directive execution or launch staging fails
- cover cross-connection activation visibility and the handoff command contract

## Verification
- `python3 -m unittest tests.test_run_slots tests.test_conductor_runtime` — 28 passed
- `python3 -m py_compile .super-coder/scripts/run.py .super-coder/scripts/conductor_runtime.py`
- `git diff --check`
- `./sc test` — 1439 passed, 2 unrelated current-main failures tracked in #716
- `./sc render-check` — unrelated current-main drift tracked in #715