### PR TITLE
fix: harden Conductor alpha across forks

### DIFF
--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -48,6 +48,21 @@ requires a new review. Merge only when the board still assigns this unit, all
 required checks are green, dependencies are satisfied, and `review-clean`
 names the exact head.
 
+When the bounded investigation proves the requested state is already true and
+the originating Planner explicitly rules that no change should be fabricated,
+send the current integrated main head through the same independent review:
+
+```sh
+sc directives emit ready-for-review \
+  --target conductor --sprint <id> --unit <unit-id> \
+  --payload '{"report_only":true,"pr_number":null,"head":"<main-sha>","branch":null,"checks":"report-only","verification":["<re-executed gate>"]}'
+```
+
+This is not a shortcut around implementation or review. Use it only for a
+Planner-ratified no-diff outcome with concrete verification. Conductor moves a
+clean report-only unit terminal after exact-head review. When that
+`review-clean` returns, do not emit `merged`; emit only the `unit-report` below.
+
 After merge emit both records:
 
 ```sh

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -35,9 +35,12 @@ Omit `--unit` for conformance.
 
 ## Unit review
 
-Pin the exact PR head and its checks. Trace correctness, authorization,
-empty/boundary/concurrent/partial-failure behavior, scope, and test strength.
-Mutate one high-value property, prove its test fails, restore, and prove green.
+Pin the exact PR head and its checks. For an explicit report-only unit, pin the
+integrated main head named by the developer and independently re-execute the
+claimed verification; a missing PR is expected only in that mode. Trace
+correctness, authorization, empty/boundary/concurrent/partial-failure behavior,
+scope, and test strength. Mutate one high-value property, prove its test fails,
+restore, and prove green.
 
 Emit all findings together:
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3823,6 +3823,21 @@ requires a new review. Merge only when the board still assigns this unit, all
 required checks are green, dependencies are satisfied, and `review-clean`
 names the exact head.
 
+When the bounded investigation proves the requested state is already true and
+the originating Planner explicitly rules that no change should be fabricated,
+send the current integrated main head through the same independent review:
+
+```sh
+sc directives emit ready-for-review \
+  --target conductor --sprint <id> --unit <unit-id> \
+  --payload ''{"report_only":true,"pr_number":null,"head":"<main-sha>","branch":null,"checks":"report-only","verification":["<re-executed gate>"]}''
+```
+
+This is not a shortcut around implementation or review. Use it only for a
+Planner-ratified no-diff outcome with concrete verification. Conductor moves a
+clean report-only unit terminal after exact-head review. When that
+`review-clean` returns, do not emit `merged`; emit only the `unit-report` below.
+
 After merge emit both records:
 
 ```sh
@@ -4054,9 +4069,12 @@ Omit `--unit` for conformance.
 
 ## Unit review
 
-Pin the exact PR head and its checks. Trace correctness, authorization,
-empty/boundary/concurrent/partial-failure behavior, scope, and test strength.
-Mutate one high-value property, prove its test fails, restore, and prove green.
+Pin the exact PR head and its checks. For an explicit report-only unit, pin the
+integrated main head named by the developer and independently re-execute the
+claimed verification; a missing PR is expected only in that mode. Trace
+correctness, authorization, empty/boundary/concurrent/partial-failure behavior,
+scope, and test strength. Mutate one high-value property, prove its test fails,
+restore, and prove green.
 
 Emit all findings together:
 

