### PR TITLE
Feature #24: expose browser conversation API and events

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -1,0 +1,1194 @@
+"""Browser-native normal conversation HTTP resources (Feature #24).
+
+The localhost operator is the only actor for normal-mode conversations.
+Browser mutations additionally prove same-origin.  Native harness session and
+run references remain server-side; projections and SSE expose normalized
+conversation data only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import http.client
+import io
+import json
+import re
+import sys
+import uuid
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+DB_PATH = ENGINE / "shell_db.db"
+SCRIPTS = ENGINE / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import conversation_broker
+import conversation_events
+import db_driver
+import run as run_mod
+from conversation_adapters import ADAPTER_TYPES
+
+_ALLOWED_HOST_SET = frozenset(("127.0.0.1", "localhost", "::1"))
+_CONVERSATION_STATES = frozenset(
+    ("idle", "queued", "running", "waiting", "error", "closed")
+)
+_ID = re.compile(r"^cv_[0-9a-f]{32}$")
+_DETAIL_PATH = re.compile(r"^/api/conversations/(cv_[0-9a-f]{32})$")
+_MESSAGES_PATH = re.compile(r"^/api/conversations/(cv_[0-9a-f]{32})/messages$")
+_EVENTS_PATH = re.compile(r"^/api/conversations/(cv_[0-9a-f]{32})/events$")
+_INTERRUPTIONS_PATH = re.compile(
+    r"^/api/conversations/(cv_[0-9a-f]{32})/interruptions$"
+)
+_SENSITIVE_EVENT_KEYS = frozenset(
+    (
+        "api_key",
+        "authorization",
+        "credential",
+        "credentials",
+        "harness_session_ref",
+        "analysis",
+        "native_type",
+        "native_session",
+        "process_ref",
+        "run_ref",
+        "secret",
+        "session_id",
+        "session_ref",
+        "thinking",
+        "threadid",
+        "token",
+        "turnid",
+        "reasoning",
+    )
+)
+SSE_HEARTBEAT_SECONDS = 15.0
+SSE_BATCH = 200
+
+
+class ApiError(RuntimeError):
+    def __init__(
+        self,
+        status: int,
+        code: str,
+        message: str,
+        details: dict | None = None,
+    ) -> None:
+        self.status = status
+        self.code = code
+        self.message = message
+        self.details = details or {}
+        super().__init__(f"{code}: {message}")
+
+
+def _db():
+    return db_driver.connect(str(DB_PATH))
+
+
+def _json(status: int, obj, headers=None):
+    return (
+        status,
+        [
+            ("Content-Type", "application/json"),
+            ("Cache-Control", "no-store"),
+            *list(headers or []),
+        ],
+        json.dumps(obj, ensure_ascii=False, separators=(",", ":")).encode(),
+    )
+
+
+def _err(
+    status: int,
+    code: str,
+    message: str,
+    details: dict | None = None,
+    headers=None,
+):
+    return _json(
+        status,
+        {"error": {"code": code, "message": message, "details": details or {}}},
+        headers,
+    )
+
+
+def _api_error(exc: ApiError):
+    return _err(exc.status, exc.code, exc.message, exc.details)
+
+
+def _parse_headers(headers_raw: str):
+    return http.client.parse_headers(io.BytesIO(headers_raw.encode("latin-1")))
+
+
+def _host_ok(headers) -> bool:
+    host = (headers.get("Host") or "").strip()
+    if host.startswith("["):
+        host = host[1:].split("]", 1)[0]
+    elif ":" in host:
+        host = host.rsplit(":", 1)[0]
+    return host in _ALLOWED_HOST_SET
+
+
+def _same_origin_as_host(origin: str, host: str) -> bool:
+    parsed = urlparse(origin)
+    return (
+        parsed.scheme in ("http", "https")
+        and not (parsed.path or parsed.params or parsed.query or parsed.fragment)
+        and parsed.netloc == host
+    )
+
+
+def _mutation_site_ok(headers) -> bool:
+    origin = headers.get("Origin")
+    if origin and not _same_origin_as_host(origin, headers.get("Host") or ""):
+        return False
+    return headers.get("Sec-Fetch-Site") in (None, "same-origin", "none")
+
+
+def _operator(con, headers) -> dict:
+    authz = headers.get("Authorization") or ""
+    if authz:
+        if authz[:7].lower() != "bearer " or not authz[7:].strip():
+            raise ApiError(401, "UNAUTHORIZED", "invalid Authorization header")
+        shell = con.execute(
+            "SELECT shell_id FROM shells WHERE api_key=? AND COALESCE(is_deleted,0)=0",
+            (authz[7:].strip(),),
+        ).fetchone()
+        if shell is None:
+            raise ApiError(
+                401,
+                "UNAUTHORIZED",
+                "the presented Bearer token matches no shell",
+            )
+        raise ApiError(
+            403,
+            "OPERATOR_REQUIRED",
+            "normal conversations are owned by the browser operator",
+        )
+    row = con.execute(
+        "SELECT user_id,username FROM users WHERE is_active=1 ORDER BY user_id LIMIT 1"
+    ).fetchone()
+    if row is None:
+        raise ApiError(503, "OPERATOR_UNAVAILABLE", "no active operator exists")
+    return {"user_id": int(row["user_id"]), "username": row["username"]}
+
+
+def _body(raw: bytes) -> dict:
+    try:
+        value = json.loads(raw) if raw else {}
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise ApiError(400, "BAD_JSON", "request body is not valid JSON") from exc
+    if not isinstance(value, dict):
+        raise ApiError(400, "BAD_JSON", "request body must be a JSON object")
+    return value
+
+
+def _only_fields(body: dict, allowed: set[str]) -> None:
+    unknown = sorted(set(body) - allowed)
+    if unknown:
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            "unknown field(s): " + ", ".join(unknown),
+            {"fields": unknown},
+        )
+
+
+def _integer(value, name: str) -> int:
+    if isinstance(value, bool):
+        raise ApiError(422, "VALIDATION_ERROR", f"{name} must be an integer")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ApiError(422, "VALIDATION_ERROR", f"{name} must be an integer") from exc
+
+
+def _nonblank(
+    value,
+    name: str,
+    *,
+    maximum: int = 255,
+    optional: bool = False,
+) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ApiError(422, "VALIDATION_ERROR", f"{name} must be a nonblank string")
+    value = value.strip()
+    if len(value) > maximum:
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            f"{name} must be at most {maximum} characters",
+        )
+    return value
+
+
+def _idempotency_key(headers) -> str:
+    key = headers.get("Idempotency-Key")
+    if not isinstance(key, str) or not key.strip():
+        raise ApiError(
+            422,
+            "IDEMPOTENCY_KEY_REQUIRED",
+            "Idempotency-Key header is required for this mutation",
+        )
+    key = key.strip()
+    if len(key) > 255:
+        raise ApiError(
+            422,
+            "IDEMPOTENCY_KEY_INVALID",
+            "Idempotency-Key must be at most 255 characters",
+        )
+    return key
+
+
+def _request_hash(body: dict) -> str:
+    encoded = json.dumps(
+        body,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _cursor_encode(value: dict) -> str:
+    raw = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _cursor_decode(raw: str, kind: str) -> dict:
+    try:
+        padding = "=" * (-len(raw) % 4)
+        value = json.loads(base64.urlsafe_b64decode(raw + padding))
+    except Exception as exc:
+        raise ApiError(422, "CURSOR_INVALID", f"invalid {kind} cursor") from exc
+    if not isinstance(value, dict) or value.get("v") != 1:
+        raise ApiError(422, "CURSOR_INVALID", f"invalid {kind} cursor")
+    return value
+
+
+def _limit(query, *, default: int = 50, maximum: int = 200) -> int:
+    raw = query.get("limit", [str(default)])[0]
+    value = _integer(raw, "limit")
+    if not 1 <= value <= maximum:
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            f"limit must be between 1 and {maximum}",
+        )
+    return value
+
+
+def _append_event(
+    con,
+    conversation_id: str,
+    event_type: str,
+    payload: dict,
+    *,
+    message_id: int | None = None,
+    run_id: int | None = None,
+) -> int:
+    sequence = int(
+        con.execute(
+            "SELECT COALESCE(MAX(sequence),0)+1 FROM conversation_events "
+            "WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()[0]
+    )
+    con.execute(
+        "INSERT INTO conversation_events "
+        "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+        "VALUES (?,?,?,?,?,?)",
+        (
+            conversation_id,
+            sequence,
+            event_type,
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+            message_id,
+            run_id,
+        ),
+    )
+    return sequence
+
+
+def _conversation_row(con, conversation_id: str, owner_user_id: int):
+    return con.execute(
+        "SELECT c.conversation_id,c.shell_id,c.mode,c.owner_user_id,c.harness,"
+        "c.provider,c.model,c.effort,c.state,c.title,c.created_at,"
+        "c.last_activity_at,c.closed_at,c.version,s.display_name,s.shortname "
+        "FROM conversations c JOIN shells s ON s.shell_id=c.shell_id "
+        "WHERE c.conversation_id=? AND c.mode='normal' AND c.owner_user_id=?",
+        (conversation_id, owner_user_id),
+    ).fetchone()
+
+
+def _conversation_projection(row) -> dict:
+    return {
+        "conversation_id": row["conversation_id"],
+        "shell": {
+            "shell_id": int(row["shell_id"]),
+            "display_name": row["display_name"],
+            "shortname": row["shortname"],
+        },
+        "mode": row["mode"],
+        "route": {
+            "harness": row["harness"],
+            "provider": row["provider"],
+            "model": row["model"],
+            "effort": row["effort"],
+        },
+        "state": row["state"],
+        "title": row["title"],
+        "created_at": row["created_at"],
+        "last_activity_at": row["last_activity_at"],
+        "closed_at": row["closed_at"],
+        "version": int(row["version"]),
+    }
+
+
+def _message_projection(row) -> dict:
+    return {
+        "message_id": int(row["message_id"]),
+        "conversation_id": row["conversation_id"],
+        "sender_kind": row["sender_kind"],
+        "sender_ref": row["sender_ref"],
+        "message_kind": row["message_kind"],
+        "body": row["body"],
+        "caused_by_message_id": row["caused_by_message_id"],
+        "state": row["state"],
+        "created_at": row["created_at"],
+        "completed_at": row["completed_at"],
+    }
+
+
+def _message_row(con, message_id: int):
+    return con.execute(
+        "SELECT message_id,conversation_id,sender_kind,sender_ref,message_kind,"
+        "body,caused_by_message_id,state,created_at,completed_at "
+        "FROM conversation_messages WHERE message_id=?",
+        (message_id,),
+    ).fetchone()
+
+
+def _require_conversation(con, conversation_id: str, owner_user_id: int):
+    row = _conversation_row(con, conversation_id, owner_user_id)
+    if row is None:
+        raise ApiError(404, "CONVERSATION_NOT_FOUND", "conversation does not exist")
+    return row
+
+
+def _create_conversation(con, operator: dict, headers, body: dict):
+    _only_fields(body, {"shell_id", "title", "harness", "model", "effort"})
+    key = _idempotency_key(headers)
+    request_hash = _request_hash(body)
+    shell_id = _integer(body.get("shell_id"), "shell_id")
+
+    con.execute("BEGIN IMMEDIATE")
+    existing = con.execute(
+        "SELECT conversation_id,creation_request_hash FROM conversations "
+        "WHERE mode='normal' AND owner_user_id=? "
+        "AND creation_idempotency_key=?",
+        (operator["user_id"], key),
+    ).fetchone()
+    if existing is not None:
+        if existing["creation_request_hash"] != request_hash:
+            con.rollback()
+            raise ApiError(
+                409,
+                "CONVERSATION_IDEMPOTENCY_CONFLICT",
+                "Idempotency-Key was reused with a different request",
+            )
+        row = _require_conversation(
+            con, existing["conversation_id"], operator["user_id"]
+        )
+        con.commit()
+        return _json(
+            201,
+            _conversation_projection(row),
+            [("Location", f"/api/conversations/{row['conversation_id']}")],
+        )
+
+    shell = con.execute(
+        "SELECT shell_id,display_name,shortname,flavor FROM shells "
+        "WHERE shell_id=? AND (user_id=? OR is_shared=1) "
+        "AND COALESCE(is_deleted,0)=0",
+        (shell_id, operator["user_id"]),
+    ).fetchone()
+    if shell is None:
+        con.rollback()
+        raise ApiError(
+            422,
+            "SHELL_NOT_LAUNCHABLE",
+            "shell is unknown, deleted, or unavailable to this operator",
+        )
+
+    defaults = run_mod.flavor_defaults(con).get(shell["flavor"])
+    harness = body.get("harness")
+    if harness is None:
+        harness = (
+            (defaults or {}).get("default_harness")
+            or run_mod._configured_harness()
+            or "claude"
+        )
+    harness = _nonblank(harness, "harness", maximum=64)
+    if harness not in ADAPTER_TYPES:
+        con.rollback()
+        raise ApiError(
+            422,
+            "HARNESS_CONVERSATION_UNSUPPORTED",
+            f"harness {harness!r} has no browser conversation adapter",
+        )
+    try:
+        run_mod.conductor_policy.require_harness(shell["flavor"], harness)
+    except ValueError as exc:
+        con.rollback()
+        raise ApiError(422, "HARNESS_ROUTE_INVALID", str(exc)) from exc
+
+    model = body.get("model")
+    if model is None and defaults:
+        model = defaults["models"].get(harness)
+    model = _nonblank(model, "model", maximum=255, optional=True)
+    effort = _nonblank(body.get("effort"), "effort", maximum=64, optional=True)
+    title = _nonblank(body.get("title"), "title", maximum=200, optional=True)
+    worktree = run_mod.shell_work_dir(shell["shortname"], shell["flavor"])
+    try:
+        worktree = worktree.resolve(strict=True)
+    except OSError as exc:
+        con.rollback()
+        raise ApiError(
+            422,
+            "HARNESS_WORKTREE_MISSING",
+            "the shell worktree must be booted before starting a conversation",
+            {"shell_id": shell_id},
+        ) from exc
+    if not worktree.is_dir():
+        con.rollback()
+        raise ApiError(
+            422,
+            "HARNESS_WORKTREE_MISSING",
+            "the shell worktree is not a directory",
+            {"shell_id": shell_id},
+        )
+
+    conversation_id = "cv_" + uuid.uuid4().hex
+    provider = run_mod.session_provider(harness, model)
+    con.execute(
+        "INSERT INTO conversations "
+        "(conversation_id,shell_id,mode,owner_user_id,harness,provider,model,"
+        "effort,worktree,title,creation_idempotency_key,"
+        "creation_request_hash) VALUES (?,?,'normal',?,?,?,?,?,?,?,?,?)",
+        (
+            conversation_id,
+            shell_id,
+            operator["user_id"],
+            harness,
+            provider,
+            model,
+            effort,
+            str(worktree),
+            title,
+            key,
+            request_hash,
+        ),
+    )
+    _append_event(
+        con,
+        conversation_id,
+        "conversation.created",
+        {
+            "shell_id": shell_id,
+            "harness": harness,
+            "model": model,
+            "effort": effort,
+        },
+    )
+    con.commit()
+    conversation_events.notify(conversation_id)
+    row = _require_conversation(con, conversation_id, operator["user_id"])
+    return _json(
+        201,
+        _conversation_projection(row),
+        [("Location", f"/api/conversations/{conversation_id}")],
+    )
+
+
+def _list_conversations(con, operator: dict, query):
+    limit = _limit(query, maximum=100)
+    clauses = ["c.mode='normal'", "c.owner_user_id=?"]
+    params: list = [operator["user_id"]]
+    shell = query.get("shell_id", [None])[0]
+    if shell not in (None, ""):
+        clauses.append("c.shell_id=?")
+        params.append(_integer(shell, "shell_id"))
+    state = query.get("state", [None])[0]
+    if state:
+        if state not in _CONVERSATION_STATES:
+            raise ApiError(422, "VALIDATION_ERROR", "invalid conversation state")
+        clauses.append("c.state=?")
+        params.append(state)
+    mode = query.get("mode", [None])[0]
+    if mode and mode != "normal":
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            "this endpoint exposes normal conversations only",
+        )
+    cursor = query.get("cursor", [None])[0]
+    if cursor:
+        decoded = _cursor_decode(cursor, "conversation")
+        if not isinstance(decoded.get("a"), str) or not _ID.fullmatch(
+            str(decoded.get("id", ""))
+        ):
+            raise ApiError(422, "CURSOR_INVALID", "invalid conversation cursor")
+        clauses.append(
+            "(c.last_activity_at<? OR (c.last_activity_at=? AND c.conversation_id<?))"
+        )
+        params.extend((decoded["a"], decoded["a"], decoded["id"]))
+    rows = con.execute(
+        "SELECT c.conversation_id,c.shell_id,c.mode,c.owner_user_id,c.harness,"
+        "c.provider,c.model,c.effort,c.state,c.title,c.created_at,"
+        "c.last_activity_at,c.closed_at,c.version,s.display_name,s.shortname "
+        "FROM conversations c JOIN shells s ON s.shell_id=c.shell_id WHERE "
+        + " AND ".join(clauses)
+        + " ORDER BY c.last_activity_at DESC,c.conversation_id DESC LIMIT ?",
+        (*params, limit + 1),
+    ).fetchall()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit:
+        last = page[-1]
+        next_cursor = _cursor_encode(
+            {"v": 1, "a": last["last_activity_at"], "id": last["conversation_id"]}
+        )
+    return _json(
+        200,
+        {
+            "items": [_conversation_projection(row) for row in page],
+            "next_cursor": next_cursor,
+        },
+    )
+
+
+def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
+    _only_fields(body, {"version", "title", "state"})
+    if "version" not in body:
+        raise ApiError(
+            422, "VALIDATION_ERROR", "version is required for conversation updates"
+        )
+    version = _integer(body["version"], "version")
+    if version <= 0:
+        raise ApiError(422, "VALIDATION_ERROR", "version must be positive")
+    if "title" not in body and "state" not in body:
+        raise ApiError(422, "VALIDATION_ERROR", "no conversation change supplied")
+    title = (
+        _nonblank(body.get("title"), "title", maximum=200, optional=True)
+        if "title" in body
+        else None
+    )
+    if "state" in body and body["state"] != "closed":
+        raise ApiError(422, "VALIDATION_ERROR", "state may only be changed to closed")
+
+    con.execute("BEGIN IMMEDIATE")
+    row = _require_conversation(con, conversation_id, operator["user_id"])
+    if int(row["version"]) != version:
+        con.rollback()
+        raise ApiError(
+            409,
+            "CONVERSATION_VERSION_CONFLICT",
+            "conversation version does not match",
+            {"expected": int(row["version"]), "received": version},
+        )
+    closing = body.get("state") == "closed"
+    if row["state"] == "closed":
+        con.rollback()
+        raise ApiError(409, "CONVERSATION_CLOSED", "conversation is already closed")
+    if closing and row["state"] not in ("idle", "waiting", "error"):
+        con.rollback()
+        raise ApiError(
+            409,
+            "SHELL_BUSY",
+            "a queued or running conversation cannot be closed",
+            {"state": row["state"]},
+        )
+    sets = ["version=version+1", "last_activity_at=datetime('now')"]
+    params: list = []
+    if "title" in body:
+        sets.append("title=?")
+        params.append(title)
+    if closing:
+        sets.extend(("state='closed'", "closed_at=datetime('now')"))
+    changed = con.execute(
+        f"UPDATE conversations SET {','.join(sets)} "
+        "WHERE conversation_id=? AND owner_user_id=? AND version=?",
+        (*params, conversation_id, operator["user_id"], version),
+    ).rowcount
+    if changed != 1:
+        con.rollback()
+        raise ApiError(
+            409,
+            "CONVERSATION_VERSION_CONFLICT",
+            "conversation changed concurrently",
+        )
+    _append_event(
+        con,
+        conversation_id,
+        (
+            "conversation.updated"
+            if "title" in body and closing
+            else "conversation.closed"
+            if closing
+            else "conversation.renamed"
+        ),
+        {
+            **({"title": title} if "title" in body else {}),
+            **({"state": "closed"} if closing else {}),
+        },
+    )
+    con.commit()
+    conversation_events.notify(conversation_id)
+    return _json(
+        200,
+        _conversation_projection(
+            _require_conversation(con, conversation_id, operator["user_id"])
+        ),
+    )
+
+
+def _create_message(con, operator: dict, conversation_id: str, headers, body: dict):
+    _only_fields(body, {"text"})
+    key = _idempotency_key(headers)
+    text = _nonblank(body.get("text"), "text", maximum=1048576)
+    normalized = {"text": text}
+    request_hash = _request_hash(normalized)
+
+    con.execute("BEGIN IMMEDIATE")
+    conversation = _require_conversation(con, conversation_id, operator["user_id"])
+    existing = con.execute(
+        "SELECT message_id,request_hash FROM conversation_messages "
+        "WHERE conversation_id=? AND idempotency_key=?",
+        (conversation_id, key),
+    ).fetchone()
+    if existing is not None:
+        if existing["request_hash"] != request_hash:
+            con.rollback()
+            raise ApiError(
+                409,
+                "MESSAGE_IDEMPOTENCY_CONFLICT",
+                "Idempotency-Key was reused with a different message",
+            )
+        message = _message_projection(_message_row(con, int(existing["message_id"])))
+        con.commit()
+        return _json(
+            202,
+            {
+                "message": message,
+                "queue_position": _accepted_queue_position(con, message["message_id"]),
+            },
+            [("Location", f"/api/conversations/{conversation_id}/messages")],
+        )
+    if conversation["state"] == "closed":
+        con.rollback()
+        raise ApiError(
+            409, "CONVERSATION_CLOSED", "closed conversations reject messages"
+        )
+    target_state = (
+        conversation["state"]
+        if conversation["state"] in ("queued", "running")
+        else "queued"
+    )
+    message_id = int(
+        con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash,state) "
+            "VALUES (?,'user',?,'prompt',?,?,?,'queued')",
+            (
+                conversation_id,
+                str(operator["user_id"]),
+                text,
+                key,
+                request_hash,
+            ),
+        ).lastrowid
+    )
+    con.execute(
+        "INSERT INTO conversation_outbox (conversation_id,message_id) VALUES (?,?)",
+        (conversation_id, message_id),
+    )
+    con.execute(
+        "UPDATE conversations SET state=?,last_activity_at=datetime('now'),"
+        "version=version+1 WHERE conversation_id=?",
+        (target_state, conversation_id),
+    )
+    position = _queue_position(con, message_id)
+    _append_event(
+        con,
+        conversation_id,
+        "message.accepted",
+        {
+            "message_id": message_id,
+            "queue_state": "queued",
+            "queue_position": position,
+        },
+        message_id=message_id,
+    )
+    con.commit()
+    conversation_events.notify(conversation_id)
+    conversation_broker.notify_commit()
+    return _json(
+        202,
+        {
+            "message": _message_projection(_message_row(con, message_id)),
+            "queue_position": position,
+        },
+        [("Location", f"/api/conversations/{conversation_id}/messages")],
+    )
+
+
+def _queue_position(con, message_id: int) -> int:
+    row = con.execute(
+        "SELECT COUNT(*) FROM conversation_outbox target "
+        "JOIN conversation_outbox queued "
+        "ON queued.conversation_id=target.conversation_id "
+        "AND queued.outbox_id<=target.outbox_id "
+        "WHERE target.message_id=? AND queued.state IN ('pending','claimed')",
+        (message_id,),
+    ).fetchone()
+    return int(row[0]) if row else 0
+
+
+def _accepted_queue_position(con, message_id: int) -> int:
+    row = con.execute(
+        "SELECT payload FROM conversation_events "
+        "WHERE message_id=? AND event_type='message.accepted' "
+        "ORDER BY sequence LIMIT 1",
+        (message_id,),
+    ).fetchone()
+    if row is None:
+        return _queue_position(con, message_id)
+    try:
+        value = json.loads(row["payload"]).get("queue_position")
+    except (TypeError, ValueError):
+        return _queue_position(con, message_id)
+    return int(value) if isinstance(value, int) and value >= 0 else 0
+
+
+def _list_messages(con, operator: dict, conversation_id: str, query):
+    _require_conversation(con, conversation_id, operator["user_id"])
+    limit = _limit(query)
+    after = 0
+    cursor = query.get("cursor", [None])[0]
+    if cursor:
+        decoded = _cursor_decode(cursor, "message")
+        after = _integer(decoded.get("id"), "cursor message id")
+        if after < 0:
+            raise ApiError(422, "CURSOR_INVALID", "invalid message cursor")
+    rows = con.execute(
+        "SELECT message_id,conversation_id,sender_kind,sender_ref,message_kind,"
+        "body,caused_by_message_id,state,created_at,completed_at "
+        "FROM conversation_messages WHERE conversation_id=? AND message_id>? "
+        "ORDER BY message_id LIMIT ?",
+        (conversation_id, after, limit + 1),
+    ).fetchall()
+    page = rows[:limit]
+    next_cursor = (
+        _cursor_encode({"v": 1, "id": int(page[-1]["message_id"])})
+        if len(rows) > limit
+        else None
+    )
+    return _json(
+        200,
+        {
+            "items": [_message_projection(row) for row in page],
+            "next_cursor": next_cursor,
+        },
+    )
+
+
+def _request_interrupt(run_id: int, *, replay: bool) -> None:
+    try:
+        conversation_broker.interrupt_run(run_id)
+        return
+    except conversation_broker.BrokerError as exc:
+        if exc.code == "CONVERSATION_BROKER_UNAVAILABLE":
+            try:
+                conversation_broker.BrokerStore(DB_PATH).request_interrupt(run_id)
+            except conversation_broker.BrokerError as store_exc:
+                exc = store_exc
+            else:
+                # The durable event is enough for startup reconciliation; this
+                # wake additionally reaches a broker that came online in the
+                # narrow gap between the service lookup and the store commit.
+                conversation_broker.notify_commit()
+                return
+        if exc.code in (
+            "CONVERSATION_RUN_NOT_ACTIVE",
+            "CONVERSATION_RUN_NOT_FOUND",
+        ):
+            if replay:
+                return
+            raise ApiError(
+                409,
+                "RUN_ALREADY_TERMINAL",
+                "the run became terminal before interruption delivery",
+            ) from exc
+        raise ApiError(503, exc.code, exc.detail) from exc
+
+
+def _interrupt(con, operator: dict, conversation_id: str, headers, body: dict):
+    _only_fields(body, {"run_id"})
+    key = _idempotency_key(headers)
+    requested_run = _integer(body["run_id"], "run_id") if "run_id" in body else None
+    normalized = {"run_id": requested_run}
+    request_hash = _request_hash(normalized)
+
+    con.execute("BEGIN IMMEDIATE")
+    _require_conversation(con, conversation_id, operator["user_id"])
+    existing = con.execute(
+        "SELECT message_id,request_hash,body FROM conversation_messages "
+        "WHERE conversation_id=? AND idempotency_key=?",
+        (conversation_id, key),
+    ).fetchone()
+    if existing is not None:
+        if existing["request_hash"] != request_hash:
+            con.rollback()
+            raise ApiError(
+                409,
+                "MESSAGE_IDEMPOTENCY_CONFLICT",
+                "Idempotency-Key was reused with a different interruption",
+            )
+        audit = _message_projection(_message_row(con, int(existing["message_id"])))
+        run_id = int(json.loads(existing["body"])["run_id"])
+        con.commit()
+        _request_interrupt(run_id, replay=True)
+        return _json(202, {"interruption": audit, "run_id": run_id})
+
+    clauses = [
+        "conversation_id=?",
+        "state IN ('leased','starting','running')",
+    ]
+    params: list = [conversation_id]
+    if requested_run is not None:
+        clauses.append("run_id=?")
+        params.append(requested_run)
+    active = con.execute(
+        "SELECT run_id FROM conversation_runs WHERE "
+        + " AND ".join(clauses)
+        + " ORDER BY run_id DESC LIMIT 1",
+        params,
+    ).fetchone()
+    if active is None:
+        con.rollback()
+        raise ApiError(
+            409,
+            "RUN_ALREADY_TERMINAL",
+            "no matching active run can be interrupted",
+        )
+    run_id = int(active["run_id"])
+    audit_body = json.dumps(
+        {"kind": "interrupt", "run_id": run_id},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    message_id = int(
+        con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash,state,completed_at) "
+            "VALUES (?,'user',?,'control',?,?,?,'completed',datetime('now'))",
+            (
+                conversation_id,
+                str(operator["user_id"]),
+                audit_body,
+                key,
+                request_hash,
+            ),
+        ).lastrowid
+    )
+    con.execute(
+        "UPDATE conversations SET last_activity_at=datetime('now'),"
+        "version=version+1 WHERE conversation_id=?",
+        (conversation_id,),
+    )
+    con.commit()
+    _request_interrupt(run_id, replay=False)
+    return _json(
+        202,
+        {
+            "interruption": _message_projection(_message_row(con, message_id)),
+            "run_id": run_id,
+        },
+    )
+
+
+def handle(method: str, path: str, headers_raw: str, raw_body: bytes) -> tuple:
+    headers = _parse_headers(headers_raw)
+    if not _host_ok(headers):
+        return _err(
+            403,
+            "HOST_NOT_ALLOWED",
+            "conversation API serves 127.0.0.1/localhost only",
+        )
+    parsed = urlparse(path)
+    query = parse_qs(parsed.query)
+    con = _db()
+    try:
+        try:
+            operator = _operator(con, headers)
+            if method in ("POST", "PATCH", "PUT", "DELETE") and not _mutation_site_ok(
+                headers
+            ):
+                raise ApiError(
+                    403, "NOT_SAME_ORIGIN", "cross-site conversation mutation rejected"
+                )
+            body = _body(raw_body)
+            if parsed.path == "/api/conversations":
+                if method == "GET":
+                    return _list_conversations(con, operator, query)
+                if method == "POST":
+                    return _create_conversation(con, operator, headers, body)
+            detail = _DETAIL_PATH.fullmatch(parsed.path)
+            if detail:
+                conversation_id = detail.group(1)
+                if method == "GET":
+                    return _json(
+                        200,
+                        _conversation_projection(
+                            _require_conversation(
+                                con, conversation_id, operator["user_id"]
+                            )
+                        ),
+                    )
+                if method == "PATCH":
+                    return _patch_conversation(con, operator, conversation_id, body)
+            messages = _MESSAGES_PATH.fullmatch(parsed.path)
+            if messages:
+                conversation_id = messages.group(1)
+                if method == "GET":
+                    return _list_messages(con, operator, conversation_id, query)
+                if method == "POST":
+                    return _create_message(
+                        con, operator, conversation_id, headers, body
+                    )
+            interruptions = _INTERRUPTIONS_PATH.fullmatch(parsed.path)
+            if interruptions and method == "POST":
+                return _interrupt(con, operator, interruptions.group(1), headers, body)
+            if _EVENTS_PATH.fullmatch(parsed.path) and method == "GET":
+                return _err(
+                    406,
+                    "SSE_REQUIRED",
+                    "conversation events require the live SSE transport",
+                )
+            return _err(
+                404,
+                "NO_SUCH_ROUTE",
+                f"no conversation route: {method} {parsed.path}",
+            )
+        except ApiError as exc:
+            if con.in_transaction:
+                con.rollback()
+            return _api_error(exc)
+        except Exception:  # noqa: BLE001 — uniform boundary for handler faults
+            if con.in_transaction:
+                con.rollback()
+            return _err(
+                500,
+                "INTERNAL_ERROR",
+                "conversation request failed",
+            )
+    finally:
+        con.close()
+
+
+def _sensitive_event_key(key: str) -> bool:
+    lowered = key.lower()
+    normalized = lowered.replace("-", "_")
+    return (
+        lowered in _SENSITIVE_EVENT_KEYS
+        or normalized in _SENSITIVE_EVENT_KEYS
+        or normalized.endswith(("_token", "_secret", "_credential"))
+    )
+
+
+def _redact_event_value(value, secrets: tuple[str, ...]):
+    if isinstance(value, dict):
+        return {
+            key: _redact_event_value(child, secrets)
+            for key, child in value.items()
+            if not _sensitive_event_key(key)
+        }
+    if isinstance(value, list):
+        return [_redact_event_value(child, secrets) for child in value]
+    if isinstance(value, str):
+        for secret in secrets:
+            value = value.replace(secret, "[redacted]")
+    return value
+
+
+def _event_projection(row, secrets: tuple[str, ...]) -> dict:
+    return {
+        "sequence": int(row["sequence"]),
+        "event_type": row["event_type"],
+        "payload_version": int(row["payload_version"]),
+        "payload": _redact_event_value(json.loads(row["payload"]), secrets),
+        "message_id": row["message_id"],
+        "run_id": row["run_id"],
+        "created_at": row["created_at"],
+    }
+
+
+def _stream_authorize(headers_raw: str, conversation_id: str):
+    headers = _parse_headers(headers_raw)
+    if not _host_ok(headers):
+        raise ApiError(
+            403,
+            "HOST_NOT_ALLOWED",
+            "conversation API serves 127.0.0.1/localhost only",
+        )
+    con = _db()
+    try:
+        operator = _operator(con, headers)
+        _require_conversation(con, conversation_id, operator["user_id"])
+    finally:
+        con.close()
+    return headers
+
+
+def _after_sequence(query, headers) -> int:
+    cursor = query.get("cursor", [None])[0]
+    last_event = headers.get("Last-Event-ID")
+    raw_after = query.get("after", [None])[0]
+    supplied = sum(value not in (None, "") for value in (cursor, last_event, raw_after))
+    if supplied > 1:
+        raise ApiError(
+            422,
+            "CURSOR_INVALID",
+            "supply only one of cursor, after, or Last-Event-ID",
+        )
+    if cursor:
+        decoded = _cursor_decode(cursor, "event")
+        after = _integer(decoded.get("sequence"), "event sequence")
+    elif last_event:
+        after = _integer(last_event, "Last-Event-ID")
+    elif raw_after:
+        after = _integer(raw_after, "after")
+    else:
+        after = 0
+    if after < 0:
+        raise ApiError(422, "CURSOR_INVALID", "event sequence cannot be negative")
+    return after
+
+
+def _event_batch(conversation_id: str, after: int) -> list[dict]:
+    con = _db()
+    try:
+        secret_values = [
+            row[0]
+            for row in con.execute(
+                "SELECT harness_session_ref FROM conversations "
+                "WHERE conversation_id=? AND harness_session_ref IS NOT NULL "
+                "UNION SELECT harness_session_before FROM conversation_runs "
+                "WHERE conversation_id=? AND harness_session_before IS NOT NULL "
+                "UNION SELECT harness_session_after FROM conversation_runs "
+                "WHERE conversation_id=? AND harness_session_after IS NOT NULL "
+                "UNION SELECT runner_ref FROM conversation_runs "
+                "WHERE conversation_id=? AND runner_ref IS NOT NULL",
+                (conversation_id,) * 4,
+            )
+            if isinstance(row[0], str) and row[0]
+        ]
+        secrets = tuple(sorted(set(secret_values), key=len, reverse=True))
+        rows = con.execute(
+            "SELECT sequence,event_type,payload_version,payload,message_id,"
+            "run_id,created_at FROM conversation_events "
+            "WHERE conversation_id=? AND sequence>? "
+            "ORDER BY sequence LIMIT ?",
+            (conversation_id, after, SSE_BATCH),
+        ).fetchall()
+        return [_event_projection(row, secrets) for row in rows]
+    finally:
+        con.close()
+
+
+async def _stream_error(writer, exc: ApiError) -> None:
+    status, headers, body = _api_error(exc)
+    lines = [f"HTTP/1.1 {status} Error"]
+    for key, value in headers:
+        lines.append(f"{key}: {value}")
+    lines.extend((f"Content-Length: {len(body)}", "Connection: close"))
+    writer.write(("\r\n".join(lines) + "\r\n\r\n").encode() + body)
+    await writer.drain()
+    writer.close()
+
+
+async def stream_events(
+    method: str,
+    path: str,
+    headers_raw: str,
+    writer,
+) -> bool:
+    """Claim and serve a conversation event request; return False otherwise."""
+    parsed = urlparse(path)
+    match = _EVENTS_PATH.fullmatch(parsed.path)
+    if match is None or method != "GET":
+        return False
+    conversation_id = match.group(1)
+    try:
+        headers = await asyncio.to_thread(
+            _stream_authorize, headers_raw, conversation_id
+        )
+        after = _after_sequence(parse_qs(parsed.query), headers)
+    except ApiError as exc:
+        await _stream_error(writer, exc)
+        return True
+    except Exception:  # noqa: BLE001 — stream faults need a JSON response
+        await _stream_error(
+            writer,
+            ApiError(500, "INTERNAL_ERROR", "conversation event stream failed"),
+        )
+        return True
+
+    response_head = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Type: text/event-stream\r\n"
+        b"Cache-Control: no-store\r\n"
+        b"X-Accel-Buffering: no\r\n"
+        b"Connection: keep-alive\r\n\r\n"
+    )
+    writer.write(response_head)
+    await writer.drain()
+    try:
+        while True:
+            observed = conversation_events.generation(conversation_id)
+            events = await asyncio.to_thread(_event_batch, conversation_id, after)
+            if events:
+                for event in events:
+                    after = event["sequence"]
+                    data = json.dumps(
+                        event,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    )
+                    frame = (
+                        f"id: {after}\nevent: {event['event_type']}\ndata: {data}\n\n"
+                    ).encode()
+                    writer.write(frame)
+                await writer.drain()
+                continue
+            await asyncio.to_thread(
+                conversation_events.wait,
+                conversation_id,
+                observed,
+                SSE_HEARTBEAT_SECONDS,
+            )
+            if conversation_events.generation(conversation_id) == observed:
+                writer.write(b": keepalive\n\n")
+                await writer.drain()
+    except (BrokenPipeError, ConnectionError, asyncio.CancelledError):
+        pass
+    finally:
+        writer.close()
+    return True

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -69,6 +69,7 @@ import mem_credentials  # noqa: E402  (runtime Admin credential provisioning, sp
 import sprint_lifecycle  # noqa: E402  (authoritative sprint state/ownership)
 sys.path.insert(0, str(ENGINE / "api"))
 import conductor_routes  # noqa: E402  (Step 4 directive/event contracts)
+import conversation_routes  # noqa: E402  (Feature #24 browser conversations)
 import sprint_routes  # noqa: E402  (sprint board API — /api/sprint-units)
 import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
 import pr_poller  # noqa: E402  (watched-PR polling — the service scheduler)
@@ -3535,6 +3536,8 @@ def dispatch_http(method: str, path: str, headers_raw: str,
     if parsed.path.startswith(("/api/directives",
                                "/api/sentinel-events")):
         return conductor_routes.handle(method, path, headers_raw, body)
+    if parsed.path.startswith("/api/conversations"):
+        return conversation_routes.handle(method, path, headers_raw, body)
     if parsed.path.startswith((
         "/api/sprint-units",
         "/api/spec-qaqc-reviews",
@@ -3724,6 +3727,7 @@ def main(argv):
             dispatch_http,
             _ws_unavailable,
             on_started=lambda: conversation_broker.start_service(DB_PATH),
+            stream_handler=conversation_routes.stream_events,
         )
 
     print(f"super-coder review layer → http://127.0.0.1:{port}  (bind {bind}, DB: {DB_PATH.name})")

--- a/.super-coder/api/transport.py
+++ b/.super-coder/api/transport.py
@@ -19,6 +19,10 @@ Contract:
       async callable taking full ownership of an upgraded connection.
       `head_raw` is the verbatim request head (ending CRLFCRLF) plus any
       already-read leftover bytes, ready to feed a sans-io protocol.
+  stream_handler(method, path, headers_raw, writer) -> bool
+      optional async callable checked before buffered HTTP dispatch. Returning
+      true takes ownership of the response connection (used by replay/live
+      conversation SSE); false continues through `http_handler`.
 
 Limits: 64 KiB request head, 8 MiB body. Every HTTP response is
 `Connection: close` (the multiplex reads exactly one request per connection;
@@ -65,11 +69,12 @@ async def _read_head(reader: asyncio.StreamReader):
 
 class Transport:
     def __init__(self, host: str, port: int, http_handler, ws_handler,
-                 log=print):
+                 log=print, stream_handler=None):
         self.host = host
         self.port = port
         self.http_handler = http_handler
         self.ws_handler = ws_handler
+        self.stream_handler = stream_handler
         self._log = log
         self._tcp: asyncio.AbstractServer | None = None
 
@@ -98,8 +103,18 @@ class Transport:
             if "upgrade" in headers.get("connection", "").lower():
                 await self.ws_handler(reader, writer, raw)
             else:
-                await self._handle_http(reader, writer, request_line,
-                                        headers, headers_raw, raw)
+                parts = (request_line.split(" ", 2) + ["", ""])[:3]
+                method, path = parts[0].upper(), parts[1]
+                streamed = (
+                    await self.stream_handler(
+                        method, path, headers_raw, writer
+                    )
+                    if self.stream_handler is not None
+                    else False
+                )
+                if not streamed:
+                    await self._handle_http(reader, writer, request_line,
+                                            headers, headers_raw, raw)
         except (ConnectionError, asyncio.IncompleteReadError):
             pass
         except Exception as exc:  # noqa: BLE001 — one bad connection must not kill the server
@@ -114,10 +129,34 @@ class Transport:
                            raw: bytes) -> None:
         parts = (request_line.split(" ", 2) + ["", ""])[:3]
         method, path = parts[0].upper(), parts[1]
-        length = int(headers.get("content-length") or 0)
+        try:
+            length = int(headers.get("content-length") or 0)
+        except ValueError:
+            await self._respond(
+                writer,
+                400,
+                [("Content-Type", "application/json")],
+                b'{"error":{"code":"BAD_CONTENT_LENGTH",'
+                b'"message":"Content-Length must be an integer","details":{}}}',
+            )
+            return
+        if length < 0:
+            await self._respond(
+                writer,
+                400,
+                [("Content-Type", "application/json")],
+                b'{"error":{"code":"BAD_CONTENT_LENGTH",'
+                b'"message":"Content-Length cannot be negative","details":{}}}',
+            )
+            return
         if length > MAX_BODY:
-            await self._respond(writer, 413, [],
-                                b'{"error":"request body too large"}')
+            await self._respond(
+                writer,
+                413,
+                [("Content-Type", "application/json")],
+                b'{"error":{"code":"REQUEST_BODY_TOO_LARGE",'
+                b'"message":"request body exceeds 8 MiB","details":{}}}',
+            )
             return
         head_len = raw.find(b"\r\n\r\n") + 4
         body = raw[head_len:head_len + length]
@@ -132,7 +171,12 @@ class Transport:
                 None, self.http_handler, method, path, headers_raw, body)
         except Exception as exc:  # noqa: BLE001 — defense in depth; handlers catch their own
             self._log(f"transport: handler error {method} {path}: {exc!r}")
-            status, resp_headers, resp_body = 500, [], b'{"error":"internal"}'
+            status = 500
+            resp_headers = [("Content-Type", "application/json")]
+            resp_body = (
+                b'{"error":{"code":"INTERNAL_ERROR",'
+                b'"message":"request handler failed","details":{}}}'
+            )
         await self._respond(writer, status, resp_headers, resp_body)
 
     async def _respond(self, writer, status: int,
@@ -158,7 +202,7 @@ class Transport:
 
 
 async def serve(host: str, port: int, http_handler, ws_handler,
-                log=print, on_started=None) -> int:
+                log=print, on_started=None, stream_handler=None) -> int:
     """Start the multiplex and block forever (until cancelled). Returns the
     bound port after start for callers that passed port=0 — via `log` line and
     the Transport object; this coroutine simply runs until shutdown.
