### PR TITLE
fix: hide bearer-token plumbing from ordinary shell-facing docs

### DIFF
--- a/.super-coder/assets/skills/db_map/SKILL.md
+++ b/.super-coder/assets/skills/db_map/SKILL.md
@@ -20,10 +20,10 @@ through the engine API, via `sc mem`:
 
 There is NO raw `sqlite3` path — not as a fallback, not for "ad-hoc" reads.
 If the API isn't wired, `sc mem` fails loud instead of writing the DB behind
-its back. Your identity rides in your bearer token — the server resolves
-token -> shell; never name a shell in a write. Decisions read FLEET-WIDE
-(every row, tagged `@shortname`) so cross-shell citations resolve; every
-other identity surface reads as you.
+its back. `sc mem` is already wired to this launched shell — the engine
+resolves API identity for you; never name a shell in a write. Decisions read
+FLEET-WIDE (every row, tagged `@shortname`) so cross-shell citations
+resolve; every other identity surface reads as you.
 
 **The `sc sql` lane** (read-only; `sc sql-rw` gated) is real and blessed for
 what `sc mem` doesn't cover: admin/reporting reads and sweep queries — the
@@ -74,7 +74,7 @@ are ALWAYS empty there — a `dr_*` query against `shell_db.db` silently returns
 
 Each routes through the engine API to the live shared DB. `sc mem which`
 orients; `sc mem <cmd> -h` shows flags. Writes always target your own shell —
-the server resolves it from your token.
+the engine resolves API identity for you.
 
 ```
 # current_state (rolling status, not a log — replaces in place):

--- a/.super-coder/assets/skills/memory/SKILL.md
+++ b/.super-coder/assets/skills/memory/SKILL.md
@@ -11,8 +11,8 @@ All memory = DB rows; no flat files. Write at the moment it matters, never in a
 close ritual.
 
 Every write goes through `sc mem` -> lands in the live shared engine DB, visible
-to all shells on commit. It always targets your own shell (identity resolved
-from your token) — never name a shell.
+to all shells on commit. It always targets your own shell (the engine resolves
+API identity for you) — never name a shell.
 
 ## current_state — rolling status, NOT a log
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1143,10 +1143,10 @@ through the engine API, via `sc mem`:
 
 There is NO raw `sqlite3` path — not as a fallback, not for "ad-hoc" reads.
 If the API isn''t wired, `sc mem` fails loud instead of writing the DB behind
-its back. Your identity rides in your bearer token — the server resolves
-token -> shell; never name a shell in a write. Decisions read FLEET-WIDE
-(every row, tagged `@shortname`) so cross-shell citations resolve; every
-other identity surface reads as you.
+its back. `sc mem` is already wired to this launched shell — the engine
+resolves API identity for you; never name a shell in a write. Decisions read
+FLEET-WIDE (every row, tagged `@shortname`) so cross-shell citations
+resolve; every other identity surface reads as you.
 
 **The `sc sql` lane** (read-only; `sc sql-rw` gated) is real and blessed for
 what `sc mem` doesn''t cover: admin/reporting reads and sweep queries — the
@@ -1197,7 +1197,7 @@ are ALWAYS empty there — a `dr_*` query against `shell_db.db` silently returns
 
 Each routes through the engine API to the live shared DB. `sc mem which`
 orients; `sc mem <cmd> -h` shows flags. Writes always target your own shell —
-the server resolves it from your token.
+the engine resolves API identity for you.
 
 ```
 # current_state (rolling status, not a log — replaces in place):
@@ -2540,8 +2540,8 @@ All memory = DB rows; no flat files. Write at the moment it matters, never in a
 close ritual.
 
 Every write goes through `sc mem` -> lands in the live shared engine DB, visible
-to all shells on commit. It always targets your own shell (identity resolved
-from your token) — never name a shell.
+to all shells on commit. It always targets your own shell (the engine resolves
+API identity for you) — never name a shell.
 
 ## current_state — rolling status, NOT a log
 

