### PR TITLE
fix(conversations): reconcile recovered Kimi runs

### DIFF
--- a/.super-coder/scripts/conversation_adapters/kimi.py
+++ b/.super-coder/scripts/conversation_adapters/kimi.py
@@ -621,14 +621,18 @@ class KimiAdapter(ConversationAdapter):
         return []
 
     @staticmethod
-    def _run_coordinates(turn: NativeTurn) -> tuple[int, int]:
-        match = RUN_REF.fullmatch(turn.run_ref)
+    def _parse_run_ref(run_ref: str) -> tuple[int, int]:
+        match = RUN_REF.fullmatch(run_ref)
         if not match:
             raise AdapterError(
                 "HARNESS_SESSION_INSPECTION_FAILED",
-                f"Kimi run ref is malformed: {turn.run_ref}",
+                f"Kimi run ref is malformed: {run_ref}",
             )
-        prompt_time, prompt_offset = (int(value) for value in match.groups())
+        return int(match.group(1)), int(match.group(2))
+
+    @classmethod
+    def _run_coordinates(cls, turn: NativeTurn) -> tuple[int, int]:
+        prompt_time, prompt_offset = cls._parse_run_ref(turn.run_ref)
         if (
             turn.metadata.get("prompt_time") != prompt_time
             or turn.metadata.get("prompt_offset") != prompt_offset
@@ -638,6 +642,43 @@ class KimiAdapter(ConversationAdapter):
                 "Kimi run metadata does not match its persisted run ref",
             )
         return prompt_time, prompt_offset
+
+    def _restore_recovered_run_metadata(
+        self,
+        turn: NativeTurn,
+        context: ConversationContext,
+    ) -> None:
+        if turn.metadata.get("recovered") is not True:
+            return
+        session_ref = self._validate_session_ref(turn.session_ref)
+        prompt_time, prompt_offset = self._parse_run_ref(turn.run_ref)
+        worktree = context.checked_worktree()
+        _env, root = self._environment(context)
+        session_dir = self._matching_session_dir(root, session_ref)
+        if session_dir is None:
+            raise AdapterError(
+                "HARNESS_SESSION_LOST",
+                f"Kimi session does not exist: {session_ref}",
+            )
+        if self._state_worktree(session_dir) != worktree:
+            raise AdapterError(
+                "HARNESS_WORKTREE_MISMATCH",
+                "Kimi session belongs to a different worktree",
+            )
+        restored = {
+            "session_path": str(session_dir),
+            "wire_path": str(self._wire_path(session_dir)),
+            "prompt_time": prompt_time,
+            "prompt_offset": prompt_offset,
+        }
+        for key, value in restored.items():
+            existing = turn.metadata.get(key, value)
+            if existing != value:
+                raise AdapterError(
+                    "HARNESS_SESSION_INSPECTION_FAILED",
+                    f"Kimi recovered {key} conflicts with persisted identity",
+                )
+        turn.metadata.update(restored)
 
     def _run_slice(self, turn: NativeTurn) -> list[Mapping[str, Any]]:
         prompt_time, prompt_offset = self._run_coordinates(turn)
@@ -902,6 +943,7 @@ class KimiAdapter(ConversationAdapter):
                 "Kimi process is still running",
             )
         try:
+            self._restore_recovered_run_metadata(turn, context)
             records = self._run_slice(turn)
         except AdapterError:
             return ReconcileResult(

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -1225,6 +1225,98 @@ class ConversationAdapterTest(unittest.TestCase):
         self.assertFalse(result.proven)
         self.assertTrue(turn.metadata["identity_mismatch"])
 
+    def test_kimi_recovered_turn_rebuilds_exact_usage_slice(self) -> None:
+        adapter, runner = self.build("kimi")
+        session_ref = "session_dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+        session, wire = runner.write_session(
+            runner.sessions_root,
+            session_ref,
+            self.root,
+            "recovered",
+            prompt_time=8000,
+            after_prompt=[
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {"inputOther": 4, "output": 2},
+                },
+                {
+                    "type": "turn.prompt",
+                    "input": [{"type": "text", "text": "later"}],
+                    "time": 8001,
+                },
+                {"type": "turn.cancel", "time": 8002},
+            ],
+            directory="wd_recovered_usage",
+        )
+        recovered = NativeTurn(
+            "kimi",
+            session_ref,
+            "kimi-8000-0",
+            self.root,
+            metadata={"recovered": True},
+        )
+
+        result = adapter.reconcile(recovered, self.context)
+
+        self.assertEqual(result.outcome, "succeeded")
+        self.assertTrue(result.proven)
+        self.assertEqual(recovered.metadata["session_path"], str(session))
+        self.assertEqual(recovered.metadata["wire_path"], str(wire))
+        self.assertEqual(recovered.metadata["prompt_time"], 8000)
+        self.assertEqual(recovered.metadata["prompt_offset"], 0)
+        self.assertNotEqual(
+            result.outcome,
+            "cancelled",
+            "a later turn.cancel must not terminate the recovered run",
+        )
+
+    def test_kimi_recovered_turn_rebuilds_exact_cancel_slice(self) -> None:
+        adapter, runner = self.build("kimi")
+        session_ref = "session_eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+        session, wire = runner.write_session(
+            runner.sessions_root,
+            session_ref,
+            self.root,
+            "interrupted",
+            prompt_time=8100,
+            after_prompt=[
+                {"type": "turn.cancel", "time": 8101},
+                {
+                    "type": "turn.prompt",
+                    "input": [{"type": "text", "text": "later"}],
+                    "time": 8102,
+                },
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {"inputOther": 99},
+                },
+            ],
+            directory="wd_recovered_cancel",
+        )
+        recovered = NativeTurn(
+            "kimi",
+            session_ref,
+            "kimi-8100-0",
+            self.root,
+            metadata={"recovered": True},
+        )
+
+        result = adapter.reconcile(recovered, self.context)
+
+        self.assertEqual(result.outcome, "cancelled")
+        self.assertTrue(result.proven)
+        self.assertEqual(recovered.metadata["session_path"], str(session))
+        self.assertEqual(recovered.metadata["wire_path"], str(wire))
+        self.assertEqual(recovered.metadata["prompt_time"], 8100)
+        self.assertEqual(recovered.metadata["prompt_offset"], 0)
+        self.assertNotEqual(
+            result.outcome,
+            "succeeded",
+            "a later usage record must not complete the recovered run",
+        )
+
     def test_kimi_inspect_and_reconcile_use_only_main_exact_run_slice(
         self,
     ) -> None:

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import sys
 import tempfile
