### PR TITLE
fix: keep updates available during active sprints

### DIFF
--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -17,8 +17,9 @@ kept as `.sc-state/engine.ref.prev` — the engine half of the restore point tha
 makes `./sc rollback` sound (DB + engine restored together).
 
 Flow:
-    1. fetch upstream objects, then run the installed engine's read-only live
-       state guard. A refusal changes no installed file or pin.
+    1. attempt to fast-forward the current checkout with `git pull --ff-only`,
+       then fetch upstream engine objects. Checkout sync failures and active
+       sprints warn but never prevent an engine update.
     2. capture the restore point: the current `engine.ref` → `engine.ref.prev`.
     3. materialize the engine paths at the new ref into the
        gitignored `.super-coder/` dir; write the new `engine.ref`. Per-instance
@@ -484,17 +485,17 @@ def check_local_edits(force: bool) -> None:
         "  - ./sc eject            one-way: stop tracking upstream and own the engine")
 
 
-def sync_source_checkout() -> None:
-    """Fast-forward the SOURCE repo's checkout before reconciling from it.
+def sync_repo_checkout() -> None:
+    """Fast-forward the current repo checkout before reconciling the engine.
 
-    Here the engine is tracked, so the update skips fetch/materialize and lays
-    the floor FROM THE WORKING TREE. A checkout behind its upstream therefore
-    reconciles stale code and reports success — the operator's only defence was
-    remembering to pull first, with no signal on the runs they didn't.
+    Source installs lay the floor FROM THE WORKING TREE, while installed forks
+    may need app changes that accompany a newer engine. In either case, updating
+    from a checkout behind its own upstream can reconcile an incoherent floor
+    and report success.
 
-    Fast-forward ONLY. This never merges, rebases, resets, or changes branch,
-    and it never touches a tree with uncommitted work — the main checkout is the
-    running server's tree and may hold work in flight.
+    Fast-forward ONLY. This never merges, rebases, resets, or changes branch.
+    Git itself protects overlapping uncommitted work; non-overlapping local work
+    is not a reason to skip the fast-forward.
 
     ADVISORY, NEVER BLOCKING (FnB ruling 2026-07-27). Anything that cannot be
     fast-forwarded warns loudly, names the remedy, and lets the update proceed
@@ -512,41 +513,28 @@ def sync_source_checkout() -> None:
     if upstream.returncode != 0 or not tracking:
         print(f"→ engine sync: '{branch}' tracks no upstream — skipped")
         return
-    if git("fetch", "--quiet", check=False).returncode != 0:
-        print(f"! engine sync: fetch failed (offline?) — reconciling against the "
-              f"current tree, which may be behind {tracking}")
-        return
-    behind = git("rev-list", "--count", f"HEAD..{tracking}",
-                 check=False).stdout.strip()
-    if behind in ("", "0"):
-        print(f"→ engine sync: {branch} already current with {tracking}")
-        return
-    if git("status", "--porcelain", check=False).stdout.strip():
-        print(f"! engine sync: {branch} is {behind} commit(s) behind {tracking}, but "
-              f"the checkout has uncommitted changes — not fast-forwarding a tree "
-              f"with work in flight.")
-        print(f"  Updating anyway from the CURRENT tree, so the floor will be "
-              f"{behind} commit(s) stale.")
-        print(f"  To take the newer floor: commit or stash in {REPO_ROOT}, re-run.")
-        return
-    before = git("rev-parse", "--short", "HEAD", check=False).stdout.strip()
+    before = git("rev-parse", "HEAD", check=False).stdout.strip()
     pull = git("pull", "--ff-only", check=False)
     if pull.returncode != 0:
-        print(f"! engine sync: cannot fast-forward {branch} to {tracking} "
-              f"({behind} commit(s) behind) — the branch has diverged.")
+        print(f"! engine sync: `git pull --ff-only` failed for "
+              f"{branch} → {tracking}.")
         print(f"  {pull.stderr.strip().splitlines()[-1] if pull.stderr.strip() else ''}")
         print(f"  Updating anyway from the CURRENT tree — update never merges, "
               f"rebases or resets. Reconcile {REPO_ROOT} by hand for the newer floor.")
         return
