### PR TITLE
feat(conversations): add Kimi browser adapter

### DIFF
--- a/.super-coder/adapters/kimi/adapter.json
+++ b/.super-coder/adapters/kimi/adapter.json
@@ -11,5 +11,53 @@
     "model_flag": "-m",
     "effort": { "env": "KIMI_MODEL_THINKING_EFFORT" }
   },
+  "conversation": {
+    "contract_version": 1,
+    "minimum_cli_version": "0.30.0",
+    "verified_cli_version": "0.30.0",
+    "driver": "kimi-print",
+    "session_ref": {
+      "source": "native-session-store",
+      "field": "session-directory-name"
+    },
+    "start": {
+      "stream_flags": ["--output-format", "stream-json"],
+      "identity_source": "new-main-wire-turn.prompt"
+    },
+    "resume": {
+      "session_flag": "-S",
+      "identity_source": "appended-main-wire-turn.prompt"
+    },
+    "stream": { "transport": "stdout-jsonl-with-raw-interleave" },
+    "interrupt": { "mechanism": "signal", "signal": "SIGINT" },
+    "inspect": { "mechanism": "native-session-store" },
+    "permission_policy": "kimi-prompt-auto-mode",
+    "execution_permissions": {
+      "requirement": "worktree-command-access",
+      "unrestricted_mechanism": "prompt-mode-auto",
+      "sandbox_flag_required": false
+    },
+    "normalized_events": [
+      "session.started",
+      "run.started",
+      "assistant.delta",
+      "tool.started",
+      "tool.completed",
+      "permission.requested",
+      "input.requested",
+      "usage",
+      "run.completed",
+      "run.failed",
+      "run.interrupted"
+    ],
+    "capabilities": {
+      "exact_session_resume": true,
+      "structured_streaming": true,
+      "interruption": true,
+      "interactive_permission_response": false,
+      "server_backed": false,
+      "session_inspection": true
+    }
+  },
   "sandbox": { "launch_flags": ["--yolo"] }
 }

--- a/.super-coder/scripts/conversation_adapters/__init__.py
+++ b/.super-coder/scripts/conversation_adapters/__init__.py
@@ -18,6 +18,7 @@ from .base import (
 )
 from .claude import ClaudeAdapter
 from .codex import CodexAdapter, JsonLineRpcProcess, RpcTransport
+from .kimi import KimiAdapter
 from .opencode import OpenCodeAdapter
 
 
@@ -25,6 +26,7 @@ ADAPTER_TYPES = {
     "opencode": OpenCodeAdapter,
     "claude": ClaudeAdapter,
     "codex": CodexAdapter,
+    "kimi": KimiAdapter,
 }
 
 
