### PR TITLE
feat(interface): surface shell state and star chats

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -318,7 +318,7 @@ def _append_event(
 def _conversation_row(con, conversation_id: str, owner_user_id: int):
     return con.execute(
         "SELECT c.conversation_id,c.shell_id,c.mode,c.owner_user_id,c.harness,"
-        "c.provider,c.model,c.effort,c.state,c.title,c.created_at,"
+        "c.provider,c.model,c.effort,c.state,c.title,c.starred,c.created_at,"
         "c.last_activity_at,c.closed_at,c.version,s.display_name,s.shortname "
         "FROM conversations c JOIN shells s ON s.shell_id=c.shell_id "
         "WHERE c.conversation_id=? AND c.mode='normal' AND c.owner_user_id=?",
@@ -343,6 +343,7 @@ def _conversation_projection(row) -> dict:
         },
         "state": row["state"],
         "title": row["title"],
+        "starred": bool(row["starred"]),
         "created_at": row["created_at"],
         "last_activity_at": row["last_activity_at"],
         "closed_at": row["closed_at"],
@@ -677,7 +678,7 @@ def _list_conversations(con, operator: dict, query):
         params.extend((decoded["a"], decoded["a"], decoded["id"]))
     rows = con.execute(
         "SELECT c.conversation_id,c.shell_id,c.mode,c.owner_user_id,c.harness,"
-        "c.provider,c.model,c.effort,c.state,c.title,c.created_at,"
+        "c.provider,c.model,c.effort,c.state,c.title,c.starred,c.created_at,"
         "c.last_activity_at,c.closed_at,c.version,s.display_name,s.shortname "
         "FROM conversations c JOIN shells s ON s.shell_id=c.shell_id WHERE "
         + " AND ".join(clauses)
@@ -701,7 +702,7 @@ def _list_conversations(con, operator: dict, query):
 
 
 def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
-    _only_fields(body, {"version", "title", "state"})
+    _only_fields(body, {"version", "title", "state", "starred"})
     if "version" not in body:
         raise ApiError(
             422, "VALIDATION_ERROR", "version is required for conversation updates"
@@ -709,13 +710,15 @@ def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
     version = _integer(body["version"], "version")
     if version <= 0:
         raise ApiError(422, "VALIDATION_ERROR", "version must be positive")
-    if "title" not in body and "state" not in body:
+    if not {"title", "state", "starred"}.intersection(body):
         raise ApiError(422, "VALIDATION_ERROR", "no conversation change supplied")
     title = (
         _nonblank(body.get("title"), "title", maximum=200, optional=True)
         if "title" in body
         else None
     )
+    if "starred" in body and not isinstance(body["starred"], bool):
+        raise ApiError(422, "VALIDATION_ERROR", "starred must be a boolean")
     if "state" in body and body["state"] != "closed":
         raise ApiError(422, "VALIDATION_ERROR", "state may only be changed to closed")
 
@@ -729,7 +732,7 @@ def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
                 {"expected": int(row["version"]), "received": version},
             )
         closing = body.get("state") == "closed"
-        if row["state"] == "closed":
+        if row["state"] == "closed" and {"title", "state"}.intersection(body):
             raise ApiError(
                 409,
                 "CONVERSATION_CLOSED",
@@ -742,11 +745,16 @@ def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
                 "a queued or running conversation cannot be closed",
                 {"state": row["state"]},
             )
-        sets = ["version=version+1", "last_activity_at=datetime('now')"]
+        sets = ["version=version+1"]
+        if "title" in body or closing:
+            sets.append("last_activity_at=datetime('now')")
         params: list = []
         if "title" in body:
             sets.append("title=?")
             params.append(title)
+        if "starred" in body:
+            sets.append("starred=?")
+            params.append(int(body["starred"]))
         if closing:
             sets.extend(("state='closed'", "closed_at=datetime('now')"))
         changed = con.execute(
@@ -764,14 +772,15 @@ def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
             con,
             conversation_id,
             (
-                "conversation.updated"
-                if "title" in body and closing
-                else "conversation.closed"
-                if closing
+                "conversation.closed"
+                if closing and set(body) == {"version", "state"}
                 else "conversation.renamed"
+                if set(body) == {"version", "title"}
+                else "conversation.updated"
             ),
             {
                 **({"title": title} if "title" in body else {}),
+                **({"starred": body["starred"]} if "starred" in body else {}),
                 **({"state": "closed"} if closing else {}),
             },
         )

--- a/.super-coder/migrations/0134_conversation_stars.sql
+++ b/.super-coder/migrations/0134_conversation_stars.sql
@@ -1,0 +1,6 @@
+-- Conversation stars are durable operator metadata. Existing conversations
+-- remain unstarred, and the boolean check keeps direct SQL writers honest.
+
+ALTER TABLE conversations
+    ADD COLUMN starred INTEGER NOT NULL DEFAULT 0
+    CHECK (starred IN (0, 1));

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3080,6 +3080,13 @@ function chatHeaderLabel(conversation) {
   ].filter(Boolean).join(" | ");
 }
 
+function chatWorkingDots() {
+  return el("span", { className: "chat-working-dots", ariaHidden: "true" },
+    el("span", {}, "."),
+    el("span", {}, "."),
+    el("span", {}, "."));
+}
+
 function chatStatePill(state) {
   const label = {
     queued: "queued", running: "working", waiting: "waiting",
@@ -3092,14 +3099,29 @@ function chatStatePill(state) {
     pill.textContent = label;
     return pill;
   }
-  pill.append(
-    label,
-    el("span", { className: "chat-working-dots", ariaHidden: "true" },
-      el("span", {}, "."),
-      el("span", {}, "."),
-      el("span", {}, ".")),
-  );
+  pill.append(label, chatWorkingDots());
   return pill;
+}
+
+function chatWorkingIndicator() {
+  const indicator = el("div", {
+    className: "chat-working-indicator",
+    role: "status",
+    ariaLabel: "Working",
+  });
+  indicator.append("<Working>", chatWorkingDots());
+  return indicator;
+}
+
+const CHAT_SHELL_STATE_CLASSES = [
+  "active-chat", "state-idle", "state-queued", "state-running",
+  "state-waiting", "state-error",
+];
+
+function chatPaintShellState(button, state) {
+  button.classList.remove(...CHAT_SHELL_STATE_CLASSES);
+  if (!["idle", "queued", "running", "waiting", "error"].includes(state)) return;
+  button.classList.add("active-chat", `state-${state}`);
 }
 
 function chatQueuedCount(messages) {
@@ -3228,6 +3250,12 @@ function chatPaintTranscript(
     });
   for (const activity of activities) {
     if (activity.message_id == null) addActivity(activity);
+  }
+  if (conversation.state === "running") {
+    items.push({
+      node: chatWorkingIndicator(),
+      failed: false,
+    });
   }
   for (const item of items) {
     if (item.failed) {
@@ -3405,7 +3433,6 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
 
   const header = el("div", { className: "chat-pane-head" });
   const title = el("div", { className: "chat-pane-title" });
-  const state = el("div", { className: "chat-pane-state" });
   const queueState = el("span", { className: "chat-queue-state", hidden: true });
   const actions = el("div", { className: "chat-actions" });
   const transcriptHost = el("div", { className: "chat-transcript-host" });
@@ -3446,21 +3473,16 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   const composerRow = el("div", { className: "chat-composer" },
     composer, el("div", { className: "chat-compose-actions" }, pending, send, stop));
   const updateStreamStatus = () => {
-    const pill = state.querySelector(".chat-state");
-    if (!pill) return;
     const connected = streamStatus === "connected";
     const connectionLabel = connected
       ? "Connected"
       : streamStatus === "reconnecting" ? "Reconnecting" : "Connecting";
-    pill.title = `Connection: ${connectionLabel}`;
-    pill.setAttribute(
+    transcriptHost.title = `Connection: ${connectionLabel}`;
+    transcriptHost.setAttribute(
       "aria-label",
-      `${pill.textContent}; connection ${connectionLabel.toLowerCase()}`,
+      `Conversation transcript; connection ${connectionLabel.toLowerCase()}`,
     );
-    pill.classList.toggle(
-      "stream-disconnected",
-      conversation.state === "idle" && !connected,
-    );
+    transcriptHost.classList.toggle("stream-disconnected", !connected);
   };
 
   const retry = async (text) => {
@@ -3494,7 +3516,6 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     const queued = chatQueuedCount(messages);
     queueState.hidden = queued === 0;
     queueState.textContent = `${queued} queued`;
-    state.replaceChildren(chatStatePill(conversation.state), queueState);
     updateStreamStatus();
     const closed = conversation.state === "closed";
     composer.disabled = closed;
@@ -3542,7 +3563,7 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     } catch (error) { toast(`${error.code}: ${error.message}`); refresh(); }
   };
   actions.append(analytics, close);
-  header.append(title, state, actions);
+  header.append(title, queueState, actions);
 
   async function submit() {
     const text = composer.value.trim();
@@ -3670,6 +3691,7 @@ async function renderInterface(root) {
   ];
   const orderedShells = orderedFlavors.flatMap((flavor) =>
     shells.filter((item) => (item.flavor || "bespoke") === flavor));
+  const shellItems = new Map();
   let previousFlavor = "";
   for (const item of orderedShells) {
     const flavor = item.flavor || "bespoke";
@@ -3681,12 +3703,13 @@ async function renderInterface(root) {
         && conversation.state !== "closed");
     const button = el("button", {
       className: "chat-shell"
-        + (item.shell_id === shell.shell_id ? " selected" : "")
-        + (active ? " active-chat" : ""),
+        + (item.shell_id === shell.shell_id ? " selected" : ""),
       type: "button",
     },
     el("span", { className: "chat-shell-name" }, item.display_name),
     el("span", { className: "chat-shell-shortname" }, item.shortname || ""));
+    chatPaintShellState(button, active?.state);
+    shellItems.set(item.shell_id, button);
     button.onclick = () => {
       if (item.shell_id === shell.shell_id) return;
       location.hash = chatHash(item.shortname);
@@ -3765,7 +3788,10 @@ async function renderInterface(root) {
     try {
       const page = await chatApi("/conversations?limit=100");
       if (generation !== chatRenderGeneration || !chatHistoryPollTimer) return;
+      const openByShell = new Map();
       for (const conversation of page.items) {
+        if (conversation.state !== "closed")
+          openByShell.set(conversation.shell.shell_id, conversation.state || "idle");
         if (conversation.shell.shell_id !== shell.shell_id) continue;
         const button = historyItems.get(conversation.conversation_id);
         const pill = button?.querySelector(".chat-state");
@@ -3773,6 +3799,8 @@ async function renderInterface(root) {
         if (!pill || pill.classList.contains(`state-${nextState}`)) continue;
         pill.replaceWith(chatStatePill(nextState));
       }
+      for (const [shellId, button] of shellItems)
+        chatPaintShellState(button, openByShell.get(shellId));
     } catch { /* The next poll retries without disrupting the open chat. */ }
     finally { historyPollInFlight = false; }
   };

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3124,6 +3124,28 @@ function chatPaintShellState(button, state) {
   button.classList.add("active-chat", `state-${state}`);
 }
 
+function chatPaintStar(button, starred) {
+  button.textContent = starred ? "★" : "☆";
+  button.classList.toggle("starred", starred);
+  button.title = starred ? "Unstar chat" : "Star chat";
+  button.setAttribute("aria-label", button.title);
+  button.setAttribute("aria-pressed", String(starred));
+}
+
+function chatPaintHistoryItem(item, conversation) {
+  item.conversation = conversation;
+  item.context.textContent =
+    `${chatStartedLabel(conversation)} | ${chatModelLabel(conversation)}`;
+  item.name.textContent = chatConversationName(conversation);
+  const nextState = conversation.state || "idle";
+  if (!item.state.classList.contains(`state-${nextState}`)) {
+    const state = chatStatePill(nextState);
+    item.state.replaceWith(state);
+    item.state = state;
+  }
+  chatPaintStar(item.star, Boolean(conversation.starred));
+}
+
 function chatQueuedCount(messages) {
   return messages.filter(
     (message) => message.message_kind !== "control"
@@ -3635,7 +3657,8 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
       paint();
       if (["message.accepted", "run.completed", "run.failed",
            "run.interrupted", "run.unknown",
-           "conversation.renamed", "conversation.closed"].includes(event.event_type))
+           "conversation.updated", "conversation.renamed",
+           "conversation.closed"].includes(event.event_type))
         refresh();
     },
     (value) => {
@@ -3678,7 +3701,7 @@ async function renderInterface(root) {
       || "";
   if (selectedId && !conversations.some((item) => item.conversation_id === selectedId))
     selectedId = "";
-  const selectedConversation = allConversations.items.find(
+  let selectedConversation = allConversations.items.find(
     (item) => item.conversation_id === selectedId);
 
   const layout = el("div", { className: "chat-layout" });
@@ -3760,23 +3783,51 @@ async function renderInterface(root) {
   const history = el("div", { className: "chat-history-list" });
   const historyItems = new Map();
   for (const conversation of conversations) {
-    const button = el("button", {
+    const card = el("div", {
       className: "chat-history-item"
         + (conversation.conversation_id === selectedId ? " selected" : ""),
+    });
+    const open = el("button", {
+      className: "chat-history-open",
       type: "button",
     });
-    button.append(el("span", { className: "chat-history-context" },
-      `${chatStartedLabel(conversation)} | ${chatModelLabel(conversation)}`),
-      el("span", { className: "chat-history-name" },
-      chatConversationName(conversation)),
-      chatStatePill(conversation.state));
-    historyItems.set(conversation.conversation_id, button);
-    button.onclick = async () => {
+    const context = el("span", { className: "chat-history-context" });
+    const name = el("span", { className: "chat-history-name" });
+    const state = chatStatePill(conversation.state);
+    const star = el("button", {
+      className: "chat-history-star",
+      type: "button",
+    });
+    const item = { card, open, context, name, state, star, conversation };
+    open.append(context, name, state);
+    card.append(open, star);
+    chatPaintHistoryItem(item, conversation);
+    historyItems.set(conversation.conversation_id, item);
+    open.onclick = async () => {
       if (conversation.conversation_id === selectedId) return;
       if (await chatCloseForSwitch(selectedConversation))
         location.hash = chatHash(shell.shortname, conversation.conversation_id);
     };
-    history.append(button);
+    star.onclick = async (event) => {
+      event.stopPropagation();
+      star.disabled = true;
+      try {
+        const current = item.conversation;
+        const updated = await chatApi(
+          `/conversations/${current.conversation_id}`,
+          "PATCH",
+          { version: current.version, starred: !current.starred },
+        );
+        chatPaintHistoryItem(item, updated);
+        if (updated.conversation_id === selectedConversation?.conversation_id)
+          selectedConversation = updated;
+      } catch (error) {
+        toast(`${error.code}: ${error.message}`);
+      } finally {
+        star.disabled = false;
+      }
+    };
+    history.append(card);
   }
   if (!conversations.length)
     history.append(el("div", { className: "chat-history-empty" }, "No chats yet."));
@@ -3793,11 +3844,10 @@ async function renderInterface(root) {
         if (conversation.state !== "closed")
           openByShell.set(conversation.shell.shell_id, conversation.state || "idle");
         if (conversation.shell.shell_id !== shell.shell_id) continue;
-        const button = historyItems.get(conversation.conversation_id);
-        const pill = button?.querySelector(".chat-state");
-        const nextState = conversation.state || "idle";
-        if (!pill || pill.classList.contains(`state-${nextState}`)) continue;
-        pill.replaceWith(chatStatePill(nextState));
+        const item = historyItems.get(conversation.conversation_id);
+        if (item) chatPaintHistoryItem(item, conversation);
+        if (conversation.conversation_id === selectedConversation?.conversation_id)
+          selectedConversation = conversation;
       }
       for (const [shellId, button] of shellItems)
         chatPaintShellState(button, openByShell.get(shellId));

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -108,8 +108,13 @@ body.interface-view main {
 .chat-shell.selected { color: var(--ink); border-color: var(--line); background: var(--panel); }
 .chat-shell.active-chat::before {
   content: ""; position: absolute; left: 0; top: .3rem; bottom: .3rem; width: 3px;
-  border-radius: 99px; background: var(--ok);
+  border-radius: 99px; background: var(--shell-state-color, var(--ok));
 }
+.chat-shell.state-idle { --shell-state-color: var(--ok); }
+.chat-shell.state-queued,
+.chat-shell.state-running,
+.chat-shell.state-waiting { --shell-state-color: var(--accent); }
+.chat-shell.state-error { --shell-state-color: #ef7d86; }
 .chat-shell-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
 .chat-shell-shortname {
   color: rgba(255,255,255,.46); font: .68rem ui-monospace, monospace;
@@ -155,7 +160,7 @@ body.interface-view main {
   color: var(--dim); font-size: .64rem; text-transform: uppercase; letter-spacing: .06em;
 }
 .chat-state.state-running, .chat-state.state-queued { color: var(--accent); border-color: rgba(110,168,254,.45); }
-.chat-working-dots { display: inline-flex; margin-left: .12rem; }
+.chat-working-dots { display: inline-flex; gap: .08rem; margin-left: .12rem; }
 .chat-working-dots span {
   display: inline-block;
   animation: chat-working-dot 1.2s ease-in-out infinite;
@@ -173,9 +178,6 @@ body.interface-view main {
 .chat-state.state-waiting { color: var(--warn); border-color: rgba(212,145,74,.45); }
 .chat-state.state-error { color: #ef7d86; border-color: rgba(239,125,134,.45); }
 .chat-state.state-idle { color: var(--ok); border-color: rgba(76,175,125,.4); }
-.chat-state.state-idle.stream-disconnected {
-  color: var(--warn); border-color: rgba(212,145,74,.45);
-}
 .chat-state.state-closed { opacity: .6; }
 .chat-pane {
   min-width: 0; min-height: 0; display: grid;
@@ -198,7 +200,6 @@ body.interface-view main {
   font: inherit; padding: 0;
 }
 .chat-title-button:hover { color: var(--accent); text-decoration: underline; }
-.chat-pane-state { display: flex; align-items: center; gap: .5rem; }
 .chat-queue-state { color: var(--accent); font-size: .68rem; white-space: nowrap; }
 .chat-actions { display: flex; align-items: center; gap: .35rem; }
 .chat-actions .act { margin: 0; padding: .3rem .65rem; font-size: .72rem; }
@@ -227,6 +228,10 @@ body.interface-view main {
 .chat-bubble.chat-activity {
   align-self: flex-start; background: transparent; border-style: dashed;
   color: var(--dim); font-size: .78rem; padding: .4rem .65rem;
+}
+.chat-working-indicator {
+  align-self: flex-start; display: inline-flex; align-items: baseline;
+  margin-left: .8rem; color: var(--accent); font-size: .78rem;
 }
 .chat-who {
   color: var(--dim); font-size: calc(.62rem + 1px); text-transform: uppercase;

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -142,17 +142,35 @@ body.interface-view main {
 .chat-shortname { color: var(--dim); font: .76rem ui-monospace, monospace; }
 .chat-history-list { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: .5rem; }
 .chat-history-item {
-  width: 100%; background: transparent; color: var(--dim); border: 1px solid transparent;
-  border-radius: 9px; padding: .6rem; cursor: pointer; text-align: left;
+  position: relative; width: 100%; background: transparent;
+  border: 1px solid transparent; border-radius: 9px;
+}
+.chat-history-open {
+  width: 100%; background: transparent; color: var(--dim); border: 0;
+  border-radius: inherit; padding: .6rem; cursor: pointer; text-align: left;
   display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: .12rem .4rem;
 }
-.chat-history-item:hover { background: var(--accent2); color: var(--ink); }
-.chat-history-item.selected { background: var(--panel2); border-color: var(--line); color: var(--ink); }
+.chat-history-item:hover { background: var(--accent2); }
+.chat-history-item:hover .chat-history-open { color: var(--ink); }
+.chat-history-item.selected { background: var(--panel2); border-color: var(--line); }
+.chat-history-item.selected .chat-history-open { color: var(--ink); }
 .chat-history-name, .chat-history-context {
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.chat-history-context { grid-column: 1 / -1; font-size: .68rem; color: var(--dim); }
+.chat-history-context {
+  grid-column: 1 / -1; padding-right: 1.3rem; font-size: .68rem; color: var(--dim);
+}
 .chat-history-name { font-size: .84rem; }
+.chat-history-star {
+  position: absolute; z-index: 1; top: .42rem; right: .48rem;
+  width: 1.25rem; height: 1.25rem; display: grid; place-items: center;
+  background: transparent; border: 0; color: var(--dim); padding: 0;
+  cursor: pointer; font: 1rem/1 ui-sans-serif, sans-serif; opacity: .72;
+}
+.chat-history-star:hover, .chat-history-star.starred {
+  color: #f4cf4a; opacity: 1;
+}
+.chat-history-star:disabled { cursor: default; opacity: .4; }
 .chat-history-empty { color: var(--dim); padding: 1rem .65rem; font-size: .8rem; }
 .chat-state {
   display: inline-flex; align-items: center; width: fit-content; flex: none;

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -8,6 +8,7 @@ import sqlite3
 import sys
 import tempfile
 import unittest
+from contextlib import closing
 from pathlib import Path
 from unittest import mock
 
@@ -634,6 +635,92 @@ class ConversationResourceTest(ConversationApiCase):
         )
         self.assertEqual(status, 409)
         self.assertEqual(conflict["error"]["code"], "CONVERSATION_VERSION_CONFLICT")
+
+    def test_star_round_trip_is_durable_versioned_and_preserves_activity(self) -> None:
+        created = self.create(title="Keep my place")
+        self.assertFalse(created["starred"])
+        conversation_id = created["conversation_id"]
+        original_version = created["version"]
+        original_activity = created["last_activity_at"]
+
+        status, _, starred = self.request(
+            "PATCH",
+            f"/api/conversations/{conversation_id}",
+            body={"version": original_version, "starred": True},
+        )
+
+        self.assertEqual(status, 200, starred)
+        self.assertTrue(starred["starred"])
+        self.assertEqual(starred["version"], original_version + 1)
+        self.assertEqual(starred["title"], "Keep my place")
+        self.assertEqual(starred["state"], "idle")
+        self.assertEqual(starred["last_activity_at"], original_activity)
+        with closing(self.connect()) as con:
+            row = con.execute(
+                "SELECT starred,title,state,last_activity_at,version "
+                "FROM conversations WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()
+            self.assertEqual(
+                tuple(row),
+                (1, "Keep my place", "idle", original_activity, original_version + 1),
+            )
+
+        conflict_status, _, conflict = self.request(
+            "PATCH",
+            f"/api/conversations/{conversation_id}",
+            body={"version": original_version, "starred": False},
+        )
+        self.assertEqual(conflict_status, 409, conflict)
+        self.assertEqual(
+            conflict["error"]["code"],
+            "CONVERSATION_VERSION_CONFLICT",
+        )
+        with closing(self.connect()) as con:
+            self.assertEqual(
+                con.execute(
+                    "SELECT starred FROM conversations WHERE conversation_id=?",
+                    (conversation_id,),
+                ).fetchone()[0],
+                1,
+            )
+
+    def test_star_requires_boolean_and_closed_history_remains_starrable(self) -> None:
+        created = self.create()
+        conversation_id = created["conversation_id"]
+
+        status, _, invalid = self.request(
+            "PATCH",
+            f"/api/conversations/{conversation_id}",
+            body={"version": created["version"], "starred": 1},
+        )
+        self.assertEqual(status, 422, invalid)
+        self.assertEqual(invalid["error"]["code"], "VALIDATION_ERROR")
+        with closing(self.connect()) as con:
+            self.assertEqual(
+                tuple(con.execute(
+                    "SELECT starred,version FROM conversations "
+                    "WHERE conversation_id=?",
+                    (conversation_id,),
+                ).fetchone()),
+                (0, created["version"]),
+            )
+
+        close_status, _, closed = self.request(
+            "PATCH",
+            f"/api/conversations/{conversation_id}",
+            body={"version": created["version"], "state": "closed"},
+        )
+        self.assertEqual(close_status, 200, closed)
+        star_status, _, starred = self.request(
+            "PATCH",
+            f"/api/conversations/{conversation_id}",
+            body={"version": closed["version"], "starred": True},
+        )
+        self.assertEqual(star_status, 200, starred)
+        self.assertEqual(starred["state"], "closed")
+        self.assertTrue(starred["starred"])
+        self.assertEqual(starred["version"], closed["version"] + 1)
 
     def test_closed_conversation_rejects_messages(self) -> None:
         conversation = self.create()

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -7,6 +7,7 @@ import sqlite3
 import sys
 import tempfile
 import unittest
+from contextlib import closing
 from pathlib import Path
 
 
@@ -215,6 +216,57 @@ class MigrationAndShapeTest(ConversationDbCase):
             "conversation_outbox",
         }.issubset(tables))
         con.close()
+
+    def test_star_migration_defaults_legacy_rows_and_enforces_boolean_values(self) -> None:
+        with closing(sqlite3.connect(":memory:")) as con:
+            apply_schema(
+                con,
+                through="0133_one_open_normal_conversation_per_shell.sql",
+            )
+            con.execute(
+                "INSERT INTO users (user_id,username) VALUES (9,'legacy')"
+            )
+            con.execute(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (9,'Legacy','legacy','dev','prompt',9)"
+            )
+            con.execute(
+                "INSERT INTO conversations "
+                "(shell_id,mode,owner_user_id,harness,worktree,"
+                "creation_idempotency_key,creation_request_hash) "
+                "VALUES (9,'normal',9,'codex','/tmp/legacy','legacy','hash')"
+            )
+
+            con.executescript(
+                (
+                    MIGRATIONS / "0134_conversation_stars.sql"
+                ).read_text()
+            )
+
+            self.assertEqual(
+                con.execute(
+                    "SELECT starred FROM conversations "
+                    "WHERE creation_idempotency_key='legacy'"
+                ).fetchone()[0],
+                0,
+            )
+            con.execute(
+                "UPDATE conversations SET starred=1 "
+                "WHERE creation_idempotency_key='legacy'"
+            )
+            self.assertEqual(
+                con.execute(
+                    "SELECT starred FROM conversations "
+                    "WHERE creation_idempotency_key='legacy'"
+                ).fetchone()[0],
+                1,
+            )
+            with self.assertRaises(sqlite3.IntegrityError):
+                con.execute(
+                    "UPDATE conversations SET starred=2 "
+                    "WHERE creation_idempotency_key='legacy'"
+                )
 
     def test_normal_and_reserved_sprint_ownership_shapes(self) -> None:
         normal = self.add_conversation()

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -208,19 +208,22 @@ def test_shell_rail_hides_labels_but_retains_ordered_flavor_dividers():
     assert ".chat-shell-divider" in STYLE
 
 
-def test_history_badges_and_all_shell_accents_poll_without_repainting_the_interface():
+def test_history_metadata_and_all_shell_accents_poll_without_repainting_interface():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
     assert "const CHAT_HISTORY_POLL_MS = 2000" in interface
     assert "if (chatHistoryPollTimer) clearInterval(chatHistoryPollTimer)" in interface
     assert "const historyItems = new Map()" in interface
     assert "const shellItems = new Map()" in interface
-    assert "historyItems.set(conversation.conversation_id, button)" in interface
+    assert "historyItems.set(conversation.conversation_id, item)" in interface
     assert "shellItems.set(item.shell_id, button)" in interface
     assert 'await chatApi("/conversations?limit=100")' in interface
     assert "generation !== chatRenderGeneration || !chatHistoryPollTimer" in interface
     assert "historyItems.get(conversation.conversation_id)" in interface
-    assert "pill.replaceWith(chatStatePill(nextState))" in interface
+    assert "chatPaintHistoryItem(item, conversation)" in interface
+    assert "item.name.textContent = chatConversationName(conversation)" in interface
+    assert "chatPaintStar(item.star, Boolean(conversation.starred))" in interface
+    assert "selectedConversation = conversation" in interface
     assert "const openByShell = new Map()" in interface
     assert 'if (conversation.state !== "closed")' in interface
     assert "openByShell.set(conversation.shell.shell_id" in interface
@@ -232,6 +235,26 @@ def test_history_badges_and_all_shell_accents_poll_without_repainting_the_interf
     poll = interface[interface.index("const pollHistory = async"):
                      interface.index("chatHistoryPollTimer = setInterval")]
     assert "renderInterface(" not in poll
+
+
+def test_history_card_has_independent_durable_star_button():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    history = interface[interface.index('const history = el("div"'):
+                        interface.index("if (!conversations.length)")]
+
+    assert 'const card = el("div", {' in history
+    assert 'className: "chat-history-open"' in history
+    assert 'className: "chat-history-star"' in history
+    assert "open.append(context, name, state)" in history
+    assert "card.append(open, star)" in history
+    assert "event.stopPropagation()" in history
+    assert '{ version: current.version, starred: !current.starred }' in history
+    assert "chatPaintHistoryItem(item, updated)" in history
+    assert 'button.textContent = starred ? "★" : "☆"' in interface
+    assert 'button.setAttribute("aria-pressed", String(starred))' in interface
+    assert ".chat-history-star:hover, .chat-history-star.starred" in STYLE
+    assert "color: #f4cf4a; opacity: 1;" in STYLE
 
 
 def test_working_state_is_plain_animated_transcript_text_not_a_header_pill():
@@ -303,6 +326,8 @@ def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
         ".chat-title-button",
         ".chat-shell.active-chat::before",
         ".chat-working-indicator",
+        ".chat-history-open",
+        ".chat-history-star",
     ):
         assert selector in STYLE
     assert "grid-template-columns: 260px 260px minmax(0, 1fr)" in STYLE

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -76,17 +76,20 @@ def test_transcript_streams_normalized_events_and_reconnects_natively():
     assert "mdBlock(body)" in interface
 
 
-def test_connection_status_is_encoded_in_the_idle_pill_without_visible_copy():
+def test_connection_status_is_attached_to_transcript_without_visible_copy():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
     assert 'let streamStatus = "connecting"' in interface
     assert 'source.onopen = () => onState("connected")' in interface
     assert 'source.onerror = () => onState("reconnecting")' in interface
-    assert "pill.title = `Connection: ${connectionLabel}`" in interface
+    assert "transcriptHost.title = `Connection: ${connectionLabel}`" in interface
+    assert "`Conversation transcript; connection ${connectionLabel.toLowerCase()}`" in interface
     assert '"stream-disconnected"' in interface
+    assert 'const state = el("div", { className: "chat-pane-state" })' not in interface
+    assert "state.replaceChildren(chatStatePill" not in interface
     assert 'className: "chat-stream-state"' not in interface
     assert ".chat-stream-state" not in STYLE
-    assert ".chat-state.state-idle.stream-disconnected" in STYLE
+    assert ".chat-state.state-idle.stream-disconnected" not in STYLE
 
 
 def test_transcript_hides_routine_tools_but_keeps_actionable_activity():
@@ -171,7 +174,7 @@ def test_conversation_identity_uses_shell_context_and_neutral_user_label():
     assert '"Untitled chat"' in interface
     assert 'className: "chat-history-context"' in interface
     assert 'className: "chat-shell-shortname"' in interface
-    assert '(active ? " active-chat" : "")' in interface
+    assert "chatPaintShellState(button, active?.state)" in interface
 
 
 def test_interface_owns_scroll_with_fixed_history_and_conversation_controls():
@@ -205,23 +208,65 @@ def test_shell_rail_hides_labels_but_retains_ordered_flavor_dividers():
     assert ".chat-shell-divider" in STYLE
 
 
-def test_history_badges_poll_without_repainting_the_interface():
+def test_history_badges_and_all_shell_accents_poll_without_repainting_the_interface():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
     assert "const CHAT_HISTORY_POLL_MS = 2000" in interface
     assert "if (chatHistoryPollTimer) clearInterval(chatHistoryPollTimer)" in interface
     assert "const historyItems = new Map()" in interface
+    assert "const shellItems = new Map()" in interface
     assert "historyItems.set(conversation.conversation_id, button)" in interface
+    assert "shellItems.set(item.shell_id, button)" in interface
     assert 'await chatApi("/conversations?limit=100")' in interface
     assert "generation !== chatRenderGeneration || !chatHistoryPollTimer" in interface
     assert "historyItems.get(conversation.conversation_id)" in interface
     assert "pill.replaceWith(chatStatePill(nextState))" in interface
+    assert "const openByShell = new Map()" in interface
+    assert 'if (conversation.state !== "closed")' in interface
+    assert "openByShell.set(conversation.shell.shell_id" in interface
+    assert "for (const [shellId, button] of shellItems)" in interface
+    assert "chatPaintShellState(button, openByShell.get(shellId))" in interface
     assert "if (document.hidden || historyPollInFlight) return" in interface
     assert "finally { historyPollInFlight = false; }" in interface
     assert "setInterval(pollHistory, CHAT_HISTORY_POLL_MS)" in interface
     poll = interface[interface.index("const pollHistory = async"):
                      interface.index("chatHistoryPollTimer = setInterval")]
     assert "renderInterface(" not in poll
+
+
+def test_working_state_is_plain_animated_transcript_text_not_a_header_pill():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    transcript = interface[interface.index("function chatPaintTranscript"):
+                           interface.index("async function chatRefreshConversation")]
+    header = interface[interface.index("async function chatRenderOpen"):
+                       interface.index("async function submit()")]
+    indicator_style = STYLE[STYLE.index(".chat-working-indicator {"):
+                            STYLE.index("}", STYLE.index(".chat-working-indicator {"))]
+
+    assert 'indicator.append("<Working>", chatWorkingDots())' in interface
+    assert 'className: "chat-working-indicator"' in interface
+    assert 'role: "status"' in interface
+    assert 'if (conversation.state === "running")' in transcript
+    assert "node: chatWorkingIndicator()" in transcript
+    assert "chatStatePill(conversation.state)" not in transcript
+    assert "header.append(title, queueState, actions)" in header
+    assert "chatStatePill(conversation.state)" not in header
+    assert "border" not in indicator_style
+    assert "background" not in indicator_style
+
+
+def test_shell_accent_colors_cover_idle_working_waiting_and_error_states():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    assert '"state-idle", "state-queued", "state-running"' in interface
+    assert '"state-waiting", "state-error"' in interface
+    assert 'button.classList.add("active-chat", `state-${state}`)' in interface
+    assert ".chat-shell.state-idle { --shell-state-color: var(--ok); }" in STYLE
+    assert ".chat-shell.state-queued," in STYLE
+    assert ".chat-shell.state-running," in STYLE
+    assert ".chat-shell.state-waiting { --shell-state-color: var(--accent); }" in STYLE
+    assert ".chat-shell.state-error { --shell-state-color: #ef7d86; }" in STYLE
 
 
 def test_redline_chat_text_is_one_pixel_larger():
@@ -257,6 +302,7 @@ def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
         ".chat-compose-actions .chat-stop:disabled",
         ".chat-title-button",
         ".chat-shell.active-chat::before",
+        ".chat-working-indicator",
     ):
         assert selector in STYLE
     assert "grid-template-columns: 260px 260px minmax(0, 1fr)" in STYLE


### PR DESCRIPTION
## Summary
- remove the open-conversation status pill from the pane header and render plain animated `<Working> . . .` text at the transcript tail
- repaint every shell rail accent through the existing 2s conversation poll: queued/running/waiting blue, idle green, error red, closed/no open chat unmarked
- add additive migration `0134_conversation_stars.sql`; conversation projections and optimistic `PATCH` now expose durable boolean `starred` state
- render each history card as a neutral container with a full-card open button and an independent overlaid star button—valid sibling controls, so toggling never opens the chat
- show outline `☆`, yellow hover, and filled yellow `★` with `aria-pressed`
- make the poll update chat title, version, star, badge, selected-conversation version, and all shell accents independently
- allow closed history to be starred without changing `last_activity_at` or reordering the list

## Verification
- `./sc test tests/test_conversation_schema.py tests/test_conversation_api.py tests/test_conversation_ui.py` — 64 passed
- `./sc test` — 1,593 passed, including clean-clone verification and the full migration chain
- `node --check .super-coder/ui/app.js`
- scoped Ruff clean after excluding only the repository-baseline codes tracked in #785
- `./sc render-check`
- `git diff --check`

## Known verification baseline
- Repository-wide `./sc lint` reports 1,087 pre-existing Ruff findings on current main; tracked in #785. No new scoped source finding remains.
- Linked-worktree `./sc verify` intentionally refuses because it would target the shared live instance. The full suite’s clean-clone verify test passes this branch instead.

## Trade-off
The existing conversation poll remains the single cross-shell state and metadata source. This avoids another timer or endpoint; remote changes may trail durable state by at most the existing two-second interval.