@@ -167,7 +211,14 @@ async def serve(host: str, port: int, http_handler, ws_handler,
     that can cause external side effects belong behind that boundary: a second
     process must lose the bind race before it can dispatch work.
     """
-    transport = Transport(host, port, http_handler, ws_handler, log=log)
+    transport = Transport(
+        host,
+        port,
+        http_handler,
+        ws_handler,
+        log=log,
+        stream_handler=stream_handler,
+    )
     await transport.start()
     try:
         log(f"transport: listening on {host}:{transport.port}")

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -26,6 +26,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+import conversation_events
 import db_driver
 from conversation_adapters import (
     ConversationAdapter,
@@ -572,12 +573,14 @@ class BrokerStore:
                 (now, row["conversation_id"]),
             )
             con.commit()
-            return sequence
+            conversation_id = row["conversation_id"]
         except Exception:
             self._rollback(con)
             raise
         finally:
             con.close()
+        conversation_events.notify(conversation_id)
+        return sequence
 
     def finish_run(
         self,
@@ -678,12 +681,14 @@ class BrokerStore:
                 run_id=run_id,
             )
             con.commit()
-            return True
+            conversation_id = row["conversation_id"]
         except Exception:
             self._rollback(con)
             raise
         finally:
             con.close()
+        conversation_events.notify(conversation_id)
+        return True
 
     def renew_runs(self, owner: str, run_ids: list[int]) -> int:
         if not run_ids:
@@ -762,12 +767,16 @@ class BrokerStore:
                     (now, row["conversation_id"]),
                 )
             con.commit()
-            return exists is None
+            conversation_id = row["conversation_id"]
+            created = exists is None
         except Exception:
             self._rollback(con)
             raise
         finally:
             con.close()
+        if created:
+            conversation_events.notify(conversation_id)
+        return created
 
     def heartbeat_service(self, interval_seconds: int) -> None:
         con = self.connect()

--- a/.super-coder/scripts/conversation_events.py
+++ b/.super-coder/scripts/conversation_events.py
@@ -1,0 +1,39 @@
+"""Process-local wake hints for durable conversation event replay.
+
+The database is the source of truth.  This condition only prevents a live SSE
+consumer from polling while it waits for the next committed sequence.  A
+generation snapshot taken before the replay query closes the query/wait race:
+if a commit lands between those operations, ``wait`` returns immediately.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+_CONDITION = threading.Condition()
+_GENERATIONS: dict[str, int] = {}
+
+
+def generation(conversation_id: str) -> int:
+    with _CONDITION:
+        return _GENERATIONS.get(conversation_id, 0)
+
+
+def notify(conversation_id: str) -> int:
+    with _CONDITION:
+        value = _GENERATIONS.get(conversation_id, 0) + 1
+        _GENERATIONS[conversation_id] = value
+        _CONDITION.notify_all()
+        return value
+
+
+def wait(conversation_id: str, after: int, timeout: float) -> int:
+    deadline = time.monotonic() + max(0.0, timeout)
+    with _CONDITION:
+        while _GENERATIONS.get(conversation_id, 0) == after:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            _CONDITION.wait(remaining)
+        return _GENERATIONS.get(conversation_id, 0)

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -1,0 +1,498 @@
+"""Feature #24 conversation API, idempotency, isolation, and SSE contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ENGINE / "api"))
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import conversation_broker
+import conversation_events
+import conversation_routes
+
+
+def apply_schema(con: sqlite3.Connection) -> None:
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+def decoded(response):
+    status, headers, body = response
+    return status, dict(headers), json.loads(body)
+
+
+class _DisconnectingWriter:
+    def __init__(self) -> None:
+        self.body = bytearray()
+        self.drains = 0
+        self.closed = False
+        self.head_written = asyncio.Event()
+
+    def write(self, value: bytes) -> None:
+        self.body.extend(value)
+
+    async def drain(self) -> None:
+        self.drains += 1
+        if self.drains == 1:
+            self.head_written.set()
+        elif b"data:" in self.body:
+            raise ConnectionError("test client disconnected")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class ConversationApiCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.db_path = self.root / "shell.db"
+        con = sqlite3.connect(self.db_path)
+        apply_schema(con)
+        con.execute(
+            "INSERT INTO users (user_id,username,is_active) "
+            "VALUES (1,'operator',1),(2,'other',1)"
+        )
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id,"
+            "api_key) VALUES (1,'Dev','dev','dev','prompt',1,'shell-token')"
+        )
+        con.commit()
+        con.close()
+        (self.root / ".sc-worktrees" / "dev").mkdir(parents=True)
+
+        patches = (
+            mock.patch.object(conversation_routes, "DB_PATH", self.db_path),
+            mock.patch.object(conversation_routes.run_mod, "REPO_ROOT", self.root),
+            mock.patch.object(
+                conversation_routes.conversation_broker,
+                "notify_commit",
+                return_value=True,
+            ),
+        )
+        for patch in patches:
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def connect(self):
+        con = sqlite3.connect(self.db_path)
+        con.row_factory = sqlite3.Row
+        con.execute("PRAGMA foreign_keys=ON")
+        return con
+
+    @staticmethod
+    def headers(*, key: str | None = None, extra: dict | None = None) -> str:
+        values = {"Host": "localhost:8800", **(extra or {})}
+        if key is not None:
+            values["Idempotency-Key"] = key
+        return "\r\n".join(f"{name}: {value}" for name, value in values.items())
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict | None = None,
+        key: str | None = None,
+        extra_headers: dict | None = None,
+    ):
+        return decoded(
+            conversation_routes.handle(
+                method,
+                path,
+                self.headers(key=key, extra=extra_headers),
+                json.dumps(body).encode() if body is not None else b"",
+            )
+        )
+
+    def create(self, key: str = "create-1", **changes) -> dict:
+        body = {"shell_id": 1, "harness": "codex", **changes}
+        status, _, obj = self.request("POST", "/api/conversations", body=body, key=key)
+        self.assertEqual(status, 201, obj)
+        return obj
+
+
+class ConversationResourceTest(ConversationApiCase):
+    def test_create_is_idempotent_and_never_exposes_native_identity(self) -> None:
+        first = self.create(title="API")
+        second = self.create(title="API")
+        self.assertEqual(first, second)
+        self.assertNotIn("worktree", first)
+        self.assertNotIn("harness_session_ref", json.dumps(first))
+        self.assertEqual(first["route"]["harness"], "codex")
+
+        status, _, error = self.request(
+            "POST",
+            "/api/conversations",
+            body={"shell_id": 1, "harness": "codex", "title": "different"},
+            key="create-1",
+        )
+        self.assertEqual(status, 409)
+        self.assertEqual(error["error"]["code"], "CONVERSATION_IDEMPOTENCY_CONFLICT")
+
+        con = self.connect()
+        event = con.execute(
+            "SELECT sequence,event_type FROM conversation_events"
+        ).fetchone()
+        count = con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+        con.close()
+        self.assertEqual(count, 1)
+        self.assertEqual(tuple(event), (1, "conversation.created"))
+
+    def test_operator_boundary_rejects_tokens_and_cross_site_mutations(self) -> None:
+        status, _, obj = self.request(
+            "POST",
+            "/api/conversations",
+            body={"shell_id": 1, "harness": "codex"},
+        )
+        self.assertEqual(status, 422)
+        self.assertEqual(obj["error"]["code"], "IDEMPOTENCY_KEY_REQUIRED")
+
+        status, _, obj = self.request(
+            "GET",
+            "/api/conversations",
+            extra_headers={"Authorization": "Bearer shell-token"},
+        )
+        self.assertEqual(status, 403)
+        self.assertEqual(obj["error"]["code"], "OPERATOR_REQUIRED")
+
+        status, _, obj = self.request(
+            "GET",
+            "/api/conversations",
+            extra_headers={"Authorization": "Bearer stale"},
+        )
+        self.assertEqual(status, 401)
+        self.assertEqual(obj["error"]["code"], "UNAUTHORIZED")
+
+        status, _, obj = self.request(
+            "POST",
+            "/api/conversations",
+            body={"shell_id": 1, "harness": "codex"},
+            key="cross-site",
+            extra_headers={
+                "Origin": "https://hostile.example",
+                "Sec-Fetch-Site": "cross-site",
+            },
+        )
+        self.assertEqual(status, 403)
+        self.assertEqual(obj["error"]["code"], "NOT_SAME_ORIGIN")
+
+    def test_message_outbox_event_commit_atomically_before_broker_wake(self) -> None:
+        conversation = self.create()
+        conversation_id = conversation["conversation_id"]
+        observed = []
+
+        def notified():
+            con = self.connect()
+            observed.append(
+                (
+                    con.execute(
+                        "SELECT COUNT(*) FROM conversation_messages"
+                    ).fetchone()[0],
+                    con.execute("SELECT COUNT(*) FROM conversation_outbox").fetchone()[
+                        0
+                    ],
+                    con.execute(
+                        "SELECT COUNT(*) FROM conversation_events "
+                        "WHERE event_type='message.accepted'"
+                    ).fetchone()[0],
+                )
+            )
+            con.close()
+            return True
+
+        with mock.patch.object(
+            conversation_routes.conversation_broker,
+            "notify_commit",
+            side_effect=notified,
+        ):
+            status, _, accepted = self.request(
+                "POST",
+                f"/api/conversations/{conversation_id}/messages",
+                body={"text": "hello"},
+                key="message-1",
+            )
+        self.assertEqual(status, 202, accepted)
+        self.assertEqual(observed, [(1, 1, 1)])
+        self.assertEqual(accepted["queue_position"], 1)
+        self.assertEqual(accepted["message"]["state"], "queued")
+
+        replay_status, _, replay = self.request(
+            "POST",
+            f"/api/conversations/{conversation_id}/messages",
+            body={"text": "hello"},
+            key="message-1",
+        )
+        self.assertEqual(replay_status, 202)
+        self.assertEqual(
+            replay["message"]["message_id"],
+            accepted["message"]["message_id"],
+        )
+        con = self.connect()
+        self.assertEqual(
+            con.execute("SELECT COUNT(*) FROM conversation_messages").fetchone()[0],
+            1,
+        )
+        con.close()
+
+        status, _, conflict = self.request(
+            "POST",
+            f"/api/conversations/{conversation_id}/messages",
+            body={"text": "not hello"},
+            key="message-1",
+        )
+        self.assertEqual(status, 409)
+        self.assertEqual(conflict["error"]["code"], "MESSAGE_IDEMPOTENCY_CONFLICT")
+
+    def test_cursor_pages_have_no_duplicates_and_patch_uses_version(self) -> None:
+        identifiers = {
+            self.create(key=f"create-{number}")["conversation_id"]
+            for number in range(3)
+        }
+        seen = []
+        cursor = None
+        while True:
+            path = "/api/conversations?limit=1"
+            if cursor:
+                path += f"&cursor={cursor}"
+            status, _, page = self.request("GET", path)
+            self.assertEqual(status, 200, page)
+            seen.extend(item["conversation_id"] for item in page["items"])
+            cursor = page["next_cursor"]
+            if cursor is None:
+                break
+        self.assertEqual(set(seen), identifiers)
+        self.assertEqual(len(seen), 3)
+
+        conversation_id = seen[0]
+        status, _, updated = self.request(
+            "PATCH",
+            f"/api/conversations/{conversation_id}",
+            body={"version": 1, "title": "Renamed"},
+        )
+        self.assertEqual(status, 200, updated)
+        self.assertEqual(updated["title"], "Renamed")
+        self.assertEqual(updated["version"], 2)
+        status, _, conflict = self.request(
+            "PATCH",
+            f"/api/conversations/{conversation_id}",
+            body={"version": 1, "title": "Stale"},
+        )
+        self.assertEqual(status, 409)
+        self.assertEqual(conflict["error"]["code"], "CONVERSATION_VERSION_CONFLICT")
+
+    def test_closed_conversation_rejects_messages(self) -> None:
+        conversation = self.create()
+        conversation_id = conversation["conversation_id"]
+        status, _, closed = self.request(
+            "PATCH",
+            f"/api/conversations/{conversation_id}",
+            body={"version": 1, "state": "closed"},
+        )
+        self.assertEqual(status, 200, closed)
+        status, _, error = self.request(
+            "POST",
+            f"/api/conversations/{conversation_id}/messages",
+            body={"text": "too late"},
+            key="message-closed",
+        )
+        self.assertEqual(status, 409)
+        self.assertEqual(error["error"]["code"], "CONVERSATION_CLOSED")
+
+    def test_message_cursor_and_auditable_idempotent_interruption(self) -> None:
+        conversation_id = self.create()["conversation_id"]
+        message_ids = []
+        for number in range(3):
+            status, _, accepted = self.request(
+                "POST",
+                f"/api/conversations/{conversation_id}/messages",
+                body={"text": f"message {number}"},
+                key=f"message-{number}",
+            )
+            self.assertEqual(status, 202, accepted)
+            message_ids.append(accepted["message"]["message_id"])
+
+        status, _, first = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/messages?limit=2",
+        )
+        self.assertEqual(status, 200, first)
+        self.assertEqual(
+            [item["message_id"] for item in first["items"]],
+            message_ids[:2],
+        )
+        status, _, second = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/messages"
+            f"?limit=2&cursor={first['next_cursor']}",
+        )
+        self.assertEqual(status, 200, second)
+        self.assertEqual(
+            [item["message_id"] for item in second["items"]],
+            message_ids[2:],
+        )
+
+        run = conversation_broker.BrokerStore(self.db_path).claim_next("test")
+        self.assertIsNotNone(run)
+        with mock.patch.object(
+            conversation_routes.conversation_broker,
+            "interrupt_run",
+            return_value=True,
+        ) as interrupt:
+            status, _, receipt = self.request(
+                "POST",
+                f"/api/conversations/{conversation_id}/interruptions",
+                body={"run_id": run.run_id},
+                key="interrupt-1",
+            )
+            self.assertEqual(status, 202, receipt)
+            replay_status, _, replay = self.request(
+                "POST",
+                f"/api/conversations/{conversation_id}/interruptions",
+                body={"run_id": run.run_id},
+                key="interrupt-1",
+            )
+        self.assertEqual(replay_status, 202)
+        self.assertEqual(
+            replay["interruption"]["message_id"],
+            receipt["interruption"]["message_id"],
+        )
+        self.assertEqual(interrupt.call_count, 2)
+        self.assertEqual(receipt["interruption"]["message_kind"], "control")
+        self.assertEqual(receipt["interruption"]["state"], "completed")
+
+        con = self.connect()
+        controls = con.execute(
+            "SELECT COUNT(*) FROM conversation_messages WHERE message_kind='control'"
+        ).fetchone()[0]
+        con.close()
+        self.assertEqual(controls, 1)
+
+    def test_interruption_intent_survives_a_temporarily_absent_broker(self) -> None:
+        conversation_id = self.create()["conversation_id"]
+        status, _, _ = self.request(
+            "POST",
+            f"/api/conversations/{conversation_id}/messages",
+            body={"text": "long turn"},
+            key="message-long",
+        )
+        self.assertEqual(status, 202)
+        run = conversation_broker.BrokerStore(self.db_path).claim_next("test")
+        self.assertIsNotNone(run)
+        unavailable = conversation_broker.BrokerError(
+            "CONVERSATION_BROKER_UNAVAILABLE",
+            "test broker is restarting",
+        )
+        with mock.patch.object(
+            conversation_routes.conversation_broker,
+            "interrupt_run",
+            side_effect=unavailable,
+        ):
+            status, _, receipt = self.request(
+                "POST",
+                f"/api/conversations/{conversation_id}/interruptions",
+                body={"run_id": run.run_id},
+                key="interrupt-durable",
+            )
+        self.assertEqual(status, 202, receipt)
+        con = self.connect()
+        event = con.execute(
+            "SELECT event_type FROM conversation_events "
+            "WHERE run_id=? ORDER BY sequence DESC LIMIT 1",
+            (run.run_id,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(event["event_type"], "run.interrupt.requested")
+
+
+class ConversationEventStreamTest(ConversationApiCase):
+    def test_replay_then_live_sse_redacts_native_session_fields(self) -> None:
+        conversation_id = self.create()["conversation_id"]
+
+        async def exercise():
+            writer = _DisconnectingWriter()
+            task = asyncio.create_task(
+                conversation_routes.stream_events(
+                    "GET",
+                    f"/api/conversations/{conversation_id}/events?after=1",
+                    self.headers(),
+                    writer,
+                )
+            )
+            await asyncio.wait_for(writer.head_written.wait(), timeout=2)
+            con = self.connect()
+            con.execute(
+                "UPDATE conversations SET harness_session_ref=? "
+                "WHERE conversation_id=?",
+                ("native-secret", conversation_id),
+            )
+            con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload) "
+                "VALUES (?,2,'session.started',?)",
+                (
+                    conversation_id,
+                    json.dumps(
+                        {
+                            "status": "ready",
+                            "session_ref": "native-secret",
+                            "detail": "session native-secret failed",
+                            "access_token": "credential-secret",
+                            "nested": {"threadId": "also-secret", "safe": True},
+                        }
+                    ),
+                ),
+            )
+            con.commit()
+            con.close()
+            conversation_events.notify(conversation_id)
+            await asyncio.wait_for(task, timeout=2)
+            return bytes(writer.body), writer.closed
+
+        body, closed = asyncio.run(exercise())
+        self.assertTrue(closed)
+        self.assertIn(b"Content-Type: text/event-stream", body)
+        self.assertIn(b"id: 2", body)
+        self.assertIn(b"event: session.started", body)
+        self.assertIn(b'"status":"ready"', body)
+        self.assertIn(b'"safe":true', body)
+        self.assertIn(b"session [redacted] failed", body)
+        self.assertNotIn(b"native-secret", body)
+        self.assertNotIn(b"also-secret", body)
+        self.assertNotIn(b"credential-secret", body)
+
+    def test_stream_authorization_errors_use_uniform_envelope(self) -> None:
+        conversation_id = self.create()["conversation_id"]
+
+        async def exercise():
+            writer = _DisconnectingWriter()
+            handled = await conversation_routes.stream_events(
+                "GET",
+                f"/api/conversations/{conversation_id}/events",
+                self.headers(extra={"Authorization": "Bearer stale"}),
+                writer,
+            )
+            return handled, bytes(writer.body)
+
+        handled, body = asyncio.run(exercise())
+        self.assertTrue(handled)
+        payload = body.split(b"\r\n\r\n", 1)[1]
+        self.assertEqual(json.loads(payload)["error"]["code"], "UNAUTHORIZED")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -331,8 +331,14 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
             ws_handler,
             log=print,
             on_started=None,
+            stream_handler=None,
         ):
             served.append(host)
+            self.assertIs(
+                stream_handler,
+                server.conversation_routes.stream_events,
+                "startup did not wire browser conversation SSE to transport",
+            )
             if on_started is not None:
                 on_started()
             return port


### PR DESCRIPTION
Implements Task #94 for Feature #24 / Spec #32.

- adds operator-owned normal conversation, message, close/rename, and interruption resources
- enforces required idempotency, optimistic versions, opaque cursor pagination, localhost/origin fencing, and uniform error envelopes
- commits prompt + outbox intent + accepted event atomically, then wakes the broker after commit
- adds replay-then-live SSE on the shared transport with database-backed ordering and commit notifications
- prevents browser exposure of native harness session/run references, credential-shaped data, and raw reasoning
- preserves interruption intent across a broker restart

Verification:
- 1,506 tests passed
- ./sc verify passed
- focused Ruff checks passed
- git diff --check passed