-    after = git("rev-parse", "--short", "HEAD", check=False).stdout.strip()
-    print(f"→ engine sync: fast-forwarded {branch} {before} → {after} "
-          f"({behind} commit(s) from {tracking})")
+    after = git("rev-parse", "HEAD", check=False).stdout.strip()
+    if after == before:
+        print(f"→ engine sync: {branch} already current with {tracking}")
+        return
+    advanced = git("rev-list", "--count", f"{before}..{after}",
+                   check=False).stdout.strip()
+    print(f"→ engine sync: fast-forwarded {branch} {before[:7]} → {after[:7]} "
+          f"({advanced or '?'} commit(s) from {tracking})")
 
 
 def fetch_update_ref(branch: str, ref: str | None = None) -> str:
     """Refresh remote objects and resolve the engine ref without touching the
-    installed floor. Git object refresh is the sole mutation allowed before
-    the live-state refusal preflight."""
+    installed engine floor."""
     remote = super_coder_remote()
     if ref:
         # Pin to an explicit upstream version. `git fetch <remote> <ref>` serves
@@ -634,15 +622,15 @@ def active_sprint_ids(db_path: Path | None = None) -> set[int]:
         con.close()
 
 
-def preflight_live_state() -> None:
-    """Refuse before mutation while any structurally ACTIVE sprint exists."""
+def warn_live_state() -> None:
+    """Surface active sprints without withholding the update recovery path."""
     active = active_sprint_ids()
     if not active:
         return
     ids = ", ".join(str(doc_id) for doc_id in sorted(active))
-    sys.exit(
-        "update: refusing — ACTIVE sprint(s) exist: "
-        f"{ids}. Close or freeze every sprint before updating.")
+    print(
+        "! update: ACTIVE sprint(s) exist: "
+        f"{ids} — continuing; sprint rows and board state will be preserved.")
 
 
 def migrate_engine_untrack() -> None:
@@ -703,16 +691,15 @@ def migrate_generated_artifacts_local() -> None:
     )
 
 
-def migrate_or_rebuild(*, live_preflight_done: bool = False) -> None:
+def migrate_or_rebuild(*, live_warning_done: bool = False) -> None:
     if not DB_PATH.exists() or DB_PATH.stat().st_size == 0:
         print("→ no live DB (fresh fork) — building from text")
         rebuild_mod.main([])
         return
-    # Direct callers still get the live guard. update.main passes the explicit
-    # preflight receipt so no second, post-materialization refusal can strand a
-    # half-applied installed floor.
-    if not live_preflight_done:
-        preflight_live_state()
+    # Direct callers still surface the warning. update.main passes the explicit
+    # receipt so the same active sprint is not announced twice.
+    if not live_warning_done:
+        warn_live_state()
     rebuild_mod.backup_existing()  # restore point before any structural change
     print("→ migrate in place (pending migrations → the live DB; data preserved)")
     migrate_mod.migrate(str(DB_PATH))
@@ -849,25 +836,25 @@ def main(argv: list[str]) -> int:
                  "like any other code. (To re-adopt upstream, that's a manual "
                  "re-fork — see README → 'Customize a fork vs diverge from it'.)")
 
-    # Fetch may refresh remote Git objects, but nothing installed is touched
-    # until the CURRENT engine's guard has approved the live floor. In
-    # particular this precedes untracking/ignore edits, engine materialization,
-    # workflow seeding, and both pin files (#528).
+    # Keep the app/source checkout current before reconciling its engine. This
+    # is deliberately advisory: dirty, detached, offline, or diverged checkouts
+    # warn and continue from their current tree. The one allowed mutation is an
+    # explicit fast-forward; update never creates a merge, rebase, or reset.
+    if not no_fetch:
+        sync_repo_checkout()
+
     target_sha = None
     if not source and not no_fetch:
         target_sha = fetch_update_ref(branch, ref=ref)
-    preflight_live_state()
+    warn_live_state()
 
     if source:
         # The source repo IS the engine — it has no upstream to materialize from
         # and must keep tracking .super-coder/. Reconcile its own tree only.
         print("→ super-coder SOURCE repo — engine is tracked here; "
               "skipping fetch/materialize/untrack (reconcile in place only)")
-        # Reconciling in place makes the WORKING TREE the floor's source, so it
-        # has to be current first. --no-fetch keeps its meaning (touch no
-        # network) and is the escape hatch for reconciling a tree deliberately.
-        if not no_fetch:
-            sync_source_checkout()
+        # --no-fetch keeps its meaning (touch no network) and is the escape
+        # hatch for reconciling a tree deliberately.
         no_fetch = True
     else:
         migrate_engine_untrack()  # one-time B7: untrack the engine (idempotent)
@@ -911,7 +898,7 @@ def main(argv: list[str]) -> int:
         print(f"→ expire the sandbox's baked harness CLIs (epoch {epoch})")
         print("  they reinstall on the next image build — `./sc restart` / `make dos-r`")
 
-    migrate_or_rebuild(live_preflight_done=True)
+    migrate_or_rebuild(live_warning_done=True)
 
     print("→ sync skills catalogue (id-stable)")
     sync_skills()

--- a/sc
+++ b/sc
@@ -1573,11 +1573,11 @@ super-coder — forkable shell substrate
   ./sc ensure-harness      install claude + opencode + codex + vibe + kimi if missing (official native installers, no npm)
   ./sc doctor              sandbox readiness: docker (rootless/rootful) + harness login
   ./sc update              fetch + materialize the engine (gitignored dep) + reconcile IN PLACE (migrate, sync skills, map);
-                             refuses while any sprint is ACTIVE
+                             ACTIVE sprints warn and continue; their rows and board state are preserved
                              --no-fetch skips the fetch · --ref <tag|sha> pins a version · blocks on local engine edits (--force discards them)
-                             source repo: no materialize — the floor is reconciled FROM the checkout, so it is fast-forwarded first.
-                             Advisory, never blocking: a tree it cannot fast-forward (uncommitted work, or diverged) WARNS that the
-                             floor will be stale and updates anyway. Never merges, rebases or resets. --no-fetch skips the sync.
+                             first runs git pull --ff-only for any tracked checkout; source repos then reconcile FROM that tree.
+                             Advisory, never blocking: an unsafe/offline pull WARNS and engine update continues from the current
+                             checkout. Update never merges, rebases or resets. --no-fetch skips checkout and engine network sync.
   ./sc update-harnesses    refresh the harness CLIs the SHELLS run: rolls the harness epoch + rebuilds the sandbox image
                              (they are baked, never mounted — so a running sandbox keeps the old ones until ./sc restart)
                              without docker, updates this host's CLIs instead — there the host IS the runtime

--- a/tests/test_operator_surface.py
+++ b/tests/test_operator_surface.py
@@ -162,6 +162,16 @@ class EnterPreAttachPrintTest(unittest.TestCase):
 class HelpChartTest(unittest.TestCase):
     """A live verb absent from the chart is a verb its operator cannot find."""
 
+    def test_update_help_matches_warning_and_ff_only_runtime_contract(self):
+        help_text = sc("help").stdout
+        update_block = help_text.split("./sc update", 1)[1].split(
+            "./sc update-harnesses", 1
+        )[0]
+        self.assertIn("ACTIVE sprints warn and continue", update_block)
+        self.assertIn("git pull --ff-only", update_block)
+        self.assertIn("engine update continues", update_block)
+        self.assertNotIn("refuses while any sprint", update_block)
+
     def test_every_dispatch_verb_is_charted(self):
         help_text = sc("help").stdout
         uncharted = [

--- a/tests/test_update_preflight.py
+++ b/tests/test_update_preflight.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-"""Mutation sentinel for update's installed live-state preflight (#528)."""
+"""Active sprints warn during update but never withhold the recovery path."""
 from __future__ import annotations
 
 import contextlib
