### PR TITLE
fix(conductor): refuse re-tasking terminal units

### DIFF
--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -116,6 +116,31 @@ Do not issue routine kickoff directives after handoff: Conductor releases
 dependency-ready developers itself. Do not boot shells, relay messages, poll,
 merge, or make mechanical state moves.
 
+### Post-merge conformance findings
+
+`merged` and `cancelled` units are terminal and must never be reopened with
+`re-task` or `re-scope`. When integrated conformance finds work after every
+declared unit is terminal:
+
+1. add a bounded follow-up unit with the next sequence, assigned developer and
+   reviewer, and dependencies on the merged work it corrects;
+2. emit `kickoff` for that new unit and its assigned developer;
+3. after the follow-up merges and reports, request integrated conformance again.
+
+```sh
+sc sprint unit add \
+  --sprint <id> --seq U<n> --title "<bounded conformance correction>" \
+  --dev DEV1 --reviewer REV1 \
+  --depends-on U1 --overlap "<owned correction surface>"
+sc directives emit kickoff \
+  --target conductor --sprint <id> --unit <new-unit-id> \
+  --payload '{"to":"DEV1","instruction":"<required correction>"}'
+```
+
+Use `re-task` or `re-scope` only for a non-terminal unit. A terminal-unit
+directive is refused and returned to you so the correction becomes a new,
+independently reviewed board record.
+
 ## Stop
 
 Declaration stops after an inspected `handoff`. Re-entry stops after the

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -4005,6 +4005,31 @@ Do not issue routine kickoff directives after handoff: Conductor releases
 dependency-ready developers itself. Do not boot shells, relay messages, poll,
 merge, or make mechanical state moves.
 
+### Post-merge conformance findings
+
+`merged` and `cancelled` units are terminal and must never be reopened with
+`re-task` or `re-scope`. When integrated conformance finds work after every
+declared unit is terminal:
+
+1. add a bounded follow-up unit with the next sequence, assigned developer and
+   reviewer, and dependencies on the merged work it corrects;
+2. emit `kickoff` for that new unit and its assigned developer;
+3. after the follow-up merges and reports, request integrated conformance again.
+
+```sh
+sc sprint unit add \
+  --sprint <id> --seq U<n> --title "<bounded conformance correction>" \
+  --dev DEV1 --reviewer REV1 \
+  --depends-on U1 --overlap "<owned correction surface>"
+sc directives emit kickoff \
+  --target conductor --sprint <id> --unit <new-unit-id> \
+  --payload ''{"to":"DEV1","instruction":"<required correction>"}''
+```
+
+Use `re-task` or `re-scope` only for a non-terminal unit. A terminal-unit
+directive is refused and returned to you so the correction becomes a new,
+independently reviewed board record.
+
 ## Stop
 
 Declaration stops after an inspected `handoff`. Re-entry stops after the

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -24,7 +24,12 @@ from conductor_policy import CONDUCTOR_HARNESS, DEFAULT_CONDUCTOR_MODEL
 import shell_liveness
 import sprint_lifecycle
 import sprint_state
-from sprint_units import SPRINT_UNIT_EDGES, SprintTransitionError, check_transition
+from sprint_units import (
+    SPRINT_UNIT_EDGES,
+    TERMINAL_UNIT_STATES,
+    SprintTransitionError,
+    check_transition,
+)
 
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
@@ -113,13 +118,13 @@ TRANSITIONS = (
     (
         "planner",
         "re-scope",
-        "move working; reboot target dev",
+        "move non-terminal unit working; reboot target dev",
         "developer receives the new boundary",
     ),
     (
         "planner",
         "re-task",
-        "move working; reboot target dev",
+        "move non-terminal unit working; reboot target dev",
         "developer receives the replacement path",
     ),
     (
@@ -813,8 +818,19 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
             _text(payload, "reason")
             if unit["dev_shell_id"] != target["shell_id"]:
                 raise DirectiveRefused(f"{kind} target is not the assigned developer")
-            if unit["state"] == "blocked":
+            if unit["state"] in TERMINAL_UNIT_STATES:
+                raise DirectiveRefused(
+                    f"{kind} requires a non-terminal unit; add a follow-up "
+                    "unit for post-merge work"
+                )
+            if unit["state"] != "working":
                 _move(con, unit, "working", actor_shell_id)
+            con.execute(
+                "UPDATE sprint_units SET review_head=NULL,"
+                "updated_at=datetime('now'),updated_by_shell_id=? "
+                "WHERE unit_id=?",
+                (actor_shell_id, unit["unit_id"]),
+            )
             _spawn(con, launches, target, "dev", row, payload, unit=unit)
         elif kind == "answer":
             if unit is None:

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -545,6 +545,60 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             "refused",
         )
 
+    def test_retask_returns_reviewed_unit_to_working_and_clears_review_head(self):
+        self.set_unit("working")
+        self.set_unit("in_review", review_head="approved-old-head")
+        directive_id = self.emit(
+            "planner",
+            "re-task",
+            {
+                "to": "DEV1",
+                "instruction": "revise the implementation",
+                "reason": "new evidence",
+            },
+        )
+        self.con.commit()
+
+        result = runtime.act(
+            self.con, directive_id, 1, launcher=self.launcher
+        )
+
+        self.assertEqual(result["status"], "executed")
+        unit = self.con.execute(
+            "SELECT state,review_head FROM sprint_units WHERE unit_id=10"
+        ).fetchone()
+        self.assertEqual(tuple(unit), ("working", None))
+        self.assertIn("DEV1", result["launches"][0])
+
+    def test_retask_refuses_merged_unit_before_worker_launch(self):
+        self.set_unit("working")
+        self.set_unit("merged", review_head="approved-head")
+        directive_id = self.emit(
+            "planner",
+            "re-task",
+            {
+                "to": "DEV1",
+                "instruction": "revise the merged implementation",
+                "reason": "integrated conformance finding",
+            },
+        )
+        self.con.commit()
+
+        result = runtime.act(
+            self.con, directive_id, 1, launcher=self.launcher
+        )
+
+        self.assertEqual(result["status"], "refused")
+        self.assertIn("add a follow-up unit", result["reason"])
+        self.assertEqual(
+            self.con.execute(
+                "SELECT state FROM sprint_units WHERE unit_id=10"
+            ).fetchone()[0],
+            "merged",
+        )
+        self.assertIn("PLN1", result["escalation"]["command"])
+        self.assertNotIn("DEV1", result["escalation"]["command"])
+
     def test_handoff_slot_waits_for_the_act_transaction_to_commit(self):
         self.set_declared()
         directive_id = self.emit("planner", "handoff", {}, unit=False)


### PR DESCRIPTION
## Summary
- refuse `re-task` and `re-scope` on merged/cancelled units before worker launch instead of surfacing a server-side 500
- consistently return non-terminal reviewed/blocked/pending work to `working` and clear stale review approval
- teach Planner to create a new follow-up unit for post-merge conformance findings

Closes #724.

## Verification
- focused Conductor/sprint suite — 107 passed
- `./sc map` — passed
- `./sc render-check` — passed after the known #715/#719 local render reconciliation
- `./sc verify` — passed
- `./sc test` — 1445 passed, 2 pre-existing failures tracked in #716
- `git diff --check` — passed