### PR TITLE
Feature #24: ship browser-native normal chat

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -452,24 +452,23 @@ def _create_conversation(con, operator: dict, headers, body: dict):
         model = defaults["models"].get(harness)
     model = _nonblank(model, "model", maximum=255, optional=True)
     effort = _nonblank(body.get("effort"), "effort", maximum=64, optional=True)
+    adapter = run_mod.load_adapter(harness)
+    if effort is None:
+        effort = run_mod.default_headless_effort(adapter)
+    try:
+        run_mod.validate_headless_request(adapter, model, effort)
+    except ValueError as exc:
+        con.rollback()
+        raise ApiError(422, "HARNESS_ROUTE_INVALID", str(exc)) from exc
     title = _nonblank(body.get("title"), "title", maximum=200, optional=True)
     worktree = run_mod.shell_work_dir(shell["shortname"], shell["flavor"])
-    try:
-        worktree = worktree.resolve(strict=True)
-    except OSError as exc:
+    worktree = worktree.resolve(strict=False)
+    if worktree.exists() and not worktree.is_dir():
         con.rollback()
         raise ApiError(
             422,
             "HARNESS_WORKTREE_MISSING",
-            "the shell worktree must be booted before starting a conversation",
-            {"shell_id": shell_id},
-        ) from exc
-    if not worktree.is_dir():
-        con.rollback()
-        raise ApiError(
-            422,
-            "HARNESS_WORKTREE_MISSING",
-            "the shell worktree is not a directory",
+            "the shell worktree path exists but is not a directory",
             {"shell_id": shell_id},
         )
 

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -63,6 +63,7 @@ import artifact_policy  # noqa: E402
 import backfill_shell_api_keys  # noqa: E402  (startup key provisioning)
 import conductor_runtime  # noqa: E402  (Step 8 wake/config/doctor)
 import conversation_broker  # noqa: E402  (Feature #24 durable turn service)
+import conversation_launch  # noqa: E402  (canonical shell launch preparation)
 import db_driver  # noqa: E402
 import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import mem_credentials  # noqa: E402  (runtime Admin credential provisioning, spec #30 req 11)
@@ -3726,7 +3727,12 @@ def main(argv):
             port,
             dispatch_http,
             _ws_unavailable,
-            on_started=lambda: conversation_broker.start_service(DB_PATH),
+            on_started=lambda: conversation_broker.start_service(
+                DB_PATH,
+                launch_preparer=conversation_launch.ConversationLaunchPreparer(
+                    DB_PATH
+                ),
+            ),
             stream_handler=conversation_routes.stream_events,
         )
 

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -451,6 +451,25 @@ class BrokerStore:
         finally:
             con.close()
 
+    def bind_archive(self, run_id: int, owner: str, archive_id: int) -> None:
+        """Attach the canonical shell session archive before native dispatch."""
+        con = self.connect()
+        try:
+            changed = con.execute(
+                "UPDATE conversation_runs SET archive_id=? "
+                "WHERE run_id=? AND lease_owner=? AND state='leased' "
+                "AND archive_id IS NULL",
+                (archive_id, run_id, owner),
+            ).rowcount
+            if changed != 1:
+                raise BrokerError(
+                    "CONVERSATION_RUN_LEASE_LOST",
+                    f"run {run_id} is not an unbound lease owned by this broker",
+                )
+            con.commit()
+        finally:
+            con.close()
+
     def mark_native_started(
         self,
         run_id: int,
@@ -802,6 +821,9 @@ class ConversationBroker(threading.Thread):
         *,
         store: BrokerStore | None = None,
         adapter_factory: Callable[[str], ConversationAdapter] = adapter_for,
+        launch_preparer: (
+            Callable[[BrokerRun], tuple[ConversationContext, int]] | None
+        ) = None,
         owner: str | None = None,
         max_workers: int = DEFAULT_MAX_WORKERS,
         heartbeat_seconds: int = DEFAULT_HEARTBEAT_SECONDS,
@@ -811,6 +833,7 @@ class ConversationBroker(threading.Thread):
         super().__init__(name="conversation-broker", daemon=True)
         self.store = store or BrokerStore(db_path)
         self.adapter_factory = adapter_factory
+        self.launch_preparer = launch_preparer
         self.owner = owner or (
             f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:12]}"
         )
@@ -1055,6 +1078,13 @@ class ConversationBroker(threading.Thread):
             if run.state == "leased":
                 try:
                     # Validate failures here are proven pre-dispatch.
+                    if self.launch_preparer is not None:
+                        context, archive_id = self.launch_preparer(run)
+                        self.store.bind_archive(
+                            run.run_id,
+                            self.owner,
+                            archive_id,
+                        )
                     context.checked_worktree()
                     adapter = self.adapter_factory(run.harness)
                     active.adapter = adapter

--- a/.super-coder/scripts/conversation_launch.py
+++ b/.super-coder/scripts/conversation_launch.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Prepare browser conversation turns through the canonical shell boot path."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import db_driver
+import run as run_mod
+import shell_liveness
+from conversation_adapters import ConversationContext
+
+
+class ConversationLaunchError(RuntimeError):
+    """Stable pre-dispatch refusal owned by browser conversation launching."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(f"{code}: {detail}")
+
+
+class ConversationLaunchPreparer:
+    """Turn an immutable broker route into a fully prepared adapter context.
+
+    ``run.prepare_launch`` is intentionally reused without executing its argv:
+    native conversation adapters own dispatch and streaming, while the normal
+    CLI path remains the source of truth for shell identity, worktree, rendered
+    boot files, harness permissions, session archives, and injected environment.
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        *,
+        prepare_launch: Callable[..., Any] = run_mod.prepare_launch,
+        liveness: Callable[[], dict] = shell_liveness.compute,
+    ) -> None:
+        self.db_path = str(db_path)
+        self.prepare_launch = prepare_launch
+        self.liveness = liveness
+
+    def _shell(self, shell_id: int) -> tuple[str, str | None]:
+        con = db_driver.connect(self.db_path)
+        try:
+            row = con.execute(
+                "SELECT shortname,flavor FROM shells WHERE shell_id=? "
+                "AND COALESCE(is_deleted,0)=0",
+                (shell_id,),
+            ).fetchone()
+        finally:
+            con.close()
+        if row is None:
+            raise ConversationLaunchError(
+                "SHELL_NOT_LAUNCHABLE",
+                f"shell_id {shell_id} is unknown or deleted",
+            )
+        return str(row["shortname"]), row["flavor"]
+
+    def __call__(self, broker_run) -> tuple[ConversationContext, int]:
+        shortname, flavor = self._shell(broker_run.shell_id)
+        def occupying_state() -> str | None:
+            snapshot = self.liveness()
+            return (
+                "busy"
+                if flavor == "admin" and snapshot.get("admin_root_pids")
+                else shell_liveness.session_state(shortname, snapshot)
+            )
+
+        state = occupying_state()
+        if state is not None:
+            raise ConversationLaunchError(
+                "SHELL_BUSY",
+                f"shell {shortname!r} already has a live CLI session "
+                f"({state}); close it before starting a browser turn",
+            )
+
+        try:
+            plan = self.prepare_launch(
+                shell_id=broker_run.shell_id,
+                harness=broker_run.harness,
+                model=broker_run.model,
+                effort=broker_run.effort,
+                headless_prompt=broker_run.body,
+            )
+        except (run_mod.LaunchError, SystemExit) as exc:
+            raise ConversationLaunchError(
+                "CONVERSATION_LAUNCH_REFUSED",
+                str(exc),
+            ) from exc
+
+        # Preparation renders and may create/sync the worktree. Recheck at the
+        # dispatch edge so a CLI launch that raced that work is still refused
+        # before the adapter can send the prompt.
+        state = occupying_state()
+        if state is not None:
+            raise ConversationLaunchError(
+                "SHELL_BUSY",
+                f"shell {shortname!r} acquired a live CLI session during "
+                f"browser preparation ({state}); no prompt was dispatched",
+            )
+
+        expected = broker_run.worktree.resolve()
+        actual = Path(plan.cwd).resolve()
+        if actual != expected:
+            raise ConversationLaunchError(
+                "HARNESS_WORKTREE_MISMATCH",
+                f"conversation is bound to {expected}, launch prepared {actual}",
+            )
+        if (
+            plan.harness != broker_run.harness
+            or plan.model != broker_run.model
+            or plan.effort != broker_run.effort
+        ):
+            raise ConversationLaunchError(
+                "HARNESS_ROUTE_MISMATCH",
+                "canonical launch preparation changed the conversation's "
+                "immutable harness, model, or effort",
+            )
+
+        return (
+            ConversationContext(
+                worktree=actual,
+                provider=broker_run.provider,
+                model=plan.model,
+                effort=plan.effort,
+                permission_mode="unrestricted",
+                title=broker_run.title,
+                env=plan.env,
+            ),
+            int(plan.archive_id),
+        )

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -596,6 +596,27 @@ def open_db():
     return con
 
 