--- a/.super-coder/migrations/0129_reseed_api_identity_wording.sql
+++ b/.super-coder/migrations/0129_reseed_api_identity_wording.sql
@@ -1,0 +1,44 @@
+-- 0129 — shell-facing API identity wording (feature #23).
+--
+-- Ordinary shell-facing skill text stops teaching bearer-token mechanics:
+-- identity is described as already resolved by the engine for the launched
+-- shell. Carry the db_map and memory corrections forward without replacing
+-- the skill rows or their grants. Token terminology remains in
+-- implementation comments, auth code, maintainer docs, and test-authoring
+-- skills, where it is the subject.
+
+BEGIN;
+
+UPDATE skills
+SET content = REPLACE(
+  content,
+  'its back. Your identity rides in your bearer token — the server resolves
+token -> shell; never name a shell in a write. Decisions read FLEET-WIDE
+(every row, tagged `@shortname`) so cross-shell citations resolve; every
+other identity surface reads as you.',
+  'its back. `sc mem` is already wired to this launched shell — the engine
+resolves API identity for you; never name a shell in a write. Decisions read
+FLEET-WIDE (every row, tagged `@shortname`) so cross-shell citations
+resolve; every other identity surface reads as you.'
+)
+WHERE name = 'db_map';
+
+UPDATE skills
+SET content = REPLACE(
+  content,
+  'the server resolves it from your token.',
+  'the engine resolves API identity for you.'
+)
+WHERE name = 'db_map';
+
+UPDATE skills
+SET content = REPLACE(
+  content,
+  'to all shells on commit. It always targets your own shell (identity resolved
+from your token) — never name a shell.',
+  'to all shells on commit. It always targets your own shell (the engine resolves
+API identity for you) — never name a shell.'
+)
+WHERE name = 'memory';
+
+COMMIT;

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -420,9 +420,9 @@ def render_api(port: "int | None", api_key: "str | None") -> str:
     if port is None or not api_key:
         return "(API not configured — run `sc rebuild` to assign a key)"
     return (
-        f"- **Base URL:** `http://127.0.0.1:{port}`\n"
-        "- **Token:** available as `$SC_API_TOKEN` in your environment (set at launch).\n\n"
-        "Write memory via `sc mem` (proxied here automatically when `SC_API_TOKEN` is set). "
+        f"- **Base URL:** `http://127.0.0.1:{port}`\n\n"
+        "Write memory via `sc mem` — it is already wired to this launched shell; the engine "
+        "resolves API identity for you. "
         "Read messages: `GET /_sc/mem/messages`. Command reference: the `memory` and `db_map` skills."
     )
 

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -28,7 +28,7 @@ Discovery still calls the API; it is never a direct-DB path.
 
 Run from the repo root, like every engine command:
 
-    ./sc mem which                                 # confirm API reachability + who your token resolves to
+    ./sc mem which                                 # confirm the memory API is reachable + which shell this session resolves as
     ./sc mem get <surface>           [--json]      # read: state|seed|lns|decisions|flags|roadmap|narrative|messages
     ./sc mem get decisions [<id>|--all]            # default: active index (no rationale); <id> = full row; --all incl. superseded
                                                    # decisions read FLEET-WIDE (author tagged @shortname); writes stay your own
@@ -328,7 +328,7 @@ def cmd_which(args) -> int:
     if _DISCOVERED_FROM is not None:
         print(f"credential : discovered from runtime artifact {_DISCOVERED_FROM}")
     else:
-        print("identity   : resolved from your bearer token (SC_API_TOKEN), server-side")
+        print("identity   : resolved by the engine for this launched shell, server-side")
     return 0
 
 
@@ -914,7 +914,7 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="sc mem", description="engine memory surface (over the API)")
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    sub.add_parser("which", help="confirm API reachability + who your token resolves to") \
+    sub.add_parser("which", help="confirm the memory API is reachable + which shell this session resolves as") \
        .set_defaults(fn=cmd_which)
 
     sp = sub.add_parser("get", help=f"read a memory surface ({'/'.join(GET_SURFACES)}; doc/docs = documents)")

--- a/.super-coder/scripts/seed_dogfood.py
+++ b/.super-coder/scripts/seed_dogfood.py
@@ -59,10 +59,11 @@ live in DB tables — no flat-file memory, no harness auto-memory.
 
 Write as it happens, not at close. **Writes go through `sc mem`** (state · seed ·
 lns · decision · flag · roadmap · doc · narrative): it routes through the engine
-API, which resolves your identity from your token — no DB path, no direct-DB
-fallback. The write lands in the live engine DB — the single source of truth
-shared by every shell, durable and visible to all at once. That is the whole
-write: **you don't snapshot or render** — persisting to git is an admin/GUI step.
+API — already wired to this launched shell, identity resolved by the engine —
+no DB path, no direct-DB fallback. The write lands in the live engine DB — the
+single source of truth shared by every shell, durable and visible to all at
+once. That is the whole write: **you don't snapshot or render** — persisting
+to git is an admin/GUI step.
 `sc mem which` to orient. See the `memory` and `db_map` skills.
 
 **Flat files are renders, not sources.** Every local `.md` and git-tracked file

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -37,10 +37,11 @@ different ways, so keep them straight:
   `.super-coder/`. Holds your identity, memory, roadmap, specs, and the repo map.
   Gitignored and rebuilt from tracked text. **Write through `sc mem`** — the
   write lands in the live engine DB, durable and visible to all. `sc mem which`