-import hashlib
+import io
 import sqlite3
-import subprocess
 import sys
 import tempfile
 import unittest
@@ -17,26 +16,6 @@ SCHEMA = ENGINE / "schema.sql"
 MIGRATIONS = ENGINE / "migrations"
 sys.path.insert(0, str(ENGINE / "scripts"))
 import update  # noqa: E402
-
-
-def fingerprint(paths: list[Path]) -> dict[str, tuple[int, int, str | None]]:
-    out = {}
-    for path in paths:
-        stat = path.stat()
-        digest = None
-        if path.is_file():
-            digest = hashlib.sha256(path.read_bytes()).hexdigest()
-        out[str(path)] = (stat.st_mtime_ns, stat.st_size, digest)
-    return out
-
-
-def git(cwd: Path, *args: str) -> str:
-    return subprocess.run(
-        ["git", "-C", str(cwd), *args],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
 
 
 def build_live_db(path: Path) -> None:
@@ -55,11 +34,11 @@ def build_live_db(path: Path) -> None:
             "VALUES (1,'Admin','AMI','test','test',1,0,1,1)")
         con.execute(
             "INSERT INTO documents (document_id, kind, title, frozen) "
-            "VALUES (59,'doc','SPRINT: update guard',0)")
+            "VALUES (59,'doc','SPRINT: update recovery',0)")
         con.execute(
             "INSERT INTO sprint_units "
             "(sprint_doc_id, seq, unit_title, state) "
-            "VALUES (59,'U1','guard proof','working')")
+            "VALUES (59,'U1','recovery proof','working')")
         con.execute(
             "INSERT INTO sprints (sprint_doc_id, state, legacy) "
             "VALUES (59,'active',1)")
