### PR TITLE
Wire chat Stop and Close recovery

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -319,7 +319,13 @@ def _conversation_row(con, conversation_id: str, owner_user_id: int):
     return con.execute(
         "SELECT c.conversation_id,c.shell_id,c.mode,c.owner_user_id,c.harness,"
         "c.provider,c.model,c.effort,c.state,c.title,c.starred,c.created_at,"
-        "c.last_activity_at,c.closed_at,c.version,s.display_name,s.shortname "
+        "c.last_activity_at,c.closed_at,c.version,s.display_name,s.shortname,"
+        "CASE WHEN c.state!='closed' THEN ("
+        " SELECT requested.created_at FROM conversation_events requested "
+        " WHERE requested.conversation_id=c.conversation_id "
+        " AND requested.event_type='conversation.close.requested' "
+        " ORDER BY requested.sequence DESC LIMIT 1"
+        ") END AS close_requested_at "
         "FROM conversations c JOIN shells s ON s.shell_id=c.shell_id "
         "WHERE c.conversation_id=? AND c.mode='normal' AND c.owner_user_id=?",
         (conversation_id, owner_user_id),
@@ -347,6 +353,7 @@ def _conversation_projection(row) -> dict:
         "created_at": row["created_at"],
         "last_activity_at": row["last_activity_at"],
         "closed_at": row["closed_at"],
+        "close_requested_at": row["close_requested_at"],
         "version": int(row["version"]),
     }
 
@@ -380,6 +387,128 @@ def _require_conversation(con, conversation_id: str, owner_user_id: int):
     if row is None:
         raise ApiError(404, "CONVERSATION_NOT_FOUND", "conversation does not exist")
     return row
