### PR TITLE
fix(conversations): finish Kimi turns with persistent children

### DIFF
--- a/.super-coder/scripts/conversation_adapters/base.py
+++ b/.super-coder/scripts/conversation_adapters/base.py
@@ -398,6 +398,9 @@ class ProcessRunner(Protocol):
 
 
 class SubprocessRunner:
+    def __init__(self, *, start_new_session: bool = False) -> None:
+        self.start_new_session = start_new_session
+
     def spawn(
         self,
         argv: list[str],
@@ -414,7 +417,10 @@ class SubprocessRunner:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
+            start_new_session=self.start_new_session,
         )
+        if self.start_new_session:
+            process.__dict__["_sc_conversation_process_group"] = process.pid
         captured: list[str] = []
 
         def drain_stderr() -> None:

--- a/.super-coder/scripts/conversation_adapters/kimi.py
+++ b/.super-coder/scripts/conversation_adapters/kimi.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import signal
 import subprocess
+import threading
 import time
 from collections.abc import Iterator, Mapping
 from pathlib import Path
@@ -41,6 +43,8 @@ USAGE_KEYS = {
 }
 STDERR_LIMIT = 16384
 POLL_INTERVAL = 0.01
+COMPLETION_POLL_INTERVAL = 0.05
+COMPLETION_DRAIN_SECONDS = 0.1
 
 
 class KimiAdapter(ConversationAdapter):
@@ -57,7 +61,7 @@ class KimiAdapter(ConversationAdapter):
         super().__init__(manifest or load_manifest(self.harness))
         if identity_timeout <= 0:
             raise ValueError("identity_timeout must be positive")
-        self.runner = runner or SubprocessRunner()
+        self.runner = runner or SubprocessRunner(start_new_session=True)
         self.sessions_root = sessions_root
         self.identity_timeout = identity_timeout
 
@@ -264,17 +268,57 @@ class KimiAdapter(ConversationAdapter):
         return matches
 
     @staticmethod
-    def _cleanup_process(process: Any, timeout: float) -> None:
-        poll = getattr(process, "poll", None)
-        running = callable(poll) and poll() is None
-        if running:
+    def _signal_owned_process(process: Any, value: signal.Signals) -> None:
+        process_group = getattr(
+            process,
+            "_sc_conversation_process_group",
+            None,
+        )
+        if isinstance(process_group, int):
+            try:
+                os.killpg(process_group, value)
+                return
+            except ProcessLookupError:
+                return
+            except OSError:
+                pass
+        if value == signal.SIGTERM:
             terminate = getattr(process, "terminate", None)
             if callable(terminate):
                 terminate()
