### PR TITLE
fix: finish browser conversation resume and ownership

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -16,6 +16,7 @@ import io
 import json
 import re
 import sys
+import time
 import uuid
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -380,6 +381,27 @@ def _require_conversation(con, conversation_id: str, owner_user_id: int):
     return row
 
 
+def _live_shell_session(shell) -> str | None:
+    snapshot = run_mod.shell_liveness.compute()
+    if shell["flavor"] == "admin":
+        return "busy" if snapshot.get("admin_root_pids") else None
+    return run_mod.shell_liveness.session_state(
+        shell["shortname"] or "",
+        snapshot,
+    )
+
+
+def _wait_for_cli_release(shell) -> str | None:
+    """Drain a just-finished browser process, but never steal a live CLI slot."""
+    state = _live_shell_session(shell)
+    for _ in range(40):
+        if state is None:
+            return None
+        time.sleep(0.05)
+        state = _live_shell_session(shell)
+    return state
+
+
 def _create_conversation(con, operator: dict, headers, body: dict):
     _only_fields(body, {"shell_id", "title", "harness", "model", "effort"})
     key = _idempotency_key(headers)
@@ -424,6 +446,23 @@ def _create_conversation(con, operator: dict, headers, body: dict):
             "SHELL_NOT_LAUNCHABLE",
             "shell is unknown, deleted, or unavailable to this operator",
         )
+
+    open_conversations = con.execute(
+        "SELECT conversation_id,state FROM conversations "
+        "WHERE mode='normal' AND shell_id=? AND state!='closed'",
+        (shell_id,),
+    ).fetchall()
+    if not open_conversations:
+        live_state = _wait_for_cli_release(shell)
+        if live_state is not None:
+            con.rollback()
+            raise ApiError(
+                409,
+                "SHELL_BUSY",
+                f"shell {shell['shortname']!r} has a live CLI session; "
+                "close it before opening a browser chat",
+                {"shell_id": shell_id, "state": live_state},
+            )
 
     defaults = run_mod.flavor_defaults(con).get(shell["flavor"])
     harness = body.get("harness")
@@ -482,11 +521,6 @@ def _create_conversation(con, operator: dict, headers, body: dict):
 
     conversation_id = "cv_" + uuid.uuid4().hex
     provider = run_mod.session_provider(harness, model)
-    open_conversations = con.execute(
-        "SELECT conversation_id,state FROM conversations "
-        "WHERE mode='normal' AND owner_user_id=? AND state!='closed'",
-        (operator["user_id"],),
-    ).fetchall()
     running = [
         row for row in open_conversations
         if row["state"] in ("queued", "running")
@@ -650,7 +684,7 @@ def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
         con.rollback()
         raise ApiError(
             409,
-            "SHELL_BUSY",
+            "BROWSER_CHAT_BUSY",
             "a queued or running conversation cannot be closed",
             {"state": row["state"]},
         )

--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -482,6 +482,38 @@ def _create_conversation(con, operator: dict, headers, body: dict):
 
     conversation_id = "cv_" + uuid.uuid4().hex
     provider = run_mod.session_provider(harness, model)
+    open_conversations = con.execute(
+        "SELECT conversation_id,state FROM conversations "
+        "WHERE mode='normal' AND owner_user_id=? AND state!='closed'",
+        (operator["user_id"],),
+    ).fetchall()
+    running = [
+        row for row in open_conversations
+        if row["state"] in ("queued", "running")
+    ]
+    if running:
+        con.rollback()
+        raise ApiError(
+            409,
+            "BROWSER_CHAT_BUSY",
+            "the open browser chat has a turn in progress",
+            {"conversation_id": running[0]["conversation_id"]},
+        )
+    auto_closed = []
+    for row in open_conversations:
+        con.execute(
+            "UPDATE conversations SET state='closed',closed_at=datetime('now'),"
+            "last_activity_at=datetime('now'),version=version+1 "
+            "WHERE conversation_id=?",
+            (row["conversation_id"],),
+        )
+        _append_event(
+            con,
+            row["conversation_id"],
+            "conversation.closed",
+            {"status": "closed", "reason": "another browser chat opened"},
+        )
+        auto_closed.append(row["conversation_id"])
     con.execute(
         "INSERT INTO conversations "
         "(conversation_id,shell_id,mode,owner_user_id,harness,provider,model,"
@@ -513,6 +545,8 @@ def _create_conversation(con, operator: dict, headers, body: dict):
         },
     )
     con.commit()
