### PR TITLE
fix: refresh image harnesses on restart

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -11,8 +11,10 @@
 # node_modules via `./sc deps`, so versions track the fork's pins, not the image.
 #
 # Why bake the binaries but mount the creds: claude installs as a symlink into
-# ~/.local/share/claude/versions/<v> (awkward to bind-mount); opencode + codex
-# are fat self-contained binaries. Baking them sidesteps the symlink dance.
+# ~/.local/share/claude/versions/<v> (awkward to bind-mount); opencode is a fat
+# self-contained binary; Codex's standalone package lives under ~/.codex and
+# must be relocated after install because that state home is mounted at runtime.
+# Baking them sidesteps host ABI differences and the symlink dance.
 # Auth/config (~/.claude, ~/.claude.json, ~/.config/opencode,
 # ~/.local/share/opencode, ~/.codex, ~/.vibe, ~/.kimi-code) is mounted rw from
 # the host so the container reuses the login you already did — no in-container
@@ -130,11 +132,11 @@ RUN printf '%s\n' \
 # REFERENCED inside each RUN so the bust is guaranteed, not merely implied by
 # docker's arg-cache heuristics.
 #
-# Who rolls it: `./sc update` (dos-u) and `./sc update-harnesses`, to today's
-# date — see sc's harness_epoch()/harness_epoch_roll(). Routine launches reuse
-# the stored value and stay fully cached. Because the value is a DATE and every
-# fork on a machine shares the `super-coder-sandbox` tag, the first fork to
-# update that day refreshes harnesses for all of them; the rest cache-hit.
+# Who rolls it: every normal `./sc restart`, plus `./sc update` (dos-u),
+# `./sc update-harnesses`, and `./sc build --harnesses` — see sc's
+# harness_epoch()/harness_epoch_roll(). Each explicit refresh gets a unique UTC
+# token; routine launch/plain build reuse the stored value and stay cache-warm.
+# `restart --no-build` deliberately reuses the existing image.
 ARG SC_HARNESS_EPOCH=0
 
 # Kimi Code — baked HERE (root stage) with its binary DELIBERATELY redirected to
@@ -163,8 +165,13 @@ ENV HOME=/home/${SC_USER}
 ENV PATH=/home/${SC_USER}/.local/bin:/home/${SC_USER}/.opencode/bin:${PATH}
 
 # Harness CLIs — official native installers, no npm (mirrors install.py).
-# codex drops into ~/.local/bin (already on PATH above), same as claude. vibe's
-# installer self-bootstraps uv (astral.sh) then `uv tool install`s into ~/.local/bin.
+# Codex drops a launcher in ~/.local/bin whose standalone target is under
+# ~/.codex/packages. Runtime mounts the host's whole ~/.codex so auth, sessions,
+# goals, plugins, and other durable state survive; without relocation that mount
+# also masks the image's newer package (#775). Copy the resolved standalone
+# executable into image-owned ~/.local/libexec and repoint the launcher there.
+# Vibe's installer self-bootstraps uv (astral.sh) then `uv tool install`s into
+# ~/.local/bin.
 # (kimi is baked earlier, in the root stage — see the comment there.)
 # SC_HARNESS_EPOCH is referenced so a rolled epoch re-runs these installers; they
 # resolve "latest" themselves, so the epoch is an expiry, not a version pin.
@@ -172,6 +179,12 @@ RUN echo "harness epoch: ${SC_HARNESS_EPOCH}" \
  && curl -fsSL https://claude.ai/install.sh | bash \
  && curl -fsSL https://opencode.ai/install | bash \
  && curl -fsSL https://chatgpt.com/codex/install.sh | sh \
+ && codex_installed="$(readlink -f "$HOME/.local/bin/codex")" \
+ && test -x "$codex_installed" \
+ && mkdir -p "$HOME/.local/libexec" \
+ && install -m 0755 "$codex_installed" "$HOME/.local/libexec/codex" \
+ && ln -sfn "$HOME/.local/libexec/codex" "$HOME/.local/bin/codex" \
+ && "$HOME/.local/bin/codex" --version \
  && curl -LsSf https://mistral.ai/vibe/install.sh | bash
 
 # Stamp the epoch the harness layers were built with, so an image can be asked

--- a/.super-coder/docs/harness-freshness.md
+++ b/.super-coder/docs/harness-freshness.md
@@ -23,13 +23,14 @@ shows aliases, never the build behind them.
 
 ## Where harnesses actually live
 
-**Baked into the sandbox image, not mounted from the host.** This is the fact
-every wrong guess about this system comes from.
+**Harness executables belong to the sandbox image, never the host mount.** This
+is the fact every wrong guess about this system comes from.
 
-`./sc launch` bind-mounts your harness **creds** — `~/.claude`, `~/.claude.json`,
-`~/.codex`, `~/.vibe`, `~/.kimi-code`, opencode's two dirs — so the container
-reuses the login you already did. It mounts **no binaries**. The CLIs come from
-the image (`.super-coder/Dockerfile`).
+`./sc launch` bind-mounts harness state homes — `~/.claude`, `~/.claude.json`,
+`~/.codex`, `~/.vibe`, `~/.kimi-code`, opencode's two dirs — so authentication,
+sessions, goals, plugins, and other durable state survive container replacement.
+The launchers must still resolve image-owned executables from
+`.super-coder/Dockerfile`.
 
 Three reasons it must stay that way, each of which has already bitten someone:
 