-            else:
-                send_signal = getattr(process, "send_signal", None)
-                if callable(send_signal):
-                    send_signal(signal.SIGTERM)
+                return
+        if value == signal.SIGKILL:
+            kill = getattr(process, "kill", None)
+            if callable(kill):
+                kill()
+                return
+        send_signal = getattr(process, "send_signal", None)
+        if callable(send_signal):
+            send_signal(value)
+
+    @staticmethod
+    def _process_group_alive(process: Any) -> bool:
+        process_group = getattr(
+            process,
+            "_sc_conversation_process_group",
+            None,
+        )
+        if not isinstance(process_group, int):
+            return False
+        try:
+            os.killpg(process_group, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    @classmethod
+    def _cleanup_process(cls, process: Any, timeout: float) -> None:
+        poll = getattr(process, "poll", None)
+        running = callable(poll) and poll() is None
+        if running:
+            cls._signal_owned_process(process, signal.SIGTERM)
         wait = getattr(process, "wait", None)
         if not callable(wait):
             return
@@ -283,13 +327,54 @@ class KimiAdapter(ConversationAdapter):
         except TypeError:
             wait()
         except subprocess.TimeoutExpired:
+            pass
+        if cls._process_group_alive(process):
+            cls._signal_owned_process(process, signal.SIGKILL)
+        elif callable(poll) and poll() is None:
             kill = getattr(process, "kill", None)
             if callable(kill):
                 kill()
+        try:
+            wait(timeout=1.0)
+        except (TypeError, subprocess.TimeoutExpired):
+            pass
+
+    def _watch_native_completion(
+        self,
+        turn: NativeTurn,
+        process: Any,
+        completed: threading.Event,
+        stopped: threading.Event,
+    ) -> None:
+        wire_path = turn.metadata.get("wire_path")
+        if not isinstance(wire_path, str):
+            return
+        wire = Path(wire_path)
+        last_size = -1
+        while not stopped.wait(COMPLETION_POLL_INTERVAL):
+            poll = getattr(process, "poll", None)
+            if callable(poll) and poll() is not None:
+                return
             try:
-                wait(timeout=1.0)
-            except (TypeError, subprocess.TimeoutExpired):
-                pass
+                size = wire.stat().st_size
+                if size == last_size:
+                    continue
+                last_size = size
+                records = self._run_slice(turn)
+            except (AdapterError, OSError):
+                continue
+            if not self._usage(records):
+                continue
+            # Give final stdout metadata already in flight (especially the
+            # resume hint) a bounded window to reach the validator.
+            if stopped.wait(COMPLETION_DRAIN_SECONDS):
+                return
+            if turn.metadata.get("identity_mismatch"):
+                return
+            turn.metadata["native_completion_observed"] = True
+            completed.set()
+            self._cleanup_process(process, 1.0)
+            return
 
     def _discover_start(
         self,
@@ -766,28 +851,40 @@ class KimiAdapter(ConversationAdapter):
             {"run_ref": turn.run_ref, "status": "running"},
             "turn.prompt",
         )
-        for line in stdout:
-            if not line.strip():
-                continue
-            try:
-                raw = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(raw, dict):
-                continue
-            role = raw.get("role")
-            if not isinstance(role, str):
-                continue
-            if role == "meta" and raw.get("type") == "session.resume_hint":
-                if raw.get("session_id") != turn.session_ref:
-                    turn.metadata["identity_mismatch"] = True
-                    raise AdapterError(
-                        "HARNESS_SESSION_MISMATCH",
-                        "Kimi resume hint differs from persisted session ref",
-                    )
-                continue
-            for event in self._normalize(raw):
-                yield event
+        native_completed = threading.Event()
+        stop_watcher = threading.Event()
+        watcher = threading.Thread(
+            target=self._watch_native_completion,
+            args=(turn, process, native_completed, stop_watcher),
+            name="kimi-native-completion",
+            daemon=True,
+        )
+        watcher.start()
+        try:
+            for line in stdout:
+                if not line.strip():
+                    continue
+                try:
+                    raw = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(raw, dict):
+                    continue
+                role = raw.get("role")
+                if not isinstance(role, str):
+                    continue
+                if role == "meta" and raw.get("type") == "session.resume_hint":
+                    if raw.get("session_id") != turn.session_ref:
+                        turn.metadata["identity_mismatch"] = True
+                        raise AdapterError(
+                            "HARNESS_SESSION_MISMATCH",
+                            "Kimi resume hint differs from persisted session ref",
+                        )
+                    continue
+                for event in self._normalize(raw):
+                    yield event
+        finally:
+            stop_watcher.set()
         returncode = process.wait()
         turn.metadata["returncode"] = returncode
         try:
@@ -808,7 +905,7 @@ class KimiAdapter(ConversationAdapter):
             turn.metadata["terminal"] = event.type
             yield event
             return
-        if returncode == 0:
+        if native_completed.is_set() or returncode == 0:
             usage = self._usage(records)
             if usage:
                 yield NormalizedEvent(
@@ -819,7 +916,11 @@ class KimiAdapter(ConversationAdapter):
             event = NormalizedEvent(
                 "run.completed",
                 {"status": "completed"},
-                "process.exit",
+                (
+                    "usage.record"
+                    if native_completed.is_set()
+                    else "process.exit"
+                ),
             )
             turn.metadata["terminal"] = event.type
             yield event
@@ -840,7 +941,7 @@ class KimiAdapter(ConversationAdapter):
         process = turn.opaque
         if process is None or process.poll() is not None:
             return InterruptResult(False, "Kimi process is not running")
-        process.send_signal(signal.SIGINT)
+        self._signal_owned_process(process, signal.SIGINT)
         turn.metadata["interrupt_acknowledged"] = True
         return InterruptResult(True)
 

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -7,10 +7,12 @@ import json
 import signal
 import sys
 import tempfile
+import threading
 import unittest
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".super-coder" / "scripts"
@@ -254,12 +256,23 @@ class FakeKimiProcess:
         exit_before_identity: bool = False,
         stderr: str = "",
         cancel_wire: Path | None = None,
+        block_after_stdout: bool = False,
     ) -> None:
         encoded = [
             line if isinstance(line, str) else json.dumps(line)
             for line in stdout_lines
         ]
-        self.stdout = io.StringIO("".join(line + "\n" for line in encoded))
+        self.stdout_released = threading.Event()
+        self.stdout_blocked = threading.Event()
+        self.stdout = (
+            BlockingKimiStdout(
+                encoded,
+                self.stdout_blocked,
+                self.stdout_released,
+            )
+            if block_after_stdout
+            else io.StringIO("".join(line + "\n" for line in encoded))
+        )
         self.stderr = io.StringIO(stderr)
         self.pid = 9876
         self.returncode: int | None = (
@@ -284,10 +297,12 @@ class FakeKimiProcess:
     def terminate(self) -> None:
         self.terminated = True
         self.returncode = -signal.SIGTERM
+        self.stdout_released.set()
 
     def kill(self) -> None:
         self.killed = True
         self.returncode = -signal.SIGKILL
+        self.stdout_released.set()
 
     def send_signal(self, value: int) -> None:
         self.signals.append(value)
@@ -297,6 +312,25 @@ class FakeKimiProcess:
                     json.dumps({"type": "turn.cancel", "time": 9000}) + "\n"
                 )
             self.returncode = -signal.SIGINT
+            self.stdout_released.set()
+
+
+class BlockingKimiStdout:
+    def __init__(
+        self,
+        lines: list[str],
+        blocked: threading.Event,
+        released: threading.Event,
+    ) -> None:
+        self.lines = lines
+        self.blocked = blocked
+        self.released = released
+
+    def __iter__(self) -> Iterator[str]:
+        yield from (line + "\n" for line in self.lines)
+        self.blocked.set()
+        if not self.released.wait(2.0):
+            raise AssertionError("Kimi stdout remained blocked")
 
 
 class FakeKimiRunner:
@@ -440,6 +474,7 @@ class FakeKimiRunner:
             exit_before_identity=plan.get("exit_before_identity", False),
             stderr=plan.get("stderr", ""),
             cancel_wire=wire,
+            block_after_stdout=plan.get("block_after_stdout", False),
         )
         self.calls.append((list(argv), cwd, dict(env)))
         self.processes.append(process)