+    for closed_id in auto_closed:
+        conversation_events.notify(closed_id)
     conversation_events.notify(conversation_id)
     row = _require_conversation(con, conversation_id, operator["user_id"])
     return _json(

--- a/.super-coder/migrations/0133_one_open_normal_conversation_per_shell.sql
+++ b/.super-coder/migrations/0133_one_open_normal_conversation_per_shell.sql
@@ -1,0 +1,33 @@
+-- One browser conversation owns a shell until Close or same-shell replacement.
+-- Older builds allowed several idle rows. Preserve the most recently active one
+-- and close older rows before installing the durable per-shell uniqueness fence.
+
+BEGIN;
+
+UPDATE conversations AS older
+SET state='closed',
+    closed_at=COALESCE(closed_at, datetime('now')),
+    last_activity_at=datetime('now'),
+    version=version+1
+WHERE mode='normal'
+  AND state<>'closed'
+  AND EXISTS (
+      SELECT 1
+      FROM conversations AS newer
+      WHERE newer.mode='normal'
+        AND newer.state<>'closed'
+        AND newer.shell_id=older.shell_id
+        AND (
+            newer.last_activity_at > older.last_activity_at
+            OR (
+                newer.last_activity_at = older.last_activity_at
+                AND newer.conversation_id > older.conversation_id
+            )
+        )
+  );
+
+CREATE UNIQUE INDEX idx_conversations_live_normal_shell
+    ON conversations(shell_id)
+    WHERE mode='normal' AND state<>'closed';
+
+COMMIT;

--- a/.super-coder/scripts/conversation_adapters/claude.py
+++ b/.super-coder/scripts/conversation_adapters/claude.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import signal
 import uuid
 from pathlib import Path
@@ -363,7 +364,12 @@ class ClaudeAdapter(ConversationAdapter):
             self.config_dir
             or Path(os.environ.get("CLAUDE_CONFIG_DIR", "~/.claude")).expanduser()
         )
-        project = str(worktree).replace(os.sep, "-")
+        # Claude maps the absolute cwd to a project directory by replacing
+        # every non-alphanumeric character independently. In particular,
+        # ``/.sc-worktrees`` becomes ``--sc-worktrees``; replacing separators
+        # alone points at a plausible but nonexistent ``-.sc-worktrees`` path
+        # and makes every exact resume look like a lost session.
+        project = re.sub(r"[^A-Za-z0-9]", "-", str(worktree))
         return root / "projects" / project / f"{session_ref}.jsonl"
 
     def inspect(

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -301,10 +301,8 @@ class OpenCodeAdapter(ConversationAdapter):
         session_ref: str,
         context: ConversationContext,
         message: str,
-        run_ref: str,
     ) -> None:
         body: dict[str, Any] = {
-            "messageID": run_ref,
             "parts": [{"type": "text", "text": message}],
         }
         route = self._route(context)
@@ -353,7 +351,7 @@ class OpenCodeAdapter(ConversationAdapter):
                 "resumed": resumed,
             },
         )
-        self._prompt(session_ref, context, message, run_ref)
+        self._prompt(session_ref, context, message)
         return turn
 
     def start(self, context: ConversationContext, message: str) -> NativeTurn:

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -582,11 +582,27 @@ class OpenCodeAdapter(ConversationAdapter):
             },
             "session.create-or-resume",
         )
+        observed_activity = False
         for raw in native_stream:
             event_session = self._session_of(raw)
             if event_session and event_session != turn.session_ref:
                 continue
             for event in self._normalize(raw):
+                # Opening `/event` for an existing session can enqueue its
+                # current idle state before prompt_async is dispatched. That
+                # idle belongs to the previous turn; accepting it would mark
+                # the new message complete without ever generating a reply.
+                if event.type == "run.completed" and not observed_activity:
+                    continue
+                if event.type in {
+                    "run.started",
+                    "assistant.delta",
+                    "tool.started",
+                    "tool.completed",
+                    "permission.requested",
+                    "input.requested",
+                }:
+                    observed_activity = True
                 if event.type in TERMINAL_EVENTS:
                     turn.metadata["terminal"] = event.type
                 yield event

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -237,6 +237,7 @@ class OpenCodeAdapter(ConversationAdapter):
             self.transport = UrlHttpTransport(
                 endpoint,
                 password=password if password is not None else ensure_server(),
+                timeout=600.0,
             )
 
     def probe(self) -> ProbeResult:
@@ -314,7 +315,7 @@ class OpenCodeAdapter(ConversationAdapter):
             }
         self.transport.request(
             "POST",
-            f"/session/{session_ref}/prompt_async",
+            f"/session/{session_ref}/message",
             query=self._query(context.checked_worktree()),
             body=body,
         )
@@ -330,7 +331,12 @@ class OpenCodeAdapter(ConversationAdapter):
         worktree = context.checked_worktree()
         run_ref = f"msg_{uuid.uuid4().hex}"
         # `/event` is live rather than replayable. Open the subscription before
-        # dispatch so a fast generation cannot finish in the prompt/stream gap.
+        # the synchronous message dispatch so all native activity is buffered
+        # while `/message` waits for the completed assistant response.
+        #
+        # Do not use `/prompt_async`: OpenCode can lose async session state
+        # after the first turn, accept later user messages without running
+        # inference, and report those turns idle.
         event_stream = iter(
             self.transport.stream(
                 "/event",
@@ -385,7 +391,6 @@ class OpenCodeAdapter(ConversationAdapter):
         context: ConversationContext,
         message: str,
     ) -> NativeTurn:
-        worktree = context.checked_worktree()
         message = ensure_nonempty_message(message)
         inspected = self.inspect(session_ref, context)
         if not inspected.exists:
@@ -393,14 +398,9 @@ class OpenCodeAdapter(ConversationAdapter):
                 "HARNESS_SESSION_LOST",
                 f"OpenCode session does not exist: {session_ref}",
             )
-        permission = self._permission_rules(context)
-        if permission:
-            self.transport.request(
-                "PATCH",
-                f"/session/{session_ref}",
-                query=self._query(worktree),
-                body={"permission": permission},
-            )
+        # Session permissions are persisted from create. OpenCode's session
+        # PATCH contract is for mutable metadata such as title; repeatedly
+        # sending permission rules duplicates them in native session state.
         return self._turn(session_ref, context, message, resumed=True)
 
     @staticmethod
