### PR TITLE
feat(sprints): add conversation binding floor

### DIFF
--- a/.super-coder/migrations/0135_sprint_conversation_bindings.sql
+++ b/.super-coder/migrations/0135_sprint_conversation_bindings.sql
@@ -1,0 +1,273 @@
+-- 0135 — Sprint conversation identity and assignment concurrency floor.
+--
+-- Migration 0132 reserved one live Sprint conversation per Sprint. Browser
+-- orchestration needs a narrower fence: one persistent Conductor conversation
+-- plus fresh one-shot Planner, Developer, Reviewer, and conformance
+-- conversations. Keep the hot conversations table intact and bind Sprint
+-- identity in this additive child table.
+--
+-- Existing reserved Sprint conversations are preserved but not guessed into a
+-- role. The activation/assignment API owns explicit binding in a short write
+-- transaction; an inferred Conductor or worker would be unsafe.
+
+BEGIN;
+
+DROP INDEX idx_conversations_live_sprint;
+
+CREATE TABLE sprint_conversation_bindings (
+    binding_id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id        TEXT NOT NULL UNIQUE
+                           REFERENCES conversations(conversation_id),
+    sprint_doc_id          INTEGER NOT NULL
+                           REFERENCES sprints(sprint_doc_id),
+    role                   TEXT NOT NULL
+                           CHECK (role IN (
+                             'conductor','planner','developer','reviewer',
+                             'conformance'
+                           )),
+    lifecycle              TEXT NOT NULL
+                           CHECK (lifecycle IN ('persistent','one_shot')),
+    slot                   TEXT NOT NULL
+                           CHECK (length(trim(slot)) BETWEEN 1 AND 64),
+    unit_id                INTEGER REFERENCES sprint_units(unit_id),
+    source_directive_id    INTEGER REFERENCES directives(directive_id),
+    source_message_id      INTEGER REFERENCES shell_messages(message_id),
+    required_result_kind   TEXT
+                           CHECK (
+                             required_result_kind IS NULL
+                             OR length(trim(required_result_kind))
+                                BETWEEN 1 AND 64
+                           ),
+    state                  TEXT NOT NULL DEFAULT 'pending'
+                           CHECK (state IN ('pending','active','terminal')),
+    outcome                TEXT
+                           CHECK (outcome IN (
+                             'succeeded','failed','cancelled','unknown','closed'
+                           )),
+    result_message_id      INTEGER REFERENCES shell_messages(message_id),
+    created_at             TEXT NOT NULL DEFAULT (datetime('now')),
+    started_at             TEXT,
+    completed_at           TEXT,
+    CHECK (
+      (role='conductor' AND lifecycle='persistent')
+      OR
+      (role<>'conductor' AND lifecycle='one_shot')
+    ),
+    CHECK (
+      (role='conductor'
+       AND unit_id IS NULL
+       AND source_directive_id IS NULL
+       AND source_message_id IS NULL
+       AND required_result_kind IS NULL)
+      OR
+      (role<>'conductor'
+       AND source_directive_id IS NOT NULL
+       AND trim(COALESCE(required_result_kind,'')) <> '')
+    ),
+    CHECK (
+      (role IN ('developer','reviewer') AND unit_id IS NOT NULL)
+      OR
+      (role='conformance' AND unit_id IS NULL)
+      OR
+      role IN ('conductor','planner')
+    ),
+    CHECK (
+      (state='pending'
+       AND outcome IS NULL
+       AND started_at IS NULL
+       AND completed_at IS NULL
+       AND result_message_id IS NULL)
+      OR
+      (state='active'
+       AND outcome IS NULL
+       AND started_at IS NOT NULL
+       AND completed_at IS NULL
+       AND result_message_id IS NULL)
+      OR
+      (state='terminal'
+       AND outcome IS NOT NULL
+       AND completed_at IS NOT NULL
+       AND (
+         (outcome='succeeded' AND result_message_id IS NOT NULL)
+         OR
+         (outcome<>'succeeded' AND result_message_id IS NULL)
+       ))
+    ),
+    CHECK (
+      (role='conductor' AND (outcome IS NULL OR outcome='closed'))
+      OR
+      (role<>'conductor' AND (outcome IS NULL OR outcome<>'closed'))
+    )
+);
+
+-- A Sprint can retain closed Conductor history, but only one non-terminal
+-- Conductor may own it. Worker histories do not collide with this fence.
+CREATE UNIQUE INDEX idx_sprint_conversation_live_conductor
+    ON sprint_conversation_bindings(sprint_doc_id)
+    WHERE role='conductor' AND state<>'terminal';
+
+-- A committed directive names one assignment identity. A retry may recover the
+-- existing row; it may not create another native session for the same role and
+-- slot, even after the first assignment becomes terminal.
+CREATE UNIQUE INDEX idx_sprint_conversation_assignment_source
+    ON sprint_conversation_bindings(source_directive_id, role, slot)
+    WHERE lifecycle='one_shot';
+
+CREATE INDEX idx_sprint_conversation_bindings_state
+    ON sprint_conversation_bindings(sprint_doc_id, state, binding_id);
+CREATE INDEX idx_sprint_conversation_bindings_unit
+    ON sprint_conversation_bindings(sprint_doc_id, unit_id, role, binding_id);
+
+CREATE TRIGGER trg_sprint_conversation_binding_links_insert
+BEFORE INSERT ON sprint_conversation_bindings
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM conversations c
+  JOIN shells s ON s.shell_id=c.shell_id
+  WHERE c.conversation_id=NEW.conversation_id
+    AND c.mode='sprint'
+    AND c.sprint_doc_id=NEW.sprint_doc_id
+    AND COALESCE(s.is_deleted,0)=0
+    AND s.shortname=NEW.slot
+    AND (
+      s.flavor=NEW.role
+      OR (NEW.role='developer' AND s.flavor='dev')
+      OR (NEW.role='conformance' AND s.flavor='reviewer')
+    )
+)
+BEGIN
+  SELECT RAISE(
+    ABORT,
+    'Sprint binding conversation, Sprint, role, or shell does not match'
+  );
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_unit_insert
+BEFORE INSERT ON sprint_conversation_bindings
+WHEN NEW.unit_id IS NOT NULL AND NOT EXISTS (
+  SELECT 1 FROM sprint_units u
+  WHERE u.unit_id=NEW.unit_id
+    AND u.sprint_doc_id=NEW.sprint_doc_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint binding unit does not belong to Sprint');
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_source_insert
+BEFORE INSERT ON sprint_conversation_bindings
+WHEN NEW.source_directive_id IS NOT NULL AND NOT EXISTS (
+  SELECT 1 FROM directives d
+  WHERE d.directive_id=NEW.source_directive_id
+    AND d.sprint_doc_id=NEW.sprint_doc_id
+    AND d.unit_id IS NEW.unit_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint binding source directive does not match');
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_message_insert
+BEFORE INSERT ON sprint_conversation_bindings
+WHEN NEW.source_message_id IS NOT NULL AND NOT EXISTS (
+  SELECT 1
+  FROM shell_messages m
+  JOIN conversations c ON c.conversation_id=NEW.conversation_id
+  WHERE m.message_id=NEW.source_message_id
+    AND m.sprint_doc_id=NEW.sprint_doc_id
+    AND m.to_shell_id=c.shell_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint binding source message does not match');
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_result_insert
+BEFORE INSERT ON sprint_conversation_bindings
+WHEN NEW.result_message_id IS NOT NULL AND NOT EXISTS (
+  SELECT 1
+  FROM shell_messages m
+  JOIN conversations c ON c.conversation_id=NEW.conversation_id
+  WHERE m.message_id=NEW.result_message_id
+    AND m.sprint_doc_id=NEW.sprint_doc_id
+    AND m.kind='result'
+    AND m.from_shell_id=c.shell_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint binding result message does not match');
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_identity_immutable
+BEFORE UPDATE OF
+    binding_id, conversation_id, sprint_doc_id, role, lifecycle, slot, unit_id,
+    source_directive_id, source_message_id, required_result_kind, created_at
+ON sprint_conversation_bindings
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint conversation binding identity is immutable');
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_state
+BEFORE UPDATE OF state ON sprint_conversation_bindings
+WHEN NEW.state<>OLD.state AND NOT (
+  (OLD.state='pending' AND NEW.state IN ('active','terminal'))
+  OR
+  (OLD.state='active' AND NEW.state='terminal')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal Sprint conversation binding transition');
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_terminal_insert
+BEFORE INSERT ON sprint_conversation_bindings
+WHEN NEW.state='terminal' AND NOT EXISTS (
+  SELECT 1 FROM conversations c
+  WHERE c.conversation_id=NEW.conversation_id
+    AND c.state='closed'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'terminal Sprint binding requires closed conversation');
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_terminal_update
+BEFORE UPDATE OF state ON sprint_conversation_bindings
+WHEN NEW.state='terminal' AND OLD.state<>'terminal' AND NOT EXISTS (
+  SELECT 1 FROM conversations c
+  WHERE c.conversation_id=NEW.conversation_id
+    AND c.state='closed'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'terminal Sprint binding requires closed conversation');
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_terminal_immutable
+BEFORE UPDATE OF outcome, result_message_id, started_at, completed_at
+ON sprint_conversation_bindings
+WHEN OLD.state='terminal' AND (
+  NEW.outcome IS NOT OLD.outcome
+  OR NEW.result_message_id IS NOT OLD.result_message_id
+  OR NEW.started_at IS NOT OLD.started_at
+  OR NEW.completed_at IS NOT OLD.completed_at
+)
+BEGIN
+  SELECT RAISE(ABORT, 'terminal Sprint conversation binding is immutable');
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_delete
+BEFORE DELETE ON sprint_conversation_bindings
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint conversation bindings are durable history');
+END;
+
+CREATE TRIGGER trg_sprint_conversation_binding_result_update
+BEFORE UPDATE OF result_message_id ON sprint_conversation_bindings
+WHEN NEW.result_message_id IS NOT NULL AND NOT EXISTS (
+  SELECT 1
+  FROM shell_messages m
+  JOIN conversations c ON c.conversation_id=NEW.conversation_id
+  WHERE m.message_id=NEW.result_message_id
+    AND m.sprint_doc_id=NEW.sprint_doc_id
+    AND m.kind='result'
+    AND m.from_shell_id=c.shell_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint binding result message does not match');
+END;
+
+COMMIT;

--- a/.super-coder/scripts/conversation_state.py
+++ b/.super-coder/scripts/conversation_state.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Conversation state-machine vocabulary mirrored by migration 0132.
+"""Conversation state-machine vocabulary mirrored by migrations 0132 and 0135.
 
 The database triggers are the final backstop. API and broker code import these
 maps to reject a bad edge with a useful typed error before SQLite reduces it to
@@ -46,11 +46,18 @@ OUTBOX_TRANSITIONS = {
     "cancelled": frozenset(),
 }
 
+SPRINT_BINDING_TRANSITIONS = {
+    "pending": frozenset({"active", "terminal"}),
+    "active": frozenset({"terminal"}),
+    "terminal": frozenset(),
+}
+
 MACHINES = {
     "conversation": CONVERSATION_TRANSITIONS,
     "message": MESSAGE_TRANSITIONS,
     "run": RUN_TRANSITIONS,
     "outbox": OUTBOX_TRANSITIONS,
+    "sprint_binding": SPRINT_BINDING_TRANSITIONS,
 }
 
 INITIAL_STATES = {
@@ -58,6 +65,7 @@ INITIAL_STATES = {
     "message": "accepted",
     "run": "leased",
     "outbox": "pending",
+    "sprint_binding": "pending",
 }
 
 

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -102,11 +102,12 @@ PER_INSTANCE_TABLES = [
     "directives",
     "sentinel_events",
     "wake_machine_retirements",
-    # Browser-native conversations are durable instance truth: the exact
-    # harness ref, message queue, recovery evidence, replay events, and pending
-    # outbox must all survive update/rebuild. Parents precede children so a
-    # snapshot remains readable and foreign-key-valid when loaded.
+    # Browser-native conversations are durable instance truth: Sprint bindings,
+    # exact harness refs, message queues, recovery evidence, replay events, and
+    # pending outbox work must all survive update/rebuild. Parents precede
+    # children so a snapshot stays readable and foreign-key-valid when loaded.
     "conversations",
+    "sprint_conversation_bindings",
     "conversation_messages",
     "conversation_runs",
     "conversation_events",

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -2,10 +2,12 @@
 """Feature #24 conversation schema, transition, and rebuild contracts."""
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import sqlite3
 import sys
 import tempfile
+import threading
 import unittest
 from contextlib import closing
 from pathlib import Path
@@ -19,6 +21,7 @@ FOUNDATION = MIGRATIONS / "0132_conversation_foundation.sql"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import conversation_state  # noqa: E402
+import db_driver  # noqa: E402
 import snapshot  # noqa: E402
 
 
@@ -48,6 +51,16 @@ class ConversationDbCase(unittest.TestCase):
             "INSERT INTO shells "
             "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
             "VALUES (2,'Review','rev1','reviewer','prompt',1)"
+        )
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (3,'Planner','plan1','planner','prompt',1)"
+        )
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (4,'Conductor','con1','conductor','prompt',1)"
         )
         self.con.execute(
             "INSERT INTO documents "
@@ -127,6 +140,84 @@ class ConversationDbCase(unittest.TestCase):
                 caused_by_message_id,
                 state,
                 completed_at,
+            ),
+        ).lastrowid
+
+    def add_sprint(self) -> int:
+        self.con.execute(
+            "INSERT OR IGNORE INTO sprints "
+            "(sprint_doc_id,state,legacy) VALUES (24,'declared',1)"
+        )
+        return 24
+
+    def add_unit(self, *, seq: str = "U1") -> int:
+        self.add_sprint()
+        return self.con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id,seq,unit_title) VALUES (24,?,'Unit')",
+            (seq,),
+        ).lastrowid
+
+    def add_directive(self, *, unit_id: int | None = None) -> int:
+        self.add_sprint()
+        return self.con.execute(
+            "INSERT INTO directives "
+            "(issuer_flavor,kind,target,sprint_doc_id,unit_id) "
+            "VALUES ('system','stall','conductor',24,?)",
+            (unit_id,),
+        ).lastrowid
+
+    def add_shell_message(self, *, kind: str = "result") -> int:
+        self.add_sprint()
+        return self.con.execute(
+            "INSERT INTO shell_messages "
+            "(from_shell_id,to_shell_id,body,kind,sprint_doc_id) "
+            "VALUES (1,4,'Sprint evidence',?,24)",
+            (kind,),
+        ).lastrowid
+
+    def add_binding(
+        self,
+        conversation_id: str,
+        *,
+        role: str = "conductor",
+        slot: str | None = None,
+        unit_id: int | None = None,
+        source_directive_id: int | None = None,
+        source_message_id: int | None = None,
+        required_result_kind: str | None = None,
+        state: str = "pending",
+        outcome: str | None = None,
+        result_message_id: int | None = None,
+    ) -> int:
+        self.add_sprint()
+        return self.con.execute(
+            "INSERT INTO sprint_conversation_bindings "
+            "(conversation_id,sprint_doc_id,role,lifecycle,slot,unit_id,"
+            "source_directive_id,source_message_id,required_result_kind,"
+            "state,outcome,result_message_id,started_at,completed_at) "
+            "VALUES (?,24,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                conversation_id,
+                role,
+                "persistent" if role == "conductor" else "one_shot",
+                slot
+                or {
+                    "conductor": "con1",
+                    "planner": "plan1",
+                    "developer": "dev1",
+                    "reviewer": "rev1",
+                    "conformance": "rev1",
+                }[role],
+                unit_id,
+                source_directive_id,
+                source_message_id,
+                required_result_kind,
+                state,
+                outcome,
+                result_message_id,
+                "2026-07-30 00:01:00" if state == "active" else None,
+                "2026-07-30 00:02:00" if state == "terminal" else None,
             ),
         ).lastrowid
 