@@ -49,6 +51,7 @@ __all__ = [
     "ConversationContext",
     "InterruptResult",
     "JsonLineRpcProcess",
+    "KimiAdapter",
     "NativeTurn",
     "NormalizedEvent",
     "OpenCodeAdapter",

--- a/.super-coder/scripts/conversation_adapters/kimi.py
+++ b/.super-coder/scripts/conversation_adapters/kimi.py
@@ -1,0 +1,928 @@
+#!/usr/bin/env python3
+"""Kimi process-per-turn conversation adapter."""
+from __future__ import annotations
+
+import json
+import re
+import signal
+import subprocess
+import time
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+from .base import (
+    TERMINAL_EVENTS,
+    AdapterError,
+    ConversationAdapter,
+    ConversationContext,
+    InterruptResult,
+    NativeTurn,
+    NormalizedEvent,
+    ProbeResult,
+    ProcessRunner,
+    ReconcileResult,
+    SessionInspection,
+    SubprocessRunner,
+    command_version,
+    ensure_nonempty_message,
+    load_manifest,
+    merged_env,
+    terminal_outcome,
+)
+
+SESSION_REF = re.compile(r"^session_[0-9a-fA-F-]{36}$")
+RUN_REF = re.compile(r"^kimi-(\d+)-(\d+)$")
+USAGE_KEYS = {
+    "inputOther": "input_tokens",
+    "output": "output_tokens",
+    "inputCacheRead": "cache_read_tokens",
+    "inputCacheCreation": "cache_write_tokens",
+}
+STDERR_LIMIT = 16384
+POLL_INTERVAL = 0.01
+
+
+class KimiAdapter(ConversationAdapter):
+    harness = "kimi"
+
+    def __init__(
+        self,
+        *,
+        runner: ProcessRunner | None = None,
+        manifest: Mapping[str, Any] | None = None,
+        sessions_root: Path | None = None,
+        identity_timeout: float = 5.0,
+    ) -> None:
+        super().__init__(manifest or load_manifest(self.harness))
+        if identity_timeout <= 0:
+            raise ValueError("identity_timeout must be positive")
+        self.runner = runner or SubprocessRunner()
+        self.sessions_root = sessions_root
+        self.identity_timeout = identity_timeout
+
+    def probe(self) -> ProbeResult:
+        launch = self.manifest["headless"]["launch"][0]
+        return self._probe_result(command_version([launch, "--version"]))
+
+    @staticmethod
+    def _validate_session_ref(session_ref: str) -> str:
+        if not isinstance(session_ref, str) or not SESSION_REF.fullmatch(
+            session_ref
+        ):
+            raise AdapterError(
+                "HARNESS_SESSION_LOST",
+                f"Kimi session ref is malformed: {session_ref}",
+            )
+        return session_ref
+
+    def _environment(
+        self,
+        context: ConversationContext,
+    ) -> tuple[dict[str, str], Path]:
+        env = merged_env(self.manifest, context)
+        effort_env = self.manifest["headless"].get("effort", {}).get("env")
+        if effort_env:
+            if context.effort:
+                env[effort_env] = context.effort
+            else:
+                env.pop(effort_env, None)
+        if self.sessions_root is not None:
+            root = self.sessions_root
+        else:
+            configured = env.get("KIMI_CODE_HOME", "").strip()
+            if not configured:
+                env.pop("KIMI_CODE_HOME", None)
+            merged_home = env.get("HOME", "").strip()
+            home = Path(merged_home) if merged_home else Path.home()
+            if configured == "~":
+                data_root = home
+            elif configured.startswith("~/"):
+                data_root = home / configured[2:]
+            elif configured:
+                data_root = Path(configured)
+                if not data_root.is_absolute():
+                    data_root = context.worktree / data_root
+            else:
+                data_root = home / ".kimi-code"
+            root = data_root / "sessions"
+        return env, root.expanduser().resolve()
+
+    def _command(
+        self,
+        context: ConversationContext,
+        message: str,
+        session_ref: str | None,
+    ) -> list[str]:
+        hcfg = self.manifest["headless"]
+        command = list(hcfg["launch"])
+        command.extend([hcfg.get("prompt_flag", "-p"), message])
+        command.extend(self.manifest["conversation"]["start"]["stream_flags"])
+        if session_ref is not None:
+            resume_flag = self.manifest["conversation"]["resume"][
+                "session_flag"
+            ]
+            command.extend([resume_flag, session_ref])
+        if context.model:
+            model_flag = hcfg.get("model_flag")
+            if not model_flag:
+                raise AdapterError(
+                    "HARNESS_MODEL_ROUTE_INVALID",
+                    "Kimi adapter cannot apply a model",
+                )
+            command.extend([model_flag, context.model])
+        return command
+
+    @staticmethod
+    def _session_dirs(root: Path) -> set[Path]:
+        try:
+            return {
+                path.resolve()
+                for path in root.glob("wd_*/session_*")
+                if path.is_dir()
+            }
+        except OSError:
+            return set()
+
+    @staticmethod
+    def _state_worktree(session_dir: Path) -> Path:
+        state_path = session_dir / "state.json"
+        try:
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"cannot read Kimi session state: {state_path}",
+                retryable=True,
+            ) from exc
+        stored = state.get("workDir") if isinstance(state, dict) else None
+        if not isinstance(stored, str) or not stored:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"Kimi session state has no workDir: {state_path}",
+            )
+        stored_path = Path(stored)
+        if not stored_path.is_absolute():
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"Kimi session workDir is not absolute: {state_path}",
+            )
+        return stored_path.resolve()
+
+    @staticmethod
+    def _wire_path(session_dir: Path) -> Path:
+        return session_dir / "agents" / "main" / "wire.jsonl"
+
+    @staticmethod
+    def _wire_records(
+        wire: Path,
+        *,
+        start_offset: int = 0,
+    ) -> list[tuple[int, Mapping[str, Any]]]:
+        records: list[tuple[int, Mapping[str, Any]]] = []
+        try:
+            with wire.open("rb") as stream:
+                stream.seek(start_offset)
+                while True:
+                    offset = stream.tell()
+                    line = stream.readline()
+                    if not line:
+                        break
+                    if not line.endswith(b"\n"):
+                        break
+                    try:
+                        raw = json.loads(line)
+                    except (UnicodeDecodeError, json.JSONDecodeError):
+                        continue
+                    if isinstance(raw, dict):
+                        records.append((offset, raw))
+        except OSError as exc:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"cannot read Kimi main wire: {wire}",
+                retryable=True,
+            ) from exc
+        return records
+
+    @staticmethod
+    def _prompt_text(raw: Mapping[str, Any]) -> str | None:
+        prompt_input = raw.get("input")
+        if not isinstance(prompt_input, list):
+            return None
+        parts = [
+            part.get("text")
+            for part in prompt_input
+            if isinstance(part, dict)
+            and part.get("type") == "text"
+            and isinstance(part.get("text"), str)
+        ]
+        return "".join(parts) if parts else None
+
+    @classmethod
+    def _prompt_markers(cls, wire: Path) -> set[tuple[int, int]]:
+        markers: set[tuple[int, int]] = set()
+        for offset, raw in cls._wire_records(wire):
+            if raw.get("type") != "turn.prompt":
+                continue
+            prompt_time = raw.get("time")
+            if isinstance(prompt_time, int) and not isinstance(
+                prompt_time, bool
+            ):
+                markers.add((prompt_time, offset))
+        return markers
+
+    @classmethod
+    def _matching_prompts(
+        cls,
+        wire: Path,
+        message: str,
+        *,
+        start_offset: int,
+        known_markers: set[tuple[int, int]],
+    ) -> list[tuple[int, int]]:
+        matches: list[tuple[int, int]] = []
+        for offset, raw in cls._wire_records(
+            wire,
+            start_offset=start_offset,
+        ):
+            if raw.get("type") != "turn.prompt":
+                continue
+            prompt_time = raw.get("time")
+            prompt_text = cls._prompt_text(raw)
+            if (
+                not isinstance(prompt_time, int)
+                or isinstance(prompt_time, bool)
+                or prompt_text is None
+            ):
+                raise AdapterError(
+                    "HARNESS_SESSION_DISCOVERY_FAILED",
+                    "Kimi emitted a malformed turn.prompt marker",
+                )
+            marker = (prompt_time, offset)
+            if marker not in known_markers and prompt_text == message:
+                matches.append(marker)
+        return matches
+
+    @staticmethod
+    def _cleanup_process(process: Any, timeout: float) -> None:
+        poll = getattr(process, "poll", None)
+        running = callable(poll) and poll() is None
+        if running:
+            terminate = getattr(process, "terminate", None)
+            if callable(terminate):
+                terminate()
+            else:
+                send_signal = getattr(process, "send_signal", None)
+                if callable(send_signal):
+                    send_signal(signal.SIGTERM)
+        wait = getattr(process, "wait", None)
+        if not callable(wait):
+            return
+        try:
+            wait(timeout=min(timeout, 1.0))
+        except TypeError:
+            wait()
+        except subprocess.TimeoutExpired:
+            kill = getattr(process, "kill", None)
+            if callable(kill):
+                kill()
+            try:
+                wait(timeout=1.0)
+            except (TypeError, subprocess.TimeoutExpired):
+                pass
+
+    def _discover_start(
+        self,
+        root: Path,
+        existing: set[Path],
+        worktree: Path,
+        message: str,
+        process: Any,
+    ) -> tuple[Path, int, int]:
+        deadline = time.monotonic() + self.identity_timeout
+        last_store_error: AdapterError | None = None
+        while True:
+            matches: list[tuple[Path, int, int]] = []
+            for session_dir in sorted(self._session_dirs(root) - existing):
+                if not SESSION_REF.fullmatch(session_dir.name):
+                    continue
+                try:
+                    stored_worktree = self._state_worktree(session_dir)
+                except AdapterError as exc:
+                    last_store_error = exc
+                    continue
+                if stored_worktree != worktree:
+                    continue
+                wire = self._wire_path(session_dir)
+                try:
+                    prompts = self._matching_prompts(
+                        wire,
+                        message,
+                        start_offset=0,
+                        known_markers=set(),
+                    )
+                except AdapterError as exc:
+                    last_store_error = exc
+                    continue
+                matches.extend(
+                    (session_dir, prompt_time, offset)
+                    for prompt_time, offset in prompts
+                )
+            if len(matches) > 1:
+                raise AdapterError(
+                    "HARNESS_SESSION_DISCOVERY_FAILED",
+                    "multiple new Kimi sessions matched the dispatched prompt",
+                )
+            if matches:
+                return matches[0]
+            poll = getattr(process, "poll", None)
+            if callable(poll) and poll() is not None:
+                detail = (
+                    last_store_error.detail
+                    if last_store_error is not None
+                    else "Kimi exited before native identity was captured"
+                )
+                raise AdapterError(
+                    "HARNESS_SESSION_DISCOVERY_FAILED",
+                    detail,
+                )
+            if time.monotonic() >= deadline:
+                detail = (
+                    last_store_error.detail
+                    if last_store_error is not None
+                    else "timed out discovering the new Kimi session"
+                )
+                raise AdapterError(
+                    "HARNESS_SESSION_DISCOVERY_FAILED",
+                    detail,
+                    retryable=True,
+                )
+            time.sleep(POLL_INTERVAL)
+
+    def _matching_session_dir(
+        self,
+        root: Path,
+        session_ref: str,
+    ) -> Path | None:
+        try:
+            matches = [
+                path.resolve()
+                for path in root.glob(f"wd_*/{session_ref}")
+                if path.is_dir()
+            ]
+        except OSError as exc:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"cannot search Kimi session store: {root}",
+                retryable=True,
+            ) from exc
+        if len(matches) > 1:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"Kimi session ref is ambiguous: {session_ref}",
+            )
+        return matches[0] if matches else None
+
+    def _discover_resume(
+        self,
+        wire: Path,
+        start_offset: int,
+        known_markers: set[tuple[int, int]],
+        message: str,
+        process: Any,
+    ) -> tuple[int, int]:
+        deadline = time.monotonic() + self.identity_timeout
+        last_store_error: AdapterError | None = None
+        while True:
+            try:
+                if wire.stat().st_size < start_offset:
+                    raise AdapterError(
+                        "HARNESS_SESSION_DISCOVERY_FAILED",
+                        "Kimi main wire shrank during resume",
+                    )
+                matches = self._matching_prompts(
+                    wire,
+                    message,
+                    start_offset=start_offset,
+                    known_markers=known_markers,
+                )
+            except (OSError, AdapterError) as exc:
+                last_store_error = (
+                    exc
+                    if isinstance(exc, AdapterError)
+                    else AdapterError(
+                        "HARNESS_SESSION_INSPECTION_FAILED",
+                        f"cannot inspect Kimi main wire: {wire}",
+                        retryable=True,
+                    )
+                )
+                matches = []
+            if len(matches) > 1:
+                raise AdapterError(
+                    "HARNESS_SESSION_DISCOVERY_FAILED",
+                    "multiple Kimi prompt markers matched the resumed turn",
+                )
+            if matches:
+                return matches[0]
+            poll = getattr(process, "poll", None)
+            if callable(poll) and poll() is not None:
+                detail = (
+                    last_store_error.detail
+                    if last_store_error is not None
+                    else "Kimi exited before resumed turn identity was captured"
+                )
+                raise AdapterError(
+                    "HARNESS_SESSION_DISCOVERY_FAILED",
+                    detail,
+                )
+            if time.monotonic() >= deadline:
+                detail = (
+                    last_store_error.detail
+                    if last_store_error is not None
+                    else "timed out discovering the resumed Kimi turn"
+                )
+                raise AdapterError(
+                    "HARNESS_SESSION_DISCOVERY_FAILED",
+                    detail,
+                    retryable=True,
+                )
+            time.sleep(POLL_INTERVAL)
+
+    def _native_turn(
+        self,
+        process: Any,
+        worktree: Path,
+        session_dir: Path,
+        prompt_time: int,
+        prompt_offset: int,
+        command: list[str],
+        *,
+        resumed: bool,
+    ) -> NativeTurn:
+        wire = self._wire_path(session_dir)
+        pid = getattr(process, "pid", None)
+        return NativeTurn(
+            harness=self.harness,
+            session_ref=session_dir.name,
+            run_ref=f"kimi-{prompt_time}-{prompt_offset}",
+            worktree=worktree,
+            process_ref=str(pid) if pid is not None else None,
+            metadata={
+                "command": command,
+                "resumed": resumed,
+                "session_path": str(session_dir),
+                "wire_path": str(wire),
+                "prompt_offset": prompt_offset,
+                "prompt_time": prompt_time,
+            },
+            opaque=process,
+        )
+
+    def start(self, context: ConversationContext, message: str) -> NativeTurn:
+        worktree = context.checked_worktree()
+        if context.permission_mode == "interactive":
+            raise AdapterError(
+                "HARNESS_PERMISSION_RESPONSE_UNSUPPORTED",
+                "Kimi prompt mode cannot bridge interactive permissions",
+            )
+        message = ensure_nonempty_message(message)
+        env, root = self._environment(context)
+        existing = self._session_dirs(root)
+        command = self._command(context, message, None)
+        process = self.runner.spawn(command, cwd=worktree, env=env)
+        try:
+            session_dir, prompt_time, prompt_offset = self._discover_start(
+                root,
+                existing,
+                worktree,
+                message,
+                process,
+            )
+        except Exception:
+            self._cleanup_process(process, self.identity_timeout)
+            raise
+        return self._native_turn(
+            process,
+            worktree,
+            session_dir,
+            prompt_time,
+            prompt_offset,
+            command,
+            resumed=False,
+        )
+
+    def resume(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+    ) -> NativeTurn:
+        session_ref = self._validate_session_ref(session_ref)
+        worktree = context.checked_worktree()
+        if context.permission_mode == "interactive":
+            raise AdapterError(
+                "HARNESS_PERMISSION_RESPONSE_UNSUPPORTED",
+                "Kimi prompt mode cannot bridge interactive permissions",
+            )
+        message = ensure_nonempty_message(message)
+        env, root = self._environment(context)
+        session_dir = self._matching_session_dir(root, session_ref)
+        if session_dir is None:
+            raise AdapterError(
+                "HARNESS_SESSION_LOST",
+                f"Kimi session does not exist: {session_ref}",
+            )
+        if self._state_worktree(session_dir) != worktree:
+            raise AdapterError(
+                "HARNESS_WORKTREE_MISMATCH",
+                "Kimi session belongs to a different worktree",
+            )
+        wire = self._wire_path(session_dir)
+        try:
+            start_offset = wire.stat().st_size
+        except OSError as exc:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"cannot inspect Kimi main wire: {wire}",
+                retryable=True,
+            ) from exc
+        known_markers = self._prompt_markers(wire)
+        command = self._command(context, message, session_ref)
+        process = self.runner.spawn(command, cwd=worktree, env=env)
+        try:
+            prompt_time, prompt_offset = self._discover_resume(
+                wire,
+                start_offset,
+                known_markers,
+                message,
+                process,
+            )
+        except Exception:
+            self._cleanup_process(process, self.identity_timeout)
+            raise
+        return self._native_turn(
+            process,
+            worktree,
+            session_dir,
+            prompt_time,
+            prompt_offset,
+            command,
+            resumed=True,
+        )
+
+    @staticmethod
+    def _normalize(raw: Mapping[str, Any]) -> list[NormalizedEvent]:
+        role = raw.get("role")
+        if not isinstance(role, str):
+            return []
+        if role == "assistant":
+            events: list[NormalizedEvent] = []
+            content = raw.get("content")
+            if isinstance(content, str):
+                events.append(
+                    NormalizedEvent(
+                        "assistant.delta",
+                        {"text": content},
+                        "assistant",
+                    )
+                )
+            tool_calls = raw.get("tool_calls")
+            if isinstance(tool_calls, list):
+                for tool_call in tool_calls:
+                    if not isinstance(tool_call, dict):
+                        continue
+                    function = tool_call.get("function")
+                    if not isinstance(function, dict):
+                        continue
+                    tool_ref = tool_call.get("id")
+                    name = function.get("name")
+                    if not isinstance(tool_ref, str) or not isinstance(
+                        name, str
+                    ):
+                        continue
+                    events.append(
+                        NormalizedEvent(
+                            "tool.started",
+                            {"tool_ref": tool_ref, "name": name},
+                            "assistant.tool_call",
+                        )
+                    )
+            return events
+        if role == "tool":
+            tool_ref = raw.get("tool_call_id")
+            if isinstance(tool_ref, str):
+                return [
+                    NormalizedEvent(
+                        "tool.completed",
+                        {"tool_ref": tool_ref, "status": "completed"},
+                        "tool",
+                    )
+                ]
+        return []
+
+    @staticmethod
+    def _run_coordinates(turn: NativeTurn) -> tuple[int, int]:
+        match = RUN_REF.fullmatch(turn.run_ref)
+        if not match:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"Kimi run ref is malformed: {turn.run_ref}",
+            )
+        prompt_time, prompt_offset = (int(value) for value in match.groups())
+        if (
+            turn.metadata.get("prompt_time") != prompt_time
+            or turn.metadata.get("prompt_offset") != prompt_offset
+        ):
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                "Kimi run metadata does not match its persisted run ref",
+            )
+        return prompt_time, prompt_offset
+
+    def _run_slice(self, turn: NativeTurn) -> list[Mapping[str, Any]]:
+        prompt_time, prompt_offset = self._run_coordinates(turn)
+        wire_value = turn.metadata.get("wire_path")
+        if not isinstance(wire_value, str):
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                "Kimi turn has no persisted main-wire path",
+            )
+        records = self._wire_records(
+            Path(wire_value),
+            start_offset=prompt_offset,
+        )
+        if not records:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                "Kimi run prompt is missing from the main wire",
+            )
+        first_offset, first = records[0]
+        if (
+            first_offset != prompt_offset
+            or first.get("type") != "turn.prompt"
+            or first.get("time") != prompt_time
+        ):
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                "Kimi run boundary does not identify its prompt marker",
+            )
+        run: list[Mapping[str, Any]] = []
+        for _offset, raw in records:
+            if run and raw.get("type") == "turn.prompt":
+                break
+            run.append(raw)
+        return run
+
+    @staticmethod
+    def _usage(records: list[Mapping[str, Any]]) -> dict[str, int | float]:
+        totals: dict[str, int | float] = {}
+        for raw in records:
+            if (
+                raw.get("type") != "usage.record"
+                or raw.get("usageScope") != "turn"
+            ):
+                continue
+            usage = raw.get("usage")
+            if not isinstance(usage, dict):
+                continue
+            for native, normalized in USAGE_KEYS.items():
+                value = usage.get(native)
+                if isinstance(value, (int, float)) and not isinstance(
+                    value, bool
+                ):
+                    totals[normalized] = totals.get(normalized, 0) + value
+        return totals
+
+    @staticmethod
+    def _stderr(process: Any) -> str:
+        captured = getattr(process, "_sc_conversation_stderr", None)
+        if isinstance(captured, list):
+            return "".join(str(part) for part in captured)[:STDERR_LIMIT]
+        stderr = getattr(process, "stderr", None)
+        getvalue = getattr(stderr, "getvalue", None)
+        if callable(getvalue):
+            return str(getvalue())[:STDERR_LIMIT]
+        return ""
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        process = turn.opaque
+        stdout = getattr(process, "stdout", None)
+        if stdout is None:
+            raise AdapterError(
+                "HARNESS_PROTOCOL_ERROR",
+                "Kimi process exposes no stdout stream",
+            )
+        yield NormalizedEvent(
+            "session.started",
+            {
+                "session_ref": turn.session_ref,
+                "resumed": bool(turn.metadata.get("resumed")),
+            },
+            "native-session-store",
+        )
+        yield NormalizedEvent(
+            "run.started",
+            {"run_ref": turn.run_ref, "status": "running"},
+            "turn.prompt",
+        )
+        for line in stdout:
+            if not line.strip():
+                continue
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(raw, dict):
+                continue
+            role = raw.get("role")
+            if not isinstance(role, str):
+                continue
+            if role == "meta" and raw.get("type") == "session.resume_hint":
+                if raw.get("session_id") != turn.session_ref:
+                    turn.metadata["identity_mismatch"] = True
+                    raise AdapterError(
+                        "HARNESS_SESSION_MISMATCH",
+                        "Kimi resume hint differs from persisted session ref",
+                    )
+                continue
+            for event in self._normalize(raw):
+                yield event
+        returncode = process.wait()
+        turn.metadata["returncode"] = returncode
+        try:
+            records = self._run_slice(turn)
+        except AdapterError:
+            records = []
+        cancelled = any(raw.get("type") == "turn.cancel" for raw in records)
+        acknowledged_sigint = (
+            bool(turn.metadata.get("interrupt_acknowledged"))
+            and returncode in {-signal.SIGINT, 128 + signal.SIGINT}
+        )
+        if cancelled or acknowledged_sigint:
+            event = NormalizedEvent(
+                "run.interrupted",
+                {"status": "interrupted"},
+                "turn.cancel" if cancelled else "process.exit",
+            )
+            turn.metadata["terminal"] = event.type
+            yield event
+            return
+        if returncode == 0:
+            usage = self._usage(records)
+            if usage:
+                yield NormalizedEvent(
+                    "usage",
+                    {"tokens": usage},
+                    "usage.record",
+                )
+            event = NormalizedEvent(
+                "run.completed",
+                {"status": "completed"},
+                "process.exit",
+            )
+            turn.metadata["terminal"] = event.type
+            yield event
+            return
+        event = NormalizedEvent(
+            "run.failed",
+            {
+                "status": "failed",
+                "exit_code": returncode,
+                "error": self._stderr(process),
+            },
+            "process.exit",
+        )
+        turn.metadata["terminal"] = event.type
+        yield event
+
+    def interrupt(self, turn: NativeTurn) -> InterruptResult:
+        process = turn.opaque
+        if process is None or process.poll() is not None:
+            return InterruptResult(False, "Kimi process is not running")
+        process.send_signal(signal.SIGINT)
+        turn.metadata["interrupt_acknowledged"] = True
+        return InterruptResult(True)
+
+    def inspect(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+    ) -> SessionInspection:
+        session_ref = self._validate_session_ref(session_ref)
+        worktree = context.checked_worktree()
+        _env, root = self._environment(context)
+        session_dir = self._matching_session_dir(root, session_ref)
+        if session_dir is None:
+            return SessionInspection(session_ref, False, "missing")
+        if self._state_worktree(session_dir) != worktree:
+            raise AdapterError(
+                "HARNESS_WORKTREE_MISMATCH",
+                "Kimi session belongs to a different worktree",
+            )
+        wire = self._wire_path(session_dir)
+        records = self._wire_records(wire)
+        model: str | None = None
+        effort: str | None = None
+        last_prompt: str | None = None
+        last_prompt_time: int | None = None
+        last_prompt_offset: int | None = None
+        latest_slice: list[Mapping[str, Any]] = []
+        for offset, raw in records:
+            native_type = raw.get("type")
+            if native_type in {"config.update", "llm.request"}:
+                if isinstance(raw.get("modelAlias"), str):
+                    model = raw["modelAlias"]
+                if isinstance(raw.get("thinkingEffort"), str):
+                    effort = raw["thinkingEffort"]
+            if native_type == "turn.prompt":
+                prompt_time = raw.get("time")
+                prompt_text = self._prompt_text(raw)
+                if (
+                    not isinstance(prompt_time, int)
+                    or isinstance(prompt_time, bool)
+                    or prompt_text is None
+                ):
+                    raise AdapterError(
+                        "HARNESS_SESSION_INSPECTION_FAILED",
+                        "Kimi main wire has a malformed turn.prompt marker",
+                    )
+                last_prompt = prompt_text
+                last_prompt_time = prompt_time
+                last_prompt_offset = offset
+                latest_slice = [raw]
+            elif latest_slice:
+                latest_slice.append(raw)
+        terminal = any(
+            raw.get("type") == "turn.cancel"
+            or (
+                raw.get("type") == "usage.record"
+                and raw.get("usageScope") == "turn"
+            )
+            for raw in latest_slice
+        )
+        return SessionInspection(
+            session_ref,
+            True,
+            "idle" if terminal else "unknown",
+            worktree,
+            {
+                "session_path": str(session_dir),
+                "wire_path": str(wire),
+                "model": model,
+                "effort": effort,
+                "last_prompt": last_prompt,
+                "last_prompt_time": last_prompt_time,
+                "last_prompt_offset": last_prompt_offset,
+            },
+        )
+
+    def reconcile(
+        self,
+        turn: NativeTurn,
+        context: ConversationContext,
+    ) -> ReconcileResult:
+        terminal = turn.metadata.get("terminal")
+        if terminal in TERMINAL_EVENTS:
+            return ReconcileResult(
+                terminal_outcome(str(terminal)),
+                True,
+                f"terminal {terminal} was observed on Kimi stdout",
+            )
+        if turn.metadata.get("identity_mismatch"):
+            return ReconcileResult(
+                "unknown",
+                False,
+                "Kimi stdout identity mismatched the persisted session",
+            )
+        process = turn.opaque
+        if process is not None and process.poll() is None:
+            return ReconcileResult(
+                "running",
+                True,
+                "Kimi process is still running",
+            )
+        try:
+            records = self._run_slice(turn)
+        except AdapterError:
+            return ReconcileResult(
+                "unknown",
+                False,
+                "Kimi exact run slice is unavailable",
+            )
+        if any(raw.get("type") == "turn.cancel" for raw in records):
+            return ReconcileResult(
+                "cancelled",
+                True,
+                "Kimi exact run slice contains turn.cancel",
+            )
+        if self._usage(records):
+            return ReconcileResult(
+                "succeeded",
+                True,
+                "Kimi exact run slice contains turn-scoped usage",
+            )
+        return ReconcileResult(
+            "unknown",
+            False,
+            "Kimi exact run slice has no durable terminal proof",
+        )

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3021,7 +3021,7 @@ async function renderSprints(root) {
 // A browser conversation owns the shell's single session slot until ended. It
 // uses the normal CLI preparation path server-side, but deliberately has no
 // terminal, tmux controls, or live hand-off between browser and CLI.
-const CHAT_HARNESSES = ["opencode", "claude", "codex"];
+const CHAT_HARNESSES = ["opencode", "claude", "codex", "kimi"];
 const CHAT_FLAVOR_ORDER = [
   "cartographer", "admin", "conductor", "planner", "dev", "reviewer", "devops",
 ];

--- a/tests/fixtures/conversations/capability_probes.json
+++ b/tests/fixtures/conversations/capability_probes.json
@@ -62,16 +62,27 @@
         "resume_after_server_restart": true,
         "unrestricted_permission_policy": true
       }