@@ -42,13 +43,18 @@ Three reasons it must stay that way, each of which has already bitten someone:
   without that interpreter tree gives you a dangling shebang.
 - **libc baselines differ.** We support Arch, Ubuntu and macOS hosts against a
   Debian container. Auth is portable JSON; native binaries are not.
+- **State homes can grow packages.** Codex's installer now stores its standalone
+  package under `~/.codex/packages`, inside the state tree we mount. The
+  Dockerfile copies the installed executable to image-owned
+  `~/.local/libexec/codex` and repoints its launcher there, so an older host
+  package cannot mask a newer image package.
 
 The cost of baking is that the CLIs are only as new as the image, and docker
 serves those installer layers from cache indefinitely. Hence the epoch.
 
 ## The harness epoch
 
-`SC_HARNESS_EPOCH` is the **expiry date on the image's harness layers**. It is
+`SC_HARNESS_EPOCH` is the **cache key on the image's harness layers**. It is
 referenced inside both harness `RUN` instructions, so changing it re-runs the
 vendor installers (which resolve "latest" themselves — the epoch is an expiry,
 never a version pin). It sits below the node/playwright/pip layers, so rolling
@@ -58,7 +64,7 @@ it costs the harness downloads and nothing else.
 |---|---|
 | Stored at | `${XDG_CONFIG_HOME:-~/.config}/super-coder/harness-epoch` |
 | Scope | **The machine**, not the repo — every fork shares the `super-coder-sandbox` image tag |
-| Value | Today's date, so two forks rolling on the same day produce one build arg and the second cache-hits |
+| Value | A unique UTC token for every explicit refresh |
 | Unrolled | `0` — the Dockerfile default, so an untouched machine builds exactly what it always did |
 | Recorded in the image | `LABEL sc.harness_epoch`, which is how `harness-status` knows whether a build is owed |
 
@@ -67,21 +73,28 @@ it costs the harness downloads and nothing else.
 | Command | What it does |
 |---|---|
 | `./sc harness-status` / `make dos-harness-status` | Versions **inside the sandbox** + whether the image owes a rebuild |
-| `./sc update-harnesses` / `make dos-update-harnesses` | Roll the epoch, rebuild the image. Says which restart runs it |
-| `./sc build --harnesses` | Same rebuild without the rest of `update-harnesses`' output |
+| `./sc restart` / `make dos-r` | Roll a fresh epoch, rebuild the image, then bounce into it |
+| `./sc restart --no-build` | Deliberately reuse the existing image; no refresh and no build |
+| `./sc update-harnesses` / `make dos-update-harnesses` | Roll and rebuild without bouncing; activate that exact build with `restart --no-build` |
+| `./sc build --harnesses` | Same staged refresh without the rest of `update-harnesses`' output |
 | `./sc build` | Ordinary rebuild — passes the **stored** epoch, so it stays cache-warm |
-| `./sc update` / `make dos-u` | Rolls the epoch as part of the update; the rebuild rides the relaunch you already owe |
+| `./sc update` / `make dos-u` | Marks harness layers stale as part of the update; the normal restart refreshes and activates them |
 
 ## Routine cadence
 
-Nothing to remember. `dos-u` rolls the epoch, and the restart an update already
-requires bakes fresh CLIs. Between updates, `dos-update-harnesses` + `dos-r`.
+Nothing to remember. A normal restart is the convergence boundary: it asks each
+official installer for current, finishes the image build, and only then tears
+down the running sandbox.
 
 ```
-make dos-u                 # engine floor + epoch rolled
-make dos-r                 # rebuild bakes fresh harnesses, sandbox comes back current
+make dos-u                 # update the engine floor
+make dos-r                 # fresh harnesses + safe bounce
 make dos-harness-status    # confirm
 ```
+
+To stage the potentially slow/networked build while the old sandbox keeps
+running, use `make dos-update-harnesses`, then activate that exact image later
+with `./sc restart --no-build`.
 
 ## Runbook: a shell cannot reach a model that exists
 
@@ -105,8 +118,7 @@ docker exec sc-<repo> sh -c 'grep -c "claude-opus-5" "$(readlink -f "$(command -
 **3. Refresh and bounce.**
 
 ```
-make dos-update-harnesses   # rolls the epoch + rebuilds the image
-make dos-r                  # the running container keeps the OLD image until this
+make dos-r                  # refreshes harnesses, builds, then safely bounces
 make dos-harness-status     # verify the new build is what shells got
 ```
 
@@ -118,12 +130,18 @@ CLI-probed routes `available` and models.dev-sourced ones `advisory`.
 ## Gotchas
 
 - **A rebuilt image is not a refreshed sandbox.** Running containers keep the