@@ -268,6 +359,77 @@ class MigrationAndShapeTest(ConversationDbCase):
                     "WHERE creation_idempotency_key='legacy'"
                 )
 
+    def test_binding_migration_preserves_reserved_sprint_conversation(
+        self,
+    ) -> None:
+        with closing(sqlite3.connect(":memory:")) as con:
+            apply_schema(
+                con,
+                through="0134_conversation_stars.sql",
+            )
+            con.execute(
+                "INSERT INTO users (user_id,username) VALUES (9,'legacy')"
+            )
+            con.execute(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (9,'Conductor','con9','conductor','prompt',9)"
+            )
+            con.execute(
+                "INSERT INTO documents "
+                "(document_id,kind,title,body) "
+                "VALUES (99,'doc','SPRINT: reserved','x')"
+            )
+            con.execute(
+                "INSERT INTO sprints "
+                "(sprint_doc_id,state,legacy) VALUES (99,'declared',1)"
+            )
+            con.execute(
+                "INSERT INTO conversations "
+                "(conversation_id,shell_id,mode,sprint_doc_id,harness,worktree,"
+                "creation_idempotency_key,creation_request_hash) "
+                "VALUES ('cv_reserved',9,'sprint',99,'opencode','/tmp/con9',"
+                "'reserved','hash')"
+            )
+
+            con.executescript(
+                (
+                    MIGRATIONS / "0135_sprint_conversation_bindings.sql"
+                ).read_text()
+            )
+
+            self.assertEqual(
+                con.execute(
+                    "SELECT conversation_id FROM conversations"
+                ).fetchone()[0],
+                "cv_reserved",
+            )
+            self.assertIsNone(
+                con.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='index' "
+                    "AND name='idx_conversations_live_sprint'"
+                ).fetchone()
+            )
+            con.execute(
+                "INSERT INTO sprint_conversation_bindings "
+                "(conversation_id,sprint_doc_id,role,lifecycle,slot) "
+                "VALUES ('cv_reserved',99,'conductor','persistent','con9')"
+            )
+            con.execute(
+                "INSERT INTO conversations "
+                "(conversation_id,shell_id,mode,sprint_doc_id,harness,worktree,"
+                "creation_idempotency_key,creation_request_hash) "
+                "VALUES ('cv_second',9,'sprint',99,'opencode','/tmp/con9',"
+                "'second','hash')"
+            )
+            with self.assertRaises(sqlite3.IntegrityError):
+                con.execute(
+                    "INSERT INTO sprint_conversation_bindings "
+                    "(conversation_id,sprint_doc_id,role,lifecycle,slot) "
+                    "VALUES ('cv_second',99,'conductor','persistent','con9')"
+                )
+
     def test_normal_and_reserved_sprint_ownership_shapes(self) -> None:
         normal = self.add_conversation()
         sprint = self.add_conversation(mode="sprint")
