### PR TITLE
feat(sprints): extend canonical conversation launch

### DIFF
--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -230,19 +230,47 @@ def render_slot_directive(context: "dict | None") -> str:
     if context is None:
         return ""
     title = context.get("sprint_title") or "(untitled sprint)"
+    browser_binding = context.get("binding_id") is not None
     lines = [
-        "This ephemeral session has one launcher-validated role. Execute only "
-        "this slot and finish by emitting the directive required by its loaded "
-        "skill.",
+        (
+            "This browser-launched session has one validated Sprint binding. "
+            "Execute only this assignment and return the required typed result."
+            if browser_binding
+            else
+            "This ephemeral session has one launcher-validated role. Execute "
+            "only this slot and finish by emitting the directive required by "
+            "its loaded skill."
+        ),
         "",
         f"- **Slot:** `{context['slot']}`",
         f"- **Sprint:** document `{context['sprint_doc_id']}` — {title}",
         f"- **Loaded skill:** `{context['skill_name']}`",
-        "",
-        "### Kickoff context",
-        "",
     ]
-    for unit in context["units"]:
+    if context.get("role"):
+        lines.append(f"- **Role:** `{context['role']}`")
+    if context.get("lifecycle"):
+        lines.append(f"- **Lifecycle:** `{context['lifecycle']}`")
+    if context.get("binding_id") is not None:
+        lines.append(f"- **Assignment:** `{context['binding_id']}`")
+    if context.get("spec_doc_id") is not None:
+        spec_title = context.get("spec_title") or "(untitled spec)"
+        lines.append(
+            f"- **Governing spec:** document `{context['spec_doc_id']}` — "
+            f"{spec_title}"
+        )
+    if context.get("source_directive_id") is not None:
+        lines.append(
+            f"- **Source directive:** `{context['source_directive_id']}`"
+        )
+    if context.get("source_message_id") is not None:
+        lines.append(f"- **Source message:** `{context['source_message_id']}`")
+    if context.get("required_result_kind"):
+        lines.append(
+            f"- **Required result:** `{context['required_result_kind']}`"
+        )
+    lines.extend(["", "### Kickoff context", ""])
+    units = context.get("units") or []
+    for unit in units:
         detail = (
             f"`{unit['seq']}` (unit id `{unit['unit_id']}`) — "
             f"{unit['unit_title']} · state `{unit['state']}`"
@@ -256,6 +284,8 @@ def render_slot_directive(context: "dict | None") -> str:
         lines.append(f"- {detail}")
         if unit.get("overlap"):
             lines.append(f"  - overlap: {unit['overlap']}")
+    if not units:
+        lines.append("- Sprint-wide assignment; no unit is bound.")
     lines.extend([
         "",
         f"### Loaded skill — {context['skill_name']}",
@@ -509,7 +539,11 @@ def compose_boot(con: sqlite3.Connection, shell, user, session_id: str,
     stays a pure render, no git).
     """
     if shell["flavor"] == "conductor":
-        return conductor_runtime.render_boot(con, shell)
+        return conductor_runtime.render_boot(
+            con,
+            shell,
+            slot_context=slot_context,
+        )
 
     template = TEMPLATE_PATH.read_text().rstrip()
     template = template.replace(

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -1170,13 +1170,22 @@ def act(
         )
 
 
-def render_boot(con, shell) -> str:
+def render_boot(con, shell, *, slot_context: dict | None = None) -> str:
     """Render the Conductor's complete transition-table boot doc."""
-    pending = con.execute(
+    sprint_id = (
+        int(slot_context["sprint_doc_id"])
+        if slot_context is not None
+        else None
+    )
+    sql = (
         "SELECT directive_id,issuer_flavor,kind,sprint_doc_id,unit_id "
         "FROM directives WHERE status='pending' AND target='conductor' "
-        "ORDER BY directive_id"
-    ).fetchall()
+    )
+    params: tuple = ()
+    if sprint_id is not None:
+        sql += "AND sprint_doc_id=? "
+        params = (sprint_id,)
+    pending = con.execute(sql + "ORDER BY directive_id", params).fetchall()
     lines = [
         "# CONDUCTOR — MECHANICAL RELAY",
         "",
@@ -1188,6 +1197,29 @@ def render_boot(con, shell) -> str:
         "| Never write directly | Board/session changes occur only inside the authenticated act command |",
         "| Never select an owner or route | Use the recorded originating Planner and each stored role route |",
         "",
+    ]
+    if slot_context is not None:
+        lines += [
+            "## Browser Sprint binding",
+            "",
+            f"- **Sprint:** document `{sprint_id}` — "
+            f"{slot_context.get('sprint_title') or '(untitled sprint)'}",
+            f"- **Slot:** `{slot_context['slot']}`",
+            f"- **Lifecycle:** `{slot_context['lifecycle']}`",
+            f"- **Assignment:** `{slot_context['binding_id']}`",
+            "",
+            "Act only on pending directives for this Sprint. Other Sprints "
+            "belong to their own persistent Conductor conversations.",
+            "",
+        ]
+        if slot_context.get("spec_doc_id") is not None:
+            lines.insert(
+                -2,
+                f"- **Governing spec:** document "
+                f"`{slot_context['spec_doc_id']}` — "
+                f"{slot_context.get('spec_title') or '(untitled spec)'}",
+            )
+    lines += [
         "| Issuer | Kind | Mechanical action | Pass |",
         "|---|---|---|---|",
     ]
@@ -1207,13 +1239,23 @@ def render_boot(con, shell) -> str:
             )
     else:
         lines.append("| — | — | — | — | — |")
+    list_command = "sc directives list --status pending"
+    if sprint_id is not None:
+        list_command += f" --sprint {sprint_id}"
     lines += [
         "",
-        "1. Run `sc directives list --status pending`.",
+        f"1. Run `{list_command}`.",
         "2. For each id in ascending order run `sc directives act <id>`.",
         "3. Inspect every result; continue after executed or refused.",
-        "4. Exit when the pending list is empty.",
+        "4. Exit when this Sprint's pending list is empty.",
         "",
         f"Shell: `{shell['shortname']}` · flavor: `conductor` · skill: `sprint_cond`",
     ]
+    if slot_context is not None:
+        lines += [
+            "",
+            "## Loaded skill — sprint_cond",
+            "",
+            slot_context["skill_body"].strip(),
+        ]
     return "\n".join(lines) + "\n"

--- a/.super-coder/scripts/conversation_launch.py
+++ b/.super-coder/scripts/conversation_launch.py
@@ -9,9 +9,31 @@ from pathlib import Path
 from typing import Any
 
 import db_driver
+import conductor_policy
 import run as run_mod
 import shell_liveness
 from conversation_adapters import ConversationContext
+
+_ROLE_FLAVORS = {
+    "conductor": "conductor",
+    "planner": "planner",
+    "developer": "dev",
+    "reviewer": "reviewer",
+    "conformance": "reviewer",
+}
+_ROLE_SKILLS = {
+    "conductor": "sprint_cond",
+    "planner": "sprint_pln",
+    "developer": "sprint_dev",
+    "reviewer": "sprint_rev",
+    "conformance": "sprint_rev",
+}
+_ROLE_ROUTES = {
+    "planner": "planner_route",
+    "developer": "dev_route",
+    "reviewer": "reviewer_route",
+    "conformance": "reviewer_route",
+}
 
 
 class ConversationLaunchError(RuntimeError):
@@ -66,8 +88,192 @@ class ConversationLaunchPreparer:
             )
         return str(row["shortname"]), row["flavor"]
 
+    def _sprint_context(
+        self,
+        broker_run,
+        *,
+        shortname: str,
+        flavor: str | None,
+    ) -> dict[str, Any] | None:
+        """Resolve one immutable Sprint binding before canonical preparation."""
+        con = db_driver.connect(self.db_path)
+        try:
+            row = con.execute(
+                "SELECT c.mode,c.sprint_doc_id AS conversation_sprint_doc_id,"
+                "b.binding_id,b.sprint_doc_id,b.role,b.lifecycle,b.slot,"
+                "b.unit_id,b.source_directive_id,b.source_message_id,"
+                "b.required_result_kind,b.state AS binding_state,"
+                "sp.state AS sprint_state,sp.spec_doc_id,sp.planner_shell_id,"
+                "sp.planner_route,"
+                "sp.dev_route,sp.reviewer_route,"
+                "sprint_doc.title AS sprint_title,"
+                "spec_doc.title AS spec_title,"
+                "u.seq AS unit_seq,u.unit_title,u.state AS unit_state,"
+                "u.dev_shell_id,u.reviewer_shell_id,"
+                "u.depends_on,u.overlap,u.branch,u.pr_number,"
+                "sk.name AS skill_name,sk.content AS skill_body "
+                "FROM conversations c "
+                "LEFT JOIN sprint_conversation_bindings b "
+                " ON b.conversation_id=c.conversation_id "
+                "LEFT JOIN sprints sp ON sp.sprint_doc_id=b.sprint_doc_id "
+                "LEFT JOIN documents sprint_doc "
+                " ON sprint_doc.document_id=b.sprint_doc_id "
+                "LEFT JOIN documents spec_doc "
+                " ON spec_doc.document_id=sp.spec_doc_id "
+                "LEFT JOIN sprint_units u ON u.unit_id=b.unit_id "
+                "LEFT JOIN skills sk ON sk.name=CASE b.role "
+                " WHEN 'conductor' THEN 'sprint_cond' "
+                " WHEN 'planner' THEN 'sprint_pln' "
+                " WHEN 'developer' THEN 'sprint_dev' "
+                " ELSE 'sprint_rev' END "
+                " AND COALESCE(sk.is_deleted,0)=0 "
+                "WHERE c.conversation_id=?",
+                (broker_run.conversation_id,),
+            ).fetchone()
+        finally:
+            con.close()
+
+        if row is None:
+            raise ConversationLaunchError(
+                "CONVERSATION_NOT_FOUND",
+                f"conversation {broker_run.conversation_id!r} no longer exists",
+            )
+        if row["mode"] == "normal":
+            if row["binding_id"] is not None:
+                raise ConversationLaunchError(
+                    "SPRINT_BINDING_INVALID",
+                    "a normal conversation cannot carry a Sprint binding",
+                )
+            return None
+        if row["binding_id"] is None:
+            raise ConversationLaunchError(
+                "SPRINT_BINDING_REQUIRED",
+                "Sprint conversation has no validated role binding",
+            )
+
+        role = str(row["role"])
+        lifecycle = str(row["lifecycle"])
+        expected_flavor = _ROLE_FLAVORS.get(role)
+        expected_lifecycle = (
+            "persistent" if role == "conductor" else "one_shot"
+        )
+        if (
+            expected_flavor is None
+            or flavor != expected_flavor
+            or row["slot"] != shortname
+            or row["conversation_sprint_doc_id"] != row["sprint_doc_id"]
+            or lifecycle != expected_lifecycle
+        ):
+            raise ConversationLaunchError(
+                "SPRINT_BINDING_INVALID",
+                "Sprint binding does not match the conversation shell, role, "
+                "lifecycle, or Sprint",
+            )
+        if row["binding_state"] == "terminal":
+            raise ConversationLaunchError(
+                "SPRINT_BINDING_TERMINAL",
+                f"Sprint assignment {row['binding_id']} is already terminal",
+            )
+        if row["sprint_state"] not in {"active", "closing"}:
+            raise ConversationLaunchError(
+                "SPRINT_NOT_LAUNCHABLE",
+                f"Sprint {row['sprint_doc_id']} is "
+                f"{row['sprint_state'] or 'missing'}, not active or closing",
+            )
+        if row["skill_name"] != _ROLE_SKILLS[role] or not row["skill_body"]:
+            raise ConversationLaunchError(
+                "SPRINT_ROLE_SKILL_MISSING",
+                f"Sprint role skill {_ROLE_SKILLS[role]!r} is unavailable",
+            )
+        if (
+            (role == "planner" and row["planner_shell_id"] != broker_run.shell_id)
+            or (
+                role == "developer"
+                and row["dev_shell_id"] != broker_run.shell_id
+            )
+            or (
+                role == "reviewer"
+                and row["reviewer_shell_id"] != broker_run.shell_id
+            )
+        ):
+            raise ConversationLaunchError(
+                "SPRINT_ASSIGNMENT_MISMATCH",
+                f"{role} binding is not assigned to shell {shortname!r}",
+            )
+
+        if role == "conductor":
+            try:
+                conductor_policy.require_harness(flavor, broker_run.harness)
+            except ValueError as exc:
+                raise ConversationLaunchError(
+                    "SPRINT_ROUTE_MISMATCH",
+                    str(exc),
+                ) from exc
+        else:
+            route_column = _ROLE_ROUTES[role]
+            try:
+                expected_harness, expected_model = (
+                    run_mod.sprint_lifecycle.split_route(row[route_column])
+                )
+            except run_mod.sprint_lifecycle.SprintLifecycleError as exc:
+                raise ConversationLaunchError(
+                    "SPRINT_ROUTE_INVALID",
+                    str(exc),
+                ) from exc
+            if (
+                broker_run.harness != expected_harness
+                or broker_run.model != expected_model
+            ):
+                raise ConversationLaunchError(
+                    "SPRINT_ROUTE_MISMATCH",
+                    f"{role} binding requires "
+                    f"{expected_harness}/{expected_model}; conversation has "
+                    f"{broker_run.harness}/{broker_run.model}",
+                )
+            if broker_run.session_before is not None:
+                raise ConversationLaunchError(
+                    "SPRINT_ONE_SHOT_ALREADY_STARTED",
+                    f"{role} assignment {row['binding_id']} must start a fresh "
+                    "native session and cannot resume one",
+                )
+
+        unit = None
+        if row["unit_id"] is not None:
+            unit = {
+                "unit_id": int(row["unit_id"]),
+                "seq": row["unit_seq"],
+                "unit_title": row["unit_title"],
+                "state": row["unit_state"],
+                "depends_on": row["depends_on"],
+                "overlap": row["overlap"],
+                "branch": row["branch"],
+                "pr_number": row["pr_number"],
+            }
+        return {
+            "binding_id": int(row["binding_id"]),
+            "role": role,
+            "lifecycle": lifecycle,
+            "slot": row["slot"],
+            "skill_name": row["skill_name"],
+            "skill_body": row["skill_body"],
+            "sprint_doc_id": int(row["sprint_doc_id"]),
+            "sprint_title": row["sprint_title"],
+            "spec_doc_id": row["spec_doc_id"],
+            "spec_title": row["spec_title"],
+            "source_directive_id": row["source_directive_id"],
+            "source_message_id": row["source_message_id"],
+            "required_result_kind": row["required_result_kind"],
+            "units": [unit] if unit is not None else [],
+        }
+
     def __call__(self, broker_run) -> tuple[ConversationContext, int]:
         shortname, flavor = self._shell(broker_run.shell_id)
+        sprint_context = self._sprint_context(
+            broker_run,
+            shortname=shortname,
+            flavor=flavor,
+        )
+
         def occupying_state() -> str | None:
             snapshot = self.liveness()
             return (
@@ -97,12 +303,17 @@ class ConversationLaunchPreparer:
             )
 
         try:
+            launch_args = {
+                "shell_id": broker_run.shell_id,
+                "harness": broker_run.harness,
+                "model": broker_run.model,
+                "effort": broker_run.effort,
+                "headless_prompt": broker_run.body,
+            }
+            if sprint_context is not None:
+                launch_args["slot_context"] = sprint_context
             plan = self.prepare_launch(
-                shell_id=broker_run.shell_id,
-                harness=broker_run.harness,
-                model=broker_run.model,
-                effort=broker_run.effort,
-                headless_prompt=broker_run.body,
+                **launch_args,
             )
         except (run_mod.LaunchError, SystemExit) as exc:
             raise ConversationLaunchError(

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -910,6 +910,35 @@ def slot_default_prompt(context: dict) -> str:
     )
 
 
+def sprint_launch_env(context: "dict | None") -> dict[str, str]:
+    """Serialize one validated Sprint binding into the launched process env."""
+    if context is None:
+        return {}
+    env = {
+        "SC_SPRINT_REF": str(context["sprint_doc_id"]),
+        "SC_SPRINT_ROLE": str(context["role"]),
+        "SC_SPRINT_SLOT": str(context["slot"]),
+        "SC_SPRINT_ASSIGNMENT_ID": str(context["binding_id"]),
+        "SC_SPRINT_LIFECYCLE": str(context["lifecycle"]),
+    }
+    optional = {
+        "SC_SPRINT_SPEC_DOC_ID": context.get("spec_doc_id"),
+        "SC_SPRINT_SOURCE_DIRECTIVE_ID": context.get("source_directive_id"),
+        "SC_SPRINT_SOURCE_MESSAGE_ID": context.get("source_message_id"),
+        "SC_SPRINT_REQUIRED_RESULT_KIND": context.get("required_result_kind"),
+    }
+    env.update(
+        {name: str(value) for name, value in optional.items() if value is not None}
+    )
+    units = context.get("units") or []
+    if units:
+        env["SC_SPRINT_UNITS"] = ",".join(str(row["seq"]) for row in units)
+        if len(units) == 1:
+            env["SC_SPRINT_UNIT_ID"] = str(units[0]["unit_id"])
+            env["SC_SPRINT_UNIT"] = str(units[0]["seq"])
+    return env
+
+
 def _shell_status(shell, snap: "dict | None") -> str:
     """Styled picker status derived from liveness plus sprint reservation."""
     if shell["flavor"] == "admin":
@@ -1184,7 +1213,8 @@ def _cli_version(binary: str) -> "str | None":
 
 def prepare_launch(*, shell_id: int, harness: "str | None" = None,
                    model: "str | None" = None, effort: "str | None" = None,
-                   headless_prompt: "str | None" = None) -> LaunchPlan:
+                   headless_prompt: "str | None" = None,
+                   slot_context: "dict | None" = None) -> LaunchPlan:
     """Prepare a launch exactly as main() would, without any TTY.
 
     Spec #20 (sprint 25 seq 5): starting an Interface chat uses the NORMAL
@@ -1204,6 +1234,8 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
     this seam (open_db, authenticate, ensure_worktree) still sys.exit, so
     callers must also treat SystemExit as a refusal."""
     headless = headless_prompt is not None
