### PR TITLE
fix(conductor): persist failed refusal escalations

### DIFF
--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -1043,7 +1043,7 @@ def _act_locked(
                 model=model,
             )
             escalation = {"command": command, "pid": launcher(command)}
-        except DirectiveRefused as escalation_error:
+        except (DirectiveRefused, ConductorLaunchError) as escalation_error:
             escalation = {"error": str(escalation_error)}
         _trail(
             con,

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -1006,7 +1006,7 @@ def _act_locked(
             "launches": launches,
             "pids": pids,
         }
-    except DirectiveRefused as exc:
+    except (DirectiveRefused, ConductorLaunchError) as exc:
         con.execute("ROLLBACK TO conductor_act")
         con.execute("RELEASE conductor_act")
         reason = str(exc)

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -636,6 +636,53 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         self.assertEqual(row["status"], "refused")
         self.assertIn("add a follow-up unit", row["refusal_reason"])
 
+    def test_worker_launch_failure_rolls_back_and_is_durably_refused(self):
+        self.set_unit("working")
+        self.set_unit("blocked")
+        directive_id = self.emit(
+            "planner",
+            "answer",
+            {
+                "to": "DEV1",
+                "question_directive_id": 42,
+                "answer": "resume the unit",
+            },
+        )
+        self.con.commit()
+        calls = []
+
+        def fail_worker_then_launch_planner(command):
+            calls.append(command)
+            if len(calls) == 1:
+                raise runtime.ConductorLaunchError(
+                    "worker slot is no longer live"
+                )
+            return 31337
+
+        result = runtime.act(
+            self.con,
+            directive_id,
+            1,
+            launcher=fail_worker_then_launch_planner,
+        )
+
+        self.assertEqual(result["status"], "refused")
+        self.assertEqual(result["reason"], "worker slot is no longer live")
+        self.assertEqual(result["escalation"]["pid"], 31337)
+        self.assertIn("PLN1", result["escalation"]["command"])
+        self.assertEqual(
+            self.con.execute(
+                "SELECT state FROM sprint_units WHERE unit_id=10"
+            ).fetchone()[0],
+            "blocked",
+        )
+        row = self.con.execute(
+            "SELECT status,refusal_reason FROM directives "
+            "WHERE directive_id=?",
+            (directive_id,),
+        ).fetchone()
+        self.assertEqual(tuple(row), ("refused", "worker slot is no longer live"))
+
     def test_handoff_slot_waits_for_the_act_transaction_to_commit(self):
         self.set_declared()
         directive_id = self.emit("planner", "handoff", {}, unit=False)

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -599,6 +599,43 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         self.assertIn("PLN1", result["escalation"]["command"])
         self.assertNotIn("DEV1", result["escalation"]["command"])
 
+    def test_refusal_persists_when_planner_escalation_launch_fails(self):
+        self.set_unit("working")
+        self.set_unit("merged", review_head="approved-head")
+        directive_id = self.emit(
+            "planner",
+            "re-task",
+            {
+                "to": "DEV1",
+                "instruction": "revise the merged implementation",
+                "reason": "integrated conformance finding",
+            },
+        )
+        self.con.commit()
+
+        def failing_launcher(_command):
+            raise runtime.ConductorLaunchError(
+                "planner slot cannot launch on a closed sprint"
+            )
+
+        result = runtime.act(
+            self.con, directive_id, 1, launcher=failing_launcher
+        )
+
+        self.assertEqual(result["status"], "refused")
+        self.assertIn("add a follow-up unit", result["reason"])
+        self.assertEqual(
+            result["escalation"],
+            {"error": "planner slot cannot launch on a closed sprint"},
+        )
+        row = self.con.execute(
+            "SELECT status,refusal_reason FROM directives "
+            "WHERE directive_id=?",
+            (directive_id,),
+        ).fetchone()
+        self.assertEqual(row["status"], "refused")
+        self.assertIn("add a follow-up unit", row["refusal_reason"])
+
     def test_handoff_slot_waits_for_the_act_transaction_to_commit(self):
         self.set_declared()
         directive_id = self.emit("planner", "handoff", {}, unit=False)


### PR DESCRIPTION
Closes #724.

When a directive is correctly refused but the follow-up Planner slot cannot launch (for example because the sprint was frozen/closed), `ConductorLaunchError` escaped the refusal handler. The connection rollback left the directive pending and permanently poisoned the queue.

This makes refusal escalation best-effort: the directive and refusal event commit with the launch error recorded.

Verification:
- `pytest -q tests/test_conductor_runtime.py` — 19 passed, 23 subtests
- `pytest -q tests/test_conductor_contracts.py tests/test_boot_sprint_directive.py` — 30 passed
- `./sc render-check`
- `./sc verify`
- `git diff --check`