@@ -281,16 +443,185 @@ class MigrationAndShapeTest(ConversationDbCase):
                 "VALUES (1,'normal','codex','/tmp/x','bad','hash')"
             )
 
-    def test_one_live_sprint_conversation(self) -> None:
-        first = self.add_conversation(mode="sprint")
-        with self.assertRaises(sqlite3.IntegrityError):
-            self.add_conversation(mode="sprint")
-        self.con.execute(
-            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
-            "WHERE conversation_id=?",
-            (first,),
+    def test_sprint_binding_scopes_conductor_and_worker_uniqueness(self) -> None:
+        self.add_sprint()
+        conductor = self.add_conversation(shell_id=4, mode="sprint")
+        conductor_binding = self.add_binding(conductor)
+
+        unit_id = self.add_unit()
+        directive_id = self.add_directive(unit_id=unit_id)
+        worker = self.add_conversation(shell_id=1, mode="sprint")
+        worker_binding = self.add_binding(
+            worker,
+            role="developer",
+            slot="dev1",
+            unit_id=unit_id,
+            source_directive_id=directive_id,
+            required_result_kind="unit-report",
         )
-        self.add_conversation(mode="sprint")
+
+        second_conductor = self.add_conversation(shell_id=4, mode="sprint")
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_binding(second_conductor)
+
+        duplicate = self.add_conversation(shell_id=1, mode="sprint")
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_binding(
+                duplicate,
+                role="developer",
+                slot="dev1",
+                unit_id=unit_id,
+                source_directive_id=directive_id,
+                required_result_kind="unit-report",
+            )
+
+        self.con.execute(
+            "UPDATE sprint_conversation_bindings "
+            "SET state='active',started_at=datetime('now') "
+            "WHERE binding_id IN (?,?)",
+            (conductor_binding, worker_binding),
+        )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "UPDATE sprint_conversation_bindings "
+                "SET state='terminal',outcome='closed',"
+                "completed_at=datetime('now') WHERE binding_id=?",
+                (conductor_binding,),
+            )
+        self.con.execute(
+            "UPDATE conversations "
+            "SET state='closed',closed_at=datetime('now') "
+            "WHERE conversation_id IN (?,?)",
+            (conductor, worker),
+        )
+        self.con.execute(
+            "UPDATE sprint_conversation_bindings "
+            "SET state='terminal',outcome='closed',completed_at=datetime('now') "
+            "WHERE binding_id=?",
+            (conductor_binding,),
+        )
+        self.con.execute(
+            "UPDATE sprint_conversation_bindings "
+            "SET state='terminal',outcome='failed',completed_at=datetime('now') "
+            "WHERE binding_id=?",
+            (worker_binding,),
+        )
+
+        self.add_binding(second_conductor)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_binding(
+                duplicate,
+                role="developer",
+                slot="dev1",
+                unit_id=unit_id,
+                source_directive_id=directive_id,
+                required_result_kind="unit-report",
+            )
+
+        self.assertEqual(
+            [
+                row[0]
+                for row in self.con.execute(
+                    "SELECT role FROM sprint_conversation_bindings "
+                    "ORDER BY binding_id"
+                ).fetchall()
+            ],
+            ["conductor", "developer", "conductor"],
+        )
+
+    def test_sprint_binding_rejects_wrong_mode_role_and_source_scope(
+        self,
+    ) -> None:
+        normal = self.add_conversation(shell_id=4)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_binding(normal)
+
+        wrong_role = self.add_conversation(shell_id=1, mode="sprint")
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_binding(wrong_role, role="planner")
+
+        self.add_sprint()
+        self.con.execute(
+            "INSERT INTO documents "
+            "(document_id,kind,title,body) "
+            "VALUES (25,'doc','SPRINT: other','x')"
+        )
+        self.con.execute(
+            "INSERT INTO sprints "
+            "(sprint_doc_id,state,legacy) VALUES (25,'declared',1)"
+        )
+        other_directive = self.con.execute(
+            "INSERT INTO directives "
+            "(issuer_flavor,kind,target,sprint_doc_id) "
+            "VALUES ('system','stall','conductor',25)"
+        ).lastrowid
+        planner = self.add_conversation(shell_id=3, mode="sprint")
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.add_binding(
+                planner,
+                role="planner",
+                slot="plan1",
+                source_directive_id=other_directive,
+                required_result_kind="answer",
+            )
+
+    def test_succeeded_assignment_requires_scoped_result_and_is_immutable(
+        self,
+    ) -> None:
+        unit_id = self.add_unit()
+        directive_id = self.add_directive(unit_id=unit_id)
+        conversation = self.add_conversation(shell_id=1, mode="sprint")
+        binding_id = self.add_binding(
+            conversation,
+            role="developer",
+            slot="dev1",
+            unit_id=unit_id,
+            source_directive_id=directive_id,
+            required_result_kind="unit-report",
+        )
+        self.con.execute(
+            "UPDATE sprint_conversation_bindings "
+            "SET state='active',started_at=datetime('now') "
+            "WHERE binding_id=?",
+            (binding_id,),
+        )
+
+        wrong_kind = self.add_shell_message(kind="task")
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "UPDATE sprint_conversation_bindings "
+                "SET state='terminal',outcome='succeeded',"
+                "result_message_id=?,completed_at=datetime('now') "
+                "WHERE binding_id=?",
+                (wrong_kind, binding_id),
+            )
+
+        result_message = self.add_shell_message()
+        self.con.execute(
+            "UPDATE conversations "
+            "SET state='closed',closed_at=datetime('now') "
+            "WHERE conversation_id=?",
+            (conversation,),
+        )
+        self.con.execute(
+            "UPDATE sprint_conversation_bindings "
+            "SET state='terminal',outcome='succeeded',"
+            "result_message_id=?,completed_at=datetime('now') "
+            "WHERE binding_id=?",
+            (result_message, binding_id),
+        )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "UPDATE sprint_conversation_bindings "
+                "SET outcome='failed',result_message_id=NULL "
+                "WHERE binding_id=?",
+                (binding_id,),
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.con.execute(
+                "DELETE FROM sprint_conversation_bindings WHERE binding_id=?",
+                (binding_id,),
+            )
 
     def test_conversation_and_message_idempotency_are_scoped(self) -> None:
         conversation = self.add_conversation()