+    if slot_context is not None and not headless:
+        raise LaunchError("Sprint launch context requires a headless prompt")
     con = open_db()
     # Same best-effort skill heal as main() — compose's SKILLS block reads
     # what this repairs. RENDER_ONLY never mutates, here as there.
@@ -1280,7 +1312,11 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
             "harness": harness,
             "provider": session_provider(harness, session_model),
             "model": session_model,
-            "sprint_ref": os.environ.get("SC_SPRINT_REF") or None,
+            "sprint_ref": (
+                str(slot_context["sprint_doc_id"])
+                if slot_context is not None
+                else (os.environ.get("SC_SPRINT_REF") or None)
+            ),
         })
     except SessionOpenError as exc:
         con.close()
@@ -1313,7 +1349,8 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
                            floor_note=floor_note,
                            source_mode=install.is_source_repo(),
                            api_key=full["api_key"],
-                           api_port=api_port)
+                           api_port=api_port,
+                           slot_context=slot_context)
     render_harness_skills(
         con, full["shell_id"], work_dir, adapter
     )
@@ -1382,6 +1419,7 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
     env["SC_SHELL_WORKTREE"] = str(work_dir)
     env["SC_ROOT"] = str(REPO_ROOT)
     env["PATH"] = os.pathsep.join([str(REPO_ROOT), env.get("PATH", "")])