@@ -589,7 +589,7 @@ class OpenCodeAdapter(ConversationAdapter):
                 continue
             for event in self._normalize(raw):
                 # Opening `/event` for an existing session can enqueue its
-                # current idle state before prompt_async is dispatched. That
+                # current idle state before the message is dispatched. That
                 # idle belongs to the previous turn; accepting it would mark
                 # the new message complete without ever generating a reply.
                 if event.type == "run.completed" and not observed_activity:

--- a/.super-coder/scripts/conversation_launch.py
+++ b/.super-coder/scripts/conversation_launch.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -37,10 +38,16 @@ class ConversationLaunchPreparer:
         *,
         prepare_launch: Callable[..., Any] = run_mod.prepare_launch,
         liveness: Callable[[], dict] = shell_liveness.compute,
+        liveness_retries: int = 40,
+        liveness_delay: float = 0.05,
+        sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         self.db_path = str(db_path)
         self.prepare_launch = prepare_launch
         self.liveness = liveness
+        self.liveness_retries = liveness_retries
+        self.liveness_delay = liveness_delay
+        self.sleep = sleep
 
     def _shell(self, shell_id: int) -> tuple[str, str | None]:
         con = db_driver.connect(self.db_path)
@@ -69,7 +76,19 @@ class ConversationLaunchPreparer:
                 else shell_liveness.session_state(shortname, snapshot)
             )
 
-        state = occupying_state()
+        def wait_for_free_slot() -> str | None:
+            state = occupying_state()
+            for _ in range(self.liveness_retries):
+                if state is None:
+                    return None
+                self.sleep(self.liveness_delay)
+                state = occupying_state()
+            return state
+
+        # Native harnesses can emit their terminal result just before their
+        # process disappears from /proc. Give that browser-owned teardown a
+        # short drain window; a genuinely occupied CLI slot remains a refusal.
+        state = wait_for_free_slot()
         if state is not None:
             raise ConversationLaunchError(
                 "SHELL_BUSY",
@@ -94,7 +113,7 @@ class ConversationLaunchPreparer:
         # Preparation renders and may create/sync the worktree. Recheck at the
         # dispatch edge so a CLI launch that raced that work is still refused
         # before the adapter can send the prompt.
-        state = occupying_state()
+        state = wait_for_free_slot()
         if state is not None:
             raise ConversationLaunchError(
                 "SHELL_BUSY",

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -1529,7 +1529,7 @@ def main() -> None:
         con.close()
         sys.exit(
             f"shell '{chosen['shortname']}': Browser chat is open. "
-            "End it in Interface before starting a CLI session."
+            "Close it in Interface before starting a CLI session."
         )
     slot_context = None
     if slot is not None:

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -597,11 +597,11 @@ def open_db():
 
 
 def browser_conversation_active(con, shell_id: int) -> bool:
-    """Does a durable browser turn currently own this shell's mutation slot?"""
+    """Does an open browser chat own this shell's single session slot?"""
     try:
         row = con.execute(
-            "SELECT COUNT(*) FROM conversation_runs WHERE shell_id=? "
-            "AND state IN ('leased','starting','running')",
+            "SELECT COUNT(*) FROM conversations WHERE shell_id=? "
+            "AND state!='closed'",
             (shell_id,),
         ).fetchone()
         return row is not None and int(row[0]) > 0
@@ -609,7 +609,7 @@ def browser_conversation_active(con, shell_id: int) -> bool:
         # An older, not-yet-migrated fork has no conversation tables. Its
         # existing CLI launch path must remain usable. Other DB failures must
         # stay fail-closed instead of silently permitting a second surface.
-        if "no such table: conversation_runs" in str(exc):
+        if "no such table: conversations" in str(exc):
             return False
         raise
     except (IndexError, KeyError, TypeError, ValueError):
@@ -1528,9 +1528,8 @@ def main() -> None:
     if browser_conversation_active(con, chosen["shell_id"]):
         con.close()
         sys.exit(
-            f"shell '{chosen['shortname']}' has an active browser turn — "
-            "wait for it to finish or interrupt it in Interface before "
-            "starting a CLI session"
+            f"shell '{chosen['shortname']}': Browser chat is open. "
+            "End it in Interface before starting a CLI session."
         )
     slot_context = None
     if slot is not None:

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3019,8 +3019,8 @@ async function renderSprints(root) {
 }
 
 // ── Interface / browser-native conversations ────────────────────────────────
-// A browser conversation is a second, independent way to use a shell. It uses
-// the normal CLI preparation path server-side, but deliberately has no
+// A browser conversation owns the shell's single session slot until ended. It
+// uses the normal CLI preparation path server-side, but deliberately has no
 // terminal, tmux controls, or live hand-off between browser and CLI.
 const CHAT_HARNESSES = ["opencode", "claude", "codex"];
 const CHAT_FLAVOR_ORDER = ["cartographer", "admin", "planner", "dev", "reviewer", "devops"];
@@ -3058,6 +3058,26 @@ function chatConversationName(conversation) {
   return conversation.title
     || `Chat · ${conversation.route?.harness || "harness"} · `
       + new Date(`${conversation.created_at}Z`).toLocaleString();
+}
+
+async function chatCloseForSwitch(conversation) {
+  if (!conversation || conversation.state === "closed") return true;
+  if (!["idle", "waiting", "error"].includes(conversation.state)) {
+    toast("Finish or interrupt the current turn before switching chats.");
+    return false;
+  }
+  try {
+    await chatApi(
+      `/conversations/${conversation.conversation_id}`,
+      "PATCH",
+      { version: conversation.version, state: "closed" },
+    );
+    conversation.state = "closed";
+    return true;
+  } catch (error) {
+    toast(`${error.code}: ${error.message}`);
+    return false;
+  }
 }
 
 function chatActivity(events) {
@@ -3382,9 +3402,15 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     } catch (error) { toast(`${error.code}: ${error.message}`); }
     finally { interrupt.disabled = false; }
   };
-  const close = el("button", { className: "act danger", type: "button", textContent: "Close" });
+  const close = el("button", {
+    className: "act danger",
+    type: "button",
+    textContent: "Close",
+  });
   close.onclick = async () => {
-    if (!confirm("Close this conversation? Its transcript will remain available.")) return;
+    if (!confirm(
+      "Close this conversation? Its transcript will remain available."
+    )) return;
     try {
       conversation = await chatApi(`/conversations/${conversation.conversation_id}`,
         "PATCH", { version: conversation.version, state: "closed" });
@@ -3486,12 +3512,22 @@ async function renderInterface(root) {
     root.replaceChildren(el("div", { className: "card muted" }, "No shells."));
     return;
   }
-  const shell = shells.find((item) => item.shortname === chatRouteShell) || shells[0];
+  const openConversation = allConversations.items.find(
+    (item) => item.state !== "closed");
+  const shell = shells.find((item) => item.shortname === chatRouteShell)
+    || (!chatRouteShell && openConversation
+      ? shells.find((item) => item.shell.shell_id === openConversation.shell.shell_id)
+      : null)
+    || shells[0];
   const conversations = allConversations.items.filter(
     (item) => item.shell.shell_id === shell.shell_id);
-  let selectedId = chatRouteConversation;
+  let selectedId = chatRouteConversation
+    || conversations.find((item) => item.state !== "closed")?.conversation_id
+    || "";
   if (selectedId && !conversations.some((item) => item.conversation_id === selectedId))
     selectedId = "";
+  const selectedConversation = allConversations.items.find(
+    (item) => item.conversation_id === selectedId);
 
   const layout = el("div", { className: "chat-layout" });
   const rail = el("aside", { className: "chat-rail" });
@@ -3511,17 +3547,20 @@ async function renderInterface(root) {
         type: "button",
       }, el("span", { className: "chat-shell-name" }, item.display_name));
       if (latest) button.append(chatStatePill(latest.state));
-      button.onclick = () => { location.hash = chatHash(item.shortname); };
+      button.onclick = async () => {
+        if (item.shell_id === shell.shell_id) return;
+        if (await chatCloseForSwitch(selectedConversation))
+          location.hash = chatHash(item.shortname);
+      };
       rail.append(button);
     }
   }
 
   const side = el("aside", { className: "chat-history" });
   const newChat = el("button", { className: "act primary", type: "button", textContent: "＋ New chat" });
