### PR TITLE
fix(conductor): require OpenCode for every launch

### DIFF
--- a/.super-coder/scripts/conductor_policy.py
+++ b/.super-coder/scripts/conductor_policy.py
@@ -1,0 +1,14 @@
+"""Non-negotiable launch policy for the ephemeral Conductor shell."""
+
+CONDUCTOR_FLAVOR = "conductor"
+CONDUCTOR_HARNESS = "opencode"
+DEFAULT_CONDUCTOR_MODEL = "openai/gpt-5.6-luna"
+
+
+def require_harness(flavor: "str | None", harness: str) -> None:
+    """Reject a Conductor launch outside its required OpenCode runtime."""
+    if flavor == CONDUCTOR_FLAVOR and harness != CONDUCTOR_HARNESS:
+        raise ValueError(
+            f"conductor requires harness '{CONDUCTOR_HARNESS}'; "
+            f"'{harness}' is unsupported"
+        )

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from conductor_policy import CONDUCTOR_HARNESS, DEFAULT_CONDUCTOR_MODEL
 import shell_liveness
 import sprint_lifecycle
 import sprint_state
@@ -28,8 +29,6 @@ from sprint_units import SPRINT_UNIT_EDGES, SprintTransitionError, check_transit
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
 INSTANCE_CONFIG = ENGINE / "instance.json"
-CONDUCTOR_HARNESS = "opencode"
-DEFAULT_CONDUCTOR_MODEL = "openai/gpt-5.6-luna"
 _LAUNCH_GUARD_SECONDS = 20
 LAUNCH_LOG = ENGINE / "logs" / "conductor-launches.log"
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -55,6 +55,7 @@ import flat  # noqa: E402
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import artifact_policy  # noqa: E402
+import conductor_policy  # noqa: E402
 import db_driver  # noqa: E402
 import install  # noqa: E402  — reuse its canonical HARNESS_BIN (one source of truth)
 import git_prune  # noqa: E402  — boot-time prune of provably-merged local branches
@@ -1176,6 +1177,11 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
     ensure_harness_path()
     harness = (harness or (fdef["default_harness"] if fdef else None)
                or _configured_harness() or "claude")
+    try:
+        conductor_policy.require_harness(chosen["flavor"], harness)
+    except ValueError as exc:
+        con.close()
+        raise LaunchError(str(exc)) from exc
     adapter = load_adapter(harness)
 
     # Model route: an explicit model wins; else the (flavor, harness) cell,
@@ -1527,6 +1533,11 @@ def main() -> None:
     harness = (flag_harness or os.environ.get("HARNESS")
                or pick_harness(detect_harnesses(), default_harness, first or headless)
                or default_harness)
+    try:
+        conductor_policy.require_harness(chosen["flavor"], harness)
+    except ValueError as exc:
+        con.close()
+        sys.exit(f"sc run: {exc}")
 
     # Resolve + validate the complete headless route before opening a session.
     # `sc run` is the sprint-worker primitive, so high effort is the default

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(SCRIPTS))
 sys.path.insert(0, str(RENDER))
 
 import compose
+import conductor_policy
 import conductor_runtime as runtime
 import run
 
@@ -148,6 +149,7 @@ class ConductorFlavorAndDoctorTests(RuntimeFixture):
         return probe
 
     def test_template_migration_and_boot_have_exact_skill_and_are_exhaustive(self):
+        self.assertEqual(runtime.CONDUCTOR_HARNESS, "opencode")
         self.assertEqual(
             runtime.DEFAULT_CONDUCTOR_MODEL,
             "openai/gpt-5.6-luna",
@@ -189,6 +191,16 @@ class ConductorFlavorAndDoctorTests(RuntimeFixture):
             1,
         )
         self.assertEqual(composed, rendered)