+    env.update(sprint_launch_env(slot_context))
 
     return LaunchPlan(argv=argv, env=env, cwd=str(work_dir),
                       session_id=session_id, archive_id=archive_id,

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -256,6 +256,45 @@ class ConductorFlavorAndDoctorTests(RuntimeFixture):
         )
         self.assertEqual(composed, rendered)
 
+    def test_browser_binding_limits_conductor_boot_to_its_exact_sprint(self):
+        sprint_directive = self.emit(
+            "system",
+            "stall",
+            {"evidence": "bounded"},
+        )
+        other_directive = self.con.execute(
+            "INSERT INTO directives "
+            "(issuer_flavor,kind,payload,target) "
+            "VALUES ('system','stall','{}','conductor')"
+        ).lastrowid
+        self.con.commit()
+        shell = self.con.execute(
+            "SELECT * FROM shells WHERE shell_id=1"
+        ).fetchone()
+        context = {
+            "binding_id": 901,
+            "role": "conductor",
+            "lifecycle": "persistent",
+            "slot": "CON1",
+            "sprint_doc_id": 100,
+            "sprint_title": "SPRINT: synthetic",
+            "spec_doc_id": 99,
+            "spec_title": "Synthetic spec",
+            "skill_body": "SPRINT CONDUCTOR SKILL BODY",
+        }
+
+        rendered = runtime.render_boot(
+            self.con,
+            shell,
+            slot_context=context,
+        )
+
+        self.assertIn("## Browser Sprint binding", rendered)
+        self.assertIn("`sc directives list --status pending --sprint 100`", rendered)
+        self.assertIn(f"| {sprint_directive} |", rendered)
+        self.assertNotIn(f"| {other_directive} |", rendered)
+        self.assertIn("SPRINT CONDUCTOR SKILL BODY", rendered)
+
     def test_conductor_harness_policy_rejects_every_non_opencode_route(self):
         conductor_policy.require_harness("conductor", "opencode")
         conductor_policy.require_harness("dev", "codex")

