### PR TITLE
fix(ui): restore shell flavor dividers

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3022,7 +3022,9 @@ async function renderSprints(root) {
 // uses the normal CLI preparation path server-side, but deliberately has no
 // terminal, tmux controls, or live hand-off between browser and CLI.
 const CHAT_HARNESSES = ["opencode", "claude", "codex"];
-const CHAT_FLAVOR_ORDER = ["cartographer", "admin", "planner", "dev", "reviewer", "devops"];
+const CHAT_FLAVOR_ORDER = [
+  "cartographer", "admin", "conductor", "planner", "dev", "reviewer", "devops",
+];
 const CHAT_CONFIGURE_ROUTE = "configure";
 let chatRouteShell = "";
 let chatRouteConversation = "";
@@ -3392,7 +3394,6 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   let messages = [...initialMessages];
   const events = [];
   const seen = new Set();
-  let latestRunId = null;
 
   const header = el("div", { className: "chat-pane-head" });
   const title = el("div", { className: "chat-pane-title" });
@@ -3474,7 +3475,6 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     const closed = conversation.state === "closed";
     composer.disabled = closed;
     send.disabled = closed;
-    interrupt.disabled = !["queued", "running", "waiting"].includes(conversation.state);
     close.disabled = !["idle", "waiting", "error"].includes(conversation.state);
     composer.placeholder = closed ? "This conversation is closed." : "Message this shell…";
     chatPaintTranscript(
@@ -3502,15 +3502,6 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     anFilters.model = conversation.route.model || "";
     location.hash = "analytics";
   };
-  const interrupt = el("button", { className: "act", type: "button", textContent: "Interrupt" });
-  interrupt.onclick = async () => {
-    interrupt.disabled = true;
-    try {
-      await chatApi(`/conversations/${conversation.conversation_id}/interruptions`,
-        "POST", latestRunId ? { run_id: latestRunId } : {}, requestKey());
-    } catch (error) { toast(`${error.code}: ${error.message}`); }
-    finally { interrupt.disabled = false; }
-  };
   const close = el("button", {
     className: "act danger",
     type: "button",
@@ -3526,7 +3517,7 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
       paint();
     } catch (error) { toast(`${error.code}: ${error.message}`); refresh(); }
   };
-  actions.append(analytics, interrupt, close);
+  actions.append(analytics, close);
   header.append(title, state, actions);
 
   async function submit() {
@@ -3579,7 +3570,6 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
       if (seen.has(event.sequence)) return;
       seen.add(event.sequence);
       events.push(event);
-      if (event.run_id) latestRunId = event.run_id;
       const message = messages.find((item) => item.message_id === event.message_id);
       if (message && event.event_type === "run.started") message.state = "running";
       if (message && event.event_type === "run.completed") message.state = "completed";
@@ -3655,7 +3645,12 @@ async function renderInterface(root) {
   ];
   const orderedShells = orderedFlavors.flatMap((flavor) =>
     shells.filter((item) => (item.flavor || "bespoke") === flavor));
+  let previousFlavor = "";
   for (const item of orderedShells) {
+    const flavor = item.flavor || "bespoke";
+    if (previousFlavor && flavor !== previousFlavor)
+      rail.append(el("div", { className: "chat-shell-divider", role: "separator" }));
+    previousFlavor = flavor;
     const active = allConversations.items.find(
       (conversation) => conversation.shell.shell_id === item.shell_id
         && conversation.state !== "closed");

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3026,15 +3026,22 @@ const CHAT_FLAVOR_ORDER = [
   "cartographer", "admin", "conductor", "planner", "dev", "reviewer", "devops",
 ];
 const CHAT_CONFIGURE_ROUTE = "configure";
+const CHAT_HISTORY_POLL_MS = 2000;
 let chatRouteShell = "";
 let chatRouteConversation = "";
 let chatSource = null;
+let chatHistoryPollTimer = null;
 let chatRenderGeneration = 0;
 let chatPendingSend = null;
 
 function chatStopStream() {
   if (chatSource) chatSource.close();
   chatSource = null;
+}
+
+function chatStopHistoryPoll() {
+  if (chatHistoryPollTimer) clearInterval(chatHistoryPollTimer);
+  chatHistoryPollTimer = null;
 }
 
 function chatHash(shortname, conversationId = "") {
@@ -3619,6 +3626,7 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
 
 async function renderInterface(root) {
   chatStopStream();
+  chatStopHistoryPoll();
   const generation = ++chatRenderGeneration;
   root.replaceChildren(el("div", { className: "chat-loading" }, "Loading conversations…"));
   const [{ shells }, defaults, catalog, allConversations] = await Promise.all([
@@ -3727,6 +3735,7 @@ async function renderInterface(root) {
       configure),
     newChat));
   const history = el("div", { className: "chat-history-list" });
+  const historyItems = new Map();
   for (const conversation of conversations) {
     const button = el("button", {
       className: "chat-history-item"
@@ -3738,6 +3747,7 @@ async function renderInterface(root) {
       el("span", { className: "chat-history-name" },
       chatConversationName(conversation)),
       chatStatePill(conversation.state));
+    historyItems.set(conversation.conversation_id, button);
     button.onclick = async () => {
       if (conversation.conversation_id === selectedId) return;
       if (await chatCloseForSwitch(selectedConversation))
@@ -3748,6 +3758,25 @@ async function renderInterface(root) {
   if (!conversations.length)
     history.append(el("div", { className: "chat-history-empty" }, "No chats yet."));
   side.append(history);
+  let historyPollInFlight = false;
+  const pollHistory = async () => {
+    if (document.hidden || historyPollInFlight) return;
+    historyPollInFlight = true;
+    try {
+      const page = await chatApi("/conversations?limit=100");
+      if (generation !== chatRenderGeneration || !chatHistoryPollTimer) return;
+      for (const conversation of page.items) {
+        if (conversation.shell.shell_id !== shell.shell_id) continue;
+        const button = historyItems.get(conversation.conversation_id);
+        const pill = button?.querySelector(".chat-state");
+        const nextState = conversation.state || "idle";
+        if (!pill || pill.classList.contains(`state-${nextState}`)) continue;
+        pill.replaceWith(chatStatePill(nextState));
+      }
+    } catch { /* The next poll retries without disrupting the open chat. */ }
+    finally { historyPollInFlight = false; }
+  };
+  chatHistoryPollTimer = setInterval(pollHistory, CHAT_HISTORY_POLL_MS);
 
   const pane = el("section", { className: "chat-pane" });
   layout.append(rail, side, pane);
@@ -3805,7 +3834,10 @@ function show(tab) {
   document.body.classList.toggle("sprints-view", tab === "sprints");
   document.body.classList.toggle("interface-view", tab === "interface");
   if (tab !== "sprints") sprintsStopRender();
-  if (tab !== "interface") chatStopStream();
+  if (tab !== "interface") {
+    chatStopStream();
+    chatStopHistoryPoll();
+  }
   setDocumentTitle(tab);
   load(tab);
 }

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3394,12 +3394,12 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   let messages = [...initialMessages];
   const events = [];
   const seen = new Set();
+  let streamStatus = "connecting";
 
   const header = el("div", { className: "chat-pane-head" });
   const title = el("div", { className: "chat-pane-title" });
   const state = el("div", { className: "chat-pane-state" });
   const queueState = el("span", { className: "chat-queue-state", hidden: true });
-  const streamState = el("span", { className: "chat-stream-state" }, "connecting");
   const actions = el("div", { className: "chat-actions" });
   const transcriptHost = el("div", { className: "chat-transcript-host" });
   const transcript = el("div", { className: "chat-transcript" });
@@ -3438,6 +3438,23 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   const pending = el("div", { className: "chat-pending", hidden: true });
   const composerRow = el("div", { className: "chat-composer" },
     composer, el("div", { className: "chat-compose-actions" }, pending, send, stop));
+  const updateStreamStatus = () => {
+    const pill = state.querySelector(".chat-state");
+    if (!pill) return;
+    const connected = streamStatus === "connected";
+    const connectionLabel = connected
+      ? "Connected"
+      : streamStatus === "reconnecting" ? "Reconnecting" : "Connecting";
+    pill.title = `Connection: ${connectionLabel}`;
+    pill.setAttribute(
+      "aria-label",
+      `${pill.textContent}; connection ${connectionLabel.toLowerCase()}`,
+    );
+    pill.classList.toggle(
+      "stream-disconnected",
+      conversation.state === "idle" && !connected,
+    );
+  };
 
   const retry = async (text) => {
     composer.value = text;
@@ -3470,8 +3487,8 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     const queued = chatQueuedCount(messages);
     queueState.hidden = queued === 0;
     queueState.textContent = `${queued} queued`;
-    state.replaceChildren(
-      chatStatePill(conversation.state), queueState, streamState);
+    state.replaceChildren(chatStatePill(conversation.state), queueState);
+    updateStreamStatus();
     const closed = conversation.state === "closed";
     composer.disabled = closed;
     send.disabled = closed;
@@ -3594,8 +3611,8 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
         refresh();
     },
     (value) => {
-      streamState.textContent = value;
-      streamState.classList.toggle("reconnecting", value === "reconnecting");
+      streamStatus = value;
+      updateStreamStatus();
     },
   );
 }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -102,6 +102,7 @@ body.interface-view main {
   position: relative; width: 100%; display: flex; align-items: center; gap: .45rem;
   background: transparent; border: 1px solid transparent; color: var(--dim);
   border-radius: 8px; padding: .48rem .55rem; cursor: pointer; text-align: left;
+  font-size: 15px;
 }
 .chat-shell:hover { color: var(--ink); background: var(--panel); }
 .chat-shell.selected { color: var(--ink); border-color: var(--line); background: var(--panel); }
@@ -219,7 +220,7 @@ body.interface-view main {
 .chat-bubble {
   width: fit-content; max-width: min(720px, 82%);
   border: 1px solid var(--line); border-radius: 12px; padding: .65rem .8rem;
-  background: var(--panel);
+  background: var(--panel); font-size: 15px;
 }
 .chat-bubble.chat-user { align-self: flex-end; background: #202936; border-color: #2c3b50; }
 .chat-bubble.chat-assistant { align-self: flex-start; }
@@ -228,7 +229,7 @@ body.interface-view main {
   color: var(--dim); font-size: .78rem; padding: .4rem .65rem;
 }
 .chat-who {
-  color: var(--dim); font-size: .62rem; text-transform: uppercase;
+  color: var(--dim); font-size: calc(.62rem + 1px); text-transform: uppercase;
   letter-spacing: .12em; margin-bottom: .22rem;
 }
 .chat-bubble .md > :first-child { margin-top: 0; }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -95,6 +95,9 @@ body.interface-view main {
   letter-spacing: .14em; padding: .35rem .55rem;
 }
 .chat-rail-title { color: var(--ink); font-size: .74rem; margin-bottom: .45rem; }
+.chat-shell-divider {
+  height: 1px; margin: .65rem .55rem; background: var(--line-soft);
+}
 .chat-shell {
   position: relative; width: 100%; display: flex; align-items: center; gap: .45rem;
   background: transparent; border: 1px solid transparent; color: var(--dim);

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -172,6 +172,9 @@ body.interface-view main {
 .chat-state.state-waiting { color: var(--warn); border-color: rgba(212,145,74,.45); }
 .chat-state.state-error { color: #ef7d86; border-color: rgba(239,125,134,.45); }
 .chat-state.state-idle { color: var(--ok); border-color: rgba(76,175,125,.4); }
+.chat-state.state-idle.stream-disconnected {
+  color: var(--warn); border-color: rgba(212,145,74,.45);
+}
 .chat-state.state-closed { opacity: .6; }
 .chat-pane {
   min-width: 0; min-height: 0; display: grid;
@@ -196,8 +199,6 @@ body.interface-view main {
 .chat-title-button:hover { color: var(--accent); text-decoration: underline; }
 .chat-pane-state { display: flex; align-items: center; gap: .5rem; }
 .chat-queue-state { color: var(--accent); font-size: .68rem; white-space: nowrap; }
-.chat-stream-state { color: var(--dim); font-size: .68rem; }
-.chat-stream-state.reconnecting { color: var(--warn); }
 .chat-actions { display: flex; align-items: center; gap: .35rem; }
 .chat-actions .act { margin: 0; padding: .3rem .65rem; font-size: .72rem; }
 .chat-actions .danger { color: #ef7d86; }

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -198,6 +198,32 @@ def test_shell_rail_hides_labels_but_retains_ordered_flavor_dividers():
     assert ".chat-shell-divider" in STYLE
 
 
+def test_history_badges_poll_without_repainting_the_interface():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    assert "const CHAT_HISTORY_POLL_MS = 2000" in interface
+    assert "if (chatHistoryPollTimer) clearInterval(chatHistoryPollTimer)" in interface
+    assert "const historyItems = new Map()" in interface
+    assert "historyItems.set(conversation.conversation_id, button)" in interface
+    assert 'await chatApi("/conversations?limit=100")' in interface
+    assert "generation !== chatRenderGeneration || !chatHistoryPollTimer" in interface
+    assert "historyItems.get(conversation.conversation_id)" in interface
+    assert "pill.replaceWith(chatStatePill(nextState))" in interface
+    assert "if (document.hidden || historyPollInFlight) return" in interface
+    assert "finally { historyPollInFlight = false; }" in interface
+    assert "setInterval(pollHistory, CHAT_HISTORY_POLL_MS)" in interface
+    poll = interface[interface.index("const pollHistory = async"):
+                     interface.index("chatHistoryPollTimer = setInterval")]
+    assert "renderInterface(" not in poll
+
+
+def test_redline_chat_text_is_one_pixel_larger():
+    assert "font-size: 15px;" in STYLE[STYLE.index(".chat-shell {"):
+                                      STYLE.index(".chat-shell:hover")]
+    assert "background: var(--panel); font-size: 15px;" in STYLE
+    assert "font-size: calc(.62rem + 1px)" in STYLE
+
+
 def test_history_header_places_configure_under_identity_and_centers_chat_action():
     interface = APP[APP.index('side.append(el("div", { className: "chat-history-head" }'):
                     APP.index('const history = el("div"', APP.index(

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -115,7 +115,7 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert 'queueState.textContent = `${queued} queued`' in interface
     assert 'conversation.state !== "running"' in interface
     assert 'event.event_type === "run.started") message.state = "running"' in interface
-    assert 'textContent: "Interrupt"' in interface
+    assert 'textContent: "Interrupt"' not in interface
     assert 'textContent: "Retry"' in interface
     assert 'textContent: "Close"' in interface
     assert 'textContent: "Analytics"' in interface
@@ -129,7 +129,8 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert 'className: "chat-title-button"' in interface
     assert 'title: "Rename conversation"' in interface
     assert 'textContent: "Rename"' not in interface
-    assert "actions.append(analytics, interrupt, close)" in interface
+    assert "actions.append(analytics, close)" in interface
+    assert "/interruptions" not in interface
     assert "chatCloseForSwitch(selectedConversation)" in interface
     assert "Finish the current turn and queued messages before switching chats." in interface
     assert 'item.state !== "closed"' in interface
@@ -167,13 +168,21 @@ def test_interface_owns_scroll_with_fixed_history_and_conversation_controls():
     assert "height: 100%; overflow-y: auto;" in STYLE
 
 
-def test_shell_rail_is_flat_but_retains_flavor_order():
+def test_shell_rail_hides_labels_but_retains_ordered_flavor_dividers():
     interface = APP[APP.index("async function renderInterface"):
                     APP.index("// ── Tabs + boot")]
+    assert (
+        '"cartographer", "admin", "conductor", "planner", "dev", '
+        '"reviewer", "devops"'
+    ) in APP
     assert "const orderedShells = orderedFlavors.flatMap" in interface
     assert "for (const item of orderedShells)" in interface
+    assert 'const flavor = item.flavor || "bespoke"' in interface
+    assert "previousFlavor && flavor !== previousFlavor" in interface
+    assert 'className: "chat-shell-divider", role: "separator"' in interface
     assert 'className: "chat-shell-group"' not in interface
     assert ".chat-shell-group" not in STYLE
+    assert ".chat-shell-divider" in STYLE
 
 
 def test_history_header_places_configure_under_identity_and_centers_chat_action():

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -69,6 +69,19 @@ def test_transcript_streams_normalized_events_and_reconnects_natively():
     assert "mdBlock(body)" in interface
 
 
+def test_connection_status_is_encoded_in_the_idle_pill_without_visible_copy():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    assert 'let streamStatus = "connecting"' in interface
+    assert 'source.onopen = () => onState("connected")' in interface
+    assert 'source.onerror = () => onState("reconnecting")' in interface
+    assert "pill.title = `Connection: ${connectionLabel}`" in interface
+    assert '"stream-disconnected"' in interface
+    assert 'className: "chat-stream-state"' not in interface
+    assert ".chat-stream-state" not in STYLE
+    assert ".chat-state.state-idle.stream-disconnected" in STYLE
+
+
 def test_transcript_hides_routine_tools_but_keeps_actionable_activity():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]


### PR DESCRIPTION
## Summary
- prioritize Cartographer, Admin, and Conductor shells before grouped Planner, Dev, Reviewer, and DevOps shells
- restore unlabeled dividers only at shell flavor boundaries
- remove the Interface header Interrupt button and its client-side request while retaining the disabled Stop placeholder for later backend wiring
- remove visible connection copy; encode connected state in the Idle pill (green connected, amber connecting/reconnecting) with a hover tooltip and accessible label
- poll chat-history states every 2 seconds and replace only changed badges, with hidden-page, overlap, generation, and teardown guards
- increase redlined shell-name, message-label, and message-body text by exactly 1px

## Trade-off
Flavor boundaries use the existing ordered-shell render, connection status reuses the state pill, and history polling mutates only existing badges. The Interface is never repainted by the poll, preserving transcript position and composer focus.

## Verification
- ./sc test — 1563 passed
- ./sc render-check
- focused Interface/UI contracts — 20 passed
- node --check .super-coder/ui/app.js
- git diff --check