@@ -68,182 +47,88 @@ def build_live_db(path: Path) -> None:
         con.close()
 
 
-class UpdatePreflightSentinelTest(unittest.TestCase):
-    def test_live_refusal_precedes_every_installed_floor_mutation(self):
-        with tempfile.TemporaryDirectory() as raw_tmp:
-            root = Path(raw_tmp)
-            engine = root / ".super-coder"
-            state = root / ".sc-state"
-            workflow = root / ".github" / "workflows"
-            engine.mkdir()
-            state.mkdir()
-            workflow.mkdir(parents=True)
-
-            paths = [
-                root / "sc",
-                engine,
-                engine / "schema.sql",
-                engine / "scripts",
-                engine / "scripts" / "update.py",
-                workflow,
-                workflow / "subfloor-visual-qa.yml",
-                root / ".gitignore",
-                state / "engine.ref.prev",
-                state / "engine.ref",
-            ]
-            for path in paths:
-                if path.suffix == "" and path.name in {"scripts"}:
-                    path.mkdir()
-                elif path in {engine, workflow}:
-                    continue
-                else:
-                    path.write_text(f"sentinel:{path.name}\n")
-
-            before = fingerprint(paths)
-            with mock.patch.multiple(
-                update,
-                REPO_ROOT=root,
-                ENGINE=engine,
-                DB_PATH=engine / "shell_db.db",
-                STATE_DIR=state,
-                ENGINE_REF=state / "engine.ref",
-                ENGINE_REF_PREV=state / "engine.ref.prev",
-                EJECTED_MARKER=state / "ejected",
-            ), mock.patch.object(
-                update, "is_source_repo", return_value=False
-            ), mock.patch.object(
-                update, "fetch_update_ref", return_value="a" * 40
-            ) as fetch, mock.patch.object(
-                update, "active_sprint_ids", return_value={59}
-            ), mock.patch.object(
-                update, "migrate_engine_untrack"
-            ) as untrack, mock.patch.object(
-                update.install_mod, "ensure_gitignore"
-            ) as gitignore, mock.patch.object(
-                update, "materialize_fetched_engine"
-            ) as materialize, mock.patch.object(
-                update, "ensure_workflows"
-            ) as workflows:
-                with self.assertRaises(SystemExit) as ctx:
-                    update.main([])
-
-            self.assertIn("refusing", str(ctx.exception))
-            fetch.assert_called_once()
-            untrack.assert_not_called()
-            gitignore.assert_not_called()
-            materialize.assert_not_called()
-            workflows.assert_not_called()
-            self.assertEqual(
-                fingerprint(paths),
-                before,
-                "update refusal changed installed hashes or mtimes",
-            )
-
-    def test_real_fork_fetch_refusal_preserves_dispatcher_pins_db_and_engine(self):
-        with tempfile.TemporaryDirectory() as raw_tmp:
-            root = Path(raw_tmp)
-            upstream_work = root / "upstream-work"
-            upstream_remote = root / "subfloor.git"
-            fork = root / "fork"
-            upstream_work.mkdir()
-            fork.mkdir()
-
-            git(upstream_work, "init", "-b", "main")
-            git(upstream_work, "config", "user.name", "Update Test")
-            git(upstream_work, "config", "user.email", "update@example.invalid")
-            (upstream_work / ".super-coder" / "migrations").mkdir(parents=True)
-            (upstream_work / "sc").write_text("target dispatcher\n")
-            (upstream_work / ".super-coder" / "schema.sql").write_text(
-                "target engine schema\n")
-            (upstream_work / ".super-coder" / "migrations"
-             / "9999_target.sql").write_text("CREATE TABLE target_new(x);\n")
-            git(upstream_work, "add", ".")
-            git(upstream_work, "commit", "-m", "target floor")
-            subprocess.run(
-                ["git", "clone", "--bare", str(upstream_work),
-                 str(upstream_remote)],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-
-            git(fork, "init", "-b", "main")
-            git(fork, "config", "user.name", "Update Test")
-            git(fork, "config", "user.email", "update@example.invalid")
-            git(fork, "remote", "add", "origin", str(root / "ami-fork.git"))
-            git(fork, "remote", "add", "super-coder", str(upstream_remote))
-            engine = fork / ".super-coder"
-            state = fork / ".sc-state"
-            scripts = engine / "scripts"
-            migrations = engine / "migrations"
-            scripts.mkdir(parents=True)
-            migrations.mkdir()
-            state.mkdir()
-            installed = {
-                fork / "sc": "installed dispatcher\n",
-                engine / "schema.sql": "installed engine schema\n",
-                engine / "engine.manifest": "{\"installed\": true}\n",
-                scripts / "update.py": "installed updater\n",
-                migrations / "0084_installed.sql": "installed migration\n",
-                state / "engine.ref": "1" * 40 + "\n",
-                state / "engine.ref.prev": "0" * 40 + "\n",
-            }
-            for path, content in installed.items():
-                path.write_text(content)
-            db_path = engine / "shell_db.db"
-            build_live_db(db_path)
-            git(fork, "add", ".")
-            git(fork, "commit", "-m", "installed fork floor")
-
-            watched = list(installed)
-            before_files = fingerprint(watched)
-            with contextlib.closing(sqlite3.connect(db_path)) as con:
-                before_ledger = con.execute(
-                    "SELECT filename, applied_at FROM schema_migrations "
-                    "ORDER BY filename").fetchall()
-                before_schema = con.execute(
-                    "SELECT type, name, sql FROM sqlite_master "
-                    "WHERE sql IS NOT NULL ORDER BY type, name").fetchall()
-
-            with mock.patch.multiple(
-                update,
-                REPO_ROOT=fork,
-                ENGINE=engine,
-                DB_PATH=db_path,
-                STATE_DIR=state,
-                ENGINE_REF=state / "engine.ref",
-                ENGINE_REF_PREV=state / "engine.ref.prev",
-                EJECTED_MARKER=state / "ejected",
-            ), mock.patch.object(
-                sys.stdin, "isatty", return_value=False
-            ), self.assertRaises(SystemExit) as ctx:
-                update.main([])
-
-            self.assertIn("refusing", str(ctx.exception))
-            self.assertIn("ACTIVE sprint", str(ctx.exception))
-            self.assertEqual(fingerprint(watched), before_files)
-            with contextlib.closing(sqlite3.connect(db_path)) as con:
-                self.assertEqual(con.execute(
-                    "SELECT filename, applied_at FROM schema_migrations "
-                    "ORDER BY filename").fetchall(), before_ledger)
-                self.assertEqual(con.execute(
-                    "SELECT type, name, sql FROM sqlite_master "
-                    "WHERE sql IS NOT NULL ORDER BY type, name").fetchall(),
-                    before_schema)
+class Stop(Exception):
+    """Sentinel proving main() reached the first installed-floor mutation."""
 
 
-class UpdateActiveSprintGuardTest(unittest.TestCase):
-    def test_active_sprint_refuses_without_consent_path(self):
+class UpdateActiveSprintWarningTest(unittest.TestCase):
+    def test_active_sprints_warn_and_proceed(self):
+        out = io.StringIO()
         with mock.patch.object(
             update, "active_sprint_ids", return_value={59, 60}
-        ), self.assertRaises(SystemExit) as ctx:
-            update.preflight_live_state()
-        self.assertIn("59, 60", str(ctx.exception))
-        self.assertIn("Close or freeze", str(ctx.exception))
+        ), contextlib.redirect_stdout(out):
+            self.assertIsNone(update.warn_live_state())
+        warning = out.getvalue()
+        self.assertIn("ACTIVE sprint(s) exist: 59, 60", warning)
+        self.assertIn("continuing", warning)
+        self.assertIn("preserved", warning)
 