--- a/tests/test_conversation_launch.py
+++ b/tests/test_conversation_launch.py
@@ -28,15 +28,22 @@ def apply_schema(con: sqlite3.Connection) -> None:
         con.executescript(migration.read_text())
 
 
-def make_run(worktree: Path, *, session_before: str | None = None) -> BrokerRun:
+def make_run(
+    worktree: Path,
+    *,
+    conversation_id: str = "cv_" + "a" * 32,
+    harness: str = "codex",
+    model: str = "gpt-test",
+    session_before: str | None = None,
+) -> BrokerRun:
     return BrokerRun(
         run_id=7,
-        conversation_id="cv_" + "a" * 32,
+        conversation_id=conversation_id,
         message_id=8,
         shell_id=1,
-        harness="codex",
+        harness=harness,
         provider="openai",
-        model="gpt-test",
+        model=model,
         effort="high",
         worktree=worktree,
         title="A chat",
@@ -63,11 +70,118 @@ def launch_case():
             "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
             "VALUES (1,'Dev','dev','dev','prompt',1)"
         )
+        con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,owner_user_id,harness,provider,"
+            "model,effort,worktree,state,creation_idempotency_key,"
+            "creation_request_hash) "
+            "VALUES (?,1,'normal',1,'codex','openai','gpt-test','high',"
+            "?,'idle','normal-create','normal-hash')",
+            ("cv_" + "a" * 32, str(root / ".sc-worktrees" / "dev")),
+        )
         con.commit()
         con.close()
         worktree = root / ".sc-worktrees" / "dev"
         worktree.mkdir(parents=True)
         yield db_path, worktree