+def browser_conversation_active(con, shell_id: int) -> bool:
+    """Does a durable browser turn currently own this shell's mutation slot?"""
+    try:
+        row = con.execute(
+            "SELECT COUNT(*) FROM conversation_runs WHERE shell_id=? "
+            "AND state IN ('leased','starting','running')",
+            (shell_id,),
+        ).fetchone()
+        return row is not None and int(row[0]) > 0
+    except db_driver.OperationalError as exc:
+        # An older, not-yet-migrated fork has no conversation tables. Its
+        # existing CLI launch path must remain usable. Other DB failures must
+        # stay fail-closed instead of silently permitting a second surface.
+        if "no such table: conversation_runs" in str(exc):
+            return False
+        raise
+    except (IndexError, KeyError, TypeError, ValueError):
+        # Mock/partial databases used by launcher tests do not assert a lease.
+        return False
+
+
 # ── Auth (username-only) ────────────────────────────────────────────────────
 
 def authenticate(con, interactive: bool = True):
@@ -1504,6 +1525,13 @@ def main() -> None:
             if not headless and sys.stdin.isatty() else None)
     chosen = pick_shell(list_shells(con, user["user_id"]), requested, first,
                         fdefaults, snap)
+    if browser_conversation_active(con, chosen["shell_id"]):
+        con.close()
+        sys.exit(
+            f"shell '{chosen['shortname']}' has an active browser turn — "
+            "wait for it to finish or interrupt it in Interface before "
+            "starting a CLI session"
+        )
     slot_context = None
     if slot is not None:
         try:

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -67,6 +67,38 @@ async function api(path, method = "GET", body) {
   return data;
 }
 