-  image they started with until `./sc restart`. `harness-status` tells you when
-  those two disagree.
+  image they started with until a bounce. After a staged
+  `update-harnesses`/`build --harnesses`, use `restart --no-build` to activate
+  exactly that image without downloading the harnesses again.
 - **Restart discards in-container installs.** `launch`/`restart` do
   `docker rm -f`, destroying the writable layer. Installing a harness inside a
   running container "works" and then evaporates at the next bounce — which is
-  exactly how a fixed sandbox appears to un-fix itself. Roll the epoch instead.
+  exactly how a fixed sandbox appears to un-fix itself. Let normal restart
+  rebuild the image instead.
+- **Normal restart needs the network.** It refreshes all official installers
+  before teardown. If that build fails, the healthy container remains running
+  and the stored epoch records that a build is still owed. Use `--no-build`
+  only when deliberately pinning/reusing the existing image.
 - **`update-harnesses` without docker does something different, on purpose.**
   There the host *is* the runtime, so it runs the vendor installers against
   `$HOME` as it always did.
@@ -136,9 +154,9 @@ CLI-probed routes `available` and models.dev-sourced ones `advisory`.
 ## Several forks on one machine
 
 They share the image tag, so harnesses are installed **once for all of them** —
-there is no per-container install to repeat. The first fork to roll the epoch on
-a given day rebuilds; every other fork's build that day cache-hits and picks up
-the same CLIs on its next restart.
+there is no per-container installation. Every normal restart deliberately
+requests a fresh image-wide harness build; all later containers use that shared
+image until another explicit refresh changes it.
 
 To see the fleet's drift at a glance:
 
@@ -159,5 +177,6 @@ existed, **nothing anywhere printed the harness CLI version**. The picker and th
 model catalogue show aliases (`opus`, `sonnet`); the launch banner showed ports.
 A sandbox one release behind a new model looked identical to a current one, and
 three separate commands (`update`, `update-harnesses`, `restart`) each reported
-success while changing nothing a shell could see. `./sc launch` now names the
-claude build in its banner, and `harness-status` answers the rest.
+success while changing nothing a shell could see. Normal restart now expires
+the installer layers; `./sc launch` names the Claude build in its banner, and
+`harness-status` answers the rest.

--- a/.super-coder/scripts/harness_versions.py
+++ b/.super-coder/scripts/harness_versions.py
@@ -9,7 +9,8 @@ could see the version that decided it.
 
 Run inside the sandbox (`./sc harness-status` docker-execs it there) so the
 answer is the version SHELLS run, not the host's own copy. The host's CLIs are
-irrelevant on the docker path: the container mounts creds, never binaries.
+irrelevant on the docker path: state homes are mounted, but launchers must
+resolve image-owned executables.
 
 Each probe is capped by a timeout — a harness that hangs on `--version` must not
 be able to hang a launch banner — and a missing harness is reported, not fatal.

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -41,7 +41,7 @@ import subprocess
 import sys
 import threading
 import time
