### PR TITLE
fix(conversations): refresh version before chat switch

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3114,18 +3114,22 @@ function chatConversationName(conversation) {
 }
 
 async function chatCloseForSwitch(conversation) {
-  if (!conversation || conversation.state === "closed") return true;
-  if (!["idle", "waiting", "error"].includes(conversation.state)) {
-    toast("Finish the current turn and queued messages before switching chats.");
-    return false;
-  }
+  if (!conversation) return true;
   try {
-    await chatApi(
+    const latest = await chatApi(
+      `/conversations/${conversation.conversation_id}`,
+    );
+    if (latest.state === "closed") return true;
+    if (!["idle", "waiting", "error"].includes(latest.state)) {
+      toast("Finish the current turn and queued messages before switching chats.");
+      return false;
+    }
+    const closed = await chatApi(
       `/conversations/${conversation.conversation_id}`,
       "PATCH",
-      { version: conversation.version, state: "closed" },
+      { version: latest.version, state: "closed" },
     );
-    conversation.state = "closed";
+    Object.assign(conversation, closed);
     return true;
   } catch (error) {
     toast(`${error.code}: ${error.message}`);

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -161,6 +161,21 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert "chatCloseForSwitch" not in shell_switch
 
 
+def test_chat_switch_refetches_authoritative_version_before_close():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    close_for_switch = interface[
+        interface.index("async function chatCloseForSwitch"):
+        interface.index("function chatActivity")
+    ]
+    assert "const latest = await chatApi(" in close_for_switch
+    assert 'if (latest.state === "closed") return true' in close_for_switch
+    assert '["idle", "waiting", "error"].includes(latest.state)' in close_for_switch
+    assert "{ version: latest.version, state: \"closed\" }" in close_for_switch
+    assert "Object.assign(conversation, closed)" in close_for_switch
+    assert "{ version: conversation.version" not in close_for_switch
+
+
 def test_conversation_identity_uses_shell_context_and_neutral_user_label():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]


### PR DESCRIPTION
Closes #783.

## What changed
- refetch the selected conversation immediately before a New Chat, Configure, or history-switch close
- decide switchability from the authoritative server state
- PATCH with the freshly fetched version and retain the returned projection
- add a focused UI regression contract preventing render-time versions from returning

## Verification
- `node --check .super-coder/ui/app.js`
- `python -m pytest -q tests/test_conversation_ui.py` — 16 passed
- full `python -m pytest -q` — 1,588 passed, 775 subtests passed
- `./sc map`
- `./sc render-check`
- `git diff --check`

`./sc verify` is structurally unavailable from the git-skill-required linked worktree; the exact existing defect is tracked in #769 with this run added as a repro. The command refused before opening or modifying the live DB.