### PR TITLE
fix: enable Conductor after update

### DIFF
--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -57,6 +57,43 @@ class ConductorLaunchError(RuntimeError):
     """A role or Conductor process that refused before it could start."""
 
 
+def _operational_config() -> ConductorConfig:
+    return ConductorConfig(True, "CON1", DEFAULT_CONDUCTOR_MODEL)
+
+
+def reconcile_config(path: Path = INSTANCE_CONFIG) -> bool:
+    """Persist the default Conductor block when an instance has none.
+
+    Existing blocks are operator-owned, including an explicit opt-out.  The
+    compatibility fallback in :func:`load_config` covers the first restart
+    after an old updater materializes this code; fresh installs and subsequent
+    updates call this function so the effective default becomes explicit.
+    """
+    path = Path(path)
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise ConductorConfigError(
+            f"cannot enable conductor without instance config at {path}"
+        ) from exc
+    except OSError as exc:
+        raise ConductorConfigError(f"cannot read conductor config: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ConductorConfigError(f"instance.json is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ConductorConfigError("instance.json must contain a JSON object")
+    if "conductor" in raw:
+        return False
+    config = _operational_config()
+    raw["conductor"] = {
+        "enabled": config.enabled,
+        "shell": config.shell,
+        "model": config.model,
+    }
+    path.write_text(json.dumps(raw, indent=2) + "\n")
+    return True
+
+
 # issuer, kind, mechanical action, success condition.  The renderer and runtime
 # tests consume the same rows so the boot table cannot drift from the executor.
 TRANSITIONS = (
@@ -178,7 +215,12 @@ _launching_until = 0.0
 
 
 def load_config(path: Path = INSTANCE_CONFIG) -> ConductorConfig:
-    """Read the top-level ``conductor`` block; absent means disabled."""
+    """Read the top-level ``conductor`` block.
+
+    Installed instances that predate the block use the operational default.
+    Missing instance configuration still fails closed, while an explicit block
+    remains authoritative and can disable automatic wakes.
+    """
     try:
         raw = json.loads(Path(path).read_text())
     except FileNotFoundError:
@@ -187,6 +229,10 @@ def load_config(path: Path = INSTANCE_CONFIG) -> ConductorConfig:
         raise ConductorConfigError(f"cannot read conductor config: {exc}") from exc
     except json.JSONDecodeError as exc:
         raise ConductorConfigError(f"instance.json is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ConductorConfigError("instance.json must contain a JSON object")
+    if "conductor" not in raw:
+        return _operational_config()
     block = raw.get("conductor")
     if not isinstance(block, dict):
         return ConductorConfig()

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -50,6 +50,7 @@ PY = sys.executable
 IS_MAC = platform.system() == "Darwin"  # guidance arms differ (colima/brew vs systemd/apt)
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+import conductor_policy  # noqa: E402
 import engine_manifest  # noqa: E402
 import ports as ports_mod  # noqa: E402
 
@@ -798,6 +799,11 @@ def main(argv: list[str]) -> int:
     cfg = ports_mod.resolve(persist=False)
     cfg["harness"] = harness
     cfg["installed_at"] = date.today().isoformat()
+    cfg["conductor"] = {
+        "enabled": True,
+        "shell": "CON1",
+        "model": conductor_policy.DEFAULT_CONDUCTOR_MODEL,
+    }
     ports_mod.CONFIG.write_text(json.dumps(cfg, indent=2) + "\n")
 
     # 9. Done -----------------------------------------------------------------

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -69,6 +69,7 @@ PY = sys.executable
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import artifact_policy  # noqa: E402
+import conductor_runtime  # noqa: E402
 import db_driver  # noqa: E402
 import engine_manifest  # noqa: E402
 import install as install_mod  # noqa: E402  (ensure_harnesses)
@@ -906,6 +907,12 @@ def main(argv: list[str]) -> int:
     print(f"  {regrant()} grant change(s)")
     print("→ reconcile singleton Conductor")
     print("  created CON1" if reconcile_conductor() else "  CON1 current")
+    print("→ reconcile Conductor config")
+    print(
+        "  enabled CON1 automatic wakes"
+        if conductor_runtime.reconcile_config()
+        else "  Conductor config current"
+    )
     print("→ wire map automation + map the repo")
     run_script("map_setup.py")
     print("→ snapshot the live state")

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -37,6 +37,70 @@ def build_db(path: Path) -> sqlite3.Connection:
     return con
 
 
+class ConductorConfigTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory(prefix="sc_conductor_config_")
+        self.addCleanup(temporary.cleanup)
+        self.path = Path(temporary.name) / "instance.json"
+
+    def test_existing_instance_without_block_uses_operational_default(self):
+        self.path.write_text('{"repo":"legacy-fork","port":8800}\n')
+
+        self.assertEqual(
+            runtime.load_config(self.path),
+            runtime.ConductorConfig(
+                True, "CON1", runtime.DEFAULT_CONDUCTOR_MODEL
+            ),
+        )
+
+    def test_missing_instance_config_still_fails_closed(self):
+        self.assertEqual(
+            runtime.load_config(self.path),
+            runtime.ConductorConfig(),
+        )
+
+    def test_explicit_disabled_block_remains_disabled(self):
+        self.path.write_text(json.dumps({
+            "conductor": {
+                "enabled": False,
+                "shell": "CON2",
+                "model": "openai/custom",
+            }
+        }))
+
+        self.assertEqual(
+            runtime.load_config(self.path),
+            runtime.ConductorConfig(False, "CON2", "openai/custom"),
+        )
+
+    def test_reconcile_config_persists_default_without_clobbering(self):
+        original = {"repo": "legacy-fork", "port": 8800}
+        self.path.write_text(json.dumps(original))
+
+        self.assertTrue(runtime.reconcile_config(self.path))
+        configured = json.loads(self.path.read_text())
+        self.assertEqual(
+            configured["conductor"],
+            {
+                "enabled": True,
+                "shell": "CON1",
+                "model": runtime.DEFAULT_CONDUCTOR_MODEL,
+            },
+        )
+        self.assertEqual(
+            {key: configured[key] for key in original},
+            original,
+        )
+
+        configured["conductor"] = {"enabled": False}
+        self.path.write_text(json.dumps(configured))
+        self.assertFalse(runtime.reconcile_config(self.path))
+        self.assertEqual(
+            json.loads(self.path.read_text())["conductor"],
+            {"enabled": False},
+        )
+
+
 class RuntimeFixture(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.TemporaryDirectory(prefix="sc_conductor8_")

--- a/tests/test_harness_epoch.py
+++ b/tests/test_harness_epoch.py
@@ -176,7 +176,8 @@ class ScFixture:
         shutil.copy2(ROOT / "sc", self.root / "sc")
         # cli_entry.py is not optional in a synthetic fork: every entrypoint
         # imports it from its __main__ block (SIGPIPE hygiene, #384).
-        for script in ("install.py", "engine_manifest.py", "ports.py",
+        for script in ("install.py", "conductor_policy.py",
+                       "engine_manifest.py", "ports.py",
                        "artifact_policy.py", "harness_versions.py",
                        "cli_entry.py"):
             shutil.copy2(ENGINE / "scripts" / script, self.scripts / script)


### PR DESCRIPTION
## Summary
- treat legacy installed instance configs without a `conductor` block as enabled with the shipped CON1/Luna defaults
- persist the explicit operational block on fresh installs and subsequent updates while preserving operator-owned blocks, including explicit disablement
- cover legacy fallback, fail-closed missing config, opt-out preservation, and config reconciliation

## Verification
- `./sc test` — 1,577 passed
- `./sc map`
- `./sc render-check`
- `./sc verify` from an isolated clean clone of the exact commit
- `git diff --check`

## Note
- `./sc lint` remains non-green on the existing repository-wide Ruff baseline; no lint autofixes were applied outside this issue.

Closes #755