-from datetime import date
+from datetime import datetime, timezone
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
@@ -200,8 +200,9 @@ HARNESS_INSTALL = {
 # Where each installer drops its binary. Checked post-install because the new
 # bin dir is NOT on this process's PATH — the installer edits shell rc files,
 # which only a fresh shell picks up. shutil.which alone would miss a just-
-# installed CLI. (codex's native installer drops into ~/.local/bin, same as
-# claude; ~/.codex is its config/auth home, not the binary.)
+# installed CLI. Codex's native installer drops a launcher into ~/.local/bin,
+# but its standalone package lives under ~/.codex; the Dockerfile relocates
+# that executable because the runtime mounts ~/.codex for durable state.)
 HARNESS_BIN = {
     "claude":   Path.home() / ".local" / "bin" / "claude",
     "opencode": Path.home() / ".opencode" / "bin" / "opencode",
@@ -219,8 +220,9 @@ def _harness_installed(name: str) -> bool:
 # The functions above install harnesses on THIS machine's $HOME. That is the
 # right thing on the no-docker path, where the host IS the runtime — and a no-op
 # for shells on the docker path, where the harness binaries are baked into the
-# `super-coder-sandbox` image and the container mounts only creds (~/.claude,
-# ~/.codex, …), never binaries. Binaries cannot be mounted in: they are host-ABI
+# `super-coder-sandbox` image. The container mounts harness state homes
+# (~/.claude, ~/.codex, …), but an image launcher must never resolve a binary
+# from those mounts. Binaries cannot be host-selected: they are host-ABI
 # artifacts (a darwin binary is fatal in a linux container, vibe's entry point
 # carries an absolute shebang into a host uv interpreter, glibc baselines differ
 # across the distros we support), which is why the Dockerfile bakes them.
@@ -231,17 +233,19 @@ def _harness_installed(name: str) -> bool:
 # update. A claude one release behind Opus 5 therefore stayed one release behind
 # through an update, a harness update, and a restart.
 #
-# The epoch is that layer's expiry. `./sc update` and `./sc update-harnesses`
-# roll it to today; `./sc build` passes it as SC_HARNESS_EPOCH; the Dockerfile
-# references it inside both harness RUNs, so a changed value re-runs the
-# installers (which resolve "latest" themselves — the epoch is an expiry, never
-# a version pin).
+# The epoch is that layer's cache key. `./sc restart`, `./sc update`, and
+# `./sc update-harnesses` roll it; `./sc build` passes it as
+# SC_HARNESS_EPOCH; the Dockerfile references it inside both harness RUNs, so a
+# changed value re-runs the installers (which resolve "latest" themselves —
+# the epoch is an expiry token, never a version pin).
 #
 # MACHINE-scoped, not per-repo: every fork on a host shares the image tag, so
 # the harness layer is a machine fact and a per-repo file would let one fork
-# roll an epoch its neighbours never see. Because the value is a DATE, two forks
-# updating the same day produce the same build arg and the second cache-hits.
-# The path follows the engine's existing host-state idiom (XDG_CONFIG_HOME).
+# roll an epoch its neighbours never see. Every explicit refresh gets a unique
+# UTC token: a normal restart means "ask every installer for current now", even
+# after another refresh earlier the same day. Plain launch/build remain
+# cache-warm; restart --no-build deliberately pins the existing image. The path
+# follows the engine's existing host-state idiom (XDG_CONFIG_HOME).
 HARNESS_EPOCH_UNSET = "0"  # the Dockerfile's default — "never rolled here"
 
 
@@ -265,10 +269,13 @@ def harness_epoch() -> str:
 
 
 def roll_harness_epoch() -> str:
-    """Expire the image's harness layers as of today, and return the value.
-    Idempotent within a day: rolling twice writes the same string, so a second
-    fork's build on the same day still cache-hits instead of re-downloading."""
-    value = date.today().isoformat()
+    """Give the image's harness layers a fresh cache key and return it.
+
+    Each explicit refresh must be unique: restart is the operator's convergence
+    boundary, so a second restart on the same day still asks the official
+    installers for current releases. Microseconds make sequential calls unique
+    while keeping the image label human-readable."""
+    value = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
     path = harness_epoch_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(value + "\n")

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -792,8 +792,9 @@ def expire_sandbox_harnesses() -> str | None:
 
     `ensure_harnesses()` installs into THIS machine's $HOME, which is the whole
     runtime on the no-docker path and none of it on the docker path: the sandbox
-    mounts creds, never binaries, so the CLIs shells actually run are the ones
-    baked into the image — behind a docker layer cache with no expiry of its own.
+    mounts harness state homes, but its launchers must resolve image-owned
+    binaries. Those binaries sit behind a docker layer cache with no expiry of
+    its own.
     An update therefore used to lay a new engine floor on top of harness CLIs
     frozen at whenever the image was first built, with no command able to move
     them (a claude one release short of Opus 5 survived exactly that).
@@ -896,7 +897,7 @@ def main(argv: list[str]) -> int:
     epoch = expire_sandbox_harnesses()
     if epoch:
         print(f"→ expire the sandbox's baked harness CLIs (epoch {epoch})")
-        print("  they reinstall on the next image build — `./sc restart` / `make dos-r`")
+        print("  they reinstall on the next image build — normal `./sc restart` / `make dos-r`")
 
     migrate_or_rebuild(live_warning_done=True)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -436,16 +436,17 @@ ergonomics degrade, correctness doesn't.
 ### Keeping harnesses (and therefore models) current
 
 A new model arrives in a new harness **CLI release** — so a shell can only reach
-the models its CLI knows about. The CLIs are baked into the sandbox image (creds
-are mounted, binaries never are: a darwin binary is fatal in a linux container,
-and vibe's entry point carries an absolute shebang into a host interpreter), and
-docker caches those layers indefinitely. `SC_HARNESS_EPOCH` is their expiry:
-`./sc update` and `./sc update-harnesses` roll it, and the next image build
-reinstalls every harness at latest.
+the models its CLI knows about. The CLIs are image-owned (harness state homes
+are mounted, but their executables must never resolve from the host: a darwin
+binary is fatal in a linux container, and vibe's entry point carries an absolute
+shebang into a host interpreter), and docker caches those layers indefinitely.
+`SC_HARNESS_EPOCH` is their cache key. A normal restart gives it a unique value
+and reinstalls every harness at latest before replacing the running sandbox.
 
 ```
 ./sc harness-status      # what the sandbox actually runs + is a rebuild owed
-./sc update-harnesses    # roll the epoch + rebuild (then ./sc restart to run it)
+./sc restart             # refresh harnesses, build safely, then bounce
+./sc restart --no-build  # deliberately reuse the current image
 ```
 
 If a model that exists is not offered to a shell, start there — it is nearly
@@ -979,7 +980,8 @@ launch, enter, snapshot, render, and the GUI work unchanged.
                          #   flag · roadmap · doc · narrative) — identity is the shell's token
 sc sql "<query>"         # read-only passthrough to the engine DB; `sc map-sql` for the repo-map dr_*
 ./sc down                # stop + remove the sandbox container
-./sc restart             # confirm-gated (YES) + DB backup, then down + launch — recreate fresh
+./sc restart             # confirm + refresh harnesses + build + DB backup, then down + launch
+./sc restart --no-build  # confirm + DB backup, then bounce on the existing image
 ./sc persist             # reboot-proof the host daemons: install every applicable systemd --user unit
 ./sc logs                # tail the sandbox server logs
 ./sc rebuild             # rebuild .super-coder/shell_db.db from schema + migrations + snapshot

--- a/sc
+++ b/sc
@@ -173,9 +173,10 @@ dnet() {
 
 # Sandbox harness freshness. The harness CLIs are baked into the image (their
 # binaries are host-ABI artifacts — see install.py's harness-epoch note for why
-# they can never be mounted in like creds), and docker serves those installer
-# layers from cache forever. The epoch is their expiry: rolling it re-runs the
-# installers on the next build, and nothing else in the image is invalidated.
+# host state mounts must never choose them), and docker serves those installer
+# layers from cache forever. The epoch is their cache key: rolling it re-runs
+# the installers on the next build, and nothing else above the harness seam is
+# invalidated.
 # install.py owns the value + its file; these are thin readers so there is one
 # implementation of it, not two that can disagree.
 harness_epoch()      { "$PY" "$S/install.py" --harness-epoch; }
@@ -1151,18 +1152,20 @@ case "$cmd" in
   update)            exec "$PY" "$S/update.py" "$@" ;;
   # Refresh the harness CLIs the SHELLS run — which, on the docker path, means
   # the image and nothing else. Running the installers on the host here is what
-  # this command used to do, and it reported success while changing nothing: the
-  # container mounts creds (~/.claude, ~/.codex, …), never binaries, and every
-  # launch `docker rm -f`s the writable layer that an in-container install would
-  # land in. So: roll the epoch, rebuild, and name the restart that runs it.
+  # this command used to do, and it reported success while changing nothing:
+  # the container mounts harness state homes but image-owned launchers must
+  # resolve image-owned binaries, and every launch `docker rm -f`s the writable
+  # layer that an in-container install would land in. So: roll the epoch,
+  # rebuild, and name the no-rebuild bounce that activates exactly this image.
   # Without docker the host IS the runtime, so the installers are correct there.
   update-harnesses)
     if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-      echo "→ harness epoch rolled to $(harness_epoch_roll)"
+      epoch="$(harness_epoch_roll)"
+      echo "→ harness epoch rolled to $epoch"
       dbuild
       echo "→ image rebuilt with fresh harness CLIs"
       sc_harness_status || true
-      echo "  running sandboxes keep the OLD image until they restart: ./sc restart"
+      echo "  running sandboxes keep the OLD image until they restart: ./sc restart --no-build"
     else
       echo "→ no docker — updating this host's harness CLIs (the no-docker runtime)"
       "$PY" "$S/install.py" --update-harnesses
@@ -1478,9 +1481,10 @@ case "$cmd" in
   # dos-e), so: typed confirmation (only YES / Yes / yes proceed — anything
   # else, including a closed stdin, aborts) + a WAL-safe DB backup BEFORE
   # anything is torn down. --yes/-y skips the prompt for scripted callers.
-  # --no-build validates the existing image before down; the default path
-  # likewise completes its build before down, so a known preflight failure
-  # cannot strand a healthy fork offline.
+  # --no-build validates and deliberately reuses the existing image. The
+  # default path gives every harness installer a fresh cache key, then completes
+  # that build before down, so a network/install failure cannot strand a
+  # healthy fork offline.
   restart)
     assume_yes=""
     no_build=""
@@ -1490,6 +1494,7 @@ case "$cmd" in
         --no-build) no_build=1 ;;
         -h|--help)
           echo "usage: ./sc restart [-y|--yes] [--no-build]"