-  newChat.onclick = () => {
-    chatRouteConversation = "";
-    history.replaceChildren();
-    chatRenderNew(pane, shell, defaults, catalog);
+  newChat.onclick = async () => {
+    if (await chatCloseForSwitch(selectedConversation))
+      location.hash = chatHash(shell.shortname);
   };
   side.append(el("div", { className: "chat-history-head" },
     el("div", {}, el("b", {}, shell.display_name),
@@ -3538,8 +3577,10 @@ async function renderInterface(root) {
       chatConversationName(conversation)),
       el("span", { className: "chat-history-route" }, chatRouteLabel(conversation)),
       chatStatePill(conversation.state));
-    button.onclick = () => {
-      location.hash = chatHash(shell.shortname, conversation.conversation_id);
+    button.onclick = async () => {
+      if (conversation.conversation_id === selectedId) return;
+      if (await chatCloseForSwitch(selectedConversation))
+        location.hash = chatHash(shell.shortname, conversation.conversation_id);
     };
     history.append(button);
   }

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3547,10 +3547,9 @@ async function renderInterface(root) {
         type: "button",
       }, el("span", { className: "chat-shell-name" }, item.display_name));
       if (latest) button.append(chatStatePill(latest.state));
-      button.onclick = async () => {
+      button.onclick = () => {
         if (item.shell_id === shell.shell_id) return;
-        if (await chatCloseForSwitch(selectedConversation))
-          location.hash = chatHash(item.shortname);
+        location.hash = chatHash(item.shortname);
       };
       rail.append(button);
     }

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -534,6 +534,11 @@ class ConversationAdapterTest(unittest.TestCase):
             if request[1].endswith("/message")
         )
         self.assertEqual(prompt[2]["directory"], str(self.root))
+        self.assertNotIn(
+            "messageID",
+            prompt[3],
+            "OpenCode must generate its own ordered native message id",
+        )
         self.assertEqual(
             prompt[3]["model"],
             {"providerID": "openrouter", "modelID": "test-model"},

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -47,9 +47,15 @@ class FakeOpenCode:
             return {"healthy": True, "version": "1.18.9"}
         if method == "POST" and path == "/session":
             return {"id": self.session_ref, "title": "test"}
-        if path.endswith("/prompt_async"):
+        if path.endswith("/message"):
             self.status = "busy"
-            return None
+            return {
+                "info": {
+                    "role": "assistant",
+                    "sessionID": self.session_ref,
+                },
+                "parts": [{"type": "text", "text": "hello"}],
+            }
         if path.endswith("/abort"):
             self.status = "idle"
             return True
@@ -525,7 +531,7 @@ class ConversationAdapterTest(unittest.TestCase):
         prompt = next(
             request
             for request in native.requests
-            if request[1].endswith("/prompt_async")
+            if request[1].endswith("/message")
         )
         self.assertEqual(prompt[2]["directory"], str(self.root))
         self.assertEqual(
@@ -542,17 +548,9 @@ class ConversationAdapterTest(unittest.TestCase):
         )
 
         fresh = adapter.resume(turn.session_ref, self.context, "again")
-        permission_patch = next(
-            request
-            for request in native.requests
-            if request[:2] == (
-                "PATCH",
-                f"/session/{turn.session_ref}",
-            )
-        )
-        self.assertEqual(
-            permission_patch[3]["permission"][0]["action"],
-            "allow",
+        self.assertFalse(
+            any(request[0] == "PATCH" for request in native.requests),
+            "resume must reuse persisted permissions, not duplicate them",
         )
         native.status = "busy"
         recovered = adapter.reconcile(fresh, self.context)
@@ -581,7 +579,7 @@ class ConversationAdapterTest(unittest.TestCase):
         prompt = next(
             request
             for request in native.requests
-            if request[1].endswith("/prompt_async")
+            if request[1].endswith("/message")
         )
         self.assertEqual(
             create[3]["model"],

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -436,6 +436,20 @@ class ConversationAdapterTest(unittest.TestCase):
         if harness == "claude":
             self.write_claude_session(adapter, session_ref)
 
+    def test_claude_session_path_matches_native_project_encoding(self) -> None:
+        adapter = ClaudeAdapter(config_dir=self.claude_config)
+        worktree = Path("/home/j3d1/Repos/dos_app/.sc-worktrees/pln1")
+        self.assertEqual(
+            adapter._session_path(
+                "b6321ad5-9363-4529-980d-93a959000968",
+                worktree,
+            ),
+            self.claude_config
+            / "projects"
+            / "-home-j3d1-Repos-dos-app--sc-worktrees-pln1"
+            / "b6321ad5-9363-4529-980d-93a959000968.jsonl",
+        )
+
     def test_identical_contract_start_stream_interrupt_resume_reconcile(
         self,
     ) -> None:

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -81,6 +81,10 @@ class FakeOpenCode:
                     },
                 },
                 {
+                    "type": "session.idle",
+                    "properties": {"sessionID": self.session_ref},
+                },
+                {
                     "type": "session.status",
                     "properties": {
                         "sessionID": self.session_ref,
@@ -531,6 +535,11 @@ class ConversationAdapterTest(unittest.TestCase):
         events = list(adapter.stream(turn))
         self.assertNotIn("wrong", repr(events))
         self.assertIn("permission.requested", [event.type for event in events])
+        self.assertEqual(
+            [event.type for event in events].count("run.completed"),
+            1,
+            "the pre-dispatch idle event must not terminate the new turn",
+        )
 
         fresh = adapter.resume(turn.session_ref, self.context, "again")
         permission_patch = next(

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -149,6 +149,45 @@ class ConversationApiCase(unittest.TestCase):
 
 
 class ConversationResourceTest(ConversationApiCase):
+    def test_creating_a_chat_closes_the_previous_idle_chat(self) -> None:
+        first = self.create(key="first-chat", title="First")
+        second = self.create(key="second-chat", title="Second")
+        self.assertNotEqual(first["conversation_id"], second["conversation_id"])
+
+        con = self.connect()
+        try:
+            rows = con.execute(
+                "SELECT conversation_id,state,closed_at FROM conversations"
+            ).fetchall()
+        finally:
+            con.close()
+        by_id = {row["conversation_id"]: row for row in rows}
+        self.assertEqual(by_id[first["conversation_id"]]["state"], "closed")
+        self.assertIsNotNone(by_id[first["conversation_id"]]["closed_at"])
+        self.assertEqual(by_id[second["conversation_id"]]["state"], "idle")
+
+    def test_creating_a_chat_refuses_while_the_open_turn_is_running(self) -> None:
+        first = self.create(key="running-chat")
+        con = self.connect()
+        try:
+            con.execute(
+                "UPDATE conversations SET state='queued' "
+                "WHERE conversation_id=?",
+                (first["conversation_id"],),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+        status, _, error = self.request(
+            "POST",
+            "/api/conversations",
+            body={"shell_id": 1, "harness": "codex", "title": "Second"},
+            key="blocked-second-chat",
+        )
+        self.assertEqual(status, 409)
+        self.assertEqual(error["error"]["code"], "BROWSER_CHAT_BUSY")
+
     def test_opencode_requires_an_exact_resolved_model(self) -> None:
         with mock.patch.object(
             conversation_routes.run_mod,
@@ -316,10 +355,11 @@ class ConversationResourceTest(ConversationApiCase):
         self.assertEqual(conflict["error"]["code"], "MESSAGE_IDEMPOTENCY_CONFLICT")
 
     def test_cursor_pages_have_no_duplicates_and_patch_uses_version(self) -> None:
-        identifiers = {
-            self.create(key=f"create-{number}")["conversation_id"]
+        created = [
+            self.create(key=f"create-{number}")
             for number in range(3)
-        }
+        ]
+        identifiers = {item["conversation_id"] for item in created}
         seen = []
         cursor = None
         while True:
@@ -335,19 +375,25 @@ class ConversationResourceTest(ConversationApiCase):
         self.assertEqual(set(seen), identifiers)
         self.assertEqual(len(seen), 3)
 
-        conversation_id = seen[0]
+        conversation_id = created[-1]["conversation_id"]
+        status, _, current = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}",
+        )
+        self.assertEqual(status, 200, current)
+        version = current["version"]
         status, _, updated = self.request(
             "PATCH",
             f"/api/conversations/{conversation_id}",
-            body={"version": 1, "title": "Renamed"},
+            body={"version": version, "title": "Renamed"},
         )
         self.assertEqual(status, 200, updated)
         self.assertEqual(updated["title"], "Renamed")
-        self.assertEqual(updated["version"], 2)
+        self.assertEqual(updated["version"], version + 1)
         status, _, conflict = self.request(
             "PATCH",
             f"/api/conversations/{conversation_id}",
-            body={"version": 1, "title": "Stale"},
+            body={"version": version, "title": "Stale"},
         )
         self.assertEqual(status, 409)
         self.assertEqual(conflict["error"]["code"], "CONVERSATION_VERSION_CONFLICT")

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -69,11 +69,14 @@ class ConversationApiCase(unittest.TestCase):
         con.execute(
             "INSERT INTO shells "
             "(shell_id,display_name,shortname,flavor,system_prompt,user_id,"
-            "api_key) VALUES (1,'Dev','dev','dev','prompt',1,'shell-token')"
+            "api_key) VALUES "
+            "(1,'Dev','dev','dev','prompt',1,'shell-token'),"
+            "(2,'Review','review','dev','prompt',1,'review-token')"
         )
         con.commit()
         con.close()
         (self.root / ".sc-worktrees" / "dev").mkdir(parents=True)
+        (self.root / ".sc-worktrees" / "review").mkdir(parents=True)
 
         patches = (
             mock.patch.object(conversation_routes, "DB_PATH", self.db_path),
@@ -82,6 +85,11 @@ class ConversationApiCase(unittest.TestCase):
                 conversation_routes.conversation_broker,
                 "notify_commit",
                 return_value=True,
+            ),
+            mock.patch.object(
+                conversation_routes,
+                "_wait_for_cli_release",
+                return_value=None,
             ),
         )
         for patch in patches:
@@ -149,6 +157,22 @@ class ConversationApiCase(unittest.TestCase):
 
 
 class ConversationResourceTest(ConversationApiCase):
+    def test_creating_a_chat_refuses_a_live_cli_owner(self) -> None:
+        with mock.patch.object(
+            conversation_routes,
+            "_wait_for_cli_release",
+            return_value="busy",
+        ):
+            status, _, error = self.request(
+                "POST",
+                "/api/conversations",
+                body={"shell_id": 1, "harness": "codex"},
+                key="cli-owned-shell",
+            )
+        self.assertEqual(status, 409)
+        self.assertEqual(error["error"]["code"], "SHELL_BUSY")
+        self.assertIn("live CLI session", error["error"]["message"])
+
     def test_creating_a_chat_closes_the_previous_idle_chat(self) -> None:
         first = self.create(key="first-chat", title="First")
         second = self.create(key="second-chat", title="Second")
@@ -165,6 +189,28 @@ class ConversationResourceTest(ConversationApiCase):
         self.assertEqual(by_id[first["conversation_id"]]["state"], "closed")
         self.assertIsNotNone(by_id[first["conversation_id"]]["closed_at"])
         self.assertEqual(by_id[second["conversation_id"]]["state"], "idle")
+
+    def test_each_shell_may_keep_one_browser_chat_open(self) -> None:
+        first = self.create(key="first-shell-chat", title="Dev")
+        second = self.create(
+            key="second-shell-chat",
+            shell_id=2,
+            title="Review",
+        )
+
+        con = self.connect()
+        try:
+            rows = con.execute(
+                "SELECT conversation_id,shell_id,state FROM conversations "
+                "ORDER BY shell_id"
+            ).fetchall()
+        finally:
+            con.close()
+        by_id = {row["conversation_id"]: row for row in rows}
+        self.assertEqual(by_id[first["conversation_id"]]["state"], "idle")
+        self.assertEqual(by_id[second["conversation_id"]]["state"], "idle")
+        self.assertEqual(by_id[first["conversation_id"]]["shell_id"], 1)
+        self.assertEqual(by_id[second["conversation_id"]]["shell_id"], 2)
 
     def test_creating_a_chat_refuses_while_the_open_turn_is_running(self) -> None:
         first = self.create(key="running-chat")
@@ -184,6 +230,32 @@ class ConversationResourceTest(ConversationApiCase):
             "/api/conversations",
             body={"shell_id": 1, "harness": "codex", "title": "Second"},
             key="blocked-second-chat",
+        )
+        self.assertEqual(status, 409)
+        self.assertEqual(error["error"]["code"], "BROWSER_CHAT_BUSY")
+
+    def test_close_refuses_while_the_open_turn_is_running(self) -> None:
+        first = self.create(key="running-close")
+        con = self.connect()
+        try:
+            con.execute(
+                "UPDATE conversations SET state='queued' "
+                "WHERE conversation_id=?",
+                (first["conversation_id"],),
+            )
+            con.execute(
+                "UPDATE conversations SET state='running' "
+                "WHERE conversation_id=?",
+                (first["conversation_id"],),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+        status, _, error = self.request(
+            "PATCH",
+            f"/api/conversations/{first['conversation_id']}",
+            body={"version": first["version"], "state": "closed"},
         )
         self.assertEqual(status, 409)
         self.assertEqual(error["error"]["code"], "BROWSER_CHAT_BUSY")

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -153,6 +153,13 @@ class ConversationBrokerCase(unittest.TestCase):
         con.execute("PRAGMA foreign_keys=ON")
         return con
 
+    def allow_legacy_duplicate_open_chats(self) -> None:
+        """Exercise the broker's independent lock against pre-migration data."""
+        con = self.connect()
+        con.execute("DROP INDEX idx_conversations_live_normal_shell")
+        con.commit()
+        con.close()
+
     def add_conversation(
         self,
         *,
@@ -361,6 +368,7 @@ class StoreContractTest(ConversationBrokerCase):
         self.assertEqual(sequences, [1, 2])
 
     def test_shell_mutation_lock_blocks_other_conversation(self) -> None:
+        self.allow_legacy_duplicate_open_chats()
         first_conversation = self.add_conversation(shell_id=1)
         second_conversation = self.add_conversation(shell_id=1)
         self.add_message(first_conversation)
@@ -395,6 +403,7 @@ class StoreContractTest(ConversationBrokerCase):
         )
 
     def test_concurrent_claims_cannot_bypass_shell_lock(self) -> None:
+        self.allow_legacy_duplicate_open_chats()
         first_conversation = self.add_conversation(shell_id=1)
         second_conversation = self.add_conversation(shell_id=1)
         self.add_message(first_conversation)

--- a/tests/test_conversation_launch.py
+++ b/tests/test_conversation_launch.py
@@ -10,17 +10,16 @@ from types import SimpleNamespace
 
 import pytest
 
-
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 sys.path.insert(0, str(ENGINE / "scripts"))
 
-from conversation_broker import BrokerRun, BrokerStore  # noqa: E402
+import run as run_mod  # noqa: E402
+from conversation_broker import BrokerRun  # noqa: E402
 from conversation_launch import (  # noqa: E402
     ConversationLaunchError,
     ConversationLaunchPreparer,
 )
-import run as run_mod  # noqa: E402
 
 
 def apply_schema(con: sqlite3.Connection) -> None:
@@ -126,6 +125,7 @@ def test_preparer_refuses_a_cli_process_holding_the_shell(launch_case):
                 "claimed": False,
             }],
         },
+        liveness_retries=0,
     )
     with pytest.raises(ConversationLaunchError) as caught:
         preparer(make_run(worktree))
