### PR TITLE
fix(opencode): render native skill tree

### DIFF
--- a/.super-coder/adapters/opencode/README.md
+++ b/.super-coder/adapters/opencode/README.md
@@ -1,9 +1,10 @@
 # adapters/opencode — OpenCode
 
-OpenCode consumes our Claude-format assets almost unchanged — it reads `AGENTS.md`
-at the repo root and `.claude/skills/<name>/SKILL.md` natively (Agent Skills
-format), both already emitted by the render chain. The adapter adds the one
-harness-specific file OpenCode wants and the launch command.
+OpenCode reads `AGENTS.md` at the repo root and discovers Agent Skills from its
+native `.opencode/skills/<name>/SKILL.md` tree. The render chain emits each
+shell's exact grants there for OpenCode while retaining the
+`.claude/skills/<name>/SKILL.md` mirror used by Claude-compatible harnesses.
+The adapter adds the harness-specific config file and launch command.
 
 - **`opencode.json`** (emitted to the repo root at launch, gitignored like the
   boot artifact) — points `instructions` at `AGENTS.md`, sets default tool
@@ -21,10 +22,12 @@ harness-specific file OpenCode wants and the launch command.
   `OPENCODE_DISABLE_LSP_DOWNLOAD=true` in the environment — OpenCode auto-fetches
   server binaries on first use, and this is the only knob for it (env-only, no
   JSON key), so we leave it to the env rather than forcing it off here.
-- **`env.OPENCODE_DISABLE_CLAUDE_CODE=1`** — best-effort: stop OpenCode from also
-  loading `CLAUDE.md` (we dual-write both with identical content; this avoids a
-  double-load). ⚠ The exact env name is a **research flag to verify on live
-  OpenCode** — if wrong it's a harmless no-op (the content is identical anyway).
+- **`skill_dirs`** — renders exact shell grants to both `.claude/skills` and
+  OpenCode's native `.opencode/skills`. Native delivery avoids depending on
+  version-sensitive project-local Claude compatibility.
+- **`env.OPENCODE_DISABLE_CLAUDE_CODE=1`** — disables Claude prompt and skill
+  compatibility so OpenCode sees only its native, exact-grant skill tree rather
+  than ambient global `~/.claude/skills`.
 - **`tool-discipline.md`** + its entry in `instructions` — a static, harness-level
   steer (not part of the render-chain-generated `AGENTS.md`, so it survives
   regeneration). It tells the model never to emit tool calls as text/XML and never
@@ -60,8 +63,7 @@ harness-specific file OpenCode wants and the launch command.
 
 ## Verify on live OpenCode (research flags from the spec)
 