+          echo "  default     refresh harness CLIs, rebuild the image, then bounce"
           echo "  --no-build  reuse the existing $IMG:latest image; preflight before down"
           exit 0 ;;
         *)
@@ -1508,7 +1513,13 @@ case "$cmd" in
       esac
     fi
     dcheck
-    if [ -n "$no_build" ]; then dimage_preflight; else dbuild; fi
+    if [ -n "$no_build" ]; then
+      dimage_preflight
+    else
+      epoch="$(harness_epoch_roll)"
+      echo "→ refresh harnesses for restart (epoch $epoch)"
+      dbuild
+    fi
     backup_dir="$(sc_db_backup_preflight)"
     sc_db_backup prerestart "$backup_dir"
     if ! "$0" down; then
@@ -1523,7 +1534,10 @@ case "$cmd" in
   build)
     dcheck
     case "${1:-}" in
-      --harnesses) echo "→ harness epoch rolled to $(harness_epoch_roll)"; shift ;;
+      --harnesses)
+        epoch="$(harness_epoch_roll)"
+        echo "→ harness epoch rolled to $epoch"
+        shift ;;
       "") : ;;
       *) echo "sc build: unknown argument '$1' (usage: ./sc build [--harnesses])" >&2; exit 2 ;;
     esac
@@ -1579,7 +1593,7 @@ super-coder — forkable shell substrate
                              Advisory, never blocking: an unsafe/offline pull WARNS and engine update continues from the current
                              checkout. Update never merges, rebases or resets. --no-fetch skips checkout and engine network sync.
   ./sc update-harnesses    refresh the harness CLIs the SHELLS run: rolls the harness epoch + rebuilds the sandbox image