+
+
+def bind_sprint_assignment(
+    db_path: Path,
+    worktree: Path,
+    *,
+    role: str = "developer",
+    state: str = "active",
+    session_ref: str | None = None,
+) -> BrokerRun:
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    conversation_id = "cv_" + "s" * 32
+    try:
+        con.execute(
+            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
+            "WHERE conversation_id=?",
+            ("cv_" + "a" * 32,),
+        )
+        con.execute(
+            "INSERT INTO documents (document_id,kind,title,body) "
+            "VALUES (24,'doc','SPRINT: launch contract','sprint')"
+        )
+        con.execute(
+            "INSERT INTO documents (document_id,kind,title,body) "
+            "VALUES (25,'spec','Browser Sprint','spec')"
+        )
+        con.execute(
+            "INSERT INTO sprints "
+            "(sprint_doc_id,spec_doc_id,planner_route,dev_route,"
+            "reviewer_route,state,legacy) "
+            "VALUES (24,25,'codex/gpt-test','codex/gpt-test',"
+            "'codex/gpt-test','active',1)"
+        )
+        if role == "conductor":
+            con.execute(
+                "UPDATE shells SET shortname='con',flavor='conductor' "
+                "WHERE shell_id=1"
+            )
+            harness, model = "opencode", "openai/gpt-5.6-luna"
+            unit_id = source_directive_id = required_result = None
+        else:
+            harness, model = "codex", "gpt-test"
+            unit_id = con.execute(
+                "INSERT INTO sprint_units "
+                "(sprint_doc_id,seq,unit_title,dev_shell_id,state,branch) "
+                "VALUES (24,'U1','Launch contract',1,'working',"
+                "'feat/launch-contract')"
+            ).lastrowid
+            source_directive_id = con.execute(
+                "INSERT INTO directives "
+                "(issuer_flavor,kind,target,sprint_doc_id,unit_id) "
+                "VALUES ('system','stall','conductor',24,?)",
+                (unit_id,),
+            ).lastrowid
+            required_result = "unit-report"
+        con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,sprint_doc_id,harness,provider,"
+            "model,effort,worktree,harness_session_ref,state,"
+            "creation_idempotency_key,creation_request_hash) "
+            "VALUES (?,1,'sprint',24,?,'openai',?,'high',?,?,"
+            "'idle','sprint-create','sprint-hash')",
+            (
+                conversation_id,
+                harness,
+                model,
+                str(worktree),
+                session_ref,
+            ),
+        )
+        con.execute(
+            "INSERT INTO sprint_conversation_bindings "
+            "(conversation_id,sprint_doc_id,role,lifecycle,slot,unit_id,"
+            "source_directive_id,required_result_kind,state,started_at) "
+            "VALUES (?,24,?,?,?,?,?,?,?,?)",
+            (
+                conversation_id,
+                role,
+                "persistent" if role == "conductor" else "one_shot",
+                "con" if role == "conductor" else "dev",
+                unit_id,
+                source_directive_id,
+                required_result,
+                state,
+                "2026-07-30 00:00:00" if state == "active" else None,
+            ),
+        )
+        con.commit()
+    finally:
+        con.close()
+    return make_run(
+        worktree,
+        conversation_id=conversation_id,
+        harness=harness,
+        model=model,
+        session_before=session_ref,
+    )
 
 
 def test_preparer_returns_canonical_environment_and_archive(launch_case):