-- skills dir spelling consumed (`.claude/skills/` ✓ vs any `agent(s)/` variant)
-- `OPENCODE_DISABLE_CLAUDE_CODE` env name (above)
+- native `.opencode/skills/` discovery
 - session-storage paths (doc 404'd at research time)
 
 None block the contract; confirm during real-repo testing.

--- a/.super-coder/adapters/opencode/adapter.json
+++ b/.super-coder/adapters/opencode/adapter.json
@@ -3,6 +3,7 @@
   "launch": ["opencode"],
   "boot_artifact": "AGENTS.md",
   "emit": ["opencode.json"],
+  "skill_dirs": [".claude/skills", ".opencode/skills"],
   "env": { "OPENCODE_DISABLE_CLAUDE_CODE": "1" },
   "model": { "file": "opencode.json", "key": "model" },
   "headless": { "launch": ["opencode", "run"], "model_flag": "-m" },

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -255,23 +255,29 @@ def render_visibility(con: sqlite3.Connection, root: "Path | None" = None) -> di
 # ── Harness skill render (per booting shell; gitignored cache) ────────────────
 
 def render_skill_md(con: sqlite3.Connection, shell_id: int,
-                    work_dir: "Path | None" = None) -> dict:
-    """Render the booting shell's granted skills to `.claude/skills/<name>/SKILL.md`
-    (Agent Skills format: name + description frontmatter, content body).
+                    work_dir: "Path | None" = None,
+                    skills_dir: "Path | None" = None) -> dict:
+    """Render the booting shell's granted skills to
+    `<skills_dir>/<name>/SKILL.md` (Agent Skills format: name + description
+    frontmatter, content body). The default is `.claude/skills`; adapters may
+    request an additional native directory such as `.opencode/skills`.
 
     Harness-consumed and gitignored, like the boot artifact — rebuilt every
     launch for whichever shell boots. Stale skill folders (a grant since
     revoked, or another shell's skills) are pruned so the dir reflects exactly
     this shell's current grants.
 
-    work_dir overrides the write root (used for dev-shell worktrees)."""
+    work_dir overrides the write root (used for dev-shell worktrees).
+    skills_dir is relative to that root."""
     rows = con.execute(
         "SELECT s.name, s.description, s.content FROM skills s "
         "JOIN resolved_shell_skills ss ON ss.skill_id = s.skill_id "
         "WHERE ss.shell_id=? AND s.is_deleted=0 ORDER BY s.name",
         (shell_id,),
     ).fetchall()
-    skills_root = (work_dir or REPO_ROOT) / ".claude" / "skills"
+    skills_root = (work_dir or REPO_ROOT) / (
+        skills_dir or Path(".claude/skills")
+    )
     written: list[Path] = []
     skipped: list[Path] = []
     current = {_skill_slug(r["name"]) for r in rows}

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -179,6 +179,32 @@ def emit_adapter(adapter: dict, root: Path = REPO_ROOT) -> list[str]:
     return written
 
 
+def render_harness_skills(con: sqlite3.Connection, shell_id: int,
+                          work_dir: Path, adapter: dict) -> dict:
+    """Render exact shell grants into every skill directory consumed by the
+    selected harness. Adapters default to the Claude-compatible path and may
+    add a native path where compatibility discovery is incomplete."""
+    skill_dirs = adapter.get("skill_dirs") or [".claude/skills"]
+    written: list[Path] = []
+    skipped: list[Path] = []
+    for raw_dir in skill_dirs:
+        skills_dir = Path(raw_dir)
+        if skills_dir.is_absolute() or ".." in skills_dir.parts:
+            raise LaunchError(
+                f"adapter skill_dirs entry must stay inside the worktree: {raw_dir}"
+            )
+        summary = flat.render_skill_md(
+            con, shell_id, work_dir, skills_dir=skills_dir
+        )
+        written.extend(summary["written"])
+        skipped.extend(summary["skipped"])
+    return {
+        "written": written,
+        "skipped": skipped,
+        "dirs": list(skill_dirs),
+    }
+
+
 def resolve_opencode_plugins(work_dir: Path) -> None:
     """Rewrite opencode.json `plugin` entries that point into the engine to
     ABSOLUTE paths. The template registers
@@ -1250,7 +1276,9 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
                            source_mode=install.is_source_repo(),
                            api_key=full["api_key"],
                            api_port=api_port)
-    flat.render_skill_md(con, full["shell_id"], work_dir)
+    render_harness_skills(
+        con, full["shell_id"], work_dir, adapter
+    )
     con.close()
     for name in ("CLAUDE.md", "AGENTS.md"):
         atomic_write(work_dir / name, content)
@@ -1657,9 +1685,11 @@ def main() -> None:
                                api_port=api_port,
                                slot_context=slot_context)
 
-        # Render this shell's granted skills to .claude/skills/<name>/SKILL.md —
-        # harness-consumed, gitignored, rebuilt per boot (like the boot artifact).
-        skills = flat.render_skill_md(con, full["shell_id"], work_dir)
+        # Render this shell's granted skills to every directory declared by the
+        # selected harness — gitignored and rebuilt per boot.
+        skills = render_harness_skills(
+            con, full["shell_id"], work_dir, adapter
+        )
         con.close()
 
         # One compose, two outputs — Claude Code reads CLAUDE.md, the AGENTS.md
@@ -1690,7 +1720,8 @@ def main() -> None:
     if headless and api_port and full["api_key"]:
         print(f"→ api: http://127.0.0.1:{api_port} (SC_API_TOKEN set)")
     print(f"→ skills: {len(skills['written'])} written, "
-          f"{len(skills['skipped'])} unchanged → .claude/skills/")
+          f"{len(skills['skipped'])} unchanged → "
+          f"{', '.join(skills['dirs'])}")
 
     # Harness was resolved up front (override / picker / default); the adapter
     # seam owns the launch command + any harness-specific config to emit.

--- a/tests/test_flavor_skill_packs.py
+++ b/tests/test_flavor_skill_packs.py
@@ -363,6 +363,24 @@ class RenderAndSnapshotTest(unittest.TestCase):
                  / "engine_surgery" / "SKILL.md").exists()
             )
 
+    def test_skill_render_supports_a_harness_native_directory(self) -> None:
+        self.con.execute(
+            "INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+            (self.custom, self.kid),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            flat.render_skill_md(
+                self.con,
+                self.custom,
+                work_dir=Path(tmp),
+                skills_dir=Path(".opencode/skills"),
+            )
+
+            self.assertTrue(
+                (Path(tmp) / ".opencode" / "skills"
+                 / "engine_surgery" / "SKILL.md").exists()
+            )
+
     def test_snapshot_serializes_pack_grants_by_skill_name(self) -> None:
         self.con.execute(
             "INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -22,6 +22,7 @@ import threading
 import unittest
 from http.server import ThreadingHTTPServer
 from pathlib import Path
+from unittest import mock
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 SCHEMA = ENGINE / "schema.sql"
@@ -1030,6 +1031,34 @@ class HeadlessTest(unittest.TestCase):
     def test_opencode_headless_argv(self):
         cmd = run.headless_command(self.adapter("opencode"), "p", "zai/glm")
         self.assertEqual(cmd, ["opencode", "run", "-m", "zai/glm", "p"])
+
+    def test_opencode_declares_native_skill_delivery(self):
+        adapter = self.adapter("opencode")
+        self.assertEqual(
+            adapter["skill_dirs"],
+            [".claude/skills", ".opencode/skills"],
+        )
+        self.assertEqual(adapter["env"]["OPENCODE_DISABLE_CLAUDE_CODE"], "1")
+
+    def test_opencode_renders_every_declared_skill_directory(self):
+        adapter = self.adapter("opencode")
+        with mock.patch.object(
+            run.flat,
+            "render_skill_md",
+            return_value={"written": [], "skipped": []},
+        ) as render:
+            summary = run.render_harness_skills(
+                object(), 7, Path("/tmp/work"), adapter
+            )
+
+        self.assertEqual(
+            [call.kwargs["skills_dir"] for call in render.call_args_list],
+            [Path(".claude/skills"), Path(".opencode/skills")],
+        )
+        self.assertEqual(
+            summary["dirs"],
+            [".claude/skills", ".opencode/skills"],
+        )
 
     def test_no_model_omits_the_flag(self):
         cmd = run.headless_command(self.adapter("claude"), "p")


### PR DESCRIPTION
## Summary
- render each shell's exact skill grants into adapter-declared skill directories
- keep the Claude-compatible `.claude/skills` mirror and add OpenCode's native `.opencode/skills` mirror
- retain `OPENCODE_DISABLE_CLAUDE_CODE=1` so ambient global Claude skills cannot pollute role-only OpenCode shells
- cover native directory rendering in both interactive and engine-prepared launch paths

## Root cause
OpenCode supports skills, but the deployed 1.18.9 build did not reliably discover project-local `.claude/skills` while the adapter deliberately disabled Claude compatibility. The boot render therefore wrote `sprint_cond` to a path the Conductor could not see. Native `.opencode/skills` delivery removes that compatibility dependency.

## Verification
- live OpenCode 1.18.9 discovers `sprint_cond` through its native skill loader with Claude compatibility disabled
- 159 focused tests green across eventing, rendering, launch, slot, and Conductor suites
- 1456 full tests passed
- `./sc render-check`
- `./sc verify`
- `git diff --check`

Closes #746