@@ -510,6 +841,46 @@ class TransitionMatrixTest(ConversationDbCase):
             self.update_outbox(row_id, "cancelled")
         return row_id, conversation, message, run_id
 
+    def update_sprint_binding(self, row_id: int, target: str) -> None:
+        if target == "terminal":
+            self.con.execute(
+                "UPDATE conversations "
+                "SET state='closed',closed_at='2026-07-30 00:02:00' "
+                "WHERE conversation_id=("
+                "SELECT conversation_id "
+                "FROM sprint_conversation_bindings WHERE binding_id=?"
+                ")",
+                (row_id,),
+            )
+        self.con.execute(
+            "UPDATE sprint_conversation_bindings "
+            "SET state=?,outcome=?,started_at=?,completed_at=? "
+            "WHERE binding_id=?",
+            (
+                target,
+                "closed" if target == "terminal" else None,
+                "2026-07-30 00:01:00"
+                if target in {"active", "terminal"}
+                else None,
+                "2026-07-30 00:02:00"
+                if target == "terminal"
+                else None,
+                row_id,
+            ),
+        )
+
+    def sprint_binding_at(self, state: str) -> int:
+        conversation = self.add_conversation(shell_id=4, mode="sprint")
+        row_id = self.add_binding(conversation)
+        paths = {
+            "pending": (),
+            "active": ("active",),
+            "terminal": ("active", "terminal"),
+        }
+        for target in paths[state]:
+            self.update_sprint_binding(row_id, target)
+        return row_id
+
     def assert_matrix(
         self,
         machine: str,
@@ -578,6 +949,16 @@ class TransitionMatrixTest(ConversationDbCase):
             self.update_outbox(row_id, target, run_id=run_id)
 
         self.assert_matrix("outbox", self.outbox_at, update)
+
+    def test_exhaustive_sprint_binding_edges_match_helper(self) -> None:
+        self.assert_matrix(
+            "sprint_binding",
+            self.sprint_binding_at,
+            lambda row_id, target, _made: self.update_sprint_binding(
+                row_id,
+                target,
+            ),
+        )
 
     def test_typed_error_names_edge_and_legal_targets(self) -> None:
         with self.assertRaises(
@@ -715,9 +1096,163 @@ class FenceAndEventTest(ConversationDbCase):
             )
 
 
+class SprintBindingConcurrencyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.db_path = Path(self.tmp.name) / "engine.db"
+        con = db_driver.connect(self.db_path)
+        apply_schema(con)
+        con.execute(
+            "INSERT INTO users (user_id,username) VALUES (1,'operator')"
+        )
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (1,'Developer','dev1','dev','prompt',1)"
+        )
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (4,'Conductor','con1','conductor','prompt',1)"
+        )
+        con.execute(
+            "INSERT INTO documents "
+            "(document_id,kind,title,body) "
+            "VALUES (24,'doc','SPRINT: concurrent bindings','x')"
+        )
+        con.execute(
+            "INSERT INTO sprints "
+            "(sprint_doc_id,state,legacy) VALUES (24,'declared',1)"
+        )
+        self.unit_id = con.execute(
+            "INSERT INTO sprint_units "
+            "(sprint_doc_id,seq,unit_title) VALUES (24,'U1','Unit')"
+        ).lastrowid
+        self.directive_id = con.execute(
+            "INSERT INTO directives "
+            "(issuer_flavor,kind,target,sprint_doc_id,unit_id) "
+            "VALUES ('system','stall','conductor',24,?)",
+            (self.unit_id,),
+        ).lastrowid
+        con.commit()
+        con.close()
+
+    def race_bindings(
+        self,
+        *,
+        role: str,
+        shell_id: int,
+        unit_id: int | None,
+        source_directive_id: int | None,
+    ) -> list[bool]:
+        barrier = threading.Barrier(3)
+
+        def create(owner: str) -> bool:
+            con = db_driver.connect(self.db_path)
+            try:
+                barrier.wait(timeout=5)
+                try:
+                    with db_driver.write_transaction(
+                        con,
+                        "test.sprint_binding",
+                    ):
+                        conversation_id = f"cv_{owner}"
+                        con.execute(
+                            "INSERT INTO conversations "
+                            "(conversation_id,shell_id,mode,sprint_doc_id,"
+                            "harness,worktree,creation_idempotency_key,"
+                            "creation_request_hash) "
+                            "VALUES (?,?, 'sprint',24,?,?,?,?)",
+                            (
+                                conversation_id,
+                                shell_id,
+                                "opencode" if role == "conductor" else "codex",
+                                f"/tmp/{owner}",
+                                f"create-{owner}",
+                                f"hash-{owner}",
+                            ),
+                        )
+                        con.execute(
+                            "INSERT INTO sprint_conversation_bindings "
+                            "(conversation_id,sprint_doc_id,role,lifecycle,"
+                            "slot,unit_id,source_directive_id,"
+                            "required_result_kind) "
+                            "VALUES (?,24,?,?,?,?,?,?)",
+                            (
+                                conversation_id,
+                                role,
+                                "persistent"
+                                if role == "conductor"
+                                else "one_shot",
+                                "con1" if role == "conductor" else "dev1",
+                                unit_id,
+                                source_directive_id,
+                                None
+                                if role == "conductor"
+                                else "unit-report",
+                            ),
+                        )
+                except sqlite3.IntegrityError:
+                    return False
+                return True
+            finally:
+                con.close()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            workers = [
+                pool.submit(create, f"broker-{index}")
+                for index in (1, 2)
+            ]
+            barrier.wait(timeout=5)
+            return [worker.result(timeout=10) for worker in workers]
+
+    def assert_single_binding(self, results: list[bool], role: str) -> None:
+        self.assertEqual(len(results), 2)
+        self.assertEqual(sum(results), 1)
+        con = db_driver.connect(self.db_path)
+        try:
+            self.assertEqual(
+                con.execute(
+                    "SELECT COUNT(*) FROM sprint_conversation_bindings "
+                    "WHERE role=?",
+                    (role,),
+                ).fetchone()[0],
+                1,
+            )
+            self.assertEqual(
+                con.execute(
+                    "SELECT COUNT(*) FROM conversations "
+                    "WHERE mode='sprint'"
+                ).fetchone()[0],
+                1,
+            )
+        finally:
+            con.close()
+
+    def test_parallel_conductor_bindings_create_exactly_one(self) -> None:
+        results = self.race_bindings(
+            role="conductor",
+            shell_id=4,
+            unit_id=None,
+            source_directive_id=None,
+        )
+        self.assert_single_binding(results, "conductor")
+
+    def test_parallel_assignment_bindings_create_exactly_one(self) -> None:
+        results = self.race_bindings(
+            role="developer",
+            shell_id=1,
+            unit_id=self.unit_id,
+            source_directive_id=self.directive_id,
+        )
+        self.assert_single_binding(results, "developer")
+
+
 class SnapshotPolicyTest(ConversationDbCase):
     TABLES = (
         "conversations",
+        "sprint_conversation_bindings",
         "conversation_messages",
         "conversation_runs",
         "conversation_events",
@@ -730,6 +1265,50 @@ class SnapshotPolicyTest(ConversationDbCase):
             for table in self.TABLES
         ]
         self.assertEqual(positions, sorted(positions))
