### PR TITLE
fix(sprints): require explicit FnB Conductor activation

### DIFF
--- a/.super-coder/api/conductor_routes.py
+++ b/.super-coder/api/conductor_routes.py
@@ -285,7 +285,12 @@ def _create_directive(con, headers, body):
         con.rollback()
         return _err(422, "directive_invalid", str(exc))
     item = _directive(con, cur.lastrowid)
-    conductor_runtime.maybe_wake(con)
+    # Alpha activation is an explicit FnB gate: Planner leaves a durable
+    # handoff for the operator to inspect, then the FnB boots Conductor.
+    # Once the sprint is active, ordinary worker/system directives retain the
+    # config-gated autonomous wake path.
+    if not (flavor == "planner" and kind == "handoff"):
+        conductor_runtime.maybe_wake(con)
     return _json(201, item)
 
 

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -21,6 +21,7 @@ Explain the lifecycle before asking for routes:
 
 ```text
 reviewed spec → Planner declaration + complete board → explicit handoff →
+Planner tells FnB how to boot Conductor → FnB activates the sprint →
 Conductor runs workers mechanically → Planner re-enters only for decisions →
 independent conformance → close
 ```
@@ -86,7 +87,17 @@ sc directives emit handoff \
 ```
 
 Inspect the directive, then exit. Never boot a worker yourself and never remain
-resident after handoff.
+resident after handoff. The handoff deliberately does **not** boot Conductor:
+initial sprint activation is the FnB's alpha gate. End the FnB-facing response
+with the exact operator action:
+
+```sh
+./sc run CON1 -p "Process pending Conductor directives in ascending id order. Act each directive, inspect the result, and exit when the pending queue is empty."
+```
+
+Tell the FnB that this one explicit boot activates the declared sprint.
+Post-activation directive/sentinel wakes remain engine-managed when enabled;
+the FnB is not the sprint's message relay.
 
 ## Decision re-entry
 
@@ -143,6 +154,7 @@ independently reviewed board record.
 
 ## Stop
 
-Declaration stops after an inspected `handoff`. Re-entry stops after the
-requested directive is inspected. The originating Planner never becomes the
-active sprint runner.
+Declaration stops after an inspected `handoff` and the exact Conductor boot
+command has been given to the FnB. Re-entry stops after the requested directive
+is inspected. The originating Planner never becomes the active sprint runner
+and never executes the boot command itself.

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -92,7 +92,7 @@ initial sprint activation is the FnB's alpha gate. End the FnB-facing response
 with the exact operator action:
 
 ```sh
-./sc run CON1 -p "Process pending Conductor directives in ascending id order. Act each directive, inspect the result, and exit when the pending queue is empty."
+sc run CON1 -p "Process pending Conductor directives in ascending id order. Act each directive, inspect the result, and exit when the pending queue is empty."
 ```
 
 Tell the FnB that this one explicit boot activates the declared sprint.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3945,7 +3945,7 @@ initial sprint activation is the FnB''s alpha gate. End the FnB-facing response
 with the exact operator action:
 
 ```sh
-./sc run CON1 -p "Process pending Conductor directives in ascending id order. Act each directive, inspect the result, and exit when the pending queue is empty."
+sc run CON1 -p "Process pending Conductor directives in ascending id order. Act each directive, inspect the result, and exit when the pending queue is empty."
 ```
 
 Tell the FnB that this one explicit boot activates the declared sprint.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3874,6 +3874,7 @@ Explain the lifecycle before asking for routes:
 
 ```text
 reviewed spec → Planner declaration + complete board → explicit handoff →
+Planner tells FnB how to boot Conductor → FnB activates the sprint →
 Conductor runs workers mechanically → Planner re-enters only for decisions →
 independent conformance → close
 ```
@@ -3939,7 +3940,17 @@ sc directives emit handoff \
 ```
 
 Inspect the directive, then exit. Never boot a worker yourself and never remain
-resident after handoff.
+resident after handoff. The handoff deliberately does **not** boot Conductor:
+initial sprint activation is the FnB''s alpha gate. End the FnB-facing response
+with the exact operator action:
+
+```sh
+./sc run CON1 -p "Process pending Conductor directives in ascending id order. Act each directive, inspect the result, and exit when the pending queue is empty."
+```
+
+Tell the FnB that this one explicit boot activates the declared sprint.
+Post-activation directive/sentinel wakes remain engine-managed when enabled;
+the FnB is not the sprint''s message relay.
 
 ## Decision re-entry
 
@@ -3996,9 +4007,10 @@ independently reviewed board record.
 
 ## Stop
 
-Declaration stops after an inspected `handoff`. Re-entry stops after the
-requested directive is inspected. The originating Planner never becomes the
-active sprint runner.',
+Declaration stops after an inspected `handoff` and the exact Conductor boot
+command has been given to the FnB. Re-entry stops after the requested directive
+is inspected. The originating Planner never becomes the active sprint runner
+and never executes the boot command itself.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/tests/test_conductor_contracts.py
+++ b/tests/test_conductor_contracts.py
@@ -172,6 +172,43 @@ class ConductorContractTests(unittest.TestCase):
         self.assertEqual(status, 201)
         wake.assert_called_once()
 
+    def test_planner_handoff_waits_for_explicit_fnb_conductor_boot(self):
+        planner_id = self.con.execute(
+            "INSERT INTO shells "
+            "(display_name,shortname,flavor,system_prompt,api_key) "
+            "VALUES ('Planner','pln','planner','x','planner-token')"
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO documents "
+            "(document_id,kind,title,body) "
+            "VALUES (100,'doc','SPRINT: activation gate','x')"
+        )
+        self.con.execute(
+            "INSERT INTO sprints "
+            "(sprint_doc_id,planner_shell_id,state,legacy) "
+            "VALUES (100,?,'declared',1)",
+            (planner_id,),
+        )
+        self.con.commit()
+
+        with mock.patch.object(
+                conductor_routes.conductor_runtime,
+                "maybe_wake",
+        ) as wake:
+            status, item = self.post(
+                {
+                    "kind": "handoff",
+                    "target": "conductor",
+                    "sprint_doc_id": 100,
+                    "payload": {},
+                },
+                token="planner-token",
+            )
+
+        self.assertEqual(status, 201)
+        self.assertEqual(item["status"], "pending")
+        wake.assert_not_called()
+
     def test_act_requires_conductor_token_and_calls_mechanical_runtime(self):
         conductor_id = self.con.execute(
             "INSERT INTO shells "


### PR DESCRIPTION
## Summary
- leave Planner handoff directives pending without waking Conductor
- make the Planner print the exact FnB activation command and exit
- retain normal configured auto-wakes after initial activation
- cover the manual activation gate in conductor contract tests

This implements the alpha workflow recorded in sprint spec #25: Planner prepares and hands off; FnB explicitly boots Conductor once.

## Verification
- 37 passed, 23 subtests passed: conductor contracts, runtime, and slot skills
- ./sc render-check
- git diff --check