### PR TITLE
fix: show browser-owned shells in CLI picker

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -617,6 +617,19 @@ def browser_conversation_active(con, shell_id: int) -> bool:
         return False
 
 
+def browser_conversation_shell_ids(con) -> set[int]:
+    """Shells whose single session slot is owned by an open browser chat."""
+    try:
+        rows = con.execute(
+            "SELECT DISTINCT shell_id FROM conversations WHERE state!='closed'"
+        ).fetchall()
+        return {int(row[0]) for row in rows}
+    except db_driver.OperationalError as exc:
+        if "no such table: conversations" in str(exc):
+            return set()
+        raise
+
+
 # ── Auth (username-only) ────────────────────────────────────────────────────
 
 def authenticate(con, interactive: bool = True):
@@ -655,6 +668,7 @@ def list_shells(con, user_id: int) -> list:
         "ORDER BY flavor IS NULL, flavor, shell_id",
         (user_id,),
     ).fetchall()]
+    browser_shell_ids = browser_conversation_shell_ids(con)
     refs_by_shell = [_sprint_doc_refs(shell) for shell in shells]
     referenced = set().union(*refs_by_shell)
     active = set()
@@ -669,6 +683,7 @@ def list_shells(con, user_id: int) -> list:
                   if _sprint_doc_is_active(doc)}
     for shell, refs in zip(shells, refs_by_shell):
         shell["sprint_reserved"] = bool(refs & active)
+        shell["browser_active"] = shell["shell_id"] in browser_shell_ids
     return shells
 
 
@@ -899,6 +914,8 @@ def _shell_status(shell, snap: "dict | None") -> str:
     """Styled picker status derived from liveness plus sprint reservation."""
     if shell["flavor"] == "admin":
         label, paint = "Exempt", style.dim
+    elif dict(shell).get("browser_active"):
+        label, paint = "BROWSER", style.red
     elif not snap or not snap.get("supported"):
         label, paint = "Unknown", style.dim
     else:
@@ -1517,8 +1534,8 @@ def main() -> None:
     user = authenticate(con, interactive=not headless)
     fdefaults = flavor_defaults(con)
     # Liveness snapshot for the interactive picker: one /proc pass (ms) so the
-    # boot list can show shell status — Busy / Orphaned / Sprint / Available /
-    # Exempt — and
+    # boot list can show shell status — BROWSER / Busy / Orphaned / Sprint /
+    # Available / Exempt — and
     # confirm before booting into a live worktree. Headless keeps its own lazy
     # compute below; non-TTY boots (--first, piped) can't confirm, so no snap.
     snap = (shell_liveness.compute()

--- a/tests/test_conversation_launch.py
+++ b/tests/test_conversation_launch.py
@@ -248,6 +248,7 @@ def test_preparer_waits_for_a_prior_browser_process_to_exit(launch_case):
 def test_cli_launch_is_reserved_until_the_browser_chat_is_ended(launch_case):
     db_path, worktree = launch_case
     con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
     con.execute(
             "INSERT INTO conversations "
             "(conversation_id,shell_id,owner_user_id,harness,worktree,state,"
@@ -259,11 +260,19 @@ def test_cli_launch_is_reserved_until_the_browser_chat_is_ended(launch_case):
     try:
         assert run_mod.browser_conversation_active(con, 1)
         assert not run_mod.browser_conversation_active(con, 999)
+        assert [
+            (shell["shortname"], shell["browser_active"])
+            for shell in run_mod.list_shells(con, 1)
+        ] == [("dev", True)]
         con.execute(
             "UPDATE conversations SET state='closed',closed_at=datetime('now') "
             "WHERE shell_id=1"
         )
         con.commit()
         assert not run_mod.browser_conversation_active(con, 1)
+        assert [
+            (shell["shortname"], shell["browser_active"])
+            for shell in run_mod.list_shells(con, 1)
+        ] == [("dev", False)]
     finally:
         con.close()

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -96,6 +96,15 @@ class ShellStatusTest(unittest.TestCase):
         self.assertEqual("Unknown     ", run._shell_status(self.shell, partial))
         self.assertEqual("Unknown     ", run._shell_status(self.shell, unsupported))
 
+    def test_browser_chat_replaces_available_status(self) -> None:
+        browser_shell = {**self.shell, "browser_active": True}
+        with mock.patch.object(style, "ON", True), mock.patch.object(
+                run.shell_liveness, "session_state", return_value=None):
+            self.assertEqual(
+                "\x1b[31mBROWSER\x1b[0m     ",
+                run._shell_status(browser_shell, self.snap),
+            )
+
     def test_sprint_reservation_replaces_only_available(self) -> None:
         sprint_shell = {
             **self.shell,


### PR DESCRIPTION
## Summary

- annotate shell picker rows that have an open Interface conversation
- render a red `BROWSER` status before the operator selects the shell
- preserve the existing post-selection ownership gate

## Verification

- focused: 28 passed, 7 subtests passed
- full Python suite: 1544 passed, 773 subtests passed
- `./sc map`
- `./sc render-check`
- `git diff --check`

`./sc verify` cannot run from the required isolated worktree while another shell owns the live checkout; workflow gap tracked in #769.