### PR TITLE
Feature #24: event-driven conversation broker

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -62,6 +62,7 @@ sys.path.insert(0, str(ENGINE / "scripts"))
 import artifact_policy  # noqa: E402
 import backfill_shell_api_keys  # noqa: E402  (startup key provisioning)
 import conductor_runtime  # noqa: E402  (Step 8 wake/config/doctor)
+import conversation_broker  # noqa: E402  (Feature #24 durable turn service)
 import db_driver  # noqa: E402
 import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import mem_credentials  # noqa: E402  (runtime Admin credential provisioning, spec #30 req 11)
@@ -3712,7 +3713,18 @@ def main(argv):
     import transport  # noqa: E402  (api/ — asyncio one-port multiplex)
 
     async def _serve():
-        await transport.serve(bind, port, dispatch_http, _ws_unavailable)
+        # Browser-native conversations are commit-woken, not interval-polled.
+        # Startup/lease timers inside the broker exist only for bounded crash
+        # reconciliation. Task #94 calls notify_commit() after its transaction.
+        # The callback runs after the TCP bind succeeds, so a losing duplicate
+        # server process cannot dispatch a queued prompt before bind refusal.
+        await transport.serve(
+            bind,
+            port,
+            dispatch_http,
+            _ws_unavailable,
+            on_started=lambda: conversation_broker.start_service(DB_PATH),
+        )
 
     print(f"super-coder review layer → http://127.0.0.1:{port}  (bind {bind}, DB: {DB_PATH.name})")
     try:

--- a/.super-coder/api/transport.py
+++ b/.super-coder/api/transport.py
@@ -158,14 +158,21 @@ class Transport:
 
 
 async def serve(host: str, port: int, http_handler, ws_handler,
-                log=print) -> int:
+                log=print, on_started=None) -> int:
     """Start the multiplex and block forever (until cancelled). Returns the
     bound port after start for callers that passed port=0 — via `log` line and
-    the Transport object; this coroutine simply runs until shutdown."""
+    the Transport object; this coroutine simply runs until shutdown.
+
+    ``on_started`` runs only after the socket bind succeeds. Background workers
+    that can cause external side effects belong behind that boundary: a second
+    process must lose the bind race before it can dispatch work.
+    """
     transport = Transport(host, port, http_handler, ws_handler, log=log)
     await transport.start()
-    log(f"transport: listening on {host}:{transport.port}")
     try:
+        log(f"transport: listening on {host}:{transport.port}")
+        if on_started is not None:
+            on_started()
         await asyncio.Event().wait()
     finally:
         await transport.stop()

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -1,0 +1,1213 @@
+#!/usr/bin/env python3
+"""Durable, event-driven browser conversation broker.
+
+The API commits messages and transactional outbox intents; this service is
+notified only after that commit.  It leases the oldest eligible turn, holds the
+database-enforced per-shell mutation lock, delegates one native turn to the
+harness adapter, and commits normalized events in conversation order.
+
+The recovery rule is intentionally conservative: a leased run has not crossed
+the native-dispatch boundary and is safe to start, while a starting/running run
+is inspected by exact native session/run reference.  An outcome that cannot be
+proved is recorded as unknown and is never replayed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import threading
+import time
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import db_driver
+from conversation_adapters import (
+    ConversationAdapter,
+    ConversationContext,
+    NativeTurn,
+    NormalizedEvent,
+    adapter_for,
+)
+from conversation_adapters.base import TERMINAL_EVENTS, terminal_outcome
+from conversation_state import require_transition
+
+LIVE_RUN_STATES = frozenset({"leased", "starting", "running"})
+TERMINAL_RUN_STATES = frozenset({"succeeded", "failed", "cancelled", "unknown"})
+DEFAULT_LEASE_SECONDS = 30
+DEFAULT_HEARTBEAT_SECONDS = 10
+DEFAULT_RECOVERY_SECONDS = 5
+DEFAULT_RECONCILE_ATTEMPTS = 3
+DEFAULT_MAX_WORKERS = 8
+
+
+class BrokerError(RuntimeError):
+    """Stable broker failure for the API boundary."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(f"{code}: {detail}")
+
+
+class BrokerInvariantError(BrokerError):
+    """Durable state contradicts the exact native identity contract."""
+
+
+@dataclass(frozen=True)
+class BrokerRun:
+    run_id: int
+    conversation_id: str
+    message_id: int
+    shell_id: int
+    harness: str
+    provider: str | None
+    model: str | None
+    effort: str | None
+    worktree: Path
+    title: str | None
+    body: str
+    session_before: str | None
+    session_after: str | None
+    runner_ref: str | None
+    state: str
+    interrupt_requested: bool = False
+
+    def context(self) -> ConversationContext:
+        # Normal-mode browser conversations run with worktree command access.
+        # Each adapter chooses its native mechanism; there is no shared
+        # requirement for a literal --sandbox flag.
+        return ConversationContext(
+            worktree=self.worktree,
+            provider=self.provider,
+            model=self.model,
+            effort=self.effort,
+            permission_mode="unrestricted",
+            title=self.title,
+        )
+
+
+@dataclass
+class _ActiveRun:
+    run: BrokerRun
+    adapter: ConversationAdapter | None = None
+    turn: NativeTurn | None = None
+    interrupt_requested: bool = False
+    interrupt_sent: bool = False
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+class BrokerStore:
+    """Short SQLite transactions for the broker state machine."""
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        *,
+        connect: Callable[[], Any] | None = None,
+        clock: Callable[[], datetime] = _utcnow,
+        lease_seconds: int = DEFAULT_LEASE_SECONDS,
+    ) -> None:
+        self.db_path = str(db_path)
+        self._connect = connect
+        self.clock = clock
+        self.lease_seconds = lease_seconds
+
+    def connect(self):
+        return (
+            self._connect()
+            if self._connect is not None
+            else db_driver.connect(self.db_path)
+        )
+
+    def _times(self) -> tuple[str, str]:
+        now = self.clock()
+        return _stamp(now), _stamp(now + timedelta(seconds=self.lease_seconds))
+
+    @staticmethod
+    def _begin(con) -> None:
+        con.execute("BEGIN IMMEDIATE")
+
+    @staticmethod
+    def _rollback(con) -> None:
+        try:
+            con.rollback()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _payload(payload: Mapping[str, Any] | None) -> str:
+        encoded = json.dumps(
+            dict(payload or {}),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(encoded.encode()) > 262144:
+            raise BrokerError(
+                "CONVERSATION_EVENT_TOO_LARGE",
+                "normalized event payload exceeds 262144 bytes",
+            )
+        return encoded
+
+    @staticmethod
+    def _append_event(
+        con,
+        *,
+        conversation_id: str,
+        event_type: str,
+        payload: Mapping[str, Any] | None,
+        message_id: int | None,
+        run_id: int | None,
+    ) -> int:
+        sequence = con.execute(
+            "SELECT COALESCE(MAX(sequence),0)+1 "
+            "FROM conversation_events WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()[0]
+        con.execute(
+            "INSERT INTO conversation_events "
+            "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+            "VALUES (?,?,?,?,?,?)",
+            (
+                conversation_id,
+                sequence,
+                event_type,
+                BrokerStore._payload(payload),
+                message_id,
+                run_id,
+            ),
+        )
+        return int(sequence)
+
+    @staticmethod
+    def _run_from_row(row) -> BrokerRun:
+        return BrokerRun(
+            run_id=int(row["run_id"]),
+            conversation_id=row["conversation_id"],
+            message_id=int(row["trigger_message_id"]),
+            shell_id=int(row["shell_id"]),
+            harness=row["harness"],
+            provider=row["provider"],
+            model=row["model"],
+            effort=row["effort"],
+            worktree=Path(row["worktree"]),
+            title=row["title"],
+            body=row["body"],
+            session_before=row["harness_session_before"],
+            session_after=row["harness_session_after"],
+            runner_ref=row["runner_ref"],
+            state=row["run_state"],
+            interrupt_requested=bool(row["interrupt_requested"]),
+        )
+
+    @staticmethod
+    def _run_select() -> str:
+        return (
+            "SELECT r.run_id,r.conversation_id,r.trigger_message_id,r.shell_id,"
+            "r.harness_session_before,r.harness_session_after,r.runner_ref,"
+            "r.state AS run_state,c.harness,c.provider,c.model,c.effort,"
+            "c.worktree,c.title,m.body,"
+            "EXISTS(SELECT 1 FROM conversation_events ie "
+            " WHERE ie.run_id=r.run_id "
+            " AND ie.event_type='run.interrupt.requested') "
+            "AS interrupt_requested "
+            "FROM conversation_runs r "
+            "JOIN conversations c ON c.conversation_id=r.conversation_id "
+            "JOIN conversation_messages m "
+            " ON m.message_id=r.trigger_message_id "
+        )
+
+    def claim_next(self, owner: str) -> BrokerRun | None:
+        """Atomically turn the oldest eligible outbox intent into a leased run.
+
+        The earlier-message predicate provides per-conversation ordering.  The
+        live-run indexes are the final shell/conversation mutation fences.
+        """
+        con = self.connect()
+        now, expires = self._times()
+        try:
+            self._begin(con)
+            row = con.execute(
+                "SELECT o.outbox_id,o.conversation_id,o.message_id,o.attempts,"
+                "c.shell_id,c.harness,c.provider,c.model,c.effort,c.worktree,"
+                "c.title,c.harness_session_ref,m.body,m.state AS message_state "
+                "FROM conversation_outbox o "
+                "JOIN conversations c "
+                " ON c.conversation_id=o.conversation_id "
+                "JOIN conversation_messages m ON m.message_id=o.message_id "
+                "WHERE o.state='pending' AND c.state='queued' "
+                "AND m.state IN ('accepted','queued') "
+                "AND NOT EXISTS ("
+                " SELECT 1 FROM conversation_messages earlier "
+                " WHERE earlier.conversation_id=m.conversation_id "
+                " AND earlier.message_id<m.message_id "
+                " AND earlier.state IN ('accepted','queued','running')) "
+                "AND NOT EXISTS ("
+                " SELECT 1 FROM conversation_runs live "
+                " WHERE live.shell_id=c.shell_id "
+                " AND live.state IN ('leased','starting','running')) "
+                "ORDER BY o.outbox_id LIMIT 1"
+            ).fetchone()
+            if row is None:
+                con.commit()
+                return None
+
+            updated = con.execute(
+                "UPDATE conversation_outbox SET state='claimed',claim_owner=?,"
+                "claimed_at=?,lease_expires_at=?,attempts=attempts+1 "
+                "WHERE outbox_id=? AND state='pending'",
+                (owner, now, expires, row["outbox_id"]),
+            ).rowcount
+            if updated != 1:
+                con.rollback()
+                return None
+
+            attempt = int(row["attempts"]) + 1
+            if row["message_state"] == "accepted":
+                require_transition("message", "accepted", "queued")
+                con.execute(
+                    "UPDATE conversation_messages SET state='queued' "
+                    "WHERE message_id=?",
+                    (row["message_id"],),
+                )
+            require_transition("message", "queued", "running")
+            con.execute(
+                "UPDATE conversation_messages SET state='running' WHERE message_id=?",
+                (row["message_id"],),
+            )
+
+            cur = con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,attempt,"
+                "harness_session_before,state,lease_owner,lease_expires_at,"
+                "heartbeat_at) VALUES (?,?,?,?,?,'leased',?,?,?)",
+                (
+                    row["conversation_id"],
+                    row["shell_id"],
+                    row["message_id"],
+                    attempt,
+                    row["harness_session_ref"],
+                    owner,
+                    expires,
+                    now,
+                ),
+            )
+            run_id = int(cur.lastrowid)
+            require_transition("outbox", "claimed", "dispatched")
+            con.execute(
+                "UPDATE conversation_outbox SET state='dispatched',run_id=?,"
+                "dispatched_at=? WHERE outbox_id=?",
+                (run_id, now, row["outbox_id"]),
+            )
+            require_transition("conversation", "queued", "running")
+            con.execute(
+                "UPDATE conversations SET state='running',"
+                "last_activity_at=?,version=version+1 "
+                "WHERE conversation_id=?",
+                (now, row["conversation_id"]),
+            )
+            con.commit()
+            return BrokerRun(
+                run_id=run_id,
+                conversation_id=row["conversation_id"],
+                message_id=int(row["message_id"]),
+                shell_id=int(row["shell_id"]),
+                harness=row["harness"],
+                provider=row["provider"],
+                model=row["model"],
+                effort=row["effort"],
+                worktree=Path(row["worktree"]),
+                title=row["title"],
+                body=row["body"],
+                session_before=row["harness_session_ref"],
+                session_after=None,
+                runner_ref=None,
+                state="leased",
+            )
+        except db_driver.IntegrityError as exc:
+            # A second broker can race the eligibility read. BEGIN IMMEDIATE
+            # serializes normal SQLite writers; the unique live-run indexes
+            # remain the final fail-closed fence.
+            self._rollback(con)
+            detail = str(exc)
+            if (
+                "conversation_runs.shell_id" in detail
+                or "conversation_runs.conversation_id" in detail
+            ):
+                return None
+            raise
+        except Exception:
+            self._rollback(con)
+            raise
+        finally:
+            con.close()
+
+    def adopt_recoverable(
+        self,
+        owner: str,
+        *,
+        startup: bool,
+        limit: int,
+    ) -> list[BrokerRun]:
+        """Adopt bounded live runs from an expired broker lease.
+
+        ``startup`` names the reconciliation trigger for callers and tests; it
+        deliberately does not weaken the lease predicate. A second API process
+        can reach startup before losing the listener bind race, so process
+        startup alone is not proof that the current lease owner is dead.
+        """
+        if limit <= 0:
+            return []
+        con = self.connect()
+        now, expires = self._times()
+        try:
+            self._begin(con)
+            selected = con.execute(
+                self._run_select() + "WHERE r.state IN ('leased','starting','running') "
+                "AND r.lease_expires_at<=? ORDER BY r.run_id LIMIT ?",
+                (now, limit),
+            ).fetchall()
+            adopted: list[BrokerRun] = []
+            for row in selected:
+                changed = con.execute(
+                    "UPDATE conversation_runs SET lease_owner=?,"
+                    "lease_expires_at=?,heartbeat_at=? "
+                    "WHERE run_id=? AND state IN "
+                    "('leased','starting','running')",
+                    (owner, expires, now, row["run_id"]),
+                ).rowcount
+                if changed:
+                    adopted.append(self._run_from_row(row))
+            con.commit()
+            return adopted
+        except Exception:
+            self._rollback(con)
+            raise
+        finally:
+            con.close()
+
+    def requeue_expired_claims(self) -> int:
+        """Repair only pre-run claims; dispatched runs recover separately."""
+        con = self.connect()
+        now, _ = self._times()
+        try:
+            self._begin(con)
+            count = con.execute(
+                "UPDATE conversation_outbox SET state='pending',"
+                "claim_owner=NULL,claimed_at=NULL,lease_expires_at=NULL,"
+                "last_error='expired before durable run creation' "
+                "WHERE state='claimed' AND lease_expires_at<=? AND run_id IS NULL",
+                (now,),
+            ).rowcount
+            con.commit()
+            return int(count)
+        except Exception:
+            self._rollback(con)
+            raise
+        finally:
+            con.close()
+
+    def mark_starting(self, run_id: int, owner: str) -> None:
+        con = self.connect()
+        now, expires = self._times()
+        try:
+            self._begin(con)
+            row = con.execute(
+                "SELECT state,lease_owner FROM conversation_runs WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+            require_transition("run", row["state"], "starting")
+            changed = con.execute(
+                "UPDATE conversation_runs SET state='starting',started_at=?,"
+                "heartbeat_at=?,lease_expires_at=? "
+                "WHERE run_id=? AND lease_owner=? AND state='leased'",
+                (now, now, expires, run_id, owner),
+            ).rowcount
+            if changed != 1:
+                raise BrokerError(
+                    "CONVERSATION_RUN_LEASE_LOST",
+                    f"run {run_id} is not leased by this broker",
+                )
+            con.commit()
+        except Exception:
+            self._rollback(con)
+            raise
+        finally:
+            con.close()
+
+    def mark_native_started(
+        self,
+        run_id: int,
+        owner: str,
+        turn: NativeTurn,
+    ) -> None:
+        """Capture exact native identity before consuming the event stream."""
+        con = self.connect()
+        now, expires = self._times()
+        try:
+            self._begin(con)
+            row = con.execute(
+                "SELECT r.state,r.conversation_id,c.harness_session_ref,"
+                "c.harness,c.worktree "
+                "FROM conversation_runs r JOIN conversations c "
+                "ON c.conversation_id=r.conversation_id WHERE r.run_id=?",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+            if turn.harness != row["harness"]:
+                raise BrokerInvariantError(
+                    "HARNESS_IDENTITY_MISMATCH",
+                    f"conversation uses {row['harness']}, "
+                    f"adapter returned {turn.harness}",
+                )
+            if not turn.session_ref or not turn.run_ref:
+                raise BrokerInvariantError(
+                    "HARNESS_IDENTITY_MISSING",
+                    "adapter returned an empty native session or run reference",
+                )
+            expected_worktree = Path(row["worktree"]).resolve()
+            actual_worktree = Path(turn.worktree).resolve()
+            if actual_worktree != expected_worktree:
+                raise BrokerInvariantError(
+                    "HARNESS_WORKTREE_MISMATCH",
+                    f"conversation is bound to {expected_worktree}, "
+                    f"adapter returned {actual_worktree}",
+                )
+            current_session = row["harness_session_ref"]
+            if current_session is not None and current_session != turn.session_ref:
+                raise BrokerInvariantError(
+                    "HARNESS_SESSION_MISMATCH",
+                    f"conversation is bound to {current_session}, "
+                    f"adapter returned {turn.session_ref}",
+                )
+            require_transition("run", row["state"], "running")
+            changed = con.execute(
+                "UPDATE conversation_runs SET state='running',"
+                "harness_session_after=?,runner_ref=?,heartbeat_at=?,"
+                "lease_expires_at=? WHERE run_id=? AND lease_owner=? "
+                "AND state='starting'",
+                (
+                    turn.session_ref,
+                    turn.run_ref,
+                    now,
+                    expires,
+                    run_id,
+                    owner,
+                ),
+            ).rowcount
+            if changed != 1:
+                raise BrokerError(
+                    "CONVERSATION_RUN_LEASE_LOST",
+                    f"run {run_id} lost its starting lease",
+                )
+            con.execute(
+                "UPDATE conversations SET harness_session_ref=?,"
+                "last_activity_at=?,version=version+1 "
+                "WHERE conversation_id=?",
+                (turn.session_ref, now, row["conversation_id"]),
+            )
+            con.commit()
+        except Exception:
+            self._rollback(con)
+            raise
+        finally:
+            con.close()
+
+    def append_event(
+        self,
+        run_id: int,
+        event: NormalizedEvent,
+    ) -> int:
+        if event.type in TERMINAL_EVENTS:
+            raise BrokerError(
+                "CONVERSATION_TERMINAL_EVENT_REQUIRES_FINISH",
+                event.type,
+            )
+        con = self.connect()
+        now, _ = self._times()
+        try:
+            self._begin(con)
+            row = con.execute(
+                "SELECT conversation_id,trigger_message_id,state "
+                "FROM conversation_runs WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+            if row["state"] not in LIVE_RUN_STATES:
+                raise BrokerError(
+                    "CONVERSATION_RUN_TERMINAL",
+                    f"run {run_id} is already {row['state']}",
+                )
+            payload = dict(event.payload)
+            if event.native_type:
+                payload["native_type"] = event.native_type
+            sequence = self._append_event(
+                con,
+                conversation_id=row["conversation_id"],
+                event_type=event.type,
+                payload=payload,
+                message_id=row["trigger_message_id"],
+                run_id=run_id,
+            )
+            con.execute(
+                "UPDATE conversations SET last_activity_at=?,version=version+1 "
+                "WHERE conversation_id=?",
+                (now, row["conversation_id"]),
+            )
+            con.commit()
+            return sequence
+        except Exception:
+            self._rollback(con)
+            raise
+        finally:
+            con.close()
+
+    def finish_run(
+        self,
+        run_id: int,
+        outcome: str,
+        *,
+        event_type: str,
+        payload: Mapping[str, Any] | None = None,
+        error_code: str | None = None,
+        error_detail: str | None = None,
+        exit_code: int | None = None,
+    ) -> bool:
+        """Commit terminal event and release every durable lock atomically."""
+        if outcome not in TERMINAL_RUN_STATES:
+            raise BrokerError(
+                "CONVERSATION_OUTCOME_INVALID",
+                f"unsupported terminal outcome: {outcome}",
+            )
+        con = self.connect()
+        now, _ = self._times()
+        try:
+            self._begin(con)
+            row = con.execute(
+                "SELECT r.state,r.conversation_id,r.trigger_message_id,"
+                "c.state AS conversation_state "
+                "FROM conversation_runs r JOIN conversations c "
+                "ON c.conversation_id=r.conversation_id WHERE r.run_id=?",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+            if row["state"] in TERMINAL_RUN_STATES:
+                con.commit()
+                return False
+            require_transition("run", row["state"], outcome)
+            message_state = {
+                "succeeded": "completed",
+                "failed": "failed",
+                "cancelled": "cancelled",
+                "unknown": "failed",
+            }[outcome]
+            message_current = con.execute(
+                "SELECT state FROM conversation_messages WHERE message_id=?",
+                (row["trigger_message_id"],),
+            ).fetchone()[0]
+            require_transition("message", message_current, message_state)
+            pending = (
+                con.execute(
+                    "SELECT 1 FROM conversation_outbox "
+                    "WHERE conversation_id=? AND state IN ('pending','claimed') "
+                    "LIMIT 1",
+                    (row["conversation_id"],),
+                ).fetchone()
+                is not None
+            )
+            conversation_target = (
+                "error"
+                if outcome in {"failed", "unknown"}
+                else "queued"
+                if pending
+                else "idle"
+            )
+            require_transition(
+                "conversation",
+                row["conversation_state"],
+                conversation_target,
+            )
+            con.execute(
+                "UPDATE conversation_runs SET state=?,ended_at=?,exit_code=?,"
+                "error_code=?,error_detail=? WHERE run_id=?",
+                (
+                    outcome,
+                    now,
+                    exit_code,
+                    error_code,
+                    (error_detail or "")[:16384] or None,
+                    run_id,
+                ),
+            )
+            con.execute(
+                "UPDATE conversation_messages SET state=?,completed_at=? "
+                "WHERE message_id=?",
+                (message_state, now, row["trigger_message_id"]),
+            )
+            con.execute(
+                "UPDATE conversations SET state=?,last_activity_at=?,"
+                "version=version+1 WHERE conversation_id=?",
+                (conversation_target, now, row["conversation_id"]),
+            )
+            terminal_payload = dict(payload or {})
+            terminal_payload.setdefault("outcome", outcome)
+            self._append_event(
+                con,
+                conversation_id=row["conversation_id"],
+                event_type=event_type,
+                payload=terminal_payload,
+                message_id=row["trigger_message_id"],
+                run_id=run_id,
+            )
+            con.commit()
+            return True
+        except Exception:
+            self._rollback(con)
+            raise
+        finally:
+            con.close()
+
+    def renew_runs(self, owner: str, run_ids: list[int]) -> int:
+        if not run_ids:
+            return 0
+        con = self.connect()
+        now, expires = self._times()
+        marks = ",".join("?" for _ in run_ids)
+        try:
+            changed = con.execute(
+                "UPDATE conversation_runs SET heartbeat_at=?,"
+                "lease_expires_at=? WHERE lease_owner=? "
+                f"AND state IN ('leased','starting','running') "
+                f"AND run_id IN ({marks})",
+                (now, expires, owner, *run_ids),
+            ).rowcount
+            con.commit()
+            return int(changed)
+        finally:
+            con.close()
+
+    def note_reconcile_error(
+        self,
+        run_id: int,
+        owner: str,
+        detail: str,
+    ) -> None:
+        con = self.connect()
+        now, expires = self._times()
+        try:
+            con.execute(
+                "UPDATE conversation_runs SET heartbeat_at=?,"
+                "lease_expires_at=?,error_detail=? "
+                "WHERE run_id=? AND lease_owner=? "
+                "AND state IN ('starting','running')",
+                (now, expires, detail[:16384], run_id, owner),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+    def request_interrupt(self, run_id: int) -> bool:
+        """Persist interrupt intent once; the active/recovery worker delivers it."""
+        con = self.connect()
+        now, _ = self._times()
+        try:
+            self._begin(con)
+            row = con.execute(
+                "SELECT conversation_id,trigger_message_id,state "
+                "FROM conversation_runs WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+            if row["state"] not in LIVE_RUN_STATES:
+                raise BrokerError(
+                    "CONVERSATION_RUN_NOT_ACTIVE",
+                    f"run {run_id} is {row['state']}",
+                )
+            exists = con.execute(
+                "SELECT 1 FROM conversation_events "
+                "WHERE run_id=? AND event_type='run.interrupt.requested'",
+                (run_id,),
+            ).fetchone()
+            if exists is None:
+                self._append_event(
+                    con,
+                    conversation_id=row["conversation_id"],
+                    event_type="run.interrupt.requested",
+                    payload={"requested_at": now},
+                    message_id=row["trigger_message_id"],
+                    run_id=run_id,
+                )
+                con.execute(
+                    "UPDATE conversations SET last_activity_at=?,"
+                    "version=version+1 WHERE conversation_id=?",
+                    (now, row["conversation_id"]),
+                )
+            con.commit()
+            return exists is None
+        except Exception:
+            self._rollback(con)
+            raise
+        finally:
+            con.close()
+
+    def heartbeat_service(self, interval_seconds: int) -> None:
+        con = self.connect()
+        try:
+            con.execute(
+                "INSERT INTO daemon_heartbeats (name,beat_at,interval_s) "
+                "VALUES ('conversation-broker',datetime('now'),?) "
+                "ON CONFLICT(name) DO UPDATE SET beat_at=excluded.beat_at,"
+                "interval_s=excluded.interval_s",
+                (interval_seconds,),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+
+class ConversationBroker(threading.Thread):
+    """Commit-woken dispatcher plus bounded lease reconciliation."""
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        *,
+        store: BrokerStore | None = None,
+        adapter_factory: Callable[[str], ConversationAdapter] = adapter_for,
+        owner: str | None = None,
+        max_workers: int = DEFAULT_MAX_WORKERS,
+        heartbeat_seconds: int = DEFAULT_HEARTBEAT_SECONDS,
+        recovery_seconds: int = DEFAULT_RECOVERY_SECONDS,
+        reconcile_attempts: int = DEFAULT_RECONCILE_ATTEMPTS,
+    ) -> None:
+        super().__init__(name="conversation-broker", daemon=True)
+        self.store = store or BrokerStore(db_path)
+        self.adapter_factory = adapter_factory
+        self.owner = owner or (
+            f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:12]}"
+        )
+        self.max_workers = max_workers
+        self.heartbeat_seconds = heartbeat_seconds
+        self.recovery_seconds = recovery_seconds
+        self.reconcile_attempts = reconcile_attempts
+        self._wake = threading.Event()
+        self._stop_event = threading.Event()
+        self._active: dict[int, _ActiveRun] = {}
+        self._active_lock = threading.Lock()
+        self._started_once = threading.Event()
+
+    def notify(self) -> None:
+        """Commit notification: call only after message/outbox commit."""
+        self._wake.set()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._wake.set()
+
+    def active_run_ids(self) -> list[int]:
+        with self._active_lock:
+            return sorted(self._active)
+
+    def wait_started(self, timeout: float = 5.0) -> bool:
+        return self._started_once.wait(timeout)
+
+    def wait_idle(self, timeout: float = 5.0) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not self.active_run_ids():
+                return True
+            time.sleep(0.01)
+        return not self.active_run_ids()
+
+    def interrupt(self, run_id: int) -> bool:
+        """Persist and, when possible, immediately deliver an interrupt."""
+        self.store.request_interrupt(run_id)
+        with self._active_lock:
+            active = self._active.get(run_id)
+            if active is not None:
+                active.interrupt_requested = True
+        if active is not None:
+            self._deliver_interrupt(active)
+        self.notify()
+        return True
+
+    def _capacity(self) -> int:
+        with self._active_lock:
+            return max(0, self.max_workers - len(self._active))
+
+    def _activate(self, run: BrokerRun) -> bool:
+        with self._active_lock:
+            if run.run_id in self._active or len(self._active) >= self.max_workers:
+                return False
+            active = _ActiveRun(
+                run=run,
+                interrupt_requested=run.interrupt_requested,
+            )
+            self._active[run.run_id] = active
+        threading.Thread(
+            target=self._execute,
+            args=(active,),
+            name=f"conversation-run-{run.run_id}",
+            daemon=True,
+        ).start()
+        return True
+
+    def _deactivate(self, run_id: int) -> None:
+        with self._active_lock:
+            self._active.pop(run_id, None)
+        # A terminal commit may have moved this conversation back to queued.
+        self.notify()
+
+    def _dispatch(self) -> int:
+        count = 0
+        while self._capacity() > 0 and not self._stop_event.is_set():
+            run = self.store.claim_next(self.owner)
+            if run is None:
+                break
+            if not self._activate(run):
+                break
+            count += 1
+        return count
+
+    def _recover(self, *, startup: bool) -> int:
+        capacity = self._capacity()
+        if capacity <= 0:
+            return 0
+        runs = self.store.adopt_recoverable(
+            self.owner,
+            startup=startup,
+            limit=capacity,
+        )
+        return sum(1 for run in runs if self._activate(run))
+
+    @staticmethod
+    def _close_adapter(adapter: ConversationAdapter | None) -> None:
+        close = getattr(adapter, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+
+    def _deliver_interrupt(self, active: _ActiveRun) -> None:
+        with self._active_lock:
+            if active.interrupt_sent or not active.interrupt_requested:
+                return
+            adapter, turn = active.adapter, active.turn
+            if adapter is None or turn is None:
+                return
+            active.interrupt_sent = True
+        try:
+            result = adapter.interrupt(turn)
+        except Exception:
+            # Durable intent remains for reconciliation; interruption failure
+            # never asserts a terminal state.
+            with self._active_lock:
+                active.interrupt_sent = False
+            return
+        if not result.acknowledged:
+            with self._active_lock:
+                active.interrupt_sent = False
+
+    @staticmethod
+    def _terminal_event(outcome: str) -> str:
+        return {
+            "succeeded": "run.completed",
+            "failed": "run.failed",
+            "cancelled": "run.interrupted",
+            "unknown": "run.unknown",
+        }[outcome]
+
+    def _finish_adapter_event(
+        self,
+        run_id: int,
+        event: NormalizedEvent,
+    ) -> None:
+        outcome = terminal_outcome(event.type)
+        error = event.payload.get("error")
+        exit_code = event.payload.get("exit_code")
+        self.store.finish_run(
+            run_id,
+            outcome,
+            event_type=event.type,
+            payload={
+                **dict(event.payload),
+                **({"native_type": event.native_type} if event.native_type else {}),
+            },
+            error_code=str(error)[:255] if error else None,
+            error_detail=str(error) if error else None,
+            exit_code=exit_code if isinstance(exit_code, int) else None,
+        )
+
+    def _finish_error(
+        self,
+        run_id: int,
+        exc: Exception,
+        *,
+        proven: bool,
+    ) -> None:
+        code = getattr(exc, "code", "BROKER_RUN_ERROR")
+        detail = getattr(exc, "detail", str(exc))
+        outcome = "failed" if proven else "unknown"
+        self.store.finish_run(
+            run_id,
+            outcome,
+            event_type=self._terminal_event(outcome),
+            payload={"error": str(code), "detail": str(detail)},
+            error_code=str(code)[:255],
+            error_detail=str(detail),
+        )
+
+    def _reconcile_loop(
+        self,
+        active: _ActiveRun,
+        context: ConversationContext,
+    ) -> None:
+        adapter = active.adapter
+        turn = active.turn
+        if adapter is None or turn is None:
+            self._finish_error(
+                active.run.run_id,
+                BrokerError(
+                    "HARNESS_IDENTITY_NOT_CAPTURED",
+                    "native dispatch crossed the starting boundary without "
+                    "a durable exact session/run reference",
+                ),
+                proven=False,
+            )
+            return
+
+        failures = 0
+        while not self._stop_event.is_set():
+            self._deliver_interrupt(active)
+            try:
+                result = adapter.reconcile(turn, context)
+            except Exception as exc:
+                failures += 1
+                self.store.note_reconcile_error(
+                    active.run.run_id,
+                    self.owner,
+                    f"reconcile attempt {failures}: {exc}",
+                )
+                if failures >= self.reconcile_attempts:
+                    self._finish_error(active.run.run_id, exc, proven=False)
+                    return
+                self._stop_event.wait(self.recovery_seconds)
+                continue
+
+            if result.outcome == "running" and result.proven:
+                failures = 0
+                self.store.renew_runs(self.owner, [active.run.run_id])
+                self._stop_event.wait(self.recovery_seconds)
+                continue
+            outcome = result.outcome if result.proven else "unknown"
+            self.store.finish_run(
+                active.run.run_id,
+                outcome,
+                event_type=self._terminal_event(outcome),
+                payload={
+                    "reconciled": True,
+                    "proven": result.proven,
+                    "detail": result.detail,
+                },
+                error_code=(
+                    "HARNESS_OUTCOME_UNKNOWN" if outcome == "unknown" else None
+                ),
+                error_detail=result.detail
+                if outcome in {"failed", "unknown"}
+                else None,
+            )
+            return
+
+    def _execute(self, active: _ActiveRun) -> None:
+        run = active.run
+        adapter: ConversationAdapter | None = None
+        try:
+            context = run.context()
+            if run.state == "leased":
+                try:
+                    # Validate failures here are proven pre-dispatch.
+                    context.checked_worktree()
+                    adapter = self.adapter_factory(run.harness)
+                    active.adapter = adapter
+                except Exception as exc:
+                    self._finish_error(run.run_id, exc, proven=True)
+                    return
+
+                self.store.mark_starting(run.run_id, self.owner)
+                try:
+                    turn = (
+                        adapter.resume(run.session_before, context, run.body)
+                        if run.session_before
+                        else adapter.start(context, run.body)
+                    )
+                except Exception as exc:
+                    # The adapter may have sent the prompt before its transport
+                    # failed. Starting is the explicit uncertain crash window.
+                    self._finish_error(run.run_id, exc, proven=False)
+                    return
+                active.turn = turn
+                self.store.mark_native_started(run.run_id, self.owner, turn)
+                self._deliver_interrupt(active)
+
+                terminal = False
+                try:
+                    for event in adapter.stream(turn):
+                        if event.type in TERMINAL_EVENTS:
+                            self._finish_adapter_event(run.run_id, event)
+                            terminal = True
+                            break
+                        self.store.append_event(run.run_id, event)
+                except Exception:
+                    # Exact identities are durable; inspect them rather than
+                    # replaying a message after a broken stream.
+                    pass
+                if terminal:
+                    return
+                self._reconcile_loop(active, context)
+                return
+
+            # Startup/expiry recovery for a native-dispatch window.
+            adapter = self.adapter_factory(run.harness)
+            active.adapter = adapter
+            session_ref = run.session_after or run.session_before
+            if run.state == "starting" or not session_ref or not run.runner_ref:
+                self._finish_error(
+                    run.run_id,
+                    BrokerError(
+                        "HARNESS_IDENTITY_NOT_CAPTURED",
+                        "no exact native session/run reference survived the "
+                        "dispatch crash window",
+                    ),
+                    proven=False,
+                )
+                return
+            active.turn = NativeTurn(
+                harness=run.harness,
+                session_ref=session_ref,
+                run_ref=run.runner_ref,
+                worktree=run.worktree.resolve(),
+                metadata={"recovered": True},
+            )
+            self._deliver_interrupt(active)
+            self._reconcile_loop(active, run.context())
+        except Exception as exc:
+            # Store failures are loud in service stderr, but try to close the
+            # durable run if its state still permits a conservative terminal.
+            try:
+                self._finish_error(run.run_id, exc, proven=False)
+            except Exception as finish_exc:
+                print(
+                    f"conversation-broker: run {run.run_id} failed: {exc}; "
+                    f"terminal commit also failed: {finish_exc}",
+                    flush=True,
+                )
+        finally:
+            self._close_adapter(adapter)
+            self._deactivate(run.run_id)
+
+    def run(self) -> None:  # pragma: no cover - loop behavior tested through seams
+        try:
+            repaired = self.store.requeue_expired_claims()
+            recovered = self._recover(startup=True)
+            self.store.heartbeat_service(self.heartbeat_seconds)
+            self._dispatch()
+            if repaired or recovered:
+                print(
+                    "conversation-broker: startup "
+                    f"requeued={repaired} recovered={recovered}",
+                    flush=True,
+                )
+        except Exception as exc:
+            # The API remains available for inspection/retry; the daemon keeps
+            # trying instead of taking the localhost server down.
+            print(f"conversation-broker: startup error ({exc})", flush=True)
+            self._wake.set()
+        self._started_once.set()
+
+        next_heartbeat = time.monotonic() + self.heartbeat_seconds
+        next_recovery = time.monotonic() + self.recovery_seconds
+        while not self._stop_event.is_set():
+            due = min(next_heartbeat, next_recovery)
+            signalled = self._wake.wait(max(0.0, due - time.monotonic()))
+            self._wake.clear()
+            now = time.monotonic()
+            try:
+                if now >= next_heartbeat:
+                    self.store.renew_runs(self.owner, self.active_run_ids())
+                    self.store.heartbeat_service(self.heartbeat_seconds)
+                    next_heartbeat = now + self.heartbeat_seconds
+                if now >= next_recovery:
+                    self.store.requeue_expired_claims()
+                    self._recover(startup=False)
+                    next_recovery = now + self.recovery_seconds
+                # Routine dispatch only follows startup, a post-commit notify,
+                # or a worker's terminal notify. Timer maintenance is not the
+                # ordinary queue transport.
+                if signalled:
+                    self._dispatch()
+            except Exception as exc:
+                print(f"conversation-broker: cycle error ({exc})", flush=True)
+                # Preserve the commit wake across transient DB contention.
+                # Back off first so a persistent fault cannot busy-loop.
+                self._stop_event.wait(min(1.0, self.recovery_seconds))
+                self._wake.set()
+
+
+_SERVICE_LOCK = threading.Lock()
+_SERVICE: ConversationBroker | None = None
+
+
+def start_service(
+    db_path: str | Path,
+    **kwargs: Any,
+) -> ConversationBroker:
+    """Install the process-wide service used by API commit notifications."""
+    global _SERVICE
+    with _SERVICE_LOCK:
+        if _SERVICE is not None and _SERVICE.is_alive():
+            return _SERVICE
+        _SERVICE = ConversationBroker(db_path, **kwargs)
+        _SERVICE.start()
+        return _SERVICE
+
+
+def service() -> ConversationBroker | None:
+    return _SERVICE
+
+
+def notify_commit() -> bool:
+    broker = service()
+    if broker is None or not broker.is_alive():
+        return False
+    broker.notify()
+    return True
+
+
+def interrupt_run(run_id: int) -> bool:
+    broker = service()
+    if broker is None or not broker.is_alive():
+        raise BrokerError(
+            "CONVERSATION_BROKER_UNAVAILABLE",
+            "conversation broker is not running",
+        )
+    return broker.interrupt(run_id)

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""Feature #24 event-driven broker ordering and crash-window contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCRIPTS = ENGINE / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from conversation_adapters import (  # noqa: E402
+    ConversationContext,
+    InterruptResult,
+    NativeTurn,
+    NormalizedEvent,
+    ReconcileResult,
+)
+from conversation_broker import (  # noqa: E402
+    BrokerInvariantError,
+    BrokerRun,
+    BrokerStore,
+    ConversationBroker,
+)
+
+
+def apply_schema(con: sqlite3.Connection) -> None:
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+class FakeAdapter:
+    harness = "codex"
+
+    def __init__(
+        self,
+        *,
+        terminal: str = "run.completed",
+        reconcile: ReconcileResult | None = None,
+        block: bool = False,
+    ) -> None:
+        self.terminal = terminal
+        self.reconcile_result = reconcile or ReconcileResult(
+            "succeeded", True, "fake exact run completed"
+        )
+        self.block = block
+        self.interrupted = threading.Event()
+        self.started = 0
+        self.resumed = 0
+        self.reconciled = 0
+        self.closed = 0
+
+    def start(
+        self,
+        context: ConversationContext,
+        message: str,
+    ) -> NativeTurn:
+        self.started += 1
+        return NativeTurn(
+            harness=self.harness,
+            session_ref="native-session",
+            run_ref=f"native-run-{self.started}",
+            worktree=context.checked_worktree(),
+        )
+
+    def resume(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+    ) -> NativeTurn:
+        self.resumed += 1
+        return NativeTurn(
+            harness=self.harness,
+            session_ref=session_ref,
+            run_ref=f"native-resume-{self.resumed}",
+            worktree=context.checked_worktree(),
+        )
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        yield NormalizedEvent("session.started", {"session_ref": turn.session_ref})
+        yield NormalizedEvent("run.started", {"status": "running"})
+        yield NormalizedEvent("assistant.delta", {"text": "hello"})
+        if self.block:
+            self.interrupted.wait(5)
+        event_type = "run.interrupted" if self.interrupted.is_set() else self.terminal
+        yield NormalizedEvent(event_type, {"status": event_type.split(".")[1]})
+
+    def interrupt(self, turn: NativeTurn) -> InterruptResult:
+        self.interrupted.set()
+        return InterruptResult(True)
+
+    def reconcile(
+        self,
+        turn: NativeTurn,
+        context: ConversationContext,
+    ) -> ReconcileResult:
+        self.reconciled += 1
+        return self.reconcile_result
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+class ConversationBrokerCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.db_path = self.root / "shell.db"
+        self.worktree = self.root / "worktree"
+        self.worktree.mkdir()
+        con = sqlite3.connect(self.db_path)
+        apply_schema(con)
+        con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+        for shell_id in (1, 2):
+            con.execute(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (?,?,?,?,?,1)",
+                (
+                    shell_id,
+                    f"Shell {shell_id}",
+                    f"sh{shell_id}",
+                    "dev",
+                    "prompt",
+                ),
+            )
+        con.commit()
+        con.close()
+        self.serial = 0
+        self.brokers: list[ConversationBroker] = []
+
+    def tearDown(self) -> None:
+        for broker in self.brokers:
+            broker.stop()
+            broker.join(2)
+        self.tmp.cleanup()
+
+    def connect(self) -> sqlite3.Connection:
+        con = sqlite3.connect(self.db_path)
+        con.row_factory = sqlite3.Row
+        con.execute("PRAGMA foreign_keys=ON")
+        return con
+
+    def add_conversation(
+        self,
+        *,
+        shell_id: int = 1,
+        state: str = "queued",
+        session_ref: str | None = None,
+    ) -> str:
+        self.serial += 1
+        key = f"conversation-{self.serial}"
+        con = self.connect()
+        con.execute(
+            "INSERT INTO conversations "
+            "(shell_id,owner_user_id,harness,worktree,state,"
+            "harness_session_ref,creation_idempotency_key,"
+            "creation_request_hash) VALUES (?,1,'codex',?,?,?,?,?)",
+            (
+                shell_id,
+                str(self.worktree),
+                state,
+                session_ref,
+                key,
+                f"hash-{key}",
+            ),
+        )
+        conversation_id = con.execute(
+            "SELECT conversation_id FROM conversations "
+            "WHERE creation_idempotency_key=?",
+            (key,),
+        ).fetchone()[0]
+        con.commit()
+        con.close()
+        return conversation_id
+
+    def add_message(self, conversation_id: str, *, state: str = "queued") -> int:
+        self.serial += 1
+        key = f"message-{self.serial}"
+        con = self.connect()
+        message_id = con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash,state) "
+            "VALUES (?,'user','1','prompt','hello',?,?,?)",
+            (conversation_id, key, f"hash-{key}", state),
+        ).lastrowid
+        con.execute(
+            "INSERT INTO conversation_outbox (conversation_id,message_id) VALUES (?,?)",
+            (conversation_id, message_id),
+        )
+        con.commit()
+        con.close()
+        return int(message_id)
+
+    def add_live_run(
+        self,
+        *,
+        state: str,
+        session_after: str | None = None,
+        runner_ref: str | None = None,
+        expired: bool = True,
+    ) -> tuple[str, int, int]:
+        conversation_id = self.add_conversation(state="running")
+        message_id = self.add_message(conversation_id, state="running")
+        con = self.connect()
+        started_at = None if state == "leased" else "2026-07-29 00:00:00"
+        run_id = con.execute(
+            "INSERT INTO conversation_runs "
+            "(conversation_id,shell_id,trigger_message_id,"
+            "harness_session_after,runner_ref,state,lease_owner,"
+            "lease_expires_at,started_at,heartbeat_at) "
+            "VALUES (?,1,?,?,?,?,?,?,?,?)",
+            (
+                conversation_id,
+                message_id,
+                session_after,
+                runner_ref,
+                state,
+                "dead-broker",
+                ("2000-01-01 00:00:00" if expired else "2999-01-01 00:00:00"),
+                started_at,
+                started_at,
+            ),
+        ).lastrowid
+        con.execute(
+            "UPDATE conversation_outbox SET state='claimed',claim_owner='dead',"
+            "claimed_at='2026-07-29 00:00:00',"
+            "lease_expires_at='2026-07-29 00:10:00' WHERE message_id=?",
+            (message_id,),
+        )
+        con.execute(
+            "UPDATE conversation_outbox SET state='dispatched',run_id=?,"
+            "dispatched_at='2026-07-29 00:00:01' WHERE message_id=?",
+            (run_id, message_id),
+        )
+        con.commit()
+        con.close()
+        return conversation_id, message_id, int(run_id)
+
+    def start_broker(
+        self,
+        factory,
+        *,
+        heartbeat_seconds: int = 60,
+        recovery_seconds: int = 60,
+    ) -> ConversationBroker:
+        broker = ConversationBroker(
+            self.db_path,
+            adapter_factory=factory,
+            owner=f"test-broker-{len(self.brokers) + 1}",
+            heartbeat_seconds=heartbeat_seconds,
+            recovery_seconds=recovery_seconds,
+        )
+        self.brokers.append(broker)
+        broker.start()
+        self.assertTrue(broker.wait_started())
+        return broker
+
+    def wait_run_state(self, run_id: int, state: str, timeout: float = 3) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            con = self.connect()
+            row = con.execute(
+                "SELECT state FROM conversation_runs WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+            con.close()
+            if row is not None and row[0] == state:
+                return
+            time.sleep(0.01)
+        self.fail(f"run {run_id} did not reach {state}")
+
+
+class StoreContractTest(ConversationBrokerCase):
+    def test_turns_are_ordered_and_terminal_commit_queues_the_next(self) -> None:
+        conversation_id = self.add_conversation()
+        first = self.add_message(conversation_id)
+        second = self.add_message(conversation_id)
+        store = BrokerStore(self.db_path)
+
+        run = store.claim_next("broker")
+        self.assertIsNotNone(run)
+        self.assertEqual(run.message_id, first)
+        self.assertIsNone(store.claim_next("broker"))
+
+        store.mark_starting(run.run_id, "broker")
+        store.mark_native_started(
+            run.run_id,
+            "broker",
+            NativeTurn(
+                "codex",
+                "native-session",
+                "native-run-1",
+                self.worktree,
+            ),
+        )
+        store.append_event(
+            run.run_id,
+            NormalizedEvent("run.started", {"status": "running"}),
+        )
+        store.finish_run(
+            run.run_id,
+            "succeeded",
+            event_type="run.completed",
+        )
+
+        next_run = store.claim_next("broker")
+        self.assertIsNotNone(next_run)
+        self.assertEqual(next_run.message_id, second)
+        con = self.connect()
+        first_state = con.execute(
+            "SELECT state FROM conversation_messages WHERE message_id=?",
+            (first,),
+        ).fetchone()[0]
+        sequences = [
+            row[0]
+            for row in con.execute(
+                "SELECT sequence FROM conversation_events "
+                "WHERE conversation_id=? ORDER BY sequence",
+                (conversation_id,),
+            )
+        ]
+        con.close()
+        self.assertEqual(first_state, "completed")
+        self.assertEqual(sequences, [1, 2])
+
+    def test_shell_mutation_lock_blocks_other_conversation(self) -> None:
+        first_conversation = self.add_conversation(shell_id=1)
+        second_conversation = self.add_conversation(shell_id=1)
+        self.add_message(first_conversation)
+        self.add_message(second_conversation)
+        store = BrokerStore(self.db_path)
+
+        first = store.claim_next("broker")
+        self.assertIsNotNone(first)
+        self.assertIsNone(store.claim_next("broker"))
+        store.finish_run(
+            first.run_id,
+            "failed",
+            event_type="run.failed",
+            error_code="TEST",
+        )
+        second = store.claim_next("broker")
+        self.assertIsNotNone(second)
+        self.assertEqual(second.conversation_id, second_conversation)
+
+    def test_different_shells_can_hold_live_runs(self) -> None:
+        first_conversation = self.add_conversation(shell_id=1)
+        second_conversation = self.add_conversation(shell_id=2)
+        self.add_message(first_conversation)
+        self.add_message(second_conversation)
+        store = BrokerStore(self.db_path)
+
+        first = store.claim_next("broker")
+        second = store.claim_next("broker")
+        self.assertEqual(
+            {first.shell_id, second.shell_id},
+            {1, 2},
+        )
+
+    def test_concurrent_claims_cannot_bypass_shell_lock(self) -> None:
+        first_conversation = self.add_conversation(shell_id=1)
+        second_conversation = self.add_conversation(shell_id=1)
+        self.add_message(first_conversation)
+        self.add_message(second_conversation)
+        barrier = threading.Barrier(3)
+        claimed: list[BrokerRun | None] = []
+
+        def claim(owner: str) -> None:
+            barrier.wait()
+            claimed.append(BrokerStore(self.db_path).claim_next(owner))
+
+        workers = [
+            threading.Thread(target=claim, args=(f"broker-{index}",))
+            for index in (1, 2)
+        ]
+        for worker in workers:
+            worker.start()
+        barrier.wait()
+        for worker in workers:
+            worker.join()
+
+        self.assertEqual(sum(run is not None for run in claimed), 1)
+        con = self.connect()
+        self.assertEqual(
+            con.execute(
+                "SELECT COUNT(*) FROM conversation_runs "
+                "WHERE state IN ('leased','starting','running')"
+            ).fetchone()[0],
+            1,
+        )
+        con.close()
+
+    def test_startup_does_not_steal_an_unexpired_lease(self) -> None:
+        _conversation, _message, run_id = self.add_live_run(
+            state="running",
+            session_after="native-session",
+            runner_ref="native-run-existing",
+            expired=False,
+        )
+        store = BrokerStore(self.db_path)
+
+        self.assertEqual(
+            store.adopt_recoverable("new-broker", startup=True, limit=8),
+            [],
+        )
+        con = self.connect()
+        row = con.execute(
+            "SELECT lease_owner,state FROM conversation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(tuple(row), ("dead-broker", "running"))
+
+    def test_expired_pre_run_claim_is_requeued(self) -> None:
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        con = self.connect()
+        con.execute(
+            "UPDATE conversation_outbox SET state='claimed',claim_owner='dead',"
+            "claimed_at='2000-01-01 00:00:00',"
+            "lease_expires_at='2000-01-01 00:00:01' WHERE message_id=?",
+            (message_id,),
+        )
+        con.commit()
+        con.close()
+        store = BrokerStore(
+            self.db_path,
+            clock=lambda: datetime(2026, 7, 29, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(store.requeue_expired_claims(), 1)
+        run = store.claim_next("broker")
+        self.assertIsNotNone(run)
+
+    def test_native_identity_capture_rejects_a_different_worktree(self) -> None:
+        conversation_id = self.add_conversation()
+        self.add_message(conversation_id)
+        store = BrokerStore(self.db_path)
+        run = store.claim_next("broker")
+        store.mark_starting(run.run_id, "broker")
+        other = self.root / "other-worktree"
+        other.mkdir()
+
+        with self.assertRaises(BrokerInvariantError) as caught:
+            store.mark_native_started(
+                run.run_id,
+                "broker",
+                NativeTurn(
+                    "codex",
+                    "native-session",
+                    "native-run",
+                    other,
+                ),
+            )
+        self.assertEqual(caught.exception.code, "HARNESS_WORKTREE_MISMATCH")
+        con = self.connect()
+        row = con.execute(
+            "SELECT state,harness_session_after FROM conversation_runs WHERE run_id=?",
+            (run.run_id,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(tuple(row), ("starting", None))
+
+
+class ServiceContractTest(ConversationBrokerCase):
+    def test_routine_dispatch_requires_post_commit_notification(self) -> None:
+        adapters: list[FakeAdapter] = []
+
+        def factory(_harness: str) -> FakeAdapter:
+            adapter = FakeAdapter()
+            adapters.append(adapter)
+            return adapter
+
+        broker = self.start_broker(factory)
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        time.sleep(0.1)
+        con = self.connect()
+        self.assertEqual(
+            con.execute("SELECT COUNT(*) FROM conversation_runs").fetchone()[0],
+            0,
+        )
+        con.close()
+
+        broker.notify()
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            con = self.connect()
+            row = con.execute(
+                "SELECT r.run_id,r.state FROM conversation_runs r "
+                "WHERE r.trigger_message_id=?",
+                (message_id,),
+            ).fetchone()
+            con.close()
+            if row is not None and row["state"] == "succeeded":
+                break
+            time.sleep(0.01)
+        else:
+            self.fail("post-commit notification did not dispatch the turn")
+        self.assertEqual(len(adapters), 1)
+        self.assertEqual(adapters[0].started, 1)
+
+    def test_interrupt_intent_precedes_terminal_interruption(self) -> None:
+        adapter = FakeAdapter(block=True)
+        broker = self.start_broker(lambda _harness: adapter)
+        conversation_id = self.add_conversation()
+        self.add_message(conversation_id)
+        broker.notify()
+        deadline = time.monotonic() + 3
+        run_id = None
+        while time.monotonic() < deadline:
+            active = broker.active_run_ids()
+            if active:
+                run_id = active[0]
+                con = self.connect()
+                state = con.execute(
+                    "SELECT state FROM conversation_runs WHERE run_id=?",
+                    (run_id,),
+                ).fetchone()[0]
+                con.close()
+                if state == "running":
+                    break
+            time.sleep(0.01)
+        self.assertIsNotNone(run_id)
+
+        self.assertTrue(broker.interrupt(run_id))
+        self.wait_run_state(run_id, "cancelled")
+        con = self.connect()
+        events = [
+            row[0]
+            for row in con.execute(
+                "SELECT event_type FROM conversation_events "
+                "WHERE run_id=? ORDER BY sequence",
+                (run_id,),
+            )
+        ]
+        con.close()
+        self.assertLess(
+            events.index("run.interrupt.requested"),
+            events.index("run.interrupted"),
+        )
+
+    def test_starting_crash_without_exact_identity_becomes_unknown(self) -> None:
+        _conversation, _message, run_id = self.add_live_run(state="starting")
+        adapter = FakeAdapter()
+        broker = self.start_broker(lambda _harness: adapter)
+        self.wait_run_state(run_id, "unknown")
+        self.assertEqual(adapter.started, 0)
+        self.assertEqual(adapter.resumed, 0)
+        self.assertEqual(adapter.reconciled, 0)
+        self.assertTrue(broker.wait_idle())
+
+    def test_running_crash_reconciles_exact_run_without_replay(self) -> None:
+        _conversation, _message, run_id = self.add_live_run(
+            state="running",
+            session_after="native-session",
+            runner_ref="native-run-existing",
+        )
+        adapter = FakeAdapter(
+            reconcile=ReconcileResult(
+                "succeeded",
+                True,
+                "thread/read proved the exact native run completed",
+            )
+        )
+        broker = self.start_broker(lambda _harness: adapter)
+        self.wait_run_state(run_id, "succeeded")
+        self.assertEqual(adapter.started, 0)
+        self.assertEqual(adapter.resumed, 0)
+        self.assertEqual(adapter.reconciled, 1)
+        self.assertTrue(broker.wait_idle())
+
+    def test_leased_crash_is_safe_to_start_once(self) -> None:
+        _conversation, _message, run_id = self.add_live_run(state="leased")
+        adapter = FakeAdapter()
+        broker = self.start_broker(lambda _harness: adapter)
+        self.wait_run_state(run_id, "succeeded")
+        self.assertEqual(adapter.started, 1)
+        self.assertEqual(adapter.resumed, 0)
+        self.assertTrue(broker.wait_idle())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -317,13 +317,24 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
         self.addCleanup(lambda: setattr(server, "_CSP", csp))
 
     def _start(self, bind, *, container=False, port=8800):
-        """Run main([]) to the bind decision. Returns (refusal, served): the
-        SystemExit main() raised or None, and the host transport.serve was
-        actually called with or None if the listener was never reached."""
+        """Run main([]) to the bind decision.
+
+        Returns refusal, served host, and whether the conversation broker
+        started after that successful bind.
+        """
         served = []
 
-        async def _fake_serve(host, port, http_handler, ws_handler, log=print):
+        async def _fake_serve(
+            host,
+            port,
+            http_handler,
+            ws_handler,
+            log=print,
+            on_started=None,
+        ):
             served.append(host)
+            if on_started is not None:
+                on_started()
             return port
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -350,6 +361,9 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                                         "backfill"))
                 enter(mock.patch.object(server.mem_credentials, "provision"))
                 enter(mock.patch.object(server.pr_poller, "Poller"))
+                broker_start = enter(mock.patch.object(
+                    server.conversation_broker, "start_service"
+                ))
                 enter(mock.patch.object(transport, "serve", _fake_serve))
                 enter(contextlib.redirect_stdout(io.StringIO()))
                 enter(contextlib.redirect_stderr(io.StringIO()))
@@ -358,12 +372,16 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                     server.main([])
                 except SystemExit as exc:
                     refusal = exc
-        return refusal, (served[0] if served else None)
+        return (
+            refusal,
+            served[0] if served else None,
+            broker_start.called,
+        )
 
     def test_startup_refuses_an_unsafe_bind_before_serving(self):
         for bind in ("0.0.0.0", "::", "192.168.1.10", "example.com"):
             with self.subTest(bind=bind):
-                refusal, served = self._start(bind)
+                refusal, served, broker_started = self._start(bind)
                 self.assertIsNotNone(
                     refusal, "main() accepted a non-loopback bind on a host")
                 self.assertIn("loopback", str(refusal))
@@ -372,15 +390,24 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                 # assert that directly rather than inferring it from the exit.
                 self.assertIsNone(
                     served, f"transport served {served!r} despite the refusal")
+                self.assertFalse(
+                    broker_started,
+                    "conversation broker started before bind refusal",
+                )
 
     def test_startup_serves_a_loopback_bind(self):
-        self.assertEqual(self._start("127.0.0.1"), (None, "127.0.0.1"))
+        self.assertEqual(
+            self._start("127.0.0.1"),
+            (None, "127.0.0.1", True),
+        )
 
     def test_startup_serves_the_wide_bind_in_the_sandbox(self):
         # The counterweight: over-refusing here would make `./sc launch`
         # unbootable, so the sandbox exception has to survive the wiring too.
-        self.assertEqual(self._start("0.0.0.0", container=True),
-                         (None, "0.0.0.0"))
+        self.assertEqual(
+            self._start("0.0.0.0", container=True),
+            (None, "0.0.0.0", True),
+        )
 
     def test_startup_binds_the_csp_to_the_served_port(self):
         # The app shell's socket sources are port-exact (SC-152), so main()


### PR DESCRIPTION
Implements Task #93 for Spec #32.

- adds a commit-woken conversation broker supervised by the localhost API service
- atomically claims outbox intents, creates ordered one-turn runs, and relies on the DB uniqueness fences for one live mutation per conversation and shell
- captures exact native session/run/worktree identity before streaming normalized events
- heartbeats run leases, commits terminal state before releasing locks, and immediately schedules the next queued turn
- persists interrupt intent before native delivery so recovery can honor it
- reconciles expired leased/starting/running crash windows conservatively; unknown outcomes are never replayed
- starts the broker only after the API transport successfully binds, preventing a duplicate server process from dispatching work before losing the port race

Verification:
- `./sc test` — 1497 passed
- `./sc verify` — rebuild/migrations/render passed
- focused Ruff F/I/UP checks on new broker files
- `git diff --check`