@@ -148,6 +148,7 @@ def test_preparer_refuses_an_admin_cli_process_at_the_repo_root(launch_case):
             "processes": [],
             "admin_root_pids": [99],
         },
+        liveness_retries=0,
     )
     with pytest.raises(ConversationLaunchError) as caught:
         preparer(make_run(worktree))
@@ -200,39 +201,69 @@ def test_preparer_rechecks_liveness_after_canonical_preparation(launch_case):
             env={},
         ),
         liveness=lambda: next(snapshots),
+        liveness_retries=0,
     )
     with pytest.raises(ConversationLaunchError) as caught:
         preparer(make_run(worktree))
     assert caught.value.code == "SHELL_BUSY"
 
 
-def test_cli_launch_sees_a_leased_browser_turn(launch_case):
+def test_preparer_waits_for_a_prior_browser_process_to_exit(launch_case):
+    db_path, worktree = launch_case
+    busy = {
+        "supported": True,
+        "processes": [{
+            "pid": 100,
+            "shortname": "dev",
+            "orphaned": False,
+            "claimed": True,
+        }],
+    }
+    clear = {"supported": True, "processes": []}
+    snapshots = iter((busy, clear, clear))
+    sleeps = []
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=lambda **_: SimpleNamespace(
+            cwd=str(worktree),
+            archive_id=42,
+            harness="codex",
+            model="gpt-test",
+            effort="high",
+            env={},
+        ),
+        liveness=lambda: next(snapshots),
+        liveness_retries=1,
+        liveness_delay=0.05,
+        sleep=sleeps.append,
+    )
+
+    context, archive_id = preparer(make_run(worktree))
+
+    assert context.worktree == worktree
+    assert archive_id == 42
+    assert sleeps == [0.05]
+
+
+def test_cli_launch_is_reserved_until_the_browser_chat_is_ended(launch_case):
     db_path, worktree = launch_case
     con = sqlite3.connect(db_path)
     con.execute(
-        "INSERT INTO conversations "
-        "(conversation_id,shell_id,owner_user_id,harness,worktree,state,"
-        "creation_idempotency_key,creation_request_hash) "
-        "VALUES (?,?,1,'codex',?,'queued','create','hash')",
-        ("cv_" + "b" * 32, 1, str(worktree)),
-    )
-    message_id = con.execute(
-        "INSERT INTO conversation_messages "
-        "(conversation_id,sender_kind,sender_ref,message_kind,body,idempotency_key,"
-        "request_hash,state) VALUES (?,'user','1','prompt','hello','message','hash','queued')",
-        ("cv_" + "b" * 32,),
-    ).lastrowid
-    con.execute(
-        "INSERT INTO conversation_outbox (conversation_id,message_id) VALUES (?,?)",
-        ("cv_" + "b" * 32, message_id),
-    )
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,owner_user_id,harness,worktree,state,"
+            "creation_idempotency_key,creation_request_hash) "
+            "VALUES (?,?,1,'codex',?,'idle','create','hash')",
+            ("cv_" + "b" * 32, 1, str(worktree)),
+        )
     con.commit()