@@ -103,6 +217,207 @@ def test_preparer_returns_canonical_environment_and_archive(launch_case):
         "effort": "high",
         "headless_prompt": "Do the work",
     }]
+
+
+def test_sprint_worker_launch_injects_validated_assignment_context(launch_case):
+    db_path, worktree = launch_case
+    run = bind_sprint_assignment(db_path, worktree)
+    called = []
+
+    def prepare(**kwargs):
+        called.append(kwargs)
+        return SimpleNamespace(
+            cwd=str(worktree),
+            archive_id=43,
+            harness="codex",
+            model="gpt-test",
+            effort="high",
+            env={
+                "SC_API_TOKEN": "shell-token",
+                **run_mod.sprint_launch_env(kwargs["slot_context"]),
+            },
+        )
+
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=prepare,
+        liveness=lambda: {"supported": True, "processes": []},
+    )
+    context, archive_id = preparer(run)
+
+    sprint = called[0]["slot_context"]
+    assert archive_id == 43
+    assert sprint["role"] == "developer"
+    assert sprint["lifecycle"] == "one_shot"
+    assert sprint["slot"] == "dev"
+    assert sprint["spec_doc_id"] == 25
+    assert sprint["source_directive_id"]
+    assert sprint["required_result_kind"] == "unit-report"
+    assert sprint["units"] == [{
+        "unit_id": sprint["units"][0]["unit_id"],
+        "seq": "U1",
+        "unit_title": "Launch contract",
+        "state": "working",
+        "depends_on": None,
+        "overlap": None,
+        "branch": "feat/launch-contract",
+        "pr_number": None,
+    }]
+    assert context.env["SC_SPRINT_REF"] == "24"
+    assert context.env["SC_SPRINT_ROLE"] == "developer"
+    assert context.env["SC_SPRINT_SLOT"] == "dev"
+    assert context.env["SC_SPRINT_UNIT"] == "U1"
+    assert context.env["SC_SPRINT_REQUIRED_RESULT_KIND"] == "unit-report"
+
+
+def test_persistent_conductor_preserves_exact_session_resume(launch_case):
+    db_path, worktree = launch_case
+    run = bind_sprint_assignment(
+        db_path,
+        worktree,
+        role="conductor",
+        session_ref="ses_exact",
+    )
+    called = []
+
+    def prepare(**kwargs):
+        called.append(kwargs)
+        return SimpleNamespace(
+            cwd=str(worktree),
+            archive_id=44,
+            harness="opencode",
+            model="openai/gpt-5.6-luna",
+            effort="high",
+            env=run_mod.sprint_launch_env(kwargs["slot_context"]),
+        )
+
+    context, archive_id = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=prepare,
+        liveness=lambda: {"supported": True, "processes": []},
+    )(run)
+
+    assert archive_id == 44
+    assert run.session_before == "ses_exact"
+    assert called[0]["slot_context"]["role"] == "conductor"
+    assert called[0]["slot_context"]["lifecycle"] == "persistent"
+    assert context.env["SC_SPRINT_ROLE"] == "conductor"
+
+
+def test_one_shot_assignment_refuses_native_session_reuse(launch_case):
+    db_path, worktree = launch_case
+    run = bind_sprint_assignment(
+        db_path,
+        worktree,
+        session_ref="ses_must_not_resume",
+    )
+    called = False
+
+    def prepare(**_kwargs):
+        nonlocal called
+        called = True
+
+    with pytest.raises(ConversationLaunchError) as caught:
+        ConversationLaunchPreparer(
+            db_path,
+            prepare_launch=prepare,
+            liveness=lambda: {"supported": True, "processes": []},
+        )(run)
+
+    assert caught.value.code == "SPRINT_ONE_SHOT_ALREADY_STARTED"
+    assert not called
+
+
+def test_sprint_launch_rejects_missing_binding_and_inactive_sprint(launch_case):
+    db_path, worktree = launch_case
+    con = sqlite3.connect(db_path)
+    conversation_id = "cv_" + "m" * 32
+    con.execute(
+        "UPDATE conversations SET state='closed',closed_at=datetime('now')"
+    )
+    con.execute(
+        "INSERT INTO documents (document_id,kind,title,body) "
+        "VALUES (24,'doc','SPRINT: missing binding','sprint')"
+    )
+    con.execute(
+        "INSERT INTO sprints (sprint_doc_id,state,legacy) "
+        "VALUES (24,'declared',1)"
+    )
+    con.execute(
+        "INSERT INTO conversations "
+        "(conversation_id,shell_id,mode,sprint_doc_id,harness,model,effort,"
+        "worktree,state,creation_idempotency_key,creation_request_hash) "
+        "VALUES (?,1,'sprint',24,'codex','gpt-test','high',?,'idle',"
+        "'missing-binding','hash')",
+        (conversation_id, str(worktree)),
+    )
+    con.commit()
+    con.close()
+    run = make_run(worktree, conversation_id=conversation_id)
+
+    with pytest.raises(ConversationLaunchError) as missing:
+        ConversationLaunchPreparer(
+            db_path,
+            prepare_launch=lambda **_: None,
+            liveness=lambda: {"supported": True, "processes": []},
+        )(run)
+    assert missing.value.code == "SPRINT_BINDING_REQUIRED"
+
+    con = sqlite3.connect(db_path)
+    unit_id = con.execute(
+        "INSERT INTO sprint_units "
+        "(sprint_doc_id,seq,unit_title,dev_shell_id,state) "
+        "VALUES (24,'U1','Unit',1,'working')"
+    ).lastrowid
+    directive_id = con.execute(
+        "INSERT INTO directives "
+        "(issuer_flavor,kind,target,sprint_doc_id,unit_id) "
+        "VALUES ('system','stall','conductor',24,?)",
+        (unit_id,),
+    ).lastrowid
+    con.execute(
+        "INSERT INTO sprint_conversation_bindings "
+        "(conversation_id,sprint_doc_id,role,lifecycle,slot,unit_id,"
+        "source_directive_id,required_result_kind) "
+        "VALUES (?,24,'developer','one_shot','dev',?,?,'unit-report')",
+        (conversation_id, unit_id, directive_id),
+    )
+    con.commit()
+    con.close()
+
+    with pytest.raises(ConversationLaunchError) as inactive:
+        ConversationLaunchPreparer(
+            db_path,
+            prepare_launch=lambda **_: None,
+            liveness=lambda: {"supported": True, "processes": []},
+        )(run)
+    assert inactive.value.code == "SPRINT_NOT_LAUNCHABLE"
+
+
+def test_conductor_policy_rejects_non_opencode_before_preparation(launch_case):
+    db_path, worktree = launch_case
+    run = bind_sprint_assignment(db_path, worktree, role="conductor")
+    run = make_run(
+        worktree,
+        conversation_id=run.conversation_id,
+        harness="codex",
+        model="gpt-test",
+    )
+    called = False
+
+    def prepare(**_kwargs):
+        nonlocal called
+        called = True
+
+    with pytest.raises(ConversationLaunchError) as caught:
+        ConversationLaunchPreparer(
+            db_path,
+            prepare_launch=prepare,
+            liveness=lambda: {"supported": True, "processes": []},
+        )(run)
+
+    assert caught.value.code == "SPRINT_ROUTE_MISMATCH"
+    assert not called
 
 
 def test_preparer_refuses_a_cli_process_holding_the_shell(launch_case):
