### PR TITLE
fix: add bounded SQLite transaction policy

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -408,7 +408,8 @@ def _create_conversation(con, operator: dict, headers, body: dict):
     request_hash = _request_hash(body)
     shell_id = _integer(body.get("shell_id"), "shell_id")
 
-    con.execute("BEGIN IMMEDIATE")
+    # Cheap idempotent replay and all external preparation happen before the
+    # write reservation. The transaction repeats every authoritative DB read.
     existing = con.execute(
         "SELECT conversation_id,creation_request_hash FROM conversations "
         "WHERE mode='normal' AND owner_user_id=? "
@@ -417,7 +418,6 @@ def _create_conversation(con, operator: dict, headers, body: dict):
     ).fetchone()
     if existing is not None:
         if existing["creation_request_hash"] != request_hash:
-            con.rollback()
             raise ApiError(
                 409,
                 "CONVERSATION_IDEMPOTENCY_CONFLICT",
@@ -426,7 +426,6 @@ def _create_conversation(con, operator: dict, headers, body: dict):
         row = _require_conversation(
             con, existing["conversation_id"], operator["user_id"]
         )
-        con.commit()
         return _json(
             201,
             _conversation_projection(row),
@@ -440,7 +439,6 @@ def _create_conversation(con, operator: dict, headers, body: dict):
         (shell_id, operator["user_id"]),
     ).fetchone()
     if shell is None:
-        con.rollback()
         raise ApiError(
             422,
             "SHELL_NOT_LAUNCHABLE",
@@ -455,7 +453,6 @@ def _create_conversation(con, operator: dict, headers, body: dict):
     if not open_conversations:
         live_state = _wait_for_cli_release(shell)
         if live_state is not None:
-            con.rollback()
             raise ApiError(
                 409,
                 "SHELL_BUSY",
@@ -474,7 +471,6 @@ def _create_conversation(con, operator: dict, headers, body: dict):
         )
     harness = _nonblank(harness, "harness", maximum=64)
     if harness not in ADAPTER_TYPES:
-        con.rollback()
         raise ApiError(
             422,
             "HARNESS_CONVERSATION_UNSUPPORTED",
@@ -483,7 +479,6 @@ def _create_conversation(con, operator: dict, headers, body: dict):
     try:
         run_mod.conductor_policy.require_harness(shell["flavor"], harness)
     except ValueError as exc:
-        con.rollback()
         raise ApiError(422, "HARNESS_ROUTE_INVALID", str(exc)) from exc
 
     model = body.get("model")
@@ -491,7 +486,6 @@ def _create_conversation(con, operator: dict, headers, body: dict):
         model = defaults["models"].get(harness)
     model = _nonblank(model, "model", maximum=255, optional=True)
     if harness == "opencode" and model is None:
-        con.rollback()
         raise ApiError(
             422,
             "HARNESS_MODEL_REQUIRED",
@@ -505,13 +499,11 @@ def _create_conversation(con, operator: dict, headers, body: dict):
     try:
         run_mod.validate_headless_request(adapter, model, effort)
     except ValueError as exc:
-        con.rollback()
         raise ApiError(422, "HARNESS_ROUTE_INVALID", str(exc)) from exc
     title = _nonblank(body.get("title"), "title", maximum=200, optional=True)
     worktree = run_mod.shell_work_dir(shell["shortname"], shell["flavor"])
     worktree = worktree.resolve(strict=False)
     if worktree.exists() and not worktree.is_dir():
-        con.rollback()
         raise ApiError(
             422,
             "HARNESS_WORKTREE_MISSING",
@@ -521,64 +513,125 @@ def _create_conversation(con, operator: dict, headers, body: dict):
 
     conversation_id = "cv_" + uuid.uuid4().hex
     provider = run_mod.session_provider(harness, model)
-    running = [
-        row for row in open_conversations
-        if row["state"] in ("queued", "running")
-    ]
-    if running:
-        con.rollback()
-        raise ApiError(
-            409,
-            "BROWSER_CHAT_BUSY",
-            "the open browser chat has a turn in progress",
-            {"conversation_id": running[0]["conversation_id"]},
-        )
     auto_closed = []
-    for row in open_conversations:
+    with db_driver.write_transaction(con, "conversation.create"):
+        existing = con.execute(
+            "SELECT conversation_id,creation_request_hash FROM conversations "
+            "WHERE mode='normal' AND owner_user_id=? "
+            "AND creation_idempotency_key=?",
+            (operator["user_id"], key),
+        ).fetchone()
+        if existing is not None:
+            if existing["creation_request_hash"] != request_hash:
+                raise ApiError(
+                    409,
+                    "CONVERSATION_IDEMPOTENCY_CONFLICT",
+                    "Idempotency-Key was reused with a different request",
+                )
+            row = _require_conversation(
+                con, existing["conversation_id"], operator["user_id"]
+            )
+            return _json(
+                201,
+                _conversation_projection(row),
+                [("Location", f"/api/conversations/{row['conversation_id']}")],
+            )
+
+        current_shell = con.execute(
+            "SELECT shell_id,display_name,shortname,flavor FROM shells "
+            "WHERE shell_id=? AND (user_id=? OR is_shared=1) "
+            "AND COALESCE(is_deleted,0)=0",
+            (shell_id, operator["user_id"]),
+        ).fetchone()
+        if current_shell is None:
+            raise ApiError(
+                422,
+                "SHELL_NOT_LAUNCHABLE",
+                "shell is unknown, deleted, or unavailable to this operator",
+            )
+        if (
+            current_shell["shortname"] != shell["shortname"]
+            or current_shell["flavor"] != shell["flavor"]
+        ):
+            raise ApiError(
+                409,
+                "SHELL_CHANGED",
+                "shell routing changed while the browser chat was prepared; retry",
+                {"shell_id": shell_id},
+            )
+
+        open_conversations = con.execute(
+            "SELECT conversation_id,state FROM conversations "
+            "WHERE mode='normal' AND shell_id=? AND state!='closed'",
+            (shell_id,),
+        ).fetchall()
+        if not open_conversations:
+            live_state = _live_shell_session(current_shell)
+            if live_state is not None:
+                raise ApiError(
+                    409,
+                    "SHELL_BUSY",
+                    f"shell {current_shell['shortname']!r} has a live CLI session; "
+                    "close it before opening a browser chat",
+                    {"shell_id": shell_id, "state": live_state},
+                )
+
+        running = [
+            row for row in open_conversations
+            if row["state"] in ("queued", "running")
+        ]
+        if running:
+            raise ApiError(
+                409,
+                "BROWSER_CHAT_BUSY",
+                "the open browser chat has a turn in progress",
+                {"conversation_id": running[0]["conversation_id"]},
+            )
+        for row in open_conversations:
+            con.execute(
+                "UPDATE conversations SET state='closed',"
+                "closed_at=datetime('now'),last_activity_at=datetime('now'),"
+                "version=version+1 WHERE conversation_id=?",
+                (row["conversation_id"],),
+            )
+            _append_event(
+                con,
+                row["conversation_id"],
+                "conversation.closed",
+                {"status": "closed", "reason": "another browser chat opened"},
+            )
+            auto_closed.append(row["conversation_id"])
         con.execute(
-            "UPDATE conversations SET state='closed',closed_at=datetime('now'),"
-            "last_activity_at=datetime('now'),version=version+1 "
-            "WHERE conversation_id=?",
-            (row["conversation_id"],),
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,owner_user_id,harness,provider,model,"
+            "effort,worktree,title,creation_idempotency_key,"
+            "creation_request_hash) VALUES (?,?,'normal',?,?,?,?,?,?,?,?,?)",
+            (
+                conversation_id,
+                shell_id,
+                operator["user_id"],
+                harness,
+                provider,
+                model,
+                effort,
+                str(worktree),
+                title,
+                key,
+                request_hash,
+            ),
         )
         _append_event(
             con,
-            row["conversation_id"],
-            "conversation.closed",
-            {"status": "closed", "reason": "another browser chat opened"},
-        )
-        auto_closed.append(row["conversation_id"])
-    con.execute(
-        "INSERT INTO conversations "
-        "(conversation_id,shell_id,mode,owner_user_id,harness,provider,model,"
-        "effort,worktree,title,creation_idempotency_key,"
-        "creation_request_hash) VALUES (?,?,'normal',?,?,?,?,?,?,?,?,?)",
-        (
             conversation_id,
-            shell_id,
-            operator["user_id"],
-            harness,
-            provider,
-            model,
-            effort,
-            str(worktree),
-            title,
-            key,
-            request_hash,
-        ),
-    )
-    _append_event(
-        con,
-        conversation_id,
-        "conversation.created",
-        {
-            "shell_id": shell_id,
-            "harness": harness,
-            "model": model,
-            "effort": effort,
-        },
-    )
-    con.commit()
+            "conversation.created",
+            {
+                "shell_id": shell_id,
+                "harness": harness,
+                "model": model,
+                "effort": effort,
+            },
+        )
+
     for closed_id in auto_closed:
         conversation_events.notify(closed_id)
     conversation_events.notify(conversation_id)
@@ -666,63 +719,62 @@ def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
     if "state" in body and body["state"] != "closed":
         raise ApiError(422, "VALIDATION_ERROR", "state may only be changed to closed")
 
-    con.execute("BEGIN IMMEDIATE")
-    row = _require_conversation(con, conversation_id, operator["user_id"])
-    if int(row["version"]) != version:
-        con.rollback()
-        raise ApiError(
-            409,
-            "CONVERSATION_VERSION_CONFLICT",
-            "conversation version does not match",
-            {"expected": int(row["version"]), "received": version},
+    with db_driver.write_transaction(con, "conversation.patch"):
+        row = _require_conversation(con, conversation_id, operator["user_id"])
+        if int(row["version"]) != version:
+            raise ApiError(
+                409,
+                "CONVERSATION_VERSION_CONFLICT",
+                "conversation version does not match",
+                {"expected": int(row["version"]), "received": version},
+            )
+        closing = body.get("state") == "closed"
+        if row["state"] == "closed":
+            raise ApiError(
+                409,
+                "CONVERSATION_CLOSED",
+                "conversation is already closed",
+            )
+        if closing and row["state"] not in ("idle", "waiting", "error"):
+            raise ApiError(
+                409,
+                "BROWSER_CHAT_BUSY",
+                "a queued or running conversation cannot be closed",
+                {"state": row["state"]},
+            )
+        sets = ["version=version+1", "last_activity_at=datetime('now')"]
+        params: list = []
+        if "title" in body:
+            sets.append("title=?")
+            params.append(title)
+        if closing:
+            sets.extend(("state='closed'", "closed_at=datetime('now')"))
+        changed = con.execute(
+            f"UPDATE conversations SET {','.join(sets)} "
+            "WHERE conversation_id=? AND owner_user_id=? AND version=?",
+            (*params, conversation_id, operator["user_id"], version),
+        ).rowcount
+        if changed != 1:
+            raise ApiError(
+                409,
+                "CONVERSATION_VERSION_CONFLICT",
+                "conversation changed concurrently",
+            )
+        _append_event(
+            con,
+            conversation_id,
+            (
+                "conversation.updated"
+                if "title" in body and closing
+                else "conversation.closed"
+                if closing
+                else "conversation.renamed"
+            ),
+            {
+                **({"title": title} if "title" in body else {}),
+                **({"state": "closed"} if closing else {}),
+            },
         )
-    closing = body.get("state") == "closed"
-    if row["state"] == "closed":
-        con.rollback()
-        raise ApiError(409, "CONVERSATION_CLOSED", "conversation is already closed")
-    if closing and row["state"] not in ("idle", "waiting", "error"):
-        con.rollback()
-        raise ApiError(
-            409,
-            "BROWSER_CHAT_BUSY",
-            "a queued or running conversation cannot be closed",
-            {"state": row["state"]},
-        )
-    sets = ["version=version+1", "last_activity_at=datetime('now')"]
-    params: list = []
-    if "title" in body:
-        sets.append("title=?")
-        params.append(title)
-    if closing:
-        sets.extend(("state='closed'", "closed_at=datetime('now')"))
-    changed = con.execute(
-        f"UPDATE conversations SET {','.join(sets)} "
-        "WHERE conversation_id=? AND owner_user_id=? AND version=?",
-        (*params, conversation_id, operator["user_id"], version),
-    ).rowcount
-    if changed != 1:
-        con.rollback()
-        raise ApiError(
-            409,
-            "CONVERSATION_VERSION_CONFLICT",
-            "conversation changed concurrently",
-        )
-    _append_event(
-        con,
-        conversation_id,
-        (
-            "conversation.updated"
-            if "title" in body and closing
-            else "conversation.closed"
-            if closing
-            else "conversation.renamed"
-        ),
-        {
-            **({"title": title} if "title" in body else {}),
-            **({"state": "closed"} if closing else {}),
-        },
-    )
-    con.commit()
     conversation_events.notify(conversation_id)
     return _json(
         200,
@@ -739,78 +791,86 @@ def _create_message(con, operator: dict, conversation_id: str, headers, body: di
     normalized = {"text": text}
     request_hash = _request_hash(normalized)
 
-    con.execute("BEGIN IMMEDIATE")
-    conversation = _require_conversation(con, conversation_id, operator["user_id"])
-    existing = con.execute(
-        "SELECT message_id,request_hash FROM conversation_messages "
-        "WHERE conversation_id=? AND idempotency_key=?",
-        (conversation_id, key),
-    ).fetchone()
-    if existing is not None:
-        if existing["request_hash"] != request_hash:
-            con.rollback()
+    with db_driver.write_transaction(con, "conversation.message.create"):
+        conversation = _require_conversation(
+            con,
+            conversation_id,
+            operator["user_id"],
+        )
+        existing = con.execute(
+            "SELECT message_id,request_hash FROM conversation_messages "
+            "WHERE conversation_id=? AND idempotency_key=?",
+            (conversation_id, key),
+        ).fetchone()
+        if existing is not None:
+            if existing["request_hash"] != request_hash:
+                raise ApiError(
+                    409,
+                    "MESSAGE_IDEMPOTENCY_CONFLICT",
+                    "Idempotency-Key was reused with a different message",
+                )
+            message = _message_projection(
+                _message_row(con, int(existing["message_id"]))
+            )
+            return _json(
+                202,
+                {
+                    "message": message,
+                    "queue_position": _accepted_queue_position(
+                        con,
+                        message["message_id"],
+                    ),
+                },
+                [("Location", f"/api/conversations/{conversation_id}/messages")],
+            )
+        if conversation["state"] == "closed":
             raise ApiError(
                 409,
-                "MESSAGE_IDEMPOTENCY_CONFLICT",
-                "Idempotency-Key was reused with a different message",
+                "CONVERSATION_CLOSED",
+                "closed conversations reject messages",
             )
-        message = _message_projection(_message_row(con, int(existing["message_id"])))
-        con.commit()
-        return _json(
-            202,
-            {
-                "message": message,
-                "queue_position": _accepted_queue_position(con, message["message_id"]),
-            },
-            [("Location", f"/api/conversations/{conversation_id}/messages")],
+        target_state = (
+            conversation["state"]
+            if conversation["state"] in ("queued", "running")
+            else "queued"
         )
-    if conversation["state"] == "closed":
-        con.rollback()
-        raise ApiError(
-            409, "CONVERSATION_CLOSED", "closed conversations reject messages"
+        message_id = int(
+            con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state) "
+                "VALUES (?,'user',?,'prompt',?,?,?,'queued')",
+                (
+                    conversation_id,
+                    str(operator["user_id"]),
+                    text,
+                    key,
+                    request_hash,
+                ),
+            ).lastrowid
         )
-    target_state = (
-        conversation["state"]
-        if conversation["state"] in ("queued", "running")
-        else "queued"
-    )
-    message_id = int(
         con.execute(
-            "INSERT INTO conversation_messages "
-            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
-            "idempotency_key,request_hash,state) "
-            "VALUES (?,'user',?,'prompt',?,?,?,'queued')",
-            (
-                conversation_id,
-                str(operator["user_id"]),
-                text,
-                key,
-                request_hash,
-            ),
-        ).lastrowid
-    )
-    con.execute(
-        "INSERT INTO conversation_outbox (conversation_id,message_id) VALUES (?,?)",
-        (conversation_id, message_id),
-    )
-    con.execute(
-        "UPDATE conversations SET state=?,last_activity_at=datetime('now'),"
-        "version=version+1 WHERE conversation_id=?",
-        (target_state, conversation_id),
-    )
-    position = _queue_position(con, message_id)
-    _append_event(
-        con,
-        conversation_id,
-        "message.accepted",
-        {
-            "message_id": message_id,
-            "queue_state": "queued",
-            "queue_position": position,
-        },
-        message_id=message_id,
-    )
-    con.commit()
+            "INSERT INTO conversation_outbox (conversation_id,message_id) "
+            "VALUES (?,?)",
+            (conversation_id, message_id),
+        )
+        con.execute(
+            "UPDATE conversations SET state=?,last_activity_at=datetime('now'),"
+            "version=version+1 WHERE conversation_id=?",
+            (target_state, conversation_id),
+        )
+        position = _queue_position(con, message_id)
+        _append_event(
+            con,
+            conversation_id,
+            "message.accepted",
+            {
+                "message_id": message_id,
+                "queue_state": "queued",
+                "queue_position": position,
+            },
+            message_id=message_id,
+        )
     conversation_events.notify(conversation_id)
     conversation_broker.notify_commit()
     return _json(
@@ -920,80 +980,79 @@ def _interrupt(con, operator: dict, conversation_id: str, headers, body: dict):
     normalized = {"run_id": requested_run}
     request_hash = _request_hash(normalized)
 
-    con.execute("BEGIN IMMEDIATE")
-    _require_conversation(con, conversation_id, operator["user_id"])
-    existing = con.execute(
-        "SELECT message_id,request_hash,body FROM conversation_messages "
-        "WHERE conversation_id=? AND idempotency_key=?",
-        (conversation_id, key),
-    ).fetchone()
-    if existing is not None:
-        if existing["request_hash"] != request_hash:
-            con.rollback()
-            raise ApiError(
-                409,
-                "MESSAGE_IDEMPOTENCY_CONFLICT",
-                "Idempotency-Key was reused with a different interruption",
+    replay = False
+    with db_driver.write_transaction(con, "conversation.interrupt.create"):
+        _require_conversation(con, conversation_id, operator["user_id"])
+        existing = con.execute(
+            "SELECT message_id,request_hash,body FROM conversation_messages "
+            "WHERE conversation_id=? AND idempotency_key=?",
+            (conversation_id, key),
+        ).fetchone()
+        if existing is not None:
+            if existing["request_hash"] != request_hash:
+                raise ApiError(
+                    409,
+                    "MESSAGE_IDEMPOTENCY_CONFLICT",
+                    "Idempotency-Key was reused with a different interruption",
+                )
+            audit = _message_projection(
+                _message_row(con, int(existing["message_id"]))
             )
-        audit = _message_projection(_message_row(con, int(existing["message_id"])))
-        run_id = int(json.loads(existing["body"])["run_id"])
-        con.commit()
-        _request_interrupt(run_id, replay=True)
-        return _json(202, {"interruption": audit, "run_id": run_id})
-
-    clauses = [
-        "conversation_id=?",
-        "state IN ('leased','starting','running')",
-    ]
-    params: list = [conversation_id]
-    if requested_run is not None:
-        clauses.append("run_id=?")
-        params.append(requested_run)
-    active = con.execute(
-        "SELECT run_id FROM conversation_runs WHERE "
-        + " AND ".join(clauses)
-        + " ORDER BY run_id DESC LIMIT 1",
-        params,
-    ).fetchone()
-    if active is None:
-        con.rollback()
-        raise ApiError(
-            409,
-            "RUN_ALREADY_TERMINAL",
-            "no matching active run can be interrupted",
-        )
-    run_id = int(active["run_id"])
-    audit_body = json.dumps(
-        {"kind": "interrupt", "run_id": run_id},
-        separators=(",", ":"),
-        sort_keys=True,
-    )
-    message_id = int(
-        con.execute(
-            "INSERT INTO conversation_messages "
-            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
-            "idempotency_key,request_hash,state,completed_at) "
-            "VALUES (?,'user',?,'control',?,?,?,'completed',datetime('now'))",
-            (
-                conversation_id,
-                str(operator["user_id"]),
-                audit_body,
-                key,
-                request_hash,
-            ),
-        ).lastrowid
-    )
-    con.execute(
-        "UPDATE conversations SET last_activity_at=datetime('now'),"
-        "version=version+1 WHERE conversation_id=?",
-        (conversation_id,),
-    )
-    con.commit()
-    _request_interrupt(run_id, replay=False)
+            run_id = int(json.loads(existing["body"])["run_id"])
+            replay = True
+        else:
+            clauses = [
+                "conversation_id=?",
+                "state IN ('leased','starting','running')",
+            ]
+            params: list = [conversation_id]
+            if requested_run is not None:
+                clauses.append("run_id=?")
+                params.append(requested_run)
+            active = con.execute(
+                "SELECT run_id FROM conversation_runs WHERE "
+                + " AND ".join(clauses)
+                + " ORDER BY run_id DESC LIMIT 1",
+                params,
+            ).fetchone()
+            if active is None:
+                raise ApiError(
+                    409,
+                    "RUN_ALREADY_TERMINAL",
+                    "no matching active run can be interrupted",
+                )
+            run_id = int(active["run_id"])
+            audit_body = json.dumps(
+                {"kind": "interrupt", "run_id": run_id},
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            message_id = int(
+                con.execute(
+                    "INSERT INTO conversation_messages "
+                    "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                    "idempotency_key,request_hash,state,completed_at) "
+                    "VALUES (?,'user',?,'control',?,?,?,'completed',datetime('now'))",
+                    (
+                        conversation_id,
+                        str(operator["user_id"]),
+                        audit_body,
+                        key,
+                        request_hash,
+                    ),
+                ).lastrowid
+            )
+            con.execute(
+                "UPDATE conversations SET last_activity_at=datetime('now'),"
+                "version=version+1 WHERE conversation_id=?",
+                (conversation_id,),
+            )
+            audit = _message_projection(_message_row(con, message_id))
+    _request_interrupt(run_id, replay=replay)
     return _json(
         202,
         {
-            "interruption": _message_projection(_message_row(con, message_id)),
+            "interruption": audit,
             "run_id": run_id,
         },
     )
@@ -1066,6 +1125,21 @@ def handle(method: str, path: str, headers_raw: str, raw_body: bytes) -> tuple:
             if con.in_transaction:
                 con.rollback()
             return _api_error(exc)
+        except db_driver.OperationalError as exc:
+            if con.in_transaction:
+                con.rollback()
+            if db_driver.is_busy_error(exc):
+                return _err(
+                    503,
+                    "ENGINE_DB_BUSY",
+                    "engine database is busy; retry this request",
+                    {"retry_after": 2},
+                )
+            return _err(
+                500,
+                "INTERNAL_ERROR",
+                "conversation request failed",
+            )
         except Exception:  # noqa: BLE001 — uniform boundary for handler faults
             if con.in_transaction:
                 con.rollback()

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -138,17 +138,6 @@ class BrokerStore:
         return _stamp(now), _stamp(now + timedelta(seconds=self.lease_seconds))
 
     @staticmethod
-    def _begin(con) -> None:
-        con.execute("BEGIN IMMEDIATE")
-
-    @staticmethod
-    def _rollback(con) -> None:
-        try:
-            con.rollback()
-        except Exception:
-            pass
-
-    @staticmethod
     def _payload(payload: Mapping[str, Any] | None) -> str:
         encoded = json.dumps(
             dict(payload or {}),
@@ -240,118 +229,112 @@ class BrokerStore:
         con = self.connect()
         now, expires = self._times()
         try:
-            self._begin(con)
-            row = con.execute(
-                "SELECT o.outbox_id,o.conversation_id,o.message_id,o.attempts,"
-                "c.shell_id,c.harness,c.provider,c.model,c.effort,c.worktree,"
-                "c.title,c.harness_session_ref,m.body,m.state AS message_state "
-                "FROM conversation_outbox o "
-                "JOIN conversations c "
-                " ON c.conversation_id=o.conversation_id "
-                "JOIN conversation_messages m ON m.message_id=o.message_id "
-                "WHERE o.state='pending' AND c.state='queued' "
-                "AND m.state IN ('accepted','queued') "
-                "AND NOT EXISTS ("
-                " SELECT 1 FROM conversation_messages earlier "
-                " WHERE earlier.conversation_id=m.conversation_id "
-                " AND earlier.message_id<m.message_id "
-                " AND earlier.state IN ('accepted','queued','running')) "
-                "AND NOT EXISTS ("
-                " SELECT 1 FROM conversation_runs live "
-                " WHERE live.shell_id=c.shell_id "
-                " AND live.state IN ('leased','starting','running')) "
-                "ORDER BY o.outbox_id LIMIT 1"
-            ).fetchone()
-            if row is None:
-                con.commit()
-                return None
+            with db_driver.write_transaction(con, "conversation.broker.claim"):
+                row = con.execute(
+                    "SELECT o.outbox_id,o.conversation_id,o.message_id,o.attempts,"
+                    "c.shell_id,c.harness,c.provider,c.model,c.effort,c.worktree,"
+                    "c.title,c.harness_session_ref,m.body,m.state AS message_state "
+                    "FROM conversation_outbox o "
+                    "JOIN conversations c "
+                    " ON c.conversation_id=o.conversation_id "
+                    "JOIN conversation_messages m ON m.message_id=o.message_id "
+                    "WHERE o.state='pending' AND c.state='queued' "
+                    "AND m.state IN ('accepted','queued') "
+                    "AND NOT EXISTS ("
+                    " SELECT 1 FROM conversation_messages earlier "
+                    " WHERE earlier.conversation_id=m.conversation_id "
+                    " AND earlier.message_id<m.message_id "
+                    " AND earlier.state IN ('accepted','queued','running')) "
+                    "AND NOT EXISTS ("
+                    " SELECT 1 FROM conversation_runs live "
+                    " WHERE live.shell_id=c.shell_id "
+                    " AND live.state IN ('leased','starting','running')) "
+                    "ORDER BY o.outbox_id LIMIT 1"
+                ).fetchone()
+                if row is None:
+                    return None
 
-            updated = con.execute(
-                "UPDATE conversation_outbox SET state='claimed',claim_owner=?,"
-                "claimed_at=?,lease_expires_at=?,attempts=attempts+1 "
-                "WHERE outbox_id=? AND state='pending'",
-                (owner, now, expires, row["outbox_id"]),
-            ).rowcount
-            if updated != 1:
-                con.rollback()
-                return None
+                updated = con.execute(
+                    "UPDATE conversation_outbox SET state='claimed',claim_owner=?,"
+                    "claimed_at=?,lease_expires_at=?,attempts=attempts+1 "
+                    "WHERE outbox_id=? AND state='pending'",
+                    (owner, now, expires, row["outbox_id"]),
+                ).rowcount
+                if updated != 1:
+                    return None
 
-            attempt = int(row["attempts"]) + 1
-            if row["message_state"] == "accepted":
-                require_transition("message", "accepted", "queued")
+                attempt = int(row["attempts"]) + 1
+                if row["message_state"] == "accepted":
+                    require_transition("message", "accepted", "queued")
+                    con.execute(
+                        "UPDATE conversation_messages SET state='queued' "
+                        "WHERE message_id=?",
+                        (row["message_id"],),
+                    )
+                require_transition("message", "queued", "running")
                 con.execute(
-                    "UPDATE conversation_messages SET state='queued' "
+                    "UPDATE conversation_messages SET state='running' "
                     "WHERE message_id=?",
                     (row["message_id"],),
                 )
-            require_transition("message", "queued", "running")
-            con.execute(
-                "UPDATE conversation_messages SET state='running' WHERE message_id=?",
-                (row["message_id"],),
-            )
 
-            cur = con.execute(
-                "INSERT INTO conversation_runs "
-                "(conversation_id,shell_id,trigger_message_id,attempt,"
-                "harness_session_before,state,lease_owner,lease_expires_at,"
-                "heartbeat_at) VALUES (?,?,?,?,?,'leased',?,?,?)",
-                (
-                    row["conversation_id"],
-                    row["shell_id"],
-                    row["message_id"],
-                    attempt,
-                    row["harness_session_ref"],
-                    owner,
-                    expires,
-                    now,
-                ),
-            )
-            run_id = int(cur.lastrowid)
-            require_transition("outbox", "claimed", "dispatched")
-            con.execute(
-                "UPDATE conversation_outbox SET state='dispatched',run_id=?,"
-                "dispatched_at=? WHERE outbox_id=?",
-                (run_id, now, row["outbox_id"]),
-            )
-            require_transition("conversation", "queued", "running")
-            con.execute(
-                "UPDATE conversations SET state='running',"
-                "last_activity_at=?,version=version+1 "
-                "WHERE conversation_id=?",
-                (now, row["conversation_id"]),
-            )
-            con.commit()
-            return BrokerRun(
-                run_id=run_id,
-                conversation_id=row["conversation_id"],
-                message_id=int(row["message_id"]),
-                shell_id=int(row["shell_id"]),
-                harness=row["harness"],
-                provider=row["provider"],
-                model=row["model"],
-                effort=row["effort"],
-                worktree=Path(row["worktree"]),
-                title=row["title"],
-                body=row["body"],
-                session_before=row["harness_session_ref"],
-                session_after=None,
-                runner_ref=None,
-                state="leased",
-            )
+                cur = con.execute(
+                    "INSERT INTO conversation_runs "
+                    "(conversation_id,shell_id,trigger_message_id,attempt,"
+                    "harness_session_before,state,lease_owner,lease_expires_at,"
+                    "heartbeat_at) VALUES (?,?,?,?,?,'leased',?,?,?)",
+                    (
+                        row["conversation_id"],
+                        row["shell_id"],
+                        row["message_id"],
+                        attempt,
+                        row["harness_session_ref"],
+                        owner,
+                        expires,
+                        now,
+                    ),
+                )
+                run_id = int(cur.lastrowid)
+                require_transition("outbox", "claimed", "dispatched")
+                con.execute(
+                    "UPDATE conversation_outbox SET state='dispatched',run_id=?,"
+                    "dispatched_at=? WHERE outbox_id=?",
+                    (run_id, now, row["outbox_id"]),
+                )
+                require_transition("conversation", "queued", "running")
+                con.execute(
+                    "UPDATE conversations SET state='running',"
+                    "last_activity_at=?,version=version+1 "
+                    "WHERE conversation_id=?",
+                    (now, row["conversation_id"]),
+                )
+                return BrokerRun(
+                    run_id=run_id,
+                    conversation_id=row["conversation_id"],
+                    message_id=int(row["message_id"]),
+                    shell_id=int(row["shell_id"]),
+                    harness=row["harness"],
+                    provider=row["provider"],
+                    model=row["model"],
+                    effort=row["effort"],
+                    worktree=Path(row["worktree"]),
+                    title=row["title"],
+                    body=row["body"],
+                    session_before=row["harness_session_ref"],
+                    session_after=None,
+                    runner_ref=None,
+                    state="leased",
+                )
         except db_driver.IntegrityError as exc:
             # A second broker can race the eligibility read. BEGIN IMMEDIATE
             # serializes normal SQLite writers; the unique live-run indexes
             # remain the final fail-closed fence.
-            self._rollback(con)
             detail = str(exc)
             if (
                 "conversation_runs.shell_id" in detail
                 or "conversation_runs.conversation_id" in detail
             ):
                 return None
-            raise
-        except Exception:
-            self._rollback(con)
             raise
         finally:
             con.close()
@@ -375,28 +358,25 @@ class BrokerStore:
         con = self.connect()
         now, expires = self._times()
         try:
-            self._begin(con)
-            selected = con.execute(
-                self._run_select() + "WHERE r.state IN ('leased','starting','running') "
-                "AND r.lease_expires_at<=? ORDER BY r.run_id LIMIT ?",
-                (now, limit),
-            ).fetchall()
-            adopted: list[BrokerRun] = []
-            for row in selected:
-                changed = con.execute(
-                    "UPDATE conversation_runs SET lease_owner=?,"
-                    "lease_expires_at=?,heartbeat_at=? "
-                    "WHERE run_id=? AND state IN "
-                    "('leased','starting','running')",
-                    (owner, expires, now, row["run_id"]),
-                ).rowcount
-                if changed:
-                    adopted.append(self._run_from_row(row))
-            con.commit()
-            return adopted
-        except Exception:
-            self._rollback(con)
-            raise
+            with db_driver.write_transaction(con, "conversation.broker.adopt"):
+                selected = con.execute(
+                    self._run_select()
+                    + "WHERE r.state IN ('leased','starting','running') "
+                    "AND r.lease_expires_at<=? ORDER BY r.run_id LIMIT ?",
+                    (now, limit),
+                ).fetchall()
+                adopted: list[BrokerRun] = []
+                for row in selected:
+                    changed = con.execute(
+                        "UPDATE conversation_runs SET lease_owner=?,"
+                        "lease_expires_at=?,heartbeat_at=? "
+                        "WHERE run_id=? AND state IN "
+                        "('leased','starting','running')",
+                        (owner, expires, now, row["run_id"]),
+                    ).rowcount
+                    if changed:
+                        adopted.append(self._run_from_row(row))
+                return adopted
         finally:
             con.close()
 
@@ -405,19 +385,16 @@ class BrokerStore:
         con = self.connect()
         now, _ = self._times()
         try:
-            self._begin(con)
-            count = con.execute(
-                "UPDATE conversation_outbox SET state='pending',"
-                "claim_owner=NULL,claimed_at=NULL,lease_expires_at=NULL,"
-                "last_error='expired before durable run creation' "
-                "WHERE state='claimed' AND lease_expires_at<=? AND run_id IS NULL",
-                (now,),
-            ).rowcount
-            con.commit()
-            return int(count)
-        except Exception:
-            self._rollback(con)
-            raise
+            with db_driver.write_transaction(con, "conversation.broker.requeue"):
+                count = con.execute(
+                    "UPDATE conversation_outbox SET state='pending',"
+                    "claim_owner=NULL,claimed_at=NULL,lease_expires_at=NULL,"
+                    "last_error='expired before durable run creation' "
+                    "WHERE state='claimed' AND lease_expires_at<=? "
+                    "AND run_id IS NULL",
+                    (now,),
+                ).rowcount
+                return int(count)
         finally:
             con.close()
 
@@ -425,29 +402,29 @@ class BrokerStore:
         con = self.connect()
         now, expires = self._times()
         try:
-            self._begin(con)
-            row = con.execute(
-                "SELECT state,lease_owner FROM conversation_runs WHERE run_id=?",
-                (run_id,),
-            ).fetchone()
-            if row is None:
-                raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
-            require_transition("run", row["state"], "starting")
-            changed = con.execute(
-                "UPDATE conversation_runs SET state='starting',started_at=?,"
-                "heartbeat_at=?,lease_expires_at=? "
-                "WHERE run_id=? AND lease_owner=? AND state='leased'",
-                (now, now, expires, run_id, owner),
-            ).rowcount
-            if changed != 1:
-                raise BrokerError(
-                    "CONVERSATION_RUN_LEASE_LOST",
-                    f"run {run_id} is not leased by this broker",
-                )
-            con.commit()
-        except Exception:
-            self._rollback(con)
-            raise
+            with db_driver.write_transaction(
+                con,
+                "conversation.broker.mark_starting",
+            ):
+                row = con.execute(
+                    "SELECT state,lease_owner FROM conversation_runs "
+                    "WHERE run_id=?",
+                    (run_id,),
+                ).fetchone()
+                if row is None:
+                    raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+                require_transition("run", row["state"], "starting")
+                changed = con.execute(
+                    "UPDATE conversation_runs SET state='starting',started_at=?,"
+                    "heartbeat_at=?,lease_expires_at=? "
+                    "WHERE run_id=? AND lease_owner=? AND state='leased'",
+                    (now, now, expires, run_id, owner),
+                ).rowcount
+                if changed != 1:
+                    raise BrokerError(
+                        "CONVERSATION_RUN_LEASE_LOST",
+                        f"run {run_id} is not leased by this broker",
+                    )
         finally:
             con.close()
 
@@ -455,18 +432,21 @@ class BrokerStore:
         """Attach the canonical shell session archive before native dispatch."""
         con = self.connect()
         try:
-            changed = con.execute(
-                "UPDATE conversation_runs SET archive_id=? "
-                "WHERE run_id=? AND lease_owner=? AND state='leased' "
-                "AND archive_id IS NULL",
-                (archive_id, run_id, owner),
-            ).rowcount
-            if changed != 1:
-                raise BrokerError(
-                    "CONVERSATION_RUN_LEASE_LOST",
-                    f"run {run_id} is not an unbound lease owned by this broker",
-                )
-            con.commit()
+            with db_driver.write_transaction(
+                con,
+                "conversation.broker.bind_archive",
+            ):
+                changed = con.execute(
+                    "UPDATE conversation_runs SET archive_id=? "
+                    "WHERE run_id=? AND lease_owner=? AND state='leased' "
+                    "AND archive_id IS NULL",
+                    (archive_id, run_id, owner),
+                ).rowcount
+                if changed != 1:
+                    raise BrokerError(
+                        "CONVERSATION_RUN_LEASE_LOST",
+                        f"run {run_id} is not an unbound lease owned by this broker",
+                    )
         finally:
             con.close()
 
@@ -477,75 +457,79 @@ class BrokerStore:
         turn: NativeTurn,
     ) -> None:
         """Capture exact native identity before consuming the event stream."""
+        # Filesystem normalization is external preparation, never writer-lock
+        # work. Conversation creation stores an already-resolved absolute path.
+        actual_worktree = Path(turn.worktree).resolve()
         con = self.connect()
         now, expires = self._times()
         try:
-            self._begin(con)
-            row = con.execute(
-                "SELECT r.state,r.conversation_id,c.harness_session_ref,"
-                "c.harness,c.worktree "
-                "FROM conversation_runs r JOIN conversations c "
-                "ON c.conversation_id=r.conversation_id WHERE r.run_id=?",
-                (run_id,),
-            ).fetchone()
-            if row is None:
-                raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
-            if turn.harness != row["harness"]:
-                raise BrokerInvariantError(
-                    "HARNESS_IDENTITY_MISMATCH",
-                    f"conversation uses {row['harness']}, "
-                    f"adapter returned {turn.harness}",
+            with db_driver.write_transaction(
+                con,
+                "conversation.broker.mark_native_started",
+            ):
+                row = con.execute(
+                    "SELECT r.state,r.conversation_id,c.harness_session_ref,"
+                    "c.harness,c.worktree "
+                    "FROM conversation_runs r JOIN conversations c "
+                    "ON c.conversation_id=r.conversation_id WHERE r.run_id=?",
+                    (run_id,),
+                ).fetchone()
+                if row is None:
+                    raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+                if turn.harness != row["harness"]:
+                    raise BrokerInvariantError(
+                        "HARNESS_IDENTITY_MISMATCH",
+                        f"conversation uses {row['harness']}, "
+                        f"adapter returned {turn.harness}",
+                    )
+                if not turn.session_ref or not turn.run_ref:
+                    raise BrokerInvariantError(
+                        "HARNESS_IDENTITY_MISSING",
+                        "adapter returned an empty native session or run reference",
+                    )
+                expected_worktree = Path(row["worktree"])
+                if actual_worktree != expected_worktree:
+                    raise BrokerInvariantError(
+                        "HARNESS_WORKTREE_MISMATCH",
+                        f"conversation is bound to {expected_worktree}, "
+                        f"adapter returned {actual_worktree}",
+                    )
+                current_session = row["harness_session_ref"]
+                if (
+                    current_session is not None
+                    and current_session != turn.session_ref
+                ):
+                    raise BrokerInvariantError(
+                        "HARNESS_SESSION_MISMATCH",
+                        f"conversation is bound to {current_session}, "
+                        f"adapter returned {turn.session_ref}",
+                    )
+                require_transition("run", row["state"], "running")
+                changed = con.execute(
+                    "UPDATE conversation_runs SET state='running',"
+                    "harness_session_after=?,runner_ref=?,heartbeat_at=?,"
+                    "lease_expires_at=? WHERE run_id=? AND lease_owner=? "
+                    "AND state='starting'",
+                    (
+                        turn.session_ref,
+                        turn.run_ref,
+                        now,
+                        expires,
+                        run_id,
+                        owner,
+                    ),
+                ).rowcount
+                if changed != 1:
+                    raise BrokerError(
+                        "CONVERSATION_RUN_LEASE_LOST",
+                        f"run {run_id} lost its starting lease",
+                    )
+                con.execute(
+                    "UPDATE conversations SET harness_session_ref=?,"
+                    "last_activity_at=?,version=version+1 "
+                    "WHERE conversation_id=?",
+                    (turn.session_ref, now, row["conversation_id"]),
                 )
-            if not turn.session_ref or not turn.run_ref:
-                raise BrokerInvariantError(
-                    "HARNESS_IDENTITY_MISSING",
-                    "adapter returned an empty native session or run reference",
-                )
-            expected_worktree = Path(row["worktree"]).resolve()
-            actual_worktree = Path(turn.worktree).resolve()
-            if actual_worktree != expected_worktree:
-                raise BrokerInvariantError(
-                    "HARNESS_WORKTREE_MISMATCH",
-                    f"conversation is bound to {expected_worktree}, "
-                    f"adapter returned {actual_worktree}",
-                )
-            current_session = row["harness_session_ref"]
-            if current_session is not None and current_session != turn.session_ref:
-                raise BrokerInvariantError(
-                    "HARNESS_SESSION_MISMATCH",
-                    f"conversation is bound to {current_session}, "
-                    f"adapter returned {turn.session_ref}",
-                )
-            require_transition("run", row["state"], "running")
-            changed = con.execute(
-                "UPDATE conversation_runs SET state='running',"
-                "harness_session_after=?,runner_ref=?,heartbeat_at=?,"
-                "lease_expires_at=? WHERE run_id=? AND lease_owner=? "
-                "AND state='starting'",
-                (
-                    turn.session_ref,
-                    turn.run_ref,
-                    now,
-                    expires,
-                    run_id,
-                    owner,
-                ),
-            ).rowcount
-            if changed != 1:
-                raise BrokerError(
-                    "CONVERSATION_RUN_LEASE_LOST",
-                    f"run {run_id} lost its starting lease",
-                )
-            con.execute(
-                "UPDATE conversations SET harness_session_ref=?,"
-                "last_activity_at=?,version=version+1 "
-                "WHERE conversation_id=?",
-                (turn.session_ref, now, row["conversation_id"]),
-            )
-            con.commit()
-        except Exception:
-            self._rollback(con)
-            raise
         finally:
             con.close()
 
@@ -562,40 +546,39 @@ class BrokerStore:
         con = self.connect()
         now, _ = self._times()
         try:
-            self._begin(con)
-            row = con.execute(
-                "SELECT conversation_id,trigger_message_id,state "
-                "FROM conversation_runs WHERE run_id=?",
-                (run_id,),
-            ).fetchone()
-            if row is None:
-                raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
-            if row["state"] not in LIVE_RUN_STATES:
-                raise BrokerError(
-                    "CONVERSATION_RUN_TERMINAL",
-                    f"run {run_id} is already {row['state']}",
-                )
-            payload = dict(event.payload)
-            if event.native_type:
-                payload["native_type"] = event.native_type
-            sequence = self._append_event(
+            with db_driver.write_transaction(
                 con,
-                conversation_id=row["conversation_id"],
-                event_type=event.type,
-                payload=payload,
-                message_id=row["trigger_message_id"],
-                run_id=run_id,
-            )
-            con.execute(
-                "UPDATE conversations SET last_activity_at=?,version=version+1 "
-                "WHERE conversation_id=?",
-                (now, row["conversation_id"]),
-            )
-            con.commit()
-            conversation_id = row["conversation_id"]
-        except Exception:
-            self._rollback(con)
-            raise
+                "conversation.broker.append_event",
+            ):
+                row = con.execute(
+                    "SELECT conversation_id,trigger_message_id,state "
+                    "FROM conversation_runs WHERE run_id=?",
+                    (run_id,),
+                ).fetchone()
+                if row is None:
+                    raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+                if row["state"] not in LIVE_RUN_STATES:
+                    raise BrokerError(
+                        "CONVERSATION_RUN_TERMINAL",
+                        f"run {run_id} is already {row['state']}",
+                    )
+                payload = dict(event.payload)
+                if event.native_type:
+                    payload["native_type"] = event.native_type
+                sequence = self._append_event(
+                    con,
+                    conversation_id=row["conversation_id"],
+                    event_type=event.type,
+                    payload=payload,
+                    message_id=row["trigger_message_id"],
+                    run_id=run_id,
+                )
+                con.execute(
+                    "UPDATE conversations SET last_activity_at=?,"
+                    "version=version+1 WHERE conversation_id=?",
+                    (now, row["conversation_id"]),
+                )
+                conversation_id = row["conversation_id"]
         finally:
             con.close()
         conversation_events.notify(conversation_id)
@@ -621,89 +604,87 @@ class BrokerStore:
         con = self.connect()
         now, _ = self._times()
         try:
-            self._begin(con)
-            row = con.execute(
-                "SELECT r.state,r.conversation_id,r.trigger_message_id,"
-                "c.state AS conversation_state "
-                "FROM conversation_runs r JOIN conversations c "
-                "ON c.conversation_id=r.conversation_id WHERE r.run_id=?",
-                (run_id,),
-            ).fetchone()
-            if row is None:
-                raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
-            if row["state"] in TERMINAL_RUN_STATES:
-                con.commit()
-                return False
-            require_transition("run", row["state"], outcome)
-            message_state = {
-                "succeeded": "completed",
-                "failed": "failed",
-                "cancelled": "cancelled",
-                "unknown": "failed",
-            }[outcome]
-            message_current = con.execute(
-                "SELECT state FROM conversation_messages WHERE message_id=?",
-                (row["trigger_message_id"],),
-            ).fetchone()[0]
-            require_transition("message", message_current, message_state)
-            pending = (
-                con.execute(
-                    "SELECT 1 FROM conversation_outbox "
-                    "WHERE conversation_id=? AND state IN ('pending','claimed') "
-                    "LIMIT 1",
-                    (row["conversation_id"],),
-                ).fetchone()
-                is not None
-            )
-            conversation_target = (
-                "error"
-                if outcome in {"failed", "unknown"}
-                else "queued"
-                if pending
-                else "idle"
-            )
-            require_transition(
-                "conversation",
-                row["conversation_state"],
-                conversation_target,
-            )
-            con.execute(
-                "UPDATE conversation_runs SET state=?,ended_at=?,exit_code=?,"
-                "error_code=?,error_detail=? WHERE run_id=?",
-                (
-                    outcome,
-                    now,
-                    exit_code,
-                    error_code,
-                    (error_detail or "")[:16384] or None,
-                    run_id,
-                ),
-            )
-            con.execute(
-                "UPDATE conversation_messages SET state=?,completed_at=? "
-                "WHERE message_id=?",
-                (message_state, now, row["trigger_message_id"]),
-            )
-            con.execute(
-                "UPDATE conversations SET state=?,last_activity_at=?,"
-                "version=version+1 WHERE conversation_id=?",
-                (conversation_target, now, row["conversation_id"]),
-            )
-            terminal_payload = dict(payload or {})
-            terminal_payload.setdefault("outcome", outcome)
-            self._append_event(
+            with db_driver.write_transaction(
                 con,
-                conversation_id=row["conversation_id"],
-                event_type=event_type,
-                payload=terminal_payload,
-                message_id=row["trigger_message_id"],
-                run_id=run_id,
-            )
-            con.commit()
-            conversation_id = row["conversation_id"]
-        except Exception:
-            self._rollback(con)
-            raise
+                "conversation.broker.finish_run",
+            ):
+                row = con.execute(
+                    "SELECT r.state,r.conversation_id,r.trigger_message_id,"
+                    "c.state AS conversation_state "
+                    "FROM conversation_runs r JOIN conversations c "
+                    "ON c.conversation_id=r.conversation_id WHERE r.run_id=?",
+                    (run_id,),
+                ).fetchone()
+                if row is None:
+                    raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+                if row["state"] in TERMINAL_RUN_STATES:
+                    return False
+                require_transition("run", row["state"], outcome)
+                message_state = {
+                    "succeeded": "completed",
+                    "failed": "failed",
+                    "cancelled": "cancelled",
+                    "unknown": "failed",
+                }[outcome]
+                message_current = con.execute(
+                    "SELECT state FROM conversation_messages WHERE message_id=?",
+                    (row["trigger_message_id"],),
+                ).fetchone()[0]
+                require_transition("message", message_current, message_state)
+                pending = (
+                    con.execute(
+                        "SELECT 1 FROM conversation_outbox "
+                        "WHERE conversation_id=? "
+                        "AND state IN ('pending','claimed') LIMIT 1",
+                        (row["conversation_id"],),
+                    ).fetchone()
+                    is not None
+                )
+                conversation_target = (
+                    "error"
+                    if outcome in {"failed", "unknown"}
+                    else "queued"
+                    if pending
+                    else "idle"
+                )
+                require_transition(
+                    "conversation",
+                    row["conversation_state"],
+                    conversation_target,
+                )
+                con.execute(
+                    "UPDATE conversation_runs SET state=?,ended_at=?,"
+                    "exit_code=?,error_code=?,error_detail=? WHERE run_id=?",
+                    (
+                        outcome,
+                        now,
+                        exit_code,
+                        error_code,
+                        (error_detail or "")[:16384] or None,
+                        run_id,
+                    ),
+                )
+                con.execute(
+                    "UPDATE conversation_messages SET state=?,completed_at=? "
+                    "WHERE message_id=?",
+                    (message_state, now, row["trigger_message_id"]),
+                )
+                con.execute(
+                    "UPDATE conversations SET state=?,last_activity_at=?,"
+                    "version=version+1 WHERE conversation_id=?",
+                    (conversation_target, now, row["conversation_id"]),
+                )
+                terminal_payload = dict(payload or {})
+                terminal_payload.setdefault("outcome", outcome)
+                self._append_event(
+                    con,
+                    conversation_id=row["conversation_id"],
+                    event_type=event_type,
+                    payload=terminal_payload,
+                    message_id=row["trigger_message_id"],
+                    run_id=run_id,
+                )
+                conversation_id = row["conversation_id"]
         finally:
             con.close()
         conversation_events.notify(conversation_id)
@@ -716,15 +697,18 @@ class BrokerStore:
         now, expires = self._times()
         marks = ",".join("?" for _ in run_ids)
         try:
-            changed = con.execute(
-                "UPDATE conversation_runs SET heartbeat_at=?,"
-                "lease_expires_at=? WHERE lease_owner=? "
-                f"AND state IN ('leased','starting','running') "
-                f"AND run_id IN ({marks})",
-                (now, expires, owner, *run_ids),
-            ).rowcount
-            con.commit()
-            return int(changed)
+            with db_driver.write_transaction(
+                con,
+                "conversation.broker.renew_runs",
+            ):
+                changed = con.execute(
+                    "UPDATE conversation_runs SET heartbeat_at=?,"
+                    "lease_expires_at=? WHERE lease_owner=? "
+                    f"AND state IN ('leased','starting','running') "
+                    f"AND run_id IN ({marks})",
+                    (now, expires, owner, *run_ids),
+                ).rowcount
+                return int(changed)
         finally:
             con.close()
 
@@ -737,14 +721,17 @@ class BrokerStore:
         con = self.connect()
         now, expires = self._times()
         try:
-            con.execute(
-                "UPDATE conversation_runs SET heartbeat_at=?,"
-                "lease_expires_at=?,error_detail=? "
-                "WHERE run_id=? AND lease_owner=? "
-                "AND state IN ('starting','running')",
-                (now, expires, detail[:16384], run_id, owner),
-            )
-            con.commit()
+            with db_driver.write_transaction(
+                con,
+                "conversation.broker.note_reconcile_error",
+            ):
+                con.execute(
+                    "UPDATE conversation_runs SET heartbeat_at=?,"
+                    "lease_expires_at=?,error_detail=? "
+                    "WHERE run_id=? AND lease_owner=? "
+                    "AND state IN ('starting','running')",
+                    (now, expires, detail[:16384], run_id, owner),
+                )
         finally:
             con.close()
 
@@ -753,44 +740,43 @@ class BrokerStore:
         con = self.connect()
         now, _ = self._times()
         try:
-            self._begin(con)
-            row = con.execute(
-                "SELECT conversation_id,trigger_message_id,state "
-                "FROM conversation_runs WHERE run_id=?",
-                (run_id,),
-            ).fetchone()
-            if row is None:
-                raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
-            if row["state"] not in LIVE_RUN_STATES:
-                raise BrokerError(
-                    "CONVERSATION_RUN_NOT_ACTIVE",
-                    f"run {run_id} is {row['state']}",
-                )
-            exists = con.execute(
-                "SELECT 1 FROM conversation_events "
-                "WHERE run_id=? AND event_type='run.interrupt.requested'",
-                (run_id,),
-            ).fetchone()
-            if exists is None:
-                self._append_event(
-                    con,
-                    conversation_id=row["conversation_id"],
-                    event_type="run.interrupt.requested",
-                    payload={"requested_at": now},
-                    message_id=row["trigger_message_id"],
-                    run_id=run_id,
-                )
-                con.execute(
-                    "UPDATE conversations SET last_activity_at=?,"
-                    "version=version+1 WHERE conversation_id=?",
-                    (now, row["conversation_id"]),
-                )
-            con.commit()
-            conversation_id = row["conversation_id"]
-            created = exists is None
-        except Exception:
-            self._rollback(con)
-            raise
+            with db_driver.write_transaction(
+                con,
+                "conversation.broker.request_interrupt",
+            ):
+                row = con.execute(
+                    "SELECT conversation_id,trigger_message_id,state "
+                    "FROM conversation_runs WHERE run_id=?",
+                    (run_id,),
+                ).fetchone()
+                if row is None:
+                    raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+                if row["state"] not in LIVE_RUN_STATES:
+                    raise BrokerError(
+                        "CONVERSATION_RUN_NOT_ACTIVE",
+                        f"run {run_id} is {row['state']}",
+                    )
+                exists = con.execute(
+                    "SELECT 1 FROM conversation_events "
+                    "WHERE run_id=? AND event_type='run.interrupt.requested'",
+                    (run_id,),
+                ).fetchone()
+                if exists is None:
+                    self._append_event(
+                        con,
+                        conversation_id=row["conversation_id"],
+                        event_type="run.interrupt.requested",
+                        payload={"requested_at": now},
+                        message_id=row["trigger_message_id"],
+                        run_id=run_id,
+                    )
+                    con.execute(
+                        "UPDATE conversations SET last_activity_at=?,"
+                        "version=version+1 WHERE conversation_id=?",
+                        (now, row["conversation_id"]),
+                    )
+                conversation_id = row["conversation_id"]
+                created = exists is None
         finally:
             con.close()
         if created:
@@ -800,14 +786,17 @@ class BrokerStore:
     def heartbeat_service(self, interval_seconds: int) -> None:
         con = self.connect()
         try:
-            con.execute(
-                "INSERT INTO daemon_heartbeats (name,beat_at,interval_s) "
-                "VALUES ('conversation-broker',datetime('now'),?) "
-                "ON CONFLICT(name) DO UPDATE SET beat_at=excluded.beat_at,"
-                "interval_s=excluded.interval_s",
-                (interval_seconds,),
-            )
-            con.commit()
+            with db_driver.write_transaction(
+                con,
+                "conversation.broker.heartbeat",
+            ):
+                con.execute(
+                    "INSERT INTO daemon_heartbeats (name,beat_at,interval_s) "
+                    "VALUES ('conversation-broker',datetime('now'),?) "
+                    "ON CONFLICT(name) DO UPDATE SET beat_at=excluded.beat_at,"
+                    "interval_s=excluded.interval_s",
+                    (interval_seconds,),
+                )
         finally:
             con.close()
 

--- a/.super-coder/scripts/db_driver.py
+++ b/.super-coder/scripts/db_driver.py
@@ -7,17 +7,190 @@ connection PRAGMAs live in a single place.
 """
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+import logging
+import random
 import sqlite3
+import time
+
+
+DEFAULT_BUSY_TIMEOUT_MS = 5000
+DEFAULT_WRITE_WAIT_SECONDS = 5.0
+DEFAULT_BEGIN_ATTEMPT_TIMEOUT_MS = 100
+DEFAULT_RETRY_BASE_SECONDS = 0.01
+DEFAULT_RETRY_MAX_SECONDS = 0.25
+SLOW_WRITE_WAIT_MS = 250.0
+SLOW_WRITE_HOLD_MS = 100.0
+
+_LOG = logging.getLogger("super_coder.db")
+
+
+@dataclass(frozen=True)
+class WriteTransactionTiming:
+    """Contention evidence for one short SQLite write transaction."""
+
+    operation: str
+    attempts: int
+    wait_ms: float
+    hold_ms: float
+    acquired: bool
+    committed: bool
+
+
+def is_busy_error(exc: BaseException) -> bool:
+    """Return whether SQLite rejected work because another writer owns it."""
+    return isinstance(exc, sqlite3.OperationalError) and (
+        "locked" in str(exc).lower() or "busy" in str(exc).lower()
+    )
+
+
+def _report_timing(
+    timing: WriteTransactionTiming,
+    observer: Callable[[WriteTransactionTiming], None] | None,
+) -> None:
+    if observer is not None:
+        try:
+            observer(timing)
+        except Exception:
+            _LOG.exception(
+                "SQLite write timing observer failed for %s",
+                timing.operation,
+            )
+    log = (
+        _LOG.warning
+        if (
+            timing.wait_ms >= SLOW_WRITE_WAIT_MS
+            or timing.hold_ms >= SLOW_WRITE_HOLD_MS
+        )
+        else _LOG.debug
+    )
+    log(
+        "SQLite write operation=%s attempts=%d wait_ms=%.1f hold_ms=%.1f "
+        "acquired=%s committed=%s",
+        timing.operation,
+        timing.attempts,
+        timing.wait_ms,
+        timing.hold_ms,
+        timing.acquired,
+        timing.committed,
+    )
 
 
 def connect(path):
     """Open the engine SQLite DB at `path` with the standard PRAGMAs."""
-    con = sqlite3.connect(str(path), timeout=5)
+    con = sqlite3.connect(str(path), timeout=DEFAULT_BUSY_TIMEOUT_MS / 1000)
     con.row_factory = sqlite3.Row
     con.execute("PRAGMA foreign_keys=ON")
     con.execute("PRAGMA journal_mode=WAL")
-    con.execute("PRAGMA busy_timeout=5000")
+    con.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
     return con
+
+
+@contextmanager
+def write_transaction(
+    con: sqlite3.Connection,
+    operation: str,
+    *,
+    max_wait_seconds: float = DEFAULT_WRITE_WAIT_SECONDS,
+    attempt_timeout_ms: int = DEFAULT_BEGIN_ATTEMPT_TIMEOUT_MS,
+    retry_base_seconds: float = DEFAULT_RETRY_BASE_SECONDS,
+    retry_max_seconds: float = DEFAULT_RETRY_MAX_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    random_fraction: Callable[[], float] = random.random,
+    observer: Callable[[WriteTransactionTiming], None] | None = None,
+) -> Iterator[sqlite3.Connection]:
+    """Acquire, time, commit, or roll back one short DB-only write.
+
+    Only ``BEGIN IMMEDIATE`` acquisition is retried: no transaction body is
+    replayed, so an ambiguous commit can never duplicate a mutation. Callers
+    must perform sleeps, subprocess work, filesystem probes, and network calls
+    before entering this context, then re-read authoritative DB state inside.
+    """
+    if con.in_transaction:
+        raise RuntimeError(
+            f"{operation}: write_transaction cannot nest inside a transaction"
+        )
+    if max_wait_seconds <= 0:
+        raise ValueError("max_wait_seconds must be positive")
+    if attempt_timeout_ms <= 0:
+        raise ValueError("attempt_timeout_ms must be positive")
+    if retry_base_seconds < 0 or retry_max_seconds < retry_base_seconds:
+        raise ValueError("invalid retry delay bounds")
+
+    original_timeout_ms = int(con.execute("PRAGMA busy_timeout").fetchone()[0])
+    started = monotonic()
+    deadline = started + max_wait_seconds
+    attempts = 0
+    acquired_at: float | None = None
+    committed = False
+    last_busy: sqlite3.OperationalError | None = None
+    try:
+        while acquired_at is None:
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                if last_busy is not None:
+                    raise last_busy
+                raise sqlite3.OperationalError(
+                    f"{operation}: timed out acquiring SQLite write transaction"
+                )
+            attempts += 1
+            per_attempt_ms = max(
+                1,
+                min(attempt_timeout_ms, int(remaining * 1000)),
+            )
+            con.execute(f"PRAGMA busy_timeout={per_attempt_ms}")
+            try:
+                con.execute("BEGIN IMMEDIATE")
+            except sqlite3.OperationalError as exc:
+                if not is_busy_error(exc):
+                    raise
+                last_busy = exc
+                con.rollback()
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    raise
+                ceiling = min(
+                    retry_max_seconds,
+                    retry_base_seconds * (2 ** min(attempts - 1, 8)),
+                    remaining,
+                )
+                if ceiling > 0:
+                    # 0.75x–1.25x jitter avoids synchronized shell retries.
+                    sleep(ceiling * (0.75 + 0.5 * random_fraction()))
+            else:
+                acquired_at = monotonic()
+        con.execute(f"PRAGMA busy_timeout={original_timeout_ms}")
+        try:
+            yield con
+            con.commit()
+            committed = True
+        except BaseException:
+            con.rollback()
+            raise
+    finally:
+        if acquired_at is None:
+            con.execute(f"PRAGMA busy_timeout={original_timeout_ms}")
+        finished = monotonic()
+        timing = WriteTransactionTiming(
+            operation=operation,
+            attempts=attempts,
+            wait_ms=(
+                (acquired_at - started) * 1000
+                if acquired_at is not None
+                else (finished - started) * 1000
+            ),
+            hold_ms=(
+                (finished - acquired_at) * 1000
+                if acquired_at is not None
+                else 0.0
+            ),
+            acquired=acquired_at is not None,
+            committed=committed,
+        )
+        _report_timing(timing, observer)
 
 
 IntegrityError = sqlite3.IntegrityError

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -91,6 +91,11 @@ class ConversationApiCase(unittest.TestCase):
                 "_wait_for_cli_release",
                 return_value=None,
             ),
+            mock.patch.object(
+                conversation_routes,
+                "_live_shell_session",
+                return_value=None,
+            ),
         )
         for patch in patches:
             patch.start()
@@ -157,6 +162,56 @@ class ConversationApiCase(unittest.TestCase):
 
 
 class ConversationResourceTest(ConversationApiCase):
+    def test_write_contention_returns_a_retryable_service_error(self) -> None:
+        with mock.patch.object(
+            conversation_routes.db_driver,
+            "write_transaction",
+            side_effect=sqlite3.OperationalError("database is locked"),
+        ):
+            status, _, error = self.request(
+                "POST",
+                "/api/conversations",
+                body={"shell_id": 1, "harness": "codex"},
+                key="busy-create",
+            )
+        self.assertEqual(status, 503)
+        self.assertEqual(error["error"]["code"], "ENGINE_DB_BUSY")
+        self.assertEqual(error["error"]["details"]["retry_after"], 2)
+
+    def test_cli_release_drain_runs_before_the_write_transaction(self) -> None:
+        def assert_writer_is_unlocked(shell) -> None:
+            contender = self.connect()
+            try:
+                contender.execute("PRAGMA busy_timeout=10")
+                contender.execute("BEGIN IMMEDIATE")
+                contender.rollback()
+            finally:
+                contender.close()
+            return None
+
+        with mock.patch.object(
+            conversation_routes,
+            "_wait_for_cli_release",
+            side_effect=assert_writer_is_unlocked,
+        ):
+            created = self.create(key="drain-before-write-lock")
+        self.assertEqual(created["state"], "idle")
+
+    def test_create_rechecks_cli_owner_after_the_drain(self) -> None:
+        with mock.patch.object(
+            conversation_routes,
+            "_live_shell_session",
+            return_value="busy",
+        ):
+            status, _, error = self.request(
+                "POST",
+                "/api/conversations",
+                body={"shell_id": 1, "harness": "codex"},
+                key="cli-raced-after-drain",
+            )
+        self.assertEqual(status, 409)
+        self.assertEqual(error["error"]["code"], "SHELL_BUSY")
+
     def test_creating_a_chat_refuses_a_live_cli_owner(self) -> None:
         with mock.patch.object(
             conversation_routes,

--- a/tests/test_db_driver.py
+++ b/tests/test_db_driver.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Shared SQLite write-transaction policy contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+
+import db_driver  # noqa: E402
+
+
+class WriteTransactionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "engine.db"
+        con = db_driver.connect(self.path)
+        con.execute("CREATE TABLE writes (value TEXT NOT NULL)")
+        con.commit()
+        con.close()
+
+    def test_commits_and_reports_transaction_timing(self) -> None:
+        timings: list[db_driver.WriteTransactionTiming] = []
+        con = db_driver.connect(self.path)
+        try:
+            with db_driver.write_transaction(
+                con,
+                "test.commit",
+                observer=timings.append,
+            ):
+                con.execute("INSERT INTO writes VALUES ('committed')")
+        finally:
+            con.close()
+
+        check = db_driver.connect(self.path)
+        try:
+            self.assertEqual(
+                check.execute("SELECT value FROM writes").fetchone()[0],
+                "committed",
+            )
+        finally:
+            check.close()
+        self.assertEqual(len(timings), 1)
+        self.assertTrue(timings[0].acquired)
+        self.assertTrue(timings[0].committed)
+        self.assertEqual(timings[0].operation, "test.commit")
+
+    def test_rolls_back_the_whole_body_on_failure(self) -> None:
+        timings: list[db_driver.WriteTransactionTiming] = []
+        con = db_driver.connect(self.path)
+        try:
+            with self.assertRaisesRegex(RuntimeError, "stop"):
+                with db_driver.write_transaction(
+                    con,
+                    "test.rollback",
+                    observer=timings.append,
+                ):
+                    con.execute("INSERT INTO writes VALUES ('rolled back')")
+                    raise RuntimeError("stop")
+        finally:
+            con.close()
+
+        check = db_driver.connect(self.path)
+        try:
+            self.assertEqual(
+                check.execute("SELECT COUNT(*) FROM writes").fetchone()[0],
+                0,
+            )
+        finally:
+            check.close()
+        self.assertTrue(timings[0].acquired)
+        self.assertFalse(timings[0].committed)
+
+    def test_retries_only_write_lock_acquisition_until_owner_releases(self) -> None:
+        ready = threading.Event()
+        release = threading.Event()
+
+        def hold_writer() -> None:
+            holder = db_driver.connect(self.path)
+            try:
+                holder.execute("BEGIN IMMEDIATE")
+                holder.execute("INSERT INTO writes VALUES ('holder')")
+                ready.set()
+                release.wait(2)
+                holder.commit()
+            finally:
+                holder.close()
+
+        thread = threading.Thread(target=hold_writer)
+        thread.start()
+        self.addCleanup(thread.join, 2)
+        self.assertTrue(ready.wait(1))
+
+        timings: list[db_driver.WriteTransactionTiming] = []
+        releaser = threading.Timer(0.12, release.set)
+        releaser.start()
+        self.addCleanup(releaser.cancel)
+        con = db_driver.connect(self.path)
+        try:
+            with db_driver.write_transaction(
+                con,
+                "test.contended",
+                max_wait_seconds=1,
+                attempt_timeout_ms=20,
+                retry_base_seconds=0.005,
+                retry_max_seconds=0.02,
+                random_fraction=lambda: 0.5,
+                observer=timings.append,
+            ):
+                con.execute("INSERT INTO writes VALUES ('contender')")
+            self.assertEqual(
+                con.execute("PRAGMA busy_timeout").fetchone()[0],
+                db_driver.DEFAULT_BUSY_TIMEOUT_MS,
+            )
+        finally:
+            con.close()
+        thread.join(2)
+
+        self.assertGreater(timings[0].attempts, 1)
+        check = db_driver.connect(self.path)
+        try:
+            self.assertEqual(
+                [
+                    row[0]
+                    for row in check.execute(
+                        "SELECT value FROM writes ORDER BY rowid"
+                    ).fetchall()
+                ],
+                ["holder", "contender"],
+            )
+        finally:
+            check.close()
+
+    def test_busy_deadline_never_enters_or_replays_the_body(self) -> None:
+        holder = db_driver.connect(self.path)
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("INSERT INTO writes VALUES ('holder')")
+        body_calls = 0
+        timings: list[db_driver.WriteTransactionTiming] = []
+        contender = db_driver.connect(self.path)
+        try:
+            with self.assertRaises(sqlite3.OperationalError):
+                with db_driver.write_transaction(
+                    contender,
+                    "test.timeout",
+                    max_wait_seconds=0.05,
+                    attempt_timeout_ms=10,
+                    retry_base_seconds=0.005,
+                    retry_max_seconds=0.01,
+                    random_fraction=lambda: 0.5,
+                    observer=timings.append,
+                ):
+                    body_calls += 1
+            self.assertEqual(
+                contender.execute("PRAGMA busy_timeout").fetchone()[0],
+                db_driver.DEFAULT_BUSY_TIMEOUT_MS,
+            )
+        finally:
+            contender.close()
+            holder.rollback()
+            holder.close()
+
+        self.assertEqual(body_calls, 0)
+        self.assertFalse(timings[0].acquired)
+        self.assertFalse(timings[0].committed)
+        self.assertGreater(timings[0].attempts, 1)
+
+    def test_concurrent_shell_writers_all_commit_without_body_replay(self) -> None:
+        workers = 6
+        writes_per_worker = 12
+        barrier = threading.Barrier(workers)
+        errors: list[BaseException] = []
+        body_calls: dict[int, int] = {}
+        lock = threading.Lock()
+
+        def write_for_shell(shell_id: int) -> None:
+            con = db_driver.connect(self.path)
+            try:
+                barrier.wait(2)
+                for sequence in range(writes_per_worker):
+                    with db_driver.write_transaction(
+                        con,
+                        "test.multi_shell",
+                        max_wait_seconds=2,
+                        attempt_timeout_ms=10,
+                        retry_base_seconds=0.001,
+                        retry_max_seconds=0.01,
+                    ):
+                        with lock:
+                            body_calls[shell_id] = body_calls.get(shell_id, 0) + 1
+                        con.execute(
+                            "INSERT INTO writes VALUES (?)",
+                            (f"{shell_id}:{sequence}",),
+                        )
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                con.close()
+
+        threads = [
+            threading.Thread(target=write_for_shell, args=(shell_id,))
+            for shell_id in range(workers)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(5)
+
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            body_calls,
+            {shell_id: writes_per_worker for shell_id in range(workers)},
+        )
+        con = db_driver.connect(self.path)
+        try:
+            self.assertEqual(
+                con.execute("SELECT COUNT(*) FROM writes").fetchone()[0],
+                workers * writes_per_worker,
+            )
+        finally:
+            con.close()
+
+    def test_refuses_nested_transactions(self) -> None:
+        con = db_driver.connect(self.path)
+        try:
+            con.execute("BEGIN")
+            with self.assertRaisesRegex(RuntimeError, "cannot nest"):
+                with db_driver.write_transaction(con, "test.nested"):
+                    self.fail("nested transaction body must not run")
+        finally:
+            con.rollback()
+            con.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a shared short-write transaction context with bounded jittered BEGIN IMMEDIATE acquisition, automatic commit or rollback, and contention timing
- never replay a transaction body or ambiguous commit
- move browser CLI-liveness draining before the SQLite writer reservation, then revalidate authoritative state inside
- adopt the policy across conversation API and broker mutations
- return retryable 503 responses when conversation write contention exhausts the bounded deadline

## Concurrency boundary
SQLite remains the local-alpha store. This patch adds transaction discipline, not a centralized writer queue. If measured multi-shell contention remains material after short transactions, the planned escalation is PostgreSQL rather than more SQLite coordination machinery.

Event-delta batching remains coupled to review flag #34 because its safe buffering and durability shape depends on the selected live-streaming mechanism.

## Verification
- focused DB, conversation API, broker, launch, and run-session suites: 58 passed
- full suite: 1552 passed, 773 subtests
- six concurrent writer stress coverage with exact body-call counts
- map, render-check, live-instance verify, compile, and diff-check passed

Governing feature #24; decisions #22 and #23; resolves implementation for review flag #35 after merge.