-    }
-  },
-  "reference_only": {
+    },
     "kimi": {
-      "session_ref_shape": "session_<uuid>",
-      "state_store": "~/.kimi-code/sessions/wd_<name>_<hash>/session_<uuid>/state.json",
-      "wire_store": "agents/main/wire.jsonl",
-      "exact_worktree_field": "workDir",
-      "observed_events": ["turn.prompt", "llm.request", "turn.cancel", "usage.record"],
-      "release_gate_member": false
+      "verified_cli_version": "0.30.0",
+      "driver": "kimi-print",
+      "native_ref_shape": "session_<uuid>",
+      "observed_events": [
+        "assistant",
+        "session.resume_hint",
+        "turn.prompt",
+        "llm.request",
+        "turn.cancel",
+        "usage.record"
+      ],
+      "proof": {
+        "two_turn_exact_resume": true,
+        "same_worktree_isolation": true,
+        "structured_streaming": true,
+        "interruption": true,
+        "resume_after_compute_exit": true,
+        "session_inspection": true
+      }
     }
   }
 }

--- a/tests/fixtures/conversations/kimi/interrupted-main-wire.jsonl
+++ b/tests/fixtures/conversations/kimi/interrupted-main-wire.jsonl
@@ -1,0 +1,10 @@
+{"type":"config.update","modelAlias":"kimi-code/k3","thinkingEffort":"high","time":1785365142346}
+{"type":"turn.prompt","input":[{"type":"text","text":"Reply with exactly KIMI_PROBE_NEW."}],"origin":{"kind":"user"},"time":1785365142363}
+{"type":"llm.request","kind":"loop","provider":"kimi","model":"k3","modelAlias":"kimi-code/k3","thinkingEffort":"high","time":1785365143069}
+{"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":2212,"output":24,"inputCacheRead":19200,"inputCacheCreation":0},"usageScope":"turn","time":1785365146252}
+{"type":"turn.prompt","input":[{"type":"text","text":"Reply with exactly KIMI_PROBE_RESUME."}],"origin":{"kind":"user"},"time":1785365151620}
+{"type":"llm.request","kind":"loop","provider":"kimi","model":"k3","modelAlias":"kimi-code/k3","thinkingEffort":"high","time":1785365151652}
+{"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":332,"output":21,"inputCacheRead":21248,"inputCacheCreation":0},"usageScope":"turn","time":1785365154839}
+{"type":"turn.prompt","input":[{"type":"text","text":"Use the shell tool to run sleep 120, then reply KIMI_PROBE_INTERRUPT_DONE."}],"origin":{"kind":"user"},"time":1785365164354}
+{"type":"llm.request","kind":"loop","provider":"kimi","model":"k3","modelAlias":"kimi-code/k3","thinkingEffort":"high","time":1785365164380}
+{"type":"turn.cancel","time":1785365169604}