--- a/.super-coder/migrations/0130_conductor_reconciliation.sql
+++ b/.super-coder/migrations/0130_conductor_reconciliation.sql
@@ -1,0 +1,159 @@
+-- 0130 — same-invocation Conductor provisioning and exact skill boundary.
+--
+-- An installed fork runs its OLD update.py while materializing a new engine.
+-- The new Python reconciliation hook therefore cannot execute until a second
+-- command. Migrations are the exception: the old updater reads the newly
+-- materialized migration directory in the same invocation. This bridge makes
+-- that first update converge, then persistent guards stop the old updater's
+-- blanket common-skill regrant from re-polluting the opt-out Conductor pack.
+
+BEGIN;
+
+-- Idempotent direct replays temporarily lower only this migration's own pack
+-- guards, then restore them after the exact pack is reconciled.
+DROP TRIGGER IF EXISTS trg_conductor_skill_pack_insert;
+
+CREATE TEMP TABLE IF NOT EXISTS _conductor_reconcile_assert (
+    value INTEGER NOT NULL CHECK (value = 0)
+);
+
+-- Refuse ambiguous or identity-bearing operational shells. Seed and lineage
+-- are sovereign; migration must never delete them to force a role-only shape.
+INSERT INTO _conductor_reconcile_assert(value)
+SELECT CASE WHEN COUNT(*) > 1 THEN 1 ELSE 0 END
+FROM shells
+WHERE flavor = 'conductor' AND is_deleted = 0;
+
+INSERT INTO _conductor_reconcile_assert(value)
+SELECT CASE WHEN EXISTS (
+    SELECT 1
+    FROM shells sh
+    WHERE sh.flavor = 'conductor'
+      AND sh.is_deleted = 0
+      AND (
+          sh.has_identity <> 0
+          OR sh.lineage_seed IS NOT NULL
+          OR EXISTS (
+              SELECT 1 FROM shell_identity_entries sie
+              WHERE sie.shell_id = sh.shell_id
+          )
+      )
+) THEN 1 ELSE 0 END;
+
+INSERT INTO _conductor_reconcile_assert(value)
+SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM shells
+    WHERE shortname = 'CON1'
+      AND is_deleted = 0
+      AND flavor <> 'conductor'
+) THEN 1 ELSE 0 END;
+
+DELETE FROM _conductor_reconcile_assert;
+DROP TABLE _conductor_reconcile_assert;
+
+INSERT INTO shells (
+    display_name,
+    shortname,
+    partner,
+    role,
+    mandate,
+    system_prompt,
+    current_state,
+    connections,
+    flavor,
+    has_identity,
+    bootstrapped,
+    user_id,
+    is_shared,
+    api_key,
+    api_key_rotated_at
+)
+SELECT
+    'Conductor',
+    'CON1',
+    (SELECT username FROM users WHERE user_id = 1),
+    'Conductor shell',
+    'Run active sprints mechanically from durable directives; never decide.',
+    '# Conductor — mechanical sprint relay',
+    'Created (conductor). First session — run the bootstrap skill to orient.',
+    'Single repo: this one. One shell, one cwd.',
+    'conductor',
+    0,
+    0,
+    1,
+    0,
+    lower(hex(randomblob(32))),
+    datetime('now')
+WHERE EXISTS (
+    SELECT 1 FROM users WHERE user_id = 1
+)
+  AND NOT EXISTS (
+    SELECT 1 FROM shells
+    WHERE flavor = 'conductor' AND is_deleted = 0
+);
+
+UPDATE shells
+SET shortname = 'CON1',
+    api_key = COALESCE(api_key, lower(hex(randomblob(32)))),
+    api_key_rotated_at = CASE
+        WHEN api_key IS NULL THEN datetime('now')
+        ELSE api_key_rotated_at
+    END
+WHERE flavor = 'conductor' AND is_deleted = 0;
+
+INSERT INTO shell_memory_archives (
+    shell_id, session_id, date, full_narrative
+)
+SELECT shell_id, '0001', CURRENT_DATE, ''
+FROM shells
+WHERE flavor = 'conductor'
+  AND is_deleted = 0
+  AND active_archive_id IS NULL;
+
+UPDATE shells
+SET active_archive_id = (
+    SELECT MAX(a.archive_id)
+    FROM shell_memory_archives a
+    WHERE a.shell_id = shells.shell_id
+)
+WHERE flavor = 'conductor'
+  AND is_deleted = 0
+  AND active_archive_id IS NULL;
+
+DELETE FROM shell_skills
+WHERE shell_id IN (
+    SELECT shell_id FROM shells
+    WHERE flavor = 'conductor' AND is_deleted = 0
+);
+
+DELETE FROM flavor_skills WHERE flavor = 'conductor';
+
+INSERT INTO flavor_skills (flavor, skill_id)
+SELECT 'conductor', skill_id
+FROM skills
+WHERE name = 'sprint_cond' AND is_deleted = 0;
+
+CREATE TRIGGER IF NOT EXISTS trg_singleton_conductor
+BEFORE INSERT ON shells
+WHEN NEW.flavor = 'conductor' AND NEW.is_deleted = 0 AND (
+    SELECT COUNT(*) FROM shells
+    WHERE flavor = 'conductor' AND is_deleted = 0
+) >= 1
+BEGIN
+    SELECT RAISE(
+        ABORT,
+        'conductor is a singleton — this fork already has one'
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_conductor_skill_pack_insert
+BEFORE INSERT ON flavor_skills
+WHEN NEW.flavor = 'conductor' AND NEW.skill_id NOT IN (
+    SELECT skill_id FROM skills
+    WHERE name = 'sprint_cond' AND is_deleted = 0
+)
+BEGIN
+    SELECT RAISE(IGNORE);
+END;
+
+COMMIT;

--- a/.super-coder/migrations/0131_report_only_sprint_units.sql
+++ b/.super-coder/migrations/0131_report_only_sprint_units.sql
@@ -1,0 +1,189 @@
+-- 0131 — teach sprint workers the explicit report-only review contract.
+--
+-- Runtime support alone is insufficient: existing forks rebuild these worker
+-- instructions from the DB migration chain before the asset freshness healer
+-- runs. Re-seed both affected role skills so the same update that installs the
+-- runtime also teaches workers how to invoke it.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_dev',
+  'Execute one Conductor-assigned sprint unit, ask the originating Planner for decisions, deliver an exact reviewed head, report the merge, and exit.',
+  'craft',
+  NULL,
+  0,
+  '# sprint_dev
+
+Own only the unit in the mandatory slot context. Conductor owns the board,
+worker boots, relays, and dependency release. The originating Planner owns
+decisions. You build, prove, report, and exit.
+
+## Establish the boundary
+
+```sh
+sc sprint board --sprint <id>
+sc directives list --status pending --sprint <id>
+sc mem get documents --doc <governing-spec-id>
+```
+
+Confirm assignment, dependencies, branch, overlap, and observable completion
+gate. Never widen scope from neighboring units.
+
+When meaning, scope, authority, or evidence is ambiguous, stop and emit:
+
+```sh
+sc directives emit ask-planner \
+  --target conductor --sprint <id> --unit <unit-id> \
+  --payload ''{"question":"<decision>","alternatives":["A","B"],"evidence":["<fact>"],"downstream":["<effect>"]}''
+```
+
+Do not guess, message Planner directly, or boot another shell.
+
+## Build and review gate
+
+Use the recorded branch, preserve unrelated work, implement the smallest
+complete change, and run the unit''s focused and full gates. When green:
+
+```sh
+sc directives emit ready-for-review \
+  --target conductor --sprint <id> --unit <unit-id> \
+  --payload ''{"pr_number":123,"head":"<sha>","branch":"feat/example","checks":"green","verification":["<gate>"]}''
+```
+
+Review approval is exact-head-bound. Any relevant change after `review-clean`
+requires a new review. Merge only when the board still assigns this unit, all
+required checks are green, dependencies are satisfied, and `review-clean`
+names the exact head.
+
+When the bounded investigation proves the requested state is already true and
+the originating Planner explicitly rules that no change should be fabricated,
+send the current integrated main head through the same independent review:
+
+```sh
+sc directives emit ready-for-review \
+  --target conductor --sprint <id> --unit <unit-id> \
+  --payload ''{"report_only":true,"pr_number":null,"head":"<main-sha>","branch":null,"checks":"report-only","verification":["<re-executed gate>"]}''
+```
+
+This is not a shortcut around implementation or review. Use it only for a
+Planner-ratified no-diff outcome with concrete verification. Conductor moves a
+clean report-only unit terminal after exact-head review. When that
+`review-clean` returns, do not emit `merged`; emit only the `unit-report` below.
+
+After merge emit both records:
+
+```sh
+sc directives emit merged \
+  --target conductor --sprint <id> --unit <unit-id> \
+  --payload ''{"pr_number":123,"head":"<approved-head>","merge_sha":"<sha>"}''
+sc directives emit unit-report \
+  --target conductor --sprint <id> --unit <unit-id> \
+  --payload ''{"shipped":"<observable behavior>","judgements":[],"issues":[],"deviations":[],"follow_ups":[]}''
+```
+
+## Forbidden
+
+Never write the sprint board, boot or kill shells, schedule polling, issue
+Planner directives, approve your own head, merge without exact-head approval,
+or continue after an unresolved decision request.
+
+## Stop
+
+Exit after the inspected transition directive for the turn. Completion means
+the approved head is merged, both merge/report directives exist, and the
+worktree is clean.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_rev',
+  'Independently review one sprint unit at an exact head or run close-time conformance, route decisions to the originating Planner, emit one evidence-bound verdict, and exit.',
+  'craft',
+  NULL,
+  0,
+  '# sprint_rev
+
+Review adversarially inside the mandatory slot boundary. You never plan,
+implement the feature, merge, write the board, boot shells, poll, or wait.
+
+## Select the mode
+
+- a focused unit means exact-head code review;
+- no unit plus a conformance prompt means integrated close-time conformance;
+- anything ambiguous means `ask-planner`.
+
+```sh
+sc sprint board --sprint <id>
+sc directives list --status pending --sprint <id>
+sc mem get documents --doc <governing-spec-id>
+```
+
+For a missing/superseded head, unclear scope, unresolved overlap, or missing
+ratified deviation:
+
+```sh
+sc directives emit ask-planner \
+  --target conductor --sprint <id> --unit <unit-id> \
+  --payload ''{"question":"<decision or evidence>","alternatives":["A","B"],"evidence":["<fact>"]}''
+```
+
+Omit `--unit` for conformance.
+
+## Unit review
+
+Pin the exact PR head and its checks. For an explicit report-only unit, pin the
+integrated main head named by the developer and independently re-execute the
+claimed verification; a missing PR is expected only in that mode. Trace
+correctness, authorization, empty/boundary/concurrent/partial-failure behavior,
+scope, and test strength. Mutate one high-value property, prove its test fails,
+restore, and prove green.
+
+Emit all findings together:
+
+```sh
+sc directives emit findings \
+  --target conductor --sprint <id> --unit <unit-id> \
+  --payload ''{"head":"<sha>","findings":[{"severity":"Major","location":"path:line","consequence":"<failure>","required":"<behavior>"}],"mutation":"<proof>"}''
+```
+
+Or exact-head approval:
+
+```sh
+sc directives emit review-clean \
+  --target conductor --sprint <id> --unit <unit-id> \
+  --payload ''{"head":"<sha>","findings":[],"mutation":"<proof>"}''
+```
+
+## Conformance
+
+Require the integrated main SHA, full requirement scope, and complete
+ratified-deviation list. Give every requirement exactly one verdict:
+`as-specced`, `deviated-intentionally`, `deviated-silently`, or
+`unimplemented`.
+
+```sh
+sc directives emit findings \
+  --target conductor --sprint <id> \
+  --payload ''{"mode":"conformance","main_sha":"<sha>","findings":[{"severity":"Major","requirement":"R1","evidence":"path:line"}]}''
+sc directives emit review-clean \
+  --target conductor --sprint <id> \
+  --payload ''{"mode":"conformance","main_sha":"<sha>","verdicts":[{"requirement":"R1","verdict":"as-specced"}],"findings":[]}''
+```
+
+## Stop
+
+Inspect the one emitted verdict and exit with no unrestored mutation. A clean
+verdict never floats to another head.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -63,7 +63,7 @@ TRANSITIONS = (
     (
         "dev",
         "ready-for-review",
-        "record PR + move in_review; boot reviewer",
+        "record PR/report-only head + move in_review; boot reviewer",
         "reviewer slot starts at the exact head",
     ),
     (
@@ -87,8 +87,8 @@ TRANSITIONS = (
     (
         "reviewer",
         "review-clean",
-        "record review head; boot dev",
-        "developer receives approval for the exact head",
+        "record review head; boot dev or terminalize report-only unit",
+        "developer receives exact-head approval or report-only completion",
     ),
     (
         "reviewer",
@@ -668,11 +668,36 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
         unit = _unit(con, row)
         _assert_issuer_assignment(row, unit)
         if kind == "ready-for-review":
-            pr = _integer(payload, "pr_number")
-            head = _text(payload, "head")
-            branch = _text(payload, "branch")
-            if payload.get("checks") != "green":
-                raise DirectiveRefused("payload.checks must be 'green'")
+            report_only = payload.get("report_only") is True
+            if report_only:
+                if payload.get("pr_number") is not None:
+                    raise DirectiveRefused(
+                        "report-only ready-for-review requires null pr_number"
+                    )
+                if payload.get("branch") is not None:
+                    raise DirectiveRefused(
+                        "report-only ready-for-review requires null branch"
+                    )
+                if payload.get("checks") != "report-only":
+                    raise DirectiveRefused(
+                        "report-only ready-for-review requires "
+                        "payload.checks='report-only'"
+                    )
+                verification = payload.get("verification")
+                if not isinstance(verification, list) or not verification:
+                    raise DirectiveRefused(
+                        "report-only ready-for-review requires nonempty "
+                        "payload.verification"
+                    )
+                head = _text(payload, "head")
+                pr = None
+                branch = None
+            else:
+                pr = _integer(payload, "pr_number")
+                head = _text(payload, "head")
+                branch = _text(payload, "branch")
+                if payload.get("checks") != "green":
+                    raise DirectiveRefused("payload.checks must be 'green'")
             con.execute(
                 "UPDATE sprint_units SET pr_number=?,branch=?,"
                 "updated_at=datetime('now'),updated_by_shell_id=? "
@@ -754,7 +779,22 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
                     "SELECT shell_id,shortname,flavor FROM shells WHERE shell_id=?",
                     (unit["dev_shell_id"],),
                 ).fetchone()
-                _spawn(con, launches, dev, "dev", row, payload, unit=unit)
+                if unit["pr_number"] is None and unit["branch"] is None:
+                    _move(con, unit, "merged", actor_shell_id)
+                    _release_ready_units(
+                        con, launches, row, payload, actor_shell_id
+                    )
+                    _spawn(
+                        con,
+                        launches,
+                        dev,
+                        "dev",
+                        row,
+                        {**payload, "report_only": True},
+                        unit=unit,
+                    )
+                else:
+                    _spawn(con, launches, dev, "dev", row, payload, unit=unit)
         elif kind == "findings":
             findings = payload.get("findings")
             if not isinstance(findings, list) or not findings:

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -280,9 +280,11 @@ def _pending_ids(con) -> list[int]:
     return [
         row[0]
         for row in con.execute(
-            "SELECT directive_id FROM directives "
-            "WHERE status='pending' AND target='conductor' "
-            "ORDER BY directive_id"
+            "SELECT d.directive_id FROM directives d "
+            "JOIN sprints sp ON sp.sprint_doc_id=d.sprint_doc_id "
+            "WHERE d.status='pending' AND d.target='conductor' "
+            "AND sp.state='active' "
+            "ORDER BY d.directive_id"
         )
     ]
 

--- a/.super-coder/scripts/init_fork.py
+++ b/.super-coder/scripts/init_fork.py
@@ -52,7 +52,7 @@ TEAM_ROSTER = [
     "reviewer",
 ]
 
-from shell_factory import create_shell, flavors  # noqa: E402
+from shell_factory import create_shell, flavors, reconcile_conductor  # noqa: E402
 
 
 def already_seeded(con) -> bool:
@@ -152,6 +152,9 @@ def main(argv: list[str]) -> int:
             cart_id = create_shell(
                 con, flavor="cartographer", name="Cartographer",
                 partner=a.partner or username, repo=repo)
+        conductor_id, _ = reconcile_conductor(
+            con, partner=a.partner or username, repo=repo
+        )
         con.commit()
 
         def _sn(sid):
@@ -168,7 +171,11 @@ def main(argv: list[str]) -> int:
         if cart_id:
             print(f"init_fork: created '{_sn(cart_id)}' (cartographer, shell_id={cart_id}) "
                   "— owns the repo map.")
-        total = 1 + len(team) + (1 if cart_id else 0)
+        print(
+            f"init_fork: created '{_sn(conductor_id)}' "
+            f"(conductor, shell_id={conductor_id}) — role-only sprint relay."
+        )
+        total = 2 + len(team) + (1 if cart_id else 0)
         print(f"init_fork: seeded a {total}-shell team. "
               "next -> `SC_ADMIN=1 ./sc snapshot` (serialize), then `./sc launch`.")
     finally:

--- a/.super-coder/scripts/ports.py
+++ b/.super-coder/scripts/ports.py
@@ -61,20 +61,54 @@ def _resolve_offset(base: int, avoid: set[int]) -> int:
         port = PORT_BASE + (base + i) % SPAN
         if port not in avoid and _free(port):
             return port
-    return PORT_BASE + base  # pragma: no cover — all 100 offsets busy is implausible
+    raise RuntimeError(
+        f"no free super-coder port in {PORT_BASE}-{PORT_BASE + SPAN - 1}"
+    )
 
 
-def _dev_offset(port: int) -> int:
+def _dev_offset(port: int, avoid: set[int] | None = None) -> int:
     """Derive a dev port from a distinct seed, kept free and != the serve port."""
-    return _resolve_offset(_offset(str(REPO_ROOT) + ":dev"), avoid={port})
+    return _resolve_offset(
+        _offset(str(REPO_ROOT) + ":dev"),
+        avoid=set(avoid or ()) | {port},
+    )
 
 
-def _derive() -> dict:
+def _sibling_ports() -> set[int]:
+    """Read both assigned ports from every sibling fork we can discover.
+
+    Installed forks conventionally share one parent (for example ``~/Repos``).
+    Their gitignored instance configs are the durable host-local registry.  A
+    malformed or unrelated sibling is ignored; this fork's own config is
+    excluded.
+    """
+    occupied: set[int] = set()
+    try:
+        children = REPO_ROOT.parent.iterdir()
+    except OSError:
+        return occupied
+    for child in children:
+        candidate = child / ".super-coder" / "instance.json"
+        if candidate == CONFIG or not candidate.is_file():
+            continue
+        try:
+            sibling = json.loads(candidate.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        for key in ("port", "dev_port"):
+            value = sibling.get(key)
+            if isinstance(value, int):
+                occupied.add(value)
+    return occupied
+
+
+def _derive(avoid: set[int] | None = None) -> dict:
     """Derive serve + dev ports from the repo path. Each is bumped past any
     occupied port so it lands free, and dev_port is kept distinct from port."""
-    port = _resolve_offset(_offset(str(REPO_ROOT)), avoid=set())
+    occupied = set(avoid or ())
+    port = _resolve_offset(_offset(str(REPO_ROOT)), avoid=occupied)
     return {"repo": REPO_ROOT.name, "port": port,
-            "dev_port": _dev_offset(port), "harness": "claude"}
+            "dev_port": _dev_offset(port, occupied), "harness": "claude"}
 
 
 def resolve(persist: bool = False) -> dict:
@@ -83,6 +117,7 @@ def resolve(persist: bool = False) -> dict:
     path. `persist=True` writes it to instance.json so it stays stable. To force
     a re-derive (e.g. after a port clash), delete the file."""
     cfg = None
+    occupied = _sibling_ports()
     if CONFIG.exists():
         try:
             loaded = json.loads(CONFIG.read_text())
@@ -91,11 +126,26 @@ def resolve(persist: bool = False) -> dict:
         except json.JSONDecodeError:
             pass
     if cfg is None:
-        cfg = _derive()
-    elif "dev_port" not in cfg:
+        cfg = _derive(occupied)
+    else:
+        # Existing configs remain stable unless they collide with another
+        # fork's API *or* dev assignment. A bound copy of our own port is not a
+        # reason to move it: resolve() commonly runs while this fork is live.
+        port = cfg["port"]
+        dev_port = cfg.get("dev_port")
+        if port in occupied:
+            base = port - PORT_BASE if PORT_BASE <= port < PORT_BASE + SPAN \
+                else _offset(str(REPO_ROOT))
+            port = _resolve_offset(
+                base, occupied | ({dev_port} if isinstance(dev_port, int) else set())
+            )
+            cfg["port"] = port
+        if not isinstance(dev_port, int) or dev_port == port or dev_port in occupied:
+            cfg["dev_port"] = _dev_offset(port, occupied)
+    if "dev_port" not in cfg:
         # Instance predates dev_port — backfill without disturbing the serve port
         # (respects hand-edits to `port`); persisted below if requested.
-        cfg["dev_port"] = _dev_offset(cfg["port"])
+        cfg["dev_port"] = _dev_offset(cfg["port"], occupied)
     if persist:
         CONFIG.write_text(json.dumps(cfg, indent=2) + "\n")
     return cfg

--- a/.super-coder/scripts/shell_factory.py
+++ b/.super-coder/scripts/shell_factory.py
@@ -101,6 +101,49 @@ def load_flavor(flavor: str) -> dict:
     return _apply_overlay(tpl, ov) if ov else tpl
 
 
+def reconcile_flavor_pack(con, flavor: str) -> int:
+    """Converge one shipped flavor's engine-owned skill baseline.
+
+    Common-inheriting packs keep operator-added opt-ins and receive any new
+    common/template skills. Opt-out packs are exact: anything outside the
+    template's explicit list is removed. This makes
+    ``inherit_common_skills: false`` durable across install, update, and
+    catalogue reseeds.
+    """
+    template = load_flavor(flavor)
+    explicit = tuple(template.get("skills", ()))
+    changed = 0
+    if not template.get("inherit_common_skills", True):
+        if explicit:
+            placeholders = ",".join("?" for _ in explicit)
+            cur = con.execute(
+                "DELETE FROM flavor_skills WHERE flavor=? AND skill_id NOT IN ("
+                f"SELECT skill_id FROM skills WHERE name IN ({placeholders})"
+                ")",
+                (flavor, *explicit),
+            )
+        else:
+            cur = con.execute(
+                "DELETE FROM flavor_skills WHERE flavor=?", (flavor,)
+            )
+        changed += cur.rowcount
+    else:
+        cur = con.execute(
+            "INSERT OR IGNORE INTO flavor_skills (flavor,skill_id) "
+            "SELECT ?,skill_id FROM skills WHERE is_deleted=0 AND common=1",
+            (flavor,),
+        )
+        changed += cur.rowcount
+    for name in explicit:
+        cur = con.execute(
+            "INSERT OR IGNORE INTO flavor_skills (flavor,skill_id) "
+            "SELECT ?,skill_id FROM skills WHERE name=? AND is_deleted=0",
+            (flavor, name),
+        )
+        changed += cur.rowcount
+    return changed
+
+
 def _auto_shortname(con, abbr: str) -> str:
     """Default shortname when the caller gives none: <ABBR><n> — the flavor's
     abbreviation + the next integer (e.g. DEV3, PLN1). Numbered max-suffix + 1
@@ -186,3 +229,80 @@ def create_shell(con, *, flavor: str | None, name: str,
 
     open_session(con, shell_id)
     return shell_id
+
+
+def reconcile_conductor(
+    con, *, partner: str | None = None, repo: str | None = None
+) -> tuple[int, bool]:
+    """Provision exactly one live, role-only ``CON1`` and its exact skill pack.
+
+    Repeated calls are idempotent. Multiple live Conductors or personal
+    identity on an operational Conductor are refused instead of guessed away.
+    """
+    rows = con.execute(
+        "SELECT shell_id,shortname,has_identity,lineage_seed,api_key "
+        "FROM shells WHERE flavor='conductor' AND is_deleted=0 "
+        "ORDER BY shell_id"
+    ).fetchall()
+    if len(rows) > 1:
+        raise ValueError(
+            "multiple live conductor shells found — delete the unintended "
+            "duplicate before reconciliation"
+        )
+    created = not rows
+    if created:
+        occupied = con.execute(
+            "SELECT shell_id FROM shells "
+            "WHERE shortname='CON1' AND is_deleted=0"
+        ).fetchone()
+        if occupied is not None:
+            raise ValueError(
+                "CON1 is already assigned to a non-conductor shell"
+            )
+        shell_id = create_shell(
+            con,
+            flavor="conductor",
+            name="Conductor",
+            shortname="CON1",
+            partner=partner,
+            repo=repo,
+        )
+    else:
+        row = rows[0]
+        shell_id = row["shell_id"]
+        identity_count = con.execute(
+            "SELECT COUNT(*) FROM shell_identity_entries WHERE shell_id=?",
+            (shell_id,),
+        ).fetchone()[0]
+        if row["has_identity"] or row["lineage_seed"] or identity_count:
+            raise ValueError(
+                "conductor shell carries personal identity — refusing to "
+                "delete seed or lineage during role-only reconciliation"
+            )
+        if row["shortname"] != "CON1":
+            occupied = con.execute(
+                "SELECT shell_id FROM shells "
+                "WHERE shortname='CON1' AND is_deleted=0 AND shell_id<>?",
+                (shell_id,),
+            ).fetchone()
+            if occupied is not None:
+                raise ValueError(
+                    "CON1 is already assigned to another live shell"
+                )
+            con.execute(
+                "UPDATE shells SET shortname='CON1' WHERE shell_id=?",
+                (shell_id,),
+            )
+        if not row["api_key"]:
+            con.execute(
+                "UPDATE shells SET api_key=?,api_key_rotated_at=datetime('now') "
+                "WHERE shell_id=?",
+                (secrets.token_urlsafe(32), shell_id),
+            )
+
+    # Flavored shells must not retain stale direct rows: the server doctor
+    # treats them as an authority-boundary violation even though the resolved
+    # skill view ignores them.
+    con.execute("DELETE FROM shell_skills WHERE shell_id=?", (shell_id,))
+    reconcile_flavor_pack(con, "conductor")
+    return shell_id, created

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -74,6 +74,7 @@ import install as install_mod  # noqa: E402  (ensure_harnesses)
 import migrate as migrate_mod  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402
 import seed_skills  # noqa: E402
+import shell_factory  # noqa: E402
 import sprint_state  # noqa: E402
 
 EJECTED_MARKER = STATE_DIR / "ejected"
@@ -761,11 +762,14 @@ def regrant() -> int:
         }
         added = 0
         for flavor in sorted(template_flavors | live_flavors):
-            cur = con.execute(
-                "INSERT OR IGNORE INTO flavor_skills (flavor, skill_id) "
-                "SELECT ?, skill_id FROM skills "
-                "WHERE is_deleted=0 AND common=1", (flavor,))
-            added += cur.rowcount
+            if flavor in template_flavors:
+                added += shell_factory.reconcile_flavor_pack(con, flavor)
+            else:
+                cur = con.execute(
+                    "INSERT OR IGNORE INTO flavor_skills (flavor, skill_id) "
+                    "SELECT ?, skill_id FROM skills "
+                    "WHERE is_deleted=0 AND common=1", (flavor,))
+                added += cur.rowcount
         cur = con.execute(
             "INSERT OR IGNORE INTO shell_skills (shell_id, skill_id) "
             "SELECT s.shell_id, k.skill_id FROM shells s, skills k "
@@ -774,6 +778,24 @@ def regrant() -> int:
         added += cur.rowcount
         con.commit()
         return added
+    finally:
+        con.close()
+
+
+def reconcile_conductor() -> bool:
+    """Provision/update the singleton operational Conductor in the live DB."""
+    con = db_driver.connect(DB_PATH)
+    try:
+        user = con.execute(
+            "SELECT username FROM users WHERE user_id=1"
+        ).fetchone()
+        _, created = shell_factory.reconcile_conductor(
+            con,
+            partner=user[0] if user is not None else None,
+            repo=REPO_ROOT.name,
+        )
+        con.commit()
+        return created
     finally:
         con.close()
 
@@ -894,7 +916,9 @@ def main(argv: list[str]) -> int:
     print("→ sync skills catalogue (id-stable)")
     sync_skills()
     print("→ re-grant catalogue skills to all shells")
-    print(f"  {regrant()} new grant(s)")
+    print(f"  {regrant()} grant change(s)")
+    print("→ reconcile singleton Conductor")
+    print("  created CON1" if reconcile_conductor() else "  CON1 current")
     print("→ wire map automation + map the repo")
     run_script("map_setup.py")
     print("→ snapshot the live state")

--- a/tests/test_conductor_reconciliation.py
+++ b/tests/test_conductor_reconciliation.py
@@ -21,12 +21,18 @@ import init_fork  # noqa: E402
 import shell_factory  # noqa: E402
 import update  # noqa: E402
 
+RECONCILE_MIGRATION = MIGRATIONS / "0130_conductor_reconciliation.sql"
 
-def build_db(path: Path) -> sqlite3.Connection:
+
+def build_db(
+    path: Path, *, through_0129: bool = False
+) -> sqlite3.Connection:
     con = sqlite3.connect(path)
     con.row_factory = sqlite3.Row
     con.executescript(SCHEMA.read_text())
     for migration in sorted(MIGRATIONS.glob("*.sql")):
+        if through_0129 and migration.name >= "0130_":
+            break
         con.executescript(migration.read_text())
     con.execute("PRAGMA foreign_keys=ON")
     return con
@@ -132,6 +138,8 @@ class ConductorReconciliationTest(unittest.TestCase):
         shell_factory.create_shell(
             self.con, flavor="conductor", name="Conductor", shortname="CON1"
         )
+        # Simulate ambiguous legacy state from before the singleton trigger.
+        self.con.execute("DROP TRIGGER trg_singleton_conductor")
         shell_factory.create_shell(
             self.con, flavor="conductor", name="Conductor 2", shortname="CON2"
         )
@@ -143,6 +151,42 @@ class ConductorReconciliationTest(unittest.TestCase):
                 "WHERE flavor='conductor' AND is_deleted=0"
             ).fetchone()[0],
             2,
+        )
+
+    def test_migration_provisions_once_and_blocks_old_common_regrant(self) -> None:
+        temporary = tempfile.TemporaryDirectory(prefix="sc_conductor_migration_")
+        self.addCleanup(temporary.cleanup)
+        db_path = Path(temporary.name) / "pre-0130.db"
+        con = build_db(db_path, through_0129=True)
+        self.addCleanup(con.close)
+        con.execute(
+            "INSERT INTO users (user_id,username,is_active) VALUES (1,'Jed',1)"
+        )
+        con.execute(
+            "INSERT INTO shells "
+            "(display_name,shortname,system_prompt,flavor,user_id,api_key) "
+            "VALUES ('Planner','PLN1','prompt','planner',1,'planner-key')"
+        )
+        con.commit()
+
+        con.executescript(RECONCILE_MIGRATION.read_text())
+        con.executescript(RECONCILE_MIGRATION.read_text())
+        # This is the old update.py behavior that runs after newly materialized
+        # migrations in the same process. The trigger must keep it harmless.
+        con.execute(
+            "INSERT OR IGNORE INTO flavor_skills (flavor,skill_id) "
+            "SELECT 'conductor',skill_id FROM skills "
+            "WHERE is_deleted=0 AND common=1"
+        )
+        con.commit()
+
+        assert_conductor_contract(self, con)
+        self.assertEqual(
+            con.execute(
+                "SELECT COUNT(*) FROM shells "
+                "WHERE flavor='conductor' AND is_deleted=0"
+            ).fetchone()[0],
+            1,
         )
 
 

--- a/tests/test_conductor_reconciliation.py
+++ b/tests/test_conductor_reconciliation.py
@@ -1,0 +1,172 @@
+"""Fresh-install and update reconciliation for the singleton Conductor."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+SCRIPTS = ENGINE / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import init_fork  # noqa: E402
+import shell_factory  # noqa: E402
+import update  # noqa: E402
+
+
+def build_db(path: Path) -> sqlite3.Connection:
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+def assert_conductor_contract(
+    case: unittest.TestCase, con: sqlite3.Connection
+) -> None:
+    rows = con.execute(
+        "SELECT shell_id,shortname,flavor,lineage_seed,has_identity,api_key "
+        "FROM shells WHERE flavor='conductor' AND is_deleted=0"
+    ).fetchall()
+    case.assertEqual(len(rows), 1)
+    row = rows[0]
+    case.assertEqual(row["shortname"], "CON1")
+    case.assertIsNone(row["lineage_seed"])
+    case.assertEqual(row["has_identity"], 0)
+    case.assertTrue(row["api_key"])
+    case.assertEqual(
+        con.execute(
+            "SELECT COUNT(*) FROM shell_identity_entries WHERE shell_id=?",
+            (row["shell_id"],),
+        ).fetchone()[0],
+        0,
+    )
+    case.assertEqual(
+        {
+            item[0]
+            for item in con.execute(
+                "SELECT s.name FROM flavor_skills fs "
+                "JOIN skills s ON s.skill_id=fs.skill_id "
+                "WHERE fs.flavor='conductor' AND s.is_deleted=0"
+            )
+        },
+        {"sprint_cond"},
+    )
+    case.assertEqual(
+        con.execute(
+            "SELECT COUNT(*) FROM shell_skills WHERE shell_id=?",
+            (row["shell_id"],),
+        ).fetchone()[0],
+        0,
+    )
+    case.assertEqual(
+        tuple(con.execute(
+            "SELECT harness,model FROM flavor_defaults "
+            "WHERE flavor='conductor' AND is_default=1"
+        ).fetchone()),
+        ("opencode", "openai/gpt-5.6-luna"),
+    )
+
+
+class ConductorReconciliationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory(prefix="sc_conductor_reconcile_")
+        self.addCleanup(temporary.cleanup)
+        self.db_path = Path(temporary.name) / "shell.db"
+        self.con = build_db(self.db_path)
+        self.addCleanup(self.con.close)
+        self.con.execute(
+            "INSERT INTO users (user_id,username,is_active) VALUES (1,'Jed',1)"
+        )
+        self.con.commit()
+
+    def close_fixture_connection(self) -> None:
+        self.con.close()
+
+    def test_pre_conductor_update_creates_one_and_rerun_is_idempotent(self) -> None:
+        shell_factory.create_shell(
+            self.con, flavor="planner", name="Planner",
+            shortname="PLN1", partner="Jed",
+        )
+        self.con.commit()
+        self.close_fixture_connection()
+
+        with mock.patch.object(update, "DB_PATH", self.db_path):
+            self.assertTrue(update.reconcile_conductor())
+            self.assertFalse(update.reconcile_conductor())
+
+        con = sqlite3.connect(self.db_path)
+        con.row_factory = sqlite3.Row
+        self.addCleanup(con.close)
+        assert_conductor_contract(self, con)
+
+    def test_regrant_cleans_polluted_opt_out_pack(self) -> None:
+        shell_factory.reconcile_conductor(self.con, partner="Jed")
+        self.con.execute(
+            "INSERT OR IGNORE INTO flavor_skills (flavor,skill_id) "
+            "SELECT 'conductor',skill_id FROM skills WHERE common=1"
+        )
+        self.con.commit()
+        self.close_fixture_connection()
+
+        with mock.patch.object(update, "DB_PATH", self.db_path):
+            update.regrant()
+
+        con = sqlite3.connect(self.db_path)
+        con.row_factory = sqlite3.Row
+        self.addCleanup(con.close)
+        assert_conductor_contract(self, con)
+
+    def test_duplicate_live_conductors_are_refused(self) -> None:
+        shell_factory.create_shell(
+            self.con, flavor="conductor", name="Conductor", shortname="CON1"
+        )
+        shell_factory.create_shell(
+            self.con, flavor="conductor", name="Conductor 2", shortname="CON2"
+        )
+        with self.assertRaisesRegex(ValueError, "multiple live conductor"):
+            shell_factory.reconcile_conductor(self.con, partner="Jed")
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM shells "
+                "WHERE flavor='conductor' AND is_deleted=0"
+            ).fetchone()[0],
+            2,
+        )
+
+
+class FreshInstallConductorTest(unittest.TestCase):
+    def test_fresh_init_provisions_role_only_con1(self) -> None:
+        temporary = tempfile.TemporaryDirectory(prefix="sc_conductor_fresh_")
+        self.addCleanup(temporary.cleanup)
+        db_path = Path(temporary.name) / "shell.db"
+        con = build_db(db_path)
+        con.close()
+
+        with (
+            mock.patch.object(init_fork, "DB_PATH", db_path),
+            mock.patch.object(
+                init_fork.install_mod, "seed_visual_qa_files", return_value=[]
+            ),
+        ):
+            self.assertEqual(init_fork.main(["--username", "Jed"]), 0)
+
+        con = sqlite3.connect(db_path)
+        con.row_factory = sqlite3.Row
+        self.addCleanup(con.close)
+        assert_conductor_contract(self, con)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -290,6 +290,47 @@ class ConductorFlavorAndDoctorTests(RuntimeFixture):
         self.assertIn("opencode", self.commands[0])
         self.assertIn(runtime.DEFAULT_CONDUCTOR_MODEL, self.commands[0])
 
+    def test_declared_handoff_is_not_eligible_for_automatic_wake(self):
+        self.set_declared()
+        directive_id = self.emit("planner", "handoff", {}, unit=False)
+        self.con.commit()
+
+        config = runtime.ConductorConfig(
+            True, "CON1", runtime.DEFAULT_CONDUCTOR_MODEL
+        )
+        with mock.patch.object(
+            runtime,
+            "doctor",
+            return_value={
+                "enabled": True,
+                "ok": True,
+                "shell_id": 1,
+                "shell": "CON1",
+                "harness": "opencode",
+                "model": runtime.DEFAULT_CONDUCTOR_MODEL,
+            },
+        ):
+            result = runtime.maybe_wake(
+                self.con, config=config, launcher=self.launcher
+            )
+
+        self.assertFalse(result["launched"])
+        self.assertEqual(result["reason"], "no-pending")
+        self.assertEqual(self.commands, [])
+        self.assertEqual(
+            self.con.execute(
+                "SELECT status FROM directives WHERE directive_id=?",
+                (directive_id,),
+            ).fetchone()[0],
+            "pending",
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT state FROM sprints WHERE sprint_doc_id=100"
+            ).fetchone()[0],
+            "declared",
+        )
+
     def test_opencode_headless_route_does_not_invent_effort(self):
         adapter = run.load_adapter("opencode")
         self.assertIsNone(run.default_headless_effort(adapter))

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -586,6 +586,110 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             "refused",
         )
 
+    def test_report_only_unit_is_reviewed_then_terminal_and_reported(self):
+        self.set_unit("working")
+        ready_id = self.emit(
+            "dev",
+            "ready-for-review",
+            {
+                "report_only": True,
+                "pr_number": None,
+                "head": "main-abc",
+                "branch": None,
+                "checks": "report-only",
+                "verification": ["re-executed documented command"],
+            },
+        )
+        self.con.commit()
+
+        ready = runtime.act(self.con, ready_id, 1, launcher=self.launcher)
+
+        self.assertEqual(ready["status"], "executed")
+        self.assertEqual(len(ready["launches"]), 1)
+        unit = self.con.execute(
+            "SELECT state,pr_number,branch FROM sprint_units WHERE unit_id=10"
+        ).fetchone()
+        self.assertEqual(tuple(unit), ("in_review", None, None))
+
+        clean_id = self.emit(
+            "reviewer",
+            "review-clean",
+            {"head": "main-abc", "findings": [], "mutation": "failed then passed"},
+        )
+        self.con.commit()
+
+        clean = runtime.act(self.con, clean_id, 1, launcher=self.launcher)
+
+        self.assertEqual(clean["status"], "executed")
+        self.assertEqual(len(clean["launches"]), 1)
+        self.assertIn('"report_only": true', clean["launches"][0][-1])
+        unit = self.con.execute(
+            "SELECT state,review_head FROM sprint_units WHERE unit_id=10"
+        ).fetchone()
+        self.assertEqual(tuple(unit), ("merged", "main-abc"))
+
+        report_id = self.emit(
+            "dev",
+            "unit-report",
+            {"shipped": "verified requested state already present"},
+        )
+        self.con.commit()
+        report = runtime.act(self.con, report_id, 1, launcher=self.launcher)
+        self.assertEqual(report["status"], "executed")
+        self.assertEqual(len(report["launches"]), 1)
+        self.assertIn("PLN1", report["launches"][0])
+
+    def test_report_only_requires_explicit_null_contract_and_evidence(self):
+        cases = (
+            {
+                "report_only": True,
+                "pr_number": 7,
+                "head": "abc",
+                "branch": None,
+                "checks": "report-only",
+                "verification": ["gate"],
+            },
+            {
+                "report_only": True,
+                "pr_number": None,
+                "head": "abc",
+                "branch": "feat/not-report-only",
+                "checks": "report-only",
+                "verification": ["gate"],
+            },
+            {
+                "report_only": True,
+                "pr_number": None,
+                "head": "abc",
+                "branch": None,
+                "checks": "green",
+                "verification": ["gate"],
+            },
+            {
+                "report_only": True,
+                "pr_number": None,
+                "head": "abc",
+                "branch": None,
+                "checks": "report-only",
+                "verification": [],
+            },
+        )
+        for payload in cases:
+            with self.subTest(payload=payload):
+                self.set_unit("working")
+                directive_id = self.emit("dev", "ready-for-review", payload)
+                self.con.commit()
+                result = runtime.act(
+                    self.con, directive_id, 1, launcher=self.launcher
+                )
+                self.assertEqual(result["status"], "refused")
+                self.assertEqual(
+                    self.con.execute(
+                        "SELECT state FROM sprint_units WHERE unit_id=10"
+                    ).fetchone()[0],
+                    "working",
+                )
+
     def test_retask_returns_reviewed_unit_to_working_and_clears_review_head(self):
         self.set_unit("working")
         self.set_unit("in_review", review_head="approved-old-head")

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -1,0 +1,90 @@
+"""Global API/dev port allocation regressions."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import ports  # noqa: E402
+
+
+class GlobalPortNamespaceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory(prefix="sc_ports_")
+        self.addCleanup(temporary.cleanup)
+        self.repos = Path(temporary.name)
+        self.current = self.repos / "ami"
+        self.sibling = self.repos / "sibling"
+        self.current_config = self.current / ".super-coder" / "instance.json"
+        self.sibling_config = self.sibling / ".super-coder" / "instance.json"
+        self.current_config.parent.mkdir(parents=True)
+        self.sibling_config.parent.mkdir(parents=True)
+
+    def resolve(self, current: dict | None = None) -> dict:
+        if current is not None:
+            self.current_config.write_text(json.dumps(current))
+        with (
+            mock.patch.object(ports, "REPO_ROOT", self.current),
+            mock.patch.object(ports, "CONFIG", self.current_config),
+            mock.patch.object(ports, "_free", return_value=True),
+        ):
+            return ports.resolve(persist=True)
+
+    def test_existing_api_port_moves_off_sibling_dev_port(self) -> None:
+        self.sibling_config.write_text(json.dumps({
+            "repo": "sibling",
+            "port": 8871,
+            "dev_port": 8812,
+        }))
+
+        resolved = self.resolve({
+            "repo": "ami",
+            "port": 8812,
+            "dev_port": 8844,
+            "harness": "opencode",
+        })
+
+        self.assertNotEqual(resolved["port"], 8812)
+        self.assertEqual(resolved["dev_port"], 8844)
+        self.assertTrue({resolved["port"], resolved["dev_port"]}.isdisjoint(
+            {8871, 8812}
+        ))
+        self.assertEqual(json.loads(self.current_config.read_text()), resolved)
+
+    def test_new_pair_avoids_both_fields_from_every_sibling(self) -> None:
+        self.sibling_config.write_text(json.dumps({
+            "repo": "sibling",
+            "port": 8800,
+            "dev_port": 8801,
+        }))
+
+        with (
+            mock.patch.object(ports, "REPO_ROOT", self.current),
+            mock.patch.object(ports, "CONFIG", self.current_config),
+            mock.patch.object(ports, "_offset", return_value=0),
+            mock.patch.object(ports, "_free", return_value=True),
+        ):
+            resolved = ports.resolve()
+
+        self.assertEqual(len({resolved["port"], resolved["dev_port"]}), 2)
+        self.assertTrue({resolved["port"], resolved["dev_port"]}.isdisjoint(
+            {8800, 8801}
+        ))
+
+    def test_exhausted_global_namespace_fails_instead_of_colliding(self) -> None:
+        with mock.patch.object(ports, "_free", return_value=False):
+            with self.assertRaisesRegex(RuntimeError, "no free super-coder port"):
+                ports._resolve_offset(0, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -412,12 +412,21 @@ class RestrictedLaunchTests(unittest.TestCase):
 
 
 class MakeDispatchTests(unittest.TestCase):
+    @staticmethod
+    def make_env():
+        # The suite itself may be launched through `make dos-test`. Inheriting
+        # MAKELEVEL makes this direct probe look recursive and adds GNU Make's
+        # Entering/Leaving directory wrappers to otherwise exact output.
+        return {key: value for key, value in os.environ.items()
+                if key != "MAKELEVEL"}
+
     def test_dos_launch_forwards_no_build(self):
         result = subprocess.run(
             ["make", "-n", "dos-l", "ARGS=--no-build"],
             cwd=ROOT,
             text=True,
             capture_output=True,
+            env=self.make_env(),
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "./sc launch --no-build")
@@ -428,6 +437,7 @@ class MakeDispatchTests(unittest.TestCase):
             cwd=ROOT,
             text=True,
             capture_output=True,
+            env=self.make_env(),
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "./sc restart --yes --no-build")

--- a/tests/test_visual_qa_distribution.py
+++ b/tests/test_visual_qa_distribution.py
@@ -137,7 +137,7 @@ class VisualQaSeedTest(unittest.TestCase):
                 "WHERE sh.flavor IS NULL;"
             )
 
-        next_shell_id = iter(range(1, 11))
+        next_shell_id = iter(range(1, 12))
         identity_flags = []
 
         def create_shell(con, *, flavor, **kwargs):
@@ -150,6 +150,11 @@ class VisualQaSeedTest(unittest.TestCase):
             )
             return shell_id
 
+        def reconcile_conductor(con, **kwargs):
+            return create_shell(
+                con, flavor="conductor", partner=kwargs.get("partner")
+            ), True
+
         seeded = [Path(".github/workflows/subfloor-visual-qa.yml")]
         with (
             mock.patch.object(init_fork, "DB_PATH", database),
@@ -157,9 +162,15 @@ class VisualQaSeedTest(unittest.TestCase):
             mock.patch.object(init_fork, "create_shell", side_effect=create_shell),
             mock.patch.object(
                 init_fork,
+                "reconcile_conductor",
+                side_effect=reconcile_conductor,
+            ),
+            mock.patch.object(
+                init_fork,
                 "flavors",
                 return_value=[{"flavor": name} for name in
-                              ("admin", "planner", "dev", "reviewer", "cartographer")],
+                              ("admin", "planner", "dev", "reviewer",
+                               "cartographer", "conductor")],
             ),
         ):
             self.assertEqual(init_fork.main(["--username", "Jed"]), 0)
@@ -183,10 +194,11 @@ class VisualQaSeedTest(unittest.TestCase):
                     ("reviewer",),
                     ("reviewer",),
                     ("cartographer",),
+                    ("conductor",),
                 ],
             )
             self.assertNotIn(("devops",), flavors)
-        self.assertEqual(identity_flags, [True] + [False] * 9)
+        self.assertEqual(identity_flags, [True] + [False] * 10)
 
 
 class VisualQaUpdateTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- allocate API and dev ports from one global sibling-fork namespace
- reconcile exactly one role-only CON1 on fresh install and in-place update
- honor inherit_common_skills: false and restrict Conductor to sprint_cond
- fence declared handoffs until the FnB explicitly activates Conductor once
- support exact-head report-only units with no fabricated diff or PR

## Regression coverage
- all four AMI-reported failures
- old-updater/new-migration boundary during first reconciliation
- strict report-only payload validation and full terminal workflow

## Verification
- 1453 tests passed
- ./sc render-check
- ./sc verify
- git diff --check
- AMI update/restart pinned to 2f11ef6ec383eea56c1fb5ca48714c2072f7c837
- AMI sprint 12 closed after one explicit FnB activation with no manual port edits, shell creation, skill toggles, DB writes, or worker relays

Fixes #740
Fixes #743
Fixes #744
Fixes #745
Fixes #749