### PR TITLE
fix: separate map target from hook owner

### DIFF
--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -142,6 +142,20 @@ def is_source_repo() -> bool:
     return origin_basename() in SOURCE_REPO_NAMES
 
 
+def work_repo() -> str | None:
+    """Return this install's declared work project, if it has one.
+
+    An external-work install keeps its engine, local map database, and hooks in
+    the home repo but directs shells to maintain a different project.
+    """
+    cfg = ENGINE / "instance.json"
+    try:
+        raw = (json.loads(cfg.read_text()).get("work_repo") or "").strip()
+    except (OSError, json.JSONDecodeError):
+        return None
+    return str(Path(raw).expanduser()) if raw else None
+
+
 def seed_visual_qa_files(
     repo_root: Path = REPO_ROOT,
     template_root: Path | None = None,

--- a/.super-coder/scripts/map_repo.py
+++ b/.super-coder/scripts/map_repo.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Map the host repo into the dr_* catalogue — how the shell reads its repo.
+"""Map the shell work surface into the dr_* catalogue.
 
-super-coder lives INSIDE a host repo. This walks that repo and records what's
-there — files (with language + role), dependencies (from the common manifests),
-and env-var names — into the dr_* tables, so the shell queries the catalogue
-instead of grepping blind (see the `surface_catalogue` skill).
+Normally super-coder lives inside the project it maps. An external-work install
+instead declares ``work_repo`` in ``instance.json``: this maps that project
+while retaining the map database and generated state in the home repo.
 
 The catalogue is a DERIVED CACHE of the repo, not authored content: it is NOT
 snapshotted. Re-run any time the repo changes:
@@ -33,6 +32,18 @@ import map_db  # noqa: E402 — sibling module in scripts/ (on sys.path for scri
 
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
+
+
+def _resolve_map_root() -> Path:
+    """Return the project tree to scan, never the home-state location."""
+    import install
+
+    work_repo = install.work_repo()
+    candidate = Path(work_repo) if work_repo else None
+    return candidate if candidate and candidate.is_dir() else REPO_ROOT
+
+
+MAP_ROOT = _resolve_map_root()
 # Per-fork map tuning, authored by the cartographer (see the `cartographer`
 # skill). Tracked fork-owned state, kept OUTSIDE the gitignored engine dir (B7)
 # so a wholesale engine refresh never touches it. Absent → built-in defaults
@@ -142,7 +153,7 @@ def count_lines(p: Path) -> int | None:
 
 
 def git(*args: str) -> str | None:
-    r = subprocess.run(["git", "-C", str(REPO_ROOT), *args],
+    r = subprocess.run(["git", "-C", str(MAP_ROOT), *args],
                        capture_output=True, text=True)
     return r.stdout.strip() if r.returncode == 0 else None
 
@@ -314,8 +325,8 @@ def main() -> int:
 
         files = deps = envs = 0
         truncated = False
-        for p in sorted(REPO_ROOT.rglob("*")):
-            rel_parts = p.relative_to(REPO_ROOT).parts
+        for p in sorted(MAP_ROOT.rglob("*")):
+            rel_parts = p.relative_to(MAP_ROOT).parts
             if path_is_skipped(rel_parts, skip, skip_files) or not p.is_file():
                 continue
             if files >= MAX_FILES:
@@ -364,14 +375,14 @@ def main() -> int:
         con.execute(
             "INSERT INTO dr_repo (repo_id, name, root, remote, vcs, default_branch, "
             "file_count, mapped_at) VALUES (1, ?, ?, ?, ?, ?, ?, ?)",
-            (REPO_ROOT.name, str(REPO_ROOT), git("remote", "get-url", "origin"),
-             "git" if (REPO_ROOT / ".git").exists() else None,
+            (MAP_ROOT.name, str(MAP_ROOT), git("remote", "get-url", "origin"),
+             "git" if (MAP_ROOT / ".git").exists() else None,
              git("rev-parse", "--abbrev-ref", "HEAD"), files,
              datetime.now().isoformat(timespec="seconds")))
         con.commit()
         # Fork-owned semantic extractors (endpoints / db schema / routes), if any.
-        ext_summaries = run_extractors(con, REPO_ROOT, cfg)
-        msg = f"map_repo: {files} files, {deps} deps, {envs} env vars → dr_* ({REPO_ROOT.name})"
+        ext_summaries = run_extractors(con, MAP_ROOT, cfg)
+        msg = f"map_repo: {files} files, {deps} deps, {envs} env vars → dr_* ({MAP_ROOT.name})"
         if truncated:
             msg += f"  ⚠ stopped at MAX_FILES={MAX_FILES}"
         print(msg)

--- a/.super-coder/scripts/map_setup.py
+++ b/.super-coder/scripts/map_setup.py
@@ -4,7 +4,9 @@
 The repo map (dr_* catalogue) is kept fresh by tracked git hooks that re-run
 `./sc map` on pull / branch-switch / rebase. The hooks live in
 `.super-coder/hooks/` and fire via `core.hooksPath` — a *per-clone* git setting,
-so a fresh clone needs this run once to point git at them. This:
+so a fresh clone needs this run once to point git at them. In an external-work
+install, the hooks always remain on this HOME clone; only the map scan moves to
+the declared project. This:
 
     1. points `core.hooksPath` at .super-coder/hooks/   (idempotent)
     2. ensures the hook scripts are executable
@@ -25,7 +27,7 @@ import sys
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
-REPO_ROOT = ENGINE.parent
+HOME_ROOT = ENGINE.parent
 HOOKS_DIR = ENGINE / "hooks"
 # core.hooksPath must be ABSOLUTE. Git interprets a relative hooksPath against
 # the *current working directory* — which in a linked worktree is the worktree
@@ -43,7 +45,7 @@ import map_repo  # noqa: E402
 
 def _is_git_repo() -> bool:
     return subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "rev-parse", "--is-inside-work-tree"],
+        ["git", "-C", str(HOME_ROOT), "rev-parse", "--is-inside-work-tree"],
         capture_output=True, text=True).returncode == 0
 
 
@@ -62,7 +64,7 @@ def wire_hooks() -> bool:
               "(auto-remap needs git; `./sc map` / rebuild still refresh)")
         return False
     subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "config", "core.hooksPath", HOOKS_ABS],
+        ["git", "-C", str(HOME_ROOT), "config", "core.hooksPath", HOOKS_ABS],
         check=True)
     print(f"map-setup: core.hooksPath -> {HOOKS_ABS} "
           f"({len(hooks)} hook(s): {', '.join(h.name for h in hooks)})")

--- a/tests/test_map_repo.py
+++ b/tests/test_map_repo.py
@@ -12,6 +12,7 @@ from unittest import mock
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 sys.path.insert(0, str(ENGINE / "scripts"))
 import map_repo  # noqa: E402
+import install  # noqa: E402
 
 
 SCHEMA = """
@@ -78,6 +79,7 @@ class WorktreeSkipTest(unittest.TestCase):
                 return sqlite3.connect(db_path)
 
             with mock.patch.object(map_repo, "REPO_ROOT", root), \
+                    mock.patch.object(map_repo, "MAP_ROOT", root), \
                     mock.patch.object(map_repo, "ENGINE", root / ".super-coder"), \
                     mock.patch.object(map_repo, "CONFIG_PATH",
                                       root / ".sc-state" / "map.config.json"), \
@@ -105,6 +107,59 @@ class WorktreeSkipTest(unittest.TestCase):
         self.assertEqual(["ROOT_ONLY"], env_names)
         self.assertEqual(len(paths), file_count)
         self.assertFalse(any(path.startswith(".sc-worktrees/") for path in paths))
+
+
+class ExternalWorkProjectTest(unittest.TestCase):
+    def test_declared_work_repo_is_the_map_target(self):
+        with tempfile.TemporaryDirectory() as td:
+            temp_root = Path(td)
+            home = temp_root / "home"
+            project = temp_root / "project"
+            home.mkdir()
+            project.mkdir()
+            (project / "app.py").write_text("print('project')\n")
+            (home / "home_only.py").write_text("print('home')\n")
+            with mock.patch.object(install, "work_repo", return_value=str(project)):
+                self.assertEqual(project, map_repo._resolve_map_root())
+            db_path = temp_root / "map.db"
+            con = sqlite3.connect(db_path)
+            con.executescript(SCHEMA)
+            con.close()
+
+            def connect() -> sqlite3.Connection:
+                return sqlite3.connect(db_path)
+
+            with mock.patch.object(map_repo, "REPO_ROOT", home), \
+                    mock.patch.object(map_repo, "MAP_ROOT", project), \
+                    mock.patch.object(map_repo, "CONFIG_PATH", home / "config.json"), \
+                    mock.patch.object(map_repo, "CONFIG_PATH_LEGACY", home / "legacy.json"), \
+                    mock.patch.object(map_repo, "is_source_repo", return_value=False), \
+                    mock.patch.object(map_repo, "git", return_value=""), \
+                    mock.patch.object(map_repo.artifact_policy, "prepare_local_state"), \
+                    mock.patch.object(map_repo.map_db, "connect", side_effect=connect):
+                self.assertEqual(0, map_repo.main())
+
+            con = sqlite3.connect(db_path)
+            paths = [row[0] for row in con.execute(
+                "SELECT path FROM dr_filepath ORDER BY path")]
+            mapped_root = con.execute(
+                "SELECT root FROM dr_repo WHERE repo_id=1").fetchone()[0]
+            con.close()
+
+        self.assertEqual(["app.py"], paths)
+        self.assertEqual(str(project), mapped_root)
+
+    def test_work_repo_expands_home_directory(self):
+        with tempfile.TemporaryDirectory() as td:
+            config_dir = Path(td) / ".super-coder"
+            config_dir.mkdir()
+            (config_dir / "instance.json").write_text(
+                '{"work_repo": "~/Repos/super-coder"}')
+            with mock.patch.object(install, "ENGINE", config_dir):
+                self.assertEqual(
+                    str(Path("~/Repos/super-coder").expanduser()),
+                    install.work_repo(),
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_map_setup.py
+++ b/tests/test_map_setup.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Regression coverage for home-owned map hook wiring."""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import map_setup  # noqa: E402
+
+
+class HomeHookWiringTest(unittest.TestCase):
+    def test_external_project_never_owns_the_hooks_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td) / "home"
+            hooks = home / ".super-coder" / "hooks"
+            hooks.mkdir(parents=True)
+            (hooks / "post-checkout").write_text("#!/bin/sh\n")
+
+            with mock.patch.object(map_setup, "HOME_ROOT", home), \
+                    mock.patch.object(map_setup, "HOOKS_DIR", hooks), \
+                    mock.patch.object(map_setup, "HOOKS_ABS", str(hooks)), \
+                    mock.patch.object(map_setup, "_is_git_repo", return_value=True), \
+                    mock.patch.object(map_setup.subprocess, "run") as run:
+                self.assertTrue(map_setup.wire_hooks())
+
+        run.assert_called_once_with(
+            ["git", "-C", str(home), "config", "core.hooksPath", str(hooks)],
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Maps now honor an install's optional work_repo while keeping generated map state and core.hooksPath in the home clone. Adds regression coverage for both boundaries.