--- a/tests/fixtures/conversations/kimi/new-stream.jsonl
+++ b/tests/fixtures/conversations/kimi/new-stream.jsonl
@@ -1,0 +1,2 @@
+{"role":"assistant","content":"KIMI_PROBE_NEW"}
+{"role":"meta","type":"session.resume_hint","session_id":"session_11111111-1111-4111-8111-111111111111","command":"kimi -r session_11111111-1111-4111-8111-111111111111","content":"To resume this session: kimi -r session_11111111-1111-4111-8111-111111111111"}

--- a/tests/fixtures/conversations/kimi/resume-stream.jsonl
+++ b/tests/fixtures/conversations/kimi/resume-stream.jsonl
@@ -1,0 +1,2 @@
+{"role":"assistant","content":"KIMI_PROBE_RESUME"}
+{"role":"meta","type":"session.resume_hint","session_id":"session_11111111-1111-4111-8111-111111111111","command":"kimi -r session_11111111-1111-4111-8111-111111111111","content":"To resume this session: kimi -r session_11111111-1111-4111-8111-111111111111"}

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -21,9 +21,13 @@ from conversation_adapters import (  # noqa: E402
     ClaudeAdapter,
     CodexAdapter,
     ConversationContext,
+    KimiAdapter,
+    NativeTurn,
     OpenCodeAdapter,
     adapter_for,
 )