@@ -21,6 +22,7 @@ sys.path.insert(0, str(SCRIPTS))
 from conversation_adapters import (  # noqa: E402
     ConversationContext,
     InterruptResult,
+    KimiAdapter,
     NativeTurn,
     NormalizedEvent,
     ReconcileResult,
@@ -227,8 +229,12 @@ class ConversationBrokerCase(unittest.TestCase):
         session_after: str | None = None,
         runner_ref: str | None = None,
         expired: bool = True,
+        harness: str = "codex",
     ) -> tuple[str, int, int]:
-        conversation_id = self.add_conversation(state="running")
+        conversation_id = self.add_conversation(
+            state="running",
+            harness=harness,
+        )
         message_id = self.add_message(conversation_id, state="running")
         con = self.connect()
         started_at = None if state == "leased" else "2026-07-29 00:00:00"
@@ -681,6 +687,75 @@ class ServiceContractTest(ConversationBrokerCase):
         self.assertEqual(adapter.resumed, 0)
         self.assertEqual(adapter.reconciled, 1)
         self.assertTrue(broker.wait_idle())
+
+    def test_kimi_running_crash_rebuilds_exact_run_slice(self) -> None:
+        sessions_root = self.root / "kimi-sessions"
+        session_ref = "session_dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+        session_dir = sessions_root / "wd_recovered" / session_ref
+        wire = session_dir / "agents" / "main" / "wire.jsonl"
+        wire.parent.mkdir(parents=True)
+        (session_dir / "state.json").write_text(
+            json.dumps({"workDir": str(self.worktree)}),
+            encoding="utf-8",
+        )
+        with wire.open("w", encoding="utf-8") as stream:
+            stream.write(
+                json.dumps(
+                    {
+                        "type": "turn.prompt",
+                        "input": [{"type": "text", "text": "hello"}],
+                        "time": 8200,
+                    }
+                )
+                + "\n"
+            )
+            stream.write(
+                json.dumps(
+                    {
+                        "type": "usage.record",
+                        "usageScope": "turn",
+                        "usage": {"inputOther": 4, "output": 2},
+                    }
+                )
+                + "\n"
+            )
+        _conversation, _message, run_id = self.add_live_run(
+            state="running",
+            session_after=session_ref,
+            runner_ref="kimi-8200-0",
+            harness="kimi",
+        )
+        adapter = KimiAdapter(sessions_root=sessions_root)
+
+        broker = self.start_broker(
+            lambda harness: adapter if harness == "kimi" else None
+        )
+
+        self.wait_run_state(run_id, "succeeded")
+        self.assertTrue(broker.wait_idle())
+        con = self.connect()
+        run = con.execute(
+            "SELECT state,error_code,error_detail FROM conversation_runs "
+            "WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        events = con.execute(
+            "SELECT event_type,payload FROM conversation_events "
+            "WHERE run_id=? ORDER BY sequence",
+            (run_id,),
+        ).fetchall()
+        con.close()
+        self.assertEqual(tuple(run), ("succeeded", None, None))
+        self.assertEqual([row["event_type"] for row in events], ["run.completed"])
+        self.assertEqual(
+            json.loads(events[0]["payload"]),
+            {
+                "detail": "Kimi exact run slice contains turn-scoped usage",
+                "outcome": "succeeded",
+                "proven": True,
+                "reconciled": True,
+            },
+        )
 
     def test_leased_crash_is_safe_to_start_once(self) -> None:
         _conversation, _message, run_id = self.add_live_run(state="leased")

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -37,6 +37,7 @@ class SupervisionFixture:
         # imports it from its __main__ block (SIGPIPE hygiene, #384).
         for script in (
             "artifact_policy.py",
+            "conductor_policy.py",
             "db_backup.py",
             "cli_entry.py",
             "engine_manifest.py",


### PR DESCRIPTION
## Summary

- reconstruct Kimi session-store metadata from persisted `session_ref` and `run_ref` when the broker rebuilds a `NativeTurn` after restart
- validate the unique native session and exact worktree before reading the main-agent wire
- preserve exact prompt time/byte-offset slicing and fail closed on conflicting recovered metadata
- cover recovered usage, recovered cancellation, later-turn exclusion, and the real broker startup-recovery path
- fix #781 by including `conductor_policy.py` in the restricted restart fixture after #780 introduced that dependency

## Trade-off

Keep the broker/schema contract unchanged. Kimi's persisted `run_ref` already carries the prompt time and byte offset, while `session_ref` plus the conversation context uniquely locates and validates the wire; persisting adapter-private paths would widen the shared broker contract unnecessarily.

## Verification

- focused remote-failure tests — 2 passed
- supervision + conversation suites — 117 passed
- full local suite — 1,587 passed + 775 subtests
- scoped Ruff E/F checks passed
- render-check and diff-check passed
- remote tests, verify, render-check, and CodeQL — all passed

Resolves review blocker SC-014 from #779 and fixes #781.