### PR TITLE
fix: derive OpenCode routes from connected providers

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -451,6 +451,14 @@ def _create_conversation(con, operator: dict, headers, body: dict):
     if model is None and defaults:
         model = defaults["models"].get(harness)
     model = _nonblank(model, "model", maximum=255, optional=True)
+    if harness == "opencode" and model is None:
+        con.rollback()
+        raise ApiError(
+            422,
+            "HARNESS_MODEL_REQUIRED",
+            "OpenCode browser conversations require an exact model from a "
+            "provider connected in OpenCode",
+        )
     effort = _nonblank(body.get("effort"), "effort", maximum=64, optional=True)
     adapter = run_mod.load_adapter(harness)
     if effort is None:

--- a/.super-coder/api/model_catalog.py
+++ b/.super-coder/api/model_catalog.py
@@ -10,7 +10,9 @@ of this is load-bearing — a source that fails just thins the suggestions:
      newest-first sorting.
   2. Provider list-models APIs — only when the matching env key is present.
      Harness logins are OAuth, not API keys, so these are usually absent.
-  3. `opencode models` CLI — exactly what the local install can resolve.
+  3. OpenCode's loopback `/provider` projection — only providers OpenCode
+     reports as connected, with exactly the models each connected provider
+     exposes. This live overlay is refreshed on every served catalog.
   4. A static floor (the ids the engine ships in flavor_defaults) when every
      live source fails and no cache exists.
 
@@ -19,7 +21,7 @@ Fetched server-side (no CORS), cached under the gitignored .super-coder/logs/
 dirty the tree and trip the publish guard) with a TTL; a failed refresh serves
 the stale cache and says so.
 
-Payload v3 exposes the flat `models` list consumed by the shared searchable
+Payload v4 exposes the flat `models` list consumed by the shared searchable
 picker. Legacy `families` metadata remains for API compatibility but is not a
 selection surface: the harness is the only picker prefilter, and family-null
 local routes are ordinary results. Entries carry their route source, local
@@ -31,10 +33,14 @@ import json
 import os
 import shutil
 import subprocess
-import tomllib
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+
+import tomllib
+from conversation_adapters.opencode import (
+    connected_models as opencode_connected_models,
+)
 
 ENGINE = Path(__file__).resolve().parents[1]
 CACHE = ENGINE / "logs" / "model_catalog.json"
@@ -65,7 +71,7 @@ CLAUDE_ALIASES = ["fable", "opus", "sonnet", "haiku"]
 # Bump when the response/cache shape changes — a cached payload from another
 # version is ignored (treated as no cache) instead of being served to a
 # client that expects the new shape.
-PAYLOAD_VERSION = 3
+PAYLOAD_VERSION = 4
 
 # provider APIs, keyed by harness: (env var, url, header builder). Responses
 # are the OpenAI-style {"data": [{"id": ...}, ...]} shape on all three.
@@ -129,7 +135,7 @@ def _from_models_dev(fetch) -> dict[str, list[dict]]:
 
 
 def _families(harness: str, entries: list[dict]) -> list[dict]:
-    """Retained v3 compatibility metadata, not a picker selection surface.
+    """Retained compatibility metadata, not a picker selection surface.
 
     `latest` is the newest
     release in the family — except claude families with a CLI alias
@@ -169,28 +175,6 @@ def _from_provider_apis(fetch, env) -> dict[str, list[dict]]:
                 _entry(i, source=f"{HARNESS_PROVIDER[harness]}-api",
                        provider=HARNESS_PROVIDER[harness]) for i in ids]
     return out
-
-
-def _from_opencode_cli(run) -> list[dict]:
-    """`opencode models` lists provider/model ids the LOCAL install resolves —
-    the most accurate opencode source, merged in when the binary exists."""
-    if not shutil.which("opencode"):
-        return []
-    try:
-        r = run(["opencode", "models"], capture_output=True, text=True,
-                timeout=15)
-    except Exception:
-        return []
-    if r.returncode != 0:
-        return []
-    # The CLI lists every provider/model the install resolves (hundreds).
-    # ollama-cloud leads (the engine's opencode defaults live there), the
-    # rest sorted — the datalist filters as the operator types.
-    ids = sorted({line.strip() for line in r.stdout.splitlines()
-                  if "/" in line.strip() and " " not in line.strip()},
-                 key=lambda i: (not i.startswith("ollama-cloud/"), i))
-    return [_entry(i, source="opencode-cli", availability="available",
-                   provider=i.split("/", 1)[0]) for i in ids]
 
 
 def _cli_version(binary: str, run) -> str | None:
@@ -304,10 +288,6 @@ def build(fetch=_http_json, env=os.environ, run=subprocess.run) -> dict:
     for harness, extra in _from_provider_apis(fetch, env).items():
         harnesses[harness] = _merge(harnesses.get(harness, []), extra)
         sources.append(f"{HARNESS_PROVIDER[harness]}-api")
-    oc = _from_opencode_cli(run)
-    if oc:
-        harnesses["opencode"] = _prefer(oc, harnesses.get("opencode", []))
-        sources.append("opencode-cli")
     local = {
         "claude": _from_claude_cli(run),
         "codex": _from_codex_cache(env, run),
@@ -417,8 +397,47 @@ def _served(payload: dict, con=None) -> dict:
     return payload
 
 
+def _with_live_opencode(payload: dict, provider_models) -> dict:
+    """Replace advisory OpenCode routes with its live connected-provider set."""
+    result = {**payload}
+    harnesses = dict(payload.get("harnesses") or {})
+    sources = [
+        source for source in (payload.get("sources") or [])
+        if source != "opencode-provider-api"
+    ]
+    entries = []
+    error = None
+    if shutil.which("opencode"):
+        try:
+            entries = [
+                _entry(
+                    model["id"],
+                    model.get("release_date") or "",
+                    model.get("name") or model["id"],
+                    model.get("family"),
+                    source="opencode-provider-api",
+                    availability="available",
+                    provider=model.get("provider"),
+                    provider_model=model.get("provider_model"),
+                )
+                for model in provider_models()
+            ]
+            sources.append("opencode-provider-api")
+        except Exception as exc:  # noqa: BLE001
+            error = str(exc)
+    harnesses["opencode"] = {
+        "families": _families("opencode", entries),
+        "models": entries,
+        **({"error": error} if error else {}),
+    }
+    result["harnesses"] = harnesses
+    result["sources"] = sources
+    return result
+
+
 def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
-            run=subprocess.run, con=None) -> dict:
+            run=subprocess.run, con=None,
+            opencode_provider=opencode_connected_models) -> dict:
     """The cached-with-fallbacks entry point the API serves.
 
     fresh cache → serve it; miss/stale/refresh → live sweep, cache the result;
@@ -426,15 +445,23 @@ def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
     carries `stale` + `fetched_at` so the GUI can say how current it is."""
     cached = _load_cache()
     if cached and not refresh and _fresh(cached):
-        return _served({**cached, "stale": False}, con)
+        return _served(_with_live_opencode(
+            {**cached, "stale": False}, opencode_provider), con)
     try:
         fresh = build(fetch, env, run)
     except Exception as e:  # noqa: BLE001
         if cached:
-            return _served({**cached, "stale": True, "error": str(e)}, con)
-        return _served({"v": PAYLOAD_VERSION, "fetched_at": None,
-                        "sources": ["static"], "stale": True,
-                        "error": str(e), "harnesses": _floor()}, con)
+            return _served(_with_live_opencode(
+                {**cached, "stale": True, "error": str(e)},
+                opencode_provider,
+            ), con)
+        return _served(_with_live_opencode(
+            {"v": PAYLOAD_VERSION, "fetched_at": None,
+             "sources": ["static"], "stale": True,
+             "error": str(e), "harnesses": _floor()},
+            opencode_provider,
+        ), con)
     CACHE.parent.mkdir(parents=True, exist_ok=True)
     CACHE.write_text(json.dumps(fresh, indent=1) + "\n")
-    return _served({**fresh, "stale": False}, con)
+    return _served(_with_live_opencode(
+        {**fresh, "stale": False}, opencode_provider), con)

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -260,7 +260,14 @@ class OpenCodeAdapter(ConversationAdapter):
         if not context.model:
             return None
         if context.provider:
-            return context.provider, context.model
+            prefix = f"{context.provider}/"
+            model = (
+                context.model.removeprefix(prefix)
+                if context.model.startswith(prefix)
+                else context.model
+            )
+            if model:
+                return context.provider, model
         if "/" in context.model:
             provider, model = context.model.split("/", 1)
             if provider and model:

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -2,11 +2,20 @@
 """OpenCode server-backed conversation adapter."""
 from __future__ import annotations
 
+import atexit
+import os
+import secrets
+import shutil
+import subprocess
+import threading
+import time
 import uuid
+from collections.abc import Iterator, Mapping
 from pathlib import Path
-from typing import Any, Iterator, Mapping
+from typing import Any
 
 from .base import (
+    TERMINAL_EVENTS,
     AdapterError,
     ConversationAdapter,
     ConversationContext,
@@ -17,13 +26,197 @@ from .base import (
     ProbeResult,
     ReconcileResult,
     SessionInspection,
-    TERMINAL_EVENTS,
     UrlHttpTransport,
     ensure_exact_session,
     ensure_nonempty_message,
     load_manifest,
     terminal_outcome,
 )
+
+ENGINE = Path(__file__).resolve().parents[2]
+SERVER_ENDPOINT = "http://127.0.0.1:4096"
+SERVER_LOG = ENGINE / "logs" / "opencode-server.log"
+_SERVER_LOCK = threading.RLock()
+_SERVER_PROCESS: subprocess.Popen | None = None
+_SERVER_PASSWORD: str | None = None
+_SERVER_LOG_HANDLE = None
+
+
+def _server_healthy(password: str | None) -> bool:
+    try:
+        health = UrlHttpTransport(
+            SERVER_ENDPOINT,
+            password=password,
+            timeout=1.0,
+        ).request("GET", "/global/health")
+    except AdapterError:
+        return False
+    return bool(
+        isinstance(health, dict)
+        and health.get("healthy")
+        and isinstance(health.get("version"), str)
+    )
+
+
+def ensure_server(*, timeout: float = 10.0) -> str | None:
+    """Return the credential for a healthy loopback ``opencode serve``.
+
+    Browser conversations are server-backed, so the engine owns the local
+    sidecar lifecycle instead of requiring an operator to start it by hand.
+    An already-running compatible server is reused. A server started here is
+    loopback-only and protected with an in-memory Basic Auth password.
+    """
+    global _SERVER_PROCESS, _SERVER_PASSWORD, _SERVER_LOG_HANDLE
+    with _SERVER_LOCK:
+        configured_password = os.environ.get("OPENCODE_SERVER_PASSWORD")
+        candidate_passwords = []
+        for password in (_SERVER_PASSWORD, configured_password, None):
+            if password not in candidate_passwords:
+                candidate_passwords.append(password)
+        for password in candidate_passwords:
+            if _server_healthy(password):
+                _SERVER_PASSWORD = password
+                return password
+
+        if _SERVER_PROCESS is not None and _SERVER_PROCESS.poll() is None:
+            raise AdapterError(
+                "HARNESS_UNAVAILABLE",
+                "managed OpenCode server is running but failed its health check",
+                retryable=True,
+            )
+
+        binary = shutil.which("opencode")
+        if not binary:
+            raise AdapterError(
+                "HARNESS_UNAVAILABLE",
+                "opencode executable is not installed",
+                retryable=True,
+            )
+
+        password = configured_password or secrets.token_urlsafe(32)
+        env = dict(os.environ)
+        env["OPENCODE_SERVER_PASSWORD"] = password
+        env.setdefault("OPENCODE_SERVER_USERNAME", "opencode")
+        env["OPENCODE_DISABLE_CLAUDE_CODE"] = "1"
+        SERVER_LOG.parent.mkdir(parents=True, exist_ok=True)
+        _SERVER_LOG_HANDLE = SERVER_LOG.open("a")
+        try:
+            _SERVER_PROCESS = subprocess.Popen(
+                [
+                    binary,
+                    "serve",
+                    "--hostname",
+                    "127.0.0.1",
+                    "--port",
+                    "4096",
+                    "--log-level",
+                    "WARN",
+                ],
+                stdin=subprocess.DEVNULL,
+                stdout=_SERVER_LOG_HANDLE,
+                stderr=subprocess.STDOUT,
+                env=env,
+                start_new_session=True,
+            )
+        except OSError as exc:
+            _SERVER_LOG_HANDLE.close()
+            _SERVER_LOG_HANDLE = None
+            raise AdapterError(
+                "HARNESS_UNAVAILABLE",
+                f"could not start opencode serve: {exc}",
+                retryable=True,
+            ) from exc
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if _SERVER_PROCESS.poll() is not None:
+                break
+            if _server_healthy(password):
+                _SERVER_PASSWORD = password
+                return password
+            time.sleep(0.05)
+
+        exit_code = _SERVER_PROCESS.poll()
+        stop_server()
+        detail = (
+            f"exited with code {exit_code}"
+            if exit_code is not None
+            else f"did not become healthy within {timeout:g}s"
+        )
+        raise AdapterError(
+            "HARNESS_UNAVAILABLE",
+            f"opencode serve {detail}; see {SERVER_LOG}",
+            retryable=True,
+        )
+
+
+def stop_server() -> None:
+    """Stop only the OpenCode server process this module started."""
+    global _SERVER_PROCESS, _SERVER_PASSWORD, _SERVER_LOG_HANDLE
+    with _SERVER_LOCK:
+        process = _SERVER_PROCESS
+        _SERVER_PROCESS = None
+        _SERVER_PASSWORD = None
+        if process is not None and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=3)
+        if _SERVER_LOG_HANDLE is not None:
+            _SERVER_LOG_HANDLE.close()
+            _SERVER_LOG_HANDLE = None
+
+
+def provider_state() -> dict[str, Any]:
+    """Return OpenCode's authoritative provider/model connection projection."""
+    password = ensure_server()
+    result = UrlHttpTransport(
+        SERVER_ENDPOINT,
+        password=password,
+        timeout=10.0,
+    ).request("GET", "/provider")
+    if not isinstance(result, dict):
+        raise AdapterError(
+            "HARNESS_PROTOCOL_ERROR",
+            "OpenCode provider response was not an object",
+        )
+    return result
+
+
+def connected_models(state: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
+    """Flatten models belonging to providers OpenCode reports as connected."""
+    state = state or provider_state()
+    connected = {
+        item for item in (state.get("connected") or []) if isinstance(item, str)
+    }
+    models: list[dict[str, Any]] = []
+    for provider in state.get("all") or []:
+        if not isinstance(provider, dict) or provider.get("id") not in connected:
+            continue
+        provider_id = provider["id"]
+        for model_id, model in (provider.get("models") or {}).items():
+            if not isinstance(model_id, str) or not isinstance(model, dict):
+                continue
+            status = model.get("status")
+            if status not in (None, "active"):
+                continue
+            models.append(
+                {
+                    "id": f"{provider_id}/{model_id}",
+                    "provider": provider_id,
+                    "provider_model": model_id,
+                    "name": model.get("name") or model_id,
+                    "family": model.get("family"),
+                    "release_date": model.get("release_date") or "",
+                    "status": status or "active",
+                }
+            )
+    return sorted(models, key=lambda item: (item["provider"], item["id"]))
+
+
+atexit.register(stop_server)
 
 
 class OpenCodeAdapter(ConversationAdapter):
@@ -32,16 +225,19 @@ class OpenCodeAdapter(ConversationAdapter):
     def __init__(
         self,
         *,
-        endpoint: str = "http://127.0.0.1:4096",
+        endpoint: str = SERVER_ENDPOINT,
         password: str | None = None,
         transport: HttpTransport | None = None,
         manifest: Mapping[str, Any] | None = None,
     ) -> None:
         super().__init__(manifest or load_manifest(self.harness))
-        self.transport = transport or UrlHttpTransport(
-            endpoint,
-            password=password,
-        )
+        if transport is not None:
+            self.transport = transport
+        else:
+            self.transport = UrlHttpTransport(
+                endpoint,
+                password=password if password is not None else ensure_server(),
+            )
 
     def probe(self) -> ProbeResult:
         health = self.transport.request("GET", "/global/health")

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3210,17 +3210,30 @@ function chatOpenStream(conversationId, generation, onEvent, onState) {
 
 function chatModelOptions(select, catalog, harness, defaultModel) {
   select.replaceChildren();
-  select.append(el("option", {
-    value: "",
-    textContent: defaultModel
-      ? `Use shell default — ${defaultModel}`
-      : "Use harness default",
-  }));
   const models = catalog.harnesses?.[harness]?.models || [];
-  for (const model of models) {
-    if (model.availability !== "available") continue;
+  const available = models.filter((model) => model.availability === "available");
+  const connectedDefault = Boolean(
+    defaultModel && available.some((model) => model.id === defaultModel));
+  if (harness !== "opencode" || connectedDefault) {
+    select.append(el("option", {
+      value: "",
+      textContent: defaultModel
+        ? `Use shell default — ${defaultModel}`
+        : "Use harness default",
+    }));
+  }
+  for (const model of available) {
     select.append(el("option", { value: model.id, textContent: model.id }));
   }
+  if (!select.options.length) {
+    select.append(el("option", {
+      value: "",
+      textContent: "No connected provider models available",
+      disabled: true,
+      selected: true,
+    }));
+  }
+  return harness !== "opencode" || available.length > 0;
 }
 
 async function chatRenderNew(host, shell, defaults, catalog) {
@@ -3241,12 +3254,6 @@ async function chatRenderNew(host, shell, defaults, catalog) {
     }));
   }
   const modelSelect = el("select");
-  const paintModels = () => {
-    harness = harnessSelect.value;
-    chatModelOptions(modelSelect, catalog, harness, byHarness[harness]?.model);
-  };
-  harnessSelect.onchange = paintModels;
-  paintModels();
   const title = el("input", {
     type: "text",
     placeholder: "Optional chat title",
@@ -3257,6 +3264,18 @@ async function chatRenderNew(host, shell, defaults, catalog) {
     type: "submit",
     textContent: "Start chat",
   });
+  const routeNote = el("div", { className: "chat-route-note" });
+  const paintModels = () => {
+    harness = harnessSelect.value;
+    const ready = chatModelOptions(
+      modelSelect, catalog, harness, byHarness[harness]?.model);
+    submit.disabled = !ready;
+    routeNote.textContent = harness === "opencode"
+      ? "OpenCode models come only from providers connected in OpenCode."
+      : "Choose an exact installed model, or keep the shell/harness default.";
+  };
+  harnessSelect.onchange = paintModels;
+  paintModels();
   form.append(
     el("div", { className: "chat-new-copy" },
       el("h2", {}, `Start a chat with ${shell.display_name}`),
@@ -3264,8 +3283,7 @@ async function chatRenderNew(host, shell, defaults, catalog) {
         "This prepares the shell through its normal CLI path, then runs each turn headlessly.")),
     el("label", { className: "k" }, "Harness"), harnessSelect,
     el("label", { className: "k" }, "Model"), modelSelect,
-    el("div", { className: "chat-route-note" },
-      "Choose an exact installed model, or keep the shell/harness default."),
+    routeNote,
     el("label", { className: "k" }, "Title"), title,
     submit,
   );

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -8,9 +8,9 @@ import signal
 import sys
 import tempfile
 import unittest
+from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Any, Iterable, Mapping
-
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".super-coder" / "scripts"
@@ -553,6 +553,35 @@ class ConversationAdapterTest(unittest.TestCase):
         recovered = adapter.reconcile(fresh, self.context)
         self.assertEqual(recovered.outcome, "unknown")
         self.assertFalse(recovered.proven)
+
+    def test_opencode_strips_the_selected_provider_prefix_from_model_id(
+        self,
+    ) -> None:
+        adapter, native = self.build("opencode")
+        context = ConversationContext(
+            worktree=self.root,
+            provider="openai",
+            model="openai/gpt-5.6-terra-fast",
+        )
+        adapter.start(context, "hello")
+        create = next(
+            request
+            for request in native.requests
+            if request[:2] == ("POST", "/session")
+        )
+        prompt = next(
+            request
+            for request in native.requests
+            if request[1].endswith("/prompt_async")
+        )
+        self.assertEqual(
+            create[3]["model"],
+            {"providerID": "openai", "id": "gpt-5.6-terra-fast"},
+        )
+        self.assertEqual(
+            prompt[3]["model"],
+            {"providerID": "openai", "modelID": "gpt-5.6-terra-fast"},
+        )
 
     def test_claude_uses_exact_start_and_resume_flags_and_sigint(
         self,

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -149,6 +149,41 @@ class ConversationApiCase(unittest.TestCase):
 
 
 class ConversationResourceTest(ConversationApiCase):
+    def test_opencode_requires_an_exact_resolved_model(self) -> None:
+        with mock.patch.object(
+            conversation_routes.run_mod,
+            "flavor_defaults",
+            return_value={
+                "dev": {
+                    "default_harness": "opencode",
+                    "models": {},
+                }
+            },
+        ):
+            status, _, error = self.request(
+                "POST",
+                "/api/conversations",
+                body={"shell_id": 1, "harness": "opencode"},
+                key="opencode-no-model",
+            )
+        self.assertEqual(status, 422)
+        self.assertEqual(error["error"]["code"], "HARNESS_MODEL_REQUIRED")
+        self.assertIn("provider connected in OpenCode",
+                      error["error"]["message"])
+
+        status, _, created = self.request(
+            "POST",
+            "/api/conversations",
+            body={
+                "shell_id": 1,
+                "harness": "opencode",
+                "model": "openai/gpt-connected",
+            },
+            key="opencode-exact-model",
+        )
+        self.assertEqual(status, 201, created)
+        self.assertEqual(created["route"]["model"], "openai/gpt-connected")
+
     def test_create_is_idempotent_and_never_exposes_native_identity(self) -> None:
         first = self.create(title="API")
         second = self.create(title="API")

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -26,6 +26,10 @@ def test_start_chat_exposes_shell_harness_and_model_without_terminal_controls():
     assert 'const CHAT_HARNESSES = ["opencode", "claude", "codex"]' in interface
     assert "Use shell default" in interface
     assert "Use harness default" in interface
+    assert 'harness !== "opencode" || connectedDefault' in interface
+    assert "No connected provider models available" in interface
+    assert "providers connected in OpenCode" in interface
+    assert "submit.disabled = !ready" in interface
     assert '"Start chat"' in interface
     assert "shell_id: shell.shell_id" in interface
     assert "harness: harnessSelect.value" in interface

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -2,8 +2,8 @@
 """Tests for the model-catalog service (api/model_catalog.py).
 
 The catalog is layered and best-effort: models.dev (keyless, all five
-harnesses) → provider APIs (only with env keys) → `opencode models` CLI →
-cache → static floor. Payload v3 retains family metadata for compatibility:
+harnesses) → provider APIs (only with env keys) → OpenCode's connected-provider
+projection → cache → static floor. Payload v4 retains family metadata:
 (newest-first; claude families with a CLI alias resolve `latest` to the
 alias) plus the flat `models` list for sub-version search. These tests pin
 that contract: harness→provider mapping and opencode prefixing, family
@@ -120,17 +120,44 @@ class BuildTest(NoCLI):
         got = mc.build(fetch=fetch, env={"OPENAI_API_KEY": "bad"}, run=None)
         self.assertEqual(got["sources"], ["models.dev"])
 
-    def test_opencode_cli_merges_ollama_cloud_first(self):
+    def test_opencode_live_overlay_keeps_only_connected_provider_models(self):
         with mock.patch.object(mc.shutil, "which", return_value="/usr/bin/opencode"):
-            def run(cmd, **kw):
-                return mock.Mock(returncode=0,
-                                 stdout="zprovider/zeta\nollama-cloud/glm-5.1\n"
-                                        "not a model line\n")
-            got = mc.build(fetch=fetch_ok, env={}, run=run)
+            got = mc._with_live_opencode(
+                mc.build(fetch=fetch_ok, env={}, run=None),
+                lambda: [
+                    {
+                        "id": "openai/gpt-connected",
+                        "provider": "openai",
+                        "provider_model": "gpt-connected",
+                        "name": "GPT Connected",
+                        "family": "gpt",
+                        "release_date": "2026-07-01",
+                    },
+                    {
+                        "id": "ollama-cloud/glm-connected",
+                        "provider": "ollama-cloud",
+                        "provider_model": "glm-connected",
+                        "name": "GLM Connected",
+                        "family": "glm",
+                        "release_date": "2026-06-01",
+                    },
+                ],
+            )
         self.assertEqual(ids(got["harnesses"]["opencode"]),
-                         ["ollama-cloud/glm-5.1", "zprovider/zeta",
-                          "ollama-cloud/deepseek-v4-pro"])
-        self.assertIn("opencode-cli", got["sources"])
+                         ["openai/gpt-connected",
+                          "ollama-cloud/glm-connected"])
+        self.assertTrue(all(
+            model["availability"] == "available"
+            for model in got["harnesses"]["opencode"]["models"]
+        ))
+        self.assertIn("opencode-provider-api", got["sources"])
+
+    def test_opencode_without_local_runtime_exposes_no_available_routes(self):
+        got = mc._with_live_opencode(
+            mc.build(fetch=fetch_ok, env={}, run=None),
+            lambda: self.fail("provider API must not run without opencode"),
+        )
+        self.assertEqual(ids(got["harnesses"]["opencode"]), [])
 
     def test_all_sources_down_raises(self):
         with self.assertRaises(RuntimeError):
@@ -256,6 +283,45 @@ class CatalogCacheTest(NoCLI):
         self.assertFalse(second["stale"], "fresh cache must serve without a fetch")
         self.assertEqual(second["harnesses"], first["harnesses"])
 
+    def test_fresh_cache_still_refreshes_connected_opencode_models(self):
+        provider_models = mock.Mock(side_effect=[
+            [{
+                "id": "openai/first",
+                "provider": "openai",
+                "provider_model": "first",
+            }],
+            [{
+                "id": "anthropic/second",
+                "provider": "anthropic",
+                "provider_model": "second",
+            }],
+        ])
+        with mock.patch.object(
+            mc.shutil, "which", return_value="/usr/bin/opencode"
+        ):
+            first = mc.catalog(
+                fetch=fetch_ok,
+                env={},
+                run=None,
+                opencode_provider=provider_models,
+            )
+            second = mc.catalog(
+                fetch=fetch_down,
+                env={},
+                run=None,
+                opencode_provider=provider_models,
+            )
+        self.assertEqual(
+            ids(first["harnesses"]["opencode"]),
+            ["openai/first"],
+        )
+        self.assertEqual(
+            ids(second["harnesses"]["opencode"]),
+            ["anthropic/second"],
+        )
+        self.assertFalse(second["stale"], "the base cache remains fresh")
+        self.assertEqual(provider_models.call_count, 2)
+
     def test_stale_cache_served_when_refresh_fails(self):
         mc.catalog(fetch=fetch_ok, env={}, run=None)
         aged = json.loads(mc.CACHE.read_text())
@@ -289,8 +355,13 @@ class CatalogCacheTest(NoCLI):
         got = mc.catalog(fetch=fetch_down, env={}, run=None)
         self.assertTrue(got["stale"])
         self.assertEqual(got["sources"], ["static"])
-        for harness in ("claude", "codex", "vibe", "opencode"):
+        for harness in ("claude", "codex", "vibe"):
             self.assertTrue(got["harnesses"][harness]["models"])
+        self.assertEqual(
+            got["harnesses"]["opencode"]["models"],
+            [],
+            "OpenCode never promotes a static route without a connected provider",
+        )
         floor_fams = {f["family"]: f["latest"]
                       for f in got["harnesses"]["claude"]["families"]}
         self.assertEqual(floor_fams.get("opus"), "opus",

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Managed OpenCode server lifecycle and connected-provider projection."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from conversation_adapters import opencode  # noqa: E402
+
+
+class FakeProcess:
+    def __init__(self) -> None:
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+
+class OpenCodeServerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.log_patch = mock.patch.object(
+            opencode,
+            "SERVER_LOG",
+            Path(self.tmp.name) / "opencode-server.log",
+        )
+        self.log_patch.start()
+        self.addCleanup(self.log_patch.stop)
+        opencode._SERVER_PROCESS = None
+        opencode._SERVER_PASSWORD = None
+        opencode._SERVER_LOG_HANDLE = None
+        self.addCleanup(opencode.stop_server)
+
+    def test_healthy_existing_server_is_reused_without_spawning(self):
+        with mock.patch.object(
+            opencode, "_server_healthy", return_value=True
+        ), mock.patch.object(opencode.subprocess, "Popen") as spawn:
+            password = opencode.ensure_server()
+        self.assertIsNone(password)
+        spawn.assert_not_called()
+
+    def test_managed_server_is_loopback_authenticated_and_stoppable(self):
+        process = FakeProcess()
+        checks = iter([False, True])
+        with mock.patch.dict(os.environ, {}, clear=False), \
+                mock.patch.object(
+                    opencode, "_server_healthy",
+                    side_effect=lambda _password: next(checks),
+                ), mock.patch.object(
+                    opencode.shutil, "which", return_value="/bin/opencode"
+                ), mock.patch.object(
+                    opencode.secrets, "token_urlsafe", return_value="server-secret"
+                ), mock.patch.object(
+                    opencode.subprocess, "Popen", return_value=process
+                ) as spawn:
+            os.environ.pop("OPENCODE_SERVER_PASSWORD", None)
+            password = opencode.ensure_server(timeout=1)
+
+        self.assertEqual(password, "server-secret")
+        argv = spawn.call_args.args[0]
+        self.assertEqual(
+            argv,
+            [
+                "/bin/opencode",
+                "serve",
+                "--hostname",
+                "127.0.0.1",
+                "--port",
+                "4096",
+                "--log-level",
+                "WARN",
+            ],
+        )
+        env = spawn.call_args.kwargs["env"]
+        self.assertEqual(env["OPENCODE_SERVER_PASSWORD"], "server-secret")
+        self.assertEqual(env["OPENCODE_DISABLE_CLAUDE_CODE"], "1")
+        self.assertTrue(spawn.call_args.kwargs["start_new_session"])
+
+        opencode.stop_server()
+        self.assertTrue(process.terminated)
+        self.assertFalse(process.killed)
+
+    def test_connected_models_excludes_disconnected_and_inactive_routes(self):
+        got = opencode.connected_models(
+            {
+                "connected": ["openai"],
+                "all": [
+                    {
+                        "id": "openai",
+                        "models": {
+                            "gpt-live": {
+                                "name": "GPT Live",
+                                "family": "gpt",
+                                "status": "active",
+                            },
+                            "gpt-retired": {
+                                "name": "GPT Retired",
+                                "status": "deprecated",
+                            },
+                        },
+                    },
+                    {
+                        "id": "not-connected",
+                        "models": {
+                            "model": {"name": "Must not appear"},
+                        },
+                    },
+                ],
+            }
+        )
+        self.assertEqual(
+            got,
+            [
+                {
+                    "id": "openai/gpt-live",
+                    "provider": "openai",
+                    "provider_model": "gpt-live",
+                    "name": "GPT Live",
+                    "family": "gpt",
+                    "release_date": "",
+                    "status": "active",
+                }
+            ],
+        )
+
+    def test_default_adapter_uses_managed_server_password(self):
+        with mock.patch.object(
+            opencode, "ensure_server", return_value="managed-secret"
+        ) as ensure, mock.patch.object(
+            opencode, "UrlHttpTransport"
+        ) as transport:
+            opencode.OpenCodeAdapter()
+        ensure.assert_called_once_with()
+        transport.assert_called_once_with(
+            opencode.SERVER_ENDPOINT,
+            password="managed-secret",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- supervise a loopback-only, authenticated `opencode serve` process for browser conversations
- build the OpenCode picker from `/provider.connected` and each connected provider’s advertised active models
- require an exact OpenCode route and refresh its provider projection even when the shared catalog cache is fresh
- normalize provider/model routing and let OpenCode generate its ordered native message IDs
- use the stable synchronous message endpoint behind the pre-opened event stream for reliable exact resume

## Verification
- `./sc test` — 1529 passed
- `./sc render-check`
- GitHub tests, verify, render-check, CodeQL, and analysis — all passing
- browser E2E in `dos-app`: connected-provider picker, first turn, exact second turn, fresh-browser reconnect, full sandbox restart, third turn on unchanged native session
- `git diff --check`

Follow-up to the browser-native shell chat release proof; isolated from PR #764.