+
+KIMI_FIXTURES = ROOT / "tests" / "fixtures" / "conversations" / "kimi"
 
 
 class FakeOpenCode:
@@ -241,6 +245,207 @@ class FakeClaudeRunner:
         return process
 
 
+class FakeKimiProcess:
+    def __init__(
+        self,
+        stdout_lines: list[Any],
+        *,
+        wait_code: int = 0,
+        exit_before_identity: bool = False,
+        stderr: str = "",
+        cancel_wire: Path | None = None,
+    ) -> None:
+        encoded = [
+            line if isinstance(line, str) else json.dumps(line)
+            for line in stdout_lines
+        ]
+        self.stdout = io.StringIO("".join(line + "\n" for line in encoded))
+        self.stderr = io.StringIO(stderr)
+        self.pid = 9876
+        self.returncode: int | None = (
+            wait_code if exit_before_identity else None
+        )
+        self.wait_code = wait_code
+        self.cancel_wire = cancel_wire
+        self.signals: list[int] = []
+        self.terminated = False
+        self.killed = False
+        self.waited = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.waited = True
+        if self.returncode is None:
+            self.returncode = self.wait_code
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = -signal.SIGTERM
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -signal.SIGKILL
+
+    def send_signal(self, value: int) -> None:
+        self.signals.append(value)
+        if value == signal.SIGINT and self.cancel_wire is not None:
+            with self.cancel_wire.open("a", encoding="utf-8") as stream:
+                stream.write(
+                    json.dumps({"type": "turn.cancel", "time": 9000}) + "\n"
+                )
+            self.returncode = -signal.SIGINT
+
+
+class FakeKimiRunner:
+    def __init__(
+        self,
+        sessions_root: Path | None,
+        worktree: Path,
+    ) -> None:
+        self.sessions_root = sessions_root
+        self.worktree = worktree
+        self.calls: list[tuple[list[str], Path, dict[str, str]]] = []
+        self.processes: list[FakeKimiProcess] = []
+        self.plans: list[dict[str, Any]] = []
+        self.serial = 0
+
+    def queue(self, **plan: Any) -> None:
+        self.plans.append(plan)
+
+    def root_for(self, env: Mapping[str, str], cwd: Path) -> Path:
+        if self.sessions_root is not None:
+            return self.sessions_root
+        configured = env.get("KIMI_CODE_HOME", "").strip()
+        merged_home = Path(env.get("HOME", str(Path.home())))
+        if configured == "~":
+            data_root = merged_home
+        elif configured.startswith("~/"):
+            data_root = merged_home / configured[2:]
+        elif configured:
+            data_root = Path(configured)
+            if not data_root.is_absolute():
+                data_root = cwd / data_root
+        else:
+            data_root = merged_home / ".kimi-code"
+        return data_root / "sessions"
+
+    def session_ref(self) -> str:
+        self.serial += 1
+        return (
+            "session_00000000-0000-4000-8000-"
+            f"{self.serial:012d}"
+        )
+
+    def write_session(
+        self,
+        root: Path,
+        session_ref: str,
+        worktree: Path,
+        message: str,
+        *,
+        prompt_time: int,
+        malformed_prompt: bool = False,
+        after_prompt: list[dict[str, Any]] | None = None,
+        directory: str = "wd_test",
+        append: bool = False,
+    ) -> tuple[Path, Path]:
+        session = root / directory / session_ref
+        wire = session / "agents" / "main" / "wire.jsonl"
+        wire.parent.mkdir(parents=True, exist_ok=True)
+        (session / "state.json").write_text(
+            json.dumps({"workDir": str(worktree)}),
+            encoding="utf-8",
+        )
+        prompt = (
+            {"type": "turn.prompt", "input": [{"type": "text", "text": message}]}
+            if malformed_prompt
+            else {
+                "type": "turn.prompt",
+                "input": [{"type": "text", "text": message}],
+                "origin": {"kind": "user"},
+                "time": prompt_time,
+            }
+        )
+        mode = "a" if append else "w"
+        with wire.open(mode, encoding="utf-8") as stream:
+            for row in [prompt, *(after_prompt or [])]:
+                stream.write(json.dumps(row) + "\n")
+        return session, wire
+
+    def spawn(
+        self,
+        argv: list[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+    ) -> FakeKimiProcess:
+        plan = self.plans.pop(0) if self.plans else {}
+        root = self.root_for(env, cwd)
+        message = argv[argv.index("-p") + 1]
+        resume = "-S" in argv
+        session_ref = (
+            argv[argv.index("-S") + 1]
+            if resume
+            else plan.get("session_ref", self.session_ref())
+        )
+        prompt_time = plan.get("prompt_time", 1000 + len(self.calls))
+        wire: Path | None = None
+        if plan.get("write_identity", True):
+            worktrees = plan.get("candidate_worktrees", [cwd])
+            for index, stored_worktree in enumerate(worktrees):
+                candidate_ref = (
+                    session_ref if index == 0 else self.session_ref()
+                )
+                _session, candidate_wire = self.write_session(
+                    root,
+                    candidate_ref,
+                    stored_worktree,
+                    message,
+                    prompt_time=prompt_time,
+                    malformed_prompt=plan.get("malformed_prompt", False),
+                    after_prompt=plan.get("after_prompt"),
+                    directory=f"wd_test_{index}",
+                    append=resume and index == 0,
+                )
+                if index == 0:
+                    wire = candidate_wire
+        hint_ref = plan.get("hint_ref", session_ref)
+        stdout_lines = plan.get(
+            "stdout_lines",
+            [
+                {
+                    "role": "assistant",
+                    "content": "hello",
+                    "tool_calls": [
+                        {
+                            "id": "tool-default",
+                            "function": {"name": "Shell"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "tool-default"},
+                {
+                    "role": "meta",
+                    "type": "session.resume_hint",
+                    "session_id": hint_ref,
+                },
+            ],
+        )
+        process = FakeKimiProcess(
+            stdout_lines,
+            wait_code=plan.get("wait_code", 0),
+            exit_before_identity=plan.get("exit_before_identity", False),
+            stderr=plan.get("stderr", ""),
+            cancel_wire=wire,
+        )
+        self.calls.append((list(argv), cwd, dict(env)))
+        self.processes.append(process)
+        return process
+
+
 class FakeCodexRpc:
     def __init__(self) -> None:
         self.requests: list[tuple[str, dict[str, Any]]] = []
@@ -383,6 +588,8 @@ class ConversationAdapterTest(unittest.TestCase):
             effort="high",
         )
         self.claude_config = self.root / "claude-config"
+        self.kimi_sessions = self.root / "kimi-sessions"
+        self.kimi_runner_serial = 0
 
     def tearDown(self) -> None:
         self.temp.cleanup()
@@ -429,6 +636,20 @@ class ConversationAdapterTest(unittest.TestCase):
                 ),
                 native,
             )
+        if harness == "kimi":
+            self.kimi_runner_serial += 1
+            sessions_root = (
+                self.kimi_sessions / f"runner-{self.kimi_runner_serial}"
+            )
+            native = FakeKimiRunner(sessions_root, self.root)
+            return (
+                KimiAdapter(
+                    runner=native,
+                    sessions_root=sessions_root,
+                    identity_timeout=0.1,
+                ),
+                native,
+            )
         native = FakeCodexRpc()
         return CodexAdapter(rpc=native), native
 
@@ -453,9 +674,9 @@ class ConversationAdapterTest(unittest.TestCase):
     def test_identical_contract_start_stream_interrupt_resume_reconcile(
         self,
     ) -> None:
-        for harness in ("opencode", "claude", "codex"):
+        for harness in ("opencode", "claude", "codex", "kimi"):
             with self.subTest(harness=harness):
-                adapter, native = self.build(harness)
+                adapter, _native = self.build(harness)
                 turn = adapter.start(self.context, "first")
                 self.assertEqual(turn.harness, harness)
                 self.assertEqual(turn.worktree, self.root)
@@ -529,6 +750,43 @@ class ConversationAdapterTest(unittest.TestCase):
         self.assertEqual(thread_params["approvalPolicy"], "never")
         self.assertEqual(thread_params["sandbox"], "danger-full-access")
         self.assertNotIn("--sandbox", repr(codex_native.requests))
+
+        kimi, kimi_native = self.build("kimi")
+        kimi.start(self.context, "work")
+        kimi_argv, _cwd, kimi_env = kimi_native.calls[-1]
+        self.assertNotIn("--yolo", kimi_argv)
+        self.assertNotIn("--auto", kimi_argv)
+        self.assertEqual(kimi_env["KIMI_MODEL_THINKING_EFFORT"], "high")
+        self.assertIn("-m", kimi_argv)
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_PERMISSION_RESPONSE_UNSUPPORTED",
+        ):
+            kimi.start(
+                ConversationContext(
+                    worktree=self.root,
+                    permission_mode="interactive",
+                ),
+                "work",
+            )
+        no_effort_root = self.kimi_sessions / "no-effort"
+        no_effort_native = FakeKimiRunner(no_effort_root, self.root)
+        no_effort = KimiAdapter(
+            runner=no_effort_native,
+            sessions_root=no_effort_root,
+            identity_timeout=0.1,
+        )
+        no_effort.start(
+            ConversationContext(
+                worktree=self.root,
+                env={"KIMI_MODEL_THINKING_EFFORT": "ambient"},
+            ),
+            "work",
+        )
+        self.assertNotIn(
+            "KIMI_MODEL_THINKING_EFFORT",
+            no_effort_native.calls[-1][2],
+        )
 
     def test_opencode_exact_resources_filtering_and_unknown_recovery(
         self,
@@ -625,6 +883,437 @@ class ConversationAdapterTest(unittest.TestCase):
         self.assertNotIn("--session-id", argv)
         self.assertTrue(adapter.interrupt(resumed).acknowledged)
         self.assertEqual(runner.processes[-1].signals, [signal.SIGINT])
+
+    def test_kimi_discovers_native_identity_before_stream_and_resumes_exactly(
+        self,
+    ) -> None:
+        adapter, runner = self.build("kimi")
+        captured_ref = "session_11111111-1111-4111-8111-111111111111"
+        runner.queue(
+            session_ref=captured_ref,
+            stdout_lines=(
+                KIMI_FIXTURES / "new-stream.jsonl"
+            ).read_text().splitlines(),
+        )
+        first = adapter.start(self.context, "first")
+        self.assertEqual(first.session_ref, captured_ref)
+        self.assertRegex(
+            first.session_ref,
+            r"^session_[0-9a-f-]{36}$",
+        )
+        self.assertRegex(first.run_ref, r"^kimi-\d+-\d+$")
+        self.assertIsNone(first.opaque.poll())
+        wire = Path(first.metadata["wire_path"])
+        with wire.open("rb") as stream:
+            stream.seek(first.metadata["prompt_offset"])
+            prompt = json.loads(stream.readline())
+        self.assertEqual(prompt["time"], first.metadata["prompt_time"])
+        self.assertEqual(prompt["input"][0]["text"], "first")
+        list(adapter.stream(first))
+
+        runner.queue(
+            prompt_time=first.metadata["prompt_time"],
+            stdout_lines=(
+                KIMI_FIXTURES / "resume-stream.jsonl"
+            ).read_text().splitlines(),
+        )
+        resumed = adapter.resume(first.session_ref, self.context, "second")
+        argv = runner.calls[-1][0]
+        self.assertEqual(
+            argv[argv.index("-S") + 1],
+            first.session_ref,
+        )
+        self.assertEqual(resumed.session_ref, first.session_ref)
+        self.assertNotEqual(resumed.run_ref, first.run_ref)
+        self.assertEqual(
+            resumed.metadata["prompt_time"],
+            first.metadata["prompt_time"],
+            "the binary offset must distinguish same-millisecond prompts",
+        )
+        self.assertGreater(
+            resumed.metadata["prompt_offset"],
+            first.metadata["prompt_offset"],
+        )
+        self.assertEqual(
+            list(adapter.stream(resumed))[-1].type,
+            "run.completed",
+        )
+
+    def test_kimi_new_session_discovery_filters_and_reaps_failures(
+        self,
+    ) -> None:
+        adapter, runner = self.build("kimi")
+        preexisting = (
+            "session_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        )
+        runner.write_session(
+            runner.sessions_root,
+            preexisting,
+            self.root,
+            "target",
+            prompt_time=50,
+            directory="wd_preexisting",
+        )
+        other = self.root / "other"
+        other.mkdir()
+        runner.queue(candidate_worktrees=[other, self.root])
+        turn = adapter.start(self.context, "target")
+        self.assertNotEqual(turn.session_ref, preexisting)
+        self.assertEqual(
+            json.loads(
+                (Path(turn.metadata["session_path"]) / "state.json").read_text()
+            )["workDir"],
+            str(self.root),
+        )
+
+        ambiguous, ambiguous_runner = self.build("kimi")
+        ambiguous_runner.queue(candidate_worktrees=[self.root, self.root])
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_SESSION_DISCOVERY_FAILED",
+        ):
+            ambiguous.start(self.context, "ambiguous")
+        self.assertTrue(ambiguous_runner.processes[-1].terminated)
+        self.assertTrue(ambiguous_runner.processes[-1].waited)
+
+        timeout_runner = FakeKimiRunner(self.kimi_sessions / "timeout", self.root)
+        timeout_runner.queue(write_identity=False)
+        timeout_adapter = KimiAdapter(
+            runner=timeout_runner,
+            sessions_root=self.kimi_sessions / "timeout",
+            identity_timeout=0.03,
+        )
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_SESSION_DISCOVERY_FAILED",
+        ):
+            timeout_adapter.start(self.context, "missing")
+        self.assertTrue(timeout_runner.processes[-1].terminated)
+        self.assertTrue(timeout_runner.processes[-1].waited)
+
+        malformed_runner = FakeKimiRunner(
+            self.kimi_sessions / "malformed",
+            self.root,
+        )
+        malformed_runner.queue(
+            malformed_prompt=True,
+            exit_before_identity=True,
+            wait_code=1,
+        )
+        malformed_adapter = KimiAdapter(
+            runner=malformed_runner,
+            sessions_root=self.kimi_sessions / "malformed",
+            identity_timeout=0.03,
+        )
+        with self.assertRaisesRegex(
+            AdapterError,
+            "malformed turn.prompt",
+        ):
+            malformed_adapter.start(self.context, "malformed")
+        self.assertTrue(malformed_runner.processes[-1].waited)
+
+    def test_kimi_store_root_commands_and_resume_validation(self) -> None:
+        data_home = self.root / "kimi-home"
+        runner = FakeKimiRunner(None, self.root)
+        adapter = KimiAdapter(runner=runner, identity_timeout=0.1)
+        context = ConversationContext(
+            worktree=self.root,
+            env={"KIMI_CODE_HOME": str(data_home)},
+        )
+        turn = adapter.start(context, "root")
+        self.assertEqual(
+            Path(turn.metadata["session_path"]).parents[1],
+            data_home / "sessions",
+        )
+        self.assertNotIn("--yolo", runner.calls[-1][0])
+        self.assertNotIn("--auto", runner.calls[-1][0])
+
+        merged_home = self.root / "merged-home"
+        home_runner = FakeKimiRunner(None, self.root)
+        home_adapter = KimiAdapter(
+            runner=home_runner,
+            identity_timeout=0.1,
+        )
+        home_turn = home_adapter.start(
+            ConversationContext(
+                worktree=self.root,
+                env={"HOME": str(merged_home), "KIMI_CODE_HOME": ""},
+            ),
+            "merged home",
+        )
+        self.assertEqual(
+            Path(home_turn.metadata["session_path"]).parents[1],
+            merged_home / ".kimi-code" / "sessions",
+        )
+        self.assertNotIn("KIMI_CODE_HOME", home_runner.calls[-1][2])
+
+        before = len(runner.calls)
+        with self.assertRaisesRegex(AdapterError, "HARNESS_SESSION_LOST"):
+            adapter.resume("not-a-session", context, "again")
+        with self.assertRaisesRegex(AdapterError, "HARNESS_SESSION_LOST"):
+            adapter.resume(
+                "session_ffffffff-ffff-4fff-8fff-ffffffffffff",
+                context,
+                "again",
+            )
+        self.assertEqual(
+            len(runner.calls),
+            before,
+            "invalid and missing refs must fail before spawning",
+        )
+
+        wrong = self.root / "wrong-worktree"
+        wrong.mkdir()
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_WORKTREE_MISMATCH",
+        ):
+            adapter.resume(
+                turn.session_ref,
+                ConversationContext(
+                    worktree=wrong,
+                    env={"KIMI_CODE_HOME": str(data_home)},
+                ),
+                "again",
+            )
+        self.assertEqual(len(runner.calls), before)
+
+    def test_kimi_stream_normalizes_live_capture_and_exact_slice_usage(
+        self,
+    ) -> None:
+        adapter, runner = self.build("kimi")
+        captured = (
+            KIMI_FIXTURES / "new-stream.jsonl"
+        ).read_text().splitlines()
+        runner.queue(
+            session_ref="session_11111111-1111-4111-8111-111111111111",
+            stdout_lines=[
+                "raw subprocess output",
+                {"unrecognized": True},
+                {
+                    "role": "assistant",
+                    "content": "chunk",
+                    "tool_calls": [
+                        {
+                            "id": "tool-1",
+                            "function": {"name": "Shell"},
+                        },
+                        {
+                            "id": "tool-2",
+                            "function": {"name": "Read"},
+                        },
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "tool-1",
+                    "content": "done",
+                },
+                *captured,
+            ],
+            after_prompt=[
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {
+                        "inputOther": 10,
+                        "output": 2,
+                        "inputCacheRead": 3,
+                    },
+                },
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {
+                        "inputOther": 5,
+                        "inputCacheCreation": 7,
+                    },
+                },
+                {
+                    "type": "turn.prompt",
+                    "input": [{"type": "text", "text": "later"}],
+                    "time": 9999,
+                },
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {"output": 999},
+                },
+            ],
+        )
+        turn = adapter.start(self.context, "normalize")
+        events = list(adapter.stream(turn))
+        self.assertEqual(
+            [event.type for event in events],
+            [
+                "session.started",
+                "run.started",
+                "assistant.delta",
+                "tool.started",
+                "tool.started",
+                "tool.completed",
+                "assistant.delta",
+                "usage",
+                "run.completed",
+            ],
+        )
+        self.assertEqual(events[2].payload["text"], "chunk")
+        self.assertEqual(events[3].payload["tool_ref"], "tool-1")
+        self.assertEqual(events[4].payload["tool_ref"], "tool-2")
+        usage = next(event for event in events if event.type == "usage")
+        self.assertEqual(
+            usage.payload["tokens"],
+            {
+                "input_tokens": 15,
+                "output_tokens": 2,
+                "cache_read_tokens": 3,
+                "cache_write_tokens": 7,
+            },
+        )
+        self.assertNotIn("999", repr(events))
+
+        missing_usage, _missing_runner = self.build("kimi")
+        completed = list(missing_usage.stream(
+            missing_usage.start(self.context, "no usage")
+        ))
+        self.assertEqual(
+            [event.type for event in completed if event.type == "usage"],
+            [],
+        )
+        self.assertEqual(completed[-1].type, "run.completed")
+
+        failed, failed_runner = self.build("kimi")
+        failed_runner.queue(
+            wait_code=3,
+            stderr="native failure detail" + ("x" * 20000),
+        )
+        failed_events = list(failed.stream(
+            failed.start(self.context, "fail")
+        ))
+        self.assertEqual(failed_events[-1].type, "run.failed")
+        self.assertEqual(failed_events[-1].payload["exit_code"], 3)
+        self.assertEqual(
+            len(failed_events[-1].payload["error"]),
+            16384,
+        )
+        self.assertTrue(
+            failed_events[-1].payload["error"].startswith(
+                "native failure detail"
+            )
+        )
+
+    def test_kimi_identity_mismatch_blocks_usage_reconciliation(self) -> None:
+        adapter, runner = self.build("kimi")
+        runner.queue(
+            hint_ref="session_ffffffff-ffff-4fff-8fff-ffffffffffff",
+            after_prompt=[
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {"inputOther": 10, "output": 2},
+                }
+            ],
+        )
+        turn = adapter.start(self.context, "mismatch")
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_SESSION_MISMATCH",
+        ):
+            list(adapter.stream(turn))
+        result = adapter.reconcile(turn, self.context)
+        self.assertEqual(result.outcome, "unknown")
+        self.assertFalse(result.proven)
+        self.assertTrue(turn.metadata["identity_mismatch"])
+
+    def test_kimi_inspect_and_reconcile_use_only_main_exact_run_slice(
+        self,
+    ) -> None:
+        adapter, runner = self.build("kimi")
+        runner.queue(
+            prompt_time=7000,
+            after_prompt=[
+                {
+                    "type": "config.update",
+                    "modelAlias": "kimi-code/k3",
+                    "thinkingEffort": "high",
+                },
+                {
+                    "type": "turn.prompt",
+                    "input": [{"type": "text", "text": "later"}],
+                    "time": 7001,
+                },
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {"inputOther": 99},
+                },
+            ],
+        )
+        turn = adapter.start(self.context, "current")
+        session = Path(turn.metadata["session_path"])
+        subagent = session / "agents" / "agent-0" / "wire.jsonl"
+        subagent.parent.mkdir(parents=True)
+        subagent.write_text(
+            json.dumps({"type": "turn.cancel", "time": 7002}) + "\n",
+            encoding="utf-8",
+        )
+        turn.opaque.returncode = 0
+        result = adapter.reconcile(turn, self.context)
+        self.assertEqual(result.outcome, "unknown")
+        self.assertFalse(result.proven)
+
+        inspection = adapter.inspect(turn.session_ref, self.context)
+        self.assertEqual(inspection.state, "idle")
+        self.assertEqual(inspection.metadata["model"], "kimi-code/k3")
+        self.assertEqual(inspection.metadata["effort"], "high")
+        self.assertEqual(inspection.metadata["last_prompt"], "later")
+
+        captured = (
+            KIMI_FIXTURES / "interrupted-main-wire.jsonl"
+        ).read_bytes()
+        captured_ref = "session_cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+        captured_session = (
+            runner.sessions_root / "wd_capture" / captured_ref
+        )
+        captured_wire = (
+            captured_session / "agents" / "main" / "wire.jsonl"
+        )
+        captured_wire.parent.mkdir(parents=True)
+        (captured_session / "state.json").write_text(
+            json.dumps({"workDir": str(self.root)}),
+            encoding="utf-8",
+        )
+        captured_wire.write_bytes(captured)
+        marker = (
+            b'{"type":"turn.prompt","input":[{"type":"text","text":'
+            b'"Use the shell tool to run sleep 120'
+        )
+        offset = captured.index(marker)
+        captured_turn = NativeTurn(
+            "kimi",
+            captured_ref,
+            f"kimi-1785365164354-{offset}",
+            self.root,
+            metadata={
+                "wire_path": str(captured_wire),
+                "prompt_time": 1785365164354,
+                "prompt_offset": offset,
+            },
+            opaque=FakeKimiProcess([], exit_before_identity=True),
+        )
+        interrupted = adapter.reconcile(captured_turn, self.context)
+        self.assertEqual(interrupted.outcome, "cancelled")
+        self.assertTrue(interrupted.proven)
+
+    def test_kimi_sigint_and_run_cancel_normalize_to_interrupted(self) -> None:
+        adapter, _runner = self.build("kimi")
+        turn = adapter.start(self.context, "interrupt")
+        self.assertTrue(adapter.interrupt(turn).acknowledged)
+        self.assertEqual(turn.opaque.signals, [signal.SIGINT])
+        events = list(adapter.stream(turn))
+        self.assertEqual(events[-1].type, "run.interrupted")
+        self.assertEqual(adapter.reconcile(turn, self.context).outcome, "cancelled")
+        self.assertFalse(adapter.interrupt(turn).acknowledged)
 
     def test_codex_uses_exact_rpc_methods_and_read_reconciliation(
         self,

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -350,6 +350,74 @@ class ConversationResourceTest(ConversationApiCase):
         self.assertEqual(status, 201, created)
         self.assertEqual(created["route"]["model"], "openai/gpt-connected")
 
+    def test_kimi_create_allows_native_default_model_and_resolves_route(
+        self,
+    ) -> None:
+        with mock.patch.object(
+            conversation_routes.run_mod,
+            "flavor_defaults",
+            return_value={
+                "dev": {
+                    "default_harness": "kimi",
+                    "models": {},
+                }
+            },
+        ):
+            status, _, created = self.request(
+                "POST",
+                "/api/conversations",
+                body={"shell_id": 1, "harness": "kimi"},
+                key="kimi-native-default",
+            )
+        self.assertEqual(status, 201, created)
+        self.assertEqual(
+            created["route"],
+            {
+                "harness": "kimi",
+                "provider": "kimi",
+                "model": None,
+                "effort": "high",
+            },
+        )
+        con = self.connect()
+        try:
+            row = con.execute(
+                "SELECT harness,provider,model,effort FROM conversations "
+                "WHERE conversation_id=?",
+                (created["conversation_id"],),
+            ).fetchone()
+        finally:
+            con.close()
+        self.assertEqual(
+            tuple(row),
+            ("kimi", "kimi", None, "high"),
+        )
+
+    def test_conductor_shell_rejects_kimi_without_creating_a_chat(self) -> None:
+        con = self.connect()
+        try:
+            con.execute("UPDATE shells SET flavor='conductor' WHERE shell_id=1")
+            con.commit()
+        finally:
+            con.close()
+        status, _, error = self.request(
+            "POST",
+            "/api/conversations",
+            body={"shell_id": 1, "harness": "kimi"},
+            key="conductor-kimi",
+        )
+        self.assertEqual(status, 422)
+        self.assertEqual(error["error"]["code"], "HARNESS_ROUTE_INVALID")
+        self.assertIn("opencode", error["error"]["message"].lower())
+        con = self.connect()
+        try:
+            count = con.execute(
+                "SELECT COUNT(*) FROM conversations"
+            ).fetchone()[0]
+        finally:
+            con.close()
+        self.assertEqual(count, 0)
+
     def test_create_is_idempotent_and_never_exposes_native_identity(self) -> None:
         first = self.create(title="API")
         second = self.create(title="API")

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -49,12 +49,18 @@ class FakeAdapter:
         terminal: str = "run.completed",
         reconcile: ReconcileResult | None = None,
         block: bool = False,
+        harness: str = "codex",
+        native_session_ref: str = "native-session",
+        native_run_ref: str | None = None,
     ) -> None:
+        self.harness = harness
         self.terminal = terminal
         self.reconcile_result = reconcile or ReconcileResult(
             "succeeded", True, "fake exact run completed"
         )
         self.block = block
+        self.native_session_ref = native_session_ref
+        self.native_run_ref = native_run_ref
         self.interrupted = threading.Event()
         self.started = 0
         self.resumed = 0
@@ -69,8 +75,8 @@ class FakeAdapter:
         self.started += 1
         return NativeTurn(
             harness=self.harness,
-            session_ref="native-session",
-            run_ref=f"native-run-{self.started}",
+            session_ref=self.native_session_ref,
+            run_ref=self.native_run_ref or f"native-run-{self.started}",
             worktree=context.checked_worktree(),
         )
 
@@ -166,6 +172,7 @@ class ConversationBrokerCase(unittest.TestCase):
         shell_id: int = 1,
         state: str = "queued",
         session_ref: str | None = None,
+        harness: str = "codex",
     ) -> str:
         self.serial += 1
         key = f"conversation-{self.serial}"
@@ -174,9 +181,10 @@ class ConversationBrokerCase(unittest.TestCase):
             "INSERT INTO conversations "
             "(shell_id,owner_user_id,harness,worktree,state,"
             "harness_session_ref,creation_idempotency_key,"