-                             (they are baked, never mounted — so a running sandbox keeps the old ones until ./sc restart)
+                             (they are image-owned — activate that exact build with ./sc restart --no-build)
                              without docker, updates this host's CLIs instead — there the host IS the runtime
   ./sc harness-status      report the harness CLI versions inside the sandbox + whether the image owes a harness rebuild
                              (a model the shells cannot reach is nearly always this — see .super-coder/docs/harness-freshness.md)
@@ -1673,7 +1687,8 @@ super-coder — forkable shell substrate
                              refuses a shell that already has a live session
   ./sc down                stop + remove the sandbox container
   ./sc restart             confirm + WAL-safe backup, fully bounce, then health-check managed services
-                             --yes skips the prompt · --no-build preflights/reuses the existing image
+                             default refreshes every image-owned harness before teardown
+                             --yes skips the prompt · --no-build preflights/reuses the existing image without refreshing
   ./sc build               (re)build the sandbox image · --harnesses also expires the baked harness CLIs so they reinstall
   ./sc logs                tail the sandbox server logs
 

--- a/tests/test_harness_epoch.py
+++ b/tests/test_harness_epoch.py
@@ -25,14 +25,13 @@ import sys
 import tempfile
 import textwrap
 import unittest
-from datetime import date
 from pathlib import Path
 from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 INSTALL_PY = ENGINE / "scripts" / "install.py"
-TODAY = date.today().isoformat()
+EPOCH_RE = re.compile(r"\A\d{8}T\d{6}\.\d{6}Z\Z")
 
 
 def run_install(*args: str, epoch_file: Path) -> subprocess.CompletedProcess[str]:
@@ -58,24 +57,25 @@ class HarnessEpochValue(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "0")
 
-    def test_roll_writes_today_and_creates_its_parent_directory(self):
+    def test_roll_writes_unique_utc_token_and_creates_parent(self):
         result = run_install("--roll-harness-epoch", epoch_file=self.epoch_file)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), TODAY)
-        self.assertEqual(self.epoch_file.read_text().strip(), TODAY)
+        value = result.stdout.strip()
+        self.assertRegex(value, EPOCH_RE)
+        self.assertEqual(self.epoch_file.read_text().strip(), value)
 
-    def test_roll_is_idempotent_within_a_day(self):
-        """The value is a DATE on purpose: every fork on a machine shares the
-        image tag, so a second fork updating the same day must produce the same
-        build arg and cache-hit instead of re-downloading five installers."""
+    def test_every_explicit_roll_is_unique(self):
+        """A second same-day restart still asks installers for current."""
         first = run_install("--roll-harness-epoch", epoch_file=self.epoch_file)
         second = run_install("--roll-harness-epoch", epoch_file=self.epoch_file)
-        self.assertEqual(first.stdout.strip(), second.stdout.strip())
+        self.assertNotEqual(first.stdout.strip(), second.stdout.strip())
 
     def test_stored_value_reads_back(self):
-        run_install("--roll-harness-epoch", epoch_file=self.epoch_file)
+        rolled = run_install(
+            "--roll-harness-epoch", epoch_file=self.epoch_file
+        ).stdout.strip()
         result = run_install("--harness-epoch", epoch_file=self.epoch_file)
