### PR TITLE
fix(db): retry WAL setup under contention

### DIFF
--- a/.super-coder/scripts/db_driver.py
+++ b/.super-coder/scripts/db_driver.py
@@ -78,14 +78,62 @@ def _report_timing(
     )
 
 
+def _enable_wal(
+    con: sqlite3.Connection,
+    *,
+    max_wait_seconds: float = DEFAULT_WRITE_WAIT_SECONDS,
+    attempt_timeout_ms: int = DEFAULT_BEGIN_ATTEMPT_TIMEOUT_MS,
+    retry_base_seconds: float = DEFAULT_RETRY_BASE_SECONDS,
+    retry_max_seconds: float = DEFAULT_RETRY_MAX_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    random_fraction: Callable[[], float] = random.random,
+) -> None:
+    """Enable WAL within the shared bounded SQLite acquisition policy."""
+    deadline = monotonic() + max_wait_seconds
+    attempts = 0
+    while True:
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            raise sqlite3.OperationalError(
+                "timed out configuring SQLite journal_mode=WAL"
+            )
+        attempts += 1
+        per_attempt_ms = max(
+            1,
+            min(attempt_timeout_ms, int(remaining * 1000)),
+        )
+        con.execute(f"PRAGMA busy_timeout={per_attempt_ms}")
+        try:
+            con.execute("PRAGMA journal_mode=WAL")
+            return
+        except sqlite3.OperationalError as exc:
+            if not is_busy_error(exc):
+                raise
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                raise
+            ceiling = min(
+                retry_max_seconds,
+                retry_base_seconds * (2 ** min(attempts - 1, 8)),
+                remaining,
+            )
+            if ceiling > 0:
+                sleep(ceiling * (0.75 + 0.5 * random_fraction()))
+
+
 def connect(path):
     """Open the engine SQLite DB at `path` with the standard PRAGMAs."""
     con = sqlite3.connect(str(path), timeout=DEFAULT_BUSY_TIMEOUT_MS / 1000)
-    con.row_factory = sqlite3.Row
-    con.execute("PRAGMA foreign_keys=ON")
-    con.execute("PRAGMA journal_mode=WAL")
-    con.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
-    return con
+    try:
+        con.row_factory = sqlite3.Row
+        con.execute("PRAGMA foreign_keys=ON")
+        _enable_wal(con)
+        con.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
+        return con
+    except BaseException:
+        con.close()
+        raise
 
 
 @contextmanager

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import sqlite3
 import sys
@@ -423,22 +424,20 @@ class StoreContractTest(ConversationBrokerCase):
         self.add_message(first_conversation)
         self.add_message(second_conversation)
         barrier = threading.Barrier(3)
-        claimed: list[BrokerRun | None] = []
 
-        def claim(owner: str) -> None:
+        def claim(owner: str) -> BrokerRun | None:
             barrier.wait()
-            claimed.append(BrokerStore(self.db_path).claim_next(owner))
+            return BrokerStore(self.db_path).claim_next(owner)
 
-        workers = [
-            threading.Thread(target=claim, args=(f"broker-{index}",))
-            for index in (1, 2)
-        ]
-        for worker in workers:
-            worker.start()
-        barrier.wait()
-        for worker in workers:
-            worker.join()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            workers = [
+                pool.submit(claim, f"broker-{index}")
+                for index in (1, 2)
+            ]
+            barrier.wait()
+            claimed = [worker.result(timeout=5) for worker in workers]
 
+        self.assertEqual(len(claimed), 2)
         self.assertEqual(sum(run is not None for run in claimed), 1)
         con = self.connect()
         self.assertEqual(

--- a/tests/test_db_driver.py
+++ b/tests/test_db_driver.py
@@ -10,6 +10,7 @@ import threading
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -53,6 +54,64 @@ class WriteTransactionTest(unittest.TestCase):
         self.assertTrue(timings[0].acquired)
         self.assertTrue(timings[0].committed)
         self.assertEqual(timings[0].operation, "test.commit")
+
+    def test_connect_retries_busy_wal_configuration_and_restores_timeout(
+        self,
+    ) -> None:
+        con = mock.Mock()
+        attempts = 0
+
+        def execute(statement: str):
+            nonlocal attempts
+            if statement == "PRAGMA journal_mode=WAL":
+                attempts += 1
+                if attempts < 3:
+                    raise sqlite3.OperationalError("database is locked")
+            return mock.Mock()
+
+        con.execute.side_effect = execute
+        sleep = mock.Mock()
+        enable_wal = db_driver._enable_wal
+        with (
+            mock.patch.object(db_driver.sqlite3, "connect", return_value=con),
+            mock.patch.object(
+                db_driver,
+                "_enable_wal",
+                side_effect=lambda connection: enable_wal(
+                    connection,
+                    sleep=sleep,
+                ),
+            ),
+        ):
+            connected = db_driver.connect(self.path)
+
+        self.assertIs(connected, con)
+        self.assertEqual(attempts, 3)
+        self.assertEqual(sleep.call_count, 2)
+        con.execute.assert_any_call(
+            f"PRAGMA busy_timeout={db_driver.DEFAULT_BEGIN_ATTEMPT_TIMEOUT_MS}"
+        )
+        con.execute.assert_called_with(
+            f"PRAGMA busy_timeout={db_driver.DEFAULT_BUSY_TIMEOUT_MS}"
+        )
+        con.close.assert_not_called()
+
+    def test_connect_closes_connection_after_non_busy_wal_failure(self) -> None:
+        con = mock.Mock()
+
+        def execute(statement: str):
+            if statement == "PRAGMA journal_mode=WAL":
+                raise sqlite3.OperationalError("disk I/O error")
+            return mock.Mock()
+
+        con.execute.side_effect = execute
+        with (
+            mock.patch.object(db_driver.sqlite3, "connect", return_value=con),
+            self.assertRaisesRegex(sqlite3.OperationalError, "disk I/O"),
+        ):
+            db_driver.connect(self.path)
+
+        con.close.assert_called_once_with()
 
     def test_rolls_back_the_whole_body_on_failure(self) -> None:
         timings: list[db_driver.WriteTransactionTiming] = []


### PR DESCRIPTION
Closes #788

## Summary
- retry busy journal_mode WAL initialization under the shared bounded SQLite acquisition policy
- restore the normal connection busy timeout after setup and close partially configured connections on failure
- make the concurrent broker-claim test surface either claimant exception and prove both attempts complete

## Verification
- focused DB, capability, schema, broker, and Sprint eventing suite: 138 passed, 156 subtests
- full suite on current origin/main: 1596 passed, 775 subtests
- sc render-check
- git diff --check

## Known tooling gates
- sc verify remains unavailable from required linked worktrees: #769
- sc lint cannot see the provisioned Ruff from a linked worktree: #789