-            "creation_request_hash) VALUES (?,1,'codex',?,?,?,?,?)",
+            "creation_request_hash) VALUES (?,1,?,?,?,?,?,?)",
             (
                 shell_id,
+                harness,
                 str(self.worktree),
                 state,
                 session_ref,
@@ -545,6 +553,64 @@ class ServiceContractTest(ConversationBrokerCase):
             self.fail("post-commit notification did not dispatch the turn")
         self.assertEqual(len(adapters), 1)
         self.assertEqual(adapters[0].started, 1)
+
+    def test_kimi_native_identities_are_persisted_before_first_event(
+        self,
+    ) -> None:
+        session_ref = (
+            "session_11111111-1111-4111-8111-111111111111"
+        )
+        run_ref = "kimi-1785365142363-22866"
+        adapter = FakeAdapter(
+            harness="kimi",
+            native_session_ref=session_ref,
+            native_run_ref=run_ref,
+        )
+        broker = self.start_broker(lambda harness: (
+            adapter if harness == "kimi" else None
+        ))
+        order: list[tuple[str, str, str | None]] = []
+        mark_native_started = broker.store.mark_native_started
+        append_event = broker.store.append_event
+
+        def record_native(run_id, owner, turn):
+            order.append(("native", turn.session_ref, turn.run_ref))
+            return mark_native_started(run_id, owner, turn)
+
+        def record_event(run_id, event):
+            order.append(("event", event.type, None))
+            return append_event(run_id, event)
+
+        broker.store.mark_native_started = record_native
+        broker.store.append_event = record_event
+        conversation_id = self.add_conversation(harness="kimi")
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        deadline = time.monotonic() + 3
+        run_id = None
+        while time.monotonic() < deadline:
+            con = self.connect()
+            row = con.execute(
+                "SELECT run_id,state,harness_session_after,runner_ref "
+                "FROM conversation_runs WHERE trigger_message_id=?",
+                (message_id,),
+            ).fetchone()
+            con.close()
+            if row is not None and row["state"] == "succeeded":
+                run_id = row["run_id"]
+                break
+            time.sleep(0.01)
+        self.assertIsNotNone(run_id)
+        self.assertEqual(
+            order[0],
+            ("native", session_ref, run_ref),
+        )
+        self.assertEqual(order[1][0], "event")
+        self.assertEqual(
+            (row["harness_session_after"], row["runner_ref"]),
+            (session_ref, run_ref),
+        )
 
     def test_interrupt_intent_precedes_terminal_interruption(self) -> None:
         adapter = FakeAdapter(block=True)

--- a/tests/test_conversation_capabilities.py
+++ b/tests/test_conversation_capabilities.py
@@ -11,7 +11,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 ADAPTERS = ROOT / ".super-coder" / "adapters"
 PROBES = ROOT / "tests" / "fixtures" / "conversations" / "capability_probes.json"
-REQUIRED = ("opencode", "claude", "codex")
+REQUIRED = ("opencode", "claude", "codex", "kimi")
 CAPABILITIES = {
     "exact_session_resume",
     "structured_streaming",
@@ -135,11 +135,39 @@ class ConversationCapabilityContractTest(unittest.TestCase):
             ["resume_after_server_restart"]
         )
 
-    def test_kimi_reference_does_not_widen_the_release_gate(self) -> None:
-        kimi = self.probes["reference_only"]["kimi"]
-        self.assertEqual(kimi["exact_worktree_field"], "workDir")
-        self.assertIn("turn.cancel", kimi["observed_events"])
-        self.assertFalse(kimi["release_gate_member"])
+    def test_kimi_uses_prompt_mode_and_native_store_identity(self) -> None:
+        conversation = self.adapter("kimi")["conversation"]
+        probe = self.probes["required_harnesses"]["kimi"]
+        self.assertEqual(conversation["driver"], "kimi-print")
+        self.assertEqual(conversation["session_ref"], {
+            "source": "native-session-store",
+            "field": "session-directory-name",
+        })
+        self.assertEqual(
+            conversation["start"]["identity_source"],
+            "new-main-wire-turn.prompt",
+        )
+        self.assertEqual(
+            conversation["resume"],
+            {
+                "session_flag": "-S",
+                "identity_source": "appended-main-wire-turn.prompt",
+            },
+        )
+        self.assertEqual(
+            conversation["stream"]["transport"],
+            "stdout-jsonl-with-raw-interleave",
+        )
+        self.assertEqual(
+            conversation["permission_policy"],
+            "kimi-prompt-auto-mode",
+        )
+        self.assertFalse(
+            conversation["capabilities"]["interactive_permission_response"]
+        )
+        self.assertFalse(conversation["capabilities"]["server_backed"])
+        self.assertIn("session.resume_hint", probe["observed_events"])
+        self.assertIn("turn.cancel", probe["observed_events"])
 
 
 if __name__ == "__main__":

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -34,7 +34,14 @@ def test_open_chat_restore_matches_the_flat_shell_projection():
 def test_start_chat_has_default_and_configured_paths_without_terminal_controls():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
-    assert 'const CHAT_HARNESSES = ["opencode", "claude", "codex"]' in interface
+    assert (
+        'const CHAT_HARNESSES = ["opencode", "claude", "codex", "kimi"]'
+        in interface
+    )
+    assert (
+        'shell.flavor === "conductor"\n    ? ["opencode"] : CHAT_HARNESSES'
+        in interface
+    )
     assert 'const CHAT_CONFIGURE_ROUTE = "configure"' in interface
     assert 'textContent: "＋ Chat"' in interface
     assert 'textContent: "Configure"' in interface


### PR DESCRIPTION
## Outcome

Adds Kimi Code 0.30.0 as a required browser-chat harness with native-store-backed session and run identity.

- captures the exact native session UUID and prompt-time binary wire offset before start/resume returns and before streaming begins
- normalizes Kimi stdout and native wire events into the shared conversation contract
- slices usage reconciliation by exact session/run identity and blocks reconciliation on identity mismatch
- supports start, resume, interrupt, inspect, permissions, model/effort preparation, and capability discovery
- registers Kimi in the adapter registry and browser UI while keeping Conductor restricted to OpenCode
- adds sanitized new/resume/interrupted wire captures and focused adapter, API, broker, capability, and UI coverage
- makes no broker implementation changes

## Verification

- 1,573 tests passed; 775 subtests passed
- 74 focused conversation/UI tests passed; 8 subtests passed
- Ruff clean for the new adapter
- render-check passed
- real host browser smoke passed against Kimi 0.30.0: initial turn succeeded, second turn cancelled, resumed turn succeeded, refresh preserved the interruption, the native session UUID remained stable, and all three prompt-time run refs were distinct

The Kimi CLI floor remains 0.30.0, so no SC_HARNESS_EPOCH change is required.

## Verification note

The standard linked-worktree verify wrapper currently resolves the shared main checkout instead of the feature worktree; this is tracked in #769. Verification used the branch-local test suite, render-check, direct branch API server, and real browser smoke instead.