### PR TITLE
Feature 24: prove native conversation capabilities

### DIFF
--- a/.super-coder/adapters/claude/README.md
+++ b/.super-coder/adapters/claude/README.md
@@ -44,3 +44,19 @@ before it. Re-emitted (idempotently) each launch, so it survives `./sc update`.
 `scripts/branch-guard.sh` is the **one** branch-decision script shared by all four
 harnesses (claude + codex hooks, the opencode plugin, the git pre-commit backstop)
 — so `SC_PROTECTED_BRANCHES` and the message stay identical everywhere.
+
+## Conversation capability
+
+Feature #24 selected process-per-turn print mode. A new conversation supplies a
+broker-generated UUID through `--session-id`; every later process uses
+`--resume <uuid>`. Structured streaming requires all of `--print --verbose
+--output-format stream-json`; `--include-partial-messages` adds text deltas.
+The `system.init.session_id` field is the captured native reference.
+
+The contract was live-probed on 2.1.220. Two UUIDs in the same cwd retained
+different nonce values and exact resume returned the requested conversation.
+Sending `SIGINT` produced an `aborted_streaming` result with an explicit
+interruption record; a fresh process resumed that UUID and retained the
+interrupted prompt. Browser-mediated permission responses remain unproven, so
+the manifest advertises that capability as false until the adapter has a typed
+permission bridge.

--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -12,6 +12,29 @@
     "model_flag": "--model",
     "effort": { "flag": "--effort" }
   },
