### PR TITLE
Feature 24: implement harness conversation adapters

### DIFF
--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -13,6 +13,7 @@
     "effort": { "flag": "--effort" }
   },
   "conversation": {
+    "contract_version": 1,
     "minimum_cli_version": "2.1.220",
     "verified_cli_version": "2.1.220",
     "driver": "claude-print",
@@ -26,6 +27,24 @@
     "interrupt": { "mechanism": "signal", "signal": "SIGINT" },
     "inspect": { "mechanism": "native-session-store" },
     "permission_policy": "claude-permission-mode-and-prompt-tool",
+    "execution_permissions": {
+      "requirement": "worktree-command-access",
+      "unrestricted_mechanism": "bypassPermissions",
+      "sandbox_flag_required": false
+    },
+    "normalized_events": [
+      "session.started",
+      "run.started",
+      "assistant.delta",
+      "tool.started",
+      "tool.completed",
+      "permission.requested",
+      "input.requested",
+      "usage",
+      "run.completed",
+      "run.failed",
+      "run.interrupted"
+    ],
     "capabilities": {
       "exact_session_resume": true,
       "structured_streaming": true,

--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -11,6 +11,7 @@
     "effort": { "config_flag": "-c", "config_key": "model_reasoning_effort" }
   },
   "conversation": {
+    "contract_version": 1,
     "minimum_cli_version": "0.145.0",
     "verified_cli_version": "0.145.0",
     "driver": "codex-app-server",
@@ -25,6 +26,24 @@
       "approval": "never",
       "unrestricted": "danger-full-access"
     },
+    "execution_permissions": {
+      "requirement": "worktree-command-access",
+      "unrestricted_mechanism": "thread-policy",
+      "sandbox_flag_required": false
+    },
+    "normalized_events": [
+      "session.started",
+      "run.started",
+      "assistant.delta",
+      "tool.started",
+      "tool.completed",
+      "permission.requested",
+      "input.requested",
+      "usage",
+      "run.completed",
+      "run.failed",
+      "run.interrupted"
+    ],
     "capabilities": {
       "exact_session_resume": true,
       "structured_streaming": true,

--- a/.super-coder/adapters/opencode/adapter.json
+++ b/.super-coder/adapters/opencode/adapter.json
@@ -8,6 +8,7 @@
   "model": { "file": "opencode.json", "key": "model" },
   "headless": { "launch": ["opencode", "run"], "model_flag": "-m" },
   "conversation": {
+    "contract_version": 1,
     "minimum_cli_version": "1.18.9",
     "verified_cli_version": "1.18.9",
     "driver": "opencode-server",
@@ -16,6 +17,24 @@
     "interrupt": { "method": "POST", "path": "/session/{session_ref}/abort" },
     "inspect": { "method": "GET", "path": "/session/{session_ref}" },
     "permission_policy": "opencode-config-and-permission-events",
+    "execution_permissions": {
+      "requirement": "worktree-command-access",
+      "unrestricted_mechanism": "session-permission-rules",
+      "sandbox_flag_required": false
+    },
+    "normalized_events": [
+      "session.started",
+      "run.started",
+      "assistant.delta",
+      "tool.started",
+      "tool.completed",
+      "permission.requested",
+      "input.requested",
+      "usage",
+      "run.completed",
+      "run.failed",
+      "run.interrupted"
+    ],
     "capabilities": {
       "exact_session_resume": true,
       "structured_streaming": true,

--- a/.super-coder/scripts/conversation_adapters/__init__.py
+++ b/.super-coder/scripts/conversation_adapters/__init__.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Browser-native conversation adapter registry."""
+from __future__ import annotations
+
+from typing import Any
+
+from .base import (
+    AdapterCapabilities,
+    AdapterError,
+    ConversationAdapter,
+    ConversationContext,
+    InterruptResult,
+    NativeTurn,
+    NormalizedEvent,
+    ProbeResult,
+    ReconcileResult,
+    SessionInspection,
+)
+from .claude import ClaudeAdapter
+from .codex import CodexAdapter, JsonLineRpcProcess, RpcTransport
+from .opencode import OpenCodeAdapter
+
+
+ADAPTER_TYPES = {
+    "opencode": OpenCodeAdapter,
+    "claude": ClaudeAdapter,
+    "codex": CodexAdapter,
+}
+
+
+def adapter_for(harness: str, **kwargs: Any) -> ConversationAdapter:
+    try:
+        adapter_type = ADAPTER_TYPES[harness]
+    except KeyError as exc:
+        raise AdapterError(
+            "HARNESS_CONVERSATION_UNSUPPORTED",
+            f"no conversation adapter for harness: {harness}",
+        ) from exc
+    return adapter_type(**kwargs)
+
+
+__all__ = [
+    "ADAPTER_TYPES",
+    "AdapterCapabilities",
+    "AdapterError",
+    "ClaudeAdapter",
+    "CodexAdapter",
+    "ConversationAdapter",
+    "ConversationContext",
+    "InterruptResult",
+    "JsonLineRpcProcess",
+    "NativeTurn",
+    "NormalizedEvent",
+    "OpenCodeAdapter",
+    "ProbeResult",
+    "ReconcileResult",
+    "RpcTransport",
+    "SessionInspection",
+    "adapter_for",
+]

--- a/.super-coder/scripts/conversation_adapters/base.py
+++ b/.super-coder/scripts/conversation_adapters/base.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Harness-neutral browser conversation adapter contract.
+
+Adapters translate native session and run protocols into a deliberately small
+event vocabulary. They never own durable queue state; the conversation broker
+persists the opaque references returned here.
+"""
+from __future__ import annotations
+
+import abc
+import base64
+import json
+import os
+import re
+import subprocess
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping, Protocol
+
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+ENGINE = SCRIPTS.parent
+ADAPTERS = ENGINE / "adapters"
+
+NORMALIZED_EVENTS = frozenset(
+    {
+        "session.started",
+        "run.started",
+        "assistant.delta",
+        "tool.started",
+        "tool.completed",
+        "permission.requested",
+        "input.requested",
+        "usage",
+        "run.completed",
+        "run.failed",
+        "run.interrupted",
+    }
+)
+TERMINAL_EVENTS = frozenset(
+    {"run.completed", "run.failed", "run.interrupted"}
+)
+RECONCILE_OUTCOMES = frozenset(
+    {"running", "succeeded", "failed", "cancelled", "unknown"}
+)
+PERMISSION_MODES = frozenset({"unrestricted", "interactive"})
+
+
+class AdapterError(RuntimeError):
+    """Stable adapter error exposed to the broker."""
+
+    def __init__(
+        self,
+        code: str,
+        detail: str,
+        *,
+        retryable: bool = False,
+    ) -> None:
+        self.code = code
+        self.detail = detail
+        self.retryable = retryable
+        super().__init__(f"{code}: {detail}")
+
+
+@dataclass(frozen=True)
+class AdapterCapabilities:
+    exact_session_resume: bool
+    structured_streaming: bool
+    interruption: bool
+    interactive_permission_response: bool
+    server_backed: bool
+    session_inspection: bool
+
+    @classmethod
+    def from_manifest(cls, manifest: Mapping[str, Any]) -> "AdapterCapabilities":
+        raw = manifest["conversation"]["capabilities"]
+        return cls(**{name: bool(raw[name]) for name in cls.__annotations__})
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    harness: str
+    version: str
+    minimum_version: str
+    capabilities: AdapterCapabilities
+
+
+@dataclass(frozen=True)
+class ConversationContext:
+    """Resolved route and immutable work surface for one conversation."""
+
+    worktree: Path
+    provider: str | None = None
+    model: str | None = None
+    effort: str | None = None
+    permission_mode: str = "unrestricted"
+    title: str | None = None
+    env: Mapping[str, str] = field(default_factory=dict)
+
+    def checked_worktree(self) -> Path:
+        if self.permission_mode not in PERMISSION_MODES:
+            raise AdapterError(
+                "HARNESS_PERMISSION_POLICY_INVALID",
+                f"unsupported permission mode: {self.permission_mode}",
+            )
+        if not self.worktree.is_absolute():
+            raise AdapterError(
+                "HARNESS_WORKTREE_MISMATCH",
+                f"worktree must be absolute: {self.worktree}",
+            )
+        try:
+            resolved = self.worktree.resolve(strict=True)
+        except OSError as exc:
+            raise AdapterError(
+                "HARNESS_WORKTREE_MISSING",
+                f"worktree is unavailable: {self.worktree}",
+            ) from exc
+        if not resolved.is_dir():
+            raise AdapterError(
+                "HARNESS_WORKTREE_MISSING",
+                f"worktree is not a directory: {resolved}",
+            )
+        return resolved
+
+
+@dataclass
+class NativeTurn:
+    harness: str
+    session_ref: str
+    run_ref: str
+    worktree: Path
+    process_ref: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    opaque: Any = field(default=None, repr=False)
+
+
+@dataclass(frozen=True)
+class NormalizedEvent:
+    type: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    native_type: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.type not in NORMALIZED_EVENTS:
+            raise ValueError(f"unknown normalized conversation event: {self.type}")
+
+
+@dataclass(frozen=True)
+class InterruptResult:
+    acknowledged: bool
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionInspection:
+    session_ref: str
+    exists: bool
+    state: str
+    worktree: Path | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    outcome: str
+    proven: bool
+    detail: str
+
+    def __post_init__(self) -> None:
+        if self.outcome not in RECONCILE_OUTCOMES:
+            raise ValueError(f"unknown reconciliation outcome: {self.outcome}")
+        if self.outcome == "unknown" and self.proven:
+            raise ValueError("an unknown adapter outcome cannot be proven")
+
+
+class ConversationAdapter(abc.ABC):
+    """The only harness surface the broker consumes."""
+
+    harness: str
+
+    def __init__(self, manifest: Mapping[str, Any]) -> None:
+        self.manifest = dict(manifest)
+        self.capabilities = AdapterCapabilities.from_manifest(manifest)
+
+    @abc.abstractmethod
+    def probe(self) -> ProbeResult:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def start(self, context: ConversationContext, message: str) -> NativeTurn:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def resume(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+    ) -> NativeTurn:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def interrupt(self, turn: NativeTurn) -> InterruptResult:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def inspect(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+    ) -> SessionInspection:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def reconcile(
+        self,
+        turn: NativeTurn,
+        context: ConversationContext,
+    ) -> ReconcileResult:
+        raise NotImplementedError
+
+    def _probe_result(self, version: str) -> ProbeResult:
+        minimum = self.manifest["conversation"]["minimum_cli_version"]
+        if version_tuple(version) < version_tuple(minimum):
+            raise AdapterError(
+                "HARNESS_VERSION_UNSUPPORTED",
+                f"{self.harness} {version} is older than required {minimum}",
+            )
+        return ProbeResult(
+            harness=self.harness,
+            version=version,
+            minimum_version=minimum,
+            capabilities=self.capabilities,
+        )
+
+
+class HttpTransport(Protocol):
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: Mapping[str, str] | None = None,
+        body: Mapping[str, Any] | None = None,
+    ) -> Any: ...
+
+    def stream(
+        self,
+        path: str,
+        *,
+        query: Mapping[str, str] | None = None,
+    ) -> Iterable[Mapping[str, Any]]: ...
+
+
+class UrlHttpTransport:
+    """Small JSON + SSE transport for the loopback OpenCode server."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        username: str = "opencode",
+        password: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.endpoint = endpoint.rstrip("/")
+        self.timeout = timeout
+        self.headers = {"Accept": "application/json"}
+        if password is not None:
+            token = base64.b64encode(
+                f"{username}:{password}".encode()
+            ).decode()
+            self.headers["Authorization"] = f"Basic {token}"
+
+    def _url(
+        self,
+        path: str,
+        query: Mapping[str, str] | None,
+    ) -> str:
+        suffix = urllib.parse.urlencode(query or {})
+        return f"{self.endpoint}{path}" + (f"?{suffix}" if suffix else "")
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: Mapping[str, str] | None = None,
+        body: Mapping[str, Any] | None = None,
+    ) -> Any:
+        data = None if body is None else json.dumps(body).encode()
+        headers = dict(self.headers)
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            self._url(path, query),
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(
+                request, timeout=self.timeout
+            ) as response:
+                raw = response.read()
+        except urllib.error.HTTPError as exc:
+            code = (
+                "HARNESS_SESSION_LOST"
+                if exc.code == 404
+                else "HARNESS_PROTOCOL_ERROR"
+            )
+            raise AdapterError(
+                code,
+                f"{method} {path} returned HTTP {exc.code}",
+                retryable=exc.code >= 500,
+            ) from exc
+        except OSError as exc:
+            raise AdapterError(
+                "HARNESS_UNAVAILABLE",
+                f"{method} {path} failed: {exc}",
+                retryable=True,
+            ) from exc
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise AdapterError(
+                "HARNESS_PROTOCOL_ERROR",
+                f"{method} {path} returned invalid JSON",
+            ) from exc
+
+    def stream(
+        self,
+        path: str,
+        *,
+        query: Mapping[str, str] | None = None,
+    ) -> Iterable[Mapping[str, Any]]:
+        headers = dict(self.headers)
+        headers["Accept"] = "text/event-stream"
+        request = urllib.request.Request(
+            self._url(path, query),
+            headers=headers,
+        )
+        try:
+            response = urllib.request.urlopen(request, timeout=self.timeout)
+        except OSError as exc:
+            raise AdapterError(
+                "HARNESS_UNAVAILABLE",
+                f"GET {path} stream failed: {exc}",
+                retryable=True,
+            ) from exc
+
+        return self._iter_sse(response)
+
+    @staticmethod
+    def _iter_sse(response: Any) -> Iterator[Mapping[str, Any]]:
+        data: list[str] = []
+        try:
+            for raw_line in response:
+                line = raw_line.decode("utf-8", "replace").rstrip("\r\n")
+                if line.startswith("data:"):
+                    data.append(line[5:].lstrip())
+                    continue
+                if line or not data:
+                    continue
+                encoded = "\n".join(data)
+                data.clear()
+                try:
+                    value = json.loads(encoded)
+                except json.JSONDecodeError as exc:
+                    raise AdapterError(
+                        "HARNESS_PROTOCOL_ERROR",
+                        "SSE event contained invalid JSON",
+                    ) from exc
+                if isinstance(value, dict):
+                    yield value
+        finally:
+            response.close()
+
+
+class ProcessRunner(Protocol):
+    def spawn(
+        self,
+        argv: list[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+    ) -> Any: ...
+
+
+class SubprocessRunner:
+    def spawn(
+        self,
+        argv: list[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+    ) -> subprocess.Popen[str]:
+        process = subprocess.Popen(
+            argv,
+            cwd=cwd,
+            env=dict(env),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        captured: list[str] = []
+
+        def drain_stderr() -> None:
+            stderr = process.stderr
+            if stderr is None:
+                return
+            remaining = 16384
+            for line in stderr:
+                if remaining <= 0:
+                    continue
+                chunk = line[:remaining]
+                captured.append(chunk)
+                remaining -= len(chunk)
+
+        setattr(process, "_sc_conversation_stderr", captured)
+        threading.Thread(
+            target=drain_stderr,
+            name="conversation-stderr-drain",
+            daemon=True,
+        ).start()
+        return process
+
+
+def load_manifest(harness: str) -> dict[str, Any]:
+    path = ADAPTERS / harness / "adapter.json"
+    if not path.is_file():
+        raise AdapterError(
+            "HARNESS_CONVERSATION_UNSUPPORTED",
+            f"harness has no adapter manifest: {harness}",
+        )
+    try:
+        manifest = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AdapterError(
+            "HARNESS_MANIFEST_INVALID",
+            f"cannot read adapter manifest for {harness}",
+        ) from exc
+    conversation = manifest.get("conversation") or {}
+    if conversation.get("contract_version") != 1:
+        raise AdapterError(
+            "HARNESS_MANIFEST_INVALID",
+            f"harness has no supported conversation contract: {harness}",
+        )
+    declared_events = frozenset(conversation.get("normalized_events") or ())
+    if declared_events != NORMALIZED_EVENTS:
+        raise AdapterError(
+            "HARNESS_MANIFEST_INVALID",
+            f"harness normalized event vocabulary is incomplete: {harness}",
+        )
+    if not conversation.get("capabilities", {}).get("exact_session_resume"):
+        raise AdapterError(
+            "HARNESS_RESUME_UNSUPPORTED",
+            f"harness cannot resume an exact session: {harness}",
+        )
+    return manifest
+
+
+def command_version(argv: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            argv,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise AdapterError(
+            "HARNESS_UNAVAILABLE",
+            f"cannot probe {' '.join(argv)}: {exc}",
+            retryable=True,
+        ) from exc
+    match = re.search(r"\d+\.\d+\.\d+", result.stdout + result.stderr)
+    if not match:
+        raise AdapterError(
+            "HARNESS_PROTOCOL_ERROR",
+            f"version probe returned no semantic version: {' '.join(argv)}",
+        )
+    return match.group(0)
+
+
+def version_tuple(version: str) -> tuple[int, int, int]:
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", version)
+    if not match:
+        raise AdapterError(
+            "HARNESS_PROTOCOL_ERROR",
+            f"invalid harness version: {version}",
+        )
+    return tuple(int(part) for part in match.groups())
+
+
+def ensure_nonempty_message(message: str) -> str:
+    if not isinstance(message, str) or not message.strip():
+        raise AdapterError(
+            "HARNESS_MESSAGE_INVALID",
+            "conversation message must contain text",
+        )
+    return message
+
+
+def ensure_exact_session(expected: str, actual: Any) -> str:
+    if not isinstance(actual, str) or not actual:
+        raise AdapterError(
+            "HARNESS_PROTOCOL_ERROR",
+            "harness returned no native session reference",
+        )
+    if actual != expected:
+        raise AdapterError(
+            "HARNESS_SESSION_MISMATCH",
+            f"requested session {expected}, harness returned {actual}",
+        )
+    return actual
+
+
+def merged_env(
+    manifest: Mapping[str, Any],
+    context: ConversationContext,
+) -> dict[str, str]:
+    return {
+        **os.environ,
+        **{str(k): str(v) for k, v in manifest.get("env", {}).items()},
+        **{str(k): str(v) for k, v in context.env.items()},
+    }
+
+
+def terminal_outcome(event_type: str) -> str:
+    return {
+        "run.completed": "succeeded",
+        "run.failed": "failed",
+        "run.interrupted": "cancelled",
+    }[event_type]

--- a/.super-coder/scripts/conversation_adapters/claude.py
+++ b/.super-coder/scripts/conversation_adapters/claude.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Claude process-per-turn conversation adapter."""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import uuid
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+from .base import (
+    AdapterError,
+    ConversationAdapter,
+    ConversationContext,
+    InterruptResult,
+    NativeTurn,
+    NormalizedEvent,
+    ProbeResult,
+    ProcessRunner,
+    ReconcileResult,
+    SessionInspection,
+    SubprocessRunner,
+    TERMINAL_EVENTS,
+    command_version,
+    ensure_exact_session,
+    ensure_nonempty_message,
+    load_manifest,
+    merged_env,
+    terminal_outcome,
+)
+
+
+class ClaudeAdapter(ConversationAdapter):
+    harness = "claude"
+
+    def __init__(
+        self,
+        *,
+        runner: ProcessRunner | None = None,
+        manifest: Mapping[str, Any] | None = None,
+        config_dir: Path | None = None,
+    ) -> None:
+        super().__init__(manifest or load_manifest(self.harness))
+        self.runner = runner or SubprocessRunner()
+        self.config_dir = config_dir
+
+    def probe(self) -> ProbeResult:
+        launch = self.manifest["headless"]["launch"][0]
+        return self._probe_result(command_version([launch, "--version"]))
+
+    def _command(
+        self,
+        *,
+        context: ConversationContext,
+        message: str,
+        session_ref: str,
+        resume: bool,
+    ) -> list[str]:
+        hcfg = self.manifest["headless"]
+        command = list(hcfg["launch"])
+        prompt_flag = hcfg.get("prompt_flag", "-p")
+        command.extend([prompt_flag, message])
+        command.extend(self.manifest["conversation"]["start"]["stream_flags"])
+        session = self.manifest["conversation"][
+            "resume" if resume else "start"
+        ]["session_flag"]
+        command.extend([session, session_ref])
+        if context.model:
+            model_flag = hcfg.get("model_flag")
+            if not model_flag:
+                raise AdapterError(
+                    "HARNESS_MODEL_ROUTE_INVALID",
+                    "Claude adapter cannot apply a model",
+                )
+            command.extend([model_flag, context.model])
+        if context.effort:
+            effort = hcfg.get("effort") or {}
+            if not effort.get("flag"):
+                raise AdapterError(
+                    "HARNESS_EFFORT_UNSUPPORTED",
+                    "Claude adapter cannot apply effort",
+                )
+            command.extend([effort["flag"], context.effort])
+        if context.permission_mode == "unrestricted":
+            command.append("--dangerously-skip-permissions")
+        return command
+
+    def _launch(
+        self,
+        context: ConversationContext,
+        message: str,
+        session_ref: str,
+        *,
+        resume: bool,
+    ) -> NativeTurn:
+        worktree = context.checked_worktree()
+        if (
+            context.permission_mode == "interactive"
+            and not self.capabilities.interactive_permission_response
+        ):
+            raise AdapterError(
+                "HARNESS_PERMISSION_RESPONSE_UNSUPPORTED",
+                "Claude print mode cannot bridge interactive permissions",
+            )
+        message = ensure_nonempty_message(message)
+        command = self._command(
+            context=context,
+            message=message,
+            session_ref=session_ref,
+            resume=resume,
+        )
+        process = self.runner.spawn(
+            command,
+            cwd=worktree,
+            env=merged_env(self.manifest, context),
+        )
+        pid = getattr(process, "pid", None)
+        return NativeTurn(
+            harness=self.harness,
+            session_ref=session_ref,
+            run_ref=f"claude-{uuid.uuid4()}",
+            worktree=worktree,
+            process_ref=str(pid) if pid is not None else None,
+            metadata={"command": command, "resumed": resume},
+            opaque=process,
+        )
+
+    def start(self, context: ConversationContext, message: str) -> NativeTurn:
+        return self._launch(
+            context,
+            message,
+            str(uuid.uuid4()),
+            resume=False,
+        )
+
+    def resume(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+    ) -> NativeTurn:
+        try:
+            uuid.UUID(session_ref)
+        except ValueError as exc:
+            raise AdapterError(
+                "HARNESS_SESSION_LOST",
+                f"Claude session ref is not a UUID: {session_ref}",
+            ) from exc
+        if not self.inspect(session_ref, context).exists:
+            raise AdapterError(
+                "HARNESS_SESSION_LOST",
+                f"Claude session does not exist: {session_ref}",
+            )
+        return self._launch(
+            context,
+            message,
+            session_ref,
+            resume=True,
+        )
+
+    @staticmethod
+    def _session_from(raw: Mapping[str, Any]) -> str | None:
+        for field in ("session_id", "sessionId"):
+            value = raw.get(field)
+            if isinstance(value, str):
+                return value
+        message = raw.get("message")
+        if isinstance(message, dict):
+            return ClaudeAdapter._session_from(message)
+        return None
+
+    @staticmethod
+    def _usage(raw: Mapping[str, Any]) -> dict[str, int | float]:
+        usage = raw.get("usage")
+        if not isinstance(usage, dict):
+            message = raw.get("message")
+            usage = message.get("usage") if isinstance(message, dict) else None
+        if not isinstance(usage, dict):
+            return {}
+        return {
+            key: value
+            for key, value in usage.items()
+            if isinstance(value, (int, float))
+        }
+
+    def _normalize(
+        self,
+        raw: Mapping[str, Any],
+    ) -> list[NormalizedEvent]:
+        native_type = raw.get("type")
+        if native_type == "system" and raw.get("subtype") == "init":
+            return [
+                NormalizedEvent(
+                    "run.started",
+                    {"status": "running"},
+                    "system.init",
+                ),
+            ]
+        if native_type == "stream_event":
+            event = raw.get("event")
+            if not isinstance(event, dict):
+                return []
+            event_type = event.get("type")
+            if event_type == "content_block_delta":
+                delta = event.get("delta")
+                if (
+                    isinstance(delta, dict)
+                    and delta.get("type") == "text_delta"
+                    and isinstance(delta.get("text"), str)
+                ):
+                    return [
+                        NormalizedEvent(
+                            "assistant.delta",
+                            {"text": delta["text"]},
+                            "stream_event.content_block_delta",
+                        )
+                    ]
+            if event_type == "content_block_start":
+                block = event.get("content_block")
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    return [
+                        NormalizedEvent(
+                            "tool.started",
+                            {
+                                "tool_ref": block.get("id"),
+                                "name": block.get("name"),
+                            },
+                            "stream_event.content_block_start",
+                        )
+                    ]
+            if event_type == "message_delta":
+                usage = self._usage(event)
+                if usage:
+                    return [
+                        NormalizedEvent(
+                            "usage",
+                            {"tokens": usage},
+                            "stream_event.message_delta",
+                        )
+                    ]
+            return []
+        if native_type == "user":
+            content = raw.get("message", {}).get("content")
+            if not isinstance(content, list):
+                return []
+            events = []
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "tool_result":
+                    events.append(
+                        NormalizedEvent(
+                            "tool.completed",
+                            {
+                                "tool_ref": part.get("tool_use_id"),
+                                "status": (
+                                    "failed"
+                                    if part.get("is_error")
+                                    else "completed"
+                                ),
+                            },
+                            "user.tool_result",
+                        )
+                    )
+            return events
+        if native_type == "result":
+            subtype = str(raw.get("subtype") or "")
+            detail = str(raw.get("result") or raw.get("error") or "")
+            interrupted = any(
+                token in f"{subtype} {detail}".lower()
+                for token in ("interrupt", "aborted")
+            )
+            failed = bool(raw.get("is_error")) or subtype.startswith("error")
+            events: list[NormalizedEvent] = []
+            usage = self._usage(raw)
+            if usage:
+                events.append(
+                    NormalizedEvent(
+                        "usage",
+                        {"tokens": usage},
+                        "result",
+                    )
+                )
+            result_type = (
+                "run.interrupted"
+                if interrupted
+                else "run.failed" if failed else "run.completed"
+            )
+            events.append(
+                NormalizedEvent(
+                    result_type,
+                    {
+                        "status": (
+                            "interrupted"
+                            if interrupted
+                            else "failed" if failed else "completed"
+                        ),
+                        "result": detail if detail else None,
+                    },
+                    "result",
+                )
+            )
+            return events
+        return []
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        process = turn.opaque
+        stdout = getattr(process, "stdout", None)
+        if stdout is None:
+            raise AdapterError(
+                "HARNESS_PROTOCOL_ERROR",
+                "Claude process exposes no stdout stream",
+            )
+        yield NormalizedEvent(
+            "session.started",
+            {
+                "session_ref": turn.session_ref,
+                "resumed": bool(turn.metadata.get("resumed")),
+            },
+            "session-id-or-resume",
+        )
+        terminal = False
+        for line in stdout:
+            if not line.strip():
+                continue
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise AdapterError(
+                    "HARNESS_PROTOCOL_ERROR",
+                    "Claude emitted invalid stream JSON",
+                ) from exc
+            native_session = self._session_from(raw)
+            if native_session:
+                ensure_exact_session(turn.session_ref, native_session)
+            for event in self._normalize(raw):
+                if event.type in TERMINAL_EVENTS:
+                    terminal = True
+                    turn.metadata["terminal"] = event.type
+                yield event
+        returncode = process.wait()
+        turn.metadata["returncode"] = returncode
+        if not terminal:
+            event = NormalizedEvent(
+                "run.failed",
+                {
+                    "error": "stream ended without a terminal result",
+                    "exit_code": returncode,
+                },
+                "process.exit",
+            )
+            turn.metadata["terminal"] = event.type
+            yield event
+
+    def interrupt(self, turn: NativeTurn) -> InterruptResult:
+        process = turn.opaque
+        if process is None or process.poll() is not None:
+            return InterruptResult(False, "Claude process is not running")
+        process.send_signal(signal.SIGINT)
+        return InterruptResult(True)
+
+    def _session_path(self, session_ref: str, worktree: Path) -> Path:
+        root = (
+            self.config_dir
+            or Path(os.environ.get("CLAUDE_CONFIG_DIR", "~/.claude")).expanduser()
+        )
+        project = str(worktree).replace(os.sep, "-")
+        return root / "projects" / project / f"{session_ref}.jsonl"
+
+    def inspect(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+    ) -> SessionInspection:
+        worktree = context.checked_worktree()
+        path = self._session_path(session_ref, worktree)
+        if not path.is_file():
+            return SessionInspection(session_ref, False, "missing")
+        last: Mapping[str, Any] | None = None
+        seen_session = False
+        try:
+            with path.open() as stream:
+                for line in stream:
+                    try:
+                        raw = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(raw, dict):
+                        continue
+                    native_session = self._session_from(raw)
+                    if native_session:
+                        ensure_exact_session(session_ref, native_session)
+                        seen_session = True
+                    stored_cwd = raw.get("cwd")
+                    if (
+                        stored_cwd is not None
+                        and Path(str(stored_cwd)).resolve() != worktree
+                    ):
+                        raise AdapterError(
+                            "HARNESS_WORKTREE_MISMATCH",
+                            "Claude session belongs to a different worktree",
+                        )
+                    last = raw
+        except OSError as exc:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"cannot inspect Claude session: {exc}",
+                retryable=True,
+            ) from exc
+        terminal: str | None = None
+        if last and last.get("type") == "result":
+            events = self._normalize(last)
+            terminal_event = next(
+                (event.type for event in events if event.type in TERMINAL_EVENTS),
+                None,
+            )
+            terminal = terminal_event
+        return SessionInspection(
+            session_ref,
+            seen_session or path.is_file(),
+            "idle" if terminal else "unknown",
+            worktree,
+            {
+                "path": str(path),
+                "terminal": terminal,
+                "mtime_ns": path.stat().st_mtime_ns,
+            },
+        )
+
+    def reconcile(
+        self,
+        turn: NativeTurn,
+        context: ConversationContext,
+    ) -> ReconcileResult:
+        terminal = turn.metadata.get("terminal")
+        if terminal in TERMINAL_EVENTS:
+            return ReconcileResult(
+                terminal_outcome(terminal),
+                True,
+                f"terminal {terminal} was observed on Claude stdout",
+            )
+        process = turn.opaque
+        if process is not None and process.poll() is None:
+            return ReconcileResult(
+                "running",
+                True,
+                "Claude process is still running",
+            )
+        inspection = self.inspect(turn.session_ref, context)
+        transcript_terminal = inspection.metadata.get("terminal")
+        if transcript_terminal in TERMINAL_EVENTS:
+            return ReconcileResult(
+                terminal_outcome(str(transcript_terminal)),
+                True,
+                "Claude transcript contains a terminal result",
+            )
+        return ReconcileResult(
+            "unknown",
+            False,
+            "Claude process ended without a terminal stream or transcript result",
+        )

--- a/.super-coder/scripts/conversation_adapters/codex.py
+++ b/.super-coder/scripts/conversation_adapters/codex.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""Codex app-server conversation adapter and JSONL-RPC transport."""
+from __future__ import annotations
+
+import json
+import queue
+import subprocess
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping, Protocol
+
+from .base import (
+    AdapterError,
+    ConversationAdapter,
+    ConversationContext,
+    InterruptResult,
+    NativeTurn,
+    NormalizedEvent,
+    ProbeResult,
+    ReconcileResult,
+    SessionInspection,
+    TERMINAL_EVENTS,
+    command_version,
+    ensure_exact_session,
+    ensure_nonempty_message,
+    load_manifest,
+    merged_env,
+    terminal_outcome,
+)
+
+
+class RpcTransport(Protocol):
+    def request(self, method: str, params: Mapping[str, Any]) -> Any: ...
+
+    def notify(self, method: str, params: Mapping[str, Any]) -> None: ...
+
+    def notifications(self) -> Iterable[Mapping[str, Any]]: ...
+
+    def close(self) -> None: ...
+
+
+class JsonLineRpcProcess:
+    """Thread-safe request/notification client for `codex app-server` stdio."""
+
+    def __init__(
+        self,
+        *,
+        argv: list[str] | None = None,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.timeout = timeout
+        self.process = subprocess.Popen(
+            argv or ["codex", "app-server", "--stdio"],
+            cwd=cwd,
+            env=dict(env) if env is not None else None,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        self._write_lock = threading.Lock()
+        self._pending: dict[int, queue.Queue[Any]] = {}
+        self._pending_lock = threading.Lock()
+        self._notifications: queue.Queue[Any] = queue.Queue()
+        self._next_id = 1
+        self.stderr: list[str] = []
+        self._stderr_reader = threading.Thread(
+            target=self._drain_stderr,
+            name="codex-app-server-stderr",
+            daemon=True,
+        )
+        self._stderr_reader.start()
+        self._reader = threading.Thread(
+            target=self._read_loop,
+            name="codex-app-server-reader",
+            daemon=True,
+        )
+        self._reader.start()
+        self.request(
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": "super-coder",
+                    "title": "super-coder conversation broker",
+                    "version": "1",
+                },
+                "capabilities": {"experimentalApi": False},
+            },
+        )
+        self.notify("initialized", {})
+
+    def _drain_stderr(self) -> None:
+        stderr = self.process.stderr
+        if stderr is None:
+            return
+        remaining = 16384
+        for line in stderr:
+            if remaining <= 0:
+                continue
+            chunk = line[:remaining]
+            self.stderr.append(chunk)
+            remaining -= len(chunk)
+
+    def _write(self, message: Mapping[str, Any]) -> None:
+        stdin = self.process.stdin
+        if stdin is None:
+            raise AdapterError(
+                "HARNESS_UNAVAILABLE",
+                "Codex app-server stdin is closed",
+                retryable=True,
+            )
+        encoded = json.dumps(message, separators=(",", ":"))
+        with self._write_lock:
+            try:
+                stdin.write(encoded + "\n")
+                stdin.flush()
+            except OSError as exc:
+                raise AdapterError(
+                    "HARNESS_UNAVAILABLE",
+                    f"Codex app-server write failed: {exc}",
+                    retryable=True,
+                ) from exc
+
+    def _read_loop(self) -> None:
+        stdout = self.process.stdout
+        if stdout is None:
+            self._notifications.put(None)
+            return
+        for line in stdout:
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                self._notifications.put(
+                    AdapterError(
+                        "HARNESS_PROTOCOL_ERROR",
+                        "Codex app-server emitted invalid JSON",
+                    )
+                )
+                continue
+            if not isinstance(message, dict):
+                continue
+            request_id = message.get("id")
+            if request_id is not None and "method" not in message:
+                with self._pending_lock:
+                    waiter = self._pending.get(request_id)
+                if waiter:
+                    waiter.put(message)
+                continue
+            self._notifications.put(message)
+        error = AdapterError(
+            "HARNESS_UNAVAILABLE",
+            "Codex app-server stream closed",
+            retryable=True,
+        )
+        with self._pending_lock:
+            waiters = list(self._pending.values())
+        for waiter in waiters:
+            waiter.put(error)
+        self._notifications.put(None)
+
+    def request(self, method: str, params: Mapping[str, Any]) -> Any:
+        with self._pending_lock:
+            request_id = self._next_id
+            self._next_id += 1
+            waiter: queue.Queue[Any] = queue.Queue(maxsize=1)
+            self._pending[request_id] = waiter
+        try:
+            self._write({"id": request_id, "method": method, "params": params})
+            try:
+                response = waiter.get(timeout=self.timeout)
+            except queue.Empty as exc:
+                raise AdapterError(
+                    "HARNESS_TIMEOUT",
+                    f"Codex request timed out: {method}",
+                    retryable=True,
+                ) from exc
+            if isinstance(response, AdapterError):
+                raise response
+            if "error" in response:
+                raise AdapterError(
+                    "HARNESS_PROTOCOL_ERROR",
+                    f"Codex {method} failed: {response['error']}",
+                )
+            return response.get("result")
+        finally:
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+
+    def notify(self, method: str, params: Mapping[str, Any]) -> None:
+        self._write({"method": method, "params": params})
+
+    def notifications(self) -> Iterator[Mapping[str, Any]]:
+        while True:
+            message = self._notifications.get()
+            if message is None:
+                return
+            if isinstance(message, AdapterError):
+                raise message
+            yield message
+
+    def close(self) -> None:
+        if self.process.poll() is not None:
+            return
+        self.process.terminate()
+        try:
+            self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait(timeout=5)
+
+
+class CodexAdapter(ConversationAdapter):
+    harness = "codex"
+
+    def __init__(
+        self,
+        *,
+        rpc: RpcTransport | None = None,
+        manifest: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(manifest or load_manifest(self.harness))
+        self._rpc = rpc
+
+    def _transport(self, context: ConversationContext) -> RpcTransport:
+        if self._rpc is None:
+            self._rpc = JsonLineRpcProcess(
+                cwd=context.checked_worktree(),
+                env=merged_env(self.manifest, context),
+            )
+        return self._rpc
+
+    def close(self) -> None:
+        if self._rpc is not None:
+            self._rpc.close()
+            self._rpc = None
+
+    def probe(self) -> ProbeResult:
+        launch = self.manifest["launch"][0]
+        return self._probe_result(command_version([launch, "--version"]))
+
+    @staticmethod
+    def _thread_params(context: ConversationContext) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "cwd": str(context.checked_worktree()),
+        }
+        if context.model:
+            params["model"] = context.model
+        if context.provider:
+            params["modelProvider"] = context.provider
+        if context.permission_mode == "unrestricted":
+            params.update(
+                {
+                    "approvalPolicy": "never",
+                    "sandbox": "danger-full-access",
+                }
+            )
+        return params
+
+    @staticmethod
+    def _turn_params(
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "threadId": session_ref,
+            "input": [{"type": "text", "text": message}],
+            "cwd": str(context.checked_worktree()),
+            "clientUserMessageId": str(uuid.uuid4()),
+        }
+        if context.model:
+            params["model"] = context.model
+        if context.effort:
+            params["effort"] = context.effort
+        if context.permission_mode == "unrestricted":
+            params["approvalPolicy"] = "never"
+        return params
+
+    def _start_turn(
+        self,
+        rpc: RpcTransport,
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+        *,
+        resumed: bool,
+    ) -> NativeTurn:
+        started = rpc.request(
+            "turn/start",
+            self._turn_params(session_ref, context, message),
+        )
+        turn_data = started.get("turn") if isinstance(started, dict) else None
+        run_ref = turn_data.get("id") if isinstance(turn_data, dict) else None
+        if not isinstance(run_ref, str) or not run_ref:
+            raise AdapterError(
+                "HARNESS_PROTOCOL_ERROR",
+                "Codex turn/start returned no turn id",
+            )
+        return NativeTurn(
+            harness=self.harness,
+            session_ref=session_ref,
+            run_ref=run_ref,
+            worktree=context.checked_worktree(),
+            process_ref=f"app-server:{run_ref}",
+            metadata={"resumed": resumed},
+        )
+
+    def start(self, context: ConversationContext, message: str) -> NativeTurn:
+        message = ensure_nonempty_message(message)
+        rpc = self._transport(context)
+        started = rpc.request("thread/start", self._thread_params(context))
+        thread = started.get("thread") if isinstance(started, dict) else None
+        session_ref = thread.get("id") if isinstance(thread, dict) else None
+        if not isinstance(session_ref, str) or not session_ref:
+            raise AdapterError(
+                "HARNESS_PROTOCOL_ERROR",
+                "Codex thread/start returned no thread id",
+            )
+        return self._start_turn(
+            rpc,
+            session_ref,
+            context,
+            message,
+            resumed=False,
+        )
+
+    def resume(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+    ) -> NativeTurn:
+        message = ensure_nonempty_message(message)
+        rpc = self._transport(context)
+        params = self._thread_params(context)
+        params["threadId"] = session_ref
+        try:
+            resumed = rpc.request("thread/resume", params)
+        except AdapterError as exc:
+            if exc.code == "HARNESS_PROTOCOL_ERROR":
+                raise AdapterError(
+                    "HARNESS_SESSION_LOST",
+                    f"Codex could not resume thread {session_ref}",
+                ) from exc
+            raise
+        thread = resumed.get("thread") if isinstance(resumed, dict) else None
+        actual = thread.get("id") if isinstance(thread, dict) else None
+        ensure_exact_session(session_ref, actual)
+        stored_cwd = thread.get("cwd") if isinstance(thread, dict) else None
+        if stored_cwd is not None and Path(stored_cwd).resolve() != (
+            context.checked_worktree()
+        ):
+            raise AdapterError(
+                "HARNESS_WORKTREE_MISMATCH",
+                "Codex thread belongs to a different worktree",
+            )
+        return self._start_turn(
+            rpc,
+            session_ref,
+            context,
+            message,
+            resumed=True,
+        )
+
+    @staticmethod
+    def _matches(turn: NativeTurn, params: Mapping[str, Any]) -> bool:
+        thread_ref = params.get("threadId")
+        turn_ref = params.get("turnId")
+        nested_thread = params.get("thread")
+        if isinstance(nested_thread, dict):
+            nested_thread_ref = nested_thread.get("id")
+            if (
+                nested_thread_ref is not None
+                and nested_thread_ref != turn.session_ref
+            ):
+                return False
+        if thread_ref is not None and thread_ref != turn.session_ref:
+            return False
+        if turn_ref is not None and turn_ref != turn.run_ref:
+            return False
+        nested = params.get("turn")
+        if isinstance(nested, dict):
+            nested_ref = nested.get("id")
+            if nested_ref is not None and nested_ref != turn.run_ref:
+                return False
+        return True
+
+    @staticmethod
+    def _item_kind(params: Mapping[str, Any]) -> tuple[str | None, str | None]:
+        item = params.get("item")
+        if not isinstance(item, dict):
+            return None, None
+        kind = item.get("type")
+        ref = item.get("id")
+        return (
+            kind if isinstance(kind, str) else None,
+            ref if isinstance(ref, str) else None,
+        )
+
+    def _normalize(
+        self,
+        raw: Mapping[str, Any],
+    ) -> list[NormalizedEvent]:
+        method = raw.get("method")
+        params = raw.get("params")
+        if not isinstance(method, str) or not isinstance(params, dict):
+            return []
+        if method == "thread/started":
+            return []
+        if method == "turn/started":
+            return [
+                NormalizedEvent(
+                    "run.started",
+                    {"status": "running"},
+                    method,
+                )
+            ]
+        if method == "item/agentMessage/delta":
+            delta = params.get("delta")
+            if isinstance(delta, str):
+                return [
+                    NormalizedEvent(
+                        "assistant.delta",
+                        {"text": delta},
+                        method,
+                    )
+                ]
+            return []
+        if method == "item/started":
+            kind, ref = self._item_kind(params)
+            if kind in {None, "agentMessage", "reasoning"}:
+                return []
+            return [
+                NormalizedEvent(
+                    "tool.started",
+                    {"tool_ref": ref, "name": kind},
+                    method,
+                )
+            ]
+        if method == "item/completed":
+            kind, ref = self._item_kind(params)
+            if kind in {None, "agentMessage", "reasoning"}:
+                return []
+            item = params.get("item")
+            status = item.get("status") if isinstance(item, dict) else None
+            return [
+                NormalizedEvent(
+                    "tool.completed",
+                    {
+                        "tool_ref": ref,
+                        "name": kind,
+                        "status": status or "completed",
+                    },
+                    method,
+                )
+            ]
+        if method in {
+            "item/commandExecution/requestApproval",
+            "item/fileChange/requestApproval",
+            "item/permissions/requestApproval",
+            "applyPatchApproval",
+            "execCommandApproval",
+        }:
+            return [
+                NormalizedEvent(
+                    "permission.requested",
+                    {
+                        "request_ref": raw.get("id"),
+                        "kind": method,
+                    },
+                    method,
+                )
+            ]
+        if method in {
+            "item/tool/requestUserInput",
+            "mcpServer/elicitation/request",
+        }:
+            return [
+                NormalizedEvent(
+                    "input.requested",
+                    {
+                        "request_ref": raw.get("id"),
+                        "kind": method,
+                    },
+                    method,
+                )
+            ]
+        if method in {
+            "thread/tokenUsage/updated",
+            "turn/tokenUsage/updated",
+        }:
+            usage = {
+                key: value
+                for key, value in params.items()
+                if isinstance(value, (int, float))
+            }
+            return [
+                NormalizedEvent("usage", {"tokens": usage}, method)
+            ] if usage else []
+        if method == "turn/completed":
+            turn = params.get("turn")
+            status = turn.get("status") if isinstance(turn, dict) else None
+            event_type = {
+                "completed": "run.completed",
+                "interrupted": "run.interrupted",
+                "failed": "run.failed",
+            }.get(status, "run.failed")
+            error = turn.get("error") if isinstance(turn, dict) else None
+            return [
+                NormalizedEvent(
+                    event_type,
+                    {"status": status or "failed", "error": error},
+                    method,
+                )
+            ]
+        return []
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        if self._rpc is None:
+            raise AdapterError(
+                "HARNESS_UNAVAILABLE",
+                "Codex app-server is not connected",
+                retryable=True,
+            )
+        yield NormalizedEvent(
+            "session.started",
+            {
+                "session_ref": turn.session_ref,
+                "resumed": bool(turn.metadata.get("resumed")),
+            },
+            "thread.start-or-resume",
+        )
+        for raw in self._rpc.notifications():
+            params = raw.get("params")
+            if isinstance(params, dict) and not self._matches(turn, params):
+                continue
+            for event in self._normalize(raw):
+                session = event.payload.get("session_ref")
+                if session:
+                    ensure_exact_session(turn.session_ref, session)
+                if event.type in TERMINAL_EVENTS:
+                    turn.metadata["terminal"] = event.type
+                yield event
+                if event.type in TERMINAL_EVENTS:
+                    return
+
+    def interrupt(self, turn: NativeTurn) -> InterruptResult:
+        if self._rpc is None:
+            return InterruptResult(False, "Codex app-server is not connected")
+        self._rpc.request(
+            "turn/interrupt",
+            {"threadId": turn.session_ref, "turnId": turn.run_ref},
+        )
+        return InterruptResult(True)
+
+    def inspect(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+    ) -> SessionInspection:
+        rpc = self._transport(context)
+        try:
+            result = rpc.request(
+                "thread/read",
+                {"threadId": session_ref, "includeTurns": True},
+            )
+        except AdapterError as exc:
+            if exc.code in {
+                "HARNESS_PROTOCOL_ERROR",
+                "HARNESS_SESSION_LOST",
+            }:
+                return SessionInspection(session_ref, False, "missing")
+            raise
+        thread = result.get("thread") if isinstance(result, dict) else None
+        actual = thread.get("id") if isinstance(thread, dict) else None
+        ensure_exact_session(session_ref, actual)
+        worktree = context.checked_worktree()
+        stored_cwd = thread.get("cwd") if isinstance(thread, dict) else None
+        if stored_cwd is not None and Path(stored_cwd).resolve() != worktree:
+            raise AdapterError(
+                "HARNESS_WORKTREE_MISMATCH",
+                "Codex thread belongs to a different worktree",
+            )
+        turns = thread.get("turns", []) if isinstance(thread, dict) else []
+        state = "idle"
+        if turns and isinstance(turns[-1], dict):
+            state = str(turns[-1].get("status") or "unknown")
+        return SessionInspection(
+            session_ref,
+            True,
+            state,
+            worktree,
+            {"turns": turns},
+        )
+
+    def reconcile(
+        self,
+        turn: NativeTurn,
+        context: ConversationContext,
+    ) -> ReconcileResult:
+        terminal = turn.metadata.get("terminal")
+        if terminal in TERMINAL_EVENTS:
+            return ReconcileResult(
+                terminal_outcome(terminal),
+                True,
+                f"terminal {terminal} was observed from app-server",
+            )
+        inspection = self.inspect(turn.session_ref, context)
+        if not inspection.exists:
+            return ReconcileResult(
+                "unknown",
+                False,
+                "Codex thread is missing",
+            )
+        turns = inspection.metadata.get("turns")
+        if isinstance(turns, list):
+            for native_turn in turns:
+                if not isinstance(native_turn, dict):
+                    continue
+                if native_turn.get("id") != turn.run_ref:
+                    continue
+                status = native_turn.get("status")
+                if status == "inProgress":
+                    return ReconcileResult(
+                        "running",
+                        True,
+                        "Codex thread/read reports the exact turn in progress",
+                    )
+                outcome = {
+                    "completed": "succeeded",
+                    "failed": "failed",
+                    "interrupted": "cancelled",
+                }.get(status)
+                if outcome:
+                    return ReconcileResult(
+                        outcome,
+                        True,
+                        f"Codex thread/read reports {status}",
+                    )
+        return ReconcileResult(
+            "unknown",
+            False,
+            "Codex thread exists but the run outcome is not provable",
+        )

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""OpenCode server-backed conversation adapter."""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+from .base import (
+    AdapterError,
+    ConversationAdapter,
+    ConversationContext,
+    HttpTransport,
+    InterruptResult,
+    NativeTurn,
+    NormalizedEvent,
+    ProbeResult,
+    ReconcileResult,
+    SessionInspection,
+    TERMINAL_EVENTS,
+    UrlHttpTransport,
+    ensure_exact_session,
+    ensure_nonempty_message,
+    load_manifest,
+    terminal_outcome,
+)
+
+
+class OpenCodeAdapter(ConversationAdapter):
+    harness = "opencode"
+
+    def __init__(
+        self,
+        *,
+        endpoint: str = "http://127.0.0.1:4096",
+        password: str | None = None,
+        transport: HttpTransport | None = None,
+        manifest: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(manifest or load_manifest(self.harness))
+        self.transport = transport or UrlHttpTransport(
+            endpoint,
+            password=password,
+        )
+
+    def probe(self) -> ProbeResult:
+        health = self.transport.request("GET", "/global/health")
+        if not isinstance(health, dict) or not health.get("healthy"):
+            raise AdapterError(
+                "HARNESS_UNAVAILABLE",
+                "OpenCode server health check failed",
+                retryable=True,
+            )
+        version = health.get("version")
+        if not isinstance(version, str):
+            raise AdapterError(
+                "HARNESS_PROTOCOL_ERROR",
+                "OpenCode health response omitted version",
+            )
+        return self._probe_result(version)
+
+    @staticmethod
+    def _route(context: ConversationContext) -> tuple[str, str] | None:
+        if not context.model:
+            return None
+        if context.provider:
+            return context.provider, context.model
+        if "/" in context.model:
+            provider, model = context.model.split("/", 1)
+            if provider and model:
+                return provider, model
+        raise AdapterError(
+            "HARNESS_MODEL_ROUTE_INVALID",
+            "OpenCode models require provider plus model",
+        )
+
+    @staticmethod
+    def _query(worktree: Path) -> dict[str, str]:
+        return {"directory": str(worktree)}
+
+    @staticmethod
+    def _permission_rules(
+        context: ConversationContext,
+    ) -> list[dict[str, str]] | None:
+        if context.permission_mode != "unrestricted":
+            return None
+        return [
+            {
+                "permission": "*",
+                "pattern": "*",
+                "action": "allow",
+            }
+        ]
+
+    def _prompt(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+        run_ref: str,
+    ) -> None:
+        body: dict[str, Any] = {
+            "messageID": run_ref,
+            "parts": [{"type": "text", "text": message}],
+        }
+        route = self._route(context)
+        if route:
+            body["model"] = {
+                "providerID": route[0],
+                "modelID": route[1],
+            }
+        self.transport.request(
+            "POST",
+            f"/session/{session_ref}/prompt_async",
+            query=self._query(context.checked_worktree()),
+            body=body,
+        )
+
+    def _turn(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+        *,
+        resumed: bool,
+    ) -> NativeTurn:
+        worktree = context.checked_worktree()
+        run_ref = f"msg_{uuid.uuid4().hex}"
+        # `/event` is live rather than replayable. Open the subscription before
+        # dispatch so a fast generation cannot finish in the prompt/stream gap.
+        event_stream = iter(
+            self.transport.stream(
+                "/event",
+                query=self._query(worktree),
+            )
+        )
+        turn = NativeTurn(
+            harness=self.harness,
+            session_ref=session_ref,
+            run_ref=run_ref,
+            worktree=worktree,
+            metadata={
+                "event_stream": event_stream,
+                "resumed": resumed,
+            },
+        )
+        self._prompt(session_ref, context, message, run_ref)
+        return turn
+
+    def start(self, context: ConversationContext, message: str) -> NativeTurn:
+        worktree = context.checked_worktree()
+        message = ensure_nonempty_message(message)
+        body: dict[str, Any] = {}
+        if context.title:
+            body["title"] = context.title
+        route = self._route(context)
+        if route:
+            body["model"] = {
+                "providerID": route[0],
+                "id": route[1],
+            }
+        permission = self._permission_rules(context)
+        if permission:
+            body["permission"] = permission
+        created = self.transport.request(
+            "POST",
+            "/session",
+            query=self._query(worktree),
+            body=body,
+        )
+        session_ref = created.get("id") if isinstance(created, dict) else None
+        if not isinstance(session_ref, str) or not session_ref:
+            raise AdapterError(
+                "HARNESS_PROTOCOL_ERROR",
+                "OpenCode session.create returned no id",
+            )
+        return self._turn(session_ref, context, message, resumed=False)
+
+    def resume(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+    ) -> NativeTurn:
+        worktree = context.checked_worktree()
+        message = ensure_nonempty_message(message)
+        inspected = self.inspect(session_ref, context)
+        if not inspected.exists:
+            raise AdapterError(
+                "HARNESS_SESSION_LOST",
+                f"OpenCode session does not exist: {session_ref}",
+            )
+        permission = self._permission_rules(context)
+        if permission:
+            self.transport.request(
+                "PATCH",
+                f"/session/{session_ref}",
+                query=self._query(worktree),
+                body={"permission": permission},
+            )
+        return self._turn(session_ref, context, message, resumed=True)
+
+    @staticmethod
+    def _event_payload(raw: Mapping[str, Any]) -> Mapping[str, Any]:
+        payload = raw.get("payload")
+        return payload if isinstance(payload, dict) else raw
+
+    @classmethod
+    def _session_of(cls, raw: Mapping[str, Any]) -> str | None:
+        event = cls._event_payload(raw)
+        props = event.get("properties")
+        if isinstance(props, dict):
+            value = props.get("sessionID") or props.get("sessionId")
+            if isinstance(value, str):
+                return value
+            info = props.get("info")
+            if isinstance(info, dict):
+                value = info.get("sessionID") or info.get("sessionId")
+                return value if isinstance(value, str) else None
+        return None
+
+    @staticmethod
+    def _error_name(error: Any) -> str:
+        if isinstance(error, dict):
+            for field in ("name", "type", "code"):
+                value = error.get(field)
+                if isinstance(value, str):
+                    return value
+            nested = error.get("data")
+            if isinstance(nested, dict):
+                return OpenCodeAdapter._error_name(nested)
+        return type(error).__name__
+
+    def _normalize(
+        self,
+        raw: Mapping[str, Any],
+    ) -> list[NormalizedEvent]:
+        event = self._event_payload(raw)
+        native_type = event.get("type")
+        if not isinstance(native_type, str):
+            return []
+        props = event.get("properties")
+        props = props if isinstance(props, dict) else {}
+
+        if native_type == "session.status":
+            status = props.get("status")
+            status_type = (
+                status.get("type") if isinstance(status, dict) else status
+            )
+            if status_type == "busy":
+                return [
+                    NormalizedEvent(
+                        "run.started",
+                        {"status": "running"},
+                        native_type,
+                    )
+                ]
+            return []
+        if native_type == "session.idle":
+            return [
+                NormalizedEvent(
+                    "run.completed",
+                    {"status": "completed"},
+                    native_type,
+                )
+            ]
+        if native_type == "session.error":
+            error = props.get("error")
+            name = self._error_name(error)
+            interrupted = name == "MessageAbortedError"
+            return [
+                NormalizedEvent(
+                    "run.interrupted" if interrupted else "run.failed",
+                    {"error": name},
+                    native_type,
+                )
+            ]
+        if native_type == "message.part.delta":
+            if props.get("field") == "text" and isinstance(
+                props.get("delta"), str
+            ):
+                return [
+                    NormalizedEvent(
+                        "assistant.delta",
+                        {"text": props["delta"]},
+                        native_type,
+                    )
+                ]
+            return []
+        if native_type in {
+            "permission.asked",
+            "permission.v2.asked",
+        }:
+            return [
+                NormalizedEvent(
+                    "permission.requested",
+                    {
+                        "request_ref": props.get("id"),
+                        "action": props.get("action"),
+                        "resources": props.get("resources", []),
+                    },
+                    native_type,
+                )
+            ]
+        if native_type in {"question.asked", "question.v2.asked"}:
+            return [
+                NormalizedEvent(
+                    "input.requested",
+                    {
+                        "request_ref": props.get("id"),
+                        "questions": props.get("questions", []),
+                    },
+                    native_type,
+                )
+            ]
+        if native_type in {
+            "session.next.tool.called",
+            "session.next.shell.started",
+        }:
+            return [
+                NormalizedEvent(
+                    "tool.started",
+                    {
+                        "tool_ref": props.get("id"),
+                        "name": props.get("tool") or props.get("command"),
+                    },
+                    native_type,
+                )
+            ]
+        if native_type in {
+            "session.next.tool.success",
+            "session.next.tool.failed",
+            "session.next.shell.ended",
+        }:
+            return [
+                NormalizedEvent(
+                    "tool.completed",
+                    {
+                        "tool_ref": props.get("id"),
+                        "status": (
+                            "failed" if native_type.endswith("failed") else "completed"
+                        ),
+                    },
+                    native_type,
+                )
+            ]
+        if native_type == "message.updated":
+            info = props.get("info")
+            if isinstance(info, dict) and info.get("role") == "assistant":
+                tokens = info.get("tokens")
+                if isinstance(tokens, dict):
+                    safe = {
+                        key: value
+                        for key, value in tokens.items()
+                        if isinstance(value, (int, float))
+                    }
+                    if safe:
+                        return [
+                            NormalizedEvent(
+                                "usage",
+                                {"tokens": safe},
+                                native_type,
+                            )
+                        ]
+        return []
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        native_stream = turn.metadata.get("event_stream")
+        if native_stream is None:
+            raise AdapterError(
+                "HARNESS_PROTOCOL_ERROR",
+                "OpenCode turn has no pre-dispatch event subscription",
+            )
+        yield NormalizedEvent(
+            "session.started",
+            {
+                "session_ref": turn.session_ref,
+                "resumed": bool(turn.metadata.get("resumed")),
+            },
+            "session.create-or-resume",
+        )
+        for raw in native_stream:
+            event_session = self._session_of(raw)
+            if event_session and event_session != turn.session_ref:
+                continue
+            for event in self._normalize(raw):
+                if event.type in TERMINAL_EVENTS:
+                    turn.metadata["terminal"] = event.type
+                yield event
+                if event.type in TERMINAL_EVENTS:
+                    return
+
+    def interrupt(self, turn: NativeTurn) -> InterruptResult:
+        result = self.transport.request(
+            "POST",
+            f"/session/{turn.session_ref}/abort",
+            query=self._query(turn.worktree),
+        )
+        return InterruptResult(bool(result))
+
+    def inspect(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+    ) -> SessionInspection:
+        worktree = context.checked_worktree()
+        try:
+            session = self.transport.request(
+                "GET",
+                f"/session/{session_ref}",
+                query=self._query(worktree),
+            )
+        except AdapterError as exc:
+            if exc.code == "HARNESS_SESSION_LOST":
+                return SessionInspection(session_ref, False, "missing")
+            raise
+        actual = session.get("id") if isinstance(session, dict) else None
+        ensure_exact_session(session_ref, actual)
+        status: Any = None
+        statuses = self.transport.request(
+            "GET",
+            "/session/status",
+            query=self._query(worktree),
+        )
+        if isinstance(statuses, dict):
+            status = statuses.get(session_ref)
+        state = (
+            status.get("type")
+            if isinstance(status, dict)
+            else status if isinstance(status, str) else "idle"
+        )
+        return SessionInspection(
+            session_ref,
+            True,
+            str(state),
+            worktree,
+            {"title": session.get("title") if isinstance(session, dict) else None},
+        )
+
+    def reconcile(
+        self,
+        turn: NativeTurn,
+        context: ConversationContext,
+    ) -> ReconcileResult:
+        terminal = turn.metadata.get("terminal")
+        if terminal in TERMINAL_EVENTS:
+            return ReconcileResult(
+                terminal_outcome(terminal),
+                True,
+                f"terminal {terminal} was observed on the native stream",
+            )
+        inspection = self.inspect(turn.session_ref, context)
+        if not inspection.exists:
+            return ReconcileResult(
+                "unknown",
+                False,
+                "native OpenCode session is missing",
+            )
+        if inspection.state == "busy":
+            return ReconcileResult(
+                "running",
+                True,
+                "OpenCode reports the exact session busy",
+            )
+        return ReconcileResult(
+            "unknown",
+            False,
+            "OpenCode session is idle without a recorded terminal event",
+        )

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python3
+"""Shared and native contract tests for Feature #24 conversation adapters."""
+from __future__ import annotations
+
+import io
+import json
+import signal
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from conversation_adapters import (  # noqa: E402
+    AdapterError,
+    ClaudeAdapter,
+    CodexAdapter,
+    ConversationContext,
+    OpenCodeAdapter,
+    adapter_for,
+)
+
+
+class FakeOpenCode:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, str, dict, Any]] = []
+        self.session_ref = "ses_exact"
+        self.status = "idle"
+        self.exists = True
+        self.stream_calls: list[tuple[str, dict]] = []
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: Mapping[str, str] | None = None,
+        body: Mapping[str, Any] | None = None,
+    ) -> Any:
+        self.requests.append((method, path, dict(query or {}), body))
+        if path == "/global/health":
+            return {"healthy": True, "version": "1.18.9"}
+        if method == "POST" and path == "/session":
+            return {"id": self.session_ref, "title": "test"}
+        if path.endswith("/prompt_async"):
+            self.status = "busy"
+            return None
+        if path.endswith("/abort"):
+            self.status = "idle"
+            return True
+        if path == "/session/status":
+            return {self.session_ref: {"type": self.status}}
+        if method == "GET" and path == f"/session/{self.session_ref}":
+            if not self.exists:
+                raise AdapterError("HARNESS_SESSION_LOST", "missing")
+            return {"id": self.session_ref, "title": "test"}
+        if method == "PATCH" and path == f"/session/{self.session_ref}":
+            return {"id": self.session_ref, "title": "test"}
+        raise AssertionError(f"unexpected OpenCode request: {method} {path}")
+
+    def stream(
+        self,
+        path: str,
+        *,
+        query: Mapping[str, str] | None = None,
+    ) -> Iterable[Mapping[str, Any]]:
+        self.stream_calls.append((path, dict(query or {})))
+        return iter(
+            [
+                {
+                    "type": "message.part.delta",
+                    "properties": {
+                        "sessionID": "ses_other",
+                        "field": "text",
+                        "delta": "wrong",
+                    },
+                },
+                {
+                    "type": "session.status",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "status": {"type": "busy"},
+                    },
+                },
+                {
+                    "type": "message.part.delta",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "field": "reasoning",
+                        "delta": "secret reasoning",
+                    },
+                },
+                {
+                    "type": "message.part.delta",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "field": "text",
+                        "delta": "hello",
+                    },
+                },
+                {
+                    "type": "session.next.tool.called",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "id": "tool-1",
+                        "tool": "bash",
+                    },
+                },
+                {
+                    "type": "session.next.tool.success",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "id": "tool-1",
+                    },
+                },
+                {
+                    "type": "permission.v2.asked",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "id": "per-1",
+                        "action": "bash",
+                        "resources": ["git status"],
+                    },
+                },
+                {
+                    "type": "session.idle",
+                    "properties": {"sessionID": self.session_ref},
+                },
+            ]
+        )
+
+
+class FakeClaudeProcess:
+    def __init__(self, session_ref: str) -> None:
+        rows = [
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": session_ref,
+            },
+            {
+                "type": "stream_event",
+                "session_id": session_ref,
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "thinking_delta", "thinking": "secret"},
+                },
+            },
+            {
+                "type": "stream_event",
+                "session_id": session_ref,
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "hello"},
+                },
+            },
+            {
+                "type": "stream_event",
+                "session_id": session_ref,
+                "event": {
+                    "type": "content_block_start",
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": "tool-1",
+                        "name": "Bash",
+                    },
+                },
+            },
+            {
+                "type": "user",
+                "session_id": session_ref,
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool-1",
+                            "is_error": False,
+                        }
+                    ]
+                },
+            },
+            {
+                "type": "result",
+                "subtype": "success",
+                "session_id": session_ref,
+                "result": "done",
+                "usage": {"input_tokens": 10, "output_tokens": 2},
+            },
+        ]
+        self.stdout = io.StringIO(
+            "".join(json.dumps(row) + "\n" for row in rows)
+        )
+        self.stderr = io.StringIO()
+        self.pid = 4321
+        self.returncode: int | None = None
+        self.signals: list[int] = []
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def wait(self) -> int:
+        self.returncode = 0
+        return 0
+
+    def send_signal(self, value: int) -> None:
+        self.signals.append(value)
+
+
+class FakeClaudeRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], Path, dict[str, str]]] = []
+        self.processes: list[FakeClaudeProcess] = []
+
+    def spawn(
+        self,
+        argv: list[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+    ) -> FakeClaudeProcess:
+        flag = "--resume" if "--resume" in argv else "--session-id"
+        session_ref = argv[argv.index(flag) + 1]
+        process = FakeClaudeProcess(session_ref)
+        self.calls.append((list(argv), cwd, dict(env)))
+        self.processes.append(process)
+        return process
+
+
+class FakeCodexRpc:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, dict[str, Any]]] = []
+        self.notifications_sent: list[tuple[str, dict[str, Any]]] = []
+        self.session_ref = "codex-thread-exact"
+        self.run_ref = "codex-turn-1"
+        self.turn_number = 0
+        self.read_status = "completed"
+        self.resume_ref_override: str | None = None
+        self.closed = False
+
+    def request(self, method: str, params: Mapping[str, Any]) -> Any:
+        self.requests.append((method, dict(params)))
+        if method == "thread/start":
+            return {
+                "thread": {
+                    "id": self.session_ref,
+                    "cwd": params["cwd"],
+                }
+            }
+        if method == "thread/resume":
+            return {
+                "thread": {
+                    "id": self.resume_ref_override or params["threadId"],
+                    "cwd": params["cwd"],
+                }
+            }
+        if method == "turn/start":
+            self.turn_number += 1
+            self.run_ref = f"codex-turn-{self.turn_number}"
+            return {"turn": {"id": self.run_ref, "status": "inProgress"}}
+        if method == "turn/interrupt":
+            return {}
+        if method == "thread/read":
+            return {
+                "thread": {
+                    "id": params["threadId"],
+                    "cwd": str(WORKTREE),
+                    "turns": [
+                        {"id": self.run_ref, "status": self.read_status}
+                    ],
+                }
+            }
+        raise AssertionError(f"unexpected Codex request: {method}")
+
+    def notify(self, method: str, params: Mapping[str, Any]) -> None:
+        self.notifications_sent.append((method, dict(params)))
+
+    def notifications(self) -> Iterable[Mapping[str, Any]]:
+        return iter(
+            [
+                {
+                    "method": "item/agentMessage/delta",
+                    "params": {
+                        "threadId": "other-thread",
+                        "turnId": self.run_ref,
+                        "delta": "wrong",
+                    },
+                },
+                {
+                    "method": "thread/started",
+                    "params": {"thread": {"id": self.session_ref}},
+                },
+                {
+                    "method": "turn/started",
+                    "params": {
+                        "threadId": self.session_ref,
+                        "turn": {
+                            "id": self.run_ref,
+                            "status": "inProgress",
+                        },
+                    },
+                },
+                {
+                    "method": "item/agentMessage/delta",
+                    "params": {
+                        "threadId": self.session_ref,
+                        "turnId": self.run_ref,
+                        "delta": "hello",
+                    },
+                },
+                {
+                    "method": "item/started",
+                    "params": {
+                        "threadId": self.session_ref,
+                        "turnId": self.run_ref,
+                        "item": {"id": "tool-1", "type": "commandExecution"},
+                    },
+                },
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": self.session_ref,
+                        "turnId": self.run_ref,
+                        "item": {
+                            "id": "tool-1",
+                            "type": "commandExecution",
+                            "status": "completed",
+                        },
+                    },
+                },
+                {
+                    "id": 91,
+                    "method": "item/permissions/requestApproval",
+                    "params": {
+                        "threadId": self.session_ref,
+                        "turnId": self.run_ref,
+                    },
+                },
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": self.session_ref,
+                        "turn": {
+                            "id": self.run_ref,
+                            "status": "completed",
+                        },
+                    },
+                },
+            ]
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+WORKTREE = Path("/")
+
+
+class ConversationAdapterTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name).resolve()
+        global WORKTREE
+        WORKTREE = self.root
+        self.context = ConversationContext(
+            worktree=self.root,
+            provider="openrouter",
+            model="test-model",
+            effort="high",
+        )
+        self.claude_config = self.root / "claude-config"
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def write_claude_session(
+        self,
+        adapter: ClaudeAdapter,
+        session_ref: str,
+        *,
+        terminal: bool = True,
+    ) -> None:
+        path = adapter._session_path(session_ref, self.root)
+        path.parent.mkdir(parents=True)
+        rows = [
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": session_ref,
+                "cwd": str(self.root),
+            }
+        ]
+        if terminal:
+            rows.append(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "session_id": session_ref,
+                    "cwd": str(self.root),
+                    "result": "done",
+                }
+            )
+        path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+    def build(self, harness: str):
+        if harness == "opencode":
+            native = FakeOpenCode()
+            return OpenCodeAdapter(transport=native), native
+        if harness == "claude":
+            native = FakeClaudeRunner()
+            return (
+                ClaudeAdapter(
+                    runner=native,
+                    config_dir=self.claude_config,
+                ),
+                native,
+            )
+        native = FakeCodexRpc()
+        return CodexAdapter(rpc=native), native
+
+    def prepare_resume(self, harness: str, adapter, session_ref: str) -> None:
+        if harness == "claude":
+            self.write_claude_session(adapter, session_ref)
+
+    def test_identical_contract_start_stream_interrupt_resume_reconcile(
+        self,
+    ) -> None:
+        for harness in ("opencode", "claude", "codex"):
+            with self.subTest(harness=harness):
+                adapter, native = self.build(harness)
+                turn = adapter.start(self.context, "first")
+                self.assertEqual(turn.harness, harness)
+                self.assertEqual(turn.worktree, self.root)
+                self.assertTrue(turn.session_ref)
+                self.assertTrue(turn.run_ref)
+
+                events = list(adapter.stream(turn))
+                types = [event.type for event in events]
+                self.assertIn("session.started", types)
+                self.assertIn("run.started", types)
+                self.assertIn("assistant.delta", types)
+                self.assertIn("tool.started", types)
+                self.assertIn("tool.completed", types)
+                self.assertIn("run.completed", types)
+                self.assertNotIn("secret reasoning", repr(events))
+                self.assertEqual(
+                    adapter.reconcile(turn, self.context).outcome,
+                    "succeeded",
+                )
+
+                self.prepare_resume(harness, adapter, turn.session_ref)
+                resumed = adapter.resume(
+                    turn.session_ref,
+                    self.context,
+                    "second",
+                )
+                self.assertEqual(resumed.session_ref, turn.session_ref)
+                self.assertNotEqual(resumed.run_ref, turn.run_ref)
+                self.assertTrue(adapter.interrupt(resumed).acknowledged)
+
+    def test_native_permission_translation_has_no_shared_sandbox_flag(
+        self,
+    ) -> None:
+        opencode, opencode_native = self.build("opencode")
+        opencode.start(self.context, "work")
+        create = next(
+            request
+            for request in opencode_native.requests
+            if request[:2] == ("POST", "/session")
+        )
+        self.assertNotIn("sandbox", create[3])
+        self.assertEqual(
+            create[3]["permission"],
+            [{"permission": "*", "pattern": "*", "action": "allow"}],
+        )
+
+        claude, claude_native = self.build("claude")
+        claude.start(self.context, "work")
+        claude_argv = claude_native.calls[-1][0]
+        self.assertIn("--dangerously-skip-permissions", claude_argv)
+        self.assertNotIn("--sandbox", claude_argv)
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_PERMISSION_RESPONSE_UNSUPPORTED",
+        ):
+            claude.start(
+                ConversationContext(
+                    worktree=self.root,
+                    permission_mode="interactive",
+                ),
+                "work",
+            )
+
+        codex, codex_native = self.build("codex")
+        codex.start(self.context, "work")
+        thread_params = next(
+            params
+            for method, params in codex_native.requests
+            if method == "thread/start"
+        )
+        self.assertEqual(thread_params["approvalPolicy"], "never")
+        self.assertEqual(thread_params["sandbox"], "danger-full-access")
+        self.assertNotIn("--sandbox", repr(codex_native.requests))
+
+    def test_opencode_exact_resources_filtering_and_unknown_recovery(
+        self,
+    ) -> None:
+        adapter, native = self.build("opencode")
+        result = adapter.probe()
+        self.assertEqual(result.version, "1.18.9")
+        turn = adapter.start(self.context, "hello")
+        self.assertEqual(
+            native.stream_calls,
+            [("/event", {"directory": str(self.root)})],
+            "the SSE subscription must open before prompt dispatch",
+        )
+        prompt = next(
+            request
+            for request in native.requests
+            if request[1].endswith("/prompt_async")
+        )
+        self.assertEqual(prompt[2]["directory"], str(self.root))
+        self.assertEqual(
+            prompt[3]["model"],
+            {"providerID": "openrouter", "modelID": "test-model"},
+        )
+        events = list(adapter.stream(turn))
+        self.assertNotIn("wrong", repr(events))
+        self.assertIn("permission.requested", [event.type for event in events])
+
+        fresh = adapter.resume(turn.session_ref, self.context, "again")
+        permission_patch = next(
+            request
+            for request in native.requests
+            if request[:2] == (
+                "PATCH",
+                f"/session/{turn.session_ref}",
+            )
+        )
+        self.assertEqual(
+            permission_patch[3]["permission"][0]["action"],
+            "allow",
+        )
+        native.status = "busy"
+        recovered = adapter.reconcile(fresh, self.context)
+        self.assertEqual(recovered.outcome, "running")
+        self.assertTrue(recovered.proven)
+        native.status = "idle"
+        recovered = adapter.reconcile(fresh, self.context)
+        self.assertEqual(recovered.outcome, "unknown")
+        self.assertFalse(recovered.proven)
+
+    def test_claude_uses_exact_start_and_resume_flags_and_sigint(
+        self,
+    ) -> None:
+        adapter, runner = self.build("claude")
+        turn = adapter.start(self.context, "hello")
+        argv = runner.calls[-1][0]
+        self.assertIn("--session-id", argv)
+        self.assertNotIn("--resume", argv)
+        self.assertIn("--include-partial-messages", argv)
+        self.write_claude_session(adapter, turn.session_ref)
+        resumed = adapter.resume(turn.session_ref, self.context, "again")
+        argv = runner.calls[-1][0]
+        self.assertIn("--resume", argv)
+        self.assertNotIn("--session-id", argv)
+        self.assertTrue(adapter.interrupt(resumed).acknowledged)
+        self.assertEqual(runner.processes[-1].signals, [signal.SIGINT])
+
+    def test_codex_uses_exact_rpc_methods_and_read_reconciliation(
+        self,
+    ) -> None:
+        adapter, rpc = self.build("codex")
+        turn = adapter.start(self.context, "hello")
+        self.assertEqual(
+            [method for method, _params in rpc.requests[:2]],
+            ["thread/start", "turn/start"],
+        )
+        events = list(adapter.stream(turn))
+        self.assertIn(
+            "permission.requested",
+            [event.type for event in events],
+        )
+        resumed = adapter.resume(turn.session_ref, self.context, "again")
+        self.assertIn("thread/resume", [method for method, _ in rpc.requests])
+        rpc.read_status = "inProgress"
+        result = adapter.reconcile(resumed, self.context)
+        self.assertEqual(result.outcome, "running")
+        self.assertTrue(result.proven)
+        adapter.close()
+        self.assertTrue(rpc.closed)
+
+    def test_worktree_and_registry_fail_closed(self) -> None:
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_WORKTREE_MISSING",
+        ):
+            ConversationContext(
+                worktree=self.root / "missing"
+            ).checked_worktree()
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_WORKTREE_MISMATCH",
+        ):
+            ConversationContext(worktree=Path("relative")).checked_worktree()
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_CONVERSATION_UNSUPPORTED",
+        ):
+            adapter_for("vibe")
+
+    def test_exact_resume_fails_closed_on_lost_or_mismatched_session(
+        self,
+    ) -> None:
+        opencode, opencode_native = self.build("opencode")
+        opencode_native.exists = False
+        with self.assertRaisesRegex(AdapterError, "HARNESS_SESSION_LOST"):
+            opencode.resume(
+                opencode_native.session_ref,
+                self.context,
+                "again",
+            )
+
+        claude, _runner = self.build("claude")
+        started = claude.start(self.context, "first")
+        self.write_claude_session(claude, started.session_ref)
+        resumed = claude.resume(started.session_ref, self.context, "again")
+        resumed.opaque.stdout = io.StringIO(
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "session_id": str(
+                        "00000000-0000-0000-0000-000000000000"
+                    ),
+                }
+            )
+            + "\n"
+        )
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_SESSION_MISMATCH",
+        ):
+            list(claude.stream(resumed))
+
+        codex, rpc = self.build("codex")
+        first = codex.start(self.context, "first")
+        rpc.resume_ref_override = "wrong-thread"
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_SESSION_MISMATCH",
+        ):
+            codex.resume(first.session_ref, self.context, "again")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_conversation_capabilities.py
+++ b/tests/test_conversation_capabilities.py
@@ -20,6 +20,19 @@ CAPABILITIES = {
     "server_backed",
     "session_inspection",
 }