-        self.assertEqual(result.stdout.strip(), TODAY)
+        self.assertEqual(result.stdout.strip(), rolled)
 
     def test_unreadable_store_reads_as_unrolled_rather_than_failing(self):
         """A build must never be blocked by the freshness bookkeeping — an
@@ -156,6 +156,31 @@ class HarnessEpochDockerfile(unittest.TestCase):
         for costly in ("playwright", "nodesource"):
             with self.subTest(layer=costly):
                 self.assertLess(self.text.index(costly), arg_at)
+
+    def test_codex_launcher_resolves_outside_mounted_state_home(self):
+        """The mounted ~/.codex may contain an older standalone package."""
+        codex_run = next(
+            run for run in self.harness_runs()
+            if "chatgpt.com/codex/install.sh" in run
+        )
+        self.assertIn(
+            'readlink -f "$HOME/.local/bin/codex"', codex_run
+        )
+        self.assertIn(
+            'install -m 0755 "$codex_installed" '
+            '"$HOME/.local/libexec/codex"',
+            codex_run,
+        )
+        self.assertIn(
+            'ln -sfn "$HOME/.local/libexec/codex" '
+            '"$HOME/.local/bin/codex"',
+            codex_run,
+        )
+        self.assertIn(
+            '-v "$HOME/.codex:$HOME/.codex"',
+            (ROOT / "sc").read_text(),
+            "durable Codex state stays mounted; isolate its executable",
+        )
 
 
 class ScFixture:
@@ -269,12 +294,14 @@ class ScHarnessCommands(unittest.TestCase):
     def test_build_harnesses_rolls_first_so_the_layers_expire(self):
         result = self.fx.run("build", "--harnesses")
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(self.fx.build_args().get("SC_HARNESS_EPOCH"), TODAY)
-        self.assertEqual(self.fx.epoch_file.read_text().strip(), TODAY)
+        epoch = self.fx.epoch_file.read_text().strip()
+        self.assertRegex(epoch, EPOCH_RE)
+        self.assertEqual(
+            self.fx.build_args().get("SC_HARNESS_EPOCH"), epoch
+        )
 
     def test_plain_build_does_not_roll(self):
-        """`build` is on the launch/restart path — it must stay a cache-warm
-        no-op, or every restart would re-download five installers."""
+        """Plain build/launch stay cache-warm; restart owns refresh."""
         self.fx.run("build")
         self.assertFalse(self.fx.epoch_file.exists())
 
@@ -283,14 +310,41 @@ class ScHarnessCommands(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertFalse([c for c in self.fx.calls() if c.startswith("docker build")])
 
+    def test_build_harnesses_requires_epoch_persistence_before_build(self):
+        self.fx.epoch_file.parent.mkdir(parents=True)
+        self.fx.epoch_file.mkdir()
+
+        result = self.fx.run("build", "--harnesses")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(
+            [c for c in self.fx.calls() if c.startswith("docker build")]
+        )
+
     def test_update_harnesses_rolls_and_rebuilds_on_the_docker_path(self):
         result = self.fx.run("update-harnesses")
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(self.fx.build_args().get("SC_HARNESS_EPOCH"), TODAY)
+        epoch = self.fx.epoch_file.read_text().strip()
+        self.assertRegex(epoch, EPOCH_RE)
+        self.assertEqual(
+            self.fx.build_args().get("SC_HARNESS_EPOCH"), epoch
+        )
+
+    def test_update_harnesses_requires_epoch_persistence_before_build(self):
+        self.fx.epoch_file.parent.mkdir(parents=True)
+        self.fx.epoch_file.mkdir()
+
+        result = self.fx.run("update-harnesses")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(
+            [c for c in self.fx.calls() if c.startswith("docker build")]
+        )
 
     def test_update_harnesses_does_not_install_onto_the_host_when_docker_runs(self):
         """The old behavior: run the installers here, report success, change
-        nothing a shell can see. The container mounts creds, never binaries.
+        nothing a shell can see. State homes are mounted, but executables stay
+        image-owned.
         Asserted on the stubbed curl rather than on output text, so a regression
         is caught by what the command TRIED to do — and cannot reach the network
         from a test run either way."""
@@ -304,7 +358,7 @@ class ScHarnessCommands(unittest.TestCase):
         keeps the old one until it is bounced. Say so, or the operator reads
         'rebuilt' as 'done' (which is how this bug was reported)."""
         result = self.fx.run("update-harnesses")
-        self.assertIn("./sc restart", result.stdout)
+        self.assertIn("./sc restart --no-build", result.stdout)
 
     def test_harness_status_reports_the_versions_inside_the_sandbox(self):
         result = self.fx.run("harness-status")
@@ -321,13 +375,16 @@ class ScHarnessCommands(unittest.TestCase):
         )
 
     def test_harness_status_flags_an_image_that_owes_a_rebuild(self):
-        self.fx.run("build", "--harnesses")          # epoch rolled to today…
+        self.fx.run("build", "--harnesses")
         result = self.fx.run("harness-status", SC_TEST_LABEL="2020-01-01")
         self.assertIn("predates the stored epoch", result.stdout)
 
     def test_harness_status_is_quiet_when_the_image_matches(self):
         self.fx.run("build", "--harnesses")
-        result = self.fx.run("harness-status", SC_TEST_LABEL=TODAY)
+        result = self.fx.run(
+            "harness-status",
+            SC_TEST_LABEL=self.fx.epoch_file.read_text().strip(),
+        )
         self.assertNotIn("predates the stored epoch", result.stdout)
 
     def test_harness_status_does_not_claim_currency_for_an_unlabelled_image(self):
@@ -357,13 +414,14 @@ class UpdateExpiresSandboxHarnesses(unittest.TestCase):
         self.addCleanup(setattr, self.update_mod.install_mod, "docker_status", real)
 
     def test_update_rolls_the_epoch(self):
-        self.assertEqual(self.update_mod.expire_sandbox_harnesses(), TODAY)
-        self.assertEqual(self.epoch_file.read_text().strip(), TODAY)
+        value = self.update_mod.expire_sandbox_harnesses()
+        self.assertRegex(value, EPOCH_RE)
+        self.assertEqual(self.epoch_file.read_text().strip(), value)
 
     def test_no_docker_rolls_silently_instead_of_describing_a_missing_runtime(self):
         self.docker = {"state": "absent"}
         self.assertIsNone(self.update_mod.expire_sandbox_harnesses())
-        self.assertEqual(self.epoch_file.read_text().strip(), TODAY)
+        self.assertRegex(self.epoch_file.read_text().strip(), EPOCH_RE)
 
 
 if __name__ == "__main__":

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -25,6 +25,7 @@ class SupervisionFixture:
         self.fakebin = Path(self._tmp.name) / "bin"
         self.home = Path(self._tmp.name) / "home"
         self.log = Path(self._tmp.name) / "calls.log"