+
+
+def _close_requested(con, conversation_id: str) -> bool:
+    return (
+        con.execute(
+            "SELECT 1 FROM conversation_events WHERE conversation_id=? "
+            "AND event_type='conversation.close.requested' LIMIT 1",
+            (conversation_id,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _cancel_queued_turns(con, conversation_id: str) -> int:
+    message_ids = [
+        int(row["message_id"])
+        for row in con.execute(
+            "SELECT DISTINCT message_id FROM conversation_outbox "
+            "WHERE conversation_id=? AND state IN ('pending','claimed')",
+            (conversation_id,),
+        ).fetchall()
+    ]
+    if not message_ids:
+        return 0
+    marks = ",".join("?" for _ in message_ids)
+    cancelled = con.execute(
+        "UPDATE conversation_messages SET state='cancelled',"
+        "completed_at=datetime('now') "
+        f"WHERE message_id IN ({marks}) "
+        "AND state IN ('accepted','queued','running')",
+        message_ids,
+    ).rowcount
+    con.execute(
+        "UPDATE conversation_outbox SET state='cancelled',"
+        "claim_owner=NULL,claimed_at=NULL,lease_expires_at=NULL "
+        f"WHERE message_id IN ({marks}) AND state IN ('pending','claimed')",
+        message_ids,
+    )
+    return int(cancelled)
+
+
+def _begin_close(con, conversation_id: str, current_state: str) -> int | None:
+    active = con.execute(
+        "SELECT run_id,trigger_message_id FROM conversation_runs "
+        "WHERE conversation_id=? AND state IN ('leased','starting','running') "
+        "ORDER BY run_id DESC LIMIT 1",
+        (conversation_id,),
+    ).fetchone()
+    cancelled = _cancel_queued_turns(con, conversation_id)
+    if active is not None:
+        run_id = int(active["run_id"])
+        if not _close_requested(con, conversation_id):
+            _append_event(
+                con,
+                conversation_id,
+                "conversation.close.requested",
+                {"cancelled_queued_turns": cancelled},
+                run_id=run_id,
+            )
+        interrupt_exists = con.execute(
+            "SELECT 1 FROM conversation_events WHERE run_id=? "
+            "AND event_type='run.interrupt.requested' LIMIT 1",
+            (run_id,),
+        ).fetchone()
+        if interrupt_exists is None:
+            _append_event(
+                con,
+                conversation_id,
+                "run.interrupt.requested",
+                {"reason": "conversation.close"},
+                message_id=int(active["trigger_message_id"]),
+                run_id=run_id,
+            )
+        con.execute(
+            "UPDATE conversations SET last_activity_at=datetime('now'),"
+            "version=version+1 WHERE conversation_id=?",
+            (conversation_id,),
+        )
+        return run_id
+
+    recovered_state = None
+    if current_state == "queued":
+        con.execute(
+            "UPDATE conversations SET state='idle' WHERE conversation_id=?",
+            (conversation_id,),
+        )
+    elif current_state == "running":
+        recovered_state = current_state
+        con.execute(
+            "UPDATE conversations SET state='error' WHERE conversation_id=?",
+            (conversation_id,),
+        )
+    con.execute(
+        "UPDATE conversations SET state='closed',closed_at=datetime('now'),"
+        "last_activity_at=datetime('now'),version=version+1 "
+        "WHERE conversation_id=?",
+        (conversation_id,),
+    )
+    _append_event(
+        con,
+        conversation_id,
+        "conversation.closed",
+        {
+            "state": "closed",
+            "cancelled_queued_turns": cancelled,
+            **(
+                {"recovered_orphaned_state": recovered_state}
+                if recovered_state
+                else {}
+            ),
+        },
+    )
+    return None
+
+
+def _deliver_close_interrupt(run_id: int) -> None:
+    try:
+        conversation_broker.interrupt_run(run_id)
+    except conversation_broker.BrokerError:
+        # The close transaction already persisted interrupt intent. A live
+        # broker is nudged now; startup/lease recovery delivers it otherwise.
+        conversation_broker.notify_commit()
 
 
 def _live_shell_session(shell) -> str | None:
@@ -686,7 +815,13 @@ def _list_conversations(con, operator: dict, query):
     rows = con.execute(
         "SELECT c.conversation_id,c.shell_id,c.mode,c.owner_user_id,c.harness,"
         "c.provider,c.model,c.effort,c.state,c.title,c.starred,c.created_at,"
-        "c.last_activity_at,c.closed_at,c.version,s.display_name,s.shortname "
+        "c.last_activity_at,c.closed_at,c.version,s.display_name,s.shortname,"
+        "CASE WHEN c.state!='closed' THEN ("
+        " SELECT requested.created_at FROM conversation_events requested "
+        " WHERE requested.conversation_id=c.conversation_id "
+        " AND requested.event_type='conversation.close.requested' "
+        " ORDER BY requested.sequence DESC LIMIT 1"
+        ") END AS close_requested_at "
         "FROM conversations c JOIN shells s ON s.shell_id=c.shell_id WHERE "
         + " AND ".join(clauses)
         + " ORDER BY c.last_activity_at DESC,c.conversation_id DESC LIMIT ?",
@@ -729,6 +864,7 @@ def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
     if "state" in body and body["state"] != "closed":
         raise ApiError(422, "VALIDATION_ERROR", "state may only be changed to closed")
 
+    active_run_id = None
     with db_driver.write_transaction(con, "conversation.patch"):
         row = _require_conversation(con, conversation_id, operator["user_id"])
         if int(row["version"]) != version:
@@ -745,16 +881,7 @@ def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
                 "CONVERSATION_CLOSED",
                 "conversation is already closed",
             )
-        if closing and row["state"] not in ("idle", "waiting", "error"):
-            raise ApiError(
-                409,
-                "BROWSER_CHAT_BUSY",
-                "a queued or running conversation cannot be closed",
-                {"state": row["state"]},
-            )
-        sets = ["version=version+1"]
-        if "title" in body or closing:
-            sets.append("last_activity_at=datetime('now')")
+        sets = []
         params: list = []
         if "title" in body:
             sets.append("title=?")
@@ -763,35 +890,61 @@ def _patch_conversation(con, operator: dict, conversation_id: str, body: dict):
             sets.append("starred=?")
             params.append(int(body["starred"]))
         if closing:
-            sets.extend(("state='closed'", "closed_at=datetime('now')"))
-        changed = con.execute(
-            f"UPDATE conversations SET {','.join(sets)} "
-            "WHERE conversation_id=? AND owner_user_id=? AND version=?",
-            (*params, conversation_id, operator["user_id"], version),
-        ).rowcount
-        if changed != 1:
-            raise ApiError(
-                409,
-                "CONVERSATION_VERSION_CONFLICT",
-                "conversation changed concurrently",
+            if sets:
+                con.execute(
+                    f"UPDATE conversations SET {','.join(sets)} "
+                    "WHERE conversation_id=?",
+                    (*params, conversation_id),
+                )
+                _append_event(
+                    con,
+                    conversation_id,
+                    "conversation.updated",
+                    {
+                        **({"title": title} if "title" in body else {}),
+                        **(
+                            {"starred": body["starred"]}
+                            if "starred" in body
+                            else {}
+                        ),
+                    },
+                )
+            active_run_id = _begin_close(con, conversation_id, row["state"])
+        else:
+            sets.insert(0, "version=version+1")
+            if "title" in body:
+                sets.append("last_activity_at=datetime('now')")
+            changed = con.execute(
+                f"UPDATE conversations SET {','.join(sets)} "
+                "WHERE conversation_id=? AND owner_user_id=? AND version=?",
+                (*params, conversation_id, operator["user_id"], version),
+            ).rowcount
+            if changed != 1:
+                raise ApiError(
+                    409,
+                    "CONVERSATION_VERSION_CONFLICT",
+                    "conversation changed concurrently",
+                )
+            _append_event(
+                con,
+                conversation_id,
+                (
+                    "conversation.renamed"
+                    if set(body) == {"version", "title"}
+                    else "conversation.updated"
+                ),
+                {
+                    **({"title": title} if "title" in body else {}),
+                    **(
+                        {"starred": body["starred"]}
+                        if "starred" in body
+                        else {}
+                    ),
+                },
             )
-        _append_event(
-            con,
-            conversation_id,
-            (
-                "conversation.closed"
-                if closing and set(body) == {"version", "state"}
-                else "conversation.renamed"
-                if set(body) == {"version", "title"}
-                else "conversation.updated"
-            ),
-            {
-                **({"title": title} if "title" in body else {}),
-                **({"starred": body["starred"]} if "starred" in body else {}),
-                **({"state": "closed"} if closing else {}),
-            },
-        )
     conversation_events.notify(conversation_id)
+    if active_run_id is not None:
+        _deliver_close_interrupt(active_run_id)
     return _json(
         200,
         _conversation_projection(
@@ -844,6 +997,12 @@ def _create_message(con, operator: dict, conversation_id: str, headers, body: di
                 409,
                 "CONVERSATION_CLOSED",
                 "closed conversations reject messages",
+            )
+        if _close_requested(con, conversation_id):
+            raise ApiError(
+                409,
+                "CONVERSATION_CLOSING",
+                "the conversation is stopping active work before it closes",
             )
         target_state = (
             conversation["state"]

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -239,6 +239,11 @@ class BrokerStore:
                     " ON c.conversation_id=o.conversation_id "
                     "JOIN conversation_messages m ON m.message_id=o.message_id "
                     "WHERE o.state='pending' AND c.state='queued' "
+                    "AND NOT EXISTS ("
+                    " SELECT 1 FROM conversation_events closing "
+                    " WHERE closing.conversation_id=c.conversation_id "
+                    " AND closing.event_type='conversation.close.requested'"
+                    ") "
                     "AND m.state IN ('accepted','queued') "
                     "AND (c.mode='normal' OR NOT EXISTS ("
                     " SELECT 1 FROM sprint_cancellations cancelled "
@@ -618,7 +623,11 @@ class BrokerStore:
             ):
                 row = con.execute(
                     "SELECT r.state,r.conversation_id,r.trigger_message_id,"
-                    "c.state AS conversation_state "
+                    "c.state AS conversation_state,"
+                    "EXISTS(SELECT 1 FROM conversation_events closing "
+                    " WHERE closing.conversation_id=r.conversation_id "
+                    " AND closing.event_type='conversation.close.requested') "
+                    "AS close_requested "
                     "FROM conversation_runs r JOIN conversations c "
                     "ON c.conversation_id=r.conversation_id WHERE r.run_id=?",
                     (run_id,),
@@ -639,6 +648,33 @@ class BrokerStore:
                     (row["trigger_message_id"],),
                 ).fetchone()[0]
                 require_transition("message", message_current, message_state)
+                if row["close_requested"]:
+                    queued_ids = [
+                        int(item["message_id"])
+                        for item in con.execute(
+                            "SELECT DISTINCT message_id FROM conversation_outbox "
+                            "WHERE conversation_id=? "
+                            "AND state IN ('pending','claimed')",
+                            (row["conversation_id"],),
+                        ).fetchall()
+                    ]
+                    if queued_ids:
+                        marks = ",".join("?" for _ in queued_ids)
+                        con.execute(
+                            "UPDATE conversation_messages SET state='cancelled',"
+                            "completed_at=? "
+                            f"WHERE message_id IN ({marks}) "
+                            "AND state IN ('accepted','queued','running')",
+                            (now, *queued_ids),
+                        )
+                        con.execute(
+                            "UPDATE conversation_outbox SET state='cancelled',"
+                            "claim_owner=NULL,claimed_at=NULL,"
+                            "lease_expires_at=NULL "
+                            f"WHERE message_id IN ({marks}) "
+                            "AND state IN ('pending','claimed')",
+                            queued_ids,
+                        )
                 pending = (
                     con.execute(
                         "SELECT 1 FROM conversation_outbox "
@@ -692,6 +728,26 @@ class BrokerStore:
                     message_id=row["trigger_message_id"],
                     run_id=run_id,
                 )
+                if row["close_requested"]:
+                    require_transition(
+                        "conversation",
+                        conversation_target,
+                        "closed",
+                    )
+                    con.execute(
+                        "UPDATE conversations SET state='closed',closed_at=?,"
+                        "last_activity_at=?,version=version+1 "
+                        "WHERE conversation_id=?",
+                        (now, now, row["conversation_id"]),
+                    )
+                    self._append_event(
+                        con,
+                        conversation_id=row["conversation_id"],
+                        event_type="conversation.closed",
+                        payload={"state": "closed", "recovered": True},
+                        message_id=None,
+                        run_id=run_id,
+                    )
                 conversation_id = row["conversation_id"]
         finally:
             con.close()

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3411,7 +3411,8 @@ function chatOpenStream(conversationId, generation, onEvent, onState) {
   source.onerror = () => onState("reconnecting");
   const types = [
     "conversation.created", "conversation.updated", "conversation.renamed",
-    "conversation.closed", "message.accepted", "session.started", "run.started",
+    "conversation.close.requested", "conversation.closed",
+    "message.accepted", "session.started", "run.started",
     "assistant.delta", "tool.started", "tool.completed", "permission.requested",
     "input.requested", "usage", "run.completed", "run.failed",
     "run.interrupted", "run.unknown",
@@ -3541,6 +3542,7 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   const events = [];
   const seen = new Set();
   let streamStatus = "connecting";
+  let stopRequest = null;
 
   const header = el("div", { className: "chat-pane-head" });
   const title = el("div", { className: "chat-pane-title" });
@@ -3577,8 +3579,7 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     className: "act danger chat-stop",
     type: "button",
     textContent: "Stop",
-    title: "Reserved for future stream control",
-    disabled: true,
+    title: "Interrupt the active turn",
   });
   const pending = el("div", { className: "chat-pending", hidden: true });
   const composerRow = el("div", { className: "chat-composer" },
@@ -3629,10 +3630,16 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     queueState.textContent = `${queued} queued`;
     updateStreamStatus();
     const closed = conversation.state === "closed";
-    composer.disabled = closed;
-    send.disabled = closed;
-    close.disabled = !["idle", "waiting", "error"].includes(conversation.state);
-    composer.placeholder = closed ? "This conversation is closed." : "Message this shell…";
+    const closing = !closed && Boolean(conversation.close_requested_at);
+    composer.disabled = closed || closing;
+    send.disabled = closed || closing;
+    stop.disabled = conversation.state !== "running" || closing || Boolean(stopRequest);
+    stop.textContent = stopRequest ? "Stopping…" : "Stop";
+    close.disabled = closed || closing;
+    close.textContent = closing ? "Closing…" : "Close";
+    composer.placeholder = closed
+      ? "This conversation is closed."
+      : closing ? "Stopping work and closing…" : "Message this shell…";
     chatPaintTranscript(
       transcript,
       messages,
@@ -3664,12 +3671,19 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     textContent: "Close",
   });
   close.onclick = async () => {
-    if (!confirm(
-      "Close this conversation? Its transcript will remain available."
-    )) return;
+    if (close.disabled) return;
+    close.disabled = true;
+    close.textContent = "Closing…";
     try {
+      const latest = await chatApi(
+        `/conversations/${conversation.conversation_id}`);
+      if (latest.state === "closed") {
+        conversation = latest;
+        paint();
+        return;
+      }
       conversation = await chatApi(`/conversations/${conversation.conversation_id}`,
-        "PATCH", { version: conversation.version, state: "closed" });
+        "PATCH", { version: latest.version, state: "closed" });
       paint();
     } catch (error) { toast(`${error.code}: ${error.message}`); refresh(); }
   };
@@ -3707,10 +3721,26 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
       pending.textContent = `${error.code} — retry keeps this exact send`;
       toast(`${error.code}: ${error.message}`);
     } finally {
-      send.disabled = conversation.state === "closed";
+      send.disabled = conversation.state === "closed"
+        || Boolean(conversation.close_requested_at);
     }
   }
   send.onclick = submit;
+  stop.onclick = async () => {
+    if (conversation.state !== "running") return;
+    if (!stopRequest) stopRequest = { key: requestKey() };
+    paint();
+    try {
+      await chatApi(
+        `/conversations/${conversation.conversation_id}/interruptions`,
+        "POST", {}, stopRequest.key);
+    } catch (error) {
+      stopRequest = null;
+      toast(`${error.code}: ${error.message}`);
+      refresh();
+      paint();
+    }
+  };
   composer.onkeydown = (event) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
@@ -3737,16 +3767,22 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
           && conversation.state !== "running")
         conversation.state = "queued";
       if (event.event_type === "run.started") conversation.state = "running";
+      if (event.event_type === "conversation.close.requested")
+        conversation.close_requested_at = event.created_at || true;
       if (["permission.requested", "input.requested"].includes(event.event_type))
         conversation.state = "waiting";
       if (["run.completed", "run.interrupted"].includes(event.event_type))
         conversation.state = chatQueuedCount(messages) ? "queued" : "idle";
       if (["run.failed", "run.unknown"].includes(event.event_type))
         conversation.state = "error";
+      if (["run.completed", "run.failed", "run.interrupted", "run.unknown"]
+        .includes(event.event_type))
+        stopRequest = null;
       paint();
       if (["message.accepted", "run.completed", "run.failed",
            "run.interrupted", "run.unknown",
            "conversation.updated", "conversation.renamed",
+           "conversation.close.requested",
            "conversation.closed"].includes(event.event_type))
         refresh();
     },

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -290,7 +290,7 @@ class ConversationResourceTest(ConversationApiCase):
         self.assertEqual(status, 409)
         self.assertEqual(error["error"]["code"], "BROWSER_CHAT_BUSY")
 
-    def test_close_refuses_while_the_open_turn_is_running(self) -> None:
+    def test_close_repairs_running_state_without_a_live_run(self) -> None:
         first = self.create(key="running-close")
         con = self.connect()
         try:
@@ -308,13 +308,215 @@ class ConversationResourceTest(ConversationApiCase):
         finally:
             con.close()
 
-        status, _, error = self.request(
+        status, _, closed = self.request(
             "PATCH",
             f"/api/conversations/{first['conversation_id']}",
             body={"version": first["version"], "state": "closed"},
         )
-        self.assertEqual(status, 409)
-        self.assertEqual(error["error"]["code"], "BROWSER_CHAT_BUSY")
+        self.assertEqual(status, 200, closed)
+        self.assertEqual(closed["state"], "closed")
+        self.assertIsNone(closed["close_requested_at"])
+        con = self.connect()
+        try:
+            row = con.execute(
+                "SELECT state,closed_at FROM conversations "
+                "WHERE conversation_id=?",
+                (first["conversation_id"],),
+            ).fetchone()
+            events = con.execute(
+                "SELECT event_type,payload FROM conversation_events "
+                "WHERE conversation_id=? ORDER BY sequence",
+                (first["conversation_id"],),
+            ).fetchall()
+        finally:
+            con.close()
+        self.assertEqual(row["state"], "closed")
+        self.assertIsNotNone(row["closed_at"])
+        self.assertEqual(events[-1]["event_type"], "conversation.closed")
+        self.assertEqual(
+            json.loads(events[-1]["payload"])["recovered_orphaned_state"],
+            "running",
+        )
+
+    def test_close_cancels_every_queued_turn_before_releasing_ownership(self) -> None:
+        conversation = self.create(key="queued-close")
+        message_ids = []
+        for number in range(2):
+            status, _, accepted = self.request(
+                "POST",
+                f"/api/conversations/{conversation['conversation_id']}/messages",
+                body={"text": f"queued {number}"},
+                key=f"queued-close-{number}",
+            )
+            self.assertEqual(status, 202, accepted)
+            message_ids.append(accepted["message"]["message_id"])
+        _, _, latest = self.request(
+            "GET",
+            f"/api/conversations/{conversation['conversation_id']}",
+        )
+
+        status, _, closed = self.request(
+            "PATCH",
+            f"/api/conversations/{conversation['conversation_id']}",
+            body={"version": latest["version"], "state": "closed"},
+        )
+
+        self.assertEqual(status, 200, closed)
+        self.assertEqual(closed["state"], "closed")
+        con = self.connect()
+        try:
+            messages = con.execute(
+                "SELECT message_id,state,completed_at "
+                "FROM conversation_messages WHERE conversation_id=? "
+                "ORDER BY message_id",
+                (conversation["conversation_id"],),
+            ).fetchall()
+            outbox = con.execute(
+                "SELECT message_id,state,run_id FROM conversation_outbox "
+                "WHERE conversation_id=? ORDER BY message_id",
+                (conversation["conversation_id"],),
+            ).fetchall()
+            live_runs = con.execute(
+                "SELECT COUNT(*) FROM conversation_runs "
+                "WHERE conversation_id=? "
+                "AND state IN ('leased','starting','running')",
+                (conversation["conversation_id"],),
+            ).fetchone()[0]
+        finally:
+            con.close()
+        self.assertEqual([row["message_id"] for row in messages], message_ids)
+        self.assertEqual([row["state"] for row in messages], ["cancelled", "cancelled"])
+        self.assertTrue(all(row["completed_at"] for row in messages))
+        self.assertEqual(
+            [(row["message_id"], row["state"], row["run_id"]) for row in outbox],
+            [(message_ids[0], "cancelled", None), (message_ids[1], "cancelled", None)],
+        )
+        self.assertEqual(live_runs, 0)
+
+    def test_close_interrupts_active_run_and_closes_after_terminal_proof(self) -> None:
+        conversation = self.create(key="active-close")
+        message_ids = []
+        for number in range(2):
+            status, _, accepted = self.request(
+                "POST",
+                f"/api/conversations/{conversation['conversation_id']}/messages",
+                body={"text": f"turn {number}"},
+                key=f"active-close-{number}",
+            )
+            self.assertEqual(status, 202, accepted)
+            message_ids.append(accepted["message"]["message_id"])
+        store = conversation_broker.BrokerStore(self.db_path)
+        run = store.claim_next("test-close")
+        self.assertIsNotNone(run)
+        _, _, latest = self.request(
+            "GET",
+            f"/api/conversations/{conversation['conversation_id']}",
+        )
+
+        with mock.patch.object(
+            conversation_routes.conversation_broker,
+            "interrupt_run",
+            return_value=True,
+        ) as interrupt:
+            status, _, closing = self.request(
+                "PATCH",
+                f"/api/conversations/{conversation['conversation_id']}",
+                body={"version": latest["version"], "state": "closed"},
+            )
+
+        self.assertEqual(status, 200, closing)
+        self.assertEqual(closing["state"], "running")
+        self.assertIsNotNone(closing["close_requested_at"])
+        interrupt.assert_called_once_with(run.run_id)
+        rejected_status, _, rejected = self.request(
+            "POST",
+            f"/api/conversations/{conversation['conversation_id']}/messages",
+            body={"text": "must not queue"},
+            key="active-close-rejected",
+        )
+        self.assertEqual(rejected_status, 409)
+        self.assertEqual(rejected["error"]["code"], "CONVERSATION_CLOSING")
+
+        con = self.connect()
+        try:
+            before_messages = con.execute(
+                "SELECT message_id,state FROM conversation_messages "
+                "WHERE conversation_id=? AND message_kind='prompt' "
+                "ORDER BY message_id",
+                (conversation["conversation_id"],),
+            ).fetchall()
+            before_outbox = con.execute(
+                "SELECT message_id,state FROM conversation_outbox "
+                "WHERE conversation_id=? ORDER BY message_id",
+                (conversation["conversation_id"],),
+            ).fetchall()
+            request_events = con.execute(
+                "SELECT event_type,run_id FROM conversation_events "
+                "WHERE conversation_id=? AND event_type IN "
+                "('conversation.close.requested','run.interrupt.requested') "
+                "ORDER BY sequence",
+                (conversation["conversation_id"],),
+            ).fetchall()
+        finally:
+            con.close()
+        self.assertEqual(
+            [(row["message_id"], row["state"]) for row in before_messages],
+            [(message_ids[0], "running"), (message_ids[1], "cancelled")],
+        )
+        self.assertEqual(
+            [(row["message_id"], row["state"]) for row in before_outbox],
+            [(message_ids[0], "dispatched"), (message_ids[1], "cancelled")],
+        )
+        self.assertEqual(
+            [(row["event_type"], row["run_id"]) for row in request_events],
+            [
+                ("conversation.close.requested", run.run_id),
+                ("run.interrupt.requested", run.run_id),
+            ],
+        )
+
+        self.assertTrue(
+            store.finish_run(
+                run.run_id,
+                "cancelled",
+                event_type="run.interrupted",
+                payload={"outcome": "cancelled"},
+            )
+        )
+        _, _, closed = self.request(
+            "GET",
+            f"/api/conversations/{conversation['conversation_id']}",
+        )
+        self.assertEqual(closed["state"], "closed")
+        self.assertIsNone(closed["close_requested_at"])
+        con = self.connect()
+        try:
+            final_messages = con.execute(
+                "SELECT message_id,state FROM conversation_messages "
+                "WHERE conversation_id=? AND message_kind='prompt' "
+                "ORDER BY message_id",
+                (conversation["conversation_id"],),
+            ).fetchall()
+            final_events = con.execute(
+                "SELECT event_type FROM conversation_events "
+                "WHERE conversation_id=? ORDER BY sequence",
+                (conversation["conversation_id"],),
+            ).fetchall()
+        finally:
+            con.close()
+        self.assertEqual(
+            [(row["message_id"], row["state"]) for row in final_messages],
+            [(message_ids[0], "cancelled"), (message_ids[1], "cancelled")],
+        )
+        self.assertEqual(
+            [row["event_type"] for row in final_events][-4:],
+            [
+                "conversation.close.requested",
+                "run.interrupt.requested",
+                "run.interrupted",
+                "conversation.closed",
+            ],
+        )
 
     def test_opencode_requires_an_exact_resolved_model(self) -> None:
         with mock.patch.object(

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -382,6 +382,42 @@ class StoreContractTest(ConversationBrokerCase):
         self.assertEqual(first_state, "completed")
         self.assertEqual(sequences, [1, 2])
 
+    def test_close_requested_conversation_cannot_dispatch_queued_work(self) -> None:
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        con = self.connect()
+        con.execute(
+            "INSERT INTO conversation_events "
+            "(conversation_id,sequence,event_type,payload) "
+            "VALUES (?,1,'conversation.close.requested','{}')",
+            (conversation_id,),
+        )
+        con.commit()
+        con.close()
+
+        self.assertIsNone(BrokerStore(self.db_path).claim_next("broker"))
+
+        con = self.connect()
+        try:
+            message = con.execute(
+                "SELECT state FROM conversation_messages WHERE message_id=?",
+                (message_id,),
+            ).fetchone()[0]
+            outbox = con.execute(
+                "SELECT state,run_id FROM conversation_outbox WHERE message_id=?",
+                (message_id,),
+            ).fetchone()
+            run_count = con.execute(
+                "SELECT COUNT(*) FROM conversation_runs "
+                "WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0]
+        finally:
+            con.close()
+        self.assertEqual(message, "queued")
+        self.assertEqual(tuple(outbox), ("pending", None))
+        self.assertEqual(run_count, 0)
+
     def test_shell_mutation_lock_blocks_other_conversation(self) -> None:
         self.allow_legacy_duplicate_open_chats()
         first_conversation = self.add_conversation(shell_id=1)

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -147,13 +147,44 @@ def test_composer_is_retry_safe_and_has_turn_controls():
         interface.index("const stop ="):
         interface.index("const pending =", interface.index("const stop ="))
     ]
-    assert "disabled: true" in stop_control
-    assert ".onclick" not in stop_control
+    assert 'title: "Interrupt the active turn"' in stop_control
+    assert "disabled: true" not in stop_control
+    stop_handler = interface[
+        interface.index("stop.onclick ="):
+        interface.index("composer.onkeydown", interface.index("stop.onclick ="))
+    ]
+    assert 'conversation.state !== "running"' in stop_handler
+    assert "if (!stopRequest) stopRequest = { key: requestKey() }" in stop_handler
+    assert "/interruptions`" in stop_handler
+    assert '"POST", {}, stopRequest.key' in stop_handler
+    assert "stopRequest = null" in stop_handler
+    assert (
+        'stop.disabled = conversation.state !== "running" || closing '
+        "|| Boolean(stopRequest)"
+        in interface
+    )
+    assert 'stop.textContent = stopRequest ? "Stopping…" : "Stop"' in interface
+    assert (
+        '["run.completed", "run.failed", "run.interrupted", "run.unknown"]'
+        in interface
+    )
     assert 'className: "chat-title-button"' in interface
     assert 'title: "Rename conversation"' in interface
     assert 'textContent: "Rename"' not in interface
     assert "actions.append(analytics, close)" in interface
-    assert "/interruptions" not in interface
+    assert "/interruptions" in interface
+    close_handler = interface[
+        interface.index("close.onclick ="):
+        interface.index("actions.append", interface.index("close.onclick ="))
+    ]
+    assert "confirm(" not in close_handler
+    assert "const latest = await chatApi(" in close_handler
+    assert "{ version: latest.version, state: \"closed\" }" in close_handler
+    assert 'close.textContent = "Closing…"' in close_handler
+    assert "const closing = !closed && Boolean(conversation.close_requested_at)" in interface
+    assert "close.disabled = closed || closing" in interface
+    assert 'close.textContent = closing ? "Closing…" : "Close"' in interface
+    assert '"conversation.close.requested"' in interface
     assert "chatCloseForSwitch(selectedConversation)" in interface
     assert "Finish the current turn and queued messages before switching chats." in interface
     assert 'item.state !== "closed"' in interface


### PR DESCRIPTION
## Summary

- wire Stop to the idempotent manual-interruption resource and keep its pending state truthful
- make Close a no-confirm recovery action from every non-closed state
- cancel queued follow-up turns, durably interrupt active work, repair orphaned running state, and release browser ownership only after terminal proof
- expose close-request state to the UI and block new messages/dispatch while closing

## Trade-off

Close uses an append-only durable close-request event instead of adding a schema state. This keeps the state-machine migration-free while preserving the safety boundary: the chat does not become closed, and CLI ownership is not released, until a real active run is terminal.

## Verification

- 127 conversation tests + 154 adapter subtests passed
- render-check passed
- sc verify passed
- diff-check passed
- full suite: 1,618 passed; 8 unrelated live-Conductor test-isolation failures tracked in #801

Also reproduced the stale render-check repair text already tracked in #729.