+NORMALIZED_EVENTS = {
+    "session.started",
+    "run.started",
+    "assistant.delta",
+    "tool.started",
+    "tool.completed",
+    "permission.requested",
+    "input.requested",
+    "usage",
+    "run.completed",
+    "run.failed",
+    "run.interrupted",
+}
 VERSION = re.compile(r"^\d+\.\d+\.\d+$")
 
 
@@ -42,6 +55,17 @@ class ConversationCapabilityContractTest(unittest.TestCase):
             with self.subTest(harness=harness):
                 conversation = self.adapter(harness)["conversation"]
                 probe = self.probes["required_harnesses"][harness]
+                self.assertEqual(conversation["contract_version"], 1)
+                self.assertEqual(
+                    set(conversation["normalized_events"]),
+                    NORMALIZED_EVENTS,
+                )
+                execution = conversation["execution_permissions"]
+                self.assertEqual(
+                    execution["requirement"],
+                    "worktree-command-access",
+                )
+                self.assertFalse(execution["sandbox_flag_required"])
                 self.assertRegex(conversation["minimum_cli_version"], VERSION)
                 self.assertEqual(
                     conversation["verified_cli_version"],


### PR DESCRIPTION
## Summary

- add one typed `probe/start/resume/stream/interrupt/inspect/reconcile` contract with a registry and stable adapter errors
- implement a race-free OpenCode server slice that subscribes to SSE before dispatch, resumes exact sessions, applies session permission rules, and refuses unproven recovery
- implement Claude process-per-turn exact UUID resume, stream-json normalization, SIGINT interruption, and native transcript inspection
- implement Codex app-server JSONL-RPC, exact thread/turn operations, native permission policy translation, interruption, inspection, and bounded reconciliation
- normalize assistant, tool, permission/input, usage, and terminal events while dropping raw reasoning
- declare contract version, normalized vocabulary, and worktree-command-access permission semantics in all three manifests; no shared `--sandbox` requirement

## Verification

- `python3 tests/test_conversation_adapters.py` — 7 passed
- `python3 tests/test_conversation_capabilities.py` — 5 passed
- `python3 tests/test_conversation_schema.py` — 17 passed
- `python3 tests/test_shell_liveness.py` — 60 passed
- `python3 tests/test_activity_readers.py` — 41 passed
- `python3 tests/test_sprint_eventing.py` — 90 passed
- run/session slot tests — 25 passed
- live no-model OpenCode authenticated transport probe — passed on 1.18.9
- live no-model Codex app-server initialize/close — passed on 0.145.0
- `./sc render-check` — passed
- `./sc verify` — passed

Feature #24 · Spec #32 · Task #92