+  "conversation": {
+    "minimum_cli_version": "2.1.220",
+    "verified_cli_version": "2.1.220",
+    "driver": "claude-print",
+    "session_ref": { "source": "system.init", "field": "session_id" },
+    "start": {
+      "session_flag": "--session-id",
+      "stream_flags": ["--verbose", "--output-format", "stream-json", "--include-partial-messages"]
+    },
+    "resume": { "session_flag": "--resume" },
+    "stream": { "transport": "stdout-jsonl" },
+    "interrupt": { "mechanism": "signal", "signal": "SIGINT" },
+    "inspect": { "mechanism": "native-session-store" },
+    "permission_policy": "claude-permission-mode-and-prompt-tool",
+    "capabilities": {
+      "exact_session_resume": true,
+      "structured_streaming": true,
+      "interruption": true,
+      "interactive_permission_response": false,
+      "server_backed": false,
+      "session_inspection": true
+    }
+  },
   "merge_json": {
     ".claude/settings.local.json": {
       "hooks": {

--- a/.super-coder/adapters/codex/README.md
+++ b/.super-coder/adapters/codex/README.md
@@ -57,3 +57,20 @@ claude/opencode get).
 mounted from the host — so `codex` must be installed + logged in on the host once:
 `curl -fsSL https://chatgpt.com/codex/install.sh | sh` then `codex` and sign in
 with ChatGPT. That writes `~/.codex/auth.json`, which `./sc launch` mounts in.
+
+## Conversation capability
+
+Feature #24 selected `codex app-server`, not transcript mutation and not
+`exec resume --last`. The broker records `thread/start`'s `thread.id`, later
+opens it with `thread/resume`, starts one turn at a time, consumes JSONL-RPC
+notifications, interrupts with `turn/interrupt`, and inspects persisted state
+with `thread/read`.
+
+The contract was live-probed on 0.145.0. Exact `codex exec resume <thread-id>`
+kept two same-cwd conversations isolated. The app-server probe ran with
+`approvalPolicy=never` and `sandbox=danger-full-access`, interrupted a live
+harmless command, observed terminal status `interrupted`, stopped the server,
+started a new server, resumed the exact thread, and recovered the original
+nonce. Permission policy is the requirement; `--sandbox` is not part of the
+shared contract. This CLI version expects kebab-case `danger-full-access` in
+the app-server payload.

--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -10,6 +10,30 @@
     "model_flag": "-m",
     "effort": { "config_flag": "-c", "config_key": "model_reasoning_effort" }
   },
+  "conversation": {
+    "minimum_cli_version": "0.145.0",
+    "verified_cli_version": "0.145.0",
+    "driver": "codex-app-server",
+    "session_ref": { "source": "thread.start", "field": "thread.id" },
+    "start": { "method": "thread/start" },
+    "resume": { "method": "thread/resume", "session_field": "threadId" },
+    "stream": { "transport": "jsonl-rpc-notifications" },
+    "interrupt": { "method": "turn/interrupt" },
+    "inspect": { "method": "thread/read" },
+    "permission_policy": "approvalPolicy-and-sandbox",
+    "permission_values": {
+      "approval": "never",
+      "unrestricted": "danger-full-access"
+    },
+    "capabilities": {
+      "exact_session_resume": true,
+      "structured_streaming": true,
+      "interruption": true,
+      "interactive_permission_response": true,
+      "server_backed": true,
+      "session_inspection": true
+    }
+  },
   "sandbox": {
     "launch_flags": ["--dangerously-bypass-approvals-and-sandbox"],
     "headless_flags": ["--dangerously-bypass-approvals-and-sandbox"]

--- a/.super-coder/adapters/opencode/README.md
+++ b/.super-coder/adapters/opencode/README.md
@@ -67,3 +67,18 @@ The adapter adds the harness-specific config file and launch command.
 - session-storage paths (doc 404'd at research time)
 
 None block the contract; confirm during real-repo testing.
+
+## Conversation capability
+
+Feature #24 selected `opencode serve` as the conversation driver. The broker
+creates a session through the local authenticated HTTP API, stores the returned
+opaque `id`, submits later turns to that exact session, consumes `/event` SSE,
+interrupts through the session abort resource, and inspects the session
+resource during recovery. The server stays bound to `127.0.0.1`; credentials
+remain engine-side.
+
+The contract was live-probed on 1.18.9. Two sessions in `/tmp` retained
+different nonce values, and resuming the first by `sessionID` after the second
+ran returned only the first nonce. An asynchronous prompt emitted
+`session.status=busy`; `POST /session/:id/abort` returned `true`, emitted a
+`MessageAbortedError`, and returned the session to `idle`.

--- a/.super-coder/adapters/opencode/adapter.json
+++ b/.super-coder/adapters/opencode/adapter.json
@@ -7,6 +7,24 @@
   "env": { "OPENCODE_DISABLE_CLAUDE_CODE": "1" },
   "model": { "file": "opencode.json", "key": "model" },
   "headless": { "launch": ["opencode", "run"], "model_flag": "-m" },
+  "conversation": {
+    "minimum_cli_version": "1.18.9",
+    "verified_cli_version": "1.18.9",
+    "driver": "opencode-server",
+    "session_ref": { "source": "session.create", "field": "id" },
+    "stream": { "transport": "sse", "path": "/event" },
+    "interrupt": { "method": "POST", "path": "/session/{session_ref}/abort" },
+    "inspect": { "method": "GET", "path": "/session/{session_ref}" },
+    "permission_policy": "opencode-config-and-permission-events",
+    "capabilities": {
+      "exact_session_resume": true,
+      "structured_streaming": true,
+      "interruption": true,
+      "interactive_permission_response": true,
+      "server_backed": true,
+      "session_inspection": true
+    }
+  },
   "sandbox": {
     "merge_json": {
       "opencode.json": {

--- a/tests/fixtures/conversations/capability_probes.json
+++ b/tests/fixtures/conversations/capability_probes.json
@@ -1,0 +1,77 @@
+{
+  "probe_date": "2026-07-29",
+  "required_harnesses": {
+    "opencode": {
+      "verified_cli_version": "1.18.9",
+      "driver": "opencode-server",
+      "native_ref_shape": "ses_<opaque>",
+      "observed_events": [
+        "step_start",
+        "text",
+        "step_finish",
+        "session.status",
+        "message.updated",
+        "session.idle"
+      ],
+      "proof": {
+        "two_turn_exact_resume": true,
+        "same_worktree_isolation": true,
+        "structured_streaming": true,
+        "interruption": true,
+        "resume_after_compute_exit": true,
+        "session_inspection": true
+      }
+    },
+    "claude": {
+      "verified_cli_version": "2.1.220",
+      "driver": "claude-print",
+      "native_ref_shape": "uuid",
+      "observed_events": [
+        "system.init",
+        "stream_event.content_block_delta",
+        "assistant",
+        "result"
+      ],
+      "proof": {
+        "two_turn_exact_resume": true,
+        "same_worktree_isolation": true,
+        "structured_streaming": true,
+        "interruption": true,
+        "resume_after_compute_exit": true,
+        "session_inspection": true
+      }
+    },
+    "codex": {
+      "verified_cli_version": "0.145.0",
+      "driver": "codex-app-server",
+      "native_ref_shape": "uuid",
+      "observed_events": [
+        "thread.started",
+        "turn.started",
+        "item.started",
+        "item.agentMessage.delta",
+        "turn.completed"
+      ],
+      "proof": {
+        "two_turn_exact_resume": true,
+        "same_worktree_isolation": true,
+        "structured_streaming": true,
+        "interruption": true,
+        "resume_after_compute_exit": true,
+        "session_inspection": true,
+        "resume_after_server_restart": true,
+        "unrestricted_permission_policy": true
+      }
+    }
+  },
+  "reference_only": {
+    "kimi": {
+      "session_ref_shape": "session_<uuid>",
+      "state_store": "~/.kimi-code/sessions/wd_<name>_<hash>/session_<uuid>/state.json",
+      "wire_store": "agents/main/wire.jsonl",
+      "exact_worktree_field": "workDir",
+      "observed_events": ["turn.prompt", "llm.request", "turn.cancel", "usage.record"],
+      "release_gate_member": false
+    }
+  }
+}

--- a/tests/test_conversation_capabilities.py
+++ b/tests/test_conversation_capabilities.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Contract tests for Feature #24's live-probed harness capabilities."""
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADAPTERS = ROOT / ".super-coder" / "adapters"
+PROBES = ROOT / "tests" / "fixtures" / "conversations" / "capability_probes.json"
+REQUIRED = ("opencode", "claude", "codex")
+CAPABILITIES = {
+    "exact_session_resume",
+    "structured_streaming",
+    "interruption",
+    "interactive_permission_response",
+    "server_backed",
+    "session_inspection",
+}
+VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+class ConversationCapabilityContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.probes = json.loads(PROBES.read_text())
+
+    def adapter(self, harness: str) -> dict:
+        return json.loads(
+            (ADAPTERS / harness / "adapter.json").read_text()
+        )
+
+    def test_required_harnesses_have_verified_conversation_contracts(self) -> None:
+        self.assertEqual(
+            set(self.probes["required_harnesses"]),
+            set(REQUIRED),
+        )
+        for harness in REQUIRED:
+            with self.subTest(harness=harness):
+                conversation = self.adapter(harness)["conversation"]
+                probe = self.probes["required_harnesses"][harness]
+                self.assertRegex(conversation["minimum_cli_version"], VERSION)
+                self.assertEqual(
+                    conversation["verified_cli_version"],
+                    probe["verified_cli_version"],
+                )
+                self.assertEqual(
+                    conversation["minimum_cli_version"],
+                    conversation["verified_cli_version"],
+                    "the spike uses the conservative live-probed version as its floor",
+                )
+                self.assertEqual(conversation["driver"], probe["driver"])
+                self.assertEqual(
+                    set(conversation["capabilities"]),
+                    CAPABILITIES,
+                )
+                for proof in (
+                    "two_turn_exact_resume",
+                    "same_worktree_isolation",
+                    "structured_streaming",
+                    "interruption",
+                    "resume_after_compute_exit",
+                    "session_inspection",
+                ):
+                    self.assertIs(
+                        probe["proof"][proof],
+                        True,
+                        f"{harness} lacks live proof for {proof}",
+                    )
+
+    def test_opencode_uses_exact_server_resources(self) -> None:
+        conversation = self.adapter("opencode")["conversation"]
+        self.assertEqual(conversation["session_ref"], {
+            "source": "session.create",
+            "field": "id",
+        })
+        self.assertEqual(conversation["stream"]["path"], "/event")
+        self.assertIn("{session_ref}", conversation["interrupt"]["path"])
+        self.assertIn("{session_ref}", conversation["inspect"]["path"])
+
+    def test_claude_streaming_and_resume_flags_are_explicit(self) -> None:
+        conversation = self.adapter("claude")["conversation"]
+        flags = conversation["start"]["stream_flags"]
+        self.assertIn("--verbose", flags)
+        self.assertIn("stream-json", flags)
+        self.assertEqual(conversation["start"]["session_flag"], "--session-id")
+        self.assertEqual(conversation["resume"]["session_flag"], "--resume")
+        self.assertEqual(conversation["interrupt"]["signal"], "SIGINT")
+        self.assertFalse(
+            conversation["capabilities"]["interactive_permission_response"]
+        )
+
+    def test_codex_uses_app_server_and_permission_policy_not_resume_sandbox_flag(
+            self) -> None:
+        conversation = self.adapter("codex")["conversation"]
+        self.assertEqual(conversation["start"]["method"], "thread/start")
+        self.assertEqual(conversation["resume"], {
+            "method": "thread/resume",
+            "session_field": "threadId",
+        })
+        self.assertEqual(conversation["interrupt"]["method"], "turn/interrupt")
+        self.assertEqual(
+            conversation["permission_values"]["unrestricted"],
+            "danger-full-access",
+        )
+        self.assertTrue(
+            self.probes["required_harnesses"]["codex"]["proof"]
+            ["resume_after_server_restart"]
+        )
+
+    def test_kimi_reference_does_not_widen_the_release_gate(self) -> None:
+        kimi = self.probes["reference_only"]["kimi"]
+        self.assertEqual(kimi["exact_worktree_field"], "workDir")
+        self.assertIn("turn.cancel", kimi["observed_events"])
+        self.assertFalse(kimi["release_gate_member"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements Feature #24 / Spec #32 task #90.

- records live-probed conversation contracts for OpenCode 1.18.9, Claude Code 2.1.220, and Codex CLI 0.145.0
- proves exact-session isolation, structured streaming, interruption, inspection, and resume after ephemeral compute
- proves Codex app-server resume after server restart with explicit unrestricted permission policy
- records the dos-app Kimi session format as reference-only without widening the release gate
- adds contract fixtures and regression tests

Verification:
- python3 tests/test_conversation_capabilities.py
- python3 tests/test_sprint_eventing.py
- ./sc render-check
- ./sc verify
- git diff --check