-  confirms the API is reachable and who your token resolves to. `sc mem` routes
-  through the engine API (no direct-DB fallback). If it reports "API unreachable",
-  the engine server is down — surface this to FnB; they restart it with
-  `sc restart` / `make dos-r`. Do not retry silently; surface the error and stop.
+  confirms the API is reachable and which shell this session resolves as.
+  `sc mem` routes through the engine API (no direct-DB fallback). If it reports
+  "API unreachable", the engine server is down — surface this to FnB; they
+  restart it with `sc restart` / `make dos-r`. Do not retry silently; surface
+  the error and stop.
 - **App product DB** — the database of the product *this repo* builds. Its name
   and path **vary per fork** and live **outside** `.super-coder/`. Holds the
   product's runtime data + schema. Change it the way the product does — schema

--- a/sc
+++ b/sc
@@ -1596,7 +1596,7 @@ super-coder — forkable shell substrate
                              the target declined (decision #81); -h/--help still answers from any checkout. render-check is the
                              source-pure one: it verifies the CALLER's engine sources and local artifacts, and names the checkout it read.
   ./sc mem <cmd> [args]    a shell's own memory, over the engine API (get/state/seed/lns/decision/flag/roadmap/doc/narrative);
-                             identity is the shell's token, server-resolved — no DB path, no direct-DB fallback. `./sc mem which` to orient
+                             already wired to this launched shell, identity resolved by the engine — no DB path, no direct-DB fallback. `./sc mem which` to orient
   ./sc token               print the browser sign-in operator token (an operator capability: the Admin runtime
                              credential from the owner-only artifact .super-coder/run/mem/<shortname>.json, mode 0600)
                              — stdout carries ONLY the token, for paste into the browser sign-in prompt. Never


### PR DESCRIPTION
Implements feature #23 / spec doc #30 (Shell-facing API identity wording).

## What changed

Ordinary non-admin shell-facing text stops teaching bearer-token mechanics. The shell-facing contract is now: **`sc mem` is already wired to this launched shell; the engine resolves API identity for you.**

- `.super-coder/templates/boot.md` — `sc mem which` clause reworded ("which shell this session resolves as"); no-direct-DB-fallback and API-unreachable guidance kept verbatim.
- `.super-coder/assets/skills/db_map/SKILL.md` + `memory/SKILL.md` — token-identity sentences replaced with engine-resolves-identity wording; FLEET-WIDE decisions caveat and no-raw-sqlite rule untouched.
- `.super-coder/render/compose.py` `render_api` — the `**Token:** $SC_API_TOKEN` bullet removed; `sc mem` sentence carries the contract wording. Signature and guard unchanged.
- `.super-coder/scripts/mem.py` — docstring command list, `sc mem which` printed identity line, and argparse help reworded. Admin discovery branch untouched.
- `.super-coder/scripts/seed_dogfood.py` — seeded shell system prompt reworded, paragraph rewrapped.
- `sc` — `./sc help` mem entry no longer says "identity is the shell's token".
- `.super-coder/migrations/0001_seed_skills.sql` regenerated from assets; **new migration 0129** carries the db_map/memory corrections forward to existing DBs via targeted REPLACEs (0126 pattern).

## Deliberately preserved (spec carve-outs)

- `mem.py` implementation notes, `SC_API_TOKEN` env reads, `Authorization: Bearer` header construction, credential discovery, and the `_require_api` mis-wired-install diagnostic (names the env vars an operator must set — debug context).
- `issue_reporting` skill's "rebuild didn't re-mint api_keys" symptom row — diagnostic table, not auth teaching.
- Maintainer/operator/admin docs (`docs/`, `.super-coder/docs/`, adapters, `sc token`) — out of scope per spec.
- Historical reseed migrations — immutable.

## Verification

- Wording-only: no control flow, signature, or schema change beyond the additive 0129 reseed.
- `tests.test_fresh_install_shell_contract`, `test_mem`, `test_runtime_credentials`, `test_skills_freshness`: green.
- Full suite: 1374 tests, only the 5 pre-existing host-env failures remain (3 missing-pytest imports, 2 make-verbosity assertions) — identical before this diff.
- `./sc render-check`: green; fully-migrated hermetic DB carries the new skill bodies byte-exact with assets.
- Independent adversarial review pass over the diff found and led to the `sc` help fix; independent grep sweep confirms no banned term reaches a rendered ordinary boot doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)