@@ -249,14 +564,6 @@ def test_cli_launch_is_reserved_until_the_browser_chat_is_ended(launch_case):
     db_path, worktree = launch_case
     con = sqlite3.connect(db_path)
     con.row_factory = sqlite3.Row
-    con.execute(
-            "INSERT INTO conversations "
-            "(conversation_id,shell_id,owner_user_id,harness,worktree,state,"
-            "creation_idempotency_key,creation_request_hash) "
-            "VALUES (?,?,1,'codex',?,'idle','create','hash')",
-            ("cv_" + "b" * 32, 1, str(worktree)),
-        )
-    con.commit()
     try:
         assert run_mod.browser_conversation_active(con, 1)
         assert not run_mod.browser_conversation_active(con, 999)

--- a/tests/test_run_slots.py
+++ b/tests/test_run_slots.py
@@ -232,6 +232,62 @@ class SlotContextTest(unittest.TestCase):
         self.assertIn("sprint 25", prompt)
         self.assertIn("U1, U2", prompt)
 
+    def test_browser_binding_context_renders_result_contract(self) -> None:
+        ctx = {
+            **run.resolve_slot_context(
+                self.con, self.shell(2), "dev", 25, "U1"
+            ),
+            "binding_id": 91,
+            "role": "developer",
+            "lifecycle": "one_shot",
+            "slot": "DEV1",
+            "spec_doc_id": 24,
+            "spec_title": "Governing spec",
+            "source_directive_id": 73,
+            "source_message_id": 88,
+            "required_result_kind": "unit-report",
+        }
+        rendered = compose.render_slot_directive(ctx)
+        self.assertIn("validated Sprint binding", rendered)
+        self.assertIn("**Role:** `developer`", rendered)
+        self.assertIn("**Lifecycle:** `one_shot`", rendered)
+        self.assertIn("**Assignment:** `91`", rendered)
+        self.assertIn("**Governing spec:** document `24`", rendered)
+        self.assertIn("**Source directive:** `73`", rendered)
+        self.assertIn("**Source message:** `88`", rendered)
+        self.assertIn("**Required result:** `unit-report`", rendered)
+
+    def test_browser_binding_environment_is_explicit_and_bounded(self) -> None:
+        context = {
+            "binding_id": 91,
+            "role": "developer",
+            "lifecycle": "one_shot",
+            "slot": "DEV1",
+            "sprint_doc_id": 25,
+            "spec_doc_id": 24,
+            "source_directive_id": 73,
+            "source_message_id": None,
+            "required_result_kind": "unit-report",
+            "units": [{"unit_id": 10, "seq": "U1"}],
+        }
+        self.assertEqual(
+            run.sprint_launch_env(context),
+            {
+                "SC_SPRINT_REF": "25",
+                "SC_SPRINT_ROLE": "developer",
+                "SC_SPRINT_SLOT": "DEV1",
+                "SC_SPRINT_ASSIGNMENT_ID": "91",
+                "SC_SPRINT_LIFECYCLE": "one_shot",
+                "SC_SPRINT_SPEC_DOC_ID": "24",
+                "SC_SPRINT_SOURCE_DIRECTIVE_ID": "73",
+                "SC_SPRINT_REQUIRED_RESULT_KIND": "unit-report",
+                "SC_SPRINT_UNITS": "U1",
+                "SC_SPRINT_UNIT_ID": "10",
+                "SC_SPRINT_UNIT": "U1",
+            },
+        )
+        self.assertEqual(run.sprint_launch_env(None), {})
+
 
 class SlotArgumentTest(unittest.TestCase):
     def test_slot_and_sprint_are_required_together_before_db_open(self) -> None:


### PR DESCRIPTION
## Summary
- resolve and validate typed Sprint conversation bindings before canonical launch preparation
- inject bounded role, assignment, unit, governing-document, source, lifecycle, and required-result context through the existing boot/env seam
- preserve exact persistent Conductor resume while refusing any native-session reuse for one-shot workers
- enforce recorded Sprint routes, assignment ownership, active lifecycle, role skills, and the OpenCode-only Conductor policy before preparation
- scope browser Conductor boot output to its owning Sprint while leaving normal browser chat preparation unchanged

## Verification
- focused contract: 56 passed, 27 subtests
- conversation/run regression: 177 passed, 181 subtests
- full suite: 1,611 passed, 784 subtests
- `./sc map`
- `./sc render-check`
- `git diff --check`

`./sc verify` cannot operate from a linked feature worktree; existing issue #769 tracks that finish-gate mismatch. Full source-suite coverage is green.

## Separate finding
Full-suite scheduling exposed the pre-existing SSE secret-redaction snapshot race recorded in #792. It is intentionally not mixed into this launch-contract unit.