### PR TITLE
fix(ui): polish Interface chat flow

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3150,8 +3150,14 @@ function chatBubble(kind, body, meta = "", conversation = null) {
   return bubble;
 }
 
-function chatPaintTranscript(host, messages, events, conversation, retry) {
-  const transcript = el("div", { className: "chat-transcript" });
+function chatTranscriptAtBottom(transcript) {
+  return transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight <= 32;
+}
+
+function chatPaintTranscript(
+  transcript, messages, events, conversation, retry, shouldFollow, onPosition,
+) {
+  const previousTop = transcript.scrollTop;
   const assistants = chatAssistantRuns(events);
   const activities = chatActivity(events);
   const items = [];
@@ -3204,14 +3210,19 @@ function chatPaintTranscript(host, messages, events, conversation, retry) {
       button.onclick = () => retry(item.text);
       item.node.append(button);
     }
-    transcript.append(item.node);
   }
   if (!items.length) {
-    transcript.append(el("div", { className: "chat-empty" },
-      `Start a conversation with ${conversation.shell.display_name}.`));
+    items.push({
+      node: el("div", { className: "chat-empty" },
+        `Start a conversation with ${conversation.shell.display_name}.`),
+      failed: false,
+    });
   }
-  host.replaceChildren(transcript);
-  requestAnimationFrame(() => { transcript.scrollTop = transcript.scrollHeight; });
+  transcript.replaceChildren(...items.map((item) => item.node));
+  requestAnimationFrame(() => {
+    transcript.scrollTop = shouldFollow() ? transcript.scrollHeight : previousTop;
+    onPosition();
+  });
 }
 
 async function chatRefreshConversation(conversationId, generation, onUpdate) {
@@ -3366,15 +3377,42 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   const streamState = el("span", { className: "chat-stream-state" }, "connecting");
   const actions = el("div", { className: "chat-actions" });
   const transcriptHost = el("div", { className: "chat-transcript-host" });
+  const transcript = el("div", { className: "chat-transcript" });
+  const jumpToLatest = el("button", {
+    className: "chat-jump-latest",
+    type: "button",
+    title: "Jump to latest",
+    ariaLabel: "Jump to latest message",
+    textContent: "↓",
+    hidden: true,
+  });
+  transcriptHost.append(transcript, jumpToLatest);
+  let followTranscriptTail = true;
+  const updateTranscriptFollow = () => {
+    followTranscriptTail = chatTranscriptAtBottom(transcript);
+    jumpToLatest.hidden = followTranscriptTail;
+  };
+  transcript.onscroll = updateTranscriptFollow;
+  jumpToLatest.onclick = () => {
+    transcript.scrollTop = transcript.scrollHeight;
+    updateTranscriptFollow();
+  };
   const composer = el("textarea", {
     className: "chat-composer-input",
     placeholder: "Message this shell…",
     rows: 3,
   });
   const send = el("button", { className: "act primary", type: "button", textContent: "Send" });
+  const stop = el("button", {
+    className: "act danger chat-stop",
+    type: "button",
+    textContent: "Stop",
+    title: "Reserved for future stream control",
+    disabled: true,
+  });
   const pending = el("div", { className: "chat-pending", hidden: true });
   const composerRow = el("div", { className: "chat-composer" },
-    composer, el("div", { className: "chat-compose-actions" }, pending, send));
+    composer, el("div", { className: "chat-compose-actions" }, pending, send, stop));
 
   const retry = async (text) => {
     composer.value = text;
@@ -3411,7 +3449,15 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     interrupt.disabled = !["queued", "running", "waiting"].includes(conversation.state);
     close.disabled = !["idle", "waiting", "error"].includes(conversation.state);
     composer.placeholder = closed ? "This conversation is closed." : "Message this shell…";
-    chatPaintTranscript(transcriptHost, messages, events, conversation, retry);
+    chatPaintTranscript(
+      transcript,
+      messages,
+      events,
+      conversation,
+      retry,
+      () => followTranscriptTail,
+      updateTranscriptFollow,
+    );
   };
   const refresh = () => chatRefreshConversation(
     conversation.conversation_id,

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -254,8 +254,7 @@ async function openSkillContentModal(skill) {
   } catch (e) { toast("error: " + e.message); }
 }
 