-    def test_no_active_sprint_proceeds(self):
-        with mock.patch.object(update, "active_sprint_ids", return_value=set()):
-            self.assertIsNone(update.preflight_live_state())
+    def test_no_active_sprint_is_quiet(self):
+        out = io.StringIO()
+        with mock.patch.object(
+            update, "active_sprint_ids", return_value=set()
+        ), contextlib.redirect_stdout(out):
+            self.assertIsNone(update.warn_live_state())
+        self.assertEqual(out.getvalue(), "")
+
+    def test_real_active_sprint_warning_does_not_mutate_board_or_lifecycle(self):
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            db_path = Path(raw_tmp) / "shell_db.db"
+            build_live_db(db_path)
+            with contextlib.closing(sqlite3.connect(db_path)) as con:
+                before = (
+                    con.execute(
+                        "SELECT sprint_doc_id,state,closed_at FROM sprints"
+                    ).fetchall(),
+                    con.execute(
+                        "SELECT sprint_doc_id,seq,state FROM sprint_units"
+                    ).fetchall(),
+                    con.execute(
+                        "SELECT document_id,frozen FROM documents "
+                        "WHERE document_id=59"
+                    ).fetchall(),
+                )
+
+            out = io.StringIO()
+            with mock.patch.object(update, "DB_PATH", db_path), \
+                    contextlib.redirect_stdout(out):
+                update.warn_live_state()
+
+            self.assertIn("ACTIVE sprint(s) exist: 59", out.getvalue())
+            with contextlib.closing(sqlite3.connect(db_path)) as con:
+                after = (
+                    con.execute(
+                        "SELECT sprint_doc_id,state,closed_at FROM sprints"
+                    ).fetchall(),
+                    con.execute(
+                        "SELECT sprint_doc_id,seq,state FROM sprint_units"
+                    ).fetchall(),
+                    con.execute(
+                        "SELECT document_id,frozen FROM documents "
+                        "WHERE document_id=59"
+                    ).fetchall(),
+                )
+            self.assertEqual(after, before)
+
+    def test_installed_fork_main_continues_past_active_sprint_warning(self):
+        out = io.StringIO()
+        with mock.patch.object(update, "is_source_repo", return_value=False), \
+                mock.patch.object(update, "sync_repo_checkout") as sync, \
+                mock.patch.object(
+                    update, "fetch_update_ref", return_value="a" * 40
+                ) as fetch, mock.patch.object(
+                    update, "active_sprint_ids", return_value={59}
+                ), mock.patch.object(
+                    update, "migrate_engine_untrack", side_effect=Stop
+                ) as first_mutation, contextlib.redirect_stdout(out):
+            with self.assertRaises(Stop):
+                update.main([])
+
+        sync.assert_called_once()
+        fetch.assert_called_once_with("main", ref=None)
+        first_mutation.assert_called_once()
+        self.assertIn("ACTIVE sprint(s) exist: 59", out.getvalue())
+        self.assertIn("continuing", out.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_update_source_sync.py
+++ b/tests/test_update_source_sync.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Source-repo update fast-forwards its checkout before reconciling from it.
+"""Update fast-forwards its checkout before reconciling the engine.
 
-In the source repo `./sc update` skips fetch/materialize and lays the floor FROM
-THE WORKING TREE, so a stale checkout reconciles stale code and reports success.
-These pin the sync that closes that, and — just as load-bearing — the two cases
-where it must REFUSE rather than touch the tree.
+The source repo lays the floor FROM THE WORKING TREE, while installed forks can
+carry app changes that accompany a newer engine. These pin the checkout sync and
+the cases where it must warn rather than touch the tree.
 """
 from __future__ import annotations
 
@@ -53,7 +52,7 @@ class SourceSyncCase(unittest.TestCase):
         buf = io.StringIO()
         with mock.patch.object(update, "REPO_ROOT", self.work), \
                 contextlib.redirect_stdout(buf):
-            update.sync_source_checkout()
+            update.sync_repo_checkout()
         return buf.getvalue()
 
     def fall_behind(self, n: int = 1) -> str:
@@ -93,31 +92,50 @@ class SourceSyncCase(unittest.TestCase):
         parents = git(self.work, "rev-list", "--parents", "-n", "1", "HEAD").split()
         self.assertEqual(len(parents), 2, f"HEAD is not a linear commit: {parents}")
 
+    def test_sync_invokes_pull_with_explicit_ff_only(self):
+        self.fall_behind()
+        with mock.patch.object(update, "REPO_ROOT", self.work), \
+                mock.patch.object(update, "git", wraps=update.git) as git_spy, \
+                contextlib.redirect_stdout(io.StringIO()):
+            update.sync_repo_checkout()
+        self.assertIn(
+            mock.call("pull", "--ff-only", check=False),
+            git_spy.call_args_list,
+        )
+
     def test_already_current_is_a_quiet_noop(self):
         before = self.head()
         out = self.sync()
         self.assertEqual(self.head(), before)
         self.assertIn("already current", out)
 
-    # ── the declines: warn, leave the tree alone, let the update through ─────
+    # ── local work: pull when safe, warn and continue when Git refuses ────────
     #
     # ADVISORY, NEVER BLOCKING (FnB ruling 2026-07-27): an operator who cannot
     # update is a worse failure than one updating a commit behind. Each leg
     # asserts BOTH halves — the tree is untouched AND the update is not stopped.
 
-    def test_uncommitted_work_warns_and_does_not_block(self):
-        """The main checkout is the running server's tree — never fast-forward
-        one holding work in flight. But never refuse the update over it."""
+    def test_nonoverlapping_uncommitted_work_allows_fast_forward(self):
+        """Git can preserve unrelated work while applying a safe ff-only pull."""
         tip = self.fall_behind()
         (self.work / "scratch.txt").write_text("operator work in flight\n")
-        before = self.head()
-        out = self.sync()   # must NOT raise — SystemExit would fail the test here
-        self.assertEqual(self.head(), before, "fast-forwarded over work in flight")
-        self.assertNotEqual(self.head(), tip)
+        out = self.sync()
+        self.assertEqual(self.head(), tip, "safe fast-forward was skipped")
         self.assertTrue((self.work / "scratch.txt").exists(),
                         "the operator's file was discarded")
-        self.assertIn("uncommitted changes", out)
-        self.assertIn("stale", out, "the warning must say the floor will be stale")
+        self.assertIn("fast-forwarded", out)
+
+    def test_overlapping_uncommitted_work_warns_without_blocking(self):
+        """Git refuses an unsafe pull; update keeps its recovery path open."""
+        tip = self.fall_behind()
+        (self.work / "a.txt").write_text("operator edit\n")
+        before = self.head()
+        out = self.sync()   # must NOT raise — SystemExit would fail the test here
+        self.assertEqual(self.head(), before)
+        self.assertNotEqual(self.head(), tip)
+        self.assertEqual((self.work / "a.txt").read_text(), "operator edit\n")
+        self.assertIn("git pull --ff-only", out)
+        self.assertIn("Updating anyway", out)
 
     def test_diverged_warns_without_merging_resetting_or_blocking(self):
         tip = self.fall_behind()
@@ -127,7 +145,7 @@ class SourceSyncCase(unittest.TestCase):
         before = self.head()
         out = self.sync()   # must NOT raise
         self.assertEqual(self.head(), before, "diverged branch was moved")
-        self.assertIn("diverged", out)
+        self.assertIn("git pull --ff-only", out)
         # the upstream commit must NOT have been merged in
         merged = git(self.work, "branch", "--contains", tip, "--format=%(refname)")
         self.assertEqual(merged, "", "upstream commit was merged despite divergence")
@@ -176,23 +194,43 @@ class SourceSyncWiringCase(unittest.TestCase):
 
     def test_source_repo_update_syncs_before_reconciling(self):
         with mock.patch.object(update, "is_source_repo", return_value=True), \
-                mock.patch.object(update, "preflight_live_state"), \
                 mock.patch.object(update, "ensure_workflows", side_effect=Stop), \
-                mock.patch.object(update, "sync_source_checkout",
+                mock.patch.object(update, "sync_repo_checkout",
                                   side_effect=Stop) as sync, \
                 contextlib.redirect_stdout(io.StringIO()):
             with self.assertRaises(Stop):
                 update.main([])
         sync.assert_called_once()
 
+    def test_installed_fork_syncs_checkout_before_fetching_engine(self):
+        order = []
+
+        def stop_after_fetch(*_args, **_kwargs):
+            order.append("fetch")
+            raise Stop
+
+        with mock.patch.object(update, "is_source_repo", return_value=False), \
+                mock.patch.object(
+                    update, "sync_repo_checkout",
+                    side_effect=lambda: order.append("pull"),
+                ) as sync, mock.patch.object(
+                    update, "fetch_update_ref",
+                    side_effect=stop_after_fetch,
+                ) as fetch, contextlib.redirect_stdout(io.StringIO()):
+            with self.assertRaises(Stop):
+                update.main([])
+        sync.assert_called_once()
+        fetch.assert_called_once_with("main", ref=None)
+        self.assertEqual(order, ["pull", "fetch"])
+
     def test_no_fetch_opts_out_of_the_sync(self):
         """--no-fetch means touch no network; it stays the escape hatch for
         reconciling a tree deliberately. Positive control: the test above shows
         this same harness DOES reach the sync without the flag."""
         with mock.patch.object(update, "is_source_repo", return_value=True), \
-                mock.patch.object(update, "preflight_live_state"), \
+                mock.patch.object(update, "warn_live_state"), \
                 mock.patch.object(update, "ensure_workflows", side_effect=Stop), \
-                mock.patch.object(update, "sync_source_checkout") as sync, \
+                mock.patch.object(update, "sync_repo_checkout") as sync, \
                 contextlib.redirect_stdout(io.StringIO()):
             with self.assertRaises(Stop):
                 update.main(["--no-fetch"])


### PR DESCRIPTION
## Summary
- change active sprint update handling from refusal to warning
- preserve sprint lifecycle, board, and document state during update
- run `git pull --ff-only` for both source installs and installed forks before engine reconciliation
- warn and continue when Git cannot safely fast-forward

## Verification
- `python3 -m unittest -v tests.test_update_preflight tests.test_update_source_sync`
- `python3 -m unittest discover -v -s tests -p 'test_update*.py'`
- `./sc map`
- `./sc render-check`
- `./sc verify`
- `./sc test` — 1524 passed
- `git diff --check`