### PR TITLE
feat: make sprint worker handoffs atomic

### DIFF
--- a/.super-coder/api/conductor_routes.py
+++ b/.super-coder/api/conductor_routes.py
@@ -24,6 +24,8 @@ ENGINE = Path(__file__).resolve().parents[1]
 DB_PATH = ENGINE / "shell_db.db"
 sys.path.insert(0, str(ENGINE / "scripts"))
 import conductor_runtime  # noqa: E402
+import conversation_broker  # noqa: E402
+import conversation_events  # noqa: E402
 import db_driver  # noqa: E402
 import sprint_lifecycle  # noqa: E402
 
@@ -292,7 +294,6 @@ def _create_directive(con, headers, body):
         con.rollback()
         return _err(422, "directive_invalid", str(exc))
     item = _directive(con, cur.lastrowid)
-    conductor_runtime.maybe_wake(con)
     return _json(201, item)
 
 
@@ -315,6 +316,10 @@ def _act_directive(con, headers, directive_id: int):
         return _err(404, "not_found", "no such directive")
     except PermissionError as exc:
         return _err(403, "conductor_required", str(exc))
+    for conversation_id in result.get("conversation_ids", ()):
+        conversation_events.notify(conversation_id)
+    if result.get("conversation_ids"):
+        conversation_broker.notify_commit()
     return _json(200, result)
 
 

--- a/.super-coder/api/sprint_routes.py
+++ b/.super-coder/api/sprint_routes.py
@@ -27,7 +27,6 @@ import io
 import json
 import sys
 import time
-import uuid
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -41,6 +40,7 @@ import conductor_runtime  # noqa: E402
 import conversation_broker  # noqa: E402
 import conversation_events  # noqa: E402
 import run as run_mod  # noqa: E402
+import sprint_conversations  # noqa: E402
 import sprint_lifecycle  # noqa: E402
 import sprint_state  # noqa: E402
 from sprint_units import SPRINT_UNIT_EDGES  # noqa: E402
@@ -889,27 +889,14 @@ def _append_conversation_event(
     message_id: int | None = None,
     run_id: int | None = None,
 ) -> int:
-    sequence = int(
-        con.execute(
-            "SELECT COALESCE(MAX(sequence),0)+1 FROM conversation_events "
-            "WHERE conversation_id=?",
-            (conversation_id,),
-        ).fetchone()[0]
+    return sprint_conversations.append_event(
+        con,
+        conversation_id,
+        event_type,
+        payload,
+        message_id=message_id,
+        run_id=run_id,
     )
-    con.execute(
-        "INSERT INTO conversation_events "
-        "(conversation_id,sequence,event_type,payload,message_id,run_id) "
-        "VALUES (?,?,?,?,?,?)",
-        (
-            conversation_id,
-            sequence,
-            event_type,
-            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
-            message_id,
-            run_id,
-        ),
-    )
-    return sequence
 
 
 def _conversation_route(con, shell, harness: str, model: str | None):
@@ -947,97 +934,24 @@ def _create_sprint_conversation(
     title: str,
     creation_key: str,
     prompt: str,
+    unit_id: int | None = None,
     required_result_kind: str | None = None,
     source_directive_id: int | None = None,
 ) -> str:
-    conversation_id = "cv_" + uuid.uuid4().hex
-    creation_body = {
-        "sprint_doc_id": sprint_doc_id,
-        "shell_id": int(shell["shell_id"]),
-        "role": role,
-        "route": route,
-        "title": title,
-    }
-    creation_hash = hashlib.sha256(
-        json.dumps(creation_body, sort_keys=True).encode()
-    ).hexdigest()
-    con.execute(
-        "INSERT INTO conversations "
-        "(conversation_id,shell_id,mode,owner_user_id,sprint_doc_id,harness,"
-        "provider,model,effort,worktree,state,title,"
-        "creation_idempotency_key,creation_request_hash) "
-        "VALUES (?,?, 'sprint',NULL,?,?,?,?,?,?,'queued',?,?,?)",
-        (
-            conversation_id,
-            shell["shell_id"],
-            sprint_doc_id,
-            route["harness"],
-            route["provider"],
-            route["model"],
-            route["effort"],
-            route["worktree"],
-            title,
-            creation_key,
-            creation_hash,
-        ),
-    )
-    binding_state = "active" if lifecycle == "persistent" else "pending"
-    con.execute(
-        "INSERT INTO sprint_conversation_bindings "
-        "(conversation_id,sprint_doc_id,role,lifecycle,slot,"
-        "source_directive_id,required_result_kind,state,started_at) "
-        "VALUES (?,?,?,?,?,?,?,?,"
-        "CASE WHEN ?='active' THEN datetime('now') ELSE NULL END)",
-        (
-            conversation_id,
-            sprint_doc_id,
-            role,
-            lifecycle,
-            shell["shortname"],
-            source_directive_id,
-            required_result_kind,
-            binding_state,
-            binding_state,
-        ),
-    )
-    prompt_key = f"{creation_key}:prompt"
-    prompt_hash = hashlib.sha256(prompt.encode()).hexdigest()
-    message_id = int(
-        con.execute(
-            "INSERT INTO conversation_messages "
-            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
-            "idempotency_key,request_hash,state) "
-            "VALUES (?,'engine','sprint','prompt',?,?,?,'queued')",
-            (conversation_id, prompt, prompt_key, prompt_hash),
-        ).lastrowid
-    )
-    con.execute(
-        "INSERT INTO conversation_outbox (conversation_id,message_id) "
-        "VALUES (?,?)",
-        (conversation_id, message_id),
-    )
-    _append_conversation_event(
+    return sprint_conversations.create_sprint_conversation(
         con,
-        conversation_id,
-        "conversation.created",
-        {
-            "shell_id": int(shell["shell_id"]),
-            "mode": "sprint",
-            "sprint_doc_id": sprint_doc_id,
-            "role": role,
-            "harness": route["harness"],
-            "model": route["model"],
-            "effort": route["effort"],
-        },
+        sprint_doc_id=sprint_doc_id,
+        shell=shell,
+        role=role,
+        lifecycle=lifecycle,
+        route=route,
+        title=title,
+        creation_key=creation_key,
+        prompt=prompt,
+        unit_id=unit_id,
+        required_result_kind=required_result_kind,
+        source_directive_id=source_directive_id,
     )
-    _append_conversation_event(
-        con,
-        conversation_id,
-        "message.accepted",
-        {"message_id": message_id, "queue_state": "queued", "queue_position": 1},
-        message_id=message_id,
-    )
-    return conversation_id
 
 
 def _conductor_projection(con, sprint_doc_id: int):

--- a/.super-coder/migrations/0137_sprint_assignment_source_units.sql
+++ b/.super-coder/migrations/0137_sprint_assignment_source_units.sql
@@ -1,0 +1,23 @@
+-- 0137 — allow one directive to release a different unit in the same Sprint.
+--
+-- A completed U1 can mechanically release dependency-ready U2.  Migration
+-- 0135 correctly required both the source directive and assignment unit to
+-- belong to the binding's Sprint, but incorrectly required them to be the
+-- same unit.  Keep both Sprint fences while allowing that cross-unit handoff.
+
+BEGIN;
+
+DROP TRIGGER trg_sprint_conversation_binding_source_insert;
+
+CREATE TRIGGER trg_sprint_conversation_binding_source_insert
+BEFORE INSERT ON sprint_conversation_bindings
+WHEN NEW.source_directive_id IS NOT NULL AND NOT EXISTS (
+  SELECT 1 FROM directives d
+  WHERE d.directive_id=NEW.source_directive_id
+    AND d.sprint_doc_id=NEW.sprint_doc_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint binding source directive does not match');
+END;
+
+COMMIT;

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -20,10 +20,11 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-from conductor_policy import CONDUCTOR_HARNESS, DEFAULT_CONDUCTOR_MODEL
+import db_driver
 import shell_liveness
+import sprint_conversations
 import sprint_lifecycle
-import sprint_state
+from conductor_policy import CONDUCTOR_HARNESS, DEFAULT_CONDUCTOR_MODEL
 from sprint_units import (
     SPRINT_UNIT_EDGES,
     TERMINAL_UNIT_STATES,
@@ -55,6 +56,10 @@ class DirectiveRefused(ValueError):
 
 class ConductorLaunchError(RuntimeError):
     """A role or Conductor process that refused before it could start."""
+
+
+class _RoutePreparationStale(RuntimeError):
+    """The durable route/roster changed after external route preparation."""
 
 
 def _operational_config() -> ConductorConfig:
@@ -485,6 +490,62 @@ def _route_for_slot(con, sprint_id: int, slot: str) -> tuple[str, str]:
         raise DirectiveRefused(str(exc)) from exc
 
 
+def _prepare_assignment_routes(con, sprint_id: int) -> dict[tuple[int, str], dict]:
+    """Prepare every eligible role route before the write transaction.
+
+    Adapter loading and worktree inspection touch the filesystem, so they stay
+    outside the action's short DB-only transaction.  ``_spawn`` revalidates the
+    selected shell and stored route after ``BEGIN IMMEDIATE``.
+    """
+    import run as run_mod
+
+    prepared: dict[tuple[int, str], dict] = {}
+    shells = con.execute(
+        "SELECT shell_id,shortname,flavor FROM shells "
+        "WHERE flavor IN ('planner','dev','reviewer') "
+        "AND COALESCE(is_deleted,0)=0 ORDER BY shell_id"
+    ).fetchall()
+    for shell in shells:
+        harness = model = None
+        slot = {
+            "planner": "plan",
+            "dev": "dev",
+            "reviewer": "rev",
+        }[shell["flavor"]]
+        key = (int(shell["shell_id"]), slot)
+        try:
+            harness, model = _route_for_slot(con, sprint_id, slot)
+            adapter = run_mod.load_adapter(harness)
+            effort = run_mod.default_headless_effort(adapter)
+            run_mod.validate_headless_request(adapter, model, effort)
+            worktree = run_mod.shell_work_dir(
+                shell["shortname"], shell["flavor"]
+            ).resolve(strict=False)
+            if worktree.exists() and not worktree.is_dir():
+                raise ValueError(
+                    f"shell {shell['shortname']!r} worktree is not a directory"
+                )
+            prepared[key] = {
+                "shell_id": int(shell["shell_id"]),
+                "shortname": shell["shortname"],
+                "harness": harness,
+                "provider": run_mod.session_provider(harness, model),
+                "model": model,
+                "effort": effort,
+                "worktree": str(worktree),
+                "error": None,
+            }
+        except (DirectiveRefused, OSError, ValueError) as exc:
+            prepared[key] = {
+                "shell_id": int(shell["shell_id"]),
+                "shortname": shell["shortname"],
+                "harness": harness,
+                "model": model,
+                "error": str(exc),
+            }
+    return prepared
+
+
 def _assert_issuer_assignment(row, unit) -> None:
     if row["issuer_flavor"] == "dev" and row["issuer_shell_id"] != unit["dev_shell_id"]:
         raise DirectiveRefused("dev issuer is not the unit's assigned developer")
@@ -514,46 +575,51 @@ def _block_when_legal(con, unit, actor_shell_id: int) -> None:
         _move(con, unit, "blocked", actor_shell_id)
 
 
-def _slot_command(
-    shell,
-    slot: str,
-    sprint_id: int,
-    *,
-    unit_seq: str | None,
-    prompt: str,
-    harness: str,
-    model: str,
-) -> list[str]:
-    command = [
-        str(REPO_ROOT / "sc"),
-        "run",
-        shell["shortname"],
-        "--slot",
-        slot,
-        "--sprint",
-        str(sprint_id),
-        "--await-sprint-active",
-        "--harness",
-        harness,
-        "--model",
-        model,
-    ]
-    if unit_seq is not None:
-        command += ["--unit", unit_seq]
-    command += ["--prompt", prompt]
-    return command
+def _assignment_role(slot: str, unit) -> str:
+    if slot == "plan":
+        return "planner"
+    if slot == "dev":
+        return "developer"
+    return "reviewer" if unit is not None else "conformance"
+
+
+def _required_result_kind(role: str) -> str:
+    return {
+        "planner": "planner-directive",
+        "developer": "unit-report",
+        "reviewer": "review-verdict",
+        "conformance": "conformance-verdict",
+    }[role]
 
 
 def _spawn(
     con,
-    launches: list[list[str]],
+    assignments: list[dict],
     shell,
     slot: str,
     row,
     payload: dict,
     *,
+    prepared_routes: dict[tuple[int, str], dict],
     unit=None,
 ) -> None:
+    key = (int(shell["shell_id"]), slot)
+    prepared = prepared_routes.get(key)
+    if prepared is None or prepared["shortname"] != shell["shortname"]:
+        raise _RoutePreparationStale(
+            f"assignment route changed for shell {shell['shortname']}"
+        )
+    harness, model = _route_for_slot(con, row["sprint_doc_id"], slot)
+    if (harness, model) != (prepared.get("harness"), prepared.get("model")):
+        raise _RoutePreparationStale(
+            f"Sprint {row['sprint_doc_id']} {slot} route changed"
+        )
+    if prepared["error"] is not None:
+        raise DirectiveRefused(
+            f"target shell {shell['shortname']!r} route is not runnable: "
+            f"{prepared['error']}"
+        )
+    role = _assignment_role(slot, unit)
     prompt = json.dumps(
         {
             "directive_id": row["directive_id"],
@@ -563,17 +629,34 @@ def _spawn(
         },
         sort_keys=True,
     )
-    harness, model = _route_for_slot(con, row["sprint_doc_id"], slot)
-    launches.append(
-        _slot_command(
-            shell,
-            slot,
-            row["sprint_doc_id"],
-            unit_seq=unit["seq"] if unit is not None else None,
-            prompt=prompt,
-            harness=harness,
-            model=model,
-        )
+    creation_key = (
+        f"sprint:{row['sprint_doc_id']}:assignment:{row['directive_id']}:"
+        f"{role}:{shell['shortname']}"
+    )
+    conversation_id = sprint_conversations.create_sprint_conversation(
+        con,
+        sprint_doc_id=int(row["sprint_doc_id"]),
+        shell=shell,
+        role=role,
+        lifecycle="one_shot",
+        route=prepared,
+        title=(
+            f"Sprint #{row['sprint_doc_id']} {role} "
+            f"{shell['shortname']}"
+        ),
+        creation_key=creation_key,
+        prompt=prompt,
+        unit_id=int(unit["unit_id"]) if unit is not None else None,
+        source_directive_id=int(row["directive_id"]),
+        required_result_kind=_required_result_kind(role),
+    )
+    assignments.append(
+        {
+            "conversation_id": conversation_id,
+            "role": role,
+            "slot": shell["shortname"],
+            "unit_id": int(unit["unit_id"]) if unit is not None else None,
+        }
     )
 
 
@@ -608,7 +691,14 @@ def _ready_pending_units(con, sprint_id: int):
     return ready
 
 
-def _release_ready_units(con, launches, row, payload, actor_shell_id: int):
+def _release_ready_units(
+    con,
+    assignments,
+    row,
+    payload,
+    actor_shell_id: int,
+    prepared_routes,
+):
     released = []
     for unit in _ready_pending_units(con, row["sprint_doc_id"]):
         dev = con.execute(
@@ -621,7 +711,16 @@ def _release_ready_units(con, launches, row, payload, actor_shell_id: int):
                 f"unit {unit['seq']} has no active assigned developer"
             )
         _move(con, unit, "working", actor_shell_id)
-        _spawn(con, launches, dev, "dev", row, payload, unit=unit)
+        _spawn(
+            con,
+            assignments,
+            dev,
+            "dev",
+            row,
+            payload,
+            prepared_routes=prepared_routes,
+            unit=unit,
+        )
         released.append(unit["seq"])
     return released
 
@@ -685,7 +784,13 @@ def validate_arm_board(con, sprint_id: int) -> None:
         )
 
 
-def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
+def _execute(
+    con,
+    row,
+    payload: dict,
+    actor_shell_id: int,
+    prepared_routes,
+) -> list[dict]:
     issuer, kind = row["issuer_flavor"], row["kind"]
     if (issuer, kind) not in _TRANSITION_SET:
         raise DirectiveRefused(f"no transition for {issuer}:{kind}")
@@ -714,7 +819,7 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
             raise DirectiveRefused(
                 f"planner issuer is not sprint {sprint_id}'s originating Planner"
             )
-    launches: list[list[str]] = []
+    assignments: list[dict] = []
 
     if issuer == "dev":
         unit = _unit(con, row)
@@ -765,13 +870,28 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
             ).fetchone()
             if reviewer is None:
                 raise DirectiveRefused("unit has no assigned reviewer")
-            _spawn(con, launches, reviewer, "rev", row, payload, unit=unit)
+            _spawn(
+                con,
+                assignments,
+                reviewer,
+                "rev",
+                row,
+                payload,
+                prepared_routes=prepared_routes,
+                unit=unit,
+            )
         elif kind == "ask-planner":
             _text(payload, "question")
             _block_when_legal(con, unit, actor_shell_id)
             _spawn(
-                con, launches, _planner_for_sprint(con, sprint_id),
-                "plan", row, payload,
+                con,
+                assignments,
+                _planner_for_sprint(con, sprint_id),
+                "plan",
+                row,
+                payload,
+                prepared_routes=prepared_routes,
+                unit=unit,
             )
         elif kind == "merged":
             pr_number = _integer(payload, "pr_number")
@@ -784,15 +904,28 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
                     "merged head does not match the recorded review head"
                 )
             _move(con, unit, "merged", actor_shell_id)
-            _release_ready_units(con, launches, row, payload, actor_shell_id)
+            _release_ready_units(
+                con,
+                assignments,
+                row,
+                payload,
+                actor_shell_id,
+                prepared_routes,
+            )
         elif kind == "unit-report":
             _text(payload, "shipped")
             if _all_units_terminal(con, sprint_id):
                 _spawn(
-                    con, launches, _planner_for_sprint(con, sprint_id),
-                    "plan", row, payload,
+                    con,
+                    assignments,
+                    _planner_for_sprint(con, sprint_id),
+                    "plan",
+                    row,
+                    payload,
+                    prepared_routes=prepared_routes,
+                    unit=unit,
                 )
-        return launches
+        return assignments
 
     if issuer == "reviewer":
         unit = _unit(con, row) if row["unit_id"] is not None else None
@@ -803,8 +936,14 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
             if unit is not None:
                 _block_when_legal(con, unit, actor_shell_id)
             _spawn(
-                con, launches, _planner_for_sprint(con, sprint_id),
-                "plan", row, payload,
+                con,
+                assignments,
+                _planner_for_sprint(con, sprint_id),
+                "plan",
+                row,
+                payload,
+                prepared_routes=prepared_routes,
+                unit=unit,
             )
         elif kind == "review-clean":
             if unit is None:
@@ -814,8 +953,13 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
                     )
                 _text(payload, "main_sha")
                 _spawn(
-                    con, launches, _planner_for_sprint(con, sprint_id),
-                    "plan", row, payload,
+                    con,
+                    assignments,
+                    _planner_for_sprint(con, sprint_id),
+                    "plan",
+                    row,
+                    payload,
+                    prepared_routes=prepared_routes,
                 )
             else:
                 if unit["state"] != "in_review":
@@ -834,35 +978,64 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
                 if unit["pr_number"] is None and unit["branch"] is None:
                     _move(con, unit, "merged", actor_shell_id)
                     _release_ready_units(
-                        con, launches, row, payload, actor_shell_id
+                        con,
+                        assignments,
+                        row,
+                        payload,
+                        actor_shell_id,
+                        prepared_routes,
                     )
                     _spawn(
                         con,
-                        launches,
+                        assignments,
                         dev,
                         "dev",
                         row,
                         {**payload, "report_only": True},
+                        prepared_routes=prepared_routes,
                         unit=unit,
                     )
                 else:
-                    _spawn(con, launches, dev, "dev", row, payload, unit=unit)
+                    _spawn(
+                        con,
+                        assignments,
+                        dev,
+                        "dev",
+                        row,
+                        payload,
+                        prepared_routes=prepared_routes,
+                        unit=unit,
+                    )
         elif kind == "findings":
             findings = payload.get("findings")
             if not isinstance(findings, list) or not findings:
                 raise DirectiveRefused("payload.findings must be a nonempty array")
             if unit is None:
                 _spawn(
-                    con, launches, _planner_for_sprint(con, sprint_id),
-                    "plan", row, payload,
+                    con,
+                    assignments,
+                    _planner_for_sprint(con, sprint_id),
+                    "plan",
+                    row,
+                    payload,
+                    prepared_routes=prepared_routes,
                 )
             else:
                 dev = con.execute(
                     "SELECT shell_id,shortname,flavor FROM shells WHERE shell_id=?",
                     (unit["dev_shell_id"],),
                 ).fetchone()
-                _spawn(con, launches, dev, "dev", row, payload, unit=unit)
-        return launches
+                _spawn(
+                    con,
+                    assignments,
+                    dev,
+                    "dev",
+                    row,
+                    payload,
+                    prepared_routes=prepared_routes,
+                    unit=unit,
+                )
+        return assignments
 
     if issuer == "planner":
         sprint_id = row["sprint_doc_id"]
@@ -881,13 +1054,31 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
                     )
                 if unit["state"] in ("pending", "blocked"):
                     _move(con, unit, "working", actor_shell_id)
-                _spawn(con, launches, target, "dev", row, payload, unit=unit)
+                _spawn(
+                    con,
+                    assignments,
+                    target,
+                    "dev",
+                    row,
+                    payload,
+                    prepared_routes=prepared_routes,
+                    unit=unit,
+                )
             elif target["flavor"] == "reviewer":
                 if unit is None and payload.get("mode") != "conformance":
                     raise DirectiveRefused(
                         "unitless reviewer kickoff requires mode=conformance"
                     )
-                _spawn(con, launches, target, "rev", row, payload, unit=unit)
+                _spawn(
+                    con,
+                    assignments,
+                    target,
+                    "rev",
+                    row,
+                    payload,
+                    prepared_routes=prepared_routes,
+                    unit=unit,
+                )
             else:
                 raise DirectiveRefused("kickoff target must be dev or reviewer")
         elif kind == "hold":
@@ -915,7 +1106,16 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
                 "WHERE unit_id=?",
                 (actor_shell_id, unit["unit_id"]),
             )
