### PR TITLE
fix: show stacked chat work honestly

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3076,7 +3076,28 @@ function chatStatePill(state) {
     queued: "queued", running: "working", waiting: "waiting",
     error: "failed", idle: "idle", closed: "closed",
   }[state] || state;
-  return el("span", { className: `chat-state state-${state || "idle"}` }, label);
+  const pill = el("span", {
+    className: `chat-state state-${state || "idle"}`,
+  });
+  if (state !== "running") {
+    pill.textContent = label;
+    return pill;
+  }
+  pill.append(
+    label,
+    el("span", { className: "chat-working-dots", ariaHidden: "true" },
+      el("span", {}, "."),
+      el("span", {}, "."),
+      el("span", {}, ".")),
+  );
+  return pill;
+}
+
+function chatQueuedCount(messages) {
+  return messages.filter(
+    (message) => message.message_kind !== "control"
+      && ["accepted", "queued"].includes(message.state)
+  ).length;
 }
 
 function chatConversationName(conversation) {
@@ -3086,7 +3107,7 @@ function chatConversationName(conversation) {
 async function chatCloseForSwitch(conversation) {
   if (!conversation || conversation.state === "closed") return true;
   if (!["idle", "waiting", "error"].includes(conversation.state)) {
-    toast("Finish or interrupt the current turn before switching chats.");
+    toast("Finish the current turn and queued messages before switching chats.");
     return false;
   }
   try {
@@ -3226,8 +3247,11 @@ function chatPaintTranscript(
 
 async function chatRefreshConversation(conversationId, generation, onUpdate) {
   try {
-    const next = await chatApi(`/conversations/${conversationId}`);
-    if (generation === chatRenderGeneration) onUpdate(next);
+    const [next, messagePage] = await Promise.all([
+      chatApi(`/conversations/${conversationId}`),
+      chatApi(`/conversations/${conversationId}/messages?limit=100`),
+    ]);
+    if (generation === chatRenderGeneration) onUpdate(next, messagePage.items);
   } catch { /* SSE remains authoritative enough to keep the open view usable. */ }
 }
 
@@ -3373,6 +3397,7 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   const header = el("div", { className: "chat-pane-head" });
   const title = el("div", { className: "chat-pane-title" });
   const state = el("div", { className: "chat-pane-state" });
+  const queueState = el("span", { className: "chat-queue-state", hidden: true });
   const streamState = el("span", { className: "chat-stream-state" }, "connecting");
   const actions = el("div", { className: "chat-actions" });
   const transcriptHost = el("div", { className: "chat-transcript-host" });
@@ -3441,7 +3466,11 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
         el("span", {}, chatStartedLabel(conversation)),
         el("span", { className: "chat-context-separator" }, " | "),
         rename));
-    state.replaceChildren(chatStatePill(conversation.state), streamState);
+    const queued = chatQueuedCount(messages);
+    queueState.hidden = queued === 0;
+    queueState.textContent = `${queued} queued`;
+    state.replaceChildren(
+      chatStatePill(conversation.state), queueState, streamState);
     const closed = conversation.state === "closed";
     composer.disabled = closed;
     send.disabled = closed;
@@ -3461,7 +3490,11 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   const refresh = () => chatRefreshConversation(
     conversation.conversation_id,
     generation,
-    (next) => { conversation = next; paint(); });
+    (next, nextMessages) => {
+      conversation = next;
+      messages = nextMessages;
+      paint();
+    });
 
   const analytics = el("button", { className: "act", type: "button", textContent: "Analytics" });
   analytics.onclick = () => {
@@ -3519,7 +3552,7 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
       chatPendingSend = null;
       composer.value = "";
       pending.hidden = true;
-      conversation.state = "queued";
+      if (conversation.state !== "running") conversation.state = "queued";
       paint();
       refresh();
     } catch (error) {
@@ -3547,22 +3580,26 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
       seen.add(event.sequence);
       events.push(event);
       if (event.run_id) latestRunId = event.run_id;
-      if (event.event_type === "message.accepted") conversation.state = "queued";
-      if (event.event_type === "run.started") conversation.state = "running";
-      if (["permission.requested", "input.requested"].includes(event.event_type))
-        conversation.state = "waiting";
-      if (["run.completed", "run.interrupted"].includes(event.event_type))
-        conversation.state = "idle";
-      if (["run.failed", "run.unknown"].includes(event.event_type))
-        conversation.state = "error";
       const message = messages.find((item) => item.message_id === event.message_id);
+      if (message && event.event_type === "run.started") message.state = "running";
       if (message && event.event_type === "run.completed") message.state = "completed";
       if (message && ["run.failed", "run.unknown"].includes(event.event_type))
         message.state = "failed";
       if (message && event.event_type === "run.interrupted")
         message.state = "cancelled";
+      if (event.event_type === "message.accepted"
+          && conversation.state !== "running")
+        conversation.state = "queued";
+      if (event.event_type === "run.started") conversation.state = "running";
+      if (["permission.requested", "input.requested"].includes(event.event_type))
+        conversation.state = "waiting";
+      if (["run.completed", "run.interrupted"].includes(event.event_type))
+        conversation.state = chatQueuedCount(messages) ? "queued" : "idle";
+      if (["run.failed", "run.unknown"].includes(event.event_type))
+        conversation.state = "error";
       paint();
-      if (["run.completed", "run.failed", "run.interrupted", "run.unknown",
+      if (["message.accepted", "run.completed", "run.failed",
+           "run.interrupted", "run.unknown",
            "conversation.renamed", "conversation.closed"].includes(event.event_type))
         refresh();
     },

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -147,6 +147,21 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
   color: var(--dim); font-size: .64rem; text-transform: uppercase; letter-spacing: .06em;
 }
 .chat-state.state-running, .chat-state.state-queued { color: var(--accent); border-color: rgba(110,168,254,.45); }
+.chat-working-dots { display: inline-flex; margin-left: .12rem; }
+.chat-working-dots span {
+  display: inline-block;
+  animation: chat-working-dot 1.2s ease-in-out infinite;
+  opacity: .25;
+}
+.chat-working-dots span:nth-child(2) { animation-delay: .16s; }
+.chat-working-dots span:nth-child(3) { animation-delay: .32s; }
+@keyframes chat-working-dot {
+  0%, 60%, 100% { opacity: .25; transform: translateY(0); }
+  30% { opacity: 1; transform: translateY(-1px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-working-dots span { animation: none; opacity: 1; }
+}
 .chat-state.state-waiting { color: var(--warn); border-color: rgba(212,145,74,.45); }
 .chat-state.state-error { color: #ef7d86; border-color: rgba(239,125,134,.45); }
 .chat-state.state-idle { color: var(--ok); border-color: rgba(76,175,125,.4); }
@@ -173,6 +188,7 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
 }
 .chat-title-button:hover { color: var(--accent); text-decoration: underline; }
 .chat-pane-state { display: flex; align-items: center; gap: .5rem; }
+.chat-queue-state { color: var(--accent); font-size: .68rem; white-space: nowrap; }
 .chat-stream-state { color: var(--dim); font-size: .68rem; }
 .chat-stream-state.reconnecting { color: var(--warn); }
 .chat-actions { display: flex; align-items: center; gap: .35rem; }

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -481,6 +481,48 @@ class ConversationResourceTest(ConversationApiCase):
         self.assertEqual(status, 409)
         self.assertEqual(conflict["error"]["code"], "MESSAGE_IDEMPOTENCY_CONFLICT")
 
+    def test_message_stacked_during_run_queues_without_interrupting(self) -> None:
+        conversation_id = self.create()["conversation_id"]
+        status, _, first = self.request(
+            "POST",
+            f"/api/conversations/{conversation_id}/messages",
+            body={"text": "keep working"},
+            key="message-active",
+        )
+        self.assertEqual(status, 202, first)
+        run = conversation_broker.BrokerStore(self.db_path).claim_next("test")
+        self.assertIsNotNone(run)
+
+        status, _, stacked = self.request(
+            "POST",
+            f"/api/conversations/{conversation_id}/messages",
+            body={"text": "do this next"},
+            key="message-stacked",
+        )
+        self.assertEqual(status, 202, stacked)
+        self.assertEqual(stacked["queue_position"], 1)
+        self.assertEqual(stacked["message"]["state"], "queued")
+
+        con = self.connect()
+        conversation_state = con.execute(
+            "SELECT state FROM conversations WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()[0]
+        interrupt_events = con.execute(
+            "SELECT COUNT(*) FROM conversation_events "
+            "WHERE conversation_id=? AND event_type='run.interrupt.requested'",
+            (conversation_id,),
+        ).fetchone()[0]
+        control_messages = con.execute(
+            "SELECT COUNT(*) FROM conversation_messages "
+            "WHERE conversation_id=? AND message_kind='control'",
+            (conversation_id,),
+        ).fetchone()[0]
+        con.close()
+        self.assertEqual(conversation_state, "running")
+        self.assertEqual(interrupt_events, 0)
+        self.assertEqual(control_messages, 0)
+
     def test_cursor_pages_have_no_duplicates_and_patch_uses_version(self) -> None:
         created = [
             self.create(key=f"create-{number}")

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -110,6 +110,11 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert "chatPendingSend.key" in interface
     assert "retry keeps this exact send" in interface
     assert 'event.key === "Enter" && !event.shiftKey' in interface
+    assert "function chatQueuedCount(messages)" in interface
+    assert 'className: "chat-queue-state"' in interface
+    assert 'queueState.textContent = `${queued} queued`' in interface
+    assert 'conversation.state !== "running"' in interface
+    assert 'event.event_type === "run.started") message.state = "running"' in interface
     assert 'textContent: "Interrupt"' in interface
     assert 'textContent: "Retry"' in interface
     assert 'textContent: "Close"' in interface
@@ -126,7 +131,7 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert 'textContent: "Rename"' not in interface
     assert "actions.append(analytics, interrupt, close)" in interface
     assert "chatCloseForSwitch(selectedConversation)" in interface
-    assert "Finish or interrupt the current turn before switching chats." in interface
+    assert "Finish the current turn and queued messages before switching chats." in interface
     assert 'item.state !== "closed"' in interface
     shell_switch = interface[
         interface.index('button.onclick = () => {', interface.index("chat-shell-name")):
@@ -167,3 +172,6 @@ def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
     assert "grid-template-columns: 198px 260px minmax(0, 1fr)" in STYLE
     assert "grid-template-columns: 145px 210px minmax(0, 1fr)" in STYLE
     assert "grid-template-columns: 101px minmax(0, 1fr)" in STYLE
+    assert ".chat-working-dots" in STYLE
+    assert "@keyframes chat-working-dot" in STYLE
+    assert ".chat-queue-state" in STYLE


### PR DESCRIPTION
## Summary

- keep manual interruption as a separate operator control; ordinary message submission never invokes it
- preserve `running` while messages stack, show an animated `Working...` indicator, and display the durable queued-message count
- refresh conversation and message projections together so stacked messages remain accurate across SSE/reconnect paths
- add an API regression proving a message stacked during a live run stays queued and creates no interrupt event or control message

Decision #25 / spec #32 define OpenCode final-output-only as an accepted alpha capability difference. Review finding #34 is addressed by the truthful running/queue UX; finding #33 remains open for reliable manual Stop delivery.

## Verification

- `./sc test` — 1544 passed
- focused conversation UI/API/broker suite after rebase — 38 passed
- `node --check .super-coder/ui/app.js`
- `./sc map`
- `./sc render-check`
- live checkout `./sc verify`
- `git diff --check`