+
+    def test_conductor_harness_policy_rejects_every_non_opencode_route(self):
+        conductor_policy.require_harness("conductor", "opencode")
+        conductor_policy.require_harness("dev", "codex")
+        for harness in ("claude", "codex", "kimi", "vibe"):
+            with (
+                self.subTest(harness=harness),
+                self.assertRaisesRegex(ValueError, "requires harness 'opencode'"),
+            ):
+                conductor_policy.require_harness("conductor", harness)
 
     def test_luna_migration_upgrades_only_the_shipped_conductor_route(self):
         self.con.execute(

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -310,6 +310,99 @@ class OpenSessionContentionTest(unittest.TestCase):
 
 
 class HeadlessSessionFailureTest(unittest.TestCase):
+    def test_conductor_rejects_cli_harness_override_before_launch_side_effects(
+            self) -> None:
+        con = mock.Mock()
+        chosen = {"shell_id": 11, "shortname": "CON1", "flavor": "conductor"}
+        fdefaults = {
+            "conductor": {
+                "default_harness": "opencode",
+                "models": {"opencode": "openai/gpt-5.6-luna"},
+            }
+        }
+        load_adapter = mock.Mock()
+        open_session = mock.Mock()
+        ensure_worktree = mock.Mock()
+
+        with mock.patch.dict(run.os.environ, {}, clear=True), \
+                mock.patch.object(
+                    run.sys, "argv",
+                    ["run.py", "--headless", "CON1", "--harness", "codex"]), \
+                mock.patch.object(run, "open_db", return_value=con), \
+                mock.patch.object(
+                    run.seed_skills, "sync_engine_skills", return_value=[]), \
+                mock.patch.object(
+                    run, "authenticate", return_value={"user_id": 1}), \
+                mock.patch.object(run, "flavor_defaults", return_value=fdefaults), \
+                mock.patch.object(run, "list_shells", return_value=[chosen]), \
+                mock.patch.object(run, "pick_shell", return_value=chosen), \
+                mock.patch.object(
+                    run.shell_liveness, "compute",
+                    return_value={"supported": False, "indeterminate": 0}), \
+                mock.patch.object(run, "ensure_harness_path"), \
+                mock.patch.object(run, "load_adapter", load_adapter), \
+                mock.patch.object(run, "open_session", open_session), \
+                mock.patch.object(run, "ensure_worktree", ensure_worktree), \
+                self.assertRaises(SystemExit) as raised:
+            run.main()
+
+        self.assertIn(
+            "conductor requires harness 'opencode'",
+            str(raised.exception),
+        )
+        con.close.assert_called_once_with()
+        load_adapter.assert_not_called()
+        open_session.assert_not_called()
+        ensure_worktree.assert_not_called()
+
+    def test_engine_prepared_conductor_rejects_non_opencode_before_session(
+            self) -> None:
+        con = mock.Mock()
+        con.execute.return_value.fetchone.return_value = {
+            "shell_id": 11,
+            "display_name": "Maestro",
+            "shortname": "CON1",
+            "mandate": "relay",
+            "is_shared": 1,
+            "flavor": "conductor",
+            "current_state": "",
+        }
+        fdefaults = {
+            "conductor": {
+                "default_harness": "opencode",
+                "models": {"opencode": "openai/gpt-5.6-luna"},
+            }
+        }
+        load_adapter = mock.Mock()
+        open_session = mock.Mock()
+        ensure_worktree = mock.Mock()
+
+        with mock.patch.dict(run.os.environ, {"RENDER_ONLY": "1"}, clear=True), \
+                mock.patch.object(run, "open_db", return_value=con), \
+                mock.patch.object(
+                    run, "authenticate",
+                    return_value={"user_id": 1, "username": "Jed"}), \
+                mock.patch.object(run, "flavor_defaults", return_value=fdefaults), \
+                mock.patch.object(run, "ensure_harness_path"), \
+                mock.patch.object(run, "load_adapter", load_adapter), \
+                mock.patch.object(run, "open_session", open_session), \
+                mock.patch.object(run, "ensure_worktree", ensure_worktree), \
+                self.assertRaisesRegex(
+                    run.LaunchError,
+                    "conductor requires harness 'opencode'",
+                ):
+            run.prepare_launch(
+                shell_id=11,
+                harness="codex",
+                model="gpt-5.6-sol",
+                headless_prompt="act",
+            )
+
+        con.close.assert_called_once_with()
+        load_adapter.assert_not_called()
+        open_session.assert_not_called()
+        ensure_worktree.assert_not_called()
+
     def test_sc_run_exits_before_worktree_or_harness_artifacts(self) -> None:
         con = mock.Mock()
         # No armed sprint binding — resolve_sprint_ref stamps nothing.


### PR DESCRIPTION
## Summary
- centralize the Conductor runtime contract: OpenCode only, with Luna as its default model
- reject non-OpenCode CLI, environment, and engine-prepared launch routes before adapter/session/worktree side effects
- cover direct and prepared launch paths with regression tests

Decision #13 records OpenCode as a non-negotiable Conductor dependency.

## Verification
- `python -m unittest tests.test_conductor_runtime tests.test_run_session tests.test_run_slots` — 41 passed
- `./sc map` — passed
- `./sc render-check` — passed
- `./sc verify` — passed
- `./sc test` — 1443 passed, 2 pre-existing failures tracked in #716 (Make dry-run directory chatter)
- `git diff --check` — passed