-            _spawn(con, launches, target, "dev", row, payload, unit=unit)
+            _spawn(
+                con,
+                assignments,
+                target,
+                "dev",
+                row,
+                payload,
+                prepared_routes=prepared_routes,
+                unit=unit,
+            )
         elif kind == "answer":
             if unit is None:
                 raise DirectiveRefused("answer requires unit_id")
@@ -925,7 +1125,16 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
             if target["flavor"] == "dev":
                 if unit["state"] == "blocked":
                     _move(con, unit, "working", actor_shell_id)
-                _spawn(con, launches, target, "dev", row, payload, unit=unit)
+                _spawn(
+                    con,
+                    assignments,
+                    target,
+                    "dev",
+                    row,
+                    payload,
+                    prepared_routes=prepared_routes,
+                    unit=unit,
+                )
             elif target["flavor"] == "reviewer":
                 if unit["state"] == "blocked":
                     _move(con, unit, "working", actor_shell_id)
@@ -934,7 +1143,16 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
                         (unit["unit_id"],),
                     ).fetchone()
                     _move(con, unit, "in_review", actor_shell_id)
-                _spawn(con, launches, target, "rev", row, payload, unit=unit)
+                _spawn(
+                    con,
+                    assignments,
+                    target,
+                    "rev",
+                    row,
+                    payload,
+                    prepared_routes=prepared_routes,
+                    unit=unit,
+                )
             else:
                 raise DirectiveRefused("answer target must be dev or reviewer")
         elif kind == "close":