@@ -1200,6 +1235,61 @@ class ConversationAdapterTest(unittest.TestCase):
             failed_events[-1].payload["error"].startswith(
                 "native failure detail"
             )
+        )
+
+    def test_kimi_durable_usage_completes_when_child_holds_stdout_open(
+        self,
+    ) -> None:
+        adapter, runner = self.build("kimi")
+        runner.queue(
+            stdout_lines=[
+                {"role": "assistant", "content": "server started"},
+            ],
+            after_prompt=[
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {"inputOther": 10, "output": 2},
+                },
+            ],
+            block_after_stdout=True,
+        )
+
+        turn = adapter.start(self.context, "start server")
+        events = list(adapter.stream(turn))
+
+        self.assertTrue(turn.opaque.stdout_blocked.is_set())
+        self.assertTrue(turn.opaque.terminated)
+        self.assertEqual(
+            [event.type for event in events],
+            [
+                "session.started",
+                "run.started",
+                "assistant.delta",
+                "usage",
+                "run.completed",
+            ],
+        )
+        self.assertEqual(events[-1].native_type, "usage.record")
+
+    def test_kimi_default_runner_owns_and_cleans_up_process_group(self) -> None:
+        adapter = KimiAdapter()
+        self.assertTrue(adapter.runner.start_new_session)
+        process = FakeKimiProcess([])
+        process._sc_conversation_process_group = 4321
+
+        with mock.patch(
+            "conversation_adapters.kimi.os.killpg"
+        ) as kill_process_group:
+            adapter._cleanup_process(process, 0.1)
+
+        self.assertEqual(
+            kill_process_group.call_args_list,
+            [
+                mock.call(4321, signal.SIGTERM),
+                mock.call(4321, 0),
+                mock.call(4321, signal.SIGKILL),
+            ],
         )
 
     def test_kimi_identity_mismatch_blocks_usage_reconciliation(self) -> None:


### PR DESCRIPTION
## Summary

- monitor the exact Kimi main-wire run slice while stdout streaming is active
- treat turn-scoped native usage as durable success proof, preserving final buffered stdout before terminalizing
- launch Kimi in an adapter-owned process group and clean that group up after durable completion or interruption
- cover the persistent-child/stdout-hold regression and process-group policy

## Lifecycle policy

The adapter owns every descendant launched inside its ephemeral Kimi turn and cleans the group up when the turn is durably complete. Services intended to survive a browser turn must use the project supervisor or `sc job`, which owns a separate lifecycle. This avoids releasing the conversation lock while leaving an unbounded Kimi/bash/server tree behind.

## Verification

- `.venv/bin/pytest -q tests/test_conversation_*.py` — 124 passed, 154 subtests passed
- `.venv/bin/ruff check --isolated --select E9,F63,F7,F82 ...` — passed
- `./sc render-check` — passed
- `git diff --check` — passed
- `./sc verify` — passed in disposable standalone clone of exact commit `a57dc4b` (linked dev worktrees correctly refuse this live-instance gate)

The broader targeted ruff baseline has nine unrelated pre-existing findings, tracked separately in #797.

Fixes #794