+function requestKey() {
+  return globalThis.crypto?.randomUUID?.()
+    || `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+async function chatApi(path, method = "GET", body, idempotencyKey) {
+  const headers = body === undefined ? {} : { "Content-Type": "application/json" };
+  if (idempotencyKey) headers["Idempotency-Key"] = idempotencyKey;
+  let response;
+  try {
+    response = await fetch("/api" + path, {
+      method, headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  } catch (cause) {
+    const error = new Error("The conversation service could not be reached.");
+    error.code = "NETWORK_ERROR";
+    error.cause = cause;
+    throw error;
+  }
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const detail = data.error || {};
+    const error = new Error(detail.message || response.statusText);
+    error.code = detail.code || "CONVERSATION_REQUEST_FAILED";
+    error.details = detail.details || {};
+    error.status = response.status;
+    throw error;
+  }
+  return data;
+}
+
 function toast(msg) {
   const t = el("div", { className: "toast" }, msg);
   document.body.append(t);
@@ -2986,9 +3018,536 @@ async function renderSprints(root) {
     setInterval(sprintsUpdateDurations, SPRINTS_DURATION_MS);
 }
 
+// ── Interface / browser-native conversations ────────────────────────────────
+// A browser conversation is a second, independent way to use a shell. It uses
+// the normal CLI preparation path server-side, but deliberately has no
+// terminal, tmux controls, or live hand-off between browser and CLI.
+const CHAT_HARNESSES = ["opencode", "claude", "codex"];
+const CHAT_FLAVOR_ORDER = ["cartographer", "admin", "planner", "dev", "reviewer", "devops"];
+let chatRouteShell = "";
+let chatRouteConversation = "";
+let chatSource = null;
+let chatRenderGeneration = 0;
+let chatPendingSend = null;
+
+function chatStopStream() {
+  if (chatSource) chatSource.close();
+  chatSource = null;
+}
+
+function chatHash(shortname, conversationId = "") {
+  return `interface/${encodeURIComponent(shortname)}`
+    + (conversationId ? `/${encodeURIComponent(conversationId)}` : "");
+}
+
+function chatRouteLabel(conversation) {
+  const route = conversation.route || {};
+  return [route.harness, route.model || "harness default", route.effort]
+    .filter(Boolean).join(" · ");
+}
+
+function chatStatePill(state) {
+  const label = {
+    queued: "queued", running: "working", waiting: "waiting",
+    error: "failed", idle: "idle", closed: "closed",
+  }[state] || state;
+  return el("span", { className: `chat-state state-${state || "idle"}` }, label);
+}
+
+function chatConversationName(conversation) {
+  return conversation.title
+    || `Chat · ${conversation.route?.harness || "harness"} · `
+      + new Date(`${conversation.created_at}Z`).toLocaleString();
+}
+
+function chatActivity(events) {
+  const rows = [];
+  const tools = new Map();
+  for (const event of events) {
+    if (event.event_type === "tool.started") {
+      const row = { ...event, done: false };
+      tools.set(`${event.run_id}:${event.payload?.tool_call_id || rows.length}`, row);
+      rows.push(row);
+    } else if (event.event_type === "tool.completed") {
+      const key = `${event.run_id}:${event.payload?.tool_call_id || rows.length}`;
+      const prior = tools.get(key);
+      if (prior) {
+        prior.done = true;
+        prior.payload = { ...prior.payload, ...event.payload };
+      } else {
+        rows.push({ ...event, done: true });
+      }
+    } else if (["permission.requested", "input.requested", "run.failed",
+                "run.interrupted", "run.unknown"].includes(event.event_type)) {
+      rows.push(event);
+    }
+  }
+  return rows;
+}
+
+function chatAssistantRuns(events) {
+  const runs = [];
+  const byId = new Map();
+  for (const event of events) {
+    if (event.event_type !== "assistant.delta") continue;
+    const id = event.run_id || `message-${event.message_id || "unknown"}`;
+    let run = byId.get(id);
+    if (!run) {
+      run = {
+        id,
+        text: "",
+        created_at: event.created_at,
+        message_id: event.message_id,
+        sequence: event.sequence,
+      };
+      byId.set(id, run);
+      runs.push(run);
+    }
+    run.text += event.payload?.text || "";
+  }
+  return runs;
+}
+
+function chatBubble(kind, body, meta = "") {
+  const bubble = el("article", { className: `chat-bubble chat-${kind}` });
+  bubble.append(el("div", { className: "chat-who" },
+    kind === "user" ? "FnB" : kind === "assistant" ? "Shell" : "Activity"));
+  bubble.append(kind === "activity"
+    ? el("div", { className: "chat-activity-text" }, body)
+    : mdBlock(body));
+  if (meta) bubble.append(el("div", { className: "chat-meta" }, meta));
+  return bubble;
+}
+
+function chatPaintTranscript(host, messages, events, conversation, retry) {
+  const transcript = el("div", { className: "chat-transcript" });
+  const assistants = chatAssistantRuns(events);
+  const activities = chatActivity(events);
+  const items = [];
+  const addActivity = (activity) => {
+    const payload = activity.payload || {};
+    const type = activity.event_type;
+    const label = type.startsWith("tool.")
+      ? `${activity.done ? "✓" : "…" } ${payload.title || payload.name || "tool"}`
+      : type === "permission.requested" ? "Waiting for permission"
+      : type === "input.requested" ? "Waiting for input"
+      : type === "run.interrupted" ? "Turn interrupted"
+      : type === "run.unknown" ? "Turn outcome could not be proven"
+      : `Turn failed${payload.error ? ` — ${payload.error}` : ""}`;
+    items.push({
+      node: chatBubble("activity", label),
+      failed: false,
+    });
+  };
+  for (const message of [...messages].sort((a, b) => a.message_id - b.message_id)) {
+    if (message.message_kind === "control") continue;
+    items.push({
+      node: chatBubble("user", message.body, message.state),
+      failed: message.state === "failed",
+      text: message.body,
+    });
+    for (const run of assistants.filter((item) => item.message_id === message.message_id))
+      items.push({ node: chatBubble("assistant", run.text), failed: false });
+    for (const activity of activities.filter(
+      (item) => item.message_id === message.message_id))
+      addActivity(activity);
+  }
+  // Conversation-scoped events are uncommon, but keeping them visible is
+  // better than dropping a recovery/error signal whose message link is absent.
+  for (const run of assistants.filter((item) => item.message_id == null))
+    items.push({ node: chatBubble("assistant", run.text), failed: false });
+  for (const activity of activities) {
+    if (activity.message_id == null) addActivity(activity);
+  }
+  for (const item of items) {
+    if (item.failed) {
+      const button = el("button", {
+        className: "chat-retry",
+        type: "button",
+        textContent: "Retry",
+      });
+      button.onclick = () => retry(item.text);
+      item.node.append(button);
+    }
+    transcript.append(item.node);
+  }
+  if (!items.length) {
+    transcript.append(el("div", { className: "chat-empty" },
+      `Start a conversation with ${conversation.shell.display_name}.`));
+  }
+  host.replaceChildren(transcript);
+  requestAnimationFrame(() => { transcript.scrollTop = transcript.scrollHeight; });
+}
+
+async function chatRefreshConversation(conversationId, generation, onUpdate) {
+  try {
+    const next = await chatApi(`/conversations/${conversationId}`);
+    if (generation === chatRenderGeneration) onUpdate(next);
+  } catch { /* SSE remains authoritative enough to keep the open view usable. */ }
+}
+
+function chatOpenStream(conversationId, generation, onEvent, onState) {
+  chatStopStream();
+  const source = new EventSource(`/api/conversations/${conversationId}/events`);
+  chatSource = source;
+  source.onopen = () => onState("connected");
+  source.onerror = () => onState("reconnecting");
+  const types = [
+    "conversation.created", "conversation.updated", "conversation.renamed",
+    "conversation.closed", "message.accepted", "session.started", "run.started",
+    "assistant.delta", "tool.started", "tool.completed", "permission.requested",
+    "input.requested", "usage", "run.completed", "run.failed",
+    "run.interrupted", "run.unknown",
+  ];
+  for (const type of types) {
+    source.addEventListener(type, (raw) => {
+      if (generation !== chatRenderGeneration) return;
+      try { onEvent(JSON.parse(raw.data)); } catch { /* malformed frames reconnect */ }
+    });
+  }
+  return source;
+}
+
+function chatModelOptions(select, catalog, harness, defaultModel) {
+  select.replaceChildren();
+  select.append(el("option", {
+    value: "",
+    textContent: defaultModel
+      ? `Use shell default — ${defaultModel}`
+      : "Use harness default",
+  }));
+  const models = catalog.harnesses?.[harness]?.models || [];
+  for (const model of models) {
+    if (model.availability !== "available") continue;
+    select.append(el("option", { value: model.id, textContent: model.id }));
+  }
+}
+
+async function chatRenderNew(host, shell, defaults, catalog) {
+  const rows = defaults.flavors?.[shell.flavor] || [];
+  const byHarness = Object.fromEntries(rows.map((row) => [row.harness, row]));
+  const defaultHarness = rows.find((row) => row.is_default)?.harness;
+  const availableHarnesses = shell.flavor === "conductor"
+    ? ["opencode"] : CHAT_HARNESSES;
+  let harness = availableHarnesses.includes(defaultHarness)
+    ? defaultHarness : availableHarnesses[0];
+  const form = el("form", { className: "chat-new-form" });
+  const harnessSelect = el("select");
+  for (const value of availableHarnesses) {
+    harnessSelect.append(el("option", {
+      value,
+      selected: value === harness,
+      textContent: value + (value === defaultHarness ? " — shell default" : ""),
+    }));
+  }
+  const modelSelect = el("select");
+  const paintModels = () => {
+    harness = harnessSelect.value;
+    chatModelOptions(modelSelect, catalog, harness, byHarness[harness]?.model);
+  };
+  harnessSelect.onchange = paintModels;
+  paintModels();
+  const title = el("input", {
+    type: "text",
+    placeholder: "Optional chat title",
+    maxlength: 200,
+  });
+  const submit = el("button", {
+    className: "act primary",
+    type: "submit",
+    textContent: "Start chat",
+  });
+  form.append(
+    el("div", { className: "chat-new-copy" },
+      el("h2", {}, `Start a chat with ${shell.display_name}`),
+      el("p", { className: "muted" },
+        "This prepares the shell through its normal CLI path, then runs each turn headlessly.")),
+    el("label", { className: "k" }, "Harness"), harnessSelect,
+    el("label", { className: "k" }, "Model"), modelSelect,
+    el("div", { className: "chat-route-note" },
+      "Choose an exact installed model, or keep the shell/harness default."),
+    el("label", { className: "k" }, "Title"), title,
+    submit,
+  );
+  form.onsubmit = async (event) => {
+    event.preventDefault();
+    submit.disabled = true;
+    submit.textContent = "Starting…";
+    const body = {
+      shell_id: shell.shell_id,
+      harness: harnessSelect.value,
+      title: title.value.trim() || null,
+    };
+    if (modelSelect.value) body.model = modelSelect.value;
+    try {
+      const conversation = await chatApi(
+        "/conversations", "POST", body, requestKey());
+      location.hash = chatHash(shell.shortname, conversation.conversation_id);
+    } catch (error) {
+      toast(`${error.code}: ${error.message}`);
+      submit.disabled = false;
+      submit.textContent = "Start chat";
+    }
+  };
+  host.replaceChildren(form);
+}
+
+async function chatRenderOpen(host, initialConversation, initialMessages) {
+  const generation = chatRenderGeneration;
+  let conversation = initialConversation;
+  let messages = [...initialMessages];
+  const events = [];
+  const seen = new Set();
+  let latestRunId = null;
+
+  const header = el("div", { className: "chat-pane-head" });
+  const title = el("div", { className: "chat-pane-title" });
+  const state = el("div", { className: "chat-pane-state" });
+  const streamState = el("span", { className: "chat-stream-state" }, "connecting");
+  const actions = el("div", { className: "chat-actions" });
+  const transcriptHost = el("div", { className: "chat-transcript-host" });
+  const composer = el("textarea", {
+    className: "chat-composer-input",
+    placeholder: "Message this shell…",
+    rows: 3,
+  });
+  const send = el("button", { className: "act primary", type: "button", textContent: "Send" });
+  const pending = el("div", { className: "chat-pending", hidden: true });
+  const composerRow = el("div", { className: "chat-composer" },
+    composer, el("div", { className: "chat-compose-actions" }, pending, send));
+
+  const retry = async (text) => {
+    composer.value = text;
+    composer.focus();
+    await submit();
+  };
+  const paint = () => {
+    title.replaceChildren(
+      el("h2", {}, chatConversationName(conversation)),
+      el("div", { className: "chat-route" }, chatRouteLabel(conversation)));
+    state.replaceChildren(chatStatePill(conversation.state), streamState);
+    const closed = conversation.state === "closed";
+    composer.disabled = closed;
+    send.disabled = closed;
+    interrupt.disabled = !["queued", "running", "waiting"].includes(conversation.state);
+    close.disabled = !["idle", "waiting", "error"].includes(conversation.state);
+    composer.placeholder = closed ? "This conversation is closed." : "Message this shell…";
+    chatPaintTranscript(transcriptHost, messages, events, conversation, retry);
+  };
+  const refresh = () => chatRefreshConversation(
+    conversation.conversation_id,
+    generation,
+    (next) => { conversation = next; paint(); });
+
+  const rename = el("button", { className: "act", type: "button", textContent: "Rename" });
+  rename.onclick = async () => {
+    const value = (prompt("Conversation title", conversation.title || "") || "").trim();
+    if (!value) return;
+    try {
+      conversation = await chatApi(`/conversations/${conversation.conversation_id}`,
+        "PATCH", { version: conversation.version, title: value });
+      paint();
+    } catch (error) { toast(`${error.code}: ${error.message}`); refresh(); }
+  };
+  const analytics = el("button", { className: "act", type: "button", textContent: "Analytics" });
+  analytics.onclick = () => {
+    anFilters.harness = conversation.route.harness || "";
+    anFilters.model = conversation.route.model || "";
+    location.hash = "analytics";
+  };
+  const interrupt = el("button", { className: "act", type: "button", textContent: "Interrupt" });
+  interrupt.onclick = async () => {
+    interrupt.disabled = true;
+    try {
+      await chatApi(`/conversations/${conversation.conversation_id}/interruptions`,
+        "POST", latestRunId ? { run_id: latestRunId } : {}, requestKey());
+    } catch (error) { toast(`${error.code}: ${error.message}`); }
+    finally { interrupt.disabled = false; }
+  };
+  const close = el("button", { className: "act danger", type: "button", textContent: "Close" });
+  close.onclick = async () => {
+    if (!confirm("Close this conversation? Its transcript will remain available.")) return;
+    try {
+      conversation = await chatApi(`/conversations/${conversation.conversation_id}`,
+        "PATCH", { version: conversation.version, state: "closed" });
+      paint();
+    } catch (error) { toast(`${error.code}: ${error.message}`); refresh(); }
+  };
+  actions.append(rename, analytics, interrupt, close);
+  header.append(title, state, actions);
+
+  async function submit() {
+    const text = composer.value.trim();
+    if (!text || send.disabled) return;
+    if (!chatPendingSend || chatPendingSend.text !== text
+        || chatPendingSend.conversationId !== conversation.conversation_id) {
+      chatPendingSend = {
+        conversationId: conversation.conversation_id,
+        text,
+        key: requestKey(),
+      };
+    }
+    send.disabled = true;
+    pending.hidden = false;
+    pending.textContent = "sending…";
+    try {
+      const result = await chatApi(
+        `/conversations/${conversation.conversation_id}/messages`,
+        "POST", { text }, chatPendingSend.key);
+      if (!messages.some((item) => item.message_id === result.message.message_id))
+        messages.push(result.message);
+      chatPendingSend = null;
+      composer.value = "";
+      pending.hidden = true;
+      conversation.state = "queued";
+      paint();
+      refresh();
+    } catch (error) {
+      pending.hidden = false;
+      pending.textContent = `${error.code} — retry keeps this exact send`;
+      toast(`${error.code}: ${error.message}`);
+    } finally {
+      send.disabled = conversation.state === "closed";
+    }
+  }
+  send.onclick = submit;
+  composer.onkeydown = (event) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submit();
+    }
+  };
+  host.replaceChildren(header, transcriptHost, composerRow);
+  paint();
+  chatOpenStream(
+    conversation.conversation_id,
+    generation,
+    (event) => {
+      if (seen.has(event.sequence)) return;
+      seen.add(event.sequence);
+      events.push(event);
+      if (event.run_id) latestRunId = event.run_id;
+      if (event.event_type === "message.accepted") conversation.state = "queued";
+      if (event.event_type === "run.started") conversation.state = "running";
+      if (["permission.requested", "input.requested"].includes(event.event_type))
+        conversation.state = "waiting";
+      if (["run.completed", "run.interrupted"].includes(event.event_type))
+        conversation.state = "idle";
+      if (["run.failed", "run.unknown"].includes(event.event_type))
+        conversation.state = "error";
+      const message = messages.find((item) => item.message_id === event.message_id);
+      if (message && event.event_type === "run.completed") message.state = "completed";
+      if (message && ["run.failed", "run.unknown"].includes(event.event_type))
+        message.state = "failed";
+      if (message && event.event_type === "run.interrupted")
+        message.state = "cancelled";
+      paint();
+      if (["run.completed", "run.failed", "run.interrupted", "run.unknown",
+           "conversation.renamed", "conversation.closed"].includes(event.event_type))
+        refresh();
+    },
+    (value) => {
+      streamState.textContent = value;
+      streamState.classList.toggle("reconnecting", value === "reconnecting");
+    },
+  );
+}
+
+async function renderInterface(root) {
+  chatStopStream();
+  const generation = ++chatRenderGeneration;
+  root.replaceChildren(el("div", { className: "chat-loading" }, "Loading conversations…"));
+  const [{ shells }, defaults, catalog, allConversations] = await Promise.all([
+    api("/shells"),
+    api("/flavor-defaults"),
+    api("/models").catch(() => ({ harnesses: {}, stale: true })),
+    chatApi("/conversations?limit=100"),
+  ]);
+  if (generation !== chatRenderGeneration) return;
+  if (!shells.length) {
+    root.replaceChildren(el("div", { className: "card muted" }, "No shells."));
+    return;
+  }
+  const shell = shells.find((item) => item.shortname === chatRouteShell) || shells[0];
+  const conversations = allConversations.items.filter(
+    (item) => item.shell.shell_id === shell.shell_id);
+  let selectedId = chatRouteConversation;
+  if (selectedId && !conversations.some((item) => item.conversation_id === selectedId))
+    selectedId = "";
+
+  const layout = el("div", { className: "chat-layout" });
+  const rail = el("aside", { className: "chat-rail" });
+  rail.append(el("div", { className: "chat-rail-title" }, "Shells"));
+  const orderedFlavors = [
+    ...CHAT_FLAVOR_ORDER.filter((flavor) => shells.some((item) => item.flavor === flavor)),
+    ...[...new Set(shells.map((item) => item.flavor || "bespoke"))]
+      .filter((flavor) => !CHAT_FLAVOR_ORDER.includes(flavor)).sort(),
+  ];
+  for (const flavor of orderedFlavors) {
+    rail.append(el("div", { className: "chat-shell-group" }, flavor || "bespoke"));
+    for (const item of shells.filter((candidate) => (candidate.flavor || "bespoke") === flavor)) {
+      const latest = allConversations.items.find(
+        (conversation) => conversation.shell.shell_id === item.shell_id);
+      const button = el("button", {
+        className: "chat-shell" + (item.shell_id === shell.shell_id ? " selected" : ""),
+        type: "button",
+      }, el("span", { className: "chat-shell-name" }, item.display_name));
+      if (latest) button.append(chatStatePill(latest.state));
+      button.onclick = () => { location.hash = chatHash(item.shortname); };
+      rail.append(button);
+    }
+  }
+
+  const side = el("aside", { className: "chat-history" });
+  const newChat = el("button", { className: "act primary", type: "button", textContent: "＋ New chat" });
+  newChat.onclick = () => {
+    chatRouteConversation = "";
+    history.replaceChildren();
+    chatRenderNew(pane, shell, defaults, catalog);
+  };
+  side.append(el("div", { className: "chat-history-head" },
+    el("div", {}, el("b", {}, shell.display_name),
+      el("span", { className: "chat-shortname" }, ` /${shell.shortname}`)),
+    newChat));
+  const history = el("div", { className: "chat-history-list" });
+  for (const conversation of conversations) {
+    const button = el("button", {
+      className: "chat-history-item"
+        + (conversation.conversation_id === selectedId ? " selected" : ""),
+      type: "button",
+    });
+    button.append(el("span", { className: "chat-history-name" },
+      chatConversationName(conversation)),
+      el("span", { className: "chat-history-route" }, chatRouteLabel(conversation)),
+      chatStatePill(conversation.state));
+    button.onclick = () => {
+      location.hash = chatHash(shell.shortname, conversation.conversation_id);
+    };
+    history.append(button);
+  }
+  if (!conversations.length)
+    history.append(el("div", { className: "chat-history-empty" }, "No chats yet."));
+  side.append(history);
+
+  const pane = el("section", { className: "chat-pane" });
+  layout.append(rail, side, pane);
+  root.replaceChildren(layout);
+  if (!selectedId) {
+    await chatRenderNew(pane, shell, defaults, catalog);
+    return;
+  }
+  const [conversation, messagePage] = await Promise.all([
+    chatApi(`/conversations/${selectedId}`),
+    chatApi(`/conversations/${selectedId}/messages?limit=100`),
+  ]);
+  if (generation !== chatRenderGeneration) return;
+  await chatRenderOpen(pane, conversation, messagePage.items);
+}
+
 // ── Tabs + boot ────────────────────────────────────────────────────────────────
 const VIEWS = {
   shells: ["#view-shells", renderShells],
+  interface: ["#view-interface", renderInterface],
   sprints: ["#view-sprints", renderSprints],
   roadmap: ["#view-roadmap", renderRoadmap],
   docs: ["#view-docs", renderDocs],
@@ -3019,7 +3578,9 @@ function show(tab) {
   for (const b of document.querySelectorAll("nav button")) b.classList.toggle("active", b.dataset.tab === tab);
   for (const k of Object.keys(VIEWS)) $(VIEWS[k][0]).hidden = k !== tab;
   document.body.classList.toggle("sprints-view", tab === "sprints");
+  document.body.classList.toggle("interface-view", tab === "interface");
   if (tab !== "sprints") sprintsStopRender();
+  if (tab !== "interface") chatStopStream();
   setDocumentTitle(tab);
   load(tab);
 }
@@ -3032,6 +3593,13 @@ function show(tab) {
 // #shells-default-models.
 function routeFromHash() {
   const raw = location.hash.slice(1);
+  if (raw === "interface" || raw.startsWith("interface/")) {
+    const [, shell = "", conversation = ""] = raw.split("/");
+    chatRouteShell = decodeURIComponent(shell);
+    chatRouteConversation = decodeURIComponent(conversation);
+    show("interface");
+    return;
+  }
   if (raw === "" || raw === "shells" || raw.startsWith("shells-")) {
     shellTab = Object.entries(SHELL_TAB_HASH).find(([, hash]) => hash === raw)?.[0]
       || "harness";

--- a/.super-coder/ui/index.html
+++ b/.super-coder/ui/index.html
@@ -11,6 +11,7 @@
     <h1>subfloor<span id="repo"></span></h1>
     <nav>
       <button data-tab="shells" class="active">Shells</button>
+      <button data-tab="interface">Interface</button>
       <span class="navsep"></span>
       <button data-tab="sprints" hidden>Sprints</button>
       <button data-tab="roadmap">Roadmap</button>
@@ -30,6 +31,7 @@
   </header>
   <main>
     <section id="view-shells" class="view"></section>
+    <section id="view-interface" class="view" hidden></section>
     <section id="view-sprints" class="view" hidden></section>
     <section id="view-roadmap" class="view" hidden></section>
     <section id="view-docs" class="view" hidden></section>

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -70,6 +70,152 @@ main { padding: 1.2rem; flex: 1 0 auto; min-height: 0; }
 .view { display: grid; grid-template-columns: minmax(0, 1fr); gap: 1rem; margin: 0 auto; width: 100%; max-width: 1000px; }
 .view[hidden] { display: none; }  /* class selector would otherwise beat [hidden] */
 
+/* ── Browser-native Interface ───────────────────────────────────────────────
+   The old Interface rail/transcript silhouette, without its embedded terminal
+   or tmux/session-management layer. */
+body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 52px); }
+#view-interface {
+  max-width: none; margin: 0; gap: 0; min-height: calc(100dvh - 52px);
+}
+.chat-loading { color: var(--dim); padding: 2rem; }
+.chat-layout {
+  display: grid; grid-template-columns: 180px 260px minmax(0, 1fr);
+  min-height: calc(100dvh - 52px); background: var(--panel2);
+}
+.chat-rail, .chat-history {
+  min-width: 0; border-right: 1px solid var(--line); background: var(--bg);
+  overflow-y: auto;
+}
+.chat-rail { padding: .8rem .6rem; }
+.chat-rail-title, .chat-shell-group {
+  color: var(--dim); font-size: .66rem; text-transform: uppercase;
+  letter-spacing: .14em; padding: .35rem .55rem;
+}
+.chat-rail-title { color: var(--ink); font-size: .74rem; margin-bottom: .45rem; }
+.chat-shell-group { margin-top: .65rem; border-top: 1px solid var(--line-soft); padding-top: .7rem; }
+.chat-shell {
+  width: 100%; display: flex; align-items: center; gap: .45rem;
+  background: transparent; border: 1px solid transparent; color: var(--dim);
+  border-radius: 8px; padding: .48rem .55rem; cursor: pointer; text-align: left;
+}
+.chat-shell:hover { color: var(--ink); background: var(--panel); }
+.chat-shell.selected { color: var(--ink); border-color: var(--line); background: var(--panel); }
+.chat-shell-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+.chat-history { background: var(--panel); display: flex; flex-direction: column; }
+.chat-history-head {
+  padding: .8rem; border-bottom: 1px solid var(--line);
+  display: flex; align-items: center; gap: .6rem; min-height: 67px;
+}
+.chat-history-head > div { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; }
+.chat-history-head .act { margin: 0; padding: .34rem .65rem; white-space: nowrap; }
+.chat-shortname { color: var(--dim); font: .76rem ui-monospace, monospace; }
+.chat-history-list { overflow-y: auto; padding: .5rem; }
+.chat-history-item {
+  width: 100%; background: transparent; color: var(--dim); border: 1px solid transparent;
+  border-radius: 9px; padding: .6rem; cursor: pointer; text-align: left;
+  display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: .12rem .4rem;
+}
+.chat-history-item:hover { background: var(--accent2); color: var(--ink); }
+.chat-history-item.selected { background: var(--panel2); border-color: var(--line); color: var(--ink); }
+.chat-history-name, .chat-history-route {
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.chat-history-name { grid-column: 1 / -1; font-size: .84rem; }
+.chat-history-route { font-size: .68rem; color: var(--dim); }
+.chat-history-empty { color: var(--dim); padding: 1rem .65rem; font-size: .8rem; }
+.chat-state {
+  display: inline-flex; align-items: center; width: fit-content; flex: none;
+  border: 1px solid var(--line); border-radius: 99px; padding: .06rem .4rem;
+  color: var(--dim); font-size: .64rem; text-transform: uppercase; letter-spacing: .06em;
+}
+.chat-state.state-running, .chat-state.state-queued { color: var(--accent); border-color: rgba(110,168,254,.45); }
+.chat-state.state-waiting { color: var(--warn); border-color: rgba(212,145,74,.45); }
+.chat-state.state-error { color: #ef7d86; border-color: rgba(239,125,134,.45); }
+.chat-state.state-idle { color: var(--ok); border-color: rgba(76,175,125,.4); }
+.chat-state.state-closed { opacity: .6; }
+.chat-pane {
+  min-width: 0; min-height: 0; display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto; background: var(--panel2);
+}
+.chat-pane-head {
+  min-height: 67px; padding: .65rem 1rem; border-bottom: 1px solid var(--line);
+  display: grid; grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center; gap: .8rem; background: var(--bg);
+}
+.chat-pane-title h2 { margin: 0; font-size: .95rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.chat-route { color: var(--dim); font-size: .7rem; margin-top: .08rem; }
+.chat-pane-state { display: flex; align-items: center; gap: .5rem; }
+.chat-stream-state { color: var(--dim); font-size: .68rem; }
+.chat-stream-state.reconnecting { color: var(--warn); }
+.chat-actions { display: flex; align-items: center; gap: .35rem; }
+.chat-actions .act { margin: 0; padding: .3rem .65rem; font-size: .72rem; }
+.chat-actions .danger { color: #ef7d86; }
+.chat-transcript-host { min-height: 0; overflow: hidden; }
+.chat-transcript {
+  height: 100%; overflow-y: auto; padding: 1.2rem clamp(1rem, 4vw, 4rem);
+  display: flex; flex-direction: column; gap: .8rem;
+}
+.chat-bubble {
+  width: fit-content; max-width: min(720px, 82%);
+  border: 1px solid var(--line); border-radius: 12px; padding: .65rem .8rem;
+  background: var(--panel);
+}
+.chat-bubble.chat-user { align-self: flex-end; background: #202936; border-color: #2c3b50; }
+.chat-bubble.chat-assistant { align-self: flex-start; }
+.chat-bubble.chat-activity {
+  align-self: flex-start; background: transparent; border-style: dashed;
+  color: var(--dim); font-size: .78rem; padding: .4rem .65rem;
+}
+.chat-who {
+  color: var(--dim); font-size: .62rem; text-transform: uppercase;
+  letter-spacing: .12em; margin-bottom: .22rem;
+}
+.chat-bubble .md > :first-child { margin-top: 0; }
+.chat-bubble .md > :last-child { margin-bottom: 0; }
+.chat-meta { color: var(--dim); font-size: .64rem; margin-top: .35rem; }
+.chat-retry {
+  margin-top: .4rem; background: transparent; color: var(--accent);
+  border: 0; padding: 0; cursor: pointer; font: inherit; font-size: .72rem;
+}
+.chat-empty {
+  margin: auto; color: var(--dim); text-align: center; padding: 2rem;
+}
+.chat-composer {
+  padding: .8rem clamp(1rem, 4vw, 4rem) 1rem; border-top: 1px solid var(--line);
+  background: var(--bg);
+}
+.chat-composer-input {
+  min-height: 72px; max-height: 220px; resize: vertical;
+  border-radius: 12px; padding: .7rem .8rem;
+}
+.chat-compose-actions {
+  display: flex; align-items: center; justify-content: flex-end; gap: .7rem;
+}
+.chat-compose-actions .act { margin-top: .5rem; }
+.chat-pending { color: var(--warn); font-size: .72rem; }
+.chat-new-form {
+  width: min(620px, calc(100% - 2rem)); margin: auto; padding: 1.4rem;
+  background: var(--panel); border: 1px solid var(--line); border-radius: var(--r);
+}
+.chat-new-copy h2 { margin: 0 0 .25rem; font-size: 1.05rem; }
+.chat-new-copy p { margin: 0 0 1rem; }
+.chat-route-note { color: var(--dim); font-size: .72rem; margin-top: .3rem; }
+.chat-new-form .act { margin-top: 1rem; }
+
+@media (max-width: 900px) {
+  .chat-layout { grid-template-columns: 132px 210px minmax(0, 1fr); }
+  .chat-actions { flex-wrap: wrap; justify-content: flex-end; }
+  .chat-pane-head { align-items: start; }
+}
+@media (max-width: 680px) {
+  .chat-layout { grid-template-columns: 92px minmax(0, 1fr); }
+  .chat-history { display: none; }
+  .chat-shell { justify-content: center; }
+  .chat-shell .chat-state { display: none; }
+  .chat-pane-head { grid-template-columns: minmax(0, 1fr) auto; }
+  .chat-actions { grid-column: 1 / -1; justify-content: flex-start; }
+}
+
 /* ── Tight card rhythm (Skill Assignments / Roadmap / Docs / Flags) ─────────
    Stacked card panels on these tabs sit a small 5px apart. Section headers
    (funnel stages, skill categories) keep enough room to read as group labels;

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -125,6 +125,28 @@ class ConversationApiCase(unittest.TestCase):
         self.assertEqual(status, 201, obj)
         return obj
 
+    def test_create_prepares_never_booted_worktree_on_first_turn(self):
+        worktree = self.root / ".sc-worktrees" / "dev"
+        worktree.rmdir()
+        created = self.create()
+        self.assertEqual(
+            created["route"]["effort"],
+            "high",
+            "headless effort must be resolved and immutable at creation",
+        )
+        self.assertFalse(worktree.exists())
+        con = self.connect()
+        try:
+            row = con.execute(
+                "SELECT worktree,effort FROM conversations "
+                "WHERE conversation_id=?",
+                (created["conversation_id"],),
+            ).fetchone()
+        finally:
+            con.close()
+        self.assertEqual(Path(row["worktree"]), worktree)
+        self.assertEqual(row["effort"], "high")
+
 
 class ConversationResourceTest(ConversationApiCase):
     def test_create_is_idempotent_and_never_exposes_native_identity(self) -> None:

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -285,6 +285,29 @@ class ConversationBrokerCase(unittest.TestCase):
 
 
 class StoreContractTest(ConversationBrokerCase):
+    def test_prepared_shell_archive_is_bound_while_the_run_is_leased(self) -> None:
+        conversation_id = self.add_conversation()
+        self.add_message(conversation_id)
+        con = self.connect()
+        con.execute(
+            "INSERT INTO shell_memory_archives "
+            "(archive_id,shell_id,session_id,date) VALUES (42,1,'session-42','2026-07-29')"
+        )
+        con.commit()
+        con.close()
+        store = BrokerStore(self.db_path)
+        run = store.claim_next("broker")
+
+        store.bind_archive(run.run_id, "broker", 42)
+
+        con = self.connect()
+        row = con.execute(
+            "SELECT archive_id,state FROM conversation_runs WHERE run_id=?",
+            (run.run_id,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(tuple(row), (42, "leased"))
+
     def test_turns_are_ordered_and_terminal_commit_queues_the_next(self) -> None:
         conversation_id = self.add_conversation()
         first = self.add_message(conversation_id)

--- a/tests/test_conversation_launch.py
+++ b/tests/test_conversation_launch.py
@@ -1,0 +1,238 @@
+"""Browser turns use the canonical shell launch path before native dispatch."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+from conversation_broker import BrokerRun, BrokerStore  # noqa: E402
+from conversation_launch import (  # noqa: E402
+    ConversationLaunchError,
+    ConversationLaunchPreparer,
+)
+import run as run_mod  # noqa: E402
+
+
+def apply_schema(con: sqlite3.Connection) -> None:
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+        con.executescript(migration.read_text())
+
+
+def make_run(worktree: Path, *, session_before: str | None = None) -> BrokerRun:
+    return BrokerRun(
+        run_id=7,
+        conversation_id="cv_" + "a" * 32,
+        message_id=8,
+        shell_id=1,
+        harness="codex",
+        provider="openai",
+        model="gpt-test",
+        effort="high",
+        worktree=worktree,
+        title="A chat",
+        body="Do the work",
+        session_before=session_before,
+        session_after=None,
+        runner_ref=None,
+        state="leased",
+    )
+
+
+@pytest.fixture
+def launch_case():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        db_path = root / "shell.db"
+        con = sqlite3.connect(db_path)
+        apply_schema(con)
+        con.execute(
+            "INSERT INTO users (user_id,username,is_active) VALUES (1,'operator',1)"
+        )
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (1,'Dev','dev','dev','prompt',1)"
+        )
+        con.commit()
+        con.close()
+        worktree = root / ".sc-worktrees" / "dev"
+        worktree.mkdir(parents=True)
+        yield db_path, worktree
+
+
+def test_preparer_returns_canonical_environment_and_archive(launch_case):
+    db_path, worktree = launch_case
+    called = []
+
+    def prepare(**kwargs):
+        called.append(kwargs)
+        return SimpleNamespace(
+            cwd=str(worktree),
+            archive_id=42,
+            harness="codex",
+            model="gpt-test",
+            effort="high",
+            env={"SC_API_TOKEN": "shell-token", "MARKER": "prepared"},
+        )
+
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=prepare,
+        liveness=lambda: {"supported": True, "processes": []},
+    )
+    context, archive_id = preparer(make_run(worktree))
+
+    assert archive_id == 42
+    assert context.worktree == worktree
+    assert context.env["SC_API_TOKEN"] == "shell-token"
+    assert context.permission_mode == "unrestricted"
+    assert called == [{
+        "shell_id": 1,
+        "harness": "codex",
+        "model": "gpt-test",
+        "effort": "high",
+        "headless_prompt": "Do the work",
+    }]
+
+
+def test_preparer_refuses_a_cli_process_holding_the_shell(launch_case):
+    db_path, worktree = launch_case
+    called = False
+
+    def prepare(**_kwargs):
+        nonlocal called
+        called = True
+
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=prepare,
+        liveness=lambda: {
+            "supported": True,
+            "processes": [{
+                "pid": 99,
+                "shortname": "dev",
+                "orphaned": False,
+                "claimed": False,
+            }],
+        },
+    )
+    with pytest.raises(ConversationLaunchError) as caught:
+        preparer(make_run(worktree))
+
+    assert caught.value.code == "SHELL_BUSY"
+    assert not called
+
+
+def test_preparer_refuses_an_admin_cli_process_at_the_repo_root(launch_case):
+    db_path, worktree = launch_case
+    con = sqlite3.connect(db_path)
+    con.execute("UPDATE shells SET flavor='admin' WHERE shell_id=1")
+    con.commit()
+    con.close()
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=lambda **_: None,
+        liveness=lambda: {
+            "supported": True,
+            "processes": [],
+            "admin_root_pids": [99],
+        },
+    )
+    with pytest.raises(ConversationLaunchError) as caught:
+        preparer(make_run(worktree))
+    assert caught.value.code == "SHELL_BUSY"
+
+
+def test_preparer_rejects_route_or_worktree_drift(launch_case):
+    db_path, worktree = launch_case
+    other = worktree.parent / "other"
+    other.mkdir()
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=lambda **_: SimpleNamespace(
+            cwd=str(other),
+            archive_id=42,
+            harness="codex",
+            model="gpt-test",
+            effort="high",
+            env={},
+        ),
+        liveness=lambda: {"supported": True, "processes": []},
+    )
+    with pytest.raises(ConversationLaunchError) as caught:
+        preparer(make_run(worktree))
+    assert caught.value.code == "HARNESS_WORKTREE_MISMATCH"
+
+
+def test_preparer_rechecks_liveness_after_canonical_preparation(launch_case):
+    db_path, worktree = launch_case
+    snapshots = iter((
+        {"supported": True, "processes": []},
+        {
+            "supported": True,
+            "processes": [{
+                "pid": 100,
+                "shortname": "dev",
+                "orphaned": False,
+                "claimed": False,
+            }],
+        },
+    ))
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=lambda **_: SimpleNamespace(
+            cwd=str(worktree),
+            archive_id=42,
+            harness="codex",
+            model="gpt-test",
+            effort="high",
+            env={},
+        ),
+        liveness=lambda: next(snapshots),
+    )
+    with pytest.raises(ConversationLaunchError) as caught:
+        preparer(make_run(worktree))
+    assert caught.value.code == "SHELL_BUSY"
+
+
+def test_cli_launch_sees_a_leased_browser_turn(launch_case):
+    db_path, worktree = launch_case
+    con = sqlite3.connect(db_path)
+    con.execute(
+        "INSERT INTO conversations "
+        "(conversation_id,shell_id,owner_user_id,harness,worktree,state,"
+        "creation_idempotency_key,creation_request_hash) "
+        "VALUES (?,?,1,'codex',?,'queued','create','hash')",
+        ("cv_" + "b" * 32, 1, str(worktree)),
+    )
+    message_id = con.execute(
+        "INSERT INTO conversation_messages "
+        "(conversation_id,sender_kind,sender_ref,message_kind,body,idempotency_key,"
+        "request_hash,state) VALUES (?,'user','1','prompt','hello','message','hash','queued')",
+        ("cv_" + "b" * 32,),
+    ).lastrowid
+    con.execute(
+        "INSERT INTO conversation_outbox (conversation_id,message_id) VALUES (?,?)",
+        ("cv_" + "b" * 32, message_id),
+    )
+    con.commit()
+    con.close()
+    assert BrokerStore(db_path).claim_next("browser") is not None
+
+    con = sqlite3.connect(db_path)
+    try:
+        assert run_mod.browser_conversation_active(con, 1)
+        assert not run_mod.browser_conversation_active(con, 999)
+    finally:
+        con.close()

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -1,0 +1,75 @@
+"""Minimal browser-native conversation UI contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
+INDEX = (ROOT / ".super-coder" / "ui" / "index.html").read_text()
+STYLE = (ROOT / ".super-coder" / "ui" / "style.css").read_text()
+
+
+def test_interface_is_a_first_class_reload_safe_view():
+    assert 'data-tab="interface"' in INDEX
+    assert 'id="view-interface"' in INDEX
+    assert 'interface: ["#view-interface", renderInterface]' in APP
+    assert 'raw === "interface" || raw.startsWith("interface/")' in APP
+    assert "chatRouteShell = decodeURIComponent(shell)" in APP
+    assert "chatRouteConversation = decodeURIComponent(conversation)" in APP
+
+
+def test_start_chat_exposes_shell_harness_and_model_without_terminal_controls():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    assert 'const CHAT_HARNESSES = ["opencode", "claude", "codex"]' in interface
+    assert "Use shell default" in interface
+    assert "Use harness default" in interface
+    assert '"Start chat"' in interface
+    assert "shell_id: shell.shell_id" in interface
+    assert "harness: harnessSelect.value" in interface
+    assert "if (modelSelect.value) body.model = modelSelect.value" in interface
+    assert "xterm" not in interface.lower()
+    assert "tmux" not in interface.lower()
+    assert "attach" not in interface.lower()
+
+
+def test_transcript_streams_normalized_events_and_reconnects_natively():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    assert "new EventSource" in interface
+    assert '"assistant.delta"' in interface
+    assert '"tool.started"' in interface
+    assert '"permission.requested"' in interface
+    assert '"input.requested"' in interface
+    assert "source.onerror" in interface
+    assert "reconnecting" in interface
+    assert "mdBlock(body)" in interface
+
+
+def test_composer_is_retry_safe_and_has_turn_controls():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    assert "chatPendingSend.key" in interface
+    assert "retry keeps this exact send" in interface
+    assert 'event.key === "Enter" && !event.shiftKey' in interface
+    assert 'textContent: "Interrupt"' in interface
+    assert 'textContent: "Retry"' in interface
+    assert 'textContent: "Rename"' in interface
+    assert 'textContent: "Close"' in interface
+    assert 'textContent: "Analytics"' in interface
+
+
+def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
+    for selector in (
+        ".chat-layout",
+        ".chat-rail",
+        ".chat-history",
+        ".chat-transcript",
+        ".chat-bubble.chat-user",
+        ".chat-bubble.chat-assistant",
+        ".chat-composer",
+    ):
+        assert selector in STYLE
+    assert "grid-template-columns: 180px 260px minmax(0, 1fr)" in STYLE


### PR DESCRIPTION
Implements Task #95 from Spec #32.

- adds the Interface tab with shell rail, per-shell history, default/explicit harness and model selection, transcript replay, live SSE, retry-safe composer, interruption, retry, rename, close, and analytics links
- prepares every browser turn through the canonical CLI shell path so worktrees, rendered identity, permissions, injected environment, and session archives stay consistent
- records each conversation run's archive and enforces CLI/web mutual exclusion in both directions without live switching
- keeps the surface deliberately terminal-free: no xterm, TMUX controls, multi-client leases, or attach/detach workflow

Verification:
- `./sc test` — 1,521 passed
- `./sc verify`
- live Brave headless capture at 1500×980 reviewed against `INTERFACE TAB.png`