@@ -983,7 +1201,7 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
             )
             sprint_lifecycle.transition(con, sprint_id, "closing")
             sprint_lifecycle.transition(con, sprint_id, "closed")
-        return launches
+        return assignments
 
     unit = _unit(con, row)
     if kind == "pr-green":
@@ -995,7 +1213,16 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
         ).fetchone()
         if reviewer is None:
             raise DirectiveRefused("unit has no assigned reviewer")
-        _spawn(con, launches, reviewer, "rev", row, payload, unit=unit)
+        _spawn(
+            con,
+            assignments,
+            reviewer,
+            "rev",
+            row,
+            payload,
+            prepared_routes=prepared_routes,
+            unit=unit,
+        )
     elif kind == "pr-red":
         if unit["state"] != "working":
             _move(con, unit, "working", actor_shell_id)
@@ -1003,22 +1230,50 @@ def _execute(con, row, payload: dict, actor_shell_id: int) -> list[list[str]]:
             "SELECT shell_id,shortname,flavor FROM shells WHERE shell_id=?",
             (unit["dev_shell_id"],),
         ).fetchone()
-        _spawn(con, launches, dev, "dev", row, payload, unit=unit)
+        _spawn(
+            con,
+            assignments,
+            dev,
+            "dev",
+            row,
+            payload,
+            prepared_routes=prepared_routes,
+            unit=unit,
+        )
     elif kind == "pr-merged":
         _move(con, unit, "merged", actor_shell_id)
-        _release_ready_units(con, launches, row, payload, actor_shell_id)
+        _release_ready_units(
+            con,
+            assignments,
+            row,
+            payload,
+            actor_shell_id,
+            prepared_routes,
+        )
         if _all_units_terminal(con, sprint_id):
             _spawn(
-                con, launches, _planner_for_sprint(con, sprint_id),
-                "plan", row, payload,
+                con,
+                assignments,
+                _planner_for_sprint(con, sprint_id),
+                "plan",
+                row,
+                payload,
+                prepared_routes=prepared_routes,
+                unit=unit,
             )
     elif kind in ("stall", "dead-shell"):
         _block_when_legal(con, unit, actor_shell_id)
         _spawn(
-            con, launches, _planner_for_sprint(con, sprint_id),
-            "plan", row, payload,
+            con,
+            assignments,
+            _planner_for_sprint(con, sprint_id),
+            "plan",
+            row,
+            payload,
+            prepared_routes=prepared_routes,
+            unit=unit,
         )
-    return launches
+    return assignments
 
 
 def _trail(con, row, actor_shell_id: int, event_kind: str, evidence: dict) -> None:
@@ -1037,14 +1292,54 @@ def _trail(con, row, actor_shell_id: int, event_kind: str, evidence: dict) -> No
     )
 
 
+def _source_unit(con, row):
+    if row["unit_id"] is None:
+        return None
+    return con.execute(
+        "SELECT * FROM sprint_units "
+        "WHERE unit_id=? AND sprint_doc_id=?",
+        (row["unit_id"], row["sprint_doc_id"]),
+    ).fetchone()
+
+
+def _queue_refusal_assignment(
+    con,
+    row,
+    reason: str,
+    prepared_routes,
+) -> dict:
+    """Atomically queue the originating Planner after a mechanical refusal."""
+    if row["sprint_doc_id"] is None:
+        return {"error": "cannot escalate without sprint_doc_id"}
+    con.execute("SAVEPOINT conductor_refusal_assignment")
+    try:
+        assignments: list[dict] = []
+        _spawn(
+            con,
+            assignments,
+            _planner_for_sprint(con, row["sprint_doc_id"]),
+            "plan",
+            row,
+            {
+                "refusal": reason,
+                "source_payload": row["payload"],
+            },
+            prepared_routes=prepared_routes,
+            unit=_source_unit(con, row),
+        )
+        con.execute("RELEASE conductor_refusal_assignment")
+        return assignments[0]
+    except DirectiveRefused as exc:
+        con.execute("ROLLBACK TO conductor_refusal_assignment")
+        con.execute("RELEASE conductor_refusal_assignment")
+        return {"error": str(exc)}
+
+
 def _act_locked(
     con,
     directive_id: int,
     actor_shell_id: int,
-    *,
-    launcher: Callable[[list[str]], int] | None = None,
 ) -> dict:
-    launcher = launcher or _default_launcher
     actor = con.execute(
         "SELECT shell_id,flavor FROM shells "
         "WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
@@ -1065,104 +1360,139 @@ def _act_locked(
             "replayed": True,
         }
 
-    con.execute("SAVEPOINT conductor_act")
-    try:
-        payload = _payload(row)
-        launches = _execute(con, row, payload, actor_shell_id)
-        pids = [launcher(command) for command in launches]
-        con.execute("RELEASE conductor_act")
-        con.execute(
-            "UPDATE directives SET status='executed',"
-            "executed_at=datetime('now') WHERE directive_id=?",
-            (directive_id,),
-        )
-        evidence = {
-            "issuer": row["issuer_flavor"],
-            "kind": row["kind"],
-            "launches": launches,
-            "pids": pids,
-        }
-        _trail(con, row, actor_shell_id, "conductor-executed", evidence)
-        con.commit()
-        return {
-            "directive_id": directive_id,
-            "status": "executed",
-            "launches": launches,
-            "pids": pids,
-        }
-    except (DirectiveRefused, ConductorLaunchError) as exc:
-        con.execute("ROLLBACK TO conductor_act")
-        con.execute("RELEASE conductor_act")
-        reason = str(exc)
-        con.execute(
-            "UPDATE directives SET status='refused',refusal_reason=?,"
-            "executed_at=datetime('now') WHERE directive_id=?",
-            (reason, directive_id),
-        )
-        escalation = None
+    for attempt in range(3):
+        prepared_routes = _prepare_assignment_routes(
+            con, int(row["sprint_doc_id"])
+        ) if row["sprint_doc_id"] is not None else {}
         try:
-            if row["sprint_doc_id"] is None:
-                raise DirectiveRefused("cannot escalate without sprint_doc_id")
-            planner = _planner_for_sprint(con, row["sprint_doc_id"])
-            harness, model = _route_for_slot(
-                con, row["sprint_doc_id"], "plan"
-            )
-            prompt = json.dumps(
-                {
-                    "directive_id": directive_id,
-                    "refusal": reason,
-                    "issuer": row["issuer_flavor"],
-                    "kind": row["kind"],
-                    "payload": row["payload"],
-                },
-                sort_keys=True,
-            )
-            command = _slot_command(
-                planner,
-                "plan",
-                row["sprint_doc_id"],
-                unit_seq=None,
-                prompt=prompt,
-                harness=harness,
-                model=model,
-            )
-            escalation = {"command": command, "pid": launcher(command)}
-        except (DirectiveRefused, ConductorLaunchError) as escalation_error:
-            escalation = {"error": str(escalation_error)}
-        _trail(
-            con,
-            row,
-            actor_shell_id,
-            "conductor-refused",
-            {"reason": reason, "escalation": escalation},
-        )
-        con.commit()
-        return {
-            "directive_id": directive_id,
-            "status": "refused",
-            "reason": reason,
-            "escalation": escalation,
-        }
-    except Exception:
-        con.execute("ROLLBACK TO conductor_act")
-        con.execute("RELEASE conductor_act")
-        raise
+            with db_driver.write_transaction(
+                con,
+                "conductor.directive_act",
+            ):
+                actor = con.execute(
+                    "SELECT shell_id,flavor FROM shells "
+                    "WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+                    (actor_shell_id,),
+                ).fetchone()
+                if actor is None or actor["flavor"] != "conductor":
+                    raise PermissionError(
+                        "directive act requires a conductor shell"
+                    )
+                row = con.execute(
+                    "SELECT * FROM directives WHERE directive_id=?",
+                    (directive_id,),
+                ).fetchone()
+                if row is None:
+                    raise KeyError(f"no directive {directive_id}")
+                if row["status"] != "pending":
+                    return {
+                        "directive_id": directive_id,
+                        "status": row["status"],
+                        "replayed": True,
+                    }
+
+                con.execute("SAVEPOINT conductor_act")
+                try:
+                    payload = _payload(row)
+                    assignments = _execute(
+                        con,
+                        row,
+                        payload,
+                        actor_shell_id,
+                        prepared_routes,
+                    )
+                except DirectiveRefused as exc:
+                    con.execute("ROLLBACK TO conductor_act")
+                    con.execute("RELEASE conductor_act")
+                    reason = str(exc)
+                    escalation = _queue_refusal_assignment(
+                        con,
+                        row,
+                        reason,
+                        prepared_routes,
+                    )
+                    con.execute(
+                        "UPDATE directives SET status='refused',"
+                        "refusal_reason=?,executed_at=datetime('now') "
+                        "WHERE directive_id=?",
+                        (reason, directive_id),
+                    )
+                    evidence = {
+                        "reason": reason,
+                        "escalation": escalation,
+                    }
+                    _trail(
+                        con,
+                        row,
+                        actor_shell_id,
+                        "conductor-refused",
+                        evidence,
+                    )
+                    conversation_ids = (
+                        [escalation["conversation_id"]]
+                        if "conversation_id" in escalation
+                        else []
+                    )
+                    result = {
+                        "directive_id": directive_id,
+                        "status": "refused",
+                        "reason": reason,
+                        "escalation": escalation,
+                        "conversation_ids": conversation_ids,
+                    }
+                else:
+                    con.execute(
+                        "UPDATE directives SET status='executed',"
+                        "executed_at=datetime('now') WHERE directive_id=?",
+                        (directive_id,),
+                    )
+                    evidence = {
+                        "issuer": row["issuer_flavor"],
+                        "kind": row["kind"],
+                        "assignments": assignments,
+                    }
+                    _trail(
+                        con,
+                        row,
+                        actor_shell_id,
+                        "conductor-executed",
+                        evidence,
+                    )
+                    con.execute("RELEASE conductor_act")
+                    result = {
+                        "directive_id": directive_id,
+                        "status": "executed",
+                        "assignments": assignments,
+                        # Retained response fields for old API/CLI consumers.
+                        # Browser-native actions never populate process evidence.
+                        "launches": [],
+                        "pids": [],
+                        "conversation_ids": [
+                            item["conversation_id"] for item in assignments
+                        ],
+                    }
+            return result
+        except _RoutePreparationStale:
+            if attempt == 2:
+                raise
+            row = con.execute(
+                "SELECT * FROM directives WHERE directive_id=?",
+                (directive_id,),
+            ).fetchone()
+    raise RuntimeError("directive route preparation did not converge")
 
 
 def act(
     con,
     directive_id: int,
     actor_shell_id: int,
-    *,
-    launcher: Callable[[list[str]], int] | None = None,
 ) -> dict:
-    """Execute or refuse one pending directive as a Conductor shell."""
+    """Commit one directive transition and every worker handoff atomically."""
     with _act_lock:
         return _act_locked(
             con,
             directive_id,
             actor_shell_id,
-            launcher=launcher,
         )
 
 

--- a/.super-coder/scripts/sprint_conversations.py
+++ b/.super-coder/scripts/sprint_conversations.py
@@ -1,0 +1,160 @@
+"""Transactional creation primitives for browser-native Sprint conversations.
+
+Callers own the surrounding write transaction.  These helpers only persist
+conversation, binding, prompt, event, and outbox rows; they never notify the
+broker or perform harness/filesystem work.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+
+
+def append_event(
+    con,
+    conversation_id: str,
+    event_type: str,
+    payload: dict,
+    *,
+    message_id: int | None = None,
+    run_id: int | None = None,
+) -> int:
+    sequence = int(
+        con.execute(
+            "SELECT COALESCE(MAX(sequence),0)+1 FROM conversation_events "
+            "WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()[0]
+    )
+    con.execute(
+        "INSERT INTO conversation_events "
+        "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+        "VALUES (?,?,?,?,?,?)",
+        (
+            conversation_id,
+            sequence,
+            event_type,
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+            message_id,
+            run_id,
+        ),
+    )
+    return sequence
+
+
+def create_sprint_conversation(
+    con,
+    *,
+    sprint_doc_id: int,
+    shell,
+    role: str,
+    lifecycle: str,
+    route: dict,
+    title: str,
+    creation_key: str,
+    prompt: str,
+    unit_id: int | None = None,
+    required_result_kind: str | None = None,
+    source_directive_id: int | None = None,
+) -> str:
+    """Persist one Sprint conversation and its initial dispatch intent.
+
+    Idempotency and assignment uniqueness are enforced by the conversations
+    and sprint_conversation_bindings indices.  A successful return means every
+    durable row exists in the caller's still-open transaction.
+    """
+    conversation_id = "cv_" + uuid.uuid4().hex
+    prompt_hash = hashlib.sha256(prompt.encode()).hexdigest()
+    creation_body = {
+        "sprint_doc_id": sprint_doc_id,
+        "shell_id": int(shell["shell_id"]),
+        "role": role,
+        "lifecycle": lifecycle,
+        "unit_id": unit_id,
+        "source_directive_id": source_directive_id,
+        "required_result_kind": required_result_kind,
+        "route": route,
+        "title": title,
+        "prompt_hash": prompt_hash,
+    }
+    creation_hash = hashlib.sha256(
+        json.dumps(creation_body, sort_keys=True).encode()
+    ).hexdigest()
+    con.execute(
+        "INSERT INTO conversations "
+        "(conversation_id,shell_id,mode,owner_user_id,sprint_doc_id,harness,"
+        "provider,model,effort,worktree,state,title,"
+        "creation_idempotency_key,creation_request_hash) "
+        "VALUES (?,?, 'sprint',NULL,?,?,?,?,?,?,'queued',?,?,?)",
+        (
+            conversation_id,
+            shell["shell_id"],
+            sprint_doc_id,
+            route["harness"],
+            route["provider"],
+            route["model"],
+            route["effort"],
+            route["worktree"],
+            title,
+            creation_key,
+            creation_hash,
+        ),
+    )
+    binding_state = "active" if lifecycle == "persistent" else "pending"
+    con.execute(
+        "INSERT INTO sprint_conversation_bindings "
+        "(conversation_id,sprint_doc_id,role,lifecycle,slot,unit_id,"
+        "source_directive_id,required_result_kind,state,started_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,"
+        "CASE WHEN ?='active' THEN datetime('now') ELSE NULL END)",
+        (
+            conversation_id,
+            sprint_doc_id,
+            role,
+            lifecycle,
+            shell["shortname"],
+            unit_id,
+            source_directive_id,
+            required_result_kind,
+            binding_state,
+            binding_state,
+        ),
+    )
+    prompt_key = f"{creation_key}:prompt"
+    message_id = int(
+        con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash,state) "
+            "VALUES (?,'engine','sprint','prompt',?,?,?,'queued')",
+            (conversation_id, prompt, prompt_key, prompt_hash),
+        ).lastrowid
+    )
+    con.execute(
+        "INSERT INTO conversation_outbox (conversation_id,message_id) "
+        "VALUES (?,?)",
+        (conversation_id, message_id),
+    )
+    append_event(
+        con,
+        conversation_id,
+        "conversation.created",
+        {
+            "shell_id": int(shell["shell_id"]),
+            "mode": "sprint",
+            "sprint_doc_id": sprint_doc_id,
+            "role": role,
+            "harness": route["harness"],
+            "model": route["model"],
+            "effort": route["effort"],
+        },
+    )
+    append_event(
+        con,
+        conversation_id,
+        "message.accepted",
+        {"message_id": message_id, "queue_state": "queued", "queue_position": 1},
+        message_id=message_id,
+    )
+    return conversation_id

--- a/tests/test_conductor_contracts.py
+++ b/tests/test_conductor_contracts.py
@@ -158,11 +158,10 @@ class ConductorContractTests(unittest.TestCase):
         })
         self.assertEqual((status, obj["error"]["code"]), (422, "validation"))
 
-    def test_valid_creation_requests_config_gated_conductor_wake(self):
+    def test_valid_creation_never_launches_a_conductor_process(self):
         with mock.patch.object(
                 conductor_routes.conductor_runtime,
                 "maybe_wake",
-                return_value={"launched": True},
         ) as wake:
             status, _item = self.post({
                 "kind": "ready-for-review",
@@ -170,7 +169,7 @@ class ConductorContractTests(unittest.TestCase):
                 "payload": {"head": "abc"},
             })
         self.assertEqual(status, 201)
-        wake.assert_called_once()
+        wake.assert_not_called()
 
     def test_planner_handoff_is_retired_in_favor_of_planner_arm(self):
         planner_id = self.con.execute(
@@ -241,20 +240,37 @@ class ConductorContractTests(unittest.TestCase):
         expected = {
             "directive_id": directive_id,
             "status": "executed",
-            "launches": [],
-            "pids": [],
+            "assignments": [{
+                "conversation_id": "cv_worker",
+                "role": "developer",
+                "slot": "dev",
+                "unit_id": 10,
+            }],
+            "conversation_ids": ["cv_worker"],
         }
-        with mock.patch.object(
+        with (
+            mock.patch.object(
                 conductor_routes.conductor_runtime,
                 "act",
                 return_value=expected,
-        ) as act:
+            ) as act,
+            mock.patch.object(
+                conductor_routes.conversation_events,
+                "notify",
+            ) as event_notify,
+            mock.patch.object(
+                conductor_routes.conversation_broker,
+                "notify_commit",
+            ) as broker_notify,
+        ):
             status, obj = response(conductor_routes.handle(
                 "POST", f"/api/directives/{directive_id}/act",
                 self.headers("con-token"), b"{}"))
         self.assertEqual((status, obj), (200, expected))
         act.assert_called_once()
         self.assertEqual(act.call_args.args[2], conductor_id)
+        event_notify.assert_called_once_with("cv_worker")
+        broker_notify.assert_called_once_with()
 
     def test_sentinel_events_are_readable_and_append_only(self):
         event_id = conductor_routes.append_sentinel_event(

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import sqlite3
 import subprocess
@@ -105,7 +106,8 @@ class RuntimeFixture(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.TemporaryDirectory(prefix="sc_conductor8_")
         self.addCleanup(self.tmp.cleanup)
-        self.con = build_db(Path(self.tmp.name) / "runtime.db")
+        self.db_path = Path(self.tmp.name) / "runtime.db"
+        self.con = build_db(self.db_path)
         self.addCleanup(self.con.close)
         shells = (
             (1, "Conductor", "CON1", "conductor", "con-token"),
@@ -650,8 +652,18 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
                         ),
                     ).lastrowid
                     con.commit()
-                    result = runtime.act(con, directive_id, 1, launcher=self.launcher)
+                    result = runtime.act(con, directive_id, 1)
                     self.assertEqual(result["status"], "executed")
+                    for assignment in result["assignments"]:
+                        self.assertEqual(
+                            con.execute(
+                                "SELECT COUNT(*) FROM "
+                                "sprint_conversation_bindings "
+                                "WHERE conversation_id=?",
+                                (assignment["conversation_id"],),
+                            ).fetchone()[0],
+                            1,
+                        )
                     row = con.execute(
                         "SELECT status,refusal_reason FROM directives "
                         "WHERE directive_id=?",
@@ -669,11 +681,11 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
     def test_malformed_payload_is_refused_and_escalated(self):
         directive_id = self.emit("dev", "ready-for-review", {"pr_number": "not-int"})
         self.con.commit()
-        result = runtime.act(self.con, directive_id, 1, launcher=self.launcher)
+        result = runtime.act(self.con, directive_id, 1)
         self.assertEqual(result["status"], "refused")
         self.assertIn("payload.pr_number", result["reason"])
-        self.assertIn("command", result["escalation"])
-        self.assertIn("PLN1", result["escalation"]["command"])
+        self.assertEqual(result["escalation"]["role"], "planner")
+        self.assertEqual(result["escalation"]["slot"], "PLN1")
         self.assertEqual(
             self.con.execute(
                 "SELECT status FROM directives WHERE directive_id=?",
@@ -698,10 +710,11 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         )
         self.con.commit()
 
-        ready = runtime.act(self.con, ready_id, 1, launcher=self.launcher)
+        ready = runtime.act(self.con, ready_id, 1)
 
         self.assertEqual(ready["status"], "executed")
-        self.assertEqual(len(ready["launches"]), 1)
+        self.assertEqual(len(ready["assignments"]), 1)
+        self.assertEqual(ready["assignments"][0]["role"], "reviewer")
         unit = self.con.execute(
             "SELECT state,pr_number,branch FROM sprint_units WHERE unit_id=10"
         ).fetchone()
@@ -714,11 +727,15 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         )
         self.con.commit()
 
-        clean = runtime.act(self.con, clean_id, 1, launcher=self.launcher)
+        clean = runtime.act(self.con, clean_id, 1)
 
         self.assertEqual(clean["status"], "executed")
-        self.assertEqual(len(clean["launches"]), 1)
-        self.assertIn('"report_only": true', clean["launches"][0][-1])
+        self.assertEqual(len(clean["assignments"]), 1)
+        prompt = self.con.execute(
+            "SELECT body FROM conversation_messages WHERE conversation_id=?",
+            (clean["assignments"][0]["conversation_id"],),
+        ).fetchone()[0]
+        self.assertIn('"report_only": true', prompt)
         unit = self.con.execute(
             "SELECT state,review_head FROM sprint_units WHERE unit_id=10"
         ).fetchone()
@@ -730,10 +747,10 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             {"shipped": "verified requested state already present"},
         )
         self.con.commit()
-        report = runtime.act(self.con, report_id, 1, launcher=self.launcher)
+        report = runtime.act(self.con, report_id, 1)
         self.assertEqual(report["status"], "executed")
-        self.assertEqual(len(report["launches"]), 1)
-        self.assertIn("PLN1", report["launches"][0])
+        self.assertEqual(len(report["assignments"]), 1)
+        self.assertEqual(report["assignments"][0]["slot"], "PLN1")
 
     def test_report_only_requires_explicit_null_contract_and_evidence(self):
         cases = (
@@ -775,9 +792,7 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
                 self.set_unit("working")
                 directive_id = self.emit("dev", "ready-for-review", payload)
                 self.con.commit()
-                result = runtime.act(
-                    self.con, directive_id, 1, launcher=self.launcher
-                )
+                result = runtime.act(self.con, directive_id, 1)
                 self.assertEqual(result["status"], "refused")
                 self.assertEqual(
                     self.con.execute(
@@ -800,16 +815,14 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         )
         self.con.commit()
 
-        result = runtime.act(
-            self.con, directive_id, 1, launcher=self.launcher
-        )
+        result = runtime.act(self.con, directive_id, 1)
 
         self.assertEqual(result["status"], "executed")
         unit = self.con.execute(
             "SELECT state,review_head FROM sprint_units WHERE unit_id=10"
         ).fetchone()
         self.assertEqual(tuple(unit), ("working", None))
-        self.assertIn("DEV1", result["launches"][0])
+        self.assertEqual(result["assignments"][0]["slot"], "DEV1")
 
     def test_retask_refuses_merged_unit_before_worker_launch(self):
         self.set_unit("working")
@@ -825,9 +838,7 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         )
         self.con.commit()
 
-        result = runtime.act(
-            self.con, directive_id, 1, launcher=self.launcher
-        )
+        result = runtime.act(self.con, directive_id, 1)
 
         self.assertEqual(result["status"], "refused")
         self.assertIn("add a follow-up unit", result["reason"])
@@ -837,10 +848,9 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             ).fetchone()[0],
             "merged",
         )
-        self.assertIn("PLN1", result["escalation"]["command"])
-        self.assertNotIn("DEV1", result["escalation"]["command"])
+        self.assertEqual(result["escalation"]["slot"], "PLN1")
 
-    def test_refusal_persists_when_planner_escalation_launch_fails(self):
+    def test_refusal_persists_when_planner_route_is_unavailable(self):
         self.set_unit("working")
         self.set_unit("merged", review_head="approved-head")
         directive_id = self.emit(
@@ -854,20 +864,19 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         )
         self.con.commit()
 
-        def failing_launcher(_command):
-            raise runtime.ConductorLaunchError(
-                "planner slot cannot launch on a closed sprint"
-            )
-
-        result = runtime.act(
-            self.con, directive_id, 1, launcher=failing_launcher
-        )
+        with mock.patch.object(
+            run,
+            "load_adapter",
+            side_effect=ValueError("route temporarily unavailable"),
+        ):
+            result = runtime.act(self.con, directive_id, 1)
 
         self.assertEqual(result["status"], "refused")
         self.assertIn("add a follow-up unit", result["reason"])
         self.assertEqual(
             result["escalation"],
-            {"error": "planner slot cannot launch on a closed sprint"},
+            {"error": "target shell 'PLN1' route is not runnable: "
+             "route temporarily unavailable"},
         )
         row = self.con.execute(
             "SELECT status,refusal_reason FROM directives "
@@ -877,7 +886,7 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         self.assertEqual(row["status"], "refused")
         self.assertIn("add a follow-up unit", row["refusal_reason"])
 
-    def test_worker_launch_failure_rolls_back_and_is_durably_refused(self):
+    def test_assignment_persistence_failure_rolls_back_the_whole_action(self):
         self.set_unit("working")
         self.set_unit("blocked")
         directive_id = self.emit(
@@ -890,27 +899,16 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             },
         )
         self.con.commit()
-        calls = []
+        with (
+            mock.patch.object(
+                runtime.sprint_conversations,
+                "create_sprint_conversation",
+                side_effect=RuntimeError("forced persistence failure"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "forced persistence failure"),
+        ):
+            runtime.act(self.con, directive_id, 1)
 
-        def fail_worker_then_launch_planner(command):
-            calls.append(command)
-            if len(calls) == 1:
-                raise runtime.ConductorLaunchError(
-                    "worker slot is no longer live"
-                )
-            return 31337
-
-        result = runtime.act(
-            self.con,
-            directive_id,
-            1,
-            launcher=fail_worker_then_launch_planner,
-        )
-
-        self.assertEqual(result["status"], "refused")
-        self.assertEqual(result["reason"], "worker slot is no longer live")
-        self.assertEqual(result["escalation"]["pid"], 31337)
-        self.assertIn("PLN1", result["escalation"]["command"])
         self.assertEqual(
             self.con.execute(
                 "SELECT state FROM sprint_units WHERE unit_id=10"
@@ -922,16 +920,115 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             "WHERE directive_id=?",
             (directive_id,),
         ).fetchone()
-        self.assertEqual(tuple(row), ("refused", "worker slot is no longer live"))
+        self.assertEqual(tuple(row), ("pending", None))
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM conversations WHERE mode='sprint'"
+            ).fetchone()[0],
+            0,
+        )
+
+    def test_action_does_no_external_work_inside_the_transaction(self):
+        directive_id = self.emit(
+            "planner",
+            "kickoff",
+            {"to": "DEV1", "instruction": "build the bounded unit"},
+        )
+        self.con.commit()
+        load_adapter = run.load_adapter
+        transaction_states = []
+
+        def checked_adapter(harness):
+            transaction_states.append(self.con.in_transaction)
+            return load_adapter(harness)
+
+        with (
+            mock.patch.object(run, "load_adapter", side_effect=checked_adapter),
+            mock.patch.object(
+                runtime.subprocess,
+                "Popen",
+                side_effect=AssertionError("action attempted process launch"),
+            ),
+        ):
+            result = runtime.act(self.con, directive_id, 1)
+
+        self.assertEqual(result["status"], "executed")
+        self.assertTrue(transaction_states)
+        self.assertEqual(set(transaction_states), {False})
+        prompt = self.con.execute(
+            "SELECT body FROM conversation_messages WHERE conversation_id=?",
+            (result["conversation_ids"][0],),
+        ).fetchone()[0]
+        self.assertNotIn("await-sprint-active", prompt)
+
+    def test_parallel_duplicate_action_commits_one_complete_assignment(self):
+        directive_id = self.emit(
+            "planner",
+            "kickoff",
+            {"to": "DEV1", "instruction": "build the bounded unit"},
+        )
+        self.con.commit()
+
+        def act_once():
+            con = runtime.db_driver.connect(self.db_path)
+            try:
+                return runtime._act_locked(con, directive_id, 1)
+            finally:
+                con.close()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            results = [
+                future.result(timeout=10)
+                for future in (pool.submit(act_once), pool.submit(act_once))
+            ]
+
+        self.assertEqual([item["status"] for item in results], [
+            "executed",
+            "executed",
+        ])
+        self.assertEqual(
+            sum(bool(item.get("replayed")) for item in results),
+            1,
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT state FROM sprint_units WHERE unit_id=10"
+            ).fetchone()[0],
+            "working",
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_conversation_bindings "
+                "WHERE source_directive_id=?",
+                (directive_id,),
+            ).fetchone()[0],
+            1,
+        )
+        conversation_id = self.con.execute(
+            "SELECT conversation_id FROM sprint_conversation_bindings "
+            "WHERE source_directive_id=?",
+            (directive_id,),
+        ).fetchone()[0]
+        self.assertEqual(
+            tuple(self.con.execute(
+                "SELECT "
+                "(SELECT COUNT(*) FROM conversation_messages "
+                " WHERE conversation_id=?),"
+                "(SELECT COUNT(*) FROM conversation_outbox "
+                " WHERE conversation_id=?),"
+                "(SELECT COUNT(*) FROM conversation_events "
+                " WHERE conversation_id=?)",
+                (conversation_id, conversation_id, conversation_id),
+            ).fetchone()),
+            (1, 1, 2),
+        )
 
     def test_runtime_backstop_refuses_retired_handoff(self):
         self.set_declared()
         directive_id = self.emit("planner", "handoff", {}, unit=False)
         self.con.commit()
 
-        result = runtime.act(
-            self.con, directive_id, 1, launcher=self.launcher
-        )
+        result = runtime.act(self.con, directive_id, 1)
 
         self.assertEqual(result["status"], "refused")
         self.assertEqual(result["reason"], "no transition for planner:handoff")
@@ -952,7 +1049,7 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         )
         self.con.commit()
 
-        result = runtime.act(self.con, directive_id, 1, launcher=self.launcher)
+        result = runtime.act(self.con, directive_id, 1)
 
         self.assertEqual(result["status"], "refused")
         unit = self.con.execute(
@@ -964,7 +1061,7 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         directive_id = self.emit("dev", "unit-report", {"shipped": "x"})
         self.con.commit()
         with self.assertRaisesRegex(PermissionError, "conductor"):
-            runtime.act(self.con, directive_id, 2, launcher=self.launcher)
+            runtime.act(self.con, directive_id, 2)
 
     def test_declared_zero_unit_and_dependency_cycle_arming_is_refused(self):
         self.set_declared()
@@ -1001,16 +1098,15 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             {"question": "choose", "alternatives": ["a", "b"]},
         )
         self.con.commit()
-        result = runtime.act(
-            self.con, directive_id, 1, launcher=self.launcher
-        )
+        result = runtime.act(self.con, directive_id, 1)
         self.assertEqual(result["status"], "executed")
-        self.assertEqual(len(result["launches"]), 1)
-        command = result["launches"][0]
-        self.assertIn("PLN1", command)
-        self.assertNotIn("PLN2", command)
+        self.assertEqual(len(result["assignments"]), 1)
+        self.assertEqual(result["assignments"][0]["slot"], "PLN1")
         self.assertEqual(
-            command[command.index("--model") + 1],
+            self.con.execute(
+                "SELECT model FROM conversations WHERE conversation_id=?",
+                (result["assignments"][0]["conversation_id"],),
+            ).fetchone()[0],
             "sonnet",
         )
 
@@ -1022,9 +1118,7 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             (json.dumps({"reason": "not mine"}),),
         ).lastrowid
         self.con.commit()
-        refused = runtime.act(
-            self.con, nonowner, 1, launcher=self.launcher
-        )
+        refused = runtime.act(self.con, nonowner, 1)
         self.assertEqual(refused["status"], "refused")
         self.assertIn("originating Planner", refused["reason"])
 
@@ -1043,9 +1137,7 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             {"pr_number": 7, "head": "abc", "merge_sha": "def"},
         )
         self.con.commit()
-        result = runtime.act(
-            self.con, directive_id, 1, launcher=self.launcher
-        )
+        result = runtime.act(self.con, directive_id, 1)
         self.assertEqual(result["status"], "executed")
         self.assertEqual(
             self.con.execute(
@@ -1053,32 +1145,31 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
             ).fetchone()[0],
             "working",
         )
-        self.assertEqual(len(result["launches"]), 1)
-        self.assertIn("DEV1", result["launches"][0])
-        self.assertNotIn("PLN1", result["launches"][0])
+        self.assertEqual(len(result["assignments"]), 1)
+        self.assertEqual(result["assignments"][0]["slot"], "DEV1")
 
     def test_unit_report_boots_planner_only_after_all_units_terminal(self):
         self.set_unit("working")
         first = self.emit("dev", "unit-report", {"shipped": "partial"})
         self.con.commit()
-        ordinary = runtime.act(self.con, first, 1, launcher=self.launcher)
-        self.assertEqual(ordinary["launches"], [])
+        ordinary = runtime.act(self.con, first, 1)
+        self.assertEqual(ordinary["assignments"], [])
 
         self.con.execute(
             "UPDATE sprint_units SET state='merged' WHERE unit_id=10"
         )
         last = self.emit("dev", "unit-report", {"shipped": "complete"})
         self.con.commit()
-        terminal = runtime.act(self.con, last, 1, launcher=self.launcher)
-        self.assertEqual(len(terminal["launches"]), 1)
-        self.assertIn("PLN1", terminal["launches"][0])
+        terminal = runtime.act(self.con, last, 1)
+        self.assertEqual(len(terminal["assignments"]), 1)
+        self.assertEqual(terminal["assignments"][0]["slot"], "PLN1")
 
 
 class ConductorSyntheticSprintTests(RuntimeFixture):
     def act_one(self, issuer, kind, payload, *, unit=True):
         directive_id = self.emit(issuer, kind, payload, unit=unit)
         self.con.commit()
-        result = runtime.act(self.con, directive_id, 1, launcher=self.launcher)
+        result = runtime.act(self.con, directive_id, 1)
         self.assertEqual(result["status"], "executed")
         return directive_id
 

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -565,6 +565,32 @@ class MigrationAndShapeTest(ConversationDbCase):
                 required_result_kind="answer",
             )
 
+    def test_sprint_binding_allows_source_to_release_another_sprint_unit(
+        self,
+    ) -> None:
+        source_unit_id = self.add_unit(seq="U1")
+        assignment_unit_id = self.add_unit(seq="U2")
+        directive_id = self.add_directive(unit_id=source_unit_id)
+        conversation = self.add_conversation(shell_id=1, mode="sprint")
+
+        binding_id = self.add_binding(
+            conversation,
+            role="developer",
+            slot="dev1",
+            unit_id=assignment_unit_id,
+            source_directive_id=directive_id,
+            required_result_kind="unit-report",
+        )
+
+        self.assertEqual(
+            tuple(self.con.execute(
+                "SELECT sprint_doc_id,unit_id,source_directive_id "
+                "FROM sprint_conversation_bindings WHERE binding_id=?",
+                (binding_id,),
+            ).fetchone()),
+            (24, assignment_unit_id, directive_id),
+        )
+
     def test_succeeded_assignment_requires_scoped_result_and_is_immutable(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- commit Conductor board transitions, directive consumption, one-shot role binding, initial prompt, events, and outbox intent in one bounded DB-only transaction
- notify the conversation broker only after commit and remove directive-creation process wakes
- share Sprint conversation creation across arm/cancel and worker handoffs
- relax the binding source trigger so a directive for U1 may release U2 within the same Sprint while preserving same-Sprint fences

## Verification

- `./sc test` — 1,622 passed
- focused Conductor/conversation/Sprint suites — 111 passed, 172 subtests
- `./sc render-check`
- `git diff --check`
- targeted Ruff F/E9 checks and Python compilation

`./sc verify` was not run: its linked-worktree guard correctly refuses to operate on the shared live instance from this isolated seat.