-    con.close()
-    assert BrokerStore(db_path).claim_next("browser") is not None
-
-    con = sqlite3.connect(db_path)
     try:
         assert run_mod.browser_conversation_active(con, 1)
         assert not run_mod.browser_conversation_active(con, 999)
+        con.execute(
+            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
+            "WHERE shell_id=1"
+        )
+        con.commit()
+        assert not run_mod.browser_conversation_active(con, 1)
     finally:
         con.close()

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -539,6 +539,37 @@ class TransitionMatrixTest(ConversationDbCase):
 
 
 class FenceAndEventTest(ConversationDbCase):
+    def test_open_chat_migration_closes_older_legacy_rows(self) -> None:
+        self.con.execute("DROP INDEX idx_conversations_live_normal_shell")
+        older = self.add_conversation(shell_id=1)
+        self.con.execute(
+            "UPDATE conversations SET last_activity_at='2026-01-01 00:00:00' "
+            "WHERE conversation_id=?",
+            (older,),
+        )
+        newer = self.add_conversation(shell_id=1)
+        self.con.execute(
+            "UPDATE conversations SET last_activity_at='2026-07-29 00:00:00' "
+            "WHERE conversation_id=?",
+            (newer,),
+        )
+
+        self.con.executescript(
+            (ENGINE / "migrations"
+             / "0133_one_open_normal_conversation_per_shell.sql").read_text()
+        )
+
+        states = dict(
+            self.con.execute(
+                "SELECT conversation_id,state FROM conversations "
+                "WHERE shell_id=1"
+            ).fetchall()
+        )
+        self.assertEqual(states[older], "closed")
+        self.assertEqual(states[newer], "idle")
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_conversation(shell_id=1)
+
     def test_one_live_run_per_conversation_and_shell(self) -> None:
         first = self.add_conversation()
         first_message = self.add_message(first)