-// New-shell form in a 600×300 modal — Create bottom-left, Cancel bottom-right,
-// same dialog pattern as the new-flag modal.
+// New-shell form in a 600×300 modal — Cancel bottom-left, Create bottom-right.
 function openNewShellModal(templates, root) {
   const fl = el("select", {});
   for (const t of templates)
@@ -271,7 +270,7 @@ function openNewShellModal(templates, root) {
     el("span", { className: "k" }, "shell type"), fl,
     el("span", { className: "k" }, "name"), nm);
   const close = openModal({ title: "New shell", bodyNode: form,
-    footNodes: [create, cancel], width: 600, height: 300 });
+    footNodes: [cancel, create], width: 600, height: 300 });
   create.onclick = async () => {
     if (!nm.value.trim()) return toast("name required");
     create.disabled = true; create.textContent = "Creating…";

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3024,6 +3024,7 @@ async function renderSprints(root) {
 // terminal, tmux controls, or live hand-off between browser and CLI.
 const CHAT_HARNESSES = ["opencode", "claude", "codex"];
 const CHAT_FLAVOR_ORDER = ["cartographer", "admin", "planner", "dev", "reviewer", "devops"];
+const CHAT_CONFIGURE_ROUTE = "configure";
 let chatRouteShell = "";
 let chatRouteConversation = "";
 let chatSource = null;
@@ -3040,10 +3041,35 @@ function chatHash(shortname, conversationId = "") {
     + (conversationId ? `/${encodeURIComponent(conversationId)}` : "");
 }
 
-function chatRouteLabel(conversation) {
-  const route = conversation.route || {};
-  return [route.harness, route.model || "harness default", route.effort]
-    .filter(Boolean).join(" · ");
+function chatModelLabel(conversation) {
+  return conversation.route?.model || "harness default";
+}
+
+function chatStartedLabel(conversation) {
+  if (!conversation.created_at) return "Start time unavailable";
+  const raw = String(conversation.created_at);
+  const timestamp = /(?:Z|[+-]\d\d:\d\d)$/.test(raw) ? raw : `${raw}Z`;
+  const started = new Date(timestamp);
+  if (Number.isNaN(started.getTime())) return raw;
+  return new Intl.DateTimeFormat(undefined, {
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(started);
+}
+
+function chatShellLabel(conversation) {
+  const shell = conversation?.shell || {};
+  return [shell.display_name, shell.shortname].filter(Boolean).join(" | ") || "Shell";
+}
+
+function chatHeaderLabel(conversation) {
+  return [
+    conversation.shell?.shortname,
+    chatModelLabel(conversation),
+    conversation.route?.harness,
+  ].filter(Boolean).join(" | ");
 }
 
 function chatStatePill(state) {
@@ -3055,9 +3081,7 @@ function chatStatePill(state) {
 }
 
 function chatConversationName(conversation) {
-  return conversation.title
-    || `Chat · ${conversation.route?.harness || "harness"} · `
-      + new Date(`${conversation.created_at}Z`).toLocaleString();
+  return conversation.title || "Untitled chat";
 }
 
 async function chatCloseForSwitch(conversation) {
@@ -3081,28 +3105,13 @@ async function chatCloseForSwitch(conversation) {
 }
 
 function chatActivity(events) {
-  const rows = [];
-  const tools = new Map();
-  for (const event of events) {
-    if (event.event_type === "tool.started") {
-      const row = { ...event, done: false };
-      tools.set(`${event.run_id}:${event.payload?.tool_call_id || rows.length}`, row);
-      rows.push(row);
-    } else if (event.event_type === "tool.completed") {
-      const key = `${event.run_id}:${event.payload?.tool_call_id || rows.length}`;
-      const prior = tools.get(key);
-      if (prior) {
-        prior.done = true;
-        prior.payload = { ...prior.payload, ...event.payload };
-      } else {
-        rows.push({ ...event, done: true });
-      }
-    } else if (["permission.requested", "input.requested", "run.failed",
-                "run.interrupted", "run.unknown"].includes(event.event_type)) {
-      rows.push(event);
-    }
-  }
-  return rows;
+  return events.filter((event) => [
+    "permission.requested",
+    "input.requested",
+    "run.failed",
+    "run.interrupted",
+    "run.unknown",
+  ].includes(event.event_type));
 }
 
 function chatAssistantRuns(events) {
@@ -3128,10 +3137,12 @@ function chatAssistantRuns(events) {
   return runs;
 }
 
-function chatBubble(kind, body, meta = "") {
+function chatBubble(kind, body, meta = "", conversation = null) {
   const bubble = el("article", { className: `chat-bubble chat-${kind}` });
   bubble.append(el("div", { className: "chat-who" },
-    kind === "user" ? "FnB" : kind === "assistant" ? "Shell" : "Activity"));
+    kind === "user" ? "You"
+      : kind === "assistant" ? chatShellLabel(conversation)
+      : "Activity"));
   bubble.append(kind === "activity"
     ? el("div", { className: "chat-activity-text" }, body)
     : mdBlock(body));
@@ -3147,9 +3158,7 @@ function chatPaintTranscript(host, messages, events, conversation, retry) {
   const addActivity = (activity) => {
     const payload = activity.payload || {};
     const type = activity.event_type;
-    const label = type.startsWith("tool.")
-      ? `${activity.done ? "✓" : "…" } ${payload.title || payload.name || "tool"}`
-      : type === "permission.requested" ? "Waiting for permission"
+    const label = type === "permission.requested" ? "Waiting for permission"
       : type === "input.requested" ? "Waiting for input"
       : type === "run.interrupted" ? "Turn interrupted"
       : type === "run.unknown" ? "Turn outcome could not be proven"
@@ -3167,7 +3176,10 @@ function chatPaintTranscript(host, messages, events, conversation, retry) {
       text: message.body,
     });
     for (const run of assistants.filter((item) => item.message_id === message.message_id))
-      items.push({ node: chatBubble("assistant", run.text), failed: false });
+      items.push({
+        node: chatBubble("assistant", run.text, "", conversation),
+        failed: false,
+      });
     for (const activity of activities.filter(
       (item) => item.message_id === message.message_id))
       addActivity(activity);
@@ -3175,7 +3187,10 @@ function chatPaintTranscript(host, messages, events, conversation, retry) {
   // Conversation-scoped events are uncommon, but keeping them visible is
   // better than dropping a recovery/error signal whose message link is absent.
   for (const run of assistants.filter((item) => item.message_id == null))
-    items.push({ node: chatBubble("assistant", run.text), failed: false });
+    items.push({
+      node: chatBubble("assistant", run.text, "", conversation),
+      failed: false,
+    });
   for (const activity of activities) {
     if (activity.message_id == null) addActivity(activity);
   }
@@ -3256,6 +3271,15 @@ function chatModelOptions(select, catalog, harness, defaultModel) {
   return harness !== "opencode" || available.length > 0;
 }
 
+function chatCreateConversation(shell, fields = {}) {
+  return chatApi(
+    "/conversations",
+    "POST",
+    { shell_id: shell.shell_id, ...fields },
+    requestKey(),
+  );
+}
+
 async function chatRenderNew(host, shell, defaults, catalog) {
   const rows = defaults.flavors?.[shell.flavor] || [];
   const byHarness = Object.fromEntries(rows.map((row) => [row.harness, row]));
@@ -3312,14 +3336,12 @@ async function chatRenderNew(host, shell, defaults, catalog) {
     submit.disabled = true;
     submit.textContent = "Starting…";
     const body = {
-      shell_id: shell.shell_id,
       harness: harnessSelect.value,
       title: title.value.trim() || null,
     };
     if (modelSelect.value) body.model = modelSelect.value;
     try {
-      const conversation = await chatApi(
-        "/conversations", "POST", body, requestKey());
+      const conversation = await chatCreateConversation(shell, body);
       location.hash = chatHash(shell.shortname, conversation.conversation_id);
     } catch (error) {
       toast(`${error.code}: ${error.message}`);
@@ -3359,10 +3381,29 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     composer.focus();
     await submit();
   };
+  const renameConversation = async () => {
+    const value = (prompt("Conversation title", conversation.title || "") || "").trim();
+    if (!value) return;
+    try {
+      conversation = await chatApi(`/conversations/${conversation.conversation_id}`,
+        "PATCH", { version: conversation.version, title: value });
+      paint();
+    } catch (error) { toast(`${error.code}: ${error.message}`); refresh(); }
+  };
   const paint = () => {
+    const rename = el("button", {
+      className: "chat-title-button",
+      type: "button",
+      title: "Rename conversation",
+      textContent: chatConversationName(conversation),
+    });
+    rename.onclick = renameConversation;
     title.replaceChildren(
-      el("h2", {}, chatConversationName(conversation)),
-      el("div", { className: "chat-route" }, chatRouteLabel(conversation)));
+      el("h2", {}, chatHeaderLabel(conversation)),
+      el("div", { className: "chat-conversation-line" },
+        el("span", {}, chatStartedLabel(conversation)),
+        el("span", { className: "chat-context-separator" }, " | "),
+        rename));
     state.replaceChildren(chatStatePill(conversation.state), streamState);
     const closed = conversation.state === "closed";
     composer.disabled = closed;
@@ -3377,16 +3418,6 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     generation,
     (next) => { conversation = next; paint(); });
 
-  const rename = el("button", { className: "act", type: "button", textContent: "Rename" });
-  rename.onclick = async () => {
-    const value = (prompt("Conversation title", conversation.title || "") || "").trim();
-    if (!value) return;
-    try {
-      conversation = await chatApi(`/conversations/${conversation.conversation_id}`,
-        "PATCH", { version: conversation.version, title: value });
-      paint();
-    } catch (error) { toast(`${error.code}: ${error.message}`); refresh(); }
-  };
   const analytics = el("button", { className: "act", type: "button", textContent: "Analytics" });
   analytics.onclick = () => {
     anFilters.harness = conversation.route.harness || "";
@@ -3417,7 +3448,7 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
       paint();
     } catch (error) { toast(`${error.code}: ${error.message}`); refresh(); }
   };
-  actions.append(rename, analytics, interrupt, close);
+  actions.append(analytics, interrupt, close);
   header.append(title, state, actions);
 
   async function submit() {
@@ -3521,9 +3552,12 @@ async function renderInterface(root) {
     || shells[0];
   const conversations = allConversations.items.filter(
     (item) => item.shell.shell_id === shell.shell_id);
-  let selectedId = chatRouteConversation
-    || conversations.find((item) => item.state !== "closed")?.conversation_id
-    || "";
+  const configuring = chatRouteConversation === CHAT_CONFIGURE_ROUTE;
+  let selectedId = configuring
+    ? ""
+    : chatRouteConversation
+      || conversations.find((item) => item.state !== "closed")?.conversation_id
+      || "";
   if (selectedId && !conversations.some((item) => item.conversation_id === selectedId))
     selectedId = "";
   const selectedConversation = allConversations.items.find(
@@ -3540,13 +3574,17 @@ async function renderInterface(root) {
   for (const flavor of orderedFlavors) {
     rail.append(el("div", { className: "chat-shell-group" }, flavor || "bespoke"));
     for (const item of shells.filter((candidate) => (candidate.flavor || "bespoke") === flavor)) {
-      const latest = allConversations.items.find(
-        (conversation) => conversation.shell.shell_id === item.shell_id);
+      const active = allConversations.items.find(
+        (conversation) => conversation.shell.shell_id === item.shell_id
+          && conversation.state !== "closed");
       const button = el("button", {
-        className: "chat-shell" + (item.shell_id === shell.shell_id ? " selected" : ""),
+        className: "chat-shell"
+          + (item.shell_id === shell.shell_id ? " selected" : "")
+          + (active ? " active-chat" : ""),
         type: "button",
-      }, el("span", { className: "chat-shell-name" }, item.display_name));
-      if (latest) button.append(chatStatePill(latest.state));
+      },
+      el("span", { className: "chat-shell-name" }, item.display_name),
+      el("span", { className: "chat-shell-shortname" }, item.shortname || ""));
       button.onclick = () => {
         if (item.shell_id === shell.shell_id) return;
         location.hash = chatHash(item.shortname);
@@ -3557,14 +3595,38 @@ async function renderInterface(root) {
 
   const side = el("aside", { className: "chat-history" });
   const newChat = el("button", { className: "act primary", type: "button", textContent: "＋ New chat" });
+  const configure = el("button", {
+    className: "chat-configure",
+    type: "button",
+    textContent: "Configure",
+  });
   newChat.onclick = async () => {
-    if (await chatCloseForSwitch(selectedConversation))
-      location.hash = chatHash(shell.shortname);
+    if (!await chatCloseForSwitch(selectedConversation)) return;
+    newChat.disabled = true;
+    configure.disabled = true;
+    newChat.textContent = "Starting…";
+    try {
+      const conversation = await chatCreateConversation(shell);
+      location.hash = chatHash(shell.shortname, conversation.conversation_id);
+    } catch (error) {
+      toast(`${error.code}: ${error.message}`);
+      newChat.disabled = false;
+      configure.disabled = false;
+      newChat.textContent = "＋ New chat";
+    }
+  };
+  configure.onclick = async () => {
+    configure.disabled = true;
+    if (!await chatCloseForSwitch(selectedConversation)) {
+      configure.disabled = false;
+      return;
+    }
+    location.hash = chatHash(shell.shortname, CHAT_CONFIGURE_ROUTE);
   };
   side.append(el("div", { className: "chat-history-head" },
-    el("div", {}, el("b", {}, shell.display_name),
+    el("div", { className: "chat-history-shell" }, el("b", {}, shell.display_name),
       el("span", { className: "chat-shortname" }, ` /${shell.shortname}`)),
-    newChat));
+    el("div", { className: "chat-history-actions" }, newChat, configure)));
   const history = el("div", { className: "chat-history-list" });
   for (const conversation of conversations) {
     const button = el("button", {
@@ -3572,9 +3634,10 @@ async function renderInterface(root) {
         + (conversation.conversation_id === selectedId ? " selected" : ""),
       type: "button",
     });
-    button.append(el("span", { className: "chat-history-name" },
+    button.append(el("span", { className: "chat-history-context" },
+      `${chatStartedLabel(conversation)} | ${chatModelLabel(conversation)}`),
+      el("span", { className: "chat-history-name" },
       chatConversationName(conversation)),
-      el("span", { className: "chat-history-route" }, chatRouteLabel(conversation)),
       chatStatePill(conversation.state));
     button.onclick = async () => {
       if (conversation.conversation_id === selectedId) return;
@@ -3591,7 +3654,12 @@ async function renderInterface(root) {
   layout.append(rail, side, pane);
   root.replaceChildren(layout);
   if (!selectedId) {
-    await chatRenderNew(pane, shell, defaults, catalog);
+    if (configuring) {
+      await chatRenderNew(pane, shell, defaults, catalog);
+    } else {
+      pane.append(el("div", { className: "chat-empty chat-no-selection" },
+        "No chat selected."));
+    }
     return;
   }
   const [conversation, messagePage] = await Promise.all([

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -79,7 +79,7 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
 }
 .chat-loading { color: var(--dim); padding: 2rem; }
 .chat-layout {
-  display: grid; grid-template-columns: 180px 260px minmax(0, 1fr);
+  display: grid; grid-template-columns: 198px 260px minmax(0, 1fr);
   min-height: calc(100dvh - 52px); background: var(--panel2);
 }
 .chat-rail, .chat-history {
@@ -94,20 +94,38 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
 .chat-rail-title { color: var(--ink); font-size: .74rem; margin-bottom: .45rem; }
 .chat-shell-group { margin-top: .65rem; border-top: 1px solid var(--line-soft); padding-top: .7rem; }
 .chat-shell {
-  width: 100%; display: flex; align-items: center; gap: .45rem;
+  position: relative; width: 100%; display: flex; align-items: center; gap: .45rem;
   background: transparent; border: 1px solid transparent; color: var(--dim);
   border-radius: 8px; padding: .48rem .55rem; cursor: pointer; text-align: left;
 }
 .chat-shell:hover { color: var(--ink); background: var(--panel); }
 .chat-shell.selected { color: var(--ink); border-color: var(--line); background: var(--panel); }
+.chat-shell.active-chat::before {
+  content: ""; position: absolute; left: 0; top: .3rem; bottom: .3rem; width: 3px;
+  border-radius: 99px; background: var(--ok);
+}
 .chat-shell-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+.chat-shell-shortname {
+  color: rgba(255,255,255,.46); font: .68rem ui-monospace, monospace;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: none;
+}
+.chat-shell.selected .chat-shell-shortname { color: rgba(255,255,255,.72); }
 .chat-history { background: var(--panel); display: flex; flex-direction: column; }
 .chat-history-head {
   padding: .8rem; border-bottom: 1px solid var(--line);
   display: flex; align-items: center; gap: .6rem; min-height: 67px;
 }
-.chat-history-head > div { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; }
-.chat-history-head .act { margin: 0; padding: .34rem .65rem; white-space: nowrap; }
+.chat-history-shell { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; }
+.chat-history-actions {
+  display: flex; flex-direction: column; align-items: stretch; gap: .1rem; flex: none;
+}
+.chat-history-actions .act { margin: 0; padding: .34rem .65rem; white-space: nowrap; }
+.chat-configure {
+  background: transparent; border: 0; color: var(--accent); cursor: pointer;
+  font: inherit; font-size: .67rem; padding: .08rem .25rem;
+}
+.chat-configure:hover { color: #fff; }
+.chat-configure:disabled { cursor: default; opacity: .45; }
 .chat-shortname { color: var(--dim); font: .76rem ui-monospace, monospace; }
 .chat-history-list { overflow-y: auto; padding: .5rem; }
 .chat-history-item {
@@ -117,11 +135,11 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
 }
 .chat-history-item:hover { background: var(--accent2); color: var(--ink); }
 .chat-history-item.selected { background: var(--panel2); border-color: var(--line); color: var(--ink); }
-.chat-history-name, .chat-history-route {
+.chat-history-name, .chat-history-context {
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.chat-history-name { grid-column: 1 / -1; font-size: .84rem; }
-.chat-history-route { font-size: .68rem; color: var(--dim); }
+.chat-history-context { grid-column: 1 / -1; font-size: .68rem; color: var(--dim); }
+.chat-history-name { font-size: .84rem; }
 .chat-history-empty { color: var(--dim); padding: 1rem .65rem; font-size: .8rem; }
 .chat-state {
   display: inline-flex; align-items: center; width: fit-content; flex: none;
@@ -143,7 +161,17 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
   align-items: center; gap: .8rem; background: var(--bg);
 }
 .chat-pane-title h2 { margin: 0; font-size: .95rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.chat-route { color: var(--dim); font-size: .7rem; margin-top: .08rem; }
+.chat-conversation-line {
+  display: flex; align-items: baseline; min-width: 0; color: var(--dim);
+  font-size: .7rem; margin-top: .08rem;
+}
+.chat-context-separator { padding: 0 .3rem; }
+.chat-title-button {
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  background: transparent; border: 0; color: var(--ink); cursor: pointer;
+  font: inherit; padding: 0;
+}
+.chat-title-button:hover { color: var(--accent); text-decoration: underline; }
 .chat-pane-state { display: flex; align-items: center; gap: .5rem; }
 .chat-stream-state { color: var(--dim); font-size: .68rem; }
 .chat-stream-state.reconnecting { color: var(--warn); }
@@ -180,6 +208,7 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
 .chat-empty {
   margin: auto; color: var(--dim); text-align: center; padding: 2rem;
 }
+.chat-no-selection { grid-row: 1 / -1; }
 .chat-composer {
   padding: .8rem clamp(1rem, 4vw, 4rem) 1rem; border-top: 1px solid var(--line);
   background: var(--bg);
@@ -203,12 +232,12 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
 .chat-new-form .act { margin-top: 1rem; }
 
 @media (max-width: 900px) {
-  .chat-layout { grid-template-columns: 132px 210px minmax(0, 1fr); }
+  .chat-layout { grid-template-columns: 145px 210px minmax(0, 1fr); }
   .chat-actions { flex-wrap: wrap; justify-content: flex-end; }
   .chat-pane-head { align-items: start; }
 }
 @media (max-width: 680px) {
-  .chat-layout { grid-template-columns: 92px minmax(0, 1fr); }
+  .chat-layout { grid-template-columns: 101px minmax(0, 1fr); }
   .chat-history { display: none; }
   .chat-shell { justify-content: center; }
   .chat-shell .chat-state { display: none; }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -178,11 +178,20 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
 .chat-actions { display: flex; align-items: center; gap: .35rem; }
 .chat-actions .act { margin: 0; padding: .3rem .65rem; font-size: .72rem; }
 .chat-actions .danger { color: #ef7d86; }
-.chat-transcript-host { min-height: 0; overflow: hidden; }
+.chat-transcript-host { position: relative; min-height: 0; overflow: hidden; }
 .chat-transcript {
   height: 100%; overflow-y: auto; padding: 1.2rem clamp(1rem, 4vw, 4rem);
   display: flex; flex-direction: column; gap: .8rem;
 }
+.chat-jump-latest {
+  position: absolute; left: 50%; bottom: .7rem; z-index: 2;
+  width: 2rem; height: 2rem; display: inline-flex; align-items: center;
+  justify-content: center; transform: translateX(-50%); border: 1px solid var(--line);
+  border-radius: 50%; background: var(--panel); color: var(--ink); cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0,0,0,.35); font: 1rem/1 ui-monospace, monospace;
+}
+.chat-jump-latest:hover { border-color: var(--accent); color: var(--accent); }
+.chat-jump-latest[hidden] { display: none; }
 .chat-bubble {
   width: fit-content; max-width: min(720px, 82%);
   border: 1px solid var(--line); border-radius: 12px; padding: .65rem .8rem;
@@ -221,6 +230,8 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
   display: flex; align-items: center; justify-content: flex-end; gap: .7rem;
 }
 .chat-compose-actions .act { margin-top: .5rem; }
+.chat-compose-actions .chat-stop { color: #ef7d86; }
+.chat-compose-actions .chat-stop:disabled { cursor: default; opacity: .45; }
 .chat-pending { color: var(--warn); font-size: .72rem; }
 .chat-new-form {
   width: min(620px, calc(100% - 2rem)); margin: auto; padding: 1.4rem;

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -85,6 +85,25 @@ def test_transcript_hides_routine_tools_but_keeps_actionable_activity():
     assert '"run.unknown"' in activity
 
 
+def test_transcript_follow_pauses_for_reading_and_offers_jump_to_latest():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    assert (
+        "transcript.scrollHeight - transcript.scrollTop "
+        "- transcript.clientHeight <= 32"
+    ) in interface
+    assert "const previousTop = transcript.scrollTop" in interface
+    assert (
+        "transcript.scrollTop = shouldFollow() "
+        "? transcript.scrollHeight : previousTop"
+    ) in interface
+    assert 'className: "chat-jump-latest"' in interface
+    assert 'ariaLabel: "Jump to latest message"' in interface
+    assert "transcript.onscroll = updateTranscriptFollow" in interface
+    assert "jumpToLatest.hidden = followTranscriptTail" in interface
+    assert "transcript.scrollTop = transcript.scrollHeight" in interface
+
+
 def test_composer_is_retry_safe_and_has_turn_controls():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
@@ -95,6 +114,13 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert 'textContent: "Retry"' in interface
     assert 'textContent: "Close"' in interface
     assert 'textContent: "Analytics"' in interface
+    assert 'textContent: "Stop"' in interface
+    stop_control = interface[
+        interface.index("const stop ="):
+        interface.index("const pending =", interface.index("const stop ="))
+    ]
+    assert "disabled: true" in stop_control
+    assert ".onclick" not in stop_control
     assert 'className: "chat-title-button"' in interface
     assert 'title: "Rename conversation"' in interface
     assert 'textContent: "Rename"' not in interface
@@ -131,6 +157,9 @@ def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
         ".chat-bubble.chat-user",
         ".chat-bubble.chat-assistant",
         ".chat-composer",
+        ".chat-jump-latest",
+        ".chat-jump-latest[hidden]",
+        ".chat-compose-actions .chat-stop:disabled",
         ".chat-title-button",
         ".chat-shell.active-chat::before",
     ):

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
 INDEX = (ROOT / ".super-coder" / "ui" / "index.html").read_text()
@@ -32,10 +31,17 @@ def test_open_chat_restore_matches_the_flat_shell_projection():
     )
 
 
-def test_start_chat_exposes_shell_harness_and_model_without_terminal_controls():
+def test_start_chat_has_default_and_configured_paths_without_terminal_controls():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
     assert 'const CHAT_HARNESSES = ["opencode", "claude", "codex"]' in interface
+    assert 'const CHAT_CONFIGURE_ROUTE = "configure"' in interface
+    assert 'textContent: "＋ New chat"' in interface
+    assert 'textContent: "Configure"' in interface
+    assert "const conversation = await chatCreateConversation(shell);" in interface
+    assert "{ shell_id: shell.shell_id, ...fields }" in interface
+    assert "chatRouteConversation === CHAT_CONFIGURE_ROUTE" in interface
+    assert "await chatRenderNew(pane, shell, defaults, catalog)" in interface
     assert "Use shell default" in interface
     assert "Use harness default" in interface
     assert 'harness !== "opencode" || connectedDefault' in interface
@@ -43,7 +49,6 @@ def test_start_chat_exposes_shell_harness_and_model_without_terminal_controls():
     assert "providers connected in OpenCode" in interface
     assert "submit.disabled = !ready" in interface
     assert '"Start chat"' in interface
-    assert "shell_id: shell.shell_id" in interface
     assert "harness: harnessSelect.value" in interface
     assert "if (modelSelect.value) body.model = modelSelect.value" in interface
     assert "xterm" not in interface.lower()
@@ -64,6 +69,22 @@ def test_transcript_streams_normalized_events_and_reconnects_natively():
     assert "mdBlock(body)" in interface
 
 
+def test_transcript_hides_routine_tools_but_keeps_actionable_activity():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    activity = interface[
+        interface.index("function chatActivity"):
+        interface.index("function chatAssistantRuns")
+    ]
+    assert '"tool.started"' not in activity
+    assert '"tool.completed"' not in activity
+    assert '"permission.requested"' in activity
+    assert '"input.requested"' in activity
+    assert '"run.failed"' in activity
+    assert '"run.interrupted"' in activity
+    assert '"run.unknown"' in activity
+
+
 def test_composer_is_retry_safe_and_has_turn_controls():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
@@ -72,9 +93,12 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert 'event.key === "Enter" && !event.shiftKey' in interface
     assert 'textContent: "Interrupt"' in interface
     assert 'textContent: "Retry"' in interface
-    assert 'textContent: "Rename"' in interface
     assert 'textContent: "Close"' in interface
     assert 'textContent: "Analytics"' in interface
+    assert 'className: "chat-title-button"' in interface
+    assert 'title: "Rename conversation"' in interface
+    assert 'textContent: "Rename"' not in interface
+    assert "actions.append(analytics, interrupt, close)" in interface
     assert "chatCloseForSwitch(selectedConversation)" in interface
     assert "Finish or interrupt the current turn before switching chats." in interface
     assert 'item.state !== "closed"' in interface
@@ -83,6 +107,19 @@ def test_composer_is_retry_safe_and_has_turn_controls():
         interface.index("rail.append(button);", interface.index("chat-shell-name"))
     ]
     assert "chatCloseForSwitch" not in shell_switch
+
+
+def test_conversation_identity_uses_shell_context_and_neutral_user_label():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    assert 'kind === "user" ? "You"' in interface
+    assert "chatShellLabel(conversation)" in interface
+    assert "chatHeaderLabel(conversation)" in interface
+    assert "chatStartedLabel(conversation)" in interface
+    assert '"Untitled chat"' in interface
+    assert 'className: "chat-history-context"' in interface
+    assert 'className: "chat-shell-shortname"' in interface
+    assert '(active ? " active-chat" : "")' in interface
 
 
 def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
@@ -94,6 +131,10 @@ def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
         ".chat-bubble.chat-user",
         ".chat-bubble.chat-assistant",
         ".chat-composer",
+        ".chat-title-button",
+        ".chat-shell.active-chat::before",
     ):
         assert selector in STYLE
-    assert "grid-template-columns: 180px 260px minmax(0, 1fr)" in STYLE
+    assert "grid-template-columns: 198px 260px minmax(0, 1fr)" in STYLE
+    assert "grid-template-columns: 145px 210px minmax(0, 1fr)" in STYLE
+    assert "grid-template-columns: 101px minmax(0, 1fr)" in STYLE

--- a/tests/test_shells_ui_contract.py
+++ b/tests/test_shells_ui_contract.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import pytest
 
-
 ROOT = Path(__file__).resolve().parents[1]
 APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
 INDEX = (ROOT / ".super-coder" / "ui" / "index.html").read_text()
@@ -50,6 +49,8 @@ def test_new_shell_creator_offers_bespoke_without_a_flavor_template():
     assert "Bespoke — custom skill pack" in creator
     assert "flavor: fl.value || null" in creator
     assert '"shell type"' in creator
+    assert "footNodes: [cancel, create]" in creator
+    assert "footNodes: [create, cancel]" not in creator
 
 
 def test_skill_assignments_are_flavor_scoped_with_bespoke_exceptions():


### PR DESCRIPTION
## Summary
- show shell shortnames, active-chat accents, compact timestamps, and inline conversation rename
- label browser messages as You and hide routine tool activity while preserving actionable events
- make New chat use server-selected defaults immediately and move harness/model/title controls behind Configure
- keep the header and composer fixed while transcript output scrolls independently
- follow streamed output only while pinned to the bottom; preserve reading position and show a jump-to-latest control when scrolled up
- render a disabled, unwired Stop placeholder beside Send for possible future stream control
- place Cancel left and Create right in the New shell modal

## Verification
- ./sc test tests/test_conversation_ui.py tests/test_conversation_api.py (27 passed)
- pytest tests/test_shells_ui_contract.py (5 passed)
- ./sc test (1546 passed before the modal-only ordering follow-up)
- ./sc map
- ./sc render-check
- ./sc verify
- node --check .super-coder/ui/app.js
- ruff check touched test contracts
- git diff --check

## Trade-off
The Configure view uses a dedicated reload-safe Interface hash sentinel. The default path sends only shell_id so route defaults remain server-owned; no API or schema change is needed. Stop is intentionally disabled and has no event handler or backend contract.