+
+    def test_snapshot_round_trip_preserves_sprint_binding(self) -> None:
+        self.add_sprint()
+        conversation = self.add_conversation(shell_id=4, mode="sprint")
+        self.add_binding(conversation, slot="con1")
+
+        body = ["PRAGMA foreign_keys=OFF;", "BEGIN;"]
+        for table in ("conversations", "sprint_conversation_bindings"):
+            body.extend(snapshot.dump_table(self.con, table))
+        body.extend(["COMMIT;", "PRAGMA foreign_keys=ON;"])
+
+        target = sqlite3.connect(":memory:")
+        apply_schema(target)
+        target.execute(
+            "INSERT INTO users (user_id,username) VALUES (1,'operator')"
+        )
+        target.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (4,'Conductor','con1','conductor','prompt',1)"
+        )
+        target.execute(
+            "INSERT INTO documents "
+            "(document_id,kind,title,body) "
+            "VALUES (24,'doc','SPRINT: conversation test','x')"
+        )
+        target.execute(
+            "INSERT INTO sprints "
+            "(sprint_doc_id,state,legacy) VALUES (24,'declared',1)"
+        )
+        target.executescript("\n".join(body))
+
+        self.assertEqual(
+            target.execute(
+                "SELECT conversation_id,sprint_doc_id,role,lifecycle,slot,"
+                "state FROM sprint_conversation_bindings"
+            ).fetchone(),
+            (conversation, 24, "conductor", "persistent", "con1", "pending"),
+        )
+        self.assertEqual(
+            target.execute("PRAGMA foreign_key_check").fetchall(),
+            [],
+        )
+        target.close()
 
     def test_snapshot_round_trip_preserves_queue_and_recovery_evidence(
             self) -> None:


### PR DESCRIPTION
Implements task #131, spec #38 construction step 1 after #788/#790.

## Summary
- add migration 0135 with a narrow sprint_conversation_bindings table; preserve existing Sprint conversations without guessing roles
- replace the one-live-Sprint-conversation reservation with one live persistent Conductor plus durable one-shot assignment identity per source directive, role, and canonical shell slot
- enforce Sprint, role, shell, unit, directive, handoff-message, result-message, terminal-conversation, and immutable-history contracts in SQLite
- mirror pending to active to terminal transitions in conversation_state and include bindings in snapshot order
- cover installed-fork upgrade, fresh schema/rebuild shape, snapshot round trip, exhaustive transitions, link/result failures, and real two-thread Conductor/assignment races

## Verification
- schema: 27 passed, 146 subtests
- focused conversation, Sprint, migration, rebuild: 302 passed, 214 subtests
- concurrency gate repeated 25 times
- full suite: 1603 passed, 784 subtests
- critical Ruff checks and py_compile
- sc render-check
- git diff --check

## Known tooling gate
- sc verify safely refuses linked worktrees; tracked in #769. No live DB was opened or mutated.