+        self.epoch_file = Path(self._tmp.name) / "harness-epoch"
         self.docker_state = Path(self._tmp.name) / "docker-state"
         self.root.mkdir()
         self.scripts.mkdir(parents=True)
@@ -34,7 +35,13 @@ class SupervisionFixture:
         shutil.copy2(ROOT / "sc", self.root / "sc")
         # cli_entry.py rides along with every script copied here: each one
         # imports it from its __main__ block (SIGPIPE hygiene, #384).
-        for script in ("artifact_policy.py", "db_backup.py", "cli_entry.py"):
+        for script in (
+            "artifact_policy.py",
+            "db_backup.py",
+            "cli_entry.py",
+            "engine_manifest.py",
+            "install.py",
+        ):
             shutil.copy2(
                 ROOT / ".super-coder" / "scripts" / script,
                 self.scripts / script,
@@ -62,6 +69,7 @@ class SupervisionFixture:
                 "HOME": str(self.home),
                 "PATH": f"{self.fakebin}:{self.env['PATH']}",
                 "SC_PYTHON": sys.executable,
+                "SC_HARNESS_EPOCH_FILE": str(self.epoch_file),
                 "SC_TEST_LOG": str(self.log),
                 "SC_TEST_IMAGE": "present",
                 "SC_TEST_DOCKER_STATE": str(self.docker_state),
@@ -125,7 +133,10 @@ class SupervisionFixture:
             fi
             if [ "$1" = network ] && [ "$2" = inspect ]; then exit 0; fi
             if [ "$1" = network ] && [ "$2" = create ]; then exit 0; fi
-            if [ "$1" = build ]; then exit 0; fi
+            if [ "$1" = build ]; then
+              [ "${SC_TEST_BUILD_FAIL:-}" != 1 ]
+              exit
+            fi
             if [ "$1" = rm ]; then
               name="$3"
               if [ "$name" = "$SC_TEST_PG_NAME" ] &&
@@ -293,6 +304,56 @@ class RestrictedLaunchTests(unittest.TestCase):
         self.assertFalse((self.fx.home / "db_backups").exists())
         calls = self.fx.calls()
         self.assertFalse(any(line.startswith("docker rm ") for line in calls))
+
+    def test_restart_refreshes_harnesses_before_build_and_teardown(self):
+        result = self.fx.run("restart", "--yes")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        epoch = self.fx.epoch_file.read_text().strip()
+        self.assertRegex(epoch, r"\A\d{8}T\d{6}\.\d{6}Z\Z")
+        calls = self.fx.calls()
+        build_at = next(
+            i for i, line in enumerate(calls)
+            if line.startswith("docker build ")
+        )
+        down_at = next(
+            i for i, line in enumerate(calls)
+            if line.startswith("docker rm -f ")
+        )
+        self.assertLess(build_at, down_at)
+        self.assertIn(f"SC_HARNESS_EPOCH={epoch}", calls[build_at])
+        self.assertIn("refresh harnesses for restart", result.stdout)
+
+    def test_restart_refresh_failure_keeps_running_sandbox_intact(self):
+        self.fx.env["SC_TEST_BUILD_FAIL"] = "1"
+
+        result = self.fx.run("restart", "--yes")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(self.fx.epoch_file.exists())
+        self.assertFalse((self.fx.home / "db_backups").exists())
+        self.assertFalse(
+            any(line.startswith("docker rm ") for line in self.fx.calls())
+        )
+
+    def test_restart_epoch_write_failure_prevents_build_and_teardown(self):
+        self.fx.epoch_file.mkdir()
+
+        result = self.fx.run("restart", "--yes")
+
+        self.assertNotEqual(result.returncode, 0)
+        calls = self.fx.calls()
+        self.assertFalse(any(line.startswith("docker build ") for line in calls))
+        self.assertFalse(any(line.startswith("docker rm ") for line in calls))
+
+    def test_restart_no_build_neither_rolls_nor_builds(self):
+        result = self.fx.run("restart", "--yes", "--no-build")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse(self.fx.epoch_file.exists())
+        self.assertFalse(
+            any(line.startswith("docker build ") for line in self.fx.calls())
+        )
 
     def test_restart_no_writable_backup_destination_refuses_before_down(self):
         bad_home = Path(self.fx._tmp.name) / "home-file"


### PR DESCRIPTION
## Summary

- relocate the Codex standalone executable out of the mounted `~/.codex` state tree so an older host package cannot mask the image build
- make normal `./sc restart` roll a unique harness epoch and finish rebuilding before any healthy sandbox is torn down
- preserve `./sc restart --no-build` as the explicit pinned-image path, and document staged refresh activation
- fail safely when epoch persistence or the image build fails

## Verification

- 1,567 pytest tests passed; 773 subtests passed
- standalone clean-clone `./sc verify` passed
- live Docker build installed Codex 0.146.0
- with the host Codex 0.145 `~/.codex` mounted, the patched image still resolved and ran the image-owned 0.146.0 executable

Closes #775