### PR TITLE
fix: restore open browser chat shell selection

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3516,7 +3516,7 @@ async function renderInterface(root) {
     (item) => item.state !== "closed");
   const shell = shells.find((item) => item.shortname === chatRouteShell)
     || (!chatRouteShell && openConversation
-      ? shells.find((item) => item.shell.shell_id === openConversation.shell.shell_id)
+      ? shells.find((item) => item.shell_id === openConversation.shell.shell_id)
       : null)
     || shells[0];
   const conversations = allConversations.items.filter(

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -20,6 +20,18 @@ def test_interface_is_a_first_class_reload_safe_view():
     assert "chatRouteConversation = decodeURIComponent(conversation)" in APP
 
 
+def test_open_chat_restore_matches_the_flat_shell_projection():
+    assert (
+        "shells.find((item) => item.shell_id === openConversation.shell.shell_id)"
+        in APP
+    )
+    assert (
+        "shells.find((item) => item.shell.shell_id "
+        "=== openConversation.shell.shell_id)"
+        not in APP
+    )
+
+
 def test_start_chat_exposes_shell_harness_and_model_without_terminal_controls():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]


### PR DESCRIPTION
## Summary
- match route-less Interface reloads against the flat shell-list projection
- prevent the undefined shell_id dereference introduced in PR #766
- add a regression contract for the open-chat restore lookup

## Root cause
Conversation list items embed a nested shell, but API shell-list entries are already shell objects. The new restore path mixed those projection shapes while iterating the flat shell list.

## Verification
- focused UI tests: 6 passed
- full suite: 1543 passed, 773 subtests
- map, render-check, live-instance verify, and diff-check passed

Governing feature #24 / task #96.