### PR TITLE
fix(ui): constrain Interface scroll regions

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3653,30 +3653,33 @@ async function renderInterface(root) {
     ...[...new Set(shells.map((item) => item.flavor || "bespoke"))]
       .filter((flavor) => !CHAT_FLAVOR_ORDER.includes(flavor)).sort(),
   ];
-  for (const flavor of orderedFlavors) {
-    rail.append(el("div", { className: "chat-shell-group" }, flavor || "bespoke"));
-    for (const item of shells.filter((candidate) => (candidate.flavor || "bespoke") === flavor)) {
-      const active = allConversations.items.find(
-        (conversation) => conversation.shell.shell_id === item.shell_id
-          && conversation.state !== "closed");
-      const button = el("button", {
-        className: "chat-shell"
-          + (item.shell_id === shell.shell_id ? " selected" : "")
-          + (active ? " active-chat" : ""),
-        type: "button",
-      },
-      el("span", { className: "chat-shell-name" }, item.display_name),
-      el("span", { className: "chat-shell-shortname" }, item.shortname || ""));
-      button.onclick = () => {
-        if (item.shell_id === shell.shell_id) return;
-        location.hash = chatHash(item.shortname);
-      };
-      rail.append(button);
-    }
+  const orderedShells = orderedFlavors.flatMap((flavor) =>
+    shells.filter((item) => (item.flavor || "bespoke") === flavor));
+  for (const item of orderedShells) {
+    const active = allConversations.items.find(
+      (conversation) => conversation.shell.shell_id === item.shell_id
+        && conversation.state !== "closed");
+    const button = el("button", {
+      className: "chat-shell"
+        + (item.shell_id === shell.shell_id ? " selected" : "")
+        + (active ? " active-chat" : ""),
+      type: "button",
+    },
+    el("span", { className: "chat-shell-name" }, item.display_name),
+    el("span", { className: "chat-shell-shortname" }, item.shortname || ""));
+    button.onclick = () => {
+      if (item.shell_id === shell.shell_id) return;
+      location.hash = chatHash(item.shortname);
+    };
+    rail.append(button);
   }
 
   const side = el("aside", { className: "chat-history" });
-  const newChat = el("button", { className: "act primary", type: "button", textContent: "＋ New chat" });
+  const newChat = el("button", {
+    className: "act primary",
+    type: "button",
+    textContent: "＋ Chat",
+  });
   const configure = el("button", {
     className: "chat-configure",
     type: "button",
@@ -3694,7 +3697,7 @@ async function renderInterface(root) {
       toast(`${error.code}: ${error.message}`);
       newChat.disabled = false;
       configure.disabled = false;
-      newChat.textContent = "＋ New chat";
+      newChat.textContent = "＋ Chat";
     }
   };
   configure.onclick = async () => {
@@ -3706,9 +3709,11 @@ async function renderInterface(root) {
     location.hash = chatHash(shell.shortname, CHAT_CONFIGURE_ROUTE);
   };
   side.append(el("div", { className: "chat-history-head" },
-    el("div", { className: "chat-history-shell" }, el("b", {}, shell.display_name),
-      el("span", { className: "chat-shortname" }, ` /${shell.shortname}`)),
-    el("div", { className: "chat-history-actions" }, newChat, configure)));
+    el("div", { className: "chat-history-shell" },
+      el("div", {}, el("b", {}, shell.display_name),
+        el("span", { className: "chat-shortname" }, ` /${shell.shortname}`)),
+      configure),
+    newChat));
   const history = el("div", { className: "chat-history-list" });
   for (const conversation of conversations) {
     const button = el("button", {

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -73,26 +73,28 @@ main { padding: 1.2rem; flex: 1 0 auto; min-height: 0; }
 /* ── Browser-native Interface ───────────────────────────────────────────────
    The old Interface rail/transcript silhouette, without its embedded terminal
    or tmux/session-management layer. */
-body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 52px); }
+body.interface-view { height: 100dvh; overflow: hidden; }
+body.interface-view main {
+  display: flex; flex: 1 1 auto; height: calc(100dvh - 52px);
+  min-height: 0; padding: 0; overflow: hidden;
+}
 #view-interface {
-  max-width: none; margin: 0; gap: 0; min-height: calc(100dvh - 52px);
+  max-width: none; height: 100%; min-height: 0; margin: 0; gap: 0;
 }
 .chat-loading { color: var(--dim); padding: 2rem; }
 .chat-layout {
-  display: grid; grid-template-columns: 198px 260px minmax(0, 1fr);
-  min-height: calc(100dvh - 52px); background: var(--panel2);
+  display: grid; grid-template-columns: 260px 260px minmax(0, 1fr);
+  height: 100%; min-height: 0; background: var(--panel2);
 }
 .chat-rail, .chat-history {
   min-width: 0; border-right: 1px solid var(--line); background: var(--bg);
-  overflow-y: auto;
 }
-.chat-rail { padding: .8rem .6rem; }
-.chat-rail-title, .chat-shell-group {
+.chat-rail { padding: .8rem .6rem; overflow-y: auto; }
+.chat-rail-title {
   color: var(--dim); font-size: .66rem; text-transform: uppercase;
   letter-spacing: .14em; padding: .35rem .55rem;
 }
 .chat-rail-title { color: var(--ink); font-size: .74rem; margin-bottom: .45rem; }
-.chat-shell-group { margin-top: .65rem; border-top: 1px solid var(--line-soft); padding-top: .7rem; }
 .chat-shell {
   position: relative; width: 100%; display: flex; align-items: center; gap: .45rem;
   background: transparent; border: 1px solid transparent; color: var(--dim);
@@ -110,24 +112,26 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: none;
 }
 .chat-shell.selected .chat-shell-shortname { color: rgba(255,255,255,.72); }
-.chat-history { background: var(--panel); display: flex; flex-direction: column; }
+.chat-history {
+  min-height: 0; overflow: hidden; background: var(--panel);
+  display: flex; flex-direction: column;
+}
 .chat-history-head {
   padding: .8rem; border-bottom: 1px solid var(--line);
-  display: flex; align-items: center; gap: .6rem; min-height: 67px;
+  display: flex; flex: none; align-items: center; gap: .6rem; min-height: 67px;
 }
-.chat-history-shell { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; }
-.chat-history-actions {
-  display: flex; flex-direction: column; align-items: stretch; gap: .1rem; flex: none;
+.chat-history-shell {
+  min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis;
 }
-.chat-history-actions .act { margin: 0; padding: .34rem .65rem; white-space: nowrap; }
+.chat-history-head > .act { margin: 0; padding: .34rem .65rem; white-space: nowrap; }
 .chat-configure {
-  background: transparent; border: 0; color: var(--accent); cursor: pointer;
-  font: inherit; font-size: .67rem; padding: .08rem .25rem;
+  display: block; background: transparent; border: 0; color: var(--accent);
+  cursor: pointer; font: inherit; font-size: .67rem; padding: .08rem 0;
 }
 .chat-configure:hover { color: #fff; }
 .chat-configure:disabled { cursor: default; opacity: .45; }
 .chat-shortname { color: var(--dim); font: .76rem ui-monospace, monospace; }
-.chat-history-list { overflow-y: auto; padding: .5rem; }
+.chat-history-list { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: .5rem; }
 .chat-history-item {
   width: 100%; background: transparent; color: var(--dim); border: 1px solid transparent;
   border-radius: 9px; padding: .6rem; cursor: pointer; text-align: left;
@@ -259,7 +263,7 @@ body.interface-view main { display: flex; padding: 0; min-height: calc(100dvh - 
 .chat-new-form .act { margin-top: 1rem; }
 
 @media (max-width: 900px) {
-  .chat-layout { grid-template-columns: 145px 210px minmax(0, 1fr); }
+  .chat-layout { grid-template-columns: 210px 210px minmax(0, 1fr); }
   .chat-actions { flex-wrap: wrap; justify-content: flex-end; }
   .chat-pane-head { align-items: start; }
 }

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -36,7 +36,7 @@ def test_start_chat_has_default_and_configured_paths_without_terminal_controls()
                     APP.index("// ── Tabs + boot")]
     assert 'const CHAT_HARNESSES = ["opencode", "claude", "codex"]' in interface
     assert 'const CHAT_CONFIGURE_ROUTE = "configure"' in interface
-    assert 'textContent: "＋ New chat"' in interface
+    assert 'textContent: "＋ Chat"' in interface
     assert 'textContent: "Configure"' in interface
     assert "const conversation = await chatCreateConversation(shell);" in interface
     assert "{ shell_id: shell.shell_id, ...fields }" in interface
@@ -153,6 +153,41 @@ def test_conversation_identity_uses_shell_context_and_neutral_user_label():
     assert '(active ? " active-chat" : "")' in interface
 
 
+def test_interface_owns_scroll_with_fixed_history_and_conversation_controls():
+    assert "body.interface-view { height: 100dvh; overflow: hidden; }" in STYLE
+    assert "height: calc(100dvh - 52px);" in STYLE
+    assert ".chat-layout {" in STYLE
+    assert "height: 100%; min-height: 0; background: var(--panel2);" in STYLE
+    assert ".chat-rail { padding: .8rem .6rem; overflow-y: auto; }" in STYLE
+    assert "min-height: 0; overflow: hidden; background: var(--panel);" in STYLE
+    assert (
+        ".chat-history-list { flex: 1 1 auto; min-height: 0; "
+        "overflow-y: auto; padding: .5rem; }"
+    ) in STYLE
+    assert "height: 100%; overflow-y: auto;" in STYLE
+
+
+def test_shell_rail_is_flat_but_retains_flavor_order():
+    interface = APP[APP.index("async function renderInterface"):
+                    APP.index("// ── Tabs + boot")]
+    assert "const orderedShells = orderedFlavors.flatMap" in interface
+    assert "for (const item of orderedShells)" in interface
+    assert 'className: "chat-shell-group"' not in interface
+    assert ".chat-shell-group" not in STYLE
+
+
+def test_history_header_places_configure_under_identity_and_centers_chat_action():
+    interface = APP[APP.index('side.append(el("div", { className: "chat-history-head" }'):
+                    APP.index('const history = el("div"', APP.index(
+                        'side.append(el("div", { className: "chat-history-head" }'))]
+    assert 'className: "chat-history-shell"' in interface
+    assert "configure)," in interface
+    assert "newChat));" in interface
+    assert 'className: "chat-history-actions"' not in interface
+    assert ".chat-history-head > .act" in STYLE
+    assert "display: block; background: transparent;" in STYLE
+
+
 def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
     for selector in (
         ".chat-layout",
@@ -169,8 +204,8 @@ def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
         ".chat-shell.active-chat::before",
     ):
         assert selector in STYLE
-    assert "grid-template-columns: 198px 260px minmax(0, 1fr)" in STYLE
-    assert "grid-template-columns: 145px 210px minmax(0, 1fr)" in STYLE
+    assert "grid-template-columns: 260px 260px minmax(0, 1fr)" in STYLE
+    assert "grid-template-columns: 210px 210px minmax(0, 1fr)" in STYLE
     assert "grid-template-columns: 101px minmax(0, 1fr)" in STYLE
     assert ".chat-working-dots" in STYLE
     assert "@keyframes chat-working-dot" in STYLE


### PR DESCRIPTION
## Summary
- lock the Interface view to the viewport and give chat history and transcript independent scroll regions
- keep conversation headers and composers fixed, with the existing jump-to-latest control
- flatten shell grouping, equalize the shell/chat rail widths, and place Configure beneath shell identity beside a centered ＋ Chat action

## Trade-off
The viewport boundary stays entirely in CSS; no resize listener or extra JavaScript state is needed.

## Verification
- ./sc test — 1560 passed
- ./sc render-check
- node --check .super-coder/ui/app.js
- git diff --check