### PR TITLE
Feature 24: add conversation schema and state machine

### DIFF
--- a/.super-coder/migrations/0132_conversation_foundation.sql
+++ b/.super-coder/migrations/0132_conversation_foundation.sql
@@ -1,0 +1,424 @@
+-- 0132 — durable browser-native conversation foundation (feature #24).
+--
+-- Conversations outlive harness processes. The engine stores the exact native
+-- session reference, ordered messages, one-turn runs, normalized replay events,
+-- and transactional dispatch intent. Harness transcripts remain harness-owned.
+--
+-- No trigger automatically dispatches work on INSERT. The API/broker must
+-- insert a message and its outbox row in one explicit transaction; snapshot
+-- replay therefore restores durable state without accidentally launching it.
+
+BEGIN;
+
+CREATE TABLE conversations (
+    conversation_id         TEXT PRIMARY KEY
+                            DEFAULT ('cv_' || lower(hex(randomblob(16)))),
+    shell_id                INTEGER NOT NULL REFERENCES shells(shell_id),
+    mode                    TEXT NOT NULL DEFAULT 'normal'
+                            CHECK (mode IN ('normal','sprint')),
+    owner_user_id           INTEGER REFERENCES users(user_id),
+    sprint_doc_id           INTEGER REFERENCES documents(document_id),
+    harness                 TEXT NOT NULL CHECK (trim(harness) <> ''),
+    provider                TEXT,
+    model                   TEXT,
+    effort                  TEXT,
+    worktree                TEXT NOT NULL CHECK (trim(worktree) <> ''),
+    harness_session_ref     TEXT,
+    state                   TEXT NOT NULL DEFAULT 'idle'
+                            CHECK (state IN
+                                ('idle','queued','running','waiting',
+                                 'error','closed')),
+    title                   TEXT CHECK (title IS NULL OR length(title) <= 200),
+    creation_idempotency_key TEXT NOT NULL
+                            CHECK (
+                              length(creation_idempotency_key) BETWEEN 1 AND 255
+                            ),
+    creation_request_hash   TEXT NOT NULL
+                            CHECK (length(creation_request_hash) BETWEEN 1 AND 256),
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    last_activity_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    closed_at               TEXT,
+    version                 INTEGER NOT NULL DEFAULT 1 CHECK (version > 0),
+    CHECK (
+      (mode='normal' AND owner_user_id IS NOT NULL AND sprint_doc_id IS NULL)
+      OR
+      (mode='sprint' AND sprint_doc_id IS NOT NULL)
+    ),
+    CHECK (
+      (state='closed' AND closed_at IS NOT NULL)
+      OR
+      (state<>'closed' AND closed_at IS NULL)
+    )
+);
+
+CREATE TABLE conversation_messages (
+    message_id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id         TEXT NOT NULL
+                            REFERENCES conversations(conversation_id),
+    sender_kind             TEXT NOT NULL
+                            CHECK (sender_kind IN ('user','engine','shell')),
+    sender_ref              TEXT NOT NULL CHECK (trim(sender_ref) <> ''),
+    message_kind            TEXT NOT NULL
+                            CHECK (
+                              message_kind IN
+                                ('prompt','control','result','notice')
+                            ),
+    body                    TEXT NOT NULL
+                            CHECK (length(body) BETWEEN 1 AND 1048576),
+    idempotency_key         TEXT NOT NULL
+                            CHECK (length(idempotency_key) BETWEEN 1 AND 255),
+    request_hash            TEXT NOT NULL
+                            CHECK (length(request_hash) BETWEEN 1 AND 256),
+    caused_by_message_id    INTEGER
+                            REFERENCES conversation_messages(message_id),
+    state                   TEXT NOT NULL DEFAULT 'accepted'
+                            CHECK (state IN
+                                ('accepted','queued','running','completed',
+                                 'failed','cancelled')),
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at            TEXT,
+    UNIQUE (conversation_id, idempotency_key),
+    CHECK (
+      (state IN ('completed','failed','cancelled')
+       AND completed_at IS NOT NULL)
+      OR
+      (state IN ('accepted','queued','running')
+       AND completed_at IS NULL)
+    ),
+    CHECK (
+      caused_by_message_id IS NULL
+      OR caused_by_message_id <> message_id
+    )
+);
+
+CREATE TABLE conversation_runs (
+    run_id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id         TEXT NOT NULL
+                            REFERENCES conversations(conversation_id),
+    shell_id                INTEGER NOT NULL REFERENCES shells(shell_id),
+    trigger_message_id      INTEGER NOT NULL
+                            REFERENCES conversation_messages(message_id),
+    attempt                 INTEGER NOT NULL DEFAULT 1 CHECK (attempt > 0),
+    harness_session_before  TEXT,
+    harness_session_after   TEXT,
+    runner_ref              TEXT,
+    state                   TEXT NOT NULL DEFAULT 'leased'
+                            CHECK (state IN
+                                ('leased','starting','running','succeeded',
+                                 'failed','cancelled','unknown')),
+    lease_owner             TEXT NOT NULL CHECK (trim(lease_owner) <> ''),
+    lease_expires_at        TEXT NOT NULL,
+    started_at              TEXT,
+    heartbeat_at            TEXT,
+    ended_at                TEXT,
+    exit_code               INTEGER,
+    error_code              TEXT,
+    error_detail            TEXT
+                            CHECK (
+                              error_detail IS NULL
+                              OR length(error_detail) <= 16384
+                            ),
+    archive_id              INTEGER
+                            REFERENCES shell_memory_archives(archive_id),
+    UNIQUE (trigger_message_id, attempt),
+    CHECK (
+      (state='leased' AND started_at IS NULL AND ended_at IS NULL)
+      OR
+      (state IN ('starting','running')
+       AND started_at IS NOT NULL AND ended_at IS NULL)
+      OR
+      (state IN ('succeeded','failed','cancelled','unknown')
+       AND ended_at IS NOT NULL)
+    )
+);
+
+CREATE TABLE conversation_events (
+    event_id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id         TEXT NOT NULL
+                            REFERENCES conversations(conversation_id),
+    sequence                INTEGER NOT NULL CHECK (sequence > 0),
+    event_type              TEXT NOT NULL CHECK (trim(event_type) <> ''),
+    payload_version         INTEGER NOT NULL DEFAULT 1
+                            CHECK (payload_version > 0),
+    payload                 TEXT NOT NULL DEFAULT '{}'
+                            CHECK (
+                              json_valid(payload)
+                              AND json_type(payload)='object'
+                              AND length(payload) <= 262144
+                            ),
+    message_id              INTEGER
+                            REFERENCES conversation_messages(message_id),
+    run_id                  INTEGER REFERENCES conversation_runs(run_id),
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (conversation_id, sequence)
+);
+
+CREATE TABLE conversation_outbox (
+    outbox_id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id         TEXT NOT NULL
+                            REFERENCES conversations(conversation_id),
+    message_id              INTEGER NOT NULL UNIQUE
+                            REFERENCES conversation_messages(message_id),
+    state                   TEXT NOT NULL DEFAULT 'pending'
+                            CHECK (
+                              state IN
+                                ('pending','claimed','dispatched','cancelled')
+                            ),
+    claim_owner             TEXT,
+    claimed_at              TEXT,
+    lease_expires_at        TEXT,
+    attempts                INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    run_id                  INTEGER UNIQUE REFERENCES conversation_runs(run_id),
+    last_error              TEXT
+                            CHECK (
+                              last_error IS NULL
+                              OR length(last_error) <= 16384
+                            ),
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    dispatched_at           TEXT,
+    CHECK (
+      (state='pending'
+       AND claim_owner IS NULL
+       AND claimed_at IS NULL
+       AND lease_expires_at IS NULL
+       AND run_id IS NULL
+       AND dispatched_at IS NULL)
+      OR
+      (state='claimed'
+       AND trim(COALESCE(claim_owner,'')) <> ''
+       AND claimed_at IS NOT NULL
+       AND lease_expires_at IS NOT NULL
+       AND run_id IS NULL
+       AND dispatched_at IS NULL)
+      OR
+      (state='dispatched'
+       AND trim(COALESCE(claim_owner,'')) <> ''
+       AND claimed_at IS NOT NULL
+       AND run_id IS NOT NULL
+       AND dispatched_at IS NOT NULL)
+      OR
+      (state='cancelled'
+       AND run_id IS NULL
+       AND dispatched_at IS NULL)
+    )
+);
+
+-- Optimistic idempotency: the API compares the stored request hash when a key
+-- already exists. The unique key itself is the DB backstop against duplicates.
+CREATE UNIQUE INDEX idx_conversations_normal_idempotency
+    ON conversations(owner_user_id, creation_idempotency_key)
+    WHERE mode='normal';
+CREATE UNIQUE INDEX idx_conversations_sprint_idempotency
+    ON conversations(sprint_doc_id, creation_idempotency_key)
+    WHERE mode='sprint';
+
+-- Reserved Sprint binding: at most one non-closed conversation per sprint.
+CREATE UNIQUE INDEX idx_conversations_live_sprint
+    ON conversations(sprint_doc_id)
+    WHERE mode='sprint' AND state<>'closed';
+
+CREATE INDEX idx_conversations_shell_activity
+    ON conversations(shell_id, last_activity_at, conversation_id);
+CREATE INDEX idx_conversation_messages_queue
+    ON conversation_messages(conversation_id, state, message_id);
+
+-- Exactly one mutating run per conversation and per shell work surface.
+CREATE UNIQUE INDEX idx_conversation_runs_live_conversation
+    ON conversation_runs(conversation_id)
+    WHERE state IN ('leased','starting','running');
+CREATE UNIQUE INDEX idx_conversation_runs_live_shell
+    ON conversation_runs(shell_id)
+    WHERE state IN ('leased','starting','running');
+CREATE INDEX idx_conversation_runs_recovery
+    ON conversation_runs(state, lease_expires_at, run_id);
+
+CREATE INDEX idx_conversation_events_replay
+    ON conversation_events(conversation_id, sequence);
+CREATE INDEX idx_conversation_outbox_claim
+    ON conversation_outbox(state, lease_expires_at, outbox_id);
+
+-- Identity and routing fields are immutable. Rename/close/session capture use
+-- the explicitly mutable title, state, timestamps, version, and session ref.
+CREATE TRIGGER trg_conversations_identity_immutable
+BEFORE UPDATE OF
+    conversation_id, shell_id, mode, owner_user_id, sprint_doc_id,
+    harness, provider, model, effort, worktree,
+    creation_idempotency_key, creation_request_hash, created_at
+ON conversations
+BEGIN
+  SELECT RAISE(ABORT, 'conversation identity and route are immutable');
+END;
+
+CREATE TRIGGER trg_conversations_state
+BEFORE UPDATE OF state ON conversations
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state='idle'    AND NEW.state IN ('queued','closed')) OR
+    (OLD.state='queued'  AND NEW.state='running') OR
+    (OLD.state='running' AND NEW.state IN
+        ('idle','queued','waiting','error')) OR
+    (OLD.state='waiting' AND NEW.state IN ('queued','closed')) OR
+    (OLD.state='error'   AND NEW.state IN ('queued','closed'))
+    -- closed is terminal.
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal conversation transition');
+END;
+
+CREATE TRIGGER trg_conversation_messages_immutable
+BEFORE UPDATE OF
+    message_id, conversation_id, sender_kind, sender_ref, message_kind,
+    body, idempotency_key, request_hash, caused_by_message_id, created_at
+ON conversation_messages
+BEGIN
+  SELECT RAISE(ABORT, 'conversation message identity and content are immutable');
+END;
+
+CREATE TRIGGER trg_conversation_messages_cause_insert
+BEFORE INSERT ON conversation_messages
+WHEN NEW.caused_by_message_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM conversation_messages cause
+    WHERE cause.message_id=NEW.caused_by_message_id
+      AND cause.conversation_id=NEW.conversation_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'causal message does not belong to conversation');
+END;
+
+CREATE TRIGGER trg_conversation_messages_state
+BEFORE UPDATE OF state ON conversation_messages
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state='accepted' AND NEW.state IN
+        ('queued','running','completed','failed','cancelled')) OR
+    (OLD.state='queued'   AND NEW.state IN
+        ('running','failed','cancelled')) OR
+    (OLD.state='running'  AND NEW.state IN
+        ('completed','failed','cancelled'))
+    -- completed, failed, and cancelled are terminal.
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal conversation message transition');
+END;
+
+CREATE TRIGGER trg_conversation_runs_links_insert
+BEFORE INSERT ON conversation_runs
+WHEN NOT EXISTS (
+    SELECT 1
+    FROM conversations c
+    JOIN conversation_messages m
+      ON m.conversation_id=c.conversation_id
+    WHERE c.conversation_id=NEW.conversation_id
+      AND c.shell_id=NEW.shell_id
+      AND m.message_id=NEW.trigger_message_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'conversation run links do not share a conversation');
+END;
+
+CREATE TRIGGER trg_conversation_runs_links_update
+BEFORE UPDATE OF conversation_id, shell_id, trigger_message_id
+ON conversation_runs
+BEGIN
+  SELECT RAISE(ABORT, 'conversation run identity is immutable');
+END;
+
+CREATE TRIGGER trg_conversation_runs_state
+BEFORE UPDATE OF state ON conversation_runs
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state='leased' AND NEW.state IN
+        ('starting','failed','cancelled','unknown')) OR
+    (OLD.state='starting' AND NEW.state IN
+        ('running','failed','cancelled','unknown')) OR
+    (OLD.state='running' AND NEW.state IN
+        ('succeeded','failed','cancelled','unknown'))
+    -- terminal run states have no exits.
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal conversation run transition');
+END;
+
+CREATE TRIGGER trg_conversation_events_links_insert
+BEFORE INSERT ON conversation_events
+WHEN (
+    NEW.message_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM conversation_messages m
+      WHERE m.message_id=NEW.message_id
+        AND m.conversation_id=NEW.conversation_id
+    )
+) OR (
+    NEW.run_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM conversation_runs r
+      WHERE r.run_id=NEW.run_id
+        AND r.conversation_id=NEW.conversation_id
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'conversation event links do not share a conversation');
+END;
+
+CREATE TRIGGER trg_conversation_events_append_only_update
+BEFORE UPDATE ON conversation_events
+BEGIN
+  SELECT RAISE(ABORT, 'conversation events are append-only');
+END;
+
+CREATE TRIGGER trg_conversation_events_append_only_delete
+BEFORE DELETE ON conversation_events
+BEGIN
+  SELECT RAISE(ABORT, 'conversation events are append-only');
+END;
+
+CREATE TRIGGER trg_conversation_outbox_links_insert
+BEFORE INSERT ON conversation_outbox
+WHEN (
+  NOT EXISTS (
+    SELECT 1 FROM conversation_messages m
+    WHERE m.message_id=NEW.message_id
+      AND m.conversation_id=NEW.conversation_id
+  )
+) OR (
+  NEW.run_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM conversation_runs r
+    WHERE r.run_id=NEW.run_id
+      AND r.conversation_id=NEW.conversation_id
+      AND r.trigger_message_id=NEW.message_id
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'conversation outbox links do not share a message');
+END;
+
+CREATE TRIGGER trg_conversation_outbox_identity_immutable
+BEFORE UPDATE OF outbox_id, conversation_id, message_id, created_at
+ON conversation_outbox
+BEGIN
+  SELECT RAISE(ABORT, 'conversation outbox identity is immutable');
+END;
+
+CREATE TRIGGER trg_conversation_outbox_run_update
+BEFORE UPDATE OF run_id ON conversation_outbox
+WHEN NEW.run_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM conversation_runs r
+    WHERE r.run_id=NEW.run_id
+      AND r.conversation_id=NEW.conversation_id
+      AND r.trigger_message_id=NEW.message_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'conversation outbox run does not match message');
+END;
+
+CREATE TRIGGER trg_conversation_outbox_state
+BEFORE UPDATE OF state ON conversation_outbox
+WHEN NEW.state <> OLD.state AND NOT (
+    (OLD.state='pending' AND NEW.state IN ('claimed','cancelled')) OR
+    (OLD.state='claimed' AND NEW.state IN
+        ('pending','dispatched','cancelled'))
+    -- dispatched and cancelled are terminal.
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal conversation outbox transition');
+END;
+
+COMMIT;

--- a/.super-coder/scripts/conversation_state.py
+++ b/.super-coder/scripts/conversation_state.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Conversation state-machine vocabulary mirrored by migration 0132.
+
+The database triggers are the final backstop. API and broker code import these
+maps to reject a bad edge with a useful typed error before SQLite reduces it to
+an IntegrityError. Keep the maps and migration trigger edges in lockstep; the
+conversation schema tests walk every old/new pair through both layers.
+"""
+from __future__ import annotations
+
+
+CONVERSATION_TRANSITIONS = {
+    "idle": frozenset({"queued", "closed"}),
+    "queued": frozenset({"running"}),
+    "running": frozenset({"idle", "queued", "waiting", "error"}),
+    "waiting": frozenset({"queued", "closed"}),
+    "error": frozenset({"queued", "closed"}),
+    "closed": frozenset(),
+}
+
+MESSAGE_TRANSITIONS = {
+    "accepted": frozenset(
+        {"queued", "running", "completed", "failed", "cancelled"}
+    ),
+    "queued": frozenset({"running", "failed", "cancelled"}),
+    "running": frozenset({"completed", "failed", "cancelled"}),
+    "completed": frozenset(),
+    "failed": frozenset(),
+    "cancelled": frozenset(),
+}
+
+RUN_TRANSITIONS = {
+    "leased": frozenset({"starting", "failed", "cancelled", "unknown"}),
+    "starting": frozenset({"running", "failed", "cancelled", "unknown"}),
+    "running": frozenset({"succeeded", "failed", "cancelled", "unknown"}),
+    "succeeded": frozenset(),
+    "failed": frozenset(),
+    "cancelled": frozenset(),
+    "unknown": frozenset(),
+}
+
+OUTBOX_TRANSITIONS = {
+    "pending": frozenset({"claimed", "cancelled"}),
+    "claimed": frozenset({"pending", "dispatched", "cancelled"}),
+    "dispatched": frozenset(),
+    "cancelled": frozenset(),
+}
+
+MACHINES = {
+    "conversation": CONVERSATION_TRANSITIONS,
+    "message": MESSAGE_TRANSITIONS,
+    "run": RUN_TRANSITIONS,
+    "outbox": OUTBOX_TRANSITIONS,
+}
+
+INITIAL_STATES = {
+    "conversation": "idle",
+    "message": "accepted",
+    "run": "leased",
+    "outbox": "pending",
+}
+
+
+class ConversationStateError(ValueError):
+    """A caller requested an unknown machine/state or an illegal edge."""
+
+    def __init__(
+        self,
+        machine: str,
+        current: str,
+        target: str,
+        allowed: frozenset[str],
+    ) -> None:
+        self.machine = machine
+        self.current = current
+        self.target = target
+        self.allowed = allowed
+        choices = ", ".join(sorted(allowed)) or "none (terminal)"
+        super().__init__(
+            f"illegal {machine} transition {current} -> {target}; "
+            f"allowed: {choices}"
+        )
+
+
+def states(machine: str) -> frozenset[str]:
+    """The complete state vocabulary for one conversation machine."""
+    try:
+        return frozenset(MACHINES[machine])
+    except KeyError as exc:
+        raise KeyError(f"unknown conversation state machine: {machine}") from exc
+
+
+def allowed_targets(machine: str, current: str) -> frozenset[str]:
+    """Legal changed-state targets. Same-state idempotent reasserts are separate."""
+    try:
+        transitions = MACHINES[machine]
+    except KeyError as exc:
+        raise KeyError(f"unknown conversation state machine: {machine}") from exc
+    try:
+        return transitions[current]
+    except KeyError as exc:
+        raise KeyError(f"unknown {machine} state: {current}") from exc
+
+
+def transition_allowed(machine: str, current: str, target: str) -> bool:
+    """True for a legal edge or an idempotent same-state reassertion."""
+    if target not in states(machine):
+        return False
+    return target == current or target in allowed_targets(machine, current)
+
+
+def require_transition(machine: str, current: str, target: str) -> None:
+    """Raise a typed, actionable error before the DB trigger backstop fires."""
+    allowed = allowed_targets(machine, current)
+    if target == current:
+        return
+    if target not in states(machine) or target not in allowed:
+        raise ConversationStateError(machine, current, target, allowed)

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -102,6 +102,15 @@ PER_INSTANCE_TABLES = [
     "directives",
     "sentinel_events",
     "wake_machine_retirements",
+    # Browser-native conversations are durable instance truth: the exact
+    # harness ref, message queue, recovery evidence, replay events, and pending
+    # outbox must all survive update/rebuild. Parents precede children so a
+    # snapshot remains readable and foreign-key-valid when loaded.
+    "conversations",
+    "conversation_messages",
+    "conversation_runs",
+    "conversation_events",
+    "conversation_outbox",
     # NOTE: dr_section is authored navigation but lives in the MAP DB now
     # (.sc-state/map.db), not shell_db.db — it is serialized separately to
     # .sc-state/local/map/content.sql by snapshot_map() below, not here.

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -1,0 +1,709 @@
+#!/usr/bin/env python3
+"""Feature #24 conversation schema, transition, and rebuild contracts."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+FOUNDATION = MIGRATIONS / "0132_conversation_foundation.sql"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import conversation_state  # noqa: E402
+import snapshot  # noqa: E402
+
+
+def apply_schema(con: sqlite3.Connection, *, through: str | None = None) -> None:
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        if through is not None and migration.name > through:
+            break
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+class ConversationDbCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = sqlite3.connect(":memory:")
+        self.con.row_factory = sqlite3.Row
+        apply_schema(self.con)
+        self.con.execute(
+            "INSERT INTO users (user_id, username) VALUES (1,'operator')"
+        )
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (1,'Dev','dev1','dev','prompt',1)"
+        )
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (2,'Review','rev1','reviewer','prompt',1)"
+        )
+        self.con.execute(
+            "INSERT INTO documents "
+            "(document_id,kind,title,body) "
+            "VALUES (24,'doc','SPRINT: conversation test','x')"
+        )
+        self.con.commit()
+        self.serial = 0
+
+    def tearDown(self) -> None:
+        self.con.close()
+
+    def next_key(self, prefix: str) -> str:
+        self.serial += 1
+        return f"{prefix}-{self.serial}"
+
+    def add_conversation(
+        self,
+        *,
+        shell_id: int = 1,
+        state: str = "idle",
+        mode: str = "normal",
+    ) -> str:
+        key = self.next_key("conversation")
+        closed_at = "2026-07-29 00:00:00" if state == "closed" else None
+        if mode == "normal":
+            owner_user_id, sprint_doc_id = 1, None
+        else:
+            owner_user_id, sprint_doc_id = None, 24
+        self.con.execute(
+            "INSERT INTO conversations "
+            "(shell_id,mode,owner_user_id,sprint_doc_id,harness,worktree,"
+            "state,closed_at,creation_idempotency_key,creation_request_hash) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (
+                shell_id,
+                mode,
+                owner_user_id,
+                sprint_doc_id,
+                "codex",
+                f"/tmp/worktree-{shell_id}",
+                state,
+                closed_at,
+                key,
+                f"hash-{key}",
+            ),
+        )
+        return self.con.execute(
+            "SELECT conversation_id FROM conversations "
+            "WHERE creation_idempotency_key=?",
+            (key,),
+        ).fetchone()[0]
+
+    def add_message(
+        self,
+        conversation_id: str,
+        *,
+        state: str = "accepted",
+        caused_by_message_id: int | None = None,
+    ) -> int:
+        key = self.next_key("message")
+        completed_at = (
+            "2026-07-29 00:00:00"
+            if state in {"completed", "failed", "cancelled"}
+            else None
+        )
+        return self.con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash,caused_by_message_id,state,"
+            "completed_at) "
+            "VALUES (?,'user','1','prompt','hello',?,?,?,?,?)",
+            (
+                conversation_id,
+                key,
+                f"hash-{key}",
+                caused_by_message_id,
+                state,
+                completed_at,
+            ),
+        ).lastrowid
+
+    def add_run(
+        self,
+        conversation_id: str,
+        message_id: int,
+        *,
+        shell_id: int = 1,
+        state: str = "leased",
+    ) -> int:
+        started_at = (
+            "2026-07-29 00:00:00"
+            if state in {"starting", "running"}
+            else None
+        )
+        ended_at = (
+            "2026-07-29 00:01:00"
+            if state in {"succeeded", "failed", "cancelled", "unknown"}
+            else None
+        )
+        return self.con.execute(
+            "INSERT INTO conversation_runs "
+            "(conversation_id,shell_id,trigger_message_id,state,lease_owner,"
+            "lease_expires_at,started_at,ended_at) "
+            "VALUES (?,?,?,?,?,'2026-07-29 00:10:00',?,?)",
+            (
+                conversation_id,
+                shell_id,
+                message_id,
+                state,
+                self.next_key("broker"),
+                started_at,
+                ended_at,
+            ),
+        ).lastrowid
+
+    def add_outbox(
+        self,
+        conversation_id: str,
+        message_id: int,
+        *,
+        state: str = "pending",
+        run_id: int | None = None,
+    ) -> int:
+        claimed = state in {"claimed", "dispatched"}
+        return self.con.execute(
+            "INSERT INTO conversation_outbox "
+            "(conversation_id,message_id,state,claim_owner,claimed_at,"
+            "lease_expires_at,run_id,dispatched_at) "
+            "VALUES (?,?,?,?,?,?,?,?)",
+            (
+                conversation_id,
+                message_id,
+                state,
+                "broker" if claimed else None,
+                "2026-07-29 00:00:00" if claimed else None,
+                "2026-07-29 00:10:00" if claimed else None,
+                run_id if state == "dispatched" else None,
+                "2026-07-29 00:01:00"
+                if state == "dispatched"
+                else None,
+            ),
+        ).lastrowid
+
+
+class MigrationAndShapeTest(ConversationDbCase):
+    def test_installed_fork_upgrades_from_pre_foundation_schema(self) -> None:
+        con = sqlite3.connect(":memory:")
+        apply_schema(con, through="0131_report_only_sprint_units.sql")
+        self.assertIsNone(con.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='conversations'"
+        ).fetchone())
+        con.executescript(FOUNDATION.read_text())
+        tables = {
+            row[0]
+            for row in con.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        self.assertTrue({
+            "conversations",
+            "conversation_messages",
+            "conversation_runs",
+            "conversation_events",
+            "conversation_outbox",
+        }.issubset(tables))
+        con.close()
+
+    def test_normal_and_reserved_sprint_ownership_shapes(self) -> None:
+        normal = self.add_conversation()
+        sprint = self.add_conversation(mode="sprint")
+        self.assertTrue(normal.startswith("cv_"))
+        self.assertTrue(sprint.startswith("cv_"))
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO conversations "
+                "(shell_id,mode,harness,worktree,creation_idempotency_key,"
+                "creation_request_hash) "
+                "VALUES (1,'normal','codex','/tmp/x','bad','hash')"
+            )
+
+    def test_one_live_sprint_conversation(self) -> None:
+        first = self.add_conversation(mode="sprint")
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_conversation(mode="sprint")
+        self.con.execute(
+            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
+            "WHERE conversation_id=?",
+            (first,),
+        )
+        self.add_conversation(mode="sprint")
+
+    def test_conversation_and_message_idempotency_are_scoped(self) -> None:
+        conversation = self.add_conversation()
+        row = self.con.execute(
+            "SELECT owner_user_id,creation_idempotency_key "
+            "FROM conversations WHERE conversation_id=?",
+            (conversation,),
+        ).fetchone()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO conversations "
+                "(shell_id,owner_user_id,harness,worktree,"
+                "creation_idempotency_key,creation_request_hash) "
+                "VALUES (2,?,'claude','/tmp/other',?,'different-hash')",
+                tuple(row),
+            )
+
+        key = self.next_key("idem")
+        self.con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash) "
+            "VALUES (?,'user','1','prompt','one',?,'hash-one')",
+            (conversation, key),
+        )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash) "
+                "VALUES (?,'user','1','prompt','two',?,'hash-two')",
+                (conversation, key),
+            )
+        other = self.add_conversation(shell_id=2)
+        self.con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash) "
+            "VALUES (?,'user','1','prompt','other',?,'hash-other')",
+            (other, key),
+        )
+
+    def test_outbox_is_one_dispatch_intent_per_message(self) -> None:
+        conversation = self.add_conversation()
+        message = self.add_message(conversation)
+        self.add_outbox(conversation, message)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_outbox(conversation, message)
+
+    def test_cross_conversation_links_are_refused(self) -> None:
+        first = self.add_conversation()
+        second = self.add_conversation(shell_id=2)
+        message = self.add_message(first)
+        self.add_message(first, caused_by_message_id=message)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_message(second, caused_by_message_id=message)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_run(second, message, shell_id=2)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_outbox(second, message)
+
+        run = self.add_run(first, message)
+        second_message = self.add_message(second)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_outbox(
+                second,
+                second_message,
+                state="dispatched",
+                run_id=run,
+            )
+        other_message = self.add_message(first)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_outbox(
+                first,
+                other_message,
+                state="dispatched",
+                run_id=run,
+            )
+
+
+class TransitionMatrixTest(ConversationDbCase):
+    def update_conversation(self, row_id: str, target: str) -> None:
+        self.con.execute(
+            "UPDATE conversations SET state=?,closed_at=? "
+            "WHERE conversation_id=?",
+            (
+                target,
+                "2026-07-29 00:02:00" if target == "closed" else None,
+                row_id,
+            ),
+        )
+
+    def conversation_at(self, state: str) -> str:
+        row_id = self.add_conversation()
+        paths = {
+            "idle": (),
+            "queued": ("queued",),
+            "running": ("queued", "running"),
+            "waiting": ("queued", "running", "waiting"),
+            "error": ("queued", "running", "error"),
+            "closed": ("closed",),
+        }
+        for target in paths[state]:
+            self.update_conversation(row_id, target)
+        return row_id
+
+    def update_message(self, row_id: int, target: str) -> None:
+        self.con.execute(
+            "UPDATE conversation_messages SET state=?,completed_at=? "
+            "WHERE message_id=?",
+            (
+                target,
+                "2026-07-29 00:02:00"
+                if target in {"completed", "failed", "cancelled"}
+                else None,
+                row_id,
+            ),
+        )
+
+    def message_at(self, state: str) -> int:
+        row_id = self.add_message(self.add_conversation())
+        paths = {
+            "accepted": (),
+            "queued": ("queued",),
+            "running": ("queued", "running"),
+            "completed": ("completed",),
+            "failed": ("failed",),
+            "cancelled": ("cancelled",),
+        }
+        for target in paths[state]:
+            self.update_message(row_id, target)
+        return row_id
+
+    def update_run(self, row_id: int, target: str) -> None:
+        started_at = (
+            "2026-07-29 00:00:00"
+            if target in {"starting", "running"}
+            else None
+        )
+        ended_at = (
+            "2026-07-29 00:02:00"
+            if target in {"succeeded", "failed", "cancelled", "unknown"}
+            else None
+        )
+        self.con.execute(
+            "UPDATE conversation_runs "
+            "SET state=?,started_at=?,ended_at=? WHERE run_id=?",
+            (target, started_at, ended_at, row_id),
+        )
+
+    def run_at(self, state: str) -> int:
+        conversation = self.add_conversation()
+        message = self.add_message(conversation)
+        row_id = self.add_run(conversation, message)
+        paths = {
+            "leased": (),
+            "starting": ("starting",),
+            "running": ("starting", "running"),
+            "succeeded": ("starting", "running", "succeeded"),
+            "failed": ("failed",),
+            "cancelled": ("cancelled",),
+            "unknown": ("unknown",),
+        }
+        for target in paths[state]:
+            self.update_run(row_id, target)
+        return row_id
+
+    def terminal_run_for_message(
+        self,
+        conversation_id: str,
+        message_id: int,
+    ) -> int:
+        run_id = self.add_run(conversation_id, message_id)
+        self.update_run(run_id, "failed")
+        return run_id
+
+    def update_outbox(
+        self,
+        row_id: int,
+        target: str,
+        *,
+        run_id: int | None = None,
+    ) -> None:
+        claimed = target in {"claimed", "dispatched"}
+        self.con.execute(
+            "UPDATE conversation_outbox "
+            "SET state=?,claim_owner=?,claimed_at=?,lease_expires_at=?,"
+            "run_id=?,dispatched_at=? WHERE outbox_id=?",
+            (
+                target,
+                "broker" if claimed else None,
+                "2026-07-29 00:00:00" if claimed else None,
+                "2026-07-29 00:10:00" if claimed else None,
+                run_id if target == "dispatched" else None,
+                "2026-07-29 00:02:00"
+                if target == "dispatched"
+                else None,
+                row_id,
+            ),
+        )
+
+    def outbox_at(
+        self,
+        state: str,
+    ) -> tuple[int, str, int, int | None]:
+        conversation = self.add_conversation()
+        message = self.add_message(conversation)
+        row_id = self.add_outbox(conversation, message)
+        run_id = None
+        if state == "claimed":
+            self.update_outbox(row_id, "claimed")
+        elif state == "dispatched":
+            self.update_outbox(row_id, "claimed")
+            run_id = self.terminal_run_for_message(conversation, message)
+            self.update_outbox(row_id, "dispatched", run_id=run_id)
+        elif state == "cancelled":
+            self.update_outbox(row_id, "cancelled")
+        return row_id, conversation, message, run_id
+
+    def assert_matrix(
+        self,
+        machine: str,
+        factory,
+        updater,
+    ) -> None:
+        transitions = conversation_state.MACHINES[machine]
+        for old, allowed in transitions.items():
+            for new in transitions:
+                with self.subTest(machine=machine, edge=f"{old}->{new}"):
+                    self.con.execute("SAVEPOINT transition_case")
+                    try:
+                        made = factory(old)
+                        row_id = (
+                            made[0] if isinstance(made, tuple) else made
+                        )
+                        legal = new == old or new in allowed
+                        try:
+                            updater(row_id, new, made)
+                        except sqlite3.IntegrityError:
+                            db_allowed = False
+                        else:
+                            db_allowed = True
+                        self.assertEqual(db_allowed, legal)
+                        self.assertEqual(
+                            conversation_state.transition_allowed(
+                                machine, old, new
+                            ),
+                            legal,
+                        )
+                    finally:
+                        self.con.execute("ROLLBACK TO transition_case")
+                        self.con.execute("RELEASE transition_case")
+
+    def test_exhaustive_conversation_edges_match_helper(self) -> None:
+        self.assert_matrix(
+            "conversation",
+            self.conversation_at,
+            lambda row_id, target, _made: self.update_conversation(
+                row_id, target
+            ),
+        )
+
+    def test_exhaustive_message_edges_match_helper(self) -> None:
+        self.assert_matrix(
+            "message",
+            self.message_at,
+            lambda row_id, target, _made: self.update_message(row_id, target),
+        )
+
+    def test_exhaustive_run_edges_match_helper(self) -> None:
+        self.assert_matrix(
+            "run",
+            self.run_at,
+            lambda row_id, target, _made: self.update_run(row_id, target),
+        )
+
+    def test_exhaustive_outbox_edges_match_helper(self) -> None:
+        def update(row_id, target, made):
+            _row_id, conversation, message, existing_run = made
+            run_id = existing_run
+            if target == "dispatched" and run_id is None:
+                run_id = self.terminal_run_for_message(
+                    conversation, message
+                )
+            self.update_outbox(row_id, target, run_id=run_id)
+
+        self.assert_matrix("outbox", self.outbox_at, update)
+
+    def test_typed_error_names_edge_and_legal_targets(self) -> None:
+        with self.assertRaises(
+            conversation_state.ConversationStateError
+        ) as raised:
+            conversation_state.require_transition(
+                "conversation", "closed", "idle"
+            )
+        self.assertIn("closed -> idle", str(raised.exception))
+        self.assertIn("terminal", str(raised.exception))
+
+
+class FenceAndEventTest(ConversationDbCase):
+    def test_one_live_run_per_conversation_and_shell(self) -> None:
+        first = self.add_conversation()
+        first_message = self.add_message(first)
+        first_run = self.add_run(first, first_message)
+
+        second_message = self.add_message(first)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_run(first, second_message)
+
+        second = self.add_conversation()
+        second_message = self.add_message(second)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_run(second, second_message)
+
+        self.con.execute(
+            "UPDATE conversation_runs "
+            "SET state='failed',ended_at=datetime('now') WHERE run_id=?",
+            (first_run,),
+        )
+        self.add_run(second, second_message)
+
+    def test_different_shells_may_run_concurrently(self) -> None:
+        first = self.add_conversation(shell_id=1)
+        second = self.add_conversation(shell_id=2)
+        self.add_run(first, self.add_message(first), shell_id=1)
+        self.add_run(second, self.add_message(second), shell_id=2)
+
+    def test_events_are_ordered_append_only_and_scoped(self) -> None:
+        conversation = self.add_conversation()
+        message = self.add_message(conversation)
+        run = self.add_run(conversation, message)
+        self.con.execute(
+            "INSERT INTO conversation_events "
+            "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+            "VALUES (?,1,'run.started',?, ?, ?)",
+            (conversation, json.dumps({"ok": True}), message, run),
+        )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type) "
+                "VALUES (?,1,'duplicate')",
+                (conversation,),
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "UPDATE conversation_events SET event_type='changed'"
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute("DELETE FROM conversation_events")
+
+        other = self.add_conversation(shell_id=2)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,message_id) "
+                "VALUES (?,1,'wrong.message',?)",
+                (other, message),
+            )
+
+    def test_bounded_message_and_event_payloads(self) -> None:
+        conversation = self.add_conversation()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash) "
+                "VALUES (?,'user','1','prompt',?,?,'hash')",
+                (
+                    conversation,
+                    "x" * (1048576 + 1),
+                    self.next_key("large-message"),
+                ),
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload) "
+                "VALUES (?,1,'bad.payload','[]')",
+                (conversation,),
+            )
+
+
+class SnapshotPolicyTest(ConversationDbCase):
+    TABLES = (
+        "conversations",
+        "conversation_messages",
+        "conversation_runs",
+        "conversation_events",
+        "conversation_outbox",
+    )
+
+    def test_conversation_tables_are_snapshotted_in_dependency_order(self) -> None:
+        positions = [
+            snapshot.PER_INSTANCE_TABLES.index(table)
+            for table in self.TABLES
+        ]
+        self.assertEqual(positions, sorted(positions))
+
+    def test_snapshot_round_trip_preserves_queue_and_recovery_evidence(
+            self) -> None:
+        conversation = self.add_conversation()
+        message = self.add_message(conversation, state="queued")
+        run = self.add_run(
+            conversation, message, state="unknown"
+        )
+        self.con.execute(
+            "INSERT INTO conversation_events "
+            "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+            "VALUES (?,1,'run.failed','{\"delivery\":\"unknown\"}',?,?)",
+            (conversation, message, run),
+        )
+        self.add_outbox(conversation, message)
+
+        body = ["PRAGMA foreign_keys=OFF;", "BEGIN;"]
+        for table in self.TABLES:
+            body.extend(snapshot.dump_table(self.con, table))
+        body.extend(["COMMIT;", "PRAGMA foreign_keys=ON;"])
+
+        target = sqlite3.connect(":memory:")
+        apply_schema(target)
+        target.execute(
+            "INSERT INTO users (user_id,username) VALUES (1,'operator')"
+        )
+        target.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (1,'Dev','dev1','dev','prompt',1)"
+        )
+        target.executescript("\n".join(body))
+        self.assertEqual(
+            target.execute(
+                "SELECT state,harness,worktree FROM conversations"
+            ).fetchone(),
+            ("idle", "codex", "/tmp/worktree-1"),
+        )
+        self.assertEqual(
+            target.execute(
+                "SELECT state,body FROM conversation_messages"
+            ).fetchone(),
+            ("queued", "hello"),
+        )
+        self.assertEqual(
+            target.execute(
+                "SELECT state,error_detail FROM conversation_runs"
+            ).fetchone(),
+            ("unknown", None),
+        )
+        self.assertEqual(
+            target.execute(
+                "SELECT event_type,payload FROM conversation_events"
+            ).fetchone(),
+            ("run.failed", '{"delivery":"unknown"}'),
+        )
+        self.assertEqual(
+            target.execute(
+                "SELECT state FROM conversation_outbox"
+            ).fetchone()[0],
+            "pending",
+        )
+        self.assertEqual(target.execute(
+            "PRAGMA foreign_key_check"
+        ).fetchall(), [])
+        target.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add durable conversations, messages, runs, replay events, and transactional outbox tables
- enforce ownership, idempotency, transition, causal-link, live-run, and shell-mutation fences in SQLite
- add a shared typed state-machine helper and preserve all conversation state through snapshot/rebuild
- cover forward migration, exhaustive transition parity, crash fences, event append-only behavior, and snapshot round trips

## Verification

- `python3 tests/test_conversation_schema.py` — 17 passed
- `python3 tests/test_snapshot_secrets.py` — 4 passed
- `python3 tests/test_rebuild_integrity.py` — 4 passed
- `python3 tests/test_conductor_contracts.py` — 14 passed
- `python3 tests/test_sprint_eventing.py` — 90 passed
- `./sc render-check` — passed
- `./sc verify` — passed
- host-wide unittest discovery executed 1,413 tests; its only loader errors were three pytest-only UI modules because pytest is not installed on this host. CI installs pytest and runs the canonical suite.

Feature #24 · Spec #32 · Task #91