@@ -548,7 +579,10 @@ class FenceAndEventTest(ConversationDbCase):
         with self.assertRaises(sqlite3.IntegrityError):
             self.add_run(first, second_message)
 
-        second = self.add_conversation()
+        # The run fence remains independent of the newer open-chat fence. A
+        # closed historical row supplies a second same-shell conversation
+        # without violating the one-open-normal-conversation invariant.
+        second = self.add_conversation(state="closed")
         second_message = self.add_message(second)
         with self.assertRaises(sqlite3.IntegrityError):
             self.add_run(second, second_message)
@@ -559,6 +593,13 @@ class FenceAndEventTest(ConversationDbCase):
             (first_run,),
         )
         self.add_run(second, second_message)
+
+    def test_one_open_normal_conversation_per_shell(self) -> None:
+        self.add_conversation(shell_id=1)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_conversation(shell_id=1)
+        self.add_conversation(shell_id=1, state="closed")
+        self.add_conversation(shell_id=2)
 
     def test_different_shells_may_run_concurrently(self) -> None:
         first = self.add_conversation(shell_id=1)

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -63,6 +63,9 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert 'textContent: "Rename"' in interface
     assert 'textContent: "Close"' in interface
     assert 'textContent: "Analytics"' in interface
+    assert "chatCloseForSwitch(selectedConversation)" in interface
+    assert "Finish or interrupt the current turn before switching chats." in interface
+    assert 'item.state !== "closed"' in interface
 
 
 def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -66,6 +66,11 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert "chatCloseForSwitch(selectedConversation)" in interface
     assert "Finish or interrupt the current turn before switching chats." in interface
     assert 'item.state !== "closed"' in interface
+    shell_switch = interface[
+        interface.index('button.onclick = () => {', interface.index("chat-shell-name")):
+        interface.index("rail.append(button);", interface.index("chat-shell-name"))
+    ]
+    assert "chatCloseForSwitch" not in shell_switch
 
 
 def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -156,6 +156,7 @@ class OpenCodeServerTest(unittest.TestCase):
         transport.assert_called_once_with(
             opencode.SERVER_ENDPOINT,
             password="managed-secret",
+            timeout=600.0,
         )
 
 


### PR DESCRIPTION
## Summary
- make OpenCode browser turns use its stable synchronous message stream and native ordered message IDs
- enforce one open browser conversation per shell with explicit Close-to-CLI handoff, same-shell replacement, and cross-shell independence
- drain native process teardown between turns and resolve Claude session paths using Claude’s native project encoding

## Verification
- `uv run --with pytest pytest tests/ -q` — 1538 passed, 773 subtests
- `./sc render-check`
- dos-app browser E2E: Codex, OpenCode GLM 5.2, and Claude exact resume; reconnect/restart; active-turn switch refusal; New/history auto-close; per-shell independence; Close releases CLI
- migration 0133 applied to the test fork with active sprint 5 preserved

Governing spec: document #32; ownership decision: #20.